### PR TITLE
Add assertions for having readlocks when closing read or write tx in WAL

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -825,6 +825,7 @@ impl Pager {
                 self.wal.borrow().end_write_tx();
             }
             self.wal.borrow().end_read_tx();
+            connection.transaction_state.set(TransactionState::None);
             self.rollback(schema_did_change, connection)?;
             return Ok(IOResult::Done(PagerCommitResult::Rollback));
         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -771,10 +771,15 @@ pub fn handle_program_error(
                         }
                     }
                 }
-            } else if let Err(e) = pager.end_read_tx() {
-                tracing::error!("end_read_tx failed: {e}");
+            } else if matches!(
+                state,
+                TransactionState::Read | TransactionState::PendingUpgrade
+            ) {
+                if let Err(e) = pager.end_read_tx() {
+                    tracing::error!("end_read_tx failed: {e}");
+                }
+                connection.transaction_state.replace(TransactionState::None);
             }
-            connection.transaction_state.replace(TransactionState::None);
         }
     }
     Ok(())


### PR DESCRIPTION
We want to assert that we are not improperly calling `end_read_tx` or `end_write_tx` out of order or improperly.

The only failing test was for when a readonly database tried a write query, and it would error and we would assume that it had a read_tx. 