### PR TITLE
bindings/rust: Enhance API by removing verbosity

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -345,7 +345,6 @@ impl Statement {
                 }
             }
         }
-        #[allow(clippy::arc_with_non_send_sync)]
         let rows = Rows::new(&self.inner);
         Ok(rows)
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -33,6 +33,7 @@
 //! ```
 
 pub mod params;
+mod rows;
 pub mod transaction;
 pub mod value;
 
@@ -46,6 +47,9 @@ pub use params::IntoParams;
 use std::fmt::Debug;
 use std::num::NonZero;
 use std::sync::{Arc, Mutex};
+
+// Re-exports rows
+pub use crate::rows::{Row, Rows};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -338,9 +342,7 @@ impl Statement {
             }
         }
         #[allow(clippy::arc_with_non_send_sync)]
-        let rows = Rows {
-            inner: Arc::clone(&self.inner),
-        };
+        let rows = Rows::new(&self.inner);
         Ok(rows)
     }
 
@@ -452,98 +454,6 @@ pub enum Params {
 }
 
 pub struct Transaction {}
-
-/// Results of a prepared statement query.
-pub struct Rows {
-    inner: Arc<Mutex<turso_core::Statement>>,
-}
-
-impl Clone for Rows {
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
-    }
-}
-
-unsafe impl Send for Rows {}
-unsafe impl Sync for Rows {}
-
-impl Rows {
-    /// Fetch the next row of this result set.
-    pub async fn next(&mut self) -> Result<Option<Row>> {
-        loop {
-            let mut stmt = self
-                .inner
-                .lock()
-                .map_err(|e| Error::MutexError(e.to_string()))?;
-            match stmt.step()? {
-                turso_core::StepResult::Row => {
-                    let row = stmt.row().unwrap();
-                    return Ok(Some(Row {
-                        values: row.get_values().map(|v| v.to_owned()).collect(),
-                    }));
-                }
-                turso_core::StepResult::Done => return Ok(None),
-                turso_core::StepResult::IO => {
-                    if let Err(e) = stmt.run_once() {
-                        return Err(e.into());
-                    }
-                    continue;
-                }
-                turso_core::StepResult::Busy => {
-                    return Err(Error::SqlExecutionFailure("database is locked".to_string()))
-                }
-                turso_core::StepResult::Interrupt => {
-                    return Err(Error::SqlExecutionFailure("interrupted".to_string()))
-                }
-            }
-        }
-    }
-}
-
-/// Query result row.
-#[derive(Debug)]
-pub struct Row {
-    values: Vec<turso_core::Value>,
-}
-
-unsafe impl Send for Row {}
-unsafe impl Sync for Row {}
-
-impl Row {
-    pub fn get_value(&self, index: usize) -> Result<Value> {
-        let value = &self.values[index];
-        match value {
-            turso_core::Value::Integer(i) => Ok(Value::Integer(*i)),
-            turso_core::Value::Null => Ok(Value::Null),
-            turso_core::Value::Float(f) => Ok(Value::Real(*f)),
-            turso_core::Value::Text(text) => Ok(Value::Text(text.to_string())),
-            turso_core::Value::Blob(items) => Ok(Value::Blob(items.to_vec())),
-        }
-    }
-
-    pub fn column_count(&self) -> usize {
-        self.values.len()
-    }
-}
-
-impl<'a> FromIterator<&'a turso_core::Value> for Row {
-    fn from_iter<T: IntoIterator<Item = &'a turso_core::Value>>(iter: T) -> Self {
-        let values = iter
-            .into_iter()
-            .map(|v| match v {
-                turso_core::Value::Integer(i) => turso_core::Value::Integer(*i),
-                turso_core::Value::Null => turso_core::Value::Null,
-                turso_core::Value::Float(f) => turso_core::Value::Float(*f),
-                turso_core::Value::Text(s) => turso_core::Value::Text(s.clone()),
-                turso_core::Value::Blob(b) => turso_core::Value::Blob(b.clone()),
-            })
-            .collect();
-
-        Row { values }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/bindings/rust/src/rows.rs
+++ b/bindings/rust/src/rows.rs
@@ -1,0 +1,102 @@
+use turso_core::types::FromValue;
+
+use crate::{Error, Result, Value};
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+/// Results of a prepared statement query.
+pub struct Rows {
+    inner: Arc<Mutex<turso_core::Statement>>,
+}
+
+impl Clone for Rows {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+unsafe impl Send for Rows {}
+unsafe impl Sync for Rows {}
+
+impl Rows {
+    pub(crate) fn new(inner: &Arc<Mutex<turso_core::Statement>>) -> Self {
+        Self {
+            inner: Arc::clone(inner),
+        }
+    }
+    /// Fetch the next row of this result set.
+    pub async fn next(&mut self) -> Result<Option<Row>> {
+        loop {
+            let mut stmt = self
+                .inner
+                .lock()
+                .map_err(|e| Error::MutexError(e.to_string()))?;
+            match stmt.step()? {
+                turso_core::StepResult::Row => {
+                    let row = stmt.row().unwrap();
+                    return Ok(Some(Row {
+                        values: row.get_values().map(|v| v.to_owned()).collect(),
+                    }));
+                }
+                turso_core::StepResult::Done => return Ok(None),
+                turso_core::StepResult::IO => {
+                    if let Err(e) = stmt.run_once() {
+                        return Err(e.into());
+                    }
+                    continue;
+                }
+                turso_core::StepResult::Busy => {
+                    return Err(Error::SqlExecutionFailure("database is locked".to_string()))
+                }
+                turso_core::StepResult::Interrupt => {
+                    return Err(Error::SqlExecutionFailure("interrupted".to_string()))
+                }
+            }
+        }
+    }
+}
+
+/// Query result row.
+#[derive(Debug)]
+pub struct Row {
+    values: Vec<turso_core::Value>,
+}
+
+unsafe impl Send for Row {}
+unsafe impl Sync for Row {}
+
+impl Row {
+    pub fn get_value(&self, index: usize) -> Result<Value> {
+        let value = &self.values[index];
+        match value {
+            turso_core::Value::Integer(i) => Ok(Value::Integer(*i)),
+            turso_core::Value::Null => Ok(Value::Null),
+            turso_core::Value::Float(f) => Ok(Value::Real(*f)),
+            turso_core::Value::Text(text) => Ok(Value::Text(text.to_string())),
+            turso_core::Value::Blob(items) => Ok(Value::Blob(items.to_vec())),
+        }
+    }
+
+    pub fn column_count(&self) -> usize {
+        self.values.len()
+    }
+}
+
+impl<'a> FromIterator<&'a turso_core::Value> for Row {
+    fn from_iter<T: IntoIterator<Item = &'a turso_core::Value>>(iter: T) -> Self {
+        let values = iter
+            .into_iter()
+            .map(|v| match v {
+                turso_core::Value::Integer(i) => turso_core::Value::Integer(*i),
+                turso_core::Value::Null => turso_core::Value::Null,
+                turso_core::Value::Float(f) => turso_core::Value::Float(*f),
+                turso_core::Value::Text(s) => turso_core::Value::Text(s.clone()),
+                turso_core::Value::Blob(b) => turso_core::Value::Blob(b.clone()),
+            })
+            .collect();
+
+        Row { values }
+    }
+}

--- a/bindings/rust/src/rows.rs
+++ b/bindings/rust/src/rows.rs
@@ -79,6 +79,14 @@ impl Row {
         }
     }
 
