### PR TITLE
Fix page_count pragma

### DIFF
--- a/cli/commands/import.rs
+++ b/cli/commands/import.rs
@@ -40,58 +40,60 @@ impl<'a> ImportFile<'a> {
             args.table
         );
 
-        let table_exists = 'check: {
-            match self.conn.query(table_check_query) {
-                Ok(rows) => {
-                    if let Some(mut rows) = rows {
-                        loop {
-                            match rows.step() {
-                                Ok(turso_core::StepResult::Row) => {
-                                    break 'check true;
-                                }
-                                Ok(turso_core::StepResult::Done) => break 'check false,
-                                Ok(turso_core::StepResult::IO) => {
-                                    if let Err(e) = rows.run_once() {
+        let mut table_exists = false;
+        if self.conn.is_db_initialized() {
+            table_exists = 'check: {
+                match self.conn.query(table_check_query) {
+                    Ok(rows) => {
+                        if let Some(mut rows) = rows {
+                            loop {
+                                match rows.step() {
+                                    Ok(turso_core::StepResult::Row) => {
+                                        break 'check true;
+                                    }
+                                    Ok(turso_core::StepResult::Done) => break 'check false,
+                                    Ok(turso_core::StepResult::IO) => {
+                                        if let Err(e) = rows.run_once() {
+                                            let _ = self.writer.write_all(
+                                                format!("Error checking table existence: {e:?}\n")
+                                                    .as_bytes(),
+                                            );
+                                            return;
+                                        }
+                                    }
+                                    Ok(
+                                        turso_core::StepResult::Interrupt
+                                        | turso_core::StepResult::Busy,
+                                    ) => {
+                                        if let Err(e) = rows.run_once() {
+                                            let _ = self.writer.write_all(
+                                                format!("Error checking table existence: {e:?}\n")
+                                                    .as_bytes(),
+                                            );
+                                            return;
+                                        }
+                                    }
+                                    Err(e) => {
                                         let _ = self.writer.write_all(
                                             format!("Error checking table existence: {e:?}\n")
                                                 .as_bytes(),
                                         );
                                         return;
                                     }
-                                }
-                                Ok(
-                                    turso_core::StepResult::Interrupt
-                                    | turso_core::StepResult::Busy,
-                                ) => {
-                                    if let Err(e) = rows.run_once() {
-                                        let _ = self.writer.write_all(
-                                            format!("Error checking table existence: {e:?}\n")
-                                                .as_bytes(),
-                                        );
-                                        return;
-                                    }
-                                }
-                                Err(e) => {
-                                    let _ = self.writer.write_all(
-                                        format!("Error checking table existence: {e:?}\n")
-                                            .as_bytes(),
-                                    );
-                                    return;
                                 }
                             }
                         }
+                        false
                     }
-                    false
+                    Err(e) => {
+                        let _ = self.writer.write_all(
+                            format!("Error checking table existence: {e:?}\n").as_bytes(),
+                        );
+                        return;
+                    }
                 }
-                Err(e) => {
-                    let _ = self
-                        .writer
-                        .write_all(format!("Error checking table existence: {e:?}\n").as_bytes());
-                    return;
-                }
-            }
-        };
-
+            };
+        }
         let file = match File::open(args.file) {
             Ok(file) => file,
             Err(e) => {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1167,6 +1167,10 @@ impl Connection {
         let schema = Arc::make_mut(&mut *schema_ref);
         f(schema)
     }
+
+    pub fn is_db_initialized(&self) -> bool {
+        self._db.db_state.is_initialized()
+    }
 }
 
 pub struct Statement {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -874,7 +874,7 @@ impl Connection {
     #[cfg(feature = "fs")]
     pub fn wal_insert_begin(&self) -> Result<()> {
         let pager = self.pager.borrow();
-        match pager.io.block(|| pager.begin_read_tx())? {
+        match pager.begin_read_tx()? {
             result::LimboResult::Busy => return Err(LimboError::Busy),
             result::LimboResult::Ok => {}
         }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -156,7 +156,7 @@ impl Schema {
         let mut automatic_indices: HashMap<String, Vec<(String, usize)>> =
             HashMap::with_capacity(10);
 
-        if matches!(pager.io.block(|| pager.begin_read_tx())?, LimboResult::Busy) {
+        if matches!(pager.begin_read_tx()?, LimboResult::Busy) {
             return Err(LimboError::Busy);
         }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7111,7 +7111,7 @@ mod tests {
             tracing::info!("seed: {seed}");
             for insert_id in 0..inserts {
                 let do_validate = do_validate_btree || (insert_id % VALIDATE_INTERVAL == 0);
-                run_until_done(|| pager.begin_read_tx(), &pager).unwrap();
+                pager.begin_read_tx().unwrap();
                 run_until_done(|| pager.begin_write_tx(), &pager).unwrap();
                 let size = size(&mut rng);
                 let key = {
@@ -7163,7 +7163,7 @@ mod tests {
                         }
                     }
                 }
-                run_until_done(|| pager.begin_read_tx(), &pager).unwrap();
+                pager.begin_read_tx().unwrap();
                 // FIXME: add sorted vector instead, should be okay for small amounts of keys for now :P, too lazy to fix right now
                 cursor.move_to_root().unwrap();
                 let mut valid = true;
@@ -7193,7 +7193,7 @@ mod tests {
                 }
                 pager.end_read_tx().unwrap();
             }
-            run_until_done(|| pager.begin_read_tx(), &pager).unwrap();
+            pager.begin_read_tx().unwrap();
             tracing::info!(
                 "=========== btree ===========\n{}\n\n",
                 format_btree(pager.clone(), root_page, 0)

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -736,11 +736,6 @@ impl Pager {
     #[inline(always)]
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn begin_read_tx(&self) -> Result<IOResult<LimboResult>> {
-        // We allocate the first page lazily in the first transaction
-        match self.maybe_allocate_page1()? {
-            IOResult::Done(_) => {}
-            IOResult::IO => return Ok(IOResult::IO),
-        }
         let (result, changed) = self.wal.borrow_mut().begin_read_tx()?;
         if changed {
             // Someone else changed the database -> assume our page cache is invalid (this is default SQLite behavior, we can probably do better with more granular invalidation)

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -735,13 +735,13 @@ impl Pager {
 
     #[inline(always)]
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn begin_read_tx(&self) -> Result<IOResult<LimboResult>> {
+    pub fn begin_read_tx(&self) -> Result<LimboResult> {
         let (result, changed) = self.wal.borrow_mut().begin_read_tx()?;
         if changed {
             // Someone else changed the database -> assume our page cache is invalid (this is default SQLite behavior, we can probably do better with more granular invalidation)
             self.clear_page_cache();
         }
-        Ok(IOResult::Done(result))
+        Ok(result)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1961,7 +1961,7 @@ pub fn op_transaction(
         };
 
         if updated && matches!(current_state, TransactionState::None) {
-            if let LimboResult::Busy = return_if_io!(pager.begin_read_tx()) {
+            if let LimboResult::Busy = pager.begin_read_tx()? {
                 return Ok(InsnFunctionStepResult::Busy);
             }
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5841,8 +5841,8 @@ pub fn op_page_count(
         // TODO: implement temp databases
         todo!("temp databases not implemented yet");
     }
-    let count = header_accessor::get_database_size(pager)?.into();
-    state.registers[*dest] = Register::Value(Value::Integer(count));
+    let count = header_accessor::get_database_size(pager).unwrap_or(0);
+    state.registers[*dest] = Register::Value(Value::Integer(count as i64));
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -5902,11 +5902,11 @@ pub fn op_read_cookie(
         todo!("temp databases not implemented yet");
     }
     let cookie_value = match cookie {
-        Cookie::ApplicationId => header_accessor::get_application_id(pager)?.into(),
-        Cookie::UserVersion => header_accessor::get_user_version(pager)?.into(),
-        Cookie::SchemaVersion => header_accessor::get_schema_cookie(pager)?.into(),
+        Cookie::ApplicationId => header_accessor::get_application_id(pager).unwrap_or(0) as i64,
+        Cookie::UserVersion => header_accessor::get_user_version(pager).unwrap_or(0) as i64,
+        Cookie::SchemaVersion => header_accessor::get_schema_cookie(pager).unwrap_or(0) as i64,
         Cookie::LargestRootPageNumber => {
-            header_accessor::get_vacuum_mode_largest_root_page(pager)?.into()
+            header_accessor::get_vacuum_mode_largest_root_page(pager).unwrap_or(0) as i64
         }
         cookie => todo!("{cookie:?} is not yet implement for ReadCookie"),
     };

--- a/testing/pragma.test
+++ b/testing/pragma.test
@@ -104,10 +104,14 @@ do_execsql_test pragma-vtab-table-info-invalid-table {
   SELECT * FROM pragma_table_info WHERE arg = 'pekka'
 } {}
 
-# temporarily skip this test case. The issue is detailed in #1407
-#do_execsql_test_on_specific_db ":memory:" pragma-page-count-empty {
-#  PRAGMA page_count
-#} {0}
+do_execsql_test_on_specific_db ":memory:" pragma-page-count-empty {
+  PRAGMA page_count
+} {0}
+
+do_execsql_test_on_specific_db ":memory:" pragma-page-count-empty {
+  PRAGMA user_version=1;
+  PRAGMA page_count
+} {1}
 
 do_execsql_test_on_specific_db ":memory:" pragma-page-count-table {
   CREATE TABLE foo (bar);


### PR DESCRIPTION
Closes: #1415

### What this PR does
1. Removes database initialization from the `read_tx` function. 
2. Adds checks for database initialization when executing `.schema`, `.indexes`, `.tables` and `.import` commands, as they rely on `sqlite_schema` table.

### About the second issue
I think we have another solution for the second issue: create the `sqlite_schema` table in `Schema` only during page1 initialization,  rather than during `Schema` initialization. 
#### Pros
This approach has the advantage of unifying the logic for the `sqlite_schema` table with other user tables when running `select` statements
#### Cons

- we still need to check error codes for commands like  `.schema`.  
- this approach may increase the complexity of the `pager` implementation. 

I'd like to hear your thoughts and feedback.

