### PR TITLE
test/fuzz: fix rowid_seek_fuzz not being a proper fuzz test

### DIFF
--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -64,9 +64,19 @@ mod tests {
         let db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x INTEGER PRIMARY KEY)", false); // INTEGER PRIMARY KEY is a rowid alias, so an index is not created
         let sqlite_conn = rusqlite::Connection::open(db.path.clone()).unwrap();
 
+        let (mut rng, _seed) = rng_from_time_or_env();
+
+        let mut values: Vec<i32> = Vec::with_capacity(3000);
+        while values.len() < 3000 {
+            let val = rng.random_range(-100000..100000);
+            if !values.contains(&val) {
+                values.push(val);
+            }
+        }
         let insert = format!(
             "INSERT INTO t VALUES {}",
-            (1..100)
+            values
+                .iter()
                 .map(|x| format!("({x})"))
                 .collect::<Vec<_>>()
                 .join(", ")


### PR DESCRIPTION
The original `rowid_seek_fuzz` test had a design flaw: it inserted contiguous non-random integers (so not really fuzzing), which prevented issues such as the one fixed in #2065 from being discovered.

Further, the test has at some point also been neutered a bit by only inserting 100 values which makes the btree very small, hiding interactions between interior pages and neighboring leaf pages.

This should not be merged until #2065 is merged.