### PR TITLE
turso-serverless: Transaction API

### DIFF
--- a/packages/turso-serverless/README.md
+++ b/packages/turso-serverless/README.md
@@ -45,6 +45,38 @@ await conn.batch([
 ]);
 ```
 
+### Transactions
+
+The driver supports interactive transactions with commit and rollback:
+
+```javascript
+// Start a transaction
+const tx = await conn.transaction();
+
+try {
+  await tx.execute("INSERT INTO users (email) VALUES (?)", [
+    "user1@example.com",
+  ]);
+  await tx.execute("INSERT INTO users (email) VALUES (?)", [
+    "user2@example.com",
+  ]);
+
+  // Commit the transaction
+  await tx.commit();
+} catch (error) {
+  // Rollback on error
+  await tx.rollback();
+}
+```
+
+Transaction modes are supported:
+
+```javascript
+const writeTx = await conn.transaction("write"); // Immediate write lock
+const readTx = await conn.transaction("read"); // Read-only transaction
+const deferredTx = await conn.transaction("deferred"); // Default mode
+```
+
 ### Compatibility layer for libSQL API
 
 This driver supports the libSQL API as a compatibility layer.

--- a/packages/turso-serverless/examples/transactions/README.md
+++ b/packages/turso-serverless/examples/transactions/README.md
@@ -1,0 +1,17 @@
+# Transactions
+
+This example demonstrates how to use transactions with Turso Cloud.
+
+## Install Dependencies
+
+```bash
+npm i
+```
+
+## Running
+
+Execute the example:
+
+```bash
+TURSO_DATABASE_URL="..." TURSO_AUTH_TOKEN="..." node index.mjs
+```

--- a/packages/turso-serverless/examples/transactions/index.mjs
+++ b/packages/turso-serverless/examples/transactions/index.mjs
@@ -1,0 +1,59 @@
+import { connect } from "@tursodatabase/serverless";
+
+const client = connect({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+await client.batch(
+  [
+    `DROP TABLE IF EXISTS accounts`,
+    `CREATE TABLE accounts (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      balance DECIMAL(10,2) NOT NULL DEFAULT 0.00
+    )`,
+  ],
+  "write",
+);
+
+await client.execute("INSERT INTO accounts (name, balance) VALUES (?, ?)", [
+  "Alice",
+  1000.0,
+]);
+await client.execute("INSERT INTO accounts (name, balance) VALUES (?, ?)", [
+  "Bob",
+  500.0,
+]);
+
+const tx = await client.transaction();
+
+try {
+  console.log("Starting money transfer...");
+
+  await tx.execute("UPDATE accounts SET balance = balance - ? WHERE name = ?", [
+    100,
+    "Alice",
+  ]);
+
+  await tx.execute("UPDATE accounts SET balance = balance + ? WHERE name = ?", [
+    100,
+    "Bob",
+  ]);
+
+  // Commit the transaction
+  await tx.commit();
+  console.log("Transaction committed successfully!");
+
+  // Check the results
+  const result = await client.execute(
+    "SELECT name, balance FROM accounts ORDER BY name",
+  );
+  console.log("Account balances after transfer:");
+  for (const row of result.rows) {
+    console.log(`  ${row[0]}: $${row[1]}`);
+  }
+} catch (error) {
+  console.error("Transaction failed:", error.message);
+  await tx.rollback();
+}

--- a/packages/turso-serverless/examples/transactions/package-lock.json
+++ b/packages/turso-serverless/examples/transactions/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "transactions",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "transactions",
+      "dependencies": {
+        "@tursodatabase/serverless": "../.."
+      }
+    },
+    "../..": {
+      "name": "@tursodatabase/serverless",
+      "version": "0.1.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.0.13",
+        "ava": "^6.4.1",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@tursodatabase/serverless": {
+      "resolved": "../..",
+      "link": true
+    }
+  }
+}

--- a/packages/turso-serverless/examples/transactions/package.json
+++ b/packages/turso-serverless/examples/transactions/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "transactions",
+  "private": true,
+  "dependencies": {
+    "@tursodatabase/serverless": "../.."
+  }
+}

--- a/packages/turso-serverless/integration-tests/serverless.test.mjs
+++ b/packages/turso-serverless/integration-tests/serverless.test.mjs
@@ -8,26 +8,26 @@ const client = connect({
 
 test.serial('execute() method creates table and inserts data', async t => {
   await client.execute('DROP TABLE IF EXISTS test_users');
-  
+
   await client.execute('CREATE TABLE test_users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)');
-  
+
   const insertResult = await client.execute(
     'INSERT INTO test_users (name, email) VALUES (?, ?)',
     ['John Doe', 'john@example.com']
   );
-  
+
   t.is(insertResult.rowsAffected, 1);
   t.is(typeof insertResult.lastInsertRowid, 'number');
 });
 
 test.serial('execute() method queries data correctly', async t => {
   const queryResult = await client.execute('SELECT * FROM test_users WHERE name = ?', ['John Doe']);
-  
+
   t.is(queryResult.columns.length, 3);
   t.true(queryResult.columns.includes('id'));
   t.true(queryResult.columns.includes('name'));
   t.true(queryResult.columns.includes('email'));
-  
+
   t.is(queryResult.rows.length, 1);
   t.is(queryResult.rows[0][1], 'John Doe');
   t.is(queryResult.rows[0][2], 'john@example.com');
@@ -35,11 +35,11 @@ test.serial('execute() method queries data correctly', async t => {
 
 test.serial('prepare() method creates statement', async t => {
   const stmt = client.prepare('SELECT * FROM test_users WHERE name = ?');
-  
+
   const row = await stmt.get(['John Doe']);
   t.is(row[1], 'John Doe');
   t.is(row[2], 'john@example.com');
-  
+
   const rows = await stmt.all(['John Doe']);
   t.is(rows.length, 1);
   t.is(rows[0][1], 'John Doe');
@@ -55,37 +55,37 @@ test.serial('statement iterate() method works', async t => {
   // Ensure test data exists
   await client.execute('CREATE TABLE IF NOT EXISTS test_users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)');
   await client.execute('INSERT OR IGNORE INTO test_users (name, email) VALUES (?, ?)', ['John Doe', 'john@example.com']);
-  
+
   const stmt = client.prepare('SELECT * FROM test_users');
-  
+
   const rows = [];
   for await (const row of stmt.iterate()) {
     rows.push(row);
   }
-  
+
   t.true(rows.length >= 1);
   t.is(rows[0][1], 'John Doe');
 });
 
 test.serial('batch() method executes multiple statements', async t => {
   await client.execute('DROP TABLE IF EXISTS test_products');
-  
+
   const batchResult = await client.batch([
     'CREATE TABLE test_products (id INTEGER PRIMARY KEY, name TEXT, price REAL)',
     'INSERT INTO test_products (name, price) VALUES ("Widget", 9.99)',
     'INSERT INTO test_products (name, price) VALUES ("Gadget", 19.99)',
     'INSERT INTO test_products (name, price) VALUES ("Tool", 29.99)'
   ]);
-  
+
   t.is(batchResult.rowsAffected, 3);
-  
+
   const queryResult = await client.execute('SELECT COUNT(*) as count FROM test_products');
   t.is(queryResult.rows[0][0], 3);
 });
 
 test.serial('execute() method queries a single value', async t => {
   const rs = await client.execute('SELECT 42');
-  
+
   t.is(rs.columns.length, 1);
   t.is(rs.columnTypes.length, 1);
   t.is(rs.rows.length, 1);
@@ -97,7 +97,7 @@ test.serial('execute() method queries a single row', async t => {
   const rs = await client.execute(
     "SELECT 1 AS one, 'two' AS two, 0.5 AS three"
   );
-  
+
   t.deepEqual(rs.columns, ["one", "two", "three"]);
   t.deepEqual(rs.columnTypes, ["", "", ""]);
   t.is(rs.rows.length, 1);
@@ -110,7 +110,7 @@ test.serial('execute() method queries a single row', async t => {
     ["1", "two"],
     ["2", 0.5],
   ]);
-  
+
   // Test column name access
   t.is(r.one, 1);
   t.is(r.two, "two");
@@ -122,4 +122,100 @@ test.serial('error handling works correctly', async t => {
     () => client.execute('SELECT * FROM nonexistent_table')
   );
   t.regex(error.message, /SQLite error.*no such table|no such table|HTTP error/);
+});
+test.serial("transaction() method creates transaction", async (t) => {
+  await client.execute("DROP TABLE IF EXISTS test_transactions");
+  await client.execute(
+    "CREATE TABLE test_transactions (id INTEGER PRIMARY KEY, value INTEGER)",
+  );
+
+  const tx = await client.transaction();
+  t.false(tx.closed);
+
+  await tx.execute("INSERT INTO test_transactions (value) VALUES (?)", [100]);
+  await tx.execute("INSERT INTO test_transactions (value) VALUES (?)", [200]);
+  await tx.commit();
+
+  t.true(tx.closed);
+  t.true(tx.committed);
+
+  const result = await client.execute(
+    "SELECT COUNT(*) as count FROM test_transactions",
+  );
+  t.is(result.rows[0][0], 2);
+});
+
+test.serial("transaction rollback works correctly", async (t) => {
+  await client.execute("DELETE FROM test_transactions");
+
+  const tx = await client.transaction();
+  await tx.execute("INSERT INTO test_transactions (value) VALUES (?)", [300]);
+  await tx.execute("INSERT INTO test_transactions (value) VALUES (?)", [400]);
+  await tx.rollback();
+
+  t.true(tx.closed);
+  t.true(tx.rolledBack);
+
+  const result = await client.execute(
+    "SELECT COUNT(*) as count FROM test_transactions",
+  );
+  t.is(result.rows[0][0], 0);
+});
+
+test.serial("transaction batch() method works", async (t) => {
+  await client.execute("DELETE FROM test_transactions");
+
+  const tx = await client.transaction();
+  await tx.batch([
+    "INSERT INTO test_transactions (value) VALUES (500)",
+    "INSERT INTO test_transactions (value) VALUES (600)",
+  ]);
+  await tx.commit();
+
+  const result = await client.execute(
+    "SELECT COUNT(*) as count FROM test_transactions",
+  );
+  t.is(result.rows[0][0], 2);
+});
+
+test.serial("transaction error handling works", async (t) => {
+  const tx = await client.transaction();
+
+  const error = await t.throwsAsync(() =>
+    tx.execute("SELECT * FROM nonexistent_table"),
+  );
+  t.regex(
+    error.message,
+    /SQLite error.*no such table|no such table|HTTP error/,
+  );
+
+  await tx.rollback();
+});
+
+test.serial("transaction close() method works", async (t) => {
+  const tx = await client.transaction();
+  await tx.execute("INSERT INTO test_transactions (value) VALUES (700)");
+
+  tx.close();
+  t.true(tx.closed);
+
+  // Changes should be rolled back
+  const result = await client.execute(
+    "SELECT COUNT(*) as count FROM test_transactions WHERE value = 700",
+  );
+  t.is(result.rows[0][0], 0);
+});
+
+test.serial("transaction modes work correctly", async (t) => {
+  const writeModeTx = await client.transaction("write");
+  t.false(writeModeTx.closed);
+  await writeModeTx.rollback();
+
+  const readModeTx = await client.transaction("read");
+  t.false(readModeTx.closed);
+  await readModeTx.rollback();
+
+  const deferredTx = await client.transaction("deferred");
+  t.false(deferredTx.closed);
+  await deferredTx.rollback();
 });

--- a/packages/turso-serverless/src/connection.ts
+++ b/packages/turso-serverless/src/connection.ts
@@ -1,5 +1,6 @@
 import { Session, type SessionConfig } from './session.js';
 import { Statement } from './statement.js';
+import { Transaction, TransactionMode } from './transaction.js';
 
 /**
  * Configuration options for connecting to a Turso database.
@@ -8,7 +9,7 @@ export interface Config extends SessionConfig {}
 
 /**
  * A connection to a Turso database.
- * 
+ *
  * Provides methods for executing SQL statements and managing prepared statements.
  * Uses the SQL over HTTP protocol with streaming cursor support for optimal performance.
  */
@@ -23,12 +24,12 @@ export class Connection {
 
   /**
    * Prepare a SQL statement for execution.
-   * 
+   *
    * Each prepared statement gets its own session to avoid conflicts during concurrent execution.
-   * 
+   *
    * @param sql - The SQL statement to prepare
    * @returns A Statement object that can be executed multiple ways
-   * 
+   *
    * @example
    * ```typescript
    * const stmt = client.prepare("SELECT * FROM users WHERE id = ?");
