### PR TITLE
Show explanation for the NewRowid opcode

### DIFF
--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1050,13 +1050,13 @@ pub fn insn_to_str(
                 rowid_reg,
                 prev_largest_reg,
             } => (
-                "NewRowId",
+                "NewRowid",
                 *cursor as i32,
                 *rowid_reg as i32,
                 *prev_largest_reg as i32,
                 OwnedValue::build_text(""),
                 0,
-                "".to_string(),
+                format!("r[{}]=rowid", rowid_reg),
             ),
             Insn::MustBeInt { reg } => (
                 "MustBeInt",


### PR DESCRIPTION
After this commit explain will start showing a comment for NewRowid.

```
limbo> explain insert into t(id) values (1);
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     17    0                    0   Start at 17
...
6     NewRowid           0     1     0                    0   r[1]=rowid
...
18    Goto               0     1     0                    0
```