### PR TITLE
CDC modes

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1289,6 +1289,7 @@ pub fn emit_cdc_full_record(
     columns_reg
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn emit_cdc_insns(
     program: &mut ProgramBuilder,
     resolver: &Resolver,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1157,7 +1157,7 @@ fn emit_update_insns(
                         "rowid_set_clause_reg must be set because has_user_provided_rowid is true",
                     ),
                     dst_reg: rowid_reg,
-                    amount: 1,
+                    amount: 0,
                 });
                 emit_cdc_insns(
                     program,
@@ -1173,7 +1173,7 @@ fn emit_update_insns(
                 program.emit_insn(Insn::Copy {
                     src_reg: rowid_set_clause_reg.unwrap_or(beg),
                     dst_reg: rowid_reg,
-                    amount: 1,
+                    amount: 0,
                 });
                 emit_cdc_insns(
                     program,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -22,7 +22,7 @@ use super::select::emit_simple_count;
 use super::subquery::emit_subqueries;
 use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
 use crate::function::Func;
-use crate::schema::Schema;
+use crate::schema::{Schema, Table};
 use crate::translate::compound_select::emit_program_for_compound_select;
 use crate::translate::plan::{DeletePlan, Plan, QueryDestination, Search};
 use crate::translate::values::emit_values;
@@ -570,6 +570,7 @@ fn emit_delete_insns(
             }
         }
 
+        // Emit update in the CDC table if necessary (before DELETE updated the table)
         if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
             let rowid_reg = program.alloc_register();
             program.emit_insn(Insn::RowId {
@@ -578,18 +579,12 @@ fn emit_delete_insns(
             });
             let cdc_has_before = program.capture_data_changes_mode().has_before();
             let before_record_reg = if cdc_has_before {
-                let columns = table_reference.columns();
-                let columns_reg = program.alloc_registers(columns.len() + 1);
-                for i in 0..columns.len() {
-                    program.emit_column(main_table_cursor_id, i, columns_reg + 1 + i);
-                }
-                program.emit_insn(Insn::MakeRecord {
-                    start_reg: columns_reg + 1,
-                    count: columns.len(),
-                    dest_reg: columns_reg,
-                    index_name: None,
-                });
-                Some(columns_reg)
+                Some(emit_cdc_full_record(
+                    program,
+                    &table_reference.table,
+                    main_table_cursor_id,
+                    rowid_reg,
+                ))
             } else {
                 None
             };
@@ -1116,77 +1111,36 @@ fn emit_update_insns(
             });
         }
 
-        if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
-            let rowid_reg = program.alloc_register();
-            let has_after = program.capture_data_changes_mode().has_after();
-            let has_before = program.capture_data_changes_mode().has_before();
-            let before_record_reg = if has_before {
-                let columns = table_ref.columns();
-                let columns_reg = program.alloc_registers(columns.len() + 1);
-                for i in 0..columns.len() {
-                    program.emit_column(cursor_id, i, columns_reg + 1 + i);
-                }
-                program.emit_insn(Insn::MakeRecord {
-                    start_reg: columns_reg + 1,
-                    count: columns.len(),
-                    dest_reg: columns_reg,
-                    index_name: None,
-                });
-                Some(columns_reg)
-            } else {
-                None
-            };
-            let after_record_reg = if has_after { Some(record_reg) } else { None };
+        // create alias for CDC rowid after the change (will differ from cdc_rowid_before_reg only in case of UPDATE with change in rowid alias)
+        let cdc_rowid_after_reg = rowid_set_clause_reg.unwrap_or(beg);
+
+        // create separate register with rowid before UPDATE for CDC
+        let cdc_rowid_before_reg = if t_ctx.cdc_cursor_id.is_some() {
+            let cdc_rowid_before_reg = program.alloc_register();
             if has_user_provided_rowid {
                 program.emit_insn(Insn::RowId {
                     cursor_id,
-                    dest: rowid_reg,
+                    dest: cdc_rowid_before_reg,
                 });
-                emit_cdc_insns(
-                    program,
-                    &t_ctx.resolver,
-                    OperationMode::DELETE,
-                    cdc_cursor_id,
-                    rowid_reg,
-                    before_record_reg,
-                    None,
-                    table_ref.table.get_name(),
-                )?;
-                program.emit_insn(Insn::Copy {
-                    src_reg: rowid_set_clause_reg.expect(
-                        "rowid_set_clause_reg must be set because has_user_provided_rowid is true",
-                    ),
-                    dst_reg: rowid_reg,
-                    amount: 0,
-                });
-                emit_cdc_insns(
-                    program,
-                    &t_ctx.resolver,
-                    OperationMode::INSERT,
-                    cdc_cursor_id,
-                    rowid_reg,
-                    None,
-                    after_record_reg,
-                    table_ref.table.get_name(),
-                )?;
+                Some(cdc_rowid_before_reg)
             } else {
-                program.emit_insn(Insn::Copy {
-                    src_reg: rowid_set_clause_reg.unwrap_or(beg),
-                    dst_reg: rowid_reg,
-                    amount: 0,
-                });
-                emit_cdc_insns(
-                    program,
-                    &t_ctx.resolver,
-                    OperationMode::UPDATE,
-                    cdc_cursor_id,
-                    rowid_reg,
-                    before_record_reg,
-                    after_record_reg,
-                    table_ref.table.get_name(),
-                )?;
+                Some(cdc_rowid_after_reg)
             }
-        }
+        } else {
+            None
+        };
+
+        // create full CDC record before update if necessary
+        let cdc_before_reg = if program.capture_data_changes_mode().has_before() {
+            Some(emit_cdc_full_record(
+                program,
+                &table_ref.table,
+                cursor_id,
+                cdc_rowid_before_reg.expect("cdc_rowid_before_reg must be set"),
+            ))
+        } else {
+            None
+        };
 
         // If we are updating the rowid, we cannot rely on overwrite on the
         // Insert instruction to update the cell. We need to first delete the current cell
