### PR TITLE
cli: fix not being able to redirect traces to a file from inline query

### DIFF
--- a/cli/config/terminal.rs
+++ b/cli/config/terminal.rs
@@ -25,8 +25,8 @@ impl TerminalDetector {
 impl TerminalDetector {
     /// Detects terminal background using ANSI escape sequences on Unix systems
     pub fn detect_theme() -> TerminalTheme {
-        // Only works on interactive terminals
-        if !io::stdin().is_terminal() {
+        // Only works on interactive terminals where both stdin and stdout are terminals
+        if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
             return TerminalTheme::Unknown; // No colors for non-interactive
         }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -26,8 +26,7 @@ pub static HOME_DIR: LazyLock<PathBuf> =
 pub static HISTORY_FILE: LazyLock<PathBuf> = LazyLock::new(|| HOME_DIR.join(".limbo_history"));
 
 fn main() -> anyhow::Result<()> {
-    let mut app = app::Limbo::new()?;
-    let _guard = app.init_tracing()?;
+    let (mut app, _guard) = app::Limbo::new()?;
 
     if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
         let mut rl = Editor::with_config(rustyline_config())?;


### PR DESCRIPTION
doing e.g. `RUST_LOG=debug target/debug/tursodb foo.db 'SELECT * FROM bar' &> output.txt` didn't generate traces because the tracer was initialized after `app.first_run()`