### PR TITLE
Switch to runtime flag for enabling indexes

### DIFF
--- a/.github/workflows/long_fuzz_tests_btree.yml
+++ b/.github/workflows/long_fuzz_tests_btree.yml
@@ -29,7 +29,7 @@ jobs:
       env:
         RUST_BACKTRACE: 1
     - name: Run ignored long tests with index
-      run: cargo test --features index_experimental -- --ignored fuzz_long
+      run: cargo test -- --ignored fuzz_long
       env:
         RUST_BACKTRACE: 1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,12 +41,6 @@ jobs:
         RUST_LOG: ${{ runner.debug && 'limbo_core::storage=trace' || '' }}
       run: cargo test --verbose
       timeout-minutes: 20
-    - name: Tests with indexes
-      env:
-        RUST_LOG: ${{ runner.debug && 'limbo_core::storage=trace' || '' }}
-      run: cargo test --verbose --features index_experimental
-      timeout-minutes: 20
-
 
   clippy:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/bindings/go/rs_src/lib.rs
+++ b/bindings/go/rs_src/lib.rs
@@ -24,7 +24,7 @@ pub unsafe extern "C" fn db_open(path: *const c_char) -> *mut c_void {
         p if p.contains(":memory:") => Arc::new(limbo_core::MemoryIO::new()),
         _ => Arc::new(limbo_core::PlatformIO::new().expect("Failed to create IO")),
     };
-    let db = Database::open_file(io.clone(), path, false);
+    let db = Database::open_file(io.clone(), path, false, false);
     match db {
         Ok(db) => {
             let conn = db.connect().unwrap();

--- a/bindings/java/rs_src/limbo_db.rs
+++ b/bindings/java/rs_src/limbo_db.rs
@@ -68,7 +68,7 @@ pub extern "system" fn Java_tech_turso_core_LimboDB_openUtf8<'local>(
         }
     };
 
