### PR TITLE
emit SetCookie after DropTable

### DIFF
--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -932,6 +932,13 @@ pub fn translate_drop_table(
         table_name: tbl_name.name.0,
     });
 
+    program.emit_insn(Insn::SetCookie {
+        db: 0,
+        cookie: Cookie::SchemaVersion,
+        value: schema.schema_version as i32 + 1,
+        p5: 0,
+    });
+
     //  end of the program
     program.epilogue(super::emitter::TransactionMode::Write);
 


### PR DESCRIPTION
The SetCookie opcode is used, among other things, to notify the transaction of schema changes. We are not issuing it on DropTable.

Without it, the transaction thinks the schema hasn't changed, and does not update the schema of the connection back to the database.

SQLite will, of course, issue it:

35    DropTable      0     0     0     foo            0
36    SetCookie      0     1     2                    0

Unfortunately I don't have a unit test that breaks with this, because the one that is supposed to break is having, let's put it this way, bigger problems.