### PR TITLE
`parse_schema_rows` optimizations

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -11,6 +11,53 @@ fn rusqlite_open() -> rusqlite::Connection {
     sqlite_conn
 }
 
+fn bench_open(criterion: &mut Criterion) {
+    // https://github.com/tursodatabase/turso/issues/174
+    // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
+    let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
+
+    if !std::fs::exists("../testing/schema_5k.db").unwrap() {
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false, false).unwrap();
+        let conn = db.connect().unwrap();
+
+        for i in 0..5000 {
+            conn.execute(
+                format!("CREATE TABLE table_{i} ( id INTEGER PRIMARY KEY, name TEXT, value INTEGER, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP )")
+            ).unwrap();
+        }
+    }
+
+    let mut group = criterion.benchmark_group("Open/Connect");
+
+    group.bench_function(
+        BenchmarkId::new("limbo_schema", ""),
+        |b| {
+            b.iter(|| {
+                #[allow(clippy::arc_with_non_send_sync)]
+                let io = Arc::new(PlatformIO::new().unwrap());
+                let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false, false)
+                    .unwrap();
+                black_box(db.connect().unwrap());
+            });
+        },
+    );
+
+    if enable_rusqlite {
+        group.bench_function(
+            BenchmarkId::new("sqlite_schema", ""),
+            |b| {
+                b.iter(|| {
+                    black_box(rusqlite::Connection::open("../testing/schema_5k.db").unwrap());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn bench_prepare_query(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/turso/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
@@ -233,6 +280,6 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count
+    targets = bench_open, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count
 }
 criterion_main!(benches);

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -31,28 +31,22 @@ fn bench_open(criterion: &mut Criterion) {
 
     let mut group = criterion.benchmark_group("Open/Connect");
 
-    group.bench_function(
-        BenchmarkId::new("limbo_schema", ""),
-        |b| {
-            b.iter(|| {
-                #[allow(clippy::arc_with_non_send_sync)]
-                let io = Arc::new(PlatformIO::new().unwrap());
-                let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false, false)
-                    .unwrap();
-                black_box(db.connect().unwrap());
-            });
-        },
-    );
+    group.bench_function(BenchmarkId::new("limbo_schema", ""), |b| {
+        b.iter(|| {
+            #[allow(clippy::arc_with_non_send_sync)]
+            let io = Arc::new(PlatformIO::new().unwrap());
+            let db =
+                Database::open_file(io.clone(), "../testing/schema_5k.db", false, false).unwrap();
+            black_box(db.connect().unwrap());
+        });
+    });
 
     if enable_rusqlite {
-        group.bench_function(
-            BenchmarkId::new("sqlite_schema", ""),
-            |b| {
-                b.iter(|| {
-                    black_box(rusqlite::Connection::open("../testing/schema_5k.db").unwrap());
-                });
-            },
-        );
+        group.bench_function(BenchmarkId::new("sqlite_schema", ""), |b| {
+            b.iter(|| {
+                black_box(rusqlite::Connection::open("../testing/schema_5k.db").unwrap());
+            });
+        });
     }
 
     group.finish();

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -261,10 +261,7 @@ impl BTreeTable {
                 sql.push_str(", ");
             }
             sql.push_str(column.name.as_ref().expect("column name is None"));
-            if !matches!(column.ty, Type::Null) {
-                sql.push(' ');
-            }
-            sql.push_str(&column.ty.to_string());
+            sql.push_str(&column.ty_str.to_string());
 
             if column.unique {
                 sql.push_str(" UNIQUE");
@@ -1449,42 +1446,6 @@ mod tests {
         let table = BTreeTable::from_sql(sql, 0)?;
         let column = table.get_column("a").unwrap().1;
         assert_eq!(column.ty_str, "INTEGER");
-        Ok(())
-    }
-
-    #[test]
-    pub fn test_col_type_string_int() -> Result<()> {
-        let sql = r#"CREATE TABLE t1 (a InT);"#;
-        let table = BTreeTable::from_sql(sql, 0)?;
-        let column = table.get_column("a").unwrap().1;
-        assert_eq!(column.ty_str, "INT");
-        Ok(())
-    }
-
-    #[test]
-    pub fn test_col_type_string_blob() -> Result<()> {
-        let sql = r#"CREATE TABLE t1 (a bLoB);"#;
-        let table = BTreeTable::from_sql(sql, 0)?;
-        let column = table.get_column("a").unwrap().1;
-        assert_eq!(column.ty_str, "BLOB");
-        Ok(())
-    }
-
-    #[test]
-    pub fn test_col_type_string_empty() -> Result<()> {
-        let sql = r#"CREATE TABLE t1 (a);"#;
-        let table = BTreeTable::from_sql(sql, 0)?;
-        let column = table.get_column("a").unwrap().1;
-        assert_eq!(column.ty_str, "");
-        Ok(())
-    }
-
-    #[test]
-    pub fn test_col_type_string_some_nonsense() -> Result<()> {
-        let sql = r#"CREATE TABLE t1 (a someNonsenseName);"#;
-        let table = BTreeTable::from_sql(sql, 0)?;
-        let column = table.get_column("a").unwrap().1;
-        assert_eq!(column.ty_str, "someNonsenseName");
         Ok(())
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -242,9 +242,8 @@ impl Schema {
 
             drop(row);
 
-            match cursor.next()? {
-                CursorResult::IO => pager.io.run_once()?,
-                _ => {}
+            if matches!(cursor.next()?, CursorResult::IO) {
+                pager.io.run_once()?;
             };
         }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -410,7 +410,11 @@ impl BTreeTable {
                 sql.push_str(", ");
             }
             sql.push_str(column.name.as_ref().expect("column name is None"));
-            sql.push_str(&column.ty_str.to_string());
+
+            if !column.ty_str.is_empty() {
+                sql.push(' ');
+                sql.push_str(&column.ty_str);
+            }
 
             if column.unique {
                 sql.push_str(" UNIQUE");

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1605,13 +1605,13 @@ mod tests {
         let sql = r#"CREATE TABLE t1 (a InTeGeR);"#;
         let table = BTreeTable::from_sql(sql, 0)?;
         let column = table.get_column("a").unwrap().1;
-        assert_eq!(column.ty_str, "INTEGER");
+        assert_eq!(column.ty_str, "InTeGeR");
         Ok(())
     }
 
     #[test]
     pub fn test_sqlite_schema() {
-        let expected = r#"CREATE TABLE sqlite_schema (type TEXT, name TEXT, tbl_name TEXT, rootpage INTEGER, sql TEXT)"#;
+        let expected = r#"CREATE TABLE sqlite_schema (type TEXT, name TEXT, tbl_name TEXT, rootpage INT, sql TEXT)"#;
         let actual = sqlite_schema_table().to_sql();
         assert_eq!(expected, actual);
     }

--- a/core/util.rs
+++ b/core/util.rs
@@ -42,10 +42,10 @@ pub const PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX: &str = "sqlite_autoindex_";
 /// Unparsed index that comes from a sql query, i.e not an automatic index
 ///
 /// CREATE INDEX idx ON table_name(sql)
-struct UnparsedFromSqlIndex {
-    table_name: String,
-    root_page: usize,
-    sql: String,
+pub struct UnparsedFromSqlIndex {
+    pub table_name: String,
+    pub root_page: usize,
+    pub sql: String,
 }
 
 pub fn parse_schema_rows(
@@ -188,7 +188,7 @@ pub fn check_ident_equivalency(ident1: &str, ident2: &str) -> bool {
     strip_quotes(ident1).eq_ignore_ascii_case(strip_quotes(ident2))
 }
 
-fn module_name_from_sql(sql: &str) -> Result<&str> {
+pub fn module_name_from_sql(sql: &str) -> Result<&str> {
     if let Some(start) = sql.find("USING") {
         let start = start + 6;
         // stop at the first space, semicolon, or parenthesis
@@ -206,7 +206,7 @@ fn module_name_from_sql(sql: &str) -> Result<&str> {
 
 // CREATE VIRTUAL TABLE table_name USING module_name(arg1, arg2, ...);
 // CREATE VIRTUAL TABLE table_name USING module_name;
-fn module_args_from_sql(sql: &str) -> Result<Vec<turso_ext::Value>> {
+pub fn module_args_from_sql(sql: &str) -> Result<Vec<turso_ext::Value>> {
     if !sql.contains('(') {
         return Ok(vec![]);
     }


### PR DESCRIPTION
- Also added a benchmark for opening databases, the main thing that is slowing `Database::open_file` is `parse_schema_rows`.

- `to_uppercase` was being called multiple times, leaving a relevant mark on stack traces due to multiple allocations. `make_ascii_upper` reuses the memory and is faster due to not handling unicode characters (still compatible with sqlite).

- Do direct btree calls instead of creating a program for updating `Schema` with `Schema::make_from_btree`.

- Faster type substr comparison using fixed size `u8` slices.

<img width="952" height="507" alt="image" src="https://github.com/user-attachments/assets/0d0c52ff-05a1-431e-a93d-e333b53c0bb8" />
