### PR TITLE
github: Update to newest Nyrkiö Github action

### DIFF
--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -88,7 +88,7 @@ jobs:
           nyrkio-public: true
 
       - name: Analyze SQLITE3 result with Nyrkiö
-        uses: nyrkio/github-action-benchmark@HEAD
+        uses: nyrkio/change-detection@HEAD
         with:
           name: clickbench/sqlite3
           tool: time


### PR DESCRIPTION
I noticed on instance of the nyrkio github action was still using the old name. Updating to nyrkio/change-detection@HEAD. All other entries are already updaeted,