### PR TITLE
rename operation_xxx to change_xxx to make naming more consistent

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1300,7 +1300,7 @@ pub fn emit_cdc_insns(
     after_record_reg: Option<usize>,
     table_name: &str,
 ) -> Result<()> {
-    // (operation_id INTEGER PRIMARY KEY AUTOINCREMENT, operation_time INTEGER, operation_type INTEGER, table_name TEXT, id, before BLOB, after BLOB)
+    // (change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB)
     let turso_cdc_registers = program.alloc_registers(7);
     program.emit_insn(Insn::Null {
         dest: turso_cdc_registers,
@@ -1323,12 +1323,12 @@ pub fn emit_cdc_insns(
         func: unixepoch_fn_ctx,
     });
 
-    let operation_type = match operation_mode {
+    let change_type = match operation_mode {
         OperationMode::INSERT => 1,
         OperationMode::UPDATE | OperationMode::SELECT => 0,
         OperationMode::DELETE => -1,
     };
-    program.emit_int(operation_type, turso_cdc_registers + 2);
+    program.emit_int(change_type, turso_cdc_registers + 2);
     program.mark_last_insn_constant();
 
     program.emit_string8(table_name.to_string(), turso_cdc_registers + 3);

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -478,7 +478,7 @@ pub const TURSO_CDC_DEFAULT_TABLE_NAME: &str = "turso_cdc";
 fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
     vec![
         ast::ColumnDefinition {
-            col_name: ast::Name("operation_id".to_string()),
+            col_name: ast::Name("change_id".to_string()),
             col_type: Some(ast::Type {
                 name: "INTEGER".to_string(),
                 size: None,
@@ -493,7 +493,7 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             }],
         },
         ast::ColumnDefinition {
-            col_name: ast::Name("operation_time".to_string()),
+            col_name: ast::Name("change_time".to_string()),
             col_type: Some(ast::Type {
                 name: "INTEGER".to_string(),
                 size: None,
@@ -501,7 +501,7 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             constraints: vec![],
         },
         ast::ColumnDefinition {
-            col_name: ast::Name("operation_type".to_string()),
+            col_name: ast::Name("change_type".to_string()),
             col_type: Some(ast::Type {
                 name: "INTEGER".to_string(),
                 size: None,

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -599,7 +599,7 @@ fn test_cdc_ignore_changes_in_cdc_table() {
         ]
     );
     conn1
-        .execute("DELETE FROM custom_cdc WHERE operation_id < 2")
+        .execute("DELETE FROM custom_cdc WHERE change_id < 2")
         .unwrap();
     let rows =
         replace_column_with_null(limbo_exec_rows(&db, &conn1, "SELECT * FROM custom_cdc"), 1);
@@ -768,10 +768,10 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
     conn2.execute("INSERT INTO t VALUES (3, 30)").unwrap();
     conn2.execute("INSERT INTO t VALUES (4, 40)").unwrap();
     conn1
-        .execute("DELETE FROM custom_cdc2 WHERE operation_id < 2")
+        .execute("DELETE FROM custom_cdc2 WHERE change_id < 2")
         .unwrap();
     conn2
-        .execute("DELETE FROM custom_cdc1 WHERE operation_id < 2")
+        .execute("DELETE FROM custom_cdc1 WHERE change_id < 2")
         .unwrap();
     let rows = limbo_exec_rows(&db, &conn1, "SELECT * FROM t");
     assert_eq!(


### PR DESCRIPTION
This PR renames CDC table column names to use "change"-centric terminology and avoid using `operation_xxx` column names.

Just a small refactoring to bring more consistency as `turso-db` refer to the feature as capture data **changes** - and there is no word operation here.