### PR TITLE
CDC functions

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -318,6 +318,8 @@ pub enum ScalarFunc {
     Likely,
     TimeDiff,
     Likelihood,
+    TableColumnsJsonArray,
+    BinRecordJsonObject,
 }
 
 impl ScalarFunc {
@@ -375,6 +377,8 @@ impl ScalarFunc {
             ScalarFunc::Likely => true,
             ScalarFunc::TimeDiff => false,
             ScalarFunc::Likelihood => true,
+            ScalarFunc::TableColumnsJsonArray => true, // while columns of the table can change with DDL statements, within single query plan it's static
+            ScalarFunc::BinRecordJsonObject => true,
         }
     }
 }
@@ -434,6 +438,8 @@ impl Display for ScalarFunc {
             Self::Likely => "likely".to_string(),
             Self::TimeDiff => "timediff".to_string(),
             Self::Likelihood => "likelihood".to_string(),
+            Self::TableColumnsJsonArray => "table_columns_json_array".to_string(),
+            Self::BinRecordJsonObject => "bin_record_json_object".to_string(),
         };
         write!(f, "{str}")
     }
@@ -777,6 +783,8 @@ impl Func {
             "unhex" => Ok(Self::Scalar(ScalarFunc::Unhex)),
             "zeroblob" => Ok(Self::Scalar(ScalarFunc::ZeroBlob)),
             "soundex" => Ok(Self::Scalar(ScalarFunc::Soundex)),
+            "table_columns_json_array" => Ok(Self::Scalar(ScalarFunc::TableColumnsJsonArray)),
+            "bin_record_json_object" => Ok(Self::Scalar(ScalarFunc::BinRecordJsonObject)),
             "acos" => Ok(Self::Math(MathFunc::Acos)),
             "acosh" => Ok(Self::Math(MathFunc::Acosh)),
             "asin" => Ok(Self::Math(MathFunc::Asin)),

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -106,7 +106,9 @@ pub fn convert_dbtype_to_jsonb(val: &Value, strict: Conv) -> crate::Result<Jsonb
             Value::Null => RefValue::Null,
             Value::Integer(x) => RefValue::Integer(*x),
             Value::Float(x) => RefValue::Float(*x),
-            Value::Text(text) => RefValue::Text(TextRef::create_from(text.as_str().as_bytes())),
+            Value::Text(text) => {
+                RefValue::Text(TextRef::create_from(text.as_str().as_bytes(), text.subtype))
+            }
             Value::Blob(items) => RefValue::Blob(RawSlice::create_from(items)),
         },
         strict,

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -107,7 +107,7 @@ pub fn convert_dbtype_to_jsonb(val: &Value, strict: Conv) -> crate::Result<Jsonb
             Value::Integer(x) => RefValue::Integer(*x),
             Value::Float(x) => RefValue::Float(*x),
             Value::Text(text) => RefValue::Text(TextRef::create_from(text.as_str().as_bytes())),
-            Value::Blob(items) => RefValue::Blob(RawSlice::create_from(&items)),
+            Value::Blob(items) => RefValue::Blob(RawSlice::create_from(items)),
         },
         strict,
     )

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -60,7 +60,9 @@ use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_thr
 use crate::storage::buffer_pool::BufferPool;
 use crate::storage::database::DatabaseStorage;
 use crate::storage::pager::Pager;
-use crate::types::{RawSlice, RefValue, SerialType, SerialTypeKind, TextRef};
+use crate::types::{
+    RawSlice, RefValue, SerialType, SerialTypeKind, TextRef, TextSubtype,
+};
 use crate::{File, Result, WalFileShared};
 use std::cell::{RefCell, UnsafeCell};
 use std::collections::HashMap;
@@ -1162,7 +1164,10 @@ pub fn read_value(buf: &[u8], serial_type: SerialType) -> Result<(RefValue, usiz
             }
 
             Ok((
-                RefValue::Text(TextRef::create_from(&buf[..content_size])),
+                RefValue::Text(TextRef::create_from(
+                    &buf[..content_size],
+                    TextSubtype::Text,
+                )),
                 content_size,
             ))
         }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -60,7 +60,7 @@ use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_thr
 use crate::storage::buffer_pool::BufferPool;
 use crate::storage::database::DatabaseStorage;
 use crate::storage::pager::Pager;
