### PR TITLE
Change function signatures to return IO Completions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,13 +50,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Clippy
         run: |
-          cargo clippy --workspace --all-features --all-targets --exclude limbo-wasm -- --deny=warnings
+          cargo clippy --workspace --all-features --all-targets --exclude limbo-wasm -- -A unused-variables --deny=warnings
       - name: Clippy `limbo-wasm` crate `nodejs` feature
         run: |
-          cargo clippy --package limbo-wasm --features nodejs --all-targets --no-deps -- -A clippy::all -W clippy::correctness -W clippy::perf -W clippy::suspicious --deny=warnings
+          cargo clippy --package limbo-wasm --features nodejs --all-targets --no-deps -- -A clippy::all -A unused-variables -W clippy::correctness -W clippy::perf -W clippy::suspicious --deny=warnings
       - name: Clippy `limbo-wasm` crate `web` feature
         run: |
-          cargo clippy --package limbo-wasm --no-default-features --features web --all-targets --no-deps -- -A clippy::all -W clippy::correctness -W clippy::perf -W clippy::suspicious --deny=warnings
+          cargo clippy --package limbo-wasm --no-default-features --features web --all-targets --no-deps -- -A clippy::all -A unused-variables -W clippy::correctness -W clippy::perf -W clippy::suspicious --deny=warnings
 
   build-wasm:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -702,7 +702,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
             return Err(turso_core::LimboError::NotADB);
         }
         let pos = (page_idx - 1) * size;
