### PR TITLE
sim: ignore fsync faults

### DIFF
--- a/simulator/runner/file.rs
+++ b/simulator/runner/file.rs
@@ -177,11 +177,8 @@ impl File for SimulatorFile {
     fn sync(&self, mut c: turso_core::Completion) -> Result<Arc<turso_core::Completion>> {
         self.nr_sync_calls.set(self.nr_sync_calls.get() + 1);
         if self.fault.get() {
-            tracing::debug!("sync fault");
-            self.nr_sync_faults.set(self.nr_sync_faults.get() + 1);
-            return Err(turso_core::LimboError::InternalError(
-                FAULT_ERROR_MSG.into(),
-            ));
+            tracing::debug!("ignoring sync fault because it causes false positives with current simulator design");
+            self.fault.set(false);
         }
         if let Some(latency) = self.generate_latency_duration() {
             let CompletionType::Sync(sync_completion) = &mut c.completion_type else {


### PR DESCRIPTION
`FaultyQuery` causes frequent false positives in simulator due to the following chain of events:

- we write rows and flush wal to disk
- inject fault during fsync which fails
- error is returned to caller, simulator thinks those rows dont exist because the query failed
- we reopen the database i.e. read the WAL back to memory from disk, it has those extra rows we think we didn't write
- assertion fails because table has more rows than simulator expected

More discussion about fsync behavior in issue #2091