### PR TITLE
Fix `ScalarFunc::Glob` to handle NULL and other value types

### DIFF
--- a/testing/glob.test
+++ b/testing/glob.test
@@ -69,6 +69,19 @@ do_execsql_test where-glob-impossible {
     select * from products where 'foobar' glob 'fooba';
 } {}
 
+do_execsql_test glob-null-other-types {
+    DROP TABLE IF EXISTS t0;
+    CREATE TABLE IF NOT EXISTS t0 (c0 REAL);
+    UPDATE t0 SET c0='C2IS*24', c0=0Xffffffffbfc4330f, c0=0.6463854797956918 WHERE ((((((((t0.c0)AND(t0.c0)))AND(0.23913649834358142)))OR(CASE t0.c0  WHEN t0.c0 THEN 'j2' WHEN t0.c0 THEN t0.c0 WHEN t0.c0 THEN t0.c0 END)))OR(((((((((t0.c0)AND(t0.c0)))AND(t0.c0)))OR(t0.c0)))AND(t0.c0)))); 
+    INSERT INTO t0 VALUES (NULL);
+    INSERT INTO t0 VALUES ('0&');
+    UPDATE t0 SET c0=2352448 WHERE ((((t0.c0)GLOB(t0.c0))) NOT NULL);
+    SELECT * from t0;
+} {
+    {}
+    2352448.0
+}
+
 foreach {testnum pattern text ans} {
    1  abcdefg   abcdefg   1
    2  abcdefG   abcdefg   0


### PR DESCRIPTION
Previously `ScalarFunc::Glob` only handled Text based values. After this fix it will be able to handle all types of values. 

Now:

```SQL
turso> CREATE TABLE IF NOT EXISTS  t0 (c0 REAL ); 

turso> UPDATE t0 SET c0='C2IS*24', c0=0Xffffffffbfc4330f, c0=0.6463854797956918 WHERE ((((((((t0.c0)AND(t0.c0)))AND(0.23913649834358142)))OR(CASE t0.c0  WHEN t0.c0 THEN 'j2' WHEN t0.c0 THEN t0.c0 WHEN t0.c0 THEN t0.c0 END)))OR(((((((((t0.c0)AND(t0.c0)))AND(t0.c0)))OR(t0.c0)))AND(t0.c0)))); 

turso> INSERT INTO t0 VALUES (NULL);
INSERT INTO t0 VALUES ('0&');
UPDATE t0 SET c0=2352448 WHERE ((((t0.c0)GLOB(t0.c0))) NOT NULL);
turso> SELECT * from t0;
┌───────────┐
│ c0        │
├───────────┤
│           │
├───────────┤
│ 2352448.0 │
└───────────┘
```



Fixes: https://github.com/tursodatabase/turso/issues/1953