### PR TITLE
fix: SUM returns correct float for mixed numeric/non-numeric types & return value on empty set

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -498,7 +498,7 @@ impl Value {
 #[derive(Debug, Clone, PartialEq)]
 pub enum AggContext {
     Avg(Value, Value), // acc and count
-    Sum(Value),
+    Sum(Value, bool),  // acc and has_non_numeric
     Count(Value),
     Max(Option<Value>),
     Min(Option<Value>),
@@ -522,7 +522,7 @@ impl AggContext {
     pub fn final_value(&self) -> &Value {
         match self {
             Self::Avg(acc, _count) => acc,
-            Self::Sum(acc) => acc,
+            Self::Sum(acc, _) => acc,
             Self::Count(count) => count,
             Self::Max(max) => max.as_ref().unwrap_or(&NULL),
             Self::Min(min) => min.as_ref().unwrap_or(&NULL),
@@ -596,7 +596,7 @@ impl PartialOrd<AggContext> for AggContext {
     fn partial_cmp(&self, other: &AggContext) -> Option<std::cmp::Ordering> {
         match (self, other) {
             (Self::Avg(a, _), Self::Avg(b, _)) => a.partial_cmp(b),
-            (Self::Sum(a), Self::Sum(b)) => a.partial_cmp(b),
+            (Self::Sum(a, _), Self::Sum(b, _)) => a.partial_cmp(b),
             (Self::Count(a), Self::Count(b)) => a.partial_cmp(b),
             (Self::Max(a), Self::Max(b)) => a.partial_cmp(b),
             (Self::Min(a), Self::Min(b)) => a.partial_cmp(b),


### PR DESCRIPTION
# Fix SUM aggregate function for mixed types

Fixes #2133

The SUM aggregate function was returning incorrect results when processing tables with mixed numeric and non-numeric values. According to SQLite documentation:
> "If any input to sum() is neither an integer nor a NULL, then sum() returns a floating point value" [*](https://sqlite.org/lang_aggfunc.html)

Now both SQLite and Turso yield the same output of 44.0.

--
I modified `Sum` to increment only for numeric values, skipping non-numeric values. However, if we have mixed numeric values or non-numeric values, we return a float output. Added a flag to keep track of it.

as pointed out by @FHaggs , If there are no non-NULL input rows then sum() returns NULL but total() returns 0.0. I decided to include it in this PR as well. Empty was such a natural test case.

