### PR TITLE
core: Disable `ROLLBACK` statement

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -78,7 +78,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | RELEASE SAVEPOINT         | No      |                                                                                   |
 | REPLACE                   | No      |                                                                                   |
 | RETURNING clause          | No      |                                                                                   |
-| ROLLBACK TRANSACTION      | Yes     |                                                                                   |
+| ROLLBACK TRANSACTION      | No      | Disabled due to https://github.com/tursodatabase/turso/issues/1890                |
 | SAVEPOINT                 | No      |                                                                                   |
 | SELECT                    | Yes     |                                                                                   |
 | SELECT ... WHERE          | Yes     |                                                                                   |

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -43,7 +43,6 @@ use crate::{bail_parse_error, Connection, Result, SymbolTable};
 use alter::translate_alter_table;
 use index::{translate_create_index, translate_drop_index};
 use insert::translate_insert;
-use rollback::translate_rollback;
 use schema::{translate_create_table, translate_create_virtual_table, translate_drop_table};
 use select::translate_select;
 use std::rc::Rc;
@@ -186,10 +185,7 @@ pub fn translate_inner(
         }
         ast::Stmt::Reindex { .. } => bail_parse_error!("REINDEX not supported yet"),
         ast::Stmt::Release(_) => bail_parse_error!("RELEASE not supported yet"),
-        ast::Stmt::Rollback {
-            tx_name,
-            savepoint_name,
-        } => translate_rollback(query_mode, schema, syms, program, tx_name, savepoint_name)?,
+        ast::Stmt::Rollback { .. } => bail_parse_error!("ROLLBACK not supported yet"),
         ast::Stmt::Savepoint(_) => bail_parse_error!("SAVEPOINT not supported yet"),
         ast::Stmt::Select(select) => {
             translate_select(

--- a/core/translate/rollback.rs
+++ b/core/translate/rollback.rs
@@ -10,6 +10,7 @@ use crate::{
     Result, SymbolTable,
 };
 
+#[allow(dead_code)]
 pub fn translate_rollback(
     _query_mode: QueryMode,
     _schema: &Schema,

--- a/stress/main.rs
+++ b/stress/main.rs
@@ -349,11 +349,7 @@ fn generate_plan(opts: &Opts) -> Result<Plan, Box<dyn std::error::Error + Send +
             }
             queries.push(sql);
             if tx.is_some() {
-                if get_random() % 2 == 0 {
-                    queries.push("COMMIT".to_string());
-                } else {
-                    queries.push("ROLLBACK".to_string());
-                }
+                queries.push("COMMIT".to_string());
             }
         }
         plan.queries_per_thread.push(queries);

--- a/testing/all.test
+++ b/testing/all.test
@@ -37,4 +37,3 @@ source $testdir/create_table.test
 source $testdir/collate.test
 source $testdir/values.test
 source $testdir/integrity_check.test
-source $testdir/rollback.test


### PR DESCRIPTION
There's bad interaction with schema changes and `ROLLBACK`:

https://github.com/tursodatabase/turso/issues/1890

Disable the statement for now to avoid people hitting the issue.