### PR TITLE
remove experimental_flag from script + remove -q flag default flag from `TestTursoShell`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,13 +79,6 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
-      - name: Install cargo-c
-        env:
-          LINK: https://github.com/lu-zero/cargo-c/releases/download/v0.10.7
-          CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
-        run: |
-          curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
-
       - uses: actions/checkout@v3
 
       - name: Install uv
@@ -95,9 +88,6 @@ jobs:
 
       - name: Set up Python
         run: uv python install
-
-      - name: Install the project
-        run: uv sync --all-extras --dev --all-packages
 
       - uses: "./.github/shared/install_sqlite"
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ uv-sync:
 	uv sync --all-packages
 .PHONE: uv-sync
 
-test: limbo uv-sync test-compat test-vector test-sqlite3 test-shell test-extensions test-memory test-write test-update test-constraint test-collate
+test: limbo uv-sync test-compat test-vector test-sqlite3 test-shell test-memory test-write test-update test-constraint test-collate test-extensions
 .PHONY: test
 
 test-extensions: limbo uv-sync

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,18 @@ uv-sync:
 	uv sync --all-packages
 .PHONE: uv-sync
 
-test: limbo uv-sync test-compat test-vector test-sqlite3 test-shell test-memory test-write test-update test-constraint test-collate test-extensions
+uv-sync-test:
+	uv sync --all-extras --dev --package turso_test
+.PHONE: uv-sync
+
+test: limbo uv-sync-test test-compat test-vector test-sqlite3 test-shell test-memory test-write test-update test-constraint test-collate test-extensions
 .PHONY: test
 
-test-extensions: limbo uv-sync
+test-extensions: limbo uv-sync-test
 	RUST_LOG=$(RUST_LOG) uv run --project limbo_test test-extensions
 .PHONY: test-extensions
 
-test-shell: limbo uv-sync
+test-shell: limbo uv-sync-test
 	RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-shell
 .PHONY: test-shell
 
@@ -89,11 +93,11 @@ test-json:
 	RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) ./testing/json.test
 .PHONY: test-json
 
-test-memory: limbo uv-sync
+test-memory: limbo uv-sync-test
 	RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-memory
 .PHONY: test-memory
 
-test-write: limbo uv-sync
+test-write: limbo uv-sync-test
 	@if [ "$(SQLITE_EXEC)" != "scripts/limbo-sqlite3" ]; then \
 		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-write; \
 	else \
@@ -101,7 +105,7 @@ test-write: limbo uv-sync
 	fi
 .PHONY: test-write
 
-test-update: limbo uv-sync
+test-update: limbo uv-sync-test
 	@if [ "$(SQLITE_EXEC)" != "scripts/limbo-sqlite3" ]; then \
 		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-update; \
 	else \
@@ -109,7 +113,7 @@ test-update: limbo uv-sync
 	fi
 .PHONY: test-update
 
-test-collate: limbo uv-sync
+test-collate: limbo uv-sync-test
 	@if [ "$(SQLITE_EXEC)" != "scripts/limbo-sqlite3" ]; then \
 		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-collate; \
 	else \
@@ -117,7 +121,7 @@ test-collate: limbo uv-sync
 	fi
 .PHONY: test-collate
 
-test-constraint: limbo uv-sync
+test-constraint: limbo uv-sync-test
 	@if [ "$(SQLITE_EXEC)" != "scripts/limbo-sqlite3" ]; then \
 		RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) uv run --project limbo_test test-constraint; \
 	else \
@@ -125,7 +129,7 @@ test-constraint: limbo uv-sync
 	fi
 .PHONY: test-constraint
 
-bench-vfs: uv-sync
+bench-vfs: uv-sync-test
 	cargo build --release
 	RUST_LOG=$(RUST_LOG) uv run --project limbo_test bench-vfs "$(SQL)" "$(N)"
 

--- a/scripts/limbo-sqlite3
+++ b/scripts/limbo-sqlite3
@@ -7,7 +7,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 TURSODB="$PROJECT_ROOT/target/debug/tursodb"
 
 # Add experimental features for testing
-EXPERIMENTAL_FLAGS="--experimental-indexes"
+EXPERIMENTAL_FLAGS=""
 
 # if RUST_LOG is non-empty, enable tracing output
 if [ -n "$RUST_LOG" ]; then

--- a/scripts/limbo-sqlite3-index-experimental
+++ b/scripts/limbo-sqlite3-index-experimental
@@ -1,8 +1,17 @@
 #!/bin/bash
 
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Go to the project root (one level up from scripts/)
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+TURSODB="$PROJECT_ROOT/target/debug/tursodb"
+
+# Add experimental features for testing
+EXPERIMENTAL_FLAGS="--experimental-indexes"
+
 # if RUST_LOG is non-empty, enable tracing output
 if [ -n "$RUST_LOG" ]; then
-   target/debug/tursodb --experimental-indexes -m list -t testing/test.log "$@"
+   "$TURSODB" -m list -q $EXPERIMENTAL_FLAGS -t testing/test.log "$@"
 else
-   target/debug/tursodb --experimental-indexes -m list "$@"
+   "$TURSODB" -m list -q $EXPERIMENTAL_FLAGS "$@"
 fi

--- a/testing/cli_tests/cli_test_cases.py
+++ b/testing/cli_tests/cli_test_cases.py
@@ -275,7 +275,7 @@ def test_insert_default_values():
 
 
 def test_uri_readonly():
-    turso = TestTursoShell(flags="-q file:testing/testing_small.db?mode=ro", init_commands="")
+    turso = TestTursoShell(flags="file:testing/testing_small.db?mode=ro", init_commands="")
     turso.run_test("read-only-uri-reads-work", "SELECT COUNT(*) FROM demo;", "5")
     turso.run_test_fn(
         "INSERT INTO demo (id, value) values (6, 'demo');",

--- a/testing/cli_tests/test_turso_cli.py
+++ b/testing/cli_tests/test_turso_cli.py
@@ -105,8 +105,6 @@ class TestTursoShell:
     ):
         if exec_name is None:
             exec_name = os.environ.get("SQLITE_EXEC", "./scripts/limbo-sqlite3")
-            if flags == "":
-                flags = "-q"
         self.config = ShellConfig(exe_name=exec_name, flags=flags)
         if use_testing_db:
             self.init_test_db()

--- a/testing/cli_tests/vfs_bench.py
+++ b/testing/cli_tests/vfs_bench.py
@@ -32,7 +32,7 @@ def bench_one(vfs: str, sql: str, iterations: int) -> list[float]:
     """
     shell = TestTursoShell(
         exec_name=str(LIMBO_BIN),
-        flags=f"-q -m list --vfs {vfs} {DB_FILE}",
+        flags=f"-m list --vfs {vfs} {DB_FILE}",
         init_commands="",
     )
 


### PR DESCRIPTION
Should fix CI issues right now and decrease some of the time it takes to execute the tests. 