### PR TITLE
antithesis: Fix transaction management

### DIFF
--- a/antithesis-tests/bank-test/first_setup.py
+++ b/antithesis-tests/bank-test/first_setup.py
@@ -50,3 +50,5 @@ cur.execute(f"""
     INSERT INTO initial_state (num_accts, total)
     VALUES ({num_accts}, {total})
 """)
+
+con.commit()

--- a/antithesis-tests/stress-composer/first_setup.py
+++ b/antithesis-tests/stress-composer/first_setup.py
@@ -83,4 +83,6 @@ for i in range(tbl_count):
         CREATE TABLE tbl_{i} ({cols_str})
     """)
 
+con.commit()
+
 print(f"DB Schemas\n------------\n{json.dumps(schemas, indent=2)}")

--- a/antithesis-tests/stress-composer/parallel_driver_delete.py
+++ b/antithesis-tests/stress-composer/parallel_driver_delete.py
@@ -37,6 +37,13 @@ print(f"Attempt to delete {deletions} rows in tbl_{selected_tbl}...")
 for i in range(deletions):
     where_clause = f"col_{pk} = {generate_random_value(tbl_schema[f'col_{pk}']['data_type'])}"
 
-    cur.execute(f"""
-        DELETE FROM tbl_{selected_tbl} WHERE {where_clause}
-    """)
+    try:
+        cur.execute(f"""
+            DELETE FROM tbl_{selected_tbl} WHERE {where_clause}
+        """)
+    except turso.OperationalError:
+        con.rollback()
+        # Re-raise other operational errors
+        raise
+
+con.commit()

--- a/antithesis-tests/stress-composer/parallel_driver_insert.py
+++ b/antithesis-tests/stress-composer/parallel_driver_insert.py
@@ -44,5 +44,8 @@ for i in range(insertions):
             # Ignore UNIQUE constraint violations
             pass
         else:
+            con.rollback()
             # Re-raise other operational errors
             raise
+
+con.commit()

--- a/antithesis-tests/stress-composer/parallel_driver_update.py
+++ b/antithesis-tests/stress-composer/parallel_driver_update.py
@@ -58,5 +58,8 @@ for i in range(updates):
             # Ignore UNIQUE constraint violations
             pass
         else:
+            con.rollback()
             # Re-raise other operational errors
             raise
+
+con.commit()


### PR DESCRIPTION
Commit 5216e67d ("bindings/python: Start transaction implicitly in execute()") fixed transaction management in Python bindings, which means we now need to execute explicit commit().