### PR TITLE
make readonly a property of the database

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1118,7 +1118,7 @@ impl Limbo {
                         StepResult::Row => {
                             let row = rows.row().unwrap();
                             if let (
-                                Ok(Value::Integer(_seq)),
+                                Ok(Value::Integer(seq)),
                                 Ok(Value::Text(name)),
                                 Ok(file_value),
                             ) = (
@@ -1140,7 +1140,7 @@ impl Limbo {
                                 };
 
                                 // Detect readonly mode from connection
-                                let mode = if self.conn.is_readonly() {
+                                let mode = if self.conn.is_readonly(*seq as usize) {
                                     "r/o"
                                 } else {
                                     "r/w"

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -313,7 +313,6 @@ impl Database {
             _shared_cache: false,
             cache_size: Cell::new(default_cache_size),
             page_size: Cell::new(page_size),
-            readonly: Cell::new(false),
             wal_checkpoint_disabled: Cell::new(false),
             capture_data_changes: RefCell::new(CaptureDataChangesMode::Off),
             closed: Cell::new(false),
@@ -322,6 +321,10 @@ impl Database {
         // add built-in extensions symbols to the connection to prevent having to load each time
         conn.syms.borrow_mut().extend(&builtin_syms);
         Ok(conn)
+    }
+
+    pub fn is_readonly(&self) -> bool {
+        self.open_flags.contains(OpenFlags::ReadOnly)
     }
 
     fn init_pager(&self, page_size: Option<usize>) -> Result<Pager> {
@@ -569,7 +572,6 @@ pub struct Connection {
     /// page size used for an uninitialized database or the next vacuum command.
     /// it's not always equal to the current page size of the database
     page_size: Cell<u32>,
-    readonly: Cell<bool>,
     wal_checkpoint_disabled: Cell<bool>,
     capture_data_changes: RefCell<CaptureDataChangesMode>,
     closed: Cell<bool>,
@@ -781,12 +783,7 @@ impl Connection {
             std::fs::set_permissions(&opts.path, perms.permissions())?;
         }
         let conn = db.connect()?;
-        conn.set_readonly(opts.immutable);
         Ok((io, conn))
-    }
-
-    pub fn set_readonly(&self, readonly: bool) {
-        self.readonly.replace(readonly);
     }
 
     pub fn maybe_update_schema(&self) -> Result<()> {
@@ -902,8 +899,12 @@ impl Connection {
         }
     }
 
-    pub fn is_readonly(&self) -> bool {
-        self._db.open_flags.contains(OpenFlags::ReadOnly)
+    /// Check if a specific attached database is read only or not, by its index
+    pub fn is_readonly(&self, index: usize) -> bool {
+        // Only internal callers for now. Nobody should be passing
+        // anything else here
+        assert_eq!(index, 0);
+        self._db.is_readonly()
     }
 
     /// Reset the page size for the current connection.

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -107,7 +107,7 @@ pub fn translate_alter_table(
                 program.emit_insn(Insn::OpenWrite {
                     cursor_id,
                     root_page: RegisterOrLiteral::Literal(root_page),
-                    name: table_name.clone(),
+                    db: 0,
                 });
 
                 program.cursor_loop(cursor_id, |program, rowid| {
@@ -241,7 +241,7 @@ pub fn translate_alter_table(
             program.emit_insn(Insn::OpenWrite {
                 cursor_id,
                 root_page: RegisterOrLiteral::Literal(sqlite_schema.root_page),
-                name: sqlite_schema.name.clone(),
+                db: 0,
             });
 
             program.cursor_loop(cursor_id, |program, rowid| {
@@ -328,7 +328,7 @@ pub fn translate_alter_table(
             program.emit_insn(Insn::OpenWrite {
                 cursor_id,
                 root_page: RegisterOrLiteral::Literal(sqlite_schema.root_page),
-                name: sqlite_schema.name.clone(),
+                db: 0,
             });
 
             program.cursor_loop(cursor_id, |program, rowid| {

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -692,7 +692,7 @@ fn emit_program_for_update(
             program.emit_insn(Insn::OpenWrite {
                 cursor_id: cursor,
                 root_page: RegisterOrLiteral::Literal(index.root_page),
-                name: index.name.clone(),
+                db: 0,
             });
             cursor
         };

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -97,7 +97,7 @@ pub fn translate_create_index(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: RegisterOrLiteral::Literal(sqlite_table.root_page),
-        name: sqlite_table.name.clone(),
+        db: 0,
     });
     let sql = create_idx_stmt_to_sql(&tbl_name, &idx_name, unique_if_not_exists, &columns);
     emit_schema_entry(
@@ -178,7 +178,7 @@ pub fn translate_create_index(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: btree_cursor_id,
         root_page: RegisterOrLiteral::Register(root_page_reg),
-        name: idx_name.clone(),
+        db: 0,
     });
 
     let sorted_loop_start = program.allocate_label();
@@ -367,7 +367,7 @@ pub fn translate_drop_index(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: RegisterOrLiteral::Literal(sqlite_table.root_page),
-        name: sqlite_table.name.clone(),
+        db: 0,
     });
 
     let loop_start_label = program.allocate_label();

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -246,13 +246,13 @@ pub fn translate_insert(
                     program.emit_insn(Insn::OpenWrite {
                         cursor_id,
                         root_page: RegisterOrLiteral::Literal(root_page),
-                        name: table_name.0.clone(),
+                        db: 0,
                     });
                 } else {
                     program.emit_insn(Insn::OpenWrite {
                         cursor_id,
                         root_page: RegisterOrLiteral::Literal(root_page),
-                        name: table_name.0.clone(),
+                        db: 0,
                     });
 
                     // Main loop
@@ -338,7 +338,7 @@ pub fn translate_insert(
         program.emit_insn(Insn::OpenWrite {
             cursor_id,
             root_page: RegisterOrLiteral::Literal(root_page),
-            name: table_name.0.clone(),
+            db: 0,
         });
 
         populate_column_registers(
@@ -355,7 +355,7 @@ pub fn translate_insert(
         program.emit_insn(Insn::OpenWrite {
             cursor_id: *cdc_cursor_id,
             root_page: cdc_btree.root_page.into(),
-            name: cdc_btree.name.clone(),
+            db: 0,
         });
     }
 
@@ -364,7 +364,7 @@ pub fn translate_insert(
         program.emit_insn(Insn::OpenWrite {
             cursor_id: idx_cursor.2,
             root_page: idx_cursor.1.into(),
-            name: idx_cursor.0.clone(),
+            db: 0,
         });
     }
     // Common record insertion logic for both single and multiple rows

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -137,7 +137,7 @@ pub fn init_loop(
             program.emit_insn(Insn::OpenWrite {
                 cursor_id: cdc_cursor_id,
                 root_page: cdc_btree.root_page.into(),
-                name: cdc_btree.name.clone(),
+                db: 0,
             });
             t_ctx.cdc_cursor_id = Some(cdc_cursor_id);
         }
@@ -224,13 +224,13 @@ pub fn init_loop(
                         cursor_id: table_cursor_id
                             .expect("table cursor is always opened in OperationMode::DELETE"),
                         root_page: root_page.into(),
-                        name: btree.name.clone(),
+                        db: 0,
                     });
                     if let Some(index_cursor_id) = index_cursor_id {
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id: index_cursor_id,
                             root_page: index.as_ref().unwrap().root_page.into(),
-                            name: index.as_ref().unwrap().name.clone(),
+                            db: 0,
                         });
                     }
                     // For delete, we need to open all the other indexes too for writing
@@ -250,7 +250,7 @@ pub fn init_loop(
                             program.emit_insn(Insn::OpenWrite {
                                 cursor_id,
                                 root_page: index.root_page.into(),
-                                name: index.name.clone(),
+                                db: 0,
                             });
                         }
                     }
@@ -261,13 +261,13 @@ pub fn init_loop(
                         cursor_id: table_cursor_id
                             .expect("table cursor is always opened in OperationMode::UPDATE"),
                         root_page: root_page.into(),
-                        name: btree.name.clone(),
+                        db: 0,
                     });
                     if let Some(index_cursor_id) = index_cursor_id {
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id: index_cursor_id,
                             root_page: index.as_ref().unwrap().root_page.into(),
-                            name: index.as_ref().unwrap().name.clone(),
+                            db: 0,
                         });
                     }
                 }
@@ -297,7 +297,7 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id: table_cursor_id,
                             root_page: table.table.get_root_page().into(),
-                            name: table.table.get_name().to_string(),
+                            db: 0,
                         });
 
                         // For DELETE, we need to open all the indexes for writing
@@ -321,7 +321,7 @@ pub fn init_loop(
                                     program.emit_insn(Insn::OpenWrite {
                                         cursor_id,
                                         root_page: index.root_page.into(),
-                                        name: index.name.clone(),
+                                        db: 0,
                                     });
                                 }
                             }
@@ -352,7 +352,7 @@ pub fn init_loop(
                                     cursor_id: index_cursor_id
                                         .expect("index cursor is always opened in Seek with index"),
                                     root_page: index.root_page.into(),
-                                    name: index.name.clone(),
+                                    db: 0,
                                 });
                             }
                             _ => {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -110,7 +110,7 @@ pub fn translate_create_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
-        name: tbl_name.name.0.clone(),
+        db: 0,
     });
 
     // Add the table entry to sqlite_schema
@@ -585,7 +585,7 @@ pub fn translate_create_virtual_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1usize.into(),
-        name: table_name.clone(),
+        db: 0,
     });
 
     let sql = create_vtable_body_to_str(&vtab, vtab_module.clone());
@@ -662,7 +662,7 @@ pub fn translate_drop_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id_0,
         root_page: 1usize.into(),
-        name: SQLITE_TABLEID.to_string(),
+        db: 0,
     });
 
     //  1. Remove all entries from the schema table related to the table we are dropping, except for triggers
