### PR TITLE
Core: Introduce external sorting

### DIFF
--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -217,13 +217,14 @@ impl limbo_core::File for File {
             limbo_core::Completion::Read(ref r) => r,
             _ => unreachable!(),
         };
+        let nr = 0;
         {
             let mut buf = r.buf_mut();
             let buf: &mut [u8] = buf.as_mut_slice();
             let nr = self.vfs.pread(self.fd, buf, pos);
             assert!(nr >= 0);
         }
-        r.complete();
+        r.complete(nr);
         Ok(())
     }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -78,6 +78,7 @@ miette = "7.6.0"
 strum = { workspace = true }
 parking_lot = "0.12.3"
 crossbeam-skiplist = "0.1.3"
+tempfile = "3.8.0"
 tracing = "0.1.41"
 ryu = "1.0.19"
 uncased = "0.9.10"
@@ -100,7 +101,6 @@ criterion = { version = "0.5", features = [
 ] }
 rstest = "0.18.2"
 rusqlite = "0.34.0"
-tempfile = "3.8.0"
 quickcheck = { version = "1.0", default-features = false }
 quickcheck_macros = { version = "1.0", default-features = false }
 rand = "0.8.5" # Required for quickcheck

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -97,8 +97,8 @@ impl File for GenericFile {
             let mut buf = r.buf_mut();
             let buf = buf.as_mut_slice();
             file.read_exact(buf)?;
-        }
-        c.complete(0);
+            c.complete(buf.len() as i32);
+        };
         Ok(())
     }
 

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -49,7 +49,7 @@ pub trait IO: Clock + Send + Sync {
     fn get_memory_io(&self) -> Arc<MemoryIO>;
 }
 
-pub type Complete = dyn Fn(Arc<RefCell<Buffer>>);
+pub type Complete = dyn Fn(Arc<RefCell<Buffer>>, i32);
 pub type WriteComplete = dyn Fn(i32);
 pub type SyncComplete = dyn Fn(i32);
 
@@ -76,7 +76,7 @@ impl Completion {
 
     pub fn complete(&self, result: i32) {
         match self {
-            Self::Read(r) => r.complete(),
+            Self::Read(r) => r.complete(result),
             Self::Write(w) => w.complete(result),
             Self::Sync(s) => s.complete(result), // fix
         }
@@ -119,8 +119,8 @@ impl ReadCompletion {
         self.buf.borrow_mut()
     }
 
-    pub fn complete(&self) {
-        (self.complete)(self.buf.clone());
+    pub fn complete(&self, bytes_read: i32) {
+        (self.complete)(self.buf.clone(), bytes_read);
         self.is_completed.set(true);
     }
 }

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -246,7 +246,7 @@ impl IO for UnixIO {
                 };
                 match result {
                     Ok(n) => match &cf {
-                        CompletionCallback::Read(_, ref c, _) => c.complete(0),
+                        CompletionCallback::Read(_, ref c, _) => c.complete(n as i32),
                         CompletionCallback::Write(_, ref c, _, _) => c.complete(n as i32),
                     },
                     Err(e) => return Err(e.into()),
@@ -344,7 +344,7 @@ impl File for UnixFile<'_> {
             Ok(n) => {
                 trace!("pread n: {}", n);
                 // Read succeeded immediately
-                c.complete(0);
+                c.complete(n as i32);
                 Ok(())
             }
             Err(Errno::AGAIN) => {

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -89,8 +89,8 @@ impl File for WindowsFile {
             let mut buf = r.buf_mut();
             let buf = buf.as_mut_slice();
             file.read_exact(buf)?;
-        }
-        c.complete(0);
+            c.complete(buf.len() as i32);
+        };
         Ok(())
     }
 

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1105,7 +1105,7 @@ impl<T: Default + Copy, const N: usize> Iterator for SmallVecIter<'_, T, N> {
     }
 }
 
-pub fn read_record(payload: &[u8], reuse_immutable: &mut ImmutableRecord) -> Result<()> {
+pub fn read_record(payload: &[u8], reuse_immutable: &mut ImmutableRecord) -> Result<usize> {
     // Let's clear previous use
     reuse_immutable.invalidate();
     // Copy payload to ImmutableRecord in order to make RefValue that point to this new buffer.
@@ -1146,7 +1146,7 @@ pub fn read_record(payload: &[u8], reuse_immutable: &mut ImmutableRecord) -> Res
         }
     }
 
