### PR TITLE
Treat table-valued functions as tables

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -43,6 +43,9 @@ impl Schema {
             SCHEMA_TABLE_NAME.to_string(),
             Arc::new(Table::BTree(sqlite_schema_table().into())),
         );
+        for function in VirtualTable::builtin_functions() {
+            tables.insert(function.name.to_owned(), Arc::new(Table::Virtual(function)));
+        }
         Self {
             tables,
             indexes,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -667,6 +667,7 @@ fn create_table(
                     default,
                     unique,
                     collation,
+                    hidden: false,
                 });
             }
             if options.contains(TableOptions::WITHOUT_ROWID) {
@@ -738,6 +739,7 @@ pub struct Column {
     pub default: Option<Expr>,
     pub unique: bool,
     pub collation: Option<CollationSeq>,
+    pub hidden: bool,
 }
 
 impl Column {
@@ -816,6 +818,7 @@ impl From<ColumnDefinition> for Column {
             is_rowid_alias: primary_key && matches!(ty, Type::Integer),
             unique,
             collation,
+            hidden: false,
         }
     }
 }
@@ -1031,6 +1034,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 default: None,
                 unique: false,
                 collation: None,
+                hidden: false,
             },
             Column {
                 name: Some("name".to_string()),
@@ -1042,6 +1046,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 default: None,
                 unique: false,
                 collation: None,
+                hidden: false,
             },
             Column {
                 name: Some("tbl_name".to_string()),
@@ -1053,6 +1058,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 default: None,
                 unique: false,
                 collation: None,
+                hidden: false,
             },
             Column {
                 name: Some("rootpage".to_string()),
@@ -1064,6 +1070,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 default: None,
                 unique: false,
                 collation: None,
+                hidden: false,
             },
             Column {
                 name: Some("sql".to_string()),
@@ -1075,6 +1082,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
                 default: None,
                 unique: false,
                 collation: None,
+                hidden: false,
             },
         ],
         unique_sets: None,
