### PR TITLE
cli: fix panic of queries with less than 7 chars

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -426,7 +426,12 @@ impl Limbo {
         // TODO this is a quickfix. Some ideas to do case insensitive comparisons is to use
         // Uncased or Unicase.
         let explain_str = "explain";
-        if input.trim_start()[0..explain_str.len()].eq_ignore_ascii_case(explain_str) {
+        if input
+            .trim_start()
+            .get(..explain_str.len())
+            .map(|s| s.eq_ignore_ascii_case(explain_str))
+            .unwrap_or(false)
+        {
             match self.conn.query(input) {
                 Ok(Some(stmt)) => {
                     let _ = self.writeln(stmt.explain().as_bytes());


### PR DESCRIPTION
Hey everyone! I think this project is really really cool and I am here to answer @jussisaurio [call](https://x.com/jussisaur/status/1930290889496129562).

I started tinkering around with limbo and ran into this panic. Any input with less than 7 characters (`"explain".len()`) will trigger it. In my case it was `show;`. The issue was introduced a week ago in #1678.

PS: As I [said on X](https://x.com/nilskch/status/1930362930605723818), I would love to help you with Limbo. I have a lot of experience with DSLs and LSPs, and I have recently become interested in databases. I don't have much experience with databases yet, but I am happy to learn. I see that you have a lot of stuff going on with DSLs at the moment, so I would be productive straight away in that area. Happy to chat if you need help :) 

