### PR TITLE
bench: add insert benchmark (batch sizes: 1,10,100)

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -271,9 +271,109 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
     group.finish();
 }
 
+fn bench_insert_rows(criterion: &mut Criterion) {
+    // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
+    let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
+
+    let mut group = criterion.benchmark_group("Insert rows in batches");
+
+    // Test different batch sizes
+    for batch_size in [1, 10, 100] {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("bench.db");
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io.clone(), db_path.to_str().unwrap(), false, false).unwrap();
+        let limbo_conn = db.connect().unwrap();
+
+        let mut stmt = limbo_conn
+            .query("CREATE TABLE test (id INTEGER, value TEXT)")
+            .unwrap()
+            .unwrap();
+
+        loop {
+            match stmt.step().unwrap() {
+                turso_core::StepResult::IO => {
+                    stmt.run_once().unwrap();
+                }
+                turso_core::StepResult::Done => {
+                    break;
+                }
+                turso_core::StepResult::Row => {
+                    unreachable!();
+                }
+                turso_core::StepResult::Interrupt | turso_core::StepResult::Busy => {
+                    unreachable!();
+                }
+            }
+        }
+
+        group.bench_function(format!("limbo_insert_{batch_size}_rows"), |b| {
+            let mut values = String::from("INSERT INTO test VALUES ");
+            for i in 0..batch_size {
+                if i > 0 {
+                    values.push(',');
+                }
+                values.push_str(&format!("({}, '{}')", i, format_args!("value_{i}")));
+            }
+            let mut stmt = limbo_conn.prepare(&values).unwrap();
+            b.iter(|| {
+                loop {
+                    match stmt.step().unwrap() {
+                        turso_core::StepResult::IO => {
+                            stmt.run_once().unwrap();
+                        }
+                        turso_core::StepResult::Done => {
+                            break;
+                        }
+                        turso_core::StepResult::Row => {
+                            unreachable!();
+                        }
+                        turso_core::StepResult::Interrupt | turso_core::StepResult::Busy => {
+                            unreachable!();
+                        }
+                    }
+                }
+                stmt.reset();
+            });
+        });
+
+        if enable_rusqlite {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let db_path = temp_dir.path().join("bench.db");
+            let sqlite_conn = rusqlite::Connection::open(db_path).unwrap();
+
+            // Create test table
+            sqlite_conn
+                .execute("CREATE TABLE test (id INTEGER, value TEXT)", [])
+                .unwrap();
+
+            group.bench_function(format!("sqlite_insert_{batch_size}_rows"), |b| {
+                let mut values = String::from("INSERT INTO test VALUES ");
+                for i in 0..batch_size {
+                    if i > 0 {
+                        values.push(',');
+                    }
+                    values.push_str(&format!("({}, '{}')", i, format_args!("value_{i}")));
+                }
+                let mut stmt = sqlite_conn.prepare(&values).unwrap();
+                b.iter(|| {
+                    let mut rows = stmt.raw_query();
+                    while let Some(row) = rows.next().unwrap() {
+                        black_box(row);
+                    }
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench_open, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count
+    targets = bench_open, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_insert_rows
 }
 criterion_main!(benches);


### PR DESCRIPTION
```
Insert rows in batches/limbo_insert_1_rows
                        time:   [344.71 µs 363.45 µs 379.31 µs]
Insert rows in batches/sqlite_insert_1_rows
                        time:   [575.12 µs 769.16 µs 983.30 µs]

Insert rows in batches/limbo_insert_10_rows
                        time:   [1.4964 ms 1.5694 ms 1.6334 ms]
Insert rows in batches/sqlite_insert_10_rows
                        time:   [510.79 µs 766.56 µs 1.0677 ms]

Insert rows in batches/limbo_insert_100_rows
                        time:   [5.5177 ms 5.6806 ms 5.8619 ms]
Insert rows in batches/sqlite_insert_100_rows
                        time:   [439.91 µs 879.43 µs 1.4260 ms]
```