### PR TITLE
core/mvcc: simplify mvcc cursor types

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -108,7 +108,7 @@ enum TransactionState {
 
 pub(crate) type MvStore = mvcc::MvStore<mvcc::LocalClock>;
 
-pub(crate) type MvCursor = mvcc::cursor::ScanCursor<mvcc::LocalClock>;
+pub(crate) type MvCursor = mvcc::cursor::MvccLazyCursor<mvcc::LocalClock>;
 
 /// The database manager ensures that there is a single, shared
 /// `Database` object per a database file. We need because it is not safe


### PR DESCRIPTION
We have so many cursor types that it will be unbearable to properly make all of them work. Let's simplify this and only focus on lazy cursor which in the future will load from database in case we need it.