### PR TITLE
sim: return LimboError::Busy when busy, instead of looping forever

### DIFF
--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -446,7 +446,9 @@ impl Interaction {
                     StepResult::Done => {
                         break;
                     }
-                    StepResult::Busy => {}
+                    StepResult::Busy => {
+                        return Err(turso_core::LimboError::Busy);
+                    }
                 }
             }
 
@@ -579,7 +581,10 @@ impl Interaction {
                     StepResult::Done => {
                         break;
                     }
-                    StepResult::Interrupt | StepResult::Busy => {}
+                    StepResult::Busy => {
+                        return Err(turso_core::LimboError::Busy);
+                    }
+                    StepResult::Interrupt => {}
                 }
             }
 
@@ -646,7 +651,10 @@ impl Interaction {
                     StepResult::Done => {
                         break;
                     }
-                    StepResult::Interrupt | StepResult::Busy => {}
+                    StepResult::Busy => {
+                        return Err(turso_core::LimboError::Busy);
+                    }
+                    StepResult::Interrupt => {}
                 }
             }
 

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -268,7 +268,9 @@ fn limbo_integrity_check(conn: &Arc<Connection>) -> Result<()> {
             StepResult::Done => {
                 break;
             }
-            StepResult::Busy => {}
+            StepResult::Busy => {
+                return Err(LimboError::Busy);
+            }
         }
     }
 


### PR DESCRIPTION
Although we don't support concurrency in the simulator yet (#2059), we do want to support it, and one good first step is not to make the simulator hang forever once any connection gets a `Busy` result from the VDBE