### PR TITLE
Accumulate/batch vectored writes when backfilling during checkpoint

### DIFF
--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -701,12 +701,14 @@ impl turso_core::DatabaseStorage for DatabaseFile {
     }
     fn write_pages(
         &self,
-        _first_page_idx: usize,
-        _page_size: usize,
-        _buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
-        _c: turso_core::Completion,
+        page_idx: usize,
+        page_size: usize,
+        buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
+        c: turso_core::Completion,
     ) -> turso_core::Result<()> {
-        todo!();
+        let pos = (page_idx - 1) * page_size;
+        self.file.pwritev(pos, buffers, c.into())?;
+        Ok(())
     }
 
     fn sync(&self, c: turso_core::Completion) -> turso_core::Result<()> {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -699,6 +699,15 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         self.file.pwrite(pos, buffer, c.into())?;
         Ok(())
     }
+    fn write_pages(
+        &self,
+        _first_page_idx: usize,
+        _page_size: usize,
+        _buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
+        _c: turso_core::Completion,
+    ) -> turso_core::Result<()> {
+        todo!();
+    }
 
     fn sync(&self, c: turso_core::Completion) -> turso_core::Result<()> {
         let _ = self.file.sync(c.into())?;

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -370,6 +370,15 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         self.file.pwrite(pos, buffer, c.into())?;
         Ok(())
     }
