### PR TITLE
 core/lib: init_pager lock shared wal until filled 

### DIFF
--- a/tests/integration/query_processing/test_multi_thread.rs
+++ b/tests/integration/query_processing/test_multi_thread.rs
@@ -1,6 +1,8 @@
-use std::sync::Arc;
+use std::sync::{atomic::AtomicUsize, Arc};
 
-use crate::common::TempDatabase;
+use turso_core::StepResult;
+
+use crate::common::{maybe_setup_tracing, TempDatabase};
 
 #[test]
 fn test_schema_change() {
@@ -29,8 +31,10 @@ fn test_schema_change() {
 }
 
 #[test]
+#[ignore]
 fn test_create_multiple_connections() -> anyhow::Result<()> {
-    let tries = 10;
+    maybe_setup_tracing();
+    let tries = 1;
     for _ in 0..tries {
         let tmp_db = Arc::new(TempDatabase::new_empty(false));
         {
@@ -43,8 +47,34 @@ fn test_create_multiple_connections() -> anyhow::Result<()> {
             let tmp_db_ = tmp_db.clone();
             threads.push(std::thread::spawn(move || {
                 let conn = tmp_db_.connect_limbo();
-                conn.execute(format!("INSERT INTO t VALUES ({i})").as_str())
-                    .unwrap();
+                'outer: loop {
+                    let mut stmt = conn
+                        .prepare(format!("INSERT INTO t VALUES ({i})").as_str())
+                        .unwrap();
+                    tracing::info!("inserting row {}", i);
+                    loop {
+                        match stmt.step().unwrap() {
+                            StepResult::Row => {
+                                panic!("unexpected row result");
+                            }
+                            StepResult::IO => {
+                                stmt.run_once().unwrap();
+                            }
+                            StepResult::Done => {
+                                tracing::info!("inserted row {}", i);
+                                break 'outer;
+                            }
+                            StepResult::Interrupt => {
+                                panic!("unexpected step result");
+                            }
+                            StepResult::Busy => {
+                                // repeat until we can insert it
+                                tracing::info!("busy {}, repeating", i);
+                                break;
+                            }
+                        }
+                    }
+                }
             }));
         }
         for thread in threads {
@@ -54,12 +84,105 @@ fn test_create_multiple_connections() -> anyhow::Result<()> {
         let conn = tmp_db.connect_limbo();
         let mut stmt = conn.prepare("SELECT * FROM t").unwrap();
         let mut rows = Vec::new();
-        while matches!(stmt.step().unwrap(), turso_core::StepResult::Row) {
-            let row = stmt.row().unwrap();
-            rows.push(row.get::<i64>(0).unwrap());
+        loop {
+            match stmt.step().unwrap() {
+                StepResult::Row => {
+                    let row = stmt.row().unwrap();
+                    rows.push(row.get::<i64>(0).unwrap());
+                }
+                StepResult::IO => {
+                    stmt.run_once().unwrap();
+                }
+                StepResult::Done => {
+                    break;
+                }
+                StepResult::Interrupt => {
+                    panic!("unexpected step result");
+                }
+                StepResult::Busy => {
+                    panic!("unexpected busy result on select");
+                }
+            }
         }
         rows.sort();
         assert_eq!(rows, (0..10).collect::<Vec<_>>());
+    }
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_reader_writer() -> anyhow::Result<()> {
+    let tries = 10;
+    for _ in 0..tries {
+        let tmp_db = Arc::new(TempDatabase::new_empty(false));
+        {
+            let conn = tmp_db.connect_limbo();
+            conn.execute("CREATE TABLE t(x)").unwrap();
+        }
+
+        let mut threads = Vec::new();
+        let number_of_writers = 100;
+        let current_written_rows = Arc::new(AtomicUsize::new(0));
+        {
+            let tmp_db = tmp_db.clone();
+            let mut current_written_rows = current_written_rows.clone();
+            threads.push(std::thread::spawn(move || {
+                let conn = tmp_db.connect_limbo();
+                for i in 0..number_of_writers {
+                    conn.execute(format!("INSERT INTO t VALUES ({i})").as_str())
+                        .unwrap();
+                    current_written_rows.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+            }));
+        }
+        {
+            let current_written_rows = current_written_rows.clone();
+            threads.push(std::thread::spawn(move || {
+                let conn = tmp_db.connect_limbo();
+                loop {
+                    let current_written_rows =
+                        current_written_rows.load(std::sync::atomic::Ordering::Relaxed);
+                    if current_written_rows == number_of_writers {
+                        break;
+                    }
+                    let mut stmt = conn.prepare("SELECT * FROM t").unwrap();
+                    let mut rows = Vec::new();
+                    loop {
+                        match stmt.step().unwrap() {
+                            StepResult::Row => {
+                                let row = stmt.row().unwrap();
+                                let x = row.get::<i64>(0).unwrap();
+                                rows.push(x);
+                            }
+                            StepResult::IO => {
+                                stmt.run_once().unwrap();
+                            }
+                            StepResult::Done => {
+                                rows.sort();
+                                for i in 0..current_written_rows {
+                                    let i = i as i64;
+                                    assert!(
+                                        rows.contains(&i),
+                                        "row {} not found in {:?}. current_written_rows: {}",
+                                        i,
+                                        rows,
+                                        current_written_rows
+                                    );
+                                }
+                                break;
+                            }
+                            StepResult::Interrupt | StepResult::Busy => {
+                                panic!("unexpected step result");
+                            }
+                        }
+                    }
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
     }
     Ok(())
 }

--- a/tests/integration/query_processing/test_multi_thread.rs
+++ b/tests/integration/query_processing/test_multi_thread.rs
@@ -126,7 +126,7 @@ fn test_reader_writer() -> anyhow::Result<()> {
         let current_written_rows = Arc::new(AtomicUsize::new(0));
         {
             let tmp_db = tmp_db.clone();
-            let mut current_written_rows = current_written_rows.clone();
+            let current_written_rows = current_written_rows.clone();
             threads.push(std::thread::spawn(move || {
                 let conn = tmp_db.connect_limbo();
                 for i in 0..number_of_writers {
@@ -164,10 +164,7 @@ fn test_reader_writer() -> anyhow::Result<()> {
                                     let i = i as i64;
                                     assert!(
                                         rows.contains(&i),
-                                        "row {} not found in {:?}. current_written_rows: {}",
-                                        i,
-                                        rows,
-                                        current_written_rows
+                                        "row {i} not found in {rows:?}. current_written_rows: {current_written_rows}",
                                     );
                                 }
                                 break;

--- a/tests/integration/query_processing/test_multi_thread.rs
+++ b/tests/integration/query_processing/test_multi_thread.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::common::TempDatabase;
 
 #[test]
@@ -24,4 +26,40 @@ fn test_schema_change() {
         }
     };
     println!("{:?} {:?}", row.get_value(0), row.get_value(1));
+}
+
+#[test]
+fn test_create_multiple_connections() -> anyhow::Result<()> {
+    let tries = 10;
+    for _ in 0..tries {
+        let tmp_db = Arc::new(TempDatabase::new_empty(false));
+        {
+            let conn = tmp_db.connect_limbo();
+            conn.execute("CREATE TABLE t(x)").unwrap();
+        }
+
+        let mut threads = Vec::new();
+        for i in 0..10 {
+            let tmp_db_ = tmp_db.clone();
+            threads.push(std::thread::spawn(move || {
+                let conn = tmp_db_.connect_limbo();
+                conn.execute(format!("INSERT INTO t VALUES ({i})").as_str())
+                    .unwrap();
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        let conn = tmp_db.connect_limbo();
+        let mut stmt = conn.prepare("SELECT * FROM t").unwrap();
+        let mut rows = Vec::new();
+        while matches!(stmt.step().unwrap(), turso_core::StepResult::Row) {
+            let row = stmt.row().unwrap();
+            rows.push(row.get::<i64>(0).unwrap());
+        }
+        rows.sort();
+        assert_eq!(rows, (0..10).collect::<Vec<_>>());
+    }
+    Ok(())
 }

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -765,11 +765,11 @@ fn test_read_wal_dumb_no_frames() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_query(tmp_db: &TempDatabase, conn: &Arc<Connection>, query: &str) -> anyhow::Result<()> {
+pub fn run_query(tmp_db: &TempDatabase, conn: &Arc<Connection>, query: &str) -> anyhow::Result<()> {
     run_query_core(tmp_db, conn, query, None::<fn(&Row)>)
 }
 
-fn run_query_on_row(
+pub fn run_query_on_row(
     tmp_db: &TempDatabase,
     conn: &Arc<Connection>,
     query: &str,
@@ -778,7 +778,7 @@ fn run_query_on_row(
     run_query_core(tmp_db, conn, query, Some(on_row))
 }
 
-fn run_query_core(
+pub fn run_query_core(
     _tmp_db: &TempDatabase,
     conn: &Arc<Connection>,
     query: &str,


### PR DESCRIPTION
maybe_shared_wal's lock is held for a limited time increasing the chance
of initializing the shared wal twice.