### PR TITLE
Fix: OP_NewRowId to generate semi random rowid when largest rowid is `i64::MAX`

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -10,6 +10,8 @@ pub enum LimboError {
     InternalError(String),
     #[error("Page cache is full")]
     CacheFull,
+    #[error("Database is full: {0}")]
+    DatabaseFull(String),
     #[error("Parse error: {0}")]
     ParseError(String),
     #[error(transparent)]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -29,6 +29,7 @@ use crate::{
     function::{AggFunc, FuncCtx},
     storage::{pager::PagerCacheflushStatus, sqlite3_ondisk::SmallVec},
     translate::plan::TableReferences,
+    types::{SeekKey, SeekOp},
 };
 
 use crate::{
@@ -514,38 +515,54 @@ impl Program {
     }
 }
 
-fn get_new_rowid<R: Rng>(cursor: &mut BTreeCursor, mut _rng: R) -> Result<CursorResult<i64>> {
+fn get_new_rowid<R: Rng>(cursor: &mut BTreeCursor, mut rng: R) -> Result<CursorResult<i64>> {
+    const MAX_ROWID: i64 = i64::MAX;
+
     match cursor.seek_to_last()? {
         CursorResult::Ok(()) => {}
         CursorResult::IO => return Ok(CursorResult::IO),
     }
-    let rowid = match cursor.rowid()? {
-        CursorResult::Ok(Some(rowid)) => rowid.checked_add(1).unwrap_or(i64::MAX), // add 1 but be careful with overflows, in case of overflow - use i64::MAX
-        CursorResult::Ok(None) => 1,
+
+    let current_max_rowid = match cursor.rowid()? {
+        CursorResult::Ok(Some(rowid)) => rowid,
+        CursorResult::Ok(None) => {
+            return Ok(CursorResult::Ok(1));
+        }
         CursorResult::IO => return Ok(CursorResult::IO),
     };
-    // NOTE(nilskch): I commented this part out because this condition will never be true.
-    // if rowid > i64::MAX {
-    //     let distribution = Uniform::from(1..=i64::MAX);
-    //     let max_attempts = 100;
-    //     for count in 0..max_attempts {
-    //         rowid = distribution.sample(&mut rng);
-    //         match cursor.seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true })? {
-    //             CursorResult::Ok(false) => break, // Found a non-existing rowid
-    //             CursorResult::Ok(true) => {
-    //                 if count == max_attempts - 1 {
-    //                     return Err(LimboError::InternalError(
-    //                         "Failed to generate a new rowid".to_string(),
-    //                     ));
-    //                 } else {
-    //                     continue; // Try next random rowid
-    //                 }
-    //             }
-    //             CursorResult::IO => return Ok(CursorResult::IO),
-    //         }
-    //     }
-    // }
-    Ok(CursorResult::Ok(rowid))
+
+    if current_max_rowid < MAX_ROWID {
+        return Ok(CursorResult::Ok(current_max_rowid + 1));
+    }
+
+    // Current max rowid == i64::MAX, so we need to generate random rowids
+    let max_attempts = 100;
+
+    for _ in 0..max_attempts {
+        // Generate a random i64 and constrain it to the lower half of the rowid range.
+        // We use the lower half (1 to MAX_ROWID/2) because we're in random mode only
+        // when sequential allocation reached MAX_ROWID, meaning the upper range is full.
+        let mut random_rowid: i64 = rng.gen();
+        random_rowid &= MAX_ROWID >> 1; // Mask to keep value in range [0, MAX_ROWID/2]
+        random_rowid += 1; // Ensure positive
+
+        match cursor.seek(
+            SeekKey::TableRowId(random_rowid),
+            SeekOp::GE { eq_only: true },
+        )? {
+            CursorResult::Ok(false) => {
+                return Ok(CursorResult::Ok(random_rowid));
+            }
+            CursorResult::Ok(true) => {
+                continue;
+            }
+            CursorResult::IO => return Ok(CursorResult::IO),
+        }
+    }
+
+    Err(LimboError::DatabaseFull(
+        "Unable to find an unused rowid after 100 attempts - database is probably full".to_string(),
+    ))
 }
 
 fn make_record(registers: &[Register], start_reg: &usize, count: &usize) -> ImmutableRecord {

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -369,3 +369,11 @@ do_execsql_test_on_specific_db {:memory:} negative-primary-integer-key {
 } {-2
 13}
 
+
+do_execsql_test_on_specific_db {:memory:} rowid-overflow-random-generation {
+    CREATE TABLE q(x INTEGER PRIMARY KEY, y);
+    INSERT INTO q VALUES (9223372036854775807, 1);
+    INSERT INTO q(y) VALUES (2);
+    INSERT INTO q(y) VALUES (3);
+    SELECT COUNT(*) FROM q;
+} {3}


### PR DESCRIPTION
- `OP_NewRowId` now generates new rowid semi randomly when the largest rowid in the table is `i64::MAX`. 
- Introduced new `LimboError` variant `DatabaseFull` to signify that database might be full (SQLite behaves this way returning `SQLITE_FULL`).

Now:

```SQL
turso> CREATE TABLE q(x INTEGER PRIMARY KEY, y);
turso> INSERT INTO q VALUES (9223372036854775807, 1);
turso> INSERT INTO q(y) VALUES (2);
turso> INSERT INTO q(y) VALUES (3);
turso> SELECT * FROM q;
┌─────────────────────┬───┐
│ x                   │ y │
├─────────────────────┼───┤
│ 1841427626667347484 │ 2 │
├─────────────────────┼───┤
│ 4000338366725695791 │ 3 │
├─────────────────────┼───┤
│ 9223372036854775807 │ 1 │
└─────────────────────┴───┘
```
Fixes: https://github.com/tursodatabase/turso/issues/1977