### PR TITLE
translate/create index: fix wrong collations

### DIFF
--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -117,7 +117,7 @@ pub fn translate_create_index(
         cursor_id: sorter_cursor_id,
         columns: columns.len(),
         order,
-        collations: tbl.column_collations(),
+        collations: idx.columns.iter().map(|c| c.collation).collect(),
     });
     let content_reg = program.alloc_register();
     program.emit_insn(Insn::OpenPseudo {


### PR DESCRIPTION
We were passing the table columns' collations (all of them) in order, instead of the index column collations. Two issues:

1. This is wrong
2. There's now an assertion in the Sorter that actually panics if the length of sort order and collations is not the same