### PR TITLE
implement write side of pragma schema_version

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -156,7 +156,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | PRAGMA read_uncommitted          | No         |                                              |
 | PRAGMA recursive_triggers        | No         |                                              |
 | PRAGMA reverse_unordered_selects | No         |                                              |
-| PRAGMA schema_version            | No         |                                              |
+| PRAGMA schema_version            | Yes        | For writes, emulate defensive mode (always noop)|
 | PRAGMA secure_delete             | No         |                                              |
 | PRAGMA short_column_names        | Not Needed | deprecated in SQLite                         |
 | PRAGMA shrink_memory             | No         |                                              |

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -133,8 +133,10 @@ fn update_pragma(
             Ok((program, TransactionMode::Write))
         }
         PragmaName::SchemaVersion => {
-            // TODO: Implement updating schema_version
-            todo!("updating schema_version not yet implemented")
+            // SQLite allowing this to be set is an incredibly stupid idea in my view.
+            // In "defensive mode", this is a silent nop. So let's emulate that always.
+            program.emit_insn(Insn::Noop {});
+            Ok((program, TransactionMode::None))
         }
         PragmaName::TableInfo => {
             // because we need control over the write parameter for the transaction,


### PR DESCRIPTION
It is insane that SQLite even allows this.
They actually don't if "defensive mode" is enabled:

"It is always safe to read the schema_version, but changing the schema_version can cause problems. For this reason, attempts to change the value of schema_version are a silent no-op when defensive mode is enabled for a database connection.

Warning: Misuse of this pragma can result in database corruption."

We also update the compat table, which was not updated to reflect the read version of this pragma being implemented.