### PR TITLE
Fix schema reparse logic

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -715,7 +715,7 @@ impl Connection {
             pager.end_read_tx().expect("read txn must be finished");
         }
         // now we can safely propagate error after ensured that transaction state is reset
-        let _ = reparse_result?;
+        reparse_result?;
 
         let schema = self.schema.borrow().clone();
         self._db.update_schema_if_newer(schema)?;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5872,14 +5872,14 @@ pub fn op_parse_schema(
 
         conn.with_schema_mut(|schema| {
             // TODO: This function below is synchronous, make it async
-            parse_schema_rows(Some(stmt), schema, &conn.syms.borrow(), state.mv_tx_id)
+            parse_schema_rows(stmt, schema, &conn.syms.borrow(), state.mv_tx_id)
         })?;
     } else {
         let stmt = conn.prepare("SELECT * FROM sqlite_schema")?;
 
         conn.with_schema_mut(|schema| {
             // TODO: This function below is synchronous, make it async
-            parse_schema_rows(Some(stmt), schema, &conn.syms.borrow(), state.mv_tx_id)
+            parse_schema_rows(stmt, schema, &conn.syms.borrow(), state.mv_tx_id)
         })?;
     }
     conn.auto_commit.set(previous_auto_commit);


### PR DESCRIPTION
`maybe_reparse_schema` function introduced in the #2246 was incorrect as it didn't update `schema_version` for internal schema representation and basically updated only schema for connection which called `maybe_reparse_schema`.

This PR fixes this issue by reading schema and cookie value within a single transaction and updating both schema content and its version for internal representation.