### PR TITLE
Force Sqlite to parse schema on connection benchmark

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -37,14 +37,16 @@ fn bench_open(criterion: &mut Criterion) {
             let io = Arc::new(PlatformIO::new().unwrap());
             let db =
                 Database::open_file(io.clone(), "../testing/schema_5k.db", false, false).unwrap();
-            black_box(db.connect().unwrap());
+            let conn = db.connect().unwrap();
+            conn.execute("SELECT * FROM table_0").unwrap();
         });
     });
 
     if enable_rusqlite {
         group.bench_function(BenchmarkId::new("sqlite_schema", ""), |b| {
             b.iter(|| {
-                black_box(rusqlite::Connection::open("../testing/schema_5k.db").unwrap());
+                let conn = rusqlite::Connection::open("../testing/schema_5k.db").unwrap();
+                conn.execute("SELECT * FROM table_0", ()).unwrap();
             });
         });
     }


### PR DESCRIPTION
Resolves #2312.

<img width="973" height="213" alt="image" src="https://github.com/user-attachments/assets/a243d61c-9987-4520-9155-6bef5d162179" />

```
Open/Connect/limbo_schema/
                        time:   [11.669 ms 11.683 ms 11.700 ms]
                        change: [-4.3350% -1.8204% +0.2040%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
Open/Connect/sqlite_schema/
                        time:   [10.479 ms 10.693 ms 10.969 ms]
                        change: [+0.3783% +2.4616% +5.2808%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
  ```