### PR TITLE
btree: fix interior cell replacement in btrees with depth >=3

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -190,6 +190,7 @@ enum DeleteState {
         post_balancing_seek_key: Option<DeleteSavepoint>,
     },
     InteriorNodeReplacement {
+        page: PageRef,
         cell_idx: usize,
         original_child_pointer: Option<u32>,
         post_balancing_seek_key: Option<DeleteSavepoint>,
@@ -4342,6 +4343,7 @@ impl BTreeCursor {
                     let delete_info = self.state.mut_delete_info().unwrap();
                     if !contents.is_leaf() {
                         delete_info.state = DeleteState::InteriorNodeReplacement {
+                            page: page.clone(),
                             cell_idx,
                             original_child_pointer,
                             post_balancing_seek_key,
@@ -4359,6 +4361,7 @@ impl BTreeCursor {
                 }
 
                 DeleteState::InteriorNodeReplacement {
+                    page,
                     cell_idx,
                     original_child_pointer,
                     post_balancing_seek_key,
@@ -4371,7 +4374,6 @@ impl BTreeCursor {
                     // Step 1: Move cursor to the largest key in the left subtree.
                     // The largest key is always in a leaf, and so this traversal may involvegoing multiple pages downwards,
                     // so we store the page we are currently on.
-                    let parent_page = self.stack.top();
                     return_if_io!(self.prev());
                     let (cell_payload, leaf_cell_idx) = {
                         let leaf_page_ref = self.stack.top();
@@ -4414,16 +4416,15 @@ impl BTreeCursor {
 
                     let leaf_page = self.stack.top();
 
-                    parent_page.get().set_dirty();
-                    self.pager.add_dirty(parent_page.get().get().id);
+                    page.set_dirty();
+                    self.pager.add_dirty(page.get().id);
                     leaf_page.get().set_dirty();
                     self.pager.add_dirty(leaf_page.get().get().id);
 
                     // Step 2: Replace the cell in the parent (interior) page.
                     {
-                        let parent_page_ref = parent_page.get();
-                        let parent_contents = parent_page_ref.get_contents();
-                        let parent_page_id = parent_page_ref.get().id;
+                        let parent_contents = page.get_contents();
+                        let parent_page_id = page.get().id;
                         let left_child_page = u32::from_be_bytes(
                             cell_payload[..4].try_into().expect("invalid cell payload"),
                         );


### PR DESCRIPTION
## Background

When a divider cell is deleted from an index interior page, the following algorithm is used:

1. Find predecessor: Move to largest key in left subtree of the current page. This is always a leaf page.
2. Create replacement: Convert this predecessor leaf cell to interior cell format, using original cell's left child page pointer
3. Replace: Drop original cell from parent page, insert replacement at same position
4. Cleanup: Delete the taken predecessor cell from the leaf page

<img width="845" height="266" alt="Screenshot 2025-07-16 at 10 39 18" src="https://github.com/user-attachments/assets/30517da4-a4dc-471e-a8f5-c27ba0979c86" />

## The faulty code leading to the bug

The error in our logic was that we always expected to only traverse down one level of the btree:

```rust
let parent_page = self.stack.parent_page().unwrap();
let leaf_page = self.stack.top();
```

This meant that when the deletion happened on say, level 1, and the replacement cell was taken from level 3, we actually inserted the replacement cell into level 2 instead of level 1.

## Manifestation of the bug in issue 2106

In #2106, this manifested as the following chain of pages, going from parent to children:

3 -> 111 -> 119

- Cell to be deleted was on page 3 (whose left pointer is 111)
- Going to the largest key in the left subtree meant traversing from 3 to 111 and then from 111 to 119
- a replacement cell was taken from 119
- incorrectly inserted into 111
- and its left child pointer also set as 111!
- now whenever page 111 wanted to go to its left child page, it would just traverse back to itself, eventually causing a crash because we have a hard limit of the number of pages on the page stack.

## The fix

The fix is quite trivial: store the page we are on before we start traversing down.

Closes #2106