### PR TITLE
Rust binding improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,6 +3620,7 @@ dependencies = [
 name = "turso"
 version = "0.1.0-pre.5"
 dependencies = [
+ "futures-util",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 description = "Turso Rust API"
 
 [features]
-default = []
+default = ["futures"]
 experimental_indexes = []
 antithesis = ["turso_core/antithesis"]
 futures = ["dep:futures-util"]

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -13,10 +13,12 @@ description = "Turso Rust API"
 default = []
 experimental_indexes = []
 antithesis = ["turso_core/antithesis"]
+futures = ["dep:futures-util"]
 
 [dependencies]
 turso_core = { workspace = true, features = ["io_uring"] }
 thiserror = "2.0.9"
+futures-util = { version = "0.3.31", optional = true, default-features = false, features = ["std", "async-await"] }
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/bindings/rust/examples/example.rs
+++ b/bindings/rust/examples/example.rs
@@ -46,4 +46,16 @@ async fn main() {
         let value = row.get_value(0).unwrap();
         println!("Row: {:?}", value);
     }
+
+    let rows = stmt.query(["foo@example.com"]).await.unwrap();
+
+    // As `Rows` implement streams you can easily map over it and apply other transformations you see fit
+    println!("Using Stream map");
+    rows.map_ok(|row| row.get_value(0).unwrap())
+        .try_for_each(|val| {
+            println!("Row: {:?}", val.as_text().unwrap());
+            futures_util::future::ready(Ok(()))
+        })
+        .await
+        .unwrap();
 }

--- a/bindings/rust/examples/example.rs
+++ b/bindings/rust/examples/example.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "futures")]
+use futures_util::stream::StreamExt;
 use turso::Builder;
 
 #[tokio::main]

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -20,13 +20,14 @@
 //! You can also prepare statements with the [`Connection`] object and then execute the [`Statement`] objects:
 //!
 //! ```rust,no_run
+//! # use crate::turso::futures_util::TryStreamExt;
 //! # async fn run() {
 //! # use turso::Builder;
 //! # let db = Builder::new_local(":memory:").build().await.unwrap();
 //! # let conn = db.connect().unwrap();
 //! let mut stmt = conn.prepare("SELECT * FROM users WHERE email = ?1").await.unwrap();
 //! let mut rows = stmt.query(["foo@example.com"]).await.unwrap();
-//! let row = rows.next().await.unwrap().unwrap();
+//! let row = rows.try_next().await.unwrap().unwrap();
 //! let value = row.get_value(0).unwrap();
 //! println!("Row: {:?}", value);
 //! # }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -37,9 +37,10 @@ pub mod row;
 pub mod statement;
 pub mod value;
 
-pub use value::Value;
-
+#[cfg(feature = "futures")]
+pub use futures_util;
 pub use params::params_from_iter;
+pub use value::Value;
 
 use crate::params::*;
 use crate::row::{Row, Rows};
