### PR TITLE
Integrity check debug for each instruction

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,6 +34,7 @@ csv = ["limbo_csv/static"]
 omit_autovacuum = []
 simulator = ["fuzz", "serde"]
 serde = ["dep:serde"]
+debug_integrity_check = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.5", optional = true }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -873,6 +873,8 @@ impl ProgramBuilder {
             change_cnt_on,
             result_columns: self.result_columns,
             table_references: self.table_references,
+            #[cfg(feature = "debug_integrity_check")]
+            integrity_check: Cell::new(false),
         }
     }
 }


### PR DESCRIPTION
Add a feature flag to execute an integrity check for each instruction. This will help us narrow down possible corruption bugs in the future.