### PR TITLE
refactor: Changes CursorResult to IOResult

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -77,18 +77,18 @@ use std::{
 #[cfg(feature = "fs")]
 use storage::database::DatabaseFile;
 use storage::page_cache::DumbLruPageCache;
-pub use storage::pager::PagerCacheflushStatus;
-use storage::pager::{DB_STATE_INITIALIZED, DB_STATE_UNINITIALIZED};
+use storage::pager::{PagerCacheflushResult, DB_STATE_INITIALIZED, DB_STATE_UNINITIALIZED};
 pub use storage::{
     buffer_pool::BufferPool,
     database::DatabaseStorage,
     pager::PageRef,
     pager::{Page, Pager},
-    wal::{CheckpointMode, CheckpointResult, CheckpointStatus, Wal, WalFile, WalFileShared},
+    wal::{CheckpointMode, CheckpointResult, Wal, WalFile, WalFileShared},
 };
 use tracing::{instrument, Level};
 use translate::select::prepare_select_plan;
 use turso_sqlite3_parser::{ast, ast::Cmd, lexer::sql::Parser};
+use types::IOResult;
 pub use types::RefValue;
 pub use types::Value;
 use util::parse_schema_rows;
@@ -755,7 +755,7 @@ impl Connection {
     /// This will write the dirty pages to the WAL and then fsync the WAL.
     /// If the WAL size is over the checkpoint threshold, it will checkpoint the WAL to
     /// the database file and then fsync the database file.
-    pub fn cacheflush(&self) -> Result<PagerCacheflushStatus> {
+    pub fn cacheflush(&self) -> Result<IOResult<PagerCacheflushResult>> {
         if self.closed.get() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }

--- a/core/types.rs
+++ b/core/types.rs
@@ -1724,7 +1724,7 @@ fn compare_records_int(
 /// This function is an optimized version of `compare_records_generic()` for the
 /// common case where:
 /// - (a) The first field of the unpacked record is a string
-/// - (b) The serialized record's first field is also a string  
+/// - (b) The serialized record's first field is also a string
 /// - (c) The header size varint fits in a single byte (most records)
 ///
 /// This optimization avoids the overhead of generic field parsing by directly
@@ -1754,7 +1754,7 @@ fn compare_records_int(
 /// The function follows SQLite's string comparison semantics:
 ///
 /// 1. **Type checking**: Ensures both sides are strings, otherwise falls back
-/// 2. **String comparison**: Uses collation if provided, binary otherwise  
+/// 2. **String comparison**: Uses collation if provided, binary otherwise
 /// 3. **Sort order**: Applies ascending/descending order to comparison result
 /// 4. **Length comparison**: If strings are equal, compares lengths
 /// 5. **Remaining fields**: If first field is equal and more fields exist,
@@ -1886,7 +1886,7 @@ fn compare_records_string(
 /// # Arguments
 ///
 /// * `serialized` - The left-hand side record in serialized format
-/// * `unpacked` - The right-hand side record as an array of parsed values  
+/// * `unpacked` - The right-hand side record as an array of parsed values
 /// * `index_info` - Contains sort order information for each field
 /// * `collations` - Array of collation sequences for string comparisons
 /// * `skip` - Number of initial fields to skip (assumes caller verified equality)
@@ -2308,9 +2308,20 @@ impl Cursor {
 }
 
 #[derive(Debug)]
-pub enum CursorResult<T> {
-    Ok(T),
+pub enum IOResult<T> {
+    Done(T),
     IO,
+}
+
+/// Evaluate a Result<IOResult<T>>, if IO return IO.
+#[macro_export]
+macro_rules! return_if_io {
+    ($expr:expr) => {
+        match $expr? {
+            IOResult::Done(v) => v,
+            IOResult::IO => return Ok(IOResult::IO),
+        }
+    };
 }
 
 #[derive(Debug)]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2666,8 +2666,8 @@ pub fn seek_internal(
                         }
                     };
                         match cursor.seek(seek_key, *op)? {
-                            CursorResult::Ok(seek_result) => seek_result,
-                            CursorResult::IO => return Ok(SeekInternalResult::IO),
+                            IOResult::Done(seek_result) => seek_result,
+                            IOResult::IO => return Ok(SeekInternalResult::IO),
                         }
                     };
                     let found = match seek_result {
@@ -2712,8 +2712,8 @@ pub fn seek_internal(
                             SeekOp::LT { .. } | SeekOp::LE { .. } => cursor.prev()?,
                         };
                         match result {
-                            CursorResult::Ok(found) => found,
-                            CursorResult::IO => return Ok(SeekInternalResult::IO),
+                            IOResult::Done(found) => found,
+                            IOResult::IO => return Ok(SeekInternalResult::IO),
                         }
                     };
                     return Ok(if found {
@@ -2726,8 +2726,8 @@ pub fn seek_internal(
                     let mut cursor = state.get_cursor(cursor_id);
                     let cursor = cursor.as_btree_mut();
                     match cursor.last()? {
-                        CursorResult::Ok(()) => {}
-                        CursorResult::IO => return Ok(SeekInternalResult::IO),
+                        IOResult::Done(()) => {}
+                        IOResult::IO => return Ok(SeekInternalResult::IO),
                     }
                     // the MoveLast variant is only used for SeekOp::LT and SeekOp::LE when the seek condition is always true,
                     // so we have always found what we were looking for.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -42,9 +42,7 @@ use crate::{
 
 use crate::{
     storage::wal::CheckpointResult,
-    types::{
-        AggContext, Cursor, CursorResult, ExternalAggState, SeekKey, SeekOp, Value, ValueType,
-    },
+    types::{AggContext, Cursor, ExternalAggState, IOResult, SeekKey, SeekOp, Value, ValueType},
     util::{
         cast_real_to_integer, cast_text_to_integer, cast_text_to_numeric, cast_text_to_real,
         checked_cast_text_to_numeric, parse_schema_rows, RoundToPrecision,
@@ -95,8 +93,8 @@ use crate::{
 macro_rules! return_if_io {
     ($expr:expr) => {
         match $expr? {
-            CursorResult::Ok(v) => v,
-            CursorResult::IO => return Ok(InsnFunctionStepResult::IO),
+            IOResult::Done(v) => v,
+            IOResult::IO => return Ok(InsnFunctionStepResult::IO),
         }
     };
 }
@@ -1293,7 +1291,7 @@ pub fn op_last(
 /// - **Single-byte case**: Values 0-127 (0x00-0x7F) are returned immediately
 /// - **Two-byte case**: Values 128-16383 (0x80-0x3FFF) are handled inline
 /// - **Multi-byte case**: Larger values fall back to the full `read_varint()` implementation
-///   
+///
 /// This function is similar to `sqlite3GetVarint32`
 #[inline(always)]
 fn read_varint_fast(buf: &[u8]) -> Result<(u64, usize)> {
@@ -1396,10 +1394,10 @@ pub fn op_column(
                 let mut index_cursor = state.get_cursor(index_cursor_id);
                 let index_cursor = index_cursor.as_btree_mut();
                 match index_cursor.rowid()? {
-                    CursorResult::IO => {
+                    IOResult::IO => {
                         break 'd Some((index_cursor_id, table_cursor_id));
                     }
-                    CursorResult::Ok(rowid) => rowid,
+                    IOResult::Done(rowid) => rowid,
                 }
             };
             let mut table_cursor = state.get_cursor(table_cursor_id);
@@ -1408,8 +1406,8 @@ pub fn op_column(
                 SeekKey::TableRowId(rowid.unwrap()),
                 SeekOp::GE { eq_only: true },
             )? {
-                CursorResult::Ok(_) => None,
-                CursorResult::IO => Some((index_cursor_id, table_cursor_id)),
+                IOResult::Done(_) => None,
+                IOResult::IO => Some((index_cursor_id, table_cursor_id)),
             }
         };
         if let Some(deferred_seek) = deferred_seek {
@@ -2245,10 +2243,10 @@ pub fn op_row_id(
                 let mut index_cursor = state.get_cursor(index_cursor_id);
                 let index_cursor = index_cursor.as_btree_mut();
                 let record = match index_cursor.record()? {
-                    CursorResult::IO => {
+                    IOResult::IO => {
                         break 'd Some((index_cursor_id, table_cursor_id));
                     }
-                    CursorResult::Ok(record) => record,
+                    IOResult::Done(record) => record,
                 };
                 let record = record.as_ref().unwrap();
                 let mut record_cursor_ref = index_cursor.record_cursor.borrow_mut();
@@ -2262,8 +2260,8 @@ pub fn op_row_id(
             let mut table_cursor = state.get_cursor(table_cursor_id);
             let table_cursor = table_cursor.as_btree_mut();
             match table_cursor.seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true })? {
-                CursorResult::Ok(_) => None,
-                CursorResult::IO => Some((index_cursor_id, table_cursor_id)),
+                IOResult::Done(_) => None,
+                IOResult::IO => Some((index_cursor_id, table_cursor_id)),
             }
         };
         if let Some(deferred_seek) = deferred_seek {
@@ -2770,7 +2768,7 @@ pub fn seek_internal(
 ///   - `IdxLE`: "less than or equal" - equality should be treated as "less"
 ///   - `IdxGT`: "greater than" - equality should be treated as "less" (so condition fails)
 ///
-/// - **`IdxGE` and `IdxLT`**: Return `Ordering::Equal` (equivalent to `default_rc = 0`)  
+/// - **`IdxGE` and `IdxLT`**: Return `Ordering::Equal` (equivalent to `default_rc = 0`)
 ///   - When keys are equal, these operations should treat it as true equality
 ///   - `IdxGE`: "greater than or equal" - equality should be treated as "equal"
 ///   - `IdxLT`: "less than" - equality should be treated as "equal" (so condition fails)
@@ -5700,7 +5698,7 @@ pub fn op_destroy(
     // TODO not sure if should be BTreeCursor::new_table or BTreeCursor::new_index here or neither and just pass an emtpy vec
     let mut cursor = BTreeCursor::new(None, pager.clone(), *root, Vec::new(), 0);
     let former_root_page_result = cursor.btree_destroy()?;
-    if let CursorResult::Ok(former_root_page) = former_root_page_result {
+    if let IOResult::Done(former_root_page) = former_root_page_result {
         state.registers[*former_root_reg] =
             Register::Value(Value::Integer(former_root_page.unwrap_or(0) as i64));
     }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     translate::plan::TableReferences,
     types::{IOResult, RawSlice, TextRef},
     vdbe::execute::{OpIdxInsertState, OpInsertState, OpNewRowidState, OpSeekState},
-    PagerCacheflushStatus, RefValue,
+    RefValue,
 };
 
 use crate::{
@@ -506,7 +506,7 @@ impl Program {
             connection.wal_checkpoint_disabled.get(),
         )?;
         match cacheflush_status {
-            PagerCacheflushStatus::Done(status) => {
+            IOResult::Done(status) => {
                 if self.change_cnt_on {
                     self.connection.set_changes(self.n_change.get());
                 }
@@ -519,7 +519,7 @@ impl Program {
                 connection.transaction_state.replace(TransactionState::None);
                 *commit_state = CommitState::Ready;
             }
-            PagerCacheflushStatus::IO => {
+            IOResult::IO => {
                 tracing::trace!("Cacheflush IO");
                 *commit_state = CommitState::Committing;
                 return Ok(StepResult::IO);

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -27,14 +27,11 @@ pub mod sorter;
 use crate::{
     error::LimboError,
     function::{AggFunc, FuncCtx},
-    storage::{pager::PagerCacheflushStatus, sqlite3_ondisk::SmallVec},
+    storage::sqlite3_ondisk::SmallVec,
     translate::plan::TableReferences,
-    types::{RawSlice, TextRef},
-    vdbe::execute::OpIdxInsertState,
-    vdbe::execute::OpInsertState,
-    vdbe::execute::OpNewRowidState,
-    vdbe::execute::OpSeekState,
-    RefValue,
+    types::{IOResult, RawSlice, TextRef},
+    vdbe::execute::{OpIdxInsertState, OpInsertState, OpNewRowidState, OpSeekState},
+    PagerCacheflushStatus, RefValue,
 };
 
 use crate::{
@@ -159,13 +156,13 @@ pub enum StepResult {
 }
 
 /// If there is I/O, the instruction is restarted.
-/// Evaluate a Result<CursorResult<T>>, if IO return Ok(StepResult::IO).
+/// Evaluate a Result<IOResult<T>>, if IO return Ok(StepResult::IO).
 #[macro_export]
-macro_rules! return_if_io {
+macro_rules! return_step_if_io {
     ($expr:expr) => {
         match $expr? {
-            CursorResult::Ok(v) => v,
-            CursorResult::IO => return Ok(StepResult::IO),
+            IOResult::Ok(v) => v,
+            IOResult::IO => return Ok(StepResult::IO),
         }
     };
 }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -116,10 +116,10 @@ impl TempDatabase {
 pub(crate) fn do_flush(conn: &Arc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
     loop {
         match conn.cacheflush()? {
-            PagerCacheflushStatus::Done(_) => {
+            IOResult::Done(_) => {
                 break;
             }
-            PagerCacheflushStatus::IO => {
+            IOResult::IO => {
                 tmp_db.io.run_once()?;
             }
         }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -6,7 +6,8 @@ use tempfile::TempDir;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
-use turso_core::{Connection, Database, PagerCacheflushStatus, IO};
+use turso_core::types::IOResult;
+use turso_core::{Connection, Database, IO};
 
 #[allow(dead_code)]
 pub struct TempDatabase {


### PR DESCRIPTION
This PR unify the concept of a result that either have something done or yields to IO, into a single type.   