### PR TITLE
refactor/btree/vdbe: reduce number of different seek-related states

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -89,7 +89,7 @@ pub fn handle_distinct(program: &mut ProgramBuilder, agg: &Aggregate, agg_arg_re
         record_reg,
         unpacked_start: None,
         unpacked_count: None,
-        flags: IdxInsertFlags::new(),
+        flags: IdxInsertFlags::new().require_seek(),
     });
 }
 

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -2,7 +2,7 @@ use crate::schema::{Index, IndexColumn, Schema};
 use crate::translate::emitter::{emit_query, LimitCtx, TransactionMode, TranslateCtx};
 use crate::translate::plan::{Plan, QueryDestination, SelectPlan};
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
-use crate::vdbe::insn::Insn;
+use crate::vdbe::insn::{IdxInsertFlags, Insn};
 use crate::vdbe::BranchOffset;
 use crate::SymbolTable;
 use std::sync::Arc;
@@ -461,7 +461,7 @@ fn read_intersect_rows(
             record_reg: row_content_reg,
             unpacked_start: Some(cols_start_reg),
             unpacked_count: Some(column_count as u16),
-            flags: Default::default(),
+            flags: IdxInsertFlags::new().require_seek(),
         });
     } else if let Some(yield_reg) = yield_reg {
         program.emit_insn(Insn::Yield {

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1107,7 +1107,7 @@ fn emit_update_insns(
                 record_reg,
                 unpacked_start: Some(start),
                 unpacked_count: Some((index.columns.len() + 1) as u16),
-                flags: IdxInsertFlags::new(),
+                flags: IdxInsertFlags::new().require_seek(),
             });
         }
 

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -207,7 +207,7 @@ pub fn translate_create_index(
         record_reg: sorted_record_reg,
         unpacked_start: None, // TODO: optimize with these to avoid decoding record twice
         unpacked_count: None,
-        flags: IdxInsertFlags::new().use_seek(false),
+        flags: IdxInsertFlags::new(), // data is already sorted, so we don't need to seek.
     });
     program.emit_insn(Insn::SorterNext {
         cursor_id: sorter_cursor_id,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -533,7 +533,7 @@ pub fn translate_insert(
             unpacked_start: Some(idx_start_reg), // TODO: enable optimization
             unpacked_count: Some((num_cols + 1) as u16),
             // TODO: figure out how to determine whether or not we need to seek prior to insert.
-            flags: IdxInsertFlags::new(),
+            flags: IdxInsertFlags::new().require_seek(),
         });
     }
 

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -1454,7 +1454,7 @@ fn emit_autoindex(
         record_reg,
         unpacked_start: Some(ephemeral_cols_start_reg),
         unpacked_count: Some(num_regs_to_reserve as u16),
-        flags: IdxInsertFlags::new().use_seek(false),
+        flags: IdxInsertFlags::new().require_seek(),
     });
     program.emit_insn(Insn::Next {
         cursor_id: table_cursor_id,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -409,7 +409,7 @@ impl DistinctCtx {
             record_reg,
             unpacked_start: None,
             unpacked_count: None,
-            flags: IdxInsertFlags::new(),
+            flags: IdxInsertFlags::new().require_seek(),
         });
     }
 }

