### PR TITLE
chore: update rust to version 1.88.0

### DIFF
--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -155,7 +155,7 @@ pub fn translate_create_table(
     });
     // TODO: remove format, it sucks for performance but is convenient
     let parse_schema_where_clause =
-        format!("tbl_name = '{}' AND type != 'trigger'", normalized_tbl_name);
+        format!("tbl_name = '{normalized_tbl_name}' AND type != 'trigger'");
     program.emit_insn(Insn::ParseSchema {
         db: sqlite_schema_cursor_id,
         where_clause: Some(parse_schema_where_clause),

--- a/core/types.rs
+++ b/core/types.rs
@@ -1028,10 +1028,7 @@ impl ImmutableRecord {
                     return None;
                 }
 
-                match cursor.deserialize_column(self, idx) {
-                    Ok(value) => Some(value),
-                    Err(_) => None,
-                }
+                cursor.deserialize_column(self, idx).ok()
             }
             Err(_) => None,
         }
@@ -2536,8 +2533,7 @@ mod tests {
 
         assert_eq!(
             gold_result, optimized_result,
-            "Test '{}' failed: Full Comparison: {:?}, Optimized: {:?}, Strategy: {:?}",
-            test_name, gold_result, optimized_result, comparer
+            "Test '{test_name}' failed: Full Comparison: {gold_result:?}, Optimized: {optimized_result:?}, Strategy: {comparer:?}"
         );
 
         let generic_result = compare_records_generic(
@@ -2551,8 +2547,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             gold_result, generic_result,
-            "Test '{}' failed with generic: Full Comparison: {:?}, Generic: {:?}",
-            test_name, gold_result, generic_result
+            "Test '{test_name}' failed with generic: Full Comparison: {gold_result:?}, Generic: {generic_result:?}"
         );
     }
 
@@ -3074,7 +3069,7 @@ mod tests {
         for i in 0..values.len() {
             let full = cursor1.get_value(&record, i).expect("full failed");
             let incr = cursor2.get_value(&record, i).expect("incr failed");
-            assert_eq!(full, incr, "Mismatch at column {}", i);
+            assert_eq!(full, incr, "Mismatch at column {i}");
         }
 
         assert_eq!(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1492,14 +1492,12 @@ pub fn op_column(
                         n if n >= 13 && n % 2 == 1 => (n - 13) / 2,
                         10 | 11 => {
                             return Err(LimboError::Corrupt(format!(
-                                "Reserved serial type: {}",
-                                serial_type
+                                "Reserved serial type: {serial_type}"
                             )))
                         }
                         _ => {
                             return Err(LimboError::Corrupt(format!(
-                                "Invalid serial type: {}",
-                                serial_type
+                                "Invalid serial type: {serial_type}"
                             )))
                         }
                     } as usize;
@@ -1557,8 +1555,7 @@ pub fn op_column(
                             Value::Integer(read_integer_fast(data_slice, expected_len))
                         } else {
                             return Err(LimboError::Corrupt(format!(
-                                "Insufficient data for integer type {}: expected {}, got {}",
-                                serial_type, expected_len, data_len
+                                "Insufficient data for integer type {serial_type}: expected {expected_len}, got {data_len}"
                             )));
                         }
                     }
@@ -2708,8 +2705,8 @@ pub fn seek_internal(
                         // this same logic applies for indexes, but the next/prev record is expected to be found in the parent page's
                         // divider cell.
                         let result = match op {
-                            SeekOp::GT { .. } | SeekOp::GE { .. } => cursor.next()?,
-                            SeekOp::LT { .. } | SeekOp::LE { .. } => cursor.prev()?,
+                            SeekOp::GT | SeekOp::GE { .. } => cursor.next()?,
+                            SeekOp::LT | SeekOp::LE { .. } => cursor.prev()?,
                         };
                         match result {
                             IOResult::Done(found) => found,
@@ -4254,8 +4251,7 @@ pub fn op_function(
                             Some(table) => table,
                             None => {
                                 return Err(LimboError::InvalidArgument(format!(
-                                    "table_columns_json_array: table {} doesn't exists",
-                                    table
+                                    "table_columns_json_array: table {table} doesn't exists"
                                 )))
                             }
                         }

--- a/extensions/completion/build.rs
+++ b/extensions/completion/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}

--- a/extensions/core/build.rs
+++ b/extensions/core/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}

--- a/extensions/crypto/build.rs
+++ b/extensions/crypto/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}

