### PR TITLE
core: Add Antithesis-aware `turso_assert`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3753,6 +3753,7 @@ dependencies = [
 name = "turso_core"
 version = "0.1.0-pre.2"
 dependencies = [
+ "antithesis_sdk",
  "bitflags 2.9.0",
  "built",
  "cfg_block",

--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -71,7 +71,7 @@ COPY --from=planner /app/testing/sqlite_test_ext ./testing/sqlite_test_ext/
 RUN if [ "$antithesis" = "true" ]; then \
         cp /opt/antithesis/libvoidstar.so /usr/lib/libvoidstar.so && \
         export RUSTFLAGS="-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -L/usr/lib/ -lvoidstar" && \
-        cargo build --bin limbo_stress --profile antithesis; \
+        cargo build --bin limbo_stress --features antithesis --profile antithesis; \
     else \
         cargo build --bin limbo_stress --release; \
     fi

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -9,6 +9,10 @@ license.workspace = true
 repository.workspace = true
 description = "Limbo Rust API"
 
+[features]
+default = []
+antithesis = ["turso_core/antithesis"]
+
 [dependencies]
 turso_core = { workspace = true, features = ["io_uring"] }
 thiserror = "2.0.9"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ name = "turso_core"
 path = "lib.rs"
 
 [features]
+antithesis = ["dep:antithesis_sdk"]
 default = ["fs", "uuid", "time", "json", "static", "series"]
 fs = ["limbo_ext/vfs"]
 json = []
@@ -45,6 +46,7 @@ mimalloc = { version = "0.1.46", default-features = false }
 libloading = "0.8.6"
 
 [dependencies]
+antithesis_sdk = { version = "0.2.5", optional = true }
 limbo_ext = { workspace = true, features = ["core_only"] }
 cfg_block = "0.1.1"
 fallible-iterator = "0.3.0"

--- a/core/assert.rs
+++ b/core/assert.rs
@@ -1,0 +1,25 @@
+/// turso_assert! is a direct replacement for assert! builtin macros which under the hood
+/// uses Antithesis SDK to guide Antithesis simulator if --features antithesis is enabled
+#[cfg(not(feature = "antithesis"))]
+#[macro_export]
+macro_rules! turso_assert {
+    ($cond:expr, $msg:literal, $($optional:tt)+) => {
+        assert!($cond, $msg, $($optional)+);
+    };
+    ($cond:expr, $msg:literal) => {
+        assert!($cond, $msg);
+    };
+}
+
+#[cfg(feature = "antithesis")]
+#[macro_export]
+macro_rules! turso_assert {
+    ($cond:expr, $msg:literal, $($optional:tt)+) => {
+        antithesis_sdk::assert_always_or_unreachable!($cond, $msg);
+        assert!($cond, $msg, $($optional)+);
+    };
+    ($cond:expr, $msg:literal) => {
+        antithesis_sdk::assert_always_or_unreachable!($cond, $msg);
+        assert!($cond, $msg);
+    };
+}

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::arc_with_non_send_sync)]
 
+mod assert;
 mod error;
 mod ext;
 mod fast_lock;

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -14,6 +14,10 @@ publish = false
 name = "limbo_stress"
 path = "main.rs"
 
+[features]
+default = []
+antithesis = ["limbo/antithesis"]
+
 [dependencies]
 antithesis_sdk = "0.2.5"
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
This adds a `turso_assert` macro that is Antithesis aware when `antithesis` feature flag is enabled. I did not yet convert any call-sites to use it.