### PR TITLE
Fix parent page stack location after interior node replacement

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -680,6 +680,8 @@ impl BTreeCursor {
             if self.stack.current_cell_index() == i32::MAX && !self.going_upwards {
                 let rightmost_pointer = contents.rightmost_pointer();
                 if let Some(rightmost_pointer) = rightmost_pointer {
+                    let past_rightmost_pointer = cell_count as i32 + 1;
+                    self.stack.set_cell_index(past_rightmost_pointer);
                     self.stack
                         .push_backwards(self.read_page(rightmost_pointer as usize)?);
                     continue;
@@ -4472,7 +4474,7 @@ impl BTreeCursor {
                     // Step 1: Move cursor to the largest key in the left subtree.
                     // The largest key is always in a leaf, and so this traversal may involvegoing multiple pages downwards,
                     // so we store the page we are currently on.
-                    return_if_io!(self.prev());
+                    return_if_io!(self.get_prev_record()); // avoid calling prev() because it internally calls restore_context() which may cause unintended behavior.
                     let (cell_payload, leaf_cell_idx) = {
                         let leaf_page_ref = self.stack.top();
                         let leaf_page = leaf_page_ref.get();


### PR DESCRIPTION
Another fix extracted from running simulations on the #1988 branch.

## What

When interior cell replacement happens as described in #2108, we use the `cursor.prev()` method to locate the largest key in the left subtree.

There was an error during backwards traversal in the `get_prev_record()` method where the parent's cell index was set as `i32::MAX` but not properly set to `cell_count + 1` (indicating that rightmost pointer has been visited).

This meant that if the child page we took the replacement cell from underflowed and needed balancing, the parent page would now have `i32::MAX` as its cell index and crash at the point where we determine based on the parent page which page is going to undergo balancing.

## Fix

This PR fixes the issue by setting the cell index of the parent properly when visiting the rightmost child. This way the balance procedure will correctly detect that the rightmost child page is going to undergo balancing.

### Trivia

The reason `i32::MAX` is used is that the cell count of the page is not necessarily known at the time it is pushed to the stack.