+    pub fn get<T>(&self, idx: usize) -> Result<T>
+    where
+        T: FromValue,
+    {
+        let val = &self.values[idx];
+        T::from_sql(val.clone()).map_err(|err| Error::ConversionFailure(err.to_string()))
+    }
+
     pub fn column_count(&self) -> usize {
         self.values.len()
     }

--- a/bindings/rust/src/transaction.rs
+++ b/bindings/rust/src/transaction.rs
@@ -344,17 +344,13 @@ mod test {
         }
         {
             let tx = conn.transaction().await?;
-            let mut result = tx.query("SELECT SUM(x) FROM foo", ()).await?;
-            assert_eq!(
-                2,
-                *result
-                    .next()
-                    .await?
-                    .unwrap()
-                    .get_value(0)?
-                    .as_integer()
-                    .unwrap()
-            );
+            let result = tx
+                .prepare("SELECT SUM(x) FROM foo")
+                .await?
+                .query_row(())
+                .await?;
+
+            assert_eq!(2, result.get::<i32>(0)?);
             tx.finish().await?;
         }
         Ok(())
@@ -390,17 +386,12 @@ mod test {
             tx.commit().await?;
         }
 
-        let mut result = conn.query("SELECT SUM(x) FROM foo", ()).await?;
-        assert_eq!(
-            2,
-            *result
-                .next()
-                .await?
-                .unwrap()
-                .get_value(0)?
-                .as_integer()
-                .unwrap()
-        );
+        let result = conn
+            .prepare("SELECT SUM(x) FROM foo")
+            .await?
+            .query_row(())
+            .await?;
+        assert_eq!(2, result.get::<i32>(0)?);
         Ok(())
     }
 
