### PR TITLE
Add vector_concat and vector_slice support

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -632,7 +632,7 @@ The `vector` extension is compatible with libSQL native vector search.
 | vector_distance_cos(x, y)                      | Yes    |         |
 | vector_distance_l2(x, y)                              | Yes    |Euclidean distance|
 | vector_concat(x, y)                            | Yes    |         |
-| subvector(x, start_index, length)              | Yes    |         |
+| vector_slice(x, start_index, length)              | Yes    |         |
 
 ### Time
 

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -632,7 +632,7 @@ The `vector` extension is compatible with libSQL native vector search.
 | vector_distance_cos(x, y)                      | Yes    |         |
 | vector_distance_l2(x, y)                              | Yes    |Euclidean distance|
 | vector_concat(x, y)                            | Yes    |         |
-| vector_slice(x, start_index, length)              | Yes    |         |
+| vector_slice(x, start_index, end_index)        | Yes    |         |
 
 ### Time
 

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -631,6 +631,8 @@ The `vector` extension is compatible with libSQL native vector search.
 | vector_extract(x)                              | Yes    |         |
 | vector_distance_cos(x, y)                      | Yes    |         |
 | vector_distance_l2(x, y)                              | Yes    |Euclidean distance|
+| vector_concat(x, y)                            | Yes    |         |
+| subvector(x, start_index, length)              | Yes    |         |
 
 ### Time
 

--- a/core/function.rs
+++ b/core/function.rs
@@ -179,7 +179,7 @@ impl Display for VectorFunc {
             // We use `distance_l2` to reduce user input
             Self::VectorDistanceEuclidean => "vector_distance_l2".to_string(),
             Self::VectorConcat => "vector_concat".to_string(),
-            Self::VectorSlice => "subvector".to_string(),
+            Self::VectorSlice => "vector_slice".to_string(),
         };
         write!(f, "{str}")
     }
@@ -843,7 +843,7 @@ impl Func {
             "vector_distance_cos" => Ok(Self::Vector(VectorFunc::VectorDistanceCos)),
             "vector_distance_l2" => Ok(Self::Vector(VectorFunc::VectorDistanceEuclidean)),
             "vector_concat" => Ok(Self::Vector(VectorFunc::VectorConcat)),
-            "subvector" => Ok(Self::Vector(VectorFunc::VectorSlice)),
+            "vector_slice" => Ok(Self::Vector(VectorFunc::VectorSlice)),
             _ => crate::bail_parse_error!("no such function: {}", name),
         }
     }

--- a/core/function.rs
+++ b/core/function.rs
@@ -159,6 +159,7 @@ pub enum VectorFunc {
     VectorDistanceCos,
     VectorDistanceEuclidean,
     VectorConcat,
+    VectorSlice,
 }
 
 impl VectorFunc {
@@ -178,6 +179,7 @@ impl Display for VectorFunc {
             // We use `distance_l2` to reduce user input
             Self::VectorDistanceEuclidean => "vector_distance_l2".to_string(),
             Self::VectorConcat => "vector_concat".to_string(),
+            Self::VectorSlice => "subvector".to_string(),
         };
         write!(f, "{str}")
     }
@@ -841,6 +843,7 @@ impl Func {
             "vector_distance_cos" => Ok(Self::Vector(VectorFunc::VectorDistanceCos)),
             "vector_distance_l2" => Ok(Self::Vector(VectorFunc::VectorDistanceEuclidean)),
             "vector_concat" => Ok(Self::Vector(VectorFunc::VectorConcat)),
+            "subvector" => Ok(Self::Vector(VectorFunc::VectorSlice)),
             _ => crate::bail_parse_error!("no such function: {}", name),
         }
     }