-    Ok(())
+    Ok(pos)
 }
 
 /// Reads a value that might reference the buffer it is reading from. Be sure to store RefValue with the buffer

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -295,7 +295,7 @@ pub fn begin_read_database_header(
     let buf = Arc::new(RefCell::new(Buffer::allocate(512, drop_fn)));
     let result = Arc::new(SpinLock::new(DatabaseHeader::default()));
     let header = result.clone();
-    let complete = Box::new(move |buf: Arc<RefCell<Buffer>>| {
+    let complete = Box::new(move |buf: Arc<RefCell<Buffer>>, _bytes_read: i32| {
         let header = header.clone();
         finish_read_database_header(buf, header).unwrap();
     });
@@ -793,7 +793,7 @@ pub fn begin_read_page(
     });
     #[allow(clippy::arc_with_non_send_sync)]
     let buf = Arc::new(RefCell::new(Buffer::new(buf, drop_fn)));
-    let complete = Box::new(move |buf: Arc<RefCell<Buffer>>| {
+    let complete = Box::new(move |buf: Arc<RefCell<Buffer>>, _bytes_read: i32| {
         let page = page.clone();
         if finish_read_page(page_idx, buf, page.clone()).is_err() {
             page.set_error();
@@ -1368,7 +1368,7 @@ pub fn read_entire_wal_dumb(file: &Arc<dyn File>) -> Result<Arc<UnsafeCell<WalFi
     }));
     let wal_file_shared_for_completion = wal_file_shared_ret.clone();
 
-    let complete: Box<Complete> = Box::new(move |buf: Arc<RefCell<Buffer>>| {
+    let complete: Box<Complete> = Box::new(move |buf: Arc<RefCell<Buffer>>, _bytes_read: i32| {
         let buf = buf.borrow();
         let buf_slice = buf.as_slice();
         let mut header_locked = header.lock();
@@ -1514,7 +1514,7 @@ pub fn begin_read_wal_frame(
     io: &Arc<dyn File>,
     offset: usize,
     buffer_pool: Rc<BufferPool>,
-    complete: Box<dyn Fn(Arc<RefCell<Buffer>>)>,
+    complete: Box<dyn Fn(Arc<RefCell<Buffer>>, i32)>,
 ) -> Result<Arc<Completion>> {
     tracing::trace!("begin_read_wal_frame(offset={})", offset);
     let buf = buffer_pool.get();

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -579,7 +579,7 @@ impl Wal for WalFile {
         let offset = self.frame_offset(frame_id);
         page.set_locked();
         let frame = page.clone();
-        let complete = Box::new(move |buf: Arc<RefCell<Buffer>>| {
+        let complete = Box::new(move |buf: Arc<RefCell<Buffer>>, _bytes_read: i32| {
             let frame = frame.clone();
             finish_read_page(page.get().id, buf, frame).unwrap();
         });
@@ -601,7 +601,7 @@ impl Wal for WalFile {
     ) -> Result<Arc<Completion>> {
         tracing::debug!("read_frame({})", frame_id);
         let offset = self.frame_offset(frame_id);
-        let complete = Box::new(move |buf: Arc<RefCell<Buffer>>| {
+        let complete = Box::new(move |buf: Arc<RefCell<Buffer>>, _bytes_read: i32| {
             let buf = buf.borrow();
             let buf_ptr = buf.as_ptr();
             unsafe {

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1,28 +1,60 @@
 use limbo_sqlite3_parser::ast::SortOrder;
 
+use std::fs::File;
+use std::io;
+use std::io::prelude::*;
+use tempfile;
+
 use crate::{
+    storage::sqlite3_ondisk::read_record,
     translate::collate::CollationSeq,
     types::{compare_immutable, ImmutableRecord, IndexKeySortOrder},
+    LimboError, Result,
 };
 
 pub struct Sorter {
+    /// The records in the in-memory buffer.
     records: Vec<ImmutableRecord>,
+    /// The current record.
     current: Option<ImmutableRecord>,
+    /// The sort order.
     order: IndexKeySortOrder,
+    /// The number of values in the key.
     key_len: usize,
+    /// The collations.
     collations: Vec<CollationSeq>,
+    /// Readers for the sorted chunks stored on disk.
+    chunk_readers: Vec<ChunkReader>,
+    /// The maximum size of the in-memory buffer in bytes.
+    max_buffer_size: usize,
+    /// The current size of the in-memory buffer in bytes.
+    current_buffer_size: usize,
+    /// The maximum record payload size in the in-memory buffer in bytes.
+    max_payload_size_in_buffer: usize,
+    /// The maximum number of values in a record in the in-memory buffer.
+    max_values_len_in_buffer: usize,
 }
 
 impl Sorter {
-    pub fn new(order: &[SortOrder], collations: Vec<CollationSeq>) -> Self {
+    pub fn new(
+        order: &[SortOrder],
+        collations: Vec<CollationSeq>,
+        max_buffer_size_bytes: usize,
+    ) -> Self {
         Self {
             records: Vec::new(),
             current: None,
             key_len: order.len(),
             order: IndexKeySortOrder::from_list(order),
             collations,
+            chunk_readers: Vec::new(),
+            max_buffer_size: max_buffer_size_bytes,
+            current_buffer_size: 0,
+            max_payload_size_in_buffer: 0,
+            max_values_len_in_buffer: 0,
         }
     }
+
     pub fn is_empty(&self) -> bool {
         self.records.is_empty()
     }
@@ -32,7 +64,99 @@ impl Sorter {
     }
 
     // We do the sorting here since this is what is called by the SorterSort instruction
-    pub fn sort(&mut self) {
+    pub fn sort(&mut self) -> Result<()> {
+        if self.chunk_readers.is_empty() {
+            self.sort_buffer();
+            self.records.reverse();
+        } else {
+            self.flush()?;
+            for chunk_reader in &mut self.chunk_readers {
+                chunk_reader.next()?;
+            }
+        }
+        self.next()
+    }
+
+    pub fn next(&mut self) -> Result<()> {
+        if self.chunk_readers.is_empty() {
+            self.current = self.records.pop();
+        } else {
+            self.current = self.consume_from_chunks()?;
+        }
+        Ok(())
+    }
+
+    pub fn record(&self) -> Option<&ImmutableRecord> {
+        self.current.as_ref()
+    }
+
+    pub fn insert(&mut self, record: &ImmutableRecord) -> Result<()> {
+        let payload_size = record.get_payload().len();
+        if self.current_buffer_size + payload_size > self.max_buffer_size {
+            self.flush()?;
+        }
+        self.records.push(record.clone());
+        self.current_buffer_size += payload_size;
+        self.max_payload_size_in_buffer = self.max_payload_size_in_buffer.max(payload_size);
+        self.max_values_len_in_buffer = self.max_values_len_in_buffer.max(record.len());
+        Ok(())
+    }
+
+    fn consume_from_chunks(&mut self) -> Result<Option<ImmutableRecord>> {
+        let mut next_chunk_idx: Option<usize> = None;
+        let mut next_chunk_record: Option<&ImmutableRecord> = None;
+        for (chunk_idx, chunk_reader) in self.chunk_readers.iter().enumerate() {
+            if chunk_reader.has_more() {
+                let record = chunk_reader.record().unwrap();
+                if next_chunk_record.is_none()
+                    || compare_immutable(
+                        &record.values[..self.key_len],
+                        &next_chunk_record.unwrap().values[..self.key_len],
+                        self.order,
+                        &self.collations,
+                    )
+                    .is_le()
+                {
+                    next_chunk_idx = Some(chunk_idx);
+                    next_chunk_record = Some(record);
+                }
+            }
+        }
+        if let Some(idx) = next_chunk_idx {
+            Ok(self.chunk_readers[idx].consume_record()?)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.sort_buffer();
+
+        let mut fd = tempfile::tempfile()?;
+        let mut writer = io::BufWriter::new(fd.try_clone()?);
+        for record in self.records.drain(..) {
+            writer
+                .write(record.get_payload())
+                .map_err(LimboError::IOError)?;
+        }
+        writer.flush().map_err(LimboError::IOError)?;
+
+        fd.seek(io::SeekFrom::Start(0))
+            .map_err(LimboError::IOError)?;
+        self.chunk_readers.push(ChunkReader::new(
+            fd,
+            self.max_payload_size_in_buffer,
+            self.max_values_len_in_buffer,
+        ));
+
+        self.current_buffer_size = 0;
+        self.max_payload_size_in_buffer = 0;
+        self.max_values_len_in_buffer = 0;
+
+        Ok(())
+    }
+
+    fn sort_buffer(&mut self) {
         self.records.sort_by(|a, b| {
             compare_immutable(
                 &a.values[..self.key_len],
@@ -41,17 +165,149 @@ impl Sorter {
                 &self.collations,
             )
         });
-        self.records.reverse();
-        self.next()
     }
-    pub fn next(&mut self) {
-        self.current = self.records.pop();
+}
+
+struct ChunkReader {
+    /// The reader for the chunk file.
+    reader: io::BufReader<File>,
+    /// The read buffer.
+    buffer: Vec<u8>,
+    /// The current length of the buffer.
+    buffer_len: usize,
+    /// The maximum number of values in a record in this chunk.
+    max_values_len: usize,
+    /// The current record.
+    current: Option<ImmutableRecord>,
+}
+
+impl ChunkReader {
+    fn new(fd: File, max_payload_size: usize, max_values_len: usize) -> Self {
+        Self {
+            reader: io::BufReader::new(fd),
+            buffer: vec![0; max_payload_size],
+            buffer_len: 0, // Start with empty buffer
+            max_values_len,
+            current: None,
+        }
     }
-    pub fn record(&self) -> Option<&ImmutableRecord> {
+
+    fn has_more(&self) -> bool {
+        self.current.is_some()
+    }
+
+    fn record(&self) -> Option<&ImmutableRecord> {
         self.current.as_ref()
     }
 
-    pub fn insert(&mut self, record: &ImmutableRecord) {
-        self.records.push(record.clone());
+    fn consume_record(&mut self) -> Result<Option<ImmutableRecord>> {
+        let result = self.current.take();
+        self.next()?;
+        Ok(result)
+    }
+
+    fn next(&mut self) -> Result<()> {
+        let mut record = ImmutableRecord::new(self.buffer.len(), self.max_values_len);
+
+        let bytes_read = self
+            .reader
+            .read(&mut self.buffer[self.buffer_len..])
+            .map_err(LimboError::IOError)?;
+
+        if bytes_read == 0 && self.buffer_len == 0 {
+            // There are no more records in the chunk.
+            self.current = None;
+            return Ok(());
+        }
+        self.buffer_len += bytes_read;
+
+        let bytes_consumed = read_record(&self.buffer[..self.buffer_len], &mut record)?;
+
+        if bytes_consumed < self.buffer_len {
+            self.buffer.copy_within(bytes_consumed..self.buffer_len, 0);
+            self.buffer_len -= bytes_consumed;
+        } else {
+            self.buffer_len = 0;
+        }
+
+        self.current = Some(record);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ImmutableRecord, RefValue, Value};
+    use crate::vdbe::Register;
+
+    #[test]
+    fn test_chunk_reader() {
+        let record_a = ImmutableRecord::from_registers(&[
+            Register::Value(Value::Null),
+            Register::Value(Value::Integer(1)),
+            Register::Value(Value::Integer(1234)),
+        ]);
+        let record_b = ImmutableRecord::from_registers(&[
+            Register::Value(Value::Null),
+            Register::Value(Value::Integer(0)),
+            Register::Value(Value::Integer(1)),
+        ]);
+
+        let mut fd = tempfile::tempfile().expect("Failed to create temp file");
+        fd.write(record_a.get_payload())
+            .expect("Failed to write the first record");
+        fd.write(record_b.get_payload())
+            .expect("Failed to write the second record");
+        fd.flush().expect("Failed to flush the file");
+        fd.seek(io::SeekFrom::Start(0))
+            .expect("Failed to seek to the start of the file");
+
+        let mut reader = ChunkReader::new(fd, 64, 4);
+
+        reader.next().expect("Failed to read the first record");
+        assert!(reader.has_more());
+
+        let record_a_from_chunk = reader
+            .consume_record()
+            .expect("Failed to read the second record")
+            .unwrap();
+        assert_eq!(record_a_from_chunk.values, record_a.values);
+
+        assert!(reader.has_more());
+        let record_b_from_chunk = reader.record().unwrap();
+        assert_eq!(record_b_from_chunk.values, record_b.values);
+
+        assert!(reader.has_more());
+        reader.next().expect("Failed to perform the next read");
+        assert!(!reader.has_more());
+        assert!(reader.record().is_none());
+
+        reader.next().expect("Failed to perform the next read");
+        assert!(reader
+            .consume_record()
+            .expect("Failed to consume the record")
+            .is_none());
+    }
+
+    #[test]
+    fn test_external_sort() {
+        let mut sorter = Sorter::new(&[SortOrder::Asc], vec![], 64);
+        for i in (0..1024).rev() {
+            sorter
+                .insert(&ImmutableRecord::from_registers(&[Register::Value(
+                    Value::Integer(i),
+                )]))
+                .expect("Failed to insert the record");
+        }
+
+        sorter.sort().expect("Failed to sort the records");
+
+        for i in 0..1024 {
+            assert!(sorter.has_more());
+            let record = sorter.record().unwrap();
+            assert_eq!(record.values[0], RefValue::Integer(i));
+            sorter.next().expect("Failed to get the next record");
+        }
     }
 }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -408,9 +408,8 @@ impl SortedChunk {
         let buffer_ref_copy = buffer_ref.clone();
         let chunk_io_state_copy = self.io_state.clone();
         let write_complete = Box::new(move |bytes_written: i32| {
-            let buf_len = buffer_ref_copy.borrow().len();
             chunk_io_state_copy.set(SortedChunkIOState::WriteComplete);
-
+            let buf_len = buffer_ref_copy.borrow().len();
             if bytes_written < buf_len as i32 {
                 tracing::error!("wrote({bytes_written}) less than expected({buf_len})");
             }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -255,9 +255,9 @@ mod tests {
         ]);
 
         let mut fd = tempfile::tempfile().expect("Failed to create temp file");
-        fd.write(record_a.get_payload())
+        fd.write_all(record_a.get_payload())
             .expect("Failed to write the first record");
-        fd.write(record_b.get_payload())
+        fd.write_all(record_b.get_payload())
             .expect("Failed to write the second record");
         fd.flush().expect("Failed to flush the file");
         fd.seek(io::SeekFrom::Start(0))

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -309,5 +309,6 @@ mod tests {
             assert_eq!(record.values[0], RefValue::Integer(i));
             sorter.next().expect("Failed to get the next record");
         }
+        assert!(!sorter.has_more());
     }
 }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1,18 +1,19 @@
 use limbo_sqlite3_parser::ast::SortOrder;
 
+use std::cell::{Cell, RefCell};
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd, Reverse};
 use std::collections::BinaryHeap;
-use std::fs::File;
-use std::io;
-use std::io::prelude::*;
 use std::rc::Rc;
+use std::sync::Arc;
 use tempfile;
 
 use crate::{
+    error::LimboError,
+    io::{Buffer, BufferData, Completion, File, OpenFlags, ReadCompletion, WriteCompletion, IO},
     storage::sqlite3_ondisk::read_record,
     translate::collate::CollationSeq,
-    types::{compare_immutable, ImmutableRecord, IndexKeySortOrder},
-    LimboError, Result,
+    types::{compare_immutable, CursorResult, ImmutableRecord, IndexKeySortOrder},
+    Result,
 };
 
 pub struct Sorter {
@@ -26,18 +27,27 @@ pub struct Sorter {
     key_len: usize,
     /// The collations.
     collations: Rc<Vec<CollationSeq>>,
-    /// Readers for the sorted chunks stored on disk.
-    chunk_readers: Vec<ChunkReader>,
-    /// The heap of records and their chunk index.
+    /// Sorted chunks stored on disk.
+    chunks: Vec<SortedChunk>,
+    /// The heap of records consumed from the chunks and their corresponding chunk index.
     chunk_heap: BinaryHeap<(Reverse<SortableImmutableRecord>, usize)>,
-    /// The maximum size of the in-memory buffer in bytes.
+    /// The maximum size of the in-memory buffer in bytes before the records are flushed to a chunk file.
     max_buffer_size: usize,
     /// The current size of the in-memory buffer in bytes.
     current_buffer_size: usize,
-    /// The maximum record payload size in the in-memory buffer in bytes.
+    /// The minimum size of a chunk buffer in bytes. The actual buffer size can be larger if the largest
+    /// record in the buffer is larger than this value.
+    min_chunk_buffer_size: usize,
+    /// The maximum record payload size in the in-memory buffer.
     max_payload_size_in_buffer: usize,
     /// The maximum number of values in a record in the in-memory buffer.
     max_values_len_in_buffer: usize,
+    /// The IO object.
+    io: Arc<dyn IO>,
+    /// The indices of the chunks that are waiting for the read to complete.
+    wait_for_read_complete: Vec<usize>,
+    /// The temporary directory for chunk files.
+    temp_dir: Option<tempfile::TempDir>,
 }
 
 impl Sorter {
@@ -45,6 +55,8 @@ impl Sorter {
         order: &[SortOrder],
         collations: Vec<CollationSeq>,
         max_buffer_size_bytes: usize,
+        min_chunk_buffer_size_bytes: usize,
+        io: Arc<dyn IO>,
     ) -> Self {
         Self {
             records: Vec::new(),
@@ -52,17 +64,21 @@ impl Sorter {
             key_len: order.len(),
             order: IndexKeySortOrder::from_list(order),
             collations: Rc::new(collations),
-            chunk_readers: Vec::new(),
+            chunks: Vec::new(),
             chunk_heap: BinaryHeap::new(),
             max_buffer_size: max_buffer_size_bytes,
             current_buffer_size: 0,
+            min_chunk_buffer_size: min_chunk_buffer_size_bytes,
             max_payload_size_in_buffer: 0,
             max_values_len_in_buffer: 0,
+            io,
+            wait_for_read_complete: Vec::new(),
+            temp_dir: None,
         }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.records.is_empty()
+        self.records.is_empty() && self.chunks.is_empty()
     }
 
     pub fn has_more(&self) -> bool {
@@ -70,32 +86,31 @@ impl Sorter {
     }
 
     // We do the sorting here since this is what is called by the SorterSort instruction
-    pub fn sort(&mut self) -> Result<()> {
-        if self.chunk_readers.is_empty() {
+    pub fn sort(&mut self) -> Result<CursorResult<()>> {
+        if self.chunks.is_empty() {
             self.records.sort();
             self.records.reverse();
         } else {
             self.flush()?;
-            self.chunk_heap.reserve(self.chunk_readers.len());
-            for chunk_idx in 0..self.chunk_readers.len() {
-                self.push_to_heap_from_chunk(chunk_idx, true)?;
+            if let CursorResult::IO = self.init_chunk_heap()? {
+                return Ok(CursorResult::IO);
             }
         }
         self.next()
     }
 
-    pub fn next(&mut self) -> Result<()> {
-        if self.chunk_readers.is_empty() {
+    pub fn next(&mut self) -> Result<CursorResult<()>> {
+        if self.chunks.is_empty() {
+            // Serve from the in-memory buffer.
             self.current = self.records.pop().map(|r| r.record);
         } else {
-            if let Some((next_record, next_chunk_idx)) = self.chunk_heap.pop() {
-                self.current = Some(next_record.0.record);
-                self.push_to_heap_from_chunk(next_chunk_idx, false)?;
-            } else {
-                self.current = None;
+            // Serve from sorted chunk files.
+            match self.next_from_chunk_heap()? {
+                CursorResult::IO => return Ok(CursorResult::IO),
+                CursorResult::Ok(record) => self.current = record,
             }
         }
-        Ok(())
+        Ok(CursorResult::Ok(()))
     }
 
     pub fn record(&self) -> Option<&ImmutableRecord> {
@@ -119,15 +134,68 @@ impl Sorter {
         Ok(())
     }
 
-    fn push_to_heap_from_chunk(&mut self, chunk_idx: usize, init: bool) -> Result<()> {
-        let chunk_reader = &mut self.chunk_readers[chunk_idx];
-
-        if init {
-            chunk_reader.next()?;
+    fn init_chunk_heap(&mut self) -> Result<CursorResult<()>> {
+        let mut all_read_complete = true;
+        // Make sure all chunks read at least one record into their buffer.
+        for chunk in self.chunks.iter_mut() {
+            match chunk.io_state.get() {
+                SortedChunkIOState::WriteComplete => {
+                    all_read_complete = false;
+                    // Write complete, we can now read from the chunk.
+                    chunk.read()?;
+                }
+                SortedChunkIOState::WaitingForWrite => {
+                    all_read_complete = false;
+                }
+                SortedChunkIOState::ReadEOF | SortedChunkIOState::ReadComplete => {}
+                _ => {
+                    unreachable!("Unexpected chunk IO state: {:?}", chunk.io_state.get())
+                }
+            }
         }
+        if !all_read_complete {
+            return Ok(CursorResult::IO);
+        }
+        self.chunk_heap.reserve(self.chunks.len());
+        for chunk_idx in 0..self.chunks.len() {
+            self.push_to_chunk_heap(chunk_idx)?;
+        }
+        Ok(CursorResult::Ok(()))
+    }
+
+    fn next_from_chunk_heap(&mut self) -> Result<CursorResult<Option<ImmutableRecord>>> {
+        let mut all_read_complete = true;
+        for chunk_idx in self.wait_for_read_complete.iter() {
+            let chunk_io_state = self.chunks[*chunk_idx].io_state.get();
+            match chunk_io_state {
+                SortedChunkIOState::ReadComplete | SortedChunkIOState::ReadEOF => {}
+                SortedChunkIOState::WaitingForRead => {
+                    all_read_complete = false;
+                }
+                _ => {
+                    unreachable!("Unexpected chunk IO state: {:?}", chunk_io_state)
+                }
+            }
+        }
+        if !all_read_complete {
+            // We need to wait for the read to complete.
+            return Ok(CursorResult::IO);
+        }
+        self.wait_for_read_complete.clear();
+
+        if let Some((next_record, next_chunk_idx)) = self.chunk_heap.pop() {
+            self.push_to_chunk_heap(next_chunk_idx)?;
+            Ok(CursorResult::Ok(Some(next_record.0.record)))
+        } else {
+            Ok(CursorResult::Ok(None))
+        }
+    }
+
+    fn push_to_chunk_heap(&mut self, chunk_idx: usize) -> Result<()> {
+        let chunk_reader = &mut self.chunks[chunk_idx];
 
         if chunk_reader.has_more() {
-            let record = chunk_reader.consume_record()?.unwrap();
+            let record = chunk_reader.next()?.unwrap();
             self.chunk_heap.push((
                 Reverse(SortableImmutableRecord::new(
                     record,
@@ -137,29 +205,45 @@ impl Sorter {
                 )),
                 chunk_idx,
             ));
+            if let SortedChunkIOState::WaitingForRead = chunk_reader.io_state.get() {
+                self.wait_for_read_complete.push(chunk_idx);
+            }
         }
         Ok(())
     }
 
     fn flush(&mut self) -> Result<()> {
+        if self.records.is_empty() {
+            return Ok(());
+        }
+
         self.records.sort();
 
-        let mut fd = tempfile::tempfile()?;
-        let mut writer = io::BufWriter::new(fd.try_clone()?);
-        for record in self.records.drain(..) {
-            writer
-                .write(record.record.get_payload())
-                .map_err(LimboError::IOError)?;
+        if self.temp_dir.is_none() {
+            self.temp_dir = Some(tempfile::tempdir().map_err(LimboError::IOError)?);
         }
-        writer.flush().map_err(LimboError::IOError)?;
 
-        fd.seek(io::SeekFrom::Start(0))
-            .map_err(LimboError::IOError)?;
-        self.chunk_readers.push(ChunkReader::new(
-            fd,
-            self.max_payload_size_in_buffer,
+        let chunk_file_path = self
+            .temp_dir
+            .as_ref()
+            .unwrap()
+            .path()
+            .join(format!("chunk_{}", self.chunks.len()));
+        let chunk_file =
+            self.io
+                .open_file(chunk_file_path.to_str().unwrap(), OpenFlags::Create, false)?;
+
+        // Make sure the chunk buffer size can fit the largest record.
+        let chunk_buffer_size = self
+            .min_chunk_buffer_size
+            .max(self.max_payload_size_in_buffer);
+        let mut chunk = SortedChunk::new(
+            chunk_file.clone(),
+            chunk_buffer_size,
             self.max_values_len_in_buffer,
-        ));
+        );
+        chunk.write(&mut self.records, self.current_buffer_size)?;
+        self.chunks.push(chunk);
 
         self.current_buffer_size = 0;
         self.max_payload_size_in_buffer = 0;
@@ -169,66 +253,172 @@ impl Sorter {
     }
 }
 
-struct ChunkReader {
-    /// The reader for the chunk file.
-    reader: io::BufReader<File>,
+struct SortedChunk {
+    /// The chunk file.
+    file: Arc<dyn File>,
     /// The read buffer.
-    buffer: Vec<u8>,
+    buffer: Rc<RefCell<Vec<u8>>>,
     /// The current length of the buffer.
-    buffer_len: usize,
+    buffer_len: Rc<Cell<usize>>,
     /// The maximum number of values in a record in this chunk.
     max_values_len: usize,
-    /// The current record.
-    current: Option<ImmutableRecord>,
+    /// The records decoded from the chunk file.
+    records: Vec<ImmutableRecord>,
+    /// The current IO state of the chunk.
+    io_state: Rc<Cell<SortedChunkIOState>>,
+    /// The total number of bytes read from the chunk file.
+    total_bytes_read: Rc<Cell<usize>>,
 }
 
-impl ChunkReader {
-    fn new(fd: File, max_payload_size: usize, max_values_len: usize) -> Self {
+impl SortedChunk {
+    fn new(file: Arc<dyn File>, buffer_size: usize, max_values_len: usize) -> Self {
         Self {
-            reader: io::BufReader::new(fd),
-            buffer: vec![0; max_payload_size],
-            buffer_len: 0, // Start with empty buffer
+            file,
+            buffer: Rc::new(RefCell::new(vec![0; buffer_size])),
+            buffer_len: Rc::new(Cell::new(0)),
             max_values_len,
-            current: None,
+            records: Vec::new(),
+            io_state: Rc::new(Cell::new(SortedChunkIOState::None)),
+            total_bytes_read: Rc::new(Cell::new(0)),
         }
     }
 
     fn has_more(&self) -> bool {
-        self.current.is_some()
+        !self.records.is_empty() || self.io_state.get() != SortedChunkIOState::ReadEOF
     }
 
-    fn consume_record(&mut self) -> Result<Option<ImmutableRecord>> {
-        let result = self.current.take();
-        self.next()?;
-        Ok(result)
+    fn next(&mut self) -> Result<Option<ImmutableRecord>> {
+        let mut buffer_len = self.buffer_len.get();
+        if self.records.is_empty() && buffer_len == 0 {
+            return Ok(None);
+        }
+
+        if self.records.is_empty() {
+            let mut buffer_ref = self.buffer.borrow_mut();
+            let buffer = buffer_ref.as_mut_slice();
+            let mut buffer_offset = 0;
+            while buffer_offset < buffer_len {
+                // Decode records from the buffer until we run out of the buffer or we hit an incomplete record.
+                let mut record = ImmutableRecord::new(buffer_len, self.max_values_len);
+
+                buffer_offset += match read_record(&buffer[buffer_offset..buffer_len], &mut record)
+                {
+                    Ok(bytes_consumed) => bytes_consumed,
+                    Err(LimboError::Corrupt(_))
+                        if self.io_state.get() != SortedChunkIOState::ReadEOF =>
+                    {
+                        // Failed to decode a partial record.
+                        break;
+                    }
+                    Err(e) => {
+                        return Err(e);
+                    }
+                };
+
+                self.records.push(record);
+            }
+            if buffer_offset < buffer_len {
+                buffer.copy_within(buffer_offset..buffer_len, 0);
+                buffer_len -= buffer_offset;
+            } else {
+                buffer_len = 0;
+            }
+            self.buffer_len.set(buffer_len);
+
+            self.records.reverse();
+        }
+
+        let record = self.records.pop();
+        if self.records.is_empty() && self.io_state.get() != SortedChunkIOState::ReadEOF {
+            // We've consumed the last record. Read more payload into the buffer.
+            self.read()?;
+        }
+        Ok(record)
     }
 
-    fn next(&mut self) -> Result<()> {
-        let mut record = ImmutableRecord::new(self.buffer.len(), self.max_values_len);
-
-        let bytes_read = self
-            .reader
-            .read(&mut self.buffer[self.buffer_len..])
-            .map_err(LimboError::IOError)?;
-
-        if bytes_read == 0 && self.buffer_len == 0 {
-            // There are no more records in the chunk.
-            self.current = None;
+    fn read(&mut self) -> Result<()> {
+        if self.io_state.get() == SortedChunkIOState::ReadEOF {
             return Ok(());
         }
-        self.buffer_len += bytes_read;
+        self.io_state.set(SortedChunkIOState::WaitingForRead);
 
-        let bytes_consumed = read_record(&self.buffer[..self.buffer_len], &mut record)?;
+        let drop_fn = Rc::new(|_buffer: BufferData| {});
+        let read_buffer =
+            Buffer::allocate(self.buffer.borrow().len() - self.buffer_len.get(), drop_fn);
+        #[allow(clippy::arc_with_non_send_sync)]
+        let read_buffer_ref = Arc::new(RefCell::new(read_buffer));
 
-        if bytes_consumed < self.buffer_len {
-            self.buffer.copy_within(bytes_consumed..self.buffer_len, 0);
-            self.buffer_len -= bytes_consumed;
-        } else {
-            self.buffer_len = 0;
+        let chunk_io_state_copy = self.io_state.clone();
+        let stored_buffer_copy = self.buffer.clone();
+        let stored_buffer_len_copy = self.buffer_len.clone();
+        let total_bytes_read_copy = self.total_bytes_read.clone();
+        let read_complete = Box::new(move |buf: Arc<RefCell<Buffer>>, bytes_read: i32| {
+            let read_buf_ref = buf.borrow();
+            let read_buf = read_buf_ref.as_slice();
+
+            let bytes_read = bytes_read as usize;
+            if bytes_read == 0 {
+                chunk_io_state_copy.set(SortedChunkIOState::ReadEOF);
+                return;
+            }
+            chunk_io_state_copy.set(SortedChunkIOState::ReadComplete);
+
+            let mut stored_buf_ref = stored_buffer_copy.borrow_mut();
+            let stored_buf = stored_buf_ref.as_mut_slice();
+            let mut stored_buf_len = stored_buffer_len_copy.get();
+
+            stored_buf[stored_buf_len..stored_buf_len + bytes_read]
+                .copy_from_slice(&read_buf[..bytes_read]);
+            stored_buf_len += bytes_read;
+
+            stored_buffer_len_copy.set(stored_buf_len);
+            total_bytes_read_copy.set(total_bytes_read_copy.get() + bytes_read);
+        });
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let c = Arc::new(Completion::Read(ReadCompletion::new(
+            read_buffer_ref,
+            read_complete,
+        )));
+        self.file.pread(self.total_bytes_read.get(), c)
+    }
+
+    fn write(
+        &mut self,
+        records: &mut Vec<SortableImmutableRecord>,
+        total_size: usize,
+    ) -> Result<()> {
+        assert!(self.io_state.get() == SortedChunkIOState::None);
+        self.io_state.set(SortedChunkIOState::WaitingForWrite);
+
+        let drop_fn = Rc::new(|_buffer: BufferData| {});
+        let mut buffer = Buffer::allocate(total_size, drop_fn);
+
+        let mut buf_pos = 0;
+        let buf = buffer.as_mut_slice();
+        for record in records.drain(..) {
+            let payload = record.record.get_payload();
+            buf[buf_pos..buf_pos + payload.len()].copy_from_slice(payload);
+            buf_pos += payload.len();
         }
 
-        self.current = Some(record);
-        Ok(())
+        #[allow(clippy::arc_with_non_send_sync)]
+        let buffer_ref = Arc::new(RefCell::new(buffer));
+
+        let buffer_ref_copy = buffer_ref.clone();
+        let chunk_io_state_copy = self.io_state.clone();
+        let write_complete = Box::new(move |bytes_written: i32| {
+            let buf_len = buffer_ref_copy.borrow().len();
+            chunk_io_state_copy.set(SortedChunkIOState::WriteComplete);
+
+            if bytes_written < buf_len as i32 {
+                tracing::error!("wrote({bytes_written}) less than expected({buf_len})");
+            }
+        });
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let c = Arc::new(Completion::Write(WriteCompletion::new(write_complete)));
+        self.file.pwrite(0, buffer_ref, c)
     }
 }
 
@@ -280,79 +470,58 @@ impl PartialEq for SortableImmutableRecord {
 
 impl Eq for SortableImmutableRecord {}
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum SortedChunkIOState {
+    WaitingForRead,
+    ReadComplete,
+    ReadEOF,
+    WaitingForWrite,
+    WriteComplete,
+    None,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::types::{ImmutableRecord, RefValue, Value};
     use crate::vdbe::Register;
-
-    #[test]
-    fn test_chunk_reader() {
-        let record_a = ImmutableRecord::from_registers(&[
-            Register::Value(Value::Null),
-            Register::Value(Value::Integer(1)),
-            Register::Value(Value::Integer(1234)),
-        ]);
-        let record_b = ImmutableRecord::from_registers(&[
-            Register::Value(Value::Null),
-            Register::Value(Value::Integer(0)),
-            Register::Value(Value::Integer(1)),
-        ]);
-
-        let mut fd = tempfile::tempfile().expect("Failed to create temp file");
-        fd.write_all(record_a.get_payload())
-            .expect("Failed to write the first record");
-        fd.write_all(record_b.get_payload())
-            .expect("Failed to write the second record");
-        fd.flush().expect("Failed to flush the file");
-        fd.seek(io::SeekFrom::Start(0))
-            .expect("Failed to seek to the start of the file");
-
-        let mut reader = ChunkReader::new(fd, 64, 4);
-
-        reader.next().expect("Failed to read the first record");
-        assert!(reader.has_more());
-
-        let record_a_from_chunk = reader
-            .consume_record()
-            .expect("Failed to read the second record")
-            .unwrap();
-        assert_eq!(record_a_from_chunk.values, record_a.values);
-
-        assert!(reader.has_more());
-        let record_b_from_chunk = reader
-            .consume_record()
-            .expect("Failed to consume the record")
-            .unwrap();
-        assert_eq!(record_b_from_chunk.values, record_b.values);
-
-        assert!(!reader.has_more());
-        reader.next().expect("Failed to perform the next read");
-        assert!(reader
-            .consume_record()
-            .expect("Failed to consume the record")
-            .is_none());
-    }
+    use crate::PlatformIO;
 
     #[test]
     fn test_external_sort() {
-        let mut sorter = Sorter::new(&[SortOrder::Asc], vec![], 64);
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let mut sorter = Sorter::new(&[SortOrder::Asc], vec![], 64, 13, io.clone());
         for i in (0..1024).rev() {
             sorter
-                .insert(&ImmutableRecord::from_registers(&[Register::Value(
-                    Value::Integer(i),
-                )]))
+                .insert(&ImmutableRecord::from_registers(
+                    &[Register::Value(Value::Integer(i))],
+                    1,
+                ))
                 .expect("Failed to insert the record");
         }
 
-        sorter.sort().expect("Failed to sort the records");
-        assert_eq!(sorter.chunk_readers.len(), 63);
+        loop {
+            if let CursorResult::IO = sorter.sort().expect("Failed to sort the records") {
+                io.run_once().expect("Failed to run the IO");
+                continue;
+            }
+            break;
+        }
+
+        assert!(!sorter.is_empty());
+        assert_eq!(sorter.chunks.len(), 63);
 
         for i in 0..1024 {
             assert!(sorter.has_more());
             let record = sorter.record().unwrap();
             assert_eq!(record.values[0], RefValue::Integer(i));
-            sorter.next().expect("Failed to get the next record");
+            loop {
+                if let CursorResult::IO = sorter.next().expect("Failed to get the next record") {
+                    io.run_once().expect("Failed to run the IO");
+                    continue;
+                }
+                break;
+            }
         }
         assert!(!sorter.has_more());
     }


### PR DESCRIPTION
Closes #91 

This PR adds support for external sorting. The maximum size of the in-memory buffer is determined by the settings that configure the page-cache size.

In scope:
- Spill the in-memory buffer to a temporary file on disk if its size exceeds the threshold
- When iterating over the sorter, the next record is picked using the ~~naive k-way merge approach~~ heap populated from sorted chunks
- Flushing the in-memory buffer and reading from chunk files occur asynchronously.