### PR TITLE
do not check rowid alias for null

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -553,6 +553,10 @@ pub fn translate_insert(
         .enumerate()
         .filter(|(_, col)| col.column.notnull)
     {
+        // if this is rowid alias - turso-db will emit NULL as a column value and always use rowid for the row as a column value
+        if col.column.is_rowid_alias {
+            continue;
+        }
         let target_reg = i + column_registers_start;
         program.emit_insn(Insn::HaltIfNull {
             target_reg,

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -380,3 +380,9 @@ do_execsql_test_on_specific_db {:memory:} negative-primary-integer-key {
 } {-2
 13}
 
+do_execsql_test_on_specific_db {:memory:} not-null-rowid-alias {
+    CREATE TABLE t(a INTEGER PRIMARY KEY NOT NULL, b);
+    insert into t values (1, 2);
+    select * from t;
+} {1|2}
+


### PR DESCRIPTION
Simple PR to check minor issue that `INTEGER PRIMARY KEY NOT NULL` (`NOT NULL` is redundant here obviously) will prevent user to insert anything to the table as rowid-alias column always set to null by `turso-db`