### PR TITLE
Remove Tokio dependency for Dart/Flutter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,16 +1106,13 @@ dependencies = [
  "dart-sys",
  "delegate-attr",
  "flutter_rust_bridge_macros",
- "futures",
  "js-sys",
  "lazy_static",
  "log",
  "oslog",
  "portable-atomic",
  "threadpool",
- "tokio",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 

--- a/bindings/dart/rust/Cargo.toml
+++ b/bindings/dart/rust/Cargo.toml
@@ -11,7 +11,15 @@ publish = false
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-flutter_rust_bridge = "=2.10.0"
+flutter_rust_bridge = { version = "=2.10.0", default-features = false, features  = [
+  "anyhow",
+  "dart-opaque",
+  "log",
+  "portable-atomic",
+  "thread-pool",
+  "user-utils",
+  "wasm-start"
+]}
 turso_core = { workspace = true, features = ["fs"] }
 
 [lints.rust]


### PR DESCRIPTION
Applies the changes @penberg suggested to fix #2029 