@@ -1688,6 +1696,7 @@ mod tests {
                 default: None,
                 unique: false,
                 collation: None,
+                hidden: false,
             }],
             unique_sets: None,
         };

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -457,8 +457,8 @@ pub fn open_loop(
                                 // We then materialise the RHS/LHS into registers before issuing VFilter.
                                 let converted_constraints = predicates
                                     .iter()
-                                    .filter(|p| p.should_eval_at_loop(join_index, join_order))
                                     .enumerate()
+                                    .filter(|(_, p)| p.should_eval_at_loop(join_index, join_order))
                                     .filter_map(|(i, p)| {
                                         // Build ConstraintInfo from the predicates
                                         convert_where_to_vtab_constraint(

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -1,4 +1,3 @@
-use turso_ext::VTabKind;
 use turso_sqlite3_parser::ast::{self, SortOrder};
 
 use std::sync::Arc;
@@ -442,116 +441,94 @@ pub fn open_loop(
                         program.preassign_label_to_next_insn(loop_start);
                     }
                     Table::Virtual(vtab) => {
-                        let (start_reg, count, maybe_idx_str, maybe_idx_int) =
-                            if vtab.kind.eq(&VTabKind::VirtualTable) {
-                                // Virtual‑table (non‑TVF) modules can receive constraints via xBestIndex.
-                                // They return information with which to pass to VFilter operation.
-                                // We forward every predicate that touches vtab columns.
-                                //
-                                // vtab.col = literal             (always usable)
-                                // vtab.col = outer_table.col     (usable, because outer_table is already positioned)
-                                // vtab.col = later_table.col     (forwarded with usable = false)
-                                //
-                                // xBestIndex decides which ones it wants by setting argvIndex and whether the
-                                // core layer may omit them (omit = true).
-                                // We then materialise the RHS/LHS into registers before issuing VFilter.
-                                let converted_constraints = predicates
-                                    .iter()
-                                    .enumerate()
-                                    .filter(|(_, p)| p.should_eval_at_loop(join_index, join_order))
-                                    .filter_map(|(i, p)| {
-                                        // Build ConstraintInfo from the predicates
-                                        convert_where_to_vtab_constraint(
-                                            p,
-                                            joined_table_index,
-                                            i,
-                                            join_order,
-                                        )
-                                        .unwrap_or(None)
-                                    })
-                                    .collect::<Vec<_>>();
-                                // TODO: get proper order_by information to pass to the vtab.
-                                // maybe encode more info on t_ctx? we need: [col_idx, is_descending]
-                                let index_info = vtab.best_index(&converted_constraints, &[]);
+                        let (start_reg, count, maybe_idx_str, maybe_idx_int) = {
+                            // Virtual‑table modules can receive constraints via xBestIndex.
+                            // They return information with which to pass to VFilter operation.
+                            // We forward every predicate that touches vtab columns.
+                            //
+                            // vtab.col = literal             (always usable)
+                            // vtab.col = outer_table.col     (usable, because outer_table is already positioned)
+                            // vtab.col = later_table.col     (forwarded with usable = false)
+                            //
+                            // xBestIndex decides which ones it wants by setting argvIndex and whether the
+                            // core layer may omit them (omit = true).
+                            // We then materialise the RHS/LHS into registers before issuing VFilter.
+                            let converted_constraints = predicates
+                                .iter()
+                                .enumerate()
+                                .filter(|(_, p)| p.should_eval_at_loop(join_index, join_order))
+                                .filter_map(|(i, p)| {
+                                    // Build ConstraintInfo from the predicates
+                                    convert_where_to_vtab_constraint(
+                                        p,
+                                        joined_table_index,
+                                        i,
+                                        join_order,
+                                    )
+                                    .unwrap_or(None)
+                                })
+                                .collect::<Vec<_>>();
+                            // TODO: get proper order_by information to pass to the vtab.
+                            // maybe encode more info on t_ctx? we need: [col_idx, is_descending]
+                            let index_info = vtab.best_index(&converted_constraints, &[]);
 
-                                // Determine the number of VFilter arguments (constraints with an argv_index).
-                                let args_needed = index_info
-                                    .constraint_usages
-                                    .iter()
-                                    .filter(|u| u.argv_index.is_some())
-                                    .count();
-                                let start_reg = program.alloc_registers(args_needed);
+                            // Determine the number of VFilter arguments (constraints with an argv_index).
+                            let args_needed = index_info
+                                .constraint_usages
+                                .iter()
+                                .filter(|u| u.argv_index.is_some())
+                                .count();
+                            let start_reg = program.alloc_registers(args_needed);
 
-                                // For each constraint used by best_index, translate the opposite side.
-                                for (i, usage) in index_info.constraint_usages.iter().enumerate() {
-                                    if let Some(argv_index) = usage.argv_index {
-                                        if let Some(cinfo) = converted_constraints.get(i) {
-                                            let (pred_idx, is_rhs) = cinfo.unpack_plan_info();
-                                            if let ast::Expr::Binary(lhs, _, rhs) =
-                                                &predicates[pred_idx].expr
-                                            {
-                                                // translate the opposite side of the referenced vtab column
-                                                let expr = if is_rhs { lhs } else { rhs };
-                                                // argv_index is 1-based; adjust to get the proper register offset.
-                                                if argv_index == 0 {
-                                                    // invalid since argv_index is 1-based
-                                                    continue;
-                                                }
-                                                let target_reg =
-                                                    start_reg + (argv_index - 1) as usize;
-                                                translate_expr(
-                                                    program,
-                                                    Some(table_references),
-                                                    expr,
-                                                    target_reg,
-                                                    &t_ctx.resolver,
-                                                )?;
-                                                if cinfo.usable && usage.omit {
-                                                    predicates[pred_idx].consumed.set(true);
-                                                }
+                            // For each constraint used by best_index, translate the opposite side.
+                            for (i, usage) in index_info.constraint_usages.iter().enumerate() {
+                                if let Some(argv_index) = usage.argv_index {
+                                    if let Some(cinfo) = converted_constraints.get(i) {
+                                        let (pred_idx, is_rhs) = cinfo.unpack_plan_info();
+                                        if let ast::Expr::Binary(lhs, _, rhs) =
+                                            &predicates[pred_idx].expr
+                                        {
+                                            // translate the opposite side of the referenced vtab column
+                                            let expr = if is_rhs { lhs } else { rhs };
+                                            // argv_index is 1-based; adjust to get the proper register offset.
+                                            if argv_index == 0 {
+                                                // invalid since argv_index is 1-based
+                                                continue;
+                                            }
+                                            let target_reg = start_reg + (argv_index - 1) as usize;
+                                            translate_expr(
+                                                program,
+                                                Some(table_references),
+                                                expr,
+                                                target_reg,
+                                                &t_ctx.resolver,
+                                            )?;
+                                            if cinfo.usable && usage.omit {
+                                                predicates[pred_idx].consumed.set(true);
                                             }
                                         }
                                     }
                                 }
+                            }
 
-                                // If best_index provided an idx_str, translate it.
-                                let maybe_idx_str = if let Some(idx_str) = index_info.idx_str {
-                                    let reg = program.alloc_register();
-                                    program.emit_insn(Insn::String8 {
-                                        dest: reg,
-                                        value: idx_str,
-                                    });
-                                    Some(reg)
-                                } else {
-                                    None
-                                };
-                                (
-                                    start_reg,
-                                    args_needed,
-                                    maybe_idx_str,
-                                    Some(index_info.idx_num),
-                                )
+                            // If best_index provided an idx_str, translate it.
+                            let maybe_idx_str = if let Some(idx_str) = index_info.idx_str {
+                                let reg = program.alloc_register();
+                                program.emit_insn(Insn::String8 {
+                                    dest: reg,
+                                    value: idx_str,
+                                });
+                                Some(reg)
                             } else {
-                                // For table-valued functions: translate the table args.
-                                let args = match vtab.args.as_ref() {
-                                    Some(args) => args,
-                                    None => &vec![],
-                                };
-                                let start_reg = program.alloc_registers(args.len());
-                                let mut cur_reg = start_reg;
-                                for arg in args {
-                                    let reg = cur_reg;
-                                    cur_reg += 1;
-                                    let _ = translate_expr(
-                                        program,
-                                        Some(table_references),
-                                        arg,
-                                        reg,
-                                        &t_ctx.resolver,
-                                    )?;
-                                }
-                                (start_reg, args.len(), None, None)
+                                None
                             };
+                            (
+                                start_reg,
+                                args_needed,
+                                maybe_idx_str,
+                                Some(index_info.idx_num),
+                            )
+                        };
 
                         // Emit VFilter with the computed arguments.
                         program.emit_insn(Insn::VFilter {

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1610,6 +1610,7 @@ mod tests {
             default: None,
             unique: false,
             collation: None,
+            hidden: false,
         }
     }
     fn _create_column_of_type(name: &str, ty: Type) -> Column {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -243,11 +243,11 @@ fn optimize_table_access(
             let try_to_build_ephemeral_index = if schema.indexes_enabled() {
                 let is_leftmost_table = i == 0;
                 let uses_index = access_method.index.is_some();
-                let source_table_is_from_clause_subquery = matches!(
+                let source_table_does_not_support_search = matches!(
                     &joined_tables[table_idx].table,
-                    Table::FromClauseSubquery(_)
+                    Table::FromClauseSubquery(_) | Table::Virtual(_)
                 );
-                !is_leftmost_table && !uses_index && !source_table_is_from_clause_subquery
+                !is_leftmost_table && !uses_index && !source_table_does_not_support_search
             } else {
                 false
             };

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -555,6 +555,7 @@ pub fn select_star(tables: &[JoinedTable], out_columns: &mut Vec<ResultSetColumn
                 .columns()
                 .iter()
                 .enumerate()
+                .filter(|(_, col)| !col.hidden)
                 .filter(|(_, col)| {
                     // If we are joining with USING, we need to deduplicate the columns from the right table
                     // that are also present in the USING clause.
@@ -917,6 +918,7 @@ impl JoinedTable {
                 default: None,
                 unique: false,
                 collation: None, // FIXME: infer collation from subquery
+                hidden: false,
             })
             .collect();
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -386,7 +386,7 @@ fn query_pragma(
             translate_integrity_check(schema, &mut program)?;
         }
         PragmaName::UnstableCaptureDataChangesConn => {
-            let pragma = pragma_for(pragma);
+            let pragma = pragma_for(&pragma);
             let second_column = program.alloc_register();
             let opts = connection.get_capture_data_changes();
             program.emit_string8(opts.mode_name().to_string(), register);

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -303,7 +303,10 @@ fn query_pragma(
             let base_reg = register;
             program.alloc_registers(5);
             if let Some(table) = table {
-                for (i, column) in table.columns().iter().enumerate() {
+                // According to the SQLite documentation: "The 'cid' column should not be taken to
+                // mean more than 'rank within the current result set'."
+                // Therefore, we enumerate only after filtering out hidden columns.
+                for (i, column) in table.columns().iter().filter(|col| !col.hidden).enumerate() {
                     // cid
                     program.emit_int(i as i64, base_reg);
                     // name

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -783,6 +783,7 @@ pub fn translate_drop_table(
                 default: None,
                 unique: false,
                 collation: None,
+                hidden: false,
             }],
             is_strict: false,
             unique_sets: None,

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -250,6 +250,7 @@ pub fn prepare_update_plan(
                 default: None,
                 unique: false,
                 collation: None,
+                hidden: false,
             }],
             is_strict: false,
             unique_sets: None,

--- a/core/util.rs
+++ b/core/util.rs
@@ -490,91 +490,90 @@ pub fn columns_from_create_table_body(body: &ast::CreateTableBody) -> crate::Res
 
     Ok(columns
         .into_iter()
-        .filter_map(|(name, column_def)| {
-            // if column_def.col_type includes HIDDEN, omit it for now
-            if let Some(data_type) = column_def.col_type.as_ref() {
-                if data_type.name.as_str().contains("HIDDEN") {
-                    return None;
-                }
-            }
-            let column =
-                Column {
-                    name: Some(normalize_ident(&name.0)),
-                    ty: match column_def.col_type {
-                        Some(ref data_type) => {
-                            // https://www.sqlite.org/datatype3.html
-                            let type_name = data_type.name.as_str().to_uppercase();
-                            if type_name.contains("INT") {
-                                Type::Integer
-                            } else if type_name.contains("CHAR")
-                                || type_name.contains("CLOB")
-                                || type_name.contains("TEXT")
-                            {
-                                Type::Text
-                            } else if type_name.contains("BLOB") || type_name.is_empty() {
-                                Type::Blob
-                            } else if type_name.contains("REAL")
-                                || type_name.contains("FLOA")
-                                || type_name.contains("DOUB")
-                            {
-                                Type::Real
-                            } else {
-                                Type::Numeric
-                            }
+        .map(|(name, column_def)| {
+            Column {
+                name: Some(normalize_ident(&name.0)),
+                ty: match column_def.col_type {
+                    Some(ref data_type) => {
+                        // https://www.sqlite.org/datatype3.html
+                        let type_name = data_type.name.as_str().to_uppercase();
+                        if type_name.contains("INT") {
+                            Type::Integer
+                        } else if type_name.contains("CHAR")
+                            || type_name.contains("CLOB")
+                            || type_name.contains("TEXT")
+                        {
+                            Type::Text
+                        } else if type_name.contains("BLOB") || type_name.is_empty() {
+                            Type::Blob
+                        } else if type_name.contains("REAL")
+                            || type_name.contains("FLOA")
+                            || type_name.contains("DOUB")
+                        {
+                            Type::Real
+                        } else {
+                            Type::Numeric
                         }
-                        None => Type::Null,
-                    },
-                    default: column_def
-                        .constraints
-                        .iter()
-                        .find_map(|c| match &c.constraint {
-                            turso_sqlite3_parser::ast::ColumnConstraint::Default(val) => {
-                                Some(val.clone())
-                            }
-                            _ => None,
-                        }),
-                    notnull: column_def.constraints.iter().any(|c| {
-                        matches!(
-                            c.constraint,
-                            turso_sqlite3_parser::ast::ColumnConstraint::NotNull { .. }
-                        )
+                    }
+                    None => Type::Null,
+                },
+                default: column_def
+                    .constraints
+                    .iter()
+                    .find_map(|c| match &c.constraint {
+                        turso_sqlite3_parser::ast::ColumnConstraint::Default(val) => {
+                            Some(val.clone())
+                        }
+                        _ => None,
                     }),
-                    ty_str: column_def
-                        .col_type
-                        .clone()
-                        .map(|t| t.name.to_string())
-                        .unwrap_or_default(),
-                    primary_key: column_def.constraints.iter().any(|c| {
-                        matches!(
-                            c.constraint,
-                            turso_sqlite3_parser::ast::ColumnConstraint::PrimaryKey { .. }
-                        )
+                notnull: column_def.constraints.iter().any(|c| {
+                    matches!(
+                        c.constraint,
+                        turso_sqlite3_parser::ast::ColumnConstraint::NotNull { .. }
+                    )
+                }),
+                ty_str: column_def
+                    .col_type
+                    .clone()
+                    .map(|t| t.name.to_string())
+                    .unwrap_or_default(),
+                primary_key: column_def.constraints.iter().any(|c| {
+                    matches!(
+                        c.constraint,
+                        turso_sqlite3_parser::ast::ColumnConstraint::PrimaryKey { .. }
+                    )
+                }),
+                is_rowid_alias: false,
+                unique: column_def.constraints.iter().any(|c| {
+                    matches!(
+                        c.constraint,
+                        turso_sqlite3_parser::ast::ColumnConstraint::Unique(..)
+                    )
+                }),
+                collation: column_def
+                    .constraints
+                    .iter()
+                    .find_map(|c| match &c.constraint {
+                        // TODO: see if this should be the correct behavior
+                        // currently there cannot be any user defined collation sequences.
+                        // But in the future, when a user defines a collation sequence, creates a table with it,
+                        // then closes the db and opens it again. This may panic here if the collation seq is not registered
+                        // before reading the columns
+                        turso_sqlite3_parser::ast::ColumnConstraint::Collate { collation_name } => {
+                            Some(
+                                CollationSeq::new(collation_name.0.as_str()).expect(
+                                    "collation should have been set correctly in create table",
+                                ),
+                            )
+                        }
+                        _ => None,
                     }),
-                    is_rowid_alias: false,
-                    unique: column_def.constraints.iter().any(|c| {
-                        matches!(
-                            c.constraint,
-                            turso_sqlite3_parser::ast::ColumnConstraint::Unique(..)
-                        )
-                    }),
-                    collation: column_def
-                        .constraints
-                        .iter()
-                        .find_map(|c| match &c.constraint {
-                            // TODO: see if this should be the correct behavior
-                            // currently there cannot be any user defined collation sequences.
-                            // But in the future, when a user defines a collation sequence, creates a table with it,
-                            // then closes the db and opens it again. This may panic here if the collation seq is not registered
-                            // before reading the columns
-                            turso_sqlite3_parser::ast::ColumnConstraint::Collate {
-                                collation_name,
-                            } => Some(CollationSeq::new(collation_name.0.as_str()).expect(
-                                "collation should have been set correctly in create table",
-                            )),
-                            _ => None,
-                        }),
-                };
-            Some(column)
+                hidden: column_def
+                    .col_type
+                    .as_ref()
+                    .map(|data_type| data_type.name.as_str().contains("HIDDEN"))
+                    .unwrap_or(false),
+            }
         })
         .collect::<Vec<_>>())
 }

--- a/core/util.rs
+++ b/core/util.rs
@@ -1074,35 +1074,6 @@ pub fn parse_pragma_bool(expr: &Expr) -> Result<bool> {
     ))
 }
 
-// for TVF's we need these at planning time so we cannot emit translate_expr
-pub fn vtable_args(args: &[ast::Expr]) -> Vec<turso_ext::Value> {
-    let mut vtable_args = Vec::new();
-    for arg in args {
-        match arg {
-            Expr::Literal(lit) => match lit {
-                Literal::Numeric(i) => {
-                    if i.contains('.') {
-                        vtable_args.push(turso_ext::Value::from_float(i.parse().unwrap()));
-                    } else {
-                        vtable_args.push(turso_ext::Value::from_integer(i.parse().unwrap()));
-                    }
-                }
-                Literal::String(s) => {
-                    vtable_args.push(turso_ext::Value::from_text(s.clone()));
-                }
-                Literal::Blob(b) => {
-                    vtable_args.push(turso_ext::Value::from_blob(b.as_bytes().into()));
-                }
-                _ => {
-                    vtable_args.push(turso_ext::Value::null());
-                }
-            },
-            _ => vtable_args.push(turso_ext::Value::null()),
-        }
-    }
-    vtable_args
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -1,6 +1,6 @@
 use crate::pragma::{PragmaVirtualTable, PragmaVirtualTableCursor};
 use crate::schema::Column;
-use crate::util::{columns_from_create_table_body, vtable_args};
+use crate::util::columns_from_create_table_body;
 use crate::{Connection, LimboError, SymbolTable, Value};
 use fallible_iterator::FallibleIterator;
 use std::cell::RefCell;
@@ -19,29 +19,33 @@ enum VirtualTableType {
 #[derive(Clone, Debug)]
 pub struct VirtualTable {
     pub(crate) name: String,
-    pub(crate) args: Option<Vec<ast::Expr>>,
     pub(crate) columns: Vec<Column>,
     pub(crate) kind: VTabKind,
     vtab_type: VirtualTableType,
 }
 
 impl VirtualTable {
-    pub(crate) fn function(
-        name: &str,
-        args: Option<Vec<ast::Expr>>,
-        syms: &SymbolTable,
-    ) -> crate::Result<Rc<VirtualTable>> {
+    pub(crate) fn builtin_functions() -> Vec<Rc<VirtualTable>> {
+        PragmaVirtualTable::functions()
+            .into_iter()
+            .map(|(tab, schema)| {
+                let vtab = VirtualTable {
+                    name: format!("pragma_{}", tab.pragma_name),
+                    columns: Self::resolve_columns(schema)
+                        .expect("built-in function schema resolution should not fail"),
+                    kind: VTabKind::TableValuedFunction,
+                    vtab_type: VirtualTableType::Pragma(tab),
+                };
+                Rc::new(vtab)
+            })
+            .collect()
+    }
+
+    pub(crate) fn function(name: &str, syms: &SymbolTable) -> crate::Result<Rc<VirtualTable>> {
         let module = syms.vtab_modules.get(name);
         let (vtab_type, schema) = if module.is_some() {
-            let ext_args = match args {
-                Some(ref args) => vtable_args(args),
-                None => vec![],
-            };
-            ExtVirtualTable::create(name, module, ext_args, VTabKind::TableValuedFunction)
+            ExtVirtualTable::create(name, module, Vec::new(), VTabKind::TableValuedFunction)
                 .map(|(vtab, columns)| (VirtualTableType::External(vtab), columns))?
-        } else if let Some(pragma_name) = name.strip_prefix("pragma_") {
-            PragmaVirtualTable::create(pragma_name)
-                .map(|(vtab, columns)| (VirtualTableType::Pragma(vtab), columns))?
         } else {
             return Err(LimboError::ParseError(format!(
                 "No such table-valued function: {name}"
@@ -50,7 +54,6 @@ impl VirtualTable {
 
         let vtab = VirtualTable {
             name: name.to_owned(),
-            args,
             columns: Self::resolve_columns(schema)?,
             kind: VTabKind::TableValuedFunction,
             vtab_type,
@@ -69,7 +72,6 @@ impl VirtualTable {
             ExtVirtualTable::create(module_name, module, args, VTabKind::VirtualTable)?;
         let vtab = VirtualTable {
             name: tbl_name.unwrap_or(module_name).to_owned(),
-            args: None,
             columns: Self::resolve_columns(schema)?,
             kind: VTabKind::VirtualTable,
             vtab_type: VirtualTableType::External(table),

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -121,12 +121,7 @@ impl VirtualTable {
         order_by: &[OrderByInfo],
     ) -> IndexInfo {
         match &self.vtab_type {
-            VirtualTableType::Pragma(_) => {
-                // SQLite tries to estimate cost and row count for pragma_ TVFs,
-                // but since Limbo doesn't have cost-based planning yet, this
-                // estimation is not currently implemented.
-                Default::default()
-            }
+            VirtualTableType::Pragma(table) => table.best_index(constraints),
             VirtualTableType::External(table) => table.best_index(constraints, order_by),
         }
     }

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -442,6 +442,10 @@ def _test_kv(exec_name, ext_path):
         lambda res: res == "100|updated2",
         "there is only 1 key remaining after setting all keys to same value",
     )
+    limbo.run_test_fn(
+        "select * from t a, other b where b.c = 23 and a.key='100';",
+        lambda res: "100|updated2|23|32|23" == res,
+    )
     limbo.quit()
 
 

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -328,6 +328,16 @@ def _test_series(limbo: TestTursoShell):
         "SELECT * FROM generate_series(10, 1, -2);",
         lambda res: res == "10\n8\n6\n4\n2",
     )
+    limbo.run_test_fn(
+        "SELECT "
+        "   a.value a_val, "
+        "   b.value b_val "
+        "FROM "
+        "   generate_series(1, 3) a "
+        "JOIN "
+        "   generate_series(1, 1) b ON a.value = b.value;",
+        lambda res: res == "1|1",
+    )
     limbo.execute_dot("CREATE TABLE target (id integer primary key);")
     limbo.execute_dot("INSERT INTO target SELECT * FROM generate_series(1, 5);")
     limbo.run_test_fn(
@@ -919,11 +929,22 @@ def _test_hidden_columns(exec_name, ext_path):
         "SELECT * FROM l JOIN r ON l.comment = r.comment;",
         lambda res: "2|3|comment1|4|5" == res,
     )
-    # TODO: Limbo panics for:
-    # - SELECT * FROM l NATURAL JOIN r NATURAL JOIN r;
-    # - SELECT * FROM l NATURAL JOIN r NATURAL JOIN l;
-    # - SELECT * FROM r NATURAL JOIN l;
-    # - SELECT * FROM r NATURAL JOIN l NATURAL JOIN r;
+    limbo.run_test_fn(
+        "SELECT * FROM l NATURAL JOIN r NATURAL JOIN r;",
+        lambda res: "2|3|comment0" == res,
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM l NATURAL JOIN r NATURAL JOIN l;",
+        lambda res: "2|3|comment0" == res,
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM r NATURAL JOIN l;",
+        lambda res: "comment0|2|3" == res,
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM r NATURAL JOIN l NATURAL JOIN r;",
+        lambda res: "comment0|2|3" == res,
+    )
 
     limbo.quit()
 

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -317,12 +317,40 @@ def _test_series(limbo: TestTursoShell):
         lambda res: res == "1\n2\n3\n4\n5\n6\n7\n8\n9\n10",
     )
     limbo.run_test_fn(
+        "SELECT * FROM generate_series WHERE start = 1 AND stop = 10;",
+        lambda res: res == "1\n2\n3\n4\n5\n6\n7\n8\n9\n10",
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM generate_series(1, 10) WHERE value < 5;",
+        lambda res: res == "1\n2\n3\n4",
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM generate_series WHERE start = 1 AND stop = 10 AND value < 5;",
+        lambda res: res == "1\n2\n3\n4",
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM generate_series WHERE start = 1 AND stop = 10 AND start = 5;",
+        lambda res: res == "",
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM generate_series WHERE start = 1 AND stop = 10 AND start > 5;",
+        lambda res: res == "",
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM generate_series;",
+        lambda res: "Invalid Argument" in res or 'first argument to "generate_series()" missing or unusable' in res,
+    )
+    limbo.run_test_fn(
         "SELECT * FROM generate_series(1, 10, 2);",
         lambda res: res == "1\n3\n5\n7\n9",
     )
     limbo.run_test_fn(
+        "SELECT * FROM generate_series WHERE start = 1 AND stop = 10 AND step = 2;",
+        lambda res: res == "1\n3\n5\n7\n9",
+    )
+    limbo.run_test_fn(
         "SELECT * FROM generate_series(1, 10, 2, 3);",
-        lambda res: "Invalid Argument" in res or "too many arguments" in res,
+        lambda res: "too many arguments" in res.lower(),
     )
     limbo.run_test_fn(
         "SELECT * FROM generate_series(10, 1, -2);",
@@ -948,6 +976,22 @@ def _test_hidden_columns(exec_name, ext_path):
     limbo.run_test_fn(
         "SELECT * FROM r NATURAL JOIN l NATURAL JOIN r;",
         lambda res: "comment0|2|3" == res,
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM (SELECT * FROM l JOIN r USING(key, value)) JOIN r USING(comment, key, value);",
+        lambda res: "2|3|comment0" == res,
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM (SELECT * FROM l NATURAL JOIN r) JOIN r USING(comment, key, value);",
+        lambda res: "2|3|comment0" == res,
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM l JOIN r USING(key, value) JOIN r USING(comment, key, value);",
+        lambda res: "" == res,
+    )
+    limbo.run_test_fn(
+        "SELECT * FROM l NATURAL JOIN r JOIN r USING(comment, key, value);",
+        lambda res: "" == res,
     )
 
     limbo.quit()

--- a/testing/pragma.test
+++ b/testing/pragma.test
@@ -83,12 +83,25 @@ do_execsql_test pragma-function-table-info {
 4|sql|TEXT|0||0
 }
 
+do_execsql_test pragma-vtab-table-info {
+  SELECT * FROM pragma_table_info WHERE arg = 'sqlite_schema'
+} {0|type|TEXT|0||0
+1|name|TEXT|0||0
+2|tbl_name|TEXT|0||0
+3|rootpage|INT|0||0
+4|sql|TEXT|0||0
+}
+
 do_execsql_test pragma-table-info-invalid-table {
   PRAGMA table_info=pekka
 } {}
 
 do_execsql_test pragma-function-table-info-invalid-table {
   SELECT * FROM pragma_table_info('pekka')
+} {}
+
+do_execsql_test pragma-vtab-table-info-invalid-table {
+  SELECT * FROM pragma_table_info WHERE arg = 'pekka'
 } {}
 
 # temporarily skip this test case. The issue is detailed in #1407
@@ -128,17 +141,17 @@ do_execsql_test pragma-legacy-file-format {
   PRAGMA legacy_file_format
 } {}
 
-do_execsql_test_error_content pragma-function-legacy-file-format {
+do_execsql_test_error pragma-function-legacy-file-format {
   SELECT * FROM pragma_legacy_file_format()
-} {"No such table"}
+} {(no such table|Table.*not found)}
 
 do_execsql_test_error_content pragma-function-too-many-arguments {
   SELECT * FROM pragma_table_info('sqlite_schema', 'main', 'arg3')
 } {"Too many arguments"}
 
-do_execsql_test_error_content pragma-function-update {
+do_execsql_test_error pragma-function-update {
   SELECT * FROM pragma_wal_checkpoint()
-} {"No such table"}
+} {(no such table|Table.*not found)}
 
 do_execsql_test pragma-function-nontext-argument {
   SELECT * FROM pragma_table_info('sqlite_schema', NULL);
@@ -149,8 +162,21 @@ do_execsql_test pragma-function-nontext-argument {
 4|sql|TEXT|0||0
 }
 
+do_execsql_test pragma-vtab-nontext-argument {
+  SELECT * FROM pragma_table_info WHERE arg ='sqlite_schema' AND schema IS NULL;
+} {0|type|TEXT|0||0
+1|name|TEXT|0||0
+2|tbl_name|TEXT|0||0
+3|rootpage|INT|0||0
+4|sql|TEXT|0||0
+}
+
 do_execsql_test pragma-function-no-arguments {
   SELECT * FROM pragma_table_info();
+} {}
+
+do_execsql_test pragma-vtab-no-arguments {
+  SELECT * FROM pragma_table_info;
 } {}
 
 do_execsql_test_on_specific_db ":memory:" pragma-function-argument-with-space {


### PR DESCRIPTION
First step toward resolving https://github.com/tursodatabase/limbo/issues/1643.

### This PR
With this change, the following two queries are considered equivalent:
```sql
SELECT value FROM generate_series(5, 50);
SELECT value FROM generate_series WHERE start = 5 AND stop = 50;
```
Arguments passed in parentheses to the virtual table name are now matched to hidden columns.

Additionally, I fixed two bugs related to virtual tables.

### TODO (I'll handle this in a separate PR)
Column references are still not supported as table-valued function arguments. The only difference is that previously, a query like:
```sql
SELECT one.value, series.value
FROM (SELECT 1 AS value) one, generate_series(one.value, 3) series;
```
would cause a panic. Now, it returns a proper error message instead.

Adding support for column references is more nuanced for two main reasons:
* We need to ensure that in joins where a TVF depends on other tables, those other tables are processed first. For example, in:
```sql
SELECT one.value, series.value
FROM generate_series(one.value, 3) series, (SELECT 1 AS value) one;
```
the one table must be processed by the top-level loop, and series must be nested.
* For outer joins involving TVFs, the arguments must be treated as `ON` predicates, not `WHERE` predicates.