### PR TITLE
remove black color - because with dark terminal it's completely invisible

### DIFF
--- a/cli/config/mod.rs
+++ b/cli/config/mod.rs
@@ -107,7 +107,6 @@ impl TableConfig {
     fn default_column_colors() -> Vec<LimboColor> {
         vec![
             LimboColor(Color::Green),
-            LimboColor(Color::Black),
             // Comfy Table Color::Grey
             LimboColor(Color::Fixed(7)),
         ]


### PR DESCRIPTION
For terminals with dark color scheme `Black` color is invisible:

Before PR:
![image](https://github.com/user-attachments/assets/17d63958-f511-4297-b506-08af92c5a426)

After PR:
![image](https://github.com/user-attachments/assets/ef195e85-5a9a-4752-bab1-302d309817d0)