--- a/extensions/csv/build.rs
+++ b/extensions/csv/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}

--- a/extensions/ipaddr/build.rs
+++ b/extensions/ipaddr/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}

--- a/extensions/percentile/build.rs
+++ b/extensions/percentile/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}

--- a/extensions/regexp/build.rs
+++ b/extensions/regexp/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.88.0"
 components = ["clippy", "rustfmt"]

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -230,7 +230,7 @@ impl Property {
                             if env.tables.iter().any(|t| t.name == table_name) {
                                 Ok(Ok(()))
                             } else {
-                                Ok(Err(format!("table {} does not exist", table_name)))
+                                Ok(Err(format!("table {table_name} does not exist")))
                             }
                         }
                     }),
@@ -286,7 +286,7 @@ impl Property {
                         if !env.tables.iter().any(|t| t.name == table_name) {
                             Ok(Ok(()))
                         } else {
-                            Ok(Err(format!("table {} already exists", table_name)))
+                            Ok(Err(format!("table {table_name} already exists")))
                         }
                     }),
                 });
@@ -303,12 +303,12 @@ impl Property {
                             func: Box::new(move |stack: &Vec<ResultSet>, _| {
                                 let last = stack.last().unwrap();
                                 match last {
-                                    Ok(success) => Ok(Err(format!("expected table creation to fail but it succeeded: {:?}", success))),
+                                    Ok(success) => Ok(Err(format!("expected table creation to fail but it succeeded: {success:?}"))),
                                     Err(e) => {
                                         if e.to_string().to_lowercase().contains(&format!("table {table_name} already exists")) {
                                             Ok(Ok(()))
                                         } else {
-                                            Ok(Err(format!("expected table already exists error, got: {}", e)))
+                                            Ok(Err(format!("expected table already exists error, got: {e}")))
                                         }
                                     }
                                 }
@@ -347,7 +347,7 @@ impl Property {
                                     .iter()
                                     .filter(|t| !env.tables.iter().any(|t2| t2.name == **t))
                                     .collect::<Vec<&String>>();
-                                Ok(Err(format!("missing tables: {:?}", missing_tables)))
+                                Ok(Err(format!("missing tables: {missing_tables:?}")))
                             }
                         }
                     }),
@@ -401,8 +401,7 @@ impl Property {
                                     let available_tables: Vec<String> =
                                         env.tables.iter().map(|t| t.name.clone()).collect();
                                     Ok(Err(format!(
-                                        "table \'{}\' not found. Available tables: {:?}",
-                                        table, available_tables
+                                        "table \'{table}\' not found. Available tables: {available_tables:?}"
                                     )))
                                 }
                             }
@@ -470,8 +469,7 @@ impl Property {
                                     let available_tables: Vec<String> =
                                         env.tables.iter().map(|t| t.name.clone()).collect();
                                     Ok(Err(format!(
-                                        "table \'{}\' not found. Available tables: {:?}",
-                                        table, available_tables
+                                        "table \'{table}\' not found. Available tables: {available_tables:?}"
                                     )))
                                 }
                             }
