### PR TITLE
feat: Revert `power()` to use platform `powf` for SQLite compatibility

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6165,7 +6165,7 @@ impl Value {
         let result = match function {
             MathFunc::Atan2 => libm::atan2(lhs, rhs),
             MathFunc::Mod => libm::fmod(lhs, rhs),
-            MathFunc::Pow | MathFunc::Power => libm::pow(lhs, rhs),
+            MathFunc::Pow | MathFunc::Power => lhs.powf(rhs),
             _ => unreachable!("Unexpected mathematical binary function {:?}", function),
         };
 

--- a/testing/math.test
+++ b/testing/math.test
@@ -8,6 +8,11 @@ do_execsql_test fuzz-test-failure {
   SELECT mod(atanh(tanh(-1.0)), ((1.0))) / ((asinh(-1.0) / 2.0 * 1.0) + pow(0.0, 1.0) + 0.5);
 } {-16.8596516555675}
 
+# math_expression_fuzz_run failure with seed 1751638920
+do_execsql_test fuzz-test-failure-power {
+  SELECT sin(power((((degrees(1.0) + 1.0 + 2.0))), power(2.0 + 1.0 - 0.5 - 2.0, power(0.0, 0.0) * (-2.0))));
+} {0.547449893492228}
+
 do_execsql_test add-int-1 {
   SELECT 10 + 1
 } {11}


### PR DESCRIPTION
This commit reverts the implementation of the `power()` SQL function to use `f64::powf` instead of `libm::pow`. This change resolves the "math fuzz failure" described in issue #1960.

Previously, Turso's `power()` function used `libm::pow`, a pure-Rust implementation from `musl`. SQLite, however, implements its `pow()` function using the platform's C-library `pow()` (e.g., `glibc::pow`). While both are IEEE-754 compliant, they can produce slightly different results (often < 1 ULP), leading to discrepancies flagged by fuzz tests designed to ensure bit-for-bit equivalence with SQLite.

By reverting to `lhs.powf(rhs)`, both Turso and SQLite now call the same underlying C-library routine, ensuring:
- **Binary compatibility with SQLite**: Results match bit-for-bit, allowing fuzz tests to pass.
- **Improved edge-case handling**: Leverages battle-tested platform implementations for NaNs, infinities, etc.
- **Potential performance benefits**: Platform `powf` can be highly optimized with specialized CPU instructions.
- **Reduced maintenance burden**: Eliminates the need to re-audit differences with `musl`'s algorithm changes.

The original motivations for using `libm` (avoiding linker flags on embedded/`no_std` targets and ensuring determinism in non-SQLite contexts) are not applicable to Turso's SQL engine running on full operating systems, where platform `libm` is always available and deterministic equivalence with SQLite is paramount.

Fixes #1960