### PR TITLE
feat(vector): implement Euclidean distance for vector search module

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -633,6 +633,7 @@ The `vector` extension is compatible with libSQL native vector search.
 | vector64(x)                                    | Yes    |         |
 | vector_extract(x)                              | Yes    |         |
 | vector_distance_cos(x, y)                      | Yes    |         |
+| distance_l2(x, y)                              | Yes    |Euclidean distance|
 
 ### Time
 

--- a/core/function.rs
+++ b/core/function.rs
@@ -156,6 +156,7 @@ pub enum VectorFunc {
     Vector64,
     VectorExtract,
     VectorDistanceCos,
+    VectorDistanceEuclidean,
 }
 
 impl VectorFunc {
@@ -172,6 +173,8 @@ impl Display for VectorFunc {
             Self::Vector64 => "vector64".to_string(),
             Self::VectorExtract => "vector_extract".to_string(),
             Self::VectorDistanceCos => "vector_distance_cos".to_string(),
+            // We use `distance_l2` to reduce user input
+            Self::VectorDistanceEuclidean => "distance_l2".to_string(),
         };
         write!(f, "{}", str)
     }
@@ -814,6 +817,7 @@ impl Func {
             "vector64" => Ok(Self::Vector(VectorFunc::Vector64)),
             "vector_extract" => Ok(Self::Vector(VectorFunc::VectorExtract)),
             "vector_distance_cos" => Ok(Self::Vector(VectorFunc::VectorDistanceCos)),
+            "distance_l2" => Ok(Self::Vector(VectorFunc::VectorDistanceEuclidean)),
             _ => crate::bail_parse_error!("no such function: {}", name),
         }
     }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -920,6 +920,19 @@ pub fn translate_expr(
                         });
                         Ok(target_register)
                     }
+                    VectorFunc::VectorDistanceEuclidean => {
+                        let args = expect_arguments_exact!(args, 2, vector_func);
+                        let regs = program.alloc_registers(2);
+                        translate_expr(program, referenced_tables, &args[0], regs, resolver)?;
+                        translate_expr(program, referenced_tables, &args[1], regs + 1, resolver)?;
+                        program.emit_insn(Insn::Function {
+                            constant_mask: 0,
+                            start_reg: regs,
+                            dest: target_register,
+                            func: func_ctx,
+                        });
+                        Ok(target_register)
+                    }
                 },
                 Func::Scalar(srf) => {
                     match srf {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -48,7 +48,7 @@ use crate::{
         builder::CursorType,
         insn::{IdxInsertFlags, Insn},
     },
-    vector::{vector32, vector64, vector_distance_cos, vector_extract},
+    vector::{vector32, vector64, vector_distance_cos, vector_distance_l2, vector_extract},
 };
 
 use crate::{
@@ -3800,6 +3800,11 @@ pub fn op_function(
             VectorFunc::VectorDistanceCos => {
                 let result =
                     vector_distance_cos(&state.registers[*start_reg..*start_reg + arg_count])?;
+                state.registers[*dest] = Register::Value(result);
+            }
+            VectorFunc::VectorDistanceEuclidean => {
+                let result =
+                    vector_distance_l2(&state.registers[*start_reg..*start_reg + arg_count])?;
                 state.registers[*dest] = Register::Value(result);
             }
         },

--- a/core/vector/distance.rs
+++ b/core/vector/distance.rs
@@ -1,0 +1,31 @@
+use super::vector_types::Vector;
+use crate::Result;
+
+pub(crate) mod euclidean;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DistanceType {
+    /// Euclidean distance. This is a very common distance metric that
+    /// accounts for both magnitude and direction when determining the distance
+    /// between vectors. Euclidean distance has a range of [0, ∞).
+    Euclidean,
+
+    // TODO(asukamilet): Refactor the current `vector_types.rs` to integrate
+    #[allow(dead_code)]
+    /// Cosine distance. This is a measure of similarity between two vectors
+    Cosine,
+}
+
+pub trait DistanceCalculator {
+    #[allow(unused)]
+    fn distance_type() -> DistanceType;
+
+    fn calculate(v1: &[Vector], v2: &[Vector]) -> Result<f64>;
+
+    #[allow(unused)]
+    fn batch_calculate<'a>(
+        v1: &'a [Vector],
+        v2: &'a [Vector],
+    ) -> Box<dyn Iterator<Item = Result<f64>> + 'a>;
+}

--- a/core/vector/distance/euclidean.rs
+++ b/core/vector/distance/euclidean.rs
@@ -42,7 +42,7 @@ impl DistanceCalculator for Euclidean {
         _v1: &'a [Vector],
         _v2: &'a [Vector],
     ) -> Box<dyn Iterator<Item = Result<f64>> + 'a> {
-        unimplemented!();
+        todo!()
     }
 }
 

