### PR TITLE
Simulator - only output color on terminal

### DIFF
--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -14,7 +14,7 @@ use runner::{differential, watch};
 use std::any::Any;
 use std::backtrace::Backtrace;
 use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex};
 use tracing_subscriber::field::MakeExt;
@@ -697,7 +697,6 @@ fn run_simulation(
     result
 }
 
-#[allow(deprecated)]
 fn init_logger() {
     let file = OpenOptions::new()
         .create(true)
@@ -705,16 +704,20 @@ fn init_logger() {
         .truncate(true)
         .open("simulator.log")
         .unwrap();
+
+    let requires_ansi = std::io::stdout().is_terminal();
+
     let _ = tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
-                .with_ansi(true)
+                .with_ansi(requires_ansi)
                 .with_line_number(true)
                 .without_time()
                 .with_thread_ids(false),
         )
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .with(
+            #[allow(deprecated)]
             tracing_subscriber::fmt::layer()
                 .with_writer(file)
                 .with_ansi(false)


### PR DESCRIPTION
This inhibits ANSI color codes on non-TTY stdouts. It should fix logs with mangled color codes such as https://github.com/tursodatabase/turso/issues/2046.

## Result

On this branch:

<img width="1492" height="421" alt="image" src="https://github.com/user-attachments/assets/1d281203-bda1-41c6-944e-f10dac16834e" />

If I don't pipe or redirect, on this branch, the color is displayed.

On main:

<img width="1496" height="438" alt="image" src="https://github.com/user-attachments/assets/3844edac-dead-4655-96fb-df6ab5353021" />

