### PR TITLE
Explicit rowid insert

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -556,7 +556,7 @@ pub fn translate_insert(
             Some(emit_cdc_patch_record(
                 &mut program,
                 &table,
-                column_registers_start,
+                column_registers_start + 1,
                 record_register,
                 column_registers_start,
             ))
@@ -794,7 +794,7 @@ fn populate_columns_multiple_rows(
         if let Some(value_index) = mapping.value_index {
             let write_directly_to_rowid_reg = mapping.column.is_rowid_alias;
             let write_reg = if write_directly_to_rowid_reg {
-                if last_rowid_explicit_value.map_or(false, |x| x > value_index) {
+                if last_rowid_explicit_value.is_some_and(|x| x > value_index) {
                     continue;
                 }
                 last_rowid_explicit_value = Some(value_index);
@@ -864,7 +864,7 @@ fn populate_column_registers(
             // directly into the rowid register and writes a NULL into the rowid alias column.
             let write_directly_to_rowid_reg = mapping.column.is_rowid_alias;
             let write_reg = if write_directly_to_rowid_reg {
-                if last_rowid_explicit_value.map_or(false, |x| x > value_index) {
+                if last_rowid_explicit_value.is_some_and(|x| x > value_index) {
                     continue;
                 }
                 last_rowid_explicit_value = Some(value_index);

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -392,15 +392,9 @@ pub fn translate_insert(
         });
         let rowid_column = column_mappings
             .iter()
-            .filter(|x| x.value_index.is_some() && x.column.is_rowid_alias)
-            .next()
+            .find(|x| x.value_index.is_some() && x.column.is_rowid_alias)
             .expect("rowid alias column must be provided");
-        let rowid_column_name = rowid_column
-            .column
-            .name
-            .as_ref()
-            .map(|x| x.as_str())
-            .unwrap_or(ROWID);
+        let rowid_column_name = rowid_column.column.name.as_deref().unwrap_or(ROWID);
         program.emit_insn(Insn::Halt {
             err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
             description: format!("{}.{}", table_name.0, rowid_column_name),
@@ -614,7 +608,7 @@ struct ColumnMapping<'a> {
     default_value: Option<&'a Expr>,
 }
 
-pub const ROWID_COLUMN: &'static Column = &Column {
+pub const ROWID_COLUMN: &Column = &Column {
     name: None,
     ty: schema::Type::Integer,
     ty_str: String::new(),
@@ -659,7 +653,7 @@ fn resolve_columns_for_insert<'a>(
     });
     for column in table_columns {
         column_mappings.push(ColumnMapping {
-            column: column,
+            column,
             value_index: None,
             default_value: column.default.as_ref(),
         });

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -488,3 +488,32 @@ do_execsql_test_on_specific_db {:memory:} insert-tricky-column-order-table {
 4||5
 |3|2
 |6|5}
+
+do_execsql_test_on_specific_db {:memory:} insert-explicit-rowid {
+    create table t (x, y, z);
+    insert into t(z, x, y, rowid) values (1, 2, 3, 4), (5, 6, 7, 8);
+    insert into t(z, x, y, rowid) values (9, 10, 11, 12);
+    select rowid, x, y, z from t;
+} {4|2|3|1
+8|6|7|5
+12|10|11|9}
+
+do_execsql_test_on_specific_db {:memory:} insert-explicit-rowid-with-rowidalias {
+    create table t (x, y INTEGER PRIMARY KEY, z);
+    insert into t(z, x, y, rowid) values (1, 2, 3, 4), (5, 6, 7, 8);
+    insert into t(z, x, y, rowid) values (9, 10, 11, 12);
+    insert into t(z, x, rowid, y) values (-1, -2, -3, -4), (-5, -6, -7, -8);
+    insert into t(z, x, rowid, y) values (-9, -10, -11, -12);
+    select rowid, x, y, z from t;
+} {-12|-10|-12|-9
+-8|-6|-8|-5
+-4|-2|-4|-1
+4|2|4|1
+8|6|8|5
+12|10|12|9}
+
+do_execsql_test_in_memory_error_content insert-explicit-rowid-conflict {
+    create table t (x);
+    insert into t(rowid, x) values (1, 1);
+    insert into t(rowid, x) values (1, 2);
+} {UNIQUE constraint failed: t.rowid (19)}


### PR DESCRIPTION
This PR adds support for `INSERT` queries with explicit value for `rowid` column (not thought rowid alias):
```
turso> create table t(x, y, z);
turso> insert into t(rowid, x, y, z) values (10, 1, 2, 3);
turso> select rowid, * from t;
┌───────┬───┬───┬───┐
│ rowid │ x │ y │ z │
├───────┼───┼───┼───┤
│    10 │ 1 │ 2 │ 3 │
└───────┴───┴───┴───┘
```