### PR TITLE
Fix parser error for repetition in row values

### DIFF
--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -557,7 +557,7 @@ impl ToTokens for UpdatePlan {
                     .unwrap();
 
                 ast::Set {
-                    col_names: ast::DistinctNames::single(ast::Name::from_str(col_name)),
+                    col_names: ast::Names::single(ast::Name::from_str(col_name)),
                     expr: set_expr.clone(),
                 }
             }),

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -825,7 +825,6 @@ fn emit_update_insns(
     });
 
     // Check if rowid was provided (through INTEGER PRIMARY KEY as a rowid alias)
-
     let rowid_alias_index = table_ref.columns().iter().position(|c| c.is_rowid_alias);
 
     let has_user_provided_rowid = if let Some(index) = rowid_alias_index {

--- a/testing/update.test
+++ b/testing/update.test
@@ -200,7 +200,7 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
         SELECT y FROM t; -- uses ty index
         UPDATE t SET x=2, y=2;
         SELECT x FROM t; -- uses tx index
-        SELECT y FROM t; -- uses ty index    
+        SELECT y FROM t; -- uses ty index
     } {1
     1
     2
@@ -220,34 +220,34 @@ if {[info exists ::env(SQLITE_EXEC)] && ($::env(SQLITE_EXEC) eq "scripts/limbo-s
 do_execsql_test_on_specific_db {:memory:} update_where_or_regression_test {
     CREATE TABLE t (a INTEGER);
     INSERT INTO t VALUES (1), ('hi');
-    UPDATE t SET a = X'6C6F76656C795F7265766F6C74' WHERE ~ 'gorgeous_thropy' OR NOT -3830873834.233324;  
+    UPDATE t SET a = X'6C6F76656C795F7265766F6C74' WHERE ~ 'gorgeous_thropy' OR NOT -3830873834.233324;
     SELECT * from t;
 } {lovely_revolt
 lovely_revolt}
 
 do_execsql_test_in_memory_any_error update_primary_key_constraint_error {
-    CREATE TABLE eye (study REAL, spring BLOB, save TEXT, thank REAL, election INTEGER, PRIMARY KEY (election));                  
+    CREATE TABLE eye (study REAL, spring BLOB, save TEXT, thank REAL, election INTEGER, PRIMARY KEY (election));
     INSERT INTO eye VALUES (183559032.521585, x'6625d092', 'Trial six should.', 2606132742.43174, 2817);
     INSERT INTO eye VALUES (78255586.9204539, x'651061e8', 'World perhaps.', -5815764.49018679, 1917);
     UPDATE eye SET election = 6150;
 }
 
 do_execsql_test_in_memory_any_error update_primary_key_constraint_error_2 {
-    CREATE TABLE eye (study REAL, spring BLOB, save TEXT, thank REAL, election INTEGER, PRIMARY KEY (election));                  
-    INSERT INTO eye VALUES (183559032.521585,  x'6625d092', 'Trial six should.', 2606132742.43174, 2817); 
-    INSERT INTO eye VALUES (78255586.9204539, x'651061e8', 'World perhaps.', -5815764.49018679, 1917); 
-    INSERT INTO eye VALUES (53.3274327094467, x'f574c507', 'Senior wish degree.', -423.432750526747, 2650); 
-    INSERT INTO eye VALUES (-908148213048.983, x'6d812051', 'Possible able.', 101.171781837336, 4100); 
+    CREATE TABLE eye (study REAL, spring BLOB, save TEXT, thank REAL, election INTEGER, PRIMARY KEY (election));
+    INSERT INTO eye VALUES (183559032.521585,  x'6625d092', 'Trial six should.', 2606132742.43174, 2817);
+    INSERT INTO eye VALUES (78255586.9204539, x'651061e8', 'World perhaps.', -5815764.49018679, 1917);
+    INSERT INTO eye VALUES (53.3274327094467, x'f574c507', 'Senior wish degree.', -423.432750526747, 2650);
+    INSERT INTO eye VALUES (-908148213048.983, x'6d812051', 'Possible able.', 101.171781837336, 4100);
     INSERT INTO eye VALUES (-572332773760.924, x'd7a4d9fb', 'Money catch expect.', -271065488.756746, 4667);
     UPDATE eye SET election = 6150 WHERE election != 1917;
 }
 
 do_execsql_test_in_memory_any_error update_primary_key_constraint_error_3 {
-    CREATE TABLE eye (study REAL, spring BLOB, save TEXT, thank REAL, election INTEGER, PRIMARY KEY (election));                  
-    INSERT INTO eye VALUES (183559032.521585,  x'6625d092', 'Trial six should.', 2606132742.43174, 2817); 
-    INSERT INTO eye VALUES (78255586.9204539, x'651061e8', 'World perhaps.', -5815764.49018679, 1917); 
-    INSERT INTO eye VALUES (53.3274327094467, x'f574c507', 'Senior wish degree.', -423.432750526747, 2650); 
-    INSERT INTO eye VALUES (-908148213048.983, x'6d812051', 'Possible able.', 101.171781837336, 4100); 
+    CREATE TABLE eye (study REAL, spring BLOB, save TEXT, thank REAL, election INTEGER, PRIMARY KEY (election));
+    INSERT INTO eye VALUES (183559032.521585,  x'6625d092', 'Trial six should.', 2606132742.43174, 2817);
+    INSERT INTO eye VALUES (78255586.9204539, x'651061e8', 'World perhaps.', -5815764.49018679, 1917);
+    INSERT INTO eye VALUES (53.3274327094467, x'f574c507', 'Senior wish degree.', -423.432750526747, 2650);
+    INSERT INTO eye VALUES (-908148213048.983, x'6d812051', 'Possible able.', 101.171781837336, 4100);
     INSERT INTO eye VALUES (-572332773760.924, x'd7a4d9fb', 'Money catch expect.', -271065488.756746, 4667);
     UPDATE eye SET election = 6150 WHERE election > 1000 AND study > 1;
 }
@@ -350,3 +350,21 @@ do_execsql_test_on_specific_db {:memory:} update-returning-null-values {
     INSERT INTO test (id, name, value) VALUES (1, 'test', 10);
     UPDATE test SET name = NULL, value = NULL WHERE id = 1 RETURNING id, name, value;
 } {1||}
+
+do_execsql_test_on_specific_db {:memory:} basic-row-values {
+    CREATE TABLE test (id INTEGER, name TEXT);
+    INSERT INTO test (id, name) VALUES (1, 'test');
+    UPDATE test SET (id, name) = (2, 'mordor') RETURNING id, name;
+} {2|mordor}
+
+do_execsql_test_in_memory_any_error parse-error-row-values {
+    CREATE TABLE test (id INTEGER, name TEXT);
+    INSERT INTO test (id, name) VALUES (1, 'test');
+    UPDATE test SET (id, name) = (2);
+}
+
+do_execsql_test_on_specific_db {:memory:} row-values-repeated-values-should-take-latter {
+    CREATE TABLE test (id INTEGER, name TEXT);
+    INSERT INTO test (id, name) VALUES (1, 'test');
+    UPDATE test SET (name, name) = ('mordor', 'shire') RETURNING id, name;
+} {1|shire}

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1292,6 +1292,39 @@ impl QualifiedName {
     }
 }
 
+/// Ordered set of column names
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Names(Vec<Name>);
+
+impl Names {
+    /// Initialize
+    pub fn new(name: Name) -> Self {
+        let mut dn = Self(Vec::new());
+        dn.0.push(name);
+        dn
+    }
+    /// Single column name
+    pub fn single(name: Name) -> Self {
+        let mut dn = Self(Vec::with_capacity(1));
+        dn.0.push(name);
+        dn
+    }
+    /// Push name
+    pub fn insert(&mut self, name: Name) -> Result<(), ParserError> {
+        self.0.push(name);
+        Ok(())
+    }
+}
+
+impl Deref for Names {
+    type Target = Vec<Name>;
+
+    fn deref(&self) -> &Vec<Name> {
+        &self.0
+    }
+}
+
 /// Ordered set of distinct column names
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1319,6 +1352,7 @@ impl DistinctNames {
         Ok(())
     }
 }
+
 impl Deref for DistinctNames {
     type Target = IndexSet<Name>;
 
@@ -1735,7 +1769,7 @@ pub enum InsertBody {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Set {
     /// column name(s)
-    pub col_names: DistinctNames,
+    pub col_names: Names,
     /// expression
     pub expr: Expr,
 }

--- a/vendored/sqlite3-parser/src/parser/parse.y
+++ b/vendored/sqlite3-parser/src/parser/parse.y
@@ -802,22 +802,28 @@ cmd ::= with(C) UPDATE orconf(R) xfullname(X) indexed_opt(I) SET setlist(Y) from
 }
 %endif
 
+%type reidlist {Names}
 
+reidlist(A) ::= reidlist(A) COMMA nm(Y).
+    {let id = Y; A.insert(id)?;}
+reidlist(A) ::= nm(Y).
+    { A = Names::new(Y); /*A-overwrites-Y*/}
 
 %type setlist {Vec<Set>}
 
 setlist(A) ::= setlist(A) COMMA nm(X) EQ expr(Y). {
-  let s = Set{ col_names: DistinctNames::single(X), expr: Y };
+  let s = Set{ col_names: Names::single(X), expr: Y };
   A.push(s);
 }
-setlist(A) ::= setlist(A) COMMA LP idlist(X) RP EQ expr(Y). {
+setlist(A) ::= setlist(A) COMMA LP reidlist(X) RP EQ expr(Y). {
   let s = Set{ col_names: X, expr: Y };
   A.push(s);
 }
 setlist(A) ::= nm(X) EQ expr(Y). {
-  A = vec![Set{ col_names: DistinctNames::single(X), expr: Y }];
+  A = vec![Set{ col_names: Names::single(X), expr: Y }];
+
 }
-setlist(A) ::= LP idlist(X) RP EQ expr(Y). {
+setlist(A) ::= LP reidlist(X) RP EQ expr(Y). {
   A = vec![Set{ col_names: X, expr: Y }];
 }
 


### PR DESCRIPTION
Closes #1948 

This PR also adds pretty basic support for [row values in UPDATE statements](https://sqlite.org/rowvalue.html#row_values_in_update_statements), but it only accepts expressions like:

```sql
UPDATE t SET (a, b) = (2 + 2, 'joe');
```

While SQLite accepts whole new statements, like:

```sql
UPDATE tab3 
   SET (a,b,c) = (SELECT x,y,z
                    FROM tab4
                   WHERE tab4.w=tab3.d)
 WHERE tab3.e BETWEEN 55 AND 66;
 ```
 
I noticed we don't explicitly have the concept of row values, maybe doing some plumbing in that matter could solve it?
 
If there is a way to implement that with our current infrastructure (a.k.a my skill issue) please comment here.