--- a/core/translate/result_row.rs
+++ b/core/translate/result_row.rs
@@ -107,7 +107,7 @@ pub fn emit_result_row_and_limit(
                     record_reg,
                     unpacked_start: None,
                     unpacked_count: None,
-                    flags: IdxInsertFlags::new().no_op_duplicate(),
+                    flags: IdxInsertFlags::new().no_op_duplicate().require_seek(),
                 });
             }
         }

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -62,7 +62,7 @@ pub struct IdxInsertFlags(pub u8);
 impl IdxInsertFlags {
     pub const APPEND: u8 = 0x01; // Hint: insert likely at the end
     pub const NCHANGE: u8 = 0x02; // Increment the change counter
-    pub const USE_SEEK: u8 = 0x04; // Skip seek if last one was same key
+    pub const REQUIRE_SEEK: u8 = 0x04; // Cursor is not guaranteed to be positioned correctly, so we need to seek.
     pub const NO_OP_DUPLICATE: u8 = 0x08; // Do not error on duplicate key
     pub fn new() -> Self {
         IdxInsertFlags(0)
@@ -78,12 +78,8 @@ impl IdxInsertFlags {
         }
         self
     }
-    pub fn use_seek(mut self, seek: bool) -> Self {
-        if seek {
-            self.0 |= IdxInsertFlags::USE_SEEK;
-        } else {
-            self.0 &= !IdxInsertFlags::USE_SEEK;
-        }
+    pub fn require_seek(mut self) -> Self {
+        self.0 |= IdxInsertFlags::REQUIRE_SEEK;
         self
     }
     pub fn nchange(mut self, change: bool) -> Self {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     storage::{pager, sqlite3_ondisk::SmallVec},
     translate::plan::TableReferences,
     types::{IOResult, RawSlice, TextRef},
-    vdbe::execute::{OpIdxInsertState, OpInsertState, OpNewRowidState, OpSeekState},
+    vdbe::execute::{OpDeleteState, OpIdxInsertState, OpInsertState, OpNewRowidState, OpSeekState},
     RefValue,
 };
 
@@ -249,7 +249,8 @@ pub struct ProgramState {
     commit_state: CommitState,
     #[cfg(feature = "json")]
     json_cache: JsonCacheCell,
-    op_idx_delete_state: Option<OpIdxDeleteState>,
+    op_delete_state: OpDeleteState,
+    op_idx_delete_state: OpIdxDeleteState,
     op_integrity_check_state: OpIntegrityCheckState,
     op_open_ephemeral_state: OpOpenEphemeralState,
     op_new_rowid_state: OpNewRowidState,
@@ -279,11 +280,12 @@ impl ProgramState {
             commit_state: CommitState::Ready,
             #[cfg(feature = "json")]
             json_cache: JsonCacheCell::new(),
-            op_idx_delete_state: None,
+            op_delete_state: OpDeleteState::Delete,
+            op_idx_delete_state: OpIdxDeleteState::Seeking,
             op_integrity_check_state: OpIntegrityCheckState::Start,
             op_open_ephemeral_state: OpOpenEphemeralState::Start,
             op_new_rowid_state: OpNewRowidState::Start,
-            op_idx_insert_state: OpIdxInsertState::SeekIfUnique,
+            op_idx_insert_state: OpIdxInsertState::MaybeSeek,
             op_insert_state: OpInsertState::Insert,
             seek_state: OpSeekState::Start,
         }


### PR DESCRIPTION
Closes #2164 

## Problem

We currently have a _lot_ of different state tracking for whether or not a btree cursor needs to seek:

```rust
moved_before: bool // passed to BTreeCursor::insert() as a flag
CursorValidState // enum state on BTreeCursor
CursorContext // optional rowid/indexkey on BTreeCursor
self.save_context() / self.restore_context() // methods for operating on CursorContext
SeekResult // result of a Seek operation
DeleteSavepoint // basically exactly same thing as CursorContext but specialized for delete balancing
DeleteState::SeekAfterBalancing // separate "restore_context()" specialized for delete balancing
DeleteState::TryAdvance // seek after balancing may return SeekResult::TryAdvance, so this handles that case.
```

This is a pretty horrible ball of state and it makes sense to consolidate these.

## Solution

Essentially this PR does two things:

1. Removes redundant states:

- `moved_before`: entirely removed. Every VDBE instruction that calls `BTreeCursor::insert()` will itself determine using a state machine whether or not it needs to seek.
- `CursorValidState`: entirely removed. As above, VDBE instructions will self-determine whether they need to seek.
- `CursorContext`: add a new variant `Advance` which encodes the scenario when the cursor needs to call `next()`/`prev()` to be correctly positioned. This is determined by `SeekResult` returned by a seek operation. VDBE instructions will use the presence or absence of `CursorContext` to determine whether to restore context.
- `SeekResult`: left as is.
- `DeleteSavepoint`: removed. delete path uses `save_context()` instead.
- `DeleteState::SeekAfterBalancing`: removed. `op_delete` uses `restore_context()` instead.
- `DeleteState::TryAdvance`: removed. `op_delete uses `restore_context()` instead, which also handles advancing.

Hence, from the above original list, these remain:

```rust
CursorContext
self.save_context() / self.restore_context()
SeekResult
```

2. Moves responsibility out of `BTreeCursor` to the VDBE:

- `op_insert`, `op_idx_insert`, `op_delete` and `op_idx_delete` now handle making the decision about when to pre-seek before executing the main operation, and whether to restore cursor context afterwards.
- The PR diff is mainly about moving code out of `btree.rs` to `vdbe/execute.rs` as you can see.