### PR TITLE
fix/wal: only rollback WAL if txn was write + fix start state for WalFile

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1190,7 +1190,7 @@ impl Connection {
                 wal.end_read_tx();
             }
             // remove all non-commited changes in case if WAL session left some suffix without commit frame
-            pager.rollback(false, self)?;
+            pager.rollback(false, self, true)?;
         }
 
         // let's re-parse schema from scratch if schema cookie changed compared to the our in-memory view of schema

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1292,6 +1292,7 @@ impl WalFile {
 
         let header = unsafe { shared.get().as_mut().unwrap().wal_header.lock() };
         let last_checksum = unsafe { (*shared.get()).last_checksum };
+        let start_pages_in_frames = unsafe { (*shared.get()).pages_in_frames.lock().len() };
         Self {
             io,
             // default to max frame in WAL, so that when we read schema we can read from WAL too if it's there.
@@ -1315,7 +1316,7 @@ impl WalFile {
             last_checksum,
             prev_checkpoint: CheckpointResult::default(),
             checkpoint_guard: None,
-            start_pages_in_frames: 0,
+            start_pages_in_frames,
             header: *header,
         }
     }


### PR DESCRIPTION
Closes #2363 

## What

The following sequence of actions is possible:

```
Some committed frames already exist in the WAL. shared.pages_in_frames.len() > 0.

Brand new connection does this:
BEGIN 
^-- deferred, no read tx started yet, so its `self.start_pages_in_frames` is `0`
       because it's a brand new WalFile instance

ROLLBACK   <-- calls `wal.rollback()` and truncates `shared.pages_in_frames` to length `0`

PRAGMA wal_checkpoint();
^-- because `pages_in_frames` is empty, it doesnt actually
checkpoint anything but still sets shared.max_frame to 0, causing effectively data loss
```

## Fix

- Only call `wal.rollback()` for write transactions
- Set `start_pages_in_frames` correctly so that this doesn't happen even if a regression starts calling `wal.rollback()` again
