### PR TITLE
test/stress&sim: enable indexes by default

### DIFF
--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -61,8 +61,8 @@ pub struct SimulatorCLI {
     pub disable_delete: bool,
     #[clap(long, help = "disable CREATE Statement", default_value_t = false)]
     pub disable_create: bool,
-    #[clap(long, help = "enable CREATE INDEX Statement", default_value_t = false)]
-    pub enable_create_index: bool,
+    #[clap(long, help = "disable CREATE INDEX Statement", default_value_t = false)]
+    pub disable_create_index: bool,
     #[clap(long, help = "disable DROP Statement", default_value_t = false)]
     pub disable_drop: bool,
     #[clap(

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -178,7 +178,7 @@ impl SimulatorEnv {
             // Create percent should be 5-15% of the write percent
             create_percent = rng.gen_range(0.05..=0.15) * write_percent;
         }
-        if cli_opts.enable_create_index {
+        if !cli_opts.disable_create_index {
             // Create indexpercent should be 2-5% of the write percent
             create_index_percent = rng.gen_range(0.02..=0.05) * write_percent;
         }

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -15,7 +15,7 @@ name = "turso_stress"
 path = "main.rs"
 
 [features]
-default = []
+default = ["experimental_indexes"]
 antithesis = ["turso/antithesis"]
 experimental_indexes = ["turso/experimental_indexes"]
 


### PR DESCRIPTION
Life is too boring without any simulator-created issues