### PR TITLE
sim: show seed in 'execute_interaction()' trace

### DIFF
--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -173,7 +173,7 @@ pub(crate) enum ExecutionContinuation {
     NextProperty,
 }
 
-#[instrument(skip(env, interaction, stack), fields(interaction = %interaction))]
+#[instrument(skip(env, interaction, stack), fields(seed = %env.opts.seed, interaction = %interaction))]
 pub(crate) fn execute_interaction(
     env: &mut SimulatorEnv,
     connection_index: usize,


### PR DESCRIPTION
This helps e.g. when you hit some infinite loop