### PR TITLE
btree: fix trying to go upwards when we are already at the end of the entire btree

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -47,6 +47,7 @@ pub enum CacheError {
     InternalError(String),
     Locked,
     Dirty { pgno: usize },
+    Pinned { pgno: usize },
     ActiveRefs,
     Full,
     KeyExists,
@@ -134,6 +135,7 @@ impl DumbLruPageCache {
         }
 
         let ptr = *self.map.borrow().get(&key).unwrap();
+
         // Try to detach from LRU list first, can fail
         self.detach(ptr, clean_page)?;
         let ptr = self.map.borrow_mut().remove(&key).unwrap();
@@ -177,10 +179,11 @@ impl DumbLruPageCache {
         }
     }
 
-    fn detach(
+    fn _detach(
         &mut self,
         mut entry: NonNull<PageCacheEntry>,
         clean_page: bool,
+        allow_detach_pinned: bool,
     ) -> Result<(), CacheError> {
         let entry_mut = unsafe { entry.as_mut() };
         if entry_mut.page.is_locked() {
@@ -188,6 +191,11 @@ impl DumbLruPageCache {
         }
         if entry_mut.page.is_dirty() {
             return Err(CacheError::Dirty {
+                pgno: entry_mut.page.get().id,
+            });
+        }
+        if entry_mut.page.is_pinned() && !allow_detach_pinned {
+            return Err(CacheError::Pinned {
                 pgno: entry_mut.page.get().id,
             });
         }
@@ -199,6 +207,22 @@ impl DumbLruPageCache {
         }
         self.unlink(entry);
         Ok(())
+    }
+
+    fn detach(
+        &mut self,
+        entry: NonNull<PageCacheEntry>,
+        clean_page: bool,
+    ) -> Result<(), CacheError> {
+        self._detach(entry, clean_page, false)
+    }
+
+    fn detach_even_if_pinned(
+        &mut self,
+        entry: NonNull<PageCacheEntry>,
+        clean_page: bool,
+    ) -> Result<(), CacheError> {
+        self._detach(entry, clean_page, true)
     }
 
     fn unlink(&mut self, mut entry: NonNull<PageCacheEntry>) {
@@ -276,7 +300,8 @@ impl DumbLruPageCache {
         while need_to_evict > 0 && current_opt.is_some() {
             let current = current_opt.unwrap();
             let entry = unsafe { current.as_ref() };
-            current_opt = entry.prev; // Pick prev before modifying entry
+            // Pick prev before modifying entry
+            current_opt = entry.prev;
             match self.delete(entry.key.clone()) {
                 Err(_) => {}
                 Ok(_) => need_to_evict -= 1,
@@ -296,7 +321,7 @@ impl DumbLruPageCache {
                 self.map.borrow_mut().remove(&current_entry.as_ref().key);
             }
             let next = unsafe { current_entry.as_ref().next };
-            self.detach(current_entry, true)?;
+            self.detach_even_if_pinned(current_entry, true)?;
             unsafe {
                 assert!(!current_entry.as_ref().page.is_dirty());
             }


### PR DESCRIPTION
## What does this fix

This PR fixes an issue with BTree upwards traversal logic where we would try to go up to a parent node in `next()` even though we are at the very end of the btree. This behavior can leave the cursor incorrectly positioned at an interior node when it should be at the right edge of the rightmost leaf.

## Why doesn't it cause problems on main

This bug is masked on `main` by every table `insert()` (wastefully) calling `find_cell()`:

- `op_new_rowid` called, let's say the current max rowid is `666`. Cursor is left pointing at `666`.
- `insert()` is called with rowid `667`, cursor is currently pointing at `666`, which is incorrect.
- `find_cell()` does a binary search every time, and hence somewhat accidentally positions the cursor correctly _after_ `666` so that the insert goes to the correct place

## Why was this issue found

in #1988, I am removing `find_cell()` entirely in favor of always performing a seek to the correct location - and skipping `seek` when it is not required, saving us from wasting a binary search on every insert - but this change means that we need to call `next()` after `op_new_rowid` to have the cursor positioned correctly at the new insertion slot. Doing this surfaces this upwards traversal bug in that PR branch.

## Details of solution

- Store `cell_count` together with `cell_idx` in pagestack, so that chlidren can know whether their parents have reached their end without doing IO
- To make this foolproof, pin pages on `PageStack` so the page cache cannot evict them during tree traversal
- `cell_indices` renamed to `node_states` since it now carries more information (cell index AND count, instead of just index)