### PR TITLE
remove non-existent opcode

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -572,7 +572,6 @@ Modifiers:
 | VUpdate        | Yes    |         |
 | Vacuum         | No     |         |
 | Variable       | Yes    |         |
-| VerifyCookie   | No     |         |
 | Yield          | Yes    |         |
 | ZeroOrNull     | Yes    |         |
 


### PR DESCRIPTION
$ egrep -rI "define OP" sqlite3.c | grep Cookie
sqlite3.c:#define OP_ReadCookie     99
sqlite3.c:#define OP_SetCookie     100