### PR TITLE
Fix error handling in JavaScript bindings

### DIFF
--- a/bindings/javascript/__test__/better-sqlite3.spec.mjs
+++ b/bindings/javascript/__test__/better-sqlite3.spec.mjs
@@ -84,7 +84,10 @@ test("Empty prepared statement should throw", async (t) => {
     () => {
       db.prepare("");
     },
-    { instanceOf: Error },
+    {
+      instanceOf: RangeError,
+      message: "The supplied SQL string contains no statements",
+    },
   );
 });
 

--- a/bindings/javascript/__test__/limbo.spec.mjs
+++ b/bindings/javascript/__test__/limbo.spec.mjs
@@ -77,7 +77,11 @@ test("Empty prepared statement should throw", async (t) => {
     () => {
       db.prepare("");
     },
-    { instanceOf: Error },
+    {
+      instanceOf: Error,
+      code: "GenericFailure",
+      message: "Invalid argument supplied: The supplied SQL string contains no statements",
+    },
   );
 });
 

--- a/bindings/javascript/wrapper.js
+++ b/bindings/javascript/wrapper.js
@@ -50,11 +50,7 @@ class Database {
    * @param {string} sql - The SQL statement string to prepare.
    */
   prepare(sql) {
-    try {
-      return new Statement(this.db.prepare(sql), this);
-    } catch (err) {
-      throw convertError(err);
-    }
+    return new Statement(this.db.prepare(sql), this);
   }
 
   /**


### PR DESCRIPTION
The js bindings were failing on an error path because they were referring to a method `convertError` that didn't exist. 

The missing `convertError` function is likely [this one](https://github.com/tursodatabase/libsql-js/blob/main/wrapper.js#L7-L29) in libSQL. It's responsible for extracting some json-encoded errors that libSQL will throw when [the db connection is not open](https://github.com/tursodatabase/libsql-js/blob/main/src/lib.rs#L362-L366) or when [authorization is denied](https://github.com/tursodatabase/libsql-js/blob/main/src/lib.rs#L62-L67).  But Turso doesn't throw these errors, so there is nothing do convert here.

-----
as part of https://github.com/tursodatabase/turso/issues/1900