@@ -65,7 +66,7 @@ impl From<turso_core::LimboError> for Error {
 
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-pub(crate) type Result<T> = std::result::Result<T, Error>;
+pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// A builder for `Database`.
 pub struct Builder {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -66,7 +66,7 @@ impl From<turso_core::LimboError> for Error {
 
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// A builder for `Database`.
 pub struct Builder {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -33,6 +33,7 @@
 //! ```
 
 pub mod params;
+pub mod row;
 pub mod statement;
 pub mod value;
 
@@ -41,6 +42,7 @@ pub use value::Value;
 pub use params::params_from_iter;
 
 use crate::params::*;
+use crate::row::{Row, Rows};
 use crate::statement::Statement;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
@@ -244,141 +246,6 @@ pub enum Params {
 }
 
 pub struct Transaction {}
-
-/// Results of a prepared statement query.
-pub struct Rows {
-    inner: Arc<Mutex<turso_core::Statement>>,
-}
-
-impl Clone for Rows {
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
-    }
-}
-
-unsafe impl Send for Rows {}
-unsafe impl Sync for Rows {}
-
-impl Rows {
-    #[cfg(not(feature = "futures"))]
-    /// Fetch the next row of this result set.
-    pub async fn next(&mut self) -> Result<Option<Row>> {
-        loop {
-            let mut stmt = self
-                .inner
-                .lock()
-                .map_err(|e| Error::MutexError(e.to_string()))?;
-            match stmt.step()? {
-                turso_core::StepResult::Row => {
-                    let row = stmt.row().unwrap();
-                    return Ok(Some(Row {
-                        values: row.get_values().map(|v| v.to_owned()).collect(),
-                    }));
-                }
-                turso_core::StepResult::Done => return Ok(None),
-                turso_core::StepResult::IO => {
-                    if let Err(e) = stmt.run_once() {
-                        return Err(e.into());
-                    }
-                    continue;
-                }
-                // TODO: Busy should probably be an error
-                turso_core::StepResult::Busy => return Ok(None),
-                turso_core::StepResult::Interrupt => return Ok(None),
-            }
-        }
-    }
-}
-
-#[cfg(feature = "futures")]
-impl futures_util::Stream for Rows {
-    type Item = Result<Row>;
-
-    fn poll_next(
-        self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        use std::task::Poll;
-        loop {
-            let stmt = self
-                .inner
-                .lock()
-                .map_err(|e| Error::MutexError(e.to_string()));
-
-            if let Err(err) = stmt {
-                return Poll::Ready(Some(Err(err)));
-            }
-            let mut stmt = stmt.unwrap();
-            match stmt.step() {
-                Ok(step_result) => match step_result {
-                    turso_core::StepResult::Row => {
-                        let row = stmt.row().unwrap();
-                        return Poll::Ready(Some(Ok(Row {
-                            values: row.get_values().map(|v| v.to_owned()).collect(),
-                        })));
-                    }
-                    turso_core::StepResult::Done => return Poll::Ready(None),
-                    turso_core::StepResult::IO => {
-                        if let Err(e) = stmt.run_once() {
-                            return Poll::Ready(Some(Err(e.into())));
-                        }
-                        return Poll::Pending;
-                    }
-                    turso_core::StepResult::Busy => return Poll::Ready(None),
-                    turso_core::StepResult::Interrupt => return Poll::Ready(None),
-                },
-                Err(err) => {
-                    return Poll::Ready(Some(Err(Error::from(err))));
-                }
-            }
-        }
-    }
-}
-
-/// Query result row.
-#[derive(Debug)]
-pub struct Row {
-    values: Vec<turso_core::Value>,
-}
-
-unsafe impl Send for Row {}
-unsafe impl Sync for Row {}
-
-impl Row {
-    pub fn get_value(&self, index: usize) -> Result<Value> {
-        let value = &self.values[index];
-        match value {
-            turso_core::Value::Integer(i) => Ok(Value::Integer(*i)),
-            turso_core::Value::Null => Ok(Value::Null),
-            turso_core::Value::Float(f) => Ok(Value::Real(*f)),
-            turso_core::Value::Text(text) => Ok(Value::Text(text.to_string())),
-            turso_core::Value::Blob(items) => Ok(Value::Blob(items.to_vec())),
-        }
-    }
-
-    pub fn column_count(&self) -> usize {
-        self.values.len()
-    }
-}
-
-impl<'a> FromIterator<&'a turso_core::Value> for Row {
-    fn from_iter<T: IntoIterator<Item = &'a turso_core::Value>>(iter: T) -> Self {
-        let values = iter
-            .into_iter()
-            .map(|v| match v {
-                turso_core::Value::Integer(i) => turso_core::Value::Integer(*i),
-                turso_core::Value::Null => turso_core::Value::Null,
-                turso_core::Value::Float(f) => turso_core::Value::Float(*f),
-                turso_core::Value::Text(s) => turso_core::Value::Text(s.clone()),
-                turso_core::Value::Blob(b) => turso_core::Value::Blob(b.clone()),
-            })
-            .collect();
-
-        Row { values }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/bindings/rust/src/params.rs
+++ b/bindings/rust/src/params.rs
@@ -106,7 +106,7 @@ pub enum Params {
 /// # Example
 ///
 /// ```rust
-/// # use turso::{Connection, params_from_iter, Rows};
+/// # use turso::{Connection, params_from_iter};
 /// # async fn run(conn: &Connection) {
 ///
 /// let iter = vec![1, 2, 3];

--- a/bindings/rust/src/params.rs
+++ b/bindings/rust/src/params.rs
@@ -9,14 +9,14 @@ mod sealed {
 use sealed::Sealed;
 
 /// Converts some type into parameters that can be passed
-/// to libsql.
+/// to Turso.
 ///
 /// The trait is sealed and not designed to be implemented by hand
 /// but instead provides a few ways to use it.
 ///
-/// # Passing parameters to libsql
+/// # Passing parameters to Turso
 ///
-/// Many functions in this library let you pass parameters to libsql. Doing this
+/// Many functions in this library let you pass parameters to Turso. Doing this
 /// lets you avoid any risk of SQL injection, and is simpler than escaping
 /// things manually. These functions generally contain some parameter that generically
 /// accepts some implementation this trait.
@@ -27,7 +27,7 @@ use sealed::Sealed;
 ///
 /// - For heterogeneous parameter lists of 16 or less items a tuple syntax is supported
 ///     by doing `(1, "foo")`.
-/// - For hetergeneous parameter lists of 16 or greater, the [`turso::params!`] is supported
+/// - For hetergeneous parameter lists of 16 or greater, the [`crate::params!`] is supported
 ///     by doing `turso::params![1, "foo"]`.
 /// - For homogeneous parameter types (where they are all the same type), const arrays are
 ///     supported by doing `[1, 2, 3]`.
@@ -62,8 +62,8 @@ use sealed::Sealed;
 ///
 /// - For heterogeneous parameter lists of 16 or less items a tuple syntax is supported
 ///     by doing `(("key1", 1), ("key2", "foo"))`.
-/// - For hetergeneous parameter lists of 16 or greater, the [`turso::params!`] is supported
-///     by doing `turso::named_params!["key1": 1, "key2": "foo"]`.
+/// - For hetergeneous parameter lists of 16 or greater, the [`crate::named_params!`] is supported
+///     by doing `turso::named_params!{"key1": 1, "key2": "foo"}`.
 /// - For homogeneous parameter types (where they are all the same type), const arrays are
 ///     supported by doing `[("key1", 1), ("key2, 2), ("key3", 3)]`.
 ///
@@ -77,7 +77,7 @@ use sealed::Sealed;
 /// // Using a tuple:
 /// stmt.execute(((":key1", 0), (":key2", "foobar"))).await?;
 ///
-/// // Using `turso::named_params!`:
+/// // Using `named_params!`:
 /// stmt.execute(named_params! {":key1": 1i32, ":key2": "blah" }).await?;
 ///
 /// // const array:

--- a/bindings/rust/src/row.rs
+++ b/bindings/rust/src/row.rs
@@ -1,0 +1,142 @@
+use std::sync::{Arc, Mutex};
+
+use crate::Value;
+
+/// Results of a prepared statement query.
+#[must_use = "Rows is lazy and will do nothing unless consumed"]
+pub struct Rows {
+    pub(crate) inner: Arc<Mutex<turso_core::Statement>>,
+}
+
+impl Clone for Rows {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+unsafe impl Send for Rows {}
+unsafe impl Sync for Rows {}
+
+impl Rows {
+    #[cfg(not(feature = "futures"))]
+    /// Fetch the next row of this result set.
+    pub async fn next(&mut self) -> Result<Option<Row>> {
+        loop {
+            let mut stmt = self
+                .inner
+                .lock()
+                .map_err(|e| Error::MutexError(e.to_string()))?;
+            match stmt.step()? {
+                turso_core::StepResult::Row => {
+                    let row = stmt.row().unwrap();
+                    return Ok(Some(Row {
+                        values: row.get_values().map(|v| v.to_owned()).collect(),
+                    }));
+                }
+                turso_core::StepResult::Done => return Ok(None),
+                turso_core::StepResult::IO => {
+                    if let Err(e) = stmt.run_once() {
+                        return Err(e.into());
+                    }
+                    continue;
+                }
+                // TODO: Busy should probably be an error
+                turso_core::StepResult::Busy => return Ok(None),
+                turso_core::StepResult::Interrupt => return Ok(None),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "futures")]
+impl futures_util::Stream for Rows {
+    type Item = crate::Result<Row>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use crate::Error;
+        use std::task::Poll;
+        loop {
+            let stmt = self
+                .inner
+                .lock()
+                .map_err(|e| Error::MutexError(e.to_string()));
+
+            if let Err(err) = stmt {
+                return Poll::Ready(Some(Err(err)));
+            }
+            let mut stmt = stmt.unwrap();
+            match stmt.step() {
+                Ok(step_result) => match step_result {
+                    turso_core::StepResult::Row => {
+                        let row = stmt.row().unwrap();
+                        return Poll::Ready(Some(Ok(Row {
+                            values: row.get_values().map(|v| v.to_owned()).collect(),
+                        })));
+                    }
+                    turso_core::StepResult::Done => return Poll::Ready(None),
+                    turso_core::StepResult::IO => {
+                        if let Err(e) = stmt.run_once() {
+                            return Poll::Ready(Some(Err(e.into())));
+                        }
+                        return Poll::Pending;
+                    }
+                    turso_core::StepResult::Busy => return Poll::Ready(None),
+                    turso_core::StepResult::Interrupt => return Poll::Ready(None),
+                },
+                Err(err) => {
+                    use crate::Error;
+
+                    return Poll::Ready(Some(Err(Error::from(err))));
+                }
+            }
+        }
+    }
+}
+
+/// Query result row.
+#[derive(Debug)]
+pub struct Row {
+    values: Vec<turso_core::Value>,
+}
+
+unsafe impl Send for Row {}
+unsafe impl Sync for Row {}
+
+impl Row {
+    pub fn get_value(&self, index: usize) -> crate::Result<Value> {
+        let value = &self.values[index];
+        match value {
+            turso_core::Value::Integer(i) => Ok(Value::Integer(*i)),
+            turso_core::Value::Null => Ok(Value::Null),
+            turso_core::Value::Float(f) => Ok(Value::Real(*f)),
+            turso_core::Value::Text(text) => Ok(Value::Text(text.to_string())),
+            turso_core::Value::Blob(items) => Ok(Value::Blob(items.to_vec())),
+        }
+    }
+
+    pub fn column_count(&self) -> usize {
+        self.values.len()
+    }
+}
+
+impl<'a> FromIterator<&'a turso_core::Value> for Row {
+    fn from_iter<T: IntoIterator<Item = &'a turso_core::Value>>(iter: T) -> Self {
+        let values = iter
+            .into_iter()
+            .map(|v| match v {
+                turso_core::Value::Integer(i) => turso_core::Value::Integer(*i),
+                turso_core::Value::Null => turso_core::Value::Null,
+                turso_core::Value::Float(f) => turso_core::Value::Float(*f),
+                turso_core::Value::Text(s) => turso_core::Value::Text(s.clone()),
+                turso_core::Value::Blob(b) => turso_core::Value::Blob(b.clone()),
+            })
+            .collect();
+
+        Row { values }
+    }
+}

--- a/bindings/rust/src/row.rs
+++ b/bindings/rust/src/row.rs
@@ -19,10 +19,11 @@ impl Clone for Rows {
 unsafe impl Send for Rows {}
 unsafe impl Sync for Rows {}
 
+#[cfg(not(feature = "futures"))]
 impl Rows {
-    #[cfg(not(feature = "futures"))]
     /// Fetch the next row of this result set.
-    pub async fn next(&mut self) -> Result<Option<Row>> {
+    pub async fn next(&mut self) -> crate::Result<Option<Row>> {
+        use crate::Error;
         loop {
             let mut stmt = self
                 .inner
@@ -139,4 +140,11 @@ impl<'a> FromIterator<&'a turso_core::Value> for Row {
 
         Row { values }
     }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[tokio::test]
+    async fn test_row() {}
 }

--- a/bindings/rust/src/statement.rs
+++ b/bindings/rust/src/statement.rs
@@ -9,6 +9,8 @@ use crate::{
 };
 
 /// A prepared statement.
+///
+/// Statements when executed or queried are reset after they encounter an error or run to completion
 pub struct Statement {
     pub(crate) inner: Arc<Mutex<turso_core::Statement>>,
 }

--- a/bindings/rust/src/statement.rs
+++ b/bindings/rust/src/statement.rs
@@ -1,0 +1,122 @@
+use std::{
+    num::NonZero,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    params::{self, IntoParams},
+    Column, Rows,
+};
+
+/// A prepared statement.
+pub struct Statement {
+    pub(crate) inner: Arc<Mutex<turso_core::Statement>>,
+}
+
+impl Clone for Statement {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+unsafe impl Send for Statement {}
+unsafe impl Sync for Statement {}
+
+impl Statement {
+    /// Query the database with this prepared statement.
+    pub async fn query(&mut self, params: impl IntoParams) -> crate::Result<Rows> {
+        let params = params.into_params()?;
+        match params {
+            params::Params::None => (),
+            params::Params::Positional(values) => {
+                for (i, value) in values.into_iter().enumerate() {
+                    let mut stmt = self.inner.lock().unwrap();
+                    stmt.bind_at(NonZero::new(i + 1).unwrap(), value.into());
+                }
+            }
+            params::Params::Named(values) => {
+                for (name, value) in values.into_iter() {
+                    let mut stmt = self.inner.lock().unwrap();
+                    let i = stmt.parameters().index(name).unwrap();
+                    stmt.bind_at(i, value.into());
+                }
+            }
+        }
+        #[allow(clippy::arc_with_non_send_sync)]
+        let rows = Rows {
+            inner: Arc::clone(&self.inner),
+        };
+        Ok(rows)
+    }
+
+    /// Execute this prepared statement.
+    pub async fn execute(&mut self, params: impl IntoParams) -> crate::Result<u64> {
+        {
+            // Reset the statement before executing
+            self.inner.lock().unwrap().reset();
+        }
+        let params = params.into_params()?;
+        match params {
+            params::Params::None => (),
+            params::Params::Positional(values) => {
+                for (i, value) in values.into_iter().enumerate() {
+                    let mut stmt = self.inner.lock().unwrap();
+                    stmt.bind_at(NonZero::new(i + 1).unwrap(), value.into());
+                }
+            }
+            params::Params::Named(values) => {
+                for (name, value) in values.into_iter() {
+                    let mut stmt = self.inner.lock().unwrap();
+                    let i = stmt.parameters().index(name).unwrap();
+                    stmt.bind_at(i, value.into());
+                }
+            }
+        }
+        loop {
+            let mut stmt = self.inner.lock().unwrap();
+            match stmt.step() {
+                Ok(turso_core::StepResult::Row) => {
+                    // unexpected row during execution, error out.
+                    return Ok(2);
+                }
+                Ok(turso_core::StepResult::Done) => {
+                    return Ok(0);
+                }
+                Ok(turso_core::StepResult::IO) => {
+                    let _ = stmt.run_once();
+                    //return Ok(1);
+                }
+                Ok(turso_core::StepResult::Busy) => {
+                    return Ok(4);
+                }
+                Ok(turso_core::StepResult::Interrupt) => {
+                    return Ok(3);
+                }
+                Err(err) => {
+                    return Err(err.into());
+                }
+            }
+        }
+    }
+
+    /// Returns columns of the result of this prepared statement.
+    pub fn columns(&self) -> Vec<Column> {
+        let stmt = self.inner.lock().unwrap();
+
+        let n = stmt.num_columns();
+
+        let mut cols = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let name = stmt.get_column_name(i).into_owned();
+            cols.push(Column {
+                name,
+                decl_type: None, // TODO
+            });
+        }
+
+        cols
+    }
+}

--- a/bindings/rust/src/statement.rs
+++ b/bindings/rust/src/statement.rs
@@ -77,23 +77,24 @@ impl Statement {
         loop {
             let mut stmt = self.inner.lock().unwrap();
             match stmt.step() {
-                Ok(turso_core::StepResult::Row) => {
-                    // unexpected row during execution, error out.
-                    return Ok(2);
-                }
+                Ok(turso_core::StepResult::Row) => {}
                 Ok(turso_core::StepResult::Done) => {
+                    stmt.reset();
                     return Ok(0);
                 }
                 Ok(turso_core::StepResult::IO) => {
                     stmt.run_once()?;
                 }
                 Ok(turso_core::StepResult::Busy) => {
+                    stmt.reset();
                     return Ok(4);
                 }
                 Ok(turso_core::StepResult::Interrupt) => {
+                    stmt.reset();
                     return Ok(3);
                 }
                 Err(err) => {
+                    stmt.reset();
                     return Err(err.into());
                 }
             }

--- a/bindings/rust/src/statement.rs
+++ b/bindings/rust/src/statement.rs
@@ -85,8 +85,7 @@ impl Statement {
                     return Ok(0);
                 }
                 Ok(turso_core::StepResult::IO) => {
-                    let _ = stmt.run_once();
-                    //return Ok(1);
+                    stmt.run_once()?;
                 }
                 Ok(turso_core::StepResult::Busy) => {
                     return Ok(4);

--- a/bindings/rust/src/value.rs
+++ b/bindings/rust/src/value.rs
@@ -11,7 +11,7 @@ pub enum Value {
     Blob(Vec<u8>),
 }
 
-/// The possible types a column can be in libsql.
+/// The possible types a column can be in Turso.
 #[derive(Debug, Copy, Clone)]
 pub enum ValueType {
     Integer = 1,

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1,4 +1,20 @@
+#[cfg(feature = "futures")]
+use futures_util::TryStreamExt;
 use turso::{Builder, Value};
+
+#[cfg(not(feature = "futures"))]
+macro_rules! rows_next {
+    ($rows:expr) => {
+        $rows.next()
+    };
+}
+
+#[cfg(feature = "futures")]
+macro_rules! rows_next {
+    ($rows:expr) => {
+        $rows.try_next()
+    };
+}
 
 #[tokio::test]
 async fn test_rows_next() {
@@ -34,24 +50,49 @@ async fn test_rows_next() {
     .unwrap();
     let mut res = conn.query("SELECT * FROM test", ()).await.unwrap();
     assert_eq!(
-        res.next().await.unwrap().unwrap().get_value(0).unwrap(),
+        rows_next!(res)
+            .await
+            .unwrap()
+            .unwrap()
+            .get_value(0)
+            .unwrap(),
         1.into()
     );
     assert_eq!(
-        res.next().await.unwrap().unwrap().get_value(0).unwrap(),
+        rows_next!(res)
+            .await
+            .unwrap()
+            .unwrap()
+            .get_value(0)
+            .unwrap(),
         2.into()
     );
     assert_eq!(
-        res.next().await.unwrap().unwrap().get_value(0).unwrap(),
+        rows_next!(res)
+            .await
+            .unwrap()
+            .unwrap()
+            .get_value(0)
+            .unwrap(),
         3.into()
     );
     assert_eq!(
-        res.next().await.unwrap().unwrap().get_value(0).unwrap(),
+        rows_next!(res)
+            .await
+            .unwrap()
+            .unwrap()
+            .get_value(0)
+            .unwrap(),
         4.into()
     );
     assert_eq!(
-        res.next().await.unwrap().unwrap().get_value(0).unwrap(),
+        rows_next!(res)
+            .await
+            .unwrap()
+            .unwrap()
+            .get_value(0)
+            .unwrap(),
         5.into()
     );
-    assert!(res.next().await.unwrap().is_none());
+    assert!(rows_next!(res).await.unwrap().is_none());
 }

--- a/stress/main.rs
+++ b/stress/main.rs
@@ -15,6 +15,7 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
+use turso::futures_util::TryStreamExt;
 use turso::Builder;
 
 pub struct Plan {
@@ -522,7 +523,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 const INTEGRITY_CHECK_INTERVAL: usize = 100;
                 if query_index % INTEGRITY_CHECK_INTERVAL == 0 {
                     let mut res = conn.query("PRAGMA integrity_check", ()).await.unwrap();
-                    if let Some(row) = res.next().await? {
+                    if let Some(row) = res.try_next().await? {
                         let value = row.get_value(0).unwrap();
                         if value != "ok".into() {
                             panic!("integrity check failed: {:?}", value);


### PR DESCRIPTION
This PR aims to add some more comments and documentation to the Rust binding. It also fixes an issue where you could not reuse the statement after it ran to completion or errored. Now the statement resets in those cases. Also implemented `Stream` for the Rows struct allowing users to leverage the built-in iterator like methods for better ergonomics.