### PR TITLE
Experimental: Add `close_async` to Connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,6 +1768,7 @@ dependencies = [
  "ctrlc",
  "dirs 5.0.1",
  "env_logger 0.10.2",
+ "futures",
  "libc",
  "limbo_core",
  "miette",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ name = "py-limbo"
 version = "0.0.22-pre.1"
 dependencies = [
  "anyhow",
+ "futures",
  "limbo_core",
  "pyo3",
  "pyo3-build-config",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -17,6 +17,7 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 anyhow = "1.0"
+futures = "0.3"
 limbo_core = { path = "../../core", features = ["io_uring"] }
 pyo3 = { version = "0.24.1", features = ["anyhow"] }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use errors::*;
+use futures::executor::block_on;
 use limbo_core::types::Text;
 use limbo_core::Value;
 use pyo3::prelude::*;
@@ -245,7 +246,7 @@ impl Connection {
     }
 
     pub fn close(&self) -> PyResult<()> {
-        self.conn.close().map_err(|e| {
+        block_on(self.conn.close_async()).map_err(|e| {
             PyErr::new::<OperationalError, _>(format!("Failed to close connection: {:?}", e))
         })?;
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,6 +47,7 @@ schemars = {version = "0.8.22", features = ["preserve_order"]}
 serde = { workspace = true, features = ["derive"]}
 validator = {version = "0.20.0", features = ["derive"]}
 toml_edit = {version = "0.22.24", features = ["serde"]}
+futures = "0.3.31"
 
 [features]
 default = ["io_uring"]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -5,8 +5,8 @@ mod config;
 mod helper;
 mod input;
 mod opcodes_dictionary;
-
 use config::CONFIG_DIR;
+use futures::executor::block_on;
 use rustyline::{error::ReadlineError, Config, Editor};
 use std::{
     path::PathBuf,
@@ -58,7 +58,7 @@ fn main() -> anyhow::Result<()> {
                 // At prompt, increment interrupt count
                 if app.interrupt_count.fetch_add(1, Ordering::SeqCst) >= 1 {
                     eprintln!("Interrupted. Exiting...");
-                    let _ = app.close_conn();
+                    let _ = block_on(app.close_conn());
                     break;
                 }
                 println!("Use .quit to exit or press Ctrl-C again to force quit.");
@@ -67,11 +67,11 @@ fn main() -> anyhow::Result<()> {
             }
             Err(ReadlineError::Eof) => {
                 app.handle_remaining_input();
-                let _ = app.close_conn();
+                let _ = block_on(app.close_conn());
                 break;
             }
             Err(err) => {
-                let _ = app.close_conn();
+                let _ = block_on(app.close_conn());
                 anyhow::bail!(err)
             }
         }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -581,7 +581,7 @@ impl Connection {
         }
     }
 
-    pub fn close_async(&self) -> impl Future<Output = Result<()>> + '_ {
+    pub fn close_async(&self) -> impl Future<Output = Result<(), LimboError>> + '_ {
         future::poll_fn(move |cx| match self.pager.checkpoint() {
             Ok(CheckpointStatus::Done(_)) => Poll::Ready(Ok(())),
             Ok(CheckpointStatus::IO) => {

--- a/testing/cli_tests/test_limbo_cli.py
+++ b/testing/cli_tests/test_limbo_cli.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 import select
-from time import sleep
 import subprocess
 from pathlib import Path
 from typing import Callable, List, Optional
@@ -92,7 +91,6 @@ class LimboShell:
 
     def quit(self) -> None:
         self._write_to_pipe(".quit")
-        sleep(0.3)
         self.pipe.terminate()
         self.pipe.kill()
 

--- a/testing/cli_tests/write.py
+++ b/testing/cli_tests/write.py
@@ -4,7 +4,6 @@ import tempfile
 from cli_tests.test_limbo_cli import TestLimboShell
 from pydantic import BaseModel
 from cli_tests import console
-from time import sleep
 
 
 sqlite_flags = os.getenv("SQLITE_FLAGS", "-q").split(" ")
@@ -153,7 +152,6 @@ def main():
                 with TestLimboShell("") as limbo:
                     limbo.execute_dot(f".open {test.db_path}")
                     test.run(limbo)
-                sleep(0.3)
                 test.test_compat()
 
             except Exception as e:


### PR DESCRIPTION
Due checkpoints, closing a connection can take some time, so it's reasonable to expose it through an async interface.

It also blocks Python's close until the operation is finished to avoid having to use workarounds with concurrent access.