### PR TITLE
chore: make every CREATE TABLE stmt in entire repo have 1 space after tbl name

### DIFF
--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -122,7 +122,7 @@ async fn test_rows_returned() {
     let conn = db.connect().unwrap();
 
     //--- CRUD Operations ---//
-    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)", ())
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)", ())
         .await
         .unwrap();
     let changed = conn

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -120,7 +120,7 @@ impl PragmaVirtualTable {
         let mut max_arg_count = 0;
         let mut has_pragma_arg = false;
 
-        let mut sql = String::from("CREATE TABLE x(");
+        let mut sql = String::from("CREATE TABLE x (");
         let col_defs = pragma
             .columns
             .iter()

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -407,7 +407,7 @@ impl BTreeTable {
 
     /// Returns the column position and column for a given column name.
     /// Returns None if the column name is not found.
-    /// E.g. if table is CREATE TABLE t(a, b, c)
+    /// E.g. if table is CREATE TABLE t (a, b, c)
     /// then get_column("b") returns (1, &Column { .. })
     pub fn get_column(&self, name: &str) -> Option<(usize, &Column)> {
         let name = normalize_ident(name);
@@ -429,8 +429,13 @@ impl BTreeTable {
         }
     }
 
+    /// Reconstruct the SQL for the table.
+    /// FIXME: this makes us incompatible with SQLite since sqlite stores the user-provided SQL as is in
+    /// `sqlite_schema.sql`
+    /// For example, if a user creates a table like: `CREATE TABLE t              (x)`, we store it as
+    /// `CREATE TABLE t (x)`, whereas sqlite stores it with the original extra whitespace.
     pub fn to_sql(&self) -> String {
-        let mut sql = format!("CREATE TABLE {}(", self.name);
+        let mut sql = format!("CREATE TABLE {} (", self.name);
         for (i, column) in self.columns.iter().enumerate() {
             if i > 0 {
                 sql.push_str(", ");
@@ -1153,7 +1158,7 @@ pub struct IndexColumn {
     pub order: SortOrder,
     /// the position of the column in the source table.
     /// for example:
-    /// CREATE TABLE t(a,b,c)
+    /// CREATE TABLE t (a,b,c)
     /// CREATE INDEX idx ON t(b)
     /// b.pos_in_table == 1
     pub pos_in_table: usize,
@@ -1389,7 +1394,7 @@ impl Index {
     /// Given a column position in the table, return the position in the index.
     /// Returns None if the column is not found in the index.
     /// For example, given:
-    /// CREATE TABLE t(a, b, c)
+    /// CREATE TABLE t (a, b, c)
     /// CREATE INDEX idx ON t(b)
     /// then column_table_pos_to_index_pos(1) returns Some(0)
     pub fn column_table_pos_to_index_pos(&self, table_pos: usize) -> Option<usize> {

--- a/core/series.rs
+++ b/core/series.rs
@@ -31,7 +31,7 @@ impl VTabModule for GenerateSeriesVTabModule {
     const VTAB_KIND: VTabKind = VTabKind::TableValuedFunction;
 
     fn create(_args: &[Value]) -> Result<(String, Self::Table), ResultCode> {
-        let schema = "CREATE TABLE generate_series(
+        let schema = "CREATE TABLE generate_series (
             value INTEGER,
             start INTEGER HIDDEN,
             stop INTEGER HIDDEN,

--- a/extensions/completion/src/lib.rs
+++ b/extensions/completion/src/lib.rs
@@ -71,7 +71,7 @@ impl VTabModule for CompletionVTabModule {
     const VTAB_KIND: turso_ext::VTabKind = turso_ext::VTabKind::TableValuedFunction;
 
     fn create(_args: &[Value]) -> Result<(String, Self::Table), ResultCode> {
-        let schema = "CREATE TABLE completion(
+        let schema = "CREATE TABLE completion (
             candidate TEXT,
             prefix TEXT HIDDEN,
             wholeline TEXT HIDDEN,

--- a/extensions/csv/src/lib.rs
+++ b/extensions/csv/src/lib.rs
@@ -209,7 +209,7 @@ impl VTabModule for CsvVTabModule {
         }
 
         if schema.is_none() {
-            let mut sql = String::from("CREATE TABLE x(");
+            let mut sql = String::from("CREATE TABLE x (");
             for (i, col) in columns.iter().enumerate() {
                 sql.push('"');
                 sql.push_str(col);
@@ -541,7 +541,7 @@ mod tests {
         let cursor = table.open(None).unwrap();
         let rows = read_rows(cursor, 2);
         assert!(rows.is_empty());
-        assert_eq!(schema, "CREATE TABLE x(\"c0\" TEXT)");
+        assert_eq!(schema, "CREATE TABLE x (\"c0\" TEXT)");
     }
 
     #[test]
@@ -550,7 +550,7 @@ mod tests {
         let cursor = table.open(None).unwrap();
         let rows = read_rows(cursor, 2);
         assert!(rows.is_empty());
-        assert_eq!(schema, "CREATE TABLE x(\"c0\" TEXT)");
+        assert_eq!(schema, "CREATE TABLE x (\"c0\" TEXT)");
     }
 
     #[test]
@@ -564,7 +564,7 @@ mod tests {
         let cursor = table.open(None).unwrap();
         let rows = read_rows(cursor, 2);
         assert!(rows.is_empty());
-        assert_eq!(schema, "CREATE TABLE x(\"(NULL)\" TEXT)");
+        assert_eq!(schema, "CREATE TABLE x (\"(NULL)\" TEXT)");
     }
 
     #[test]
@@ -573,7 +573,7 @@ mod tests {
         let cursor = table.open(None).unwrap();
         let rows = read_rows(cursor, 2);
         assert!(rows.is_empty());
-        assert_eq!(schema, "CREATE TABLE x(\"(NULL)\" TEXT)");
+        assert_eq!(schema, "CREATE TABLE x (\"(NULL)\" TEXT)");
     }
 
     #[test]
@@ -609,7 +609,7 @@ mod tests {
         let table = new_table(vec![
             &format!("filename={}", file.path().to_string_lossy()),
             "header=false",
-            "schema=CREATE TABLE x(id INT, name TEXT)",
+            "schema=CREATE TABLE x (id INT, name TEXT)",
         ]);
         let cursor = table.open(None).unwrap();
         let rows = read_rows(cursor, 2);
@@ -637,8 +637,8 @@ mod tests {
     #[test]
     fn test_more_than_one_schema_argument() {
         let result = try_new_table(vec![
-            "schema=CREATE TABLE x(id INT, name TEXT)",
-            "schema=CREATE TABLE x(key INT, value TEXT)",
+            "schema=CREATE TABLE x (id INT, name TEXT)",
+            "schema=CREATE TABLE x (key INT, value TEXT)",
         ]);
         assert!(matches!(result, Err(ResultCode::InvalidArgs)));
     }
@@ -731,9 +731,9 @@ mod tests {
     fn test_unparsable_argument() {
         let unparsable_arguments = [
             "header",
-            "schema='CREATE TABLE x(id INT, name TEXT)",
-            "schema=\"CREATE TABLE x(id INT, name TEXT)",
-            "schema=\"CREATE TABLE x(id INT, name TEXT)'",
+            "schema='CREATE TABLE x (id INT, name TEXT)",
+            "schema=\"CREATE TABLE x (id INT, name TEXT)",
+            "schema=\"CREATE TABLE x (id INT, name TEXT)'",
         ];
 
         for &val in &unparsable_arguments {
@@ -825,7 +825,7 @@ mod tests {
             &format!("filename={}", file.path().to_string_lossy()),
             "header=false",
             "columns=1",
-            "schema='CREATE TABLE x(id INT, name TEXT)'",
+            "schema='CREATE TABLE x (id INT, name TEXT)'",
         ]);
         let cursor = table.open(None).unwrap();
         let rows = read_rows(cursor, 2);
@@ -839,7 +839,7 @@ mod tests {
             &format!("filename={}", file.path().to_string_lossy()),
             "header=false",
             "columns=5",
-            "schema='CREATE TABLE x(id INT, name TEXT)'",
+            "schema='CREATE TABLE x (id INT, name TEXT)'",
         ]);
         let cursor = table.open(None).unwrap();
         let rows = read_rows(cursor, 2);
@@ -871,7 +871,7 @@ mod tests {
         );
         assert_eq!(
             schema,
-            "CREATE TABLE x(\"id\" TEXT, \"first\"\"name\" TEXT)"
+            "CREATE TABLE x (\"id\" TEXT, \"first\"\"name\" TEXT)"
         );
     }
 }

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -334,7 +334,7 @@ impl VTabModule for TableStatsVtabModule {
     const NAME: &'static str = "tablestats";
 
     fn create(_args: &[Value]) -> Result<(String, Self::Table), ResultCode> {
-        let schema = "CREATE TABLE x(name TEXT, rows INT);".to_string();
+        let schema = "CREATE TABLE x (name TEXT, rows INT);".to_string();
         Ok((schema, StatsTable {}))
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -238,7 +238,7 @@ pub fn derive_agg_func(input: TokenStream) -> TokenStream {
 ///
 ///   /// Declare your virtual table and its schema
 ///  fn create(args: &[Value]) -> Result<(String, Self::Table), ResultCode> {
-///     let schema = "CREATE TABLE csv_data(
+///     let schema = "CREATE TABLE csv_data (
 ///             name TEXT,
 ///             age TEXT,
 ///             city TEXT

--- a/testing/agg-functions.test
+++ b/testing/agg-functions.test
@@ -56,13 +56,13 @@ do_execsql_test select-min {
 } {1}
 
 do_execsql_test_on_specific_db {:memory:} min-null-regression-test {
-  CREATE TABLE t(a);
+  CREATE TABLE t (a);
   INSERT INTO t VALUES ('abc'), (NULL);
   SELECT min(a) FROM t;
 } {abc}
 
 do_execsql_test_on_specific_db {:memory:} max-null-regression-test {
-  CREATE TABLE t(a);
+  CREATE TABLE t (a);
   INSERT INTO t VALUES ('abc'), (NULL);
   SELECT max(a) FROM t;
 } {abc}

--- a/testing/alter_table.test
+++ b/testing/alter_table.test
@@ -4,25 +4,25 @@ set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
 do_execsql_test_on_specific_db {:memory:} alter-table-rename-table {
-    CREATE TABLE t1(x INTEGER PRIMARY KEY, u);
+    CREATE TABLE t1 (x INTEGER PRIMARY KEY, u);
     ALTER TABLE t1 RENAME TO t2;
     SELECT name FROM sqlite_schema WHERE type = 'table';
 } { "t2" }
 
 if {[info exists ::env(SQLITE_EXEC)] && $::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental"} {
     do_execsql_test_on_specific_db {:memory:} alter-table-rename-column {
-        CREATE TABLE t(a);
+        CREATE TABLE t (a);
         CREATE INDEX i ON t(a);
         ALTER TABLE t RENAME a TO b;
         SELECT sql FROM sqlite_schema;
     } {
-        "CREATE TABLE t(b)"
+        "CREATE TABLE t (b)"
         "CREATE INDEX i ON t(b)"
     }
 }
 
 do_execsql_test_on_specific_db {:memory:} alter-table-add-column {
-    CREATE TABLE t(a);
+    CREATE TABLE t (a);
     INSERT INTO t VALUES (1);
     SELECT * FROM t;
 
@@ -31,12 +31,12 @@ do_execsql_test_on_specific_db {:memory:} alter-table-add-column {
     SELECT * FROM t;
 } {
   "1"
-  "CREATE TABLE t(a, b)"
+  "CREATE TABLE t (a, b)"
   "1|"
 }
 
 do_execsql_test_on_specific_db {:memory:} alter-table-add-column-typed {
-    CREATE TABLE t(a);
+    CREATE TABLE t (a);
     ALTER TABLE t ADD b DEFAULT 0;
 
     SELECT sql FROM sqlite_schema;
@@ -44,13 +44,13 @@ do_execsql_test_on_specific_db {:memory:} alter-table-add-column-typed {
     INSERT INTO t (a) VALUES (1);
     SELECT * FROM t;
 } {
-  "CREATE TABLE t(a, b DEFAULT 0)"
+  "CREATE TABLE t (a, b DEFAULT 0)"
   "1|0"
 }
 
 if {[info exists ::env(SQLITE_EXEC)] && $::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental"} {
     do_execsql_test_on_specific_db {:memory:} alter-table-add-column-default {
-        CREATE TABLE test(a);
+        CREATE TABLE test (a);
         INSERT INTO test VALUES (1), (2), (3);
 
         ALTER TABLE test ADD b DEFAULT 0.1;
@@ -79,7 +79,7 @@ if {[info exists ::env(SQLITE_EXEC)] && $::env(SQLITE_EXEC) eq "scripts/limbo-sq
 }
 
 do_execsql_test_on_specific_db {:memory:} alter-table-drop-column {
-    CREATE TABLE t(a, b);
+    CREATE TABLE t (a, b);
     INSERT INTO t VALUES (1, 1), (2, 2), (3, 3);
     SELECT * FROM t;
 
@@ -92,7 +92,7 @@ do_execsql_test_on_specific_db {:memory:} alter-table-drop-column {
   "2|2"
   "3|3"
 
-  "CREATE TABLE t(a)"
+  "CREATE TABLE t (a)"
 
   "1"
   "2"
@@ -100,7 +100,7 @@ do_execsql_test_on_specific_db {:memory:} alter-table-drop-column {
 }
 
 do_execsql_test_on_specific_db {:memory:} alter-table-drop-column-special-name {
-    CREATE TABLE t(a, b, [c c]);
+    CREATE TABLE t (a, b, [c c]);
     INSERT INTO t VALUES (1, 2, 3);
     ALTER TABLE t DROP COLUMN b;
 
@@ -108,25 +108,25 @@ do_execsql_test_on_specific_db {:memory:} alter-table-drop-column-special-name {
     SELECT sql FROM sqlite_schema;
 } {
     3
-    "CREATE TABLE t(a, [c c])"
+    "CREATE TABLE t (a, [c c])"
 }
 
 do_execsql_test_in_memory_any_error fail-alter-table-drop-unique-column {
-    CREATE TABLE t(a, b UNIQUE);
+    CREATE TABLE t (a, b UNIQUE);
     ALTER TABLE t DROP b;
 }
 
 do_execsql_test_in_memory_any_error fail-alter-table-drop-unique-column-constraint {
-    CREATE TABLE t(a, b, UNIQUE (b));
+    CREATE TABLE t (a, b, UNIQUE (b));
     ALTER TABLE t DROP b;
 }
 
 do_execsql_test_in_memory_any_error fail-alter-table-drop-primary-key-column {
-    CREATE TABLE t(a PRIMARY KEY, b);
+    CREATE TABLE t (a PRIMARY KEY, b);
     ALTER TABLE t DROP a;
 }
 
 do_execsql_test_in_memory_any_error fail-alter-table-drop-primary-key-column-constrait {
-    CREATE TABLE t(a, b, PRIMARY KEY (a));
+    CREATE TABLE t (a, b, PRIMARY KEY (a));
     ALTER TABLE t DROP a;
 }

--- a/testing/collate.test
+++ b/testing/collate.test
@@ -42,11 +42,11 @@ do_execsql_test collate_left_precedence_2 {
 } {1}
 
 do_execsql_test_in_memory_any_error collate_unique_constraint {
-    CREATE TABLE t(a TEXT COLLATE NOCASE PRIMARY KEY);
+    CREATE TABLE t (a TEXT COLLATE NOCASE PRIMARY KEY);
     INSERT INTO t VALUES ('lol'), ('LOL'), ('lOl');
 }
 
 do_execsql_test_in_memory_any_error collate_unique_constraint {
-    CREATE TABLE t(a TEXT COLLATE NOCASE PRIMARY KEY);
+    CREATE TABLE t (a TEXT COLLATE NOCASE PRIMARY KEY);
     INSERT INTO t VALUES ('lol'), ('LOL'), ('lOl');
 }

--- a/testing/create_table.test
+++ b/testing/create_table.test
@@ -5,14 +5,14 @@ source $testdir/tester.tcl
 
 if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
     do_execsql_test_in_memory_any_error create_table_one_unique_set {
-        CREATE TABLE t4(a, unique(b));
+        CREATE TABLE t4 (a, unique(b));
     }
 
     do_execsql_test_on_specific_db {:memory:} create_table_same_uniques_and_primary_keys {
-        CREATE TABLE t2(a,b, unique(a,b), primary key(a,b));
+        CREATE TABLE t2 (a,b, unique(a,b), primary key(a,b));
     } {}
 
     do_execsql_test_on_specific_db {:memory:} create_table_unique_contained_in_primary_keys {
-        CREATE TABLE t4(a,b, primary key(a,b), unique(a));
+        CREATE TABLE t4 (a,b, primary key(a,b), unique(a));
     } {}
 }

--- a/testing/default_value.test
+++ b/testing/default_value.test
@@ -4,37 +4,37 @@ set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
 do_execsql_test_on_specific_db {:memory:} default-value-text {
-    CREATE TABLE t1(x INTEGER PRIMARY KEY, y TEXT DEFAULT 'default_value');
+    CREATE TABLE t1 (x INTEGER PRIMARY KEY, y TEXT DEFAULT 'default_value');
     INSERT INTO t1 (x) VALUES (1);
     SELECT y FROM t1 WHERE x = 1;
 } {default_value}
 
 do_execsql_test_on_specific_db {:memory:} default-value-integer {
-    CREATE TABLE t2(x INTEGER PRIMARY KEY, y INTEGER DEFAULT 42);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY, y INTEGER DEFAULT 42);
     INSERT INTO t2 (x) VALUES (1);
     SELECT y FROM t2 WHERE x = 1;
 } {42}
 
 do_execsql_test_on_specific_db {:memory:} default-value-real {
-    CREATE TABLE t3(x INTEGER PRIMARY KEY, y REAL DEFAULT 3.14);
+    CREATE TABLE t3 (x INTEGER PRIMARY KEY, y REAL DEFAULT 3.14);
     INSERT INTO t3 (x) VALUES (1);
     SELECT y FROM t3 WHERE x = 1;
 } {3.14}
 
 do_execsql_test_on_specific_db {:memory:} default-value-null {
-    CREATE TABLE t5(x INTEGER PRIMARY KEY, y TEXT DEFAULT NULL);
+    CREATE TABLE t5 (x INTEGER PRIMARY KEY, y TEXT DEFAULT NULL);
     INSERT INTO t5 (x) VALUES (1);
     SELECT y FROM t5 WHERE x = 1;
 } {}
 
 do_execsql_test_on_specific_db {:memory:} default-value-boolean {
-    CREATE TABLE t6(x INTEGER PRIMARY KEY, y BOOLEAN DEFAULT 1);
+    CREATE TABLE t6 (x INTEGER PRIMARY KEY, y BOOLEAN DEFAULT 1);
     INSERT INTO t6 (x) VALUES (1);
     SELECT y FROM t6 WHERE x = 1;
 } {1}
 
 do_execsql_test_on_specific_db {:memory:} default-value-function {
-    CREATE TABLE t7(x INTEGER PRIMARY KEY, y INTEGER DEFAULT (ABS(-5)));
+    CREATE TABLE t7 (x INTEGER PRIMARY KEY, y INTEGER DEFAULT (ABS(-5)));
     INSERT INTO t7 (x) VALUES (1);
     SELECT y FROM t7 WHERE x = 1;
 } {5}

--- a/testing/delete.test
+++ b/testing/delete.test
@@ -5,7 +5,7 @@ source $testdir/tester.tcl
 
 # Basic single row delete test
 do_execsql_test_on_specific_db {:memory:} delete-single-1 {
-    CREATE TABLE t1(x INTEGER PRIMARY KEY);
+    CREATE TABLE t1 (x INTEGER PRIMARY KEY);
     INSERT INTO t1 VALUES (1);
     INSERT INTO t1 VALUES (2);
     INSERT INTO t1 VALUES (3);
@@ -15,7 +15,7 @@ do_execsql_test_on_specific_db {:memory:} delete-single-1 {
 
 # Test alternating delete-insert pattern to stress freelist
 do_execsql_test_on_specific_db {:memory:} delete-insert-alternate-1 {
-    CREATE TABLE t4(x INTEGER PRIMARY KEY);
+    CREATE TABLE t4 (x INTEGER PRIMARY KEY);
     INSERT INTO t4 VALUES (1);
     INSERT INTO t4 VALUES (2);
     INSERT INTO t4 VALUES (3);
@@ -28,7 +28,7 @@ do_execsql_test_on_specific_db {:memory:} delete-insert-alternate-1 {
 
 # Test deleting from both ends
 do_execsql_test_on_specific_db {:memory:} delete-ends-1 {
-    CREATE TABLE t5(x INTEGER PRIMARY KEY);
+    CREATE TABLE t5 (x INTEGER PRIMARY KEY);
     INSERT INTO t5 VALUES (1);
     INSERT INTO t5 VALUES (2);
     INSERT INTO t5 VALUES (3);
@@ -42,7 +42,7 @@ do_execsql_test_on_specific_db {:memory:} delete-ends-1 {
 
 # Test delete-insert cycles with value reuse
 do_execsql_test_on_specific_db {:memory:} delete-reuse-1 {
-    CREATE TABLE t6(x INTEGER PRIMARY KEY);
+    CREATE TABLE t6 (x INTEGER PRIMARY KEY);
     INSERT INTO t6 VALUES (1);
     INSERT INTO t6 VALUES (2);
     INSERT INTO t6 VALUES (3);
@@ -54,7 +54,7 @@ do_execsql_test_on_specific_db {:memory:} delete-reuse-1 {
 # Test delete works when there are indexes
 if {[info exists ::env(SQLITE_EXEC)] && $::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental"} {
     do_execsql_test_on_specific_db {:memory:} delete-all-with-indexes-1 {
-        CREATE TABLE t(a PRIMARY KEY);
+        CREATE TABLE t (a PRIMARY KEY);
         CREATE INDEX tasc ON t(a);
         CREATE INDEX tdesc ON t(a DESC);
         INSERT INTO t VALUES (randomblob(1000));

--- a/testing/drop_index.test
+++ b/testing/drop_index.test
@@ -6,7 +6,7 @@ source $testdir/tester.tcl
 if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
     # Basic DROP INDEX functionality
     do_execsql_test_on_specific_db {:memory:} drop-index-basic-1 {
-        CREATE TABLE t1(x INTEGER PRIMARY KEY);
+        CREATE TABLE t1 (x INTEGER PRIMARY KEY);
         CREATE INDEX t_idx on t1 (x);
         INSERT INTO t1 VALUES (1);
         INSERT INTO t1 VALUES (2);
@@ -16,7 +16,7 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
 
     # Test DROP INDEX IF EXISTS on existing index
     do_execsql_test_on_specific_db {:memory:} drop-index-if-exists-1 {
-        CREATE TABLE t2(x INTEGER PRIMARY KEY);
+        CREATE TABLE t2 (x INTEGER PRIMARY KEY);
         CREATE INDEX t_idx2 on t2 (x);
         DROP INDEX IF EXISTS t_idx2;
         SELECT count(*) FROM sqlite_schema WHERE type='index' AND name='t_idx2';
@@ -36,7 +36,7 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
 
     # Test dropping index after multiple inserts and deletes
     do_execsql_test_on_specific_db {:memory:} drop-index-after-ops-1 {
-        CREATE TABLE t6(x INTEGER PRIMARY KEY);
+        CREATE TABLE t6 (x INTEGER PRIMARY KEY);
         CREATE INDEX t_idx6 on t6 (x);
         INSERT INTO t6 VALUES (1);
         INSERT INTO t6 VALUES (2);

--- a/testing/drop_table.test
+++ b/testing/drop_table.test
@@ -5,7 +5,7 @@ source $testdir/tester.tcl
 
 # Basic DROP TABLE functionality
 do_execsql_test_on_specific_db {:memory:} drop-table-basic-1 {
-    CREATE TABLE t1(x INTEGER PRIMARY KEY);
+    CREATE TABLE t1 (x INTEGER PRIMARY KEY);
     INSERT INTO t1 VALUES (1);
     INSERT INTO t1 VALUES (2);
     DROP TABLE t1;
@@ -14,7 +14,7 @@ do_execsql_test_on_specific_db {:memory:} drop-table-basic-1 {
 
 # Test DROP TABLE IF EXISTS on existing table
 do_execsql_test_on_specific_db {:memory:} drop-table-if-exists-1 {
-    CREATE TABLE t2(x INTEGER PRIMARY KEY);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY);
     DROP TABLE IF EXISTS t2;
     SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='t2';
 } {0}
@@ -28,7 +28,7 @@ do_execsql_test_on_specific_db {:memory:} drop-table-if-exists-2 {
 if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
     # Test dropping table with index
     do_execsql_test_on_specific_db {:memory:} drop-table-with-index-1 {
-        CREATE TABLE t3(x INTEGER PRIMARY KEY, y TEXT);
+        CREATE TABLE t3 (x INTEGER PRIMARY KEY, y TEXT);
         CREATE INDEX idx_t3_y ON t3(y);
         INSERT INTO t3 VALUES(1, 'one');
         DROP TABLE t3;
@@ -36,7 +36,7 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {0}
     # Test dropping table cleans up related schema entries
     do_execsql_test_on_specific_db {:memory:} drop-table-schema-cleanup-1 {
-        CREATE TABLE t4(x INTEGER PRIMARY KEY, y TEXT);
+        CREATE TABLE t4 (x INTEGER PRIMARY KEY, y TEXT);
         CREATE INDEX idx1_t4 ON t4(x);
         CREATE INDEX idx2_t4 ON t4(y);
         INSERT INTO t4 VALUES(1, 'one');
@@ -48,7 +48,7 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
 
 # Test dropping table after multiple inserts and deletes
 do_execsql_test_on_specific_db {:memory:} drop-table-after-ops-1 {
-    CREATE TABLE t6(x INTEGER PRIMARY KEY);
+    CREATE TABLE t6 (x INTEGER PRIMARY KEY);
     INSERT INTO t6 VALUES (1);
     INSERT INTO t6 VALUES (2);
     DELETE FROM t6 WHERE x = 1;

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -18,32 +18,32 @@ do_execsql_test_on_specific_db {:memory:} must-be-int-insert {
 4}
 
 do_execsql_test_on_specific_db {:memory:} strict-basic-creation {
-    CREATE TABLE test1(id INTEGER, name TEXT, price REAL) STRICT;
+    CREATE TABLE test1 (id INTEGER, name TEXT, price REAL) STRICT;
     INSERT INTO test1 VALUES(1, 'item1', 10.5);
     SELECT * FROM test1;
 } {1|item1|10.5}
 
 do_execsql_test_in_memory_any_error  strict-require-datatype {
-    CREATE TABLE test2(id INTEGER, name) STRICT;
+    CREATE TABLE test2 (id INTEGER, name) STRICT;
 }
 
 do_execsql_test_in_memory_any_error strict-valid-datatypes {
-    CREATE TABLE test2(id INTEGER, value DATETIME) STRICT;
+    CREATE TABLE test2 (id INTEGER, value DATETIME) STRICT;
 }
 
 do_execsql_test_in_memory_any_error strict-type-enforcement {
-    CREATE TABLE test3(id INTEGER, name TEXT, price REAL) STRICT;
+    CREATE TABLE test3 (id INTEGER, name TEXT, price REAL) STRICT;
     INSERT INTO test3 VALUES(1, 'item1', 'not-a-number');
 }
 
 do_execsql_test_on_specific_db {:memory:} strict-type-coercion {
-    CREATE TABLE test4(id INTEGER, name TEXT, price REAL) STRICT;
+    CREATE TABLE test4 (id INTEGER, name TEXT, price REAL) STRICT;
     INSERT INTO test4 VALUES(1, 'item1', '10.5');
     SELECT typeof(price), price FROM test4;
 } {real|10.5}
 
 do_execsql_test_on_specific_db {:memory:} strict-any-flexibility {
-    CREATE TABLE test5(id INTEGER, data ANY) STRICT;
+    CREATE TABLE test5 (id INTEGER, data ANY) STRICT;
     INSERT INTO test5 VALUES(1, 100);
     INSERT INTO test5 VALUES(2, 'text');
     INSERT INTO test5 VALUES(3, 3.14);
@@ -53,25 +53,25 @@ do_execsql_test_on_specific_db {:memory:} strict-any-flexibility {
 3|real}
 
 do_execsql_test_on_specific_db {:memory:} strict-any-preservation {
-    CREATE TABLE test6(id INTEGER, code ANY) STRICT;
+    CREATE TABLE test6 (id INTEGER, code ANY) STRICT;
     INSERT INTO test6 VALUES(1, '000123');
     SELECT typeof(code), code FROM test6;
 } {text|000123}
 
 do_execsql_test_in_memory_any_error strict-int-vs-integer-pk {
-    CREATE TABLE test8(id INT PRIMARY KEY, name TEXT) STRICT
+    CREATE TABLE test8 (id INT PRIMARY KEY, name TEXT) STRICT
     INSERT INTO test8 VALUES(NULL, 'test');
 }
 
 do_execsql_test_on_specific_db {:memory:} strict-integer-pk-behavior {
-    CREATE TABLE test9(id INTEGER PRIMARY KEY, name TEXT) STRICT;
+    CREATE TABLE test9 (id INTEGER PRIMARY KEY, name TEXT) STRICT;
     INSERT INTO test9 VALUES(NULL, 'test');
     SELECT id, name FROM test9;
 } {1|test}
 
 
 do_execsql_test_on_specific_db {:memory:} strict-mixed-inserts {
-    CREATE TABLE test11(
+    CREATE TABLE test11 (
         id INTEGER PRIMARY KEY,
         name TEXT,
         price REAL,
@@ -87,27 +87,27 @@ do_execsql_test_on_specific_db {:memory:} strict-mixed-inserts {
 2|item2|20.75|10|integer}
 
 do_execsql_test_on_specific_db {:memory:} strict-update-basic {
-    CREATE TABLE test1(id INTEGER, name TEXT, price REAL) STRICT;
+    CREATE TABLE test1 (id INTEGER, name TEXT, price REAL) STRICT;
     INSERT INTO test1 VALUES(1, 'item1', 10.5);
     UPDATE test1 SET price = 15.75 WHERE id = 1;
     SELECT * FROM test1;
 } {1|item1|15.75}
 
 do_execsql_test_in_memory_any_error  strict-update-type-enforcement {
-    CREATE TABLE test2(id INTEGER, name TEXT, price REAL) STRICT;
+    CREATE TABLE test2 (id INTEGER, name TEXT, price REAL) STRICT;
     INSERT INTO test2 VALUES(1, 'item1', 10.5);
     UPDATE test2 SET price = 'not-a-number' WHERE id = 1;
 }
 
 do_execsql_test_on_specific_db {:memory:} strict-update-type-coercion {
-    CREATE TABLE test3(id INTEGER, name TEXT, price REAL) STRICT;
+    CREATE TABLE test3 (id INTEGER, name TEXT, price REAL) STRICT;
     INSERT INTO test3 VALUES(1, 'item1', 10.5);
     UPDATE test3 SET price = '15.75' WHERE id = 1;
     SELECT id, typeof(price), price FROM test3;
 } {1|real|15.75}
 
 do_execsql_test_on_specific_db {:memory:} strict-update-any-flexibility {
-    CREATE TABLE test4(id INTEGER, data ANY) STRICT;
+    CREATE TABLE test4 (id INTEGER, data ANY) STRICT;
     INSERT INTO test4 VALUES(1, 100);
     UPDATE test4 SET data = 'text' WHERE id = 1;
     INSERT INTO test4 VALUES(2, 'original');
@@ -117,35 +117,35 @@ do_execsql_test_on_specific_db {:memory:} strict-update-any-flexibility {
 2|real|3.14}
 
 do_execsql_test_on_specific_db {:memory:} strict-update-any-preservation {
-    CREATE TABLE test5(id INTEGER, code ANY) STRICT;
+    CREATE TABLE test5 (id INTEGER, code ANY) STRICT;
     INSERT INTO test5 VALUES(1, 'text');
     UPDATE test5 SET code = '000123' WHERE id = 1;
     SELECT typeof(code), code FROM test5;
 } {text|000123}
 
 do_execsql_test_in_memory_any_error strict-update-not-null-constraint {
-    CREATE TABLE test7(id INTEGER, name TEXT NOT NULL) STRICT;
+    CREATE TABLE test7 (id INTEGER, name TEXT NOT NULL) STRICT;
     INSERT INTO test7 VALUES(1, 'name');
     UPDATE test7 SET name = NULL WHERE id = 1;
 }
 
 # Uncomment following test case when unique constraint is added
 do_execsql_test_in_memory_any_error strict-update-pk-constraint {
-    CREATE TABLE test8(id INTEGER PRIMARY KEY, name TEXT) STRICT;
+    CREATE TABLE test8 (id INTEGER PRIMARY KEY, name TEXT) STRICT;
     INSERT INTO test8 VALUES(1, 'name1');
     INSERT INTO test8 VALUES(2, 'name2');
     UPDATE test8 SET id = 2 WHERE id = 1;
 }
 
 do_execsql_test_on_specific_db {:memory:} strict-update-multiple-columns {
-    CREATE TABLE test9(id INTEGER, name TEXT, price REAL, quantity INT) STRICT;
+    CREATE TABLE test9 (id INTEGER, name TEXT, price REAL, quantity INT) STRICT;
     INSERT INTO test9 VALUES(1, 'item1', 10.5, 5);
     UPDATE test9 SET name = 'updated', price = 20.75, quantity = 10 WHERE id = 1;
     SELECT * FROM test9;
 } {1|updated|20.75|10}
 
 do_execsql_test_on_specific_db {:memory:} strict-update-where-clause {
-    CREATE TABLE test10(id INTEGER, category TEXT, price REAL) STRICT;
+    CREATE TABLE test10 (id INTEGER, category TEXT, price REAL) STRICT;
     INSERT INTO test10 VALUES(1, 'A', 10);
     INSERT INTO test10 VALUES(2, 'A', 20);
     INSERT INTO test10 VALUES(3, 'B', 30);
@@ -156,14 +156,14 @@ do_execsql_test_on_specific_db {:memory:} strict-update-where-clause {
 3|30.0}
 
 do_execsql_test_on_specific_db {:memory:} strict-update-expression {
-    CREATE TABLE test11(id INTEGER, name TEXT, price REAL, discount REAL) STRICT;
+    CREATE TABLE test11 (id INTEGER, name TEXT, price REAL, discount REAL) STRICT;
     INSERT INTO test11 VALUES(1, 'item1', 100, 0.1);
     UPDATE test11 SET price = price - (price * discount);
     SELECT id, price FROM test11;
 } {1|90.0}
 
 do_execsql_test_on_specific_db {:memory:} duplicate-set {
-    CREATE TABLE t(x, y);
+    CREATE TABLE t (x, y);
     INSERT INTO t VALUES(1, 'A');
     UPDATE t SET y = 'B', y = 'C', y = 'D' WHERE x = 1;
     SELECT x, y FROM t;
@@ -234,8 +234,8 @@ do_execsql_test_in_memory_any_error not_null_insert_multiple_values {
 }
 
 do_execsql_test_on_specific_db {:memory:} insert_from_select_1 {
-    CREATE TABLE t(a);
-    CREATE TABLE t2(b, c);
+    CREATE TABLE t (a);
+    CREATE TABLE t2 (b, c);
     INSERT INTO t2 values (1, 2), (10, 20);
     INSERT INTO t SELECT b FROM t2;
     SELECT * FROM t;
@@ -249,8 +249,8 @@ do_execsql_test_on_specific_db {:memory:} insert_from_select_1 {
 20}
 
 do_execsql_test_on_specific_db {:memory:} insert_from_select_where {
-    CREATE TABLE t(a);
-    CREATE TABLE t2(b, c);
+    CREATE TABLE t (a);
+    CREATE TABLE t2 (b, c);
     INSERT INTO t2 values (1, 2), (10, 20);
     INSERT INTO t SELECT b FROM t2 WHERE b < 10;
     SELECT * FROM t;
@@ -261,9 +261,9 @@ do_execsql_test_on_specific_db {:memory:} insert_from_select_where {
 20}
 
 do_execsql_test_on_specific_db {:memory:} insert_from_select_union_all {
-    CREATE TABLE t1(x INTEGER);
-    CREATE TABLE t2(x INTEGER); 
-    CREATE TABLE t3(x INTEGER);
+    CREATE TABLE t1 (x INTEGER);
+    CREATE TABLE t2 (x INTEGER); 
+    CREATE TABLE t3 (x INTEGER);
     
     INSERT INTO t1 VALUES(1),(2),(3);
     INSERT INTO t2 VALUES(4),(5),(6);
@@ -282,9 +282,9 @@ do_execsql_test_on_specific_db {:memory:} insert_from_select_union_all {
 9}
 
 do_execsql_test_on_specific_db {:memory:} insert_from_select_union_all_where {
-    CREATE TABLE t1(x INTEGER);
-    CREATE TABLE t2(x INTEGER); 
-    CREATE TABLE t3(x INTEGER);
+    CREATE TABLE t1 (x INTEGER);
+    CREATE TABLE t2 (x INTEGER); 
+    CREATE TABLE t3 (x INTEGER);
     
     INSERT INTO t1 VALUES(1),(2),(3);
     INSERT INTO t2 VALUES(4),(5),(6);
@@ -300,7 +300,7 @@ do_execsql_test_on_specific_db {:memory:} insert_from_select_union_all_where {
 8}
 
 do_execsql_test_on_specific_db {:memory:} insert_from_select_same_table {
-    CREATE TABLE t(a INTEGER PRIMARY KEY, b);
+    CREATE TABLE t (a INTEGER PRIMARY KEY, b);
     
     INSERT INTO t(b) VALUES (1),(2),(3);
     SELECT * FROM t;
@@ -317,7 +317,7 @@ do_execsql_test_on_specific_db {:memory:} insert_from_select_same_table {
 6|3}
 
 do_execsql_test_on_specific_db {:memory:} insert_from_select_same_table_2 {
-    CREATE TABLE t(a INTEGER PRIMARY KEY, b, c);
+    CREATE TABLE t (a INTEGER PRIMARY KEY, b, c);
     
     INSERT INTO t(b, c) VALUES (1, 100),(2, 200),(3, 300);
     SELECT * FROM t;
@@ -335,8 +335,8 @@ do_execsql_test_on_specific_db {:memory:} insert_from_select_same_table_2 {
 
 if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
     do_execsql_test_on_specific_db {:memory:} insert_from_select_union {
-        CREATE TABLE t(a, b); 
-        CREATE TABLE t2(b, c);
+        CREATE TABLE t (a, b); 
+        CREATE TABLE t2 (b, c);
 
         INSERT INTO t2 VALUES (1, 100), (2, 200);
         INSERT INTO t SELECT * FROM t UNION SELECT * FROM t2;
@@ -345,9 +345,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     2|200}
 
     do_execsql_test_on_specific_db {:memory:} insert_from_select_intersect {
-        CREATE TABLE t(a, b);
-        CREATE TABLE t1(a, b);
-        CREATE TABLE t2(a, b);
+        CREATE TABLE t (a, b);
+        CREATE TABLE t1 (a, b);
+        CREATE TABLE t2 (a, b);
 
         INSERT INTO t1 VALUES (1, 100), (2, 200);
         INSERT INTO t2 VALUES (2, 200), (3, 300);
@@ -356,10 +356,10 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {2|200}
 
     do_execsql_test_on_specific_db {:memory:} insert_from_select_intersect-2 {
-        CREATE TABLE t(a, b);
-        CREATE TABLE t1(a, b);
-        CREATE TABLE t2(a, b);
-        CREATE TABLE t3(a, b);
+        CREATE TABLE t (a, b);
+        CREATE TABLE t1 (a, b);
+        CREATE TABLE t2 (a, b);
+        CREATE TABLE t3 (a, b);
 
         INSERT INTO t1 VALUES (1, 100), (2, 200);
         INSERT INTO t2 VALUES (2, 200), (3, 300);
@@ -369,9 +369,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {2|200}
 
     do_execsql_test_on_specific_db {:memory:} insert_from_select_except {
-        CREATE TABLE t(a, b);
-        CREATE TABLE t1(a, b);
-        CREATE TABLE t2(a, b);
+        CREATE TABLE t (a, b);
+        CREATE TABLE t1 (a, b);
+        CREATE TABLE t2 (a, b);
 
         INSERT INTO t1 VALUES (1, 100), (2, 200);
         INSERT INTO t2 VALUES (2, 200), (3, 300);
@@ -381,20 +381,20 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
 }
 
 do_execsql_test_on_specific_db {:memory:} negative-primary-integer-key {
-    CREATE TABLE t(a INTEGER PRIMARY KEY);
+    CREATE TABLE t (a INTEGER PRIMARY KEY);
     insert into t values (-2),(13);
     select * from t order by a asc;
 } {-2
 13}
 
 do_execsql_test_on_specific_db {:memory:} not-null-rowid-alias {
-    CREATE TABLE t(a INTEGER PRIMARY KEY NOT NULL, b);
+    CREATE TABLE t (a INTEGER PRIMARY KEY NOT NULL, b);
     insert into t values (1, 2);
     select * from t;
 } {1|2}
 
 do_execsql_test_on_specific_db {:memory:} rowid-overflow-random-generation {
-    CREATE TABLE q(x INTEGER PRIMARY KEY, y);
+    CREATE TABLE q (x INTEGER PRIMARY KEY, y);
     INSERT INTO q VALUES (9223372036854775807, 1);
     INSERT INTO q(y) VALUES (2);
     INSERT INTO q(y) VALUES (3);
@@ -404,7 +404,7 @@ do_execsql_test_on_specific_db {:memory:} rowid-overflow-random-generation {
 # regression test for incorrect processing of record header in the case of large text columns
 if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
     do_execsql_test_on_specific_db {:memory:} large-text-index-seek {
-        CREATE TABLE t(x TEXT, y);
+        CREATE TABLE t (x TEXT, y);
         CREATE INDEX t_idx ON t(x);
         INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'a', 1);
         INSERT INTO t VALUES (replace(hex(zeroblob(1000)), '00', 'a') || 'b', 2);
@@ -468,7 +468,7 @@ do_execsql_test_skip_lines_on_specific_db 1 {:memory:} double-quote-inner-quotes
 
 # regression test for incorrect order of column in insert
 do_execsql_test_on_specific_db {:memory:} insert-tricky-column-order-values {
-    create table t(x, y, z);
+    create table t (x, y, z);
     insert into t(z, x) values (1, 2), (3, 4);
     insert into t(y, z) values (5, 6), (7, 8);
     select * from t;
@@ -478,8 +478,8 @@ do_execsql_test_on_specific_db {:memory:} insert-tricky-column-order-values {
 |7|8}
 
 do_execsql_test_on_specific_db {:memory:} insert-tricky-column-order-table {
-    create table t(x, y, z);
-    create table q(x, y, z);
+    create table t (x, y, z);
+    create table q (x, y, z);
     insert into q values (1, 2, 3), (4, 5, 6);
     insert into t(z, x) select y, x from q;
     insert into t(y, z) select z, y from q;

--- a/testing/pragma.test
+++ b/testing/pragma.test
@@ -110,7 +110,7 @@ do_execsql_test pragma-vtab-table-info-invalid-table {
 #} {0}
 
 do_execsql_test_on_specific_db ":memory:" pragma-page-count-table {
-  CREATE TABLE foo(bar);
+  CREATE TABLE foo (bar);
   PRAGMA page_count
 } {2}
 
@@ -214,14 +214,14 @@ do_execsql_test_on_specific_db ":memory:" pragma-function-argument-with-space {
 } {0|c0||0||0}
 
 # If the argument passed to the first function call were simply concatenated with the underlying PRAGMA statement,
-# we would end up with: PRAGMA table_info='sqlite_schema';CREATE TABLE foo(c0);SELECT 'bar'. Depending on how many
+# we would end up with: PRAGMA table_info='sqlite_schema';CREATE TABLE foo (c0);SELECT 'bar'. Depending on how many
 # statements are executed at once, at least one of the following would run:
 # - PRAGMA table_info='sqlite_schema';
-# - CREATE TABLE foo(c0);
+# - CREATE TABLE foo (c0);
 # - SELECT 'bar';
 # No output means that none of them were executed.
 do_execsql_test pragma-function-sql-injection {
-  SELECT * FROM pragma_table_info('sqlite_schema'';CREATE TABLE foo(c0);SELECT ''bar');
+  SELECT * FROM pragma_table_info('sqlite_schema'';CREATE TABLE foo (c0);SELECT ''bar');
   SELECT * FROM pragma_table_info('foo');
 } {}
 

--- a/testing/select.test
+++ b/testing/select.test
@@ -242,9 +242,9 @@ do_execsql_test select-invalid-numeric-text {
 } {0}
 
 do_execsql_test_on_specific_db {:memory:} select-union-all-1 {
-  CREATE TABLE t1(x INTEGER);
-  CREATE TABLE t2(x INTEGER); 
-  CREATE TABLE t3(x INTEGER);
+  CREATE TABLE t1 (x INTEGER);
+  CREATE TABLE t2 (x INTEGER); 
+  CREATE TABLE t3 (x INTEGER);
   
   INSERT INTO t1 VALUES(1),(2),(3);
   INSERT INTO t2 VALUES(4),(5),(6);
@@ -266,9 +266,9 @@ do_execsql_test_on_specific_db {:memory:} select-union-all-1 {
 9}
 
 do_execsql_test_on_specific_db {:memory:} select-union-all-with-filters {
-  CREATE TABLE t4(x INTEGER);
-  CREATE TABLE t5(x INTEGER);
-  CREATE TABLE t6(x INTEGER);
+  CREATE TABLE t4 (x INTEGER);
+  CREATE TABLE t5 (x INTEGER);
+  CREATE TABLE t6 (x INTEGER);
   
   INSERT INTO t4 VALUES(1),(2),(3),(4);
   INSERT INTO t5 VALUES(5),(6),(7),(8);
@@ -299,8 +299,8 @@ do_execsql_test_error select-star-subquery {
 
 if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
     do_execsql_test_on_specific_db {:memory:} select-union-1 {
-    CREATE TABLE t(x TEXT, y TEXT);
-    CREATE TABLE u(x TEXT, y TEXT);
+    CREATE TABLE t (x TEXT, y TEXT);
+    CREATE TABLE u (x TEXT, y TEXT);
     INSERT INTO t VALUES('x','x'),('y','y');
     INSERT INTO u VALUES('x','x'),('y','y');
 
@@ -309,9 +309,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-union-all-union {
-    CREATE TABLE t(x TEXT, y TEXT);
-    CREATE TABLE u(x TEXT, y TEXT);
-    CREATE TABLE v(x TEXT, y TEXT);
+    CREATE TABLE t (x TEXT, y TEXT);
+    CREATE TABLE u (x TEXT, y TEXT);
+    CREATE TABLE v (x TEXT, y TEXT);
     INSERT INTO t VALUES('x','x'),('y','y');
     INSERT INTO u VALUES('x','x'),('y','y');
     INSERT INTO v VALUES('x','x'),('y','y');
@@ -323,9 +323,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-union-all-union-2 {
-    CREATE TABLE t(x TEXT, y TEXT);
-    CREATE TABLE u(x TEXT, y TEXT);
-    CREATE TABLE v(x TEXT, y TEXT);
+    CREATE TABLE t (x TEXT, y TEXT);
+    CREATE TABLE u (x TEXT, y TEXT);
+    CREATE TABLE v (x TEXT, y TEXT);
     INSERT INTO t VALUES('x','x'),('y','y');
     INSERT INTO u VALUES('x','x'),('y','y');
     INSERT INTO v VALUES('x','x'),('y','y');
@@ -335,9 +335,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-union-3 {
-    CREATE TABLE t(x TEXT, y TEXT);
-    CREATE TABLE u(x TEXT, y TEXT);
-    CREATE TABLE v(x TEXT, y TEXT);
+    CREATE TABLE t (x TEXT, y TEXT);
+    CREATE TABLE u (x TEXT, y TEXT);
+    CREATE TABLE v (x TEXT, y TEXT);
     INSERT INTO t VALUES('x','x'),('y','y');
     INSERT INTO u VALUES('x','x'),('y','y');
     INSERT INTO v VALUES('x','x'),('y','y');
@@ -347,9 +347,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-union-4 {
-    CREATE TABLE t(x TEXT, y TEXT);
-    CREATE TABLE u(x TEXT, y TEXT);
-    CREATE TABLE v(x TEXT, y TEXT);
+    CREATE TABLE t (x TEXT, y TEXT);
+    CREATE TABLE u (x TEXT, y TEXT);
+    CREATE TABLE v (x TEXT, y TEXT);
     INSERT INTO t VALUES('x','x'),('y','y');
     INSERT INTO u VALUES('x','x'),('y','y');
     INSERT INTO v VALUES('x','x'),('y','y');
@@ -359,9 +359,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-union-all-union-3 {
-    CREATE TABLE t(x TEXT, y TEXT);
-    CREATE TABLE u(x TEXT, y TEXT);
-    CREATE TABLE v(x TEXT, y TEXT);
+    CREATE TABLE t (x TEXT, y TEXT);
+    CREATE TABLE u (x TEXT, y TEXT);
+    CREATE TABLE v (x TEXT, y TEXT);
     INSERT INTO t VALUES('x','x'),('y','y');
     INSERT INTO u VALUES('x','x'),('y','y');
     INSERT INTO v VALUES('x','x'),('y','y');
@@ -373,8 +373,8 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-intersect-1 {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
 
@@ -382,9 +382,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {x|x}
 
     do_execsql_test_on_specific_db {:memory:} select-intersect-2 {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('y','y');
       INSERT INTO v VALUES('a','x'),('y','y');
@@ -393,9 +393,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-intersect-union {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('x','x'),('z','z');
@@ -405,9 +405,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     z|z}
 
     do_execsql_test_on_specific_db {:memory:} select-union-intersect {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('x','x'),('z','z');
@@ -416,9 +416,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {x|x}
 
     do_execsql_test_on_specific_db {:memory:} select-union-all-intersect {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('x','x'),('z','z');
@@ -427,9 +427,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {x|x}
 
     do_execsql_test_on_specific_db {:memory:} select-intersect-union-all {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('x','x'),('z','z');
@@ -440,8 +440,8 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     z|z}
 
     do_execsql_test_on_specific_db {:memory:} select-intersect-with-limit {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y'), ('z','z');
       INSERT INTO u VALUES('x','x'),('y','y'), ('z','z');
 
@@ -450,9 +450,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-intersect-union-with-limit {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y'), ('z','z');
       INSERT INTO u VALUES('d','d'),('e','e'), ('z','z');
       INSERT INTO v VALUES('a','a'),('b','b');
@@ -463,8 +463,8 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     z|z}
 
     do_execsql_test_on_specific_db {:memory:} select-except-1 {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
 
@@ -472,8 +472,8 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-except-2 {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('y','y');
 
@@ -481,9 +481,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {}
 
     do_execsql_test_on_specific_db {:memory:} select-except-3 {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('a','y');
       INSERT INTO v VALUES('a','x'),('b','y');
@@ -492,8 +492,8 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-except-limit {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
       INSERT INTO t VALUES('a', 'a'),('x','x'),('y','y'),('z','z');
       INSERT INTO u VALUES('x','x'),('z','y');
 
@@ -502,9 +502,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-except-union-all {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('x','x'),('y','y');
@@ -515,9 +515,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-union-all-except {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('x','x'),('y','y');
@@ -526,9 +526,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {z|y}
 
     do_execsql_test_on_specific_db {:memory:} select-except-union {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('x','x'),('z','z');
@@ -539,9 +539,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     z|z}
 
     do_execsql_test_on_specific_db {:memory:} select-union-except {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('x','x'),('z','z');
@@ -551,9 +551,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     z|y}
 
     do_execsql_test_on_specific_db {:memory:} select-except-intersect {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('y','y'),('z','z');
@@ -562,9 +562,9 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     } {y|y}
 
     do_execsql_test_on_specific_db {:memory:} select-intersect-except {
-      CREATE TABLE t(x TEXT, y TEXT);
-      CREATE TABLE u(x TEXT, y TEXT);
-      CREATE TABLE v(x TEXT, y TEXT);
+      CREATE TABLE t (x TEXT, y TEXT);
+      CREATE TABLE u (x TEXT, y TEXT);
+      CREATE TABLE v (x TEXT, y TEXT);
       INSERT INTO t VALUES('x','x'),('y','y');
       INSERT INTO u VALUES('x','x'),('z','y');
       INSERT INTO v VALUES('x','x'),('z','z');
@@ -574,7 +574,7 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
 }
 
 do_execsql_test_on_specific_db {:memory:} select-no-match-in-leaf-page {
-    CREATE TABLE t(a INTEGER PRIMARY KEY, b);
+    CREATE TABLE t (a INTEGER PRIMARY KEY, b);
     insert into t values (1, randomblob(1024));
     insert into t values (2, randomblob(1024));
     insert into t values (3, randomblob(1024));

--- a/testing/sqlite3/alter.test
+++ b/testing/sqlite3/alter.test
@@ -51,7 +51,7 @@ do_test alter-1.1 {
     set ::temp {}
   }
   execsql [subst -nocommands {
-    CREATE TABLE t1(a,b);
+    CREATE TABLE t1 (a,b);
     INSERT INTO t1 VALUES(1,2);
     CREATE TABLE [t1'x1](c UNIQUE, b PRIMARY KEY);
     INSERT INTO [t1'x1] VALUES(3,4);
@@ -229,7 +229,7 @@ ifcapable attach {
   } {}
   do_test alter-1.8.2 {
     execsql {
-      CREATE TABLE t4(a PRIMARY KEY, b, c);
+      CREATE TABLE t4 (a PRIMARY KEY, b, c);
       CREATE TABLE aux.t4(a PRIMARY KEY, b, c);
       CREATE INDEX i4 ON t4(b);
       CREATE INDEX aux.i4 ON t4(b);
@@ -298,7 +298,7 @@ do_test alter-2.1 {
 } {1 {no such table: none}}
 do_test alter-2.2 {
   execsql {
-    CREATE TABLE t3(p,q,r);
+    CREATE TABLE t3 (p,q,r);
   }
   catchsql {
     ALTER TABLE [<t2>] RENAME TO t3;
@@ -348,7 +348,7 @@ db func trigfunc trigfunc
 
 do_test alter-3.1.0 {
   execsql {
-    CREATE TABLE t6(a, b, c);
+    CREATE TABLE t6 (a, b, c);
     -- Different case for the table name in the trigger.
     CREATE TRIGGER trig1 AFTER INSERT ON T6 BEGIN
       SELECT trigfunc('trig1', new.a, new.b, new.c);
@@ -449,12 +449,12 @@ ifcapable attach {
 }
 do_test alter-3.2.6 {
   catchsql {
-    CREATE TABLE t10(a, ON, c);
+    CREATE TABLE t10 (a, ON, c);
   }
 } {1 {near "ON": syntax error}}
 do_test alter-3.2.7 {
   catchsql {
-    CREATE TABLE t10(a, 'ON', c);
+    CREATE TABLE t10 (a, 'ON', c);
   }
 } {0 {}}
 do_test alter-3.2.8 {
@@ -477,7 +477,7 @@ do_test alter-3.2.10 {
 
 do_test alter-3.3.1 {
   execsql [subst {
-    CREATE TABLE tbl1(a, b, c);
+    CREATE TABLE tbl1 (a, b, c);
     CREATE $::temp TRIGGER trig1 AFTER INSERT ON tbl1 BEGIN
       SELECT trigfunc('trig1', new.a, new.b, new.c);
     END;
@@ -536,7 +536,7 @@ ifcapable autoinc {
 
 do_test alter-4.1 {
   execsql {
-    CREATE TABLE tbl1(a INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE tbl1 (a INTEGER PRIMARY KEY AUTOINCREMENT);
     INSERT INTO tbl1 VALUES(10);
   }
 } {}
@@ -566,7 +566,7 @@ do_test alter-4.4 {
 # opening a database.
 do_test alter-5.1 {
   execsql {
-    CREATE TABLE tbl1(a, b, c);
+    CREATE TABLE tbl1 (a, b, c);
     INSERT INTO tbl1 VALUES('x', 'y', 'z');
   }
 } {}
@@ -653,7 +653,7 @@ do_test alter-6.7 {
 #
 do_realnum_test alter-7.1 {
   execsql {
-    CREATE TABLE t1(a TEXT COLLATE BINARY);
+    CREATE TABLE t1 (a TEXT COLLATE BINARY);
     ALTER TABLE t1 ADD COLUMN b INTEGER COLLATE NOCASE;
     INSERT INTO t1 VALUES(1,'-2');
     INSERT INTO t1 VALUES(5.4e-08,'5.4e-08');
@@ -666,7 +666,7 @@ do_realnum_test alter-7.1 {
 #
 do_test alter-8.1 {
   execsql {
-    CREATE TABLE t2(a INTEGER);
+    CREATE TABLE t2 (a INTEGER);
     INSERT INTO t2 VALUES(1);
     INSERT INTO t2 VALUES(1);
     INSERT INTO t2 VALUES(2);
@@ -711,7 +711,7 @@ do_catchsql_test alter-9.3 {
 # in the names.
 #
 do_test alter-10.1 {
-  execsql "CREATE TABLE xyz(x UNIQUE)"
+  execsql "CREATE TABLE xyz (x UNIQUE)"
   execsql "ALTER TABLE xyz RENAME TO xyz\u1234abc"
   execsql {SELECT name FROM sqlite_master WHERE name GLOB 'xyz*'}
 } [list xyz\u1234abc]
@@ -727,7 +727,7 @@ do_test alter-10.4 {
 } [list sqlite_autoindex_xyzabc_1]
 
 do_test alter-11.1 {
-  sqlite3_exec db {CREATE TABLE t11(%c6%c6)}
+  sqlite3_exec db {CREATE TABLE t11 (%c6%c6)}
   execsql {
     ALTER TABLE t11 ADD COLUMN abc;
   }
@@ -743,7 +743,7 @@ if {!$isutf16} {
   } {0 {xyz abc 1 2}}
 }
 do_test alter-11.3 {
-  sqlite3_exec db {CREATE TABLE t11b("%81%82%83" text)}
+  sqlite3_exec db {CREATE TABLE t11b ("%81%82%83" text)}
   execsql {
     ALTER TABLE t11b ADD COLUMN abc;
   }
@@ -764,7 +764,7 @@ if {!$isutf16} {
   } {0 {xyz abc 3 4}}
 }
 do_test alter-11.7 {
-  sqlite3_exec db {CREATE TABLE t11c(%81%82%83 text)}
+  sqlite3_exec db {CREATE TABLE t11c (%81%82%83 text)}
   execsql {
     ALTER TABLE t11c ADD COLUMN abc;
   }
@@ -787,7 +787,7 @@ if {!$isutf16} {
 
 do_test alter-12.1 {
   execsql {
-    CREATE TABLE t12(a, b, c);
+    CREATE TABLE t12 (a, b, c);
     CREATE VIEW v1 AS SELECT * FROM t12;
   }
 } {}
@@ -839,7 +839,7 @@ do_test alter-13.3 {
 # Ticket #3651
 do_test alter-14.1 {
   catchsql {
-    CREATE TABLE t3651(a UNIQUE);
+    CREATE TABLE t3651 (a UNIQUE);
     INSERT INTO t3651 VALUES(5);
     ALTER TABLE t3651 ADD COLUMN b UNIQUE;
   }
@@ -873,7 +873,7 @@ foreach {tn tbl} $system_table_list {
 # Verify that ALTER TABLE works on tables with the WITHOUT rowid option.
 #
 do_execsql_test alter-16.1 {
-  CREATE TABLE t16a(a TEXT, b REAL, c INT, PRIMARY KEY(a,b)) WITHOUT rowid;
+  CREATE TABLE t16a (a TEXT, b REAL, c INT, PRIMARY KEY(a,b)) WITHOUT rowid;
   INSERT INTO t16a VALUES('abc',1.25,99);
   ALTER TABLE t16a ADD COLUMN d TEXT DEFAULT 'xyzzy';
   INSERT INTO t16a VALUES('cba',5.5,98,'fizzle');
@@ -890,7 +890,7 @@ ifcapable rtree {
   db close
   sqlite3 db :memory:
   do_execsql_test alter-17.100 {
-    CREATE TABLE t1(a INTEGER PRIMARY KEY, b);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY, b);
     CREATE VIRTUAL TABLE t2 USING rtree(id,x0,x1);
     INSERT INTO t1 VALUES(1,'apple'),(2,'fig'),(3,'pear');
     INSERT INTO t2 VALUES(1,1.0,2.0),(2,2.0,3.0),(3,1.5,3.5);
@@ -906,8 +906,8 @@ ifcapable rtree {
 # 2021-03-08 dbsqlfuzz 3f0a7245b69cd08617d7d7781ebaedb0fe765a93
 reset_db
 do_catchsql_test alter-18.1 {
-  CREATE TABLE t1(a,b,c);
-  CREATE TABLE log(a INTEGER PRIMARY KEY,b,c);
+  CREATE TABLE t1 (a,b,c);
+  CREATE TABLE log (a INTEGER PRIMARY KEY,b,c);
   CREATE TRIGGER tr1 AFTER INSERT ON t1 BEGIN
     INSERT INTO logx(a,b,c) VALUES(new.a,new.b,new.c)
     ON CONFLICT(a) DO UPDATE SET c=excluded.c, b=new.b;
@@ -918,8 +918,8 @@ do_catchsql_test alter-18.1 {
 # 2021-10-13 dbsqlfuzz e89174cbfad2d904f06b5e24df0a22510b6a1c1e
 reset_db
 do_execsql_test alter-19.1 {
-  CREATE TABLE t1(x);
-  CREATE TABLE t2(c);
+  CREATE TABLE t1 (x);
+  CREATE TABLE t2 (c);
   CREATE TRIGGER r1 AFTER INSERT ON t2 BEGIN
     UPDATE t2 SET (c)=(
        EXISTS(SELECT 1 WHERE (WITH cte1(a) AS (SELECT 1 FROM t1 WHERE (SELECT 1 WHERE (WITH cte2(b) AS (VALUES(1))SELECT b FROM cte2)))SELECT a FROM cte1))
@@ -940,7 +940,7 @@ do_execsql_test alter-19.3 {
 #
 reset_db
 do_execsql_test alter-20.1 {
-  CREATE TABLE t1(a INT) STRICT;
+  CREATE TABLE t1 (a INT) STRICT;
   INSERT INTO t1(a) VALUES(45);
 } {}
 do_catchsql_test alter-20.2 {
@@ -960,8 +960,8 @@ do_catchsql_test alter-20.3 {
 #
 reset_db
 do_execsql_test alter-21.1 {
-  CREATE TABLE t1(a,b,c,d);
-  CREATE TABLE t2(a,b,c,d,x);
+  CREATE TABLE t1 (a,b,c,d);
+  CREATE TABLE t2 (a,b,c,d,x);
   CREATE TRIGGER r1 AFTER INSERT ON t2 BEGIN
     SELECT unknown_function(a ORDER BY (SELECT group_concat(DISTINCT a ORDER BY a) FROM t1)) FROM t1;
   END;

--- a/testing/sqlite3/alter2.test
+++ b/testing/sqlite3/alter2.test
@@ -95,7 +95,7 @@ do_test alter2-1.0 {
 sqlite3_db_config db DEFENSIVE 0
 do_test alter2-1.1 {
   execsql {
-    CREATE TABLE abc(a, b);
+    CREATE TABLE abc (a, b);
     INSERT INTO abc VALUES(1, 2);
     INSERT INTO abc VALUES(3, 4);
     INSERT INTO abc VALUES(5, 6);
@@ -103,7 +103,7 @@ do_test alter2-1.1 {
 } {}
 do_test alter2-1.2 {
   # ALTER TABLE abc ADD COLUMN c;
-  alter_table abc {CREATE TABLE abc(a, b, c);}
+  alter_table abc {CREATE TABLE abc (a, b, c);}
 } {}
 do_test alter2-1.3 {
   execsql {
@@ -138,7 +138,7 @@ do_test alter2-1.8 {
 } {8 {} 1 10}
 do_test alter2-1.9 {
   # ALTER TABLE abc ADD COLUMN d;
-  alter_table abc {CREATE TABLE abc(a, b, c, d);}
+  alter_table abc {CREATE TABLE abc (a, b, c, d);}
   if {[permutation] == "prepare"} { db cache flush }
   execsql { SELECT * FROM abc; }
   execsql {
@@ -163,7 +163,7 @@ do_test alter2-1.99 {
 ifcapable view {
   do_test alter2-2.1 {
     execsql {
-      CREATE TABLE abc2(a, b, c);
+      CREATE TABLE abc2 (a, b, c);
       INSERT INTO abc2 VALUES(1, 2, 10);
       INSERT INTO abc2 VALUES(3, 4, NULL);
       INSERT INTO abc2 VALUES(5, 6, NULL);
@@ -173,7 +173,7 @@ ifcapable view {
   } {1 2 10 3 4 {} 5 6 {}}
   do_test alter2-2.2 {
     # ALTER TABLE abc ADD COLUMN d;
-    alter_table abc2 {CREATE TABLE abc2(a, b, c, d);}
+    alter_table abc2 {CREATE TABLE abc2 (a, b, c, d);}
     execsql {
       SELECT * FROM abc2_v;
     }
@@ -193,8 +193,8 @@ ifcapable view {
 ifcapable trigger {
   do_test alter2-3.1 {
     execsql {
-      CREATE TABLE abc3(a, b);
-      CREATE TABLE blog(o, n);
+      CREATE TABLE abc3 (a, b);
+      CREATE TABLE blog (o, n);
       CREATE TRIGGER abc3_t AFTER UPDATE OF b ON abc3 BEGIN
         INSERT INTO blog VALUES(old.b, new.b);
       END;
@@ -212,7 +212,7 @@ ifcapable trigger {
       INSERT INTO abc3 VALUES(3, 4);
       INSERT INTO abc3 VALUES(5, 6);
     }
-    alter_table abc3 {CREATE TABLE abc3(a, b, c);}
+    alter_table abc3 {CREATE TABLE abc3 (a, b, c);}
     execsql {
       SELECT * FROM abc3;
     }
@@ -231,7 +231,7 @@ ifcapable trigger {
 
   do_test alter2-3.6 {
     execsql {
-      CREATE TABLE clog(o, n);
+      CREATE TABLE clog (o, n);
       CREATE TRIGGER abc3_t2 AFTER UPDATE OF c ON abc3 BEGIN
         INSERT INTO clog VALUES(old.c, new.c);
       END;
@@ -240,7 +240,7 @@ ifcapable trigger {
     }
   } {{} 2 {} 6 {} 10}
 } else {
-  execsql { CREATE TABLE abc3(a, b); }
+  execsql { CREATE TABLE abc3 (a, b); }
 }
 
 #---------------------------------------------------------------------
@@ -328,7 +328,7 @@ ifcapable attach {
 }
 do_test alter2-6.3 {
   execsql {
-    CREATE TABLE t1(a, b);
+    CREATE TABLE t1 (a, b);
   }
   get_file_format 
 } {2}
@@ -340,7 +340,7 @@ do_test alter2-6.3 {
 do_test alter2-7.1 {
   execsql {
     DROP TABLE t1;
-    CREATE TABLE t1(a);
+    CREATE TABLE t1 (a);
     INSERT INTO t1 VALUES(1);
     INSERT INTO t1 VALUES(2);
     INSERT INTO t1 VALUES(3);
@@ -349,7 +349,7 @@ do_test alter2-7.1 {
   }
 } {1 2 3 4}
 do_test alter2-7.2 {
-  set sql {CREATE TABLE t1(a, b DEFAULT '123', c INTEGER DEFAULT '123')}
+  set sql {CREATE TABLE t1 (a, b DEFAULT '123', c INTEGER DEFAULT '123')}
   alter_table t1 $sql 3
   execsql {
     SELECT * FROM t1 LIMIT 1;
@@ -366,7 +366,7 @@ do_test alter2-7.4 {
   }
 } {1 integer 123 text 123 integer}
 do_test alter2-7.5 {
-  set sql {CREATE TABLE t1(a, b DEFAULT -123.0, c VARCHAR(10) default 5)}
+  set sql {CREATE TABLE t1 (a, b DEFAULT -123.0, c VARCHAR(10) default 5)}
   alter_table t1 $sql 3
   execsql {
     SELECT a, typeof(a), b, typeof(b), c, typeof(c) FROM t1 LIMIT 1;
@@ -434,13 +434,13 @@ ifcapable trigger {
 ifcapable bloblit {
   do_test alter2-10.1 {
     execsql {
-      CREATE TABLE t2(a);
+      CREATE TABLE t2 (a);
       INSERT INTO t2 VALUES('a');
       INSERT INTO t2 VALUES('b');
       INSERT INTO t2 VALUES('c');
       INSERT INTO t2 VALUES('d');
     }
-    alter_table t2 {CREATE TABLE t2(a, b DEFAULT X'ABCD', c DEFAULT NULL);} 3
+    alter_table t2 {CREATE TABLE t2 (a, b DEFAULT X'ABCD', c DEFAULT NULL);} 3
     catchsql {
       SELECT * FROM sqlite_master;
     }

--- a/testing/sqlite3/alter3.test
+++ b/testing/sqlite3/alter3.test
@@ -54,51 +54,51 @@ proc get_file_format {{fname test.db}} {
 do_test alter3-1.1 {
   sqlite3_db_config db LEGACY_FILE_FORMAT 1
   execsql {
-    CREATE TABLE abc(a, b, c);
+    CREATE TABLE abc (a, b, c);
     SELECT sql FROM sqlite_master;
   }
-} {{CREATE TABLE abc(a, b, c)}}
+} {{CREATE TABLE abc (a, b, c)}}
 do_test alter3-1.2 {
   execsql {ALTER TABLE abc ADD d INTEGER;}
   execsql {
     SELECT sql FROM sqlite_master;
   }
-} {{CREATE TABLE abc(a, b, c, d INTEGER)}}
+} {{CREATE TABLE abc (a, b, c, d INTEGER)}}
 do_test alter3-1.3 {
   execsql {ALTER TABLE abc ADD e}
   execsql {
     SELECT sql FROM sqlite_master;
   }
-} {{CREATE TABLE abc(a, b, c, d INTEGER, e)}}
+} {{CREATE TABLE abc (a, b, c, d INTEGER, e)}}
 do_test alter3-1.4 {
   execsql {
     CREATE TABLE main.t1(a, b);
     ALTER TABLE t1 ADD c;
     SELECT sql FROM sqlite_master WHERE tbl_name = 't1';
   }
-} {{CREATE TABLE t1(a, b, c)}}
+} {{CREATE TABLE t1 (a, b, c)}}
 do_test alter3-1.5 {
   execsql {
     ALTER TABLE t1 ADD d CHECK (a>d);
     SELECT sql FROM sqlite_master WHERE tbl_name = 't1';
   }
-} {{CREATE TABLE t1(a, b, c, d CHECK (a>d))}}
+} {{CREATE TABLE t1 (a, b, c, d CHECK (a>d))}}
 ifcapable foreignkey {
   do_test alter3-1.6 {
     execsql {
-      CREATE TABLE t2(a, b, UNIQUE(a, b));
+      CREATE TABLE t2 (a, b, UNIQUE(a, b));
       ALTER TABLE t2 ADD c REFERENCES t1(c)  ;
       SELECT sql FROM sqlite_master WHERE tbl_name = 't2' AND type = 'table';
     }
-  } {{CREATE TABLE t2(a, b, c REFERENCES t1(c), UNIQUE(a, b))}}
+  } {{CREATE TABLE t2 (a, b, c REFERENCES t1(c), UNIQUE(a, b))}}
 }
 do_test alter3-1.7 {
   execsql {
-    CREATE TABLE t3(a, b, UNIQUE(a, b));
+    CREATE TABLE t3 (a, b, UNIQUE(a, b));
     ALTER TABLE t3 ADD COLUMN c VARCHAR(10, 20);
     SELECT sql FROM sqlite_master WHERE tbl_name = 't3' AND type = 'table';
   }
-} {{CREATE TABLE t3(a, b, c VARCHAR(10, 20), UNIQUE(a, b))}}
+} {{CREATE TABLE t3 (a, b, c VARCHAR(10, 20), UNIQUE(a, b))}}
 do_test alter3-1.99 {
   catchsql {
     # May not exist if foreign-keys are omitted at compile time.
@@ -113,7 +113,7 @@ do_test alter3-1.99 {
 
 do_test alter3-2.1 {
   execsql {
-    CREATE TABLE t1(a, b);
+    CREATE TABLE t1 (a, b);
     INSERT INTO t1 VALUES(1,2);
   }
   catchsql {
@@ -163,7 +163,7 @@ do_test alter3-2.99 {
 
 do_test alter3-3.1 {
   execsql {
-    CREATE TABLE t1(a, b);
+    CREATE TABLE t1 (a, b);
     INSERT INTO t1 VALUES(1, 100);
     INSERT INTO t1 VALUES(2, 300);
     SELECT * FROM t1;
@@ -199,7 +199,7 @@ do_test alter3-4.1 {
   set ::DB [sqlite3 db test.db]
   sqlite3_db_config db LEGACY_FILE_FORMAT 1
   execsql {
-    CREATE TABLE t1(a, b);
+    CREATE TABLE t1 (a, b);
     INSERT INTO t1 VALUES(1, 100);
     INSERT INTO t1 VALUES(2, 300);
     SELECT * FROM t1;
@@ -239,7 +239,7 @@ ifcapable attach {
     forcedelete test2.db
     forcedelete test2.db-journal
     execsql {
-      CREATE TABLE t1(a, b);
+      CREATE TABLE t1 (a, b);
       INSERT INTO t1 VALUES(1, 'one');
       INSERT INTO t1 VALUES(2, 'two');
       ATTACH 'test2.db' AS aux;
@@ -247,13 +247,13 @@ ifcapable attach {
       PRAGMA aux.schema_version = 30;
       SELECT sql FROM aux.sqlite_master;
     } 
-  } {{CREATE TABLE t1(a,b)}}
+  } {{CREATE TABLE t1 (a,b)}}
   do_test alter3-5.2 {
     execsql {
       ALTER TABLE aux.t1 ADD COLUMN c VARCHAR(128);
       SELECT sql FROM aux.sqlite_master;
     }
-  } {{CREATE TABLE t1(a,b, c VARCHAR(128))}}
+  } {{CREATE TABLE t1 (a,b, c VARCHAR(128))}}
   do_test alter3-5.3 {
     execsql {
       SELECT * FROM aux.t1;
@@ -276,7 +276,7 @@ ifcapable attach {
       ALTER TABLE aux.t1 ADD COLUMN d DEFAULT 1000;
       SELECT sql FROM aux.sqlite_master;
     }
-  } {{CREATE TABLE t1(a,b, c VARCHAR(128), d DEFAULT 1000)}}
+  } {{CREATE TABLE t1 (a,b, c VARCHAR(128), d DEFAULT 1000)}}
   do_test alter3-5.7 {
     execsql {
       SELECT * FROM aux.t1;
@@ -309,8 +309,8 @@ ifcapable attach {
 ifcapable trigger&&tempdb {
   do_test alter3-6.1 {
     execsql {
-      CREATE TABLE t1(a, b);
-      CREATE TABLE log(trig, a, b);
+      CREATE TABLE t1 (a, b);
+      CREATE TABLE log (trig, a, b);
 
       CREATE TRIGGER t1_a AFTER INSERT ON t1 BEGIN
         INSERT INTO log VALUES('a', new.a, new.b);
@@ -342,7 +342,7 @@ if {!$has_codec} {
     } {1}
     do_test alter3-7.2 {
       execsql {
-        CREATE TABLE abc(a, b, c);
+        CREATE TABLE abc (a, b, c);
         ALTER TABLE abc ADD d DEFAULT NULL;
       }
       get_file_format
@@ -372,7 +372,7 @@ if {!$has_codec} {
 # memory corruption (as was the case before this bug was fixed).
 do_test alter3-8.1 {
   execsql {
-    CREATE TABLE t4(c1);
+    CREATE TABLE t4 (c1);
   }
 } {}
 set ::sql ""
@@ -384,7 +384,7 @@ do_test alter3-8.2 {
     "
     lappend cols c$i
   }
-  set ::sql "CREATE TABLE t4([join $cols {, }])"
+  set ::sql "CREATE TABLE t4 ([join $cols {, }])"
   list 
 } {}
 do_test alter3-8.2 {
@@ -398,7 +398,7 @@ do_test alter3-8.2 {
 #
 reset_db
 do_execsql_test alter3-9.1 {
-  CREATE TABLE t1(a,b);
+  CREATE TABLE t1 (a,b);
   INSERT INTO t1 VALUES(1, 2), ('null!',NULL), (3,4);
 } {}
 do_catchsql_test alter3-9.2 {

--- a/testing/sqlite3/alter4.test
+++ b/testing/sqlite3/alter4.test
@@ -44,52 +44,52 @@ do_test alter4-1.1 {
     CREATE TEMP TABLE abc(a, b, c);
     SELECT sql FROM sqlite_temp_master;
   }
-} {{CREATE TABLE abc(a, b, c)}}
+} {{CREATE TABLE abc (a, b, c)}}
 do_test alter4-1.1b {
   execsql {
     SELECT sql FROM temp.sqlite_master;
   }
-} {{CREATE TABLE abc(a, b, c)}}
+} {{CREATE TABLE abc (a, b, c)}}
 do_test alter4-1.2 {
   execsql {ALTER TABLE abc ADD d INTEGER;}
   execsql {
     SELECT sql FROM sqlite_temp_master;
   }
-} {{CREATE TABLE abc(a, b, c, d INTEGER)}}
+} {{CREATE TABLE abc (a, b, c, d INTEGER)}}
 do_test alter4-1.2b {
   execsql {
     SELECT sql FROM temp.sqlite_master;
   }
-} {{CREATE TABLE abc(a, b, c, d INTEGER)}}
+} {{CREATE TABLE abc (a, b, c, d INTEGER)}}
 do_test alter4-1.3 {
   execsql {ALTER TABLE abc ADD e}
   execsql {
     SELECT sql FROM sqlite_temp_master;
   }
-} {{CREATE TABLE abc(a, b, c, d INTEGER, e)}}
+} {{CREATE TABLE abc (a, b, c, d INTEGER, e)}}
 do_test alter4-1.3b {
   execsql {
     SELECT sql FROM temp.sqlite_master;
   }
-} {{CREATE TABLE abc(a, b, c, d INTEGER, e)}}
+} {{CREATE TABLE abc (a, b, c, d INTEGER, e)}}
 do_test alter4-1.4 {
   execsql {
     CREATE TABLE temp.t1(a, b);
     ALTER TABLE t1 ADD c;
     SELECT sql FROM sqlite_temp_master WHERE tbl_name = 't1';
   }
-} {{CREATE TABLE t1(a, b, c)}}
+} {{CREATE TABLE t1 (a, b, c)}}
 do_test alter4-1.4b {
   execsql {
     SELECT sql FROM temp.sqlite_master WHERE tbl_name = 't1';
   }
-} {{CREATE TABLE t1(a, b, c)}}
+} {{CREATE TABLE t1 (a, b, c)}}
 do_test alter4-1.5 {
   execsql {
     ALTER TABLE t1 ADD d CHECK (a>d);
     SELECT sql FROM sqlite_temp_master WHERE tbl_name = 't1';
   }
-} {{CREATE TABLE t1(a, b, c, d CHECK (a>d))}}
+} {{CREATE TABLE t1 (a, b, c, d CHECK (a>d))}}
 ifcapable foreignkey {
   do_test alter4-1.6 {
     execsql {
@@ -98,7 +98,7 @@ ifcapable foreignkey {
       SELECT sql FROM sqlite_temp_master
        WHERE tbl_name = 't2' AND type = 'table';
     }
-  } {{CREATE TABLE t2(a, b, c REFERENCES t1(c), UNIQUE(a, b))}}
+  } {{CREATE TABLE t2 (a, b, c REFERENCES t1(c), UNIQUE(a, b))}}
 }
 do_test alter4-1.7 {
   execsql {
@@ -107,7 +107,7 @@ do_test alter4-1.7 {
     SELECT sql FROM sqlite_temp_master
      WHERE tbl_name = 't3' AND type = 'table';
   }
-} {{CREATE TABLE t3(a, b, c VARCHAR(10, 20), UNIQUE(a, b))}}
+} {{CREATE TABLE t3 (a, b, c VARCHAR(10, 20), UNIQUE(a, b))}}
 do_test alter4-1.99 {
   catchsql {
     # May not exist if foreign-keys are omitted at compile time.
@@ -250,13 +250,13 @@ ifcapable attach {
       PRAGMA aux.schema_version = 30;
       SELECT sql FROM aux.sqlite_master;
     } 
-  } {{CREATE TABLE t1(a,b)}}
+  } {{CREATE TABLE t1 (a,b)}}
   do_test alter4-5.2 {
     execsql {
       ALTER TABLE aux.t1 ADD COLUMN c VARCHAR(128);
       SELECT sql FROM aux.sqlite_master;
     }
-  } {{CREATE TABLE t1(a,b, c VARCHAR(128))}}
+  } {{CREATE TABLE t1 (a,b, c VARCHAR(128))}}
   do_test alter4-5.3 {
     execsql {
       SELECT * FROM aux.t1;
@@ -274,7 +274,7 @@ ifcapable attach {
       ALTER TABLE aux.t1 ADD COLUMN d DEFAULT 1000;
       SELECT sql FROM aux.sqlite_master;
     }
-  } {{CREATE TABLE t1(a,b, c VARCHAR(128), d DEFAULT 1000)}}
+  } {{CREATE TABLE t1 (a,b, c VARCHAR(128), d DEFAULT 1000)}}
   do_test alter4-5.7 {
     execsql {
       SELECT * FROM aux.t1;
@@ -346,7 +346,7 @@ do_test alter4-8.2 {
     "
     lappend cols c$i
   }
-  set ::sql "CREATE TABLE t4([join $cols {, }])"
+  set ::sql "CREATE TABLE t4 ([join $cols {, }])"
   list 
 } {}
 do_test alter4-8.2 {
@@ -359,7 +359,7 @@ do_test alter4-8.2 {
 # Test that a default value equal to -1 multipied by the smallest possible
 # 64-bit integer is correctly converted to a real.
 do_execsql_test alter4-9.1 {
-  CREATE TABLE t5(
+  CREATE TABLE t5 (
     a INTEGER DEFAULT -9223372036854775808,
     b INTEGER DEFAULT (-(-9223372036854775808))
   );
@@ -386,7 +386,7 @@ do_test alter4-10.1 {
   sqlite3 db :memory:
   sqlite3_db_config db LEGACY_FILE_FORMAT 1
   db eval {
-    CREATE TABLE t1(a,b,c);
+    CREATE TABLE t1 (a,b,c);
     CREATE INDEX t1a ON t1(a DESC);
     INSERT INTO t1 VALUES(1,2,3);
     INSERT INTO t1 VALUES(2,3,4);
@@ -397,7 +397,7 @@ do_test alter4-10.1 {
 
 reset_db
 do_execsql_test alter4-11.0 {
-  CREATE TABLE t1(c INTEGER PRIMARY KEY, d);
+  CREATE TABLE t1 (c INTEGER PRIMARY KEY, d);
   INSERT INTO t1(c,d) VALUES(1,2);
   PRAGMA foreign_keys = on;
   ALTER TABLE t1 ADD COLUMN e;

--- a/testing/sqlite3/func.test
+++ b/testing/sqlite3/func.test
@@ -19,7 +19,7 @@ set testprefix func
 # Create a table to work with.
 #
 do_test func-0.0 {
-  execsql {CREATE TABLE tbl1(t1 text)}
+  execsql {CREATE TABLE tbl1 (t1 text)}
   foreach word {this program is free software} {
     execsql "INSERT INTO tbl1 VALUES('$word')"
   }
@@ -27,7 +27,7 @@ do_test func-0.0 {
 } {free is program software this}
 do_test func-0.1 {
   execsql {
-     CREATE TABLE t2(a);
+     CREATE TABLE t2 (a);
      INSERT INTO t2 VALUES(1);
      INSERT INTO t2 VALUES(NULL);
      INSERT INTO t2 VALUES(345);
@@ -185,7 +185,7 @@ do_test func-3.99 {
 ifcapable !floatingpoint {
   do_test func-4.1 {
     execsql {
-      CREATE TABLE t1(a,b,c);
+      CREATE TABLE t1 (a,b,c);
       INSERT INTO t1 VALUES(1,2,3);
       INSERT INTO t1 VALUES(2,12345678901234,-1234567890);
       INSERT INTO t1 VALUES(3,-2,-5);
@@ -196,7 +196,7 @@ ifcapable !floatingpoint {
 ifcapable floatingpoint {
   do_test func-4.1 {
     execsql {
-      CREATE TABLE t1(a,b,c);
+      CREATE TABLE t1 (a,b,c);
       INSERT INTO t1 VALUES(1,2,3);
       INSERT INTO t1 VALUES(2,1.2345678901234,-12345.67890);
       INSERT INTO t1 VALUES(3,-2,-5);
@@ -662,7 +662,7 @@ do_test func-12.4 {
 } {0}
 do_test func-12.5 {
   execsql {
-    CREATE TABLE t4(x);
+    CREATE TABLE t4 (x);
     INSERT INTO t4 VALUES(test_destructor('hello'));
     INSERT INTO t4 VALUES(test_destructor('world'));
     SELECT min(test_destructor(x)), max(test_destructor(x)) FROM t4;
@@ -691,7 +691,7 @@ do_test func-13.1 {
 
 do_test func-13.2 {
   execsql {
-    CREATE TABLE t4(a, b);
+    CREATE TABLE t4 (a, b);
     INSERT INTO t4 VALUES('abc', 'def');
     INSERT INTO t4 VALUES('ghi', 'jkl');
   }
@@ -784,7 +784,7 @@ do_test func-15.4 {
 # Test the quote function for BLOB and NULL values.
 do_test func-16.1 {
   execsql {
-    CREATE TABLE tbl2(a, b);
+    CREATE TABLE tbl2 (a, b);
   }
   set STMT [sqlite3_prepare $::DB "INSERT INTO tbl2 VALUES(?, ?)" -1 TAIL]
   sqlite3_bind_blob $::STMT 1 abc 3
@@ -814,7 +814,7 @@ do_test func-17.1 {
 #
 do_test func-18.1 {
   execsql {
-    CREATE TABLE t5(x);
+    CREATE TABLE t5 (x);
     INSERT INTO t5 VALUES(1);
     INSERT INTO t5 VALUES(-99);
     INSERT INTO t5 VALUES(10000);
@@ -865,7 +865,7 @@ do_test func-18.6 {
 #
 do_test func-18.10 {
   execsql {
-    CREATE TABLE t6(x INTEGER);
+    CREATE TABLE t6 (x INTEGER);
     INSERT INTO t6 VALUES(1);
     INSERT INTO t6 VALUES(1<<62);
     SELECT sum(x) - ((1<<62)+1) from t6;
@@ -1328,7 +1328,7 @@ do_test func-27.3 {
 #
 do_test func-28.1 {
   db eval {
-    CREATE TABLE t28(x, y DEFAULT(nosuchfunc(1)));
+    CREATE TABLE t28 (x, y DEFAULT(nosuchfunc(1)));
   }
   catchsql {
     INSERT INTO t28(x) VALUES(1);
@@ -1340,7 +1340,7 @@ do_test func-28.1 {
 #
 do_test func-29.1 {
   db eval {
-    CREATE TABLE t29(id INTEGER PRIMARY KEY, x, y);
+    CREATE TABLE t29 (id INTEGER PRIMARY KEY, x, y);
     INSERT INTO t29 VALUES(1, 2, 3), (2, NULL, 4), (3, 4.5, 5);
     INSERT INTO t29 VALUES(4, randomblob(1000000), 6);
     INSERT INTO t29 VALUES(5, 'hello', 7);
@@ -1387,7 +1387,7 @@ do_test func-29.6 {
 # page.  Make sure the optimization works.
 #
 do_execsql_test func-29.10 {
-  CREATE TABLE t29b(a,b,c,d,e,f,g,h,i);
+  CREATE TABLE t29b (a,b,c,d,e,f,g,h,i);
   INSERT INTO t29b 
    VALUES(1, hex(randomblob(2000)), null, 0, 1, '', zeroblob(0),'x',x'01');
   SELECT typeof(c), typeof(d), typeof(e), typeof(f),
@@ -1443,7 +1443,7 @@ do_execsql_test func-32.120 {
 } {2}
 do_execsql_test func-32.130 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(a,b,c,e,f);
+  CREATE TABLE t1 (a,b,c,e,f);
   INSERT INTO t1 VALUES(1,2.5,'xyz',x'e0c1b2a3',null);
   SELECT test_frombind(a,b,c,e,f,$xyz) FROM t1;
 } {32}
@@ -1478,8 +1478,8 @@ do_catchsql_test func-33.5 {
   SELECT * FROM c;
 } {1 {unsafe use of testdirectonly()}}
 do_execsql_test func-33.10 {
-  CREATE TABLE t33a(a,b);
-  CREATE TABLE t33b(x,y);
+  CREATE TABLE t33a (a,b);
+  CREATE TABLE t33b (x,y);
   CREATE TRIGGER r1 AFTER INSERT ON t33a BEGIN
     INSERT INTO t33b(x,y) VALUES(testdirectonly(new.a),new.b);
   END;
@@ -1503,7 +1503,7 @@ do_execsql_test func-33.20 {
 #
 reset_db
 do_execsql_test func-34.10 {
-  CREATE TABLE t1(a INT CHECK(
+  CREATE TABLE t1 (a INT CHECK(
      datetime( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
               10,11,12,13,14,15,16,17,18,19,
               20,21,22,23,24,25,26,27,28,29,
@@ -1524,14 +1524,14 @@ do_execsql_test func-34.10 {
 #
 reset_db
 do_execsql_test func-35.100 {
-  CREATE TABLE t1(x);
+  CREATE TABLE t1 (x);
   SELECT coalesce(x, abs(-9223372036854775808)) FROM t1;
 } {}
 do_execsql_test func-35.110 {
   SELECT coalesce(x, 'xyz' LIKE printf('%.1000000c','y')) FROM t1;
 } {}
 do_execsql_test func-35.200 {
-  CREATE TABLE t0(c0 CHECK(ABS(-9223372036854775808)));
+  CREATE TABLE t0 (c0 CHECK(ABS(-9223372036854775808)));
   PRAGMA integrity_check;
 } {ok}
 

--- a/testing/sqlite3/func4.test
+++ b/testing/sqlite3/func4.test
@@ -392,7 +392,7 @@ ifcapable floatingpoint {
 
 ifcapable check {
   do_execsql_test func4-3.1 {
-    CREATE TABLE t1(
+    CREATE TABLE t1 (
       x INTEGER CHECK(tointeger(x) IS NOT NULL)
     );
   } {}
@@ -494,7 +494,7 @@ ifcapable check {
 
   ifcapable floatingpoint {
     do_execsql_test func4-4.1 {
-      CREATE TABLE t2(
+      CREATE TABLE t2 (
         x REAL CHECK(toreal(x) IS NOT NULL)
       );
     } {}

--- a/testing/sqlite3/func5.test
+++ b/testing/sqlite3/func5.test
@@ -20,7 +20,7 @@ source $testdir/tester.tcl
 #
 do_execsql_test func5-1.1 {
   PRAGMA encoding=UTF16le;
-  CREATE TABLE t1(x,a,b,c);
+  CREATE TABLE t1 (x,a,b,c);
   INSERT INTO t1 VALUES(1,'ab','cd',1);
   INSERT INTO t1 VALUES(2,'gh','ef',5);
   INSERT INTO t1 VALUES(3,'pqr','fuzzy',99);
@@ -43,7 +43,7 @@ do_execsql_test func5-1.2 {
 # result multiple times.
 #
 do_execsql_test func5-2.1 {
-  CREATE TABLE t2(x,y);
+  CREATE TABLE t2 (x,y);
   INSERT INTO t2 VALUES(1,2),(3,4),(5,6),(7,8);
   SELECT x, y FROM t2 WHERE x+5=5+x ORDER BY +x;
 } {1 2 3 4 5 6 7 8}

--- a/testing/sqlite3/func6.test
+++ b/testing/sqlite3/func6.test
@@ -30,12 +30,12 @@ ifcapable null_trim {
 do_execsql_test func6-100 {
   PRAGMA page_size=4096;
   PRAGMA auto_vacuum=NONE;
-  CREATE TABLE t1(a,b,c,d);
+  CREATE TABLE t1 (a,b,c,d);
   WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<100)
    INSERT INTO t1(a,b,c,d) SELECT printf('abc%03x',x), x, 1000-x, NULL FROM c;
   CREATE INDEX t1a ON t1(a);
   CREATE INDEX t1bc ON t1(b,c);
-  CREATE TABLE t2(x TEXT PRIMARY KEY, y) WITHOUT ROWID;
+  CREATE TABLE t2 (x TEXT PRIMARY KEY, y) WITHOUT ROWID;
   INSERT INTO t2(x,y) SELECT a, b FROM t1;
 }
 
@@ -174,9 +174,9 @@ do_execsql_test func6-200 {
 # 2022-03-14 dbsqlfuzz 474499f3977d95fdf2dbcd99c50be1d0082e4c92
 reset_db
 do_execsql_test func6-300 {
-  CREATE TABLE t2(a INT, b INT PRIMARY KEY) WITHOUT ROWID;
+  CREATE TABLE t2 (a INT, b INT PRIMARY KEY) WITHOUT ROWID;
   CREATE INDEX x3 ON t2(b);
-  CREATE TABLE t1(a INT PRIMARY KEY, b TEXT);
+  CREATE TABLE t1 (a INT PRIMARY KEY, b TEXT);
   SELECT * FROM t1 WHERE a IN (SELECT sqlite_offset(b) FROM t2);
 } {}
 

--- a/testing/sqlite3/func8.test
+++ b/testing/sqlite3/func8.test
@@ -24,13 +24,13 @@ db func natural {joinx natural}
 db func outer {joinx outer}
 db func right {joinx right}
 do_execsql_test func8-100 {
-  CREATE TABLE cross(cross,full,inner,left,natural,outer,right);
-  CREATE TABLE full(cross,full,inner,left,natural,outer,right);
-  CREATE TABLE inner(cross,full,inner,left,natural,outer,right);
-  CREATE TABLE left(cross,full,inner,left,natural,outer,right);
-  CREATE TABLE natural(cross,full,inner,left,natural,outer,right);
-  CREATE TABLE outer(cross,full,inner,left,natural,outer,right);
-  CREATE TABLE right(cross,full,inner,left,natural,outer,right);
+  CREATE TABLE cross (cross,full,inner,left,natural,outer,right);
+  CREATE TABLE full (cross,full,inner,left,natural,outer,right);
+  CREATE TABLE inner (cross,full,inner,left,natural,outer,right);
+  CREATE TABLE left (cross,full,inner,left,natural,outer,right);
+  CREATE TABLE natural (cross,full,inner,left,natural,outer,right);
+  CREATE TABLE outer (cross,full,inner,left,natural,outer,right);
+  CREATE TABLE right (cross,full,inner,left,natural,outer,right);
   INSERT INTO cross VALUES(1,2,3,4,5,6,7);
   INSERT INTO full VALUES(1,2,3,4,5,6,7);
   INSERT INTO inner VALUES(1,2,3,4,5,6,7);

--- a/testing/sqlite3/insert.test
+++ b/testing/sqlite3/insert.test
@@ -32,7 +32,7 @@ do_test insert-1.2 {
 # Try to insert the wrong number of entries.
 #
 do_test insert-1.3 {
-  execsql {CREATE TABLE test1(one int, two int, three int)}
+  execsql {CREATE TABLE test1 (one int, two int, three int)}
   set v [catch {execsql {INSERT INTO test1 VALUES(1,2)}} msg]
   lappend v $msg
 } {1 {table test1 has 3 columns but 2 values were supplied}}
@@ -89,7 +89,7 @@ do_test insert-1.6c {
 #
 do_test insert-2.1 {
   execsql {
-    CREATE TABLE test2(
+    CREATE TABLE test2 (
       f1 int default -111, 
       f2 real default +4.32,
       f3 int default +222,
@@ -113,7 +113,7 @@ do_test insert-2.4 {
 do_test insert-2.10 {
   execsql {
     DROP TABLE test2;
-    CREATE TABLE test2(
+    CREATE TABLE test2 (
       f1 int default 111, 
       f2 real default -4.32,
       f3 text default hi,
@@ -170,7 +170,7 @@ integrity_check insert-3.5
 #
 do_test insert-4.1 {
   execsql {
-    CREATE TABLE t3(a,b,c);
+    CREATE TABLE t3 (a,b,c);
     INSERT INTO t3 VALUES(1+2+3,4,5);
     SELECT * FROM t3;
   }
@@ -292,7 +292,7 @@ ifcapable conflict {
   # defined at compilation time.
   do_test insert-6.1 {
     execsql {
-      CREATE TABLE t1(a INTEGER PRIMARY KEY, b UNIQUE);
+      CREATE TABLE t1 (a INTEGER PRIMARY KEY, b UNIQUE);
       INSERT INTO t1 VALUES(1,2);
       INSERT INTO t1 VALUES(2,3);
       SELECT b FROM t1 WHERE b=2;
@@ -332,7 +332,7 @@ ifcapable conflict {
 # INSERT statments.
 do_test insert-7.1 {
   execsql {
-    CREATE TABLE t1(a);
+    CREATE TABLE t1 (a);
     INSERT INTO t1 VALUES(1);
     INSERT INTO t1 VALUES(2);
     CREATE INDEX i1 ON t1(a);
@@ -366,7 +366,7 @@ ifcapable subquery&&compound {
 #
 do_test insert-9.1 {
   execsql {
-    CREATE TABLE t5(x);
+    CREATE TABLE t5 (x);
     INSERT INTO t5 VALUES(1);
     INSERT INTO t5 VALUES(2);
     INSERT INTO t5 VALUES(3);
@@ -376,7 +376,7 @@ do_test insert-9.1 {
 } {1 1 2 2 3 3 12 101 13 102 16 103}
 do_test insert-9.2 {
   execsql {
-    CREATE TABLE t6(x INTEGER PRIMARY KEY, y);
+    CREATE TABLE t6 (x INTEGER PRIMARY KEY, y);
     INSERT INTO t6 VALUES(1,1);
     INSERT INTO t6 VALUES(2,2);
     INSERT INTO t6 VALUES(3,3);
@@ -390,7 +390,7 @@ do_test insert-9.2 {
 ifcapable compound {
   do_test insert-10.1 {
     execsql {
-      CREATE TABLE t10(a,b,c);
+      CREATE TABLE t10 (a,b,c);
       INSERT INTO t10 VALUES(1,2,3), (4,5,6), (7,8,9);
       SELECT * FROM t10;
     }
@@ -416,20 +416,20 @@ do_execsql_test insert-11.1 {
 # Ticket http://sqlite.org/src/info/e9654505cfda9361
 #
 do_execsql_test insert-12.1 {
-  CREATE TABLE t12a(a,b,c,d,e,f,g);
+  CREATE TABLE t12a (a,b,c,d,e,f,g);
   INSERT INTO t12a VALUES(101,102,103,104,105,106,107);
-  CREATE TABLE t12b(x);
+  CREATE TABLE t12b (x);
   INSERT INTO t12b(x,rowid,x,x,x,x,x) SELECT * FROM t12a;
   SELECT rowid, x FROM t12b;
 } {102 101}
 do_execsql_test insert-12.2 {
-  CREATE TABLE tab1( value INTEGER);
+  CREATE TABLE tab1 ( value INTEGER);
   INSERT INTO tab1 (value, _rowid_) values( 11, 1);
   INSERT INTO tab1 (value, _rowid_) SELECT 22,999;
   SELECT * FROM tab1;
 } {11 22}
 do_execsql_test insert-12.3 {
-  CREATE TABLE t12c(a, b DEFAULT 'xyzzy', c);
+  CREATE TABLE t12c (a, b DEFAULT 'xyzzy', c);
   INSERT INTO t12c(a, rowid, c) SELECT 'one', 999, 'two';
   SELECT * FROM t12c;
 } {one xyzzy two}
@@ -441,7 +441,7 @@ do_execsql_test insert-12.3 {
 #
 do_execsql_test insert-13.1 {
   DROP TABLE IF EXISTS t13;
-  CREATE TABLE t13(a INTEGER PRIMARY KEY,b UNIQUE);
+  CREATE TABLE t13 (a INTEGER PRIMARY KEY,b UNIQUE);
   CREATE INDEX t13x1 ON t13(-b=b);
   INSERT INTO t13 VALUES(1,5),(6,2);
   REPLACE INTO t13 SELECT b,0 FROM t13;
@@ -452,7 +452,7 @@ do_execsql_test insert-13.1 {
 #
 do_execsql_test insert-14.1 {
   DROP TABLE IF EXISTS t14;
-  CREATE TABLE t14(x INTEGER PRIMARY KEY);
+  CREATE TABLE t14 (x INTEGER PRIMARY KEY);
   INSERT INTO t14 VALUES(CASE WHEN 1 THEN null END);
   SELECT x FROM t14;
 } {1}
@@ -464,9 +464,9 @@ integrity_check insert-14.2
 do_execsql_test insert-15.1 {
   DROP TABLE IF EXISTS t1;
   DROP TABLE IF EXISTS t2;
-  CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+  CREATE TABLE t1 (a INTEGER PRIMARY KEY, b TEXT);
   CREATE INDEX i1 ON t1(b);
-  CREATE TABLE t2(a, b);
+  CREATE TABLE t2 (a, b);
   INSERT INTO t2 VALUES(4, randomblob(31000));
   INSERT INTO t2 VALUES(4, randomblob(32000));
   INSERT INTO t2 VALUES(4, randomblob(33000));
@@ -483,7 +483,7 @@ db close
 sqlite3 db :memory:
 do_catchsql_test insert-16.1 {
   PRAGMA recursive_triggers = true;
-  CREATE TABLE t0(c0,c1);
+  CREATE TABLE t0 (c0,c1);
   CREATE UNIQUE INDEX i0 ON t0(c0);
   INSERT INTO t0(c0,c1) VALUES(123,1);
   CREATE TRIGGER tr0 AFTER DELETE ON t0
@@ -497,7 +497,7 @@ do_execsql_test insert-16.2 {
 } {123 1}
 integrity_check insert-16.3
 do_catchsql_test insert-16.4 {
-  CREATE TABLE t1(a INTEGER PRIMARY KEY, b);
+  CREATE TABLE t1 (a INTEGER PRIMARY KEY, b);
   CREATE INDEX t1b ON t1(b);
   INSERT INTO t1 VALUES(1, 'one');
   CREATE TRIGGER tr3 AFTER DELETE ON t1 BEGIN
@@ -508,8 +508,8 @@ do_catchsql_test insert-16.4 {
 integrity_check insert-16.5
 do_catchsql_test insert-16.6 {
   PRAGMA foreign_keys = 1;
-  CREATE TABLE p1(a, b UNIQUE);
-  CREATE TABLE c1(c, d REFERENCES p1(b) ON DELETE CASCADE);
+  CREATE TABLE p1 (a, b UNIQUE);
+  CREATE TABLE c1 (c, d REFERENCES p1(b) ON DELETE CASCADE);
   CREATE TRIGGER tr6 AFTER DELETE ON c1 BEGIN
     INSERT INTO p1 VALUES(4, 1);
   END;
@@ -523,7 +523,7 @@ integrity_check insert-16.7
 do_catchsql_test insert-17.1 {
   PRAGMA temp.recursive_triggers = true;
   DROP TABLE IF EXISTS t0;
-  CREATE TABLE t0(aa, bb);
+  CREATE TABLE t0 (aa, bb);
   CREATE UNIQUE INDEX t0bb ON t0(bb);
   CREATE TRIGGER "r17.1" BEFORE DELETE ON t0
     BEGIN INSERT INTO t0(aa,bb) VALUES(99,1);
@@ -534,7 +534,7 @@ do_catchsql_test insert-17.1 {
 integrity_check insert-17.2
 do_catchsql_test insert-17.3 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(a, b UNIQUE, c UNIQUE);
+  CREATE TABLE t1 (a, b UNIQUE, c UNIQUE);
   INSERT INTO t1(a,b,c) VALUES(1,1,1),(2,2,2),(3,3,3),(4,4,4);
   CREATE TRIGGER "r17.3" AFTER DELETE ON t1 WHEN OLD.c<>3 BEGIN
     INSERT INTO t1(rowid,a,b,c) VALUES(100,100,100,3);
@@ -543,10 +543,10 @@ do_catchsql_test insert-17.3 {
 } {1 {UNIQUE constraint failed: t1.c}}
 integrity_check insert-17.4
 do_execsql_test insert-17.5 {
-  CREATE TABLE t2(a INTEGER PRIMARY KEY, b);
+  CREATE TABLE t2 (a INTEGER PRIMARY KEY, b);
   CREATE UNIQUE INDEX t2b ON t2(b);
   INSERT INTO t2(a,b) VALUES(1,1),(2,2),(3,3),(4,4);
-  CREATE TABLE fire(x);
+  CREATE TABLE fire (x);
   CREATE TRIGGER t2r1 AFTER DELETE ON t2 BEGIN
     INSERT INTO fire VALUES(old.a);
   END;
@@ -567,7 +567,7 @@ do_execsql_test insert-17.8 {
   SELECT x FROM fire ORDER BY x;
 } {3}
 do_execsql_test insert-17.10 {
-  CREATE TABLE t3(a INTEGER PRIMARY KEY, b INT, c INT, d INT);
+  CREATE TABLE t3 (a INTEGER PRIMARY KEY, b INT, c INT, d INT);
   CREATE UNIQUE INDEX t3bpi ON t3(b) WHERE c<=d;
   CREATE UNIQUE INDEX t3d ON t3(d);
   INSERT INTO t3(a,b,c,d) VALUES(1,1,1,1),(2,1,3,2),(3,4,5,6);

--- a/testing/sqlite3/insert2.test
+++ b/testing/sqlite3/insert2.test
@@ -21,7 +21,7 @@ set testprefix insert2
 # Create some tables with data that we can select against
 #
 do_test insert2-1.0 {
-  execsql {CREATE TABLE d1(n int, log int);}
+  execsql {CREATE TABLE d1 (n int, log int);}
   for {set i 1} {$i<=20} {incr i} {
     for {set j 0} {(1<<$j)<$i} {incr j} {}
     execsql "INSERT INTO d1 VALUES($i,$j)"
@@ -33,7 +33,7 @@ do_test insert2-1.0 {
 #
 do_test insert2-1.1.1 {
   execsql {
-    CREATE TABLE t1(log int, cnt int);
+    CREATE TABLE t1 (log int, cnt int);
     PRAGMA count_changes=on;
   }
   ifcapable explain {
@@ -56,7 +56,7 @@ ifcapable compound {
 do_test insert2-1.2.1 {
   catch {execsql {DROP TABLE t1}}
   execsql {
-    CREATE TABLE t1(log int, cnt int);
+    CREATE TABLE t1 (log int, cnt int);
     INSERT INTO t1 
        SELECT log, count(*) FROM d1 GROUP BY log
        EXCEPT SELECT n-1,log FROM d1;
@@ -70,7 +70,7 @@ do_test insert2-1.2.2 {
 do_test insert2-1.3.1 {
   catch {execsql {DROP TABLE t1}}
   execsql {
-    CREATE TABLE t1(log int, cnt int);
+    CREATE TABLE t1 (log int, cnt int);
     PRAGMA count_changes=off;
     INSERT INTO t1 
        SELECT log, count(*) FROM d1 GROUP BY log
@@ -88,7 +88,7 @@ execsql {PRAGMA count_changes=off;}
 do_test insert2-1.4 {
   catch {execsql {DROP TABLE t1}}
   set r [execsql {
-    CREATE TABLE t1(log int, cnt int);
+    CREATE TABLE t1 (log int, cnt int);
     CREATE INDEX i1 ON t1(log);
     CREATE INDEX i2 ON t1(cnt);
     INSERT INTO t1 SELECT log, count() FROM d1 GROUP BY log;
@@ -100,8 +100,8 @@ do_test insert2-1.4 {
 
 do_test insert2-2.0 {
   execsql {
-    CREATE TABLE t3(a,b,c);
-    CREATE TABLE t4(x,y);
+    CREATE TABLE t3 (a,b,c);
+    CREATE TABLE t4 (x,y);
     INSERT INTO t4 VALUES(1,2);
     SELECT * FROM t4;
   }
@@ -231,7 +231,7 @@ integrity_check insert2-3.9
 ifcapable tempdb {
   do_test insert2-4.1 {
     execsql {
-      CREATE TABLE Dependencies(depId integer primary key,
+      CREATE TABLE Dependencies (depId integer primary key,
         class integer, name str, flag str);
       CREATE TEMPORARY TABLE DepCheck(troveId INT, depNum INT,
         flagCount INT, isProvides BOOL, class INTEGER, name STRING,
@@ -260,7 +260,7 @@ ifcapable tempdb {
 # only.
 do_test insert2-5.1 {
   execsql {
-    CREATE TABLE t2(a, b);
+    CREATE TABLE t2 (a, b);
     INSERT INTO t2 VALUES(1, 2);
     CREATE INDEX t2i1 ON t2(a);
     INSERT INTO t2 SELECT a, 3 FROM t2 WHERE a = 1;
@@ -277,7 +277,7 @@ ifcapable subquery {
 }
 
 do_execsql_test 6.0 { 
-  CREATE TABLE t5(a, b, c DEFAULT 'c', d);
+  CREATE TABLE t5 (a, b, c DEFAULT 'c', d);
 }
 do_execsql_test 6.1 {
   INSERT INTO t5(a) SELECT 456 UNION ALL SELECT 123 ORDER BY 1;

--- a/testing/sqlite3/insert3.test
+++ b/testing/sqlite3/insert3.test
@@ -25,8 +25,8 @@ ifcapable {trigger} {
 #
 do_test insert3-1.0 {
   execsql {
-    CREATE TABLE t1(a,b);
-    CREATE TABLE log(x UNIQUE, y);
+    CREATE TABLE t1 (a,b);
+    CREATE TABLE log (x UNIQUE, y);
     CREATE TRIGGER r1 AFTER INSERT ON t1 BEGIN
       UPDATE log SET y=y+1 WHERE x=new.a;
       INSERT OR IGNORE INTO log VALUES(new.a, 1);
@@ -44,7 +44,7 @@ do_test insert3-1.1 {
 } {5 2 hello 2}
 do_test insert3-1.2 {
   execsql {
-    CREATE TABLE log2(x PRIMARY KEY,y);
+    CREATE TABLE log2 (x PRIMARY KEY,y);
     CREATE TRIGGER r2 BEFORE INSERT ON t1 BEGIN
       UPDATE log2 SET y=y+1 WHERE x=new.b;
       INSERT OR IGNORE INTO log2 VALUES(new.b,1);
@@ -82,12 +82,12 @@ ifcapable compound {
 
 do_test insert3-2.1 {
   execsql {
-    CREATE TABLE t2(
+    CREATE TABLE t2 (
       a INTEGER PRIMARY KEY,
       b DEFAULT 'b',
       c DEFAULT 'c'
     );
-    CREATE TABLE t2dup(a,b,c);
+    CREATE TABLE t2dup (a,b,c);
     CREATE TRIGGER t2r1 BEFORE INSERT ON t2 BEGIN
       INSERT INTO t2dup(a,b,c) VALUES(new.a,new.b,new.c);
     END;
@@ -111,7 +111,7 @@ do_test insert3-2.2 {
 #
 do_test insert3-3.1 {
   execsql {
-    CREATE TABLE t3(a,b,c);
+    CREATE TABLE t3 (a,b,c);
     CREATE TRIGGER t3r1 BEFORE INSERT on t3 WHEN nosuchcol BEGIN
       SELECT 'illegal WHEN clause';
     END;
@@ -124,7 +124,7 @@ do_test insert3-3.2 {
 } {1 {no such column: nosuchcol}}
 do_test insert3-3.3 {
   execsql {
-    CREATE TABLE t4(a,b,c);
+    CREATE TABLE t4 (a,b,c);
     CREATE TRIGGER t4r1 AFTER INSERT on t4 WHEN nosuchcol BEGIN
       SELECT 'illegal WHEN clause';
     END;
@@ -142,7 +142,7 @@ do_test insert3-3.4 {
 #
 do_test insert3-3.5 {
   execsql {
-    CREATE TABLE t5(
+    CREATE TABLE t5 (
       a INTEGER PRIMARY KEY,
       b DEFAULT 'xyz'
     );
@@ -160,7 +160,7 @@ do_test insert3-3.6 {
 ifcapable bloblit {
   do_test insert3-3.7 {
     execsql {
-      CREATE TABLE t6(x,y DEFAULT 4.3, z DEFAULT x'6869');
+      CREATE TABLE t6 (x,y DEFAULT 4.3, z DEFAULT x'6869');
       INSERT INTO t6 DEFAULT VALUES;
       SELECT * FROM t6;
     }
@@ -180,7 +180,7 @@ sqlite3 db test.db
 #
 do_test insert3-4.1 {
   execsql { 
-    CREATE TABLE t1(a, b, c);
+    CREATE TABLE t1 (a, b, c);
     CREATE INDEX i1 ON t1(a, b);
     BEGIN;
     INSERT INTO t1 VALUES(randstr(10,400),randstr(10,400),randstr(10,400));

--- a/testing/sqlite3/insert4.test
+++ b/testing/sqlite3/insert4.test
@@ -35,10 +35,10 @@ proc xferopt_test {testname N} {
 #
 sqlite3_db_config db LEGACY_FILE_FORMAT 0
 execsql {
-  CREATE TABLE t1(a int, b int, check(b>a));
-  CREATE TABLE t2(x int, y int);
+  CREATE TABLE t1 (a int, b int, check(b>a));
+  CREATE TABLE t2 (x int, y int);
   CREATE VIEW v2 AS SELECT y, x FROM t2;
-  CREATE TABLE t3(a int, b int);
+  CREATE TABLE t3 (a int, b int);
 }
 
 # Ticket #2252.  Make sure the an INSERT from identical tables
@@ -136,8 +136,8 @@ xferopt_test insert4-2.4.4 0
 # the destination and source tables.
 #
 proc xfer_check {testid xferused initdata destschema srcschema} {
-  execsql "CREATE TABLE dest($destschema)"
-  execsql "CREATE TABLE src($srcschema)"
+  execsql "CREATE TABLE dest ($destschema)"
+  execsql "CREATE TABLE src ($srcschema)"
   execsql "INSERT INTO src VALUES([join $initdata ,])"
   set ::sqlite3_xferopt_count 0
   do_test $testid.1 {
@@ -236,7 +236,7 @@ xfer_check insert4-3.22 1 {1 9} \
 #
 
 do_test insert4-4.1a {
-  execsql {CREATE TABLE t4(a, b, UNIQUE(a,b))}
+  execsql {CREATE TABLE t4 (a, b, UNIQUE(a,b))}
 } {}
 ifcapable vacuum {
   do_test insert4-4.1b {
@@ -258,7 +258,7 @@ do_test insert4-5.1 {
 do_test insert4-5.2 {
   # Number of columns does not match.
   catchsql { 
-    CREATE TABLE t5(a, b, c);
+    CREATE TABLE t5 (a, b, c);
     INSERT INTO t4 SELECT * FROM t5;
   }
 } {1 {table t4 has 2 columns but 3 values were supplied}}
@@ -303,14 +303,14 @@ do_test insert4-6.4 {
 
 do_test insert4-6.5 {
   execsql {
-    CREATE TABLE t6a(x CHECK( x<>'abc' ));
+    CREATE TABLE t6a (x CHECK( x<>'abc' ));
     INSERT INTO t6a VALUES('ABC');
     SELECT * FROM t6a;
   }
 } {ABC}
 do_test insert4-6.6 {
   execsql {
-    CREATE TABLE t6b(x CHECK( x<>'abc' COLLATE nocase ));
+    CREATE TABLE t6b (x CHECK( x<>'abc' COLLATE nocase ));
   }
   catchsql {
     INSERT INTO t6b SELECT * FROM t6a;
@@ -319,7 +319,7 @@ do_test insert4-6.6 {
 do_test insert4-6.7 {
   execsql {
     DROP TABLE t6b;
-    CREATE TABLE t6b(x CHECK( x COLLATE nocase <>'abc' ));
+    CREATE TABLE t6b (x CHECK( x COLLATE nocase <>'abc' ));
   }
   catchsql {
     INSERT INTO t6b SELECT * FROM t6a;
@@ -334,9 +334,9 @@ ifcapable foreignkey {
   do_test insert4-7.1 {
     set ::sqlite3_xferopt_count 0
     execsql {
-      CREATE TABLE t7a(x INTEGER PRIMARY KEY); INSERT INTO t7a VALUES(123);
-      CREATE TABLE t7b(y INTEGER REFERENCES t7a);
-      CREATE TABLE t7c(z INT);  INSERT INTO t7c VALUES(234);
+      CREATE TABLE t7a (x INTEGER PRIMARY KEY); INSERT INTO t7a VALUES(123);
+      CREATE TABLE t7b (y INTEGER REFERENCES t7a);
+      CREATE TABLE t7c (z INT);  INSERT INTO t7c VALUES(234);
       INSERT INTO t7b SELECT * FROM t7c;
       SELECT * FROM t7b;
     }
@@ -394,8 +394,8 @@ do_test insert4-8.1 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT REPLACE, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT REPLACE, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT REPLACE, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT REPLACE, y);
     INSERT INTO t1 VALUES(1,2);
     INSERT INTO t2 VALUES(1,3);
     INSERT INTO t1 SELECT * FROM t2;
@@ -406,8 +406,8 @@ do_test insert4-8.2 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT REPLACE, b);
-    CREATE TABLE t2(x, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT REPLACE, b);
+    CREATE TABLE t2 (x, y);
     INSERT INTO t1 VALUES(1,2);
     INSERT INTO t2 VALUES(1,3);
     INSERT INTO t1 SELECT * FROM t2;
@@ -418,8 +418,8 @@ do_test insert4-8.3 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT IGNORE, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT IGNORE, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT IGNORE, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT IGNORE, y);
     INSERT INTO t1 VALUES(1,2);
     INSERT INTO t2 VALUES(1,3);
     INSERT INTO t1 SELECT * FROM t2;
@@ -430,8 +430,8 @@ do_test insert4-8.4 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT IGNORE, b);
-    CREATE TABLE t2(x, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT IGNORE, b);
+    CREATE TABLE t2 (x, y);
     INSERT INTO t1 VALUES(1,2);
     INSERT INTO t2 VALUES(1,3);
     INSERT INTO t1 SELECT * FROM t2;
@@ -442,8 +442,8 @@ do_test insert4-8.5 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT FAIL, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT FAIL, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT FAIL, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT FAIL, y);
     INSERT INTO t1 VALUES(1,2);
     INSERT INTO t2 VALUES(-99,100);
     INSERT INTO t2 VALUES(1,3);
@@ -462,8 +462,8 @@ do_test insert4-8.7 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT ABORT, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT ABORT, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT ABORT, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT ABORT, y);
     INSERT INTO t1 VALUES(1,2);
     INSERT INTO t2 VALUES(-99,100);
     INSERT INTO t2 VALUES(1,3);
@@ -482,8 +482,8 @@ do_test insert4-8.9 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT ROLLBACK, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT ROLLBACK, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT ROLLBACK, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT ROLLBACK, y);
     INSERT INTO t1 VALUES(1,2);
     INSERT INTO t2 VALUES(-99,100);
     INSERT INTO t2 VALUES(1,3);
@@ -508,8 +508,8 @@ do_test insert4-8.21 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT REPLACE, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT REPLACE, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT REPLACE, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT REPLACE, y);
     INSERT INTO t2 VALUES(1,3);
     INSERT INTO t1 SELECT * FROM t2;
     SELECT * FROM t1;
@@ -519,8 +519,8 @@ do_test insert4-8.22 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT IGNORE, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT IGNORE, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT IGNORE, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT IGNORE, y);
     INSERT INTO t2 VALUES(1,3);
     INSERT INTO t1 SELECT * FROM t2;
     SELECT * FROM t1;
@@ -530,8 +530,8 @@ do_test insert4-8.23 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT ABORT, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT ABORT, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT ABORT, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT ABORT, y);
     INSERT INTO t2 VALUES(1,3);
     INSERT INTO t1 SELECT * FROM t2;
     SELECT * FROM t1;
@@ -541,8 +541,8 @@ do_test insert4-8.24 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT FAIL, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT FAIL, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT FAIL, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT FAIL, y);
     INSERT INTO t2 VALUES(1,3);
     INSERT INTO t1 SELECT * FROM t2;
     SELECT * FROM t1;
@@ -552,8 +552,8 @@ do_test insert4-8.25 {
   execsql {
     DROP TABLE IF EXISTS t1;
     DROP TABLE IF EXISTS t2;
-    CREATE TABLE t1(a INTEGER PRIMARY KEY ON CONFLICT ROLLBACK, b);
-    CREATE TABLE t2(x INTEGER PRIMARY KEY ON CONFLICT ROLLBACK, y);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY ON CONFLICT ROLLBACK, b);
+    CREATE TABLE t2 (x INTEGER PRIMARY KEY ON CONFLICT ROLLBACK, y);
     INSERT INTO t2 VALUES(1,3);
     INSERT INTO t1 SELECT * FROM t2;
     SELECT * FROM t1;
@@ -562,7 +562,7 @@ do_test insert4-8.25 {
 
 do_catchsql_test insert4-9.1 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(x);
+  CREATE TABLE t1 (x);
   INSERT INTO t1(x) VALUES(5 COLLATE xyzzy) UNION SELECT 0;
 } {1 {no such collation sequence: xyzzy}}
 
@@ -571,7 +571,7 @@ do_catchsql_test insert4-9.1 {
 # optimization for tables with CHECK constraints.
 #
 do_execsql_test 10.1 {
-  CREATE TABLE t8(
+  CREATE TABLE t8 (
     rid INTEGER,
     pid INTEGER,
     mid INTEGER,
@@ -608,7 +608,7 @@ do_test 10.4 {
 # xfer transfer between tables where the source has an empty partial index.
 #
 do_execsql_test 11.0 {
-  CREATE TABLE t9(a, b, c);
+  CREATE TABLE t9 (a, b, c);
   CREATE INDEX t9a ON t9(a);
   CREATE INDEX t9b ON t9(b) WHERE c=0;
 
@@ -616,7 +616,7 @@ do_execsql_test 11.0 {
   INSERT INTO t9 VALUES(2, 2, 2);
   INSERT INTO t9 VALUES(3, 3, 3);
 
-  CREATE TABLE t10(a, b, c);
+  CREATE TABLE t10 (a, b, c);
   CREATE INDEX t10a ON t10(a);
   CREATE INDEX t10b ON t10(b) WHERE c=0;
 

--- a/testing/sqlite3/insert5.test
+++ b/testing/sqlite3/insert5.test
@@ -36,8 +36,8 @@ proc uses_temp_table {sql} {
 do_test insert5-1.0 {
   forcedelete test2.db test2.db-journal
   execsql {
-    CREATE TABLE MAIN(Id INTEGER, Id1 INTEGER); 
-    CREATE TABLE B(Id INTEGER, Id1 INTEGER); 
+    CREATE TABLE MAIN (Id INTEGER, Id1 INTEGER); 
+    CREATE TABLE B (Id INTEGER, Id1 INTEGER); 
     CREATE VIEW v1 AS SELECT * FROM B;
     CREATE VIEW v2 AS SELECT * FROM MAIN;
     INSERT INTO MAIN(Id,Id1) VALUES(2,3); 

--- a/testing/sqlite3/join.test
+++ b/testing/sqlite3/join.test
@@ -18,7 +18,7 @@ source $testdir/tester.tcl
 
 do_test join-1.1 {
   execsql {
-    CREATE TABLE t1(a,b,c);
+    CREATE TABLE t1 (a,b,c);
     INSERT INTO t1 VALUES(1,2,3);
     INSERT INTO t1 VALUES(2,3,4);
     INSERT INTO t1 VALUES(3,4,5);
@@ -27,7 +27,7 @@ do_test join-1.1 {
 } {1 2 3 2 3 4 3 4 5}
 do_test join-1.2 {
   execsql {
-    CREATE TABLE t2(b,c,d);
+    CREATE TABLE t2 (b,c,d);
     INSERT INTO t2 VALUES(1,2,3);
     INSERT INTO t2 VALUES(2,3,4);
     INSERT INTO t2 VALUES(3,4,5);
@@ -202,7 +202,7 @@ ifcapable subquery {
 
 do_test join-1.15 {
   execsql {
-    CREATE TABLE t3(c,d,e);
+    CREATE TABLE t3 (c,d,e);
     INSERT INTO t3 VALUES(2,3,4);
     INSERT INTO t3 VALUES(3,4,5);
     INSERT INTO t3 VALUES(4,5,6);
@@ -221,7 +221,7 @@ do_test join-1.17 {
 } {a 1 b 2 c 3 d 4 e 5 a 2 b 3 c 4 d 5 e 6}
 do_test join-1.18 {
   execsql {
-    CREATE TABLE t4(d,e,f);
+    CREATE TABLE t4 (d,e,f);
     INSERT INTO t4 VALUES(2,3,4);
     INSERT INTO t4 VALUES(3,4,5);
     INSERT INTO t4 VALUES(4,5,6);
@@ -378,8 +378,8 @@ do_test join-3.12 {
 do_test join-4.1 {
   execsql {
     BEGIN;
-    CREATE TABLE t5(a INTEGER PRIMARY KEY);
-    CREATE TABLE t6(a INTEGER);
+    CREATE TABLE t5 (a INTEGER PRIMARY KEY);
+    CREATE TABLE t6 (a INTEGER);
     INSERT INTO t6 VALUES(NULL);
     INSERT INTO t6 VALUES(NULL);
     INSERT INTO t6 SELECT * FROM t6;
@@ -487,13 +487,13 @@ ifcapable view {
 do_test join-8.1 {
   execsql {
     BEGIN;
-    CREATE TABLE t9(a INTEGER PRIMARY KEY, b);
+    CREATE TABLE t9 (a INTEGER PRIMARY KEY, b);
     INSERT INTO t9 VALUES(1,11);
     INSERT INTO t9 VALUES(2,22);
-    CREATE TABLE t10(x INTEGER PRIMARY KEY, y);
+    CREATE TABLE t10 (x INTEGER PRIMARY KEY, y);
     INSERT INTO t10 VALUES(1,2);
     INSERT INTO t10 VALUES(3,3);    
-    CREATE TABLE t11(p INTEGER PRIMARY KEY, q);
+    CREATE TABLE t11 (p INTEGER PRIMARY KEY, q);
     INSERT INTO t11 VALUES(2,111);
     INSERT INTO t11 VALUES(3,333);    
     CREATE VIEW v10_11 AS SELECT x, q FROM t10, t11 WHERE t10.y=t11.p;
@@ -540,10 +540,10 @@ ifcapable compound {
 do_test join-9.1 {
   execsql {
     BEGIN;
-    CREATE TABLE t12(a,b);
+    CREATE TABLE t12 (a,b);
     INSERT INTO t12 VALUES(1,11);
     INSERT INTO t12 VALUES(2,22);
-    CREATE TABLE t13(b,c);
+    CREATE TABLE t13 (b,c);
     INSERT INTO t13 VALUES(22,222);
     COMMIT;
   }
@@ -576,8 +576,8 @@ ifcapable subquery {
   #
   do_test join-10.1 {
     execsql {
-      CREATE TABLE t21(a,b,c);
-      CREATE TABLE t22(p,q);
+      CREATE TABLE t21 (a,b,c);
+      CREATE TABLE t22 (p,q);
       CREATE INDEX i22 ON t22(q);
       SELECT a FROM t21 LEFT JOIN t22 ON b=p WHERE q=
          (SELECT max(m.q) FROM t22 m JOIN t21 n ON n.b=m.p WHERE n.c=1);
@@ -589,8 +589,8 @@ ifcapable subquery {
   #
   do_test join-10.2 {
     execsql {
-      CREATE TABLE t23(a, b, c);
-      CREATE TABLE t24(a, b, c);
+      CREATE TABLE t23 (a, b, c);
+      CREATE TABLE t24 (a, b, c);
       INSERT INTO t23 VALUES(1, 2, 3);
     }
     execsql {
@@ -611,8 +611,8 @@ ifcapable subquery {
 do_test join-11.1 {
   drop_all_tables
   execsql {
-    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
-    CREATE TABLE t2(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2 (a INTEGER PRIMARY KEY, b TEXT);
     INSERT INTO t1 VALUES(1,'abc');
     INSERT INTO t1 VALUES(2,'def');
     INSERT INTO t2 VALUES(1,'abc');
@@ -637,8 +637,8 @@ do_test join-11.4 {
 do_test join-11.5 {
   drop_all_tables
   execsql {
-    CREATE TABLE t1(a COLLATE nocase, b);
-    CREATE TABLE t2(a, b);
+    CREATE TABLE t1 (a COLLATE nocase, b);
+    CREATE TABLE t2 (a, b);
     INSERT INTO t1 VALUES('ONE', 1);
     INSERT INTO t1 VALUES('two', 2);
     INSERT INTO t2 VALUES('one', 1);
@@ -655,8 +655,8 @@ do_test join-11.7 {
 do_test join-11.8 {
   drop_all_tables
   execsql {
-    CREATE TABLE t1(a, b TEXT);
-    CREATE TABLE t2(b INTEGER, a);
+    CREATE TABLE t1 (a, b TEXT);
+    CREATE TABLE t2 (b INTEGER, a);
     INSERT INTO t1 VALUES('one', '1.0');
     INSERT INTO t1 VALUES('two', '2');
     INSERT INTO t2 VALUES(1, 'one');
@@ -674,7 +674,7 @@ do_test join-11.10 {
 # Test that at most 64 tables are allowed in a join.
 #
 do_execsql_test join-12.1 {
-  CREATE TABLE t14(x);
+  CREATE TABLE t14 (x);
   INSERT INTO t14 VALUES('abcdefghij');
 }
 
@@ -716,9 +716,9 @@ jointest join-12.8 128 {1 {at most 64 tables in a join}}
 # Test a problem with reordering tables following a LEFT JOIN.
 #
 do_execsql_test join-13.0 {
-  CREATE TABLE aa(a);
-  CREATE TABLE bb(b);
-  CREATE TABLE cc(c);
+  CREATE TABLE aa (a);
+  CREATE TABLE bb (b);
+  CREATE TABLE cc (c);
 
   INSERT INTO aa VALUES(45);
   INSERT INTO cc VALUES(45);
@@ -759,7 +759,7 @@ do_execsql_test join-14.3 {
 
 do_execsql_test join-14.4 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(c PRIMARY KEY, a TEXT(10000), b TEXT(10000));
+  CREATE TABLE t1 (c PRIMARY KEY, a TEXT(10000), b TEXT(10000));
   SELECT * FROM (SELECT 111) LEFT JOIN (SELECT c+222 FROM t1) GROUP BY 1;
 } {111 {}}
 do_execsql_test join-14.4b {
@@ -794,7 +794,7 @@ do_execsql_test join-14.8 {
 } {111 {} 222 222}
 do_execsql_test join-14.9 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(c PRIMARY KEY) WITHOUT ROWID;
+  CREATE TABLE t1 (c PRIMARY KEY) WITHOUT ROWID;
   SELECT * FROM (SELECT 111) LEFT JOIN (SELECT c+222 FROM t1) GROUP BY 1;
 } {111 {}}
 
@@ -804,10 +804,10 @@ do_execsql_test join-14.9 {
 db close
 sqlite3 db :memory:
 do_execsql_test join-14.10 {
-  CREATE TABLE t1(a);
+  CREATE TABLE t1 (a);
   INSERT INTO t1 VALUES(1),(2),(3);
   CREATE VIEW v2 AS SELECT a, 1 AS b FROM t1;
-  CREATE TABLE t3(x);
+  CREATE TABLE t3 (x);
   INSERT INTO t3 VALUES(2),(4);
   SELECT *, '|' FROM t3 LEFT JOIN v2 ON a=x WHERE b=1;
 } {2 2 1 |}
@@ -824,9 +824,9 @@ do_execsql_test join-14.12 {
 db close
 sqlite3 db :memory:
 do_execsql_test join-14.20 {
-  CREATE TABLE t1(id INTEGER PRIMARY KEY);
-  CREATE TABLE t2(id INTEGER PRIMARY KEY, c2 INTEGER);
-  CREATE TABLE t3(id INTEGER PRIMARY KEY, c3 INTEGER);
+  CREATE TABLE t1 (id INTEGER PRIMARY KEY);
+  CREATE TABLE t2 (id INTEGER PRIMARY KEY, c2 INTEGER);
+  CREATE TABLE t3 (id INTEGER PRIMARY KEY, c3 INTEGER);
   INSERT INTO t1(id) VALUES(456);
   INSERT INTO t3(id) VALUES(1),(2);
   SELECT t1.id, x2.id, x3.id
@@ -849,9 +849,9 @@ do_execsql_test join-14.20 {
 db close
 sqlite3 db :memory:
 do_execsql_test join-15.100 {
-  CREATE TABLE t1(a INT, b INT);
+  CREATE TABLE t1 (a INT, b INT);
   INSERT INTO t1 VALUES(1,2),(3,4);
-  CREATE TABLE t2(x INT, y INT);
+  CREATE TABLE t2 (x INT, y INT);
   SELECT *, 'x'
     FROM t1 LEFT JOIN t2
    WHERE CASE WHEN FALSE THEN a=x ELSE 1 END;
@@ -879,10 +879,10 @@ do_execsql_test join-15.107 {
 do_execsql_test join-15.110 {
   DROP TABLE t1;
   DROP TABLE t2;
-  CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER);
+  CREATE TABLE t1 (a INTEGER PRIMARY KEY, b INTEGER);
   INSERT INTO t1(a,b) VALUES(1,0),(11,1),(12,1),(13,1),(121,12);
   CREATE INDEX t1b ON t1(b);
-  CREATE TABLE t2(x INTEGER PRIMARY KEY);
+  CREATE TABLE t2 (x INTEGER PRIMARY KEY);
   INSERT INTO t2(x) VALUES(0),(1);
   SELECT  a1, a2, a3, a4, a5
    FROM (SELECT a AS a1 FROM t1 WHERE b=0)
@@ -910,9 +910,9 @@ do_execsql_test join-15.110 {
 do_execsql_test join-16.100 {
   DROP TABLE IF EXISTS t1;
   DROP TABLE IF EXISTS t2;
-  CREATE TABLE t1(a INT);
+  CREATE TABLE t1 (a INT);
   INSERT INTO t1(a) VALUES(1);
-  CREATE TABLE t2(b INT);
+  CREATE TABLE t2 (b INT);
   SELECT a, b
     FROM t1 LEFT JOIN t2 ON 0
    WHERE (b IS NOT NULL)=0;
@@ -924,7 +924,7 @@ do_execsql_test join-16.100 {
 #
 do_execsql_test join-17.100 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(x);
+  CREATE TABLE t1 (x);
   INSERT INTO t1(x) VALUES(0),(1);
   SELECT * FROM t1 LEFT JOIN (SELECT abs(1) AS y FROM t1) ON x WHERE NOT(y='a');
 } {1 1 1 1}
@@ -936,8 +936,8 @@ do_execsql_test join-17.110 {
 #-------------------------------------------------------------------------
 reset_db
 do_execsql_test join-18.1 {
-  CREATE TABLE t0(a);
-  CREATE TABLE t1(b);
+  CREATE TABLE t0 (a);
+  CREATE TABLE t1 (b);
   CREATE VIEW v0 AS SELECT a FROM t1 LEFT JOIN t0;
   INSERT INTO t1 VALUES (1);
 } {}
@@ -957,8 +957,8 @@ do_execsql_test join-18.4 {
 #-------------------------------------------------------------------------
 reset_db
 do_execsql_test join-19.0 {
-  CREATE TABLE t1(a);
-  CREATE TABLE t2(b);
+  CREATE TABLE t1 (a);
+  CREATE TABLE t2 (b);
   INSERT INTO t1(a) VALUES(0);
   CREATE VIEW v0(c) AS SELECT t2.b FROM t1 LEFT JOIN t2;
 }
@@ -992,8 +992,8 @@ do_execsql_test join-19.5 {
 db close
 sqlite3 db :memory:
 do_execsql_test join-20.1 {
-  CREATE TABLE t1(c1);
-  CREATE TABLE t0(c0);
+  CREATE TABLE t1 (c1);
+  CREATE TABLE t0 (c0);
   INSERT INTO t0(c0) VALUES (0);
   SELECT * FROM t0 LEFT JOIN t1 WHERE NULL IN (c1);
 } {}
@@ -1010,9 +1010,9 @@ do_execsql_test join-20.2 {
 #
 do_execsql_test join-20.3 {
   DROP TABLE t1;
-  CREATE TABLE t1(x INT);      INSERT INTO t1(x) VALUES(1);
-  CREATE TABLE t2(y BOOLEAN);  INSERT INTO t2(y) VALUES(false);
-  CREATE TABLE t3(z INT);      INSERT INTO t3(z) VALUES(3);
+  CREATE TABLE t1 (x INT);      INSERT INTO t1(x) VALUES(1);
+  CREATE TABLE t2 (y BOOLEAN);  INSERT INTO t2(y) VALUES(false);
+  CREATE TABLE t3 (z INT);      INSERT INTO t3(z) VALUES(3);
   CREATE INDEX t2y ON t2(y) WHERE y;
   SELECT quote(z) FROM t1 RIGHT JOIN t2 ON y LEFT JOIN t3 ON y;
 } {NULL}
@@ -1024,8 +1024,8 @@ do_execsql_test join-20.3 {
 do_execsql_test join-21.10 {
   DROP TABLE t0;
   DROP TABLE t1;
-  CREATE TABLE t0(aa);
-  CREATE TABLE t1(bb);
+  CREATE TABLE t0 (aa);
+  CREATE TABLE t1 (bb);
   INSERT INTO t0(aa) VALUES (1);
   INSERT INTO t1(bb) VALUES (1);
   SELECT 11, * FROM t1 LEFT JOIN t0 WHERE aa ISNULL;
@@ -1046,7 +1046,7 @@ do_execsql_test join-21.10 {
 #
 reset_db
 do_execsql_test join-22.10 {
-  CREATE TABLE t0(a, b);
+  CREATE TABLE t0 (a, b);
   CREATE INDEX t0a ON t0(a);
   INSERT INTO t0 VALUES(10,10),(10,11),(10,12);
   SELECT DISTINCT c FROM t0 LEFT JOIN (SELECT a+1 AS c FROM t0) ORDER BY c ;
@@ -1061,7 +1061,7 @@ do_execsql_test join-22.10 {
 reset_db
 ifcapable vtab {
   do_execsql_test join-23.10 {
-    CREATE TABLE t0(c0);
+    CREATE TABLE t0 (c0);
     INSERT INTO t0(c0) VALUES(123);
     CREATE VIEW v0(c0) AS SELECT 0 GROUP BY 1;
     SELECT t0.c0, v0.c0, vt0.name
@@ -1070,9 +1070,9 @@ ifcapable vtab {
      WHERE v0.c0 == 0;
   } {123 0 c0}
   do_execsql_test join-23.20 {
-    CREATE TABLE a(value TEXT);
+    CREATE TABLE a (value TEXT);
     INSERT INTO a(value) SELECT value FROM json_each('["a", "b", null]');
-    CREATE TABLE b(value TEXT);
+    CREATE TABLE b (value TEXT);
     INSERT INTO b(value) SELECT value FROM json_each('["a", "c", null]');
     SELECT a.value, b.value FROM a RIGHT JOIN b ON a.value = b.value;
   } {a a {} c {} {}}
@@ -1108,8 +1108,8 @@ ifcapable vtab {
 #-------------------------------------------------------------------------
 reset_db
 do_execsql_test join-24.1 {
-  CREATE TABLE t1(a PRIMARY KEY, x);
-  CREATE TABLE t2(b INT);
+  CREATE TABLE t1 (a PRIMARY KEY, x);
+  CREATE TABLE t2 (b INT);
   CREATE INDEX t1aa ON t1(a, a);
 
   INSERT INTO t1 VALUES('abc', 'def');
@@ -1134,7 +1134,7 @@ do_execsql_test join-24.2 {
 #
 reset_db
 do_execsql_test join-25.1 {
-  CREATE TABLE t0(c0 INT);
+  CREATE TABLE t0 (c0 INT);
   CREATE VIEW v0 AS SELECT (NULL AND 5) as c0 FROM t0;
   INSERT INTO t0(c0) VALUES (NULL);
   SELECT count(*)  FROM v0 LEFT JOIN t0 ON v0.c0;
@@ -1144,9 +1144,9 @@ do_execsql_test join-25.1 {
 #
 reset_db
 do_catchsql_test join-26.1 {
-  CREATE TABLE t4(a,b);
-  CREATE TABLE t5(a,c);
-  CREATE TABLE t6(a,d);
+  CREATE TABLE t4 (a,b);
+  CREATE TABLE t5 (a,c);
+  CREATE TABLE t6 (a,d);
   SELECT * FROM t5 JOIN ((t4 JOIN (t5 JOIN t6)) t7);
 } {/1 {.*}/}
 
@@ -1155,10 +1155,10 @@ do_catchsql_test join-26.1 {
 #
 reset_db
 do_execsql_test join-27.1 {
-  CREATE TABLE t1(a INT,b INT,c INT);  INSERT INTO t1 VALUES(NULL,NULL,NULL);
-  CREATE TABLE t2(d INT,e INT);        INSERT INTO t2 VALUES(NULL,NULL);
+  CREATE TABLE t1 (a INT,b INT,c INT);  INSERT INTO t1 VALUES(NULL,NULL,NULL);
+  CREATE TABLE t2 (d INT,e INT);        INSERT INTO t2 VALUES(NULL,NULL);
   CREATE INDEX x2 ON t1(c,b);
-  CREATE TABLE t3(x INT);              INSERT INTO t3 VALUES(NULL);
+  CREATE TABLE t3 (x INT);              INSERT INTO t3 VALUES(NULL);
 }
 do_execsql_test join-27.2 {
   WITH t99(b) AS MATERIALIZED (
@@ -1234,10 +1234,10 @@ do_execsql_test join-27.10 {
 #
 reset_db
 do_execsql_test join-28.1 {
-  CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT, c INT);
-  CREATE TABLE t2(d INTEGER PRIMARY KEY, e INT);
+  CREATE TABLE t1 (a INTEGER PRIMARY KEY, b INT, c INT);
+  CREATE TABLE t2 (d INTEGER PRIMARY KEY, e INT);
   CREATE VIEW t3(a,b,c,d,e) AS SELECT * FROM t1 LEFT JOIN t2 ON d=c;
-  CREATE TABLE t4(x INT, y INT);
+  CREATE TABLE t4 (x INT, y INT);
   INSERT INTO t1 VALUES(1,2,3);
   INSERT INTO t2 VALUES(1,5);
   INSERT INTO t4 VALUES(1,4);
@@ -1266,8 +1266,8 @@ do_eqp_test join-28.2 {
 reset_db
 db null NULL
 do_execsql_test join-29.1 {
-  CREATE TABLE t0(a INT); INSERT INTO t0(a) VALUES (1);
-  CREATE TABLE t1(b INT); INSERT INTO t1(b) VALUES (2);
+  CREATE TABLE t0 (a INT); INSERT INTO t0(a) VALUES (1);
+  CREATE TABLE t1 (b INT); INSERT INTO t1(b) VALUES (2);
   CREATE VIEW v2(c) AS SELECT 3 FROM t1;
   SELECT * FROM t1 JOIN v2 ON 0     FULL OUTER JOIN t0 ON true;
 } {NULL NULL 1}
@@ -1286,11 +1286,11 @@ do_execsql_test join-29.3 {
 reset_db
 db null NULL
 do_execsql_test join-30.1 {
-  CREATE TABLE t0(z INT);         INSERT INTO t0 VALUES(1),(2);
-  CREATE TABLE t1(a INT);         INSERT INTO t1 VALUES(1);
-  CREATE TABLE t2(b INT);         INSERT INTO t2 VALUES(2);
-  CREATE TABLE t3(c INT, d INT);  INSERT INTO t3 VALUES(3,4);
-  CREATE TABLE t4(e INT);         INSERT INTO t4 VALUES(5);
+  CREATE TABLE t0 (z INT);         INSERT INTO t0 VALUES(1),(2);
+  CREATE TABLE t1 (a INT);         INSERT INTO t1 VALUES(1);
+  CREATE TABLE t2 (b INT);         INSERT INTO t2 VALUES(2);
+  CREATE TABLE t3 (c INT, d INT);  INSERT INTO t3 VALUES(3,4);
+  CREATE TABLE t4 (e INT);         INSERT INTO t4 VALUES(5);
   CREATE VIEW v5(x,y) AS SELECT c, d FROM t3 LEFT JOIN t4 ON false;
 }
 do_execsql_test join-30.2 {
@@ -1313,12 +1313,12 @@ do_execsql_test join-30.3 {
 reset_db
 db null NULL
 do_execsql_test join-31.1 {
-  CREATE TABLE t1(c0 INT , c1 INT); INSERT INTO t1(c0, c1) VALUES(NULL,11);
-  CREATE TABLE t2(c0 INT NOT NULL);
-  CREATE TABLE t2n(c0 INT);
-  CREATE TABLE t3(x INT);           INSERT INTO t3(x) VALUES(3);
-  CREATE TABLE t4(y INT);           INSERT INTO t4(y) VALUES(4);
-  CREATE TABLE t5(c0 INT, x INT);   INSERT INTO t5 VALUES(NULL, 5);
+  CREATE TABLE t1 (c0 INT , c1 INT); INSERT INTO t1(c0, c1) VALUES(NULL,11);
+  CREATE TABLE t2 (c0 INT NOT NULL);
+  CREATE TABLE t2n (c0 INT);
+  CREATE TABLE t3 (x INT);           INSERT INTO t3(x) VALUES(3);
+  CREATE TABLE t4 (y INT);           INSERT INTO t4(y) VALUES(4);
+  CREATE TABLE t5 (c0 INT, x INT);   INSERT INTO t5 VALUES(NULL, 5);
 }
 do_execsql_test join-31.2 {
   SELECT * FROM t2 RIGHT JOIN t3 ON true LEFT JOIN t1 USING(c0);
@@ -1349,9 +1349,9 @@ do_execsql_test join-31.8 {
 reset_db
 db null NULL
 do_execsql_test join-32.1 {
-  CREATE TABLE t0(w INT);
-  CREATE TABLE t1(x INT);
-  CREATE TABLE t2(y INT UNIQUE);
+  CREATE TABLE t0 (w INT);
+  CREATE TABLE t1 (x INT);
+  CREATE TABLE t2 (y INT UNIQUE);
   CREATE VIEW v0(z) AS SELECT CAST(x AS INT) FROM t1 LEFT JOIN t2 ON true;
   INSERT INTO t1(x) VALUES(123);
   INSERT INTO t2(y) VALUES(NULL);

--- a/testing/sqlite3/select1.test
+++ b/testing/sqlite3/select1.test
@@ -24,7 +24,7 @@ do_test select1-1.1 {
 } {1 {no such table: test1}}
 
 
-execsql {CREATE TABLE test1(f1 int, f2 int)}
+execsql {CREATE TABLE test1 (f1 int, f2 int)}
 
 do_test select1-1.2 {
   set v [catch {execsql {SELECT * FROM test1, test2}} msg]
@@ -65,7 +65,7 @@ do_test select1-1.8.3 {
   execsql {SELECT 'one', *, 'two', * FROM test1}
 } {one 11 22 two 11 22}
 
-execsql {CREATE TABLE test2(r1 real, r2 real)}
+execsql {CREATE TABLE test2 (r1 real, r2 real)}
 execsql {INSERT INTO test2(r1,r2) VALUES(1.1,2.2)}
 
 do_test select1-1.9 {
@@ -105,11 +105,11 @@ do_test select1-2.0 {
     DELETE FROM test1;
     INSERT INTO test1 VALUES(11,22);
     INSERT INTO test1 VALUES(33,44);
-    CREATE TABLE t3(a,b);
+    CREATE TABLE t3 (a,b);
     INSERT INTO t3 VALUES('abc',NULL);
     INSERT INTO t3 VALUES(NULL,'xyz');
     INSERT INTO t3 SELECT * FROM test1;
-    CREATE TABLE t4(a,b);
+    CREATE TABLE t4 (a,b);
     INSERT INTO t4 VALUES(NULL,'$long');
     SELECT * FROM t3;
   "
@@ -241,7 +241,7 @@ do_test select1-2.22 {
 } {1 {misuse of aliased aggregate m}}
 do_test select1-2.23 {
   execsql {
-    CREATE TABLE tkt2526(a,b,c PRIMARY KEY);
+    CREATE TABLE tkt2526 (a,b,c PRIMARY KEY);
     INSERT INTO tkt2526 VALUES('x','y',NULL);
     INSERT INTO tkt2526 VALUES('x','z',NULL);
   }
@@ -357,7 +357,7 @@ do_test select1-4.6 {
 
 do_test select1-4.8 {
   execsql {
-    CREATE TABLE t5(a,b);
+    CREATE TABLE t5 (a,b);
     INSERT INTO t5 VALUES(1,10);
     INSERT INTO t5 VALUES(2,9);
     SELECT * FROM t5 ORDER BY 1;
@@ -408,7 +408,7 @@ do_test select1-5.1 {
   lappend v $msg
 } {0 33}
 
-execsql {CREATE TABLE test2(t1 text, t2 text)}
+execsql {CREATE TABLE test2 (t1 text, t2 text)}
 execsql {INSERT INTO test2 VALUES('abc','xyz')}
 
 # Check for column naming
@@ -634,7 +634,7 @@ do_test select1-6.11 {
 ifcapable subquery&&compound {
 do_test select1-6.20 {
    execsql {
-     CREATE TABLE t6(a TEXT, b TEXT);
+     CREATE TABLE t6 (a TEXT, b TEXT);
      INSERT INTO t6 VALUES('a','0');
      INSERT INTO t6 VALUES('b','1');
      INSERT INTO t6 VALUES('c','2');
@@ -1005,7 +1005,7 @@ ifcapable subquery {
   do_test select1-13.1 {
     execsql {
       BEGIN;
-      create TABLE abc(a, b, c, PRIMARY KEY(a, b));
+      create TABLE abc (a, b, c, PRIMARY KEY(a, b));
       INSERT INTO abc VALUES(1, 1, 1);
     }
     for {set i 0} {$i<10} {incr i} {
@@ -1053,7 +1053,7 @@ if {[db one {PRAGMA locking_mode}]=="normal"} {
   #
   do_test select1-15.1 {
     execsql {
-      CREATE TABLE t1(a);
+      CREATE TABLE t1 (a);
       CREATE INDEX i1 ON t1(a);
       INSERT INTO t1 VALUES(1);
       INSERT INTO t1 VALUES(2);
@@ -1087,8 +1087,8 @@ do_catchsql_test select1-16.2 {
 do_execsql_test select1-17.1 {
   DROP TABLE IF EXISTS t1;
   DROP TABLE IF EXISTS t2;
-  CREATE TABLE t1(x);   INSERT INTO t1 VALUES(1);
-  CREATE TABLE t2(y,z); INSERT INTO t2 VALUES(2,3);
+  CREATE TABLE t1 (x);   INSERT INTO t1 VALUES(1);
+  CREATE TABLE t2 (y,z); INSERT INTO t2 VALUES(2,3);
   CREATE INDEX t2y ON t2(y);
   SELECT * FROM t1,(SELECT * FROM t2 WHERE y=2 ORDER BY y,z);
 } {1 2 3}
@@ -1105,8 +1105,8 @@ do_execsql_test select1-17.3 {
 do_execsql_test select1-18.1 {
   DROP TABLE IF EXISTS t1;
   DROP TABLE IF EXISTS t2;
-  CREATE TABLE t1(c);
-  CREATE TABLE t2(x PRIMARY KEY, y);
+  CREATE TABLE t1 (c);
+  CREATE TABLE t2 (x PRIMARY KEY, y);
   INSERT INTO t1(c) VALUES(123);
   INSERT INTO t2(x) VALUES(123);
   SELECT x FROM t2, t1 WHERE x BETWEEN c AND null OR x AND
@@ -1128,8 +1128,8 @@ do_execsql_test select1-18.1 {
 do_execsql_test select1-18.2 {
   DROP TABLE IF EXISTS t1;
   DROP TABLE IF EXISTS t2;
-  CREATE TABLE t1(c);
-  CREATE TABLE t2(x PRIMARY KEY, y);
+  CREATE TABLE t1 (c);
+  CREATE TABLE t2 (x PRIMARY KEY, y);
   INSERT INTO t1(c) VALUES(123);
   INSERT INTO t2(x) VALUES(123);
   SELECT x FROM t2, t1 WHERE x BETWEEN c AND (c+1) OR x AND
@@ -1169,7 +1169,7 @@ do_execsql_test select1-18.4 {
 #
 do_execsql_test select1-19.10 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(x);
+  CREATE TABLE t1 (x);
 } {}
 do_catchsql_test select1-19.20 {
   INSERT INTO t1
@@ -1205,8 +1205,8 @@ do_execsql_test select1-20.20 {
 reset_db
 # TODO: Views are not supported.
 #do_execsql_test select1-21.1 {
-#  CREATE TABLE t1(a IMTEGES PRIMARY KEY,R);
-#  CREATE TABLE t2(x UNIQUE);
+#  CREATE TABLE t1 (a IMTEGES PRIMARY KEY,R);
+#  CREATE TABLE t2 (x UNIQUE);
 #  CREATE VIEW v1a(z,y) AS SELECT x IS NULL, x FROM t2;
 #  SELECT a,(+a)b,(+a)b,(+a)b,NOT EXISTS(SELECT null FROM t2),CASE z WHEN 487 THEN 992 WHEN 391 THEN 203 WHEN 10 THEN '?k<D Q' END,'' FROM t1 LEFT JOIN v1a ON z=b;
 #} {}

--- a/testing/sqlite3/select2.test
+++ b/testing/sqlite3/select2.test
@@ -18,7 +18,7 @@ source $testdir/tester.tcl
 
 # Create a table with some data
 #
-execsql {CREATE TABLE tbl1(f1 int, f2 int)}
+execsql {CREATE TABLE tbl1 (f1 int, f2 int)}
 execsql {BEGIN}
 for {set i 0} {$i<=30} {incr i} {
   execsql "INSERT INTO tbl1 VALUES([expr {$i%9}],[expr {$i%10}])"
@@ -65,7 +65,7 @@ unset data
 #ifcapable tclvar {
 #  do_test select2-2.0.1 {
 #    set t1 [time {
-#      execsql {CREATE TABLE tbl2(f1 int, f2 int, f3 int); BEGIN;}
+#      execsql {CREATE TABLE tbl2 (f1 int, f2 int, f3 int); BEGIN;}
 #      for {set i 1} {$i<=30000} {incr i} {
 #        set i2 [expr {$i*2}]
 #        set i3 [expr {$i*3}]
@@ -80,7 +80,7 @@ unset data
 #catch {execsql {DROP TABLE tbl2}}
 #do_test select2-2.0.2 {
 #  set t2 [time {
-#    execsql {CREATE TABLE tbl2(f1 int, f2 int, f3 int); BEGIN;}
+#    execsql {CREATE TABLE tbl2 (f1 int, f2 int, f3 int); BEGIN;}
 #    for {set i 1} {$i<=30000} {incr i} {
 #      set i2 [expr {$i*2}]
 #      set i3 [expr {$i*3}]
@@ -142,8 +142,8 @@ do_test select2-3.3 {
 #
 do_test select2-4.1 {
   execsql {
-    CREATE TABLE aa(a);
-    CREATE TABLE bb(b);
+    CREATE TABLE aa (a);
+    CREATE TABLE bb (b);
     INSERT INTO aa VALUES(1);
     INSERT INTO aa VALUES(3);
     INSERT INTO bb VALUES(2);

--- a/testing/sqlite3/select3.test
+++ b/testing/sqlite3/select3.test
@@ -21,7 +21,7 @@ source $testdir/tester.tcl
 #
 do_test select3-1.0 {
   execsql {
-    CREATE TABLE t1(n int, log int);
+    CREATE TABLE t1 (n int, log int);
     BEGIN;
   }
   for {set i 1} {$i<32} {incr i} {
@@ -233,7 +233,7 @@ do_test select3-6.8 {
 #
 do_test select3-7.1 {
   execsql {
-    CREATE TABLE t2(a,b);
+    CREATE TABLE t2 (a,b);
     INSERT INTO t2 VALUES(1,2);
     SELECT a, sum(b) FROM t2 WHERE b=5 GROUP BY a;
   }
@@ -316,15 +316,15 @@ foreach {id x} {
 # 2020-03-10 ticket e0c2ad1aa8a9c691
 reset_db
 do_execsql_test select3-9.100 {
-  CREATE TABLE t0(c0 REAL, c1 REAL GENERATED ALWAYS AS (c0));
+  CREATE TABLE t0 (c0 REAL, c1 REAL GENERATED ALWAYS AS (c0));
   INSERT INTO t0(c0) VALUES (1);
   SELECT * FROM t0 GROUP BY c0;
 } {1.0 1.0}
 
 reset_db
 do_execsql_test select3.10.100 {
-  CREATE TABLE t1(a, b);
-  CREATE TABLE t2(c, d);
+  CREATE TABLE t1 (a, b);
+  CREATE TABLE t2 (c, d);
   SELECT max(t1.a), 
          (SELECT 'xyz' FROM (SELECT * FROM t2 WHERE 0) WHERE t1.b=1) 
   FROM t1;
@@ -336,19 +336,19 @@ do_execsql_test select3.10.100 {
 #
 foreach {tn sql} {
   1 {
-    CREATE TABLE t1(a TEXT);
-    CREATE TABLE t2(x INT);
+    CREATE TABLE t1 (a TEXT);
+    CREATE TABLE t2 (x INT);
     CREATE INDEX t2x ON t2(x);
     INSERT INTO t1 VALUES('abc');
   }
   2 {
-    CREATE TABLE t1(a TEXT);
-    CREATE TABLE t2(x INT);
+    CREATE TABLE t1 (a TEXT);
+    CREATE TABLE t2 (x INT);
     INSERT INTO t1 VALUES('abc');
   }
   3 {
-    CREATE TABLE t1(a TEXT);
-    CREATE TABLE t2(x INT);
+    CREATE TABLE t1 (a TEXT);
+    CREATE TABLE t2 (x INT);
     INSERT INTO t1 VALUES('abc');
     PRAGMA automatic_index=OFF;
   }
@@ -376,8 +376,8 @@ foreach {tn sql} {
 
 reset_db
 do_execsql_test 12.0 {
-  CREATE TABLE t1(a);
-  CREATE TABLE t2(x);
+  CREATE TABLE t1 (a);
+  CREATE TABLE t2 (x);
 }
 do_execsql_test 12.1 {
   SELECT count(x), m FROM t1 LEFT JOIN (SELECT x, 59 AS m FROM t2) GROUP BY a;

--- a/testing/sqlite3/select4.test
+++ b/testing/sqlite3/select4.test
@@ -24,7 +24,7 @@ ifcapable compound {
 # Build some test data
 #
 execsql {
-  CREATE TABLE t1(n int, log int);
+  CREATE TABLE t1 (n int, log int);
   BEGIN;
 }
 for {set i 1} {$i<32} {incr i} {
@@ -525,7 +525,7 @@ ifcapable subquery {
 do_test select4-8.1 {
   execsql {
     BEGIN;
-    CREATE TABLE t3(a text, b float, c text);
+    CREATE TABLE t3 (a text, b float, c text);
     INSERT INTO t3 VALUES(1, 1.1, '1.1');
     INSERT INTO t3 VALUES(2, 1.10, '1.10');
     INSERT INTO t3 VALUES(3, 1.10, '1.1');
@@ -843,7 +843,7 @@ do_test select4-12.1 {
 do_test select4-13.1 {
   sqlite3 db test.db
   db eval {
-    CREATE TABLE t13(a,b);
+    CREATE TABLE t13 (a,b);
     INSERT INTO t13 VALUES(1,1);
     INSERT INTO t13 VALUES(2,1);
     INSERT INTO t13 VALUES(3,1);
@@ -858,7 +858,7 @@ do_test select4-13.1 {
 # 2014-02-18: Make sure compound SELECTs work with VALUES clauses
 #
 do_execsql_test select4-14.1 {
-  CREATE TABLE t14(a,b,c);
+  CREATE TABLE t14 (a,b,c);
   INSERT INTO t14 VALUES(1,2,3),(4,5,6);
   SELECT * FROM t14 INTERSECT VALUES(3,2,1),(2,3,1),(1,2,3),(2,1,3);
 } {1 2 3}
@@ -921,7 +921,7 @@ do_execsql_test select4-14.17 {
 #
 do_execsql_test select4-15.1 {
   DROP TABLE IF EXISTS tx;
-  CREATE TABLE tx(id INTEGER PRIMARY KEY, a, b);
+  CREATE TABLE tx (id INTEGER PRIMARY KEY, a, b);
   INSERT INTO tx(a,b) VALUES(33,456);
   INSERT INTO tx(a,b) VALUES(33,789);
 
@@ -940,7 +940,7 @@ do_execsql_test select4-15.1 {
 #
 do_execsql_test select4-16.1 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,
+  CREATE TABLE t1 (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,
   PRIMARY KEY(a,b DESC)) WITHOUT ROWID;
 
   WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<100)
@@ -979,7 +979,7 @@ do_execsql_test select4-16.3 {
 #
 do_execsql_test select4-17.1 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(a int, b int);
+  CREATE TABLE t1 (a int, b int);
   INSERT INTO t1 VALUES(1,2),(1,18),(2,19);
   SELECT x, y FROM (
     SELECT 98 AS x, 99 AS y
@@ -1036,7 +1036,7 @@ reset_db
 #
 reset_db
 do_execsql_test select4-19.1 {
-  CREATE TABLE t1(x);
+  CREATE TABLE t1 (x);
   INSERT INTO t1 VALUES(99);
   SELECT sum((SELECT 1 FROM (SELECT 2 WHERE x IS NULL) WHERE 0)) FROM t1;
 } {{}}

--- a/testing/sqlite3/select5.test
+++ b/testing/sqlite3/select5.test
@@ -19,7 +19,7 @@ source $testdir/tester.tcl
 # Build some test data
 #
 execsql {
-  CREATE TABLE t1(x int, y int);
+  CREATE TABLE t1 (x int, y int);
   BEGIN;
 }
 for {set i 1} {$i<32} {incr i} {
@@ -127,7 +127,7 @@ do_test select5-4.5 {
 #
 do_test select5-5.1 {
   execsql {
-    CREATE TABLE t2(a, b, c);
+    CREATE TABLE t2 (a, b, c);
     INSERT INTO t2 VALUES(1, 2, 3);
     INSERT INTO t2 VALUES(1, 4, 5);
     INSERT INTO t2 VALUES(6, 4, 7);
@@ -168,7 +168,7 @@ do_test select5-5.11 {
 #
 do_test select5-6.1 {
   execsql {
-    CREATE TABLE t3(x,y);
+    CREATE TABLE t3 (x,y);
     INSERT INTO t3 VALUES(1,NULL);
     INSERT INTO t3 VALUES(2,NULL);
     INSERT INTO t3 VALUES(3,4);
@@ -177,7 +177,7 @@ do_test select5-6.1 {
 } {1 4 2 {}}
 do_test select5-6.2 {
   execsql {
-    CREATE TABLE t4(x,y,z);
+    CREATE TABLE t4 (x,y,z);
     INSERT INTO t4 VALUES(1,2,NULL);
     INSERT INTO t4 VALUES(2,3,NULL);
     INSERT INTO t4 VALUES(3,NULL,5);
@@ -200,8 +200,8 @@ do_test select5-7.2 {
 #
 do_test select5-8.1 {
   execsql {
-    CREATE TABLE t8a(a,b);
-    CREATE TABLE t8b(x);
+    CREATE TABLE t8a (a,b);
+    CREATE TABLE t8b (x);
     INSERT INTO t8a VALUES('one', 1);
     INSERT INTO t8a VALUES('one', 2);
     INSERT INTO t8a VALUES('two', 3);
@@ -253,7 +253,7 @@ do_test select5-8.8 {
 # 2021-04-26 forum https://sqlite.org/forum/forumpost/74330094d8
 reset_db
 do_execsql_test select5-9.1 {
-  CREATE TABLE t1(a INT, b INT);
+  CREATE TABLE t1 (a INT, b INT);
   INSERT INTO t1(a,b) VALUES(1,null),(null,null),(1,null);
   CREATE UNIQUE INDEX t1b ON t1(abs(b));
   SELECT quote(a), quote(b), '|' FROM t1 GROUP BY a, abs(b);

--- a/testing/sqlite3/select6.test
+++ b/testing/sqlite3/select6.test
@@ -26,7 +26,7 @@ set ::testprefix select6
 do_test select6-1.0 {
   execsql {
     BEGIN;
-    CREATE TABLE t1(x, y);
+    CREATE TABLE t1 (x, y);
     INSERT INTO t1 VALUES(1,1);
     INSERT INTO t1 VALUES(2,2);
     INSERT INTO t1 VALUES(3,2);
@@ -103,7 +103,7 @@ do_test select6-1.9 {
 
 do_test select6-2.0 {
   execsql {
-    CREATE TABLE t2(a INTEGER PRIMARY KEY, b);
+    CREATE TABLE t2 (a INTEGER PRIMARY KEY, b);
     INSERT INTO t2 SELECT * FROM t1;
     SELECT DISTINCT b FROM t2 ORDER BY b;
   }
@@ -389,10 +389,10 @@ proc is_flat {sql} {
 do_test select6-8.1 {
   execsql {
     BEGIN;
-    CREATE TABLE t3(p,q);
+    CREATE TABLE t3 (p,q);
     INSERT INTO t3 VALUES(1,11);
     INSERT INTO t3 VALUES(2,22);
-    CREATE TABLE t4(q,r);
+    CREATE TABLE t4 (q,r);
     INSERT INTO t4 VALUES(11,111);
     INSERT INTO t4 VALUES(22,222);
     COMMIT;
@@ -518,9 +518,9 @@ do_test select6-9.11 {
 # return the same number of result columns, the error is detected.
 #
 do_execsql_test 10.1 {
-  CREATE TABLE t(i,j,k);
-  CREATE TABLE j(l,m);
-  CREATE TABLE k(o);
+  CREATE TABLE t (i,j,k);
+  CREATE TABLE j (l,m);
+  CREATE TABLE k (o);
 }
 
 set err [list 1 {SELECTs to the left and right of UNION ALL do not have the same number of result columns}]
@@ -561,7 +561,7 @@ do_catchsql_test 10.8 {
 #
 do_execsql_test 11.1 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(w INT, x INT);
+  CREATE TABLE t1 (w INT, x INT);
   INSERT INTO t1(w,x)
    VALUES(1,10),(2,20),(3,30),
          (2,21),(3,31),
@@ -569,7 +569,7 @@ do_execsql_test 11.1 {
   CREATE INDEX t1wx ON t1(w,x);
 
   DROP TABLE IF EXISTS t2;
-  CREATE TABLE t2(w INT, y VARCHAR(8));
+  CREATE TABLE t2 (w INT, y VARCHAR(8));
   INSERT INTO t2(w,y) VALUES(1,'one'),(2,'two'),(3,'three'),(4,'four');
   CREATE INDEX t2wy ON t2(w,y);
 
@@ -605,8 +605,8 @@ do_execsql_test 11.5 {
 do_execsql_test 11.100 {
   DROP TABLE t1;
   DROP TABLE t2;
-  CREATE TABLE t1(x);
-  CREATE TABLE t2(y, z);
+  CREATE TABLE t1 (x);
+  CREATE TABLE t2 (y, z);
   SELECT ( SELECT y FROM t2 WHERE z = cnt )
     FROM ( SELECT count(*) AS cnt FROM t1 );
 } {{}}
@@ -617,10 +617,10 @@ do_execsql_test 11.100 {
 do_execsql_test 12.100 {
   DROP TABLE t1;
   DROP TABLE t2;
-  CREATE TABLE t1(a);
+  CREATE TABLE t1 (a);
   INSERT INTO t1 VALUES(1);
   INSERT INTO t1 VALUES(2);
-  CREATE TABLE t2(b);
+  CREATE TABLE t2 (b);
   INSERT INTO t2 VALUES(3);
   SELECT * FROM (
     SELECT * FROM (SELECT * FROM t1 LIMIT 1)

--- a/testing/sqlite3/select7.test
+++ b/testing/sqlite3/select7.test
@@ -42,9 +42,9 @@ ifcapable tempdb {
 #ifcapable view {
 #do_test select7-2.1 {
 #  execsql {
-#    CREATE TABLE x(id integer primary key, a TEXT NULL);
+#    CREATE TABLE x (id integer primary key, a TEXT NULL);
 #    INSERT INTO x (a) VALUES ('first');
-#    CREATE TABLE tempx(id integer primary key, a TEXT NULL);
+#    CREATE TABLE tempx (id integer primary key, a TEXT NULL);
 #    INSERT INTO tempx (a) VALUES ('t-first');
 #    CREATE VIEW tv1 AS SELECT x.id, tx.id FROM x JOIN tempx tx ON tx.id=x.id;
 #    CREATE VIEW tv1b AS SELECT x.id, tx.id FROM x JOIN tempx tx on tx.id=x.id;
@@ -112,7 +112,7 @@ ifcapable {subquery && compound} {
 ifcapable {subquery && compound} {
   do_test select7-5.1 {
     catchsql {
-      CREATE TABLE t2(a,b);
+      CREATE TABLE t2 (a,b);
       SELECT 5 IN (SELECT a,b FROM t2);
     }
   } {1 {sub-select returns 2 columns - expected 1}}
@@ -162,7 +162,7 @@ if {[clang_sanitize_address]==0} {
 #
 do_execsql_test select7-6.5 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(a,b,c);
+  CREATE TABLE t1 (a,b,c);
 }
 sqlite3_limit db SQLITE_LIMIT_COMPOUND_SELECT 10
 sqlite3_db_config db SQLITE_DBCONFIG_DQS_DML 0
@@ -192,7 +192,7 @@ do_execsql_test select7-6.9 {
 #
 do_test select7-7.1 {
   execsql {
-    CREATE TABLE t3(a REAL);
+    CREATE TABLE t3 (a REAL);
     INSERT INTO t3 VALUES(44.0);
     INSERT INTO t3 VALUES(56.0);
   }
@@ -206,7 +206,7 @@ do_test select7-7.2 {
 } {1.38 1 1.62 1}
 do_test select7-7.3 {
   execsql {
-    CREATE TABLE t4(a REAL);
+    CREATE TABLE t4 (a REAL);
     INSERT INTO t4 VALUES( 2.0 );
     INSERT INTO t4 VALUES( 3.0 );
   }
@@ -225,15 +225,15 @@ do_test select7-7.6 {
 
 do_test select7-7.7 {
   execsql {
-    CREATE TABLE t5(a TEXT, b INT);
+    CREATE TABLE t5 (a TEXT, b INT);
     INSERT INTO t5 VALUES(123, 456);
     SELECT typeof(a), a FROM t5 GROUP BY a HAVING a<b;
   }
 } {text 123}
 
 do_execsql_test 8.0 { 
-  CREATE TABLE t01(x, y);
-  CREATE TABLE t02(x, y);
+  CREATE TABLE t01 (x, y);
+  CREATE TABLE t02 (x, y);
 }
 
 do_catchsql_test 8.1 {

--- a/testing/sqlite3/select8.test
+++ b/testing/sqlite3/select8.test
@@ -19,7 +19,7 @@ set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
 execsql {
-  CREATE TABLE songs(songid, artist, timesplayed);
+  CREATE TABLE songs (songid, artist, timesplayed);
   INSERT INTO songs VALUES(1,'one',1);
   INSERT INTO songs VALUES(2,'one',2);
   INSERT INTO songs VALUES(3,'two',3);

--- a/testing/sqlite3/select9.test
+++ b/testing/sqlite3/select9.test
@@ -120,8 +120,8 @@ proc test_compound_select_flippable {testname sql result} {
 #
 do_test select9-1.0 {
   execsql {
-    CREATE TABLE t1(a, b, c);
-    CREATE TABLE t2(d, e, f);
+    CREATE TABLE t1 (a, b, c);
+    CREATE TABLE t2 (d, e, f);
     BEGIN;
       INSERT INTO t1 VALUES(1,  'one',   'I');
       INSERT INTO t1 VALUES(3,  NULL,    NULL);
@@ -426,8 +426,8 @@ do_test select9-4.X {
 #
 #do_test select9-5.1 {
 #  db eval {
-#    CREATE TABLE t51(x, y);
-#    CREATE TABLE t52(x, y);
+#    CREATE TABLE t51 (x, y);
+#    CREATE TABLE t52 (x, y);
 #    CREATE VIEW v5 as
 #       SELECT x, y FROM t51
 #       UNION ALL
@@ -455,8 +455,8 @@ do_test select9-4.X {
 # "WHERE 0" on the first element of a UNION causes an assertion fault
 #
 do_execsql_test select9-6.1 {
-  CREATE TABLE t61(a);
-  CREATE TABLE t62(b);
+  CREATE TABLE t61 (a);
+  CREATE TABLE t62 (b);
   INSERT INTO t61 VALUES(111);
   INSERT INTO t62 VALUES(222);
   SELECT a FROM t61 WHERE 0 UNION SELECT b FROM t62;

--- a/testing/sqlite3/selectA.test
+++ b/testing/sqlite3/selectA.test
@@ -30,7 +30,7 @@ ifcapable !compound {
 
 do_test selectA-1.0 {
   execsql {
-    CREATE TABLE t1(a,b,c COLLATE NOCASE);
+    CREATE TABLE t1 (a,b,c COLLATE NOCASE);
     INSERT INTO t1 VALUES(1,'a','a');
     INSERT INTO t1 VALUES(9.9, 'b', 'B');
     INSERT INTO t1 VALUES(NULL, 'C', 'c');
@@ -41,7 +41,7 @@ do_test selectA-1.0 {
 } {1 a a 9.9 b B {} C c hello d D abc e e}
 do_test selectA-1.1 {
   execsql {
-    CREATE TABLE t2(x,y,z COLLATE NOCASE);
+    CREATE TABLE t2 (x,y,z COLLATE NOCASE);
     INSERT INTO t2 VALUES(NULL,'U','u');
     INSERT INTO t2 VALUES('mad', 'Z', 'z');
     INSERT INTO t2 VALUES(x'68617265', 'm', 'M');
@@ -52,7 +52,7 @@ do_test selectA-1.1 {
 } {{} U u mad Z z hare m M 5200000.0 X x -23 Y y}
 do_test selectA-1.2 {
   execsql {
-    CREATE TABLE t3(a,b,c COLLATE NOCASE);
+    CREATE TABLE t3 (a,b,c COLLATE NOCASE);
     INSERT INTO t3 SELECT * FROM t1;
     INSERT INTO t3 SELECT * FROM t2;
     INSERT INTO t3 SELECT * FROM t1;
@@ -1318,8 +1318,8 @@ proc f {args} { return 1 }
 db func f f
 
 do_execsql_test 4.1.1 {
-  CREATE TABLE t4(a, b);
-  CREATE TABLE t5(c, d);
+  CREATE TABLE t4 (a, b);
+  CREATE TABLE t5 (c, d);
 
   INSERT INTO t5 VALUES(1, 'x');
   INSERT INTO t5 VALUES(2, 'x');
@@ -1356,8 +1356,8 @@ do_execsql_test 4.1.3 {
 }
 
 do_execsql_test 4.2.1 {
-  CREATE TABLE t6(a, b);
-  CREATE TABLE t7(c, d);
+  CREATE TABLE t6 (a, b);
+  CREATE TABLE t7 (c, d);
 
   INSERT INTO t7 VALUES(2, 9);
   INSERT INTO t6 VALUES(3, 0);
@@ -1393,8 +1393,8 @@ proc do_same_test {tn q1 args} {
 }
 
 do_execsql_test 5.0 {
-  CREATE TABLE t8(a, b);
-  CREATE TABLE t9(c, d);
+  CREATE TABLE t8 (a, b);
+  CREATE TABLE t9 (c, d);
 } {}
 
 do_same_test 5.1 {
@@ -1440,8 +1440,8 @@ do_catchsql_test 5.4 {
 do_execsql_test 6.1 {
   DROP TABLE IF EXISTS t1;
   DROP TABLE IF EXISTS t2;
-  CREATE TABLE t1(a INTEGER);
-  CREATE TABLE t2(b TEXT);
+  CREATE TABLE t1 (a INTEGER);
+  CREATE TABLE t2 (b TEXT);
   INSERT INTO t2(b) VALUES('12345');
   SELECT * FROM (SELECT a FROM t1 UNION SELECT b FROM t2) WHERE a=a;
 } {12345}
@@ -1451,9 +1451,9 @@ do_execsql_test 6.1 {
 reset_db
 # TODO: Views are not supported.
 #do_execsql_test 7.1 {
-#  CREATE TABLE t1(c1);     INSERT INTO t1 VALUES(12),(123),(1234),(NULL),('abc');
-#  CREATE TABLE t2(c2);     INSERT INTO t2 VALUES(44),(55),(123);
-#  CREATE TABLE t3(c3,c4);  INSERT INTO t3 VALUES(66,1),(123,2),(77,3);
+#  CREATE TABLE t1 (c1);     INSERT INTO t1 VALUES(12),(123),(1234),(NULL),('abc');
+#  CREATE TABLE t2 (c2);     INSERT INTO t2 VALUES(44),(55),(123);
+#  CREATE TABLE t3 (c3,c4);  INSERT INTO t3 VALUES(66,1),(123,2),(77,3);
 #  CREATE VIEW t4 AS SELECT c3 FROM t3;
 #  CREATE VIEW t5 AS SELECT c3 FROM t3 ORDER BY c4;
 #}
@@ -1464,7 +1464,7 @@ reset_db
 #  SELECT * FROM t1, t2 WHERE c1=(SELECT 123 INTERSECT SELECT c2 FROM t5) AND c1=123;
 #} {123 123}
 #do_execsql_test 7.4 {
-#  CREATE TABLE a(b);
+#  CREATE TABLE a (b);
 #  CREATE VIEW c(d) AS SELECT b FROM a ORDER BY b;
 #  SELECT sum(d) OVER( PARTITION BY(SELECT 0 FROM c JOIN a WHERE b =(SELECT b INTERSECT SELECT d FROM c) AND b = 123)) FROM c;
 #} {}
@@ -1472,8 +1472,8 @@ reset_db
 #-------------------------------------------------------------------------
 reset_db
 do_execsql_test 8.0 {
-  CREATE TABLE x1(x);
-  CREATE TABLE t1(a, b, c, d);
+  CREATE TABLE x1 (x);
+  CREATE TABLE t1 (a, b, c, d);
   CREATE INDEX t1a ON t1(a);
   CREATE INDEX t1b ON t1(b);
 }
@@ -1489,8 +1489,8 @@ do_execsql_test 8.1 {
 #
 reset_db
 do_execsql_test 9.0 {
-  CREATE TABLE t1(a COLLATE nocase);
-  CREATE TABLE t2(b COLLATE nocase);
+  CREATE TABLE t1 (a COLLATE nocase);
+  CREATE TABLE t2 (b COLLATE nocase);
 
   INSERT INTO t1 VALUES('ABC');
   INSERT INTO t2 VALUES('abc');

--- a/testing/sqlite3/selectB.test
+++ b/testing/sqlite3/selectB.test
@@ -43,8 +43,8 @@ proc test_transform {testname sql1 sql2 results} {
 
 do_test selectB-1.1 {
   execsql {
-    CREATE TABLE t1(a, b, c);
-    CREATE TABLE t2(d, e, f);
+    CREATE TABLE t1 (a, b, c);
+    CREATE TABLE t2 (d, e, f);
 
     INSERT INTO t1 VALUES( 2,  4,  6);
     INSERT INTO t1 VALUES( 8, 10, 12);

--- a/testing/sqlite3/selectC.test
+++ b/testing/sqlite3/selectC.test
@@ -19,7 +19,7 @@ set testprefix selectC
 # Ticket #
 do_test selectC-1.1 {
   execsql {
-    CREATE TABLE t1(a, b, c);
+    CREATE TABLE t1 (a, b, c);
     INSERT INTO t1 VALUES(1,'aaa','bbb');
     INSERT INTO t1 SELECT * FROM t1;
     INSERT INTO t1 VALUES(2,'ccc','ddd');
@@ -155,9 +155,9 @@ do_test selectC-1.14.2 {
 ifcapable trigger&&compound {
   do_test selectC-2.1 {
     catchsql {
-      CREATE TABLE t21a(a,b);
+      CREATE TABLE t21a (a,b);
       INSERT INTO t21a VALUES(1,2);
-      CREATE TABLE t21b(n);
+      CREATE TABLE t21b (n);
       CREATE TRIGGER r21 AFTER INSERT ON t21b BEGIN
         SELECT a FROM t21a WHERE a>new.x UNION ALL
         SELECT b FROM t21a WHERE b>new.x ORDER BY 1 LIMIT 2;
@@ -199,7 +199,7 @@ do_test selectC-3.1 {
 } {acorn 1 lakeside 1 meyers 3 smith 2}
 do_test selectC-3.2 {
   execsql {
-    CREATE TABLE t2(a PRIMARY KEY, b);
+    CREATE TABLE t2 (a PRIMARY KEY, b);
     INSERT INTO t2 VALUES('abc', 'xxx');
     INSERT INTO t2 VALUES('def', 'yyy');
     SELECT a, max(b || a) FROM t2 WHERE (b||b||b)!='value' GROUP BY a;
@@ -245,9 +245,9 @@ do_execsql_test selectC-4.3 {
 #
 # TODO: Views are not supported.
 #do_execsql_test 5.0 {
-#  CREATE TABLE x1(a);
-#  CREATE TABLE x2(b);
-#  CREATE TABLE x3(c);
+#  CREATE TABLE x1 (a);
+#  CREATE TABLE x2 (b);
+#  CREATE TABLE x3 (c);
 #  CREATE VIEW vvv AS SELECT b FROM x2 ORDER BY 1;
 #
 #  INSERT INTO x1 VALUES('a'), ('b');

--- a/testing/sqlite3/selectD.test
+++ b/testing/sqlite3/selectD.test
@@ -26,8 +26,8 @@ for {set i 1} {$i<=2} {incr i} {
   do_test selectD-$i.0 {
     db eval {
       ATTACH ':memory:' AS aux1;
-      CREATE TABLE t1(a,b); INSERT INTO t1 VALUES(111,'x1');
-      CREATE TABLE t2(a,b); INSERT INTO t2 VALUES(222,'x2');
+      CREATE TABLE t1 (a,b); INSERT INTO t1 VALUES(111,'x1');
+      CREATE TABLE t2 (a,b); INSERT INTO t2 VALUES(222,'x2');
       CREATE TEMP TABLE t3(a,b); INSERT INTO t3 VALUES(333,'x3');
       CREATE TABLE main.t4(a,b); INSERT INTO main.t4 VALUES(444,'x4');
       CREATE TABLE aux1.t4(a,b); INSERT INTO aux1.t4 VALUES(555,'x5');
@@ -158,9 +158,9 @@ for {set i 1} {$i<=2} {incr i} {
 # latter computation depends on the former.
 #
 do_execsql_test selectD-4.1 {
-  CREATE TABLE t41(a INTEGER PRIMARY KEY, b INTEGER);
-  CREATE TABLE t42(d INTEGER PRIMARY KEY, e INTEGER);
-  CREATE TABLE t43(f INTEGER PRIMARY KEY, g INTEGER);
+  CREATE TABLE t41 (a INTEGER PRIMARY KEY, b INTEGER);
+  CREATE TABLE t42 (d INTEGER PRIMARY KEY, e INTEGER);
+  CREATE TABLE t43 (f INTEGER PRIMARY KEY, g INTEGER);
   EXPLAIN QUERY PLAN
   SELECT * 
    FROM t41

--- a/testing/sqlite3/selectE.test
+++ b/testing/sqlite3/selectE.test
@@ -24,9 +24,9 @@
 # easily tell where the output of one query ends and the next query
 # begins. 
 # 
-#     CREATE TABLE t1(a);
+#     CREATE TABLE t1 (a);
 #     INSERT INTO t1 VALUES('abc'),('def');
-#     CREATE TABLE t2(a);
+#     CREATE TABLE t2 (a);
 #     INSERT INTO t2 VALUES('DEF');
 # 
 #     SELECT a FROM t1 EXCEPT SELECT a FROM t2 ORDER BY a;
@@ -45,11 +45,11 @@ source $testdir/tester.tcl
 
 do_test selectE-1.0 {
   db eval {
-    CREATE TABLE t1(a);
+    CREATE TABLE t1 (a);
     INSERT INTO t1 VALUES('abc'),('def'),('ghi');
-    CREATE TABLE t2(a);
+    CREATE TABLE t2 (a);
     INSERT INTO t2 VALUES('DEF'),('abc');
-    CREATE TABLE t3(a);
+    CREATE TABLE t3 (a);
     INSERT INTO t3 VALUES('def'),('jkl');
 
     SELECT a FROM t1 EXCEPT SELECT a FROM t2

--- a/testing/sqlite3/selectF.test
+++ b/testing/sqlite3/selectF.test
@@ -20,9 +20,9 @@ set testprefix selectF
 
 do_execsql_test 1 {
   BEGIN TRANSACTION;
-  CREATE TABLE t1(a, b, c);
+  CREATE TABLE t1 (a, b, c);
   INSERT INTO "t1" VALUES(1,'one','I');
-  CREATE TABLE t2(d, e, f);
+  CREATE TABLE t2 (d, e, f);
   INSERT INTO "t2" VALUES(5,'ten','XX');
   INSERT INTO "t2" VALUES(6,NULL,NULL);
 

--- a/testing/sqlite3/selectG.test
+++ b/testing/sqlite3/selectG.test
@@ -25,7 +25,7 @@ set testprefix selectG
 # the insert run for over a minute.
 #
 do_test 100 {
-  set sql "CREATE TABLE t1(x);\nINSERT INTO t1(x) VALUES"
+  set sql "CREATE TABLE t1 (x);\nINSERT INTO t1(x) VALUES"
   for {set i 1} {$i<100000} {incr i} {
     append sql "($i),"
   }

--- a/testing/sqlite3/selectH.test
+++ b/testing/sqlite3/selectH.test
@@ -17,7 +17,7 @@ source $testdir/tester.tcl
 set testprefix selectH
 
 do_execsql_test 1.1 {
-  CREATE TABLE t1(
+  CREATE TABLE t1 (
      c0,  c1,  c2,  c3,  c4,  c5,  c6,  c7,  c8,  c9,
      c10, c11, c12, c13, c14, c15, c16, c17, c18, c19,
      c20, c21, c22, c23, c24, c25, c26, c27, c28, c29,
@@ -110,7 +110,7 @@ do_test 2.2 {
 #
 do_execsql_test 4.1 {
   DROP TABLE IF EXISTS t1;
-  CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+  CREATE TABLE t1 (a INTEGER PRIMARY KEY, b TEXT);
   SELECT 1 FROM (SELECT DISTINCT name COLLATE rtrim FROM sqlite_schema
                  UNION ALL SELECT a FROM t1);
 } {1 1}

--- a/testing/update.test
+++ b/testing/update.test
@@ -184,7 +184,7 @@ do_execsql_test_on_specific_db {:memory:} update-true-expr {
 
 # https://github.com/tursodatabase/turso/issues/1625
 do_execsql_test_on_specific_db {:memory:} update_cache_full_regression_test_#1625 {
-    CREATE TABLE t(x);
+    CREATE TABLE t (x);
     INSERT INTO t VALUES (randomblob(4096));
     UPDATE t SET x = randomblob(4096) WHERE rowid = 1;
     SELECT count(*) FROM t;
@@ -192,7 +192,7 @@ do_execsql_test_on_specific_db {:memory:} update_cache_full_regression_test_#162
 
 if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-sqlite3-index-experimental" || $::env(SQLITE_EXEC) eq "sqlite3")} {
     do_execsql_test_on_specific_db {:memory:} update_index_regression_test {
-        CREATE TABLE t(x, y);
+        CREATE TABLE t (x, y);
         CREATE INDEX tx ON t (x);
         CREATE UNIQUE INDEX tyu ON t (y);
         INSERT INTO t VALUES (1, 1);
@@ -207,7 +207,7 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
     2}
 
     do_execsql_test_on_specific_db {:memory:} update_rowid_alias_index_regression_test {
-        CREATE TABLE t(a INTEGER PRIMARY KEY, b);
+        CREATE TABLE t (a INTEGER PRIMARY KEY, b);
         CREATE INDEX idx_b ON t (b);
         INSERT INTO t VALUES (1, 'foo');
         SELECT a FROM t WHERE b = 'foo';
@@ -253,19 +253,19 @@ do_execsql_test_in_memory_any_error update_primary_key_constraint_error_3 {
 }
 
 do_execsql_test_in_memory_any_error update_primary_key_constraint_error_4 {
-    CREATE TABLE t(a PRIMARY KEY INTEGER, b UNIQUE);
+    CREATE TABLE t (a PRIMARY KEY INTEGER, b UNIQUE);
     INSERT INTO t(b) VALUES (100), (200), (300);
     UPDATE t SET a = 1;
 }
 
 do_execsql_test_in_memory_any_error update_primary_key_unique_constraint_error {
-    CREATE TABLE t(a PRIMARY KEY INTEGER, b UNIQUE);
+    CREATE TABLE t (a PRIMARY KEY INTEGER, b UNIQUE);
     INSERT INTO t(b) VALUES (100), (200), (300);
     UPDATE t SET b = 2;
 }
 
 do_execsql_test_on_specific_db {:memory:} update-single-rowid {
-    CREATE TABLE t(x INTEGER PRIMARY KEY);
+    CREATE TABLE t (x INTEGER PRIMARY KEY);
     INSERT INTO t VALUES (1);
     UPDATE t SET x = 2 WHERE x = 1;
     SELECT * FROM t;

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -296,7 +296,7 @@ mod tests {
                 false,
             );
             let conn = db.connect_limbo();
-            let ret = limbo_exec_rows(&db, &conn, "CREATE table t(a)");
+            let ret = limbo_exec_rows(&db, &conn, "CREATE table t (a)");
             assert!(ret.is_empty(), "{ret:?}");
             limbo_exec_rows(&db, &conn, "INSERT INTO t values (1)");
             conn.close().unwrap()
@@ -325,7 +325,7 @@ mod tests {
         let db = TempDatabase::new_empty(true);
         let conn = db.connect_limbo();
 
-        let _ = limbo_exec_rows(&db, &conn, "CREATE TABLE t(x INTEGER UNIQUE)");
+        let _ = limbo_exec_rows(&db, &conn, "CREATE TABLE t (x INTEGER UNIQUE)");
 
         // Insert 100 random integers between -1000 and 1000
         let mut expected = Vec::new();
@@ -366,7 +366,7 @@ mod tests {
         let db = TempDatabase::new_with_existent(&path, true);
         let conn = db.connect_limbo();
 
-        let _ = limbo_exec_rows(&db, &conn, "CREATE TABLE t(x BLOB UNIQUE)");
+        let _ = limbo_exec_rows(&db, &conn, "CREATE TABLE t (x BLOB UNIQUE)");
 
         // Insert 11 unique 1MB blobs
         for i in 0..11 {
@@ -399,7 +399,7 @@ mod tests {
         let conn1 = db.connect_limbo();
 
         // Create test table
-        let _ = limbo_exec_rows(&db, &conn1, "CREATE TABLE t(x INTEGER)");
+        let _ = limbo_exec_rows(&db, &conn1, "CREATE TABLE t (x INTEGER)");
 
         // Begin transaction on first connection and insert a value
         let _ = limbo_exec_rows(&db, &conn1, "BEGIN");
@@ -432,7 +432,7 @@ mod tests {
         let conn1 = db.connect_limbo();
 
         // Create test table
-        let _ = limbo_exec_rows(&db, &conn1, "CREATE TABLE t(x INTEGER)");
+        let _ = limbo_exec_rows(&db, &conn1, "CREATE TABLE t (x INTEGER)");
 
         // Begin transaction on first connection
         let _ = limbo_exec_rows(&db, &conn1, "BEGIN");
@@ -468,7 +468,7 @@ mod tests {
         let conn = db.connect_limbo();
 
         // Create test table
-        let _ = limbo_exec_rows(&db, &conn, "CREATE TABLE t(x INTEGER)");
+        let _ = limbo_exec_rows(&db, &conn, "CREATE TABLE t (x INTEGER)");
 
         // Begin transaction on first connection and insert a value
         let _ = limbo_exec_rows(&db, &conn, "BEGIN");
@@ -510,7 +510,7 @@ mod tests {
         let conn = db.connect_limbo();
 
         // Create test table
-        let _ = limbo_exec_rows(&db, &conn, "CREATE TABLE t(x INTEGER)");
+        let _ = limbo_exec_rows(&db, &conn, "CREATE TABLE t (x INTEGER)");
 
         // Begin transaction and insert a value
         let _ = limbo_exec_rows(&db, &conn, "BEGIN");

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -20,7 +20,7 @@ fn test_cdc_simple_id() {
     let conn = db.connect_limbo();
     conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
-    conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
+    conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (10, 10), (5, 1)")
         .unwrap();
@@ -80,7 +80,7 @@ fn test_cdc_simple_before() {
     let conn = db.connect_limbo();
     conn.execute("PRAGMA unstable_capture_data_changes_conn('before')")
         .unwrap();
-    conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
+    conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (1, 2), (3, 4)").unwrap();
     conn.execute("UPDATE t SET y = 3 WHERE x = 1").unwrap();
@@ -146,7 +146,7 @@ fn test_cdc_simple_after() {
     let conn = db.connect_limbo();
     conn.execute("PRAGMA unstable_capture_data_changes_conn('after')")
         .unwrap();
-    conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
+    conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (1, 2), (3, 4)").unwrap();
     conn.execute("UPDATE t SET y = 3 WHERE x = 1").unwrap();
@@ -212,7 +212,7 @@ fn test_cdc_simple_full() {
     let conn = db.connect_limbo();
     conn.execute("PRAGMA unstable_capture_data_changes_conn('full')")
         .unwrap();
-    conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
+    conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (1, 2), (3, 4)").unwrap();
     conn.execute("UPDATE t SET y = 3 WHERE x = 1").unwrap();
@@ -278,7 +278,7 @@ fn test_cdc_crud() {
     let conn = db.connect_limbo();
     conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
-    conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
+    conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (20, 20), (10, 10), (5, 1)")
         .unwrap();
@@ -390,7 +390,7 @@ fn test_cdc_failed_op() {
     let conn = db.connect_limbo();
     conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
-    conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
+    conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (1, 10), (2, 20)")
         .unwrap();
@@ -459,7 +459,7 @@ fn test_cdc_uncaptured_connection() {
     let db = TempDatabase::new_empty(true);
     let conn1 = db.connect_limbo();
     conn1
-        .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
+        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn1
@@ -536,7 +536,7 @@ fn test_cdc_custom_table() {
     let db = TempDatabase::new_empty(true);
     let conn1 = db.connect_limbo();
     conn1
-        .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
+        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
         .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc')")
@@ -583,7 +583,7 @@ fn test_cdc_ignore_changes_in_cdc_table() {
     let db = TempDatabase::new_empty(true);
     let conn1 = db.connect_limbo();
     conn1
-        .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
+        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
         .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc')")
@@ -622,10 +622,10 @@ fn test_cdc_transaction() {
     let db = TempDatabase::new_empty(true);
     let conn1 = db.connect_limbo();
     conn1
-        .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
+        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
-        .execute("CREATE TABLE q(x INTEGER PRIMARY KEY, y UNIQUE)")
+        .execute("CREATE TABLE q (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1
         .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc')")
@@ -707,7 +707,7 @@ fn test_cdc_independent_connections() {
         .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc2')")
         .unwrap();
     conn1
-        .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
+        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn2.execute("INSERT INTO t VALUES (2, 20)").unwrap();
@@ -761,7 +761,7 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
         .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc2')")
         .unwrap();
     conn1
-        .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y UNIQUE)")
+        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn1.execute("INSERT INTO t VALUES (2, 20)").unwrap();
@@ -839,7 +839,7 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
 fn test_cdc_table_columns() {
     let db = TempDatabase::new_empty(true);
     let conn = db.connect_limbo();
-    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY, b, c UNIQUE)")
+    conn.execute("CREATE TABLE t (a INTEGER PRIMARY KEY, b, c UNIQUE)")
         .unwrap();
     let rows = limbo_exec_rows(&db, &conn, "SELECT table_columns_json_array('t')");
     assert_eq!(

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     pub fn rowid_seek_fuzz() {
-        let db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x INTEGER PRIMARY KEY)", false); // INTEGER PRIMARY KEY is a rowid alias, so an index is not created
+        let db = TempDatabase::new_with_rusqlite("CREATE TABLE t (x INTEGER PRIMARY KEY)", false); // INTEGER PRIMARY KEY is a rowid alias, so an index is not created
         let sqlite_conn = rusqlite::Connection::open(db.path.clone()).unwrap();
 
         let (mut rng, _seed) = rng_from_time_or_env();
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     pub fn index_scan_fuzz() {
-        let db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x PRIMARY KEY)", true);
+        let db = TempDatabase::new_with_rusqlite("CREATE TABLE t (x PRIMARY KEY)", true);
         let sqlite_conn = rusqlite::Connection::open(db.path.clone()).unwrap();
 
         let insert = format!(
@@ -245,14 +245,14 @@ mod tests {
             rng_from_time()
         };
         let table_defs: [&str; 8] = [
-            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y, z))",
-            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y, z))",
-            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y desc, z))",
-            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y, z desc))",
-            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y desc, z))",
-            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y, z desc))",
-            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x, y desc, z desc))",
-            "CREATE TABLE t(x, y, z, nonindexed_col, PRIMARY KEY (x desc, y desc, z desc))",
+            "CREATE TABLE t (x, y, z, nonindexed_col, PRIMARY KEY (x, y, z))",
+            "CREATE TABLE t (x, y, z, nonindexed_col, PRIMARY KEY (x desc, y, z))",
+            "CREATE TABLE t (x, y, z, nonindexed_col, PRIMARY KEY (x, y desc, z))",
+            "CREATE TABLE t (x, y, z, nonindexed_col, PRIMARY KEY (x, y, z desc))",
+            "CREATE TABLE t (x, y, z, nonindexed_col, PRIMARY KEY (x desc, y desc, z))",
+            "CREATE TABLE t (x, y, z, nonindexed_col, PRIMARY KEY (x desc, y, z desc))",
+            "CREATE TABLE t (x, y, z, nonindexed_col, PRIMARY KEY (x, y desc, z desc))",
+            "CREATE TABLE t (x, y, z, nonindexed_col, PRIMARY KEY (x desc, y desc, z desc))",
         ];
         // Create all different 3-column primary key permutations
         let dbs = [
@@ -1344,12 +1344,12 @@ mod tests {
 
         for queries in [
             [
-                "CREATE TABLE t(x)",
+                "CREATE TABLE t (x)",
                 "INSERT INTO t VALUES (10)",
                 "SELECT * FROM t WHERE  x = 1 AND 1 OR 0",
             ],
             [
-                "CREATE TABLE t(x)",
+                "CREATE TABLE t (x)",
                 "INSERT INTO t VALUES (-3258184727)",
                 "SELECT * FROM t",
             ],
@@ -1382,7 +1382,7 @@ mod tests {
         for _ in 0..1000 {
             // Create table with random datatype
             let datatype = datatypes[rng.random_range(0..datatypes.len())];
-            let create_table = format!("CREATE TABLE t(x {datatype})");
+            let create_table = format!("CREATE TABLE t (x {datatype})");
 
             let db = TempDatabase::new_empty(false);
             let limbo_conn = db.connect_limbo();

--- a/tests/integration/query_processing/test_multi_thread.rs
+++ b/tests/integration/query_processing/test_multi_thread.rs
@@ -8,7 +8,7 @@ use crate::common::{maybe_setup_tracing, TempDatabase};
 fn test_schema_change() {
     let tmp_db = TempDatabase::new_empty(false);
     let conn1 = tmp_db.connect_limbo();
-    conn1.execute("CREATE TABLE t(x, y, z)").unwrap();
+    conn1.execute("CREATE TABLE t (x, y, z)").unwrap();
     conn1
         .execute("INSERT INTO t VALUES (1, 2, 3), (10, 20, 30)")
         .unwrap();
@@ -39,7 +39,7 @@ fn test_create_multiple_connections() -> anyhow::Result<()> {
         let tmp_db = Arc::new(TempDatabase::new_empty(false));
         {
             let conn = tmp_db.connect_limbo();
-            conn.execute("CREATE TABLE t(x)").unwrap();
+            conn.execute("CREATE TABLE t (x)").unwrap();
         }
 
         let mut threads = Vec::new();
@@ -118,7 +118,7 @@ fn test_reader_writer() -> anyhow::Result<()> {
         let tmp_db = Arc::new(TempDatabase::new_empty(false));
         {
             let conn = tmp_db.connect_limbo();
-            conn.execute("CREATE TABLE t(x)").unwrap();
+            conn.execute("CREATE TABLE t (x)").unwrap();
         }
 
         let mut threads = Vec::new();

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -4,7 +4,7 @@ use crate::common::TempDatabase;
 
 #[test]
 fn test_txn_error_doesnt_rollback_txn() -> Result<()> {
-    let tmp_db = TempDatabase::new_with_rusqlite("create table t(x);", false);
+    let tmp_db = TempDatabase::new_with_rusqlite("create table t (x);", false);
     let conn = tmp_db.connect_limbo();
 
     conn.execute("begin")?;

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -457,7 +457,7 @@ fn test_delete_with_index() -> anyhow::Result<()> {
 
     maybe_setup_tracing();
 
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x UNIQUE)", true);
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t (x UNIQUE)", true);
     let conn = tmp_db.connect_limbo();
 
     run_query(&tmp_db, &conn, "INSERT INTO t VALUES (1), (2)")?;
@@ -507,7 +507,7 @@ fn test_update_regression() -> anyhow::Result<()> {
 #[test]
 fn test_multiple_statements() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x)", false);
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t (x)", false);
     let conn = tmp_db.connect_limbo();
 
     conn.execute("INSERT INTO t values(1); insert into t values(2);")?;
@@ -601,7 +601,7 @@ fn test_write_concurrent_connections() -> anyhow::Result<()> {
 
     maybe_setup_tracing();
 
-    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t(x)", false);
+    let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t (x)", false);
     let num_connections = 4;
     let num_inserts_per_connection = 100;
     let mut connections = vec![];
@@ -652,12 +652,12 @@ fn test_wal_bad_frame() -> anyhow::Result<()> {
     maybe_setup_tracing();
     let _ = env_logger::try_init();
     let db_path = {
-        let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t1(x)", false);
+        let tmp_db = TempDatabase::new_with_rusqlite("CREATE TABLE t1 (x)", false);
         let db_path = tmp_db.path.clone();
         let conn = tmp_db.connect_limbo();
         conn.execute("BEGIN")?;
-        conn.execute("CREATE TABLE t2(x)")?;
-        conn.execute("CREATE TABLE t3(x)")?;
+        conn.execute("CREATE TABLE t2 (x)")?;
+        conn.execute("CREATE TABLE t3 (x)")?;
         conn.execute("INSERT INTO t2(x) VALUES (1)")?;
         conn.execute("INSERT INTO t3(x) VALUES (1)")?;
         conn.execute("COMMIT")?;
@@ -752,7 +752,7 @@ fn test_read_wal_dumb_no_frames() -> anyhow::Result<()> {
     {
         let tmp_db = TempDatabase::new_with_existent(&db_path, false);
         let conn = tmp_db.connect_limbo();
-        conn.execute("CREATE TABLE t0(x)")?;
+        conn.execute("CREATE TABLE t0 (x)")?;
         conn.close()?;
     }
     {

--- a/vendored/sqlite3-parser/src/lexer/sql/test.rs
+++ b/vendored/sqlite3-parser/src/lexer/sql/test.rs
@@ -187,7 +187,7 @@ fn create_temporary_table_with_qualified_name() {
 #[test]
 fn create_table_with_only_generated_column() {
     expect_parser_err_msg(
-        b"CREATE TABLE test(data AS (1))",
+        b"CREATE TABLE test (data AS (1))",
         "must have at least one non-generated column",
     );
 }
@@ -208,7 +208,7 @@ fn create_strict_table_unknown_datatype() {
 #[test]
 fn foreign_key_on_column() {
     expect_parser_err_msg(
-        b"CREATE TABLE t(a REFERENCES o(a,b))",
+        b"CREATE TABLE t (a REFERENCES o(a,b))",
         "foreign key on a should reference only one column of table o",
     );
 }
@@ -307,8 +307,8 @@ fn cast_without_typename() {
 
 #[test]
 fn unknown_table_option() {
-    expect_parser_err_msg(b"CREATE TABLE t(x)o", "unknown table option: o");
-    expect_parser_err_msg(b"CREATE TABLE t(x) WITHOUT o", "unknown table option: o");
+    expect_parser_err_msg(b"CREATE TABLE t (x)o", "unknown table option: o");
+    expect_parser_err_msg(b"CREATE TABLE t (x) WITHOUT o", "unknown table option: o");
 }
 
 #[test]


### PR DESCRIPTION
`BTreeTable::to_sql` makes us incompatible with SQLite by losing e.g. the original whitespace provided during the CREATE TABLE command. For example:

`CREATE TABLE t            (x)` gets saved as `CREATE TABLE t (x)`. Sqlite preserves the user-provided whitespace.

For now let's fix our tests by regex-replacing every CREATE TABLE in the entire repo to have exactly 1 space after the table name in the CREATE TABLE statement.