### PR TITLE
bindings/python: Start transaction implicitly in execute()

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -93,6 +93,15 @@ impl Cursor {
             Ok::<(), anyhow::Error>(())
         })?;
 
+        if stmt_is_dml && self.conn.conn.get_auto_commit() {
+            self.conn.conn.execute("BEGIN").map_err(|e| {
+                PyErr::new::<OperationalError, _>(format!(
+                    "Failed to start transaction after DDL: {:?}",
+                    e
+                ))
+            })?;
+        }
+
         // For DDL and DML statements,
         // we need to execute the statement immediately
         if stmt_is_ddl || stmt_is_dml || stmt_is_tx {

--- a/bindings/python/tests/test_database.py
+++ b/bindings/python/tests/test_database.py
@@ -158,6 +158,25 @@ def test_commit(provider):
     assert record
 
 
+# Test case for: https://github.com/tursodatabase/turso/issues/2002
+@pytest.mark.parametrize("provider", ["sqlite3", "turso"])
+def test_first_rollback(provider, tmp_path):
+    db_file = tmp_path / "test_first_rollback.db"
+
+    conn = connect(provider, str(db_file))
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)")
+    cur.execute("INSERT INTO users VALUES (1, 'alice')")
+    cur.execute("INSERT INTO users VALUES (2, 'bob')")
+
+    conn.rollback()
+
+    cur.execute("SELECT * FROM users")
+    users = cur.fetchall()
+
+    assert users == []
+    conn.close()
+
 @pytest.mark.parametrize("provider", ["sqlite3", "turso"])
 def test_with_statement(provider):
     with connect(provider, "tests/database.db") as conn:


### PR DESCRIPTION
We need to start transaction implicitly in execute() for DML statements to make sure first transaction is actually started.

Fixes #2002