### PR TITLE
perf: fix logic error in is_simple_count()

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -464,7 +464,7 @@ impl SelectPlan {
                 QueryDestination::CoroutineYield { .. }
             )
             || self.table_references.joined_tables().len() != 1
-            || self.table_references.outer_query_refs().is_empty()
+            || !self.table_references.outer_query_refs().is_empty()
             || self.result_columns.len() != 1
             || self.group_by.is_some()
             || self.contains_constant_false_condition


### PR DESCRIPTION
```
Execute `SELECT count() FROM users`/limbo_execute_select_count
                        time:   [15.635 µs 15.676 µs 15.730 µs]
                        change: [-96.011% -95.991% -95.972%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Performance has improved.

Closes #2313