### PR TITLE
Fix index update when INTEGER PRIMARY KEY (rowid alias)

### DIFF
--- a/testing/update.test
+++ b/testing/update.test
@@ -205,6 +205,16 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     1
     2
     2}
+
+    do_execsql_test_on_specific_db {:memory:} update_rowid_alias_index_regression_test {
+        CREATE TABLE t(a INTEGER PRIMARY KEY, b);
+        CREATE INDEX idx_b ON t (b);
+        INSERT INTO t VALUES (1, 'foo');
+        SELECT a FROM t WHERE b = 'foo';
+        UPDATE t SET a = 2, b = 'bar';
+        SELECT a FROM t WHERE b = 'bar';
+    } {1
+    2}
 }
 
 do_execsql_test_on_specific_db {:memory:} update_where_or_regression_test {


### PR DESCRIPTION
When an `UPDATE` statement modifies a table's `INTEGER PRIMARY KEY` (which acts as a `rowid` alias) alongside other indexed columns, the index entries were incorrectly retaining the old `rowid`. This led to stale index references, causing subsequent queries to return incorrect results.

This change ensures that when the `rowid` alias is part of the `SET` clause in an `UPDATE` statement, the new `rowid` value is used for generating and updating index records. This guarantees that all index entries correctly point to the updated row, resolving the data inconsistency.

Fixes #1897 