-        self.file.pread(pos, c.into())
+        self.file.pread(pos, c)
     }
 
     fn write_page(
@@ -713,11 +713,11 @@ impl turso_core::DatabaseStorage for DatabaseFile {
     ) -> turso_core::Result<turso_core::Completion> {
         let size = buffer.borrow().len();
         let pos = (page_idx - 1) * size;
-        self.file.pwrite(pos, buffer, c.into())
+        self.file.pwrite(pos, buffer, c)
     }
 
     fn sync(&self, c: turso_core::Completion) -> turso_core::Result<turso_core::Completion> {
-        self.file.sync(c.into())
+        self.file.sync(c)
     }
 
     fn size(&self) -> turso_core::Result<u64> {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -695,10 +695,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         page_idx: usize,
         c: turso_core::Completion,
     ) -> turso_core::Result<Arc<turso_core::Completion>> {
-        let r = match c.completion_type {
-            turso_core::CompletionType::Read(ref r) => r,
-            _ => unreachable!(),
-        };
+        let r = c.as_read();
         let size = r.buf().len();
         assert!(page_idx > 0);
         if !(512..=65536).contains(&size) || size & (size - 1) != 0 {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -694,7 +694,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         &self,
         page_idx: usize,
         c: turso_core::Completion,
-    ) -> turso_core::Result<Arc<turso_core::Completion>> {
+    ) -> turso_core::Result<turso_core::Completion> {
         let r = c.as_read();
         let size = r.buf().len();
         assert!(page_idx > 0);
@@ -710,13 +710,13 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         page_idx: usize,
         buffer: Arc<std::cell::RefCell<turso_core::Buffer>>,
         c: turso_core::Completion,
-    ) -> turso_core::Result<Arc<turso_core::Completion>> {
+    ) -> turso_core::Result<turso_core::Completion> {
         let size = buffer.borrow().len();
         let pos = (page_idx - 1) * size;
         self.file.pwrite(pos, buffer, c.into())
     }
 
-    fn sync(&self, c: turso_core::Completion) -> turso_core::Result<Arc<turso_core::Completion>> {
+    fn sync(&self, c: turso_core::Completion) -> turso_core::Result<turso_core::Completion> {
         self.file.sync(c.into())
     }
 

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -690,7 +690,11 @@ impl DatabaseFile {
 }
 
 impl turso_core::DatabaseStorage for DatabaseFile {
-    fn read_page(&self, page_idx: usize, c: turso_core::Completion) -> turso_core::Result<()> {
+    fn read_page(
+        &self,
+        page_idx: usize,
+        c: turso_core::Completion,
+    ) -> turso_core::Result<Arc<turso_core::Completion>> {
         let r = match c.completion_type {
             turso_core::CompletionType::Read(ref r) => r,
             _ => unreachable!(),
@@ -701,8 +705,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
             return Err(turso_core::LimboError::NotADB);
         }
         let pos = (page_idx - 1) * size;
-        self.file.pread(pos, c.into())?;
-        Ok(())
+        self.file.pread(pos, c.into())
     }
 
     fn write_page(
@@ -710,16 +713,14 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         page_idx: usize,
         buffer: Arc<std::cell::RefCell<turso_core::Buffer>>,
         c: turso_core::Completion,
-    ) -> turso_core::Result<()> {
+    ) -> turso_core::Result<Arc<turso_core::Completion>> {
         let size = buffer.borrow().len();
         let pos = (page_idx - 1) * size;
-        self.file.pwrite(pos, buffer, c.into())?;
-        Ok(())
+        self.file.pwrite(pos, buffer, c.into())
     }
 
-    fn sync(&self, c: turso_core::Completion) -> turso_core::Result<()> {
-        let _ = self.file.sync(c.into())?;
-        Ok(())
+    fn sync(&self, c: turso_core::Completion) -> turso_core::Result<Arc<turso_core::Completion>> {
+        self.file.sync(c.into())
     }
 
     fn size(&self) -> turso_core::Result<u64> {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -266,7 +266,7 @@ impl Connection {
             .inner
             .lock()
             .map_err(|e| Error::MutexError(e.to_string()))?;
-        conn.cacheflush()?;
+        let res = conn.cacheflush()?;
         Ok(())
     }
 

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -344,7 +344,11 @@ impl DatabaseFile {
 }
 
 impl turso_core::DatabaseStorage for DatabaseFile {
-    fn read_page(&self, page_idx: usize, c: turso_core::Completion) -> Result<()> {
+    fn read_page(
+        &self,
+        page_idx: usize,
+        c: turso_core::Completion,
+    ) -> Result<Arc<turso_core::Completion>> {
         let r = match c.completion_type {
             turso_core::CompletionType::Read(ref r) => r,
             _ => unreachable!(),
@@ -355,8 +359,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
             return Err(turso_core::LimboError::NotADB);
         }
         let pos = (page_idx - 1) * size;
-        self.file.pread(pos, c.into())?;
-        Ok(())
+        self.file.pread(pos, c.into())
     }
 
     fn write_page(
@@ -364,16 +367,14 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         page_idx: usize,
         buffer: Arc<std::cell::RefCell<turso_core::Buffer>>,
         c: turso_core::Completion,
-    ) -> Result<()> {
+    ) -> Result<Arc<turso_core::Completion>> {
         let size = buffer.borrow().len();
         let pos = (page_idx - 1) * size;
-        self.file.pwrite(pos, buffer, c.into())?;
-        Ok(())
+        self.file.pwrite(pos, buffer, c.into())
     }
 
-    fn sync(&self, c: turso_core::Completion) -> Result<()> {
-        let _ = self.file.sync(c.into())?;
-        Ok(())
+    fn sync(&self, c: turso_core::Completion) -> Result<Arc<turso_core::Completion>> {
+        self.file.sync(c.into())
     }
 
     fn size(&self) -> Result<u64> {

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -213,11 +213,7 @@ impl turso_core::File for File {
         Ok(())
     }
 
-    fn pread(
-        &self,
-        pos: usize,
-        c: Arc<turso_core::Completion>,
-    ) -> Result<Arc<turso_core::Completion>> {
+    fn pread(&self, pos: usize, c: turso_core::Completion) -> Result<turso_core::Completion> {
         let r = c.as_read();
         let nr = {
             let mut buf = r.buf_mut();
@@ -233,8 +229,8 @@ impl turso_core::File for File {
         &self,
         pos: usize,
         buffer: Arc<std::cell::RefCell<turso_core::Buffer>>,
-        c: Arc<turso_core::Completion>,
-    ) -> Result<Arc<turso_core::Completion>> {
+        c: turso_core::Completion,
+    ) -> Result<turso_core::Completion> {
         let w = c.as_write();
         let buf = buffer.borrow();
         let buf: &[u8] = buf.as_slice();
@@ -244,7 +240,7 @@ impl turso_core::File for File {
         Ok(c)
     }
 
-    fn sync(&self, c: Arc<turso_core::Completion>) -> Result<Arc<turso_core::Completion>> {
+    fn sync(&self, c: turso_core::Completion) -> Result<turso_core::Completion> {
         self.vfs.sync(self.fd);
         c.complete(0);
         #[allow(clippy::arc_with_non_send_sync)]
@@ -288,7 +284,7 @@ impl turso_core::IO for PlatformIO {
         }))
     }
 
-    fn wait_for_completion(&self, c: Arc<turso_core::Completion>) -> Result<()> {
+    fn wait_for_completion(&self, c: turso_core::Completion) -> Result<()> {
         while !c.is_completed() {
             self.run_once()?;
         }
@@ -342,7 +338,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         &self,
         page_idx: usize,
         c: turso_core::Completion,
-    ) -> Result<Arc<turso_core::Completion>> {
+    ) -> Result<turso_core::Completion> {
         let r = c.as_read();
         let size = r.buf().len();
         assert!(page_idx > 0);
@@ -358,13 +354,13 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         page_idx: usize,
         buffer: Arc<std::cell::RefCell<turso_core::Buffer>>,
         c: turso_core::Completion,
-    ) -> Result<Arc<turso_core::Completion>> {
+    ) -> Result<turso_core::Completion> {
         let size = buffer.borrow().len();
         let pos = (page_idx - 1) * size;
         self.file.pwrite(pos, buffer, c.into())
     }
 
-    fn sync(&self, c: turso_core::Completion) -> Result<Arc<turso_core::Completion>> {
+    fn sync(&self, c: turso_core::Completion) -> Result<turso_core::Completion> {
         self.file.sync(c.into())
     }
 

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -218,10 +218,7 @@ impl turso_core::File for File {
         pos: usize,
         c: Arc<turso_core::Completion>,
     ) -> Result<Arc<turso_core::Completion>> {
-        let r = match c.completion_type {
-            turso_core::CompletionType::Read(ref r) => r,
-            _ => unreachable!(),
-        };
+        let r = c.as_read();
         let nr = {
             let mut buf = r.buf_mut();
             let buf: &mut [u8] = buf.as_mut_slice();
@@ -238,10 +235,7 @@ impl turso_core::File for File {
         buffer: Arc<std::cell::RefCell<turso_core::Buffer>>,
         c: Arc<turso_core::Completion>,
     ) -> Result<Arc<turso_core::Completion>> {
-        let w = match c.completion_type {
-            turso_core::CompletionType::Write(ref w) => w,
-            _ => unreachable!(),
-        };
+        let w = c.as_write();
         let buf = buffer.borrow();
         let buf: &[u8] = buf.as_slice();
         self.vfs.pwrite(self.fd, buf, pos);
@@ -349,10 +343,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         page_idx: usize,
         c: turso_core::Completion,
     ) -> Result<Arc<turso_core::Completion>> {
-        let r = match c.completion_type {
-            turso_core::CompletionType::Read(ref r) => r,
-            _ => unreachable!(),
-        };
+        let r = c.as_read();
         let size = r.buf().len();
         assert!(page_idx > 0);
         if !(512..=65536).contains(&size) || size & (size - 1) != 0 {

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -346,7 +346,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
             return Err(turso_core::LimboError::NotADB);
         }
         let pos = (page_idx - 1) * size;
-        self.file.pread(pos, c.into())
+        self.file.pread(pos, c)
     }
 
     fn write_page(
@@ -357,11 +357,11 @@ impl turso_core::DatabaseStorage for DatabaseFile {
     ) -> Result<turso_core::Completion> {
         let size = buffer.borrow().len();
         let pos = (page_idx - 1) * size;
-        self.file.pwrite(pos, buffer, c.into())
+        self.file.pwrite(pos, buffer, c)
     }
 
     fn sync(&self, c: turso_core::Completion) -> Result<turso_core::Completion> {
-        self.file.sync(c.into())
+        self.file.sync(c)
     }
 
     fn size(&self) -> Result<u64> {

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -53,7 +53,7 @@ impl IO for MemoryIO {
         Ok(())
     }
 
-    fn wait_for_completion(&self, _c: Arc<Completion>) -> Result<()> {
+    fn wait_for_completion(&self, _c: Completion) -> Result<()> {
         todo!();
     }
 
@@ -83,7 +83,7 @@ impl File for MemoryFile {
         Ok(())
     }
 
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<Arc<Completion>> {
+    fn pread(&self, pos: usize, c: Completion) -> Result<Completion> {
         let r = c.as_read();
         let buf_len = r.buf().len();
         if buf_len == 0 {
@@ -128,8 +128,8 @@ impl File for MemoryFile {
         &self,
         pos: usize,
         buffer: Arc<RefCell<Buffer>>,
-        c: Arc<Completion>,
-    ) -> Result<Arc<Completion>> {
+        c: Completion,
+    ) -> Result<Completion> {
         let buf = buffer.borrow();
         let buf_len = buf.len();
         if buf_len == 0 {
@@ -165,7 +165,7 @@ impl File for MemoryFile {
         Ok(c)
     }
 
-    fn sync(&self, c: Arc<Completion>) -> Result<Arc<Completion>> {
+    fn sync(&self, c: Completion) -> Result<Completion> {
         // no-op
         c.complete(0);
         Ok(c)

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -14,14 +14,10 @@ use std::{
 pub trait File: Send + Sync {
     fn lock_file(&self, exclusive: bool) -> Result<()>;
     fn unlock_file(&self) -> Result<()>;
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<Arc<Completion>>;
-    fn pwrite(
-        &self,
-        pos: usize,
-        buffer: Arc<RefCell<Buffer>>,
-        c: Arc<Completion>,
-    ) -> Result<Arc<Completion>>;
-    fn sync(&self, c: Arc<Completion>) -> Result<Arc<Completion>>;
+    fn pread(&self, pos: usize, c: Completion) -> Result<Completion>;
+    fn pwrite(&self, pos: usize, buffer: Arc<RefCell<Buffer>>, c: Completion)
+        -> Result<Completion>;
+    fn sync(&self, c: Completion) -> Result<Completion>;
     fn size(&self) -> Result<u64>;
 }
 
@@ -47,7 +43,7 @@ pub trait IO: Clock + Send + Sync {
 
     fn run_once(&self) -> Result<()>;
 
-    fn wait_for_completion(&self, c: Arc<Completion>) -> Result<()>;
+    fn wait_for_completion(&self, c: Completion) -> Result<()>;
 
     fn generate_random_number(&self) -> i64;
 

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -286,7 +286,7 @@ impl IO for UnixIO {
         Ok(())
     }
 
-    fn wait_for_completion(&self, c: Arc<Completion>) -> Result<()> {
+    fn wait_for_completion(&self, c: Completion) -> Result<()> {
         while !c.is_completed() {
             self.run_once()?;
         }
@@ -305,10 +305,10 @@ impl IO for UnixIO {
 }
 
 enum CompletionCallback {
-    Read(Arc<Mutex<std::fs::File>>, Arc<Completion>, usize),
+    Read(Arc<Mutex<std::fs::File>>, Completion, usize),
     Write(
         Arc<Mutex<std::fs::File>>,
-        Arc<Completion>,
+        Completion,
         Arc<RefCell<crate::Buffer>>,
         usize,
     ),
@@ -364,7 +364,7 @@ impl File for UnixFile<'_> {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<Arc<Completion>> {
+    fn pread(&self, pos: usize, c: Completion) -> Result<Completion> {
         let file = self.file.lock().unwrap();
         let result = {
             let r = c.as_read();
@@ -401,8 +401,8 @@ impl File for UnixFile<'_> {
         &self,
         pos: usize,
         buffer: Arc<RefCell<crate::Buffer>>,
-        c: Arc<Completion>,
-    ) -> Result<Arc<Completion>> {
+        c: Completion,
+    ) -> Result<Completion> {
         let file = self.file.lock().unwrap();
         let result = {
             let buf = buffer.borrow();
@@ -432,7 +432,7 @@ impl File for UnixFile<'_> {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn sync(&self, c: Arc<Completion>) -> Result<Arc<Completion>> {
+    fn sync(&self, c: Completion) -> Result<Completion> {
         let file = self.file.lock().unwrap();
         let result = fs::fsync(file.as_fd());
         match result {

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -1,7 +1,6 @@
 use super::{Buffer, Completion, File, MemoryIO, OpenFlags, IO};
 use crate::ext::VfsMod;
 use crate::io::clock::{Clock, Instant};
-use crate::io::CompletionType;
 use crate::{LimboError, Result};
 use std::cell::RefCell;
 use std::ffi::{c_void, CString};
@@ -99,10 +98,7 @@ impl File for VfsFileImpl {
     }
 
     fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<Arc<Completion>> {
-        let r = match c.completion_type {
-            CompletionType::Read(ref r) => r,
-            _ => unreachable!(),
-        };
+        let r = c.as_read();
         let result = {
             let mut buf = r.buf_mut();
             let count = buf.len();

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -43,7 +43,7 @@ impl IO for VfsMod {
         Ok(())
     }
 
-    fn wait_for_completion(&self, _c: Arc<Completion>) -> Result<()> {
+    fn wait_for_completion(&self, _c: Completion) -> Result<()> {
         todo!();
     }
 
@@ -97,7 +97,7 @@ impl File for VfsFileImpl {
         Ok(())
     }
 
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<Arc<Completion>> {
+    fn pread(&self, pos: usize, c: Completion) -> Result<Completion> {
         let r = c.as_read();
         let result = {
             let mut buf = r.buf_mut();
@@ -117,8 +117,8 @@ impl File for VfsFileImpl {
         &self,
         pos: usize,
         buffer: Arc<RefCell<Buffer>>,
-        c: Arc<Completion>,
-    ) -> Result<Arc<Completion>> {
+        c: Completion,
+    ) -> Result<Completion> {
         let buf = buffer.borrow();
         let count = buf.as_slice().len();
         if self.vfs.is_null() {
@@ -142,7 +142,7 @@ impl File for VfsFileImpl {
         }
     }
 
-    fn sync(&self, c: Arc<Completion>) -> Result<Arc<Completion>> {
+    fn sync(&self, c: Completion) -> Result<Completion> {
         let vfs = unsafe { &*self.vfs };
         let result = unsafe { (vfs.sync)(self.file) };
         if result < 0 {

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -33,7 +33,7 @@ impl IO for WindowsIO {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn wait_for_completion(&self, c: Arc<Completion>) -> Result<()> {
+    fn wait_for_completion(&self, c: Completion) -> Result<()> {
         while !c.is_completed() {
             self.run_once()?;
         }
@@ -84,7 +84,7 @@ impl File for WindowsFile {
     }
 
     #[instrument(skip(self, c), level = Level::TRACE)]
-    fn pread(&self, pos: usize, c: Arc<Completion>) -> Result<Arc<Completion>> {
+    fn pread(&self, pos: usize, c: Completion) -> Result<Completion> {
         let mut file = self.file.write();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         let nr = {
@@ -103,8 +103,8 @@ impl File for WindowsFile {
         &self,
         pos: usize,
         buffer: Arc<RefCell<crate::Buffer>>,
-        c: Arc<Completion>,
-    ) -> Result<Arc<Completion>> {
+        c: Completion,
+    ) -> Result<Completion> {
         let mut file = self.file.write();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         let buf = buffer.borrow();
@@ -115,7 +115,7 @@ impl File for WindowsFile {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn sync(&self, c: Arc<Completion>) -> Result<Arc<Completion>> {
+    fn sync(&self, c: Completion) -> Result<Completion> {
         let file = self.file.write();
         file.sync_all().map_err(LimboError::IOError)?;
         c.complete(0);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2443,7 +2443,7 @@ impl BTreeCursor {
                     }
 
                     if !self.stack.has_parent() {
-                        self.balance_root()?;
+                        let res = self.balance_root()?;
                     }
 
                     let write_info = self.state.mut_write_info().unwrap();
@@ -5256,7 +5256,8 @@ impl BTreeCursor {
                     let new_payload = &mut *new_payload;
                     // if it all fits in local space and old_local_size is enough, do an in-place overwrite
                     if new_payload.len() == *old_local_size {
-                        self.overwrite_content(page_ref.clone(), *old_offset, new_payload)?;
+                        let res =
+                            self.overwrite_content(page_ref.clone(), *old_offset, new_payload)?;
                         return Ok(IOResult::Done(()));
                     }
 
@@ -7751,7 +7752,7 @@ mod tests {
             tracing::info!("seed: {seed}");
             for i in 0..inserts {
                 pager.begin_read_tx().unwrap();
-                pager.begin_write_tx().unwrap();
+                let res = pager.begin_write_tx().unwrap();
                 let key = {
                     let result;
                     loop {
@@ -7921,7 +7922,7 @@ mod tests {
             for i in 0..operations {
                 let print_progress = i % 100 == 0;
                 pager.begin_read_tx().unwrap();
-                pager.begin_write_tx().unwrap();
+                let res = pager.begin_write_tx().unwrap();
 
                 // Decide whether to insert or delete (80% chance of insert)
                 let is_insert = rng.next_u64() % 100 < (insert_chance * 100.0) as u64;
@@ -8302,7 +8303,7 @@ mod tests {
 
         let _ = run_until_done(|| pager.allocate_page1(), &pager);
         for _ in 0..(database_size - 1) {
-            pager.allocate_page().unwrap();
+            let res = pager.allocate_page().unwrap();
         }
 
         header_accessor::set_page_size(&pager, page_size).unwrap();
@@ -8334,7 +8335,7 @@ mod tests {
             )));
             let c = Completion::new_write(|_| {});
             #[allow(clippy::arc_with_non_send_sync)]
-            pager
+            let c = pager
                 .db_file
                 .write_page(current_page as usize, buf.clone(), c)?;
             pager.io.run_once()?;

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -1,5 +1,4 @@
 use crate::error::LimboError;
-use crate::io::CompletionType;
 use crate::{io::Completion, Buffer, Result};
 use std::{cell::RefCell, sync::Arc};
 use tracing::{instrument, Level};
@@ -89,10 +88,7 @@ unsafe impl Sync for FileMemoryStorage {}
 impl DatabaseStorage for FileMemoryStorage {
     #[instrument(skip_all, level = Level::DEBUG)]
     fn read_page(&self, page_idx: usize, c: Completion) -> Result<Arc<Completion>> {
-        let r = match c.completion_type {
-            CompletionType::Read(ref r) => r,
-            _ => unreachable!(),
-        };
+        let r = c.as_read();
         let size = r.buf().len();
         assert!(page_idx > 0);
         if !(512..=65536).contains(&size) || size & (size - 1) != 0 {

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -41,7 +41,7 @@ impl DatabaseStorage for DatabaseFile {
             return Err(LimboError::NotADB);
         }
         let pos = (page_idx - 1) * size;
-        self.file.pread(pos, c.into())
+        self.file.pread(pos, c)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
@@ -57,12 +57,12 @@ impl DatabaseStorage for DatabaseFile {
         assert!(buffer_size <= 65536);
         assert_eq!(buffer_size & (buffer_size - 1), 0);
         let pos = (page_idx - 1) * buffer_size;
-        self.file.pwrite(pos, buffer, c.into())
+        self.file.pwrite(pos, buffer, c)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
     fn sync(&self, c: Completion) -> Result<Completion> {
-        self.file.sync(c.into())
+        self.file.sync(c)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
@@ -95,7 +95,7 @@ impl DatabaseStorage for FileMemoryStorage {
             return Err(LimboError::NotADB);
         }
         let pos = (page_idx - 1) * size;
-        self.file.pread(pos, c.into())
+        self.file.pread(pos, c)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
@@ -110,12 +110,12 @@ impl DatabaseStorage for FileMemoryStorage {
         assert!(buffer_size <= 65536);
         assert_eq!(buffer_size & (buffer_size - 1), 0);
         let pos = (page_idx - 1) * buffer_size;
-        self.file.pwrite(pos, buffer, c.into())
+        self.file.pwrite(pos, buffer, c)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
     fn sync(&self, c: Completion) -> Result<Completion> {
-        self.file.sync(c.into())
+        self.file.sync(c)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1464,7 +1464,7 @@ impl Pager {
                     (default_header.get_page_size() - default_header.reserved_space as u32) as u16,
                 );
                 let write_counter = Rc::new(RefCell::new(0));
-                begin_write_btree_page(self, &page1.get(), write_counter.clone())?;
+                let c= begin_write_btree_page(self, &page1.get(), write_counter.clone())?;
 
                 self.allocate_page1_state
                     .replace(AllocatePage1State::Writing {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1167,7 +1167,7 @@ impl Pager {
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn wal_get_frame(&self, frame_no: u32, frame: &mut [u8]) -> Result<Arc<Completion>> {
+    pub fn wal_get_frame(&self, frame_no: u32, frame: &mut [u8]) -> Result<Completion> {
         let wal = self.wal.borrow();
         wal.read_frame_raw(frame_no.into(), frame)
     }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -881,7 +881,7 @@ impl Pager {
             return Ok(page);
         }
 
-        sqlite3_ondisk::begin_read_page(
+        let c = sqlite3_ondisk::begin_read_page(
             self.db_file.clone(),
             self.buffer_pool.clone(),
             page.clone(),
@@ -1464,7 +1464,7 @@ impl Pager {
                     (default_header.get_page_size() - default_header.reserved_space as u32) as u16,
                 );
                 let write_counter = Rc::new(RefCell::new(0));
-                let c= begin_write_btree_page(self, &page1.get(), write_counter.clone())?;
+                let c = begin_write_btree_page(self, &page1.get(), write_counter.clone())?;
 
                 self.allocate_page1_state
                     .replace(AllocatePage1State::Writing {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -860,7 +860,7 @@ pub fn begin_sync(db_file: Arc<dyn DatabaseStorage>, syncing: Rc<RefCell<bool>>)
         *syncing.borrow_mut() = false;
     });
     #[allow(clippy::arc_with_non_send_sync)]
-    db_file.sync(completion)?;
+    let c = db_file.sync(completion)?;
     Ok(())
 }
 
@@ -1565,7 +1565,7 @@ pub fn read_entire_wal_dumb(file: &Arc<dyn File>) -> Result<Arc<UnsafeCell<WalFi
         wfs_data.loaded.store(true, Ordering::SeqCst);
     });
     let c = Completion::new_read(buf_for_pread, complete);
-    file.pread(0, c.into())?;
+    let c = file.pread(0, c)?;
 
     Ok(wal_file_shared_ret)
 }
@@ -1584,7 +1584,7 @@ pub fn begin_read_wal_frame_raw(
     )));
     #[allow(clippy::arc_with_non_send_sync)]
     let c = Completion::new_read(buf, complete);
-    let c = io.pread(offset, c.into())?;
+    let c = io.pread(offset, c)?;
     Ok(c)
 }
 
@@ -1603,7 +1603,7 @@ pub fn begin_read_wal_frame(
     let buf = Arc::new(RefCell::new(Buffer::new(buf, drop_fn)));
     #[allow(clippy::arc_with_non_send_sync)]
     let c = Completion::new_read(buf, complete);
-    let c = io.pread(offset, c.into())?;
+    let c = io.pread(offset, c)?;
     Ok(c)
 }
 
@@ -1693,7 +1693,7 @@ pub fn begin_write_wal_header(io: &Arc<dyn File>, header: &WalHeader) -> Result<
     };
     #[allow(clippy::arc_with_non_send_sync)]
     let c = Completion::new_write(write_complete);
-    io.pwrite(0, buffer.clone(), c.into())?;
+    let c = io.pwrite(0, buffer.clone(), c)?;
     Ok(())
 }
 

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -814,7 +814,7 @@ pub fn begin_write_btree_page(
     pager: &Pager,
     page: &PageRef,
     write_counter: Rc<RefCell<usize>>,
-) -> Result<()> {
+) -> Result<Arc<Completion>> {
     tracing::trace!("begin_write_btree_page(page={})", page.get().id);
     let page_source = &pager.db_file;
     let page_finish = page.clone();

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -762,7 +762,7 @@ pub fn begin_read_page(
     buffer_pool: Arc<BufferPool>,
     page: PageRef,
     page_idx: usize,
-) -> Result<()> {
+) -> Result<Arc<Completion>> {
     tracing::trace!("begin_read_btree_page(page_idx = {})", page_idx);
     let buf = buffer_pool.get();
     let drop_fn = Rc::new(move |buf| {
@@ -783,8 +783,7 @@ pub fn begin_read_page(
         }
     });
     let c = Completion::new_read(buf, complete);
-    db_file.read_page(page_idx, c)?;
-    Ok(())
+    db_file.read_page(page_idx, c)
 }
 
 #[instrument(skip_all, level = Level::INFO)]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -762,7 +762,7 @@ pub fn begin_read_page(
     buffer_pool: Arc<BufferPool>,
     page: PageRef,
     page_idx: usize,
-) -> Result<Arc<Completion>> {
+) -> Result<Completion> {
     tracing::trace!("begin_read_btree_page(page_idx = {})", page_idx);
     let buf = buffer_pool.get();
     let drop_fn = Rc::new(move |buf| {
@@ -813,7 +813,7 @@ pub fn begin_write_btree_page(
     pager: &Pager,
     page: &PageRef,
     write_counter: Rc<RefCell<usize>>,
-) -> Result<Arc<Completion>> {
+) -> Result<Completion> {
     tracing::trace!("begin_write_btree_page(page={})", page.get().id);
     let page_source = &pager.db_file;
     let page_finish = page.clone();
@@ -1575,7 +1575,7 @@ pub fn begin_read_wal_frame_raw(
     offset: usize,
     page_size: u32,
     complete: Box<dyn Fn(Arc<RefCell<Buffer>>, i32)>,
-) -> Result<Arc<Completion>> {
+) -> Result<Completion> {
     tracing::trace!("begin_read_wal_frame_raw(offset={})", offset);
     let drop_fn = Rc::new(|_buf| {});
     let buf = Arc::new(RefCell::new(Buffer::allocate(
@@ -1593,7 +1593,7 @@ pub fn begin_read_wal_frame(
     offset: usize,
     buffer_pool: Arc<BufferPool>,
     complete: Box<dyn Fn(Arc<RefCell<Buffer>>, i32)>,
-) -> Result<Arc<Completion>> {
+) -> Result<Completion> {
     tracing::trace!("begin_read_wal_frame(offset={})", offset);
     let buf = buffer_pool.get();
     let drop_fn = Rc::new(move |buf| {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -914,7 +914,7 @@ impl Wal for WalFile {
                 }
                 CheckpointState::WritePage => {
                     self.ongoing_checkpoint.page.set_dirty();
-                    begin_write_btree_page(
+                    let c = begin_write_btree_page(
                         pager,
                         &self.ongoing_checkpoint.page,
                         write_counter.clone(),

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -626,7 +626,7 @@ impl Wal for WalFile {
             let frame = frame.clone();
             finish_read_page(page.get().id, buf, frame).unwrap();
         });
-        begin_read_wal_frame(
+        let c = begin_read_wal_frame(
             &self.get_shared().file,
             offset + WAL_FRAME_HEADER_SIZE,
             buffer_pool,
@@ -784,7 +784,7 @@ impl Wal for WalFile {
                     *write_counter.borrow_mut() -= 1;
                 }
             });
-            let result = shared.file.pwrite(offset, frame_bytes.clone(), c.into());
+            let result = shared.file.pwrite(offset, frame_bytes.clone(), c);
             if let Err(err) = result {
                 *write_counter.borrow_mut() -= 1;
                 return Err(err);
@@ -1001,7 +1001,7 @@ impl Wal for WalFile {
                     syncing.set(false);
                 });
                 let shared = self.get_shared();
-                shared.file.sync(completion.into())?;
+                let c = shared.file.sync(completion)?;
                 self.sync_state.set(SyncState::Syncing);
                 Ok(IOResult::IO)
             }

--- a/core/types.rs
+++ b/core/types.rs
@@ -2323,6 +2323,7 @@ impl Cursor {
 }
 
 #[derive(Debug)]
+#[must_use]
 pub enum IOResult<T> {
     Done(T),
     IO,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6356,7 +6356,7 @@ pub fn op_open_ephemeral(
             } else {
                 BTreeCursor::new_table(mv_cursor, pager.clone(), root_page as usize, num_columns)
             };
-            cursor.rewind()?; // Will never return io
+            let res = cursor.rewind()?; // Will never return io
 
             let mut cursors: std::cell::RefMut<'_, Vec<Option<Cursor>>> =
                 state.cursors.borrow_mut();

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -402,7 +402,7 @@ impl SortedChunk {
             read_buffer_ref,
             read_complete,
         )));
-        self.file.pread(self.total_bytes_read.get(), Arc::new(c))?;
+        self.file.pread(self.total_bytes_read.get(), c)?;
         Ok(())
     }
 
@@ -448,7 +448,7 @@ impl SortedChunk {
         });
 
         let c = Completion::new(CompletionType::Write(WriteCompletion::new(write_complete)));
-        self.file.pwrite(0, buffer_ref, Arc::new(c))?;
+        self.file.pwrite(0, buffer_ref, c)?;
         Ok(())
     }
 }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -402,7 +402,7 @@ impl SortedChunk {
             read_buffer_ref,
             read_complete,
         )));
-        self.file.pread(self.total_bytes_read.get(), c)?;
+        let c = self.file.pread(self.total_bytes_read.get(), c)?;
         Ok(())
     }
 
@@ -448,7 +448,7 @@ impl SortedChunk {
         });
 
         let c = Completion::new(CompletionType::Write(WriteCompletion::new(write_complete)));
-        self.file.pwrite(0, buffer_ref, c)?;
+        let c = self.file.pwrite(0, buffer_ref, c)?;
         Ok(())
     }
 }

--- a/simulator/runner/file.rs
+++ b/simulator/runner/file.rs
@@ -38,12 +38,12 @@ pub(crate) struct SimulatorFile {
 
     pub latency_probability: usize,
 
-    pub sync_completion: RefCell<Option<Arc<turso_core::Completion>>>,
+    pub sync_completion: RefCell<Option<turso_core::Completion>>,
     pub queued_io: RefCell<Vec<DelayedIo>>,
     pub clock: Arc<SimulatorClock>,
 }
 
-type IoOperation = Box<dyn FnOnce(&SimulatorFile) -> Result<Arc<turso_core::Completion>>>;
+type IoOperation = Box<dyn FnOnce(&SimulatorFile) -> Result<turso_core::Completion>>;
 
 pub struct DelayedIo {
     pub time: turso_core::Instant,
@@ -149,11 +149,7 @@ impl File for SimulatorFile {
         self.inner.unlock_file()
     }
 
-    fn pread(
-        &self,
-        pos: usize,
-        c: Arc<turso_core::Completion>,
-    ) -> Result<Arc<turso_core::Completion>> {
+    fn pread(&self, pos: usize, c: turso_core::Completion) -> Result<turso_core::Completion> {
         self.nr_pread_calls.set(self.nr_pread_calls.get() + 1);
         if self.fault.get() {
             tracing::debug!("pread fault");
@@ -178,8 +174,8 @@ impl File for SimulatorFile {
         &self,
         pos: usize,
         buffer: Arc<RefCell<turso_core::Buffer>>,
-        c: Arc<turso_core::Completion>,
-    ) -> Result<Arc<turso_core::Completion>> {
+        c: turso_core::Completion,
+    ) -> Result<turso_core::Completion> {
         self.nr_pwrite_calls.set(self.nr_pwrite_calls.get() + 1);
         if self.fault.get() {
             tracing::debug!("pwrite fault");
@@ -200,7 +196,7 @@ impl File for SimulatorFile {
         }
     }
 
-    fn sync(&self, c: Arc<turso_core::Completion>) -> Result<Arc<turso_core::Completion>> {
+    fn sync(&self, c: turso_core::Completion) -> Result<turso_core::Completion> {
         self.nr_sync_calls.set(self.nr_sync_calls.get() + 1);
         if self.fault.get() {
             // TODO: Enable this when https://github.com/tursodatabase/turso/issues/2091 is fixed.

--- a/simulator/runner/file.rs
+++ b/simulator/runner/file.rs
@@ -121,7 +121,7 @@ impl SimulatorFile {
             if queued_io[i].time <= now {
                 let io = queued_io.remove(i);
                 // your code here
-                (io.op)(self)?;
+                let c = (io.op)(self)?;
             } else {
                 i += 1;
             }

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -104,7 +104,7 @@ impl IO for SimulatorIO {
         Ok(file)
     }
 
-    fn wait_for_completion(&self, c: Arc<turso_core::Completion>) -> Result<()> {
+    fn wait_for_completion(&self, c: turso_core::Completion) -> Result<()> {
         while !c.is_completed() {
             self.run_once()?;
         }

--- a/tests/integration/query_processing/test_btree.rs
+++ b/tests/integration/query_processing/test_btree.rs
@@ -433,7 +433,7 @@ fn write_at(io: &impl IO, file: Arc<dyn File>, offset: usize, data: &[u8]) {
     let drop_fn = Rc::new(move |_| {});
     #[allow(clippy::arc_with_non_send_sync)]
     let buffer = Arc::new(RefCell::new(Buffer::new(Pin::new(data.to_vec()), drop_fn)));
-    let result = file.pwrite(offset, buffer, completion.into()).unwrap();
+    let result = file.pwrite(offset, buffer, completion).unwrap();
     while !result.is_completed() {
         io.run_once().unwrap();
     }


### PR DESCRIPTION
Changes a couple of function signatures to return `Completion`. Also, I changed `Completion` to be internally `Arc` to abstract the `Arc` implementation detail, and to be able to attach a `#[must_use]` to the `Completion` struct, so that cargo check can show us where we are not tracking completions in the code. I also attached a `#[must_use]` to `IOResult` so that we can see the places that we are not propagating or waiting for I/O, demonstrating locations where functions should be reentrant and are not. 

Also, while we are with this refactor in progress I want to relax the Clippy CI lint on unused_variables. 