+    fn write_pages(
+        &self,
+        _first_page_idx: usize,
+        _page_size: usize,
+        _buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
+        _c: turso_core::Completion,
+    ) -> Result<()> {
+        todo!();
+    }
 
     fn sync(&self, c: turso_core::Completion) -> Result<()> {
         let _ = self.file.sync(c.into())?;

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -249,6 +249,22 @@ impl turso_core::File for File {
         #[allow(clippy::arc_with_non_send_sync)]
         Ok(c)
     }
+    fn pwritev(
+        &self,
+        pos: usize,
+        buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
+        c: Arc<turso_core::Completion>,
+    ) -> Result<Arc<turso_core::Completion>> {
+        let mut total_written = 0;
+        for buffer in buffers {
+            let buf = buffer.borrow();
+            let buf: &[u8] = buf.as_slice();
+            total_written += self.vfs.pwrite(self.fd, buf, pos + total_written) as usize;
+        }
+        c.complete(total_written as i32);
+        #[allow(clippy::arc_with_non_send_sync)]
+        Ok(c)
+    }
 
     fn sync(&self, c: Arc<turso_core::Completion>) -> Result<Arc<turso_core::Completion>> {
         self.vfs.sync(self.fd);
@@ -372,12 +388,14 @@ impl turso_core::DatabaseStorage for DatabaseFile {
     }
     fn write_pages(
         &self,
-        _first_page_idx: usize,
-        _page_size: usize,
-        _buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
-        _c: turso_core::Completion,
+        page_idx: usize,
+        page_size: usize,
+        buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
+        c: turso_core::Completion,
     ) -> Result<()> {
-        todo!();
+        let pos = (page_idx - 1) * page_size;
+        self.file.pwritev(pos, buffers, c.into())?;
+        Ok(())
     }
 
     fn sync(&self, c: turso_core::Completion) -> Result<()> {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,7 @@ default = ["fs", "uuid", "time", "json", "series"]
 fs = ["turso_ext/vfs"]
 json = []
 uuid = ["dep:uuid"]
-io_uring = ["dep:io-uring", "rustix/io_uring", "dep:libc"]
+io_uring = ["dep:io-uring", "rustix/io_uring"]
 time = []
 fuzz = []
 omit_autovacuum = []
@@ -29,10 +29,12 @@ series = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.5", optional = true }
+libc = { version = "0.2.172" }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 polling = "3.7.4"
 rustix = { version = "1.0.5", features = ["fs"] }
+libc = { version = "0.2.172" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 mimalloc = { version = "0.1.46", default-features = false }
@@ -44,7 +46,6 @@ turso_ext = { workspace = true, features = ["core_only"] }
 cfg_block = "0.1.1"
 fallible-iterator = "0.3.0"
 hex = "0.4.3"
-libc = { version = "0.2.172", optional = true }
 turso_sqlite3_parser = { workspace = true }
 thiserror = "1.0.61"
 getrandom = { version = "0.2.15" }

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -5,34 +5,16 @@ use crate::io::clock::{Clock, Instant};
 use crate::{LimboError, MemoryIO, Result};
 use rustix::fs::{self, FlockOperation, OFlags};
 use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::fmt;
+use std::collections::{HashMap, VecDeque};
 use std::io::ErrorKind;
 use std::os::fd::AsFd;
 use std::os::unix::io::AsRawFd;
 use std::rc::Rc;
 use std::sync::Arc;
-use thiserror::Error;
 use tracing::{debug, trace};
 
 const ENTRIES: u32 = 512;
 const SQPOLL_IDLE: u32 = 1000;
-
-#[derive(Debug, Error)]
-enum UringIOError {
-    IOUringCQError(i32),
-}
-
-impl fmt::Display for UringIOError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            UringIOError::IOUringCQError(code) => write!(
-                f,
-                "IOUring completion queue error occurred with code {code}",
-            ),
-        }
-    }
-}
 
 pub struct UringIO {
     inner: Rc<RefCell<InnerUringIO>>,
@@ -44,6 +26,7 @@ unsafe impl Sync for UringIO {}
 struct WrappedIOUring {
     ring: io_uring::IoUring,
     pending_ops: usize,
+    writev_states: HashMap<u64, WritevState>,
 }
 
 struct InnerUringIO {
@@ -68,6 +51,7 @@ impl UringIO {
             ring: WrappedIOUring {
                 ring,
                 pending_ops: 0,
+                writev_states: HashMap::new(),
             },
             free_files: (0..8).collect(),
         };
@@ -75,6 +59,86 @@ impl UringIO {
         Ok(Self {
             inner: Rc::new(RefCell::new(inner)),
         })
+    }
+}
+
+macro_rules! with_fd {
+    ($file:expr, |$fd:ident| $body:expr) => {
+        match $file.id {
+            Some(id) => {
+                let $fd = io_uring::types::Fixed(id);
+                $body
+            }
+            None => {
+                let $fd = io_uring::types::Fd($file.file.as_raw_fd());
+                $body
+            }
+        }
+    };
+}
+
+struct WritevState {
+    // fixed fd slot or 0xFFFF_FFFF if none
+    file_id: u32,
+    // absolute file offset for next submit
+    pos: usize,
+    // current buffer index in `bufs`
+    idx: usize,
+    // intra-buffer offset
+    off: usize,
+    bufs: Vec<Arc<RefCell<crate::Buffer>>>,
+    // completion returned to caller
+    user_c: Arc<Completion>,
+    // we keep the last iovec allocation alive until CQE:
+    // raw ptr to Box<[iovec]>
+    last_iov: *mut libc::iovec,
+    last_iov_len: usize,
+}
+
+impl WritevState {
+    fn remaining(&self) -> usize {
+        let mut total = 0;
+        for (i, b) in self.bufs.iter().enumerate().skip(self.idx) {
+            let r = b.borrow();
+            let len = r.len();
+            total += if i == self.idx { len - self.off } else { len };
+        }
+        total
+    }
+
+    /// Advance (idx, off, pos) after written bytes
+    fn advance(&mut self, written: usize) {
+        let mut rem = written;
+        while rem > 0 {
+            let len = {
+                let r = self.bufs[self.idx].borrow();
+                r.len()
+            };
+            let left = len - self.off;
+            if rem < left {
+                self.off += rem;
+                self.pos += rem;
+                rem = 0;
+            } else {
+                rem -= left;
+                self.pos += left;
+                self.idx += 1;
+                self.off = 0;
+            }
+        }
+    }
+
+    fn free_last_iov(&mut self) {
+        if !self.last_iov.is_null() {
+            unsafe {
+                drop(Box::from_raw(core::slice::from_raw_parts_mut(
+                    self.last_iov,
+                    self.last_iov_len,
+                )))
+            };
+            self.last_iov = core::ptr::null_mut();
+            self.last_iov_len = 0;
+        }
     }
 }
 
@@ -131,6 +195,41 @@ impl WrappedIOUring {
     fn empty(&self) -> bool {
         self.pending_ops == 0
     }
+
+    fn submit_writev(&mut self, key: u64) {
+        let st = self.writev_states.get_mut(&key).expect("state must exist");
+        // build iovecs for the remaining slice (respect UIO_MAXIOV)
+        const MAX_IOV: usize = libc::UIO_MAXIOV as usize;
+        let mut iov = Vec::with_capacity(MAX_IOV);
+        for (i, b) in st.bufs.iter().enumerate().skip(st.idx).take(MAX_IOV) {
+            let r = b.borrow();
+            let s = r.as_slice();
+            let slice = if i == st.idx { &s[st.off..] } else { s };
+            if slice.is_empty() {
+                continue;
+            }
+            iov.push(libc::iovec {
+                iov_base: slice.as_ptr() as *mut _,
+                iov_len: slice.len(),
+            });
+        }
+
+        // keep iov alive until CQE
+        let boxed = iov.into_boxed_slice();
+        let ptr = boxed.as_ptr() as *mut libc::iovec;
+        let len = boxed.len();
+        st.free_last_iov();
+        st.last_iov = ptr;
+        st.last_iov_len = len;
+        // leak; freed when CQE processed
+        let _ = Box::into_raw(boxed);
+        let entry =
+            io_uring::opcode::Writev::new(io_uring::types::Fixed(st.file_id), ptr, len as u32)
+                .offset(st.pos as u64)
+                .build()
+                .user_data(key);
+        self.submit_entry(&entry);
+    }
 }
 
 #[inline(always)]
@@ -184,34 +283,56 @@ impl IO for UringIO {
     }
 
     fn run_once(&self) -> Result<()> {
-        trace!("run_once()");
-        let mut inner = self.inner.borrow_mut();
-        let ring = &mut inner.ring;
+        {
+            let mut inner = self.inner.borrow_mut();
+            let ring = &mut inner.ring;
 
-        if ring.empty() {
-            return Ok(());
-        }
-
-        ring.wait_for_completion()?;
-        while let Some(cqe) = ring.ring.completion().next() {
-            ring.pending_ops -= 1;
-            let result = cqe.result();
-            if result < 0 {
-                return Err(LimboError::UringIOError(format!(
-                    "{} cqe: {:?}",
-                    UringIOError::IOUringCQError(result),
-                    cqe
-                )));
+            if ring.empty() {
+                return Ok(());
             }
-            let ud = cqe.user_data();
-            if ud == 0 {
-                // we currently don't have any linked timeouts or cancelations, but just in case
-                // lets guard against this case
-                tracing::error!("Received completion with user_data 0");
+            ring.wait_for_completion()?;
+        }
+        loop {
+            let (had, user_data, result) = {
+                let mut inner = self.inner.borrow_mut();
+                let mut cq = inner.ring.ring.completion();
+                if let Some(cqe) = cq.next() {
+                    (true, cqe.user_data(), cqe.result())
+                } else {
+                    (false, 0, 0)
+                }
+            }; // cq dropped here
+
+            if !had {
+                break;
+            }
+            self.inner.borrow_mut().ring.pending_ops -= 1;
+            if user_data == 0 {
+                tracing::error!("CQE with user_data = 0");
                 continue;
             }
-            completion_from_key(ud).complete(result);
+
+            let mut inner = self.inner.borrow_mut();
+            if let Some(mut st) = inner.ring.writev_states.remove(&user_data) {
+                if result < 0 {
+                    st.free_last_iov();
+                    st.user_c.complete(result);
+                } else {
+                    let written = result as usize;
+                    st.free_last_iov();
+                    st.advance(written);
+                    if st.remaining() == 0 {
+                        st.user_c.complete(st.pos as i32);
+                    } else {
+                        inner.ring.writev_states.insert(user_data, st);
+                        inner.ring.submit_writev(user_data); // safe: no CQ borrow alive
+                    }
+                }
+            } else {
+                completion_from_key(user_data).complete(result);
+            }
         }
+
         Ok(())
     }
 
@@ -244,21 +365,6 @@ pub struct UringFile {
 
 unsafe impl Send for UringFile {}
 unsafe impl Sync for UringFile {}
-
-macro_rules! with_fd {
-    ($file:expr, |$fd:ident| $body:expr) => {
-        match $file.id {
-            Some(id) => {
-                let $fd = io_uring::types::Fixed(id);
-                $body
-            }
-            None => {
-                let $fd = io_uring::types::Fd($file.file.as_raw_fd());
-                $body
-            }
-        }
-    };
-}
 
 impl File for UringFile {
     fn lock_file(&self, exclusive: bool) -> Result<()> {
@@ -342,46 +448,26 @@ impl File for UringFile {
         &self,
         pos: usize,
         bufs: Vec<Arc<RefCell<crate::Buffer>>>,
-        c: Arc<Completion>,
+        user_c: Arc<Completion>,
     ) -> Result<Arc<Completion>> {
-        // build iovecs
-        let mut iovs: Vec<libc::iovec> = Vec::with_capacity(bufs.len());
-        for b in &bufs {
-            let rb = b.borrow();
-            iovs.push(libc::iovec {
-                iov_base: rb.as_ptr() as *mut _,
-                iov_len: rb.len(),
-            });
-        }
-        // keep iovecs alive until completion
-        let boxed_iovs = iovs.into_boxed_slice();
-        let iov_ptr = boxed_iovs.as_ptr();
-        let iov_len = boxed_iovs.len() as u32;
-        // leak now, free in completion
-        let raw_iovs = Box::into_raw(boxed_iovs);
-
-        let comp = {
-            // wrap original completion to free resources
-            let orig = c.clone();
-            Box::new(move |res: i32| {
-                // reclaim iovecs
-                unsafe {
-                    let _ = Box::from_raw(raw_iovs);
-                }
-                // forward to user closure
-                orig.complete(res);
-            })
-        };
-        let c = Arc::new(Completion::new_write(comp));
+        // create state
+        let key = get_key(user_c.clone());
         let mut io = self.io.borrow_mut();
-        let e = with_fd!(self, |fd| {
-            io_uring::opcode::Writev::new(fd, iov_ptr, iov_len)
-                .offset(pos as u64)
-                .build()
-                .user_data(get_key(c.clone()))
-        });
-        io.ring.submit_entry(&e);
-        Ok(c)
+
+        let state = WritevState {
+            file_id: self.id.unwrap_or(u32::MAX),
+            pos,
+            idx: 0,
+            off: 0,
+            bufs,
+            user_c: user_c.clone(),
+            last_iov: core::ptr::null_mut(),
+            last_iov_len: 0,
+        };
+        io.ring.writev_states.insert(key, state);
+        io.ring.submit_writev(key);
+
+        Ok(user_c.clone())
     }
 
     fn sync(&self, c: Arc<Completion>) -> Result<Arc<Completion>> {

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -44,8 +44,6 @@ unsafe impl Sync for UringIO {}
 struct WrappedIOUring {
     ring: io_uring::IoUring,
     pending_ops: usize,
-    pub pending: [Option<Arc<Completion>>; ENTRIES as usize + 1],
-    key: u64,
 }
 
 struct InnerUringIO {
@@ -70,8 +68,6 @@ impl UringIO {
             ring: WrappedIOUring {
                 ring,
                 pending_ops: 0,
-                pending: [const { None }; ENTRIES as usize + 1],
-                key: 0,
             },
             free_files: (0..8).collect(),
         };
@@ -106,47 +102,45 @@ impl InnerUringIO {
 }
 
 impl WrappedIOUring {
-    fn submit_entry(&mut self, entry: &io_uring::squeue::Entry, c: Arc<Completion>) {
+    fn submit_entry(&mut self, entry: &io_uring::squeue::Entry) {
         trace!("submit_entry({:?})", entry);
-        self.pending[entry.get_user_data() as usize] = Some(c);
         unsafe {
-            self.ring
-                .submission()
-                .push(entry)
-                .expect("submission queue is full");
+            let mut sub = self.ring.submission_shared();
+            match sub.push(entry) {
+                Ok(_) => self.pending_ops += 1,
+                Err(e) => {
+                    tracing::error!("Failed to submit entry: {e}");
+                    self.ring.submit().expect("failed to submit entry");
+                    sub.push(entry).expect("failed to push entry after submit");
+                    self.pending_ops += 1;
+                }
+            }
         }
-        self.pending_ops += 1;
     }
 
     fn wait_for_completion(&mut self) -> Result<()> {
-        self.ring.submit_and_wait(1)?;
-        Ok(())
-    }
-
-    fn get_completion(&mut self) -> Option<io_uring::cqueue::Entry> {
-        // NOTE: This works because CompletionQueue's next function pops the head of the queue. This is not normal behaviour of iterators
-        let entry = self.ring.completion().next();
-        if entry.is_some() {
-            trace!("get_completion({:?})", entry);
-            // consumed an entry from completion queue, update pending_ops
-            self.pending_ops -= 1;
+        if self.pending_ops == 0 {
+            return Ok(());
         }
-        entry
+        let wants = std::cmp::min(self.pending_ops, 8);
+        tracing::info!("Waiting for {wants} pending operations to complete");
+        self.ring.submit_and_wait(wants)?;
+        Ok(())
     }
 
     fn empty(&self) -> bool {
         self.pending_ops == 0
     }
+}
 
-    fn get_key(&mut self) -> u64 {
-        self.key += 1;
-        if self.key == ENTRIES as u64 {
-            let key = self.key;
-            self.key = 0;
-            return key;
-        }
-        self.key
-    }
+#[inline(always)]
+fn get_key(c: Arc<Completion>) -> u64 {
+    Arc::into_raw(c) as u64
+}
+
+#[inline(always)]
+fn completion_from_key(key: u64) -> Arc<Completion> {
+    unsafe { Arc::from_raw(key as *const Completion) }
 }
 
 impl IO for UringIO {
@@ -199,7 +193,8 @@ impl IO for UringIO {
         }
 
         ring.wait_for_completion()?;
-        while let Some(cqe) = ring.get_completion() {
+        while let Some(cqe) = ring.ring.completion().next() {
+            ring.pending_ops -= 1;
             let result = cqe.result();
             if result < 0 {
                 return Err(LimboError::UringIOError(format!(
@@ -208,12 +203,14 @@ impl IO for UringIO {
                     cqe
                 )));
             }
-            {
-                if let Some(c) = ring.pending[cqe.user_data() as usize].as_ref() {
-                    c.complete(cqe.result());
-                }
+            let ud = cqe.user_data();
+            if ud == 0 {
+                // we currently don't have any linked timeouts or cancelations, but just in case
+                // lets guard against this case
+                tracing::error!("Received completion with user_data 0");
+                continue;
             }
-            ring.pending[cqe.user_data() as usize] = None;
+            completion_from_key(ud).complete(result);
         }
         Ok(())
     }
@@ -313,10 +310,10 @@ impl File for UringFile {
                 io_uring::opcode::Read::new(fd, buf, len as u32)
                     .offset(pos as u64)
                     .build()
-                    .user_data(io.ring.get_key())
+                    .user_data(get_key(c.clone()))
             })
         };
-        io.ring.submit_entry(&read_e, c.clone());
+        io.ring.submit_entry(&read_e);
         Ok(c)
     }
 
@@ -334,18 +331,56 @@ impl File for UringFile {
                 io_uring::opcode::Write::new(fd, buf.as_ptr(), buf.len() as u32)
                     .offset(pos as u64)
                     .build()
-                    .user_data(io.ring.get_key())
+                    .user_data(get_key(c.clone()))
             })
         };
-        let c_uring = c.clone();
-        io.ring.submit_entry(
-            &write,
-            Arc::new(Completion::new_write(move |result| {
-                c_uring.complete(result);
-                // NOTE: Explicitly reference buffer to ensure it lives until here
-                let _ = buffer.borrow();
-            })),
-        );
+        io.ring.submit_entry(&write);
+        Ok(c)
+    }
+
+    fn pwritev(
+        &self,
+        pos: usize,
+        bufs: Vec<Arc<RefCell<crate::Buffer>>>,
+        c: Arc<Completion>,
+    ) -> Result<Arc<Completion>> {
+        // build iovecs
+        let mut iovs: Vec<libc::iovec> = Vec::with_capacity(bufs.len());
+        for b in &bufs {
+            let rb = b.borrow();
+            iovs.push(libc::iovec {
+                iov_base: rb.as_ptr() as *mut _,
+                iov_len: rb.len(),
+            });
+        }
+        // keep iovecs alive until completion
+        let boxed_iovs = iovs.into_boxed_slice();
+        let iov_ptr = boxed_iovs.as_ptr();
+        let iov_len = boxed_iovs.len() as u32;
+        // leak now, free in completion
+        let raw_iovs = Box::into_raw(boxed_iovs);
+
+        let comp = {
+            // wrap original completion to free resources
+            let orig = c.clone();
+            Box::new(move |res: i32| {
+                // reclaim iovecs
+                unsafe {
+                    let _ = Box::from_raw(raw_iovs);
+                }
+                // forward to user closure
+                orig.complete(res);
+            })
+        };
+        let c = Arc::new(Completion::new_write(comp));
+        let mut io = self.io.borrow_mut();
+        let e = with_fd!(self, |fd| {
+            io_uring::opcode::Writev::new(fd, iov_ptr, iov_len)
+                .offset(pos as u64)
+                .build()
+                .user_data(get_key(c.clone()))
+        });
+        io.ring.submit_entry(&e);
         Ok(c)
     }
 
@@ -355,9 +390,9 @@ impl File for UringFile {
         let sync = with_fd!(self, |fd| {
             io_uring::opcode::Fsync::new(fd)
                 .build()
-                .user_data(io.ring.get_key())
+                .user_data(get_key(c.clone()))
         });
-        io.ring.submit_entry(&sync, c.clone());
+        io.ring.submit_entry(&sync);
         Ok(c)
     }
 

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -165,6 +165,49 @@ impl File for MemoryFile {
         Ok(c)
     }
 
+    fn pwritev(
+        &self,
+        pos: usize,
+        buffers: Vec<Arc<RefCell<Buffer>>>,
+        c: Arc<Completion>,
+    ) -> Result<Arc<Completion>> {
+        let mut offset = pos;
+        let mut total_written = 0;
+
+        for buffer in buffers {
+            let buf = buffer.borrow();
+            let buf_len = buf.len();
+            if buf_len == 0 {
+                continue;
+            }
+
+            let mut remaining = buf_len;
+            let mut buf_offset = 0;
+            let data = &buf.as_slice();
+
+            while remaining > 0 {
+                let page_no = offset / PAGE_SIZE;
+                let page_offset = offset % PAGE_SIZE;
+                let bytes_to_write = remaining.min(PAGE_SIZE - page_offset);
+
+                {
+                    let page = self.get_or_allocate_page(page_no);
+                    page[page_offset..page_offset + bytes_to_write]
+                        .copy_from_slice(&data[buf_offset..buf_offset + bytes_to_write]);
+                }
+
+                offset += bytes_to_write;
+                buf_offset += bytes_to_write;
+                remaining -= bytes_to_write;
+            }
+            total_written += buf_len;
+        }
+        self.size
+            .set(core::cmp::max(pos + total_written, self.size.get()));
+        c.complete(total_written as i32);
+        Ok(c)
+    }
+
     fn sync(&self, c: Arc<Completion>) -> Result<Arc<Completion>> {
         // no-op
         c.complete(0);

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -27,24 +27,39 @@ pub trait File: Send + Sync {
         buffers: Vec<Arc<RefCell<Buffer>>>,
         c: Arc<Completion>,
     ) -> Result<Arc<Completion>> {
-        // FIXME: for now, stupid default so i dont have to impl for all backends
-        let counter = Rc::new(Cell::new(0));
-        let len = buffers.len();
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        if buffers.is_empty() {
+            c.complete(0);
+            return Ok(c);
+        }
+        // naive default implementation can be overridden on backends where it makes sense to
         let mut pos = pos;
+        let outstanding = Arc::new(AtomicUsize::new(buffers.len()));
+        let total_written = Arc::new(AtomicUsize::new(0));
+
         for buf in buffers {
-            let _counter = counter.clone();
-            let _c = c.clone();
-            let default_c = Arc::new(Completion::new_write(move |_| {
-                _counter.set(_counter.get() + 1);
-                if _counter.get() == len {
-                    _c.complete(len as i32); // complete the original completion
-                }
-            }));
             let len = buf.borrow().len();
-            self.pwrite(pos, buf, default_c)?;
+            let child_c = {
+                let c_main = c.clone();
+                let outstanding = outstanding.clone();
+                let total_written = total_written.clone();
+                Arc::new(Completion::new_write(move |n| {
+                    // accumulate bytes actually reported by the backend
+                    total_written.fetch_add(n as usize, Ordering::Relaxed);
+                    if outstanding.fetch_sub(1, Ordering::AcqRel) == 1 {
+                        // last one finished
+                        c_main.complete(total_written.load(Ordering::Acquire) as i32);
+                    }
+                }))
+            };
+            if let Err(e) = self.pwrite(pos, buf.clone(), child_c) {
+                // best-effort: mark as done so caller won't wait forever
+                c.complete(-1);
+                return Err(e);
+            }
             pos += len;
         }
-        Ok(c.clone())
+        Ok(c)
     }
     fn sync(&self, c: Arc<Completion>) -> Result<Arc<Completion>>;
     fn size(&self) -> Result<u64>;

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -21,6 +21,31 @@ pub trait File: Send + Sync {
         buffer: Arc<RefCell<Buffer>>,
         c: Arc<Completion>,
     ) -> Result<Arc<Completion>>;
+    fn pwritev(
+        &self,
+        pos: usize,
+        buffers: Vec<Arc<RefCell<Buffer>>>,
+        c: Arc<Completion>,
+    ) -> Result<Arc<Completion>> {
+        // FIXME: for now, stupid default so i dont have to impl for all backends
+        let counter = Rc::new(Cell::new(0));
+        let len = buffers.len();
+        let mut pos = pos;
+        for buf in buffers {
+            let _counter = counter.clone();
+            let _c = c.clone();
+            let default_c = Arc::new(Completion::new_write(move |_| {
+                _counter.set(_counter.get() + 1);
+                if _counter.get() == len {
+                    _c.complete(len as i32); // complete the original completion
+                }
+            }));
+            let len = buf.borrow().len();
+            self.pwrite(pos, buf, default_c)?;
+            pos += len;
+        }
+        Ok(c.clone())
+    }
     fn sync(&self, c: Arc<Completion>) -> Result<Arc<Completion>>;
     fn size(&self) -> Result<u64>;
 }

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -1,15 +1,15 @@
+use super::{Completion, File, MemoryIO, OpenFlags, IO};
 use crate::error::LimboError;
+use crate::io::clock::{Clock, Instant};
 use crate::io::common;
 use crate::Result;
-
-use super::{Completion, File, MemoryIO, OpenFlags, IO};
-use crate::io::clock::{Clock, Instant};
 use polling::{Event, Events, Poller};
 use rustix::{
     fd::{AsFd, AsRawFd},
     fs::{self, FlockOperation, OFlags, OpenOptionsExt},
     io::Errno,
 };
+use std::os::fd::RawFd;
 use std::{
     cell::{RefCell, UnsafeCell},
     mem::MaybeUninit,
@@ -37,11 +37,6 @@ impl OwnedCallbacks {
 
     fn is_empty(&self) -> bool {
         self.as_mut().inline_count == 0
-    }
-
-    fn get(&self, fd: usize) -> Option<&CompletionCallback> {
-        let callbacks = unsafe { &mut *self.0.get() };
-        callbacks.get(fd)
     }
 
     fn remove(&self, fd: usize) -> Option<CompletionCallback> {
@@ -134,16 +129,6 @@ impl Callbacks {
         }
     }
 
-    fn get(&self, fd: usize) -> Option<&CompletionCallback> {
-        if let Some(pos) = self.find_inline(fd) {
-            let (_, callback) = unsafe { self.inline_entries[pos].assume_init_ref() };
-            return Some(callback);
-        } else if let Some(pos) = self.heap_entries.iter().position(|&(k, _)| k == fd) {
-            return Some(&self.heap_entries[pos].1);
-        }
-        None
-    }
-
     fn remove(&mut self, fd: usize) -> Option<CompletionCallback> {
         if let Some(pos) = self.find_inline(fd) {
             let (_, callback) = unsafe { self.inline_entries[pos].assume_init_read() };
@@ -212,6 +197,35 @@ impl Clock for UnixIO {
     }
 }
 
+fn try_pwritev_raw(
+    fd: RawFd,
+    off: u64,
+    bufs: &[Arc<RefCell<crate::Buffer>>],
+    start_idx: usize,
+    start_off: usize,
+) -> std::io::Result<usize> {
+    const MAX_IOV: usize = 1024;
+    let iov_len = std::cmp::min(bufs.len() - start_idx, MAX_IOV);
+    let mut iov = Vec::with_capacity(iov_len);
+
+    for (i, b) in bufs.iter().enumerate().skip(start_idx).take(iov_len) {
+        let r = b.borrow(); // borrow just to get pointer/len
+        let s = r.as_slice();
+        let s = if i == start_idx { &s[start_off..] } else { s };
+        iov.push(libc::iovec {
+            iov_base: s.as_ptr() as *mut _,
+            iov_len: s.len(),
+        });
+    }
+
+    let n = unsafe { libc::pwritev(fd, iov.as_ptr(), iov.len() as i32, off as i64) };
+    if n < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(n as usize)
+    }
+}
+
 impl IO for UnixIO {
     fn open_file(&self, path: &str, flags: OpenFlags, _direct: bool) -> Result<Arc<dyn File>> {
         trace!("open_file(path = {})", path);
@@ -242,46 +256,125 @@ impl IO for UnixIO {
         if self.callbacks.is_empty() {
             return Ok(());
         }
+
         self.events.clear();
         trace!("run_once() waits for events");
         self.poller.wait(self.events.as_mut(), None)?;
 
         for event in self.events.iter() {
-            if let Some(cf) = self.callbacks.get(event.key) {
-                let result = match cf {
-                    CompletionCallback::Read(ref file, ref c, pos) => {
-                        let file = file.borrow_mut();
-                        let r = c.as_read();
-                        let mut buf = r.buf_mut();
-                        rustix::io::pread(file.as_fd(), buf.as_mut_slice(), *pos as u64)
-                    }
-                    CompletionCallback::Write(ref file, _, ref buf, pos) => {
-                        let file = file.borrow_mut();
-                        let buf = buf.borrow();
-                        rustix::io::pwrite(file.as_fd(), buf.as_slice(), *pos as u64)
-                    }
-                };
-                match result {
-                    Ok(n) => {
-                        let cf = self
-                            .callbacks
-                            .remove(event.key)
-                            .expect("callback should exist");
-                        match cf {
-                            CompletionCallback::Read(_, c, _) => c.complete(0),
-                            CompletionCallback::Write(_, c, _, _) => c.complete(n as i32),
-                        }
-                    }
-                    Err(Errno::AGAIN) => (),
-                    Err(e) => {
-                        self.callbacks.remove(event.key);
+            let key = event.key;
 
-                        trace!("run_once() error: {}", e);
-                        return Err(e.into());
+            // 1) TAKE the callback – don't borrow it.
+            let cb = match self.callbacks.remove(key) {
+                Some(cb) => cb,
+                None => continue, // could have been completed/removed already
+            };
+
+            match cb {
+                CompletionCallback::Read(ref file, c, pos) => {
+                    let f = file.borrow_mut();
+                    let r = c.as_read();
+                    let mut buf = r.buf_mut();
+                    match rustix::io::pread(f.as_fd(), buf.as_mut_slice(), pos as u64) {
+                        Ok(n) => c.complete(n as i32),
+                        Err(Errno::AGAIN) => {
+                            // re-arm
+                            unsafe { self.poller.as_mut().add(&f.as_fd(), Event::readable(key))? };
+                            self.callbacks.as_mut().insert(
+                                key,
+                                CompletionCallback::Read(file.clone(), c.clone(), pos),
+                            );
+                        }
+                        Err(e) => return Err(e.into()),
+                    }
+                }
+
+                CompletionCallback::Write(ref file, c, buf, pos) => {
+                    let f = file.borrow_mut();
+                    let b = buf.borrow();
+                    match rustix::io::pwrite(f.as_fd(), b.as_slice(), pos as u64) {
+                        Ok(n) => c.complete(n as i32),
+                        Err(Errno::AGAIN) => {
+                            unsafe { self.poller.as_mut().add(&f.as_fd(), Event::writable(key))? };
+                            self.callbacks.as_mut().insert(
+                                key,
+                                CompletionCallback::Write(file.clone(), c, buf.clone(), pos),
+                            );
+                        }
+                        Err(e) => return Err(e.into()),
+                    }
+                }
+
+                CompletionCallback::Writev(file, c, bufs, mut pos, mut idx, mut off) => {
+                    let f = file.borrow_mut();
+                    // keep trying until WouldBlock or we're done with this event
+                    match try_pwritev_raw(f.as_raw_fd(), pos as u64, &bufs, idx, off) {
+                        Ok(written) => {
+                            // advance through buffers
+                            let mut rem = written;
+                            while rem > 0 {
+                                let len = {
+                                    let r = bufs[idx].borrow();
+                                    r.len()
+                                };
+                                let left = len - off;
+                                if rem < left {
+                                    off += rem;
+                                    rem = 0;
+                                } else {
+                                    rem -= left;
+                                    idx += 1;
+                                    off = 0;
+                                    if idx == bufs.len() {
+                                        break;
+                                    }
+                                }
+                            }
+                            pos += written;
+
+                            if idx == bufs.len() {
+                                c.complete(pos as i32);
+                            } else {
+                                // Not finished; re-arm and store updated state
+                                unsafe {
+                                    self.poller.as_mut().add(&f.as_fd(), Event::writable(key))?
+                                };
+                                self.callbacks.as_mut().insert(
+                                    key,
+                                    CompletionCallback::Writev(
+                                        file.clone(),
+                                        c.clone(),
+                                        bufs,
+                                        pos,
+                                        idx,
+                                        off,
+                                    ),
+                                );
+                            }
+                            break;
+                        }
+                        Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                            // re-arm with same state
+                            unsafe { self.poller.as_mut().add(&f.as_fd(), Event::writable(key))? };
+                            self.callbacks.as_mut().insert(
+                                key,
+                                CompletionCallback::Writev(
+                                    file.clone(),
+                                    c.clone(),
+                                    bufs,
+                                    pos,
+                                    idx,
+                                    off,
+                                ),
+                            );
+                            break;
+                        }
+                        Err(e) => return Err(e.into()),
                     }
                 }
             }
         }
+
         Ok(())
     }
 
@@ -310,6 +403,14 @@ enum CompletionCallback {
         Arc<Completion>,
         Arc<RefCell<crate::Buffer>>,
         usize,
+    ),
+    Writev(
+        Arc<RefCell<std::fs::File>>,
+        Arc<Completion>,
+        Vec<Arc<RefCell<crate::Buffer>>>,
+        usize, // absolute file offset
+        usize, // buf index
+        usize, // intra-buf offset
     ),
 }
 
@@ -427,6 +528,49 @@ impl File for UnixFile<'_> {
                 Ok(c)
             }
             Err(e) => Err(e.into()),
+        }
+    }
+
+    #[instrument(err, skip_all, level = Level::TRACE)]
+    fn pwritev(
+        &self,
+        pos: usize,
+        buffers: Vec<Arc<RefCell<crate::Buffer>>>,
+        c: Arc<Completion>,
+    ) -> Result<Arc<Completion>> {
+        let file = self.file.borrow();
+
+        match try_pwritev_raw(file.as_raw_fd(), pos as u64, &buffers, 0, 0) {
+            Ok(written) => {
+                trace!("pwritev wrote {written}");
+                c.complete(written as i32);
+                Ok(c)
+            }
+            Err(e) => {
+                if e.kind() == ErrorKind::WouldBlock {
+                    trace!("pwritev blocks");
+                } else {
+                    return Err(e.into());
+                }
+                // Set up state so we can resume later
+                let fd = file.as_raw_fd();
+                self.poller
+                    .add(&file.as_fd(), Event::writable(fd as usize))?;
+                let buf_idx = 0;
+                let buf_offset = 0;
+                self.callbacks.insert(
+                    fd as usize,
+                    CompletionCallback::Writev(
+                        self.file.clone(),
+                        c.clone(),
+                        buffers,
+                        pos,
+                        buf_idx,
+                        buf_offset,
+                    ),
+                );
+                Ok(c)
+            }
         }
     }
 

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -17,6 +17,14 @@ pub trait DatabaseStorage: Send + Sync {
         buffer: Arc<RefCell<Buffer>>,
         c: Completion,
     ) -> Result<()>;
+
+    fn write_pages(
+        &self,
+        first_page_idx: usize,
+        page_size: usize,
+        buffers: Vec<Arc<RefCell<Buffer>>>,
+        c: Completion,
+    ) -> Result<()>;
     fn sync(&self, c: Completion) -> Result<()>;
     fn size(&self) -> Result<u64>;
 }
@@ -60,6 +68,22 @@ impl DatabaseStorage for DatabaseFile {
         assert_eq!(buffer_size & (buffer_size - 1), 0);
         let pos = (page_idx - 1) * buffer_size;
         self.file.pwrite(pos, buffer, c.into())?;
+        Ok(())
+    }
+
+    fn write_pages(
+        &self,
+        page_idx: usize,
+        page_size: usize,
+        buffers: Vec<Arc<RefCell<Buffer>>>,
+        c: Completion,
+    ) -> Result<()> {
+        assert!(page_idx > 0);
+        assert!(page_size >= 512);
+        assert!(page_size <= 65536);
+        assert_eq!(page_size & (page_size - 1), 0);
+        let pos = (page_idx - 1) * page_size;
+        self.file.pwritev(pos, buffers, c.into())?;
         Ok(())
     }
 
@@ -119,6 +143,22 @@ impl DatabaseStorage for FileMemoryStorage {
         assert_eq!(buffer_size & (buffer_size - 1), 0);
         let pos = (page_idx - 1) * buffer_size;
         self.file.pwrite(pos, buffer, c.into())?;
+        Ok(())
+    }
+
+    fn write_pages(
+        &self,
+        page_idx: usize,
+        page_size: usize,
+        buffer: Vec<Arc<RefCell<Buffer>>>,
+        c: Completion,
+    ) -> Result<()> {
+        assert!(page_idx > 0);
+        assert!(page_size >= 512);
+        assert!(page_size <= 65536);
+        assert_eq!(page_size & (page_size - 1), 0);
+        let pos = (page_idx - 1) * page_size;
+        self.file.pwritev(pos, buffer, c.into())?;
         Ok(())
     }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1262,11 +1262,11 @@ impl Pager {
                 num_checkpointed_frames: 0,
             });
         }
-
+        let write_counter = Rc::new(RefCell::new(0));
         let checkpoint_result = self.io.block(|| {
             self.wal
                 .borrow_mut()
-                .checkpoint(self, Rc::new(RefCell::new(0)), CheckpointMode::Passive)
+                .checkpoint(self, write_counter.clone(), CheckpointMode::Passive)
                 .map_err(|err| panic!("error while clearing cache {err}"))
         })?;
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -339,7 +339,7 @@ pub struct Pager {
     /// Cache page_size and reserved_space at Pager init and reuse for subsequent
     /// `usable_space` calls. TODO: Invalidate reserved_space when we add the functionality
     /// to change it.
-    page_size: Cell<Option<u32>>,
+    pub(crate) page_size: Cell<Option<u32>>,
     reserved_space: OnceCell<u8>,
     free_page_state: RefCell<FreePageState>,
 }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -58,6 +58,7 @@ use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_thr
 use crate::storage::buffer_pool::BufferPool;
 use crate::storage::database::DatabaseStorage;
 use crate::storage::pager::Pager;
+use crate::storage::wal::{BatchItem, PendingFlush};
 use crate::types::{RawSlice, RefValue, SerialType, SerialTypeKind, TextRef, TextSubtype};
 use crate::{turso_assert, File, Result, WalFileShared};
 use std::cell::{RefCell, UnsafeCell};
@@ -820,6 +821,56 @@ pub fn begin_write_btree_page(
         *write_counter.borrow_mut() -= 1;
     }
     res
+}
+
+#[instrument(skip_all, level = Level::DEBUG)]
+pub fn begin_write_btree_pages_writev(
+    pager: &Pager,
+    batch: &[BatchItem],
+    write_counter: Rc<RefCell<usize>>,
+) -> Result<PendingFlush> {
+    if batch.is_empty() {
+        return Ok(PendingFlush::default());
+    }
+
+    let mut run = batch.to_vec();
+    run.sort_by_key(|b| b.id);
+
+    let page_sz = pager.page_size.get().unwrap_or(DEFAULT_PAGE_SIZE) as usize;
+    let done = Arc::new(AtomicBool::new(false));
+
+    let mut all_ids = Vec::with_capacity(run.len());
+    let mut start = 0;
+    while start < run.len() {
+        let mut end = start + 1;
+        while end < run.len() && run[end].id == run[end - 1].id + 1 {
+            end += 1;
+        }
+
+        // submit contiguous run
+        let first = run[start].id;
+        let bufs: Vec<_> = run[start..end].iter().map(|b| b.buf.clone()).collect();
+        all_ids.extend(run[start..end].iter().map(|b| b.id));
+
+        *write_counter.borrow_mut() += 1;
+        let wc = write_counter.clone();
+        let done_clone = done.clone();
+
+        let c = Completion::new_write(move |_| {
+            // one run finished
+            *wc.borrow_mut() -= 1;
+            if wc.borrow().eq(&0) {
+                // last run of this batch is done
+                done_clone.store(true, Ordering::Release);
+            }
+        });
+        pager.db_file.write_pages(first, page_sz, bufs, c)?;
+        start = end;
+    }
+    Ok(PendingFlush {
+        pages: all_ids,
+        done,
+    })
 }
 
 #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -61,7 +61,7 @@ use crate::storage::pager::Pager;
 use crate::storage::wal::{BatchItem, PendingFlush};
 use crate::types::{RawSlice, RefValue, SerialType, SerialTypeKind, TextRef, TextSubtype};
 use crate::{turso_assert, File, Result, WalFileShared};
-use std::cell::{RefCell, UnsafeCell};
+use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::HashMap;
 use std::mem::MaybeUninit;
 use std::pin::Pin;
@@ -827,7 +827,8 @@ pub fn begin_write_btree_page(
 pub fn begin_write_btree_pages_writev(
     pager: &Pager,
     batch: &[BatchItem],
-    write_counter: Rc<RefCell<usize>>,
+    // track writes for each flush series
+    write_counter: Rc<Cell<usize>>,
 ) -> Result<PendingFlush> {
     if batch.is_empty() {
         return Ok(PendingFlush::default());
@@ -848,23 +849,34 @@ pub fn begin_write_btree_pages_writev(
         }
 
         // submit contiguous run
-        let first = run[start].id;
+        let first_id = run[start].id;
         let bufs: Vec<_> = run[start..end].iter().map(|b| b.buf.clone()).collect();
         all_ids.extend(run[start..end].iter().map(|b| b.id));
 
-        *write_counter.borrow_mut() += 1;
+        write_counter.set(write_counter.get() + 1);
         let wc = write_counter.clone();
         let done_clone = done.clone();
 
         let c = Completion::new_write(move |_| {
             // one run finished
-            *wc.borrow_mut() -= 1;
-            if wc.borrow().eq(&0) {
+            wc.set(wc.get() - 1);
+            if wc.get().eq(&0) {
                 // last run of this batch is done
                 done_clone.store(true, Ordering::Release);
             }
         });
-        pager.db_file.write_pages(first, page_sz, bufs, c)?;
+        pager
+            .db_file
+            .write_pages(first_id, page_sz, bufs, c)
+            .inspect_err(|e| {
+                tracing::error!(
+                    "Failed to write pages {}-{}: {}",
+                    first_id,
+                    first_id + (end - start) - 1,
+                    e
+                );
+                write_counter.set(write_counter.get() - 1);
+            })?;
         start = end;
     }
     Ok(PendingFlush {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -527,7 +527,8 @@ impl fmt::Debug for WalFileShared {
 fn take_page_into_batch(scratch: &PageRef, pool: &Arc<BufferPool>, batch: &mut Vec<BatchItem>) {
     // grab id and buffer
     let id = scratch.get().id;
-    let buf = scratch.get_contents().buffer.clone(); // current data
+    let buf = scratch.get_contents().buffer.clone();
+    scratch.pin(); // ensure it isnt evicted
     batch.push(BatchItem { id, buf });
     // give scratch a brand-new empty buffer for the next read
     reinit_scratch_buffer(scratch, pool);

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -372,7 +372,7 @@ pub enum CheckpointState {
     Done,
 }
 
-const CKPT_BATCH_PAGES: usize = 256;
+const CKPT_BATCH_PAGES: usize = 512;
 
 #[derive(Clone)]
 pub(super) struct BatchItem {
@@ -389,7 +389,7 @@ pub(super) struct BatchItem {
 // current_page is a helper to iterate through all the pages that might have a frame in the safe
 // range. This is inefficient for now.
 struct OngoingCheckpoint {
-    scratch: PageRef,
+    scratch_page: PageRef,
     batch: Vec<BatchItem>,
     state: CheckpointState,
     pending_flushes: Vec<PendingFlush>,
@@ -940,11 +940,11 @@ impl Wal for WalFile {
                                 page,
                                 *frame
                             );
-                            self.ongoing_checkpoint.scratch.get().id = page as usize;
+                            self.ongoing_checkpoint.scratch_page.get().id = page as usize;
 
                             self.read_frame(
                                 *frame,
-                                self.ongoing_checkpoint.scratch.clone(),
+                                self.ongoing_checkpoint.scratch_page.clone(),
                                 self.buffer_pool.clone(),
                             )?;
                             self.ongoing_checkpoint.state = CheckpointState::WaitReadFrame;
@@ -954,7 +954,7 @@ impl Wal for WalFile {
                     self.ongoing_checkpoint.current_page += 1;
                 }
                 CheckpointState::WaitReadFrame => {
-                    if self.ongoing_checkpoint.scratch.is_locked() {
+                    if self.ongoing_checkpoint.scratch_page.is_locked() {
                         return Ok(IOResult::IO);
                     } else {
                         self.ongoing_checkpoint.state = CheckpointState::AccumulatePage;
@@ -962,17 +962,16 @@ impl Wal for WalFile {
                 }
                 CheckpointState::AccumulatePage => {
                     // mark before batching
-                    self.ongoing_checkpoint.scratch.set_dirty();
+                    self.ongoing_checkpoint.scratch_page.set_dirty();
                     take_page_into_batch(
-                        &self.ongoing_checkpoint.scratch,
+                        &self.ongoing_checkpoint.scratch_page,
                         &self.buffer_pool,
                         &mut self.ongoing_checkpoint.batch,
                     );
-
                     let more_pages = (self.ongoing_checkpoint.current_page as usize)
                         < self.get_shared().pages_in_frames.lock().len() - 1;
 
-                    if self.ongoing_checkpoint.batch.len() < CKPT_BATCH_PAGES && more_pages {
+                    if more_pages {
                         self.ongoing_checkpoint.current_page += 1;
                         self.ongoing_checkpoint.state = CheckpointState::ReadFrame;
                     } else {
@@ -980,13 +979,15 @@ impl Wal for WalFile {
                     }
                 }
                 CheckpointState::FlushBatch => {
+                    tracing::trace!("started checkpoint backfilling batch");
                     self.ongoing_checkpoint
                         .pending_flushes
                         .push(begin_write_btree_pages_writev(
                             pager,
                             &self.ongoing_checkpoint.batch,
-                            write_counter.clone(),
+                            Rc::new(Cell::new(0)),
                         )?);
+                    *write_counter.borrow_mut() += 1;
                     // batch is queued
                     self.ongoing_checkpoint.batch.clear();
                     self.ongoing_checkpoint.state = CheckpointState::WaitFlush;
@@ -1001,6 +1002,8 @@ impl Wal for WalFile {
                     {
                         return Ok(IOResult::IO);
                     }
+                    tracing::trace!("finished checkpoint backfilling batch");
+                    *write_counter.borrow_mut() -= 1;
                     for pf in self.ongoing_checkpoint.pending_flushes.drain(..) {
                         for id in pf.pages {
                             if let Some(p) = pager.cache_get(id) {
@@ -1170,7 +1173,7 @@ impl WalFile {
             max_frame: unsafe { (*shared.get()).max_frame.load(Ordering::SeqCst) },
             shared,
             ongoing_checkpoint: OngoingCheckpoint {
-                scratch: checkpoint_page,
+                scratch_page: checkpoint_page,
                 batch: Vec::new(),
                 pending_flushes: Vec::new(),
                 state: CheckpointState::Start,

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -20,8 +20,8 @@ use crate::fast_lock::SpinLock;
 use crate::io::{File, IO};
 use crate::result::LimboResult;
 use crate::storage::sqlite3_ondisk::{
-    begin_read_wal_frame, begin_read_wal_frame_raw, finish_read_page, prepare_wal_frame,
-    WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
+    begin_read_wal_frame, begin_read_wal_frame_raw, begin_write_btree_pages_writev,
+    finish_read_page, prepare_wal_frame, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
 };
 use crate::types::IOResult;
 use crate::{turso_assert, Buffer, LimboError, Result};
@@ -31,7 +31,7 @@ use self::sqlite3_ondisk::{checksum_wal, PageContent, WAL_MAGIC_BE, WAL_MAGIC_LE
 
 use super::buffer_pool::BufferPool;
 use super::pager::{PageRef, Pager};
-use super::sqlite3_ondisk::{self, begin_write_btree_page, WalHeader};
+use super::sqlite3_ondisk::{self, WalHeader};
 
 pub const READMARK_NOT_USED: u32 = 0xffffffff;
 
@@ -366,9 +366,18 @@ pub enum CheckpointState {
     Start,
     ReadFrame,
     WaitReadFrame,
-    WritePage,
-    WaitWritePage,
+    AccumulatePage,
+    FlushBatch,
+    WaitFlush,
     Done,
+}
+
+const CKPT_BATCH_PAGES: usize = 256;
+
+#[derive(Clone)]
+pub(super) struct BatchItem {
+    pub(super) id: usize,
+    pub(super) buf: Arc<RefCell<Buffer>>,
 }
 
 // Checkpointing is a state machine that has multiple steps. Since there are multiple steps we save
@@ -380,11 +389,35 @@ pub enum CheckpointState {
 // current_page is a helper to iterate through all the pages that might have a frame in the safe
 // range. This is inefficient for now.
 struct OngoingCheckpoint {
-    page: PageRef,
+    scratch: PageRef,
+    batch: Vec<BatchItem>,
     state: CheckpointState,
+    pending_flushes: Vec<PendingFlush>,
     min_frame: u64,
     max_frame: u64,
     current_page: u64,
+}
+
+pub(super) struct PendingFlush {
+    // page ids to clear
+    pub(super) pages: Vec<usize>,
+    // completion flag set by IO callback
+    pub(super) done: Arc<AtomicBool>,
+}
+
+impl Default for PendingFlush {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PendingFlush {
+    pub fn new() -> Self {
+        Self {
+            pages: Vec::with_capacity(CKPT_BATCH_PAGES),
+            done: Arc::new(AtomicBool::new(false)),
+        }
+    }
 }
 
 impl fmt::Debug for OngoingCheckpoint {
@@ -488,6 +521,30 @@ impl fmt::Debug for WalFileShared {
             .field("last_checksum", &self.last_checksum)
             // Excluding `file`, `read_locks`, and `write_lock`
             .finish()
+    }
+}
+
+fn take_page_into_batch(scratch: &PageRef, pool: &Arc<BufferPool>, batch: &mut Vec<BatchItem>) {
+    // grab id and buffer
+    let id = scratch.get().id;
+    let buf = scratch.get_contents().buffer.clone(); // current data
+    batch.push(BatchItem { id, buf });
+    // give scratch a brand-new empty buffer for the next read
+    reinit_scratch_buffer(scratch, pool);
+}
+
+fn reinit_scratch_buffer(scratch: &PageRef, pool: &Arc<BufferPool>) {
+    let raw = pool.get();
+    let pool_clone = pool.clone();
+    let drop_fn = Rc::new(move |b| {
+        pool_clone.put(b);
+    });
+    let new_buf = Arc::new(RefCell::new(Buffer::new(raw, drop_fn)));
+    // replace contents
+    unsafe {
+        let inner = &mut *scratch.inner.get();
+        inner.contents = Some(PageContent::new(0, new_buf));
+        inner.flags.store(0, Ordering::Relaxed);
     }
 }
 
@@ -849,6 +906,7 @@ impl Wal for WalFile {
                     self.ongoing_checkpoint.max_frame = max_safe_frame;
                     self.ongoing_checkpoint.current_page = 0;
                     self.ongoing_checkpoint.state = CheckpointState::ReadFrame;
+                    self.ongoing_checkpoint.batch.clear();
                     tracing::trace!(
                         "checkpoint_start(min_frame={}, max_frame={})",
                         self.ongoing_checkpoint.min_frame,
@@ -882,11 +940,11 @@ impl Wal for WalFile {
                                 page,
                                 *frame
                             );
-                            self.ongoing_checkpoint.page.get().id = page as usize;
+                            self.ongoing_checkpoint.scratch.get().id = page as usize;
 
                             self.read_frame(
                                 *frame,
-                                self.ongoing_checkpoint.page.clone(),
+                                self.ongoing_checkpoint.scratch.clone(),
                                 self.buffer_pool.clone(),
                             )?;
                             self.ongoing_checkpoint.state = CheckpointState::WaitReadFrame;
@@ -896,30 +954,61 @@ impl Wal for WalFile {
                     self.ongoing_checkpoint.current_page += 1;
                 }
                 CheckpointState::WaitReadFrame => {
-                    if self.ongoing_checkpoint.page.is_locked() {
+                    if self.ongoing_checkpoint.scratch.is_locked() {
                         return Ok(IOResult::IO);
                     } else {
-                        self.ongoing_checkpoint.state = CheckpointState::WritePage;
+                        self.ongoing_checkpoint.state = CheckpointState::AccumulatePage;
                     }
                 }
-                CheckpointState::WritePage => {
-                    self.ongoing_checkpoint.page.set_dirty();
-                    begin_write_btree_page(
-                        pager,
-                        &self.ongoing_checkpoint.page,
-                        write_counter.clone(),
-                    )?;
-                    self.ongoing_checkpoint.state = CheckpointState::WaitWritePage;
+                CheckpointState::AccumulatePage => {
+                    // mark before batching
+                    self.ongoing_checkpoint.scratch.set_dirty();
+                    take_page_into_batch(
+                        &self.ongoing_checkpoint.scratch,
+                        &self.buffer_pool,
+                        &mut self.ongoing_checkpoint.batch,
+                    );
+
+                    let more_pages = (self.ongoing_checkpoint.current_page as usize)
+                        < self.get_shared().pages_in_frames.lock().len() - 1;
+
+                    if self.ongoing_checkpoint.batch.len() < CKPT_BATCH_PAGES && more_pages {
+                        self.ongoing_checkpoint.current_page += 1;
+                        self.ongoing_checkpoint.state = CheckpointState::ReadFrame;
+                    } else {
+                        self.ongoing_checkpoint.state = CheckpointState::FlushBatch;
+                    }
                 }
-                CheckpointState::WaitWritePage => {
-                    if *write_counter.borrow() > 0 {
+                CheckpointState::FlushBatch => {
+                    self.ongoing_checkpoint
+                        .pending_flushes
+                        .push(begin_write_btree_pages_writev(
+                            pager,
+                            &self.ongoing_checkpoint.batch,
+                            write_counter.clone(),
+                        )?);
+                    // batch is queued
+                    self.ongoing_checkpoint.batch.clear();
+                    self.ongoing_checkpoint.state = CheckpointState::WaitFlush;
+                    return Ok(IOResult::IO);
+                }
+                CheckpointState::WaitFlush => {
+                    if self
+                        .ongoing_checkpoint
+                        .pending_flushes
+                        .iter()
+                        .any(|pf| !pf.done.load(Ordering::Acquire))
+                    {
                         return Ok(IOResult::IO);
                     }
-                    // If page was in cache clear it.
-                    if let Some(page) = pager.cache_get(self.ongoing_checkpoint.page.get().id) {
-                        page.clear_dirty();
+                    for pf in self.ongoing_checkpoint.pending_flushes.drain(..) {
+                        for id in pf.pages {
+                            if let Some(p) = pager.cache_get(id) {
+                                p.clear_dirty();
+                            }
+                        }
                     }
-                    self.ongoing_checkpoint.page.clear_dirty();
+                    // done with batch
                     let shared = self.get_shared();
                     if (self.ongoing_checkpoint.current_page as usize)
                         < shared.pages_in_frames.lock().len()
@@ -1081,7 +1170,9 @@ impl WalFile {
             max_frame: unsafe { (*shared.get()).max_frame.load(Ordering::SeqCst) },
             shared,
             ongoing_checkpoint: OngoingCheckpoint {
-                page: checkpoint_page,
+                scratch: checkpoint_page,
+                batch: Vec::new(),
+                pending_flushes: Vec::new(),
                 state: CheckpointState::Start,
                 min_frame: 0,
                 max_frame: 0,

--- a/simulator/runner/file.rs
+++ b/simulator/runner/file.rs
@@ -200,6 +200,33 @@ impl File for SimulatorFile {
         }
     }
 
+    fn pwritev(
+        &self,
+        pos: usize,
+        buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
+        c: Arc<turso_core::Completion>,
+    ) -> Result<Arc<turso_core::Completion>> {
+        self.nr_pwrite_calls.set(self.nr_pwrite_calls.get() + 1);
+        if self.fault.get() {
+            tracing::debug!("pwritev fault");
+            self.nr_pwrite_faults.set(self.nr_pwrite_faults.get() + 1);
+            return Err(turso_core::LimboError::InternalError(
+                FAULT_ERROR_MSG.into(),
+            ));
+        }
+        if let Some(latency) = self.generate_latency_duration() {
+            let cloned_c = c.clone();
+            let op =
+                Box::new(move |file: &SimulatorFile| file.inner.pwritev(pos, buffers, cloned_c));
+            self.queued_io
+                .borrow_mut()
+                .push(DelayedIo { time: latency, op });
+            Ok(c)
+        } else {
+            self.inner.pwritev(pos, buffers, c)
+        }
+    }
+
     fn sync(&self, c: Arc<turso_core::Completion>) -> Result<Arc<turso_core::Completion>> {
         self.nr_sync_calls.set(self.nr_sync_calls.get() + 1);
         if self.fault.get() {

--- a/testing/cli_tests/vfs_bench.py
+++ b/testing/cli_tests/vfs_bench.py
@@ -13,7 +13,7 @@ from typing import Dict
 from cli_tests.console import error, info, test
 from cli_tests.test_turso_cli import TestTursoShell
 
-LIMBO_BIN = Path("./target/release/tursodb")
+LIMBO_BIN = Path("./target/debug/tursodb")
 DB_FILE = Path("testing/temp.db")
 vfs_list = ["syscall"]
 if platform.system() == "Linux":
@@ -79,11 +79,13 @@ def main() -> None:
     averages: Dict[str, float] = {}
 
     for vfs in vfs_list:
+        setup_temp_db()
         test(f"\n### VFS: {vfs} ###")
         times = bench_one(vfs, sql, iterations)
         info(f"All times ({vfs}):", " ".join(f"{t:.6f}" for t in times))
         avg = statistics.mean(times)
         averages[vfs] = avg
+        cleanup_temp_db()
 
     info("\n" + "-" * 60)
     info("Average runtime per VFS")
@@ -106,7 +108,6 @@ def main() -> None:
             faster_slower = "slower" if pct > 0 else "faster"
             info(f"{vfs:<{name_pad}} : {avg:.6f}  ({abs(pct):.1f}% {faster_slower} than {baseline})")
         info("-" * 60)
-    cleanup_temp_db()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
After significant digging into what was causing (particularly writes) to be so much slower for io_uring back-end, it was determined that particularly checkpointing was incredibly slow, for several reasons. One is that we essentially end up calling `submit_and_wait` for every page. 

This PR (of course, heavily conflicts with my other open PR) attempts to remedy this: addding `pwritev` to the File trait for IO back-ends that want to support it, and aggregates contiguous writes into a series of `pwritev` calls instead of individually 


### Performance:
`make bench-vfs SQL="insert into products (name,price) values (randomblob(4096), randomblob(2048));" N=1000`

Before: (`main` branch)

<img width="502" height="177" alt="image" src="https://github.com/user-attachments/assets/e09b7128-ae66-4949-af5a-03cd9aa47da3" />

After: (this branch)
<img width="551" height="202" alt="image" src="https://github.com/user-attachments/assets/4472ffa2-52d8-4312-bdc4-850b7eae8b38" />
(cherry-picked of course, but the results ranged from this to ~20-60% slower, but nonetheless, a vast improvement)

This also includes some minor improvements for the io_uring module.

