### PR TITLE
WAL insert API: force schema re-parse if necessary after WAL sync session end

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1152,8 +1152,7 @@ impl BTreeCursor {
         buffer: &mut [u8],
         page: BTreePage,
     ) {
-        page.get().set_dirty();
-        self.pager.add_dirty(page.get().get().id);
+        self.pager.add_dirty(page.get().get().id, &page.get());
         // SAFETY: This is safe as long as the page is not evicted from the cache.
         let payload_mut =
             unsafe { std::slice::from_raw_parts_mut(payload.as_ptr() as *mut u8, payload.len()) };
@@ -2127,8 +2126,7 @@ impl BTreeCursor {
                         return_if_locked!(page.get());
                         let page = page.get();
 
-                        page.set_dirty();
-                        self.pager.add_dirty(page.get().id);
+                        self.pager.add_dirty(page.get().id, &page);
 
                         self.stack.current_cell_index()
                     };
@@ -2389,8 +2387,7 @@ impl BTreeCursor {
                     // to prevent panic in the asserts below due to -1 index
                     self.stack.advance();
                 }
-                parent_page.set_dirty();
-                self.pager.add_dirty(parent_page.get().id);
+                self.pager.add_dirty(parent_page.get().id, &parent_page);
                 let parent_contents = parent_page.get().contents.as_ref().unwrap();
                 let page_to_balance_idx = self.stack.current_cell_index() as usize;
 
@@ -2469,8 +2466,7 @@ impl BTreeCursor {
                     {
                         // mark as dirty
                         let sibling_page = page.get();
-                        sibling_page.set_dirty();
-                        self.pager.add_dirty(sibling_page.get().id);
+                        self.pager.add_dirty(sibling_page.get().id, &sibling_page);
                     }
                     #[cfg(debug_assertions)]
                     {
@@ -2964,7 +2960,10 @@ impl BTreeCursor {
                 for i in 0..sibling_count_new {
                     if i < balance_info.sibling_count {
                         let page = balance_info.pages_to_balance[i].as_ref().unwrap();
-                        page.get().set_dirty();
+                        turso_assert!(
+                            page.get().is_dirty(),
+                            "sibling page must be already marked dirty"
+                        );
                         pages_to_balance_new[i].replace(page.clone());
                     } else {
                         // FIXME: handle page cache is full
@@ -3865,8 +3864,11 @@ impl BTreeCursor {
             root.get_contents().page_type()
         );
 
-        self.pager.add_dirty(root.get().id);
-        self.pager.add_dirty(child_btree.get().get().id);
+        turso_assert!(root.is_dirty(), "root must be marked dirty");
+        turso_assert!(
+            child_btree.get().is_dirty(),
+            "child must be marked dirty as freshly allocated page"
+        );
 
         let root_buf = root_contents.as_ptr();
         let child = child_btree.get();
@@ -4285,8 +4287,7 @@ impl BTreeCursor {
             match delete_state {
                 DeleteState::Start => {
                     let page = self.stack.top();
-                    page.get().set_dirty();
-                    self.pager.add_dirty(page.get().get().id);
+                    self.pager.add_dirty(page.get().get().id, &page.get());
                     if matches!(
                         page.get().get_contents().page_type(),
                         PageType::TableLeaf | PageType::TableInterior
@@ -4469,10 +4470,9 @@ impl BTreeCursor {
 
                     let leaf_page = self.stack.top();
 
-                    page.set_dirty();
-                    self.pager.add_dirty(page.get().id);
-                    leaf_page.get().set_dirty();
-                    self.pager.add_dirty(leaf_page.get().get().id);
+                    self.pager.add_dirty(page.get().id, &page);
+                    self.pager
+                        .add_dirty(leaf_page.get().get().id, &leaf_page.get());
 
                     // Step 2: Replace the cell in the parent (interior) page.
                     {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1152,7 +1152,7 @@ impl BTreeCursor {
         buffer: &mut [u8],
         page: BTreePage,
     ) {
-        self.pager.add_dirty(page.get().get().id, &page.get());
+        self.pager.add_dirty(&page.get());
         // SAFETY: This is safe as long as the page is not evicted from the cache.
         let payload_mut =
             unsafe { std::slice::from_raw_parts_mut(payload.as_ptr() as *mut u8, payload.len()) };
@@ -2126,7 +2126,7 @@ impl BTreeCursor {
                         return_if_locked!(page.get());
                         let page = page.get();
 
-                        self.pager.add_dirty(page.get().id, &page);
+                        self.pager.add_dirty(&page);
 
                         self.stack.current_cell_index()
                     };
@@ -2387,7 +2387,7 @@ impl BTreeCursor {
                     // to prevent panic in the asserts below due to -1 index
                     self.stack.advance();
                 }
-                self.pager.add_dirty(parent_page.get().id, &parent_page);
+                self.pager.add_dirty(&parent_page);
                 let parent_contents = parent_page.get().contents.as_ref().unwrap();
                 let page_to_balance_idx = self.stack.current_cell_index() as usize;
 
@@ -2466,7 +2466,7 @@ impl BTreeCursor {
                     {
                         // mark as dirty
                         let sibling_page = page.get();
-                        self.pager.add_dirty(sibling_page.get().id, &sibling_page);
+                        self.pager.add_dirty(&sibling_page);
                     }
                     #[cfg(debug_assertions)]
                     {
@@ -4287,7 +4287,7 @@ impl BTreeCursor {
             match delete_state {
                 DeleteState::Start => {
                     let page = self.stack.top();
-                    self.pager.add_dirty(page.get().get().id, &page.get());
+                    self.pager.add_dirty(&page.get());
                     if matches!(
                         page.get().get_contents().page_type(),
                         PageType::TableLeaf | PageType::TableInterior
@@ -4470,9 +4470,8 @@ impl BTreeCursor {
 
                     let leaf_page = self.stack.top();
 
-                    self.pager.add_dirty(page.get().id, &page);
-                    self.pager
-                        .add_dirty(leaf_page.get().get().id, &leaf_page.get());
+                    self.pager.add_dirty(&page);
+                    self.pager.add_dirty(&leaf_page.get());
 
                     // Step 2: Replace the cell in the parent (interior) page.
                     {

--- a/core/storage/header_accessor.rs
+++ b/core/storage/header_accessor.rs
@@ -1,4 +1,5 @@
 use crate::storage::sqlite3_ondisk::MAX_PAGE_SIZE;
+use crate::turso_assert;
 use crate::{
     storage::{
         self,
@@ -59,7 +60,11 @@ fn get_header_page_for_write(pager: &Pager) -> Result<IOResult<PageRef>> {
     if page.is_locked() {
         return Ok(IOResult::IO);
     }
-    pager.add_dirty(DATABASE_HEADER_PAGE_ID, &page);
+    turso_assert!(
+        page.get().id == DATABASE_HEADER_PAGE_ID,
+        "page must have number 1"
+    );
+    pager.add_dirty(&page);
     Ok(IOResult::Done(page))
 }
 
@@ -142,7 +147,8 @@ macro_rules! impl_header_field_accessor {
                 let mut buf = page_content.buffer.borrow_mut();
                 let buf_slice = buf.as_mut_slice();
                 buf_slice[$offset..$offset + std::mem::size_of::<$type>()].copy_from_slice(&value.to_be_bytes());
-                pager.add_dirty(1, &page);
+                turso_assert!(page.get().id == 1, "page must have number 1");
+                pager.add_dirty(&page);
                 Ok(IOResult::Done(()))
             }
 

--- a/core/storage/header_accessor.rs
+++ b/core/storage/header_accessor.rs
@@ -59,8 +59,7 @@ fn get_header_page_for_write(pager: &Pager) -> Result<IOResult<PageRef>> {
     if page.is_locked() {
         return Ok(IOResult::IO);
     }
-    page.set_dirty();
-    pager.add_dirty(DATABASE_HEADER_PAGE_ID);
+    pager.add_dirty(DATABASE_HEADER_PAGE_ID, &page);
     Ok(IOResult::Done(page))
 }
 
@@ -143,8 +142,7 @@ macro_rules! impl_header_field_accessor {
                 let mut buf = page_content.buffer.borrow_mut();
                 let buf_slice = buf.as_mut_slice();
                 buf_slice[$offset..$offset + std::mem::size_of::<$type>()].copy_from_slice(&value.to_be_bytes());
-                page.set_dirty();
-                pager.add_dirty(1);
+                pager.add_dirty(1, &page);
                 Ok(IOResult::Done(()))
             }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -790,11 +790,7 @@ impl Pager {
 
                 if schema_did_change {
                     let schema = connection.schema.borrow().clone();
-                    *connection
-                        ._db
-                        .schema
-                        .lock()
-                        .map_err(|_| LimboError::SchemaLocked)? = schema;
+                    connection._db.update_schema_if_newer(schema)?;
                 }
                 Ok(commit_status)
             }
@@ -1445,14 +1441,7 @@ impl Pager {
         cache.unset_dirty_all_pages();
         cache.clear().expect("failed to clear page cache");
         if schema_did_change {
-            connection.schema.replace(
-                connection
-                    ._db
-                    .schema
-                    .lock()
-                    .map_err(|_| LimboError::SchemaLocked)?
-                    .clone(),
-            );
+            connection.schema.replace(connection._db.clone_schema()?);
         }
         self.wal.borrow_mut().rollback()?;
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1031,7 +1031,11 @@ impl Pager {
         if let Some(page) = self.cache_get(header.page_number as usize) {
             let content = page.get_contents();
             content.as_ptr().copy_from_slice(raw_page);
-            self.add_dirty(header.page_number as usize, &page);
+            turso_assert!(
+                page.get().id == header.page_number as usize,
+                "page has unexpected id"
+            );
+            self.add_dirty(&page);
         }
         if header.is_commit_frame() {
             for page_id in self.dirty_pages.borrow().iter() {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1033,7 +1033,7 @@ impl Pager {
             content.as_ptr().copy_from_slice(raw_page);
             self.add_dirty(header.page_number as usize, &page);
         }
-        if header.db_size > 0 {
+        if header.is_commit_frame() {
             for page_id in self.dirty_pages.borrow().iter() {
                 let page_key = PageCacheKey::new(*page_id);
                 let mut cache = self.page_cache.write();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1197,7 +1197,7 @@ impl Pager {
                         (self.usable_space() / LEAF_ENTRY_SIZE) - RESERVED_SLOTS;
 
                     if number_of_leaf_pages < max_free_list_entries as u32 {
-                        self.add_dirty(trunk_page_id as usize, &trunk_page);
+                        self.add_dirty(trunk_page_id as usize, trunk_page);
 
                         trunk_page_contents
                             .write_u32(TRUNK_PAGE_LEAF_COUNT_OFFSET, number_of_leaf_pages + 1);
@@ -1217,7 +1217,7 @@ impl Pager {
                         return Ok(IOResult::IO);
                     }
                     // If we get here, need to make this page a new trunk
-                    self.add_dirty(page_id, &page);
+                    self.add_dirty(page_id, page);
 
                     let trunk_page_id = header_accessor::get_freelist_trunk_page(self)?;
 

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1546,21 +1546,23 @@ pub fn begin_read_wal_frame(
     Ok(c)
 }
 
-pub fn parse_wal_frame_header(frame: &[u8]) -> WalFrameHeader {
+pub fn parse_wal_frame_header(frame: &[u8]) -> (WalFrameHeader, &[u8]) {
     let page_number = u32::from_be_bytes(frame[0..4].try_into().unwrap());
     let db_size = u32::from_be_bytes(frame[4..8].try_into().unwrap());
     let salt_1 = u32::from_be_bytes(frame[8..12].try_into().unwrap());
     let salt_2 = u32::from_be_bytes(frame[12..16].try_into().unwrap());
     let checksum_1 = u32::from_be_bytes(frame[16..20].try_into().unwrap());
     let checksum_2 = u32::from_be_bytes(frame[20..24].try_into().unwrap());
-    WalFrameHeader {
+    let header = WalFrameHeader {
         page_number,
         db_size,
         salt_1,
         salt_2,
         checksum_1,
         checksum_2,
-    }
+    };
+    let page = &frame[WAL_FRAME_HEADER_SIZE..];
+    (header, page)
 }
 
 pub fn prepare_wal_frame(

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -245,6 +245,12 @@ pub struct WalFrameHeader {
     pub(crate) checksum_2: u32,
 }
 
+impl WalFrameHeader {
+    pub fn is_commit_frame(&self) -> bool {
+        self.db_size > 0
+    }
+}
+
 impl Default for DatabaseHeader {
     fn default() -> Self {
         Self {

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -1,4 +1,5 @@
-use rand::{rng, RngCore};
+use rand::{rng, RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 use rusqlite::params;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -236,6 +237,15 @@ pub(crate) fn limbo_exec_rows_error(
             r => panic!("unexpected result {r:?}: expecting single row"),
         }
     }
+}
+
+pub(crate) fn rng_from_time() -> (ChaCha8Rng, u64) {
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let rng = ChaCha8Rng::seed_from_u64(seed);
+    (rng, seed)
 }
 
 #[cfg(test)]

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -162,7 +162,7 @@ fn test_wal_frame_api_no_schema_changes_fuzz() {
 
         let seed = rng.next_u64();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        println!("SEED: {}", seed);
+        println!("SEED: {seed}");
 
         let (mut size, mut synced_frame) = (0, conn2.wal_frame_count().unwrap());
         let mut commit_frames = vec![conn1.wal_frame_count().unwrap()];
@@ -170,8 +170,7 @@ fn test_wal_frame_api_no_schema_changes_fuzz() {
             if rng.next_u32() % 10 != 0 {
                 let key = rng.next_u32();
                 let length = rng.next_u32() % (4 * 4096);
-                let query = format!("INSERT INTO t VALUES ({}, randomblob({}))", key, length);
-                // println!("{}", query);
+                let query = format!("INSERT INTO t VALUES ({key}, randomblob({length}))");
                 conn1.execute(&query).unwrap();
                 commit_frames.push(conn1.wal_frame_count().unwrap());
             } else {
@@ -179,7 +178,6 @@ fn test_wal_frame_api_no_schema_changes_fuzz() {
                 let next_frame =
                     synced_frame + (rng.next_u32() as u64 % (last_frame - synced_frame + 1));
                 let mut frame = [0u8; 24 + 4096];
-                // println!("sync WAL frames: [{}..{}]", synced_frame + 1, next_frame);
                 conn2.wal_insert_begin().unwrap();
                 for frame_no in (synced_frame + 1)..=next_frame {
                     let c = conn1.wal_get_frame(frame_no as u32, &mut frame).unwrap();

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -1,6 +1,8 @@
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 use rusqlite::types::Value;
 
-use crate::common::{limbo_exec_rows, TempDatabase};
+use crate::common::{limbo_exec_rows, rng_from_time, TempDatabase};
 
 #[test]
 fn test_wal_frame_count() {
@@ -141,4 +143,64 @@ fn test_wal_frame_far_away_write() {
     let c = conn1.wal_get_frame(5, &mut frame).unwrap();
     db1.io.wait_for_completion(c).unwrap();
     assert!(conn2.wal_insert_frame(5, &frame).is_err());
+}
+
+#[test]
+fn test_wal_frame_api_no_schema_changes_fuzz() {
+    let (mut rng, _) = rng_from_time();
+    for _ in 0..4 {
+        let db1 = TempDatabase::new_empty(false);
+        let conn1 = db1.connect_limbo();
+        let db2 = TempDatabase::new_empty(false);
+        let conn2 = db2.connect_limbo();
+        conn1
+            .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
+            .unwrap();
+        conn2
+            .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
+            .unwrap();
+
+        let seed = rng.next_u64();
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        println!("SEED: {}", seed);
+
+        let (mut size, mut synced_frame) = (0, conn2.wal_frame_count().unwrap());
+        let mut commit_frames = vec![conn1.wal_frame_count().unwrap()];
+        for _ in 0..256 {
+            if rng.next_u32() % 10 != 0 {
+                let key = rng.next_u32();
+                let length = rng.next_u32() % (4 * 4096);
+                let query = format!("INSERT INTO t VALUES ({}, randomblob({}))", key, length);
+                // println!("{}", query);
+                conn1.execute(&query).unwrap();
+                commit_frames.push(conn1.wal_frame_count().unwrap());
+            } else {
+                let last_frame = conn1.wal_frame_count().unwrap();
+                let next_frame =
+                    synced_frame + (rng.next_u32() as u64 % (last_frame - synced_frame + 1));
+                let mut frame = [0u8; 24 + 4096];
+                // println!("sync WAL frames: [{}..{}]", synced_frame + 1, next_frame);
+                conn2.wal_insert_begin().unwrap();
+                for frame_no in (synced_frame + 1)..=next_frame {
+                    let c = conn1.wal_get_frame(frame_no as u32, &mut frame).unwrap();
+                    db1.io.wait_for_completion(c).unwrap();
+                    conn2.wal_insert_frame(frame_no as u32, &frame[..]).unwrap();
+                }
+                conn2.wal_insert_end().unwrap();
+                for (i, committed) in commit_frames.iter().enumerate() {
+                    if *committed <= next_frame {
+                        size = size.max(i);
+                        synced_frame = *committed;
+                    }
+                }
+                if rng.next_u32() % 10 == 0 {
+                    synced_frame = rng.next_u32() as u64 % synced_frame;
+                }
+                assert_eq!(
+                    limbo_exec_rows(&db2, &conn2, "SELECT COUNT(*) FROM t"),
+                    vec![vec![Value::Integer(size as i64)]]
+                );
+            }
+        }
+    }
 }

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -1,7 +1,6 @@
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use rusqlite::types::Value;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 use crate::common::{limbo_exec_rows, rng_from_time, TempDatabase};
 
@@ -61,11 +60,6 @@ fn test_wal_frame_transfer_no_schema_changes() {
 
 #[test]
 fn test_wal_frame_transfer_schema_changes() {
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
-        .with(EnvFilter::from_default_env())
-        .try_init()
-        .unwrap();
     let db1 = TempDatabase::new_empty(false);
     let conn1 = db1.connect_limbo();
     let db2 = TempDatabase::new_empty(false);

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -10,20 +10,11 @@ mod tests {
     use rusqlite::params;
 
     use crate::{
-        common::{limbo_exec_rows, sqlite_exec_rows, TempDatabase},
+        common::{limbo_exec_rows, rng_from_time, sqlite_exec_rows, TempDatabase},
         fuzz::grammar_generator::{const_str, rand_int, rand_str, GrammarGenerator},
     };
 
     use super::grammar_generator::SymbolHandle;
-
-    fn rng_from_time() -> (ChaCha8Rng, u64) {
-        let seed = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let rng = ChaCha8Rng::seed_from_u64(seed);
-        (rng, seed)
-    }
 
     /// [See this issue for more info](https://github.com/tursodatabase/turso/issues/1763)
     #[test]


### PR DESCRIPTION
This PR partially fixes issue when schema changes were invisible after WAL sync calls. Now, `wal_insert_end` always read fresh schema cookie and re-parse schema from scratch if cookie changed.

Generally, the problem of "silent" schema update can be more generic if(when?) `turso-db` will support multi-process setup. But for now only single-process can work with `turso-db`, so I decided to inject re-parse logic explicitly in WAL raw API in order to not introduce any unnecessary overhead in the ordinary execution path.

This fix is not complete, as if we will have already prepared statements - they should be re-prepared too in case of schema changes. But this problem already tracked in the PR https://github.com/tursodatabase/turso/pull/2214