@@ -425,17 +416,12 @@ mod test {
             tx.commit().await?;
         }
         {
-            let mut result = conn.query("SELECT SUM(x) FROM foo", ()).await?;
-            assert_eq!(
-                6,
-                *result
-                    .next()
-                    .await?
-                    .unwrap()
-                    .get_value(0)?
-                    .as_integer()
-                    .unwrap()
-            );
+            let result = conn
+                .prepare("SELECT SUM(x) FROM foo")
+                .await?
+                .query_row(())
+                .await?;
+            assert_eq!(6, result.get::<i32>(0)?);
         }
         Ok(())
     }

--- a/core/error.rs
+++ b/core/error.rs
@@ -69,6 +69,12 @@ pub enum LimboError {
     WriteWriteConflict,
     #[error("No such transaction ID: {0}")]
     NoSuchTransactionID(String),
+    #[error("Null value")]
+    NullValue,
+    #[error("invalid column type")]
+    InvalidColumnType,
+    #[error("Invalid blob size, expected {0}")]
+    InvalidBlobSize(usize),
 }
 
 #[macro_export]

--- a/core/types.rs
+++ b/core/types.rs
@@ -585,49 +585,26 @@ impl FromValue for Value {
 }
 impl Sealed for crate::Value {}
 
-impl FromValue for i32 {
-    fn from_sql(val: Value) -> Result<Self> {
-        match val {
-            Value::Null => Err(LimboError::NullValue),
-            Value::Integer(i) => Ok(i as i32),
-            _ => unreachable!("invalid value type"),
+macro_rules! impl_int_from_value {
+    ($ty:ty, $cast:expr) => {
+        impl FromValue for $ty {
+            fn from_sql(val: Value) -> Result<Self> {
+                match val {
+                    Value::Null => Err(LimboError::NullValue),
+                    Value::Integer(i) => Ok($cast(i)),
+                    _ => unreachable!("invalid value type"),
+                }
+            }
         }
-    }
-}
-impl Sealed for i32 {}
 
-impl FromValue for u32 {
-    fn from_sql(val: Value) -> Result<Self> {
-        match val {
-            Value::Null => Err(LimboError::NullValue),
-            Value::Integer(i) => Ok(i as u32),
-            _ => unreachable!("invalid value type"),
-        }
-    }
+        impl Sealed for $ty {}
+    };
 }
-impl Sealed for u32 {}
 
-impl FromValue for i64 {
-    fn from_sql(val: Value) -> Result<Self> {
-        match val {
-            Value::Null => Err(LimboError::NullValue),
-            Value::Integer(i) => Ok(i),
-            _ => unreachable!("invalid value type"),
-        }
-    }
-}
-impl Sealed for i64 {}
-
-impl FromValue for u64 {
-    fn from_sql(val: Value) -> Result<Self> {
-        match val {
-            Value::Null => Err(LimboError::NullValue),
-            Value::Integer(i) => Ok(i as u64),
-            _ => unreachable!("invalid value type"),
-        }
-    }
-}
-impl Sealed for u64 {}
+impl_int_from_value!(i32, |i| i as i32);
+impl_int_from_value!(u32, |i| i as u32);
+impl_int_from_value!(i64, |i| i);
+impl_int_from_value!(u64, |i| i as u64);
 
 impl FromValue for f64 {
     fn from_sql(val: Value) -> Result<Self> {

--- a/core/types.rs
+++ b/core/types.rs
@@ -571,6 +571,141 @@ impl Value {
     }
 }
 
+/// Convert a `Value` into the implementors type.
+pub trait FromValue: Sealed {
+    fn from_sql(val: Value) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+impl FromValue for Value {
+    fn from_sql(val: Value) -> Result<Self> {
+        Ok(val)
+    }
+}
+impl Sealed for crate::Value {}
+
+impl FromValue for i32 {
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Err(LimboError::NullValue),
+            Value::Integer(i) => Ok(i as i32),
+            _ => unreachable!("invalid value type"),
+        }
+    }
+}
+impl Sealed for i32 {}
+
+impl FromValue for u32 {
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Err(LimboError::NullValue),
+            Value::Integer(i) => Ok(i as u32),
+            _ => unreachable!("invalid value type"),
+        }
+    }
+}
+impl Sealed for u32 {}
+
+impl FromValue for i64 {
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Err(LimboError::NullValue),
+            Value::Integer(i) => Ok(i),
+            _ => unreachable!("invalid value type"),
+        }
+    }
+}
+impl Sealed for i64 {}
+
+impl FromValue for u64 {
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Err(LimboError::NullValue),
+            Value::Integer(i) => Ok(i as u64),
+            _ => unreachable!("invalid value type"),
+        }
+    }
+}
+impl Sealed for u64 {}
+
+impl FromValue for f64 {
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Err(LimboError::NullValue),
+            Value::Float(f) => Ok(f),
+            _ => unreachable!("invalid value type"),
+        }
+    }
+}
+impl Sealed for f64 {}
+
+impl FromValue for Vec<u8> {
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Err(LimboError::NullValue),
+            Value::Blob(blob) => Ok(blob),
+            _ => unreachable!("invalid value type"),
+        }
+    }
+}
+impl Sealed for Vec<u8> {}
+
+impl<const N: usize> FromValue for [u8; N] {
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Err(LimboError::NullValue),
+            Value::Blob(blob) => blob.try_into().map_err(|_| LimboError::InvalidBlobSize(N)),
+            _ => unreachable!("invalid value type"),
+        }
+    }
+}
+impl<const N: usize> Sealed for [u8; N] {}
+
+impl FromValue for String {
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Err(LimboError::NullValue),
+            Value::Text(s) => Ok(s.to_string()),
+            _ => unreachable!("invalid value type"),
+        }
+    }
+}
+impl Sealed for String {}
+
+impl FromValue for bool {
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Err(LimboError::NullValue),
+            Value::Integer(i) => match i {
+                0 => Ok(false),
+                1 => Ok(true),
+                _ => Err(LimboError::InvalidColumnType),
+            },
+            _ => unreachable!("invalid value type"),
+        }
+    }
+}
+impl Sealed for bool {}
+
+impl<T> FromValue for Option<T>
+where
+    T: FromValue,
+{
+    fn from_sql(val: Value) -> Result<Self> {
+        match val {
+            Value::Null => Ok(None),
+            _ => T::from_sql(val).map(Some),
+        }
+    }
+}
+impl<T> Sealed for Option<T> {}
+
+mod sealed {
+    pub trait Sealed {}
+}
+use sealed::Sealed;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct SumAggState {
     pub r_err: f64,   // Error term for Kahan-Babushka-Neumaier summation


### PR DESCRIPTION
While working on #2151 I saw myself forced to do things like:

```rust
assert_eq!(
                6,
                *result
                    .next()
                    .await?
                    .unwrap()
                    .get_value(0)?
                    .as_integer()
                    .unwrap()
            );
```

Just to get a simple value from a row, now with this PR users can just do: 
```rust
assert_eq!(6, result.get::<i32>(0)?);
```

(Thanks libsql devs, this is so much better!)