### PR TITLE
Load static extensions once and store on Database instead of once per connection

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -137,8 +137,8 @@ impl Limbo {
             let conn = db.connect()?;
             (io, conn)
         };
-        let mut ext_api = conn.build_turso_ext();
         unsafe {
+            let mut ext_api = conn._build_turso_ext();
             if !limbo_completion::register_extension_static(&mut ext_api).is_ok() {
                 return Err(anyhow!(
                     "Failed to register completion extension".to_string()

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -138,10 +138,13 @@ impl Limbo {
             (io, conn)
         };
         let mut ext_api = conn.build_turso_ext();
-        if unsafe { !limbo_completion::register_extension_static(&mut ext_api).is_ok() } {
-            return Err(anyhow!(
-                "Failed to register completion extension".to_string()
-            ));
+        unsafe {
+            if !limbo_completion::register_extension_static(&mut ext_api).is_ok() {
+                return Err(anyhow!(
+                    "Failed to register completion extension".to_string()
+                ));
+            }
+            conn._free_extension_ctx(ext_api);
         }
         let interrupt_count = Arc::new(AtomicUsize::new(0));
         {

--- a/core/ext/dynamic.rs
+++ b/core/ext/dynamic.rs
@@ -35,7 +35,7 @@ impl Connection {
     ) -> crate::Result<()> {
         use turso_ext::ExtensionApiRef;
 
-        let api = Box::new(self.build_turso_ext());
+        let api = Box::new(self._build_turso_ext());
         let lib =
             unsafe { Library::new(path).map_err(|e| LimboError::ExtensionError(e.to_string()))? };
         let entry: Symbol<ExtensionEntryPoint> = unsafe {

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -1,12 +1,14 @@
 #[cfg(feature = "fs")]
 mod dynamic;
 mod vtab_xconnect;
-use crate::vtab::VirtualTable;
+use crate::schema::{Schema, Table};
 #[cfg(all(target_os = "linux", feature = "io_uring"))]
 use crate::UringIO;
 use crate::{function::ExternalFunc, Connection, Database, LimboError, IO};
+use crate::{vtab::VirtualTable, SymbolTable};
 #[cfg(feature = "fs")]
 pub use dynamic::{add_builtin_vfs_extensions, add_vfs_module, list_vfs_modules, VfsMod};
+use parking_lot::Mutex;
 use std::{
     ffi::{c_char, c_void, CStr, CString},
     rc::Rc,
@@ -17,7 +19,113 @@ use turso_ext::{
 };
 pub use turso_ext::{FinalizeFunction, StepFunction, Value as ExtValue, ValueType as ExtValueType};
 pub use vtab_xconnect::{close, execute, prepare_stmt};
-type ExternAggFunc = (InitAggFunction, StepFunction, FinalizeFunction);
+
+/// The context passed to extensions to register with Core
+/// along with the function pointers
+#[repr(C)]
+pub struct ExtensionCtx {
+    syms: *mut SymbolTable,
+    schema_data: *mut c_void,
+    schema_handler: SchemaHandler,
+}
+
+type SchemaHandler = unsafe extern "C" fn(
+    schema_data: *mut c_void,
+    table_name: *const c_char,
+    table: *mut c_void,
+) -> ResultCode;
+
+/// Handler for our Connection that has direct Arc<Schema> access
+/// to register a table from an extension.
+unsafe extern "C" fn handle_schema_insert_connection(
+    schema_data: *mut c_void,
+    table_name: *const c_char,
+    table: *mut c_void,
+) -> ResultCode {
+    let schema = &mut *(schema_data as *mut Schema);
+    let c_str = CStr::from_ptr(table_name);
+    let name = match c_str.to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return ResultCode::InvalidArgs,
+    };
+    let table = Box::from_raw(table as *mut Arc<Table>);
+    schema.tables.insert(name, *table);
+    ResultCode::OK
+}
+
+/// Handler for Database with Mutex<Arc<Schema>> access to
+/// register a table from an extension.
+unsafe extern "C" fn handle_schema_insert_database(
+    schema_data: *mut c_void,
+    table_name: *const c_char,
+    table: *mut c_void,
+) -> ResultCode {
+    let mutex = &*(schema_data as *mut Mutex<Arc<Schema>>);
+    let mut guard = mutex.lock();
+    let schema = Arc::make_mut(&mut *guard);
+
+    let c_str = CStr::from_ptr(table_name);
+    let name = match c_str.to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return ResultCode::InvalidArgs,
+    };
+    let table = Box::from_raw(table as *mut Arc<Table>);
+    schema.tables.insert(name, *table);
+    ResultCode::OK
+}
+
+pub(crate) unsafe extern "C" fn register_vtab_module(
+    ctx: *mut c_void,
+    name: *const c_char,
+    module: VTabModuleImpl,
+    kind: VTabKind,
+) -> ResultCode {
+    if name.is_null() || ctx.is_null() {
+        return ResultCode::Error;
+    }
+
+    let c_str = unsafe { CString::from_raw(name as *mut c_char) };
+    let name_str = match c_str.to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return ResultCode::Error,
+    };
+
+    let ext_ctx = unsafe { &mut *(ctx as *mut ExtensionCtx) };
+    let module = Rc::new(module);
+    let vmodule = VTabImpl {
+        module_kind: kind,
+        implementation: module,
+    };
+
+    unsafe {
+        let syms = &mut *ext_ctx.syms;
+        syms.vtab_modules.insert(name_str.clone(), vmodule.into());
+
+        if kind == VTabKind::TableValuedFunction {
+            if let Ok(vtab) = VirtualTable::function(&name_str, syms) {
+                // Use the schema handler to insert the table
+                let table = Box::into_raw(Box::new(Arc::new(Table::Virtual(vtab))));
+                let c_name = match CString::new(name_str) {
+                    Ok(s) => s,
+                    Err(_) => return ResultCode::Error,
+                };
+
+                let result = (ext_ctx.schema_handler)(
+                    ext_ctx.schema_data,
+                    c_name.as_ptr(),
+                    table as *mut c_void,
+                );
+                if result != ResultCode::OK {
+                    let _ = Box::from_raw(table);
+                    return result;
+                }
+            } else {
+                return ResultCode::Error;
+            }
+        }
+    }
+    ResultCode::OK
+}
 
 #[derive(Clone)]
 pub struct VTabImpl {
@@ -38,8 +146,14 @@ pub(crate) unsafe extern "C" fn register_scalar_function(
     if ctx.is_null() {
         return ResultCode::Error;
     }
-    let conn = unsafe { &*(ctx as *const Connection) };
-    conn.register_scalar_function_impl(&name_str, func)
+    let ext_ctx = unsafe { &mut *(ctx as *mut ExtensionCtx) };
+    unsafe {
+        (*ext_ctx.syms).functions.insert(
+            name_str.clone(),
+            Rc::new(ExternalFunc::new_scalar(name_str, func)),
+        );
+    }
+    ResultCode::OK
 }
 
 pub(crate) unsafe extern "C" fn register_aggregate_function(
@@ -58,30 +172,18 @@ pub(crate) unsafe extern "C" fn register_aggregate_function(
     if ctx.is_null() {
         return ResultCode::Error;
     }
-    let conn = unsafe { &*(ctx as *const Connection) };
-    conn.register_aggregate_function_impl(&name_str, args, (init_func, step_func, finalize_func))
-}
-
-pub(crate) unsafe extern "C" fn register_vtab_module(
-    ctx: *mut c_void,
-    name: *const c_char,
-    module: VTabModuleImpl,
-    kind: VTabKind,
-) -> ResultCode {
-    if name.is_null() || ctx.is_null() {
-        return ResultCode::Error;
+    let ext_ctx = unsafe { &mut *(ctx as *mut ExtensionCtx) };
+    unsafe {
+        (*ext_ctx.syms).functions.insert(
+            name_str.clone(),
+            Rc::new(ExternalFunc::new_aggregate(
+                name_str,
+                args,
+                (init_func, step_func, finalize_func),
+            )),
+        );
     }
-    let c_str = unsafe { CString::from_raw(name as *mut _) };
-    let name_str = match c_str.to_str() {
-        Ok(s) => s.to_string(),
-        Err(_) => return ResultCode::Error,
-    };
-    if ctx.is_null() {
-        return ResultCode::Error;
-    }
-    let conn = unsafe { &mut *(ctx as *mut Connection) };
-
-    conn.register_vtab_module_impl(&name_str, module, kind)
+    ResultCode::OK
 }
 
 impl Database {
@@ -110,58 +212,64 @@ impl Database {
         let db = Self::open_file(io.clone(), path, false, false)?;
         Ok((io, db))
     }
+
+    /// Register any built-in extensions that can be stored on the Database so we do not have
+    /// to register these once-per-connection, and the connection can just extend its symbol table
+    pub fn register_global_builtin_extensions(&self) -> Result<(), String> {
+        let syms = self.builtin_syms.as_ptr();
+        // Pass the mutex pointer and the appropriate handler
+        let schema_mutex_ptr = &self.schema as *const Mutex<Arc<Schema>> as *mut Mutex<Arc<Schema>>;
+        let ctx = Box::into_raw(Box::new(ExtensionCtx {
+            syms,
+            schema_data: schema_mutex_ptr as *mut c_void,
+            schema_handler: handle_schema_insert_database,
+        }));
+        let mut ext_api = ExtensionApi {
+            ctx: ctx as *mut c_void,
+            register_scalar_function,
+            register_aggregate_function,
+            register_vtab_module,
+            #[cfg(feature = "fs")]
+            vfs_interface: turso_ext::VfsInterface {
+                register_vfs: dynamic::register_vfs,
+                builtin_vfs: std::ptr::null_mut(),
+                builtin_vfs_count: 0,
+            },
+        };
+
+        #[cfg(feature = "uuid")]
+        crate::uuid::register_extension(&mut ext_api);
+        #[cfg(feature = "series")]
+        crate::series::register_extension(&mut ext_api);
+        #[cfg(feature = "fs")]
+        {
+            let vfslist = add_builtin_vfs_extensions(Some(ext_api)).map_err(|e| e.to_string())?;
+            for (name, vfs) in vfslist {
+                add_vfs_module(name, vfs);
+            }
+        }
+        let _ = unsafe { Box::from_raw(ctx) };
+        Ok(())
+    }
 }
 
 impl Connection {
-    fn register_scalar_function_impl(&self, name: &str, func: ScalarFunction) -> ResultCode {
-        self.syms.borrow_mut().functions.insert(
-            name.to_string(),
-            Rc::new(ExternalFunc::new_scalar(name.to_string(), func)),
-        );
-        ResultCode::OK
-    }
-
-    fn register_aggregate_function_impl(
-        &self,
-        name: &str,
-        args: i32,
-        func: ExternAggFunc,
-    ) -> ResultCode {
-        self.syms.borrow_mut().functions.insert(
-            name.to_string(),
-            Rc::new(ExternalFunc::new_aggregate(name.to_string(), args, func)),
-        );
-        ResultCode::OK
-    }
-
-    fn register_vtab_module_impl(
-        &mut self,
-        name: &str,
-        module: VTabModuleImpl,
-        kind: VTabKind,
-    ) -> ResultCode {
-        let module = Rc::new(module);
-        let vmodule = VTabImpl {
-            module_kind: kind,
-            implementation: module,
+    /// # Safety:
+    /// Only to be used when registering a staticly linked extension manually.
+    /// you probably want to use `Connection::load_extension(path)`.
+    /// Do not call if you have multiple connection open.
+    pub fn _build_turso_ext(&self) -> ExtensionApi {
+        let schema_ptr = self.schema.as_ptr();
+        let schema_direct = unsafe { Arc::as_ptr(&*schema_ptr) as *mut Schema };
+        let ctx = ExtensionCtx {
+            syms: self.syms.as_ptr(),
+            schema_data: schema_direct as *mut c_void,
+            schema_handler: handle_schema_insert_connection,
         };
-        self.syms
-            .borrow_mut()
-            .vtab_modules
-            .insert(name.to_string(), vmodule.into());
-        if kind == VTabKind::TableValuedFunction {
-            if let Ok(vtab) = VirtualTable::function(name, &self.syms.borrow()) {
-                self.with_schema_mut(|schema| schema.add_virtual_table(vtab));
-            } else {
-                return ResultCode::Error;
-            }
-        }
-        ResultCode::OK
-    }
 
-    pub fn build_turso_ext(&self) -> ExtensionApi {
+        let ctx = Box::into_raw(Box::new(ctx)) as *mut c_void;
         ExtensionApi {
-            ctx: self as *const _ as *mut c_void,
+            ctx,
             register_scalar_function,
             register_aggregate_function,
             register_vtab_module,
@@ -174,20 +282,13 @@ impl Connection {
         }
     }
 
-    pub fn register_builtins(&self) -> Result<(), String> {
-        #[allow(unused_variables)]
-        let mut ext_api = self.build_turso_ext();
-        #[cfg(feature = "uuid")]
-        crate::uuid::register_extension(&mut ext_api);
-        #[cfg(feature = "series")]
-        crate::series::register_extension(&mut ext_api);
-        #[cfg(feature = "fs")]
-        {
-            let vfslist = add_builtin_vfs_extensions(Some(ext_api)).map_err(|e| e.to_string())?;
-            for (name, vfs) in vfslist {
-                add_vfs_module(name, vfs);
-            }
+    /// # Safety:
+    /// Only to be used if you have previously called Connection::build_turso_ext
+    /// before registering an extension manually.
+    pub unsafe fn _free_extension_ctx(&self, api: ExtensionApi) {
+        if api.ctx.is_null() {
+            return;
         }
-        Ok(())
+        let _ = unsafe { Box::from_raw(api.ctx as *mut ExtensionCtx) };
     }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -59,10 +59,9 @@ pub use io::{
     Buffer, Completion, CompletionType, File, MemoryIO, OpenFlags, PlatformIO, SyscallIO,
     WriteCompletion, IO,
 };
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use schema::Schema;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
 use std::{
     borrow::Cow,
     cell::{Cell, RefCell, UnsafeCell},
@@ -121,6 +120,7 @@ pub struct Database {
     db_state: Arc<AtomicUsize>,
     init_lock: Arc<Mutex<()>>,
     open_flags: OpenFlags,
+    builtin_syms: RefCell<SymbolTable>,
 }
 
 unsafe impl Send for Database {}
@@ -149,7 +149,7 @@ impl fmt::Debug for Database {
         };
         debug_struct.field("mv_store", &mv_store_status);
 
-        let init_lock_status = if self.init_lock.try_lock().is_ok() {
+        let init_lock_status = if self.init_lock.try_lock().is_some() {
             "unlocked"
         } else {
             "locked"
@@ -245,7 +245,7 @@ impl Database {
         };
 
         let shared_page_cache = Arc::new(RwLock::new(DumbLruPageCache::default()));
-
+        let syms = SymbolTable::new();
         let db = Arc::new(Database {
             mv_store,
             path: path.to_string(),
@@ -253,11 +253,14 @@ impl Database {
             _shared_page_cache: shared_page_cache.clone(),
             maybe_shared_wal: RwLock::new(maybe_shared_wal),
             db_file,
+            builtin_syms: syms.into(),
             io: io.clone(),
             open_flags: flags,
             db_state: Arc::new(AtomicUsize::new(db_state)),
             init_lock: Arc::new(Mutex::new(())),
         });
+        db.register_global_builtin_extensions()
+            .expect("unable to register global extensions");
 
         // Check: https://github.com/tursodatabase/turso/pull/1761#discussion_r2154013123
         if db_state == DB_STATE_INITIALIZED {
@@ -294,12 +297,7 @@ impl Database {
         let conn = Arc::new(Connection {
             _db: self.clone(),
             pager: RefCell::new(Rc::new(pager)),
-            schema: RefCell::new(
-                self.schema
-                    .lock()
-                    .map_err(|_| LimboError::SchemaLocked)?
-                    .clone(),
-            ),
+            schema: RefCell::new(self.schema.lock().clone()),
             auto_commit: Cell::new(true),
             mv_transactions: RefCell::new(Vec::new()),
             transaction_state: Cell::new(TransactionState::None),
@@ -315,10 +313,9 @@ impl Database {
             capture_data_changes: RefCell::new(CaptureDataChangesMode::Off),
             closed: Cell::new(false),
         });
-
-        if let Err(e) = conn.register_builtins() {
-            return Err(LimboError::ExtensionError(e));
-        }
+        let builtin_syms = self.builtin_syms.borrow();
+        // add built-in extensions symbols to the connection to prevent having to load each time
+        conn.syms.borrow_mut().extend(&builtin_syms);
         Ok(conn)
     }
 
@@ -443,7 +440,7 @@ impl Database {
 
     #[inline]
     pub fn with_schema_mut<T>(&self, f: impl FnOnce(&mut Schema) -> Result<T>) -> Result<T> {
-        let mut schema_ref = self.schema.lock().map_err(|_| LimboError::SchemaLocked)?;
+        let mut schema_ref = self.schema.try_lock().ok_or(LimboError::SchemaLocked)?;
         let schema = Arc::make_mut(&mut *schema_ref);
         f(schema)
     }
@@ -789,11 +786,7 @@ impl Connection {
 
     pub fn maybe_update_schema(&self) -> Result<()> {
         let current_schema_version = self.schema.borrow().schema_version;
-        let schema = self
-            ._db
-            .schema
-            .lock()
-            .map_err(|_| LimboError::SchemaLocked)?;
+        let schema = self._db.schema.try_lock().ok_or(LimboError::SchemaLocked)?;
         if matches!(self.transaction_state.get(), TransactionState::None)
             && current_schema_version < schema.schema_version
         {
@@ -1221,6 +1214,18 @@ impl SymbolTable {
         _arg_count: usize,
     ) -> Option<Rc<function::ExternalFunc>> {
         self.functions.get(name).cloned()
+    }
+
+    pub fn extend(&mut self, other: &SymbolTable) {
+        for (name, func) in &other.functions {
+            self.functions.insert(name.clone(), func.clone());
+        }
+        for (name, vtab) in &other.vtabs {
+            self.vtabs.insert(name.clone(), vtab.clone());
+        }
+        for (name, module) in &other.vtab_modules {
+            self.vtab_modules.insert(name.clone(), module.clone());
+        }
     }
 }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -9,12 +9,12 @@ use crate::types::IOResult;
 use crate::util::IOExt as _;
 use crate::{return_if_io, Completion};
 use crate::{turso_assert, Buffer, Connection, LimboError, Result};
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use std::cell::{Cell, OnceCell, RefCell, UnsafeCell};
 use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tracing::{instrument, trace, Level};
 
 use super::btree::{btree_init_page, BTreePage};
@@ -680,7 +680,7 @@ impl Pager {
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn maybe_allocate_page1(&self) -> Result<IOResult<()>> {
         if self.db_state.load(Ordering::SeqCst) < DB_STATE_INITIALIZED {
-            if let Some(_lock) = self.init_lock.try_lock() {
+            if let Ok(_lock) = self.init_lock.lock() {
                 match (
                     self.db_state.load(Ordering::SeqCst),
                     self.allocating_page1(),
@@ -738,8 +738,8 @@ impl Pager {
                     *connection
                         ._db
                         .schema
-                        .try_lock()
-                        .ok_or(LimboError::SchemaLocked)? = schema;
+                        .lock()
+                        .map_err(|_| LimboError::SchemaLocked)? = schema;
                 }
                 Ok(commit_status)
             }
@@ -1360,8 +1360,8 @@ impl Pager {
                 connection
                     ._db
                     .schema
-                    .try_lock()
-                    .ok_or(LimboError::SchemaLocked)?
+                    .lock()
+                    .map_err(|_| LimboError::SchemaLocked)?
                     .clone(),
             );
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -31,7 +31,6 @@ use crate::{
 };
 use std::ops::DerefMut;
 use std::sync::atomic::AtomicUsize;
-use std::sync::Mutex;
 use std::{borrow::BorrowMut, rc::Rc, sync::Arc};
 
 use crate::{pseudo::PseudoCursor, result::LimboResult};
@@ -62,7 +61,7 @@ use super::{
     CommitState,
 };
 use fallible_iterator::FallibleIterator;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rand::{thread_rng, Rng};
 use turso_sqlite3_parser::ast;
 use turso_sqlite3_parser::ast::fmt::ToTokens;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -31,7 +31,11 @@ use crate::{
 };
 use std::ops::DerefMut;
 use std::sync::atomic::AtomicUsize;
-use std::{borrow::BorrowMut, rc::Rc, sync::Arc};
+use std::{
+    borrow::BorrowMut,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 
 use crate::{pseudo::PseudoCursor, result::LimboResult};
 
@@ -61,7 +65,7 @@ use super::{
     CommitState,
 };
 use fallible_iterator::FallibleIterator;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use rand::{thread_rng, Rng};
 use turso_sqlite3_parser::ast;
 use turso_sqlite3_parser::ast::fmt::ToTokens;


### PR DESCRIPTION
To help make the connection speed faster, we don't need to register these every time as they are compiled in.