### PR TITLE
WIP: Integrate Stress test query generation with Simulator generation

### DIFF
--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -14,6 +14,10 @@ publish = false
 name = "limbo_sim"
 path = "main.rs"
 
+[lib]
+name = "limbo_sim"
+path = "lib.rs"
+
 [dependencies]
 limbo_core = { path = "../core", features = ["simulator"]}
 rand = "0.8.5"

--- a/simulator/generation/expr.rs
+++ b/simulator/generation/expr.rs
@@ -5,7 +5,7 @@ use limbo_sqlite3_parser::ast::{
 use crate::{
     generation::{gen_random_text, pick, pick_index, Arbitrary, ArbitraryFrom},
     model::table::SimValue,
-    SimulatorEnv,
+    runner::env::SimulatorEnv,
 };
 
 impl<T> Arbitrary for Box<T>

--- a/simulator/generation/expr.rs
+++ b/simulator/generation/expr.rs
@@ -5,7 +5,7 @@ use limbo_sqlite3_parser::ast::{
 use crate::{
     generation::{gen_random_text, pick, pick_index, Arbitrary, ArbitraryFrom},
     model::table::SimValue,
-    runner::env::SimulatorEnv,
+    runner::env::LimboSimulatorEnv,
 };
 
 impl<T> Arbitrary for Box<T>
@@ -55,8 +55,8 @@ where
 }
 
 // Freestyling generation
-impl ArbitraryFrom<&SimulatorEnv> for Expr {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Expr {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &LimboSimulatorEnv) -> Self {
         let choice = rng.gen_range(0..13);
 
         match choice {
@@ -196,8 +196,8 @@ impl Arbitrary for CollateName {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for QualifiedName {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for QualifiedName {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, t: &LimboSimulatorEnv) -> Self {
         // TODO: for now just generate table name
         let table_idx = pick_index(t.tables.len(), rng);
         let table = &t.tables[table_idx];
@@ -206,8 +206,8 @@ impl ArbitraryFrom<&SimulatorEnv> for QualifiedName {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for LikeOperator {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for LikeOperator {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &LimboSimulatorEnv) -> Self {
         let choice = rng.gen_range(0..4);
         match choice {
             0 => LikeOperator::Glob,
@@ -220,8 +220,8 @@ impl ArbitraryFrom<&SimulatorEnv> for LikeOperator {
 }
 
 // Current implementation does not take into account the columns affinity nor if table is Strict
-impl ArbitraryFrom<&SimulatorEnv> for ast::Literal {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for ast::Literal {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &LimboSimulatorEnv) -> Self {
         loop {
             let choice = rng.gen_range(0..5);
             let lit = match choice {
@@ -258,8 +258,8 @@ impl ArbitraryFrom<&Vec<&SimValue>> for ast::Expr {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for UnaryOperator {
-    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for UnaryOperator {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, _t: &LimboSimulatorEnv) -> Self {
         let choice = rng.gen_range(0..4);
         match choice {
             0 => Self::BitwiseNot,

--- a/simulator/generation/mod.rs
+++ b/simulator/generation/mod.rs
@@ -113,11 +113,7 @@ pub fn pick_index<R: Rng>(choices: usize, rng: &mut R) -> usize {
 
 /// pick_n_unique is a helper function for uniformly picking N unique elements from a range.
 /// The elements themselves are usize, typically representing indices.
-pub fn pick_n_unique<R: Rng>(
-    range: std::ops::Range<usize>,
-    n: usize,
-    rng: &mut R,
-) -> Vec<usize> {
+pub fn pick_n_unique<R: Rng>(range: std::ops::Range<usize>, n: usize, rng: &mut R) -> Vec<usize> {
     use rand::seq::SliceRandom;
     let mut items: Vec<usize> = range.collect();
     items.shuffle(rng);

--- a/simulator/generation/mod.rs
+++ b/simulator/generation/mod.rs
@@ -44,7 +44,7 @@ pub trait ArbitraryFromMaybe<T> {
 /// the operations we require for the implementation.
 // todo: switch to a simpler type signature that can accommodate all integer and float types, which
 //       should be enough for our purposes.
-pub(crate) fn frequency<
+pub fn frequency<
     T,
     R: Rng,
     N: Sum + PartialOrd + Copy + Default + SampleUniform + SubAssign,
@@ -66,7 +66,7 @@ pub(crate) fn frequency<
 }
 
 /// one_of is a helper function for composing different generators with equal probability of occurrence.
-pub(crate) fn one_of<T, R: Rng>(choices: Vec<ArbitraryFromFunc<R, T>>, rng: &mut R) -> T {
+pub fn one_of<T, R: Rng>(choices: Vec<ArbitraryFromFunc<R, T>>, rng: &mut R) -> T {
     let index = rng.gen_range(0..choices.len());
     choices[index](rng)
 }
@@ -74,7 +74,7 @@ pub(crate) fn one_of<T, R: Rng>(choices: Vec<ArbitraryFromFunc<R, T>>, rng: &mut
 /// backtrack is a helper function for composing different "failable" generators.
 /// The function takes a list of functions that return an Option<T>, along with number of retries
 /// to make before giving up.
-pub(crate) fn backtrack<T, R: Rng>(mut choices: Vec<Choice<R, T>>, rng: &mut R) -> Option<T> {
+pub fn backtrack<T, R: Rng>(mut choices: Vec<Choice<R, T>>, rng: &mut R) -> Option<T> {
     loop {
         // If there are no more choices left, we give up
         let choices_ = choices
@@ -100,20 +100,20 @@ pub(crate) fn backtrack<T, R: Rng>(mut choices: Vec<Choice<R, T>>, rng: &mut R) 
 }
 
 /// pick is a helper function for uniformly picking a random element from a slice
-pub(crate) fn pick<'a, T, R: Rng>(choices: &'a [T], rng: &mut R) -> &'a T {
+pub fn pick<'a, T, R: Rng>(choices: &'a [T], rng: &mut R) -> &'a T {
     let index = rng.gen_range(0..choices.len());
     &choices[index]
 }
 
 /// pick_index is typically used for picking an index from a slice to later refer to the element
 /// at that index.
-pub(crate) fn pick_index<R: Rng>(choices: usize, rng: &mut R) -> usize {
+pub fn pick_index<R: Rng>(choices: usize, rng: &mut R) -> usize {
     rng.gen_range(0..choices)
 }
 
 /// pick_n_unique is a helper function for uniformly picking N unique elements from a range.
 /// The elements themselves are usize, typically representing indices.
-pub(crate) fn pick_n_unique<R: Rng>(
+pub fn pick_n_unique<R: Rng>(
     range: std::ops::Range<usize>,
     n: usize,
     rng: &mut R,
@@ -126,7 +126,7 @@ pub(crate) fn pick_n_unique<R: Rng>(
 
 /// gen_random_text uses `anarchist_readable_name_generator_lib` to generate random
 /// readable names for tables, columns, text values etc.
-pub(crate) fn gen_random_text<T: Rng>(rng: &mut T) -> String {
+pub fn gen_random_text<T: Rng>(rng: &mut T) -> String {
     let big_text = rng.gen_ratio(1, 1000);
     if big_text {
         // let max_size: u64 = 2 * 1024 * 1024 * 1024;

--- a/simulator/generation/mod.rs
+++ b/simulator/generation/mod.rs
@@ -44,11 +44,7 @@ pub trait ArbitraryFromMaybe<T> {
 /// the operations we require for the implementation.
 // todo: switch to a simpler type signature that can accommodate all integer and float types, which
 //       should be enough for our purposes.
-pub fn frequency<
-    T,
-    R: Rng,
-    N: Sum + PartialOrd + Copy + Default + SampleUniform + SubAssign,
->(
+pub fn frequency<T, R: Rng, N: Sum + PartialOrd + Copy + Default + SampleUniform + SubAssign>(
     choices: Vec<(N, ArbitraryFromFunc<R, T>)>,
     rng: &mut R,
 ) -> T {

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -468,6 +468,12 @@ impl InteractionPlan {
     }
 }
 
+impl Default for InteractionPlan {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<E: SimulatorEnv> ArbitraryFrom<&mut E> for InteractionPlan {
     fn arbitrary_from<R: rand::Rng>(rng: &mut R, env: &mut E) -> Self {
         let mut plan = InteractionPlan::new();

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -655,7 +655,7 @@ impl Interaction {
                         let db_path = env.db_path();
                         let db = match limbo_core::Database::open_file(
                             env.io().clone(),
-                            &db_path,
+                            db_path,
                             false,
                             false,
                         ) {

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -19,8 +19,10 @@ use crate::{
         },
         table::SimValue,
     },
-    runner::{env::SimConnection, io::SimulatorIO},
-    SimulatorEnv,
+    runner::{
+        env::{SimConnection, SimulatorEnv},
+        io::SimulatorIO,
+    },
 };
 
 use crate::generation::{frequency, Arbitrary, ArbitraryFrom};

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         table::SimValue,
     },
-    runner::env::SimulatorEnv,
+    runner::env::LimboSimulatorEnv,
 };
 
 use super::{
@@ -172,7 +172,7 @@ impl Property {
                     message: format!("table {} exists", insert.table()),
                     func: Box::new({
                         let table_name = table.clone();
-                        move |_: &Vec<ResultSet>, env: &SimulatorEnv| {
+                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
                             Ok(env.tables.iter().any(|t| t.name == table_name))
                         }
                     }),
@@ -184,7 +184,7 @@ impl Property {
                         row.iter().map(|v| v.to_string()).collect::<Vec<String>>(),
                         insert.table(),
                     ),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &SimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
                         let rows = stack.last().unwrap();
                         match rows {
                             Ok(rows) => Ok(rows.iter().any(|r| r == &row)),
@@ -208,7 +208,7 @@ impl Property {
                 let assumption = Interaction::Assumption(Assertion {
                     message: "Double-Create-Failure should not be called on an existing table"
                         .to_string(),
-                    func: Box::new(move |_: &Vec<ResultSet>, env: &SimulatorEnv| {
+                    func: Box::new(move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
                         Ok(!env.tables.iter().any(|t| t.name == table_name))
                     }),
                 });
@@ -222,7 +222,7 @@ impl Property {
                     message:
                         "creating two tables with the name should result in a failure for the second query"
                             .to_string(),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &SimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(_) => Ok(false),
@@ -247,7 +247,7 @@ impl Property {
                     message: format!("table {} exists", table_name),
                     func: Box::new({
                         let table_name = table_name.clone();
-                        move |_: &Vec<ResultSet>, env: &SimulatorEnv| {
+                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
                             Ok(env.tables.iter().any(|t| t.name == table_name))
                         }
                     }),
@@ -259,7 +259,7 @@ impl Property {
 
                 let assertion = Interaction::Assertion(Assertion {
                     message: "select query should respect the limit clause".to_string(),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &SimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(rows) => Ok(limit >= rows.len()),
@@ -283,7 +283,7 @@ impl Property {
                     message: format!("table {} exists", table),
                     func: Box::new({
                         let table = table.clone();
-                        move |_: &Vec<ResultSet>, env: &SimulatorEnv| {
+                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
                             Ok(env.tables.iter().any(|t| t.name == table))
                         }
                     }),
@@ -304,7 +304,7 @@ impl Property {
 
                 let assertion = Interaction::Assertion(Assertion {
                     message: format!("`{}` should return no values for table `{}`", select, table,),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &SimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
                         let rows = stack.last().unwrap();
                         match rows {
                             Ok(rows) => Ok(rows.is_empty()),
@@ -331,7 +331,7 @@ impl Property {
                     message: format!("table {} exists", table),
                     func: Box::new({
                         let table = table.clone();
-                        move |_: &Vec<ResultSet>, env: &SimulatorEnv| {
+                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
                             Ok(env.tables.iter().any(|t| t.name == table))
                         }
                     }),
@@ -344,7 +344,7 @@ impl Property {
                         "select query should result in an error for table '{}'",
                         table
                     ),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &SimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(_) => Ok(false),
@@ -376,7 +376,7 @@ impl Property {
                     message: format!("table {} exists", table),
                     func: Box::new({
                         let table = table.clone();
-                        move |_: &Vec<ResultSet>, env: &SimulatorEnv| {
+                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
                             Ok(env.tables.iter().any(|t| t.name == table))
                         }
                     }),
@@ -400,7 +400,7 @@ impl Property {
 
                 let assertion = Interaction::Assertion(Assertion {
                     message: "select queries should return the same amount of results".to_string(),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &SimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
                         let select_star = stack.last().unwrap();
                         let select_predicate = stack.get(stack.len() - 2).unwrap();
                         match (select_predicate, select_star) {
@@ -443,7 +443,7 @@ pub(crate) struct Remaining {
     pub(crate) drop: f64,
 }
 
-pub(crate) fn remaining(env: &SimulatorEnv, stats: &InteractionStats) -> Remaining {
+pub(crate) fn remaining(env: &LimboSimulatorEnv, stats: &InteractionStats) -> Remaining {
     let remaining_read = ((env.opts.max_interactions as f64 * env.opts.read_percent / 100.0)
         - (stats.read_count as f64))
         .max(0.0);
@@ -482,7 +482,7 @@ pub(crate) fn remaining(env: &SimulatorEnv, stats: &InteractionStats) -> Remaini
 
 fn property_insert_values_select<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
+    env: &LimboSimulatorEnv,
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
@@ -549,7 +549,7 @@ fn property_insert_values_select<R: rand::Rng>(
     }
 }
 
-fn property_select_limit<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Property {
+fn property_select_limit<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Property {
     // Get a random table
     let table = pick(&env.tables, rng);
     // Select the table
@@ -565,7 +565,7 @@ fn property_select_limit<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Prope
 
 fn property_double_create_failure<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
+    env: &LimboSimulatorEnv,
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
@@ -600,7 +600,7 @@ fn property_double_create_failure<R: rand::Rng>(
 
 fn property_delete_select<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
+    env: &LimboSimulatorEnv,
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
@@ -643,7 +643,7 @@ fn property_delete_select<R: rand::Rng>(
 
 fn property_drop_select<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
+    env: &LimboSimulatorEnv,
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
@@ -679,7 +679,7 @@ fn property_drop_select<R: rand::Rng>(
     }
 }
 
-fn property_select_select_optimizer<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Property {
+fn property_select_select_optimizer<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Property {
     // Get a random table
     let table = pick(&env.tables, rng);
     // Generate a random predicate
@@ -697,10 +697,10 @@ fn property_select_select_optimizer<R: rand::Rng>(rng: &mut R, env: &SimulatorEn
     }
 }
 
-impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
+impl ArbitraryFrom<(&LimboSimulatorEnv, &InteractionStats)> for Property {
     fn arbitrary_from<R: rand::Rng>(
         rng: &mut R,
-        (env, stats): (&SimulatorEnv, &InteractionStats),
+        (env, stats): (&LimboSimulatorEnv, &InteractionStats),
     ) -> Self {
         let remaining_ = remaining(env, stats);
         frequency(

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -2,16 +2,14 @@ use limbo_core::LimboError;
 use limbo_sqlite3_parser::ast;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    model::{
-        query::{
-            predicate::Predicate,
-            select::{Distinctness, ResultColumn},
-            Create, Delete, Drop, Insert, Query, Select,
-        },
-        table::SimValue,
+use crate::model::{
+    query::{
+        predicate::Predicate,
+        select::{Distinctness, ResultColumn},
+        Create, Delete, Drop, Insert, Query, Select,
     },
-    runner::env::LimboSimulatorEnv,
+    table::SimValue,
+    SimulatorEnv,
 };
 
 use super::{
@@ -23,7 +21,7 @@ use super::{
 /// Properties are representations of executable specifications
 /// about the database behavior.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum Property {
+pub enum Property {
     /// Insert-Select is a property in which the inserted row
     /// must be in the resulting rows of a select query that has a
     /// where clause that matches the inserted row.
@@ -172,8 +170,8 @@ impl Property {
                     message: format!("table {} exists", insert.table()),
                     func: Box::new({
                         let table_name = table.clone();
-                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
-                            Ok(env.tables.iter().any(|t| t.name == table_name))
+                        move |_: &Vec<ResultSet>, env: &dyn SimulatorEnv| {
+                            Ok(env.tables().iter().any(|t| t.name == table_name))
                         }
                     }),
                 });
@@ -184,7 +182,7 @@ impl Property {
                         row.iter().map(|v| v.to_string()).collect::<Vec<String>>(),
                         insert.table(),
                     ),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &dyn SimulatorEnv| {
                         let rows = stack.last().unwrap();
                         match rows {
                             Ok(rows) => Ok(rows.iter().any(|r| r == &row)),
@@ -208,8 +206,8 @@ impl Property {
                 let assumption = Interaction::Assumption(Assertion {
                     message: "Double-Create-Failure should not be called on an existing table"
                         .to_string(),
-                    func: Box::new(move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
-                        Ok(!env.tables.iter().any(|t| t.name == table_name))
+                    func: Box::new(move |_: &Vec<ResultSet>, env: &dyn SimulatorEnv| {
+                        Ok(!env.tables().iter().any(|t| t.name == table_name))
                     }),
                 });
 
@@ -222,7 +220,7 @@ impl Property {
                     message:
                         "creating two tables with the name should result in a failure for the second query"
                             .to_string(),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &dyn SimulatorEnv| {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(_) => Ok(false),
@@ -247,8 +245,8 @@ impl Property {
                     message: format!("table {} exists", table_name),
                     func: Box::new({
                         let table_name = table_name.clone();
-                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
-                            Ok(env.tables.iter().any(|t| t.name == table_name))
+                        move |_: &Vec<ResultSet>, env: &dyn SimulatorEnv| {
+                            Ok(env.tables().iter().any(|t| t.name == table_name))
                         }
                     }),
                 });
@@ -259,7 +257,7 @@ impl Property {
 
                 let assertion = Interaction::Assertion(Assertion {
                     message: "select query should respect the limit clause".to_string(),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &dyn SimulatorEnv| {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(rows) => Ok(limit >= rows.len()),
@@ -283,8 +281,8 @@ impl Property {
                     message: format!("table {} exists", table),
                     func: Box::new({
                         let table = table.clone();
-                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
-                            Ok(env.tables.iter().any(|t| t.name == table))
+                        move |_: &Vec<ResultSet>, env: &dyn SimulatorEnv| {
+                            Ok(env.tables().iter().any(|t| t.name == table))
                         }
                     }),
                 });
@@ -304,7 +302,7 @@ impl Property {
 
                 let assertion = Interaction::Assertion(Assertion {
                     message: format!("`{}` should return no values for table `{}`", select, table,),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &dyn SimulatorEnv| {
                         let rows = stack.last().unwrap();
                         match rows {
                             Ok(rows) => Ok(rows.is_empty()),
@@ -331,8 +329,8 @@ impl Property {
                     message: format!("table {} exists", table),
                     func: Box::new({
                         let table = table.clone();
-                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
-                            Ok(env.tables.iter().any(|t| t.name == table))
+                        move |_: &Vec<ResultSet>, env: &dyn SimulatorEnv| {
+                            Ok(env.tables().iter().any(|t| t.name == table))
                         }
                     }),
                 });
@@ -344,7 +342,7 @@ impl Property {
                         "select query should result in an error for table '{}'",
                         table
                     ),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &dyn SimulatorEnv| {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(_) => Ok(false),
@@ -376,8 +374,8 @@ impl Property {
                     message: format!("table {} exists", table),
                     func: Box::new({
                         let table = table.clone();
-                        move |_: &Vec<ResultSet>, env: &LimboSimulatorEnv| {
-                            Ok(env.tables.iter().any(|t| t.name == table))
+                        move |_: &Vec<ResultSet>, env: &dyn SimulatorEnv| {
+                            Ok(env.tables().iter().any(|t| t.name == table))
                         }
                     }),
                 });
@@ -400,7 +398,7 @@ impl Property {
 
                 let assertion = Interaction::Assertion(Assertion {
                     message: "select queries should return the same amount of results".to_string(),
-                    func: Box::new(move |stack: &Vec<ResultSet>, _: &LimboSimulatorEnv| {
+                    func: Box::new(move |stack: &Vec<ResultSet>, _: &dyn SimulatorEnv| {
                         let select_star = stack.last().unwrap();
                         let select_predicate = stack.get(stack.len() - 2).unwrap();
                         match (select_predicate, select_star) {
@@ -443,29 +441,30 @@ pub(crate) struct Remaining {
     pub(crate) drop: f64,
 }
 
-pub(crate) fn remaining(env: &LimboSimulatorEnv, stats: &InteractionStats) -> Remaining {
-    let remaining_read = ((env.opts.max_interactions as f64 * env.opts.read_percent / 100.0)
+pub(crate) fn remaining<E: SimulatorEnv>(env: &E, stats: &InteractionStats) -> Remaining {
+    let opts = env.opts();
+    let remaining_read = ((opts.max_interactions as f64 * opts.read_percent / 100.0)
         - (stats.read_count as f64))
         .max(0.0);
-    let remaining_write = ((env.opts.max_interactions as f64 * env.opts.write_percent / 100.0)
+    let remaining_write = ((opts.max_interactions as f64 * opts.write_percent / 100.0)
         - (stats.write_count as f64))
         .max(0.0);
-    let remaining_create = ((env.opts.max_interactions as f64 * env.opts.create_percent / 100.0)
+    let remaining_create = ((opts.max_interactions as f64 * opts.create_percent / 100.0)
         - (stats.create_count as f64))
         .max(0.0);
 
-    let remaining_create_index =
-        ((env.opts.max_interactions as f64 * env.opts.create_index_percent / 100.0)
-            - (stats.create_index_count as f64))
-            .max(0.0);
+    let remaining_create_index = ((opts.max_interactions as f64 * opts.create_index_percent
+        / 100.0)
+        - (stats.create_index_count as f64))
+        .max(0.0);
 
-    let remaining_delete = ((env.opts.max_interactions as f64 * env.opts.delete_percent / 100.0)
+    let remaining_delete = ((opts.max_interactions as f64 * opts.delete_percent / 100.0)
         - (stats.delete_count as f64))
         .max(0.0);
-    let remaining_update = ((env.opts.max_interactions as f64 * env.opts.update_percent / 100.0)
+    let remaining_update = ((opts.max_interactions as f64 * opts.update_percent / 100.0)
         - (stats.update_count as f64))
         .max(0.0);
-    let remaining_drop = ((env.opts.max_interactions as f64 * env.opts.drop_percent / 100.0)
+    let remaining_drop = ((opts.max_interactions as f64 * opts.drop_percent / 100.0)
         - (stats.drop_count as f64))
         .max(0.0);
 
@@ -480,13 +479,13 @@ pub(crate) fn remaining(env: &LimboSimulatorEnv, stats: &InteractionStats) -> Re
     }
 }
 
-fn property_insert_values_select<R: rand::Rng>(
+fn property_insert_values_select<R: rand::Rng, E: SimulatorEnv>(
     rng: &mut R,
-    env: &LimboSimulatorEnv,
+    env: &E,
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(&env.tables(), rng);
     // Generate rows to insert
     let rows = (0..rng.gen_range(1..=5))
         .map(|_| Vec::<SimValue>::arbitrary_from(rng, table))
@@ -549,9 +548,9 @@ fn property_insert_values_select<R: rand::Rng>(
     }
 }
 
-fn property_select_limit<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Property {
+fn property_select_limit<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, env: &E) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(&env.tables(), rng);
     // Select the table
     let select = Select {
         table: table.name.clone(),
@@ -563,13 +562,13 @@ fn property_select_limit<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> 
     Property::SelectLimit { select }
 }
 
-fn property_double_create_failure<R: rand::Rng>(
+fn property_double_create_failure<R: rand::Rng, E: SimulatorEnv>(
     rng: &mut R,
-    env: &LimboSimulatorEnv,
+    env: &E,
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(&env.tables(), rng);
     // Create the table
     let create_query = Create {
         table: table.clone(),
@@ -598,13 +597,13 @@ fn property_double_create_failure<R: rand::Rng>(
     }
 }
 
-fn property_delete_select<R: rand::Rng>(
+fn property_delete_select<R: rand::Rng, E: SimulatorEnv>(
     rng: &mut R,
-    env: &LimboSimulatorEnv,
+    env: &E,
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(&env.tables(), rng);
     // Generate a random predicate
     let predicate = Predicate::arbitrary_from(rng, table);
 
@@ -641,13 +640,13 @@ fn property_delete_select<R: rand::Rng>(
     }
 }
 
-fn property_drop_select<R: rand::Rng>(
+fn property_drop_select<R: rand::Rng, E: SimulatorEnv>(
     rng: &mut R,
-    env: &LimboSimulatorEnv,
+    env: &E,
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(&env.tables(), rng);
 
     // Create random queries respecting the constraints
     let mut queries = Vec::new();
@@ -679,9 +678,12 @@ fn property_drop_select<R: rand::Rng>(
     }
 }
 
-fn property_select_select_optimizer<R: rand::Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Property {
+fn property_select_select_optimizer<R: rand::Rng, E: SimulatorEnv>(
+    rng: &mut R,
+    env: &E,
+) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(&env.tables(), rng);
     // Generate a random predicate
     let predicate = Predicate::arbitrary_from(rng, table);
     // Transform into a Binary predicate to force values to be casted to a bool
@@ -697,16 +699,14 @@ fn property_select_select_optimizer<R: rand::Rng>(rng: &mut R, env: &LimboSimula
     }
 }
 
-impl ArbitraryFrom<(&LimboSimulatorEnv, &InteractionStats)> for Property {
-    fn arbitrary_from<R: rand::Rng>(
-        rng: &mut R,
-        (env, stats): (&LimboSimulatorEnv, &InteractionStats),
-    ) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<(&E, &InteractionStats)> for Property {
+    fn arbitrary_from<R: rand::Rng>(rng: &mut R, (env, stats): (&E, &InteractionStats)) -> Self {
         let remaining_ = remaining(env, stats);
+        let opts = env.opts();
         frequency(
             vec![
                 (
-                    if !env.opts.disable_insert_values_select {
+                    if !opts.disable_insert_values_select {
                         f64::min(remaining_.read, remaining_.write)
                     } else {
                         0.0
@@ -714,7 +714,7 @@ impl ArbitraryFrom<(&LimboSimulatorEnv, &InteractionStats)> for Property {
                     Box::new(|rng: &mut R| property_insert_values_select(rng, env, &remaining_)),
                 ),
                 (
-                    if !env.opts.disable_double_create_failure {
+                    if !opts.disable_double_create_failure {
                         remaining_.create / 2.0
                     } else {
                         0.0
@@ -722,7 +722,7 @@ impl ArbitraryFrom<(&LimboSimulatorEnv, &InteractionStats)> for Property {
                     Box::new(|rng: &mut R| property_double_create_failure(rng, env, &remaining_)),
                 ),
                 (
-                    if !env.opts.disable_select_limit {
+                    if !opts.disable_select_limit {
                         remaining_.read
                     } else {
                         0.0
@@ -730,7 +730,7 @@ impl ArbitraryFrom<(&LimboSimulatorEnv, &InteractionStats)> for Property {
                     Box::new(|rng: &mut R| property_select_limit(rng, env)),
                 ),
                 (
-                    if !env.opts.disable_delete_select {
+                    if !opts.disable_delete_select {
                         f64::min(remaining_.read, remaining_.write).min(remaining_.delete)
                     } else {
                         0.0
@@ -738,16 +738,15 @@ impl ArbitraryFrom<(&LimboSimulatorEnv, &InteractionStats)> for Property {
                     Box::new(|rng: &mut R| property_delete_select(rng, env, &remaining_)),
                 ),
                 (
-                    if !env.opts.disable_drop_select {
-                        // remaining_.drop
-                        0.0
+                    if !opts.disable_drop_select {
+                        remaining_.drop
                     } else {
                         0.0
                     },
                     Box::new(|rng: &mut R| property_drop_select(rng, env, &remaining_)),
                 ),
                 (
-                    if !env.opts.disable_select_optimizer {
+                    if !opts.disable_select_optimizer {
                         remaining_.read / 2.0
                     } else {
                         0.0

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -486,7 +486,7 @@ fn property_insert_values_select<R: rand::Rng, E: SimulatorEnv>(
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Generate rows to insert
     let rows = (0..rng.gen_range(1..=5))
         .map(|_| Vec::<SimValue>::arbitrary_from(rng, table))
@@ -551,7 +551,7 @@ fn property_insert_values_select<R: rand::Rng, E: SimulatorEnv>(
 
 fn property_select_limit<R: rand::Rng, E: SimulatorEnv>(rng: &mut R, env: &E) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Select the table
     let select = Select {
         table: table.name.clone(),
@@ -569,7 +569,7 @@ fn property_double_create_failure<R: rand::Rng, E: SimulatorEnv>(
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Create the table
     let create_query = Create {
         table: table.clone(),
@@ -604,7 +604,7 @@ fn property_delete_select<R: rand::Rng, E: SimulatorEnv>(
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Generate a random predicate
     let predicate = Predicate::arbitrary_from(rng, table);
 
@@ -647,7 +647,7 @@ fn property_drop_select<R: rand::Rng, E: SimulatorEnv>(
     remaining: &Remaining,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
 
     // Create random queries respecting the constraints
     let mut queries = Vec::new();
@@ -684,7 +684,7 @@ fn property_select_select_optimizer<R: rand::Rng, E: SimulatorEnv>(
     env: &E,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables(), rng);
+    let table = pick(env.tables(), rng);
     // Generate a random predicate
     let predicate = Predicate::arbitrary_from(rng, table);
     // Transform into a Binary predicate to force values to be casted to a bool

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -438,6 +438,7 @@ pub(crate) struct Remaining {
     pub(crate) create_index: f64,
     pub(crate) delete: f64,
     pub(crate) update: f64,
+    #[allow(dead_code)]
     pub(crate) drop: f64,
 }
 
@@ -739,7 +740,8 @@ impl<E: SimulatorEnv> ArbitraryFrom<(&E, &InteractionStats)> for Property {
                 ),
                 (
                     if !opts.disable_drop_select {
-                        remaining_.drop
+                        // remaining_.drop
+                        0.0
                     } else {
                         0.0
                     },

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -6,7 +6,7 @@ use crate::model::query::select::{Distinctness, ResultColumn};
 use crate::model::query::update::Update;
 use crate::model::query::{Create, Delete, Drop, Insert, Query, Select};
 use crate::model::table::{SimValue, Table};
-use crate::runner::env::SimulatorEnv;
+use crate::runner::env::LimboSimulatorEnv;
 use rand::Rng;
 
 use super::property::Remaining;
@@ -20,8 +20,8 @@ impl Arbitrary for Create {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Select {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Select {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let table = pick(&env.tables, rng);
         Self {
             table: table.name.clone(),
@@ -33,8 +33,8 @@ impl ArbitraryFrom<&SimulatorEnv> for Select {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Insert {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Insert {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let gen_values = |rng: &mut R| {
             let table = pick(&env.tables, rng);
             let num_rows = rng.gen_range(1..10);
@@ -86,8 +86,8 @@ impl ArbitraryFrom<&SimulatorEnv> for Insert {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Delete {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Delete {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let table = pick(&env.tables, rng);
         Self {
             table: table.name.clone(),
@@ -96,8 +96,8 @@ impl ArbitraryFrom<&SimulatorEnv> for Delete {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Drop {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Drop {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let table = pick(&env.tables, rng);
         Self {
             table: table.name.clone(),
@@ -105,8 +105,11 @@ impl ArbitraryFrom<&SimulatorEnv> for Drop {
     }
 }
 
-impl ArbitraryFrom<(&SimulatorEnv, &Remaining)> for Query {
-    fn arbitrary_from<R: Rng>(rng: &mut R, (env, remaining): (&SimulatorEnv, &Remaining)) -> Self {
+impl ArbitraryFrom<(&LimboSimulatorEnv, &Remaining)> for Query {
+    fn arbitrary_from<R: Rng>(
+        rng: &mut R,
+        (env, remaining): (&LimboSimulatorEnv, &Remaining),
+    ) -> Self {
         frequency(
             vec![
                 (
@@ -131,8 +134,8 @@ impl ArbitraryFrom<(&SimulatorEnv, &Remaining)> for Query {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for Update {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for Update {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         let table = pick(&env.tables, rng);
         let mut seen = HashSet::new();
         let num_cols = rng.gen_range(1..=table.columns.len());

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -6,7 +6,7 @@ use crate::model::query::select::{Distinctness, ResultColumn};
 use crate::model::query::update::Update;
 use crate::model::query::{Create, Delete, Drop, Insert, Query, Select};
 use crate::model::table::{SimValue, Table};
-use crate::SimulatorEnv;
+use crate::runner::env::SimulatorEnv;
 use rand::Rng;
 
 use super::property::Remaining;

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -22,7 +22,7 @@ impl Arbitrary for Create {
 
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Select {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
-        let table = pick(&env.tables(), rng);
+        let table = pick(env.tables(), rng);
         Self {
             table: table.name.clone(),
             result_columns: vec![ResultColumn::Star],
@@ -36,7 +36,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<&E> for Select {
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Insert {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
         let gen_values = |rng: &mut R| {
-            let table = pick(&env.tables(), rng);
+            let table = pick(env.tables(), rng);
             let num_rows = rng.gen_range(1..10);
             let values: Vec<Vec<SimValue>> = (0..num_rows)
                 .map(|_| {
@@ -66,7 +66,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<&E> for Insert {
                 limit: None,
                 distinct: Distinctness::All,
             };
-            let table = pick(&env.tables(), rng);
+            let table = pick(env.tables(), rng);
             Some(Insert::Select {
                 table: table.name.clone(),
                 select: Box::new(select),
@@ -88,7 +88,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<&E> for Insert {
 
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Delete {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
-        let table = pick(&env.tables(), rng);
+        let table = pick(env.tables(), rng);
         Self {
             table: table.name.clone(),
             predicate: Predicate::arbitrary_from(rng, table),
@@ -98,7 +98,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<&E> for Delete {
 
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Drop {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
-        let table = pick(&env.tables(), rng);
+        let table = pick(env.tables(), rng);
         Self {
             table: table.name.clone(),
         }
@@ -133,7 +133,7 @@ impl<E: SimulatorEnv> ArbitraryFrom<(&E, &Remaining)> for Query {
 
 impl<E: SimulatorEnv> ArbitraryFrom<&E> for Update {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
-        let table = pick(&env.tables(), rng);
+        let table = pick(env.tables(), rng);
         let mut seen = HashSet::new();
         let num_cols = rng.gen_range(1..=table.columns.len());
         let set_values: Vec<(String, SimValue)> = (0..num_cols)

--- a/simulator/lib.rs
+++ b/simulator/lib.rs
@@ -1,4 +1,2 @@
 pub mod generation;
 pub mod model;
-pub(crate) mod runner;
-pub(crate) mod shrink;

--- a/simulator/lib.rs
+++ b/simulator/lib.rs
@@ -1,0 +1,4 @@
+pub mod generation;
+pub mod model;
+pub(crate) mod runner;
+pub(crate) mod shrink;

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -3,6 +3,7 @@ use anyhow::{anyhow, Context};
 use clap::Parser;
 use limbo_sim::generation::plan::{Interaction, InteractionPlan, InteractionPlanState};
 use limbo_sim::generation::ArbitraryFrom as _;
+use limbo_sim::model::Shadow as _;
 use notify::event::{DataChange, ModifyKind};
 use notify::{EventKind, RecursiveMode, Watcher};
 use rand::prelude::*;

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, mem, sync::Arc};
 
 use limbo_core::{Database, IO};
 
-use crate::model::table::Table;
+use crate::model::table::{SimValue, Table};
 
 pub mod query;
 pub mod table;
@@ -104,4 +104,8 @@ pub struct SimulatorOpts {
     pub max_interactions: usize,
     pub page_size: usize,
     pub max_time_simulation: usize,
+}
+
+pub trait Shadow {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>>;
 }

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -1,2 +1,107 @@
+use std::{fmt::Display, mem, sync::Arc};
+
+use limbo_core::{Database, IO};
+
+use crate::model::table::Table;
+
 pub mod query;
 pub mod table;
+
+pub trait SimulatorEnv {
+    /// List all tables
+    fn tables(&self) -> &[Table];
+    /// List all tables with a mutable reference
+    fn tables_mut(&mut self) -> &mut [Table];
+    /// Add a table
+    fn add_table(&mut self, table: Table);
+    /// Remove a table by name
+    fn remove_table(&mut self, table_name: &str);
+    /// Gets the simulator options
+    fn opts(&self) -> &SimulatorOpts;
+    fn connections(&self) -> &[SimConnection];
+    fn connections_mut(&mut self) -> &mut Vec<SimConnection>;
+    fn db_path(&self) -> &str;
+    fn io(&self) -> Arc<dyn IO>;
+    fn get_db(&self) -> Arc<Database>;
+    fn set_db(&mut self, db: Arc<Database>);
+}
+
+pub trait ConnectionTrait
+where
+    Self: std::marker::Sized + Clone,
+{
+    fn is_connected(&self) -> bool;
+    fn disconnect(&mut self);
+}
+
+pub enum SimConnection {
+    LimboConnection(Arc<limbo_core::Connection>),
+    SQLiteConnection(rusqlite::Connection),
+    Disconnected,
+}
+
+impl SimConnection {
+    pub(crate) fn is_connected(&self) -> bool {
+        match self {
+            SimConnection::LimboConnection(_) | SimConnection::SQLiteConnection(_) => true,
+            SimConnection::Disconnected => false,
+        }
+    }
+    pub(crate) fn disconnect(&mut self) {
+        let conn = mem::replace(self, SimConnection::Disconnected);
+
+        match conn {
+            SimConnection::LimboConnection(conn) => {
+                conn.close().unwrap();
+            }
+            SimConnection::SQLiteConnection(conn) => {
+                conn.close().unwrap();
+            }
+            SimConnection::Disconnected => {}
+        }
+    }
+}
+
+impl Display for SimConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SimConnection::LimboConnection(_) => {
+                write!(f, "LimboConnection")
+            }
+            SimConnection::SQLiteConnection(_) => {
+                write!(f, "SQLiteConnection")
+            }
+            SimConnection::Disconnected => {
+                write!(f, "Disconnected")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SimulatorOpts {
+    pub ticks: usize,
+    pub max_connections: usize,
+    pub max_tables: usize,
+    // this next options are the distribution of workload where read_percent + write_percent +
+    // delete_percent == 100%
+    pub create_percent: f64,
+    pub create_index_percent: f64,
+    pub read_percent: f64,
+    pub write_percent: f64,
+    pub delete_percent: f64,
+    pub update_percent: f64,
+    pub drop_percent: f64,
+
+    pub disable_select_optimizer: bool,
+    pub disable_insert_values_select: bool,
+    pub disable_double_create_failure: bool,
+    pub disable_select_limit: bool,
+    pub disable_delete_select: bool,
+    pub disable_drop_select: bool,
+    pub disable_reopen_database: bool,
+
+    pub max_interactions: usize,
+    pub page_size: usize,
+    pub max_time_simulation: usize,
+}

--- a/simulator/model/query/create.rs
+++ b/simulator/model/query/create.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     model::table::{SimValue, Table},
-    SimulatorEnv,
+    runner::env::SimulatorEnv,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/simulator/model/query/create.rs
+++ b/simulator/model/query/create.rs
@@ -2,20 +2,20 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    model::table::{SimValue, Table},
-    runner::env::LimboSimulatorEnv,
+use crate::model::{
+    table::{SimValue, Table},
+    SimulatorEnv,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct Create {
-    pub(crate) table: Table,
+pub struct Create {
+    pub table: Table,
 }
 
 impl Create {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
-        if !env.tables.iter().any(|t| t.name == self.table.name) {
-            env.tables.push(self.table.clone());
+    pub(crate) fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+        if !env.tables().iter().any(|t| t.name == self.table.name) {
+            env.add_table(self.table.clone());
         }
 
         vec![]

--- a/simulator/model/query/create.rs
+++ b/simulator/model/query/create.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     model::table::{SimValue, Table},
-    runner::env::SimulatorEnv,
+    runner::env::LimboSimulatorEnv,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,7 +13,7 @@ pub(crate) struct Create {
 }
 
 impl Create {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         if !env.tables.iter().any(|t| t.name == self.table.name) {
             env.tables.push(self.table.clone());
         }

--- a/simulator/model/query/create.rs
+++ b/simulator/model/query/create.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::{
     table::{SimValue, Table},
-    SimulatorEnv,
+    Shadow, SimulatorEnv,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -12,8 +12,8 @@ pub struct Create {
     pub table: Table,
 }
 
-impl Create {
-    pub(crate) fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Create {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         if !env.tables().iter().any(|t| t.name == self.table.name) {
             env.add_table(self.table.clone());
         }

--- a/simulator/model/query/create_index.rs
+++ b/simulator/model/query/create_index.rs
@@ -1,6 +1,6 @@
 use crate::{
     generation::{gen_random_text, pick, pick_n_unique, ArbitraryFrom},
-    runner::env::LimboSimulatorEnv,
+    model::SimulatorEnv,
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -21,16 +21,16 @@ impl std::fmt::Display for SortOrder {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub(crate) struct CreateIndex {
-    pub(crate) index_name: String,
-    pub(crate) table_name: String,
-    pub(crate) columns: Vec<(String, SortOrder)>,
+pub struct CreateIndex {
+    pub index_name: String,
+    pub table_name: String,
+    pub columns: Vec<(String, SortOrder)>,
 }
 
 impl CreateIndex {
-    pub(crate) fn shadow(
+    pub fn shadow<E: SimulatorEnv>(
         &self,
-        _env: &mut crate::runner::env::LimboSimulatorEnv,
+        _env: &mut E,
     ) -> Vec<Vec<crate::model::table::SimValue>> {
         // CREATE INDEX doesn't require any shadowing; we don't need to keep track
         // in the simulator what indexes exist.
@@ -54,14 +54,15 @@ impl std::fmt::Display for CreateIndex {
     }
 }
 
-impl ArbitraryFrom<&LimboSimulatorEnv> for CreateIndex {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
+impl<E: SimulatorEnv> ArbitraryFrom<&E> for CreateIndex {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &E) -> Self {
+        let tables = env.tables();
         assert!(
-            !env.tables.is_empty(),
+            !tables.is_empty(),
             "Cannot create an index when no tables exist in the environment."
         );
 
-        let table = pick(&env.tables, rng);
+        let table = pick(tables, rng);
 
         if table.columns.is_empty() {
             panic!(

--- a/simulator/model/query/create_index.rs
+++ b/simulator/model/query/create_index.rs
@@ -1,6 +1,6 @@
 use crate::{
     generation::{gen_random_text, pick, pick_n_unique, ArbitraryFrom},
-    runner::env::SimulatorEnv,
+    runner::env::LimboSimulatorEnv,
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -30,7 +30,7 @@ pub(crate) struct CreateIndex {
 impl CreateIndex {
     pub(crate) fn shadow(
         &self,
-        _env: &mut crate::runner::env::SimulatorEnv,
+        _env: &mut crate::runner::env::LimboSimulatorEnv,
     ) -> Vec<Vec<crate::model::table::SimValue>> {
         // CREATE INDEX doesn't require any shadowing; we don't need to keep track
         // in the simulator what indexes exist.
@@ -54,8 +54,8 @@ impl std::fmt::Display for CreateIndex {
     }
 }
 
-impl ArbitraryFrom<&SimulatorEnv> for CreateIndex {
-    fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
+impl ArbitraryFrom<&LimboSimulatorEnv> for CreateIndex {
+    fn arbitrary_from<R: Rng>(rng: &mut R, env: &LimboSimulatorEnv) -> Self {
         assert!(
             !env.tables.is_empty(),
             "Cannot create an index when no tables exist in the environment."

--- a/simulator/model/query/create_index.rs
+++ b/simulator/model/query/create_index.rs
@@ -1,6 +1,6 @@
 use crate::{
     generation::{gen_random_text, pick, pick_n_unique, ArbitraryFrom},
-    model::SimulatorEnv,
+    model::{Shadow, SimulatorEnv},
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -27,11 +27,8 @@ pub struct CreateIndex {
     pub columns: Vec<(String, SortOrder)>,
 }
 
-impl CreateIndex {
-    pub fn shadow<E: SimulatorEnv>(
-        &self,
-        _env: &mut E,
-    ) -> Vec<Vec<crate::model::table::SimValue>> {
+impl Shadow for CreateIndex {
+    fn shadow<E: SimulatorEnv>(&self, _env: &mut E) -> Vec<Vec<crate::model::table::SimValue>> {
         // CREATE INDEX doesn't require any shadowing; we don't need to keep track
         // in the simulator what indexes exist.
         vec![]

--- a/simulator/model/query/delete.rs
+++ b/simulator/model/query/delete.rs
@@ -2,20 +2,20 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 use super::predicate::Predicate;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Delete {
-    pub(crate) table: String,
-    pub(crate) predicate: Predicate,
+pub struct Delete {
+    pub table: String,
+    pub predicate: Predicate,
 }
 
 impl Delete {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env
-            .tables
+            .tables_mut()
             .iter_mut()
             .find(|t| t.name == self.table)
             .unwrap();

--- a/simulator/model/query/delete.rs
+++ b/simulator/model/query/delete.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 use super::predicate::Predicate;
 

--- a/simulator/model/query/delete.rs
+++ b/simulator/model/query/delete.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -12,8 +12,8 @@ pub struct Delete {
     pub predicate: Predicate,
 }
 
-impl Delete {
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Delete {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env
             .tables_mut()
             .iter_mut()

--- a/simulator/model/query/delete.rs
+++ b/simulator/model/query/delete.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -13,7 +13,7 @@ pub(crate) struct Delete {
 }
 
 impl Delete {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         let table = env
             .tables
             .iter_mut()

--- a/simulator/model/query/drop.rs
+++ b/simulator/model/query/drop.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct Drop {
@@ -10,7 +10,7 @@ pub(crate) struct Drop {
 }
 
 impl Drop {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         env.tables.retain(|t| t.name != self.table);
         vec![]
     }

--- a/simulator/model/query/drop.rs
+++ b/simulator/model/query/drop.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct Drop {

--- a/simulator/model/query/drop.rs
+++ b/simulator/model/query/drop.rs
@@ -2,15 +2,15 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Drop {
     pub table: String,
 }
 
-impl Drop {
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Drop {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         env.remove_table(&self.table);
         vec![]
     }

--- a/simulator/model/query/drop.rs
+++ b/simulator/model/query/drop.rs
@@ -2,16 +2,16 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Drop {
-    pub(crate) table: String,
+pub struct Drop {
+    pub table: String,
 }
 
 impl Drop {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
-        env.tables.retain(|t| t.name != self.table);
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+        env.remove_table(&self.table);
         vec![]
     }
 }

--- a/simulator/model/query/insert.rs
+++ b/simulator/model/query/insert.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 use super::select::Select;
 
@@ -19,7 +19,7 @@ pub(crate) enum Insert {
 }
 
 impl Insert {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         match self {
             Insert::Values { table, values } => {
                 if let Some(t) = env.tables.iter_mut().find(|t| &t.name == table) {

--- a/simulator/model/query/insert.rs
+++ b/simulator/model/query/insert.rs
@@ -2,12 +2,12 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 use super::select::Select;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) enum Insert {
+pub enum Insert {
     Values {
         table: String,
         values: Vec<Vec<SimValue>>,
@@ -19,16 +19,16 @@ pub(crate) enum Insert {
 }
 
 impl Insert {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Insert::Values { table, values } => {
-                if let Some(t) = env.tables.iter_mut().find(|t| &t.name == table) {
+                if let Some(t) = env.tables_mut().iter_mut().find(|t| &t.name == table) {
                     t.rows.extend(values.clone());
                 }
             }
             Insert::Select { table, select } => {
                 let rows = select.shadow(env);
-                if let Some(t) = env.tables.iter_mut().find(|t| &t.name == table) {
+                if let Some(t) = env.tables_mut().iter_mut().find(|t| &t.name == table) {
                     t.rows.extend(rows);
                 }
             }

--- a/simulator/model/query/insert.rs
+++ b/simulator/model/query/insert.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 use super::select::Select;
 
@@ -19,7 +19,15 @@ pub enum Insert {
 }
 
 impl Insert {
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+    pub(crate) fn table(&self) -> &str {
+        match self {
+            Insert::Values { table, .. } | Insert::Select { table, .. } => table,
+        }
+    }
+}
+
+impl Shadow for Insert {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Insert::Values { table, values } => {
                 if let Some(t) = env.tables_mut().iter_mut().find(|t| &t.name == table) {
@@ -35,12 +43,6 @@ impl Insert {
         }
 
         vec![]
-    }
-
-    pub(crate) fn table(&self) -> &str {
-        match self {
-            Insert::Values { table, .. } | Insert::Select { table, .. } => table,
-        }
     }
 }
 

--- a/simulator/model/query/insert.rs
+++ b/simulator/model/query/insert.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 use super::select::Select;
 

--- a/simulator/model/query/mod.rs
+++ b/simulator/model/query/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use select::Select;
 use serde::{Deserialize, Serialize};
 use update::Update;
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 pub mod create;
 pub mod create_index;
@@ -61,7 +61,7 @@ impl Query {
         }
     }
 
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         match self {
             Query::Create(create) => create.shadow(env),
             Query::Insert(insert) => insert.shadow(env),

--- a/simulator/model/query/mod.rs
+++ b/simulator/model/query/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use select::Select;
 use serde::{Deserialize, Serialize};
 use update::Update;
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 pub mod create;
 pub mod create_index;
@@ -60,8 +60,10 @@ impl Query {
             Query::CreateIndex(CreateIndex { table_name, .. }) => vec![table_name.clone()],
         }
     }
+}
 
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Query {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Query::Create(create) => create.shadow(env),
             Query::Insert(insert) => insert.shadow(env),

--- a/simulator/model/query/mod.rs
+++ b/simulator/model/query/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use select::Select;
 use serde::{Deserialize, Serialize};
 use update::Update;
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 pub mod create;
 pub mod create_index;
@@ -23,7 +23,7 @@ pub mod update;
 
 // This type represents the potential queries on the database.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum Query {
+pub enum Query {
     Create(Create),
     Select(Select),
     Insert(Insert),
@@ -34,7 +34,7 @@ pub(crate) enum Query {
 }
 
 impl Query {
-    pub(crate) fn dependencies(&self) -> HashSet<String> {
+    pub fn dependencies(&self) -> HashSet<String> {
         match self {
             Query::Create(_) => HashSet::new(),
             Query::Select(Select { table, .. })
@@ -48,7 +48,7 @@ impl Query {
             }
         }
     }
-    pub(crate) fn uses(&self) -> Vec<String> {
+    pub fn uses(&self) -> Vec<String> {
         match self {
             Query::Create(Create { table }) => vec![table.name.clone()],
             Query::Select(Select { table, .. })
@@ -61,7 +61,7 @@ impl Query {
         }
     }
 
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         match self {
             Query::Create(create) => create.shadow(env),
             Query::Insert(insert) => insert.shadow(env),

--- a/simulator/model/query/select.rs
+++ b/simulator/model/query/select.rs
@@ -2,13 +2,13 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 use super::predicate::Predicate;
 
 /// `SELECT` distinctness
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) enum Distinctness {
+pub enum Distinctness {
     /// `DISTINCT`
     Distinct,
     /// `ALL`
@@ -37,17 +37,17 @@ impl Display for ResultColumn {
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Select {
-    pub(crate) table: String,
-    pub(crate) result_columns: Vec<ResultColumn>,
-    pub(crate) predicate: Predicate,
-    pub(crate) distinct: Distinctness,
-    pub(crate) limit: Option<usize>,
+pub struct Select {
+    pub table: String,
+    pub result_columns: Vec<ResultColumn>,
+    pub predicate: Predicate,
+    pub distinct: Distinctness,
+    pub limit: Option<usize>,
 }
 
 impl Select {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
-        let table = env.tables.iter().find(|t| t.name == self.table.as_str());
+    pub(crate) fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+        let table = env.tables().iter().find(|t| t.name == self.table.as_str());
         if let Some(table) = table {
             table
                 .rows

--- a/simulator/model/query/select.rs
+++ b/simulator/model/query/select.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 use super::predicate::Predicate;
 

--- a/simulator/model/query/select.rs
+++ b/simulator/model/query/select.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -46,7 +46,7 @@ pub(crate) struct Select {
 }
 
 impl Select {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         let table = env.tables.iter().find(|t| t.name == self.table.as_str());
         if let Some(table) = table {
             table

--- a/simulator/model/query/select.rs
+++ b/simulator/model/query/select.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -45,8 +45,8 @@ pub struct Select {
     pub limit: Option<usize>,
 }
 
-impl Select {
-    pub(crate) fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Select {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env.tables().iter().find(|t| t.name == self.table.as_str());
         if let Some(table) = table {
             table

--- a/simulator/model/query/update.rs
+++ b/simulator/model/query/update.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::SimulatorEnv};
 
 use super::predicate::Predicate;
 

--- a/simulator/model/query/update.rs
+++ b/simulator/model/query/update.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::SimulatorEnv};
+use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -14,7 +14,7 @@ pub(crate) struct Update {
 }
 
 impl Update {
-    pub(crate) fn shadow(&self, env: &mut SimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
         let table = env
             .tables
             .iter_mut()

--- a/simulator/model/query/update.rs
+++ b/simulator/model/query/update.rs
@@ -2,21 +2,21 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{model::table::SimValue, runner::env::LimboSimulatorEnv};
+use crate::model::{table::SimValue, SimulatorEnv};
 
 use super::predicate::Predicate;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Update {
-    pub(crate) table: String,
-    pub(crate) set_values: Vec<(String, SimValue)>, // Pair of value for set expressions => SET name=value
-    pub(crate) predicate: Predicate,
+pub struct Update {
+    pub table: String,
+    pub set_values: Vec<(String, SimValue)>, // Pair of value for set expressions => SET name=value
+    pub predicate: Predicate,
 }
 
 impl Update {
-    pub(crate) fn shadow(&self, env: &mut LimboSimulatorEnv) -> Vec<Vec<SimValue>> {
+    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env
-            .tables
+            .tables_mut()
             .iter_mut()
             .find(|t| t.name == self.table)
             .unwrap();

--- a/simulator/model/query/update.rs
+++ b/simulator/model/query/update.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::{table::SimValue, SimulatorEnv};
+use crate::model::{table::SimValue, Shadow, SimulatorEnv};
 
 use super::predicate::Predicate;
 
@@ -13,8 +13,8 @@ pub struct Update {
     pub predicate: Predicate,
 }
 
-impl Update {
-    pub fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
+impl Shadow for Update {
+    fn shadow<E: SimulatorEnv>(&self, env: &mut E) -> Vec<Vec<SimValue>> {
         let table = env
             .tables_mut()
             .iter_mut()

--- a/simulator/model/table.rs
+++ b/simulator/model/table.rs
@@ -15,18 +15,18 @@ impl Deref for Name {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct Table {
-    pub(crate) rows: Vec<Vec<SimValue>>,
-    pub(crate) name: String,
-    pub(crate) columns: Vec<Column>,
+pub struct Table {
+    pub rows: Vec<Vec<SimValue>>,
+    pub name: String,
+    pub columns: Vec<Column>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct Column {
-    pub(crate) name: String,
-    pub(crate) column_type: ColumnType,
-    pub(crate) primary: bool,
-    pub(crate) unique: bool,
+pub struct Column {
+    pub name: String,
+    pub column_type: ColumnType,
+    pub primary: bool,
+    pub unique: bool,
 }
 
 // Uniquely defined by name in this case
@@ -45,7 +45,7 @@ impl PartialEq for Column {
 impl Eq for Column {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum ColumnType {
+pub enum ColumnType {
     Integer,
     Float,
     Text,
@@ -63,23 +63,8 @@ impl Display for ColumnType {
     }
 }
 
-fn float_to_string<S>(float: &f64, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(&format!("{}", float))
-}
-
-fn string_to_float<'de, D>(deserializer: D) -> Result<f64, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    s.parse().map_err(serde::de::Error::custom)
-}
-
 #[derive(Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
-pub(crate) struct SimValue(pub limbo_core::Value);
+pub struct SimValue(pub limbo_core::Value);
 
 fn to_sqlite_blob(bytes: &[u8]) -> String {
     format!(

--- a/simulator/runner/bugbase.rs
+++ b/simulator/runner/bugbase.rs
@@ -8,9 +8,10 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
+use limbo_sim::generation::plan::InteractionPlan;
 use serde::{Deserialize, Serialize};
 
-use crate::{generation::plan::InteractionPlan, Paths};
+use crate::Paths;
 
 use super::cli::SimulatorCLI;
 

--- a/simulator/runner/bugbase.rs
+++ b/simulator/runner/bugbase.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{InteractionPlan, Paths};
+use crate::{generation::plan::InteractionPlan, Paths};
 
 use super::cli::SimulatorCLI;
 

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -5,11 +5,10 @@ use limbo_core::Value;
 use crate::{
     generation::{
         pick_index,
-        plan::{Interaction, InteractionPlanState, ResultSet},
+        plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
     },
     model::{query::Query, table::SimValue},
     runner::execution::ExecutionContinuation,
-    InteractionPlan,
 };
 
 use super::{

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -1,18 +1,12 @@
 use std::sync::{Arc, Mutex};
 
 use limbo_core::Value;
+use limbo_sim::{generation::{pick_index, plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet}}, model::{query::Query, table::SimValue, SimConnection}};
 
-use crate::{
-    generation::{
-        pick_index,
-        plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
-    },
-    model::{query::Query, table::SimValue},
-    runner::execution::ExecutionContinuation,
-};
+use crate::runner::execution::ExecutionContinuation;
 
 use super::{
-    env::{SimConnection, LimboSimulatorEnv},
+    env::LimboSimulatorEnv,
     execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult},
 };
 

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -12,13 +12,13 @@ use crate::{
 };
 
 use super::{
-    env::{SimConnection, SimulatorEnv},
+    env::{SimConnection, LimboSimulatorEnv},
     execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult},
 };
 
 pub(crate) fn run_simulation(
-    env: Arc<Mutex<SimulatorEnv>>,
-    rusqlite_env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
+    rusqlite_env: Arc<Mutex<LimboSimulatorEnv>>,
     rusqlite_conn: &dyn Fn() -> rusqlite::Connection,
     plans: &mut [InteractionPlan],
     last_execution: Arc<Mutex<Execution>>,
@@ -115,8 +115,8 @@ fn execute_query_rusqlite(
 }
 
 pub(crate) fn execute_plans(
-    env: Arc<Mutex<SimulatorEnv>>,
-    rusqlite_env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
+    rusqlite_env: Arc<Mutex<LimboSimulatorEnv>>,
     rusqlite_conn: &dyn Fn() -> rusqlite::Connection,
     plans: &mut [InteractionPlan],
     states: &mut [InteractionPlanState],
@@ -173,8 +173,8 @@ pub(crate) fn execute_plans(
 }
 
 fn execute_plan(
-    env: &mut SimulatorEnv,
-    rusqlite_env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
+    rusqlite_env: &mut LimboSimulatorEnv,
     rusqlite_conn: &dyn Fn() -> rusqlite::Connection,
     connection_index: usize,
     plans: &mut [InteractionPlan],
@@ -311,7 +311,7 @@ fn execute_plan(
 }
 
 fn execute_interaction_rusqlite(
-    env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
     connection_index: usize,
     interaction: &Interaction,
     stack: &mut Vec<ResultSet>,

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -1,7 +1,13 @@
 use std::sync::{Arc, Mutex};
 
 use limbo_core::Value;
-use limbo_sim::{generation::{pick_index, plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet}}, model::{query::Query, table::SimValue, SimConnection}};
+use limbo_sim::{
+    generation::{
+        pick_index,
+        plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
+    },
+    model::{query::Query, table::SimValue, SimConnection},
+};
 
 use crate::runner::execution::ExecutionContinuation;
 

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -13,7 +13,7 @@ use crate::runner::io::SimulatorIO;
 
 use super::cli::SimulatorCLI;
 
-pub(crate) struct SimulatorEnv {
+pub(crate) struct LimboSimulatorEnv {
     pub(crate) opts: SimulatorOpts,
     pub(crate) tables: Vec<Table>,
     pub(crate) connections: Vec<SimConnection>,
@@ -23,9 +23,9 @@ pub(crate) struct SimulatorEnv {
     pub(crate) db_path: String,
 }
 
-impl SimulatorEnv {
+impl LimboSimulatorEnv {
     pub(crate) fn clone_without_connections(&self) -> Self {
-        SimulatorEnv {
+        LimboSimulatorEnv {
             opts: self.opts.clone(),
             tables: self.tables.clone(),
             connections: (0..self.connections.len())
@@ -39,7 +39,7 @@ impl SimulatorEnv {
     }
 }
 
-impl SimulatorEnv {
+impl LimboSimulatorEnv {
     pub(crate) fn new(seed: u64, cli_opts: &SimulatorCLI, db_path: &Path) -> Self {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
@@ -146,7 +146,7 @@ impl SimulatorEnv {
             .map(|_| SimConnection::Disconnected)
             .collect::<Vec<_>>();
 
-        SimulatorEnv {
+        LimboSimulatorEnv {
             opts,
             tables: Vec::new(),
             connections,

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -8,7 +8,7 @@ use crate::generation::{
     plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
 };
 
-use super::env::{SimConnection, SimulatorEnv};
+use super::env::{SimConnection, LimboSimulatorEnv};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Execution {
@@ -56,7 +56,7 @@ impl ExecutionResult {
 }
 
 pub(crate) fn execute_plans(
-    env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
     plans: &mut [InteractionPlan],
     states: &mut [InteractionPlanState],
     last_execution: Arc<Mutex<Execution>>,
@@ -106,7 +106,7 @@ pub(crate) fn execute_plans(
 }
 
 fn execute_plan(
-    env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
     connection_index: usize,
     plans: &mut [InteractionPlan],
     states: &mut [InteractionPlanState],
@@ -176,7 +176,7 @@ pub(crate) enum ExecutionContinuation {
 
 #[instrument(skip(env, interaction, stack), fields(interaction = %interaction))]
 pub(crate) fn execute_interaction(
-    env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
     connection_index: usize,
     interaction: &Interaction,
     stack: &mut Vec<ResultSet>,

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -6,7 +6,7 @@ use limbo_sim::{
         pick_index,
         plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
     },
-    model::SimConnection,
+    model::{Shadow as _, SimConnection},
 };
 use tracing::instrument;
 

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -1,14 +1,16 @@
 use std::sync::{Arc, Mutex};
 
 use limbo_core::{Connection, LimboError, Result, StepResult};
+use limbo_sim::{
+    generation::{
+        pick_index,
+        plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
+    },
+    model::SimConnection,
+};
 use tracing::instrument;
 
-use crate::generation::{
-    pick_index,
-    plan::{Interaction, InteractionPlan, InteractionPlanState, ResultSet},
-};
-
-use super::env::{SimConnection, LimboSimulatorEnv};
+use crate::runner::env::LimboSimulatorEnv;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Execution {
@@ -191,7 +193,7 @@ pub(crate) fn execute_interaction(
                 SimConnection::Disconnected => unreachable!(),
             };
 
-            let results = interaction.execute_query(conn, &env.io);
+            let results = interaction.execute_query(conn);
             tracing::debug!("{:?}", results);
             stack.push(results);
             limbo_integrity_check(conn)?;

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -104,6 +104,6 @@ impl IO for SimulatorIO {
     }
 
     fn get_memory_io(&self) -> Arc<limbo_core::MemoryIO> {
-        todo!()
+        Arc::new(limbo_core::MemoryIO::new())
     }
 }

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -9,12 +9,12 @@ use crate::{
 };
 
 use super::{
-    env::{SimConnection, SimulatorEnv},
+    env::{SimConnection, LimboSimulatorEnv},
     execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult},
 };
 
 pub(crate) fn run_simulation(
-    env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
     plans: &mut [Vec<Vec<Interaction>>],
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {
@@ -37,7 +37,7 @@ pub(crate) fn run_simulation(
 }
 
 pub(crate) fn execute_plans(
-    env: Arc<Mutex<SimulatorEnv>>,
+    env: Arc<Mutex<LimboSimulatorEnv>>,
     plans: &mut [Vec<Vec<Interaction>>],
     states: &mut [InteractionPlanState],
     last_execution: Arc<Mutex<Execution>>,
@@ -81,7 +81,7 @@ pub(crate) fn execute_plans(
 }
 
 fn execute_plan(
-    env: &mut SimulatorEnv,
+    env: &mut LimboSimulatorEnv,
     connection_index: usize,
     plans: &mut [Vec<Vec<Interaction>>],
     states: &mut [InteractionPlanState],

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -1,17 +1,16 @@
 use std::sync::{Arc, Mutex};
 
-use crate::{
+use limbo_sim::{
     generation::{
         pick_index,
         plan::{Interaction, InteractionPlanState},
     },
-    runner::execution::ExecutionContinuation,
+    model::SimConnection,
 };
 
-use super::{
-    env::{SimConnection, LimboSimulatorEnv},
-    execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult},
-};
+use crate::runner::{env::LimboSimulatorEnv, execution::ExecutionContinuation};
+
+use super::execution::{execute_interaction, Execution, ExecutionHistory, ExecutionResult};
 
 pub(crate) fn run_simulation(
     env: Arc<Mutex<LimboSimulatorEnv>>,

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -1,104 +1,105 @@
-use crate::{
+use limbo_sim::{
     generation::{
         plan::{Interaction, InteractionPlan, Interactions},
         property::Property,
     },
     model::query::Query,
-    runner::execution::Execution,
 };
 
-impl InteractionPlan {
-    /// Create a smaller interaction plan by deleting a property
-    pub(crate) fn shrink_interaction_plan(&self, failing_execution: &Execution) -> InteractionPlan {
-        // todo: this is a very naive implementation, next steps are;
-        // - Shrink to multiple values by removing random interactions
-        // - Shrink properties by removing their extensions, or shrinking their values
-        let mut plan = self.clone();
-        let failing_property = &self.plan[failing_execution.interaction_index];
-        let mut depending_tables = failing_property.dependencies();
+use crate::runner::execution::Execution;
 
-        let interactions = failing_property.interactions();
+/// Create a smaller interaction plan by deleting a property
+pub(crate) fn shrink_interaction_plan(
+    curr_plan: &InteractionPlan,
+    failing_execution: &Execution,
+) -> InteractionPlan {
+    // todo: this is a very naive implementation, next steps are;
+    // - Shrink to multiple values by removing random interactions
+    // - Shrink properties by removing their extensions, or shrinking their values
+    let mut plan = curr_plan.clone();
+    let failing_property = &curr_plan.plan[failing_execution.interaction_index];
+    let mut depending_tables = failing_property.dependencies();
 
-        {
-            let mut idx = failing_execution.secondary_index;
-            loop {
-                match &interactions[idx] {
-                    Interaction::Query(query) => {
-                        depending_tables = query.dependencies();
+    let interactions = failing_property.interactions();
+
+    {
+        let mut idx = failing_execution.secondary_index;
+        loop {
+            match &interactions[idx] {
+                Interaction::Query(query) => {
+                    depending_tables = query.dependencies();
+                    break;
+                }
+                // Fault does not depend on
+                Interaction::Fault(..) => break,
+                _ => {
+                    // In principle we should never fail this checked_sub.
+                    // But if there is a bug in how we count the secondary index
+                    // we may panic if we do not use a checked_sub.
+                    if let Some(new_idx) = idx.checked_sub(1) {
+                        idx = new_idx;
+                    } else {
+                        tracing::warn!("failed to find error query");
                         break;
-                    }
-                    // Fault does not depend on
-                    Interaction::Fault(..) => break,
-                    _ => {
-                        // In principle we should never fail this checked_sub.
-                        // But if there is a bug in how we count the secondary index
-                        // we may panic if we do not use a checked_sub.
-                        if let Some(new_idx) = idx.checked_sub(1) {
-                            idx = new_idx;
-                        } else {
-                            tracing::warn!("failed to find error query");
-                            break;
-                        }
                     }
                 }
             }
         }
+    }
 
-        let before = self.plan.len();
+    let before = curr_plan.plan.len();
 
-        // Remove all properties after the failing one
-        plan.plan.truncate(failing_execution.interaction_index + 1);
+    // Remove all properties after the failing one
+    plan.plan.truncate(failing_execution.interaction_index + 1);
 
-        let mut idx = 0;
-        // Remove all properties that do not use the failing tables
-        plan.plan.retain_mut(|interactions| {
-            let retain = if idx == failing_execution.interaction_index {
-                true
-            } else {
-                let mut has_table = interactions
+    let mut idx = 0;
+    // Remove all properties that do not use the failing tables
+    plan.plan.retain_mut(|interactions| {
+        let retain = if idx == failing_execution.interaction_index {
+            true
+        } else {
+            let mut has_table = interactions
+                .uses()
+                .iter()
+                .any(|t| depending_tables.contains(t));
+            if has_table {
+                // Remove the extensional parts of the properties
+                if let Interactions::Property(p) = interactions {
+                    match p {
+                        Property::InsertValuesSelect { queries, .. }
+                        | Property::DoubleCreateFailure { queries, .. }
+                        | Property::DeleteSelect { queries, .. }
+                        | Property::DropSelect { queries, .. } => {
+                            queries.clear();
+                        }
+                        Property::SelectLimit { .. } | Property::SelectSelectOptimizer { .. } => {}
+                    }
+                }
+                // Check again after query clear if the interactions still uses the failing table
+                has_table = interactions
                     .uses()
                     .iter()
                     .any(|t| depending_tables.contains(t));
-                if has_table {
-                    // Remove the extensional parts of the properties
-                    if let Interactions::Property(p) = interactions {
-                        match p {
-                            Property::InsertValuesSelect { queries, .. }
-                            | Property::DoubleCreateFailure { queries, .. }
-                            | Property::DeleteSelect { queries, .. }
-                            | Property::DropSelect { queries, .. } => {
-                                queries.clear();
-                            }
-                            Property::SelectLimit { .. }
-                            | Property::SelectSelectOptimizer { .. } => {}
-                        }
-                    }
-                    // Check again after query clear if the interactions still uses the failing table
-                    has_table = interactions
-                        .uses()
-                        .iter()
-                        .any(|t| depending_tables.contains(t));
-                }
-                has_table
-                    && !matches!(
-                        interactions,
-                        Interactions::Query(Query::Select(_))
-                            | Interactions::Property(Property::SelectLimit { .. })
-                            | Interactions::Property(Property::SelectSelectOptimizer { .. })
-                    )
-            };
-            idx += 1;
-            retain
-        });
+            }
+            has_table
+                && !matches!(
+                    interactions,
+                    Interactions::Query(Query::Select(_))
+                        | Interactions::Property(Property::SelectLimit { .. })
+                        | Interactions::Property(Property::SelectSelectOptimizer { .. })
+                )
+        };
+        idx += 1;
+        retain
+    });
 
-        let after = plan.plan.len();
+    let after = plan.plan.len();
 
-        tracing::info!(
-            "Shrinking interaction plan from {} to {} properties",
-            before,
-            after
-        );
+    tracing::info!(
+        "Shrinking interaction plan from {} to {} properties",
+        before,
+        after
+    );
 
-        plan
-    }
+    plan
 }

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -1,11 +1,10 @@
 use crate::{
     generation::{
-        plan::{InteractionPlan, Interactions},
+        plan::{Interaction, InteractionPlan, Interactions},
         property::Property,
     },
     model::query::Query,
     runner::execution::Execution,
-    Interaction,
 };
 
 impl InteractionPlan {


### PR DESCRIPTION
This PR depends on #1788 to be merged first. Instead of rewriting statement generation logic, we can just use our enhanced generation logic we have in the limbo simulator. With both things integrated, we can improve our stress testing whenever we improve our generation logic.

Eventually, I would like to integrate our own `Interactions` and `Property` structs so that we can use antithesis assertions for them. But to reduce the scope of this PR, I'm just doing a drop-in replacement with `limbo_sim` generation.

EDIT: did an incorrect rebase and lost the changes. I will do this again after #1788 is merged