### PR TITLE
Async IO: registration of file descriptors

### DIFF
--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use tracing::{debug, trace};
 
-const ENTRIES: u32 = 128;
+const ENTRIES: u32 = 512;
 const SQPOLL_IDLE: u32 = 1000;
 
 #[derive(Debug, Error)]

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -58,6 +58,7 @@ impl UringIO {
     pub fn new() -> Result<Self> {
         let ring = match io_uring::IoUring::builder()
             .setup_single_issuer()
+            .setup_coop_taskrun()
             .setup_sqpoll(SQPOLL_IDLE)
             .build(ENTRIES)
         {

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -57,6 +57,7 @@ struct InnerUringIO {
 impl UringIO {
     pub fn new() -> Result<Self> {
         let ring = match io_uring::IoUring::builder()
+            .setup_single_issuer()
             .setup_sqpoll(SQPOLL_IDLE)
             .build(ENTRIES)
         {


### PR DESCRIPTION
### Async IO performance, part 0

Relatively small and focused PR that mainly does two things, will add a .md document of the proposed/planned improvements to the io_uring module to fully revamp our async IO.

1. **Registration of file descriptors.**

At startup, by calling `io_uring_register_files_sparse` we can allocate an array in shared kernel/user space by calling register_files_sparse which initializes each slot to `-1`, and when we open a file we call `io_uring_register_files_update`, providing an index into this array and `fd`. 

Then for the IO submission, we can reference the index into this array instead of the fd, saving the kernel the work of looking up the fd in the process file table, incrementing the reference count, doing the operation, then finally decrementing the refcount. Instead the kernel can just index into the array and do the operation.

This especially provides an improvement for cases like this, where files are open for long periods of time, which the kernel will perform many operations on.

The eventual goal of this, is to use Fixed read/write operations, where both the file descriptor and the underlying buffer is registered with the kernel. There is another branch continuing this work, that introduces a buffer pool that memlock's one large 32MB arena mmap and tries to use that wherever possible. 

These Fixed operations are essentially the "holy grail" of io_uring performance (for file operations).


2. **!Vectored IO**
This is kind of backwards, because the goal is to indeed implement proper vectored IO and I'm removing some of the plumbing in this PR, but currently we have been using `Writev`/`Readv`, while never submitting > 1 iovec at a time.

Writes to the WAL, especially, would benefit immensely from vectored IO, as it is append-only and therefore all writes are contiguous. Regular checkpointing/cache flushing to disk can also be adapted to aggregate these writes and submit many in a single system call/opcode. 
Until this is implemented, the bookkeeping and iovecs are unnecessary noise/overhead, so let's temporarily remove them and revert to normal `read`/`write` until they are needed and it can be designed from scratch.

3. **Flags**
`setup_single_issuer` hints to the kernel that `IOURING_ENTER` calls will all be sent from a single thread, and `setup_coop_taskrun` removes some unnecessary kernel interrupts for providing cqe's which most single threaded applications do not need. Both these flags demonstrate modest improvement of performance.