@@ -42,11 +43,11 @@ export class Connection {
 
   /**
    * Execute a SQL statement and return all results.
-   * 
+   *
    * @param sql - The SQL statement to execute
    * @param args - Optional array of parameter values
    * @returns Promise resolving to the complete result set
-   * 
+   *
    * @example
    * ```typescript
    * const result = await client.execute("SELECT * FROM users");
@@ -60,11 +61,11 @@ export class Connection {
 
   /**
    * Execute multiple SQL statements in a batch.
-   * 
+   *
    * @param statements - Array of SQL statements to execute
    * @param mode - Optional transaction mode (currently unused)
    * @returns Promise resolving to batch execution results
-   * 
+   *
    * @example
    * ```typescript
    * await client.batch([
@@ -77,18 +78,40 @@ export class Connection {
   async batch(statements: string[], mode?: string): Promise<any> {
     return this.session.batch(statements);
   }
+
+  /**
+    * Begin a new transaction.
+    *
+    * @param mode - Optional transaction mode (write, read, or deferred)
+    * @returns Promise resolving to a new Transaction instance
+    *
+    * @example
+    * ```typescript
+    * const tx = await client.transaction();
+    * try {
+    *   await tx.execute("INSERT INTO users (name) VALUES (?)", ["Alice"]);
+    *   await tx.execute("INSERT INTO users (name) VALUES (?)", ["Bob"]);
+    *   await tx.commit();
+    * } catch (error) {
+    *   await tx.rollback();
+    * }
+    * ```
+    */
+  async transaction(mode: TransactionMode = "deferred"): Promise<Transaction> {
+    return Transaction.create(this.config, mode);
+  }
 }
 
 /**
  * Create a new connection to a Turso database.
- * 
+ *
  * @param config - Configuration object with database URL and auth token
  * @returns A new Connection instance
- * 
+ *
  * @example
  * ```typescript
  * import { connect } from "@tursodatabase/serverless";
- * 
+ *
  * const client = connect({
  *   url: process.env.TURSO_DATABASE_URL,
  *   authToken: process.env.TURSO_AUTH_TOKEN

--- a/packages/turso-serverless/src/index.ts
+++ b/packages/turso-serverless/src/index.ts
@@ -2,3 +2,4 @@
 export { Connection, connect, type Config } from './connection.js';
 export { Statement } from './statement.js';
 export { DatabaseError } from './error.js';
+export { Transaction, type TransactionMode } from './transaction.js';

--- a/packages/turso-serverless/src/transaction.ts
+++ b/packages/turso-serverless/src/transaction.ts
@@ -1,0 +1,235 @@
+import { Session, type SessionConfig } from "./session.js";
+import { DatabaseError } from "./error.js";
+
+/**
+ * Transaction mode for controlling transaction behavior.
+ */
+export type TransactionMode = "write" | "read" | "deferred";
+
+/**
+ * Transactions use a dedicated session to maintain state across multiple operations.
+ * All operations within a transaction are executed atomically - they either all
+ * succeed or all fail.
+ */
+export class Transaction {
+  private session: Session;
+  private _closed = false;
+  private _committed = false;
+  private _rolledBack = false;
+
+  private constructor(
+    sessionConfig: SessionConfig,
+    mode: TransactionMode = "deferred",
+  ) {
+    this.session = new Session(sessionConfig);
+  }
+
+  /**
+   * Create a new transaction instance.
+   *
+   * @param sessionConfig - Session configuration
+   * @param mode - Transaction mode
+   * @returns Promise resolving to a new Transaction instance
+   */
+  static async create(
+    sessionConfig: SessionConfig,
+    mode: TransactionMode = "deferred",
+  ): Promise<Transaction> {
+    const transaction = new Transaction(sessionConfig, mode);
+    await transaction.initializeTransaction(mode);
+    return transaction;
+  }
+
+  private async initializeTransaction(mode: TransactionMode): Promise<void> {
+    let beginStatement: string;
+
+    switch (mode) {
+      case "write":
+        beginStatement = "BEGIN IMMEDIATE";
+        break;
+      case "read":
+        beginStatement = "BEGIN";
+        break;
+      case "deferred":
+      default:
+        beginStatement = "BEGIN DEFERRED";
+        break;
+    }
+
+    await this.session.execute(beginStatement);
+  }
+
+  /**
+   * Execute a SQL statement within the transaction.
+   *
+   * @param sql - The SQL statement to execute
+   * @param args - Optional array of parameter values
+   * @returns Promise resolving to the complete result set
+   *
+   * @example
+   * ```typescript
+   * const tx = await client.transaction();
+   * const result = await tx.execute("INSERT INTO users (name) VALUES (?)", ["Alice"]);
+   * await tx.commit();
+   * ```
+   */
+  async execute(sql: string, args: any[] = []): Promise<any> {
+    this.checkState();
+    return this.session.execute(sql, args);
+  }
+
+  /**
+   * Execute multiple SQL statements as a batch within the transaction.
+   *
+   * @param statements - Array of SQL statements to execute
+   * @returns Promise resolving to batch execution results
+   *
+   * @example
+   * ```typescript
+   * const tx = await client.transaction();
+   * await tx.batch([
+   *   "INSERT INTO users (name) VALUES ('Alice')",
+   *   "INSERT INTO users (name) VALUES ('Bob')"
+   * ]);
+   * await tx.commit();
+   * ```
+   */
+  async batch(statements: string[]): Promise<any> {
+    this.checkState();
+    return this.session.batch(statements);
+  }
+
+  /**
+   * Execute a SQL statement and return the raw response and entries.
+   *
+   * @param sql - The SQL statement to execute
+   * @param args - Optional array of parameter values
+   * @returns Promise resolving to the raw response and cursor entries
+   */
+  async executeRaw(
+    sql: string,
+    args: any[] = [],
+  ): Promise<{ response: any; entries: AsyncGenerator<any> }> {
+    this.checkState();
+    return this.session.executeRaw(sql, args);
+  }
+
+  /**
+   * Commit the transaction, making all changes permanent.
+   *
+   * @returns Promise that resolves when the transaction is committed
+   *
+   * @example
+   * ```typescript
+   * const tx = await client.transaction();
+   * await tx.execute("INSERT INTO users (name) VALUES (?)", ["Alice"]);
+   * await tx.commit(); // Changes are now permanent
+   * ```
+   */
+  async commit(): Promise<void> {
+    this.checkState();
+
+    try {
+      await this.session.execute("COMMIT");
+      this._committed = true;
+      this._closed = true;
+    } catch (error) {
+      // If commit fails, the transaction is still open
+      if (error instanceof Error) {
+        throw new DatabaseError(error.message);
+      }
+      throw new DatabaseError('Transaction commit failed');
+    }
+  }
+
+  /**
+   * Rollback the transaction, undoing all changes.
+   *
+   * @returns Promise that resolves when the transaction is rolled back
+   *
+   * @example
+   * ```typescript
+   * const tx = await client.transaction();
+   * try {
+   *   await tx.execute("INSERT INTO users (name) VALUES (?)", ["Alice"]);
+   *   await tx.execute("INSERT INTO invalid_table VALUES (1)"); // This will fail
+   *   await tx.commit();
+   * } catch (error) {
+   *   await tx.rollback(); // Undo the first INSERT
+   * }
+   * ```
+   */
+  async rollback(): Promise<void> {
+    if (this._closed) {
+      return; // Already closed, nothing to rollback
+    }
+
+    try {
+      await this.session.execute("ROLLBACK");
+    } catch (error) {
+      // Rollback errors are generally not critical - the transaction is abandoned anyway
+    } finally {
+      this._rolledBack = true;
+      this._closed = true;
+    }
+  }
+
+  /**
+   * Close the transaction without committing or rolling back.
+   *
+   * This will automatically rollback any uncommitted changes.
+   * It's safe to call this method multiple times.
+   */
+  close(): void {
+    if (!this._closed) {
+      // Async rollback - don't wait for it to complete
+      this.rollback().catch(() => {
+        // Ignore rollback errors on close
+      });
+    }
+  }
+
+  /**
+   * Check if the transaction is closed.
+   *
+   * @returns True if the transaction has been committed, rolled back, or closed
+   */
+  get closed(): boolean {
+    return this._closed;
+  }
+
+  /**
+   * Check if the transaction has been committed.
+   *
+   * @returns True if the transaction has been successfully committed
+   */
+  get committed(): boolean {
+    return this._committed;
+  }
+
+  /**
+   * Check if the transaction has been rolled back.
+   *
+   * @returns True if the transaction has been rolled back
+   */
+  get rolledBack(): boolean {
+    return this._rolledBack;
+  }
+
+  /**
+   * Check transaction state and throw if it's not valid for operations.
+   *
+   * @throws Error if the transaction is closed
+   */
+  private checkState(): void {
+    if (this._closed) {
+      if (this._committed) {
+        throw new DatabaseError("Transaction has already been committed");
+      } else if (this._rolledBack) {
+        throw new DatabaseError("Transaction has already been rolled back");
+      } else {
+        throw new DatabaseError("Transaction has been closed");
+      }
+    }
+  }
+}


### PR DESCRIPTION
@penberg shared on Slack:

> Can you send your transaction stuff as PR to turso.git? Even if it's not perfect, better to have them in tree than bit-rotting away in your private stash somewhere

Here is that code... I haven't touched this in a few weeks, but I did quickly add `DatabaseError` after seeing that just now.

This folder would benefit from some Biome (or very least, Prettier) rules, to reduce further noise in PRs.