--- a/core/vector/distance/euclidean.rs
+++ b/core/vector/distance/euclidean.rs
@@ -1,0 +1,210 @@
+use super::{DistanceCalculator, DistanceType};
+use crate::vector::vector_types::{Vector, VectorType};
+use crate::{LimboError, Result};
+
+#[derive(Debug, Clone)]
+pub struct Euclidean;
+
+impl DistanceCalculator for Euclidean {
+    fn distance_type() -> DistanceType {
+        DistanceType::Euclidean
+    }
+
+    fn calculate(v1: &[Vector], v2: &[Vector]) -> Result<f64> {
+        let mut sum = 0.0;
+        // We only pass two vectors, so it will only iterate once, it's ok to use `sum`
+        for (v1, v2) in v1.iter().zip(v2.iter()) {
+            if v1.dims != v2.dims {
+                return Err(LimboError::ConversionError(
+                    "Vectors must have the same dimensions".to_string(),
+                ));
+            }
+
+            match (&v1.vector_type, &v2.vector_type) {
+                (VectorType::Float32, VectorType::Float32) => {
+                    sum += euclidean_distance_f32(v1.as_f32_slice(), v2.as_f32_slice());
+                }
+                (VectorType::Float64, VectorType::Float64) => {
+                    sum += euclidean_distance_f64(v1.as_f64_slice(), v2.as_f64_slice());
+                }
+                _ => {
+                    return Err(LimboError::ConversionError(
+                        "Vectors must be of the same type (either Float32 or Float64)".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(sum)
+    }
+
+    // TODO(asukamilet): Implement batch calculation for Euclidean distance
+    fn batch_calculate<'a>(
+        _v1: &'a [Vector],
+        _v2: &'a [Vector],
+    ) -> Box<dyn Iterator<Item = Result<f64>> + 'a> {
+        unimplemented!();
+    }
+}
+
+fn euclidean_distance_f32(v1: &[f32], v2: &[f32]) -> f64 {
+    let sum = v1
+        .iter()
+        .zip(v2.iter())
+        .map(|(a, b)| (a - b).powi(2))
+        .sum::<f32>() as f64;
+    sum.sqrt()
+}
+
+fn euclidean_distance_f64(v1: &[f64], v2: &[f64]) -> f64 {
+    let sum = v1
+        .iter()
+        .zip(v2.iter())
+        .map(|(a, b)| (a - b).powi(2))
+        .sum::<f64>();
+    sum.sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    // Helper to generate arbitrary vectors of specific type and dimensions
+    #[derive(Debug, Clone)]
+    struct ArbitraryVector<const DIMS: usize> {
+        vector_type: VectorType,
+        data: Vec<u8>,
+    }
+
+    /// How to create an arbitrary vector of DIMS dims.
+    impl<const DIMS: usize> ArbitraryVector<DIMS> {
+        fn generate_f32_data(g: &mut Gen) -> Vec<f32> {
+            (0..DIMS)
+                .map(|_| {
+                    loop {
+                        let f = f32::arbitrary(g);
+                        // f32::arbitrary() can generate "problem values" like NaN, infinity, and very small values
+                        // Skip these values
+                        if f.is_finite() && f.abs() >= 1e-6 {
+                            // Scale to [-1, 1] range
+                            return f % 2.0 - 1.0;
+                        }
+                    }
+                })
+                .collect()
+        }
+
+        fn generate_f64_data(g: &mut Gen) -> Vec<f64> {
+            (0..DIMS)
+                .map(|_| {
+                    loop {
+                        let f = f64::arbitrary(g);
+                        // f64::arbitrary() can generate "problem values" like NaN, infinity, and very small values
+                        // Skip these values
+                        if f.is_finite() && f.abs() >= 1e-6 {
+                            // Scale to [-1, 1] range
+                            return f % 2.0 - 1.0;
+                        }
+                    }
+                })
+                .collect()
+        }
+
+        fn generate_f32_vector(g: &mut Gen) -> ArbitraryVector<DIMS> {
+            let vector_type = VectorType::Float32;
+            let data = Self::generate_f32_data(g);
+            let data_bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+            ArbitraryVector {
+                vector_type,
+                data: data_bytes,
+            }
+        }
+
+        fn generate_f64_vector(g: &mut Gen) -> ArbitraryVector<DIMS> {
+            let vector_type = VectorType::Float64;
+            let data = Self::generate_f64_data(g);
+            let data_bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+            ArbitraryVector {
+                vector_type,
+                data: data_bytes,
+            }
+        }
+    }
+
+    /// Convert an ArbitraryVector to a Vector.
+    impl<const DIMS: usize> From<ArbitraryVector<DIMS>> for Vector {
+        fn from(v: ArbitraryVector<DIMS>) -> Self {
+            Vector {
+                vector_type: v.vector_type,
+                dims: DIMS,
+                data: v.data,
+            }
+        }
+    }
+
+    #[test]
+    fn test_type_check() {
+        let v1: Vector = ArbitraryVector::<1536>::generate_f32_vector(&mut Gen::new(0)).into();
+        let v2: Vector = ArbitraryVector::<1536>::generate_f32_vector(&mut Gen::new(0)).into();
+        assert!(Euclidean::calculate(&[v1], &[v2]).is_ok());
+
+        let v1: Vector = ArbitraryVector::<1536>::generate_f64_vector(&mut Gen::new(0)).into();
+        let v2: Vector = ArbitraryVector::<1536>::generate_f64_vector(&mut Gen::new(0)).into();
+        assert!(Euclidean::calculate(&[v1], &[v2]).is_ok());
+
+        let v1: Vector = ArbitraryVector::<1536>::generate_f32_vector(&mut Gen::new(0)).into();
+        let v2: Vector = ArbitraryVector::<1536>::generate_f64_vector(&mut Gen::new(0)).into();
+        assert!(Euclidean::calculate(&[v1], &[v2]).is_err());
+    }
+
+    #[test]
+    fn test_dims_check() {
+        let mut gen = Gen::new(0);
+
+        let v1: Vector = ArbitraryVector::<1536>::generate_f32_vector(&mut gen).into();
+        let v2: Vector = ArbitraryVector::<1024>::generate_f32_vector(&mut gen).into();
+        assert!(Euclidean::calculate(&[v1], &[v2]).is_err());
+
+        let v1: Vector = ArbitraryVector::<1024>::generate_f32_vector(&mut gen).into();
+        let v2: Vector = ArbitraryVector::<1024>::generate_f32_vector(&mut gen).into();
+        assert!(Euclidean::calculate(&[v1], &[v2]).is_ok());
+
+        let v: Vector = ArbitraryVector::<1536>::generate_f64_vector(&mut gen).into();
+        let v2: Vector = ArbitraryVector::<1536>::generate_f64_vector(&mut gen).into();
+        assert!(Euclidean::calculate(&[v], &[v2]).is_ok());
+
+        let v1: Vector = ArbitraryVector::<1536>::generate_f64_vector(&mut gen).into();
+        let v2: Vector = ArbitraryVector::<1024>::generate_f64_vector(&mut gen).into();
+        assert!(Euclidean::calculate(&[v1], &[v2]).is_err());
+    }
+
+    #[test]
+    fn test_euclidean_distance_f32() {
+        let vectors = vec![
+            (0..8).map(|x| x as f32).collect::<Vec<f32>>(),
+            (1..9).map(|x| x as f32).collect::<Vec<f32>>(),
+            (2..10).map(|x| x as f32).collect::<Vec<f32>>(),
+            (3..11).map(|x| x as f32).collect::<Vec<f32>>(),
+        ];
+        let query = (2..10).map(|x| x as f32).collect::<Vec<f32>>();
+
+        let expected: Vec<f64> = vec![
+            32.0_f64.sqrt(),
+            8.0_f64.sqrt(),
+            0.0_f64.sqrt(),
+            8.0_f64.sqrt(),
+        ];
+        let results = vectors
+            .iter()
+            .map(|v| euclidean_distance_f32(&query, v))
+            .collect::<Vec<f64>>();
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn test_odd_len() {
+        let v = (0..5).map(|x| x as f32).collect::<Vec<f32>>();
+        let query = (2..7).map(|x| x as f32).collect::<Vec<f32>>();
+        assert_eq!(euclidean_distance_f32(&v, &query), 20.0_f64.sqrt());
+    }
+}

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -3,6 +3,7 @@ use crate::vdbe::Register;
 use crate::LimboError;
 use crate::Result;
 
+pub mod distance;
 pub mod vector_types;
 use vector_types::*;
 

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -1,5 +1,6 @@
 use crate::types::Value;
 use crate::vdbe::Register;
+use crate::vector::distance::{euclidean::Euclidean, DistanceCalculator};
 use crate::LimboError;
 use crate::Result;
 
@@ -76,5 +77,18 @@ pub fn vector_distance_cos(args: &[Register]) -> Result<Value> {
     let x = parse_vector(&args[0], None)?;
     let y = parse_vector(&args[1], None)?;
     let dist = do_vector_distance_cos(&x, &y)?;
+    Ok(Value::Float(dist))
+}
+
+pub fn vector_distance_l2(args: &[Register]) -> Result<Value> {
+    if args.len() != 2 {
+        return Err(LimboError::ConversionError(
+            "distance_l2 requires exactly two arguments".to_string(),
+        ));
+    }
+
+    let x = parse_vector(&args[0], None)?;
+    let y = parse_vector(&args[1], None)?;
+    let dist = Euclidean::calculate(&[x], &[y])?;
     Ok(Value::Float(dist))
 }


### PR DESCRIPTION
This PR provides Euclidean distance support for limbo's vector search.

At the same time, some type abstractions are introduced, such as `DistanceCalculator`, etc. This is because I hope to unify the current vector module in the future to make it more structured, clearer, and more extensible.

While practicing Euclidean distance for Limbo, I discovered that many checks could be done using the type system or in advance, rather than waiting until the distance is calculated. By building these checks into the type system or doing them ahead of time, this would allow us to explore more efficient computations, such as automatic vectorization or SIMD acceleration, which is future work.