### PR TITLE
Turso, not Limbo, in pyproject.toml

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'maturin'
 
 [project]
 name = 'pyturso'
-description = "Limbo is a work-in-progress, in-process OLTP database management system, compatible with SQLite."
+description = "Turso is a work-in-progress, in-process OLTP database management system, compatible with SQLite."
 requires-python = '>=3.9'
 classifiers = [
     'Development Status :: 3 - Alpha',


### PR DESCRIPTION
https://pypi.org/project/pyturso/0.1.1/ is still showing the old name:

![CleanShot 2025-07-01 at 07 30 11@2x](https://github.com/user-attachments/assets/a80441ec-507c-4ff7-a698-3cb88625c2cc)
