### PR TITLE
Fix writing wal header for async IO

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1683,7 +1683,10 @@ pub fn begin_write_wal_header(io: &Arc<dyn File>, header: &WalHeader) -> Result<
         Arc::new(RefCell::new(buffer))
     };
 
+    let cloned = buffer.clone();
     let write_complete = move |bytes_written: i32| {
+        // make sure to reference buffer so it's alive for async IO
+        let _buf = cloned.borrow();
         turso_assert!(
             bytes_written == WAL_HEADER_SIZE as i32,
             "wal header wrote({bytes_written}) != expected({WAL_HEADER_SIZE})"


### PR DESCRIPTION
We previously were making another inline completion inside io_uring.rs, I thought this wouldn't be needed anymore because of the Arc that is now wrapping the RefCell<Buffer>, but in the case of the WAL header, where it's not pinned to a page in the cache, there is nothing to keep it alive and we will write a corrupt wal header.

```rust
        #[allow(clippy::arc_with_non_send_sync)]
        Arc::new(RefCell::new(buffer))
    };

    let write_complete = move |bytes_written: i32| {
     turso_assert!(
            bytes_written == WAL_HEADER_SIZE as i32,
            "wal header wrote({bytes_written}) != expected({WAL_HEADER_SIZE})"
        );
    };
// buffer is never referenced again, this works for sync IO but io_uring writes junk bytes
```

<img width="881" height="134" alt="image" src="https://github.com/user-attachments/assets/0ff06ad5-411a-43d2-abac-caf9e23ceaeb" />
 