### PR TITLE
makefile: bump the minimum version to stable and change to `wasm32-wasip1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MINIMUM_RUST_VERSION := 1.73.0
+MINIMUM_RUST_VERSION := 1.88.0
 CURRENT_RUST_VERSION := $(shell rustc -V | sed -E 's/rustc ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 CURRENT_RUST_TARGET := $(shell rustc -vV | grep host | cut -d ' ' -f 2)
 RUSTUP := $(shell command -v rustup 2> /dev/null)
@@ -40,10 +40,10 @@ check-tcl-version:
 .PHONY: check-tcl-version
 
 check-wasm-target:
-	@echo "Checking wasm32-wasi target..."
-	@if ! rustup target list | grep -q "wasm32-wasi (installed)"; then \
-		echo "Installing wasm32-wasi target..."; \
-		rustup target add wasm32-wasi; \
+	@echo "Checking wasm32-wasip1 target..."
+	@if ! rustup target list | grep -q "wasm32-wasip1 (installed)"; then \
+		echo "Installing wasm32-wasip1 target..."; \
+		rustup target add wasm32-wasip1; \
 	fi
 .PHONY: check-wasm-target
 
@@ -56,8 +56,8 @@ limbo-c:
 .PHONY: limbo-c
 
 limbo-wasm:
-	rustup target add wasm32-wasi
-	cargo build --package limbo-wasm --target wasm32-wasi
+	rustup target add wasm32-wasip1
+	cargo build --package limbo-wasm --target wasm32-wasip1
 .PHONY: limbo-wasm
 
 uv-sync:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: check-rust-version check-wasm-target limbo limbo-wasm
 
 check-rust-version:
 	@echo "Checking Rust version..."
-	@if [ "$(shell printf '%s\n' "$(MINIMUM_RUST_VERSION)" "$(CURRENT_RUST_VERSION)" | sort -V | head -n1)" = "$(CURRENT_RUST_VERSION)" ]; then \
+	@if [ "$(shell printf '%s\n' "$(MINIMUM_RUST_VERSION)" "$(CURRENT_RUST_VERSION)" | sort -V | head -n1)" != "$(MINIMUM_RUST_VERSION)" ]; then \
 		echo "Rust version greater than $(MINIMUM_RUST_VERSION) is required. Current version is $(CURRENT_RUST_VERSION)."; \
 		if [ -n "$(RUSTUP)" ]; then \
 			echo "Updating Rust..."; \


### PR DESCRIPTION
# The Problem
When running `make` on the latest stable version of Rust ( 1.88.0 ), the script outputs the error :
```bash
error: toolchain '1.88.0-aarch64-apple-darwin' does not support target 'wasm32-wasi'; did you mean 'wasm32-wasip1' ?
```

# Reasoning
The `wasm32-wasi` was deprecated in version 1.84. If we are to change it to `wasm32-wasip1`, it would also make sense to bump the minimum version in the Makefile to 1.88.0.  

The script for checking the Rust version ( `check-rust-version` ) also had a slight logic error, causing a `rustup update stable` when both the `MINIMUM_RUST_VERSION` and `CURRENT_RUST_VERSION` are equal.

# Fix
Bumped `MINIMUM_RUST_VERSION` to the current stable version ( 1.88.0 ), changed `wasm32-wasi` with `wasm-wasip1`, negated the logic for `check-rust-version` make script.