### PR TITLE
simulator: concurrent connection support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,6 +1921,7 @@ dependencies = [
  "clap",
  "dirs 6.0.0",
  "env_logger 0.10.2",
+ "futures",
  "hex",
  "itertools 0.14.0",
  "log",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -15,7 +15,7 @@ name = "limbo_sim"
 path = "main.rs"
 
 [dependencies]
-turso_core = { path = "../core", features = ["simulator"]}
+turso_core = { path = "../core", features = ["simulator"] }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 log = "0.4.20"
@@ -35,6 +35,7 @@ chrono = { version = "0.4.40", features = ["serde"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 anyhow.workspace = true
-turso_sqlite3_parser = { workspace = true, features = ["serde"]}
+turso_sqlite3_parser = { workspace = true, features = ["serde"] }
 hex = "0.4.3"
 itertools = "0.14.0"
+futures = "0.3.31"

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -129,6 +129,12 @@ pub struct SimulatorCLI {
     pub experimental_mvcc: bool,
     #[clap(long, help = "Disable experimental indexing feature")]
     pub disable_experimental_indexes: bool,
+    #[clap(
+        long,
+        help = "maximum number of connections to use",
+        default_value_t = 1
+    )]
+    pub max_connections: usize,
 }
 
 #[derive(Parser, Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -4,12 +4,11 @@ use turso_core::Value;
 
 use crate::{
     generation::{
-        pick_index,
         plan::{Interaction, InteractionPlanState, ResultSet},
-        Shadow as _,
+        Shadow,
     },
     model::{query::Query, table::SimValue},
-    runner::execution::ExecutionContinuation,
+    runner::{execution::ExecutionContinuation, future::FuturesByConnection},
     InteractionPlan,
 };
 
@@ -21,26 +20,30 @@ use super::{
 pub(crate) fn run_simulation(
     env: Arc<Mutex<SimulatorEnv>>,
     rusqlite_env: Arc<Mutex<SimulatorEnv>>,
-    plans: &mut [InteractionPlan],
+    plans: Vec<Arc<InteractionPlan>>,
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {
     tracing::info!("Executing database interaction plan...");
 
-    let mut states = plans
+    let states = plans
         .iter()
-        .map(|_| InteractionPlanState {
-            stack: vec![],
-            interaction_pointer: 0,
-            secondary_pointer: 0,
+        .map(|_| {
+            Arc::new(Mutex::new(InteractionPlanState {
+                stack: vec![],
+                interaction_pointer: 0,
+                secondary_pointer: 0,
+            }))
         })
         .collect::<Vec<_>>();
 
-    let mut rusqlite_states = plans
+    let rusqlite_states = plans
         .iter()
-        .map(|_| InteractionPlanState {
-            stack: vec![],
-            interaction_pointer: 0,
-            secondary_pointer: 0,
+        .map(|_| {
+            Arc::new(Mutex::new(InteractionPlanState {
+                stack: vec![],
+                interaction_pointer: 0,
+                secondary_pointer: 0,
+            }))
         })
         .collect::<Vec<_>>();
 
@@ -48,8 +51,8 @@ pub(crate) fn run_simulation(
         env,
         rusqlite_env,
         plans,
-        &mut states,
-        &mut rusqlite_states,
+        states,
+        rusqlite_states,
         last_execution,
     );
 
@@ -129,77 +132,98 @@ fn execute_query_rusqlite(
 pub(crate) fn execute_plans(
     env: Arc<Mutex<SimulatorEnv>>,
     rusqlite_env: Arc<Mutex<SimulatorEnv>>,
-    plans: &mut [InteractionPlan],
-    states: &mut [InteractionPlanState],
-    rusqlite_states: &mut [InteractionPlanState],
+    plans: Vec<Arc<InteractionPlan>>,
+    states: Vec<Arc<Mutex<InteractionPlanState>>>,
+    rusqlite_states: Vec<Arc<Mutex<InteractionPlanState>>>,
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {
     let mut history = ExecutionHistory::new();
     let now = std::time::Instant::now();
 
-    let mut env = env.lock().unwrap();
-    let mut rusqlite_env = rusqlite_env.lock().unwrap();
+    let (ticks, connections_len, max_time_simulation) = {
+        let env_guard = env.lock().unwrap();
+        (
+            env_guard.opts.ticks,
+            env_guard.connections.len(),
+            env_guard.opts.max_time_simulation,
+        )
+    };
+    let mut futures_by_connection = FuturesByConnection::new(connections_len);
+    for _tick in 0..ticks {
+        // Run every connection concurrently.
+        for connection_index in 0..connections_len {
+            let rusqlite_connection =
+                rusqlite_env.lock().unwrap().connections[connection_index].clone();
+            let connection = env.lock().unwrap().connections[connection_index].clone();
+            let state = states[connection_index].clone();
+            {
+                let state = state.lock().unwrap();
 
-    for _tick in 0..env.opts.ticks {
-        // Pick the connection to interact with
-        let connection_index = pick_index(env.connections.len(), &mut env.rng);
-        let state = &mut states[connection_index];
-
-        history.history.push(Execution::new(
-            connection_index,
-            state.interaction_pointer,
-            state.secondary_pointer,
-        ));
-        let mut last_execution = last_execution.lock().unwrap();
-        last_execution.connection_index = connection_index;
-        last_execution.interaction_index = state.interaction_pointer;
-        last_execution.secondary_index = state.secondary_pointer;
-        // Execute the interaction for the selected connection
-        match execute_plan(
-            &mut env,
-            &mut rusqlite_env,
-            connection_index,
-            plans,
-            states,
-            rusqlite_states,
-        ) {
-            Ok(_) => {}
-            Err(err) => {
-                return ExecutionResult::new(history, Some(err));
+                history.history.push(Execution::new(
+                    connection_index,
+                    state.interaction_pointer,
+                    state.secondary_pointer,
+                ));
+                let mut last_execution = last_execution.lock().unwrap();
+                last_execution.connection_index = connection_index;
+                last_execution.interaction_index = state.interaction_pointer;
+                last_execution.secondary_index = state.secondary_pointer;
             }
-        }
-        // Check if the maximum time for the simulation has been reached
-        if now.elapsed().as_secs() >= env.opts.max_time_simulation as u64 {
-            return ExecutionResult::new(
-                history,
-                Some(turso_core::LimboError::InternalError(
-                    "maximum time for simulation reached".into(),
-                )),
-            );
+            // Execute the interaction for the selected connection
+            if futures_by_connection.connection_without_future(connection_index) {
+                futures_by_connection.set_future(
+                    connection_index,
+                    Box::pin(execute_plan(
+                        env.clone(),
+                        rusqlite_env.clone(),
+                        rusqlite_connection,
+                        connection,
+                        plans[connection_index].clone(),
+                        state.clone(),
+                        rusqlite_states[connection_index].clone(),
+                        connection_index,
+                    )),
+                );
+            }
+            match futures_by_connection.poll_at(connection_index) {
+                Ok(_) => {}
+                Err(err) => {
+                    return ExecutionResult::new(history, Some(err));
+                }
+            }
+            // Check if the maximum time for the simulation has been reached
+            if now.elapsed().as_secs() >= max_time_simulation as u64 {
+                return ExecutionResult::new(
+                    history,
+                    Some(turso_core::LimboError::InternalError(
+                        "maximum time for simulation reached".into(),
+                    )),
+                );
+            }
         }
     }
 
     ExecutionResult::new(history, None)
 }
 
-fn execute_plan(
-    env: &mut SimulatorEnv,
-    rusqlite_env: &mut SimulatorEnv,
+#[allow(clippy::too_many_arguments)]
+async fn execute_plan(
+    env: Arc<Mutex<SimulatorEnv>>,
+    rusqlite_env: Arc<Mutex<SimulatorEnv>>,
+    rusqlite_conn: Arc<Mutex<SimConnection>>,
+    connection: Arc<Mutex<SimConnection>>,
+    plan: Arc<InteractionPlan>,
+    state: Arc<Mutex<InteractionPlanState>>,
+    rusqlite_state: Arc<Mutex<InteractionPlanState>>,
     connection_index: usize,
-    plans: &mut [InteractionPlan],
-    states: &mut [InteractionPlanState],
-    rusqlite_states: &mut [InteractionPlanState],
 ) -> turso_core::Result<()> {
-    let connection = &env.connections[connection_index];
-    let rusqlite_connection = &rusqlite_env.connections[connection_index];
-    let plan = &mut plans[connection_index];
-    let state = &mut states[connection_index];
-    let rusqlite_state = &mut rusqlite_states[connection_index];
-    if state.interaction_pointer >= plan.plan.len() {
+    let interaction_pointer = state.lock().unwrap().interaction_pointer;
+    let secondary_pointer = state.lock().unwrap().secondary_pointer;
+    if interaction_pointer >= plan.plan.len() {
         return Ok(());
     }
 
-    let interaction = &plan.plan[state.interaction_pointer].interactions()[state.secondary_pointer];
+    let interaction = &plan.plan[interaction_pointer].interactions()[secondary_pointer];
 
     tracing::debug!(
         "execute_plan(connection_index={}, interaction={})",
@@ -208,170 +232,175 @@ fn execute_plan(
     );
     tracing::debug!(
         "connection: {}, rusqlite_connection: {}",
-        connection,
-        rusqlite_connection
+        connection.lock().unwrap(),
+        rusqlite_conn.lock().unwrap()
     );
-    match (connection, rusqlite_connection) {
-        (SimConnection::Disconnected, SimConnection::Disconnected) => {
-            tracing::debug!("connecting {}", connection_index);
-            env.connect(connection_index);
-            rusqlite_env.connect(connection_index);
+    let both_connected = {
+        let conn = connection.lock().unwrap();
+        let rusqlite_conn = rusqlite_conn.lock().unwrap();
+        if conn.is_connected() != rusqlite_conn.is_connected() {
+            return Err(turso_core::LimboError::InternalError(
+                "limbo and rusqlite connections are not connected".into(),
+            ));
         }
-        (SimConnection::LimboConnection(_), SimConnection::SQLiteConnection(_)) => {
-            let limbo_result =
-                execute_interaction(env, connection_index, interaction, &mut state.stack);
-            let ruqlite_result = execute_interaction_rusqlite(
-                rusqlite_env,
-                connection_index,
-                interaction,
-                &mut rusqlite_state.stack,
-            );
-            match (limbo_result, ruqlite_result) {
-                (Ok(next_execution), Ok(next_execution_rusqlite)) => {
-                    if next_execution != next_execution_rusqlite {
-                        tracing::error!(
-                            "expected next executions of limbo and rusqlite do not match"
-                        );
-                        tracing::debug!(
-                            "limbo result: {:?}, rusqlite result: {:?}",
-                            next_execution,
-                            next_execution_rusqlite
-                        );
-                        return Err(turso_core::LimboError::InternalError(
-                            "expected next executions of limbo and rusqlite do not match".into(),
-                        ));
-                    }
+        conn.is_connected() && rusqlite_conn.is_connected()
+    };
+    if !both_connected {
+        env.lock().unwrap().connect(connection_index);
+        rusqlite_env.lock().unwrap().connect(connection_index);
+        return Ok(());
+    }
 
-                    let limbo_values = state.stack.last();
-                    let rusqlite_values = rusqlite_state.stack.last();
+    let limbo_result =
+        execute_interaction(env.clone(), connection.clone(), interaction, state.clone()).await;
+    let mut rusqlite_env = rusqlite_env.lock().unwrap();
+    let ruqlite_result = execute_interaction_rusqlite(
+        &mut rusqlite_env,
+        rusqlite_conn.clone(),
+        interaction,
+        &mut rusqlite_state.lock().unwrap().stack,
+    );
+    match (limbo_result, ruqlite_result) {
+        (Ok(next_execution), Ok(next_execution_rusqlite)) => {
+            if next_execution != next_execution_rusqlite {
+                tracing::error!("expected next executions of limbo and rusqlite do not match");
+                tracing::debug!(
+                    "limbo result: {:?}, rusqlite result: {:?}",
+                    next_execution,
+                    next_execution_rusqlite
+                );
+                return Err(turso_core::LimboError::InternalError(
+                    "expected next executions of limbo and rusqlite do not match".into(),
+                ));
+            }
+
+            let mut state = state.lock().unwrap();
+            let limbo_values = state.stack.last();
+            let rusqlite_state = rusqlite_state.lock().unwrap();
+            let rusqlite_values = rusqlite_state.stack.last();
+            match (limbo_values, rusqlite_values) {
+                (Some(limbo_values), Some(rusqlite_values)) => {
                     match (limbo_values, rusqlite_values) {
-                        (Some(limbo_values), Some(rusqlite_values)) => {
-                            match (limbo_values, rusqlite_values) {
-                                (Ok(limbo_values), Ok(rusqlite_values)) => {
-                                    if limbo_values != rusqlite_values {
-                                        tracing::error!("returned values from limbo and rusqlite results do not match");
-                                        let diff = limbo_values
-                                            .iter()
-                                            .zip(rusqlite_values.iter())
-                                            .enumerate()
-                                            .filter(|(_, (l, r))| l != r)
-                                            .collect::<Vec<_>>();
+                        (Ok(limbo_values), Ok(rusqlite_values)) => {
+                            if limbo_values != rusqlite_values {
+                                tracing::error!(
+                                    "returned values from limbo and rusqlite results do not match"
+                                );
+                                let diff = limbo_values
+                                    .iter()
+                                    .zip(rusqlite_values.iter())
+                                    .enumerate()
+                                    .filter(|(_, (l, r))| l != r)
+                                    .collect::<Vec<_>>();
 
-                                        let diff = diff
-                                            .iter()
-                                            .flat_map(|(i, (l, r))| {
-                                                let mut diffs = vec![];
-                                                for (j, (l, r)) in
-                                                    l.iter().zip(r.iter()).enumerate()
-                                                {
-                                                    if l != r {
-                                                        tracing::debug!(
-                                                            "difference at index {}, {}: {} != {}",
-                                                            i,
-                                                            j,
-                                                            l.to_string(),
-                                                            r.to_string()
-                                                        );
-                                                        diffs
-                                                            .push(((i, j), (l.clone(), r.clone())));
-                                                    }
-                                                }
-                                                diffs
-                                            })
-                                            .collect::<Vec<_>>();
-                                        tracing::debug!("limbo values {:?}", limbo_values);
-                                        tracing::debug!("rusqlite values {:?}", rusqlite_values);
-                                        tracing::debug!(
-                                            "differences: {}",
-                                            diff.iter()
-                                                .map(|((i, j), (l, r))| format!(
-                                                    "\t({i}, {j}): ({l}) != ({r})"
-                                                ))
-                                                .collect::<Vec<_>>()
-                                                .join("\n")
-                                        );
-                                        return Err(turso_core::LimboError::InternalError(
-                                            "returned values from limbo and rusqlite results do not match".into(),
-                                        ));
-                                    }
-                                }
-                                (Err(limbo_err), Err(rusqlite_err)) => {
-                                    tracing::warn!(
-                                        "limbo and rusqlite both fail, requires manual check"
-                                    );
-                                    tracing::warn!("limbo error {}", limbo_err);
-                                    tracing::warn!("rusqlite error {}", rusqlite_err);
-                                }
-                                (Ok(limbo_result), Err(rusqlite_err)) => {
-                                    tracing::error!("limbo and rusqlite results do not match, limbo returned values but rusqlite failed");
-                                    tracing::error!("limbo values {:?}", limbo_result);
-                                    tracing::error!("rusqlite error {}", rusqlite_err);
-                                    return Err(turso_core::LimboError::InternalError(
-                                        "limbo and rusqlite results do not match".into(),
-                                    ));
-                                }
-                                (Err(limbo_err), Ok(_)) => {
-                                    tracing::error!("limbo and rusqlite results do not match, limbo failed but rusqlite returned values");
-                                    tracing::error!("limbo error {}", limbo_err);
-                                    return Err(turso_core::LimboError::InternalError(
-                                        "limbo and rusqlite results do not match".into(),
-                                    ));
-                                }
+                                let diff = diff
+                                    .iter()
+                                    .flat_map(|(i, (l, r))| {
+                                        let mut diffs = vec![];
+                                        for (j, (l, r)) in l.iter().zip(r.iter()).enumerate() {
+                                            if l != r {
+                                                tracing::debug!(
+                                                    "difference at index {}, {}: {} != {}",
+                                                    i,
+                                                    j,
+                                                    l.to_string(),
+                                                    r.to_string()
+                                                );
+                                                diffs.push(((i, j), (l.clone(), r.clone())));
+                                            }
+                                        }
+                                        diffs
+                                    })
+                                    .collect::<Vec<_>>();
+                                tracing::debug!("limbo values {:?}", limbo_values);
+                                tracing::debug!("rusqlite values {:?}", rusqlite_values);
+                                tracing::debug!(
+                                    "differences: {}",
+                                    diff.iter()
+                                        .map(|((i, j), (l, r))| format!(
+                                            "\t({i}, {j}): ({l}) != ({r})"
+                                        ))
+                                        .collect::<Vec<_>>()
+                                        .join("\n")
+                                );
+                                return Err(turso_core::LimboError::InternalError(
+                                    "returned values from limbo and rusqlite results do not match"
+                                        .into(),
+                                ));
                             }
                         }
-                        (None, None) => {}
-                        _ => {
-                            tracing::error!("limbo and rusqlite results do not match");
+                        (Err(limbo_err), Err(rusqlite_err)) => {
+                            tracing::warn!("limbo and rusqlite both fail, requires manual check");
+                            tracing::warn!("limbo error {}", limbo_err);
+                            tracing::warn!("rusqlite error {}", rusqlite_err);
+                        }
+                        (Ok(limbo_result), Err(rusqlite_err)) => {
+                            tracing::error!("limbo and rusqlite results do not match, limbo returned values but rusqlite failed");
+                            tracing::error!("limbo values {:?}", limbo_result);
+                            tracing::error!("rusqlite error {}", rusqlite_err);
+                            return Err(turso_core::LimboError::InternalError(
+                                "limbo and rusqlite results do not match".into(),
+                            ));
+                        }
+                        (Err(limbo_err), Ok(_)) => {
+                            tracing::error!("limbo and rusqlite results do not match, limbo failed but rusqlite returned values");
+                            tracing::error!("limbo error {}", limbo_err);
                             return Err(turso_core::LimboError::InternalError(
                                 "limbo and rusqlite results do not match".into(),
                             ));
                         }
                     }
+                }
+                (None, None) => {}
+                _ => {
+                    tracing::error!("limbo and rusqlite results do not match");
+                    return Err(turso_core::LimboError::InternalError(
+                        "limbo and rusqlite results do not match".into(),
+                    ));
+                }
+            }
 
-                    // Move to the next interaction or property
-                    match next_execution {
-                        ExecutionContinuation::NextInteraction => {
-                            if state.secondary_pointer + 1
-                                >= plan.plan[state.interaction_pointer].interactions().len()
-                            {
-                                // If we have reached the end of the interactions for this property, move to the next property
-                                state.interaction_pointer += 1;
-                                state.secondary_pointer = 0;
-                            } else {
-                                // Otherwise, move to the next interaction
-                                state.secondary_pointer += 1;
-                            }
-                        }
-                        ExecutionContinuation::NextProperty => {
-                            // Skip to the next property
-                            state.interaction_pointer += 1;
-                            state.secondary_pointer = 0;
-                        }
+            // Move to the next interaction or property
+            match next_execution {
+                ExecutionContinuation::NextInteraction => {
+                    if state.secondary_pointer + 1
+                        >= plan.plan[state.interaction_pointer].interactions().len()
+                    {
+                        // If we have reached the end of the interactions for this property, move to the next property
+                        state.interaction_pointer += 1;
+                        state.secondary_pointer = 0;
+                    } else {
+                        // Otherwise, move to the next interaction
+                        state.secondary_pointer += 1;
                     }
                 }
-                (Err(err), Ok(_)) => {
-                    tracing::error!("limbo and rusqlite results do not match");
-                    tracing::error!("limbo error {}", err);
-                    return Err(err);
-                }
-                (Ok(val), Err(err)) => {
-                    tracing::error!("limbo and rusqlite results do not match");
-                    tracing::error!("limbo {:?}", val);
-                    tracing::error!("rusqlite error {}", err);
-                    return Err(err);
-                }
-                (Err(err), Err(err_rusqlite)) => {
-                    tracing::error!("limbo and rusqlite both fail, requires manual check");
-                    tracing::error!("limbo error {}", err);
-                    tracing::error!("rusqlite error {}", err_rusqlite);
-                    // todo: Previously, we returned an error here, but now we just log it.
-                    //       The problem is that the errors might be different, and we cannot
-                    //       just assume both of them being errors has the same semantics.
-                    // return Err(err);
+                ExecutionContinuation::NextProperty => {
+                    // Skip to the next property
+                    state.interaction_pointer += 1;
+                    state.secondary_pointer = 0;
                 }
             }
         }
-        _ => unreachable!("{} vs {}", connection, rusqlite_connection),
+        (Err(err), Ok(_)) => {
+            tracing::error!("limbo and rusqlite results do not match");
+            tracing::error!("limbo error {}", err);
+            return Err(err);
+        }
+        (Ok(val), Err(err)) => {
+            tracing::error!("limbo and rusqlite results do not match");
+            tracing::error!("limbo {:?}", val);
+            tracing::error!("rusqlite error {}", err);
+            return Err(err);
+        }
+        (Err(err), Err(err_rusqlite)) => {
+            tracing::error!("limbo and rusqlite both fail, requires manual check");
+            tracing::error!("limbo error {}", err);
+            tracing::error!("rusqlite error {}", err_rusqlite);
+            // todo: Previously, we returned an error here, but now we just log it.
+            //       The problem is that the errors might be different, and we cannot
+            //       just assume both of them being errors has the same semantics.
+            // return Err(err);
+        }
     }
 
     Ok(())
@@ -379,18 +408,19 @@ fn execute_plan(
 
 fn execute_interaction_rusqlite(
     env: &mut SimulatorEnv,
-    connection_index: usize,
+    connection: Arc<Mutex<SimConnection>>,
     interaction: &Interaction,
     stack: &mut Vec<ResultSet>,
 ) -> turso_core::Result<ExecutionContinuation> {
     tracing::trace!(
         "execute_interaction_rusqlite(connection_index={}, interaction={})",
-        connection_index,
+        1, // todo: add index to simconnetion
         interaction
     );
     match interaction {
         Interaction::Query(query) => {
-            let conn = match &mut env.connections[connection_index] {
+            let mut conn = connection.lock().unwrap();
+            let conn = match &mut *conn {
                 SimConnection::SQLiteConnection(conn) => conn,
                 SimConnection::LimboConnection(_) => unreachable!(),
                 SimConnection::Disconnected => unreachable!(),
@@ -420,7 +450,7 @@ fn execute_interaction_rusqlite(
             }
         }
         Interaction::Fault(_) => {
-            interaction.execute_fault(env, connection_index)?;
+            interaction.execute_fault(env, connection)?;
         }
         Interaction::FaultyQuery(_) => {
             unimplemented!("cannot implement faulty query in rusqlite, as we do not control IO");

--- a/simulator/runner/doublecheck.rs
+++ b/simulator/runner/doublecheck.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::{
-    generation::{pick_index, plan::InteractionPlanState},
-    runner::execution::ExecutionContinuation,
+    generation::plan::InteractionPlanState,
+    runner::{execution::ExecutionContinuation, future::FuturesByConnection},
     InteractionPlan,
 };
 
@@ -17,26 +17,30 @@ use super::{
 pub(crate) fn run_simulation(
     env: Arc<Mutex<SimulatorEnv>>,
     doublecheck_env: Arc<Mutex<SimulatorEnv>>,
-    plans: &mut [InteractionPlan],
+    plans: Vec<Arc<InteractionPlan>>,
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {
     tracing::info!("Executing database interaction plan...");
 
-    let mut states = plans
+    let states = plans
         .iter()
-        .map(|_| InteractionPlanState {
-            stack: vec![],
-            interaction_pointer: 0,
-            secondary_pointer: 0,
+        .map(|_| {
+            Arc::new(Mutex::new(InteractionPlanState {
+                stack: vec![],
+                interaction_pointer: 0,
+                secondary_pointer: 0,
+            }))
         })
         .collect::<Vec<_>>();
 
-    let mut doublecheck_states = plans
+    let doublecheck_states = plans
         .iter()
-        .map(|_| InteractionPlanState {
-            stack: vec![],
-            interaction_pointer: 0,
-            secondary_pointer: 0,
+        .map(|_| {
+            Arc::new(Mutex::new(InteractionPlanState {
+                stack: vec![],
+                interaction_pointer: 0,
+                secondary_pointer: 0,
+            }))
         })
         .collect::<Vec<_>>();
 
@@ -44,8 +48,8 @@ pub(crate) fn run_simulation(
         env.clone(),
         doublecheck_env.clone(),
         plans,
-        &mut states,
-        &mut doublecheck_states,
+        states,
+        doublecheck_states,
         last_execution,
     );
 
@@ -84,79 +88,97 @@ pub(crate) fn run_simulation(
 pub(crate) fn execute_plans(
     env: Arc<Mutex<SimulatorEnv>>,
     doublecheck_env: Arc<Mutex<SimulatorEnv>>,
-    plans: &mut [InteractionPlan],
-    states: &mut [InteractionPlanState],
-    doublecheck_states: &mut [InteractionPlanState],
+    plans: Vec<Arc<InteractionPlan>>,
+    states: Vec<Arc<Mutex<InteractionPlanState>>>,
+    doublecheck_states: Vec<Arc<Mutex<InteractionPlanState>>>,
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {
     let mut history = ExecutionHistory::new();
     let now = std::time::Instant::now();
 
-    let mut env = env.lock().unwrap();
-    let mut doublecheck_env = doublecheck_env.lock().unwrap();
+    let (ticks, connections_len, max_time_simulation) = {
+        let env_guard = env.lock().unwrap();
+        (
+            env_guard.opts.ticks,
+            env_guard.connections.len(),
+            env_guard.opts.max_time_simulation,
+        )
+    };
+    let mut futures_by_connection = FuturesByConnection::new(connections_len);
 
-    for _tick in 0..env.opts.ticks {
-        // Pick the connection to interact with
-        let connection_index = pick_index(env.connections.len(), &mut env.rng);
-        let state = &mut states[connection_index];
+    for _tick in 0..ticks {
+        for connection_index in 0..connections_len {
+            // Pick the connection to interact with
+            {
+                let state = states[connection_index].lock().unwrap();
 
-        history.history.push(Execution::new(
-            connection_index,
-            state.interaction_pointer,
-            state.secondary_pointer,
-        ));
-        let mut last_execution = last_execution.lock().unwrap();
-        last_execution.connection_index = connection_index;
-        last_execution.interaction_index = state.interaction_pointer;
-        last_execution.secondary_index = state.secondary_pointer;
-        // Execute the interaction for the selected connection
-        match execute_plan(
-            &mut env,
-            &mut doublecheck_env,
-            connection_index,
-            plans,
-            states,
-            doublecheck_states,
-        ) {
-            Ok(_) => {}
-            Err(err) => {
-                return ExecutionResult::new(history, Some(err));
+                history.history.push(Execution::new(
+                    connection_index,
+                    state.interaction_pointer,
+                    state.secondary_pointer,
+                ));
+                let mut last_execution = last_execution.lock().unwrap();
+                last_execution.connection_index = connection_index;
+                last_execution.interaction_index = state.interaction_pointer;
+                last_execution.secondary_index = state.secondary_pointer;
             }
-        }
-        // Check if the maximum time for the simulation has been reached
-        if now.elapsed().as_secs() >= env.opts.max_time_simulation as u64 {
-            return ExecutionResult::new(
-                history,
-                Some(turso_core::LimboError::InternalError(
-                    "maximum time for simulation reached".into(),
-                )),
-            );
+            if futures_by_connection.connection_without_future(connection_index) {
+                futures_by_connection.set_future(
+                    connection_index,
+                    Box::pin(execute_plan(
+                        env.clone(),
+                        doublecheck_env.clone(),
+                        connection_index,
+                        env.lock().unwrap().connections[connection_index].clone(),
+                        doublecheck_env.lock().unwrap().connections[connection_index].clone(),
+                        plans[connection_index].clone(),
+                        states[connection_index].clone(),
+                        doublecheck_states[connection_index].clone(),
+                    )),
+                );
+            }
+            // Execute the interaction for the selected connection
+            match futures_by_connection.poll_at(connection_index) {
+                Ok(_) => {}
+                Err(err) => {
+                    return ExecutionResult::new(history, Some(err));
+                }
+            }
+            // Check if the maximum time for the simulation has been reached
+            if now.elapsed().as_secs() >= max_time_simulation as u64 {
+                return ExecutionResult::new(
+                    history,
+                    Some(turso_core::LimboError::InternalError(
+                        "maximum time for simulation reached".into(),
+                    )),
+                );
+            }
         }
     }
 
     ExecutionResult::new(history, None)
 }
 
-fn execute_plan(
-    env: &mut SimulatorEnv,
-    doublecheck_env: &mut SimulatorEnv,
+#[allow(clippy::too_many_arguments)]
+async fn execute_plan(
+    env: Arc<Mutex<SimulatorEnv>>,
+    doublecheck_env: Arc<Mutex<SimulatorEnv>>,
     connection_index: usize,
-    plans: &mut [InteractionPlan],
-    states: &mut [InteractionPlanState],
-    doublecheck_states: &mut [InteractionPlanState],
+    connection: Arc<Mutex<SimConnection>>,
+    doublecheck_connection: Arc<Mutex<SimConnection>>,
+    plan: Arc<InteractionPlan>,
+    state: Arc<Mutex<InteractionPlanState>>,
+    doublecheck_state: Arc<Mutex<InteractionPlanState>>,
 ) -> turso_core::Result<()> {
-    let connection = &env.connections[connection_index];
-    let doublecheck_connection = &doublecheck_env.connections[connection_index];
-    let plan = &mut plans[connection_index];
-
-    let state = &mut states[connection_index];
-    let doublecheck_state = &mut doublecheck_states[connection_index];
-
-    if state.interaction_pointer >= plan.plan.len() {
+    let (interaction_pointer, secondary_pointer) = {
+        let state = state.lock().unwrap();
+        (state.interaction_pointer, state.secondary_pointer)
+    };
+    if interaction_pointer >= plan.plan.len() {
         return Ok(());
     }
 
-    let interaction = &plan.plan[state.interaction_pointer].interactions()[state.secondary_pointer];
+    let interaction = &plan.plan[interaction_pointer].interactions()[secondary_pointer];
 
     tracing::debug!(
         "execute_plan(connection_index={}, interaction={})",
@@ -165,141 +187,147 @@ fn execute_plan(
     );
     tracing::debug!(
         "connection: {}, doublecheck_connection: {}",
-        connection,
-        doublecheck_connection
+        connection.lock().unwrap(),
+        doublecheck_connection.lock().unwrap()
     );
-    match (connection, doublecheck_connection) {
-        (SimConnection::Disconnected, SimConnection::Disconnected) => {
-            tracing::debug!("connecting {}", connection_index);
-            env.connect(connection_index);
-            doublecheck_env.connect(connection_index);
+    let both_connected = {
+        let connection = connection.lock().unwrap();
+        let doublecheck_connection = doublecheck_connection.lock().unwrap();
+        if connection.is_connected() != doublecheck_connection.is_connected() {
+            return Err(turso_core::LimboError::InternalError(
+                format!(
+                    "connection and doublecheck are not both connected or disconnected {connection} vs {doublecheck_connection}"
+                )
+            ));
         }
-        (SimConnection::LimboConnection(_), SimConnection::LimboConnection(_)) => {
-            let limbo_result =
-                execute_interaction(env, connection_index, interaction, &mut state.stack);
-            let doublecheck_result = execute_interaction(
-                doublecheck_env,
-                connection_index,
-                interaction,
-                &mut doublecheck_state.stack,
-            );
-            match (limbo_result, doublecheck_result) {
-                (Ok(next_execution), Ok(next_execution_doublecheck)) => {
-                    if next_execution != next_execution_doublecheck {
-                        tracing::error!(
-                            "expected next executions of limbo and doublecheck do not match"
-                        );
-                        tracing::debug!(
-                            "limbo result: {:?}, doublecheck result: {:?}",
-                            next_execution,
-                            next_execution_doublecheck
-                        );
-                        return Err(turso_core::LimboError::InternalError(
-                            "expected next executions of limbo and doublecheck do not match".into(),
-                        ));
-                    }
+        true
+    };
 
-                    let limbo_values = state.stack.last();
-                    let doublecheck_values = doublecheck_state.stack.last();
-                    match (limbo_values, doublecheck_values) {
-                        (Some(limbo_values), Some(doublecheck_values)) => {
-                            match (limbo_values, doublecheck_values) {
-                                (Ok(limbo_values), Ok(doublecheck_values)) => {
-                                    if limbo_values != doublecheck_values {
-                                        tracing::error!("returned values from limbo and doublecheck results do not match");
-                                        tracing::debug!("limbo values {:?}", limbo_values);
-                                        tracing::debug!(
-                                            "doublecheck values {:?}",
-                                            doublecheck_values
-                                        );
-                                        return Err(turso_core::LimboError::InternalError(
+    if both_connected {
+        let limbo_result = execute_interaction(env, connection, interaction, state.clone()).await;
+        let doublecheck_result = execute_interaction(
+            doublecheck_env,
+            doublecheck_connection,
+            interaction,
+            doublecheck_state.clone(),
+        )
+        .await;
+        match (limbo_result, doublecheck_result) {
+            (Ok(next_execution), Ok(next_execution_doublecheck)) => {
+                if next_execution != next_execution_doublecheck {
+                    tracing::error!(
+                        "expected next executions of limbo and doublecheck do not match"
+                    );
+                    tracing::debug!(
+                        "limbo result: {:?}, doublecheck result: {:?}",
+                        next_execution,
+                        next_execution_doublecheck
+                    );
+                    return Err(turso_core::LimboError::InternalError(
+                        "expected next executions of limbo and doublecheck do not match".into(),
+                    ));
+                }
+
+                let mut state = state.lock().unwrap();
+                let doublecheck_state = doublecheck_state.lock().unwrap();
+                let limbo_values = state.stack.last();
+                let doublecheck_values = doublecheck_state.stack.last();
+                match (limbo_values, doublecheck_values) {
+                    (Some(limbo_values), Some(doublecheck_values)) => {
+                        match (limbo_values, doublecheck_values) {
+                            (Ok(limbo_values), Ok(doublecheck_values)) => {
+                                if limbo_values != doublecheck_values {
+                                    tracing::error!("returned values from limbo and doublecheck results do not match");
+                                    tracing::debug!("limbo values {:?}", limbo_values);
+                                    tracing::debug!("doublecheck values {:?}", doublecheck_values);
+                                    return Err(turso_core::LimboError::InternalError(
                                             "returned values from limbo and doublecheck results do not match".into(),
                                         ));
-                                    }
                                 }
-                                (Err(limbo_err), Err(doublecheck_err)) => {
-                                    if limbo_err.to_string() != doublecheck_err.to_string() {
-                                        tracing::error!(
-                                            "limbo and doublecheck errors do not match"
-                                        );
-                                        tracing::error!("limbo error {}", limbo_err);
-                                        tracing::error!("doublecheck error {}", doublecheck_err);
-                                        return Err(turso_core::LimboError::InternalError(
-                                            "limbo and doublecheck errors do not match".into(),
-                                        ));
-                                    }
-                                }
-                                (Ok(limbo_result), Err(doublecheck_err)) => {
-                                    tracing::error!("limbo and doublecheck results do not match, limbo returned values but doublecheck failed");
-                                    tracing::error!("limbo values {:?}", limbo_result);
+                            }
+                            (Err(limbo_err), Err(doublecheck_err)) => {
+                                if limbo_err.to_string() != doublecheck_err.to_string() {
+                                    tracing::error!("limbo and doublecheck errors do not match");
+                                    tracing::error!("limbo error {}", limbo_err);
                                     tracing::error!("doublecheck error {}", doublecheck_err);
                                     return Err(turso_core::LimboError::InternalError(
-                                        "limbo and doublecheck results do not match".into(),
-                                    ));
-                                }
-                                (Err(limbo_err), Ok(_)) => {
-                                    tracing::error!("limbo and doublecheck results do not match, limbo failed but doublecheck returned values");
-                                    tracing::error!("limbo error {}", limbo_err);
-                                    return Err(turso_core::LimboError::InternalError(
-                                        "limbo and doublecheck results do not match".into(),
+                                        "limbo and doublecheck errors do not match".into(),
                                     ));
                                 }
                             }
-                        }
-                        (None, None) => {}
-                        _ => {
-                            tracing::error!("limbo and doublecheck results do not match");
-                            return Err(turso_core::LimboError::InternalError(
-                                "limbo and doublecheck results do not match".into(),
-                            ));
+                            (Ok(limbo_result), Err(doublecheck_err)) => {
+                                tracing::error!("limbo and doublecheck results do not match, limbo returned values but doublecheck failed");
+                                tracing::error!("limbo values {:?}", limbo_result);
+                                tracing::error!("doublecheck error {}", doublecheck_err);
+                                return Err(turso_core::LimboError::InternalError(
+                                    "limbo and doublecheck results do not match".into(),
+                                ));
+                            }
+                            (Err(limbo_err), Ok(_)) => {
+                                tracing::error!("limbo and doublecheck results do not match, limbo failed but doublecheck returned values");
+                                tracing::error!("limbo error {}", limbo_err);
+                                return Err(turso_core::LimboError::InternalError(
+                                    "limbo and doublecheck results do not match".into(),
+                                ));
+                            }
                         }
                     }
+                    (None, None) => {}
+                    _ => {
+                        tracing::error!("limbo and doublecheck results do not match");
+                        return Err(turso_core::LimboError::InternalError(
+                            "limbo and doublecheck results do not match".into(),
+                        ));
+                    }
+                }
 
-                    // Move to the next interaction or property
-                    match next_execution {
-                        ExecutionContinuation::NextInteraction => {
-                            if state.secondary_pointer + 1
-                                >= plan.plan[state.interaction_pointer].interactions().len()
-                            {
-                                // If we have reached the end of the interactions for this property, move to the next property
-                                state.interaction_pointer += 1;
-                                state.secondary_pointer = 0;
-                            } else {
-                                // Otherwise, move to the next interaction
-                                state.secondary_pointer += 1;
-                            }
-                        }
-                        ExecutionContinuation::NextProperty => {
-                            // Skip to the next property
+                // Move to the next interaction or property
+                match next_execution {
+                    ExecutionContinuation::NextInteraction => {
+                        if state.secondary_pointer + 1
+                            >= plan.plan[state.interaction_pointer].interactions().len()
+                        {
+                            // If we have reached the end of the interactions for this property, move to the next property
                             state.interaction_pointer += 1;
                             state.secondary_pointer = 0;
+                        } else {
+                            // Otherwise, move to the next interaction
+                            state.secondary_pointer += 1;
                         }
                     }
-                }
-                (Err(err), Ok(_)) => {
-                    tracing::error!("limbo and doublecheck results do not match");
-                    tracing::error!("limbo error {}", err);
-                    return Err(err);
-                }
-                (Ok(val), Err(err)) => {
-                    tracing::error!("limbo and doublecheck results do not match");
-                    tracing::error!("limbo {:?}", val);
-                    tracing::error!("doublecheck error {}", err);
-                    return Err(err);
-                }
-                (Err(err), Err(err_doublecheck)) => {
-                    if err.to_string() != err_doublecheck.to_string() {
-                        tracing::error!("limbo and doublecheck errors do not match");
-                        tracing::error!("limbo error {}", err);
-                        tracing::error!("doublecheck error {}", err_doublecheck);
-                        return Err(turso_core::LimboError::InternalError(
-                            "limbo and doublecheck errors do not match".into(),
-                        ));
+                    ExecutionContinuation::NextProperty => {
+                        // Skip to the next property
+                        state.interaction_pointer += 1;
+                        state.secondary_pointer = 0;
                     }
                 }
             }
+            (Err(err), Ok(_)) => {
+                tracing::error!("limbo and doublecheck results do not match");
+                tracing::error!("limbo error {}", err);
+                return Err(err);
+            }
+            (Ok(val), Err(err)) => {
+                tracing::error!("limbo and doublecheck results do not match");
+                tracing::error!("limbo {:?}", val);
+                tracing::error!("doublecheck error {}", err);
+                return Err(err);
+            }
+            (Err(err), Err(err_doublecheck)) => {
+                if err.to_string() != err_doublecheck.to_string() {
+                    tracing::error!("limbo and doublecheck errors do not match");
+                    tracing::error!("limbo error {}", err);
+                    tracing::error!("doublecheck error {}", err_doublecheck);
+                    return Err(turso_core::LimboError::InternalError(
+                        "limbo and doublecheck errors do not match".into(),
+                    ));
+                }
+            }
         }
-        _ => unreachable!("{} vs {}", connection, doublecheck_connection),
+    } else {
+        tracing::debug!("connecting {}", connection_index);
+        env.lock().unwrap().connect(connection_index);
+        doublecheck_env.lock().unwrap().connect(connection_index);
     }
 
     Ok(())

--- a/simulator/runner/future.rs
+++ b/simulator/runner/future.rs
@@ -1,0 +1,88 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+};
+
+use turso_core::{LimboError, Result};
+
+type ConnectionFuture = Pin<Box<dyn Future<Output = Result<(), LimboError>>>>;
+pub(crate) struct FuturesByConnection {
+    futures: Vec<Option<ConnectionFuture>>,
+}
+
+impl FuturesByConnection {
+    pub(crate) fn new(connections_len: usize) -> Self {
+        Self {
+            futures: (0..connections_len).map(|_| None).collect(),
+        }
+    }
+    pub(crate) fn set_future(
+        &mut self,
+        connection_index: usize,
+        future: Pin<Box<dyn Future<Output = Result<(), LimboError>>>>,
+    ) {
+        self.futures[connection_index] = Some(future);
+    }
+
+    pub(crate) fn poll_at(&mut self, connection_index: usize) -> Result<()> {
+        if let Some(mut fut) = self.futures[connection_index].take() {
+            fn dummy_raw_waker() -> RawWaker {
+                fn no_op(_: *const ()) {}
+                fn clone(_: *const ()) -> RawWaker {
+                    dummy_raw_waker()
+                }
+                static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, no_op, no_op, no_op);
+                RawWaker::new(std::ptr::null(), &VTABLE)
+            }
+            let waker = unsafe { Waker::from_raw(dummy_raw_waker()) };
+            let mut cx = Context::from_waker(&waker);
+
+            // SAFETY: We know fut is a Pin<Box<impl Future>>, so we can get a mutable reference and poll it.
+            let poll_result = Future::poll(Pin::as_mut(&mut fut), &mut cx);
+            match poll_result {
+                Poll::Ready(res) => {
+                    tracing::trace!("execute_plan completed immediately: {:?}", res);
+                    self.futures[connection_index] = None;
+                    return res;
+                }
+                Poll::Pending => {
+                    tracing::trace!("execute_plan yielded (pending)");
+                    // Put the future back since it's still pending
+                    self.futures[connection_index] = Some(fut);
+                    return Ok(());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn connection_without_future(&self, connection_index: usize) -> bool {
+        self.futures[connection_index].is_none()
+    }
+}
+
+// Custom future to yield once
+pub(crate) struct YieldOnce {
+    yielded: bool,
+}
+
+impl std::future::Future for YieldOnce {
+    type Output = ();
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<()> {
+        if self.yielded {
+            std::task::Poll::Ready(())
+        } else {
+            self.yielded = true;
+            cx.waker().wake_by_ref();
+            std::task::Poll::Pending
+        }
+    }
+}
+
+pub(crate) async fn yield_once() {
+    YieldOnce { yielded: false }.await
+}

--- a/simulator/runner/mod.rs
+++ b/simulator/runner/mod.rs
@@ -7,5 +7,6 @@ pub mod env;
 pub mod execution;
 #[allow(dead_code)]
 pub mod file;
+pub mod future;
 pub mod io;
 pub mod watch;

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -1,11 +1,8 @@
 use std::sync::{Arc, Mutex};
 
 use crate::{
-    generation::{
-        pick_index,
-        plan::{Interaction, InteractionPlanState},
-    },
-    runner::execution::ExecutionContinuation,
+    generation::plan::{Interaction, InteractionPlanState},
+    runner::{execution::ExecutionContinuation, future::FuturesByConnection},
 };
 
 use super::{
@@ -15,18 +12,20 @@ use super::{
 
 pub(crate) fn run_simulation(
     env: Arc<Mutex<SimulatorEnv>>,
-    plans: &mut [Vec<Vec<Interaction>>],
+    plans: Vec<Arc<Vec<Vec<Interaction>>>>,
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {
-    let mut states = plans
+    let states = plans
         .iter()
-        .map(|_| InteractionPlanState {
-            stack: vec![],
-            interaction_pointer: 0,
-            secondary_pointer: 0,
+        .map(|_| {
+            Arc::new(Mutex::new(InteractionPlanState {
+                stack: vec![],
+                interaction_pointer: 0,
+                secondary_pointer: 0,
+            }))
         })
         .collect::<Vec<_>>();
-    let result = execute_plans(env.clone(), plans, &mut states, last_execution);
+    let result = execute_plans(env.clone(), plans, states, last_execution);
 
     let env = env.lock().unwrap();
     env.io.print_stats();
@@ -38,95 +37,124 @@ pub(crate) fn run_simulation(
 
 pub(crate) fn execute_plans(
     env: Arc<Mutex<SimulatorEnv>>,
-    plans: &mut [Vec<Vec<Interaction>>],
-    states: &mut [InteractionPlanState],
+    plans: Vec<Arc<Vec<Vec<Interaction>>>>,
+    states: Vec<Arc<Mutex<InteractionPlanState>>>,
     last_execution: Arc<Mutex<Execution>>,
 ) -> ExecutionResult {
     let mut history = ExecutionHistory::new();
     let now = std::time::Instant::now();
-    let mut env = env.lock().unwrap();
-    for _tick in 0..env.opts.ticks {
-        // Pick the connection to interact with
-        let connection_index = pick_index(env.connections.len(), &mut env.rng);
-        let state = &mut states[connection_index];
+    let (ticks, connections_len, max_time_simulation) = {
+        let env_guard = env.lock().unwrap();
+        (
+            env_guard.opts.ticks,
+            env_guard.connections.len(),
+            env_guard.opts.max_time_simulation,
+        )
+    };
+    let mut futures_by_connection = FuturesByConnection::new(connections_len);
+    for _tick in 0..ticks {
+        // Run every connection concurrently.
+        for connection_index in 0..connections_len {
+            let state = states[connection_index].clone();
+            let plan = plans[connection_index].clone();
+            let connection = env.lock().unwrap().connections[connection_index].clone();
+            {
+                let state = state.lock().unwrap();
 
-        history.history.push(Execution::new(
-            connection_index,
-            state.interaction_pointer,
-            state.secondary_pointer,
-        ));
-        let mut last_execution = last_execution.lock().unwrap();
-        last_execution.connection_index = connection_index;
-        last_execution.interaction_index = state.interaction_pointer;
-        last_execution.secondary_index = state.secondary_pointer;
-        // Execute the interaction for the selected connection
-        match execute_plan(&mut env, connection_index, plans, states) {
-            Ok(_) => {}
-            Err(err) => {
-                return ExecutionResult::new(history, Some(err));
+                history.history.push(Execution::new(
+                    connection_index,
+                    state.interaction_pointer,
+                    state.secondary_pointer,
+                ));
+                let mut last_execution = last_execution.lock().unwrap();
+                last_execution.connection_index = connection_index;
+                last_execution.interaction_index = state.interaction_pointer;
+                last_execution.secondary_index = state.secondary_pointer;
             }
-        }
-        // Check if the maximum time for the simulation has been reached
-        if now.elapsed().as_secs() >= env.opts.max_time_simulation as u64 {
-            return ExecutionResult::new(
-                history,
-                Some(turso_core::LimboError::InternalError(
-                    "maximum time for simulation reached".into(),
-                )),
-            );
+            // Execute the interaction for the selected connection
+            if futures_by_connection.connection_without_future(connection_index) {
+                futures_by_connection.set_future(
+                    connection_index,
+                    Box::pin(execute_plan(
+                        env.clone(),
+                        connection.clone(),
+                        plan.clone(),
+                        state.clone(),
+                    )),
+                );
+            }
+
+            match futures_by_connection.poll_at(connection_index) {
+                Ok(_) => {}
+                Err(err) => {
+                    return ExecutionResult::new(history, Some(err));
+                }
+            }
+            // Check if the maximum time for the simulation has been reached
+            if now.elapsed().as_secs() >= max_time_simulation as u64 {
+                return ExecutionResult::new(
+                    history,
+                    Some(turso_core::LimboError::InternalError(
+                        "maximum time for simulation reached".into(),
+                    )),
+                );
+            }
         }
     }
 
     ExecutionResult::new(history, None)
 }
 
-fn execute_plan(
-    env: &mut SimulatorEnv,
-    connection_index: usize,
-    plans: &mut [Vec<Vec<Interaction>>],
-    states: &mut [InteractionPlanState],
+async fn execute_plan(
+    env: Arc<Mutex<SimulatorEnv>>,
+    connection: Arc<Mutex<SimConnection>>,
+    plan: Arc<Vec<Vec<Interaction>>>,
+    state: Arc<Mutex<InteractionPlanState>>,
 ) -> turso_core::Result<()> {
-    let connection = &env.connections[connection_index];
-    let plan = &mut plans[connection_index];
-    let state = &mut states[connection_index];
-
-    if state.interaction_pointer >= plan.len() {
+    let interaction_pointer = state.lock().unwrap().interaction_pointer;
+    let secondary_pointer = state.lock().unwrap().secondary_pointer;
+    if interaction_pointer >= plan.len() {
         return Ok(());
     }
 
-    let interaction = &plan[state.interaction_pointer][state.secondary_pointer];
+    let interaction = &plan[interaction_pointer][secondary_pointer];
 
-    if let SimConnection::Disconnected = connection {
-        tracing::debug!("connecting {}", connection_index);
-        env.connections[connection_index] =
-            SimConnection::LimboConnection(env.db.connect().unwrap());
-    } else {
-        match execute_interaction(env, connection_index, interaction, &mut state.stack) {
-            Ok(next_execution) => {
-                tracing::debug!("connection {} processed", connection_index);
-                // Move to the next interaction or property
-                match next_execution {
-                    ExecutionContinuation::NextInteraction => {
-                        if state.secondary_pointer + 1 >= plan[state.interaction_pointer].len() {
-                            // If we have reached the end of the interactions for this property, move to the next property
-                            state.interaction_pointer += 1;
-                            state.secondary_pointer = 0;
-                        } else {
-                            // Otherwise, move to the next interaction
-                            state.secondary_pointer += 1;
-                        }
-                    }
-                    ExecutionContinuation::NextProperty => {
-                        // Skip to the next property
+    let is_connected = connection.lock().unwrap().is_connected();
+    if !is_connected {
+        let env = env.lock().unwrap();
+        let mut conn = connection.lock().unwrap();
+        tracing::debug!("connecting {}", conn);
+        *conn = SimConnection::LimboConnection(env.db.connect().unwrap());
+        return Ok(());
+    }
+
+    match execute_interaction(env.clone(), connection.clone(), interaction, state.clone()).await {
+        Ok(next_execution) => {
+            tracing::debug!("connection {} processed", 1); // todo: add index to simconnetion
+                                                           // Move to the next interaction or property
+            match next_execution {
+                ExecutionContinuation::NextInteraction => {
+                    let mut state = state.lock().unwrap();
+                    if state.secondary_pointer + 1 >= plan[state.interaction_pointer].len() {
+                        // If we have reached the end of the interactions for this property, move to the next property
                         state.interaction_pointer += 1;
                         state.secondary_pointer = 0;
+                    } else {
+                        // Otherwise, move to the next interaction
+                        state.secondary_pointer += 1;
                     }
                 }
+                ExecutionContinuation::NextProperty => {
+                    // Skip to the next property
+                    let mut state = state.lock().unwrap();
+                    state.interaction_pointer += 1;
+                    state.secondary_pointer = 0;
+                }
             }
-            Err(err) => {
-                tracing::error!("error {}", err);
-                return Err(err);
-            }
+        }
+        Err(err) => {
+            tracing::error!("error {}", err);
+            return Err(err);
         }
     }
 

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -251,7 +251,7 @@ impl InteractionPlan {
             std::panic::catch_unwind(|| {
                 run_simulation(
                     env.clone(),
-                    &mut [test_plan.clone()],
+                    vec![Arc::new(test_plan.clone())],
                     last_execution.clone(),
                 )
             }),


### PR DESCRIPTION
This commit adds support to run connections concurrently with option `--max_connections`, we achieve this with simple futures which we poll until they succeed to advance to next interaction for each connection/plan.

