### PR TITLE
improve handling of double quotes

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -659,6 +659,9 @@ impl Limbo {
                         let _ = self.write_fmt(format_args!("/****** ERROR: {e} ******/"));
                     }
                 }
+                Command::DbConfig(_args) => {
+                    let _ = self.writeln("dbconfig currently ignored");
+                }
                 Command::ListVfs => {
                     let _ = self.writeln("Available VFS modules:");
                     self.conn.list_vfs().iter().for_each(|v| {

--- a/cli/commands/args.rs
+++ b/cli/commands/args.rs
@@ -125,6 +125,19 @@ pub struct TimerArgs {
     pub mode: TimerMode,
 }
 
+#[derive(Debug, ValueEnum, Clone)]
+pub enum DbConfigMode {
+    On,
+    Off,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct DbConfigArgs {
+    pub config: Option<String>,
+    #[arg(value_enum)]
+    pub mode: Option<DbConfigMode>,
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct HeadersArgs {
     pub mode: HeadersMode,

--- a/cli/commands/mod.rs
+++ b/cli/commands/mod.rs
@@ -2,8 +2,9 @@ pub mod args;
 pub mod import;
 
 use args::{
-    CwdArgs, EchoArgs, ExitArgs, HeadersArgs, IndexesArgs, LoadExtensionArgs, NullValueArgs,
-    OpcodesArgs, OpenArgs, OutputModeArgs, SchemaArgs, SetOutputArgs, TablesArgs, TimerArgs,
+    CwdArgs, DbConfigArgs, EchoArgs, ExitArgs, HeadersArgs, IndexesArgs, LoadExtensionArgs,
+    NullValueArgs, OpcodesArgs, OpenArgs, OutputModeArgs, SchemaArgs, SetOutputArgs, TablesArgs,
+    TimerArgs,
 };
 use clap::Parser;
 use import::ImportArgs;
@@ -69,6 +70,9 @@ pub enum Command {
     LoadExtension(LoadExtensionArgs),
     /// Dump the current database as a list of SQL statements
     Dump,
+    /// Print or set the current configuration for the database. Currently ignored.
+    #[command(name = "dbconfig", display_name = ".dbconfig")]
+    DbConfig(DbConfigArgs),
     /// List vfs modules available
     #[command(name = "vfslist", display_name = ".vfslist")]
     ListVfs,

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -410,3 +410,51 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
         SELECT COUNT(*) FROM t WHERE x >= replace(hex(zeroblob(100)), '00', 'a');
     } {8}
 }
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} double-quote-string-literals {
+    .dbconfig dqs_dml on
+    CREATE TABLE test (id INTEGER, name TEXT);
+    INSERT INTO test (id, name) VALUES (1, "Dave");
+    INSERT INTO test (id,name) VALUES (2, 'Alice');
+    SELECT * FROM test ORDER BY id;
+} {1|Dave
+2|Alice}
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} mixed-quote-types {
+    .dbconfig dqs_dml on
+    CREATE TABLE mixed (a TEXT, b TEXT, c TEXT);
+    INSERT INTO mixed (a,b,c) VALUES ("double", 'single', "another");
+    SELECT * FROM mixed;
+} {double|single|another}
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} double-quote-regression-original-case {
+    .dbconfig dqs_dml on
+    CREATE TABLE users (
+        id INTEGER,
+        name TEXT,
+        email TEXT
+    );
+    INSERT INTO users (name) values ("Dave");
+    SELECT name FROM users;
+} {Dave}
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} double-quote-multiple-rows {
+    .dbconfig dqs_dml on
+    CREATE TABLE items (id INTEGER, description TEXT, category TEXT);
+    INSERT INTO items (id, description, category) VALUES
+        (1, "First_item", "category_a"),
+        (2, 'Second_item', "category_b"),
+        (3, "Third_item", 'category_c');
+    SELECT id, description, category FROM items ORDER BY id;
+} {1|First_item|category_a
+2|Second_item|category_b
+3|Third_item|category_c}
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} double-quote-inner-quotes-preservation {
+    .dbconfig dqs_dml on
+    CREATE TABLE inner_quotes_test (id INTEGER, content TEXT);
+    INSERT INTO inner_quotes_test VALUES (1, '"foo"');
+    INSERT INTO inner_quotes_test VALUES (2, "'bar'");
+    SELECT id, content FROM inner_quotes_test ORDER BY id;
+} {1|"foo"
+2|'bar'}

--- a/testing/select.test
+++ b/testing/select.test
@@ -617,3 +617,20 @@ do_execsql_test_on_specific_db {:memory:} select-no-match-in-leaf-page {
 2
 2}
 
+# Regression tests for double-quoted strings in SELECT statements
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} select-double-quotes-values {
+    .dbconfig dqs_dml on
+    SELECT * FROM (VALUES ("select", "test"), ("double", "quotes"));
+} {select|test
+double|quotes}
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} select-double-quotes-no-column {
+    .dbconfig dqs_dml on
+    SELECT "first"
+} {first}
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} select-double-quotes-literal {
+    .dbconfig dqs_dml on
+    SELECT "literal_string" AS col;
+} {literal_string}
+

--- a/testing/values.test
+++ b/testing/values.test
@@ -26,3 +26,25 @@ do_execsql_test values-in-join {
   select * from (values(1, 2)) join (values(3, 4), (5, 6));
 } {1|2|3|4
   1|2|5|6};
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} values-double-quotes-simple {
+    .dbconfig dqs_dml on
+    VALUES ("double_quoted_string");
+} {double_quoted_string}
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} values-double-quotes-multiple {
+    .dbconfig dqs_dml on
+    VALUES ("first", "second"), ("third", "fourth");
+} {first|second
+third|fourth}
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} values-mixed-quotes {
+    .dbconfig dqs_dml on
+    VALUES ("double", 'single'), ('single', "double");
+} {double|single
+single|double}
+
+do_execsql_test_skip_lines_on_specific_db 1 {:memory:} values-double-quotes-subquery {
+    .dbconfig dqs_dml on
+    SELECT * FROM (VALUES ("subquery_string"));
+} {subquery_string}


### PR DESCRIPTION
I ended up hitting #1974 today and wanted to fix it. I worked with Claude to generate a more comprehensive set of queries that could fail aside from just the insert query described in the issue. He got most of them right - lots of cases were indeed failing. The ones that were gibberish, he told me I was absolutely right for pointing out they were bad.

But alas. With the test cases generated, we can work on fixing it. The place where the assertion was hit, all we need to do there is return true (but we assert that this is indeed a string literal, it shouldn't be anything else at this point).

There are then just a couple of places where we need to make sure we handle double quotes correctly. We already tested for single quotes in a couple of places, but never for double quotes.

There is one funny corner case where you can just select "col" from tbl, and if there is no column "col" on the table, that is treated as a string literal. We handle that too.

Fixes #1974