@@ -1202,6 +1156,58 @@ fn emit_update_insns(
             flag: InsertFlags::new().update(true),
             table_name: table_ref.identifier.clone(),
         });
+
+        // create full CDC record after update if necessary
+        let cdc_after_reg = if program.capture_data_changes_mode().has_after() {
+            Some(emit_cdc_patch_record(
+                program,
+                &table_ref.table,
+                start,
+                record_reg,
+                cdc_rowid_after_reg,
+            ))
+        } else {
+            None
+        };
+
+        // emit actual CDC instructions for write to the CDC table
+        if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
+            let cdc_rowid_before_reg =
+                cdc_rowid_before_reg.expect("cdc_rowid_before_reg must be set");
+            if has_user_provided_rowid {
+                emit_cdc_insns(
+                    program,
+                    &t_ctx.resolver,
+                    OperationMode::DELETE,
+                    cdc_cursor_id,
+                    cdc_rowid_before_reg,
+                    cdc_before_reg,
+                    None,
+                    table_ref.table.get_name(),
+                )?;
+                emit_cdc_insns(
+                    program,
+                    &t_ctx.resolver,
+                    OperationMode::INSERT,
+                    cdc_cursor_id,
+                    cdc_rowid_after_reg,
+                    cdc_after_reg,
+                    None,
+                    table_ref.table.get_name(),
+                )?;
+            } else {
+                emit_cdc_insns(
+                    program,
+                    &t_ctx.resolver,
+                    OperationMode::UPDATE,
+                    cdc_cursor_id,
+                    cdc_rowid_before_reg,
+                    cdc_before_reg,
+                    cdc_after_reg,
+                    table_ref.table.get_name(),
+                )?;
+            }
+        }
     } else if table_ref.virtual_table().is_some() {
         let arg_count = table_ref.columns().len() + 2;
         program.emit_insn(Insn::VUpdate {
@@ -1225,6 +1231,62 @@ fn emit_update_insns(
     }
 
     Ok(())
+}
+
+pub fn emit_cdc_patch_record(
+    program: &mut ProgramBuilder,
+    table: &Table,
+    columns_reg: usize,
+    record_reg: usize,
+    rowid_reg: usize,
+) -> usize {
+    let columns = table.columns();
+    let rowid_alias_position = columns.iter().position(|x| x.is_rowid_alias);
+    if let Some(rowid_alias_position) = rowid_alias_position {
+        let record_reg = program.alloc_register();
+        program.emit_insn(Insn::Copy {
+            src_reg: rowid_reg,
+            dst_reg: columns_reg + rowid_alias_position,
+            amount: 0,
+        });
+        program.emit_insn(Insn::MakeRecord {
+            start_reg: columns_reg,
+            count: table.columns().len(),
+            dest_reg: record_reg,
+            index_name: None,
+        });
+        record_reg
+    } else {
+        record_reg
+    }
+}
+
+pub fn emit_cdc_full_record(
+    program: &mut ProgramBuilder,
+    table: &Table,
+    table_cursor_id: usize,
+    rowid_reg: usize,
+) -> usize {
+    let columns = table.columns();
+    let columns_reg = program.alloc_registers(columns.len() + 1);
+    for (i, column) in columns.iter().enumerate() {
+        if column.is_rowid_alias {
+            program.emit_insn(Insn::Copy {
+                src_reg: rowid_reg,
+                dst_reg: columns_reg + 1 + i,
+                amount: 0,
+            });
+        } else {
+            program.emit_column(table_cursor_id, i, columns_reg + 1 + i);
+        }
+    }
+    program.emit_insn(Insn::MakeRecord {
+        start_reg: columns_reg + 1,
+        count: columns.len(),
+        dest_reg: columns_reg,
+        index_name: None,
+    });
+    columns_reg
 }
 
 pub fn emit_cdc_insns(

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -118,7 +118,6 @@ pub fn translate_insert(
     let loop_start_label = program.allocate_label();
 
     let cdc_table = program.capture_data_changes_mode().table();
-    let cdc_has_after = program.capture_data_changes_mode().has_after();
     let cdc_table = if let Some(cdc_table) = cdc_table {
         if table.get_name() != cdc_table {
             let Some(turso_cdc_table) = schema.get_table(cdc_table) else {
@@ -566,6 +565,7 @@ pub fn translate_insert(
 
     // Write record to the turso_cdc table if necessary
     if let Some((cdc_cursor_id, _)) = &cdc_table {
+        let cdc_has_after = program.capture_data_changes_mode().has_after();
         let after_record_reg = if cdc_has_after {
             Some(record_register)
         } else {

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -510,5 +510,21 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             col_type: None,
             constraints: vec![],
         },
+        ast::ColumnDefinition {
+            col_name: ast::Name("before".to_string()),
+            col_type: Some(ast::Type {
+                name: "BLOB".to_string(),
+                size: None,
+            }),
+            constraints: vec![],
+        },
+        ast::ColumnDefinition {
+            col_name: ast::Name("after".to_string()),
+            col_type: Some(ast::Type {
+                name: "BLOB".to_string(),
+                size: None,
+            }),
+            constraints: vec![],
+        },
     ]
 }

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -115,7 +115,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(0),
                 Value::Text("t".to_string()),
                 Value::Integer(1),
-                Value::Blob(record([Value::Null, Value::Integer(2)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
                 Value::Null,
             ],
             vec![
@@ -124,7 +124,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(3),
-                Value::Blob(record([Value::Null, Value::Integer(4)])),
+                Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
                 Value::Null,
             ],
             vec![
@@ -133,7 +133,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(1),
-                Value::Blob(record([Value::Null, Value::Integer(3)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
                 Value::Null,
             ]
         ]
@@ -164,7 +164,7 @@ fn test_cdc_simple_after() {
                 Value::Text("t".to_string()),
                 Value::Integer(1),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(2)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
             ],
             vec![
                 Value::Integer(2),
@@ -173,7 +173,7 @@ fn test_cdc_simple_after() {
                 Value::Text("t".to_string()),
                 Value::Integer(3),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(4)])),
+                Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
             ],
             vec![
                 Value::Integer(3),
@@ -182,7 +182,7 @@ fn test_cdc_simple_after() {
                 Value::Text("t".to_string()),
                 Value::Integer(1),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(3)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
             ],
             vec![
                 Value::Integer(4),
@@ -230,7 +230,7 @@ fn test_cdc_simple_full() {
                 Value::Text("t".to_string()),
                 Value::Integer(1),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(2)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
             ],
             vec![
                 Value::Integer(2),
@@ -239,7 +239,7 @@ fn test_cdc_simple_full() {
                 Value::Text("t".to_string()),
                 Value::Integer(3),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(4)])),
+                Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
             ],
             vec![
                 Value::Integer(3),
@@ -247,8 +247,8 @@ fn test_cdc_simple_full() {
                 Value::Integer(0),
                 Value::Text("t".to_string()),
                 Value::Integer(1),
-                Value::Blob(record([Value::Null, Value::Integer(2)])),
-                Value::Blob(record([Value::Null, Value::Integer(3)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
             ],
             vec![
                 Value::Integer(4),
@@ -256,7 +256,7 @@ fn test_cdc_simple_full() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(3),
-                Value::Blob(record([Value::Null, Value::Integer(4)])),
+                Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
                 Value::Null,
             ],
             vec![
@@ -265,7 +265,7 @@ fn test_cdc_simple_full() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(1),
-                Value::Blob(record([Value::Null, Value::Integer(3)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
                 Value::Null,
             ]
         ]

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -17,7 +17,7 @@ fn replace_column_with_null(rows: Vec<Vec<Value>>, column: usize) -> Vec<Vec<Val
 fn test_cdc_simple() {
     let db = TempDatabase::new_empty(false);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
         .unwrap();
@@ -40,14 +40,18 @@ fn test_cdc_simple() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(10)
+                Value::Integer(10),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(5)
+                Value::Integer(5),
+                Value::Null,
+                Value::Null,
             ]
         ]
     );
@@ -57,7 +61,7 @@ fn test_cdc_simple() {
 fn test_cdc_crud() {
     let db = TempDatabase::new_empty(false);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
         .unwrap();
@@ -85,63 +89,81 @@ fn test_cdc_crud() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(20)
+                Value::Integer(20),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(10)
+                Value::Integer(10),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(5)
+                Value::Integer(5),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
                 Value::Null,
                 Value::Integer(0),
                 Value::Text("t".to_string()),
-                Value::Integer(5)
+                Value::Integer(5),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(5),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
-                Value::Integer(10)
+                Value::Integer(10),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(6),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
-                Value::Integer(20)
+                Value::Integer(20),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(7),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(8),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(9),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -151,7 +173,7 @@ fn test_cdc_crud() {
 fn test_cdc_failed_op() {
     let db = TempDatabase::new_empty(true);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
@@ -182,28 +204,36 @@ fn test_cdc_failed_op() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(6)
+                Value::Integer(6),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(7)
+                Value::Integer(7),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -218,13 +248,13 @@ fn test_cdc_uncaptured_connection() {
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (2, 20)").unwrap(); // captured
     let conn2 = db.connect_limbo();
     conn2.execute("INSERT INTO t VALUES (3, 30)").unwrap();
     conn2
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn2.execute("INSERT INTO t VALUES (4, 40)").unwrap(); // captured
     conn2
@@ -260,21 +290,27 @@ fn test_cdc_uncaptured_connection() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(4)
+                Value::Integer(4),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(6)
+                Value::Integer(6),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -288,7 +324,7 @@ fn test_cdc_custom_table() {
         .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc')")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn1.execute("INSERT INTO t VALUES (2, 20)").unwrap();
@@ -310,14 +346,18 @@ fn test_cdc_custom_table() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -331,7 +371,7 @@ fn test_cdc_ignore_changes_in_cdc_table() {
         .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc')")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn1.execute("INSERT INTO t VALUES (2, 20)").unwrap();
@@ -355,7 +395,9 @@ fn test_cdc_ignore_changes_in_cdc_table() {
             Value::Null,
             Value::Integer(1),
             Value::Text("t".to_string()),
-            Value::Integer(2)
+            Value::Integer(2),
+            Value::Null,
+            Value::Null,
         ],]
     );
 }
@@ -371,7 +413,7 @@ fn test_cdc_transaction() {
         .execute("CREATE TABLE q(x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc')")
         .unwrap();
     conn1.execute("BEGIN").unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
@@ -394,35 +436,45 @@ fn test_cdc_transaction() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("q".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(3)
+                Value::Integer(3),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(5),
                 Value::Null,
                 Value::Integer(0),
                 Value::Text("q".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -434,10 +486,10 @@ fn test_cdc_independent_connections() {
     let conn1 = db.connect_limbo();
     let conn2 = db.connect_limbo();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc1')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc1')")
         .unwrap();
     conn2
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc2')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc2')")
         .unwrap();
     conn1
         .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
@@ -461,7 +513,9 @@ fn test_cdc_independent_connections() {
             Value::Null,
             Value::Integer(1),
             Value::Text("t".to_string()),
-            Value::Integer(1)
+            Value::Integer(1),
+            Value::Null,
+            Value::Null,
         ]]
     );
     let rows =
@@ -473,7 +527,9 @@ fn test_cdc_independent_connections() {
             Value::Null,
             Value::Integer(1),
             Value::Text("t".to_string()),
-            Value::Integer(2)
+            Value::Integer(2),
+            Value::Null,
+            Value::Null,
         ]]
     );
 }
@@ -484,10 +540,10 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
     let conn1 = db.connect_limbo();
     let conn2 = db.connect_limbo();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc1')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc1')")
         .unwrap();
     conn2
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc2')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc2')")
         .unwrap();
     conn1
         .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
@@ -522,14 +578,18 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("custom_cdc2".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ]
         ]
     );
@@ -543,14 +603,18 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(4)
+                Value::Integer(4),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("custom_cdc1".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ]
         ]
     );


### PR DESCRIPTION
This PR adds more CDC modes to the initial implementation of CDC support in `turso-db` from PR #1926 

First, this PR extend CDC table schema with 2 more columns: `before BLOB` and `after BLOB` which can be optionally set to the binary record representing row before or after the change (if mode or operation is not supposed to produce that column - `NULL` is written it in the CDC table).

With this PR DB will support following modes of the change capture:
1. `PRAGMA unstable_capture_data_changes_conn('id');` - both `after` and `before` columns are empty - only `rowid` of the changed row is logged. This can be useful if CDC table must be compact and only latest value of the row is needed (which can be joined on demand for now or later `turso-db` can provide convenient helpers)
2. `PRAGMA unstable_capture_data_changes_conn('before');` - only `before` column is populated for `UPDATE` and `DELETE` operations
3. `PRAGMA unstable_capture_data_changes_conn('after');` - only `after` column is populated for `INSERT` and `UPDATE` operations
4. `PRAGMA unstable_capture_data_changes_conn('full');` - both `before` and `after` columns are populated for operations where it make sense

The binary record stored in `before` / `after` columns is almost exact binary row representation used by SQLite internally (see https://www.sqlite.org/fileformat.html#record_format). The only difference is that if table has rowid alias column - SQLite by default will populate it with `NULL`, but in CDC table `turso-db` will emit proper integer value at the position of that column in the binary record format.