--- a/core/function.rs
+++ b/core/function.rs
@@ -158,6 +158,7 @@ pub enum VectorFunc {
     VectorExtract,
     VectorDistanceCos,
     VectorDistanceEuclidean,
+    VectorConcat,
 }
 
 impl VectorFunc {
@@ -176,6 +177,7 @@ impl Display for VectorFunc {
             Self::VectorDistanceCos => "vector_distance_cos".to_string(),
             // We use `distance_l2` to reduce user input
             Self::VectorDistanceEuclidean => "vector_distance_l2".to_string(),
+            Self::VectorConcat => "vector_concat".to_string(),
         };
         write!(f, "{str}")
     }
@@ -838,6 +840,7 @@ impl Func {
             "vector_extract" => Ok(Self::Vector(VectorFunc::VectorExtract)),
             "vector_distance_cos" => Ok(Self::Vector(VectorFunc::VectorDistanceCos)),
             "vector_distance_l2" => Ok(Self::Vector(VectorFunc::VectorDistanceEuclidean)),
+            "vector_concat" => Ok(Self::Vector(VectorFunc::VectorConcat)),
             _ => crate::bail_parse_error!("no such function: {}", name),
         }
     }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -929,6 +929,16 @@ pub fn translate_expr(
                         emit_function_call(program, func_ctx, &[regs, regs + 1], target_register)?;
                         Ok(target_register)
                     }