-    let db = match Database::open_file(io.clone(), &path, false) {
+    let db = match Database::open_file(io.clone(), &path, false, false) {
         Ok(db) => db,
         Err(e) => {
             set_err_msg_and_throw_exception(&mut env, obj, LIMBO_ETC, e.to_string());

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -71,7 +71,7 @@ impl Database {
         let file = io.open_file(&path, flag, false).map_err(into_napi_error)?;
 
         let db_file = Arc::new(DatabaseFile::new(file));
-        let db = limbo_core::Database::open(io.clone(), &path, db_file, false)
+        let db = limbo_core::Database::open(io.clone(), &path, db_file, false, false)
             .map_err(into_napi_error)?;
         let conn = db.connect().map_err(into_napi_error)?;
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -305,7 +305,7 @@ pub fn connect(path: &str) -> Result<Connection> {
         io: Arc<dyn limbo_core::IO>,
         path: &str,
     ) -> std::result::Result<Arc<limbo_core::Database>, PyErr> {
-        limbo_core::Database::open_file(io, path, false).map_err(|e| {
+        limbo_core::Database::open_file(io, path, false, false).map_err(|e| {
             PyErr::new::<DatabaseError, _>(format!("Failed to open database: {:?}", e))
         })
     }

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -9,9 +9,6 @@ license.workspace = true
 repository.workspace = true
 description = "Limbo Rust API"
 
-[features]
-index_experimental = ["limbo_core/index_experimental"]
-
 [dependencies]
 limbo_core = { workspace = true, features = ["io_uring"] }
 thiserror = "2.0.9"

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -83,12 +83,12 @@ impl Builder {
         match self.path.as_str() {
             ":memory:" => {
                 let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::MemoryIO::new());
-                let db = limbo_core::Database::open_file(io, self.path.as_str(), false)?;
+                let db = limbo_core::Database::open_file(io, self.path.as_str(), false, false)?;
                 Ok(Database { inner: db })
             }
             path => {
                 let io: Arc<dyn limbo_core::IO> = Arc::new(limbo_core::PlatformIO::new()?);
-                let db = limbo_core::Database::open_file(io, path, false)?;
+                let db = limbo_core::Database::open_file(io, path, false, false)?;
                 Ok(Database { inner: db })
             }
         }

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -22,7 +22,7 @@ impl Database {
         let io: Arc<dyn limbo_core::IO> = Arc::new(PlatformIO { vfs: VFS::new() });
         let file = io.open_file(path, OpenFlags::Create, false).unwrap();
         let db_file = Arc::new(DatabaseFile::new(file));
-        let db = limbo_core::Database::open(io, path, db_file, false).unwrap();
+        let db = limbo_core::Database::open(io, path, db_file, false, false).unwrap();
         let conn = db.connect().unwrap();
         Database { db, conn }
     }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,7 +50,6 @@ toml_edit = {version = "0.22.24", features = ["serde"]}
 [features]
 default = ["io_uring"]
 io_uring = ["limbo_core/io_uring"]
-index_experimental = ["limbo_core/index_experimental"]
 
 [build-dependencies]
 syntect = "5.2.0"

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -57,6 +57,8 @@ pub struct Opts {
     pub vfs: Option<String>,
     #[clap(long, help = "Enable experimental MVCC feature")]
     pub experimental_mvcc: bool,
+    #[clap(long, help = "Enable experimental indexing feature")]
+    pub experimental_indexes: bool,
     #[clap(short = 't', long, help = "specify output file for log traces")]
     pub tracing_output: Option<String>,
 }
@@ -129,7 +131,12 @@ impl Limbo {
             };
             (
                 io.clone(),
-                Database::open_file(io.clone(), &db_file, opts.experimental_mvcc)?,
+                Database::open_file(
+                    io.clone(),
+                    &db_file,
+                    opts.experimental_mvcc,
+                    opts.experimental_indexes,
+                )?,
             )
         };
         let conn = db.connect()?;
@@ -356,7 +363,10 @@ impl Limbo {
                     _path => get_io(DbLocation::Path, &self.opts.io.to_string())?,
                 }
             };
-            (io.clone(), Database::open_file(io.clone(), path, false)?)
+            (
+                io.clone(),
+                Database::open_file(io.clone(), path, false, false)?,
+            )
         };
         self.io = io;
         self.conn = db.connect()?;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,6 @@ path = "lib.rs"
 
 [features]
 default = ["fs", "uuid", "time", "json", "static"]
-index_experimental = []
 fs = ["limbo_ext/vfs"]
 json = []
 uuid = ["limbo_uuid/static"]

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -18,7 +18,7 @@ fn bench_prepare_query(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false, false).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let queries = [
@@ -65,7 +65,7 @@ fn bench_execute_select_rows(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false, false).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT * FROM users LIMIT ?`");
@@ -134,7 +134,7 @@ fn bench_execute_select_1(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false, false).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT 1`");
@@ -187,7 +187,7 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false, false).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT count() FROM users`");

--- a/core/benches/json_benchmark.rs
+++ b/core/benches/json_benchmark.rs
@@ -22,7 +22,7 @@ fn bench(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false, false).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     // Benchmark JSONB with different payload sizes
@@ -491,7 +491,7 @@ fn bench_sequential_jsonb(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false, false).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     // Select a subset of JSON payloads to use in the sequential test
@@ -648,7 +648,7 @@ fn bench_json_patch(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db", false, false).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let json_patch_cases = [

--- a/core/benches/tpc_h_benchmark.rs
+++ b/core/benches/tpc_h_benchmark.rs
@@ -30,7 +30,7 @@ fn bench_tpc_h_queries(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), TPC_H_PATH, false).unwrap();
+    let db = Database::open_file(io.clone(), TPC_H_PATH, false, true).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let queries = [

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -109,7 +109,7 @@ impl Database {
                 }
             },
         };
-        let db = Self::open_file(io.clone(), path, false)?;
+        let db = Self::open_file(io.clone(), path, false, false)?;
         Ok((io, db))
     }
 }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6583,7 +6583,7 @@ mod tests {
                 .unwrap();
         }
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), path.to_str().unwrap(), false).unwrap();
+        let db = Database::open_file(io.clone(), path.to_str().unwrap(), false, false).unwrap();
 
         db
     }
@@ -7123,7 +7123,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "index_experimental")]
     fn btree_index_insert_fuzz_run(attempts: usize, inserts: usize) {
         use crate::storage::pager::CreateBTreeFlags;
 
@@ -7311,7 +7310,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "index_experimental")]
     pub fn btree_index_insert_fuzz_run_equal_size() {
         btree_index_insert_fuzz_run(2, 1024);
     }
@@ -7347,7 +7345,6 @@ mod tests {
 
     #[test]
     #[ignore]
-    #[cfg(feature = "index_experimental")]
     pub fn fuzz_long_btree_index_insert_fuzz_run_equal_size() {
         btree_index_insert_fuzz_run(2, 10_000);
     }

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -24,15 +24,12 @@ pub fn translate_alter_table(
 ) -> Result<ProgramBuilder> {
     let (table_name, alter_table) = alter;
     let ast::Name(table_name) = table_name.name;
-    #[cfg(not(feature = "index_experimental"))]
-    {
-        if schema.table_has_indexes(&table_name) && cfg!(not(feature = "index_experimental")) {
-            // Let's disable altering a table with indices altogether instead of checking column by
-            // column to be extra safe.
-            crate::bail_parse_error!(
-                "Alter table disabled for table with indexes without index_experimental feature flag"
-            );
-        }
+    if schema.table_has_indexes(&table_name) && !schema.indexes_enabled() {
+        // Let's disable altering a table with indices altogether instead of checking column by
+        // column to be extra safe.
+        crate::bail_parse_error!(
+            "ALTER TABLE for table with indexes is disabled by default. Run with `--experimental-indexes` to enable this feature."
+        );
     }
 
     let Some(original_btree) = schema

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -154,7 +154,7 @@ fn emit_compound_select(
                         (cursor_id, index.clone())
                     }
                     _ => {
-                        if cfg!(not(feature = "index_experimental")) {
+                        if !schema.indexes_enabled() {
                             crate::bail_parse_error!("UNION not supported without indexes");
                         } else {
                             new_dedupe_index = true;

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -18,15 +18,12 @@ pub fn translate_delete(
     syms: &SymbolTable,
     mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
-    #[cfg(not(feature = "index_experimental"))]
-    {
-        if schema.table_has_indexes(&tbl_name.name.to_string()) {
-            // Let's disable altering a table with indices altogether instead of checking column by
-            // column to be extra safe.
-            crate::bail_parse_error!(
-                "DELETE into table disabled for table with indexes and without index_experimental feature flag"
-            );
-        }
+    if schema.table_has_indexes(&tbl_name.name.to_string()) && !schema.indexes_enabled() {
+        // Let's disable altering a table with indices altogether instead of checking column by
+        // column to be extra safe.
+        crate::bail_parse_error!(
+            "DELETE for table with indexes is disabled by default. Run with `--experimental-indexes` to enable this feature."
+        );
     }
     let mut delete_plan = prepare_delete_plan(
         schema,

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -23,8 +23,10 @@ pub fn translate_create_index(
     schema: &Schema,
     mut program: ProgramBuilder,
 ) -> crate::Result<ProgramBuilder> {
-    if cfg!(not(feature = "index_experimental")) {
-        crate::bail_parse_error!("CREATE INDEX enabled only with index_experimental feature");
+    if !schema.indexes_enabled() {
+        crate::bail_parse_error!(
+            "CREATE INDEX is disabled by default. Run with `--experimental-indexes` to enable this feature."
+        );
     }
     let idx_name = normalize_ident(idx_name);
     let tbl_name = normalize_ident(tbl_name);
@@ -299,8 +301,10 @@ pub fn translate_drop_index(
     schema: &Schema,
     mut program: ProgramBuilder,
 ) -> crate::Result<ProgramBuilder> {
-    if cfg!(not(feature = "index_experimental")) {
-        crate::bail_parse_error!("DROP INDEX enabled only with index_experimental feature");
+    if !schema.indexes_enabled() {
+        crate::bail_parse_error!(
+            "DROP INDEX is disabled by default. Run with `--experimental-indexes` to enable this feature."
+        );
     }
     let idx_name = normalize_ident(idx_name);
     let opts = crate::vdbe::builder::ProgramBuilderOpts {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -58,15 +58,12 @@ pub fn translate_insert(
         crate::bail_parse_error!("ON CONFLICT clause is not supported");
     }
 
-    #[cfg(not(feature = "index_experimental"))]
-    {
-        if schema.table_has_indexes(&tbl_name.name.to_string()) {
-            // Let's disable altering a table with indices altogether instead of checking column by
-            // column to be extra safe.
-            crate::bail_parse_error!(
-                "INSERT table disabled for table with indexes and without index_experimental feature flag"
-            );
-        }
+    if schema.table_has_indexes(&tbl_name.name.to_string()) && !schema.indexes_enabled() {
+        // Let's disable altering a table with indices altogether instead of checking column by
+        // column to be extra safe.
+        crate::bail_parse_error!(
+            "INSERT to table with indexes is disabled by default. Run with `--experimental-indexes` to enable this feature."
+        );
     }
     let table_name = &tbl_name.name;
     let table = match schema.get_table(table_name.0.as_str()) {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -93,7 +93,7 @@ pub fn translate_create_table(
 
     let index_regs = check_automatic_pk_index_required(&body, &mut program, &tbl_name.name.0)?;
     if let Some(index_regs) = index_regs.as_ref() {
-        if cfg!(not(feature = "index_experimental")) {
+        if !schema.indexes_enabled() {
             bail_parse_error!("Constraints UNIQUE and PRIMARY KEY (unless INTEGER PRIMARY KEY) on table are not supported without indexes");
         }
         for index_reg in index_regs.clone() {
@@ -613,13 +613,10 @@ pub fn translate_drop_table(
     schema: &Schema,
     mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
-    #[cfg(not(feature = "index_experimental"))]
-    {
-        if schema.table_has_indexes(&tbl_name.name.to_string()) {
-            bail_parse_error!(
-                "DROP Table with indexes on the table enabled only with index_experimental feature"
-            );
-        }
+    if !schema.indexes_enabled() && schema.table_has_indexes(&tbl_name.name.to_string()) {
+        bail_parse_error!(
+            "DROP TABLE with indexes on the table is disabled by default. Run with `--experimental-indexes` to enable this feature."
+        );
     }
     let opts = ProgramBuilderOpts {
         query_mode,

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -104,15 +104,12 @@ pub fn prepare_update_plan(
         bail_parse_error!("ON CONFLICT clause is not supported");
     }
     let table_name = &body.tbl_name.name;
-    #[cfg(not(feature = "index_experimental"))]
-    {
-        if schema.table_has_indexes(&table_name.to_string()) {
-            // Let's disable altering a table with indices altogether instead of checking column by
-            // column to be extra safe.
-            bail_parse_error!(
-                "UPDATE table disabled for table with indexes and without index_experimental feature flag"
-            );
-        }
+    if schema.table_has_indexes(&table_name.to_string()) && !schema.indexes_enabled() {
+        // Let's disable altering a table with indices altogether instead of checking column by
+        // column to be extra safe.
+        bail_parse_error!(
+            "UPDATE table disabled for table with indexes is disabled by default. Run with `--experimental-indexes` to enable this feature."
+        );
     }
     let table = match schema.get_table(table_name.0.as_str()) {
         Some(table) => table,

--- a/core/util.rs
+++ b/core/util.rs
@@ -138,10 +138,9 @@ pub fn parse_schema_rows(
             }
         }
         for unparsed_sql_from_index in from_sql_indexes {
-            #[cfg(not(feature = "index_experimental"))]
-            schema.table_set_has_index(&unparsed_sql_from_index.table_name);
-            #[cfg(feature = "index_experimental")]
-            {
+            if !schema.indexes_enabled() {
+                schema.table_set_has_index(&unparsed_sql_from_index.table_name);
+            } else {
                 let table = schema
                     .get_btree_table(&unparsed_sql_from_index.table_name)
                     .unwrap();
@@ -154,10 +153,9 @@ pub fn parse_schema_rows(
             }
         }
         for automatic_index in automatic_indices {
-            #[cfg(not(feature = "index_experimental"))]
-            schema.table_set_has_index(&automatic_index.0);
-            #[cfg(feature = "index_experimental")]
-            {
+            if !schema.indexes_enabled() {
+                schema.table_set_has_index(&automatic_index.0);
+            } else {
                 let table = schema.get_btree_table(&automatic_index.0).unwrap();
                 let ret_index = schema::Index::automatic_from_primary_key_and_unique(
                     table.as_ref(),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4946,7 +4946,7 @@ pub fn op_parse_schema(
         }
     } else {
         let stmt = conn.prepare("SELECT * FROM sqlite_schema")?;
-        let mut new = Schema::new();
+        let mut new = Schema::new(conn.schema.read().indexes_enabled());
 
         // TODO: This function below is synchronous, make it async
         {

--- a/perf/latency/limbo/Cargo.toml
+++ b/perf/latency/limbo/Cargo.toml
@@ -3,9 +3,6 @@ name = "limbo-multitenancy"
 version = "0.1.0"
 edition = "2021"
 
-[features]
-index_experimental = ["limbo_core/index_experimental"]
-
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.0"

--- a/scripts/limbo-sqlite3-index-experimental
+++ b/scripts/limbo-sqlite3-index-experimental
@@ -2,7 +2,7 @@
 
 # if RUST_LOG is non-empty, enable tracing output
 if [ -n "$RUST_LOG" ]; then
-   target/debug/limbo_index_experimental -m list -t testing/test.log "$@"
+   target/debug/limbo --experimental-indexes -m list -t testing/test.log "$@"
 else
-   target/debug/limbo_index_experimental -m list "$@"
+   target/debug/limbo --experimental-indexes -m list "$@"
 fi

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -648,6 +648,7 @@ impl Interaction {
                             env.io.clone(),
                             &db_path,
                             false,
+                            false,
                         ) {
                             Ok(db) => db,
                             Err(e) => {

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -135,7 +135,7 @@ impl SimulatorEnv {
             std::fs::remove_file(wal_path).unwrap();
         }
 
-        let db = match Database::open_file(io.clone(), db_path.to_str().unwrap(), false) {
+        let db = match Database::open_file(io.clone(), db_path.to_str().unwrap(), false, false) {
             Ok(db) => db,
             Err(e) => {
                 panic!("error opening simulator test file {:?}: {:?}", db_path, e);

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn sqlite3_open(
             Err(_) => return SQLITE_CANTOPEN,
         },
     };
-    match limbo_core::Database::open_file(io.clone(), filename, false) {
+    match limbo_core::Database::open_file(io.clone(), filename, false, false) {
         Ok(db) => {
             let conn = db.connect().unwrap();
             *db_out = Box::leak(Box::new(sqlite3::new(io, db, conn)));

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -14,8 +14,6 @@ publish = false
 name = "limbo_stress"
 path = "main.rs"
 
-[features]
-index_experimental = ["limbo/index_experimental"]
 [dependencies]
 antithesis_sdk = "0.2.5"
 clap = { version = "4.5", features = ["derive"] }

--- a/stress/main.rs
+++ b/stress/main.rs
@@ -165,7 +165,8 @@ impl ArbitrarySchema {
                     .map(|col| {
                         let mut col_def =
                             format!("  {} {}", col.name, data_type_to_sql(&col.data_type));
-                        if cfg!(feature = "index_experimental") {
+                        if false {
+                            /* FIXME */
                             for constraint in &col.constraints {
                                 col_def.push(' ');
                                 col_def.push_str(&constraint_to_sql(constraint));

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,9 +14,6 @@ path = "lib.rs"
 name = "integration_tests"
 path = "integration/mod.rs"
 
-[features]
-index_experimental = ["limbo_core/index_experimental"]
-
 [dependencies]
 anyhow.workspace = true
 env_logger = "0.10.1"

--- a/tests/integration/functions/test_function_rowid.rs
+++ b/tests/integration/functions/test_function_rowid.rs
@@ -6,6 +6,7 @@ fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
     let tmp_db = TempDatabase::new_with_rusqlite(
         "CREATE TABLE test_rowid (id INTEGER PRIMARY KEY, val TEXT);",
+        false,
     );
     let conn = tmp_db.connect_limbo();
 
@@ -90,7 +91,7 @@ fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
 fn test_integer_primary_key() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
     let tmp_db =
-        TempDatabase::new_with_rusqlite("CREATE TABLE test_rowid (id INTEGER PRIMARY KEY);");
+        TempDatabase::new_with_rusqlite("CREATE TABLE test_rowid (id INTEGER PRIMARY KEY);", false);
     let conn = tmp_db.connect_limbo();
 
     for query in &[

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -3,7 +3,7 @@ use limbo_core::{StepResult, Value};
 
 #[test]
 fn test_statement_reset_bind() -> anyhow::Result<()> {
-    let tmp_db = TempDatabase::new_with_rusqlite("create table test (i integer);");
+    let tmp_db = TempDatabase::new_with_rusqlite("create table test (i integer);", false);
     let conn = tmp_db.connect_limbo();
 
     let mut stmt = conn.prepare("select ?")?;
@@ -47,7 +47,7 @@ fn test_statement_reset_bind() -> anyhow::Result<()> {
 
 #[test]
 fn test_statement_bind() -> anyhow::Result<()> {
-    let tmp_db = TempDatabase::new_with_rusqlite("create table test (i integer);");
+    let tmp_db = TempDatabase::new_with_rusqlite("create table test (i integer);", false);
     let conn = tmp_db.connect_limbo();
 
     let mut stmt = conn.prepare("select ?, ?1, :named, ?3, ?4")?;
@@ -112,6 +112,7 @@ fn test_insert_parameter_remap() -> anyhow::Result<()> {
 
     let tmp_db = TempDatabase::new_with_rusqlite(
         "create table test (a integer, b integer, c integer, d integer);",
+        false,
     );
     let conn = tmp_db.connect_limbo();
 
@@ -176,6 +177,7 @@ fn test_insert_parameter_remap_all_params() -> anyhow::Result<()> {
 
     let tmp_db = TempDatabase::new_with_rusqlite(
         "create table test (a integer, b integer, c integer, d integer);",
+        false,
     );
     let conn = tmp_db.connect_limbo();
     let mut ins = conn.prepare("insert into test (d, a, c, b) values (?, ?, ?, ?);")?;
@@ -243,6 +245,7 @@ fn test_insert_parameter_multiple_remap_backwards() -> anyhow::Result<()> {
 
     let tmp_db = TempDatabase::new_with_rusqlite(
         "create table test (a integer, b integer, c integer, d integer);",
+        false,
     );
     let conn = tmp_db.connect_limbo();
     let mut ins = conn.prepare("insert into test (d,c,b,a) values (?, ?, ?, ?);")?;
@@ -309,6 +312,7 @@ fn test_insert_parameter_multiple_no_remap() -> anyhow::Result<()> {
 
     let tmp_db = TempDatabase::new_with_rusqlite(
         "create table test (a integer, b integer, c integer, d integer);",
+        false,
     );
     let conn = tmp_db.connect_limbo();
     let mut ins = conn.prepare("insert into test (a,b,c,d) values (?, ?, ?, ?);")?;
@@ -375,6 +379,7 @@ fn test_insert_parameter_multiple_row() -> anyhow::Result<()> {
 
     let tmp_db = TempDatabase::new_with_rusqlite(
         "create table test (a integer, b integer, c integer, d integer);",
+        false,
     );
     let conn = tmp_db.connect_limbo();
     let mut ins = conn.prepare("insert into test (b,a,d,c) values (?, ?, ?, ?), (?, ?, ?, ?);")?;
@@ -440,7 +445,7 @@ fn test_insert_parameter_multiple_row() -> anyhow::Result<()> {
 
 #[test]
 fn test_bind_parameters_update_query() -> anyhow::Result<()> {
-    let tmp_db = TempDatabase::new_with_rusqlite("create table test (a integer, b text);");
+    let tmp_db = TempDatabase::new_with_rusqlite("create table test (a integer, b text);", false);
     let conn = tmp_db.connect_limbo();
     let mut ins = conn.prepare("insert into test (a, b) values (3, 'test1');")?;
     loop {
@@ -484,6 +489,7 @@ fn test_bind_parameters_update_query() -> anyhow::Result<()> {
 fn test_bind_parameters_update_query_multiple_where() -> anyhow::Result<()> {
     let tmp_db = TempDatabase::new_with_rusqlite(
         "create table test (a integer, b text, c integer, d integer);",
+        false,
     );
     let conn = tmp_db.connect_limbo();
     let mut ins = conn.prepare("insert into test (a, b, c, d) values (3, 'test1', 4, 5);")?;
@@ -529,8 +535,10 @@ fn test_bind_parameters_update_query_multiple_where() -> anyhow::Result<()> {
 
 #[test]
 fn test_bind_parameters_update_rowid_alias() -> anyhow::Result<()> {
-    let tmp_db =
-        TempDatabase::new_with_rusqlite("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);");
+    let tmp_db = TempDatabase::new_with_rusqlite(
+        "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);",
+        false,
+    );
     let conn = tmp_db.connect_limbo();
     let mut ins = conn.prepare("insert into test (id, name) values (1, 'test');")?;
     loop {
@@ -588,6 +596,7 @@ fn test_bind_parameters_update_rowid_alias() -> anyhow::Result<()> {
 fn test_bind_parameters_update_rowid_alias_seek_rowid() -> anyhow::Result<()> {
     let tmp_db = TempDatabase::new_with_rusqlite(
         "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT, age integer);",
+        false,
     );
     let conn = tmp_db.connect_limbo();
     conn.execute("insert into test (id, name, age) values (1, 'test', 4);")?;
@@ -655,6 +664,7 @@ fn test_bind_parameters_update_rowid_alias_seek_rowid() -> anyhow::Result<()> {
 fn test_bind_parameters_delete_rowid_alias_seek_out_of_order() -> anyhow::Result<()> {
     let tmp_db = TempDatabase::new_with_rusqlite(
         "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT, age integer);",
+        false,
     );
     let conn = tmp_db.connect_limbo();
     conn.execute("insert into test (id, name, age) values (1, 'correct', 4);")?;

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -20,8 +20,10 @@ macro_rules! change_state {
 #[ignore]
 fn test_simple_overflow_page() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db =
-        TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);");
+    let tmp_db = TempDatabase::new_with_rusqlite(
+        "CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);",
+        false,
+    );
     let conn = tmp_db.connect_limbo();
 
     let mut huge_text = String::new();
@@ -82,8 +84,10 @@ fn test_simple_overflow_page() -> anyhow::Result<()> {
 fn test_sequential_overflow_page() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
     maybe_setup_tracing();
-    let tmp_db =
-        TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);");
+    let tmp_db = TempDatabase::new_with_rusqlite(
+        "CREATE TABLE test (x INTEGER PRIMARY KEY, t TEXT);",
+        false,
+    );
     let conn = tmp_db.connect_limbo();
     let iterations = 10_usize;
 
@@ -152,7 +156,8 @@ fn test_sequential_write() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
     maybe_setup_tracing();
 
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+    let tmp_db =
+        TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);", false);
     let conn = tmp_db.connect_limbo();
 
     let list_query = "SELECT * FROM test";
@@ -187,7 +192,7 @@ fn test_sequential_write() -> anyhow::Result<()> {
 /// https://github.com/tursodatabase/limbo/pull/679
 fn test_regression_multi_row_insert() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x REAL);");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x REAL);", false);
     let conn = tmp_db.connect_limbo();
 
     let insert_query = "INSERT INTO test VALUES (-2), (-3), (-1)";
@@ -220,7 +225,7 @@ fn test_regression_multi_row_insert() -> anyhow::Result<()> {
 #[test]
 fn test_statement_reset() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new_with_rusqlite("create table test (i integer);");
+    let tmp_db = TempDatabase::new_with_rusqlite("create table test (i integer);", false);
     let conn = tmp_db.connect_limbo();
 
     conn.execute("insert into test values (1)")?;
@@ -267,7 +272,8 @@ fn test_statement_reset() -> anyhow::Result<()> {
 #[ignore]
 fn test_wal_checkpoint() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+    let tmp_db =
+        TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);", false);
     // threshold is 1000 by default
     let iterations = 1001_usize;
     let conn = tmp_db.connect_limbo();
@@ -294,7 +300,8 @@ fn test_wal_checkpoint() -> anyhow::Result<()> {
 #[test]
 fn test_wal_restart() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+    let tmp_db =
+        TempDatabase::new_with_rusqlite("CREATE TABLE test (x INTEGER PRIMARY KEY);", false);
     // threshold is 1000 by default
 
     fn insert(i: usize, conn: &Arc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
@@ -339,7 +346,7 @@ fn test_wal_restart() -> anyhow::Result<()> {
 #[test]
 fn test_insert_after_big_blob() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE temp (t1 BLOB, t2 INTEGER)");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE temp (t1 BLOB, t2 INTEGER)", false);
     let conn = tmp_db.connect_limbo();
 
     conn.execute("insert into temp(t1) values (zeroblob (262144))")?;
@@ -355,7 +362,7 @@ fn test_write_delete_with_index() -> anyhow::Result<()> {
 
     maybe_setup_tracing();
 
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x PRIMARY KEY);");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x PRIMARY KEY);", false);
     let conn = tmp_db.connect_limbo();
 
     let list_query = "SELECT * FROM test";
@@ -404,13 +411,13 @@ fn test_write_delete_with_index() -> anyhow::Result<()> {
 }
 
 #[test]
-#[cfg(feature = "index_experimental")]
 fn test_update_with_index() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
 
     maybe_setup_tracing();
 
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE test (x REAL PRIMARY KEY, y TEXT);");
+    let tmp_db =
+        TempDatabase::new_with_rusqlite("CREATE TABLE test (x REAL PRIMARY KEY, y TEXT);", true);
     let conn = tmp_db.connect_limbo();
 
     run_query(&tmp_db, &conn, "INSERT INTO test VALUES (1.0, 'foo')")?;
@@ -446,7 +453,7 @@ fn test_delete_with_index() -> anyhow::Result<()> {
 
     maybe_setup_tracing();
 
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x UNIQUE)");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x UNIQUE)", true);
     let conn = tmp_db.connect_limbo();
 
     run_query(&tmp_db, &conn, "INSERT INTO t VALUES (1), (2)")?;
@@ -462,7 +469,7 @@ fn test_delete_with_index() -> anyhow::Result<()> {
 #[test]
 fn test_update_regression() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE imaginative_baroja (blithesome_hall BLOB,remarkable_lester INTEGER,generous_balagun TEXT,ample_earth INTEGER,marvelous_khadzhiev BLOB,glowing_parissi TEXT,insightful_ryner BLOB)");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE imaginative_baroja (blithesome_hall BLOB,remarkable_lester INTEGER,generous_balagun TEXT,ample_earth INTEGER,marvelous_khadzhiev BLOB,glowing_parissi TEXT,insightful_ryner BLOB)", false);
     let conn = tmp_db.connect_limbo();
 
     conn.execute("INSERT INTO imaginative_baroja VALUES (X'617070726F61636861626C655F6F6D6164', 5581285929211692372, 'approachable_podur', -4145754929970306534, X'666F72747569746F75735F7368617270', 'sensible_amesly', X'636F6D70657469746976655F6669746368'), (X'6D6972746866756C5F686F6673746565', -8554670009677647372, 'shimmering_modkraftdk', 4993627046425025026, X'636F6E73696465726174655F63616765', 'breathtaking_boggs', X'616D617A696E675F73696D6F6E65'), (X'7669766163696F75735F7363687761727A', 5860599187854155616, 'sparkling_aurora', 3757552048117668067, X'756E697175655F6769617A', 'lovely_leroy', X'68617264776F726B696E675F6D696C6C6572'), (X'677265676172696F75735F7061657065', -488992130149088413, 'focused_brinker', 4503849242092922100, X'66756E6E795F6A616B736963', 'competitive_communications', X'657863656C6C656E745F7873696C656E74'), (X'7374756E6E696E675F74616E6E656E6261756D', -5634782647279946253, 'fabulous_crute', -3978009805517476564, X'72656C617865645F63617272796F7574', 'spellbinding_erkan', X'66756E6E795F646F626273'), (X'696D6167696E61746976655F746F6C6F6B6F6E6E696B6F7661', 4236471363502323025, 'excellent_wolke', 7606168469334609395, X'736C65656B5F6D6361666565', 'magnificent_riley', X'616D6961626C655F706173736164616B6973'), (X'77696C6C696E675F736872657665', 5048296470820985219, 'ambitious_jeppesen', 6961857167361512834, X'70617469656E745F6272696E6B6572', 'giving_kramm', X'726573706F6E7369626C655F7363686D696474'), (X'73656E7369626C655F6D757865726573', -5519194136843846790, 'frank_ruggero', 4354855935194921345, X'76697669645F63617365', 'focused_lovecruft', X'6D61676E69666963656E745F736B79')")?;
@@ -568,7 +575,7 @@ fn test_write_concurrent_connections() -> anyhow::Result<()> {
 
     maybe_setup_tracing();
 
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x)");
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x)", false);
     let num_connections = 4;
     let num_inserts_per_connection = 100;
     let mut connections = vec![];

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 #[test]
 fn test_wal_checkpoint_result() -> Result<()> {
     maybe_setup_tracing();
-    let tmp_db = TempDatabase::new("test_wal.db");
+    let tmp_db = TempDatabase::new("test_wal.db", false);
     let conn = tmp_db.connect_limbo();
     conn.execute("CREATE TABLE t1 (id text);")?;
 
@@ -36,8 +36,8 @@ fn test_wal_checkpoint_result() -> Result<()> {
 #[ignore = "ignored for now because it's flaky"]
 fn test_wal_1_writer_1_reader() -> Result<()> {
     maybe_setup_tracing();
-    let tmp_db = Arc::new(Mutex::new(TempDatabase::new("test_wal.db")));
-    let db = tmp_db.lock().unwrap().limbo_database();
+    let tmp_db = Arc::new(Mutex::new(TempDatabase::new("test_wal.db", false)));
+    let db = tmp_db.lock().unwrap().limbo_database(false);
 
     {
         let conn = db.connect().unwrap();


### PR DESCRIPTION
Makes it easier to test the feature:

```
$ cargo run --  --experimental-indexes
Limbo v0.0.22
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database
limbo> CREATE TABLE t(x);
limbo> CREATE INDEX t_idx ON t(x);
limbo> DROP INDEX t_idx;
```