### PR TITLE
Deserialize keys only once when sorting immutable records

### DIFF
--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -481,7 +481,7 @@ impl Ord for SortableImmutableRecord {
         let mut other_key_values = other.key_values.borrow_mut();
 
         for i in 0..self.cursor.serial_types.len() {
-            // Lazily deserialize the key values if they haven't been deserialized yet.
+            // Lazily deserialize the key values if they haven't been deserialized already.
             if i >= this_key_values.len() {
                 this_key_values.push(
                     self.cursor


### PR DESCRIPTION
Before this update, the entire immutable record was **fully** deserialized **every** time it was compared in the sorter.

This PR extends the sorter with incremental deserialization of record keys, only when needed and only if they weren’t already deserialized in a previous iteration.

I hate that we panic on failed deserialization in `cmp`, but unfortunately, I can’t return `Result` as part of this interface. Looking for feedback around a better way to handle this.

Alternatively, I could store the deserialization error as part of `SortableImmutableRecord` and check it before returning the record in `next`, thereby deferring the error handling. The downside of this approach is that it complicates debugging, since the error will be completely decoupled from the place where it occurs.