### PR TITLE
sorter: fix sorter panic on SortedChunkIOState::WaitingForRead

### DIFF
--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -149,7 +149,7 @@ impl Sorter {
                     // Write complete, we can now read from the chunk.
                     chunk.read()?;
                 }
-                SortedChunkIOState::WaitingForWrite => {
+                SortedChunkIOState::WaitingForWrite | SortedChunkIOState::WaitingForRead => {
                     all_read_complete = false;
                 }
                 SortedChunkIOState::ReadEOF | SortedChunkIOState::ReadComplete => {}


### PR DESCRIPTION
Closes #2165 

The following sequence of events is possible:

- init_chunk_heap() called
- flush() gets called, and all chunks start writing to disk
- chunk A status is WriteComplete, so chunk.read() gets called on chunk A
- chunk A sets its status to WaitingForRead
- some other chunk B is still in WaitingForWrite status after flush()
- for this reason, init_chunk_heap() returns IOResult::IO
- init_chunk_heap() is called again
- we panic because chunk A is in WaitingForRead status

So - we just allow WaitingForRead status in init_chunk_heap() instead.

This panic was caught thanks to Pedro's IO latency enhancement to the sim!