### PR TITLE
Fix stress test to ignore unique constraint violation

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -438,6 +438,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         limbo::Error::SqlExecutionFailure(e) => {
                             if e.contains("Corrupt database") {
                                 panic!("Error executing query: {}", e);
+                            } else if e.contains("UNIQUE constraint failed") {
+                                println!("Skipping UNIQUE constraint violation: {}", e);
+                                continue;
                             } else {
                                 println!("Error executing query: {}", e);
                             }

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -130,12 +130,12 @@ do_execsql_test_in_memory_any_error strict-update-not-null-constraint {
 }
 
 # Uncomment following test case when unique constraint is added
-#do_execsql_test_any_error strict-update-pk-constraint {
-#    CREATE TABLE test8(id INTEGER PRIMARY KEY, name TEXT) STRICT;
-#    INSERT INTO test8 VALUES(1, 'name1');
-#    INSERT INTO test8 VALUES(2, 'name2');
-#    UPDATE test8 SET id = 2 WHERE id = 1;
-#}
+do_execsql_test_any_error strict-update-pk-constraint {
+    CREATE TABLE test8(id INTEGER PRIMARY KEY, name TEXT) STRICT;
+    INSERT INTO test8 VALUES(1, 'name1');
+    INSERT INTO test8 VALUES(2, 'name2');
+    UPDATE test8 SET id = 2 WHERE id = 1;
+}
 
 do_execsql_test_on_specific_db {:memory:} strict-update-multiple-columns {
     CREATE TABLE test9(id INTEGER, name TEXT, price REAL, quantity INT) STRICT;


### PR DESCRIPTION
This should ignore unique constraint violation errors during the stress test.