### PR TITLE
Extract Generation Functionality for Simulator into a Library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,32 +1797,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "limbo_sim"
-version = "0.1.1"
-dependencies = [
- "anarchist-readable-name-generator-lib",
- "anyhow",
- "chrono",
- "clap",
- "dirs 6.0.0",
- "env_logger 0.10.2",
- "hex",
- "log",
- "notify",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "regex",
- "regex-syntax 0.8.5",
- "rusqlite",
- "serde",
- "serde_json",
- "tracing",
- "tracing-subscriber",
- "turso_core",
- "turso_sqlite3_parser",
-]
-
-[[package]]
 name = "limbo_sqlite3"
 version = "0.1.1"
 dependencies = [
@@ -3747,6 +3721,32 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "turso_core",
+]
+
+[[package]]
+name = "turso_sim"
+version = "0.1.1"
+dependencies = [
+ "anarchist-readable-name-generator-lib",
+ "anyhow",
+ "chrono",
+ "clap",
+ "dirs 6.0.0",
+ "env_logger 0.10.2",
+ "hex",
+ "log",
+ "notify",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "regex",
+ "regex-syntax 0.8.5",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sqlite3_parser",
 ]
 
 [[package]]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -109,15 +109,15 @@ breaking the property invariants to reach more diverse states and respect the co
 To run the simulator, you can use the following command:
 
 ```bash
-RUST_LOG=limbo_sim=debug cargo run --bin limbo_sim
+RUST_LOG=turso_sim=debug cargo run --bin turso_sim
 ```
 
 The simulator CLI has a few configuration options that you can explore via `--help` flag.
 
 ```txt
-The Limbo deterministic simulator
+The Turso deterministic simulator
 
-Usage: limbo_sim [OPTIONS]
+Usage: turso_sim [OPTIONS]
 
 Options:
   -s, --seed <SEED>                  set seed for reproducible runs

--- a/scripts/run-sim
+++ b/scripts/run-sim
@@ -18,15 +18,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -n "$iterations" ]]; then
-    echo "Running limbo_sim for $iterations iterations..."
+    echo "Running turso_sim for $iterations iterations..."
     for ((i=1; i<=iterations; i++)); do
         echo "Iteration $i of $iterations"
-        cargo run -p limbo_sim
+        cargo run -p turso_sim
     done
     echo "Completed $iterations iterations"
 else
-    echo "Running limbo_sim in infinite loop..."
+    echo "Running turso_sim in infinite loop..."
     while true; do
-        cargo run -p limbo_sim
+        cargo run -p turso_sim
     done
 fi

--- a/simulator-docker-runner/Dockerfile.simulator
+++ b/simulator-docker-runner/Dockerfile.simulator
@@ -23,7 +23,7 @@ COPY sqlite3 ./sqlite3/
 COPY stress ./stress/
 COPY tests ./tests/
 COPY testing/sqlite_test_ext ./testing/sqlite_test_ext
-RUN cargo chef prepare --bin limbo_sim --recipe-path recipe.json
+RUN cargo chef prepare --bin turso_sim --recipe-path recipe.json
 
 #
 # Build the project.
@@ -32,14 +32,14 @@ RUN cargo chef prepare --bin limbo_sim --recipe-path recipe.json
 FROM chef AS builder 
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --bin limbo_sim --release --recipe-path recipe.json
+RUN cargo chef cook --bin turso_sim --release --recipe-path recipe.json
 COPY --from=planner /app/core ./core/
 COPY --from=planner /app/vendored ./vendored/
 COPY --from=planner /app/extensions ./extensions/
 COPY --from=planner /app/macros ./macros/
 COPY --from=planner /app/simulator ./simulator/
 
-RUN cargo build --bin limbo_sim --release
+RUN cargo build --bin turso_sim --release
 
 #
 # The final image.
@@ -62,13 +62,13 @@ ARG GIT_HASH
 ENV GIT_HASH=${GIT_HASH:-unknown}
 
 WORKDIR /app
-COPY --from=builder /app/target/release/limbo_sim /app/limbo_sim
+COPY --from=builder /app/target/release/turso_sim /app/turso_sim
 COPY simulator-docker-runner/package.json simulator-docker-runner/bun.lock simulator-docker-runner/tsconfig.json ./
 RUN bun install
 COPY simulator-docker-runner/* ./
 
 RUN chmod +x /app/docker-entrypoint.simulator.ts
-RUN chmod +x /app/limbo_sim
+RUN chmod +x /app/turso_sim
 
 ENTRYPOINT ["bun", "/app/docker-entrypoint.simulator.ts"]
 # Arguments can be passed at runtime

--- a/simulator-docker-runner/docker-entrypoint.simulator.ts
+++ b/simulator-docker-runner/docker-entrypoint.simulator.ts
@@ -15,7 +15,7 @@ const github = new GithubClient();
 
 process.env.RUST_BACKTRACE = "1";
 
-console.log("Starting limbo_sim in a loop...");
+console.log("Starting turso_sim in a loop...");
 console.log(`Git hash: ${github.GIT_HASH}`);
 console.log(`GitHub issues enabled: ${github.mode === 'real'}`);
 console.log(`Time limit: ${TIME_LIMIT_MINUTES} minutes`);
@@ -159,8 +159,8 @@ while (new Date().getTime() - startTime.getTime() < TIME_LIMIT_MINUTES * 60 * 10
   const loop = args.includes("loop") ? [] : ["loop", "-n", "10", "--short-circuit"]
   args.push(...loop);
 
-  console.log(`[${timestamp}]: Running "limbo_sim ${args.join(" ")}" - (seed ${seed}, run number ${runNumber})`);
-  await run(seed, "limbo_sim", args);
+  console.log(`[${timestamp}]: Running "turso_sim ${args.join(" ")}" - (seed ${seed}, run number ${runNumber})`);
+  await run(seed, "turso_sim", args);
 
   runNumber++;
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -1,21 +1,21 @@
-# Copyright 2024 the Limbo authors. All rights reserved. MIT license.
+# Copyright 2024 the Turso authors. All rights reserved. MIT license.
 
 [package]
-name = "limbo_sim"
+name = "turso_sim"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "The Limbo deterministic simulator"
+description = "The Turso deterministic simulator"
 publish = false
 
 [[bin]]
-name = "limbo_sim"
+name = "turso_sim"
 path = "main.rs"
 
 [lib]
-name = "limbo_sim"
+name = "turso_sim"
 path = "lib.rs"
 
 [dependencies]

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -14,6 +14,10 @@ publish = false
 name = "limbo_sim"
 path = "main.rs"
 
+[lib]
+name = "limbo_sim"
+path = "lib.rs"
+
 [dependencies]
 turso_core = { path = "../core", features = ["simulator"]}
 rand = "0.8.5"

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -1,6 +1,6 @@
-# Limbo Simulator
+# Turso Simulator
 
-Limbo simulator uses randomized deterministic simulations to test the Limbo database behaviors.
+Turso simulator uses randomized deterministic simulations to test the Turso database behaviors.
 
 Each simulation begins with a random configurations:
 
@@ -42,15 +42,15 @@ The simulator code is broken into 4 main parts:
 To run the simulator, you can use the following command:
 
 ```bash
-RUST_LOG=limbo_sim=debug cargo run --bin limbo_sim
+RUST_LOG=turso_sim=debug cargo run --bin turso_sim
 ```
 
 The simulator CLI has a few configuration options that you can explore via `--help` flag.
 
 ```txt
-The Limbo deterministic simulator
+The Turso deterministic simulator
 
-Usage: limbo_sim [OPTIONS]
+Usage: turso_sim [OPTIONS]
 
 Options:
   -s, --seed <SEED>                  set seed for reproducible runs
@@ -60,7 +60,7 @@ Options:
   -t, --maximum-time <MAXIMUM_TIME>  change the maximum time of the simulation(in seconds) [default: 3600]
   -l, --load <LOAD>                  load plan from the bug base
   -w, --watch                        enable watch mode that reruns the simulation on file changes
