### PR TITLE
Rollback schema support

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -78,7 +78,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | RELEASE SAVEPOINT         | No      |                                                                                   |
 | REPLACE                   | No      |                                                                                   |
 | RETURNING clause          | No      |                                                                                   |
-| ROLLBACK TRANSACTION      | No      | Disabled due to https://github.com/tursodatabase/turso/issues/1890                |
+| ROLLBACK TRANSACTION      | Yes     |                                                                                   |
 | SAVEPOINT                 | No      |                                                                                   |
 | SELECT                    | Yes     |                                                                                   |
 | SELECT ... WHERE          | Yes     |                                                                                   |

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -258,11 +258,9 @@ impl BTreeTable {
         let mut sql = format!("CREATE TABLE {} (", self.name);
         for (i, column) in self.columns.iter().enumerate() {
             if i > 0 {
-                sql.push(',');
+                sql.push_str(", ");
             }
-            sql.push(' ');
             sql.push_str(column.name.as_ref().expect("column name is None"));
-            sql.push(' ');
             sql.push_str(&column.ty.to_string());
 
             if column.unique {
@@ -278,7 +276,7 @@ impl BTreeTable {
                 sql.push_str(&default.to_string());
             }
         }
-        sql.push_str(" )");
+        sql.push_str(")");
         sql
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -17,12 +17,14 @@ use turso_sqlite3_parser::{
 const SCHEMA_TABLE_NAME: &str = "sqlite_schema";
 const SCHEMA_TABLE_NAME_ALT: &str = "sqlite_master";
 
+#[derive(Debug, Clone)]
 pub struct Schema {
     pub tables: HashMap<String, Arc<Table>>,
     /// table_name to list of indexes for the table
     pub indexes: HashMap<String, Vec<Arc<Index>>>,
     pub has_indexes: std::collections::HashSet<String>,
     pub indexes_enabled: bool,
+    pub schema_version: u32,
 }
 
 impl Schema {
@@ -40,6 +42,7 @@ impl Schema {
             indexes,
             has_indexes,
             indexes_enabled,
+            schema_version: 0,
         }
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -276,7 +276,7 @@ impl BTreeTable {
                 sql.push_str(&default.to_string());
             }
         }
-        sql.push_str(")");
+        sql.push(')');
         sql
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -261,6 +261,9 @@ impl BTreeTable {
                 sql.push_str(", ");
             }
             sql.push_str(column.name.as_ref().expect("column name is None"));
+            if !matches!(column.ty, Type::Null) {
+                sql.push(' ');
+            }
             sql.push_str(&column.ty.to_string());
 
             if column.unique {
@@ -1492,7 +1495,7 @@ mod tests {
 
     #[test]
     pub fn test_sqlite_schema() {
-        let expected = r#"CREATE TABLE sqlite_schema ( type TEXT, name TEXT, tbl_name TEXT, rootpage INTEGER, sql TEXT )"#;
+        let expected = r#"CREATE TABLE sqlite_schema (type TEXT, name TEXT, tbl_name TEXT, rootpage INTEGER, sql TEXT)"#;
         let actual = sqlite_schema_table().to_sql();
         assert_eq!(expected, actual);
     }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -640,7 +640,8 @@ impl Pager {
         tracing::trace!("end_tx(rollback={})", rollback);
         if rollback {
             let maybe_schema_pair = if change_schema {
-                let schema = connection.schema.clone().write().clone();
+                let schema = connection.schema.borrow().clone();
+                // Lock first before writing to the database schema in case someone tries to read the schema before it's updated
                 let db_schema = connection._db.schema.write();
                 Some((schema, db_schema))
             } else {

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -43,6 +43,7 @@ use crate::{bail_parse_error, Connection, Result, SymbolTable};
 use alter::translate_alter_table;
 use index::{translate_create_index, translate_drop_index};
 use insert::translate_insert;
+use rollback::translate_rollback;
 use schema::{translate_create_table, translate_create_virtual_table, translate_drop_table};
 use select::translate_select;
 use std::rc::Rc;
@@ -168,7 +169,10 @@ pub fn translate_inner(
         }
         ast::Stmt::Reindex { .. } => bail_parse_error!("REINDEX not supported yet"),
         ast::Stmt::Release(_) => bail_parse_error!("RELEASE not supported yet"),
-        ast::Stmt::Rollback { .. } => bail_parse_error!("ROLLBACK not supported yet"),
+        ast::Stmt::Rollback {
+            tx_name,
+            savepoint_name,
+        } => translate_rollback(query_mode, schema, syms, program, tx_name, savepoint_name)?,
         ast::Stmt::Savepoint(_) => bail_parse_error!("SAVEPOINT not supported yet"),
         ast::Stmt::Select(select) => {
             translate_select(

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -39,7 +39,7 @@ use crate::storage::pager::Pager;
 use crate::translate::delete::translate_delete;
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts, QueryMode};
 use crate::vdbe::Program;
-use crate::{bail_parse_error, Connection, Result, SymbolTable, TransactionState};
+use crate::{bail_parse_error, Connection, Result, SymbolTable};
 use alter::translate_alter_table;
 use index::{translate_create_index, translate_drop_index};
 use insert::translate_insert;

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -64,12 +64,6 @@ pub fn translate(
     _input: &str, // TODO: going to be used for CREATE VIEW
 ) -> Result<Program> {
     tracing::trace!("querying {}", _input);
-    if matches!(connection.transaction_state.get(), TransactionState::None)
-        && connection.schema.borrow().schema_version < connection._db.schema.read().schema_version
-    {
-        let new_schema = connection._db.schema.read();
-        connection.schema.replace(new_schema.clone());
-    }
     let change_cnt_on = matches!(
         stmt,
         ast::Stmt::CreateIndex { .. }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -39,7 +39,7 @@ use crate::storage::pager::Pager;
 use crate::translate::delete::translate_delete;
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts, QueryMode};
 use crate::vdbe::Program;
-use crate::{bail_parse_error, Connection, Result, SymbolTable};
+use crate::{bail_parse_error, Connection, Result, SymbolTable, TransactionState};
 use alter::translate_alter_table;
 use index::{translate_create_index, translate_drop_index};
 use insert::translate_insert;
@@ -64,6 +64,12 @@ pub fn translate(
     _input: &str, // TODO: going to be used for CREATE VIEW
 ) -> Result<Program> {
     tracing::trace!("querying {}", _input);
+    if matches!(connection.transaction_state.get(), TransactionState::None)
+        && connection.schema.borrow().schema_version < connection._db.schema.read().schema_version
+    {
+        let new_schema = connection._db.schema.read();
+        connection.schema.replace(new_schema.clone());
+    }
     let change_cnt_on = matches!(
         stmt,
         ast::Stmt::CreateIndex { .. }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -172,7 +172,7 @@ pub fn translate_inner(
         ast::Stmt::Rollback {
             tx_name,
             savepoint_name,
-        } => translate_rollback(query_mode, schema, syms, program, tx_name, savepoint_name)?,
+        } => translate_rollback(schema, syms, program, tx_name, savepoint_name)?,
         ast::Stmt::Savepoint(_) => bail_parse_error!("SAVEPOINT not supported yet"),
         ast::Stmt::Select(select) => {
             translate_select(

--- a/core/translate/rollback.rs
+++ b/core/translate/rollback.rs
@@ -3,15 +3,11 @@ use turso_sqlite3_parser::ast::Name;
 use crate::{
     schema::Schema,
     translate::emitter::TransactionMode,
-    vdbe::{
-        builder::{ProgramBuilder, QueryMode},
-        insn::Insn,
-    },
+    vdbe::{builder::ProgramBuilder, insn::Insn},
     Result, SymbolTable,
 };
 
 pub fn translate_rollback(
-    _query_mode: QueryMode,
     _schema: &Schema,
     _syms: &SymbolTable,
     mut program: ProgramBuilder,

--- a/core/translate/rollback.rs
+++ b/core/translate/rollback.rs
@@ -10,7 +10,6 @@ use crate::{
     Result, SymbolTable,
 };
 
-#[allow(dead_code)]
 pub fn translate_rollback(
     _query_mode: QueryMode,
     _schema: &Schema,

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -14,6 +14,7 @@ use crate::translate::ProgramBuilder;
 use crate::translate::ProgramBuilderOpts;
 use crate::util::PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX;
 use crate::vdbe::builder::CursorType;
+use crate::vdbe::insn::Cookie;
 use crate::vdbe::insn::{CmpInsFlags, InsertFlags, Insn};
 use crate::LimboError;
 use crate::SymbolTable;
@@ -144,7 +145,12 @@ pub fn translate_create_table(
 
     program.resolve_label(parse_schema_label, program.offset());
     // TODO: SetCookie
-    //
+    program.emit_insn(Insn::SetCookie {
+        db: 0,
+        cookie: Cookie::SchemaVersion,
+        value: schema.schema_version as i32 + 1,
+        p5: 0,
+    });
     // TODO: remove format, it sucks for performance but is convenient
     let parse_schema_where_clause = format!("tbl_name = '{}' AND type != 'trigger'", tbl_name);
     program.emit_insn(Insn::ParseSchema {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -596,6 +596,12 @@ pub fn translate_create_virtual_table(
         Some(sql),
     );
 
+    program.emit_insn(Insn::SetCookie {
+        db: 0,
+        cookie: Cookie::SchemaVersion,
+        value: schema.schema_version as i32 + 1,
+        p5: 0,
+    });
     let parse_schema_where_clause = format!("tbl_name = '{}' AND type != 'trigger'", table_name);
     program.emit_insn(Insn::ParseSchema {
         db: sqlite_schema_cursor_id,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -422,7 +422,10 @@ impl Program {
                 program_state.commit_state
             );
             if program_state.commit_state == CommitState::Committing {
-                let TransactionState::Write { change_schema } = connection.transaction_state.get() else {unreachable!("invalid state for write commit step")};
+                let TransactionState::Write { change_schema } = connection.transaction_state.get()
+                else {
+                    unreachable!("invalid state for write commit step")
+                };
                 self.step_end_write_txn(
                     &pager,
                     &mut program_state.commit_state,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -47,6 +47,7 @@ use execute::{
     OpOpenEphemeralState,
 };
 
+use libloading::changelog;
 use rand::Rng;
 use regex::Regex;
 use std::{
@@ -422,21 +423,24 @@ impl Program {
                 program_state.commit_state
             );
             if program_state.commit_state == CommitState::Committing {
+                let TransactionState::Write { change_schema } = connection.transaction_state.get() else {unreachable!("invalid state for write commit step")};
                 self.step_end_write_txn(
                     &pager,
                     &mut program_state.commit_state,
                     &connection,
                     rollback,
+                    change_schema,
                 )
             } else if auto_commit {
                 let current_state = connection.transaction_state.get();
                 tracing::trace!("Auto-commit state: {:?}", current_state);
                 match current_state {
-                    TransactionState::Write => self.step_end_write_txn(
+                    TransactionState::Write { change_schema } => self.step_end_write_txn(
                         &pager,
                         &mut program_state.commit_state,
                         &connection,
                         rollback,
+                        change_schema,
                     ),
                     TransactionState::Read => {
                         connection.transaction_state.replace(TransactionState::None);
@@ -461,8 +465,9 @@ impl Program {
         commit_state: &mut CommitState,
         connection: &Connection,
         rollback: bool,
+        change_schema: bool,
     ) -> Result<StepResult> {
-        let cacheflush_status = pager.end_tx(rollback)?;
+        let cacheflush_status = pager.end_tx(rollback, change_schema, connection)?;
         match cacheflush_status {
             PagerCacheflushStatus::Done(_) => {
                 if self.change_cnt_on {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -47,7 +47,6 @@ use execute::{
     OpOpenEphemeralState,
 };
 
-use libloading::changelog;
 use rand::Rng;
 use regex::Regex;
 use std::{

--- a/stress/main.rs
+++ b/stress/main.rs
@@ -349,7 +349,11 @@ fn generate_plan(opts: &Opts) -> Result<Plan, Box<dyn std::error::Error + Send +
             }
             queries.push(sql);
             if tx.is_some() {
-                queries.push("COMMIT".to_string());
+                if get_random() % 2 == 0 {
+                    queries.push("COMMIT".to_string());
+                } else {
+                    queries.push("ROLLBACK".to_string());
+                }
             }
         }
         plan.queries_per_thread.push(queries);

--- a/testing/all.test
+++ b/testing/all.test
@@ -37,3 +37,4 @@ source $testdir/create_table.test
 source $testdir/collate.test
 source $testdir/values.test
 source $testdir/integrity_check.test
+source $testdir/rollback.test

--- a/testing/rollback.test
+++ b/testing/rollback.test
@@ -125,7 +125,7 @@ do_execsql_test_on_specific_db {:memory:} schema-alter-rollback-and-repeat {
     rollback;
     alter table t add column y;
     select sql from sqlite_schema;
-} {"CREATE TABLE t ( x , y  )"}
+} {"CREATE TABLE t (x, y)"}
 
 if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
     do_execsql_test_on_specific_db {:memory:} schema-create-index-rollback {

--- a/testing/rollback.test
+++ b/testing/rollback.test
@@ -80,6 +80,19 @@ do_execsql_test_on_specific_db {:memory:} schema-change-rollback {
     PRAGMA integrity_check;
 } {ok}
 
+do_execsql_test_on_specific_db {:memory:} schema-change-rollback-version {
+    begin;
+    create table t (x);
+    insert into t values (1);
+    rollback;
+    PRAGMA schema_version;
+} {0}
+
+do_execsql_test_on_specific_db {:memory:} schema-version-after-update {
+    create table t (x);
+    PRAGMA schema_version;
+} {1}
+
 do_execsql_test_on_specific_db {:memory:} schema-change-rollback-2 {
     begin;
     create table t (x);
@@ -95,3 +108,21 @@ do_execsql_test_on_specific_db {:memory:} schema-change-rollback-2 {
     create table after (x);
     select tbl_name from sqlite_schema;
 } {before after}
+
+
+do_execsql_test_on_specific_db {:memory:} schema-alter-rollback {
+    create table t (x);
+    begin;
+    alter table t add column y;
+    rollback;
+    select sql from sqlite_schema;
+} {"CREATE TABLE t (x)"}
+
+do_execsql_test_on_specific_db {:memory:} schema-alter-rollback-and-repeat {
+    create table t (x);
+    begin;
+    alter table t add column y;
+    rollback;
+    alter table t add column y;
+    select sql from sqlite_schema;
+} {"CREATE TABLE t ( x, y)"}

--- a/testing/rollback.test
+++ b/testing/rollback.test
@@ -125,4 +125,29 @@ do_execsql_test_on_specific_db {:memory:} schema-alter-rollback-and-repeat {
     rollback;
     alter table t add column y;
     select sql from sqlite_schema;
-} {"CREATE TABLE t ( x, y)"}
+} {"CREATE TABLE t ( x , y  )"}
+
+if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
+    do_execsql_test_on_specific_db {:memory:} schema-create-index-rollback {
+        create table t (x);
+        begin;
+        create index i on t(x);
+        rollback;
+        select sql from sqlite_schema;
+    } {"CREATE TABLE t (x)"}
+}
+
+
+do_execsql_test_on_specific_db {:memory:} schema-drop-table-rollback {
+    create table t (x);
+    begin;
+    drop table t; 
+    rollback;
+    select sql from sqlite_schema;
+} {"CREATE TABLE t (x)"}
+
+
+# TODO: add tests for:
+# * create virtual table 
+# * drop index
+# * views...

--- a/testing/rollback.test
+++ b/testing/rollback.test
@@ -70,3 +70,28 @@ do_execsql_test_on_specific_db {:memory:} insert-after-rollback {
     insert into t2 values (1);
     select * from t2 order by x;
 } {1}
+
+
+do_execsql_test_on_specific_db {:memory:} schema-change-rollback {
+    begin;
+    create table t (x);
+    insert into t values (1);
+    rollback;
+    PRAGMA integrity_check;
+} {ok}
+
+do_execsql_test_on_specific_db {:memory:} schema-change-rollback-2 {
+    begin;
+    create table t (x);
+    rollback;
+    select tbl_name from sqlite_schema;
+} {}
+
+do_execsql_test_on_specific_db {:memory:} schema-change-rollback-2 {
+    create table before (x);
+    begin;
+    create table t (x);
+    rollback;
+    create table after (x);
+    select tbl_name from sqlite_schema;
+} {before after}


### PR DESCRIPTION
Fixes #1890

Once rollback was implement we quickly saw that it lacked support for schema changes so we had to re-estructure things a bit.

## Example of failure:
```bash
turso> begin;
turso> create table t(x);
turso> rollback;
turso> pragma integrity_check;
thread 'main' panicked at core/storage/sqlite3_ondisk.rs:386:36:
called `Result::unwrap()` on an `Err` value: Corrupt("Invalid page type: 83")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This happened because it thought table `t` existed because we didn't rollback that schema.
## Changes:

* The most important change: now every connection has a private copy of schema. On write txn commit we update a global schema shared between connections in order for new connections to get updated version from there. In case of rollback, we simply change connection's schema to previous version. This change allowed us to remove locks for schema private copy and keeping schema changes locally in case of concurrency.
 Sqlite does things differently, they lazily parse schema in case of outdated schema, this many schema changes to trigger reading schema from db file which is slow. If we are able to keep local copy in memory, even when if we add multiprocessing, it will speed up schema reloading by a bunch.
* `schema_cookie` is now update for every schema change
* `Insn::ParseSchema` had a nasty bug where it would commit all the changes made in a query that changed a schema, we fixed that by setting `auto_commit` to `false` before parsing schema, and setting it back to previous value once schema is parsed.
