### PR TITLE
test/clickbench: fix clickbench

### DIFF
--- a/perf/clickbench/benchmark.sh
+++ b/perf/clickbench/benchmark.sh
@@ -12,18 +12,18 @@ if ! command -v sqlite3 >/dev/null 2>&1; then
     exit 1
 fi
 
-# Build Limbo in release mode if it's not already built
+# Build tursodb in release mode if it's not already built
 if [ ! -f "$RELEASE_BUILD_DIR/tursodb" ]; then
-    echo "Building Limbo..."
+    echo "Building tursodb..."
     cargo build --bin tursodb --release
 fi
 
 # Clean up any existing DB
 rm "$CLICKBENCH_DIR/mydb"* || true
 
-# Create DB using Limbo
+# Create DB using tursodb
 echo "Creating DB..."
-"$RELEASE_BUILD_DIR/tursodb" --quiet "$CLICKBENCH_DIR/mydb" < "$CLICKBENCH_DIR/create.sql"
+"$RELEASE_BUILD_DIR/tursodb" --quiet --experimental-indexes "$CLICKBENCH_DIR/mydb" < "$CLICKBENCH_DIR/create.sql"
 
 # Download a subset of the clickbench dataset if it doesn't exist
 NUM_ROWS=1000000
@@ -41,7 +41,7 @@ else
     echo "Using existing hits.csv file"
 fi
 
-# Import the dataset into the DB using sqlite (not Limbo, because Limbo doesn't have index insert yet)
+# Import the dataset into the DB using sqlite (not tursodb, because tursodb doesn't have index insert yet)
 echo "Importing dataset..."
 sqlite3 "$CLICKBENCH_DIR/mydb" ".import --csv $CLICKBENCH_DIR/hits.csv hits"
 

--- a/perf/clickbench/run.sh
+++ b/perf/clickbench/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is a modified version of the clickbench benchmark script from:
 # https://github.com/ClickHouse/ClickBench/tree/main/sqlite
-# It runs the queries in the queries.sql file, and prints the results for both Limbo and Sqlite.
+# It runs the queries in the queries.sql file, and prints the results for both tursodb and Sqlite.
 
 TRIES=1
 
@@ -28,16 +28,16 @@ clear_caches
 count=1;
 
 # Run the queries, skipping any that are commented out
-# Between each invocation to Limbo/Sqlite, purge the caches
+# Between each invocation to tursodb/Sqlite, purge the caches
 grep -v '^--' "$CLICKBENCH_DIR/queries.sql" | while read -r query; do
 
     echo "$count $query"
-    ((echo "$count $query") 2>&1) | tee -a clickbench-limbo.txt > /dev/null
+    ((echo "$count $query") 2>&1) | tee -a clickbench-tursodb.txt > /dev/null
     ((echo "$count $query") 2>&1) | tee -a clickbench-sqlite3.txt >/dev/null
     for _ in $(seq 1 $TRIES); do
         clear_caches
-        echo "----limbo----"
-        ((time "$RELEASE_BUILD_DIR/limbo" --quiet "$CLICKBENCH_DIR/mydb" <<< "${query}") 2>&1) | tee -a clickbench-limbo.txt
+        echo "----tursodb----"
+        ((time "$RELEASE_BUILD_DIR/tursodb" --quiet --experimental-indexes -m list "$CLICKBENCH_DIR/mydb" <<< "${query}") 2>&1) | tee -a clickbench-tursodb.txt
         clear_caches
         echo
         echo "----sqlite----"


### PR DESCRIPTION
- enable indexes, otherwise it doesnt work at all
- rename limbo to tursodb
- use mode=list instead of mode=pretty for less bulky tursodb results

Closes #1925 