### PR TITLE
silence clippy errors with features disabled

### DIFF
--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -4,8 +4,10 @@ mod vtab_xconnect;
 use crate::schema::{Schema, Table};
 #[cfg(all(target_os = "linux", feature = "io_uring"))]
 use crate::UringIO;
-use crate::{function::ExternalFunc, Connection, Database, LimboError, IO};
+use crate::{function::ExternalFunc, Connection, Database};
 use crate::{vtab::VirtualTable, SymbolTable};
+#[cfg(feature = "fs")]
+use crate::{LimboError, IO};
 #[cfg(feature = "fs")]
 pub use dynamic::{add_builtin_vfs_extensions, add_vfs_module, list_vfs_modules, VfsMod};
 use std::{
@@ -168,6 +170,7 @@ impl Database {
             syms,
             schema: schema_mutex_ptr as *mut c_void,
         }));
+        #[allow(unused)]
         let mut ext_api = ExtensionApi {
             ctx: ctx as *mut c_void,
             register_scalar_function,

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -16,7 +16,9 @@ use std::{
 };
 
 use std::{io::ErrorKind, sync::Arc};
-use tracing::{debug, instrument, trace, Level};
+#[cfg(feature = "fs")]
+use tracing::debug;
+use tracing::{instrument, trace, Level};
 
 struct OwnedCallbacks(UnsafeCell<Callbacks>);
 // We assume we locking on IO level is done by user.
@@ -25,6 +27,7 @@ unsafe impl Sync for OwnedCallbacks {}
 struct BorrowedCallbacks<'io>(UnsafeCell<&'io mut Callbacks>);
 
 impl OwnedCallbacks {
+    #[allow(dead_code)]
     fn new() -> Self {
         Self(UnsafeCell::new(Callbacks::new()))
     }
@@ -57,6 +60,7 @@ impl BorrowedCallbacks<'_> {
 struct EventsHandler(UnsafeCell<Events>);
 
 impl EventsHandler {
+    #[allow(dead_code)]
     fn new() -> Self {
         Self(UnsafeCell::new(Events::new()))
     }
@@ -87,6 +91,7 @@ impl BorrowedPollHandler<'_> {
 }
 
 impl PollHandler {
+    #[allow(dead_code)]
     fn new() -> Self {
         Self(UnsafeCell::new(Poller::new().unwrap()))
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -45,6 +45,7 @@ use crate::storage::sqlite3_ondisk::is_valid_page_size;
 use crate::storage::{header_accessor, wal::DummyWAL};
 use crate::translate::optimizer::optimize_plan;
 use crate::translate::pragma::TURSO_CDC_DEFAULT_TABLE_NAME;
+#[cfg(feature = "fs")]
 use crate::util::{OpenMode, OpenOptions};
 use crate::vtab::VirtualTable;
 use core::str;
@@ -935,6 +936,7 @@ impl Connection {
     }
 
     pub fn list_vfs(&self) -> Vec<String> {
+        #[allow(unused_mut)]
         let mut all_vfs = vec![String::from("memory")];
         #[cfg(feature = "fs")]
         {

--- a/core/util.rs
+++ b/core/util.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 use crate::translate::expr::WalkControl;
 use crate::types::IOResult;
 use crate::IO;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -90,8 +90,10 @@ use crate::{
 
 use super::{make_record, Program, ProgramState, Register};
 use crate::{
-    bail_constraint_error, must_be_btree_cursor, resolve_ext_path, MvStore, Pager, Result,
+    bail_constraint_error, must_be_btree_cursor, MvStore, Pager, Result,
 };
+#[cfg(feature = "fs")]
+use crate::resolve_ext_path;
 
 macro_rules! return_if_io {
     ($expr:expr) => {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -89,11 +89,10 @@ use crate::{
 };
 
 use super::{make_record, Program, ProgramState, Register};
-use crate::{
-    bail_constraint_error, must_be_btree_cursor, MvStore, Pager, Result,
-};
+
 #[cfg(feature = "fs")]
 use crate::resolve_ext_path;
+use crate::{bail_constraint_error, must_be_btree_cursor, MvStore, Pager, Result};
 
 macro_rules! return_if_io {
     ($expr:expr) => {


### PR DESCRIPTION
When compiling with features disabled, there are lots of clippy warnings. This PR silences them.

For the utils file, I am using a bit of a hammer and just allowing unused stuff in the whole file. Due to the box of utilities nature of this file, it'll always be the case that things will be unused depending on the feature-set.