### PR TITLE
Stop checkpointing the entire WAL after every write when wal frame size > threshold

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -802,7 +802,8 @@ impl Wal for WalFile {
     fn should_checkpoint(&self) -> bool {
         let shared = self.get_shared();
         let frame_id = shared.max_frame.load(Ordering::SeqCst) as usize;
-        frame_id > self.checkpoint_threshold
+        let nbackfills = shared.nbackfills.load(Ordering::SeqCst) as usize;
+        frame_id > self.checkpoint_threshold + nbackfills
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]


### PR DESCRIPTION
I know I have #2179 and now #2278 open both working on checkpointing, but I discovered during async IO benchmarks that once we hit `should_checkpoint` (there are greater than 1000 frames in the WAL), we will trigger checkpoint on cache flush every single write, and since we don't update `nbackfills` in the case that everything was backfilled, every checkpoint will backfill every single frame to the db file :skull:

At least this can be reviewed+merged faster and easier. 



This also fixes the return value of `pragma wal_checkpoint;` to match sqlite. 

Sqlite returns the # of possible frames (`shared.max_frame - shared.nbackfills`, and then the number of frames we successfully checkpointed `ongoing_checkpoint.max_frame - ongoing_checkpoint.min_frame + 1`)

If `pragma wal_checkpoint;` is called again when there are no pages to backfill, then it returns the value from the previous checkpoint.

 
<img width="781" height="293" alt="image" src="https://github.com/user-attachments/assets/9aa78a6c-aa18-444d-82bd-398d684fed75" />
