### PR TITLE
Disable adaptive colors when output_mode is list

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -151,6 +151,7 @@ impl Limbo {
         }
         let sql = opts.sql.clone();
         let quiet = opts.quiet;
+        let config = Config::for_output_mode(opts.output_mode);
         let mut app = Self {
             prompt: PROMPT.to_string(),
             io,
@@ -160,7 +161,7 @@ impl Limbo {
             input_buff: String::new(),
             opts: Settings::from(opts),
             rl: None,
-            config: Some(Config::default()),
+            config: Some(config),
         };
         app.first_run(sql, quiet)?;
         Ok(app)

--- a/cli/config/mod.rs
+++ b/cli/config/mod.rs
@@ -1,6 +1,7 @@
 mod palette;
 mod terminal;
 
+use crate::input::OutputMode;
 use crate::HOME_DIR;
 use nu_ansi_term::Color;
 use palette::LimboColor;
@@ -77,6 +78,18 @@ impl Config {
             result.ok()
         } else {
             None
+        }
+    }
+
+    pub fn for_output_mode(mode: OutputMode) -> Self {
+        let table = if mode == OutputMode::Pretty {
+            TableConfig::adaptive_colors()
+        } else {
+            TableConfig::no_colors()
+        };
+        Self {
+            table,
+            highlight: HighlightConfig::default(),
         }
     }
 }


### PR DESCRIPTION
As adaptive colors use `OSC 11` to query the terminal's background color,  the query string may contaminate test result and cause failures when running tests in a terminal. 

```
 make test-vector 
                                                                                                                                                                                     
SQLITE_EXEC=scripts/limbo-sqlite3 ./testing/vector.test
(testing/testing.db)                        Running test: vector-functions-valid
Test FAILED: SELECT vector_extract(vector('[]'));
  SELECT vector_extract(vector('  [  1  ,  2  ,  3  ]  '));
  SELECT vector_extract(vector('[-1000000000000000000]'));
returned '[]
[1,2,3]
[-1000000000000000000]'
expected '[]
[1,2,3]
[-1000000000000000000]'
^[]11;rgb:158e/193a/1e75^[\make: *** [test-vector] Error 1
```