### PR TITLE
Separate user-callable cacheflush from internal cacheflush logic

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -205,6 +205,17 @@ impl Connection {
         })?;
         Ok(())
     }
+
+    /// Flush dirty pages to disk.
+    /// This will write the dirty pages to the WAL.
+    pub fn cacheflush(&self) -> Result<()> {
+        let conn = self
+            .inner
+            .lock()
+            .map_err(|e| Error::MutexError(e.to_string()))?;
+        conn.cacheflush()?;
+        Ok(())
+    }
 }
 
 impl Debug for Connection {

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1,3 +1,4 @@
+use tokio::fs;
 use turso::{Builder, Value};
 
 #[tokio::test]
@@ -54,4 +55,63 @@ async fn test_rows_next() {
         5.into()
     );
     assert!(res.next().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_cacheflush() {
+    let builder = Builder::new_local("test.db");
+    let db = builder.build().await.unwrap();
+
+    let conn = db.connect().unwrap();
+
+    conn.execute("CREATE TABLE IF NOT EXISTS asdf (x INTEGER)", ())
+        .await
+        .unwrap();
+
+    // Tests if cache flush breaks transaction isolation
+    conn.execute("BEGIN", ()).await.unwrap();
+    conn.execute("INSERT INTO asdf (x) VALUES (1)", ())
+        .await
+        .unwrap();
+    conn.cacheflush().unwrap();
+    conn.execute("ROLLBACK", ()).await.unwrap();
+
+    conn.execute("INSERT INTO asdf (x) VALUES (2)", ())
+        .await
+        .unwrap();
+    conn.execute("INSERT INTO asdf (x) VALUES (3)", ())
+        .await
+        .unwrap();
+
+    let mut res = conn.query("SELECT * FROM asdf", ()).await.unwrap();
+
+    assert_eq!(
+        res.next().await.unwrap().unwrap().get_value(0).unwrap(),
+        2.into()
+    );
+    assert_eq!(
+        res.next().await.unwrap().unwrap().get_value(0).unwrap(),
+        3.into()
+    );
+
+    // Tests if cache flush doesn't break a committed transaction
+    conn.execute("BEGIN", ()).await.unwrap();
+    conn.execute("INSERT INTO asdf (x) VALUES (1)", ())
+        .await
+        .unwrap();
+    conn.cacheflush().unwrap();
+    conn.execute("COMMIT", ()).await.unwrap();
+
+    let mut res = conn
+        .query("SELECT * FROM asdf WHERE x = 1", ())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        res.next().await.unwrap().unwrap().get_value(0).unwrap(),
+        1.into()
+    );
+
+    fs::remove_file("test.db").await.unwrap();
+    fs::remove_file("test.db-wal").await.unwrap();
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -77,7 +77,7 @@ use std::{
 #[cfg(feature = "fs")]
 use storage::database::DatabaseFile;
 use storage::page_cache::DumbLruPageCache;
-use storage::pager::{PagerCacheflushResult, DB_STATE_INITIALIZED, DB_STATE_UNINITIALIZED};
+use storage::pager::{DB_STATE_INITIALIZED, DB_STATE_UNINITIALIZED};
 pub use storage::{
     buffer_pool::BufferPool,
     database::DatabaseStorage,
@@ -752,16 +752,11 @@ impl Connection {
     }
 
     /// Flush dirty pages to disk.
-    /// This will write the dirty pages to the WAL and then fsync the WAL.
-    /// If the WAL size is over the checkpoint threshold, it will checkpoint the WAL to
-    /// the database file and then fsync the database file.
-    pub fn cacheflush(&self) -> Result<IOResult<PagerCacheflushResult>> {
+    pub fn cacheflush(&self) -> Result<IOResult<()>> {
         if self.closed.get() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
-        self.pager
-            .borrow()
-            .cacheflush(self.wal_checkpoint_disabled.get())
+        self.pager.borrow().cacheflush()
     }
 
     pub fn clear_page_cache(&self) -> Result<()> {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -805,10 +805,6 @@ impl Pager {
                     )?;
                     page.clear_dirty();
                 }
-                {
-                    let mut cache = self.page_cache.write();
-                    cache.clear().unwrap();
-                }
                 self.dirty_pages.borrow_mut().clear();
                 self.flush_info.borrow_mut().state = CacheFlushState::WaitAppendFrames;
                 return Ok(IOResult::IO);

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -27,7 +27,7 @@ pub mod sorter;
 use crate::{
     error::LimboError,
     function::{AggFunc, FuncCtx},
-    storage::sqlite3_ondisk::SmallVec,
+    storage::{pager, sqlite3_ondisk::SmallVec},
     translate::plan::TableReferences,
     types::{IOResult, RawSlice, TextRef},
     vdbe::execute::{OpIdxInsertState, OpInsertState, OpNewRowidState, OpSeekState},
@@ -510,10 +510,7 @@ impl Program {
                 if self.change_cnt_on {
                     self.connection.set_changes(self.n_change.get());
                 }
-                if matches!(
-                    status,
-                    crate::storage::pager::PagerCacheflushResult::Rollback
-                ) {
+                if matches!(status, pager::PagerCommitResult::Rollback) {
                     pager.rollback(schema_did_change, connection)?;
                 }
                 connection.transaction_state.replace(TransactionState::None);

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -3,11 +3,8 @@ use rusqlite::params;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tempfile::TempDir;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::EnvFilter;
-use turso_core::types::IOResult;
-use turso_core::{Connection, Database, IO};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use turso_core::{types::IOResult, Connection, Database, IO};
 
 #[allow(dead_code)]
 pub struct TempDatabase {


### PR DESCRIPTION
Cacheflush should only spill pages to WAL as non-commit frames, without checkpointing nor syncing.

- [docs](https://sqlite.org/c3ref/db_cacheflush.html)
- [sqlite3PagerFlush](https://github.com/sqlite/sqlite/blob/625d0b70febecb0864a81b2a047a961a59e8c17e/src/pager.c#L4669)