### PR TITLE
Bail early for read-only virtual tables

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -55,7 +55,7 @@ pub enum LimboError {
     IntegerOverflow,
     #[error("Schema is locked for write")]
     SchemaLocked,
-    #[error("Database Connection is read-only")]
+    #[error("Error: Resource is read-only")]
     ReadOnly,
     #[error("Database is busy")]
     Busy,

--- a/core/series.rs
+++ b/core/series.rs
@@ -29,6 +29,7 @@ impl VTabModule for GenerateSeriesVTabModule {
     type Table = GenerateSeriesTable;
     const NAME: &'static str = "generate_series";
     const VTAB_KIND: VTabKind = VTabKind::TableValuedFunction;
+    const READONLY: bool = true;
 
     fn create(_args: &[Value]) -> Result<(String, Self::Table), ResultCode> {
         let schema = "CREATE TABLE generate_series (

--- a/core/series.rs
+++ b/core/series.rs
@@ -29,7 +29,6 @@ impl VTabModule for GenerateSeriesVTabModule {
     type Table = GenerateSeriesTable;
     const NAME: &'static str = "generate_series";
     const VTAB_KIND: VTabKind = VTabKind::TableValuedFunction;
-    const READONLY: bool = true;
 
     fn create(_args: &[Value]) -> Result<(String, Self::Table), ResultCode> {
         let schema = "CREATE TABLE generate_series (

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -478,6 +478,13 @@ fn emit_delete_insns(
     table_references: &TableReferences,
 ) -> Result<()> {
     let table_reference = table_references.joined_tables().first().unwrap();
+    if table_reference
+        .virtual_table()
+        .is_some_and(|t| t.readonly())
+    {
+        return Err(crate::LimboError::ReadOnly);
+    }
+
     let cursor_id = match &table_reference.op {
         Operation::Scan { .. } => {
             program.resolve_cursor_id(&CursorKey::table(table_reference.internal_id))

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -913,6 +913,9 @@ fn translate_virtual_table_insert(
     on_conflict: Option<ResolveType>,
     resolver: &Resolver,
 ) -> Result<ProgramBuilder> {
+    if virtual_table.readonly() {
+        crate::bail_constraint_error!("Table is read-only: {}", virtual_table.name);
+    }
     let (num_values, value) = match &mut body {
         InsertBody::Select(select, None) => match select.body.select.as_mut() {
             OneSelect::Values(values) => (values[0].len(), values.pop().unwrap()),

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -271,7 +271,14 @@ pub fn init_loop(
                         });
                     }
                 }
-                (_, Table::Virtual(_)) => {
+                (_, Table::Virtual(tbl)) => {
+                    let is_write = matches!(
+                        mode,
+                        OperationMode::INSERT | OperationMode::UPDATE | OperationMode::DELETE
+                    );
+                    if is_write && tbl.readonly() {
+                        return Err(crate::LimboError::ReadOnly);
+                    }
                     if let Some(cursor_id) = table_cursor_id {
                         program.emit_insn(Insn::VOpen { cursor_id });
                     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1090,6 +1090,9 @@ pub fn op_vupdate(
     let CursorType::VirtualTable(virtual_table) = cursor_type else {
         panic!("VUpdate on non-virtual table cursor");
     };
+    if virtual_table.readonly() {
+        return Err(LimboError::ReadOnly);
+    }
 
     if *arg_count < 2 {
         return Err(LimboError::InternalError(

--- a/extensions/core/src/vtabs.rs
+++ b/extensions/core/src/vtabs.rs
@@ -16,6 +16,7 @@ pub type RegisterModuleFn = unsafe extern "C" fn(
 #[derive(Clone, Debug)]
 pub struct VTabModuleImpl {
     pub name: *const c_char,
+    pub readonly: bool,
     pub create: VtabFnCreate,
     pub open: VtabFnOpen,
     pub close: VtabFnClose,
@@ -119,6 +120,7 @@ pub trait VTabModule: 'static {
     type Table: VTable;
     const VTAB_KIND: VTabKind;
     const NAME: &'static str;
+    const READONLY: bool = true;
 
     /// Creates a new instance of a virtual table.
     /// Returns a tuple where the first element is the table's schema.
@@ -146,7 +148,7 @@ pub trait VTable {
     }
     fn best_index(_constraints: &[ConstraintInfo], _order_by: &[OrderByInfo]) -> IndexInfo {
         IndexInfo {
-            idx_num: 0,
+            idx_num: -1,
             idx_str: None,
             order_by_consumed: false,
             estimated_cost: 1_000_000.0,

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -35,6 +35,7 @@ impl VTabModule for KVStoreVTabModule {
     type Table = KVStoreTable;
     const VTAB_KIND: VTabKind = VTabKind::VirtualTable;
     const NAME: &'static str = "kv_store";
+    const READONLY: bool = false;
 
     fn create(_args: &[Value]) -> Result<(String, Self::Table), ResultCode> {
         // The hidden column is placed first to verify that column index handling

--- a/macros/src/ext/vtab_derive.rs
+++ b/macros/src/ext/vtab_derive.rs
@@ -236,6 +236,7 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
                 let name_c = ::std::ffi::CString::new(name).unwrap().into_raw() as *const ::std::ffi::c_char;
                 let module = ::turso_ext::VTabModuleImpl {
                     name: name_c,
+                    readonly: <#struct_name as ::turso_ext::VTabModule>::READONLY,
                     create: Self::#create_fn_name,
                     open: Self::#open_fn_name,
                     close: Self::#close_fn_name,

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -688,17 +688,17 @@ def test_csv():
     )
     limbo.run_test_fn(
         "INSERT INTO temp.csv VALUES (5, 6.0, 'String3');",
-        lambda res: "Virtual table update failed" in res,
+        lambda res: "Table is read-only" in res,
         "INSERT into CSV table should fail",
     )
     limbo.run_test_fn(
         "UPDATE temp.csv SET c0 = 10 WHERE c1 = '2.0';",
-        lambda res: "Virtual table update failed" in res,
+        lambda res: "is read-only" in res,
         "UPDATE on CSV table should fail",
     )
     limbo.run_test_fn(
         "DELETE FROM temp.csv WHERE c1 = '2.0';",
-        lambda res: "Virtual table update failed" in res,
+        lambda res: "is read-only" in res,
         "DELETE on CSV table should fail",
     )
     limbo.run_test_fn("DROP TABLE temp.csv;", null, "Drop CSV table")
@@ -847,7 +847,9 @@ def test_hidden_columns():
 def _test_hidden_columns(exec_name, ext_path):
     console.info(f"Running test_hidden_columns for {ext_path}")
 
-    limbo = TestTursoShell(exec_name=exec_name,)
+    limbo = TestTursoShell(
+        exec_name=exec_name,
+    )
     limbo.execute_dot(f".load {ext_path}")
     limbo.execute_dot(
         "create virtual table t using kv_store;",


### PR DESCRIPTION
This PR adds a const associated value on the VTabModule trait, `READONLY` defaulted to `true`, so we can bail early when a write operation is done on an invalid vtable.

This prevents extensions from having to implement `insert`,`update`, `delete` just to return `Error::ReadOnly`, and prevents us from having to step through `VUpdate` just to error out. 