### PR TITLE
Update defragment page to defragment in-place

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6565,10 +6565,11 @@ fn defragment_page(page: &PageContent, usable_space: u16) {
         let new_offset = cbrk;
         let old_offset = cell.old_offset;
 
-        // Basic corruption check.
-        if new_offset < first_cell_content_byte || old_offset + cell.size > usable_space {
-            todo!("corrupt page detected during defragmentation");
-        }
+        // Basic corruption check
+        turso_assert!(
+            new_offset < first_cell_content_byte || old_offset + cell.size > usable_space,
+            "corrupt page detected during defragmentation"
+        );
 
         // Move the cell data. `copy_within` is the idiomatic and safe
         // way to perform a `memmove` operation on a slice.

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6567,8 +6567,9 @@ fn defragment_page(page: &PageContent, usable_space: u16) {
 
         // Basic corruption check
         turso_assert!(
-            new_offset < first_cell_content_byte || old_offset + cell.size > usable_space,
-            "corrupt page detected during defragmentation"
+            new_offset >= first_cell_content_byte && old_offset + cell.size <= usable_space,
+            "corrupt page detected during defragmentation: new_offset={new_offset} first_cell_content_byte={first_cell_content_byte} old_offset={old_offset} cell.size={} usable_space={usable_space}",
+            cell.size
         );
 
         // Move the cell data. `copy_within` is the idiomatic and safe

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6533,7 +6533,9 @@ fn defragment_page(page: &PageContent, usable_space: u16) {
 
         if pc > last_offset {
             // Enable a fast path preventing the sort operation
-            // for cells that are already in a sorted order
+            // for cells that are already in a sorted order, since
+            // cell grows from right to left we check if pc is
+            // greater than the last offset
             is_physically_sorted = false;
         }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6523,7 +6523,7 @@ fn defragment_page(page: &PageContent, usable_space: u16) {
 
     // Gather cell metadata.
     let cell_offset = page.cell_pointer_array_offset();
-    let mut cells_info = Vec::with_capacity(cell_count as usize);
+    let mut cells_info = Vec::with_capacity(cell_count);
     let mut is_physically_sorted = true;
     let mut last_offset = u16::MAX;
 

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -666,8 +666,14 @@ impl PageContent {
     /// - left-most cell (the cell with the smallest key) first and
     /// - the right-most cell (the cell with the largest key) last.
     pub fn cell_pointer_array_offset_and_size(&self) -> (usize, usize) {
-        let header_size = self.header_size();
-        (self.offset + header_size, self.cell_pointer_array_size())
+        (
+            self.cell_pointer_array_offset(),
+            self.cell_pointer_array_size(),
+        )
+    }
+
+    pub fn cell_pointer_array_offset(&self) -> usize {
+        self.offset + self.header_size()
     }
 
     /// Get region(start end length) of a cell's payload


### PR DESCRIPTION
Change original code from doing a full copy of the original buffer to modify the buffer in-place using a temporary vector with offsets.