### PR TITLE
Fix Python test import naming

### DIFF
--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -160,3 +160,28 @@ jobs:
       - uses: actions/checkout@v3
       - name: TPC-H
         run: ./perf/tpc-h/benchmark.sh
+
+  vfs-bench-compile:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v3
+      - uses: useblacksmith/rust-cache@v3
+        with:
+          prefix-key: "v1-rust" # can be updated if we need to reset caches due to non-trivial change in the dependencies (for example, custom env var were set for single workspace project)
+
+      - name: Build
+        run: cargo build --release --verbose
+
+      - name: Install uv
+        uses: useblacksmith/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install the project
+        run: uv sync --package turso_test
+
+      - name: Run benchmark
+        run: uv run bench-vfs "SELECT 1;" 100

--- a/testing/cli_tests/collate.py
+++ b/testing/cli_tests/collate.py
@@ -2,7 +2,7 @@
 import os
 
 from cli_tests import console
-from cli_tests.test_limbo_cli import TestTursoShell
+from cli_tests.test_turso_cli import TestTursoShell
 from pydantic import BaseModel
 
 sqlite_flags = os.getenv("SQLITE_FLAGS", "-q").split(" ")

--- a/testing/cli_tests/constraint.py
+++ b/testing/cli_tests/constraint.py
@@ -8,7 +8,7 @@ import tempfile
 from enum import Enum
 
 from cli_tests import console
-from cli_tests.test_limbo_cli import TestTursoShell
+from cli_tests.test_turso_cli import TestTursoShell
 from faker import Faker
 from faker.providers.lorem.en_US import Provider as P
 from pydantic import BaseModel

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -2,7 +2,7 @@
 import os
 
 from cli_tests import console
-from cli_tests.test_limbo_cli import TestTursoShell
+from cli_tests.test_turso_cli import TestTursoShell
 
 sqlite_exec = "./scripts/limbo-sqlite3"
 sqlite_flags = os.getenv("SQLITE_FLAGS", "-q").split(" ")
@@ -343,7 +343,7 @@ def test_kv():
 
 
 def _test_kv(exec_name, ext_path):
-    console.info(f"Running test_kv for {ext_path}")
+    console.info(f"Running test_kv for {ext_path} in {exec_name}")
 
     limbo = TestTursoShell(
         exec_name=exec_name,

--- a/testing/cli_tests/memory.py
+++ b/testing/cli_tests/memory.py
@@ -2,7 +2,7 @@
 import os
 
 from cli_tests import console
-from cli_tests.test_limbo_cli import TestTursoShell
+from cli_tests.test_turso_cli import TestTursoShell
 
 sqlite_flags = os.getenv("SQLITE_FLAGS", "-q").split(" ")
 

--- a/testing/cli_tests/update.py
+++ b/testing/cli_tests/update.py
@@ -2,7 +2,7 @@
 import os
 
 from cli_tests import console
-from cli_tests.test_limbo_cli import TestTursoShell
+from cli_tests.test_turso_cli import TestTursoShell
 from pydantic import BaseModel
 
 sqlite_flags = os.getenv("SQLITE_FLAGS", "-q").split(" ")

--- a/testing/cli_tests/vfs_bench.py
+++ b/testing/cli_tests/vfs_bench.py
@@ -3,6 +3,7 @@
 # vfs benchmarking/comparison
 import argparse
 import os
+import platform
 import statistics
 import subprocess
 from pathlib import Path
@@ -10,11 +11,13 @@ from time import perf_counter, sleep
 from typing import Dict
 
 from cli_tests.console import error, info, test
-from cli_tests.test_limbo_cli import TestTursoShell
+from cli_tests.test_turso_cli import TestTursoShell
 
-LIMBO_BIN = Path("./target/release/limbo")
+LIMBO_BIN = Path("./target/release/tursodb")
 DB_FILE = Path("testing/temp.db")
-vfs_list = ["syscall", "io_uring"]
+vfs_list = ["syscall"]
+if platform.system() == "Linux":
+    vfs_list.append("io_uring")
 
 
 def append_time(times, start, perf_counter):

--- a/testing/cli_tests/write.py
+++ b/testing/cli_tests/write.py
@@ -4,7 +4,7 @@ import tempfile
 from time import sleep
 
 from cli_tests import console
-from cli_tests.test_limbo_cli import TestTursoShell
+from cli_tests.test_turso_cli import TestTursoShell
 from pydantic import BaseModel
 
 sqlite_flags = os.getenv("SQLITE_FLAGS", "-q").split(" ")
@@ -39,8 +39,8 @@ class InsertTest(BaseModel):
         big_stmt.append("SELECT count(*) FROM test;")
         expected.append(str(self.vals * 2))
 
-        big_stmt.append("DELETE FROM temp;")
-        big_stmt.append("SELECT count(*) FROM temp;")
+        big_stmt.append("DELETE FROM test;")
+        big_stmt.append("SELECT count(*) FROM test;")
         expected.append(str(0))
 
         big_stmt = "".join(big_stmt)


### PR DESCRIPTION
When we renamed the Python imports, we forgot to rename the `test_limbo_cli` to `test_turso_cli`. Also adds a vfs-bench-compile github ci to compile and test that the bench-vfs scripts works