### PR TITLE
core: Fix read_frame_raw() to read the full frame

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1515,10 +1515,15 @@ pub fn read_entire_wal_dumb(file: &Arc<dyn File>) -> Result<Arc<UnsafeCell<WalFi
 pub fn begin_read_wal_frame(
     io: &Arc<dyn File>,
     offset: usize,
+    read_size: usize,
     buffer_pool: Rc<BufferPool>,
     complete: Box<dyn Fn(Arc<RefCell<Buffer>>) -> ()>,
 ) -> Result<Arc<Completion>> {
-    tracing::trace!("begin_read_wal_frame(offset={})", offset);
+    tracing::trace!(
+        "begin_read_wal_frame(offset={}, read_size={})",
+        offset,
+        read_size
+    );
     let buf = buffer_pool.get();
     let drop_fn = Rc::new(move |buf| {
         let buffer_pool = buffer_pool.clone();

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -580,9 +580,10 @@ impl Wal for WalFile {
             let frame = frame.clone();
             finish_read_page(page.get().id, buf, frame).unwrap();
         });
-        begin_read_wal_frame(
+        let _c = begin_read_wal_frame(
             &self.get_shared().file,
             offset + WAL_FRAME_HEADER_SIZE,
+            self.page_size as usize,
             buffer_pool,
             complete,
         )?;
@@ -607,7 +608,8 @@ impl Wal for WalFile {
         });
         let c = begin_read_wal_frame(
             &self.get_shared().file,
-            offset + WAL_FRAME_HEADER_SIZE,
+            offset,
+            WAL_FRAME_HEADER_SIZE + self.page_size as usize,
             buffer_pool,
             complete,
         )?;

--- a/sqlite3/tests/compat/mod.rs
+++ b/sqlite3/tests/compat/mod.rs
@@ -290,6 +290,7 @@ mod tests {
                 let mut frame_count = 0;
                 assert_eq!(libsql_wal_frame_count(db, &mut frame_count), SQLITE_OK);
                 assert_eq!(frame_count, 3);
+                let pages = vec![1, 2, 2];
                 for i in 1..frame_count + 1 {
                     let frame_len = 4096 + 24;
                     let mut frame = vec![0; frame_len];
@@ -297,6 +298,8 @@ mod tests {
                         libsql_wal_get_frame(db, i, frame.as_mut_ptr(), frame_len as u32),
                         SQLITE_OK
                     );
+                    let page_num = u32::from_be_bytes(frame[0..4].try_into().unwrap());
+                    assert_eq!(page_num, pages[i as usize - 1]);
                 }
                 assert_eq!(sqlite3_close(db), SQLITE_OK);
             }


### PR DESCRIPTION
Currently, we only read the page data of a frame in `read_frame_raw()`, which is wrong. Fix the code to read the whole thing, including WAL frame header.