### PR TITLE
bindings/js: support iterator, and more kinds of params

### DIFF
--- a/bindings/javascript/__test__/sync.spec.mjs
+++ b/bindings/javascript/__test__/sync.spec.mjs
@@ -84,7 +84,7 @@ dualTest.both("Statement.get() [no parameters]", async (t) => {
   t.deepEqual(stmt.raw().get(), [1, 'Alice', 'alice@example.org']);
 });
 
-dualTest.onlySqlitePasses("Statement.get() [positional]", async (t) => {
+dualTest.both("Statement.get() [positional]", async (t) => {
   const db = t.context.db;
 
   var stmt = 0;
@@ -101,7 +101,7 @@ dualTest.onlySqlitePasses("Statement.get() [positional]", async (t) => {
   t.is(stmt.get({ 1: 2 }).name, "Bob");
 });
 
-dualTest.onlySqlitePasses("Statement.get() [named]", async (t) => {
+dualTest.both("Statement.get() [named]", async (t) => {
   const db = t.context.db;
 
   var stmt = undefined;
@@ -132,7 +132,7 @@ dualTest.both("Statement.get() [raw]", async (t) => {
   t.deepEqual(stmt.raw().get(1), [1, "Alice", "alice@example.org"]);
 });
 
-dualTest.onlySqlitePasses("Statement.iterate() [empty]", async (t) => {
+dualTest.both("Statement.iterate() [empty]", async (t) => {
   const db = t.context.db;
 
   const stmt = db.prepare("SELECT * FROM users WHERE id = 0");

--- a/bindings/javascript/index.d.ts
+++ b/bindings/javascript/index.d.ts
@@ -44,4 +44,6 @@ export declare class Statement {
   static columns(): void
   bind(args?: Array<unknown> | undefined | null): Statement
 }
-export declare class IteratorStatement { }
+export declare class IteratorStatement {
+  [Symbol.iterator](): Iterator<unknown, void, void>
+}

--- a/bindings/javascript/wrapper.js
+++ b/bindings/javascript/wrapper.js
@@ -264,8 +264,11 @@ class Statement {
    *
    * @param bindParameters - The bind parameters for executing the statement.
    */
-  iterate(...bindParameters) {
-    return this.stmt.iterate(bindParameters.flat());
+  *iterate(...bindParameters) {
+    // revisit this solution when https://github.com/napi-rs/napi-rs/issues/2574 is fixed
+    for (const row of this.stmt.iterate(bindParameters.flat())) {
+      yield row;
+    }
   }
 
   /**


### PR DESCRIPTION
This PR fixes 3 tests that check param binding and iteration.

-----

as part of https://github.com/tursodatabase/turso/issues/1900