### PR TITLE
page cache: temporarily increase default size until WAL spill is implemented

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -5,7 +5,9 @@ use tracing::{debug, trace};
 
 use super::pager::PageRef;
 
-const DEFAULT_PAGE_CACHE_SIZE_IN_PAGES: usize = 2000;
+/// FIXME: https://github.com/tursodatabase/turso/issues/1661
+const DEFAULT_PAGE_CACHE_SIZE_IN_PAGES_MAKE_ME_SMALLER_ONCE_WAL_SPILL_IS_IMPLEMENTED: usize =
+    100000;
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone)]
 pub struct PageCacheKey {
@@ -505,7 +507,9 @@ impl DumbLruPageCache {
 
 impl Default for DumbLruPageCache {
     fn default() -> Self {
-        DumbLruPageCache::new(DEFAULT_PAGE_CACHE_SIZE_IN_PAGES)
+        DumbLruPageCache::new(
+            DEFAULT_PAGE_CACHE_SIZE_IN_PAGES_MAKE_ME_SMALLER_ONCE_WAL_SPILL_IS_IMPLEMENTED,
+        )
     }
 }
 


### PR DESCRIPTION
This unblocks proper testing in simulator where esp. with indexes enabled, by far the most common reason for sim failure is cache being full.