-      --differential                 run differential testing between sqlite and Limbo
+      --differential                 run differential testing between sqlite and Turso
   -h, --help                         Print help
   -V, --version                      Print version
 ```
@@ -104,7 +104,7 @@ it should generate the necessary queries and assertions for the property.
 
 ## Automatic Compatibility Testing with SQLite
 
-You can use the `--differential` flag to run the simulator in differential testing mode. This mode will run the same interaction plan on both Limbo and SQLite, and compare the results. It will also check for any panics or errors in either database.
+You can use the `--differential` flag to run the simulator in differential testing mode. This mode will run the same interaction plan on both Turso and SQLite, and compare the results. It will also check for any panics or errors in either database.
 
 ## Resources
 

--- a/simulator/generation/expr.rs
+++ b/simulator/generation/expr.rs
@@ -5,7 +5,7 @@ use turso_sqlite3_parser::ast::{
 use crate::{
     generation::{gen_random_text, pick, pick_index, Arbitrary, ArbitraryFrom},
     model::table::SimValue,
-    SimulatorEnv,
+    runner::env::SimulatorEnv,
 };
 
 impl<T> Arbitrary for Box<T>

--- a/simulator/generation/expr.rs
+++ b/simulator/generation/expr.rs
@@ -5,7 +5,7 @@ use turso_sqlite3_parser::ast::{
 use crate::{
     generation::{gen_random_text, pick, pick_index, Arbitrary, ArbitraryFrom},
     model::table::SimValue,
-    runner::env::SimulatorEnv,
+    runner::env::LimboSimulatorEnv,
 };
 
 impl<T> Arbitrary for Box<T>
@@ -55,8 +55,8 @@ where
 }
 
 // Freestyling generation
-impl ArbitraryFrom<&SimulatorEnv> for Expr {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Expr {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &LimboSimulatorEnv) -> Self {
         let choice = rng.gen_range(0..13);
 
         match choice {
@@ -196,8 +196,8 @@ impl Arbitrary for CollateName {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for QualifiedName {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for QualifiedName {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &LimboSimulatorEnv) -> Self {
         // TODO: for now just generate table name
         let table_idx = pick_index(t.tables.len(), rng);
         let table = &t.tables[table_idx];
@@ -206,8 +206,8 @@ impl ArbitraryFrom<&SimulatorEnv> for QualifiedName {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for LikeOperator {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for LikeOperator {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &LimboSimulatorEnv) -> Self {
         let choice = rng.gen_range(0..4);
         match choice {
             0 => LikeOperator::Glob,
@@ -220,8 +220,8 @@ impl ArbitraryFrom<&SimulatorEnv> for LikeOperator {
 }
 
 // Current implementation does not take into account the columns affinity nor if table is Strict
-impl ArbitraryFrom<&SimulatorEnv> for ast::Literal {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for ast::Literal {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &LimboSimulatorEnv) -> Self {
         loop {
             let choice = rng.gen_range(0..5);
             let lit = match choice {
@@ -258,8 +258,8 @@ impl ArbitraryFrom<&Vec<&SimValue>> for ast::Expr {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for UnaryOperator {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for UnaryOperator {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &LimboSimulatorEnv) -> Self {
         let choice = rng.gen_range(0..4);
         match choice {
             0 => Self::BitwiseNot,

--- a/simulator/generation/expr.rs
+++ b/simulator/generation/expr.rs
@@ -4,8 +4,7 @@ use turso_sqlite3_parser::ast::{
 
 use crate::{
     generation::{gen_random_text, pick, pick_index, Arbitrary, ArbitraryFrom},
-    model::table::SimValue,
-    runner::env::LimboSimulatorEnv,
+    model::{table::SimValue, SimulatorEnv},
 };
 
 impl<T> Arbitrary for Box<T>
@@ -55,8 +54,8 @@ where
 }
 
 // Freestyling generation
-impl ArbitraryFrom<&LimboSimulatorEnv> for Expr {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &LimboSimulatorEnv) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<&E> for Expr {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &E) -> Self {
         let choice = rng.gen_range(0..13);
 
         match choice {
@@ -112,8 +111,9 @@ impl ArbitraryFrom<&LimboSimulatorEnv> for Expr {
             // TODO: only supports one paranthesized expression
             10 => Expr::Parenthesized(vec![Expr::arbitrary_from(rng, t)]),
             11 => {
-                let table_idx = pick_index(t.tables.len(), rng);
-                let table = &t.tables[table_idx];
+                let tables = t.tables();
+                let table_idx = pick_index(tables.len(), rng);
+                let table = &tables[table_idx];
                 let col_idx = pick_index(table.columns.len(), rng);
                 let col = &table.columns[col_idx];
                 Expr::Qualified(Name(table.name.clone()), Name(col.name.clone()))
@@ -196,18 +196,19 @@ impl Arbitrary for CollateName {
     }
 }
 
-impl ArbitraryFrom<&LimboSimulatorEnv> for QualifiedName {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &LimboSimulatorEnv) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<&E> for QualifiedName {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &E) -> Self {
         // TODO: for now just generate table name
-        let table_idx = pick_index(t.tables.len(), rng);
-        let table = &t.tables[table_idx];
+        let tables = t.tables();
+        let table_idx = pick_index(tables.len(), rng);
+        let table = &tables[table_idx];
         // TODO: for now forego alias
         Self::single(Name(table.name.clone()))
     }
 }
 
-impl ArbitraryFrom<&LimboSimulatorEnv> for LikeOperator {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &LimboSimulatorEnv) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<&E> for LikeOperator {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &E) -> Self {
         let choice = rng.gen_range(0..4);
         match choice {
             0 => LikeOperator::Glob,
@@ -220,8 +221,8 @@ impl ArbitraryFrom<&LimboSimulatorEnv> for LikeOperator {
 }
 
 // Current implementation does not take into account the columns affinity nor if table is Strict
-impl ArbitraryFrom<&LimboSimulatorEnv> for ast::Literal {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &LimboSimulatorEnv) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<&E> for ast::Literal {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &E) -> Self {
         loop {
             let choice = rng.gen_range(0..5);
             let lit = match choice {
@@ -258,8 +259,8 @@ impl ArbitraryFrom<&Vec<&SimValue>> for ast::Expr {
     }
 }
 
-impl ArbitraryFrom<&LimboSimulatorEnv> for UnaryOperator {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &LimboSimulatorEnv) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<&E> for UnaryOperator {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &E) -> Self {
         let choice = rng.gen_range(0..4);
         match choice {
             0 => Self::BitwiseNot,

--- a/simulator/generation/mod.rs
+++ b/simulator/generation/mod.rs
@@ -113,11 +113,7 @@ pub fn pick_index<R: Rng>(choices: usize, rng: &mut R) -> usize {
 
 /// pick_n_unique is a helper function for uniformly picking N unique elements from a range.
 /// The elements themselves are usize, typically representing indices.
-pub fn pick_n_unique<R: Rng>(
-    range: std::ops::Range<usize>,
-    n: usize,
-    rng: &mut R,
-) -> Vec<usize> {
+pub fn pick_n_unique<R: Rng>(range: std::ops::Range<usize>, n: usize, rng: &mut R) -> Vec<usize> {
     use rand::seq::SliceRandom;
     let mut items: Vec<usize> = range.collect();
     items.shuffle(rng);

--- a/simulator/generation/mod.rs
+++ b/simulator/generation/mod.rs
@@ -44,7 +44,7 @@ pub trait ArbitraryFromMaybe<T> {
 /// the operations we require for the implementation.
 // todo: switch to a simpler type signature that can accommodate all integer and float types, which
 //       should be enough for our purposes.
-pub(crate) fn frequency<
+pub fn frequency<
     T,
     R: Rng,
     N: Sum + PartialOrd + Copy + Default + SampleUniform + SubAssign,
@@ -66,7 +66,7 @@ pub(crate) fn frequency<
 }
 
 /// one_of is a helper function for composing different generators with equal probability of occurrence.
-pub(crate) fn one_of<T, R: Rng>(choices: Vec<ArbitraryFromFunc<R, T>>, rng: &mut R) -> T {
+pub fn one_of<T, R: Rng>(choices: Vec<ArbitraryFromFunc<R, T>>, rng: &mut R) -> T {
     let index = rng.gen_range(0..choices.len());
     choices[index](rng)
 }
@@ -74,7 +74,7 @@ pub(crate) fn one_of<T, R: Rng>(choices: Vec<ArbitraryFromFunc<R, T>>, rng: &mut
 /// backtrack is a helper function for composing different "failable" generators.
 /// The function takes a list of functions that return an Option<T>, along with number of retries
 /// to make before giving up.
-pub(crate) fn backtrack<T, R: Rng>(mut choices: Vec<Choice<R, T>>, rng: &mut R) -> Option<T> {
+pub fn backtrack<T, R: Rng>(mut choices: Vec<Choice<R, T>>, rng: &mut R) -> Option<T> {
     loop {
         // If there are no more choices left, we give up
         let choices_ = choices
@@ -100,20 +100,20 @@ pub(crate) fn backtrack<T, R: Rng>(mut choices: Vec<Choice<R, T>>, rng: &mut R) 
 }
 
 /// pick is a helper function for uniformly picking a random element from a slice
-pub(crate) fn pick<'a, T, R: Rng>(choices: &'a [T], rng: &mut R) -> &'a T {
+pub fn pick<'a, T, R: Rng>(choices: &'a [T], rng: &mut R) -> &'a T {
     let index = rng.gen_range(0..choices.len());
     &choices[index]
 }
 
 /// pick_index is typically used for picking an index from a slice to later refer to the element
 /// at that index.
-pub(crate) fn pick_index<R: Rng>(choices: usize, rng: &mut R) -> usize {
+pub fn pick_index<R: Rng>(choices: usize, rng: &mut R) -> usize {
     rng.gen_range(0..choices)
 }
 
 /// pick_n_unique is a helper function for uniformly picking N unique elements from a range.
 /// The elements themselves are usize, typically representing indices.
-pub(crate) fn pick_n_unique<R: Rng>(
+pub fn pick_n_unique<R: Rng>(
     range: std::ops::Range<usize>,
     n: usize,
     rng: &mut R,
@@ -126,7 +126,7 @@ pub(crate) fn pick_n_unique<R: Rng>(
 
 /// gen_random_text uses `anarchist_readable_name_generator_lib` to generate random
 /// readable names for tables, columns, text values etc.
-pub(crate) fn gen_random_text<T: Rng>(rng: &mut T) -> String {
+pub fn gen_random_text<T: Rng>(rng: &mut T) -> String {
     let big_text = rng.gen_ratio(1, 1000);
     if big_text {
         // let max_size: u64 = 2 * 1024 * 1024 * 1024;

--- a/simulator/generation/mod.rs
+++ b/simulator/generation/mod.rs
@@ -44,11 +44,7 @@ pub trait ArbitraryFromMaybe<T> {
 /// the operations we require for the implementation.
 // todo: switch to a simpler type signature that can accommodate all integer and float types, which
 //       should be enough for our purposes.
-pub fn frequency<
-    T,
-    R: Rng,
-    N: Sum + PartialOrd + Copy + Default + SampleUniform + SubAssign,
->(
+pub fn frequency<T, R: Rng, N: Sum + PartialOrd + Copy + Default + SampleUniform + SubAssign>(
     choices: Vec<(N, ArbitraryFromFunc<R, T>)>,
     rng: &mut R,
 ) -> T {

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -17,7 +17,7 @@ use crate::model::{
         Create, CreateIndex, Delete, Drop, Insert, Query, Select,
     },
     table::SimValue,
-    SimConnection, SimulatorEnv,
+    Shadow, SimConnection, SimulatorEnv,
 };
 
 use crate::generation::{frequency, Arbitrary, ArbitraryFrom};
@@ -382,8 +382,8 @@ impl<E: SimulatorEnv> ArbitraryFrom<&mut E> for InteractionPlan {
     }
 }
 
-impl Interaction {
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Interaction {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Self::Query(query) => query.shadow(env),
             Self::FsyncQuery(query) => {
@@ -396,6 +396,9 @@ impl Interaction {
             }
         }
     }
+}
+
+impl Interaction {
     pub fn execute_query(&self, conn: &mut Arc<Connection>) -> ResultSet {
         if let Self::Query(query) = self {
             let query_str = query.to_string();

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -7,28 +7,28 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use turso_core::{Connection, Result, StepResult, IO};
+use turso_core::{Connection, Result, StepResult};
 
-use crate::{
-    model::{
-        query::{update::Update, Create, CreateIndex, Delete, Drop, Insert, Query, Select},
-        table::SimValue,
+use crate::model::{
+    query::{
+        predicate::Predicate,
+        select::{Distinctness, ResultColumn},
+        update::Update,
+        Create, CreateIndex, Delete, Drop, Insert, Query, Select,
     },
-    runner::{
-        env::{LimboSimulatorEnv, SimConnection},
-        io::SimulatorIO,
-    },
+    table::SimValue,
+    SimConnection, SimulatorEnv,
 };
 
 use crate::generation::{frequency, Arbitrary, ArbitraryFrom};
 
 use super::property::{remaining, Property};
 
-pub(crate) type ResultSet = Result<Vec<Vec<SimValue>>>;
+pub type ResultSet = Result<Vec<Vec<SimValue>>>;
 
 #[derive(Clone, Serialize, Deserialize)]
-pub(crate) struct InteractionPlan {
-    pub(crate) plan: Vec<Interactions>,
+pub struct InteractionPlan {
+    pub plan: Vec<Interactions>,
 }
 
 impl InteractionPlan {
@@ -38,7 +38,7 @@ impl InteractionPlan {
     /// delete interactions from the human readable file, and this function uses the JSON file as
     /// a baseline to detect with interactions were deleted and constructs the plan from the
     /// remaining interactions.
-    pub(crate) fn compute_via_diff(plan_path: &Path) -> Vec<Vec<Interaction>> {
+    pub fn compute_via_diff(plan_path: &Path) -> Vec<Vec<Interaction>> {
         let interactions = std::fs::read_to_string(plan_path).unwrap();
         let interactions = interactions.lines().collect::<Vec<_>>();
 
@@ -95,21 +95,21 @@ impl InteractionPlan {
     }
 }
 
-pub(crate) struct InteractionPlanState {
-    pub(crate) stack: Vec<ResultSet>,
-    pub(crate) interaction_pointer: usize,
-    pub(crate) secondary_pointer: usize,
+pub struct InteractionPlanState {
+    pub stack: Vec<ResultSet>,
+    pub interaction_pointer: usize,
+    pub secondary_pointer: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum Interactions {
+pub enum Interactions {
     Property(Property),
     Query(Query),
     Fault(Fault),
 }
 
 impl Interactions {
-    pub(crate) fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&str> {
         match self {
             Interactions::Property(property) => Some(property.name()),
             Interactions::Query(_) => None,
@@ -117,7 +117,7 @@ impl Interactions {
         }
     }
 
-    pub(crate) fn interactions(&self) -> Vec<Interaction> {
+    pub fn interactions(&self) -> Vec<Interaction> {
         match self {
             Interactions::Property(property) => property.interactions(),
             Interactions::Query(query) => vec![Interaction::Query(query.clone())],
@@ -127,7 +127,7 @@ impl Interactions {
 }
 
 impl Interactions {
-    pub(crate) fn dependencies(&self) -> HashSet<String> {
+    pub fn dependencies(&self) -> HashSet<String> {
         match self {
             Interactions::Property(property) => {
                 property
@@ -146,7 +146,7 @@ impl Interactions {
         }
     }
 
-    pub(crate) fn uses(&self) -> Vec<String> {
+    pub fn uses(&self) -> Vec<String> {
         match self {
             Interactions::Property(property) => {
                 property
@@ -211,14 +211,14 @@ impl Display for InteractionPlan {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct InteractionStats {
-    pub(crate) read_count: usize,
-    pub(crate) write_count: usize,
-    pub(crate) delete_count: usize,
-    pub(crate) update_count: usize,
-    pub(crate) create_count: usize,
-    pub(crate) create_index_count: usize,
-    pub(crate) drop_count: usize,
+pub struct InteractionStats {
+    pub read_count: usize,
+    pub write_count: usize,
+    pub delete_count: usize,
+    pub update_count: usize,
+    pub create_count: usize,
+    pub create_index_count: usize,
+    pub drop_count: usize,
 }
 
 impl Display for InteractionStats {
@@ -238,7 +238,7 @@ impl Display for InteractionStats {
 }
 
 #[derive(Debug)]
-pub(crate) enum Interaction {
+pub enum Interaction {
     Query(Query),
     Assumption(Assertion),
     Assertion(Assertion),
@@ -262,15 +262,16 @@ impl Display for Interaction {
     }
 }
 
-type AssertionFunc = dyn Fn(&Vec<ResultSet>, &LimboSimulatorEnv) -> Result<bool>;
+type AssertionFunc = dyn Fn(&Vec<ResultSet>, &dyn SimulatorEnv) -> Result<bool>;
 
+#[allow(dead_code)]
 enum AssertionAST {
     Pick(),
 }
 
-pub(crate) struct Assertion {
-    pub(crate) func: Box<AssertionFunc>,
-    pub(crate) message: String,
+pub struct Assertion {
+    pub func: Box<AssertionFunc>,
+    pub message: String,
 }
 
 impl Debug for Assertion {
@@ -282,7 +283,7 @@ impl Debug for Assertion {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum Fault {
+pub enum Fault {
     Disconnect,
     ReopenDatabase,
 }
@@ -297,11 +298,11 @@ impl Display for Fault {
 }
 
 impl InteractionPlan {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self { plan: Vec::new() }
     }
 
-    pub(crate) fn stats(&self) -> InteractionStats {
+    pub fn stats(&self) -> InteractionStats {
         let mut read = 0;
         let mut write = 0;
         let mut delete = 0;
@@ -352,15 +353,15 @@ impl InteractionPlan {
     }
 }
 
-impl ArbitraryFrom<&mut LimboSimulatorEnv> for InteractionPlan {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, env: &mut LimboSimulatorEnv) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<&mut E> for InteractionPlan {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, env: &mut E) -> Self {
         let mut plan = InteractionPlan::new();
 
-        let num_interactions = env.opts.max_interactions;
+        let num_interactions = env.opts().max_interactions;
 
         // First create at least one table
         let create_query = Create::arbitrary(rng);
-        env.tables.push(create_query.table.clone());
+        env.add_table(create_query.table.clone());
 
         plan.plan
             .push(Interactions::Query(Query::Create(create_query)));
@@ -382,7 +383,7 @@ impl ArbitraryFrom<&mut LimboSimulatorEnv> for InteractionPlan {
 }
 
 impl Interaction {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Self::Query(query) => query.shadow(env),
             Self::FsyncQuery(query) => {
@@ -395,7 +396,7 @@ impl Interaction {
             }
         }
     }
-    pub(crate) fn execute_query(&self, conn: &mut Arc<Connection>, io: &SimulatorIO) -> ResultSet {
+    pub fn execute_query(&self, conn: &mut Arc<Connection>) -> ResultSet {
         if let Self::Query(query) = self {
             let query_str = query.to_string();
             let rows = conn.query(&query_str);
@@ -424,7 +425,7 @@ impl Interaction {
                         out.push(r);
                     }
                     StepResult::IO => {
-                        io.run_once().unwrap();
+                        rows.run_once().unwrap();
                     }
                     StepResult::Interrupt => {}
                     StepResult::Done => {
@@ -440,10 +441,10 @@ impl Interaction {
         }
     }
 
-    pub(crate) fn execute_assertion(
+    pub fn execute_assertion<E: SimulatorEnv>(
         &self,
         stack: &Vec<ResultSet>,
-        env: &LimboSimulatorEnv,
+        env: &E,
     ) -> Result<()> {
         match self {
             Self::Assertion(assertion) => {
@@ -465,10 +466,10 @@ impl Interaction {
         }
     }
 
-    pub(crate) fn execute_assumption(
+    pub fn execute_assumption<E: SimulatorEnv>(
         &self,
         stack: &Vec<ResultSet>,
-        env: &LimboSimulatorEnv,
+        env: &E,
     ) -> Result<()> {
         match self {
             Self::Assumption(assumption) => {
@@ -490,23 +491,20 @@ impl Interaction {
         }
     }
 
-    pub(crate) fn execute_fault(
-        &self,
-        env: &mut LimboSimulatorEnv,
-        conn_index: usize,
-    ) -> Result<()> {
+    pub fn execute_fault<E: SimulatorEnv>(&self, env: &mut E, conn_index: usize) -> Result<()> {
         match self {
             Self::Fault(fault) => {
                 match fault {
                     Fault::Disconnect => {
-                        if env.connections[conn_index].is_connected() {
-                            env.connections[conn_index].disconnect();
+                        let connections = env.connections_mut();
+                        if connections[conn_index].is_connected() {
+                            connections[conn_index].disconnect();
                         } else {
                             return Err(turso_core::LimboError::InternalError(
                                 "connection already disconnected".into(),
                             ));
                         }
-                        env.connections[conn_index] = SimConnection::Disconnected;
+                        connections[conn_index] = SimConnection::Disconnected;
                     }
                     Fault::ReopenDatabase => {
                         reopen_database(env);
@@ -520,7 +518,7 @@ impl Interaction {
         }
     }
 
-    pub(crate) fn execute_fsync_query(
+    pub(crate) fn execute_fsync_query<E: SimulatorEnv>(
         &self,
         conn: Arc<Connection>,
         env: &mut LimboSimulatorEnv,
@@ -648,54 +646,58 @@ impl Interaction {
 fn reopen_database(env: &mut LimboSimulatorEnv) {
     // 1. Close all connections without default checkpoint-on-close behavior
     // to expose bugs related to how we handle WAL
-    let num_conns = env.connections.len();
-    env.connections.clear();
+    let num_conns = env.connections().len();
+    env.connections_mut().clear();
 
     // Clear all open files
     env.io.files.borrow_mut().clear();
 
     // 2. Re-open database
-    let db_path = env.db_path.clone();
-    let db = match turso_core::Database::open_file(env.io.clone(), &db_path, false, false) {
+    let db_path = env.db_path();
+    let db = match turso_core::Database::open_file(env.io().clone(), &db_path, false, false) {
         Ok(db) => db,
         Err(e) => {
             panic!("error opening simulator test file {:?}: {:?}", db_path, e);
         }
     };
-    env.db = db;
+    env.set_db(db);
+    let db = env.get_db();
 
+    let connections = env.connections_mut();
     for _ in 0..num_conns {
-        env.connections
-            .push(SimConnection::LimboConnection(env.db.connect().unwrap()));
+        connections.push(SimConnection::LimboConnection(db.connect().unwrap()));
     }
 }
 
-fn random_create<R: rand::Rng>(rng: &mut R, _env: &LimboSimulatorEnv) -> Interactions {
+fn random_create<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, _env: &E) -> Interactions {
     Interactions::Query(Query::Create(Create::arbitrary(rng)))
 }
 
-fn random_read<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Interactions {
+fn random_read<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, env: &E) -> Interactions {
     Interactions::Query(Query::Select(Select::arbitrary_from(rng, env)))
 }
 
-fn random_write<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Interactions {
+fn random_write<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, env: &E) -> Interactions {
     Interactions::Query(Query::Insert(Insert::arbitrary_from(rng, env)))
 }
 
-fn random_delete<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Interactions {
+fn random_delete<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, env: &E) -> Interactions {
     Interactions::Query(Query::Delete(Delete::arbitrary_from(rng, env)))
 }
 
-fn random_update<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Interactions {
+fn random_update<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, env: &E) -> Interactions {
     Interactions::Query(Query::Update(Update::arbitrary_from(rng, env)))
 }
 
-fn random_drop<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Interactions {
+fn random_drop<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, env: &E) -> Interactions {
     Interactions::Query(Query::Drop(Drop::arbitrary_from(rng, env)))
 }
 
-fn random_create_index<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Option<Interactions> {
-    if env.tables.is_empty() {
+fn random_create_index<R: rand::Rng, E: SimulatorEnv>(
+    rng: &mut R,
+    env: &E,
+) -> Option<Interactions> {
+    if env.tables().is_empty() {
         return None;
     }
     Some(Interactions::Query(Query::CreateIndex(
@@ -703,8 +705,8 @@ fn random_create_index<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Op
     )))
 }
 
-fn random_fault<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Interactions {
-    let faults = if env.opts.disable_reopen_database {
+fn random_fault<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, env: &E) -> Interactions {
+    let faults = if env.opts().disable_reopen_database {
         vec![Fault::Disconnect]
     } else {
         vec![Fault::Disconnect, Fault::ReopenDatabase]
@@ -713,11 +715,8 @@ fn random_fault<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Interacti
     Interactions::Fault(fault)
 }
 
-impl ArbitraryFrom<(&LimboSimulatorEnv, InteractionStats)> for Interactions {
-    fn arbitrary_from<R: rand::Rng>(
-        rng: &mut R,
-        (env, stats): (&LimboSimulatorEnv, InteractionStats),
-    ) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<(&E, InteractionStats)> for Interactions {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, (env, stats): (&E, InteractionStats)) -> Self {
         let remaining_ = remaining(env, &stats);
         frequency(
             vec![

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -353,6 +353,12 @@ impl InteractionPlan {
     }
 }
 
+impl Default for InteractionPlan {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<E: SimulatorEnv> ArbitraryFrom<&mut E> for InteractionPlan {
     fn arbitrary_from<R: rand::Rng>(rng: &mut R, env: &mut E) -> Self {
         let mut plan = InteractionPlan::new();

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -14,8 +14,10 @@ use crate::{
         query::{update::Update, Create, CreateIndex, Delete, Drop, Insert, Query, Select},
         table::SimValue,
     },
-    runner::{env::SimConnection, io::SimulatorIO},
-    SimulatorEnv,
+    runner::{
+        env::{SimConnection, SimulatorEnv},
+        io::SimulatorIO,
+    },
 };
 
 use crate::generation::{frequency, Arbitrary, ArbitraryFrom};

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -548,7 +548,7 @@ fn property_insert_values_select<R: rand::Rng, E: SimulatorEnv>(
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Generate rows to insert
     let rows = (0..rng.gen_range(1..=5))
         .map(|_| Vec::<SimValue>::arbitrary_from(rng, table))
@@ -613,7 +613,7 @@ fn property_insert_values_select<R: rand::Rng, E: SimulatorEnv>(
 
 fn property_select_limit<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, env: &E) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Select the table
     let select = Select {
         table: table.name.clone(),
@@ -631,7 +631,7 @@ fn property_double_create_failure<R: rand::Rng, E: SimulatorEnv>(
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Create the table
     let create_query = Create {
         table: table.clone(),
@@ -666,7 +666,7 @@ fn property_delete_select<R: rand::Rng, E: SimulatorEnv>(
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Generate a random predicate
     let predicate = Predicate::arbitrary_from(rng, table);
 
@@ -709,7 +709,7 @@ fn property_drop_select<R: rand::Rng, E: SimulatorEnv>(
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
 
     // Create random queries respecting the constraints
     let mut queries = Vec::new();
@@ -746,7 +746,7 @@ fn property_select_select_optimizer<R: rand::Rng, E: SimulatorEnv>(
     env: &E,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Generate a random predicate
     let predicate = Predicate::arbitrary_from(rng, table);
     // Transform into a Binary predicate to force values to be casted to a bool

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -500,6 +500,7 @@ pub(crate) struct Remaining {
     pub(crate) create_index: f64,
     pub(crate) delete: f64,
     pub(crate) update: f64,
+    #[allow(dead_code)]
     pub(crate) drop: f64,
 }
 
@@ -823,7 +824,8 @@ impl<E: SimulatorEnv> ArbitraryFrom<(&E, &InteractionStats)> for Property {
                 ),
                 (
                     if !opts.disable_drop_select {
-                        remaining_.drop
+                        // remaining_.drop
+                        0.0
                     } else {
                         0.0
                     },

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -6,7 +6,7 @@ use crate::model::query::select::{Distinctness, ResultColumn};
 use crate::model::query::update::Update;
 use crate::model::query::{Create, Delete, Drop, Insert, Query, Select};
 use crate::model::table::{SimValue, Table};
-use crate::runner::env::SimulatorEnv;
+use crate::runner::env::LimboSimulatorEnv;
 use rand::Rng;
 
 use super::property::Remaining;
@@ -20,8 +20,8 @@ impl Arbitrary for Create {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Select {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Select {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let table = pick(&env.tables, rng);
         Self {
             table: table.name.clone(),
@@ -33,8 +33,8 @@ impl ArbitraryFrom<&SimulatorEnv> for Select {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Insert {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Insert {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let gen_values = |rng: &mut R| {
             let table = pick(&env.tables, rng);
             let num_rows = rng.gen_range(1..10);
@@ -86,8 +86,8 @@ impl ArbitraryFrom<&SimulatorEnv> for Insert {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Delete {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Delete {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let table = pick(&env.tables, rng);
         Self {
             table: table.name.clone(),
@@ -96,8 +96,8 @@ impl ArbitraryFrom<&SimulatorEnv> for Delete {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Drop {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Drop {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let table = pick(&env.tables, rng);
         Self {
             table: table.name.clone(),
@@ -105,8 +105,11 @@ impl ArbitraryFrom<&SimulatorEnv> for Drop {
     }
 }
 
-impl ArbitraryFrom<(&SimulatorEnv, &Remaining)> for Query {
-    fn arbitrary_from<R: Rng>(rng: &mut R, (env, remaining): (&SimulatorEnv, &Remaining)) -> Self {
+impl ArbitraryFrom<(&LimboSimulatorEnv, &Remaining)> for Query {
+    fn arbitrary_from<R: Rng>(
+        rng: &mut R,
+        (env, remaining): (&LimboSimulatorEnv, &Remaining),
+    ) -> Self {
         frequency(
             vec![
                 (
@@ -131,8 +134,8 @@ impl ArbitraryFrom<(&SimulatorEnv, &Remaining)> for Query {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Update {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Update {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let table = pick(&env.tables, rng);
         let mut seen = HashSet::new();
         let num_cols = rng.gen_range(1..=table.columns.len());

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -6,7 +6,7 @@ use crate::model::query::select::{Distinctness, ResultColumn};
 use crate::model::query::update::Update;
 use crate::model::query::{Create, Delete, Drop, Insert, Query, Select};
 use crate::model::table::{SimValue, Table};
-use crate::SimulatorEnv;
+use crate::runner::env::SimulatorEnv;
 use rand::Rng;
 
 use super::property::Remaining;

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -22,7 +22,7 @@ impl Arbitrary for Create {
 
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Select {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
-        let table = pick(&env.tables(), rng);
+        let table = pick(env.tables(), rng);
         Self {
             table: table.name.clone(),
             result_columns: vec![ResultColumn::Star],
@@ -36,7 +36,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<&E> for Select {
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Insert {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
         let gen_values = |rng: &mut R| {
-            let table = pick(&env.tables(), rng);
+            let table = pick(env.tables(), rng);
             let num_rows = rng.gen_range(1..10);
             let values: Vec<Vec<SimValue>> = (0..num_rows)
                 .map(|_| {
@@ -66,7 +66,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<&E> for Insert {
                 limit: None,
                 distinct: Distinctness::All,
             };
-            let table = pick(&env.tables(), rng);
+            let table = pick(env.tables(), rng);
             Some(Insert::Select {
                 table: table.name.clone(),
                 select: Box::new(select),
@@ -88,7 +88,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<&E> for Insert {
 
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Delete {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
-        let table = pick(&env.tables(), rng);
+        let table = pick(env.tables(), rng);
         Self {
             table: table.name.clone(),
             predicate: Predicate::arbitrary_from(rng, table),
@@ -98,7 +98,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<&E> for Delete {
 
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Drop {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
-        let table = pick(&env.tables(), rng);
+        let table = pick(env.tables(), rng);
         Self {
             table: table.name.clone(),
         }
@@ -133,7 +133,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<(&E, &Remaining)> for Query {
 
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Update {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
-        let table = pick(&env.tables(), rng);
+        let table = pick(env.tables(), rng);
         let mut seen = HashSet::new();
         let num_cols = rng.gen_range(1..=table.columns.len());
         let set_values: Vec<(String, SimValue)> = (0..num_cols)

--- a/simulator/lib.rs
+++ b/simulator/lib.rs
@@ -1,4 +1,2 @@
 pub mod generation;
 pub mod model;
-pub(crate) mod runner;
-pub(crate) mod shrink;

--- a/simulator/lib.rs
+++ b/simulator/lib.rs
@@ -1,0 +1,4 @@
+pub mod generation;
+pub mod model;
+pub(crate) mod runner;
+pub(crate) mod shrink;

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -3,6 +3,7 @@ use anyhow::{anyhow, Context};
 use clap::Parser;
 use limbo_sim::generation::plan::{Interaction, InteractionPlan, InteractionPlanState};
 use limbo_sim::generation::ArbitraryFrom as _;
+use limbo_sim::model::Shadow as _;
 use notify::event::{DataChange, ModifyKind};
 use notify::{EventKind, RecursiveMode, Watcher};
 use rand::prelude::*;

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -1,9 +1,6 @@
 #![allow(clippy::arc_with_non_send_sync, dead_code)]
 use anyhow::{anyhow, Context};
 use clap::Parser;
-use limbo_sim::generation::plan::{Interaction, InteractionPlan, InteractionPlanState};
-use limbo_sim::generation::ArbitraryFrom as _;
-use limbo_sim::model::Shadow as _;
 use notify::event::{DataChange, ModifyKind};
 use notify::{EventKind, RecursiveMode, Watcher};
 use rand::prelude::*;
@@ -21,6 +18,9 @@ use tracing_subscriber::field::MakeExt;
 use tracing_subscriber::fmt::format;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use turso_sim::generation::plan::{Interaction, InteractionPlan, InteractionPlanState};
+use turso_sim::generation::ArbitraryFrom as _;
+use turso_sim::model::Shadow as _;
 
 use crate::runner::env::TursoSimulatorEnv;
 use crate::shrink::plan::shrink_interaction_plan;

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -22,7 +22,7 @@ use tracing_subscriber::fmt::format;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use crate::runner::env::LimboSimulatorEnv;
+use crate::runner::env::TursoSimulatorEnv;
 use crate::shrink::plan::shrink_interaction_plan;
 
 mod runner;
@@ -215,7 +215,7 @@ fn watch_mode(
                         std::panic::catch_unwind(|| {
                             let plan: Vec<Vec<Interaction>> =
                                 InteractionPlan::compute_via_diff(&paths.plan);
-                            let mut env = LimboSimulatorEnv::new(seed, cli_opts, &paths.db);
+                            let mut env = TursoSimulatorEnv::new(seed, cli_opts, &paths.db);
                             plan.iter().for_each(|is| {
                                 is.iter().for_each(|i| {
                                     i.shadow(&mut env);
@@ -250,7 +250,7 @@ fn run_simulator(
     bugbase: Option<&mut BugBase>,
     cli_opts: &SimulatorCLI,
     paths: &Paths,
-    env: LimboSimulatorEnv,
+    env: TursoSimulatorEnv,
     plans: Vec<InteractionPlan>,
     last_execution: Arc<Mutex<Execution>>,
 ) -> anyhow::Result<()> {
@@ -338,7 +338,7 @@ fn run_simulator(
                 f.write_all(shrunk_plans[0].to_string().as_bytes()).unwrap();
 
                 let last_execution = Arc::new(Mutex::new(*last_execution));
-                let env = LimboSimulatorEnv::new(seed, cli_opts, &paths.shrunk_db);
+                let env = TursoSimulatorEnv::new(seed, cli_opts, &paths.shrunk_db);
 
                 let env = Arc::new(Mutex::new(env));
                 let shrunk = SandboxedResult::from(
@@ -424,7 +424,7 @@ fn doublecheck(
     last_execution: Arc<Mutex<Execution>>,
     result: SandboxedResult,
 ) -> anyhow::Result<()> {
-    let env = LimboSimulatorEnv::new(seed, cli_opts, &paths.doublecheck_db);
+    let env = TursoSimulatorEnv::new(seed, cli_opts, &paths.doublecheck_db);
     let env = Arc::new(Mutex::new(env));
 
     // Run the simulation again
@@ -497,10 +497,10 @@ fn differential_testing(
     plans: Vec<InteractionPlan>,
     last_execution: Arc<Mutex<Execution>>,
 ) -> anyhow::Result<()> {
-    let env = Arc::new(Mutex::new(LimboSimulatorEnv::new(
+    let env = Arc::new(Mutex::new(TursoSimulatorEnv::new(
         seed, cli_opts, &paths.db,
     )));
-    let rusqlite_env = Arc::new(Mutex::new(LimboSimulatorEnv::new(
+    let rusqlite_env = Arc::new(Mutex::new(TursoSimulatorEnv::new(
         seed,
         cli_opts,
         &paths.diff_db,
@@ -596,7 +596,7 @@ fn setup_simulation(
     cli_opts: &SimulatorCLI,
     plan_path: fn(&Paths) -> &Path,
     db_path: fn(&Paths) -> &Path,
-) -> (u64, LimboSimulatorEnv, Vec<InteractionPlan>, Paths) {
+) -> (u64, TursoSimulatorEnv, Vec<InteractionPlan>, Paths) {
     if let Some(seed) = &cli_opts.load {
         let seed = seed.parse::<u64>().expect("seed should be a number");
         let bugbase = bugbase.expect("BugBase must be enabled to load a bug");
@@ -609,7 +609,7 @@ fn setup_simulation(
         if !paths.base.exists() {
             std::fs::create_dir_all(&paths.base).unwrap();
         }
-        let env = LimboSimulatorEnv::new(bug.seed(), cli_opts, db_path(&paths));
+        let env = TursoSimulatorEnv::new(bug.seed(), cli_opts, db_path(&paths));
 
         let plan = match bug {
             Bug::Loaded(LoadedBug { plan, .. }) => plan.clone(),
@@ -653,7 +653,7 @@ fn setup_simulation(
             Paths::new(&dir)
         };
 
-        let mut env = LimboSimulatorEnv::new(seed, cli_opts, &paths.db);
+        let mut env = TursoSimulatorEnv::new(seed, cli_opts, &paths.db);
 
         tracing::info!("Generating database interaction plan...");
 
@@ -676,7 +676,7 @@ fn setup_simulation(
 }
 
 fn run_simulation(
-    env: Arc<Mutex<LimboSimulatorEnv>>,
+    env: Arc<Mutex<TursoSimulatorEnv>>,
     plans: &mut [InteractionPlan],
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, mem, sync::Arc};
 
 use turso_core::{Database, IO};
 
-use crate::model::table::Table;
+use crate::model::table::{SimValue, Table};
 
 pub mod query;
 pub mod table;
@@ -106,4 +106,8 @@ pub struct SimulatorOpts {
     pub max_interactions: usize,
     pub page_size: usize,
     pub max_time_simulation: usize,
+}
+
+pub trait Shadow {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>>;
 }

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -24,6 +24,9 @@ pub trait SimulatorEnv {
     fn io(&self) -> Arc<dyn IO>;
     fn get_db(&self) -> Arc<Database>;
     fn set_db(&mut self, db: Arc<Database>);
+    fn reopen_database(&mut self);
+    fn syncing(&self) -> bool;
+    fn inject_fault(&self, fault: bool);
 }
 
 pub trait ConnectionTrait

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -1,2 +1,109 @@
+use std::{fmt::Display, mem, sync::Arc};
+
+use turso_core::{Database, IO};
+
+use crate::model::table::Table;
+
 pub mod query;
 pub mod table;
+
+pub trait SimulatorEnv {
+    /// List all tables
+    fn tables(&self) -> &[Table];
+    /// List all tables with a mutable reference
+    fn tables_mut(&mut self) -> &mut [Table];
+    /// Add a table
+    fn add_table(&mut self, table: Table);
+    /// Remove a table by name
+    fn remove_table(&mut self, table_name: &str);
+    /// Gets the simulator options
+    fn opts(&self) -> &SimulatorOpts;
+    fn connections(&self) -> &[SimConnection];
+    fn connections_mut(&mut self) -> &mut Vec<SimConnection>;
+    fn db_path(&self) -> &str;
+    fn io(&self) -> Arc<dyn IO>;
+    fn get_db(&self) -> Arc<Database>;
+    fn set_db(&mut self, db: Arc<Database>);
+}
+
+pub trait ConnectionTrait
+where
+    Self: std::marker::Sized + Clone,
+{
+    fn is_connected(&self) -> bool;
+    fn disconnect(&mut self);
+}
+
+pub enum SimConnection {
+    LimboConnection(Arc<turso_core::Connection>),
+    SQLiteConnection(rusqlite::Connection),
+    Disconnected,
+}
+
+impl SimConnection {
+    pub(crate) fn is_connected(&self) -> bool {
+        match self {
+            SimConnection::LimboConnection(_) | SimConnection::SQLiteConnection(_) => true,
+            SimConnection::Disconnected => false,
+        }
+    }
+    pub(crate) fn disconnect(&mut self) {
+        let conn = mem::replace(self, SimConnection::Disconnected);
+
+        match conn {
+            SimConnection::LimboConnection(conn) => {
+                conn.close().unwrap();
+            }
+            SimConnection::SQLiteConnection(conn) => {
+                conn.close().unwrap();
+            }
+            SimConnection::Disconnected => {}
+        }
+    }
+}
+
+impl Display for SimConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SimConnection::LimboConnection(_) => {
+                write!(f, "LimboConnection")
+            }
+            SimConnection::SQLiteConnection(_) => {
+                write!(f, "SQLiteConnection")
+            }
+            SimConnection::Disconnected => {
+                write!(f, "Disconnected")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SimulatorOpts {
+    pub ticks: usize,
+    pub max_connections: usize,
+    pub max_tables: usize,
+    // this next options are the distribution of workload where read_percent + write_percent +
+    // delete_percent == 100%
+    pub create_percent: f64,
+    pub create_index_percent: f64,
+    pub read_percent: f64,
+    pub write_percent: f64,
+    pub delete_percent: f64,
+    pub update_percent: f64,
+    pub drop_percent: f64,
+
+    pub disable_select_optimizer: bool,
+    pub disable_insert_values_select: bool,
+    pub disable_double_create_failure: bool,
+    pub disable_select_limit: bool,
+    pub disable_delete_select: bool,
+    pub disable_drop_select: bool,
+    pub disable_fsync_no_wait: bool,
+    pub disable_faulty_query: bool,
+    pub disable_reopen_database: bool,
+
+    pub max_interactions: usize,
+    pub page_size: usize,
+    pub max_time_simulation: usize,
+}

--- a/simulator/model/query/create.rs
+++ b/simulator/model/query/create.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     model::table::{SimValue, Table},
-    SimulatorEnv,
+    runner::env::SimulatorEnv,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/simulator/model/query/create.rs
+++ b/simulator/model/query/create.rs
@@ -2,20 +2,20 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    model::table::{SimValue, Table},
-    runner::env::LimboSimulatorEnv,
+use crate::model::{
+    table::{SimValue, Table},
+    SimulatorEnv,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct Create {
-    pub(crate) table: Table,
+pub struct Create {
+    pub table: Table,
 }
 
 impl Create {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
-        if !env.tables.iter().any(|t| t.name == self.table.name) {
-            env.tables.push(self.table.clone());
+    pub(crate) fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+        if !env.tables().iter().any(|t| t.name == self.table.name) {
+            env.add_table(self.table.clone());
         }
 
         vec![]

--- a/simulator/model/query/create.rs
+++ b/simulator/model/query/create.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     model::table::{SimValue, Table},
-    runner::env::SimulatorEnv,
+    runner::env::LimboSimulatorEnv,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,7 +13,7 @@ pub(crate) struct Create {
 }
 
 impl Create {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         if !env.tables.iter().any(|t| t.name == self.table.name) {
             env.tables.push(self.table.clone());
         }

--- a/simulator/model/query/create.rs
+++ b/simulator/model/query/create.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::{
     table::{SimValue, Table},
-    SimulatorEnv,
+    Shadow, SimulatorEnv,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -12,8 +12,8 @@ pub struct Create {
     pub table: Table,
 }
 
-impl Create {
-    pub(crate) fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Create {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         if !env.tables().iter().any(|t| t.name == self.table.name) {
             env.add_table(self.table.clone());
         }

--- a/simulator/model/query/create_index.rs
+++ b/simulator/model/query/create_index.rs
@@ -1,6 +1,6 @@
 use crate::{
     generation::{gen_random_text, pick, pick_n_unique, ArbitraryFrom},
-    runner::env::LimboSimulatorEnv,
+    model::SimulatorEnv,
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -21,16 +21,16 @@ impl std::fmt::Display for SortOrder {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub(crate) struct CreateIndex {
-    pub(crate) index_name: String,
-    pub(crate) table_name: String,
-    pub(crate) columns: Vec<(String, SortOrder)>,
+pub struct CreateIndex {
+    pub index_name: String,
+    pub table_name: String,
+    pub columns: Vec<(String, SortOrder)>,
 }
 
 impl CreateIndex {
-    pub(crate) fn shadow(
+    pub fn shadow<E: SimulatorEnv>(
         &self,
-        _env: &mut crate::runner::env::LimboSimulatorEnv,
+        _env: &mut E,
     ) -> Vec<Vec<crate::model::table::SimValue>> {
         // CREATE INDEX doesn't require any shadowing; we don't need to keep track
         // in the simulator what indexes exist.
@@ -54,14 +54,15 @@ impl std::fmt::Display for CreateIndex {
     }
 }
 
-impl ArbitraryFrom<&LimboSimulatorEnv> for CreateIndex {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<&E> for CreateIndex {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
+        let tables = env.tables();
         assert!(
-            !env.tables.is_empty(),
+            !tables.is_empty(),
             "Cannot create an index when no tables exist in the environment."
         );
 
-        let table = pick(&env.tables, rng);
+        let table = pick(tables, rng);
 
         if table.columns.is_empty() {
             panic!(

--- a/simulator/model/query/create_index.rs
+++ b/simulator/model/query/create_index.rs
@@ -1,6 +1,6 @@
 use crate::{
     generation::{gen_random_text, pick, pick_n_unique, ArbitraryFrom},
-    runner::env::SimulatorEnv,
+    runner::env::LimboSimulatorEnv,
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -30,7 +30,7 @@ pub(crate) struct CreateIndex {
 impl CreateIndex {
     pub(crate) fn shadow(
         &self,
-        _env: &mut crate::runner::env::SimulatorEnv,
+        _env: &mut crate::runner::env::LimboSimulatorEnv,
     ) -> Vec<Vec<crate::model::table::SimValue>> {
         // CREATE INDEX doesn't require any shadowing; we don't need to keep track
         // in the simulator what indexes exist.
@@ -54,8 +54,8 @@ impl std::fmt::Display for CreateIndex {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for CreateIndex {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for CreateIndex {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         assert!(
             !env.tables.is_empty(),
             "Cannot create an index when no tables exist in the environment."

--- a/simulator/model/query/create_index.rs
+++ b/simulator/model/query/create_index.rs
@@ -1,6 +1,6 @@
 use crate::{
     generation::{gen_random_text, pick, pick_n_unique, ArbitraryFrom},
-    model::SimulatorEnv,
+    model::{Shadow, SimulatorEnv},
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -27,11 +27,8 @@ pub struct CreateIndex {
     pub columns: Vec<(String, SortOrder)>,
 }
 
-impl CreateIndex {
-    pub fn shadow<E: SimulatorEnv>(
-        &self,
-        _env: &mut E,
-    ) -> Vec<Vec<crate::model::table::SimValue>> {
+impl Shadow for CreateIndex {
+    fn shadow<E: SimulatorEnv>(&self, _env: &mut E) -> Vec<Vec<crate::model::table::SimValue>> {
         // CREATE INDEX doesn't require any shadowing; we don't need to keep track
         // in the simulator what indexes exist.
         vec![]

--- a/simulator/model/query/delete.rs
+++ b/simulator/model/query/delete.rs
@@ -2,20 +2,20 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 use super::predicate::Predicate;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Delete {
-    pub(crate) table: String,
-    pub(crate) predicate: Predicate,
+pub struct Delete {
+    pub table: String,
+    pub predicate: Predicate,
 }
 
 impl Delete {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env
-            .tables
+            .tables_mut()
             .iter_mut()
             .find(|t| t.name == self.table)
             .unwrap();

--- a/simulator/model/query/delete.rs
+++ b/simulator/model/query/delete.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 use super::predicate::Predicate;
 

--- a/simulator/model/query/delete.rs
+++ b/simulator/model/query/delete.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -12,8 +12,8 @@ pub struct Delete {
     pub predicate: Predicate,
 }
 
-impl Delete {
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Delete {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env
             .tables_mut()
             .iter_mut()

--- a/simulator/model/query/delete.rs
+++ b/simulator/model/query/delete.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -13,7 +13,7 @@ pub(crate) struct Delete {
 }
 
 impl Delete {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         let table = env
             .tables
             .iter_mut()

--- a/simulator/model/query/drop.rs
+++ b/simulator/model/query/drop.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct Drop {
@@ -10,7 +10,7 @@ pub(crate) struct Drop {
 }
 
 impl Drop {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         env.tables.retain(|t| t.name != self.table);
         vec![]
     }

--- a/simulator/model/query/drop.rs
+++ b/simulator/model/query/drop.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct Drop {

--- a/simulator/model/query/drop.rs
+++ b/simulator/model/query/drop.rs
@@ -2,15 +2,15 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Drop {
     pub table: String,
 }
 
-impl Drop {
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Drop {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         env.remove_table(&self.table);
         vec![]
     }

--- a/simulator/model/query/drop.rs
+++ b/simulator/model/query/drop.rs
@@ -2,16 +2,16 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Drop {
-    pub(crate) table: String,
+pub struct Drop {
+    pub table: String,
 }
 
 impl Drop {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
-        env.tables.retain(|t| t.name != self.table);
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+        env.remove_table(&self.table);
         vec![]
     }
 }

--- a/simulator/model/query/insert.rs
+++ b/simulator/model/query/insert.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 use super::select::Select;
 
@@ -19,7 +19,7 @@ pub(crate) enum Insert {
 }
 
 impl Insert {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         match self {
             Insert::Values { table, values } => {
                 if let Some(t) = env.tables.iter_mut().find(|t| &t.name == table) {

--- a/simulator/model/query/insert.rs
+++ b/simulator/model/query/insert.rs
@@ -2,12 +2,12 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 use super::select::Select;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) enum Insert {
+pub enum Insert {
     Values {
         table: String,
         values: Vec<Vec<SimValue>>,
@@ -19,16 +19,16 @@ pub(crate) enum Insert {
 }
 
 impl Insert {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Insert::Values { table, values } => {
-                if let Some(t) = env.tables.iter_mut().find(|t| &t.name == table) {
+                if let Some(t) = env.tables_mut().iter_mut().find(|t| &t.name == table) {
                     t.rows.extend(values.clone());
                 }
             }
             Insert::Select { table, select } => {
                 let rows = select.shadow(env);
-                if let Some(t) = env.tables.iter_mut().find(|t| &t.name == table) {
+                if let Some(t) = env.tables_mut().iter_mut().find(|t| &t.name == table) {
                     t.rows.extend(rows);
                 }
             }

--- a/simulator/model/query/insert.rs
+++ b/simulator/model/query/insert.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 use super::select::Select;
 
@@ -19,7 +19,15 @@ pub enum Insert {
 }
 
 impl Insert {
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+    pub(crate) fn table(&self) -> &str {
+        match self {
+            Insert::Values { table, .. } | Insert::Select { table, .. } => table,
+        }
+    }
+}
+
+impl Shadow for Insert {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Insert::Values { table, values } => {
                 if let Some(t) = env.tables_mut().iter_mut().find(|t| &t.name == table) {
@@ -35,12 +43,6 @@ impl Insert {
         }
 
         vec![]
-    }
-
-    pub(crate) fn table(&self) -> &str {
-        match self {
-            Insert::Values { table, .. } | Insert::Select { table, .. } => table,
-        }
     }
 }
 

--- a/simulator/model/query/insert.rs
+++ b/simulator/model/query/insert.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 use super::select::Select;
 

--- a/simulator/model/query/mod.rs
+++ b/simulator/model/query/mod.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use turso_sqlite3_parser::to_sql_string::ToSqlContext;
 use update::Update;
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 pub mod create;
 pub mod create_index;
@@ -60,8 +60,10 @@ impl Query {
             Query::CreateIndex(CreateIndex { table_name, .. }) => vec![table_name.clone()],
         }
     }
+}
 
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Query {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Query::Create(create) => create.shadow(env),
             Query::Insert(insert) => insert.shadow(env),

--- a/simulator/model/query/mod.rs
+++ b/simulator/model/query/mod.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use turso_sqlite3_parser::to_sql_string::ToSqlContext;
 use update::Update;
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 pub mod create;
 pub mod create_index;
@@ -23,7 +23,7 @@ pub mod update;
 
 // This type represents the potential queries on the database.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum Query {
+pub enum Query {
     Create(Create),
     Select(Select),
     Insert(Insert),
@@ -34,7 +34,7 @@ pub(crate) enum Query {
 }
 
 impl Query {
-    pub(crate) fn dependencies(&self) -> HashSet<String> {
+    pub fn dependencies(&self) -> HashSet<String> {
         match self {
             Query::Create(_) => HashSet::new(),
             Query::Select(Select { table, .. })
@@ -48,7 +48,7 @@ impl Query {
             }
         }
     }
-    pub(crate) fn uses(&self) -> Vec<String> {
+    pub fn uses(&self) -> Vec<String> {
         match self {
             Query::Create(Create { table }) => vec![table.name.clone()],
             Query::Select(Select { table, .. })
@@ -61,7 +61,7 @@ impl Query {
         }
     }
 
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Query::Create(create) => create.shadow(env),
             Query::Insert(insert) => insert.shadow(env),

--- a/simulator/model/query/mod.rs
+++ b/simulator/model/query/mod.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use turso_sqlite3_parser::to_sql_string::ToSqlContext;
 use update::Update;
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 pub mod create;
 pub mod create_index;
@@ -61,7 +61,7 @@ impl Query {
         }
     }
 
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         match self {
             Query::Create(create) => create.shadow(env),
             Query::Insert(insert) => insert.shadow(env),

--- a/simulator/model/query/select.rs
+++ b/simulator/model/query/select.rs
@@ -2,13 +2,13 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 use super::predicate::Predicate;
 
 /// `SELECT` distinctness
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) enum Distinctness {
+pub enum Distinctness {
     /// `DISTINCT`
     Distinct,
     /// `ALL`
@@ -37,17 +37,17 @@ impl Display for ResultColumn {
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Select {
-    pub(crate) table: String,
-    pub(crate) result_columns: Vec<ResultColumn>,
-    pub(crate) predicate: Predicate,
-    pub(crate) distinct: Distinctness,
-    pub(crate) limit: Option<usize>,
+pub struct Select {
+    pub table: String,
+    pub result_columns: Vec<ResultColumn>,
+    pub predicate: Predicate,
+    pub distinct: Distinctness,
+    pub limit: Option<usize>,
 }
 
 impl Select {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
-        let table = env.tables.iter().find(|t| t.name == self.table.as_str());
+    pub(crate) fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+        let table = env.tables().iter().find(|t| t.name == self.table.as_str());
         if let Some(table) = table {
             table
                 .rows

--- a/simulator/model/query/select.rs
+++ b/simulator/model/query/select.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 use super::predicate::Predicate;
 

--- a/simulator/model/query/select.rs
+++ b/simulator/model/query/select.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -46,7 +46,7 @@ pub(crate) struct Select {
 }
 
 impl Select {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         let table = env.tables.iter().find(|t| t.name == self.table.as_str());
         if let Some(table) = table {
             table

--- a/simulator/model/query/select.rs
+++ b/simulator/model/query/select.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -45,8 +45,8 @@ pub struct Select {
     pub limit: Option<usize>,
 }
 
-impl Select {
-    pub(crate) fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Select {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env.tables().iter().find(|t| t.name == self.table.as_str());
         if let Some(table) = table {
             table

--- a/simulator/model/query/update.rs
+++ b/simulator/model/query/update.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 use super::predicate::Predicate;
 

--- a/simulator/model/query/update.rs
+++ b/simulator/model/query/update.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -14,7 +14,7 @@ pub(crate) struct Update {
 }
 
 impl Update {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         let table = env
             .tables
             .iter_mut()

--- a/simulator/model/query/update.rs
+++ b/simulator/model/query/update.rs
@@ -2,21 +2,21 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 use super::predicate::Predicate;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Update {
-    pub(crate) table: String,
-    pub(crate) set_values: Vec<(String, SimValue)>, // Pair of value for set expressions => SET name=value
-    pub(crate) predicate: Predicate,
+pub struct Update {
+    pub table: String,
+    pub set_values: Vec<(String, SimValue)>, // Pair of value for set expressions => SET name=value
+    pub predicate: Predicate,
 }
 
 impl Update {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env
-            .tables
+            .tables_mut()
             .iter_mut()
             .find(|t| t.name == self.table)
             .unwrap();

--- a/simulator/model/query/update.rs
+++ b/simulator/model/query/update.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -13,8 +13,8 @@ pub struct Update {
     pub predicate: Predicate,
 }
 
-impl Update {
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Update {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env
             .tables_mut()
             .iter_mut()

--- a/simulator/model/table.rs
+++ b/simulator/model/table.rs
@@ -15,18 +15,18 @@ impl Deref for Name {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct Table {
-    pub(crate) rows: Vec<Vec<SimValue>>,
-    pub(crate) name: String,
-    pub(crate) columns: Vec<Column>,
+pub struct Table {
+    pub rows: Vec<Vec<SimValue>>,
+    pub name: String,
+    pub columns: Vec<Column>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct Column {
-    pub(crate) name: String,
-    pub(crate) column_type: ColumnType,
-    pub(crate) primary: bool,
-    pub(crate) unique: bool,
+pub struct Column {
+    pub name: String,
+    pub column_type: ColumnType,
+    pub primary: bool,
+    pub unique: bool,
 }
 
 // Uniquely defined by name in this case
@@ -45,7 +45,7 @@ impl PartialEq for Column {
 impl Eq for Column {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum ColumnType {
+pub enum ColumnType {
     Integer,
     Float,
     Text,
@@ -63,23 +63,8 @@ impl Display for ColumnType {
     }
 }
 
-fn float_to_string<S>(float: &f64, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(&format!("{}", float))
-}
-
-fn string_to_float<'de, D>(deserializer: D) -> Result<f64, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    s.parse().map_err(serde::de::Error::custom)
-}
-
 #[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
-pub(crate) struct SimValue(pub turso_core::Value);
+pub struct SimValue(pub turso_core::Value);
 
 fn to_sqlite_blob(bytes: &[u8]) -> String {
     format!(

--- a/simulator/runner/bugbase.rs
+++ b/simulator/runner/bugbase.rs
@@ -8,9 +8,10 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
+use limbo_sim::generation::plan::InteractionPlan;
 use serde::{Deserialize, Serialize};
 
-use crate::{generation::plan::InteractionPlan, Paths};
+use crate::Paths;
 
 use super::cli::SimulatorCLI;
 

--- a/simulator/runner/bugbase.rs
+++ b/simulator/runner/bugbase.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{InteractionPlan, Paths};
+use crate::{generation::plan::InteractionPlan, Paths};
 
 use super::cli::SimulatorCLI;
 

--- a/simulator/runner/bugbase.rs
+++ b/simulator/runner/bugbase.rs
@@ -8,8 +8,8 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
-use limbo_sim::generation::plan::InteractionPlan;
 use serde::{Deserialize, Serialize};
+use turso_sim::generation::plan::InteractionPlan;
 
 use crate::Paths;
 

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use turso_core::Value;
-use limbo_sim::{
+use turso_sim::{
     generation::{
         pick_index,
         plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -5,11 +5,10 @@ use turso_core::Value;
 use crate::{
     generation::{
         pick_index,
-        plan::{Interaction, InteractionPlanState, ResultSet},
+        plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
     },
     model::{query::Query, table::SimValue},
     runner::execution::ExecutionContinuation,
-    InteractionPlan,
 };
 
 use super::{

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -12,13 +12,13 @@ use limbo_sim::{
 use crate::runner::execution::ExecutionContinuation;
 
 use super::{
-    env::LimboSimulatorEnv,
+    env::TursoSimulatorEnv,
     execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult},
 };
 
 pub(crate) fn run_simulation(
-    env: Arc<Mutex<LimboSimulatorEnv>>,
-    rusqlite_env: Arc<Mutex<LimboSimulatorEnv>>,
+    env: Arc<Mutex<TursoSimulatorEnv>>,
+    rusqlite_env: Arc<Mutex<TursoSimulatorEnv>>,
     rusqlite_conn: &dyn Fn() -> rusqlite::Connection,
     plans: &mut [InteractionPlan],
     last_execution: Arc<Mutex<Execution>>,
@@ -115,8 +115,8 @@ fn execute_query_rusqlite(
 }
 
 pub(crate) fn execute_plans(
-    env: Arc<Mutex<LimboSimulatorEnv>>,
-    rusqlite_env: Arc<Mutex<LimboSimulatorEnv>>,
+    env: Arc<Mutex<TursoSimulatorEnv>>,
+    rusqlite_env: Arc<Mutex<TursoSimulatorEnv>>,
     rusqlite_conn: &dyn Fn() -> rusqlite::Connection,
     plans: &mut [InteractionPlan],
     states: &mut [InteractionPlanState],
@@ -173,8 +173,8 @@ pub(crate) fn execute_plans(
 }
 
 fn execute_plan(
-    env: &mut LimboSimulatorEnv,
-    rusqlite_env: &mut LimboSimulatorEnv,
+    env: &mut TursoSimulatorEnv,
+    rusqlite_env: &mut TursoSimulatorEnv,
     rusqlite_conn: &dyn Fn() -> rusqlite::Connection,
     connection_index: usize,
     plans: &mut [InteractionPlan],
@@ -311,7 +311,7 @@ fn execute_plan(
 }
 
 fn execute_interaction_rusqlite(
-    env: &mut LimboSimulatorEnv,
+    env: &mut TursoSimulatorEnv,
     connection_index: usize,
     interaction: &Interaction,
     stack: &mut Vec<ResultSet>,

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -12,13 +12,13 @@ use crate::{
 };
 
 use super::{
-    env::{SimConnection, SimulatorEnv},
+    env::{SimConnection, LimboSimulatorEnv},
     execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult},
 };
 
 pub(crate) fn run_simulation(
-    env: Arc<Mutex<SimulatorEnv>>,
-    rusqlite_env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
+    rusqlite_env: Arc<Mutex<LimboSimulatorEnv>>,
     rusqlite_conn: &dyn Fn() -> rusqlite::Connection,
     plans: &mut [InteractionPlan],
     last_execution: Arc<Mutex<Execution>>,
@@ -115,8 +115,8 @@ fn execute_query_rusqlite(
 }
 
 pub(crate) fn execute_plans(
-    env: Arc<Mutex<SimulatorEnv>>,
-    rusqlite_env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
+    rusqlite_env: Arc<Mutex<LimboSimulatorEnv>>,
     rusqlite_conn: &dyn Fn() -> rusqlite::Connection,
     plans: &mut [InteractionPlan],
     states: &mut [InteractionPlanState],
@@ -173,8 +173,8 @@ pub(crate) fn execute_plans(
 }
 
 fn execute_plan(
-    env: &mut SimulatorEnv,
-    rusqlite_env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
+    rusqlite_env: &mut LimboSimulatorEnv,
     rusqlite_conn: &dyn Fn() -> rusqlite::Connection,
     connection_index: usize,
     plans: &mut [InteractionPlan],
@@ -311,7 +311,7 @@ fn execute_plan(
 }
 
 fn execute_interaction_rusqlite(
-    env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
     connection_index: usize,
     interaction: &Interaction,
     stack: &mut Vec<ResultSet>,

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -1,18 +1,12 @@
 use std::sync::{Arc, Mutex};
 
 use turso_core::Value;
+use limbo_sim::{generation::{pick_index, plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet}}, model::{query::Query, table::SimValue, SimConnection}};
 
-use crate::{
-    generation::{
-        pick_index,
-        plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
-    },
-    model::{query::Query, table::SimValue},
-    runner::execution::ExecutionContinuation,
-};
+use crate::runner::execution::ExecutionContinuation;
 
 use super::{
-    env::{SimConnection, LimboSimulatorEnv},
+    env::LimboSimulatorEnv,
     execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult},
 };
 

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -1,7 +1,13 @@
 use std::sync::{Arc, Mutex};
 
 use turso_core::Value;
-use limbo_sim::{generation::{pick_index, plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet}}, model::{query::Query, table::SimValue, SimConnection}};
+use limbo_sim::{
+    generation::{
+        pick_index,
+        plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
+    },
+    model::{query::Query, table::SimValue, SimConnection},
+};
 
 use crate::runner::execution::ExecutionContinuation;
 

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -10,7 +10,7 @@ use crate::runner::io::SimulatorIO;
 
 use super::cli::SimulatorCLI;
 
-pub(crate) struct LimboSimulatorEnv {
+pub(crate) struct TursoSimulatorEnv {
     pub(crate) opts: SimulatorOpts,
     pub(crate) tables: Vec<Table>,
     pub(crate) connections: Vec<SimConnection>,
@@ -20,7 +20,7 @@ pub(crate) struct LimboSimulatorEnv {
     pub(crate) db_path: String,
 }
 
-impl SimulatorEnv for LimboSimulatorEnv {
+impl SimulatorEnv for TursoSimulatorEnv {
     fn tables(&self) -> &[Table] {
         &self.tables
     }
@@ -66,7 +66,7 @@ impl SimulatorEnv for LimboSimulatorEnv {
     }
 }
 
-impl LimboSimulatorEnv {
+impl TursoSimulatorEnv {
     pub(crate) fn new(seed: u64, cli_opts: &SimulatorCLI, db_path: &Path) -> Self {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
@@ -176,7 +176,7 @@ impl LimboSimulatorEnv {
             .map(|_| SimConnection::Disconnected)
             .collect::<Vec<_>>();
 
-        LimboSimulatorEnv {
+        TursoSimulatorEnv {
             opts,
             tables: Vec::new(),
             connections,
@@ -188,7 +188,7 @@ impl LimboSimulatorEnv {
     }
 
     pub(crate) fn clone_without_connections(&self) -> Self {
-        LimboSimulatorEnv {
+        TursoSimulatorEnv {
             opts: self.opts.clone(),
             tables: self.tables.clone(),
             connections: (0..self.connections.len())

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use limbo_sim::model::{table::Table, SimConnection, SimulatorEnv, SimulatorOpts};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use turso_core::{Database, IO};
+use turso_sim::model::{table::Table, SimConnection, SimulatorEnv, SimulatorOpts};
 
 use crate::runner::io::SimulatorIO;
 

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -1,13 +1,10 @@
-use std::fmt::Display;
-use std::mem;
 use std::path::Path;
 use std::sync::Arc;
 
+use limbo_sim::model::{table::Table, SimConnection, SimulatorEnv, SimulatorOpts};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use turso_core::Database;
-
-use crate::model::table::Table;
+use turso_core::{Database, IO};
 
 use crate::runner::io::SimulatorIO;
 
@@ -23,19 +20,49 @@ pub(crate) struct LimboSimulatorEnv {
     pub(crate) db_path: String,
 }
 
-impl LimboSimulatorEnv {
-    pub(crate) fn clone_without_connections(&self) -> Self {
-        LimboSimulatorEnv {
-            opts: self.opts.clone(),
-            tables: self.tables.clone(),
-            connections: (0..self.connections.len())
-                .map(|_| SimConnection::Disconnected)
-                .collect(),
-            io: self.io.clone(),
-            db: self.db.clone(),
-            rng: self.rng.clone(),
-            db_path: self.db_path.clone(),
-        }
+impl SimulatorEnv for LimboSimulatorEnv {
+    fn tables(&self) -> &[Table] {
+        &self.tables
+    }
+
+    fn tables_mut(&mut self) -> &mut [Table] {
+        &mut self.tables
+    }
+
+    fn add_table(&mut self, table: Table) {
+        self.tables.push(table);
+    }
+
+    fn remove_table(&mut self, table_name: &str) {
+        self.tables.retain(|t| t.name != table_name);
+    }
+
+    fn opts(&self) -> &SimulatorOpts {
+        &self.opts
+    }
+
+    fn connections(&self) -> &[SimConnection] {
+        &self.connections
+    }
+
+    fn connections_mut(&mut self) -> &mut Vec<SimConnection> {
+        &mut self.connections
+    }
+
+    fn db_path(&self) -> &str {
+        &self.db_path
+    }
+
+    fn io(&self) -> Arc<dyn IO> {
+        self.io.clone()
+    }
+
+    fn get_db(&self) -> Arc<Database> {
+        self.db.clone()
+    }
+
+    fn set_db(&mut self, db: Arc<Database>) {
+        self.db = db;
     }
 }
 
@@ -159,86 +186,18 @@ impl LimboSimulatorEnv {
             db_path: db_path.to_str().unwrap().to_string(),
         }
     }
-}
 
-pub trait ConnectionTrait
-where
-    Self: std::marker::Sized + Clone,
-{
-    fn is_connected(&self) -> bool;
-    fn disconnect(&mut self);
-}
-
-pub(crate) enum SimConnection {
-    LimboConnection(Arc<turso_core::Connection>),
-    SQLiteConnection(rusqlite::Connection),
-    Disconnected,
-}
-
-impl SimConnection {
-    pub(crate) fn is_connected(&self) -> bool {
-        match self {
-            SimConnection::LimboConnection(_) | SimConnection::SQLiteConnection(_) => true,
-            SimConnection::Disconnected => false,
+    pub(crate) fn clone_without_connections(&self) -> Self {
+        LimboSimulatorEnv {
+            opts: self.opts.clone(),
+            tables: self.tables.clone(),
+            connections: (0..self.connections.len())
+                .map(|_| SimConnection::Disconnected)
+                .collect(),
+            io: self.io.clone(),
+            db: self.db.clone(),
+            db_path: self.db_path.clone(),
+            rng: self.rng.clone(),
         }
     }
-    pub(crate) fn disconnect(&mut self) {
-        let conn = mem::replace(self, SimConnection::Disconnected);
-
-        match conn {
-            SimConnection::LimboConnection(conn) => {
-                conn.close().unwrap();
-            }
-            SimConnection::SQLiteConnection(conn) => {
-                conn.close().unwrap();
-            }
-            SimConnection::Disconnected => {}
-        }
-    }
-}
-
-impl Display for SimConnection {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SimConnection::LimboConnection(_) => {
-                write!(f, "LimboConnection")
-            }
-            SimConnection::SQLiteConnection(_) => {
-                write!(f, "SQLiteConnection")
-            }
-            SimConnection::Disconnected => {
-                write!(f, "Disconnected")
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct SimulatorOpts {
-    pub(crate) ticks: usize,
-    pub(crate) max_connections: usize,
-    pub(crate) max_tables: usize,
-    // this next options are the distribution of workload where read_percent + write_percent +
-    // delete_percent == 100%
-    pub(crate) create_percent: f64,
-    pub(crate) create_index_percent: f64,
-    pub(crate) read_percent: f64,
-    pub(crate) write_percent: f64,
-    pub(crate) delete_percent: f64,
-    pub(crate) update_percent: f64,
-    pub(crate) drop_percent: f64,
-
-    pub(crate) disable_select_optimizer: bool,
-    pub(crate) disable_insert_values_select: bool,
-    pub(crate) disable_double_create_failure: bool,
-    pub(crate) disable_select_limit: bool,
-    pub(crate) disable_delete_select: bool,
-    pub(crate) disable_drop_select: bool,
-    pub(crate) disable_fsync_no_wait: bool,
-    pub(crate) disable_faulty_query: bool,
-    pub(crate) disable_reopen_database: bool,
-
-    pub(crate) max_interactions: usize,
-    pub(crate) page_size: usize,
-    pub(crate) max_time_simulation: usize,
 }

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -13,7 +13,7 @@ use crate::runner::io::SimulatorIO;
 
 use super::cli::SimulatorCLI;
 
-pub(crate) struct SimulatorEnv {
+pub(crate) struct LimboSimulatorEnv {
     pub(crate) opts: SimulatorOpts,
     pub(crate) tables: Vec<Table>,
     pub(crate) connections: Vec<SimConnection>,
@@ -23,9 +23,9 @@ pub(crate) struct SimulatorEnv {
     pub(crate) db_path: String,
 }
 
-impl SimulatorEnv {
+impl LimboSimulatorEnv {
     pub(crate) fn clone_without_connections(&self) -> Self {
-        SimulatorEnv {
+        LimboSimulatorEnv {
             opts: self.opts.clone(),
             tables: self.tables.clone(),
             connections: (0..self.connections.len())
@@ -39,7 +39,7 @@ impl SimulatorEnv {
     }
 }
 
-impl SimulatorEnv {
+impl LimboSimulatorEnv {
     pub(crate) fn new(seed: u64, cli_opts: &SimulatorCLI, db_path: &Path) -> Self {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
@@ -149,7 +149,7 @@ impl SimulatorEnv {
             .map(|_| SimConnection::Disconnected)
             .collect::<Vec<_>>();
 
-        SimulatorEnv {
+        LimboSimulatorEnv {
             opts,
             tables: Vec::new(),
             connections,

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -10,7 +10,7 @@ use limbo_sim::{
 use tracing::instrument;
 use turso_core::{Connection, LimboError, Result, StepResult};
 
-use crate::runner::env::LimboSimulatorEnv;
+use crate::runner::env::TursoSimulatorEnv;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Execution {
@@ -58,7 +58,7 @@ impl ExecutionResult {
 }
 
 pub(crate) fn execute_plans(
-    env: Arc<Mutex<LimboSimulatorEnv>>,
+    env: Arc<Mutex<TursoSimulatorEnv>>,
     plans: &mut [InteractionPlan],
     states: &mut [InteractionPlanState],
     last_execution: Arc<Mutex<Execution>>,
@@ -108,7 +108,7 @@ pub(crate) fn execute_plans(
 }
 
 fn execute_plan(
-    env: &mut LimboSimulatorEnv,
+    env: &mut TursoSimulatorEnv,
     connection_index: usize,
     plans: &mut [InteractionPlan],
     states: &mut [InteractionPlanState],
@@ -178,7 +178,7 @@ pub(crate) enum ExecutionContinuation {
 
 #[instrument(skip(env, interaction, stack), fields(interaction = %interaction))]
 pub(crate) fn execute_interaction(
-    env: &mut LimboSimulatorEnv,
+    env: &mut TursoSimulatorEnv,
     connection_index: usize,
     interaction: &Interaction,
     stack: &mut Vec<ResultSet>,

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -5,7 +5,7 @@ use limbo_sim::{
         pick_index,
         plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
     },
-    model::SimConnection,
+    model::{Shadow as _, SimConnection},
 };
 use tracing::instrument;
 use turso_core::{Connection, LimboError, Result, StepResult};

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -8,7 +8,7 @@ use crate::generation::{
     plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
 };
 
-use super::env::{SimConnection, SimulatorEnv};
+use super::env::{SimConnection, LimboSimulatorEnv};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Execution {
@@ -56,7 +56,7 @@ impl ExecutionResult {
 }
 
 pub(crate) fn execute_plans(
-    env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
     plans: &mut [InteractionPlan],
     states: &mut [InteractionPlanState],
     last_execution: Arc<Mutex<Execution>>,
@@ -106,7 +106,7 @@ pub(crate) fn execute_plans(
 }
 
 fn execute_plan(
-    env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
     connection_index: usize,
     plans: &mut [InteractionPlan],
     states: &mut [InteractionPlanState],
@@ -176,7 +176,7 @@ pub(crate) enum ExecutionContinuation {
 
 #[instrument(skip(env, interaction, stack), fields(interaction = %interaction))]
 pub(crate) fn execute_interaction(
-    env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
     connection_index: usize,
     interaction: &Interaction,
     stack: &mut Vec<ResultSet>,

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -236,7 +236,7 @@ pub(crate) fn execute_interaction(
                 SimConnection::Disconnected => unreachable!(),
             };
 
-            let results = interaction.execute_faulty_query(&conn, env);
+            let results = interaction.execute_faulty_query(&conn, env, &mut env.rng.clone());
             tracing::debug!(?results);
             stack.push(results);
             // Reset fault injection

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -1,14 +1,14 @@
 use std::sync::{Arc, Mutex};
 
-use limbo_sim::{
+use tracing::instrument;
+use turso_core::{Connection, LimboError, Result, StepResult};
+use turso_sim::{
     generation::{
         pick_index,
         plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
     },
     model::{Shadow as _, SimConnection},
 };
-use tracing::instrument;
-use turso_core::{Connection, LimboError, Result, StepResult};
 
 use crate::runner::env::TursoSimulatorEnv;
 

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -1,14 +1,16 @@
 use std::sync::{Arc, Mutex};
 
+use limbo_sim::{
+    generation::{
+        pick_index,
+        plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
+    },
+    model::SimConnection,
+};
 use tracing::instrument;
 use turso_core::{Connection, LimboError, Result, StepResult};
 
-use crate::generation::{
-    pick_index,
-    plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
-};
-
-use super::env::{SimConnection, LimboSimulatorEnv};
+use crate::runner::env::LimboSimulatorEnv;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Execution {
@@ -191,7 +193,7 @@ pub(crate) fn execute_interaction(
                 SimConnection::Disconnected => unreachable!(),
             };
 
-            let results = interaction.execute_query(conn, &env.io);
+            let results = interaction.execute_query(conn);
             tracing::debug!(?results);
             stack.push(results);
             limbo_integrity_check(conn)?;

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -116,6 +116,6 @@ impl IO for SimulatorIO {
     }
 
     fn get_memory_io(&self) -> Arc<turso_core::MemoryIO> {
-        todo!()
+        Arc::new(turso_core::MemoryIO::new())
     }
 }

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use limbo_sim::{
+use turso_sim::{
     generation::{
         pick_index,
         plan::{Interaction, InteractionPlanState},

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -9,12 +9,12 @@ use crate::{
 };
 
 use super::{
-    env::{SimConnection, SimulatorEnv},
+    env::{SimConnection, LimboSimulatorEnv},
     execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult},
 };
 
 pub(crate) fn run_simulation(
-    env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
     plans: &mut [Vec<Vec<Interaction>>],
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {
@@ -37,7 +37,7 @@ pub(crate) fn run_simulation(
 }
 
 pub(crate) fn execute_plans(
-    env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
     plans: &mut [Vec<Vec<Interaction>>],
     states: &mut [InteractionPlanState],
     last_execution: Arc<Mutex<Execution>>,
@@ -81,7 +81,7 @@ pub(crate) fn execute_plans(
 }
 
 fn execute_plan(
-    env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
     connection_index: usize,
     plans: &mut [Vec<Vec<Interaction>>],
     states: &mut [InteractionPlanState],

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -1,17 +1,16 @@
 use std::sync::{Arc, Mutex};
 
-use crate::{
+use limbo_sim::{
     generation::{
         pick_index,
         plan::{Interaction, InteractionPlanState},
     },
-    runner::execution::ExecutionContinuation,
+    model::SimConnection,
 };
 
-use super::{
-    env::{SimConnection, LimboSimulatorEnv},
-    execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult},
-};
+use crate::runner::{env::LimboSimulatorEnv, execution::ExecutionContinuation};
+
+use super::execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult};
 
 pub(crate) fn run_simulation(
     env: Arc<Mutex<LimboSimulatorEnv>>,

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -8,12 +8,12 @@ use limbo_sim::{
     model::SimConnection,
 };
 
-use crate::runner::{env::LimboSimulatorEnv, execution::ExecutionContinuation};
+use crate::runner::{env::TursoSimulatorEnv, execution::ExecutionContinuation};
 
 use super::execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult};
 
 pub(crate) fn run_simulation(
-    env: Arc<Mutex<LimboSimulatorEnv>>,
+    env: Arc<Mutex<TursoSimulatorEnv>>,
     plans: &mut [Vec<Vec<Interaction>>],
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {
@@ -36,7 +36,7 @@ pub(crate) fn run_simulation(
 }
 
 pub(crate) fn execute_plans(
-    env: Arc<Mutex<LimboSimulatorEnv>>,
+    env: Arc<Mutex<TursoSimulatorEnv>>,
     plans: &mut [Vec<Vec<Interaction>>],
     states: &mut [InteractionPlanState],
     last_execution: Arc<Mutex<Execution>>,
@@ -80,7 +80,7 @@ pub(crate) fn execute_plans(
 }
 
 fn execute_plan(
-    env: &mut LimboSimulatorEnv,
+    env: &mut TursoSimulatorEnv,
     connection_index: usize,
     plans: &mut [Vec<Vec<Interaction>>],
     states: &mut [InteractionPlanState],

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -1,4 +1,4 @@
-use limbo_sim::{
+use turso_sim::{
     generation::{
         plan::{Interaction, InteractionPlan, Interactions},
         property::Property,

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -1,106 +1,107 @@
-use crate::{
+use limbo_sim::{
     generation::{
         plan::{Interaction, InteractionPlan, Interactions},
         property::Property,
     },
     model::query::Query,
-    runner::execution::Execution,
 };
 
-impl InteractionPlan {
-    /// Create a smaller interaction plan by deleting a property
-    pub(crate) fn shrink_interaction_plan(&self, failing_execution: &Execution) -> InteractionPlan {
-        // todo: this is a very naive implementation, next steps are;
-        // - Shrink to multiple values by removing random interactions
-        // - Shrink properties by removing their extensions, or shrinking their values
-        let mut plan = self.clone();
-        let failing_property = &self.plan[failing_execution.interaction_index];
-        let mut depending_tables = failing_property.dependencies();
+use crate::runner::execution::Execution;
 
-        let interactions = failing_property.interactions();
+/// Create a smaller interaction plan by deleting a property
+pub(crate) fn shrink_interaction_plan(
+    curr_plan: &InteractionPlan,
+    failing_execution: &Execution,
+) -> InteractionPlan {
+    // todo: this is a very naive implementation, next steps are;
+    // - Shrink to multiple values by removing random interactions
+    // - Shrink properties by removing their extensions, or shrinking their values
+    let mut plan = curr_plan.clone();
+    let failing_property = &curr_plan.plan[failing_execution.interaction_index];
+    let mut depending_tables = failing_property.dependencies();
 
-        {
-            let mut idx = failing_execution.secondary_index;
-            loop {
-                match &interactions[idx] {
-                    Interaction::Query(query) => {
-                        depending_tables = query.dependencies();
+    let interactions = failing_property.interactions();
+
+    {
+        let mut idx = failing_execution.secondary_index;
+        loop {
+            match &interactions[idx] {
+                Interaction::Query(query) => {
+                    depending_tables = query.dependencies();
+                    break;
+                }
+                // Fault does not depend on
+                Interaction::Fault(..) => break,
+                _ => {
+                    // In principle we should never fail this checked_sub.
+                    // But if there is a bug in how we count the secondary index
+                    // we may panic if we do not use a checked_sub.
+                    if let Some(new_idx) = idx.checked_sub(1) {
+                        idx = new_idx;
+                    } else {
+                        tracing::warn!("failed to find error query");
                         break;
-                    }
-                    // Fault does not depend on
-                    Interaction::Fault(..) => break,
-                    _ => {
-                        // In principle we should never fail this checked_sub.
-                        // But if there is a bug in how we count the secondary index
-                        // we may panic if we do not use a checked_sub.
-                        if let Some(new_idx) = idx.checked_sub(1) {
-                            idx = new_idx;
-                        } else {
-                            tracing::warn!("failed to find error query");
-                            break;
-                        }
                     }
                 }
             }
         }
+    }
 
-        let before = self.plan.len();
+    let before = curr_plan.plan.len();
 
-        // Remove all properties after the failing one
-        plan.plan.truncate(failing_execution.interaction_index + 1);
+    // Remove all properties after the failing one
+    plan.plan.truncate(failing_execution.interaction_index + 1);
 
-        let mut idx = 0;
-        // Remove all properties that do not use the failing tables
-        plan.plan.retain_mut(|interactions| {
-            let retain = if idx == failing_execution.interaction_index {
-                true
-            } else {
-                let mut has_table = interactions
+    let mut idx = 0;
+    // Remove all properties that do not use the failing tables
+    plan.plan.retain_mut(|interactions| {
+        let retain = if idx == failing_execution.interaction_index {
+            true
+        } else {
+            let mut has_table = interactions
+                .uses()
+                .iter()
+                .any(|t| depending_tables.contains(t));
+            if has_table {
+                // Remove the extensional parts of the properties
+                if let Interactions::Property(p) = interactions {
+                    match p {
+                        Property::InsertValuesSelect { queries, .. }
+                        | Property::DoubleCreateFailure { queries, .. }
+                        | Property::DeleteSelect { queries, .. }
+                        | Property::DropSelect { queries, .. } => {
+                            queries.clear();
+                        }
+                        Property::SelectLimit { .. } | Property::SelectSelectOptimizer { .. }
+                            | Property::FsyncNoWait { .. }
+                            | Property::FaultyQuery { .. } => {}
+                    }
+                }
+                // Check again after query clear if the interactions still uses the failing table
+                has_table = interactions
                     .uses()
                     .iter()
                     .any(|t| depending_tables.contains(t));
-                if has_table {
-                    // Remove the extensional parts of the properties
-                    if let Interactions::Property(p) = interactions {
-                        match p {
-                            Property::InsertValuesSelect { queries, .. }
-                            | Property::DoubleCreateFailure { queries, .. }
-                            | Property::DeleteSelect { queries, .. }
-                            | Property::DropSelect { queries, .. } => {
-                                queries.clear();
-                            }
-                            Property::SelectLimit { .. }
-                            | Property::SelectSelectOptimizer { .. }
-                            | Property::FsyncNoWait { .. }
-                            | Property::FaultyQuery { .. } => {}
-                        }
-                    }
-                    // Check again after query clear if the interactions still uses the failing table
-                    has_table = interactions
-                        .uses()
-                        .iter()
-                        .any(|t| depending_tables.contains(t));
-                }
-                has_table
-                    && !matches!(
-                        interactions,
-                        Interactions::Query(Query::Select(_))
-                            | Interactions::Property(Property::SelectLimit { .. })
-                            | Interactions::Property(Property::SelectSelectOptimizer { .. })
-                    )
-            };
-            idx += 1;
-            retain
-        });
+            }
+            has_table
+                && !matches!(
+                    interactions,
+                    Interactions::Query(Query::Select(_))
+                        | Interactions::Property(Property::SelectLimit { .. })
+                        | Interactions::Property(Property::SelectSelectOptimizer { .. })
+                )
+        };
+        idx += 1;
+        retain
+    });
 
-        let after = plan.plan.len();
+    let after = plan.plan.len();
 
-        tracing::info!(
-            "Shrinking interaction plan from {} to {} properties",
-            before,
-            after
-        );
+    tracing::info!(
+        "Shrinking interaction plan from {} to {} properties",
+        before,
+        after
+    );
 
-        plan
-    }
+    plan
 }

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -72,9 +72,10 @@ pub(crate) fn shrink_interaction_plan(
                         | Property::DropSelect { queries, .. } => {
                             queries.clear();
                         }
-                        Property::SelectLimit { .. } | Property::SelectSelectOptimizer { .. }
-                            | Property::FsyncNoWait { .. }
-                            | Property::FaultyQuery { .. } => {}
+                        Property::SelectLimit { .. }
+                        | Property::SelectSelectOptimizer { .. }
+                        | Property::FsyncNoWait { .. }
+                        | Property::FaultyQuery { .. } => {}
                     }
                 }
                 // Check again after query clear if the interactions still uses the failing table

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -1,11 +1,10 @@
 use crate::{
     generation::{
-        plan::{InteractionPlan, Interactions},
+        plan::{Interaction, InteractionPlan, Interactions},
         property::Property,
     },
     model::query::Query,
     runner::execution::Execution,
-    Interaction,
 };
 
 impl InteractionPlan {


### PR DESCRIPTION
I want to expand our stress testing in Rust by leveraging our existing Sql generation in the Limbo simulator. There are some things that Antithesis can test which we currently do not (or maybe cannot) test in the Simulator. To accomplish that we need to extract the model and generation logic from the Simulator into a library. 

This PR separates the logic for the SQL models and generation to its own libraries, and abstracts the `SimulatorEnv` into a trait, so that other libraries can also generate SQL structs. While I was at it, a lot of structs had a shadow function , so I just generalized it over a `Shadow` trait.