### PR TITLE
fix/test: fix and unignore incorrectly implemented test

### DIFF
--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -420,8 +420,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    /// FIXME: This test fails.
     /// Test that a transaction cannot read committed changes that were committed after the transaction started (no: READ COMMITTED)
     fn test_tx_isolation_no_read_committed() -> anyhow::Result<()> {
         let path = TempDir::new()
@@ -438,6 +436,8 @@ mod tests {
 
         // Begin transaction on first connection
         let _ = limbo_exec_rows(&db, &conn1, "BEGIN");
+        let ret = limbo_exec_rows(&db, &conn1, "SELECT x FROM t");
+        assert!(ret.is_empty(), "Expected 0 rows but got {ret:?}");
 
         // Commit a value from the second connection
         let conn2 = db.connect_limbo();


### PR DESCRIPTION
Turns out #2192 was just me implementing a test wrong -- `BEGIN` is ofc an alias for `BEGIN DEFERRED` so just executing `BEGIN` won't start a tx yet. In short: `tursodb` does what you'd expect under snapshot isolation, at least in this specific instance.

In any case, let's not waste the test -- I've now unignored it and fixed it.