-use crate::types::{RawSlice, RefValue, SerialType, SerialTypeKind, TextRef, TextSubtype};
+use crate::types::{RawSlice, RefValue, SerialType, SerialTypeKind, TextRef};
 use crate::{File, Result, WalFileShared};
 use std::cell::{RefCell, UnsafeCell};
 use std::collections::HashMap;
@@ -1160,17 +1160,9 @@ pub fn read_value(buf: &[u8], serial_type: SerialType) -> Result<(RefValue, usiz
                     content_size
                 );
             }
-            let slice = if content_size == 0 {
-                RawSlice::new(std::ptr::null(), 0)
-            } else {
-                let ptr = &buf[0] as *const u8;
-                RawSlice::new(ptr, content_size)
-            };
+
             Ok((
-                RefValue::Text(TextRef {
-                    value: slice,
-                    subtype: TextSubtype::Text,
-                }),
+                RefValue::Text(TextRef::create_from(&buf[..content_size])),
                 content_size,
             ))
         }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -60,9 +60,7 @@ use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_thr
 use crate::storage::buffer_pool::BufferPool;
 use crate::storage::database::DatabaseStorage;
 use crate::storage::pager::Pager;
-use crate::types::{
-    RawSlice, RefValue, SerialType, SerialTypeKind, TextRef, TextSubtype,
-};
+use crate::types::{RawSlice, RefValue, SerialType, SerialTypeKind, TextRef, TextSubtype};
 use crate::{File, Result, WalFileShared};
 use std::cell::{RefCell, UnsafeCell};
 use std::collections::HashMap;

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1289,6 +1289,7 @@ pub fn emit_cdc_full_record(
     columns_reg
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn emit_cdc_insns(
     program: &mut ProgramBuilder,
     resolver: &Resolver,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1157,7 +1157,7 @@ fn emit_update_insns(
                         "rowid_set_clause_reg must be set because has_user_provided_rowid is true",
                     ),
                     dst_reg: rowid_reg,
-                    amount: 1,
+                    amount: 0,
                 });
                 emit_cdc_insns(
                     program,
@@ -1173,7 +1173,7 @@ fn emit_update_insns(
                 program.emit_insn(Insn::Copy {
                     src_reg: rowid_set_clause_reg.unwrap_or(beg),
                     dst_reg: rowid_reg,
-                    amount: 1,
+                    amount: 0,
                 });
                 emit_cdc_insns(
                     program,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -22,7 +22,7 @@ use super::select::emit_simple_count;
 use super::subquery::emit_subqueries;
 use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
 use crate::function::Func;
-use crate::schema::Schema;
+use crate::schema::{Schema, Table};
 use crate::translate::compound_select::emit_program_for_compound_select;
 use crate::translate::plan::{DeletePlan, Plan, QueryDestination, Search};
 use crate::translate::values::emit_values;
@@ -570,6 +570,7 @@ fn emit_delete_insns(
             }
         }
 
+        // Emit update in the CDC table if necessary (before DELETE updated the table)
         if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
             let rowid_reg = program.alloc_register();
             program.emit_insn(Insn::RowId {
@@ -578,18 +579,12 @@ fn emit_delete_insns(
             });
             let cdc_has_before = program.capture_data_changes_mode().has_before();
             let before_record_reg = if cdc_has_before {
-                let columns = table_reference.columns();
-                let columns_reg = program.alloc_registers(columns.len() + 1);
-                for i in 0..columns.len() {
-                    program.emit_column(main_table_cursor_id, i, columns_reg + 1 + i);
-                }
-                program.emit_insn(Insn::MakeRecord {
-                    start_reg: columns_reg + 1,
-                    count: columns.len(),
-                    dest_reg: columns_reg,
-                    index_name: None,
-                });
-                Some(columns_reg)
+                Some(emit_cdc_full_record(
+                    program,
+                    &table_reference.table,
+                    main_table_cursor_id,
+                    rowid_reg,
+                ))
             } else {
                 None
             };
@@ -1116,77 +1111,36 @@ fn emit_update_insns(
             });
         }
 
-        if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
-            let rowid_reg = program.alloc_register();
-            let has_after = program.capture_data_changes_mode().has_after();
-            let has_before = program.capture_data_changes_mode().has_before();
-            let before_record_reg = if has_before {
-                let columns = table_ref.columns();
-                let columns_reg = program.alloc_registers(columns.len() + 1);
-                for i in 0..columns.len() {
-                    program.emit_column(cursor_id, i, columns_reg + 1 + i);
-                }
-                program.emit_insn(Insn::MakeRecord {
-                    start_reg: columns_reg + 1,
-                    count: columns.len(),
-                    dest_reg: columns_reg,
-                    index_name: None,
-                });
-                Some(columns_reg)
-            } else {
-                None
-            };
-            let after_record_reg = if has_after { Some(record_reg) } else { None };
+        // create alias for CDC rowid after the change (will differ from cdc_rowid_before_reg only in case of UPDATE with change in rowid alias)
+        let cdc_rowid_after_reg = rowid_set_clause_reg.unwrap_or(beg);
+
+        // create separate register with rowid before UPDATE for CDC
+        let cdc_rowid_before_reg = if t_ctx.cdc_cursor_id.is_some() {
+            let cdc_rowid_before_reg = program.alloc_register();
             if has_user_provided_rowid {
                 program.emit_insn(Insn::RowId {
                     cursor_id,
-                    dest: rowid_reg,
+                    dest: cdc_rowid_before_reg,
                 });
-                emit_cdc_insns(
-                    program,
-                    &t_ctx.resolver,
-                    OperationMode::DELETE,
-                    cdc_cursor_id,
-                    rowid_reg,
-                    before_record_reg,
-                    None,
-                    table_ref.table.get_name(),
-                )?;
-                program.emit_insn(Insn::Copy {
-                    src_reg: rowid_set_clause_reg.expect(
-                        "rowid_set_clause_reg must be set because has_user_provided_rowid is true",
-                    ),
-                    dst_reg: rowid_reg,
-                    amount: 0,
-                });
-                emit_cdc_insns(
-                    program,
-                    &t_ctx.resolver,
-                    OperationMode::INSERT,
-                    cdc_cursor_id,
-                    rowid_reg,
-                    None,
-                    after_record_reg,
-                    table_ref.table.get_name(),
-                )?;
+                Some(cdc_rowid_before_reg)
             } else {
-                program.emit_insn(Insn::Copy {
-                    src_reg: rowid_set_clause_reg.unwrap_or(beg),
-                    dst_reg: rowid_reg,
-                    amount: 0,
-                });
-                emit_cdc_insns(
-                    program,
-                    &t_ctx.resolver,
-                    OperationMode::UPDATE,
-                    cdc_cursor_id,
-                    rowid_reg,
-                    before_record_reg,
-                    after_record_reg,
-                    table_ref.table.get_name(),
-                )?;
+                Some(cdc_rowid_after_reg)
             }
-        }
+        } else {
+            None
+        };
+
+        // create full CDC record before update if necessary
+        let cdc_before_reg = if program.capture_data_changes_mode().has_before() {
+            Some(emit_cdc_full_record(
+                program,
+                &table_ref.table,
+                cursor_id,
+                cdc_rowid_before_reg.expect("cdc_rowid_before_reg must be set"),
+            ))
+        } else {
+            None
+        };
 
         // If we are updating the rowid, we cannot rely on overwrite on the
         // Insert instruction to update the cell. We need to first delete the current cell
