### PR TITLE
Page cache spilling

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -108,7 +108,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | PRAGMA busy_timeout              | No         |                                              |
 | PRAGMA busy_timeout              | No         |                                              |
 | PRAGMA cache_size                | Yes        |                                              |
-| PRAGMA cache_spill               | No         |                                              |
+| PRAGMA cache_spill               | Yes        |                                              |
 | PRAGMA case_sensitive_like       | Not Needed | deprecated in SQLite                         |
 | PRAGMA cell_size_check           | No         |                                              |
 | PRAGMA checkpoint_fullsync       | No         |                                              |

--- a/core/error.rs
+++ b/core/error.rs
@@ -77,6 +77,8 @@ pub enum LimboError {
     InvalidBlobSize(usize),
     #[error("Planning error: {0}")]
     PlanningError(String),
+    #[error("Spill not allowed for flag")]
+    SpillNotAllowed,
 }
 
 // We only propagate the error kind so we can avoid string allocation in hot path and copying/cloning enums is cheaper

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -111,6 +111,7 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::Result0 | PragmaFlags::SchemaReq | PragmaFlags::NoColumns1,
             &["key"],
         ),
+        CacheSpill => Pragma::new(PragmaFlags::Result0, &["cache_spill"]),
     }
 }
 

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -113,7 +113,7 @@ impl DumbLruPageCache {
         }
         self.make_room_for(1)?;
         let entry = Box::new(PageCacheEntry {
-            key: key,
+            key,
             next: None,
             prev: None,
             page: value,
@@ -372,7 +372,7 @@ impl DumbLruPageCache {
         let mut current = head_ptr;
         while let Some(node) = current {
             unsafe {
-                this_keys.push(node.as_ref().key.clone());
+                this_keys.push(node.as_ref().key);
                 let node_ref = node.as_ref();
                 current = node_ref.next;
             }
@@ -668,7 +668,7 @@ mod tests {
     fn insert_page(cache: &mut DumbLruPageCache, id: usize) -> PageCacheKey {
         let key = PageCacheKey(id);
         let page = page_with_content(id);
-        assert!(cache.insert(key.clone(), page).is_ok());
+        assert!(cache.insert(key, page).is_ok());
         key
     }
 
@@ -682,7 +682,7 @@ mod tests {
     ) -> (PageCacheKey, NonNull<PageCacheEntry>) {
         let key = PageCacheKey(id);
         let page = page_with_content(id);
-        assert!(cache.insert(key.clone(), page).is_ok());
+        assert!(cache.insert(key, page).is_ok());
         let entry = cache.get_ptr(&key).expect("Entry should exist");
         (key, entry)
     }
@@ -697,7 +697,7 @@ mod tests {
         assert!(cache.tail.borrow().is_some());
         assert_eq!(*cache.head.borrow(), *cache.tail.borrow());
 
-        assert!(cache.delete(key1.clone()).is_ok());
+        assert!(cache.delete(key1).is_ok());
 
         assert_eq!(
             cache.len(),
@@ -729,7 +729,7 @@ mod tests {
             "Initial head check"
         );
 
-        assert!(cache.delete(key3.clone()).is_ok());
+        assert!(cache.delete(key3).is_ok());
 
         assert_eq!(cache.len(), 2, "Length should be 2 after deleting head");
         assert!(
@@ -773,7 +773,7 @@ mod tests {
             "Initial tail check"
         );
 
-        assert!(cache.delete(key1.clone()).is_ok()); // Delete tail
+        assert!(cache.delete(key1).is_ok()); // Delete tail
 
         assert_eq!(cache.len(), 2, "Length should be 2 after deleting tail");
         assert!(
@@ -824,7 +824,7 @@ mod tests {
         let head_ptr_before = cache.head.borrow().unwrap();
         let tail_ptr_before = cache.tail.borrow().unwrap();
 
-        assert!(cache.delete(key2.clone()).is_ok()); // Detach a middle element (key2)
+        assert!(cache.delete(key2).is_ok()); // Detach a middle element (key2)
 
         assert_eq!(cache.len(), 3, "Length should be 3 after deleting middle");
         assert!(
@@ -865,11 +865,11 @@ mod tests {
         let mut cache = DumbLruPageCache::default();
         let key1 = PageCacheKey(1);
         let page1 = page_with_content(1);
-        assert!(cache.insert(key1.clone(), page1.clone()).is_ok());
+        assert!(cache.insert(key1, page1.clone()).is_ok());
         assert!(page_has_content(&page1));
         cache.verify_list_integrity();
 
-        let result = cache.delete(key1.clone());
+        let result = cache.delete(key1);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), CacheError::ActiveRefs);
         assert_eq!(cache.len(), 1);
@@ -888,10 +888,10 @@ mod tests {
         let key1 = PageCacheKey(1);
         let page1_v1 = page_with_content(1);
         let page1_v2 = page_with_content(1);
-        assert!(cache.insert(key1.clone(), page1_v1.clone()).is_ok());
+        assert!(cache.insert(key1, page1_v1.clone()).is_ok());
         assert_eq!(cache.len(), 1);
         cache.verify_list_integrity();
-        let _ = cache.insert(key1.clone(), page1_v2.clone()); // Panic
+        let _ = cache.insert(key1, page1_v2.clone()); // Panic
     }
 
     #[test]
@@ -899,7 +899,7 @@ mod tests {
         let mut cache = DumbLruPageCache::default();
         let key_nonexist = PageCacheKey(99);
 
-        assert!(cache.delete(key_nonexist.clone()).is_ok()); // no-op
+        assert!(cache.delete(key_nonexist).is_ok()); // no-op
     }
 
     #[test]
@@ -1004,8 +1004,8 @@ mod tests {
         let (key1, _) = insert_and_get_entry(&mut cache, 1);
         let (key2, entry2) = insert_and_get_entry(&mut cache, 2);
         let (key3, _) = insert_and_get_entry(&mut cache, 3);
-        let head_key = unsafe { cache.head.borrow().unwrap().as_ref().key.clone() };
-        let tail_key = unsafe { cache.tail.borrow().unwrap().as_ref().key.clone() };
+        let head_key = unsafe { cache.head.borrow().unwrap().as_ref().key };
+        let tail_key = unsafe { cache.tail.borrow().unwrap().as_ref().key };
         assert_eq!(head_key, key3, "Head should be key3");
         assert_eq!(tail_key, key1, "Tail should be key1");
         assert!(cache.detach(entry2, false).is_ok());
@@ -1014,12 +1014,12 @@ mod tests {
         assert_eq!(head_entry.key, key3, "Head should still be key3");
         assert_eq!(tail_entry.key, key1, "Tail should still be key1");
         assert_eq!(
-            unsafe { head_entry.next.unwrap().as_ref().key.clone() },
+            unsafe { head_entry.next.unwrap().as_ref().key },
             key1,
             "Head's next should point to tail after middle element detached"
         );
         assert_eq!(
-            unsafe { tail_entry.prev.unwrap().as_ref().key.clone() },
+            unsafe { tail_entry.prev.unwrap().as_ref().key },
             key3,
             "Tail's prev should point to head after middle element detached"
         );
@@ -1055,7 +1055,7 @@ mod tests {
                         continue; // skip duplicate page ids
                     }
                     tracing::debug!("inserting page {:?}", key);
-                    match cache.insert(key.clone(), page.clone()) {
+                    match cache.insert(key, page.clone()) {
                         Err(CacheError::Full { .. } | CacheError::ActiveRefs) => {} // Ignore
                         Err(err) => {
                             // Any other error should fail the test
@@ -1076,7 +1076,7 @@ mod tests {
                         PageCacheKey(id_page as usize)
                     } else {
                         let i = rng.next_u64() as usize % lru.len();
-                        let key: PageCacheKey = lru.iter().nth(i).unwrap().0.clone();
+                        let key: PageCacheKey = *lru.iter().nth(i).unwrap().0;
                         key
                     };
                     tracing::debug!("removing page {:?}", key);
@@ -1103,7 +1103,7 @@ mod tests {
         let this_keys = cache.keys();
         let mut lru_keys = Vec::new();
         for (lru_key, _) in lru {
-            lru_keys.push(lru_key.clone());
+            lru_keys.push(*lru_key);
         }
         if this_keys != lru_keys {
             cache.print();
@@ -1138,7 +1138,7 @@ mod tests {
     fn test_page_cache_delete() {
         let mut cache = DumbLruPageCache::default();
         let key1 = insert_page(&mut cache, 1);
-        assert!(cache.delete(key1.clone()).is_ok());
+        assert!(cache.delete(key1).is_ok());
         assert!(cache.get(&key1).is_none());
     }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2033,7 +2033,7 @@ impl Pager {
             let page = {
                 let page_key = PageCacheKey(page_id);
                 let page = page_cache.get(&page_key)
-                    .expect(format!("we somehow added a page {} to dirty list but we didn't mark it as dirty, causing page_cache to drop it.", page_id).as_str());
+                    .unwrap_or_else(|| panic!("we somehow added a page {page_id} to dirty list but we didn't mark it as dirty, causing page_cache to drop it."));
                 if page.is_pinned() {
                     continue;
                 }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -385,7 +385,7 @@ pub struct Pager {
     /// Source of the database pages.
     pub db_file: Arc<dyn DatabaseStorage>,
     /// The write-ahead log (WAL) for the database.
-    /// in-memory databases, ephemeral tables and ephemeral indexes do not have a WAL.
+    /// in-memory databases do not have a WAL.
     pub(crate) wal: Option<Rc<RefCell<dyn Wal>>>,
     /// A page cache for the database.
     page_cache: Arc<RwLock<DumbLruPageCache>>,
@@ -1128,8 +1128,6 @@ impl Pager {
     #[instrument(skip_all, level = Level::INFO)]
     pub fn cacheflush(&self) -> Result<Vec<Completion>> {
         let Some(wal) = self.wal.as_ref() else {
-            // TODO: when ephemeral table spills to disk, it should cacheflush pages directly to the temporary database file.
-            // This handling is not yet implemented, but it should be when spilling is implemented.
             return Err(LimboError::InternalError(
                 "cacheflush() called on database without WAL".to_string(),
             ));

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -534,7 +534,7 @@ pub struct WalFileShared {
     // Frame cache maps a Page to all the frames it has stored in WAL in ascending order.
     // This is to easily find the frame it must checkpoint each connection if a checkpoint is
     // necessary.
-    // One difference between SQLite and limbo is that we will never support multi process, meaning
+    // One difference between SQLite and TursoDB is that we will never support multi process, meaning
     // we don't need WAL's index file. So we can do stuff like this without shared memory.
     // TODO: this will need refactoring because this is incredible memory inefficient.
     pub frame_cache: Arc<SpinLock<HashMap<u64, Vec<u64>>>>,
@@ -1626,7 +1626,7 @@ impl WalFile {
     /// because we might overwrite content the reader is reading from the database file.
     ///
     /// A checkpoint must never overwrite a page in the main DB file if some
-    /// active reader might still need to read that page from the WAL.  
+    /// active reader might still need to read that page from the WAL.
     /// Concretely: the checkpoint may only copy frames `<= aReadMark[k]` for
     /// every in-use reader slot `k > 0`.
     ///

--- a/core/types.rs
+++ b/core/types.rs
@@ -583,6 +583,16 @@ impl Value {
         unsafe { v.__free_internal_type() };
         res
     }
+
+    /// Converts the value to an integer.
+    /// If the value is a float, it will be rounded down to the nearest integer.
+    pub fn to_int(&self) -> Option<i64> {
+        match self {
+            Value::Integer(t) => Some(*t),
+            Value::Float(f) => Some(f.floor() as i64),
+            _ => None,
+        }
+    }
 }
 
 /// Convert a `Value` into the implementors type.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6853,8 +6853,8 @@ pub fn op_open_ephemeral(
                 .begin_read_tx() // we have to begin a read tx before beginning a write
                 .expect("Failed to start read transaction");
 
-            pager.begin_write_tx()?;
-            pager.allocate_page1();
+            let _ = pager.begin_write_tx()?;
+            let _ = pager.allocate_page1();
             state.op_open_ephemeral_state = OpOpenEphemeralState::CreateBtree {
                 pager: pager.clone(),
             };

--- a/fuzz/fuzz_targets/large_pages.rs
+++ b/fuzz/fuzz_targets/large_pages.rs
@@ -1,0 +1,269 @@
+#![no_main]
+use arbitrary::Arbitrary;
+use libfuzzer_sys::{fuzz_target, Corpus};
+use std::{error::Error, fs, path::PathBuf, sync::Arc};
+
+#[derive(Debug, Arbitrary, Clone)]
+struct LargeDataConfig {
+    blob_size: u32,
+    num_insertions: u8,
+    num_updates: u8,
+    use_multiple_tables: bool,
+    create_indexes: bool,
+}
+
+impl LargeDataConfig {
+    fn normalize(&mut self) {
+        self.blob_size = self.blob_size;
+        self.num_insertions = self.num_insertions.max(1).min(100);
+        self.num_updates = self.num_updates.min(50);
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum Operation {
+    Insert {
+        table_id: u8,
+        data_size: u32,
+    },
+    Update {
+        table_id: u8,
+        rowid: u8,
+        data_size: u32,
+    },
+    Delete {
+        table_id: u8,
+        rowid: u8,
+    },
+    CreateIndex {
+        table_id: u8,
+    },
+}
+
+#[derive(Debug, Arbitrary)]
+struct LargeDataWorkload {
+    config: LargeDataConfig,
+    operations: Vec<Operation>,
+}
+
+impl LargeDataWorkload {
+    fn normalize(&mut self) {
+        self.config.normalize();
+        // Limit operations to prevent timeout
+        self.operations.truncate(200);
+    }
+}
+
+fn create_temp_file() -> Result<PathBuf, Box<dyn Error>> {
+    let temp_dir = std::env::temp_dir();
+    let file_name = format!("turso_fuzz_{}.db", std::process::id());
+    Ok(temp_dir.join(file_name))
+}
+
+fn setup_wal_mode(conn: &rusqlite::Connection) -> Result<(), Box<dyn Error>> {
+    conn.execute("PRAGMA journal_mode = WAL", ())?;
+    conn.execute("PRAGMA synchronous = NORMAL", ())?;
+    Ok(())
+}
+
+fn create_tables(
+    rusqlite_conn: &rusqlite::Connection,
+    turso_conn: &Arc<turso_core::Connection>,
+    num_tables: u8,
+    create_indexes: bool,
+) -> Result<(), Box<dyn Error>> {
+    let num_tables = num_tables.max(1).min(5);
+
+    for i in 0..num_tables {
+        let create_table_sql = format!(
+            "CREATE TABLE IF NOT EXISTS t{} (id INTEGER PRIMARY KEY, data BLOB, metadata TEXT)",
+            i
+        );
+
+        rusqlite_conn.execute(&create_table_sql, ())?;
+        turso_conn.execute(&create_table_sql)?;
+
+        if create_indexes {
+            let create_index_sql = format!(
+                "CREATE INDEX IF NOT EXISTS idx_t{}_metadata ON t{} (metadata)",
+                i, i
+            );
+
+            // Indexes might not be fully supported in turso, so we ignore errors
+            let _ = rusqlite_conn.execute(&create_index_sql, ());
+            let _ = turso_conn.execute(&create_index_sql);
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_operation(
+    operation: &Operation,
+    rusqlite_conn: &rusqlite::Connection,
+    turso_conn: &Arc<turso_core::Connection>,
+    _config: &LargeDataConfig,
+) -> Result<(), Box<dyn Error>> {
+    match operation {
+        Operation::Insert {
+            table_id,
+            data_size,
+        } => {
+            let table_num = table_id % 5;
+            let blob_size = (*data_size as usize);
+
+            let insert_sql = format!(
+                "INSERT INTO t{} (data, metadata) VALUES (randomblob(?), ?)",
+                table_num
+            );
+            let metadata = format!("size_{}_table_{}", blob_size, table_num);
+
+            rusqlite_conn.execute(&insert_sql, rusqlite::params![blob_size, metadata])?;
+            let insert_turso_sql = format!(
+                "INSERT INTO t{} (data, metadata) VALUES (randomblob({}), {})",
+                table_num, blob_size, metadata
+            );
+            turso_conn.execute(&insert_turso_sql).unwrap();
+        }
+
+        Operation::Update {
+            table_id,
+            rowid,
+            data_size,
+        } => {
+            let table_num = table_id % 5;
+            let blob_size = (*data_size as usize).max(1024).min(65536);
+            let row_id = (*rowid as i64).max(1);
+
+            let update_sql = format!(
+                "UPDATE t{} SET data = randomblob(?) WHERE rowid = ?",
+                table_num
+            );
+
+            // Execute on rusqlite
+            let _ = rusqlite_conn.execute(&update_sql, rusqlite::params![blob_size, row_id]);
+
+            // Execute on turso
+            let update_turso_sql = format!(
+                "UPDATE t{} SET data = randomblob({}) WHERE rowid = {}",
+                table_num, blob_size, row_id
+            );
+            turso_conn.execute(&update_turso_sql).unwrap();
+        }
+
+        Operation::Delete { table_id, rowid } => {
+            let table_num = table_id % 5;
+            let row_id = (*rowid as i64).max(1);
+
+            let delete_sql = format!("DELETE FROM t{} WHERE rowid = ?", table_num);
+
+            // Execute on both databases
+            let _ = rusqlite_conn.execute(&delete_sql, rusqlite::params![row_id]);
+
+            let delete_sql = format!("DELETE FROM t{} WHERE rowid = {}", table_num, row_id);
+            turso_conn.execute(&delete_sql).unwrap();
+        }
+
+        Operation::CreateIndex { table_id } => {
+            let table_num = table_id % 5;
+            let index_sql = format!(
+                "CREATE INDEX IF NOT EXISTS idx_t{}_data ON t{} (metadata)",
+                table_num, table_num
+            );
+
+            let _ = rusqlite_conn.execute(&index_sql, ());
+            let _ = turso_conn.execute(&index_sql);
+        }
+    }
+
+    Ok(())
+}
+
+fn do_fuzz(mut workload: LargeDataWorkload) -> Result<Corpus, Box<dyn Error>> {
+    workload.normalize();
+
+    // Create temporary file
+    let temp_file = create_temp_file()?;
+
+    // Ensure cleanup on drop
+    struct TempFileGuard(PathBuf);
+    impl Drop for TempFileGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+            let _ = fs::remove_file(self.0.with_extension("db-wal"));
+            let _ = fs::remove_file(self.0.with_extension("db-shm"));
+        }
+    }
+    let _guard = TempFileGuard(temp_file.clone());
+
+    // Setup rusqlite connection with WAL mode
+    let rusqlite_conn = rusqlite::Connection::open(&temp_file)?;
+    setup_wal_mode(&rusqlite_conn)?;
+
+    // Setup turso connection
+    let io = Arc::new(turso_core::MemoryIO::new());
+    let db = turso_core::Database::open_file(
+        io.clone(),
+        temp_file.as_os_str().to_str().unwrap(),
+        false,
+        true,
+    )?;
+    let turso_conn = db.connect()?;
+
+    // Create tables
+    let num_tables = if workload.config.use_multiple_tables {
+        5
+    } else {
+        1
+    };
+    create_tables(
+        &rusqlite_conn,
+        &turso_conn,
+        num_tables,
+        workload.config.create_indexes,
+    )?;
+
+    // Perform initial insertions
+    for i in 0..workload.config.num_insertions {
+        let operation = Operation::Insert {
+            table_id: i % num_tables,
+            data_size: workload.config.blob_size,
+        };
+
+        if let Err(_) = execute_operation(&operation, &rusqlite_conn, &turso_conn, &workload.config)
+        {
+            // If we can't perform basic insertions, this test case isn't useful
+            return Ok(Corpus::Reject);
+        }
+    }
+
+    // Perform updates
+    for i in 0..workload.config.num_updates {
+        let operation = Operation::Update {
+            table_id: i % num_tables,
+            rowid: (i % workload.config.num_insertions) + 1,
+            data_size: workload.config.blob_size / 2, // Use smaller size for updates
+        };
+
+        let _ = execute_operation(&operation, &rusqlite_conn, &turso_conn, &workload.config);
+    }
+
+    // Execute additional operations
+    for operation in &workload.operations {
+        let _ = execute_operation(operation, &rusqlite_conn, &turso_conn, &workload.config);
+    }
+
+    // Check database integrity
+    match rusqlite_conn.execute("PRAGMA integrity_check", ()) {
+        Ok(_) => {}
+        Err(_) => return Ok(Corpus::Reject),
+    }
+    match turso_conn.execute("PRAGMA integrity_check") {
+        Ok(_) => {}
+        Err(_) => return Ok(Corpus::Reject),
+    }
+
+    Ok(Corpus::Keep)
+}
+
+fuzz_target!(|workload: LargeDataWorkload| -> Corpus { do_fuzz(workload).unwrap_or(Corpus::Keep) });

--- a/testing/pragma.test
+++ b/testing/pragma.test
@@ -329,3 +329,17 @@ do_execsql_test_in_memory_any_error pragma-max-page-count-enforcement-error {
 do_execsql_test_regex pragma-module-list-nonempty {
   SELECT * FROM pragma_module_list;
 } {\ngenerate_series\n|^generate_series\n|\ngenerate_series$|^generate_series$}
+
+do_execsql_test_on_specific_db ":memory:" pragma-cache-spill {
+  PRAGMA cache_spill;
+} {483}
+
+do_execsql_test_on_specific_db ":memory:" pragma-cache-spill-empty-when-false {
+  PRAGMA cache_spill = false;
+  PRAGMA cache_spill;
+} {0}
+
+do_execsql_test_on_specific_db ":memory:" pragma-update-cache-spill {
+  PRAGMA cache_spill = 500;
+  PRAGMA cache_spill;
+} {500}

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1815,10 +1815,12 @@ pub type PragmaValue = Expr; // TODO
 pub enum PragmaName {
     /// Returns the application ID of the database file.
     ApplicationId,
-    /// set the autovacuum mode
+    /// Set the autovacuum mode
     AutoVacuum,
     /// `cache_size` pragma
     CacheSize,
+    /// Enables or disables the pager cache spilling in the middle of a transaction.
+    CacheSpill,
     /// List databases
     DatabaseList,
     /// Encoding - only support utf8


### PR DESCRIPTION
Closes #1661, #1625 and #2074

This PR also adds pragma `cache_spill` to manage cache spilling.

About #2074, I tested it locally and it works rather fine it only takes forever, about 10min in my laptop. We can turn spilling more efficient in future. 