### PR TITLE
Fix evaluation of ISNULL/NOTNULL in OR expressions

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -362,18 +362,32 @@ pub fn translate_condition_expr(
         ast::Expr::NotNull(expr) => {
             let cur_reg = program.alloc_register();
             translate_expr(program, Some(referenced_tables), expr, cur_reg, resolver)?;
-            program.emit_insn(Insn::IsNull {
-                reg: cur_reg,
-                target_pc: condition_metadata.jump_target_when_false,
-            });
+            if condition_metadata.jump_if_condition_is_true {
+                program.emit_insn(Insn::NotNull {
+                    reg: cur_reg,
+                    target_pc: condition_metadata.jump_target_when_true,
+                });
+            } else {
+                program.emit_insn(Insn::IsNull {
+                    reg: cur_reg,
+                    target_pc: condition_metadata.jump_target_when_false,
+                });
+            }
         }
         ast::Expr::IsNull(expr) => {
             let cur_reg = program.alloc_register();
             translate_expr(program, Some(referenced_tables), expr, cur_reg, resolver)?;
-            program.emit_insn(Insn::NotNull {
-                reg: cur_reg,
-                target_pc: condition_metadata.jump_target_when_false,
-            });
+            if condition_metadata.jump_if_condition_is_true {
+                program.emit_insn(Insn::IsNull {
+                    reg: cur_reg,
+                    target_pc: condition_metadata.jump_target_when_true,
+                });
+            } else {
+                program.emit_insn(Insn::NotNull {
+                    reg: cur_reg,
+                    target_pc: condition_metadata.jump_target_when_false,
+                });
+            }
         }
         ast::Expr::Unary(_, _) => {
             // This is an inefficient implementation for op::NOT, because translate_expr() will emit an Insn::Not,

--- a/testing/where.test
+++ b/testing/where.test
@@ -62,8 +62,16 @@ do_execsql_test where-clause-isnull {
     select count(1) from users where last_name isnull;
 } {0}
 
+do_execsql_test where-clause-isnull-or-false {
+    select count(1) from users where null isnull or 1 != 1;
+} {10000}
+
 do_execsql_test where-clause-notnull {
     select count(1) from users where last_name not null;
+} {10000}
+
+do_execsql_test where-clause-notnull-or-false {
+    select count(1) from users where last_name not null or 1 != 1;
 } {10000}
 
 do_execsql_test where-clause-ne {


### PR DESCRIPTION
Previously, the `jump_if_condition_is_true` flag was not respected. As a result, for expressions like <`ISNULL`/`NOTNULL`> `OR` <rhs>, the <rhs> expression was evaluated even when the left-hand side was true, and its value was incorrectly used as the final result.