### PR TITLE
extensions/vtab: fix i32 being passed as i64 across FFI boundary

### DIFF
--- a/extensions/core/src/vtabs.rs
+++ b/extensions/core/src/vtabs.rs
@@ -412,7 +412,7 @@ impl Conn {
         };
         let arg_count = args.len() as i32;
         let args = args.as_ptr();
-        let last_insert_rowid = 0;
+        let last_insert_rowid: i64 = 0;
         if let ResultCode::OK = unsafe {
             (self._execute)(
                 self as *const _ as *mut Conn,


### PR DESCRIPTION
as nilskch points out in #1807, Rust 1.88.0 is stricter about alignment.

because rust integers default to `i32`, we were casting a pointer to an `i32` as a pointer to an `i64` causing a panic when dereferenced due to misalignment as rust expects it to be 8 byte aligned.