### PR TITLE
parser: Distinguish quoted identifiers and unify Id into Name enum

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -23,7 +23,7 @@ pub fn translate_alter_table(
     mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     let (table_name, alter_table) = alter;
-    let ast::Name(table_name) = table_name.name;
+    let table_name = table_name.name.as_str();
     if schema.table_has_indexes(&table_name) && !schema.indexes_enabled() {
         // Let's disable altering a table with indices altogether instead of checking column by
         // column to be extra safe.
@@ -45,7 +45,7 @@ pub fn translate_alter_table(
 
     Ok(match alter_table {
         ast::AlterTableBody::DropColumn(column_name) => {
-            let ast::Name(column_name) = column_name;
+            let column_name = column_name.as_str();
 
             // Tables always have at least one column.
             assert_ne!(btree.columns.len(), 0);
@@ -215,8 +215,8 @@ pub fn translate_alter_table(
             })?
         }
         ast::AlterTableBody::RenameColumn { old, new } => {
-            let ast::Name(rename_from) = old;
-            let ast::Name(rename_to) = new;
+            let rename_from = old.as_str();
+            let rename_to = new.as_str();
 
             if btree.get_column(&rename_from).is_none() {
                 return Err(LimboError::ParseError(format!(
@@ -254,13 +254,13 @@ pub fn translate_alter_table(
                     program.emit_column(cursor_id, i, first_column + i);
                 }
 
-                program.emit_string8_new_reg(table_name.clone());
+                program.emit_string8_new_reg(table_name.to_string());
                 program.mark_last_insn_constant();
 
-                program.emit_string8_new_reg(rename_from.clone());
+                program.emit_string8_new_reg(rename_from.to_string());
                 program.mark_last_insn_constant();
 
-                program.emit_string8_new_reg(rename_to.clone());
+                program.emit_string8_new_reg(rename_to.to_string());
                 program.mark_last_insn_constant();
 
                 let out = program.alloc_registers(sqlite_schema_column_len);
@@ -289,7 +289,7 @@ pub fn translate_alter_table(
                     key_reg: rowid,
                     record_reg: record,
                     flag: crate::vdbe::insn::InsertFlags(0),
-                    table_name: table_name.clone(),
+                    table_name: table_name.to_string(),
                 });
             });
 
@@ -309,7 +309,7 @@ pub fn translate_alter_table(
             program
         }
         ast::AlterTableBody::RenameTo(new_name) => {
-            let ast::Name(new_name) = new_name;
+            let new_name = new_name.as_str();
 
             if schema.get_table(&new_name).is_some() {
                 return Err(LimboError::ParseError(format!(
@@ -341,10 +341,10 @@ pub fn translate_alter_table(
                     program.emit_column(cursor_id, i, first_column + i);
                 }
 
-                program.emit_string8_new_reg(table_name.clone());
+                program.emit_string8_new_reg(table_name.to_string());
                 program.mark_last_insn_constant();
 
-                program.emit_string8_new_reg(new_name.clone());
+                program.emit_string8_new_reg(new_name.to_string());
                 program.mark_last_insn_constant();
 
                 let out = program.alloc_registers(5);
@@ -373,7 +373,7 @@ pub fn translate_alter_table(
                     key_reg: rowid,
                     record_reg: record,
                     flag: crate::vdbe::insn::InsertFlags(0),
-                    table_name: table_name.clone(),
+                    table_name: table_name.to_string(),
                 });
             });
 

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -52,7 +52,7 @@ pub fn prepare_delete_plan(
     limit: Option<Box<Limit>>,
     table_ref_counter: &mut TableRefIdCounter,
 ) -> Result<Plan> {
-    let table = match schema.get_table(tbl_name.name.0.as_str()) {
+    let table = match schema.get_table(tbl_name.name.as_str()) {
         Some(table) => table,
         None => crate::bail_parse_error!("no such table: {}", tbl_name),
     };
@@ -63,7 +63,7 @@ pub fn prepare_delete_plan(
     } else {
         crate::bail_parse_error!("Table is neither a virtual table nor a btree table");
     };
-    let name = tbl_name.name.0.as_str().to_string();
+    let name = tbl_name.name.as_str().to_string();
     let indexes = schema.get_indices(table.get_name()).to_vec();
     let joined_tables = vec![JoinedTable {
         table,

--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -560,7 +560,7 @@ impl ToTokens for UpdatePlan {
                     .unwrap();
 
                 ast::Set {
-                    col_names: ast::DistinctNames::single(ast::Name(col_name.clone())),
+                    col_names: ast::DistinctNames::single(ast::Name::from_str(&col_name)),
                     expr: set_expr.clone(),
                 }
             }),

--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -560,7 +560,7 @@ impl ToTokens for UpdatePlan {
                     .unwrap();
 
                 ast::Set {
-                    col_names: ast::DistinctNames::single(ast::Name::from_str(&col_name)),
+                    col_names: ast::DistinctNames::single(ast::Name::from_str(col_name)),
                     expr: set_expr.clone(),
                 }
             }),

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -680,10 +680,10 @@ pub fn translate_expr(
             order_by: _,
         } => {
             let args_count = if let Some(args) = args { args.len() } else { 0 };
-            let func_type = resolver.resolve_function(&name.0, args_count);
+            let func_type = resolver.resolve_function(name.as_str(), args_count);
 
             if func_type.is_none() {
-                crate::bail_parse_error!("unknown function {}", name.0);
+                crate::bail_parse_error!("unknown function {}", name.as_str());
             }
 
             let func_ctx = FuncCtx {
@@ -693,7 +693,7 @@ pub fn translate_expr(
 
             match &func_ctx.func {
                 Func::Agg(_) => {
-                    crate::bail_parse_error!("misuse of aggregate function {}()", name.0)
+                    crate::bail_parse_error!("misuse of aggregate function {}()", name.as_str())
                 }
                 Func::External(_) => {
                     let regs = program.alloc_registers(args_count);
@@ -1888,7 +1888,7 @@ pub fn translate_expr(
         ast::Expr::Id(id) => {
             // Treat double-quoted identifiers as string literals (SQLite compatibility)
             program.emit_insn(Insn::String8 {
-                value: sanitize_double_quoted_string(&id.0),
+                value: sanitize_double_quoted_string(id.as_str()),
                 dest: target_register,
             });
             Ok(target_register)

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -10,7 +10,7 @@ use crate::{
         insn::{IdxInsertFlags, Insn, RegisterOrLiteral},
     },
 };
-use turso_sqlite3_parser::ast::{self, Expr, Id, SortOrder, SortedColumn};
+use turso_sqlite3_parser::ast::{self, Expr, SortOrder, SortedColumn};
 
 use super::schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID};
 
@@ -252,7 +252,9 @@ fn resolve_sorted_columns<'a>(
         let ident = normalize_ident(match &sc.expr {
             // SQLite supports indexes on arbitrary expressions, but we don't (yet).
             // See "How to use indexes on expressions" in https://www.sqlite.org/expridx.html
-            Expr::Id(Id(col_name)) | Expr::Name(ast::Name(col_name)) => col_name,
+            Expr::Name(ast::Name::Ident(col_name)) | Expr::Name(ast::Name::Quoted(col_name)) => {
+                col_name
+            }
             _ => crate::bail_parse_error!("Error: cannot use expressions in CREATE INDEX"),
         });
         let Some(col) = table.get_column(&ident) else {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -66,7 +66,7 @@ pub fn translate_insert(
         );
     }
     let table_name = &tbl_name.name;
-    let table = match schema.get_table(table_name.0.as_str()) {
+    let table = match schema.get_table(table_name.as_str()) {
         Some(table) => table,
         None => crate::bail_parse_error!("no such table: {}", table_name),
     };
@@ -279,7 +279,7 @@ pub fn translate_insert(
     // allocate cursor id's for each btree index cursor we'll need to populate the indexes
     // (idx name, root_page, idx cursor id)
     let idx_cursors = schema
-        .get_indices(&table_name.0)
+        .get_indices(&table_name.as_str())
         .iter()
         .map(|idx| {
             (
@@ -397,7 +397,7 @@ pub fn translate_insert(
         let rowid_column_name = rowid_column.column.name.as_deref().unwrap_or(ROWID);
         program.emit_insn(Insn::Halt {
             err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
-            description: format!("{}.{}", table_name.0, rowid_column_name),
+            description: format!("{}.{}", table_name.as_str(), rowid_column_name),
         });
         program.preassign_label_to_next_insn(make_record_label);
     }
@@ -445,7 +445,7 @@ pub fn translate_insert(
         });
 
         let index = schema
-            .get_index(&table_name.0, &index_col_mapping.idx_name)
+            .get_index(&table_name.as_str(), &index_col_mapping.idx_name)
             .expect("index should be present");
 
         let record_reg = program.alloc_register();
@@ -566,7 +566,7 @@ pub fn translate_insert(
             rowid_and_columns_start_register,
             None,
             after_record_reg,
-            &table_name.0,
+            table_name.as_str(),
         )?;
     }
 
@@ -681,7 +681,7 @@ fn resolve_columns_for_insert<'a>(
         // Case 2: Columns specified - map named columns to their values
         // Map each named column to its value index
         for (value_index, column_name) in columns.as_ref().unwrap().iter().enumerate() {
-            let column_name = normalize_ident(column_name.0.as_str());
+            let column_name = normalize_ident(column_name.as_str());
             let table_index = if column_name == ROWID {
                 Some(0)
             } else {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -279,7 +279,7 @@ pub fn translate_insert(
     // allocate cursor id's for each btree index cursor we'll need to populate the indexes
     // (idx name, root_page, idx cursor id)
     let idx_cursors = schema
-        .get_indices(&table_name.as_str())
+        .get_indices(table_name.as_str())
         .iter()
         .map(|idx| {
             (
@@ -445,7 +445,7 @@ pub fn translate_insert(
         });
 
         let index = schema
-            .get_index(&table_name.as_str(), &index_col_mapping.idx_name)
+            .get_index(table_name.as_str(), &index_col_mapping.idx_name)
             .expect("index should be present");
 
         let record_reg = program.alloc_register();

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -158,7 +158,7 @@ pub fn translate_inner(
         ast::Stmt::DropIndex {
             if_exists,
             idx_name,
-        } => translate_drop_index(&idx_name.name.as_str(), if_exists, schema, program)?,
+        } => translate_drop_index(idx_name.name.as_str(), if_exists, schema, program)?,
         ast::Stmt::DropTable {
             if_exists,
             tbl_name,

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -128,8 +128,8 @@ pub fn translate_inner(
             ..
         } => translate_create_index(
             (unique, if_not_exists),
-            &idx_name.name.0,
-            &tbl_name.0,
+            idx_name.name.as_str(),
+            tbl_name.as_str(),
             &columns,
             schema,
             program,
@@ -158,7 +158,7 @@ pub fn translate_inner(
         ast::Stmt::DropIndex {
             if_exists,
             idx_name,
-        } => translate_drop_index(&idx_name.name.0, if_exists, schema, program)?,
+        } => translate_drop_index(&idx_name.name.as_str(), if_exists, schema, program)?,
         ast::Stmt::DropTable {
             if_exists,
             tbl_name,

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -593,8 +593,8 @@ impl Optimizable for ast::Expr {
             }
             Expr::Exists(_) => false,
             Expr::FunctionCall { args, name, .. } => {
-                let Some(func) =
-                    resolver.resolve_function(&name.0, args.as_ref().map_or(0, |args| args.len()))
+                let Some(func) = resolver
+                    .resolve_function(name.as_str(), args.as_ref().map_or(0, |args| args.len()))
                 else {
                     return false;
                 };
@@ -606,7 +606,7 @@ impl Optimizable for ast::Expr {
             Expr::FunctionCallStar { .. } => false,
             Expr::Id(id) => {
                 // If we got here with an id, this has to be double-quotes identifier
-                assert!(is_double_quoted_identifier(&id.0));
+                assert!(is_double_quoted_identifier(id.as_str()));
                 true
             }
             Expr::Column { .. } => false,
@@ -1307,11 +1307,11 @@ pub fn rewrite_expr(top_level_expr: &mut ast::Expr, param_idx: &mut usize) -> Re
         match expr {
             ast::Expr::Id(id) => {
                 // Convert "true" and "false" to 1 and 0
-                if id.0.eq_ignore_ascii_case("true") {
+                if id.as_str().eq_ignore_ascii_case("true") {
                     *expr = ast::Expr::Literal(ast::Literal::Numeric(1.to_string()));
                     return Ok(());
                 }
-                if id.0.eq_ignore_ascii_case("false") {
+                if id.as_str().eq_ignore_ascii_case("false") {
                     *expr = ast::Expr::Literal(ast::Literal::Numeric(0.to_string()));
                 }
             }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -482,14 +482,14 @@ impl SelectPlan {
         }
 
         let count = turso_sqlite3_parser::ast::Expr::FunctionCall {
-            name: turso_sqlite3_parser::ast::Id("count".to_string()),
+            name: turso_sqlite3_parser::ast::Name::Ident("count".to_string()),
             distinctness: None,
             args: None,
             order_by: None,
             filter_over: None,
         };
         let count_star = turso_sqlite3_parser::ast::Expr::FunctionCallStar {
-            name: turso_sqlite3_parser::ast::Id("count".to_string()),
+            name: turso_sqlite3_parser::ast::Name::Ident("count".to_string()),
             filter_over: None,
         };
         let result_col_expr = &self.result_columns.first().unwrap().expr;
@@ -563,7 +563,7 @@ pub fn select_star(tables: &[JoinedTable], out_columns: &mut Vec<ResultSetColumn
                         !using_cols.iter().any(|using_col| {
                             col.name
                                 .as_ref()
-                                .is_some_and(|name| name.eq_ignore_ascii_case(&using_col.0))
+                                .is_some_and(|name| name.eq_ignore_ascii_case(using_col.as_str()))
                         })
                     } else {
                         true

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -49,12 +49,12 @@ pub fn translate_pragma(
     };
     program.extend(&opts);
 
-    if name.name.0.eq_ignore_ascii_case("pragma_list") {
+    if name.name.as_str().eq_ignore_ascii_case("pragma_list") {
         list_pragmas(&mut program);
         return Ok(program);
     }
 
-    let pragma = match PragmaName::from_str(&name.name.0) {
+    let pragma = match PragmaName::from_str(name.name.as_str()) {
         Ok(pragma) => pragma,
         Err(_) => bail_parse_error!("Not a valid pragma name"),
     };
@@ -172,7 +172,7 @@ fn update_pragma(
         PragmaName::AutoVacuum => {
             let auto_vacuum_mode = match value {
                 Expr::Name(name) => {
-                    let name = name.0.to_lowercase();
+                    let name = name.as_str().to_lowercase();
                     match name.as_str() {
                         "none" => 0,
                         "full" => 1,
@@ -234,7 +234,7 @@ fn update_pragma(
             if let Some(table) = &opts.table() {
                 // make sure that we have table created
                 program = translate_create_table(
-                    QualifiedName::single(ast::Name(table.to_string())),
+                    QualifiedName::single(ast::Name::from_str(&table)),
                     false,
                     ast::CreateTableBody::columns_and_constraints_from_definition(
                         turso_cdc_table_columns(),
@@ -313,7 +313,7 @@ fn query_pragma(
             // Allocate two more here as one was allocated at the top.
             let mode = match value {
                 Some(ast::Expr::Name(name)) => {
-                    let mode_name = normalize_ident(&name.0);
+                    let mode_name = normalize_ident(name.as_str());
                     CheckpointMode::from_str(&mode_name).map_err(|e| {
                         LimboError::ParseError(format!("Unknown Checkpoint Mode: {e}"))
                     })?
@@ -348,7 +348,7 @@ fn query_pragma(
         PragmaName::TableInfo => {
             let table = match value {
                 Some(ast::Expr::Name(name)) => {
-                    let tbl = normalize_ident(&name.0);
+                    let tbl = normalize_ident(name.as_str());
                     schema.get_table(&tbl)
                 }
                 _ => None,
@@ -528,7 +528,7 @@ pub const TURSO_CDC_DEFAULT_TABLE_NAME: &str = "turso_cdc";
 fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
     vec![
         ast::ColumnDefinition {
-            col_name: ast::Name("change_id".to_string()),
+            col_name: ast::Name::from_str("change_id"),
             col_type: Some(ast::Type {
                 name: "INTEGER".to_string(),
                 size: None,
@@ -543,7 +543,7 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             }],
         },
         ast::ColumnDefinition {
-            col_name: ast::Name("change_time".to_string()),
+            col_name: ast::Name::from_str("change_time"),
             col_type: Some(ast::Type {
                 name: "INTEGER".to_string(),
                 size: None,
@@ -551,7 +551,7 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             constraints: vec![],
         },
         ast::ColumnDefinition {
-            col_name: ast::Name("change_type".to_string()),
+            col_name: ast::Name::from_str("change_type"),
             col_type: Some(ast::Type {
                 name: "INTEGER".to_string(),
                 size: None,
@@ -559,7 +559,7 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             constraints: vec![],
         },
         ast::ColumnDefinition {
-            col_name: ast::Name("table_name".to_string()),
+            col_name: ast::Name::from_str("table_name"),
             col_type: Some(ast::Type {
                 name: "TEXT".to_string(),
                 size: None,
@@ -567,12 +567,12 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             constraints: vec![],
         },
         ast::ColumnDefinition {
-            col_name: ast::Name("id".to_string()),
+            col_name: ast::Name::from_str("id"),
             col_type: None,
             constraints: vec![],
         },
         ast::ColumnDefinition {
-            col_name: ast::Name("before".to_string()),
+            col_name: ast::Name::from_str("before"),
             col_type: Some(ast::Type {
                 name: "BLOB".to_string(),
                 size: None,
@@ -580,7 +580,7 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             constraints: vec![],
         },
         ast::ColumnDefinition {
-            col_name: ast::Name("after".to_string()),
+            col_name: ast::Name::from_str("after"),
             col_type: Some(ast::Type {
                 name: "BLOB".to_string(),
                 size: None,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -234,7 +234,7 @@ fn update_pragma(
             if let Some(table) = &opts.table() {
                 // make sure that we have table created
                 program = translate_create_table(
-                    QualifiedName::single(ast::Name::from_str(&table)),
+                    QualifiedName::single(ast::Name::from_str(table)),
                     false,
                     ast::CreateTableBody::columns_and_constraints_from_definition(
                         turso_cdc_table_columns(),

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -290,7 +290,7 @@ fn check_automatic_pk_index_required(
                                         bail_parse_error!("No such column: {}", name.as_str());
                                     }
                                     Ok(PrimaryKeyColumnInfo {
-                                        name: &name.as_str(),
+                                        name: name.as_str(),
                                         is_descending: matches!(
                                             col.order,
                                             Some(ast::SortOrder::Desc)

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -109,7 +109,7 @@ pub fn prepare_update_plan(
             "UPDATE table disabled for table with indexes is disabled by default. Run with `--experimental-indexes` to enable this feature."
         );
     }
-    let table = match schema.get_table(table_name.0.as_str()) {
+    let table = match schema.get_table(table_name.as_str()) {
         Some(table) => table,
         None => bail_parse_error!("Parse error: no such table: {}", table_name),
     };
@@ -132,7 +132,7 @@ pub fn prepare_update_plan(
             Table::BTree(btree_table) => Table::BTree(btree_table.clone()),
             _ => unreachable!(),
         },
-        identifier: table_name.0.clone(),
+        identifier: table_name.as_str().to_string(),
         internal_id: program.table_reference_counter.next(),
         op: Operation::Scan {
             iter_dir,
@@ -152,7 +152,7 @@ pub fn prepare_update_plan(
 
     let mut set_clauses = Vec::with_capacity(body.sets.len());
     for set in &mut body.sets {
-        let ident = normalize_ident(set.col_names[0].0.as_str());
+        let ident = normalize_ident(set.col_names[0].as_str());
         let Some(col_index) = column_lookup.get(&ident) else {
             bail_parse_error!("Parse error: no such column: {}", ident);
         };
@@ -214,7 +214,7 @@ pub fn prepare_update_plan(
                 Table::BTree(btree_table) => Table::BTree(btree_table.clone()),
                 _ => unreachable!(),
             },
-            identifier: table_name.0.clone(),
+            identifier: table_name.as_str().to_string(),
             internal_id,
             op: Operation::Scan {
                 iter_dir,
@@ -317,7 +317,7 @@ pub fn prepare_update_plan(
 
     // Check what indexes will need to be updated by checking set_clauses and see
     // if a column is contained in an index.
-    let indexes = schema.get_indices(&table_name.0);
+    let indexes = schema.get_indices(table_name.as_str());
     let indexes_to_update = indexes
         .iter()
         .filter(|index| {

--- a/core/util.rs
+++ b/core/util.rs
@@ -1100,7 +1100,7 @@ pub fn parse_pragma_bool(expr: &Expr) -> Result<bool> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use turso_sqlite3_parser::ast::{self, Expr, Id, Literal, Name, Operator::*, Type};
+    use turso_sqlite3_parser::ast::{self, Expr, Literal, Name, Operator::*, Type};
 
     #[test]
     fn test_normalize_ident() {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -293,7 +293,7 @@ impl ProgramBuilder {
     pub fn add_pragma_result_column(&mut self, col_name: String) {
         // TODO figure out a better type definition for ResultSetColumn
         // or invent another way to set pragma result columns
-        let expr = ast::Expr::Id(ast::Id("".to_string()));
+        let expr = ast::Expr::Id(ast::Name::Ident("".to_string()));
         self.result_columns.push(ResultSetColumn {
             expr,
             alias: Some(col_name),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4590,7 +4590,7 @@ pub fn op_function(
                                 columns,
                                 where_clause,
                             } => {
-                                let table_name = normalize_ident(&tbl_name.0);
+                                let table_name = normalize_ident(tbl_name.as_str());
 
                                 if rename_from != table_name {
                                     break 'sql None;
@@ -4601,7 +4601,7 @@ pub fn op_function(
                                         unique,
                                         if_not_exists,
                                         idx_name,
-                                        tbl_name: ast::Name(rename_to),
+                                        tbl_name: ast::Name::from_str(&rename_to),
                                         columns,
                                         where_clause,
                                     }
@@ -4615,7 +4615,7 @@ pub fn op_function(
                                 tbl_name,
                                 body,
                             } => {
-                                let table_name = normalize_ident(&tbl_name.name.0);
+                                let table_name = normalize_ident(tbl_name.name.as_str());
 
                                 if rename_from != table_name {
                                     break 'sql None;
@@ -4627,7 +4627,7 @@ pub fn op_function(
                                         if_not_exists,
                                         tbl_name: ast::QualifiedName {
                                             db_name: None,
-                                            name: ast::Name(rename_to),
+                                            name: ast::Name::from_str(&rename_to),
                                             alias: None,
                                         },
                                         body,
@@ -4687,13 +4687,13 @@ pub fn op_function(
                                 mut columns,
                                 where_clause,
                             } => {
-                                if table != normalize_ident(&tbl_name.0) {
+                                if table != normalize_ident(tbl_name.as_str()) {
                                     break 'sql None;
                                 }
 
                                 for column in &mut columns {
                                     match &mut column.expr {
-                                        ast::Expr::Id(ast::Id(id))
+                                        ast::Expr::Id(ast::Name::Ident(id))
                                             if normalize_ident(id) == rename_from =>
                                         {
                                             *id = rename_to.clone();
@@ -4721,7 +4721,7 @@ pub fn op_function(
                                 tbl_name,
                                 body,
                             } => {
-                                if table != normalize_ident(&tbl_name.name.0) {
+                                if table != normalize_ident(tbl_name.name.as_str()) {
                                     break 'sql None;
                                 }
 
@@ -4735,16 +4735,19 @@ pub fn op_function(
                                 };
 
                                 let column_index = columns
-                                    .get_index_of(&ast::Name(rename_from))
+                                    .get_index_of(&ast::Name::from_str(&rename_from))
                                     .expect("column being renamed should be present");
 
                                 let mut column_definition =
                                     columns.get_index(column_index).unwrap().1.clone();
 
-                                column_definition.col_name = ast::Name(rename_to.clone());
+                                column_definition.col_name = ast::Name::from_str(&rename_to);
 
                                 assert!(columns
-                                    .insert(ast::Name(rename_to), column_definition.clone())
+                                    .insert(
+                                        ast::Name::from_str(&rename_to),
+                                        column_definition.clone()
+                                    )
                                     .is_none());
 
                                 // Swaps indexes with the last one and pops the end, effectively

--- a/simulator/generation/expr.rs
+++ b/simulator/generation/expr.rs
@@ -223,7 +223,7 @@ impl ArbitraryFrom<&SimulatorEnv> for QualifiedName {
         let table_idx = pick_index(t.tables.len(), rng);
         let table = &t.tables[table_idx];
         // TODO: for now forego alias
-        Self::single(Name(table.name.clone()))
+        Self::single(Name::from_str(&table.name))
     }
 }
 

--- a/simulator/generation/predicate/binary.rs
+++ b/simulator/generation/predicate/binary.rs
@@ -26,7 +26,7 @@ impl Predicate {
             vec![
                 Box::new(|_| {
                     Expr::Binary(
-                        Box::new(Expr::Id(ast::Id(column_name.to_string()))),
+                        Box::new(Expr::Id(ast::Name::Ident(column_name.to_string()))),
                         ast::Operator::Equals,
                         Box::new(Expr::Literal(value.into())),
                     )
@@ -34,7 +34,7 @@ impl Predicate {
                 Box::new(|rng| {
                     let gt_value = GTValue::arbitrary_from(rng, value).0;
                     Expr::Binary(
-                        Box::new(Expr::Id(ast::Id(column_name.to_string()))),
+                        Box::new(Expr::Id(ast::Name::Ident(column_name.to_string()))),
                         ast::Operator::Greater,
                         Box::new(Expr::Literal(gt_value.into())),
                     )
@@ -42,7 +42,7 @@ impl Predicate {
                 Box::new(|rng| {
                     let lt_value = LTValue::arbitrary_from(rng, value).0;
                     Expr::Binary(
-                        Box::new(Expr::Id(ast::Id(column_name.to_string()))),
+                        Box::new(Expr::Id(ast::Name::Ident(column_name.to_string()))),
                         ast::Operator::Less,
                         Box::new(Expr::Literal(lt_value.into())),
                     )
@@ -82,8 +82,8 @@ impl Predicate {
                     Box::new(|_| {
                         Some(Expr::Binary(
                             Box::new(ast::Expr::Qualified(
-                                ast::Name(table_name.clone()),
-                                ast::Name(column.name.clone()),
+                                ast::Name::from_str(&table_name),
+                                ast::Name::from_str(&column.name),
                             )),
                             ast::Operator::Equals,
                             Box::new(Expr::Literal(value.into())),
@@ -99,8 +99,8 @@ impl Predicate {
                         } else {
                             Some(Expr::Binary(
                                 Box::new(ast::Expr::Qualified(
-                                    ast::Name(table_name.clone()),
-                                    ast::Name(column.name.clone()),
+                                    ast::Name::from_str(&table_name),
+                                    ast::Name::from_str(&column.name),
                                 )),
                                 ast::Operator::NotEquals,
                                 Box::new(Expr::Literal(v.into())),
@@ -114,8 +114,8 @@ impl Predicate {
                         let lt_value = LTValue::arbitrary_from(rng, value).0;
                         Some(Expr::Binary(
                             Box::new(ast::Expr::Qualified(
-                                ast::Name(table_name.clone()),
-                                ast::Name(column.name.clone()),
+                                ast::Name::from_str(&table_name),
+                                ast::Name::from_str(&column.name),
                             )),
                             ast::Operator::Greater,
                             Box::new(Expr::Literal(lt_value.into())),
@@ -128,8 +128,8 @@ impl Predicate {
                         let gt_value = GTValue::arbitrary_from(rng, value).0;
                         Some(Expr::Binary(
                             Box::new(ast::Expr::Qualified(
-                                ast::Name(table_name.clone()),
-                                ast::Name(column.name.clone()),
+                                ast::Name::from_str(&table_name),
+                                ast::Name::from_str(&column.name),
                             )),
                             ast::Operator::Less,
                             Box::new(Expr::Literal(gt_value.into())),
@@ -143,8 +143,8 @@ impl Predicate {
                         LikeValue::arbitrary_from_maybe(rng, value).map(|like| {
                             Expr::Like {
                                 lhs: Box::new(ast::Expr::Qualified(
-                                    ast::Name(table_name.clone()),
-                                    ast::Name(column.name.clone()),
+                                    ast::Name::from_str(&table_name),
+                                    ast::Name::from_str(&column.name),
                                 )),
                                 not: false, // TODO: also generate this value eventually
                                 op: ast::LikeOperator::Like,
@@ -188,8 +188,8 @@ impl Predicate {
                 Box::new(|_| {
                     Expr::Binary(
                         Box::new(ast::Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::NotEquals,
                         Box::new(Expr::Literal(value.into())),
@@ -204,8 +204,8 @@ impl Predicate {
                     };
                     Expr::Binary(
                         Box::new(ast::Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::Equals,
                         Box::new(Expr::Literal(v.into())),
@@ -215,8 +215,8 @@ impl Predicate {
                     let gt_value = GTValue::arbitrary_from(rng, value).0;
                     Expr::Binary(
                         Box::new(ast::Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::Greater,
                         Box::new(Expr::Literal(gt_value.into())),
@@ -226,8 +226,8 @@ impl Predicate {
                     let lt_value = LTValue::arbitrary_from(rng, value).0;
                     Expr::Binary(
                         Box::new(ast::Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::Less,
                         Box::new(Expr::Literal(lt_value.into())),
@@ -272,8 +272,8 @@ impl SimplePredicate {
                 Box::new(|_rng| {
                     Expr::Binary(
                         Box::new(ast::Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::Equals,
                         Box::new(Expr::Literal(column_value.into())),
@@ -283,8 +283,8 @@ impl SimplePredicate {
                     let lt_value = LTValue::arbitrary_from(rng, column_value).0;
                     Expr::Binary(
                         Box::new(Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::Greater,
                         Box::new(Expr::Literal(lt_value.into())),
@@ -294,8 +294,8 @@ impl SimplePredicate {
                     let gt_value = GTValue::arbitrary_from(rng, column_value).0;
                     Expr::Binary(
                         Box::new(Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::Less,
                         Box::new(Expr::Literal(gt_value.into())),
@@ -341,8 +341,8 @@ impl SimplePredicate {
                 Box::new(|_rng| {
                     Expr::Binary(
                         Box::new(Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::NotEquals,
                         Box::new(Expr::Literal(column_value.into())),
@@ -352,8 +352,8 @@ impl SimplePredicate {
                     let gt_value = GTValue::arbitrary_from(rng, column_value).0;
                     Expr::Binary(
                         Box::new(ast::Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::Greater,
                         Box::new(Expr::Literal(gt_value.into())),
@@ -363,8 +363,8 @@ impl SimplePredicate {
                     let lt_value = LTValue::arbitrary_from(rng, column_value).0;
                     Expr::Binary(
                         Box::new(ast::Expr::Qualified(
-                            ast::Name(table_name.clone()),
-                            ast::Name(column.name.clone()),
+                            ast::Name::from_str(&table_name),
+                            ast::Name::from_str(&column.name),
                         )),
                         ast::Operator::Less,
                         Box::new(Expr::Literal(lt_value.into())),

--- a/simulator/model/query/predicate.rs
+++ b/simulator/model/query/predicate.rs
@@ -90,9 +90,11 @@ impl Predicate {
 // to already know more values before hand
 pub fn expr_to_value(expr: &ast::Expr, row: &[SimValue], table: &Table) -> Option<SimValue> {
     match expr {
-        ast::Expr::DoublyQualified(_, _, ast::Name(col_name))
-        | ast::Expr::Qualified(_, ast::Name(col_name))
-        | ast::Expr::Id(ast::Id(col_name)) => {
+        ast::Expr::DoublyQualified(_, _, ast::Name::Ident(col_name))
+        | ast::Expr::DoublyQualified(_, _, ast::Name::Quoted(col_name))
+        | ast::Expr::Qualified(_, ast::Name::Ident(col_name))
+        | ast::Expr::Qualified(_, ast::Name::Quoted(col_name))
+        | ast::Expr::Id(ast::Name::Ident(col_name)) => {
             assert_eq!(row.len(), table.columns.len());
             table
                 .columns

--- a/simulator/model/query/select.rs
+++ b/simulator/model/query/select.rs
@@ -189,7 +189,7 @@ impl FromClause {
     fn to_sql_ast(&self) -> ast::FromClause {
         ast::FromClause {
             select: Some(Box::new(ast::SelectTable::Table(
-                ast::QualifiedName::single(ast::Name(self.table.clone())),
+                ast::QualifiedName::single(ast::Name::from_str(&self.table)),
                 None,
                 None,
             ))),
@@ -218,7 +218,7 @@ impl FromClause {
                                 }
                             },
                             table: ast::SelectTable::Table(
-                                ast::QualifiedName::single(ast::Name(join.table.clone())),
+                                ast::QualifiedName::single(ast::Name::from_str(&join.table)),
                                 None,
                                 None,
                             ),
@@ -460,9 +460,10 @@ impl Select {
                                 ast::ResultColumn::Expr(expr.0.clone(), None)
                             }
                             ResultColumn::Star => ast::ResultColumn::Star,
-                            ResultColumn::Column(name) => {
-                                ast::ResultColumn::Expr(ast::Expr::Id(ast::Id(name.clone())), None)
-                            }
+                            ResultColumn::Column(name) => ast::ResultColumn::Expr(
+                                ast::Expr::Id(ast::Name::Ident(name.clone())),
+                                None,
+                            ),
                         })
                         .collect(),
                     from: self.body.select.from.as_ref().map(|f| f.to_sql_ast()),
@@ -491,7 +492,7 @@ impl Select {
                                         }
                                         ResultColumn::Star => ast::ResultColumn::Star,
                                         ResultColumn::Column(name) => ast::ResultColumn::Expr(
-                                            ast::Expr::Id(ast::Id(name.clone())),
+                                            ast::Expr::Id(ast::Name::Ident(name.clone())),
                                             None,
                                         ),
                                     })
@@ -509,7 +510,7 @@ impl Select {
                 o.columns
                     .iter()
                     .map(|(name, order)| ast::SortedColumn {
-                        expr: ast::Expr::Id(ast::Id(name.clone())),
+                        expr: ast::Expr::Id(ast::Name::Ident(name.clone())),
                         order: match order {
                             SortOrder::Asc => Some(ast::SortOrder::Asc),
                             SortOrder::Desc => Some(ast::SortOrder::Desc),

--- a/vendored/sqlite3-parser/src/lexer/sql/test.rs
+++ b/vendored/sqlite3-parser/src/lexer/sql/test.rs
@@ -77,7 +77,7 @@ fn vtab_args() -> Result<(), Error> {
         panic!("unexpected AST")
     };
     assert_eq!(create_virtual_table.tbl_name.name, "mail");
-    assert_eq!(create_virtual_table.module_name.0, "fts3");
+    assert_eq!(create_virtual_table.module_name.as_str(), "fts3");
     let args = create_virtual_table.args.as_ref().unwrap();
     assert_eq!(args.len(), 2);
     assert_eq!(args[0], "subject VARCHAR(256) NOT NULL");

--- a/vendored/sqlite3-parser/src/parser/ast/fmt.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/fmt.rs
@@ -1326,23 +1326,13 @@ impl ToTokens for GroupBy {
     }
 }
 
-impl ToTokens for Id {
-    fn to_tokens_with_context<S: TokenStream + ?Sized, C: ToSqlContext>(
-        &self,
-        s: &mut S,
-        _: &C,
-    ) -> Result<(), S::Error> {
-        double_quote(&self.0, s)
-    }
-}
-
 impl ToTokens for Name {
     fn to_tokens_with_context<S: TokenStream + ?Sized, C: ToSqlContext>(
         &self,
         s: &mut S,
         _: &C,
     ) -> Result<(), S::Error> {
-        double_quote(self.0.as_str(), s)
+        double_quote(self.as_str(), s)
     }
 }
 

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1117,20 +1117,6 @@ pub struct GroupBy {
     pub having: Option<Box<Expr>>, // HAVING clause on a non-aggregate query
 }
 
-/// identifier or one of several keywords or `INDEXED`
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Id(pub String);
-
-impl Id {
-    /// Constructor
-    pub fn from_token(ty: YYCODETYPE, token: Token) -> Self {
-        Self(from_token(ty, token))
-    }
-}
-
-// TODO ids (identifier or string)
-
 /// identifier or string or `CROSS` or `FULL` or `INNER` or `LEFT` or `NATURAL` or `OUTER` or `RIGHT`.
 #[derive(Clone, Debug, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1180,6 +1166,7 @@ impl Name {
     }
 
     /// Identifying from a string
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         let bytes = s.as_bytes();
         if s.is_empty() {

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -14,7 +14,7 @@ use indexmap::{IndexMap, IndexSet};
 
 use crate::custom_err;
 use crate::dialect::TokenType::{self, *};
-use crate::dialect::{from_token, Token};
+use crate::dialect::{from_bytes, from_token, Token};
 use crate::parser::{parse::YYCODETYPE, ParserError};
 
 /// `?` or `$` Prepared statement arg placeholder(s)
@@ -379,7 +379,7 @@ pub enum Expr {
     /// call to a built-in function
     FunctionCall {
         /// function name
-        name: Id,
+        name: Name,
         /// `DISTINCT`
         distinctness: Option<Distinctness>,
         /// arguments
@@ -392,12 +392,12 @@ pub enum Expr {
     /// Function call expression with '*' as arg
     FunctionCallStar {
         /// function name
-        name: Id,
+        name: Name,
         /// `FILTER`
         filter_over: Option<FunctionTail>,
     },
     /// Identifier
-    Id(Id),
+    Id(Name),
     /// Column
     Column {
         /// the x in `x.y.z`. index of the db in catalog.
@@ -487,7 +487,7 @@ impl Expr {
     }
     /// Constructor
     pub fn id(xt: YYCODETYPE, x: Token) -> Self {
-        Self::Id(Id::from_token(xt, x))
+        Self::Id(Name::from_token(xt, x))
     }
     /// Constructor
     pub fn collate(x: Self, ct: YYCODETYPE, c: Token) -> Self {
@@ -1027,7 +1027,7 @@ impl JoinOperator {
         Ok({
             let mut jt = JoinType::try_from(token.1)?;
             for n in [&n1, &n2].into_iter().flatten() {
-                jt |= JoinType::try_from(n.0.as_ref())?;
+                jt |= JoinType::try_from(n.as_str().as_bytes())?;
             }
             if (jt & (JoinType::INNER | JoinType::OUTER)) == (JoinType::INNER | JoinType::OUTER)
                 || (jt & (JoinType::OUTER | JoinType::LEFT | JoinType::RIGHT)) == JoinType::OUTER
@@ -1134,32 +1134,62 @@ impl Id {
 /// identifier or string or `CROSS` or `FULL` or `INNER` or `LEFT` or `NATURAL` or `OUTER` or `RIGHT`.
 #[derive(Clone, Debug, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Name(pub String); // TODO distinction between Name and "Name"/[Name]/`Name`
-
+pub enum Name {
+    /// Identifier
+    Ident(String),
+    /// Quoted values
+    Quoted(String),
+}
 impl Name {
     /// Constructor
-    pub fn from_token(ty: YYCODETYPE, token: Token) -> Self {
-        Self(from_token(ty, token))
+    pub fn from_token(_ty: YYCODETYPE, token: Token) -> Self {
+        let text = from_bytes(token.1);
+        Self::from_str(&text)
     }
 
     fn as_bytes(&self) -> QuotedIterator<'_> {
-        if self.0.is_empty() {
-            return QuotedIterator(self.0.bytes(), 0);
+        match self {
+            Name::Ident(s) => QuotedIterator(s.bytes(), 0),
+            Name::Quoted(s) => {
+                if s.is_empty() {
+                    return QuotedIterator(s.bytes(), 0);
+                }
+                let bytes = s.as_bytes();
+                let mut quote = bytes[0];
+                if quote != b'"' && quote != b'`' && quote != b'\'' && quote != b'[' {
+                    return QuotedIterator(s.bytes(), 0);
+                } else if quote == b'[' {
+                    quote = b']';
+                }
+                debug_assert!(bytes.len() > 1);
+                debug_assert_eq!(quote, bytes[bytes.len() - 1]);
+                let sub = &s.as_str()[1..bytes.len() - 1];
+                if quote == b']' {
+                    return QuotedIterator(sub.bytes(), 0); // no escape
+                }
+                QuotedIterator(sub.bytes(), quote)
+            }
         }
-        let bytes = self.0.as_bytes();
-        let mut quote = bytes[0];
-        if quote != b'"' && quote != b'`' && quote != b'\'' && quote != b'[' {
-            return QuotedIterator(self.0.bytes(), 0);
-        } else if quote == b'[' {
-            quote = b']';
+    }
+
+    /// as_str
+    pub fn as_str(&self) -> &str {
+        match self {
+            Name::Ident(s) | Name::Quoted(s) => s.as_str(),
         }
-        debug_assert!(bytes.len() > 1);
-        debug_assert_eq!(quote, bytes[bytes.len() - 1]);
-        let sub = &self.0.as_str()[1..bytes.len() - 1];
-        if quote == b']' {
-            return QuotedIterator(sub.bytes(), 0); // no escape
+    }
+
+    /// Identifying from a string
+    pub fn from_str(s: &str) -> Self {
+        let bytes = s.as_bytes();
+        if s.is_empty() {
+            return Name::Ident(s.to_string());
         }
-        QuotedIterator(sub.bytes(), quote)
+
+        match bytes[0] {
+            b'"' | b'\'' | b'`' | b'[' => Name::Quoted(s.to_string()),
+            _ => Name::Ident(s.to_string()),
+        }
     }
 }
 
@@ -1510,7 +1540,7 @@ pub enum ColumnConstraint {
         /// expression
         expr: Expr,
         /// `STORED` / `VIRTUAL`
-        typ: Option<Id>,
+        typ: Option<Name>,
     },
 }
 
@@ -2139,6 +2169,6 @@ mod test {
     }
 
     fn name(s: &'static str) -> Name {
-        Name(s.to_owned())
+        Name::from_str(s)
     }
 }

--- a/vendored/sqlite3-parser/src/parser/parse.y
+++ b/vendored/sqlite3-parser/src/parser/parse.y
@@ -376,7 +376,7 @@ generated(X) ::= LP expr(E) RP. {
   X = ColumnConstraint::Generated{ expr: E, typ: None };
 }
 generated(X) ::= LP expr(E) RP ID(TYPE). {
-  X = ColumnConstraint::Generated{ expr: E, typ: Some(Id::from_token(@TYPE, TYPE)) };
+  X = ColumnConstraint::Generated{ expr: E, typ: Some(Name::from_token(@TYPE, TYPE)) };
 }
 
 // The optional AUTOINCREMENT keyword
@@ -916,24 +916,24 @@ expr(A) ::= CAST LP expr(E) AS typetoken(T) RP. {
 %endif  SQLITE_OMIT_CAST
 
 expr(A) ::= idj(X) LP distinct(D) exprlist(Y) RP. {
-  A = Expr::FunctionCall{ name: Id::from_token(@X, X), distinctness: D, args: Y, order_by: None, filter_over: None }; /*A-overwrites-X*/
+  A = Expr::FunctionCall{ name: Name::from_token(@X, X), distinctness: D, args: Y, order_by: None, filter_over: None }; /*A-overwrites-X*/
 }
 expr(A) ::= idj(X) LP distinct(D) exprlist(Y) ORDER BY sortlist(O) RP. {
-  A = Expr::FunctionCall{ name: Id::from_token(@X, X), distinctness: D, args: Y, order_by: Some(O), filter_over: None }; /*A-overwrites-X*/
+  A = Expr::FunctionCall{ name: Name::from_token(@X, X), distinctness: D, args: Y, order_by: Some(O), filter_over: None }; /*A-overwrites-X*/
 }
 expr(A) ::= idj(X) LP STAR RP. {
-  A = Expr::FunctionCallStar{ name: Id::from_token(@X, X), filter_over: None }; /*A-overwrites-X*/
+  A = Expr::FunctionCallStar{ name: Name::from_token(@X, X), filter_over: None }; /*A-overwrites-X*/
 }
 
 %ifndef SQLITE_OMIT_WINDOWFUNC
 expr(A) ::= idj(X) LP distinct(D) exprlist(Y) RP filter_over(Z). {
-  A = Expr::FunctionCall{ name: Id::from_token(@X, X), distinctness: D, args: Y, order_by: None, filter_over: Some(Z) }; /*A-overwrites-X*/
+  A = Expr::FunctionCall{ name: Name::from_token(@X, X), distinctness: D, args: Y, order_by: None, filter_over: Some(Z) }; /*A-overwrites-X*/
 }
 expr(A) ::= idj(X) LP distinct(D) exprlist(Y) ORDER BY sortlist(O) RP filter_over(Z). {
-  A = Expr::FunctionCall{ name: Id::from_token(@X, X), distinctness: D, args: Y, order_by: Some(O), filter_over: Some(Z) }; /*A-overwrites-X*/
+  A = Expr::FunctionCall{ name: Name::from_token(@X, X), distinctness: D, args: Y, order_by: Some(O), filter_over: Some(Z) }; /*A-overwrites-X*/
 }
 expr(A) ::= idj(X) LP STAR RP filter_over(Z). {
-  A = Expr::FunctionCallStar{ name: Id::from_token(@X, X), filter_over: Some(Z) }; /*A-overwrites-X*/
+  A = Expr::FunctionCallStar{ name: Name::from_token(@X, X), filter_over: Some(Z) }; /*A-overwrites-X*/
 }
 %endif
 

--- a/vendored/sqlite3-parser/third_party/lemon/lempar.rs
+++ b/vendored/sqlite3-parser/third_party/lemon/lempar.rs
@@ -214,8 +214,8 @@ impl<'input> yyParser<'input> {
         let idx = self.shift(shift);
 
         // TODO: The compiler optimizes `std::mem::take` to two `memcpy` 
-        // but `yyStackEntry` requires 168 bytes, so it is not worth it (maybe).
-        assert_eq!(std::mem::size_of::<yyStackEntry>(), 168);
+        // but `yyStackEntry` requires 208 bytes, so it is not worth it (maybe).
+        assert_eq!(std::mem::size_of::<yyStackEntry>(), 208);
         std::mem::take(&mut self.yystack[idx])
     }
 


### PR DESCRIPTION
Closes: #1947 

This PR replaces the `Name(pub String)` struct with a `Name` enum that explicitly models how the name appeared in the source either as an unquoted identifier (`Ident`) or a quoted string (`Quoted`).

In the process, the separate `Id` wrapper type has been coalesced into the `Name` enum, simplifying the AST and reducing duplication in identifier handling logic.

While this increases the size of some AST nodes (notably `yyStackEntry`).

cc: @levydsa 