### PR TITLE
io: only rollback connections if I/O failure found in connection.run_once

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -54,7 +54,7 @@ pub trait IO: Clock + Send + Sync {
     fn get_memory_io(&self) -> Arc<MemoryIO>;
 }
 
-pub type Complete = dyn Fn(Arc<RefCell<Buffer>>, i32);
+pub type ReadComplete = dyn Fn(Arc<RefCell<Buffer>>, i32);
 pub type WriteComplete = dyn Fn(i32);
 pub type SyncComplete = dyn Fn(i32);
 
@@ -71,7 +71,7 @@ pub enum CompletionType {
 
 pub struct ReadCompletion {
     pub buf: Arc<RefCell<Buffer>>,
-    pub complete: Box<Complete>,
+    pub complete: Box<ReadComplete>,
 }
 
 impl Completion {
@@ -141,7 +141,7 @@ pub struct SyncCompletion {
 }
 
 impl ReadCompletion {
-    pub fn new(buf: Arc<RefCell<Buffer>>, complete: Box<Complete>) -> Self {
+    pub fn new(buf: Arc<RefCell<Buffer>>, complete: Box<ReadComplete>) -> Self {
         Self { buf, complete }
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -243,9 +243,10 @@ impl Database {
         let default_cache_size = header_accessor::get_default_page_cache_size(&pager)
             .unwrap_or(storage::sqlite3_ondisk::DEFAULT_CACHE_SIZE);
 
+        let pager = Rc::new(pager);
         let conn = Arc::new(Connection {
             _db: self.clone(),
-            pager: RefCell::new(Rc::new(pager)),
+            pager: RefCell::new(pager.clone()),
             schema: RefCell::new(
                 self.schema
                     .lock()
@@ -267,6 +268,7 @@ impl Database {
             capture_data_changes: RefCell::new(CaptureDataChangesMode::Off),
             closed: Cell::new(false),
         });
+        pager.set_connection(Arc::downgrade(&conn));
 
         if let Err(e) = conn.register_builtins() {
             return Err(LimboError::ExtensionError(e));

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -49,7 +49,7 @@ use super::pager::PageRef;
 use super::wal::LimboRwLock;
 use crate::error::LimboError;
 use crate::fast_lock::SpinLock;
-use crate::io::{Buffer, Complete, Completion};
+use crate::io::{Buffer, Completion, ReadComplete};
 use crate::storage::btree::offset::{
     BTREE_CELL_CONTENT_AREA, BTREE_CELL_COUNT, BTREE_FIRST_FREEBLOCK, BTREE_FRAGMENTED_BYTES_COUNT,
     BTREE_PAGE_TYPE, BTREE_RIGHTMOST_PTR,
@@ -1356,157 +1356,163 @@ pub fn read_entire_wal_dumb(file: &Arc<dyn File>) -> Result<Arc<UnsafeCell<WalFi
     }));
     let wal_file_shared_for_completion = wal_file_shared_ret.clone();
 
-    let complete: Box<Complete> = Box::new(move |buf: Arc<RefCell<Buffer>>, bytes_read: i32| {
-        let buf = buf.borrow();
-        let buf_slice = buf.as_slice();
-        turso_assert!(
-            bytes_read == buf_slice.len() as i32,
-            "read({bytes_read}) != expected({})",
-            buf_slice.len()
-        );
-        let mut header_locked = header.lock();
-        // Read header
-        header_locked.magic =
-            u32::from_be_bytes([buf_slice[0], buf_slice[1], buf_slice[2], buf_slice[3]]);
-        header_locked.file_format =
-            u32::from_be_bytes([buf_slice[4], buf_slice[5], buf_slice[6], buf_slice[7]]);
-        header_locked.page_size =
-            u32::from_be_bytes([buf_slice[8], buf_slice[9], buf_slice[10], buf_slice[11]]);
-        header_locked.checkpoint_seq =
-            u32::from_be_bytes([buf_slice[12], buf_slice[13], buf_slice[14], buf_slice[15]]);
-        header_locked.salt_1 =
-            u32::from_be_bytes([buf_slice[16], buf_slice[17], buf_slice[18], buf_slice[19]]);
-        header_locked.salt_2 =
-            u32::from_be_bytes([buf_slice[20], buf_slice[21], buf_slice[22], buf_slice[23]]);
-        header_locked.checksum_1 =
-            u32::from_be_bytes([buf_slice[24], buf_slice[25], buf_slice[26], buf_slice[27]]);
-        header_locked.checksum_2 =
-            u32::from_be_bytes([buf_slice[28], buf_slice[29], buf_slice[30], buf_slice[31]]);
-        tracing::debug!("read_entire_wal_dumb(header={:?})", *header_locked);
-
-        // Read frames into frame_cache and pages_in_frames
-        if buf_slice.len() < WAL_HEADER_SIZE {
-            panic!("WAL file too small for header");
-        }
-
-        let use_native_endian_checksum =
-            cfg!(target_endian = "big") == ((header_locked.magic & 1) != 0);
-
-        let calculated_header_checksum = checksum_wal(
-            &buf_slice[0..24],
-            &header_locked,
-            (0, 0),
-            use_native_endian_checksum,
-        );
-
-        if calculated_header_checksum != (header_locked.checksum_1, header_locked.checksum_2) {
-            panic!(
-                "WAL header checksum mismatch. Expected ({}, {}), Got ({}, {})",
-                header_locked.checksum_1,
-                header_locked.checksum_2,
-                calculated_header_checksum.0,
-                calculated_header_checksum.1
+    let complete: Box<ReadComplete> = Box::new(
+        move |buf: Arc<RefCell<Buffer>>, bytes_read: i32| {
+            let buf = buf.borrow();
+            let buf_slice = buf.as_slice();
+            turso_assert!(
+                bytes_read == buf_slice.len() as i32,
+                "read({bytes_read}) != expected({})",
+                buf_slice.len()
             );
-        }
+            let mut header_locked = header.lock();
+            // Read header
+            header_locked.magic =
+                u32::from_be_bytes([buf_slice[0], buf_slice[1], buf_slice[2], buf_slice[3]]);
+            header_locked.file_format =
+                u32::from_be_bytes([buf_slice[4], buf_slice[5], buf_slice[6], buf_slice[7]]);
+            header_locked.page_size =
+                u32::from_be_bytes([buf_slice[8], buf_slice[9], buf_slice[10], buf_slice[11]]);
+            header_locked.checkpoint_seq =
+                u32::from_be_bytes([buf_slice[12], buf_slice[13], buf_slice[14], buf_slice[15]]);
+            header_locked.salt_1 =
+                u32::from_be_bytes([buf_slice[16], buf_slice[17], buf_slice[18], buf_slice[19]]);
+            header_locked.salt_2 =
+                u32::from_be_bytes([buf_slice[20], buf_slice[21], buf_slice[22], buf_slice[23]]);
+            header_locked.checksum_1 =
+                u32::from_be_bytes([buf_slice[24], buf_slice[25], buf_slice[26], buf_slice[27]]);
+            header_locked.checksum_2 =
+                u32::from_be_bytes([buf_slice[28], buf_slice[29], buf_slice[30], buf_slice[31]]);
+            tracing::debug!("read_entire_wal_dumb(header={:?})", *header_locked);
 
-        let mut cumulative_checksum = (header_locked.checksum_1, header_locked.checksum_2);
-        let page_size_u32 = header_locked.page_size;
-
-        if !(MIN_PAGE_SIZE..=MAX_PAGE_SIZE).contains(&page_size_u32)
-            || page_size_u32.count_ones() != 1
-        {
-            panic!("Invalid page size in WAL header: {page_size_u32}");
-        }
-        let page_size = page_size_u32 as usize;
-
-        let mut current_offset = WAL_HEADER_SIZE;
-        let mut frame_idx = 1_u64;
-
-        let wfs_data = unsafe { &mut *wal_file_shared_for_completion.get() };
-
-        while current_offset + WAL_FRAME_HEADER_SIZE + page_size <= buf_slice.len() {
-            let frame_header_slice =
-                &buf_slice[current_offset..current_offset + WAL_FRAME_HEADER_SIZE];
-            let page_data_slice = &buf_slice[current_offset + WAL_FRAME_HEADER_SIZE
-                ..current_offset + WAL_FRAME_HEADER_SIZE + page_size];
-
-            let frame_h_page_number =
-                u32::from_be_bytes(frame_header_slice[0..4].try_into().unwrap());
-            let frame_h_db_size = u32::from_be_bytes(frame_header_slice[4..8].try_into().unwrap());
-            let frame_h_salt_1 = u32::from_be_bytes(frame_header_slice[8..12].try_into().unwrap());
-            let frame_h_salt_2 = u32::from_be_bytes(frame_header_slice[12..16].try_into().unwrap());
-            let frame_h_checksum_1 =
-                u32::from_be_bytes(frame_header_slice[16..20].try_into().unwrap());
-            let frame_h_checksum_2 =
-                u32::from_be_bytes(frame_header_slice[20..24].try_into().unwrap());
-
-            // It contains more frames with mismatched SALT values, which means they're leftovers from previous checkpoints
-            if frame_h_salt_1 != header_locked.salt_1 || frame_h_salt_2 != header_locked.salt_2 {
-                tracing::trace!(
-                    "WAL frame salt mismatch: expected ({}, {}), got ({}, {}), ignoring frame",
-                    header_locked.salt_1,
-                    header_locked.salt_2,
-                    frame_h_salt_1,
-                    frame_h_salt_2
-                );
-                break;
+            // Read frames into frame_cache and pages_in_frames
+            if buf_slice.len() < WAL_HEADER_SIZE {
+                panic!("WAL file too small for header");
             }
 
-            let checksum_after_fh_meta = checksum_wal(
-                &frame_header_slice[0..8],
+            let use_native_endian_checksum =
+                cfg!(target_endian = "big") == ((header_locked.magic & 1) != 0);
+
+            let calculated_header_checksum = checksum_wal(
+                &buf_slice[0..24],
                 &header_locked,
-                cumulative_checksum,
-                use_native_endian_checksum,
-            );
-            let calculated_frame_checksum = checksum_wal(
-                page_data_slice,
-                &header_locked,
-                checksum_after_fh_meta,
+                (0, 0),
                 use_native_endian_checksum,
             );
 
-            tracing::debug!(
+            if calculated_header_checksum != (header_locked.checksum_1, header_locked.checksum_2) {
+                panic!(
+                    "WAL header checksum mismatch. Expected ({}, {}), Got ({}, {})",
+                    header_locked.checksum_1,
+                    header_locked.checksum_2,
+                    calculated_header_checksum.0,
+                    calculated_header_checksum.1
+                );
+            }
+
+            let mut cumulative_checksum = (header_locked.checksum_1, header_locked.checksum_2);
+            let page_size_u32 = header_locked.page_size;
+
+            if !(MIN_PAGE_SIZE..=MAX_PAGE_SIZE).contains(&page_size_u32)
+                || page_size_u32.count_ones() != 1
+            {
+                panic!("Invalid page size in WAL header: {page_size_u32}");
+            }
+            let page_size = page_size_u32 as usize;
+
+            let mut current_offset = WAL_HEADER_SIZE;
+            let mut frame_idx = 1_u64;
+
+            let wfs_data = unsafe { &mut *wal_file_shared_for_completion.get() };
+
+            while current_offset + WAL_FRAME_HEADER_SIZE + page_size <= buf_slice.len() {
+                let frame_header_slice =
+                    &buf_slice[current_offset..current_offset + WAL_FRAME_HEADER_SIZE];
+                let page_data_slice = &buf_slice[current_offset + WAL_FRAME_HEADER_SIZE
+                    ..current_offset + WAL_FRAME_HEADER_SIZE + page_size];
+
+                let frame_h_page_number =
+                    u32::from_be_bytes(frame_header_slice[0..4].try_into().unwrap());
+                let frame_h_db_size =
+                    u32::from_be_bytes(frame_header_slice[4..8].try_into().unwrap());
+                let frame_h_salt_1 =
+                    u32::from_be_bytes(frame_header_slice[8..12].try_into().unwrap());
+                let frame_h_salt_2 =
+                    u32::from_be_bytes(frame_header_slice[12..16].try_into().unwrap());
+                let frame_h_checksum_1 =
+                    u32::from_be_bytes(frame_header_slice[16..20].try_into().unwrap());
+                let frame_h_checksum_2 =
+                    u32::from_be_bytes(frame_header_slice[20..24].try_into().unwrap());
+
+                // It contains more frames with mismatched SALT values, which means they're leftovers from previous checkpoints
+                if frame_h_salt_1 != header_locked.salt_1 || frame_h_salt_2 != header_locked.salt_2
+                {
+                    tracing::trace!(
+                        "WAL frame salt mismatch: expected ({}, {}), got ({}, {}), ignoring frame",
+                        header_locked.salt_1,
+                        header_locked.salt_2,
+                        frame_h_salt_1,
+                        frame_h_salt_2
+                    );
+                    break;
+                }
+
+                let checksum_after_fh_meta = checksum_wal(
+                    &frame_header_slice[0..8],
+                    &header_locked,
+                    cumulative_checksum,
+                    use_native_endian_checksum,
+                );
+                let calculated_frame_checksum = checksum_wal(
+                    page_data_slice,
+                    &header_locked,
+                    checksum_after_fh_meta,
+                    use_native_endian_checksum,
+                );
+
+                tracing::debug!(
                 "read_entire_wal_dumb(frame_h_checksum=({}, {}), calculated_frame_checksum=({}, {}))",
                 frame_h_checksum_1,
                 frame_h_checksum_2,
                 calculated_frame_checksum.0,
                 calculated_frame_checksum.1
             );
-            if calculated_frame_checksum != (frame_h_checksum_1, frame_h_checksum_2) {
-                panic!(
-                    "WAL frame checksum mismatch. Expected ({}, {}), Got ({}, {})",
-                    frame_h_checksum_1,
-                    frame_h_checksum_2,
-                    calculated_frame_checksum.0,
-                    calculated_frame_checksum.1
-                );
+                if calculated_frame_checksum != (frame_h_checksum_1, frame_h_checksum_2) {
+                    panic!(
+                        "WAL frame checksum mismatch. Expected ({}, {}), Got ({}, {})",
+                        frame_h_checksum_1,
+                        frame_h_checksum_2,
+                        calculated_frame_checksum.0,
+                        calculated_frame_checksum.1
+                    );
+                }
+
+                cumulative_checksum = calculated_frame_checksum;
+
+                wfs_data
+                    .frame_cache
+                    .lock()
+                    .entry(frame_h_page_number as u64)
+                    .or_default()
+                    .push(frame_idx);
+                wfs_data
+                    .pages_in_frames
+                    .lock()
+                    .push(frame_h_page_number as u64);
+
+                let is_commit_record = frame_h_db_size > 0;
+                if is_commit_record {
+                    wfs_data.max_frame.store(frame_idx, Ordering::SeqCst);
+                }
+
+                frame_idx += 1;
+                current_offset += WAL_FRAME_HEADER_SIZE + page_size;
             }
 
-            cumulative_checksum = calculated_frame_checksum;
-
-            wfs_data
-                .frame_cache
-                .lock()
-                .entry(frame_h_page_number as u64)
-                .or_default()
-                .push(frame_idx);
-            wfs_data
-                .pages_in_frames
-                .lock()
-                .push(frame_h_page_number as u64);
-
-            let is_commit_record = frame_h_db_size > 0;
-            if is_commit_record {
-                wfs_data.max_frame.store(frame_idx, Ordering::SeqCst);
-            }
-
-            frame_idx += 1;
-            current_offset += WAL_FRAME_HEADER_SIZE + page_size;
-        }
-
-        wfs_data.last_checksum = cumulative_checksum;
-        wfs_data.loaded.store(true, Ordering::SeqCst);
-    });
+            wfs_data.last_checksum = cumulative_checksum;
+            wfs_data.loaded.store(true, Ordering::SeqCst);
+        },
+    );
     let c = Completion::new_read(buf_for_pread, complete);
     file.pread(0, c.into())?;
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3434,6 +3434,7 @@ pub fn op_sorter_open(
         max_buffer_size_bytes,
         page_size,
         pager.io.clone(),
+        pager.get_connection(),
     );
     let mut cursors = state.cursors.borrow_mut();
     cursors


### PR DESCRIPTION
## Problem
After merging https://github.com/tursodatabase/turso/pull/1946 I noticed a clear problem with `io.run_once` tied with `connection.run_once`. If any of the I/O operations fails, even if they are not tied to the connection performing `connection.run_once`, it will consider the connection a failure and rollback it even though it might have executed everything in that connection successfully.

## Solution
There are few ways to do this I guess, the simplest I could think of right now is registering a connection inside each `callback` so that we can track what operation failed. Now the problem is how do we deal with processing I/O in batch while also not interfering errors? I propose that we simply keep a list of failed callbacks/IO and we provide a connection to `io.run_once` in order to let I/O choose to either store failed callback in a queue until other connection tries to verify its callbacks or to return error and rollback if that I/O failure is consistent with the conneciton performing `run_once`.


## todo

- [X] add connection to callback
- [ ] track failures for other connections in a separate queue
- [ ] consume failures related to connection from queue once connection runs `run_once` 
