### PR TITLE
fix opcodes missing a database register

### DIFF
--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -130,6 +130,7 @@ pub fn translate_create_index(
     program.emit_insn(Insn::OpenRead {
         cursor_id: table_cursor_id,
         root_page: tbl.root_page,
+        db: 0,
     });
 
     let loop_start_label = program.allocate_label();

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -207,12 +207,14 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenRead {
                             cursor_id,
                             root_page,
+                            db: 0,
                         });
                     }
                     if let Some(index_cursor_id) = index_cursor_id {
                         program.emit_insn(Insn::OpenRead {
                             cursor_id: index_cursor_id,
                             root_page: index.as_ref().unwrap().root_page,
+                            db: 0,
                         });
                     }
                 }
@@ -283,6 +285,7 @@ pub fn init_loop(
                             program.emit_insn(Insn::OpenRead {
                                 cursor_id: table_cursor_id,
                                 root_page: table.table.get_root_page(),
+                                db: 0,
                             });
                         }
                     }
@@ -341,6 +344,7 @@ pub fn init_loop(
                                     cursor_id: index_cursor_id
                                         .expect("index cursor is always opened in Seek with index"),
                                     root_page: index.root_page,
+                                    db: 0,
                                 });
                             }
                             OperationMode::UPDATE | OperationMode::DELETE => {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -806,6 +806,7 @@ pub fn translate_drop_table(
         program.emit_insn(Insn::OpenRead {
             cursor_id: sqlite_schema_cursor_id_1,
             root_page: 1usize,
+            db: 0,
         });
 
         let schema_column_0_register = program.alloc_register();

--- a/core/translate/transaction.rs
+++ b/core/translate/transaction.rs
@@ -22,7 +22,7 @@ pub fn translate_tx_begin(
             });
         }
         TransactionType::Immediate | TransactionType::Exclusive => {
-            program.emit_insn(Insn::Transaction { write: true });
+            program.emit_insn(Insn::Transaction { db: 0, write: true });
             // TODO: Emit transaction instruction on temporary tables when we support them.
             program.emit_insn(Insn::AutoCommit {
                 auto_commit: false,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -768,8 +768,11 @@ impl ProgramBuilder {
             self.preassign_label_to_next_insn(self.init_label);
 
             match txn_mode {
-                TransactionMode::Read => self.emit_insn(Insn::Transaction { write: false }),
-                TransactionMode::Write => self.emit_insn(Insn::Transaction { write: true }),
+                TransactionMode::Read => self.emit_insn(Insn::Transaction {
+                    db: 0,
+                    write: false,
+                }),
+                TransactionMode::Write => self.emit_insn(Insn::Transaction { db: 0, write: true }),
                 TransactionMode::None => {}
             }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -876,6 +876,7 @@ pub fn op_open_read(
     let Insn::OpenRead {
         cursor_id,
         root_page,
+        db,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -1912,7 +1913,7 @@ pub fn op_transaction(
     pager: &Rc<Pager>,
     mv_store: Option<&Rc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
-    let Insn::Transaction { write } = insn else {
+    let Insn::Transaction { db: 0, write } = insn else {
         unreachable!("unexpected Insn {:?}", insn)
     };
     let conn = program.connection.clone();

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -357,11 +357,12 @@ pub fn insn_to_str(
             Insn::OpenRead {
                 cursor_id,
                 root_page,
+                db,
             } => (
                 "OpenRead",
                 *cursor_id as i32,
                 *root_page as i32,
-                0,
+                *db as i32,
                 Value::build_text(""),
                 0,
                 {
@@ -377,10 +378,11 @@ pub fn insn_to_str(
                                 }
                             });
                     format!(
-                        "{}={}, root={}",
+                        "{}={}, root={}, iDb={}",
                         cursor_type,
                         get_table_or_index_name(*cursor_id),
-                        root_page
+                        root_page,
+                        db
                     )
                 },
             ),
@@ -645,14 +647,14 @@ pub fn insn_to_str(
                 0,
                 "".to_string(),
             ),
-            Insn::Transaction { write } => (
+            Insn::Transaction { db, write } => (
                 "Transaction",
-                0,
+                *db as i32,
                 *write as i32,
                 0,
                 Value::build_text(""),
                 0,
-                format!("write={write}"),
+                format!("iDb={db} write={write}"),
             ),
             Insn::Goto { target_pc } => (
                 "Goto",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -330,6 +330,7 @@ pub enum Insn {
     OpenRead {
         cursor_id: CursorID,
         root_page: PageIdx,
+        db: usize,
     },
 
     /// Open a cursor for a virtual table.
@@ -459,7 +460,8 @@ pub enum Insn {
 
     /// Start a transaction.
     Transaction {
-        write: bool,
+        db: usize,   // p1
+        write: bool, // p2
     },
 
     /// Set database auto-commit mode and potentially rollback.


### PR DESCRIPTION
Two of the opcodes we implement (OpenRead and Transaction) should have an opcode specifying the database to use, but they don't.

Add it, and for now always use 0 (the main database).