### PR TITLE
Fix boxed memory leaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,6 +2008,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3729,6 +3739,7 @@ dependencies = [
  "limbo_time",
  "limbo_uuid",
  "lru",
+ "memory-stats",
  "miette",
  "mimalloc",
  "parking_lot",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -91,6 +91,7 @@ built = { version = "0.7.5", features = ["git2", "chrono"] }
 pprof = { version = "0.14.0", features = ["criterion", "flamegraph"] }
 
 [dev-dependencies]
+memory-stats = "1.2.0"
 criterion = { version = "0.5", features = [
     "html_reports",
     "async",

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -1,4 +1,3 @@
-use std::hash::{DefaultHasher, Hash, Hasher};
 use std::{cell::RefCell, ptr::NonNull};
 
 use std::sync::Arc;

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -1211,7 +1211,7 @@ mod tests {
         let final_memory_virtual = final_memory.virtual_mem;
         let final_memory_resident = final_memory.physical_mem;
 
-        assert!(final_memory_virtual - initial_memory_virtual < 1_000_000);
-        assert!(final_memory_resident - intial_memory_resident < 1_000_000);
+        assert!(final_memory_virtual.saturating_sub(initial_memory_virtual) < 1_000_000);
+        assert!(final_memory_resident.saturating_sub(intial_memory_resident) < 1_000_000);
     }
 }

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -301,7 +301,9 @@ impl DumbLruPageCache {
             unsafe {
                 assert!(!current_entry.as_ref().page.is_dirty());
             }
-            unsafe { std::ptr::drop_in_place(current_entry.as_ptr()) };
+            unsafe {
+                let _ = Box::from_raw(current_entry.as_ptr());
+            };
             current = next;
         }
         let _ = self.head.take();
@@ -1197,7 +1199,7 @@ mod tests {
 
         let initial_memory = memory_stats::memory_stats().unwrap();
         let initial_memory_virtual = initial_memory.virtual_mem;
-        let intial_memory_resident = initial_memory.physical_mem;
+        let initial_memory_resident = initial_memory.physical_mem;
 
         for i in 0..10000 {
             let key = create_key(i);
@@ -1212,6 +1214,6 @@ mod tests {
         let final_memory_resident = final_memory.physical_mem;
 
         assert!(final_memory_virtual.saturating_sub(initial_memory_virtual) < 1_000_000);
-        assert!(final_memory_resident.saturating_sub(intial_memory_resident) < 1_000_000);
+        assert!(final_memory_resident.saturating_sub(initial_memory_resident) < 1_000_000);
     }
 }


### PR DESCRIPTION
We should recreate original box to drop it properly

Also made a fast path for hashing. When key div by 2. It should decrease cpu cycles on hot path by x10 approximately 

This thing is tricky, made a long running test that verify bug, put #[ignore] on it to not slow down CI