### PR TITLE
core/translate: Unify no such table error messages

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -569,7 +569,7 @@ mod tests {
             Ok(_) => panic!("Query succeeded after WAL deletion and DB reopen, but was expected to fail because the table definition should have been in the WAL."),
             Err(Error::SqlExecutionFailure(msg)) => {
                 assert!(
-                    msg.contains("test_large_persistence not found"),
+                    msg.contains("no such table: test_large_persistence"),
                     "Expected 'test_large_persistence not found' error, but got: {}",
                     msg
                 );

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -208,7 +208,7 @@ pub fn bind_column_references(
                 let matching_tbl = referenced_tables
                     .find_table_and_internal_id_by_identifier(&normalized_table_name);
                 if matching_tbl.is_none() {
-                    crate::bail_parse_error!("Table {} not found", normalized_table_name);
+                    crate::bail_parse_error!("no such table: {}", normalized_table_name);
                 }
                 let (tbl_id, tbl) = matching_tbl.unwrap();
                 let normalized_id = normalize_ident(id.0.as_str());
@@ -320,7 +320,7 @@ fn parse_from_clause_table(
                 }
             }
 
-            crate::bail_parse_error!("Table {} not found", normalized_qualified_name);
+            crate::bail_parse_error!("no such table: {}", normalized_qualified_name);
         }
         ast::SelectTable::Select(subselect, maybe_alias) => {
             let Plan::Select(subplan) = prepare_select_plan(

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -298,7 +298,7 @@ fn prepare_one_select_plan(
                             .find(|t| t.identifier == name_normalized);
 
                         if referenced_table.is_none() {
-                            crate::bail_parse_error!("Table {} not found", name.0);
+                            crate::bail_parse_error!("no such table: {}", name.0);
                         }
                         let table = referenced_table.unwrap();
                         let num_columns = table.columns().len();

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -662,7 +662,7 @@ def test_csv():
     limbo.run_test_fn("DROP TABLE temp.csv;", null, "Drop CSV table")
     limbo.run_test_fn(
         "SELECT * FROM temp.csv;",
-        lambda res: "Parse error: Table csv not found" in res,
+        lambda res: "Parse error: no such table: csv" in res,
         "Query dropped CSV table should fail",
     )
     limbo.run_test_fn(


### PR DESCRIPTION
We're now mixing different error messages, which makes compatibility testing pretty hard. Unify on a single, SQLite compatible error message "no such table".