### PR TITLE
Implement the Cast opcode

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -427,6 +427,7 @@ Modifiers:
 | BitOr          | Yes    |         |
 | Blob           | Yes    |         |
 | BeginSubrtn    | Yes    |         |
+| Cast           | Yes    |         |
 | Checkpoint     | Yes    |         |
 | Clear          | No     |         |
 | Close          | Yes    |         |
@@ -554,11 +555,6 @@ Modifiers:
 | String8        | Yes    |         |
 | Subtract       | Yes    |         |
 | TableLock      | No     |         |
-| ToBlob         | No     |         |
-| ToInt          | No     |         |
-| ToNumeric      | No     |         |
-| ToReal         | No     |         |
-| ToText         | No     |         |
 | Trace          | No     |         |
 | Transaction    | Yes    |         |
 | VBegin         | No     |         |

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6651,6 +6651,31 @@ pub fn op_integrity_check(
     Ok(InsnFunctionStepResult::Step)
 }
 
+pub fn op_cast(
+    _program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Rc<Pager>,
+    _mv_store: Option<&Rc<MvStore>>,
+) -> Result<InsnFunctionStepResult> {
+    let Insn::Cast { reg, affinity } = insn else {
+        unreachable!("unexpected Insn {:?}", insn)
+    };
+
+    let value = state.registers[*reg].get_owned_value().clone();
+    let result = match affinity {
+        Affinity::Blob => value.exec_cast("BLOB"),
+        Affinity::Text => value.exec_cast("TEXT"),
+        Affinity::Numeric => value.exec_cast("NUMERIC"),
+        Affinity::Integer => value.exec_cast("INTEGER"),
+        Affinity::Real => value.exec_cast("REAL"),
+    };
+
+    state.registers[*reg] = Register::Value(result);
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
 impl Value {
     pub fn exec_lower(&self) -> Option<Self> {
         match self {

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1609,6 +1609,15 @@ pub fn insn_to_str(
                 0,
                 format!("r[{}] = data", *dest),
             ),
+            Insn::Cast { reg, affinity } => (
+                "Cast",
+                *reg as i32,
+                0,
+                0,
+                Value::build_text(""),
+                0,
+                format!("affinity(r[{}]={:?})", *reg, affinity),
+            ),
         };
     format!(
         "{:<4}  {:<17}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -706,6 +706,12 @@ pub enum Insn {
         func: FuncCtx,      // P4
     },
 
+    /// Cast register P1 to affinity P2 and store in register P1
+    Cast {
+        reg: usize,
+        affinity: Affinity,
+    },
+
     InitCoroutine {
         yield_reg: usize,
         jump_on_definition: BranchOffset,
@@ -1075,6 +1081,7 @@ impl Insn {
             Insn::SorterData { .. } => execute::op_sorter_data,
             Insn::SorterNext { .. } => execute::op_sorter_next,
             Insn::Function { .. } => execute::op_function,
+            Insn::Cast { .. } => execute::op_cast,
             Insn::InitCoroutine { .. } => execute::op_init_coroutine,
             Insn::EndCoroutine { .. } => execute::op_end_coroutine,
             Insn::Yield { .. } => execute::op_yield,


### PR DESCRIPTION
Our compat matrix mentions a couple of opcodes: ToInt, ToBlob, etc. Those opcodes do not exist.

Instead, there is a single Cast opcode, that takes the affinity as a parameter.

Currently we just call a function when we need to cast. This PR fixes the compat file, implements the cast opcode, and in at least one instance, when explicitly using the CAST keyword, uses that opcode instead of a function in the generated bytecode.