### PR TITLE
Reachable assertions in Antithesis Python Test for better logging

### DIFF
--- a/antithesis-tests/bank-test/parallel_driver_generate_transaction.py
+++ b/antithesis-tests/bank-test/parallel_driver_generate_transaction.py
@@ -4,6 +4,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 
 import turso
+from antithesis.assertions import reachable
 from antithesis.random import get_random
 
 handler = RotatingFileHandler(
@@ -37,8 +38,10 @@ def transaction():
 
         logger.info(f"Sender ID: {sender} | Recipient ID: {recipient} | Txn Val: {value}")
 
+        reachable("[GENERATE TRANSACTION] BEGIN TRANSACTION")
         cur.execute("BEGIN TRANSACTION;")
 
+        reachable("[GENERATE TRANSACTION] UPDATE ACCOUNTS - subtract value from balance of the sender account")
         # subtract value from balance of the sender account
         cur.execute(f"""
             UPDATE accounts
@@ -46,6 +49,7 @@ def transaction():
             WHERE account_id = {sender};
         """)
 
+        reachable("[GENERATE TRANSACTION] UPDATE ACCOUNTS - add value to balance of the recipient account")
         # add value to balance of the recipient account
         cur.execute(f"""
             UPDATE accounts
@@ -53,6 +57,7 @@ def transaction():
             WHERE account_id = {recipient};
         """)
 
+        reachable("[GENERATE TRANSACTION] COMMIT TRANSACTION")
         cur.execute("COMMIT;")
 
 

--- a/antithesis-tests/stress-composer/parallel_driver_schema_rollback.py
+++ b/antithesis-tests/stress-composer/parallel_driver_schema_rollback.py
@@ -17,8 +17,7 @@ cur_init = con_init.cursor()
 
 tbl_len = cur_init.execute("SELECT count FROM tables").fetchone()[0]
 selected_tbl = get_random() % tbl_len
-tbl_schema = json.loads(cur_init.execute(
-    f"SELECT schema FROM schemas WHERE tbl = {selected_tbl}").fetchone()[0])
+tbl_schema = json.loads(cur_init.execute(f"SELECT schema FROM schemas WHERE tbl = {selected_tbl}").fetchone()[0])
 
 tbl_name = f"tbl_{selected_tbl}"
 
@@ -29,8 +28,7 @@ except Exception as e:
     exit(0)
 
 cur = con.cursor()
-cur.execute(
-    "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = '" + tbl_name + "'")
+cur.execute("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = '" + tbl_name + "'")
 
 result = cur.fetchone()
 
@@ -47,10 +45,8 @@ cur.execute("ALTER TABLE " + tbl_name + " RENAME TO " + tbl_name + "_old")
 con.rollback()
 
 cur = con.cursor()
-cur.execute(
-    "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = '" + tbl_name + "'")
+cur.execute("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = '" + tbl_name + "'")
 
 schema_after = cur.fetchone()[0]
 
-always(schema_before == schema_after,
-       "schema should be the same after rollback", {})
+always(schema_before == schema_after, "schema should be the same after rollback", {})

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "mypy==1.11.0",
     "pytest==8.3.1",
     "pytest-cov==5.0.0",
-    "ruff==0.5.4",
+    "ruff>=0.12.2",
     "coverage==7.6.1",
     "maturin==1.7.8",
 ]
@@ -80,6 +80,6 @@ dev = [
     "pluggy>=1.6.0",
     "pytest>=8.3.1",
     "pytest-cov>=5.0.0",
-    "ruff>=0.5.4",
+    "ruff>=0.12.2",
     "typing-extensions>=4.13.0",
 ]

--- a/perf/connection/gen-database.py
+++ b/perf/connection/gen-database.py
@@ -45,4 +45,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/perf/connection/plot.py
+++ b/perf/connection/plot.py
@@ -52,4 +52,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/testing/cli_tests/test_turso_cli.py
+++ b/testing/cli_tests/test_turso_cli.py
@@ -135,9 +135,9 @@ INSERT INTO t VALUES (zeroblob(1024 - 1), zeroblob(1024 - 2), zeroblob(1024 - 3)
     def run_test(self, name: str, sql: str, expected: str) -> None:
         console.test(f"Running test: {name}", _stack_offset=2)
         actual = self.shell.execute(sql)
-        assert actual == expected, (
-            f"Test failed: {name}\nSQL: {sql}\nExpected:\n{repr(expected)}\nActual:\n{repr(actual)}"
-        )
+        assert (
+            actual == expected
+        ), f"Test failed: {name}\nSQL: {sql}\nExpected:\n{repr(expected)}\nActual:\n{repr(actual)}"
 
     def run_debug(self, sql: str):
         console.debug(f"debugging: {sql}", _stack_offset=2)


### PR DESCRIPTION
I added some `reachable` assertions in the `parallel_driver_generate_transaction` so that Antithesis can log when we reach them, so it is easier to debug the `page_cache` panic we are getting there