### PR TITLE
core: Copy-on-write for in-memory schema

### DIFF
--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -151,8 +151,7 @@ impl Connection {
             .insert(name.to_string(), vmodule.into());
         if kind == VTabKind::TableValuedFunction {
             if let Ok(vtab) = VirtualTable::function(name, &self.syms.borrow()) {
-                let mut schema_ref = self.schema.borrow_mut();
-                Arc::make_mut(&mut *schema_ref).add_virtual_table(vtab);
+                self.with_schema_mut(|schema| schema.add_virtual_table(vtab));
             } else {
                 return ResultCode::Error;
             }

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -151,7 +151,8 @@ impl Connection {
             .insert(name.to_string(), vmodule.into());
         if kind == VTabKind::TableValuedFunction {
             if let Ok(vtab) = VirtualTable::function(name, &self.syms.borrow()) {
-                self.schema.borrow_mut().add_virtual_table(vtab);
+                let mut schema_ref = self.schema.borrow_mut();
+                Arc::make_mut(&mut *schema_ref).add_virtual_table(vtab);
             } else {
                 return ResultCode::Error;
             }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -715,18 +715,12 @@ impl Pager {
         match commit_status {
             IOResult::IO => Ok(IOResult::IO),
             IOResult::Done(_) => {
-                let maybe_schema_pair = if schema_did_change {
-                    let schema = connection.schema.borrow().clone();
-                    // Lock first before writing to the database schema in case someone tries to read the schema before it's updated
-                    let db_schema = connection._db.schema.write();
-                    Some((schema, db_schema))
-                } else {
-                    None
-                };
                 self.wal.borrow().end_write_tx()?;
                 self.wal.borrow().end_read_tx()?;
-                if let Some((schema, mut db_schema)) = maybe_schema_pair {
-                    *db_schema = schema;
+
+                if schema_did_change {
+                    let schema = connection.schema.borrow().clone();
+                    *connection._db.schema.borrow_mut() = schema;
                 }
                 Ok(commit_status)
             }
@@ -1314,8 +1308,9 @@ impl Pager {
         cache.unset_dirty_all_pages();
         cache.clear().expect("failed to clear page cache");
         if schema_did_change {
-            let prev_schema = connection._db.schema.read().clone();
-            connection.schema.replace(prev_schema);
+            connection
+                .schema
+                .replace(connection._db.schema.borrow().clone());
         }
         self.wal.borrow_mut().rollback()?;
 

--- a/core/util.rs
+++ b/core/util.rs
@@ -6,6 +6,7 @@ use crate::{
     LimboError, OpenFlags, Result, Statement, StepResult, SymbolTable,
 };
 use std::{rc::Rc, sync::Arc};
+use tracing::{instrument, Level};
 use turso_sqlite3_parser::ast::{
     self, CreateTableBody, Expr, FunctionTail, Literal, UnaryOperator,
 };
@@ -48,6 +49,7 @@ pub struct UnparsedFromSqlIndex {
     pub sql: String,
 }
 
+#[instrument(skip_all, level = Level::INFO)]
 pub fn parse_schema_rows(
     rows: Option<Statement>,
     schema: &mut Schema,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -216,7 +216,8 @@ pub fn op_drop_index(
     let Insn::DropIndex { index, db: _ } = insn else {
         unreachable!("unexpected Insn {:?}", insn)
     };
-    let mut schema = program.connection.schema.borrow_mut();
+    let mut schema_ref = program.connection.schema.borrow_mut();
+    let schema = Arc::make_mut(&mut *schema_ref);
     schema.remove_index(index);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -5719,7 +5720,8 @@ pub fn op_drop_table(
     }
     let conn = program.connection.clone();
     {
-        let mut schema = conn.schema.borrow_mut();
+        let mut schema_ref = conn.schema.borrow_mut();
+        let schema = Arc::make_mut(&mut *schema_ref);
         schema.remove_indices_for_table(table_name);
         schema.remove_table(table_name);
     }
@@ -5804,33 +5806,22 @@ pub fn op_parse_schema(
     if let Some(where_clause) = where_clause {
         let stmt = conn.prepare(format!("SELECT * FROM sqlite_schema WHERE {where_clause}"))?;
 
-        let mut new_schema = conn.schema.borrow().clone();
+        let mut schema_ref = conn.schema.borrow_mut();
+        let schema = Arc::make_mut(&mut *schema_ref);
 
         // TODO: This function below is synchronous, make it async
         {
-            parse_schema_rows(
-                Some(stmt),
-                &mut new_schema,
-                &conn.syms.borrow(),
-                state.mv_tx_id,
-            )?;
+            parse_schema_rows(Some(stmt), schema, &conn.syms.borrow(), state.mv_tx_id)?;
         }
-        conn.schema.replace(new_schema);
     } else {
         let stmt = conn.prepare("SELECT * FROM sqlite_schema")?;
-        let mut new_schema = conn.schema.borrow().clone();
+        let mut schema_ref = conn.schema.borrow_mut();
+        let schema = Arc::make_mut(&mut *schema_ref);
 
         // TODO: This function below is synchronous, make it async
         {
-            parse_schema_rows(
-                Some(stmt),
-                &mut new_schema,
-                &conn.syms.borrow(),
-                state.mv_tx_id,
-            )?;
+            parse_schema_rows(Some(stmt), schema, &conn.syms.borrow(), state.mv_tx_id)?;
         }
-
-        conn.schema.replace(new_schema);
     }
     conn.auto_commit.set(previous_auto_commit);
     state.pc += 1;
@@ -5903,7 +5894,9 @@ pub fn op_set_cookie(
                 TransactionState::None => unreachable!("invalid transaction state for SetCookie: TransactionState::None, should be write"),
             }
 
-            program.connection.schema.borrow_mut().schema_version = *value as u32;
+            let mut schema = program.connection.schema.borrow_mut();
+            Arc::make_mut(&mut *schema).schema_version = *value as u32;
+
             header_accessor::set_schema_cookie(pager, *value as u32)?;
         }
         cookie => todo!("{cookie:?} is not yet implement for SetCookie"),


### PR DESCRIPTION
<img height="400" alt="image" src="https://github.com/user-attachments/assets/bdd5c0a8-1bbb-4199-9026-57f0e5202d73" />
<img height="400" alt="image" src="https://github.com/user-attachments/assets/7ea63e58-2ab7-4132-b29e-b20597c7093f" />

We were copying the schema preemptively on each `Database::connect`, now the schema is shared until a change needs to be made by sharing a single `Arc` and mutating it via `Arc::make_mut`. This is faster as reduces memory usage.