+                    VectorFunc::VectorSlice => {
+                        let args = expect_arguments_exact!(args, 3, vector_func);
+                        let regs = program.alloc_registers(3);
+                        translate_expr(program, referenced_tables, &args[0], regs, resolver)?;
+                        translate_expr(program, referenced_tables, &args[1], regs + 1, resolver)?;
+                        translate_expr(program, referenced_tables, &args[2], regs + 2, resolver)?;
+
+                        emit_function_call(program, func_ctx, &[regs, regs + 2], target_register)?;
+                        Ok(target_register)
+                    }
                 },
                 Func::Scalar(srf) => {
                     match srf {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -920,6 +920,15 @@ pub fn translate_expr(
                         emit_function_call(program, func_ctx, &[regs, regs + 1], target_register)?;
                         Ok(target_register)
                     }
+                    VectorFunc::VectorConcat => {
+                        let args = expect_arguments_exact!(args, 2, vector_func);
+                        let regs = program.alloc_registers(2);
+                        translate_expr(program, referenced_tables, &args[0], regs, resolver)?;
+                        translate_expr(program, referenced_tables, &args[1], regs + 1, resolver)?;
+
+                        emit_function_call(program, func_ctx, &[regs, regs + 1], target_register)?;
+                        Ok(target_register)
+                    }
                 },
                 Func::Scalar(srf) => {
                     match srf {

--- a/core/types.rs
+++ b/core/types.rs
@@ -329,10 +329,10 @@ impl Value {
         }
     }
 
-    pub fn as_int(&self) -> i64 {
+    pub fn as_int(&self) -> Option<i64> {
         match self {
-            Value::Integer(i) => *i,
-            _ => panic!("as_int must be called only for Value::Int"),
+            Value::Integer(i) => Some(*i),
+            _ => None,
         }
     }
 

--- a/core/types.rs
+++ b/core/types.rs
@@ -329,6 +329,13 @@ impl Value {
         }
     }
 
+    pub fn as_int(&self) -> i64 {
+        match self {
+            Value::Integer(i) => *i,
+            _ => panic!("as_int must be called only for Value::Int"),
+        }
+    }
+
     pub fn from_text(text: &str) -> Self {
         Value::Text(Text::new(text))
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -16,6 +16,7 @@ use crate::types::{
 use crate::util::normalize_ident;
 use crate::vdbe::insn::InsertFlags;
 use crate::vdbe::registers_to_ref_values;
+use crate::vector::vector_concat;
 use crate::{
     error::{
         LimboError, SQLITE_CONSTRAINT, SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY,
@@ -4555,6 +4556,10 @@ pub fn op_function(
             VectorFunc::VectorDistanceEuclidean => {
                 let result =
                     vector_distance_l2(&state.registers[*start_reg..*start_reg + arg_count])?;
+                state.registers[*dest] = Register::Value(result);
+            }
+            VectorFunc::VectorConcat => {
+                let result = vector_concat(&state.registers[*start_reg..*start_reg + arg_count])?;
                 state.registers[*dest] = Register::Value(result);
             }
         },

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -16,7 +16,7 @@ use crate::types::{
 use crate::util::normalize_ident;
 use crate::vdbe::insn::InsertFlags;
 use crate::vdbe::registers_to_ref_values;
-use crate::vector::{subvector, vector_concat};
+use crate::vector::{vector_concat, vector_slice};
 use crate::{
     error::{
         LimboError, SQLITE_CONSTRAINT, SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY,
@@ -4563,7 +4563,7 @@ pub fn op_function(
                 state.registers[*dest] = Register::Value(result);
             }
             VectorFunc::VectorSlice => {
-                let result = subvector(&state.registers[*start_reg..*start_reg + arg_count])?;
+                let result = vector_slice(&state.registers[*start_reg..*start_reg + arg_count])?;
                 state.registers[*dest] = Register::Value(result)
             }
         },

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -16,7 +16,7 @@ use crate::types::{
 use crate::util::normalize_ident;
 use crate::vdbe::insn::InsertFlags;
 use crate::vdbe::registers_to_ref_values;
-use crate::vector::vector_concat;
+use crate::vector::{subvector, vector_concat};
 use crate::{
     error::{
         LimboError, SQLITE_CONSTRAINT, SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY,
@@ -4561,6 +4561,10 @@ pub fn op_function(
             VectorFunc::VectorConcat => {
                 let result = vector_concat(&state.registers[*start_reg..*start_reg + arg_count])?;
                 state.registers[*dest] = Register::Value(result);
+            }
+            VectorFunc::VectorSlice => {
+                let result = subvector(&state.registers[*start_reg..*start_reg + arg_count])?;
+                state.registers[*dest] = Register::Value(result)
             }
         },
         crate::function::Func::External(f) => match f.func {

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -108,7 +108,7 @@ pub fn vector_distance_l2(args: &[Register]) -> Result<Value> {
 pub fn vector_concat(args: &[Register]) -> Result<Value> {
     if args.len() != 2 {
         return Err(LimboError::ConversionError(
-            "distance_concat requires exactly two arguments".to_string(),
+            "concat requires exactly two arguments".to_string(),
         ));
     }
 
@@ -125,5 +125,30 @@ pub fn vector_concat(args: &[Register]) -> Result<Value> {
     match vector.vector_type {
         VectorType::Float32 => Ok(vector_serialize_f32(vector)),
         VectorType::Float64 => Ok(vector_serialize_f64(vector)),
+    }
+}
+
+pub fn subvector(args: &[Register]) -> Result<Value> {
+    if args.len() != 3 {
+        return Err(LimboError::ConversionError(
+            "vector_sub requires exactly three arguments".to_string(),
+        ));
+    }
+
+    let vector = parse_vector(&args[0], None)?;
+    let start_index = args[1].get_owned_value().as_int();
+    let length = args[2].get_owned_value().as_int();
+
+    if start_index < 0 || length < 0 {
+        return Err(LimboError::InvalidArgument(
+            "start index or length can't be negative".into(),
+        ));
+    }
+
+    let result = vector_types::subvector(&vector, start_index as usize, length as usize)?;
+
+    match result.vector_type {
+        VectorType::Float32 => Ok(vector_serialize_f32(result)),
+        VectorType::Float64 => Ok(vector_serialize_f64(result)),
     }
 }

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -104,3 +104,26 @@ pub fn vector_distance_l2(args: &[Register]) -> Result<Value> {
     let dist = Euclidean::calculate(&x, &y)?;
     Ok(Value::Float(dist))
 }
+
+pub fn vector_concat(args: &[Register]) -> Result<Value> {
+    if args.len() != 2 {
+        return Err(LimboError::ConversionError(
+            "distance_concat requires exactly two arguments".to_string(),
+        ));
+    }
+
+    let x = parse_vector(&args[0], None)?;
+    let y = parse_vector(&args[1], None)?;
+
+    if x.vector_type != y.vector_type {
+        return Err(LimboError::ConversionError(
+            "Vectors must be of the same type".to_string(),
+        ));
+    }
+
+    let vector = vector_types::vector_concat(&x, &y)?;
+    match vector.vector_type {
+        VectorType::Float32 => Ok(vector_serialize_f32(vector)),
+        VectorType::Float64 => Ok(vector_serialize_f64(vector)),
+    }
+}

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -128,7 +128,7 @@ pub fn vector_concat(args: &[Register]) -> Result<Value> {
     }
 }
 
-pub fn subvector(args: &[Register]) -> Result<Value> {
+pub fn vector_slice(args: &[Register]) -> Result<Value> {
     if args.len() != 3 {
         return Err(LimboError::ConversionError(
             "vector_sub requires exactly three arguments".to_string(),
@@ -145,7 +145,7 @@ pub fn subvector(args: &[Register]) -> Result<Value> {
         ));
     }
 
-    let result = vector_types::subvector(&vector, start_index as usize, length as usize)?;
+    let result = vector_types::vector_slice(&vector, start_index as usize, length as usize)?;
 
     match result.vector_type {
         VectorType::Float32 => Ok(vector_serialize_f32(result)),

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -142,18 +142,18 @@ pub fn vector_slice(args: &[Register]) -> Result<Value> {
         .as_int()
         .ok_or_else(|| LimboError::InvalidArgument("start index must be an integer".into()))?;
 
-    let length = args[2]
+    let end_index = args[2]
         .get_owned_value()
         .as_int()
-        .ok_or_else(|| LimboError::InvalidArgument("length must be an integer".into()))?;
+        .ok_or_else(|| LimboError::InvalidArgument("end_index must be an integer".into()))?;
 
-    if start_index < 0 || length < 0 {
+    if start_index < 0 || end_index < 0 {
         return Err(LimboError::InvalidArgument(
-            "start index and length must be non-negative".into(),
+            "start index and end_index must be non-negative".into(),
         ));
     }
 
-    let result = vector_types::vector_slice(&vector, start_index as usize, length as usize)?;
+    let result = vector_types::vector_slice(&vector, start_index as usize, end_index as usize)?;
 
     Ok(match result.vector_type {
         VectorType::Float32 => vector_serialize_f32(result),

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -334,7 +334,7 @@ pub fn vector_concat(v1: &Vector, v2: &Vector) -> Result<Vector> {
     })
 }
 
-pub fn subvector(vector: &Vector, start_idx: usize, length: usize) -> Result<Vector> {
+pub fn vector_slice(vector: &Vector, start_idx: usize, length: usize) -> Result<Vector> {
     fn extract_bytes<T, const N: usize>(
         slice: &[T],
         start: usize,
@@ -343,7 +343,7 @@ pub fn subvector(vector: &Vector, start_idx: usize, length: usize) -> Result<Vec
     ) -> Result<Vec<u8>> {
         if start + len > slice.len() {
             return Err(LimboError::ConversionError(
-                "Subvector range out of bounds".into(),
+                "vector_slice range out of bounds".into(),
             ));
         }
 
@@ -663,12 +663,12 @@ mod tests {
     }
 
     #[test]
-    fn test_subvector() {
+    fn test_vector_slice() {
         let input = "[1.0, 2.0, 3.0, 4.0, 5.0]";
         let value = Value::from_text(input);
         let vector = parse_string_vector(VectorType::Float32, &value).unwrap();
 
-        let result = subvector(&vector, 1, 3).unwrap();
+        let result = vector_slice(&vector, 1, 3).unwrap();
 
         assert_eq!(result.dims, 3);
         assert_eq!(result.vector_type, VectorType::Float32);

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -626,12 +626,12 @@ mod tests {
     fn test_vector_concat() {
         let input = "[1.0, 2.0, 3.0]";
         let value = Value::from_text(input);
-    
+
         let vec1 = parse_string_vector(VectorType::Float32, &value).unwrap();
         let vec2 = parse_string_vector(VectorType::Float32, &value).unwrap();
-    
+
         let result = vector_concat(&vec1, &vec2).unwrap();
-    
+
         assert_eq!(result.dims, 6);
         assert_eq!(result.vector_type, VectorType::Float32);
     }

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -316,6 +316,24 @@ pub fn vector_type(blob: &[u8]) -> Result<VectorType> {
     }
 }
 
+pub fn vector_concat(v1: &Vector, v2: &Vector) -> Result<Vector> {
+    if v1.vector_type != v2.vector_type {
+        return Err(LimboError::ConversionError(
+            "Mismatched vector types".into(),
+        ));
+    }
+
+    let mut data = Vec::with_capacity(v1.data.len() + v2.data.len());
+    data.extend_from_slice(&v1.data);
+    data.extend_from_slice(&v2.data);
+
+    Ok(Vector {
+        vector_type: v1.vector_type.clone(),
+        dims: v1.dims + v2.dims,
+        data,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -334,6 +334,22 @@ pub fn vector_concat(v1: &Vector, v2: &Vector) -> Result<Vector> {
     })
 }
 
+pub fn subvector(vector: &Vector, start_idx: usize, length: usize) -> Result<Vector> {
+    if start_idx + length > vector.data.len() {
+        return Err(LimboError::ConversionError(
+            "Subvector range out of bounds".into(),
+        ));
+    }
+
+    let data = vector.data[start_idx..start_idx + length].to_vec();
+
+    Ok(Vector {
+        vector_type: vector.vector_type.clone(),
+        dims: length,
+        data,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -346,7 +346,7 @@ pub fn vector_slice(vector: &Vector, start_idx: usize, end_idx: usize) -> Result
                 "start index must not be greater than end index".into(),
             ));
         }
-        if end > slice.len() || start >= slice.len() {
+        if end > slice.len() || end < start {
             return Err(LimboError::ConversionError(
                 "vector_slice range out of bounds".into(),
             ));
@@ -751,6 +751,14 @@ mod tests {
 
         assert_eq!(result.dims, 1);
         assert_eq!(f32_slice_from_vector(&result), vec![2.71]);
+    }
+
+    #[test]
+    fn test_vector_slice_empty_list() {
+        let input_vec = float32_vec_from(&[1.0, 2.0]);
+        let result = vector_slice(&input_vec, 2, 2).unwrap();
+
+        assert_eq!(result.dims, 0);
     }
 
     #[test]

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -622,6 +622,20 @@ mod tests {
         assert_eq!(vector.vector_type, VectorType::Float32);
     }
 
+    #[test]
+    fn test_vector_concat() {
+        let input = "[1.0, 2.0, 3.0]";
+        let value = Value::from_text(input);
+    
+        let vec1 = parse_string_vector(VectorType::Float32, &value).unwrap();
+        let vec2 = parse_string_vector(VectorType::Float32, &value).unwrap();
+    
+        let result = vector_concat(&vec1, &vec2).unwrap();
+    
+        assert_eq!(result.dims, 6);
+        assert_eq!(result.vector_type, VectorType::Float32);
+    }
+
     #[quickcheck]
     fn prop_vector_text_roundtrip_2d(v: ArbitraryVector<2>) -> bool {
         test_vector_text_roundtrip(v.into())

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -2,7 +2,7 @@ use crate::types::{Value, ValueType};
 use crate::vdbe::Register;
 use crate::{LimboError, Result};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub enum VectorType {
     Float32,
     Float64,
@@ -328,7 +328,7 @@ pub fn vector_concat(v1: &Vector, v2: &Vector) -> Result<Vector> {
     data.extend_from_slice(&v2.data);
 
     Ok(Vector {
-        vector_type: v1.vector_type.clone(),
+        vector_type: v1.vector_type,
         dims: v1.dims + v2.dims,
         data,
     })
@@ -491,7 +491,7 @@ mod tests {
 
     /// Test if the vector type identification is correct for a given vector.
     fn test_vector_type<const DIMS: usize>(v: Vector) -> bool {
-        let vtype = v.vector_type.clone();
+        let vtype = v.vector_type;
         let value = match &vtype {
             VectorType::Float32 => vector_serialize_f32(v),
             VectorType::Float64 => vector_serialize_f64(v),
@@ -746,7 +746,7 @@ mod tests {
 
     #[test]
     fn test_vector_slice_single_element() {
-        let input_vec = float32_vec_from(&[3.14, 2.71]);
+        let input_vec = float32_vec_from(&[4.40, 2.71]);
         let result = vector_slice(&input_vec, 1, 2).unwrap();
 
         assert_eq!(result.dims, 1);
@@ -813,7 +813,7 @@ mod tests {
 
         // Parse back from text
         let value = Value::from_text(&text);
-        let parsed = parse_string_vector(v.vector_type.clone(), &value);
+        let parsed = parse_string_vector(v.vector_type, &value);
 
         match parsed {
             Ok(parsed_vector) => {

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -653,30 +653,132 @@ mod tests {
         assert_eq!(vector.vector_type, VectorType::Float32);
     }
 
-    #[test]
-    fn test_vector_concat() {
-        let input = "[1.0, 2.0, 3.0]";
-        let value = Value::from_text(input);
+    fn float32_vec_from(slice: &[f32]) -> Vector {
+        let mut data = Vec::new();
+        for &v in slice {
+            data.extend_from_slice(&v.to_le_bytes());
+        }
 
-        let vec1 = parse_string_vector(VectorType::Float32, &value).unwrap();
-        let vec2 = parse_string_vector(VectorType::Float32, &value).unwrap();
+        Vector {
+            vector_type: VectorType::Float32,
+            dims: slice.len(),
+            data,
+        }
+    }
 
-        let result = vector_concat(&vec1, &vec2).unwrap();
-
-        assert_eq!(result.dims, 6);
-        assert_eq!(result.vector_type, VectorType::Float32);
+    fn f32_slice_from_vector(vector: &Vector) -> Vec<f32> {
+        vector.as_f32_slice().to_vec()
     }
 
     #[test]
-    fn test_vector_slice() {
-        let input = "[1.0, 2.0, 3.0, 4.0, 5.0]";
-        let value = Value::from_text(input);
-        let vector = parse_string_vector(VectorType::Float32, &value).unwrap();
+    fn test_vector_concat_normal_case() {
+        let v1 = float32_vec_from(&[1.0, 2.0, 3.0]);
+        let v2 = float32_vec_from(&[4.0, 5.0, 6.0]);
 
-        let result = vector_slice(&vector, 1, 3).unwrap();
+        let result = vector_concat(&v1, &v2).unwrap();
+
+        assert_eq!(result.dims, 6);
+        assert_eq!(result.vector_type, VectorType::Float32);
+        assert_eq!(
+            f32_slice_from_vector(&result),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        );
+    }
+
+    #[test]
+    fn test_vector_concat_empty_left() {
+        let v1 = float32_vec_from(&[]);
+        let v2 = float32_vec_from(&[4.0, 5.0]);
+
+        let result = vector_concat(&v1, &v2).unwrap();
+
+        assert_eq!(result.dims, 2);
+        assert_eq!(f32_slice_from_vector(&result), vec![4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_vector_concat_empty_right() {
+        let v1 = float32_vec_from(&[1.0, 2.0]);
+        let v2 = float32_vec_from(&[]);
+
+        let result = vector_concat(&v1, &v2).unwrap();
+
+        assert_eq!(result.dims, 2);
+        assert_eq!(f32_slice_from_vector(&result), vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_vector_concat_both_empty() {
+        let v1 = float32_vec_from(&[]);
+        let v2 = float32_vec_from(&[]);
+        let result = vector_concat(&v1, &v2).unwrap();
+        assert_eq!(result.dims, 0);
+    }
+
+    #[test]
+    fn test_vector_concat_different_lengths() {
+        let v1 = float32_vec_from(&[1.0]);
+        let v2 = float32_vec_from(&[2.0, 3.0, 4.0]);
+
+        let result = vector_concat(&v1, &v2).unwrap();
+
+        assert_eq!(result.dims, 4);
+        assert_eq!(f32_slice_from_vector(&result), vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn test_vector_slice_normal_case() {
+        let input_vec = float32_vec_from(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+        let result = vector_slice(&input_vec, 1, 4).unwrap();
 
         assert_eq!(result.dims, 3);
-        assert_eq!(result.vector_type, VectorType::Float32);
+        assert_eq!(f32_slice_from_vector(&result), vec![2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn test_vector_slice_full_range() {
+        let input_vec = float32_vec_from(&[10.0, 20.0, 30.0]);
+        let result = vector_slice(&input_vec, 0, 3).unwrap();
+
+        assert_eq!(result.dims, 3);
+        assert_eq!(f32_slice_from_vector(&result), vec![10.0, 20.0, 30.0]);
+    }
+
+    #[test]
+    fn test_vector_slice_single_element() {
+        let input_vec = float32_vec_from(&[3.14, 2.71]);
+        let result = vector_slice(&input_vec, 1, 2).unwrap();
+
+        assert_eq!(result.dims, 1);
+        assert_eq!(f32_slice_from_vector(&result), vec![2.71]);
+    }
+
+    #[test]
+    fn test_vector_slice_zero_length() {
+        let input_vec = float32_vec_from(&[1.0, 2.0, 3.0]);
+        let err = vector_slice(&input_vec, 2, 1);
+        assert!(err.is_err(), "Expected error on zero-length range");
+    }
+
+    #[test]
+    fn test_vector_slice_out_of_bounds() {
+        let input_vec = float32_vec_from(&[1.0, 2.0]);
+        let err = vector_slice(&input_vec, 0, 5);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_vector_slice_start_out_of_bounds() {
+        let input_vec = float32_vec_from(&[1.0, 2.0]);
+        let err = vector_slice(&input_vec, 5, 5);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_vector_slice_end_out_of_bounds() {
+        let input_vec = float32_vec_from(&[1.0, 2.0]);
+        let err = vector_slice(&input_vec, 1, 3);
+        assert!(err.is_err());
     }
 
     #[quickcheck]

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -636,6 +636,18 @@ mod tests {
         assert_eq!(result.vector_type, VectorType::Float32);
     }
 
+    #[test]
+    fn test_subvector() {
+        let input = "[1.0, 2.0, 3.0, 4.0, 5.0]";
+        let value = Value::from_text(input);
+        let vector = parse_string_vector(VectorType::Float32, &value).unwrap();
+
+        let result = subvector(&vector, 1, 3).unwrap();
+
+        assert_eq!(result.dims, 3);
+        assert_eq!(result.vector_type, VectorType::Float32);
+    }
+
     #[quickcheck]
     fn prop_vector_text_roundtrip_2d(v: ArbitraryVector<2>) -> bool {
         test_vector_text_roundtrip(v.into())


### PR DESCRIPTION
Closes: #2323 

This PR adds support for two new vector functions:
* vector_concat(x, y) – Concatenates two vectors of the same type.
* vector_slice(x, start_index, end_index) – Extracts a subvector from the input vector.

Notes:
* Negative start_index or end_index is not supported


