### PR TITLE
Add `tracing_subscriber` to javascript bindings + Fix `SqliteError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3947,6 +3947,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "tracing-subscriber",
  "turso_core",
 ]
 

--- a/bindings/javascript/Cargo.toml
+++ b/bindings/javascript/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 turso_core = { workspace = true }
 napi = { version = "3.1.3", default-features = false }
 napi-derive = { version = "3.1.1", default-features = true }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [build-dependencies]
 napi-build = "2.2.3"

--- a/bindings/javascript/sqlite-error.js
+++ b/bindings/javascript/sqlite-error.js
@@ -1,22 +1,14 @@
 'use strict';
-const descriptor = { value: 'SqliteError', writable: true, enumerable: false, configurable: true };
 
-function SqliteError(message, code, rawCode) {
-        if (new.target !== SqliteError) {
-                return new SqliteError(message, code);
-        }
-        if (typeof code !== 'string') {
-                throw new TypeError('Expected second argument to be a string');
-        }
-        Error.call(this, message);
-        descriptor.value = '' + message;
-        Object.defineProperty(this, 'message', descriptor);
-        Error.captureStackTrace(this, SqliteError);
-        this.code = code;
-        this.rawCode = rawCode
+class SqliteError extends Error {
+  constructor(message, code, rawCode) {
+    super(message);
+    this.name    = 'SqliteError';
+    this.code    = code;
+    this.rawCode = rawCode;
+
+    Error.captureStackTrace(this, SqliteError);
+  }
 }
-Object.setPrototypeOf(SqliteError, Error);
-Object.setPrototypeOf(SqliteError.prototype, Error.prototype);
-Object.defineProperty(SqliteError.prototype, 'name', descriptor);
-module.exports = SqliteError;
 
+module.exports = SqliteError;


### PR DESCRIPTION
Useful for debugging.

Also fixes  `SqliteError`'s `message` not being populated, seen in #2217 CI runs.