@@ -1202,6 +1156,58 @@ fn emit_update_insns(
             flag: InsertFlags::new().update(true),
             table_name: table_ref.identifier.clone(),
         });
+
+        // create full CDC record after update if necessary
+        let cdc_after_reg = if program.capture_data_changes_mode().has_after() {
+            Some(emit_cdc_patch_record(
+                program,
+                &table_ref.table,
+                start,
+                record_reg,
+                cdc_rowid_after_reg,
+            ))
+        } else {
+            None
+        };
+
+        // emit actual CDC instructions for write to the CDC table
+        if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
+            let cdc_rowid_before_reg =
+                cdc_rowid_before_reg.expect("cdc_rowid_before_reg must be set");
+            if has_user_provided_rowid {
+                emit_cdc_insns(
+                    program,
+                    &t_ctx.resolver,
+                    OperationMode::DELETE,
+                    cdc_cursor_id,
+                    cdc_rowid_before_reg,
+                    cdc_before_reg,
+                    None,
+                    table_ref.table.get_name(),
+                )?;
+                emit_cdc_insns(
+                    program,
+                    &t_ctx.resolver,
+                    OperationMode::INSERT,
+                    cdc_cursor_id,
+                    cdc_rowid_after_reg,
+                    cdc_after_reg,
+                    None,
+                    table_ref.table.get_name(),
+                )?;
+            } else {
+                emit_cdc_insns(
+                    program,
+                    &t_ctx.resolver,
+                    OperationMode::UPDATE,
+                    cdc_cursor_id,
+                    cdc_rowid_before_reg,
+                    cdc_before_reg,
+                    cdc_after_reg,
+                    table_ref.table.get_name(),
+                )?;
+            }
+        }
     } else if table_ref.virtual_table().is_some() {
         let arg_count = table_ref.columns().len() + 2;
         program.emit_insn(Insn::VUpdate {
@@ -1225,6 +1231,62 @@ fn emit_update_insns(
     }
 
     Ok(())
+}
+
+pub fn emit_cdc_patch_record(
+    program: &mut ProgramBuilder,
+    table: &Table,
+    columns_reg: usize,
+    record_reg: usize,
+    rowid_reg: usize,
+) -> usize {
+    let columns = table.columns();
+    let rowid_alias_position = columns.iter().position(|x| x.is_rowid_alias);
+    if let Some(rowid_alias_position) = rowid_alias_position {
+        let record_reg = program.alloc_register();
+        program.emit_insn(Insn::Copy {
+            src_reg: rowid_reg,
+            dst_reg: columns_reg + rowid_alias_position,
+            amount: 0,
+        });
+        program.emit_insn(Insn::MakeRecord {
+            start_reg: columns_reg,
+            count: table.columns().len(),
+            dest_reg: record_reg,
+            index_name: None,
+        });
+        record_reg
+    } else {
+        record_reg
+    }
+}
+
+pub fn emit_cdc_full_record(
+    program: &mut ProgramBuilder,
+    table: &Table,
+    table_cursor_id: usize,
+    rowid_reg: usize,
+) -> usize {
+    let columns = table.columns();
+    let columns_reg = program.alloc_registers(columns.len() + 1);
+    for (i, column) in columns.iter().enumerate() {
+        if column.is_rowid_alias {
+            program.emit_insn(Insn::Copy {
+                src_reg: rowid_reg,
+                dst_reg: columns_reg + 1 + i,
+                amount: 0,
+            });
+        } else {
+            program.emit_column(table_cursor_id, i, columns_reg + 1 + i);
+        }
+    }
+    program.emit_insn(Insn::MakeRecord {
+        start_reg: columns_reg + 1,
+        count: columns.len(),
+        dest_reg: columns_reg,
+        index_name: None,
+    });
+    columns_reg
 }
 
 pub fn emit_cdc_insns(

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1723,12 +1723,18 @@ pub fn translate_expr(
                             }
 
                             let start_reg = program.alloc_register();
+                            translate_expr(
+                                program,
+                                referenced_tables,
+                                &args[0],
+                                start_reg,
+                                resolver,
+                            )?;
                             program.emit_insn(Insn::Copy {
                                 src_reg: start_reg,
                                 dst_reg: target_register,
                                 amount: 0,
                             });
-
                             Ok(target_register)
                         }
                         ScalarFunc::TableColumnsJsonArray => {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -118,7 +118,6 @@ pub fn translate_insert(
     let loop_start_label = program.allocate_label();
 
     let cdc_table = program.capture_data_changes_mode().table();
-    let cdc_has_after = program.capture_data_changes_mode().has_after();
     let cdc_table = if let Some(cdc_table) = cdc_table {
         if table.get_name() != cdc_table {
             let Some(turso_cdc_table) = schema.get_table(cdc_table) else {
@@ -566,6 +565,7 @@ pub fn translate_insert(
 
     // Write record to the turso_cdc table if necessary
     if let Some((cdc_cursor_id, _)) = &cdc_table {
+        let cdc_has_after = program.capture_data_changes_mode().has_after();
         let after_record_reg = if cdc_has_after {
             Some(record_register)
         } else {

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -510,5 +510,21 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             col_type: None,
             constraints: vec![],
         },
+        ast::ColumnDefinition {
+            col_name: ast::Name("before".to_string()),
+            col_type: Some(ast::Type {
+                name: "BLOB".to_string(),
+                size: None,
+            }),
+            constraints: vec![],
+        },
+        ast::ColumnDefinition {
+            col_name: ast::Name("after".to_string()),
+            col_type: Some(ast::Type {
+                name: "BLOB".to_string(),
+                size: None,
+            }),
+            constraints: vec![],
+        },
     ]
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -48,7 +48,7 @@ impl Display for ValueType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TextSubtype {
     Text,
@@ -127,12 +127,9 @@ impl Display for TextRef {
 }
 
 impl TextRef {
-    pub fn create_from(value: &[u8]) -> Self {
+    pub fn create_from(value: &[u8], subtype: TextSubtype) -> Self {
         let value = RawSlice::create_from(value);
-        Self {
-            value,
-            subtype: TextSubtype::Text,
-        }
+        Self { value, subtype }
     }
     pub fn as_str(&self) -> &str {
         unsafe { std::str::from_utf8_unchecked(self.value.to_slice()) }

--- a/core/types.rs
+++ b/core/types.rs
@@ -127,6 +127,13 @@ impl Display for TextRef {
 }
 
 impl TextRef {
+    pub fn create_from(value: &[u8]) -> Self {
+        let value = RawSlice::create_from(value);
+        Self {
+            value,
+            subtype: TextSubtype::Text,
+        }
+    }
     pub fn as_str(&self) -> &str {
         unsafe { std::str::from_utf8_unchecked(self.value.to_slice()) }
     }
@@ -2346,6 +2353,14 @@ pub enum SeekKey<'a> {
 }
 
 impl RawSlice {
+    pub fn create_from(value: &[u8]) -> Self {
+        if value.len() == 0 {
+            RawSlice::new(std::ptr::null(), 0)
+        } else {
+            let ptr = &value[0] as *const u8;
+            RawSlice::new(ptr, value.len())
+        }
+    }
     pub fn new(data: *const u8, len: usize) -> Self {
         Self { data, len }
     }

--- a/core/types.rs
+++ b/core/types.rs
@@ -963,7 +963,7 @@ impl ImmutableRecord {
                     let ptr = unsafe { writer.buf.as_ptr().add(start_offset) };
                     let value = RefValue::Text(TextRef {
                         value: RawSlice::new(ptr, len),
-                        subtype: t.subtype.clone(),
+                        subtype: t.subtype,
                     });
                     ref_values.push(value);
                 }
@@ -1365,7 +1365,7 @@ impl RefValue {
             RefValue::Float(f) => Value::Float(*f),
             RefValue::Text(text_ref) => Value::Text(Text {
                 value: text_ref.value.to_slice().to_vec(),
-                subtype: text_ref.subtype.clone(),
+                subtype: text_ref.subtype,
             }),
             RefValue::Blob(b) => Value::Blob(b.to_slice().to_vec()),
         }

--- a/core/types.rs
+++ b/core/types.rs
@@ -2354,7 +2354,7 @@ pub enum SeekKey<'a> {
 
 impl RawSlice {
     pub fn create_from(value: &[u8]) -> Self {
-        if value.len() == 0 {
+        if value.is_empty() {
             RawSlice::new(std::ptr::null(), 0)
         } else {
             let ptr = &value[0] as *const u8;

--- a/core/types.rs
+++ b/core/types.rs
@@ -2426,7 +2426,7 @@ mod tests {
             Value::Float(f) => RefValue::Float(*f),
             Value::Text(text) => RefValue::Text(TextRef {
                 value: RawSlice::from_slice(&text.value),
-                subtype: text.subtype.clone(),
+                subtype: text.subtype,
             }),
             Value::Blob(blob) => RefValue::Blob(RawSlice::from_slice(blob)),
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4067,7 +4067,10 @@ pub fn op_function(
                 for column in table.columns() {
                     let name = column.name.as_ref().unwrap();
                     let name_json = json::convert_ref_dbtype_to_jsonb(
-                        &RefValue::Text(TextRef::create_from(name.as_str().as_bytes())),
+                        &RefValue::Text(TextRef::create_from(
+                            name.as_str().as_bytes(),
+                            TextSubtype::Text,
+                        )),
                         json::Conv::ToString,
                     )?;
                     json.append_jsonb_to_end(name_json.data());

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4105,7 +4105,7 @@ pub fn op_function(
                     let columns_len = columns_json_array.array_len()?;
 
                     let mut record = ImmutableRecord::new(bin_record.len());
-                    read_record(&bin_record, &mut record)?;
+                    read_record(bin_record, &mut record)?;
 
                     let mut json = json::jsonb::Jsonb::make_empty_obj(record.len());
                     for i in 0..columns_len {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1597,7 +1597,7 @@ pub fn op_column(
                     if existing_text.value.capacity() >= new_text.value.len() {
                         existing_text.value.clear();
                         existing_text.value.extend_from_slice(&new_text.value);
-                        existing_text.subtype = new_text.subtype.clone();
+                        existing_text.subtype = new_text.subtype;
                     } else {
                         state.registers[*dest] = Register::Value(value);
                     }
@@ -4130,7 +4130,7 @@ pub fn op_function(
                     let columns_len = columns_json_array.array_len()?;
 
                     let mut record = ImmutableRecord::new(bin_record.len());
-                    record.start_serialization(&bin_record);
+                    record.start_serialization(bin_record);
                     let mut record_cursor = RecordCursor::new();
 
                     let mut json = json::jsonb::Jsonb::make_empty_obj(columns_len);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -28,9 +28,9 @@ use crate::{
     },
 };
 use std::ops::DerefMut;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Mutex;
 use std::{borrow::BorrowMut, rc::Rc, sync::Arc};
-use std::{ sync::atomic::AtomicUsize};
 
 use crate::{pseudo::PseudoCursor, result::LimboResult};
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -598,7 +598,7 @@ pub fn registers_to_ref_values(registers: &[Register]) -> Vec<RefValue> {
                 Value::Float(f) => RefValue::Float(*f),
                 Value::Text(t) => RefValue::Text(TextRef {
                     value: RawSlice::new(t.value.as_ptr(), t.value.len()),
-                    subtype: t.subtype.clone(),
+                    subtype: t.subtype,
                 }),
                 Value::Blob(b) => RefValue::Blob(RawSlice::new(b.as_ptr(), b.len())),
             }

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -858,7 +858,8 @@ fn test_cdc_bin_record() {
     let record = record([
         Value::Null,
         Value::Integer(1),
-        Value::Real(3.1415),
+        // use golden ratio instead of pi because clippy has weird rule that I can't use PI approximation written by hand
+        Value::Real(1.61803),
         Value::Text("hello".to_string()),
     ]);
     let mut record_hex = String::new();
@@ -874,7 +875,7 @@ fn test_cdc_bin_record() {
     assert_eq!(
         rows,
         vec![vec![Value::Text(
-            r#"{"a":null,"b":1,"c":3.1415,"d":"hello"}"#.to_string()
+            r#"{"a":null,"b":1,"c":1.61803,"d":"hello"}"#.to_string()
         )]]
     );
 }

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -115,7 +115,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(0),
                 Value::Text("t".to_string()),
                 Value::Integer(1),
-                Value::Blob(record([Value::Null, Value::Integer(2)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
                 Value::Null,
             ],
             vec![
@@ -124,7 +124,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(3),
-                Value::Blob(record([Value::Null, Value::Integer(4)])),
+                Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
                 Value::Null,
             ],
             vec![
@@ -133,7 +133,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(1),
-                Value::Blob(record([Value::Null, Value::Integer(3)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
                 Value::Null,
             ]
         ]
@@ -164,7 +164,7 @@ fn test_cdc_simple_after() {
                 Value::Text("t".to_string()),
                 Value::Integer(1),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(2)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
             ],
             vec![
                 Value::Integer(2),
@@ -173,7 +173,7 @@ fn test_cdc_simple_after() {
                 Value::Text("t".to_string()),
                 Value::Integer(3),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(4)])),
+                Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
             ],
             vec![
                 Value::Integer(3),
@@ -182,7 +182,7 @@ fn test_cdc_simple_after() {
                 Value::Text("t".to_string()),
                 Value::Integer(1),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(3)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
             ],
             vec![
                 Value::Integer(4),
@@ -230,7 +230,7 @@ fn test_cdc_simple_full() {
                 Value::Text("t".to_string()),
                 Value::Integer(1),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(2)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
             ],
             vec![
                 Value::Integer(2),
@@ -239,7 +239,7 @@ fn test_cdc_simple_full() {
                 Value::Text("t".to_string()),
                 Value::Integer(3),
                 Value::Null,
-                Value::Blob(record([Value::Null, Value::Integer(4)])),
+                Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
             ],
             vec![
                 Value::Integer(3),
@@ -247,8 +247,8 @@ fn test_cdc_simple_full() {
                 Value::Integer(0),
                 Value::Text("t".to_string()),
                 Value::Integer(1),
-                Value::Blob(record([Value::Null, Value::Integer(2)])),
-                Value::Blob(record([Value::Null, Value::Integer(3)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
             ],
             vec![
                 Value::Integer(4),
@@ -256,7 +256,7 @@ fn test_cdc_simple_full() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(3),
-                Value::Blob(record([Value::Null, Value::Integer(4)])),
+                Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
                 Value::Null,
             ],
             vec![
@@ -265,7 +265,7 @@ fn test_cdc_simple_full() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(1),
-                Value::Blob(record([Value::Null, Value::Integer(3)])),
+                Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
                 Value::Null,
             ]
         ]

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -17,7 +17,7 @@ fn replace_column_with_null(rows: Vec<Vec<Value>>, column: usize) -> Vec<Vec<Val
 fn test_cdc_simple() {
     let db = TempDatabase::new_empty(false);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
         .unwrap();
@@ -40,14 +40,18 @@ fn test_cdc_simple() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(10)
+                Value::Integer(10),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(5)
+                Value::Integer(5),
+                Value::Null,
+                Value::Null,
             ]
         ]
     );
@@ -57,7 +61,7 @@ fn test_cdc_simple() {
 fn test_cdc_crud() {
     let db = TempDatabase::new_empty(false);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
         .unwrap();
@@ -85,63 +89,81 @@ fn test_cdc_crud() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(20)
+                Value::Integer(20),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(10)
+                Value::Integer(10),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(5)
+                Value::Integer(5),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
                 Value::Null,
                 Value::Integer(0),
                 Value::Text("t".to_string()),
-                Value::Integer(5)
+                Value::Integer(5),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(5),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
-                Value::Integer(10)
+                Value::Integer(10),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(6),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
-                Value::Integer(20)
+                Value::Integer(20),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(7),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(8),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(9),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -151,7 +173,7 @@ fn test_cdc_crud() {
 fn test_cdc_failed_op() {
     let db = TempDatabase::new_empty(true);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
@@ -182,28 +204,36 @@ fn test_cdc_failed_op() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(6)
+                Value::Integer(6),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(7)
+                Value::Integer(7),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -218,13 +248,13 @@ fn test_cdc_uncaptured_connection() {
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (2, 20)").unwrap(); // captured
     let conn2 = db.connect_limbo();
     conn2.execute("INSERT INTO t VALUES (3, 30)").unwrap();
     conn2
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn2.execute("INSERT INTO t VALUES (4, 40)").unwrap(); // captured
     conn2
@@ -260,21 +290,27 @@ fn test_cdc_uncaptured_connection() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(4)
+                Value::Integer(4),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(6)
+                Value::Integer(6),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -288,7 +324,7 @@ fn test_cdc_custom_table() {
         .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc')")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn1.execute("INSERT INTO t VALUES (2, 20)").unwrap();
@@ -310,14 +346,18 @@ fn test_cdc_custom_table() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -331,7 +371,7 @@ fn test_cdc_ignore_changes_in_cdc_table() {
         .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc')")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn1.execute("INSERT INTO t VALUES (2, 20)").unwrap();
@@ -355,7 +395,9 @@ fn test_cdc_ignore_changes_in_cdc_table() {
             Value::Null,
             Value::Integer(1),
             Value::Text("t".to_string()),
-            Value::Integer(2)
+            Value::Integer(2),
+            Value::Null,
+            Value::Null,
         ],]
     );
 }
@@ -371,7 +413,7 @@ fn test_cdc_transaction() {
         .execute("CREATE TABLE q(x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc')")
         .unwrap();
     conn1.execute("BEGIN").unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
@@ -394,35 +436,45 @@ fn test_cdc_transaction() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("q".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(3)
+                Value::Integer(3),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(5),
                 Value::Null,
                 Value::Integer(0),
                 Value::Text("q".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
         ]
     );
@@ -434,10 +486,10 @@ fn test_cdc_independent_connections() {
     let conn1 = db.connect_limbo();
     let conn2 = db.connect_limbo();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc1')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc1')")
         .unwrap();
     conn2
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc2')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc2')")
         .unwrap();
     conn1
         .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
@@ -461,7 +513,9 @@ fn test_cdc_independent_connections() {
             Value::Null,
             Value::Integer(1),
             Value::Text("t".to_string()),
-            Value::Integer(1)
+            Value::Integer(1),
+            Value::Null,
+            Value::Null,
         ]]
     );
     let rows =
@@ -473,7 +527,9 @@ fn test_cdc_independent_connections() {
             Value::Null,
             Value::Integer(1),
             Value::Text("t".to_string()),
-            Value::Integer(2)
+            Value::Integer(2),
+            Value::Null,
+            Value::Null,
         ]]
     );
 }
@@ -484,10 +540,10 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
     let conn1 = db.connect_limbo();
     let conn2 = db.connect_limbo();
     conn1
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc1')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc1')")
         .unwrap();
     conn2
-        .execute("PRAGMA unstable_capture_data_changes_conn('rowid-only,custom_cdc2')")
+        .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc2')")
         .unwrap();
     conn1
         .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
@@ -522,14 +578,18 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(2)
+                Value::Integer(2),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("custom_cdc2".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ]
         ]
     );
@@ -543,14 +603,18 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
                 Value::Null,
                 Value::Integer(1),
                 Value::Text("t".to_string()),
-                Value::Integer(4)
+                Value::Integer(4),
+                Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
                 Value::Null,
                 Value::Integer(-1),
                 Value::Text("custom_cdc1".to_string()),
-                Value::Integer(1)
+                Value::Integer(1),
+                Value::Null,
+                Value::Null,
             ]
         ]
     );


### PR DESCRIPTION
This PR adds few functions to the `turso-db` in order to simplify exploration of CDC table. Later we will also add API to work with changes from the code - but SQL support is also useful.

So, this PR adds 2 functions:
1. `table_columns_json_array('<table-name>')` - returns list of current table column **names** as a single string in JSON array format
2. `bin_record_json_object('<columns-array>', x'<bin-record>')` - convert record in the SQLite format to the JSON object with keys from `columns-array`

So, this functions can be used together to extract changes in human-readable format:
```sql
turso> PRAGMA unstable_capture_data_changes_conn('full');
turso> CREATE TABLE t(a INTEGER PRIMARY KEY, b);
turso> INSERT INTO t VALUES (1, 2), (3, 4);
turso> UPDATE t SET b = 20 WHERE a = 1;
turso> UPDATE t SET a = 30, b = 40 WHERE a = 3;
turso> DELETE FROM t WHERE a = 1;
turso> SELECT 
    bin_record_json_object(table_columns_json_array('t'), before) before, 
    bin_record_json_object(table_columns_json_array('t'), after) after 
    FROM turso_cdc;
┌─────────────────┬────────────────┐
│ before          │ after          │
├─────────────────┼────────────────┤
│                 │ {"a":1,"b":2}  │
├─────────────────┼────────────────┤
│                 │ {"a":3,"b":4}  │
├─────────────────┼────────────────┤
│ {"a":1,"b":2}   │ {"a":1,"b":20} │
├─────────────────┼────────────────┤
│ {"a":3,"b":4}   │                │
├─────────────────┼────────────────┤
│ {"a":30,"b":40} │                │
├─────────────────┼────────────────┤
│ {"a":1,"b":20}  │                │
└─────────────────┴────────────────┘
```

Initially, I thought to implement single function like `bin_record_json_object('<table-name', x'<bin-record')` but this design has certain flaws:
1. In case of schema changes this function can return incorrect result (imagine that you dropped a column and now JSON from CDC mentions some random subset of columns). While this feature is unstable - `turso-db` should avoid silent incorrect behavior at all cost
2. Single-function design provide no way to deal with schema changes
3. The API is unsound and user can think that under the hood `turso-db` will select proper schema for the record (but this is actually impossible with current CDC implementation)

So, I decided to stop with two-functions design which cover drawbacks mentioned above to some extent
1. First concern still remains valid
2. Two-functions design provides a way to deal with schema changes. For example, user can maintain simple `cdc_schema_changes` table and log result of `table_columns_json_array` before applying breaking schema changes. 
    * Obviously, this is not ideal UX - but it suits my needs: I don't want to design schema changes capturing, but also I don't want to block users and provide a way to have a workaround for scenarios which are not natively supported by CDC
3. Subjectively, I think that API became a bit more clear about the machinery of these two functions as user see that it extract column list of the table (without any context) and then feed it to the `bin_record_json_object` function.