### PR TITLE
core/translate: Fix "misuse of aggregate function" error message

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -693,7 +693,7 @@ pub fn translate_expr(
 
             match &func_ctx.func {
                 Func::Agg(_) => {
-                    crate::bail_parse_error!("aggregation function in non-aggregation context")
+                    crate::bail_parse_error!("misuse of aggregate function {}()", name.0)
                 }
                 Func::External(_) => {
                     let regs = program.alloc_registers(args_count);


### PR DESCRIPTION
```
sqlite> CREATE TABLE test1(f1, f2);
sqlite> SELECT SUM(min(f1)) FROM test1;
Parse error: misuse of aggregate function min()
  SELECT SUM(min(f1)) FROM test1;
             ^--- error here
```

Spotted by SQLite TCL tests.