### PR TITLE
parser: use YYSTACKDEPTH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -3727,6 +3727,7 @@ dependencies = [
  "memchr",
  "miette",
  "serde",
+ "smallvec",
  "strum",
  "strum_macros",
 ]

--- a/vendored/sqlite3-parser/Cargo.toml
+++ b/vendored/sqlite3-parser/Cargo.toml
@@ -34,6 +34,7 @@ miette = "7.4.0"
 strum = { workspace = true }
 strum_macros = {workspace = true }
 serde = { workspace = true , optional = true, features = ["derive"] }
+smallvec = { version = "1.15.1", features = ["const_generics"] }
 
 [dev-dependencies]
 env_logger = { version = "0.11", default-features = false }

--- a/vendored/sqlite3-parser/third_party/lemon/lemon.c
+++ b/vendored/sqlite3-parser/third_party/lemon/lemon.c
@@ -4519,7 +4519,8 @@ void ReportTable(
   if( lemp->stacksize ){
     fprintf(out,"const YYSTACKDEPTH: usize = %s;\n",lemp->stacksize);  lineno++;
   } else {
-    fprintf(out, "const YYSTACKDEPTH: usize = 128;\n"); lineno++;
+    // from sqlite: The default value is 100. A typical application will use less than about 20 levels of the stack. Developers whose applications contain SQL statements that need more than 100 LALR(1) stack entries should seriously consider refactoring their SQL as it is likely to be well beyond the ability of any human to comprehend.
+    fprintf(out, "const YYSTACKDEPTH: usize = 100;\n"); lineno++;
   }
   if( lemp->errsym && lemp->errsym->useCnt ){
     fprintf(out,"const YYERRORSYMBOL: YYCODETYPE = %d;\n",lemp->errsym->index); lineno++;


### PR DESCRIPTION
sqlite uses [fixed-size](https://github.com/sqlite/sqlite/blob/7fc6e6a2726e650d3b82c6d3683bdbdc10e02467/tool/lempar.c#L238) array for `yystack` and grow stack if needed. Let replace `vec` with `smallvec` in rust version.

after:

```sh
sqlparser-rs parsing benchmark/sqlparser::select
                        time:   [564.19 ns 565.63 ns 567.18 ns]
                        change: [-11.514% -11.288% -11.067%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
sqlparser-rs parsing benchmark/sqlparser::with_select
                        time:   [1.9812 µs 1.9861 µs 1.9914 µs]
                        change: [-7.5226% -7.3080% -7.0858%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild

```