### PR TITLE
use `wasm32-wasip1` target instead of `wasm32-wasi`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ check-tcl-version:
 .PHONY: check-tcl-version
 
 check-wasm-target:
-	@echo "Checking wasm32-wasi target..."
-	@if ! rustup target list | grep -q "wasm32-wasi (installed)"; then \
-		echo "Installing wasm32-wasi target..."; \
-		rustup target add wasm32-wasi; \
+	@echo "Checking wasm32-wasip1 target..."
+	@if ! rustup target list | grep -q "wasm32-wasip1 (installed)"; then \
+		echo "Installing wasm32-wasip1 target..."; \
+		rustup target add wasm32-wasip1; \
 	fi
 .PHONY: check-wasm-target
 
@@ -56,8 +56,8 @@ limbo-c:
 .PHONY: limbo-c
 
 limbo-wasm:
-	rustup target add wasm32-wasi
-	cargo build --package limbo-wasm --target wasm32-wasi
+	rustup target add wasm32-wasip1
+	cargo build --package limbo-wasm --target wasm32-wasip1
 .PHONY: limbo-wasm
 
 uv-sync:


### PR DESCRIPTION
In Rust 1.84.0, the support for the named target `wasm32-wasi` was removed in favor of `wasm32-wasip1` ([Release Notes](https://releases.rs/docs/1.84.0/#compatibility-notes)).

I missed that in https://github.com/tursodatabase/turso/pull/1807.

I got the following error when I tried to run `make`:
```
> make 
Checking Rust version...
Rust version 1.88.0 is acceptable.
Checking wasm32-wasi target...
Installing wasm32-wasi target...
error: toolchain '1.88.0-aarch64-apple-darwin' does not support target 'wasm32-wasi'; did you mean 'wasm32-wasip1'?
note: you can see a list of supported targets with `rustc --print=target-list`
note: if you are adding support for a new target to rustc itself, see https://rustc-dev-guide.rust-lang.org/building/new-target.html
make: *** [check-wasm-target] Error 1
```