### PR TITLE
make unixepoch to return i64

### DIFF
--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -349,19 +349,21 @@ fn to_julian_day_exact(dt: &NaiveDateTime) -> f64 {
     jd_days + jd_fraction
 }
 
-pub fn exec_unixepoch(time_value: &Value) -> Result<String> {
+pub fn exec_unixepoch(time_value: &Value) -> Result<Value> {
     let dt = parse_naive_date_time(time_value);
     match dt {
-        Some(dt) => Ok(get_unixepoch_from_naive_datetime(dt)),
-        None => Ok(String::new()),
+        Some(dt) if !is_leap_second(&dt) => {
+            Ok(Value::Integer(get_unixepoch_from_naive_datetime(dt)))
+        }
+        _ => Ok(Value::Null),
     }
 }
 
-fn get_unixepoch_from_naive_datetime(value: NaiveDateTime) -> String {
+fn get_unixepoch_from_naive_datetime(value: NaiveDateTime) -> i64 {
     if is_leap_second(&value) {
-        return String::new();
+        return 0;
     }
-    value.and_utc().timestamp().to_string()
+    value.and_utc().timestamp()
 }
 
 fn parse_naive_date_time(time_value: &Value) -> Option<NaiveDateTime> {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4161,15 +4161,13 @@ pub fn op_function(
             }
             ScalarFunc::UnixEpoch => {
                 if *start_reg == 0 {
-                    let unixepoch: String = exec_unixepoch(&Value::build_text("now"))?;
-                    state.registers[*dest] = Register::Value(Value::build_text(unixepoch));
+                    let result = exec_unixepoch(&Value::build_text("now"))?;
+                    state.registers[*dest] = Register::Value(result);
                 } else {
                     let datetime_value = &state.registers[*start_reg];
                     let unixepoch = exec_unixepoch(datetime_value.get_owned_value());
                     match unixepoch {
-                        Ok(time) => {
-                            state.registers[*dest] = Register::Value(Value::build_text(time))
-                        }
+                        Ok(time) => state.registers[*dest] = Register::Value(time),
                         Err(e) => {
                             return Err(LimboError::ParseError(format!(
                                 "Error encountered while parsing datetime value: {e}"


### PR DESCRIPTION
See no reason why it will be string

```
sqlite> select abs(unixepoch());
1752660221

turso> select abs(unixepoch());
┌────────────────────┐
│ abs (unixepoch ()) │
├────────────────────┤
│                0.0 │
└────────────────────┘
```