@@ -487,8 +485,7 @@ impl Property {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(success) => Ok(Err(format!(
-                                "expected table creation to fail but it succeeded: {:?}",
-                                success
+                                "expected table creation to fail but it succeeded: {success:?}"
                             ))),
                             Err(e) => {
                                 if e.to_string()
@@ -497,8 +494,7 @@ impl Property {
                                     Ok(Ok(()))
                                 } else {
                                     Ok(Err(format!(
-                                        "expected table does not exist error, got: {}",
-                                        e
+                                        "expected table does not exist error, got: {e}"
                                     )))
                                 }
                             }
@@ -535,8 +531,7 @@ impl Property {
                                     let available_tables: Vec<String> =
                                         env.tables.iter().map(|t| t.name.clone()).collect();
                                     Ok(Err(format!(
-                                        "table \'{}\' not found. Available tables: {:?}",
-                                        table, available_tables
+                                        "table \'{table}\' not found. Available tables: {available_tables:?}"
                                     )))
                                 }
                             }
@@ -668,7 +663,7 @@ impl Property {
                                     .iter()
                                     .filter(|t| !env.tables.iter().any(|t2| t2.name == **t))
                                     .collect::<Vec<&String>>();
-                                Ok(Err(format!("missing tables: {:?}", missing_tables)))
+                                Ok(Err(format!("missing tables: {missing_tables:?}")))
                             }
                         }
                     }),
@@ -818,7 +813,7 @@ impl Property {
                                     if union_count == count1 + count2 {
                                         Ok(Ok(()))
                                     } else {
-                                        Ok(Err(format!("UNION ALL should preserve cardinality but it didn't: {} + {} != {}", count1, count2, union_count)))
+                                        Ok(Err(format!("UNION ALL should preserve cardinality but it didn't: {count1} + {count2} != {union_count}")))
                                     }
                                 }
                                 (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -285,8 +285,7 @@ fn execute_plan(
                                             "differences: {}",
                                             diff.iter()
                                                 .map(|((i, j), (l, r))| format!(
-                                                    "\t({}, {}): ({}) != ({})",
-                                                    i, j, l, r
+                                                    "\t({i}, {j}): ({l}) != ({r})"
                                                 ))
                                                 .collect::<Vec<_>>()
                                                 .join("\n")

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -864,7 +864,7 @@ fn test_cdc_bin_record() {
     ]);
     let mut record_hex = String::new();
     for byte in record {
-        record_hex.push_str(&format!("{:02X}", byte));
+        record_hex.push_str(&format!("{byte:02X}"));
     }
 
     let rows = limbo_exec_rows(

--- a/tests/integration/query_processing/test_btree.rs
+++ b/tests/integration/query_processing/test_btree.rs
@@ -487,8 +487,7 @@ fn test_btree() {
                 };
                 assert_eq!(
                     limbo_sum, sqlite_sum,
-                    "query={}, limbo={:?}, sqlite={:?}",
-                    query, limbo_sum, sqlite_sum
+                    "query={query}, limbo={limbo_sum:?}, sqlite={sqlite_sum:?}"
                 );
             }
         }


### PR DESCRIPTION
This PR updates to version Rust 1.88.0 ([Release notes](https://releases.rs/docs/1.88.0/)) and fixes all the clippy errors that come with the new Rust version.

This is possible in the latest Rust version:
```rust
if let Some(foo) = bar && foo.is_cool() {
  ...
}
```

There are three complications in the migration (so far):
- A BUNCH of Clippy warnings (mostly fixed in https://github.com/tursodatabase/limbo/pull/1827)
- Windows cross compilation failed; linking `advapi32` on windows fixes it
  - Since Rust 1.87.0, advapi32 is not linked by default anymore ([Release notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes-1), [PR](https://github.com/rust-lang/rust/pull/138233))
- Rust is more strict with FFIs and aligning pointers now. CI checks failed with error below
  - Fixed in https://github.com/tursodatabase/turso/pull/2064
```
thread 'main' panicked at
core/ext/vtab_xconnect.rs:64:25:
misaligned pointer dereference: address must be
a multiple of 0x8 but is 0x7ffd9d901554
```