### PR TITLE
cli: Add support for `.headers` command

### DIFF
--- a/cli/commands/args.rs
+++ b/cli/commands/args.rs
@@ -124,3 +124,14 @@ pub struct TimerArgs {
     #[arg(value_enum)]
     pub mode: TimerMode,
 }
+
+#[derive(Debug, Clone, Args)]
+pub struct HeadersArgs {
+    pub mode: HeadersMode,
+}
+
+#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HeadersMode {
+    On,
+    Off,
+}

--- a/cli/commands/mod.rs
+++ b/cli/commands/mod.rs
@@ -2,8 +2,8 @@ pub mod args;
 pub mod import;
 
 use args::{
-    CwdArgs, EchoArgs, ExitArgs, IndexesArgs, LoadExtensionArgs, NullValueArgs, OpcodesArgs,
-    OpenArgs, OutputModeArgs, SchemaArgs, SetOutputArgs, TablesArgs, TimerArgs,
+    CwdArgs, EchoArgs, ExitArgs, HeadersArgs, IndexesArgs, LoadExtensionArgs, NullValueArgs,
+    OpcodesArgs, OpenArgs, OutputModeArgs, SchemaArgs, SetOutputArgs, TablesArgs, TimerArgs,
 };
 use clap::Parser;
 use import::ImportArgs;
@@ -77,6 +77,9 @@ pub enum Command {
     ListIndexes(IndexesArgs),
     #[command(name = "timer", display_name = ".timer")]
     Timer(TimerArgs),
+    /// Toggle column headers on/off in list mode
+    #[command(name = "headers", display_name = ".headers")]
+    Headers(HeadersArgs),
 }
 
 const _HELP_TEMPLATE: &str = "{before-help}{name}

--- a/cli/input.rs
+++ b/cli/input.rs
@@ -83,6 +83,7 @@ pub struct Settings {
     pub io: Io,
     pub tracing_output: Option<String>,
     pub timer: bool,
+    pub headers: bool,
 }
 
 impl From<Opts> for Settings {
@@ -107,6 +108,7 @@ impl From<Opts> for Settings {
             },
             tracing_output: opts.tracing_output,
             timer: false,
+            headers: false,
         }
     }
 }
@@ -115,7 +117,7 @@ impl std::fmt::Display for Settings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Settings:\nOutput mode: {}\nDB: {}\nOutput: {}\nNull value: {}\nCWD: {}\nEcho: {}",
+            "Settings:\nOutput mode: {}\nDB: {}\nOutput: {}\nNull value: {}\nCWD: {}\nEcho: {}\nHeaders: {}",
             self.output_mode,
             self.db_file,
             match self.is_stdout {
@@ -125,6 +127,10 @@ impl std::fmt::Display for Settings {
             self.null_value,
             std::env::current_dir().unwrap().display(),
             match self.echo {
+                true => "on",
+                false => "off",
+            },
+            match self.headers {
                 true => "on",
                 false => "off",
             }
@@ -220,6 +226,12 @@ pub const AFTER_HELP_MSG: &str = r#"Usage Examples:
    .listvfs
 14. To show names of indexes:
    .indexes ?TABLE?
+
+15. To turn on column headers in list mode:
+   .headers on
+
+16. To turn off column headers in list mode:
+   .headers off
 
 Note:
 - All SQL commands must end with a semicolon (;).


### PR DESCRIPTION
The `.headers` command takes `on` and `off` as parameter, supported by SQLite, which controls whether result set header is printed in list mode.