### PR TITLE
Fix issues in alter table tests and fix a small error in BTreeTable::to_sql

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -430,7 +430,7 @@ impl BTreeTable {
     }
 
     pub fn to_sql(&self) -> String {
-        let mut sql = format!("CREATE TABLE {} (", self.name);
+        let mut sql = format!("CREATE TABLE {}(", self.name);
         for (i, column) in self.columns.iter().enumerate() {
             if i > 0 {
                 sql.push_str(", ");

--- a/testing/all.test
+++ b/testing/all.test
@@ -3,6 +3,7 @@
 set testdir [file dirname $argv0]
 
 source $testdir/cmdlineshell.test
+source $testdir/alter_table.test
 source $testdir/agg-functions.test
 source $testdir/coalesce.test
 source $testdir/delete.test

--- a/testing/alter_table.test
+++ b/testing/alter_table.test
@@ -4,19 +4,21 @@ set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
 do_execsql_test_on_specific_db {:memory:} alter-table-rename-table {
-    CREATE TABLE t1(x INTEGER PRIMARY KEY, u UNIQUE);
+    CREATE TABLE t1(x INTEGER PRIMARY KEY, u);
     ALTER TABLE t1 RENAME TO t2;
     SELECT name FROM sqlite_schema WHERE type = 'table';
 } { "t2" }
 
-do_execsql_test_on_specific_db {:memory:} alter-table-rename-column {
-    CREATE TABLE t(a);
-    CREATE INDEX i ON t(a);
-    ALTER TABLE t RENAME a TO b;
-    SELECT sql FROM sqlite_schema;
-} {
-    "CREATE TABLE t(b)"
-    "CREATE INDEX i ON t(b)"
+if {[info exists ::env(SQLITE_EXEC)] && $::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental"} {
+    do_execsql_test_on_specific_db {:memory:} alter-table-rename-column {
+        CREATE TABLE t(a);
+        CREATE INDEX i ON t(a);
+        ALTER TABLE t RENAME a TO b;
+        SELECT sql FROM sqlite_schema;
+    } {
+        "CREATE TABLE t(b)"
+        "CREATE INDEX i ON t(b)"
+    }
 }
 
 do_execsql_test_on_specific_db {:memory:} alter-table-add-column {
@@ -46,32 +48,34 @@ do_execsql_test_on_specific_db {:memory:} alter-table-add-column-typed {
   "1|0"
 }
 
-do_execsql_test_on_specific_db {:memory:} alter-table-add-column-default {
-    CREATE TABLE test(a);
-    INSERT INTO test VALUES (1), (2), (3);
+if {[info exists ::env(SQLITE_EXEC)] && $::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental"} {
+    do_execsql_test_on_specific_db {:memory:} alter-table-add-column-default {
+        CREATE TABLE test(a);
+        INSERT INTO test VALUES (1), (2), (3);
 
-    ALTER TABLE test ADD b DEFAULT 0.1;
-    ALTER TABLE test ADD c DEFAULT 'hello';
-    SELECT * FROM test;
+        ALTER TABLE test ADD b DEFAULT 0.1;
+        ALTER TABLE test ADD c DEFAULT 'hello';
+        SELECT * FROM test;
 
-    CREATE INDEX idx ON test (b);
-    SELECT b, c FROM test WHERE b = 0.1;
+        CREATE INDEX idx ON test (b);
+        SELECT b, c FROM test WHERE b = 0.1;
 
-    ALTER TABLE test DROP a;
-    SELECT * FROM test;
+        ALTER TABLE test DROP a;
+        SELECT * FROM test;
 
-} {
-  "1|0.1|hello"
-  "2|0.1|hello"
-  "3|0.1|hello"
+    } {
+    "1|0.1|hello"
+    "2|0.1|hello"
+    "3|0.1|hello"
 
-  "0.1|hello"
-  "0.1|hello"
-  "0.1|hello"
+    "0.1|hello"
+    "0.1|hello"
+    "0.1|hello"
 
-  "0.1|hello"
-  "0.1|hello"
-  "0.1|hello"
+    "0.1|hello"
+    "0.1|hello"
+    "0.1|hello"
+    }
 }
 
 do_execsql_test_on_specific_db {:memory:} alter-table-drop-column {
@@ -104,7 +108,7 @@ do_execsql_test_on_specific_db {:memory:} alter-table-drop-column-special-name {
     SELECT sql FROM sqlite_schema;
 } {
     3
-    "CREATE TABLE t (a, [c c])"
+    "CREATE TABLE t(a, [c c])"
 }
 
 do_execsql_test_in_memory_any_error fail-alter-table-drop-unique-column {


### PR DESCRIPTION
Closes #2186 

```git
commit 2095e5dde13ee7d089744304ff45d718ddd67db7 (HEAD -> fix-alter-table, origin/fix-alter-table, main)
Author: Jussi Saurio <jussi.saurio@gmail.com>
Date:   Tue Jul 22 11:12:02 2025 +0300

    test/tcl: run alter_table.test in all.test

commit 58f98391d00ba3648a04142fb85e824e432d9361
Author: Jussi Saurio <jussi.saurio@gmail.com>
Date:   Tue Jul 22 11:11:50 2025 +0300

    test/tcl: fix alter table test assertions and require index flag on some tests

commit 13d40c6a732590de93f1d284ca226a94271a1f39
Author: Jussi Saurio <jussi.saurio@gmail.com>
Date:   Tue Jul 22 11:11:08 2025 +0300

    schema: fix extra whitespace in BTreeTable::from_sql
```