### PR TITLE
fix record header size calculations and incorrect assumptions

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -2547,7 +2547,7 @@ mod tests {
 
     #[test]
     fn test_calc_header_size() {
-        // Test 1-byte header size (0 to 127)
+        // Test 1-byte header size (serial type sizes 0 to 126)
         const MIN_SERIALTYPES_SIZE_FOR_1_BYTE_HEADER: usize = 0;
         assert_eq!(
             Record::calc_header_size(MIN_SERIALTYPES_SIZE_FOR_1_BYTE_HEADER),
@@ -2560,7 +2560,7 @@ mod tests {
             MAX_SERIALTYPES_SIZE_FOR_1_BYTE_HEADER + 1
         );
 
-        // Test 2-byte header size (128 to 16383)
+        // Test 2-byte header size (serial type sizes 127 to 16381)
         const MIN_SERIALTYPES_SIZE_FOR_2_BYTE_HEADER: usize =
             MAX_SERIALTYPES_SIZE_FOR_1_BYTE_HEADER + 1;
         assert_eq!(
@@ -2574,7 +2574,7 @@ mod tests {
             MAX_SERIALTYPES_SIZE_FOR_2_BYTE_HEADER + 2
         );
 
-        // Test 3-byte header size (16384 to 2097151)
+        // Test 3-byte header size (serial type sizes 16382 to 2097148)
         const MIN_SERIALTYPES_SIZE_FOR_3_BYTE_HEADER: usize =
             MAX_SERIALTYPES_SIZE_FOR_2_BYTE_HEADER + 1;
         assert_eq!(
@@ -2588,7 +2588,7 @@ mod tests {
             MAX_SERIALTYPES_SIZE_FOR_3_BYTE_HEADER + 3
         );
 
-        // Test 4-byte header size (2097152 to 268435455)
+        // Test 4-byte header size (serial type sizes 2097149 to 268435451)
         const MIN_SERIALTYPES_SIZE_FOR_4_BYTE_HEADER: usize =
             MAX_SERIALTYPES_SIZE_FOR_3_BYTE_HEADER + 1;
         assert_eq!(

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -393,3 +393,20 @@ do_execsql_test_on_specific_db {:memory:} rowid-overflow-random-generation {
     INSERT INTO q(y) VALUES (3);
     SELECT COUNT(*) FROM q;
 } {3}
+
+# regression test for incorrect processing of record header in the case of large text columns
+if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
+    do_execsql_test_on_specific_db {:memory:} large-text-index-seek {
+        CREATE TABLE t(x TEXT, y);
+        CREATE INDEX t_idx ON t(x);
+        INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'a', 1);
+        INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'b', 2);
+        INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'c', 3);
+        INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'd', 4);
+        INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'e', 5);
+        INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'f', 6);
+        INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'g', 7);
+        INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'h', 8);
+        SELECT COUNT(*) FROM t WHERE x >= replace(hex(zeroblob(100)), '00', 'a');
+    } {8}
+}


### PR DESCRIPTION
- remove assumptions that record header size fits into 1 byte or serial type fits into 1 byte
- add tests for record header size calculation

```sql
turso> CREATE TABLE t(x TEXT, y);
CREATE INDEX t_idx ON t(x);
INSERT INTO t VALUES (replace(zeroblob(1000), x'00', 'a') || 'a', 1); -- 1000 bytes of 'a'
INSERT INTO t VALUES (replace(zeroblob(1000), x'00', 'a') || 'b', 2);
INSERT INTO t VALUES (replace(zeroblob(1000), x'00', 'a') || 'c', 3);
INSERT INTO t VALUES (replace(zeroblob(1000), x'00', 'a') || 'd', 4);
INSERT INTO t VALUES (replace(zeroblob(1000), x'00', 'a') || 'e', 5);
INSERT INTO t VALUES (replace(zeroblob(1000), x'00', 'a') || 'f', 6);
INSERT INTO t VALUES (replace(zeroblob(1000), x'00', 'a') || 'g', 7);
INSERT INTO t VALUES (replace(zeroblob(1000), x'00', 'a') || 'h', 8);
SELECT COUNT(*) FROM t WHERE x >= replace(hex(zeroblob(100)), '00', 'a');
┌───────────┐
│ COUNT (*) │
├───────────┤
│         8 │
└───────────┘
```

Fixes #2096 
Fixes #2088