### PR TITLE
pager: Clear stale page cache if database changed

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -730,7 +730,12 @@ impl Pager {
             IOResult::Done(_) => {}
             IOResult::IO => return Ok(IOResult::IO),
         }
-        Ok(IOResult::Done(self.wal.borrow_mut().begin_read_tx()?))
+        let (result, changed) = self.wal.borrow_mut().begin_read_tx()?;
+        if changed {
+            // Someone else changed the database -> assume our page cache is invalid (this is default SQLite behavior, we can probably do better with more granular invalidation)
+            self.clear_page_cache();
+        }
+        Ok(IOResult::Done(result))
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]


### PR DESCRIPTION
SQLite behavior is: if another connection has modified the DB when a read tx starts, the connection beginning the transaction must clear its page cache due to the potentiality of there being stale versions of pages in it. Evidence of this here: https://github.com/sqlite/sqlite/blob/ded1959/src/pager.c#L3258-L3260 and here: https://github.com/sqlite/sqlite/blob/master/src/wal.c#L3368-L3370

In the future, we may want to do either:
1. a more granular invalidation logic for per-conn cache, or
2. a shared versioned page cache

But right now we must follow SQLite to make our current behavior not corrupt data

Closes #2248 