### PR TITLE
implement Debug for Database

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -373,6 +373,10 @@ impl DumbLruPageCache {
         self.map.borrow().len()
     }
 
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
     #[cfg(test)]
     fn get_entry_ptr(&self, key: &PageCacheKey) -> Option<NonNull<PageCacheEntry>> {
         self.map.borrow().get(key).copied()


### PR DESCRIPTION
Very useful in printing data structures containing databases, like maps

Example output:

Connecting to Database { path: "sq.db", open_flags: OpenFlags(1), db_state: "initialized", mv_store: "none", init_lock: "unlocked", wal_state: "present", page_cache: "( capacity 100000, used: 0 )" }