### PR TITLE
core: Fix resolve_function() error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,8 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
+ "regex",
+ "semver",
  "syn 2.0.100",
 ]
 

--- a/core/function.rs
+++ b/core/function.rs
@@ -616,7 +616,8 @@ impl Func {
         }
     }
     pub fn resolve_function(name: &str, arg_count: usize) -> Result<Self, LimboError> {
-        match name {
+        let normalized_name = crate::util::normalize_ident(name);
+        match normalized_name.as_str() {
             "avg" => {
                 if arg_count != 1 {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -9,7 +9,7 @@ use crate::function::JsonFunc;
 use crate::function::{Func, FuncCtx, MathFuncArity, ScalarFunc, VectorFunc};
 use crate::functions::datetime;
 use crate::schema::{Affinity, Table, Type};
-use crate::util::{exprs_are_equivalent, normalize_ident, parse_numeric_literal};
+use crate::util::{exprs_are_equivalent, parse_numeric_literal};
 use crate::vdbe::builder::CursorKey;
 use crate::vdbe::{
     builder::ProgramBuilder,
@@ -680,8 +680,7 @@ pub fn translate_expr(
             order_by: _,
         } => {
             let args_count = if let Some(args) = args { args.len() } else { 0 };
-            let func_name = normalize_ident(name.0.as_str());
-            let func_type = resolver.resolve_function(&func_name, args_count);
+            let func_type = resolver.resolve_function(&name.0, args_count);
 
             if func_type.is_none() {
                 crate::bail_parse_error!("unknown function {}", name.0);

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -51,8 +51,7 @@ pub fn resolve_aggregates(
                 } else {
                     0
                 };
-                match Func::resolve_function(normalize_ident(name.0.as_str()).as_str(), args_count)
-                {
+                match Func::resolve_function(&name.0, args_count) {
                     Ok(Func::Agg(f)) => {
                         let distinctness = Distinctness::from_ast(distinctness.as_ref());
                         if !schema.indexes_enabled() && distinctness.is_distinct() {
@@ -84,9 +83,7 @@ pub fn resolve_aggregates(
                 }
             }
             Expr::FunctionCallStar { name, .. } => {
-                if let Ok(Func::Agg(f)) =
-                    Func::resolve_function(normalize_ident(name.0.as_str()).as_str(), 0)
-                {
+                if let Ok(Func::Agg(f)) = Func::resolve_function(&name.0, 0) {
                     aggs.push(Aggregate {
                         func: f,
                         args: vec![],


### PR DESCRIPTION
We need to return the original function name, not normalized one to be compatible with SQLite.

Spotted by SQLite TCL tests.