### PR TITLE
fix/wal: make db_changed check detect cases where max frame happens to be the same

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -776,11 +776,9 @@ impl Wal for WalFile {
             let checkpoint_seq = shared.wal_header.lock().checkpoint_seq;
             (mx, nb, ck, checkpoint_seq)
         };
-        // This needs to be an != comparison because either of the following can be true:
-        // - Another connection added more WAL frames -> shared max is bigger
-        // - Another connection checkpointed -> shared max is smaller
-        // TODO: are there cases where shared_max == self.max_frame but the DB has still changed in between??
-        let db_changed = shared_max != self.max_frame;
+        let db_changed = shared_max != self.max_frame
+            || last_checksum != self.last_checksum
+            || checkpoint_seq != self.header.checkpoint_seq;
 
         // WAL is already fully back‑filled into the main DB image
         // (mxFrame == nBackfill). Readers can therefore ignore the


### PR DESCRIPTION
Closes #2361 (already been reopened once)

Only `max_frame` check is not enough -- connections can have the same max frame but the DB has still changed. Compare checksums and checkpoint sequences too.