@@ -863,7 +863,7 @@ pub fn translate_drop_table(
         program.emit_insn(Insn::OpenWrite {
             cursor_id: sqlite_schema_cursor_id_1,
             root_page: 1usize.into(),
-            name: SQLITE_TABLEID.to_string(),
+            db: 0,
         });
 
         //  Loop to copy over row id's from the ephemeral table and then re-insert into the schema table with the correct root page

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5567,12 +5567,12 @@ pub fn op_open_write(
     let Insn::OpenWrite {
         cursor_id,
         root_page,
-        ..
+        db,
     } = insn
     else {
         unreachable!("unexpected Insn {:?}", insn)
     };
-    if program.connection.readonly.get() {
+    if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
     let root_page = match root_page {
@@ -5671,7 +5671,7 @@ pub fn op_create_btree(
     let Insn::CreateBtree { db, root, flags } = insn else {
         unreachable!("unexpected Insn {:?}", insn)
     };
-    if program.connection.readonly.get() {
+    if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
     if *db > 0 {

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1215,7 +1215,7 @@ pub fn insn_to_str(
             Insn::OpenWrite {
                 cursor_id,
                 root_page,
-                name,
+                db,
                 ..
             } => (
                 "OpenWrite",
@@ -1224,10 +1224,10 @@ pub fn insn_to_str(
                     RegisterOrLiteral::Literal(i) => *i as _,
                     RegisterOrLiteral::Register(i) => *i as _,
                 },
-                0,
+                *db as i32,
                 Value::build_text(""),
                 0,
-                format!("root={root_page}; {name}"),
+                format!("root={root_page}; iDb={db}"),
             ),
             Insn::Copy {
                 src_reg,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -793,7 +793,7 @@ pub enum Insn {
     OpenWrite {
         cursor_id: CursorID,
         root_page: RegisterOrLiteral<PageIdx>,
-        name: String,
+        db: usize,
     },
 
     Copy {


### PR DESCRIPTION
There's no such thing as a read-only connection.
In a normal connection, you can have many attached databases. Some r/o, some r/w.

To properly fix that, we also need to fix the OpenWrite opcode. Right now we are passing a name, which is the name of the table. That parameter is not used anywhere. That is also not what the SQLite opcode specifies. Same as OpenRead, the p3 register should be the database index.

With that change, we can - for now - pass the index 0, which is all we support anyway, and then use that to test if we are r/o.