### PR TITLE
Rename IO::run_once() to IO::step()

### DIFF
--- a/bindings/dart/rust/src/api/statement.rs
+++ b/bindings/dart/rust/src/api/statement.rs
@@ -96,7 +96,7 @@ impl RustStatement {
                     break;
                 }
                 Ok(turso_core::StepResult::IO) => {
-                    self.inner.run_once().unwrap();
+                    self.inner.step().unwrap();
                 }
                 _ => break,
             };

--- a/bindings/go/rs_src/rows.rs
+++ b/bindings/go/rs_src/rows.rs
@@ -55,7 +55,7 @@ pub extern "C" fn rows_next(ctx: *mut c_void) -> ResultCode {
         Ok(StepResult::Row) => ResultCode::Row,
         Ok(StepResult::Done) => ResultCode::Done,
         Ok(StepResult::IO) => {
-            let res = ctx.stmt.run_once();
+            let res = ctx.stmt.step();
             if res.is_err() {
                 ResultCode::Error
             } else {

--- a/bindings/go/rs_src/statement.rs
+++ b/bindings/go/rs_src/statement.rs
@@ -64,7 +64,7 @@ pub extern "C" fn stmt_execute(
                 return ResultCode::Done;
             }
             Ok(StepResult::IO) => {
-                let res = statement.run_once();
+                let res = statement.step();
                 if res.is_err() {
                     return ResultCode::Error;
                 }

--- a/bindings/java/rs_src/turso_statement.rs
+++ b/bindings/java/rs_src/turso_statement.rs
@@ -76,7 +76,7 @@ pub extern "system" fn Java_tech_turso_core_TursoStatement_step<'local>(
                 };
             }
             StepResult::IO => {
-                if let Err(e) = stmt.stmt.run_once() {
+                if let Err(e) = stmt.stmt.step() {
                     set_err_msg_and_throw_exception(&mut env, obj, TURSO_ETC, e.to_string());
                     return to_turso_step_result(&mut env, STEP_RESULT_ID_ERROR, None);
                 }

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -170,7 +170,7 @@ impl Database {
     #[napi]
     pub fn io_loop_sync(&self) -> Result<()> {
         self.io
-            .run_once()
+            .step()
             .map_err(|e| Error::new(Status::GenericFailure, format!("IO error: {e}")))?;
         Ok(())
     }
@@ -413,7 +413,7 @@ impl Task for IoLoopTask {
     type JsValue = ();
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
-        self.io.run_once().map_err(|e| {
+        self.io.step().map_err(|e| {
             napi::Error::new(napi::Status::GenericFailure, format!("IO error: {e}"))
         })?;
         Ok(())

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -109,7 +109,7 @@ impl Cursor {
                 .step()
                 .map_err(|e| PyErr::new::<OperationalError, _>(format!("Step error: {e:?}")))?
             {
-                stmt.run_once()
+                stmt.step()
                     .map_err(|e| PyErr::new::<OperationalError, _>(format!("IO error: {e:?}")))?;
             }
         }
@@ -139,7 +139,7 @@ impl Cursor {
                         return Ok(Some(py_row));
                     }
                     turso_core::StepResult::IO => {
-                        stmt.run_once().map_err(|e| {
+                        stmt.step().map_err(|e| {
                             PyErr::new::<OperationalError, _>(format!("IO error: {e:?}"))
                         })?;
                     }
@@ -176,7 +176,7 @@ impl Cursor {
                         results.push(py_row);
                     }
                     turso_core::StepResult::IO => {
-                        stmt.run_once().map_err(|e| {
+                        stmt.step().map_err(|e| {
                             PyErr::new::<OperationalError, _>(format!("IO error: {e:?}"))
                         })?;
                     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -381,7 +381,7 @@ impl Statement {
                     return Ok(changes as u64);
                 }
                 Ok(turso_core::StepResult::IO) => {
-                    stmt.run_once()?;
+                    stmt.step()?;
                 }
                 Ok(turso_core::StepResult::Busy) => {
                     return Err(Error::SqlExecutionFailure("database is locked".to_string()));
@@ -486,7 +486,7 @@ impl Rows {
                 }
                 turso_core::StepResult::Done => return Ok(None),
                 turso_core::StepResult::IO => {
-                    if let Err(e) = stmt.run_once() {
+                    if let Err(e) = stmt.step() {
                         return Err(e.into());
                     }
                     continue;

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -98,7 +98,7 @@ macro_rules! query_internal {
                         $body(row)?;
                     }
                     StepResult::IO => {
-                        rows.run_once()?;
+                        rows.step()?;
                     }
                     StepResult::Interrupt => break,
                     StepResult::Done => break,
@@ -769,7 +769,7 @@ impl Limbo {
                             }
                             Ok(StepResult::IO) => {
                                 let start = Instant::now();
-                                rows.run_once()?;
+                                rows.step()?;
                                 if let Some(ref mut stats) = statistics {
                                     stats.io_time_elapsed_samples.push(start.elapsed());
                                 }
@@ -858,7 +858,7 @@ impl Limbo {
                             }
                             Ok(StepResult::IO) => {
                                 let start = Instant::now();
-                                rows.run_once()?;
+                                rows.step()?;
                                 if let Some(ref mut stats) = statistics {
                                     stats.io_time_elapsed_samples.push(start.elapsed());
                                 }
@@ -1001,7 +1001,7 @@ impl Limbo {
                         found |= self.print_schema_entry(db_display_name, row);
                     }
                     StepResult::IO => {
-                        rows.run_once()?;
+                        rows.step()?;
                     }
                     StepResult::Interrupt => break,
                     StepResult::Done => break,
@@ -1034,7 +1034,7 @@ impl Limbo {
                         self.print_schema_entry(db_display_name, row);
                     }
                     StepResult::IO => {
-                        rows.run_once()?;
+                        rows.step()?;
                     }
                     StepResult::Interrupt => break,
                     StepResult::Done => break,
@@ -1149,7 +1149,7 @@ impl Limbo {
                             }
                         }
                         StepResult::IO => {
-                            rows.run_once()?;
+                            rows.step()?;
                         }
                         StepResult::Interrupt => break,
                         StepResult::Done => break,
@@ -1210,7 +1210,7 @@ impl Limbo {
                             }
                         }
                         StepResult::IO => {
-                            rows.run_once()?;
+                            rows.step()?;
                         }
                         StepResult::Interrupt => break,
                         StepResult::Done => break,
@@ -1293,7 +1293,7 @@ impl Limbo {
                             }
                         }
                         StepResult::IO => {
-                            rows.run_once()?;
+                            rows.step()?;
                         }
                         StepResult::Interrupt => break,
                         StepResult::Done => break,

--- a/cli/commands/import.rs
+++ b/cli/commands/import.rs
@@ -53,7 +53,7 @@ impl<'a> ImportFile<'a> {
                                     }
                                     Ok(turso_core::StepResult::Done) => break 'check false,
                                     Ok(turso_core::StepResult::IO) => {
-                                        if let Err(e) = rows.run_once() {
+                                        if let Err(e) = rows.step() {
                                             let _ = self.writer.write_all(
                                                 format!("Error checking table existence: {e:?}\n")
                                                     .as_bytes(),
@@ -65,7 +65,7 @@ impl<'a> ImportFile<'a> {
                                         turso_core::StepResult::Interrupt
                                         | turso_core::StepResult::Busy,
                                     ) => {
-                                        if let Err(e) = rows.run_once() {
+                                        if let Err(e) = rows.step() {
                                             let _ = self.writer.write_all(
                                                 format!("Error checking table existence: {e:?}\n")
                                                     .as_bytes(),
@@ -138,7 +138,7 @@ impl<'a> ImportFile<'a> {
                 loop {
                     match rows.step() {
                         Ok(turso_core::StepResult::IO) => {
-                            if let Err(e) = rows.run_once() {
+                            if let Err(e) = rows.step() {
                                 let _ = self
                                     .writer
                                     .write_all(format!("Error creating table: {e:?}\n").as_bytes());
@@ -206,7 +206,7 @@ impl<'a> ImportFile<'a> {
                                 loop {
                                     match rows.step() {
                                         Ok(turso_core::StepResult::IO) => {
-                                            if let Err(e) = rows.run_once() {
+                                            if let Err(e) = rows.step() {
                                                 let _ = self.writer.write_all(
                                                     format!("Error executing query: {e:?}\n")
                                                         .as_bytes(),
@@ -268,7 +268,7 @@ impl<'a> ImportFile<'a> {
                         loop {
                             match rows.step() {
                                 Ok(turso_core::StepResult::IO) => {
-                                    if let Err(e) = rows.run_once() {
+                                    if let Err(e) = rows.step() {
                                         let _ = self.writer.write_all(
                                             format!("Error executing query: {e:?}\n").as_bytes(),
                                         );

--- a/cli/helper.rs
+++ b/cli/helper.rs
@@ -222,7 +222,7 @@ impl<C: Parser + Send + Sync + 'static> SqlCompleter<C> {
                         candidates.push(pair);
                     }
                     StepResult::IO => {
-                        try_result!(rows.run_once(), (prefix_pos, candidates));
+                        try_result!(rows.step(), (prefix_pos, candidates));
                     }
                     StepResult::Interrupt => break,
                     StepResult::Done => break,

--- a/cli/mcp_server.rs
+++ b/cli/mcp_server.rs
@@ -358,7 +358,7 @@ impl TursoMcpServer {
                             }
                         }
                         Ok(StepResult::IO) => {
-                            if rows.run_once().is_err() {
+                            if rows.step().is_err() {
                                 break;
                             }
                         }
@@ -445,7 +445,7 @@ impl TursoMcpServer {
                             }
                         }
                         Ok(StepResult::IO) => {
-                            if rows.run_once().is_err() {
+                            if rows.step().is_err() {
                                 break;
                             }
                         }
@@ -509,7 +509,7 @@ impl TursoMcpServer {
                             results.push(row_data);
                         }
                         Ok(StepResult::IO) => {
-                            if rows.run_once().is_err() {
+                            if rows.step().is_err() {
                                 break;
                             }
                         }

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -129,7 +129,7 @@ fn bench_execute_select_rows(criterion: &mut Criterion) {
                                 black_box(stmt.row());
                             }
                             turso_core::StepResult::IO => {
-                                stmt.run_once().unwrap();
+                                stmt.step().unwrap();
                             }
                             turso_core::StepResult::Done => {
                                 break;
@@ -190,7 +190,7 @@ fn bench_execute_select_1(criterion: &mut Criterion) {
                         black_box(stmt.row());
                     }
                     turso_core::StepResult::IO => {
-                        stmt.run_once().unwrap();
+                        stmt.step().unwrap();
                     }
                     turso_core::StepResult::Done => {
                         break;
@@ -242,7 +242,7 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
                         black_box(stmt.row());
                     }
                     turso_core::StepResult::IO => {
-                        stmt.run_once().unwrap();
+                        stmt.step().unwrap();
                     }
                     turso_core::StepResult::Done => {
                         break;
@@ -297,7 +297,7 @@ fn bench_insert_rows(criterion: &mut Criterion) {
         loop {
             match stmt.step().unwrap() {
                 turso_core::StepResult::IO => {
-                    stmt.run_once().unwrap();
+                    stmt.step().unwrap();
                 }
                 turso_core::StepResult::Done => {
                     break;
@@ -324,7 +324,7 @@ fn bench_insert_rows(criterion: &mut Criterion) {
                 loop {
                     match stmt.step().unwrap() {
                         turso_core::StepResult::IO => {
-                            stmt.run_once().unwrap();
+                            stmt.step().unwrap();
                         }
                         turso_core::StepResult::Done => {
                             break;

--- a/core/benches/json_benchmark.rs
+++ b/core/benches/json_benchmark.rs
@@ -452,7 +452,7 @@ fn bench(criterion: &mut Criterion) {
                     match stmt.step().unwrap() {
                         turso_core::StepResult::Row => {}
                         turso_core::StepResult::IO => {
-                            stmt.run_once().unwrap();
+                            stmt.step().unwrap();
                         }
                         turso_core::StepResult::Done => {
                             break;
@@ -610,7 +610,7 @@ fn bench_sequential_jsonb(criterion: &mut Criterion) {
                 match stmt.step().unwrap() {
                     turso_core::StepResult::Row => {}
                     turso_core::StepResult::IO => {
-                        stmt.run_once().unwrap();
+                        stmt.step().unwrap();
                     }
                     turso_core::StepResult::Done => {
                         break;
@@ -902,7 +902,7 @@ fn bench_json_patch(criterion: &mut Criterion) {
                     match stmt.step().unwrap() {
                         turso_core::StepResult::Row => {}
                         turso_core::StepResult::IO => {
-                            stmt.run_once().unwrap();
+                            stmt.step().unwrap();
                         }
                         turso_core::StepResult::Done => {
                             break;

--- a/core/benches/tpc_h_benchmark.rs
+++ b/core/benches/tpc_h_benchmark.rs
@@ -97,7 +97,7 @@ fn bench_tpc_h_queries(criterion: &mut Criterion) {
                                 black_box(stmt.row());
                             }
                             turso_core::StepResult::IO => {
-                                stmt.run_once().unwrap();
+                                stmt.step().unwrap();
                             }
                             turso_core::StepResult::Done => {
                                 break;

--- a/core/ext/vtab_xconnect.rs
+++ b/core/ext/vtab_xconnect.rs
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn execute(
                         return ResultCode::OK;
                     }
                     Ok(StepResult::IO) => {
-                        let res = stmt.run_once();
+                        let res = stmt.step();
                         if res.is_err() {
                             return ResultCode::Error;
                         }
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn stmt_bind_args_fn(ctx: *mut Stmt, idx: i32, arg: ExtVal
 
 /// Wraps the functionality of the core Statement::step function,
 /// preferring to handle the IO step result internally to prevent having to expose
-/// run_once. Returns the equivalent ResultCode which then maps to an external StepResult.
+/// step. Returns the equivalent ResultCode which then maps to an external StepResult.
 pub unsafe extern "C" fn stmt_step(stmt: *mut Stmt) -> ResultCode {
     let Ok(stmt) = Stmt::from_ptr(stmt) else {
         tracing::error!("stmt_step: failed to convert stmt to Stmt");
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn stmt_step(stmt: *mut Stmt) -> ResultCode {
             StepResult::Done => return ResultCode::EOF,
             StepResult::IO => {
                 // always handle IO step result internally.
-                let res = stmt_ctx.run_once();
+                let res = stmt_ctx.step();
                 if res.is_err() {
                     return ResultCode::Error;
                 }

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -37,12 +37,12 @@ impl IO for GenericIO {
 
     fn wait_for_completion(&self, c: Completion) -> Result<()> {
         while !c.is_completed() {
-            self.run_once()?;
+            self.step()?;
         }
         Ok(())
     }
 
-    fn run_once(&self) -> Result<()> {
+    fn step(&self) -> Result<()> {
         Ok(())
     }
 

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -418,13 +418,13 @@ impl IO for UringIO {
 
     fn wait_for_completion(&self, c: Completion) -> Result<()> {
         while !c.is_completed() {
-            self.run_once()?;
+            self.step()?;
         }
         Ok(())
     }
 
-    fn run_once(&self) -> Result<()> {
-        trace!("run_once()");
+    fn step(&self) -> Result<()> {
+        trace!("step()");
         let mut inner = self.inner.borrow_mut();
         let ring = &mut inner.ring;
         if ring.empty() {

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -48,14 +48,14 @@ impl IO for MemoryIO {
         }))
     }
 
-    fn run_once(&self) -> Result<()> {
+    fn step(&self) -> Result<()> {
         // nop
         Ok(())
     }
 
     fn wait_for_completion(&self, c: Completion) -> Result<()> {
         while !c.is_completed() {
-            self.run_once()?;
+            self.step()?;
         }
         Ok(())
     }

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -82,7 +82,7 @@ impl Default for OpenFlags {
 pub trait IO: Clock + Send + Sync {
     fn open_file(&self, path: &str, flags: OpenFlags, direct: bool) -> Result<Arc<dyn File>>;
 
-    fn run_once(&self) -> Result<()>;
+    fn step(&self) -> Result<()>;
 
     fn wait_for_completion(&self, c: Completion) -> Result<()>;
 

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -253,13 +253,13 @@ impl IO for UnixIO {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn run_once(&self) -> Result<()> {
+    fn step(&self) -> Result<()> {
         if self.callbacks.is_empty() {
             return Ok(());
         }
 
         self.events.clear();
-        trace!("run_once() waits for events");
+        trace!("step() waits for events");
         self.poller.wait(self.events.as_mut(), None)?;
 
         for event in self.events.iter() {
@@ -385,7 +385,7 @@ impl IO for UnixIO {
 
     fn wait_for_completion(&self, c: Completion) -> Result<()> {
         while !c.is_completed() {
-            self.run_once()?;
+            self.step()?;
         }
         Ok(())
     }

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -31,12 +31,12 @@ impl IO for VfsMod {
         Ok(Arc::new(turso_ext::VfsFileImpl::new(file, self.ctx)?))
     }
 
-    fn run_once(&self) -> Result<()> {
+    fn step(&self) -> Result<()> {
         if self.ctx.is_null() {
             return Err(LimboError::ExtensionError("VFS is null".to_string()));
         }
         let vfs = unsafe { &*self.ctx };
-        let result = unsafe { (vfs.run_once)(vfs.vfs) };
+        let result = unsafe { (vfs.step)(vfs.vfs) };
         if !result.is_ok() {
             return Err(LimboError::ExtensionError(result.to_string()));
         }

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -35,13 +35,13 @@ impl IO for WindowsIO {
     #[instrument(err, skip_all, level = Level::TRACE)]
     fn wait_for_completion(&self, c: Completion) -> Result<()> {
         while !c.is_completed() {
-            self.run_once()?;
+            self.step()?;
         }
         Ok(())
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn run_once(&self) -> Result<()> {
+    fn step(&self) -> Result<()> {
         Ok(())
     }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -621,7 +621,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 }
                 Ok(crate::types::IOResult::IO) => {
                     // FIXME: this is a hack to make the pager run the IO loop
-                    pager.io.run_once().unwrap();
+                    pager.io.step().unwrap();
                     continue;
                 }
                 Err(e) => {
@@ -917,7 +917,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             {
                 Ok(IOResult::Done(())) => break,
                 Ok(IOResult::IO) => {
-                    pager.io.run_once().unwrap();
+                    pager.io.step().unwrap();
                     continue;
                 }
                 Err(e) => {
@@ -975,7 +975,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             {
                 IOResult::Done(()) => break,
                 IOResult::IO => {
-                    pager.io.run_once().unwrap();
+                    pager.io.step().unwrap();
                     continue;
                 }
             }
@@ -988,7 +988,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 IOResult::Done(Some(row_id)) => row_id,
                 IOResult::Done(None) => break,
                 IOResult::IO => {
-                    pager.io.run_once().unwrap();
+                    pager.io.step().unwrap();
                     continue;
                 }
             };

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1349,7 +1349,7 @@ impl Pager {
                 //         "Failed to fsync WAL before final checkpoint, fd likely closed".into(),
                 //     ));
                 // }
-                self.io.run_once()?;
+                self.io.step()?;
                 _attempts += 1;
             }
         }
@@ -2202,7 +2202,7 @@ mod ptrmap_tests {
                 IOResult::Done(res) => {
                     return Ok(res);
                 }
-                IOResult::IO => pager.io.run_once().unwrap(),
+                IOResult::IO => pager.io.step().unwrap(),
             }
         }
     }

--- a/core/util.rs
+++ b/core/util.rs
@@ -23,7 +23,7 @@ impl<I: ?Sized + IO> IOExt for I {
         Ok(loop {
             match f()? {
                 IOResult::Done(v) => break v,
-                IOResult::IO => self.run_once()?,
+                IOResult::IO => self.step()?,
             }
         })
     }
@@ -147,7 +147,7 @@ pub fn parse_schema_rows(
             StepResult::IO => {
                 // TODO: How do we ensure that the I/O we submitted to
                 // read the schema is actually complete?
-                rows.run_once()?;
+                rows.step()?;
             }
             StepResult::Interrupt => break,
             StepResult::Done => break,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -767,7 +767,7 @@ pub fn handle_program_error(
             if let TransactionState::Write { schema_did_change } = state {
                 loop {
                     match pager.end_tx(true, schema_did_change, connection, false) {
-                        Ok(IOResult::IO) => connection.run_once()?,
+                        Ok(IOResult::IO) => connection.step()?,
                         Ok(IOResult::Done(_)) => break,
                         Err(e) => {
                             tracing::error!("end_tx failed: {e}");

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -636,7 +636,7 @@ mod tests {
 
             loop {
                 if let IOResult::IO = sorter.sort().expect("Failed to sort the records") {
-                    io.run_once().expect("Failed to run the IO");
+                    io.step().expect("Failed to run the IO");
                     continue;
                 }
                 break;
@@ -654,7 +654,7 @@ mod tests {
 
                 loop {
                     if let IOResult::IO = sorter.next().expect("Failed to get the next record") {
-                        io.run_once().expect("Failed to run the IO");
+                        io.step().expect("Failed to run the IO");
                         continue;
                     }
                     break;

--- a/extensions/core/README.md
+++ b/extensions/core/README.md
@@ -344,7 +344,7 @@ impl VfsExtension for ExampleFS {
         Ok(TestFile { file })
     }
 
-    fn run_once(&self) -> Result<()> {
+    fn step(&self) -> Result<()> {
     // (optional) method to cycle/advance IO, if your extension is asynchronous
         Ok(())
     }

--- a/extensions/core/src/vfs_modules.rs
+++ b/extensions/core/src/vfs_modules.rs
@@ -15,7 +15,7 @@ pub trait VfsExtension: Default + Send + Sync {
     const NAME: &'static str;
     type File: VfsFile;
     fn open_file(&self, path: &str, flags: i32, direct: bool) -> ExtResult<Self::File>;
-    fn run_once(&self) -> ExtResult<()> {
+    fn step(&self) -> ExtResult<()> {
         Ok(())
     }
     fn close(&self, _file: Self::File) -> ExtResult<()> {
@@ -57,7 +57,7 @@ pub struct VfsImpl {
     pub lock: VfsLock,
     pub unlock: VfsUnlock,
     pub size: VfsSize,
-    pub run_once: VfsRunOnce,
+    pub step: VfsRunOnce,
     pub current_time: VfsGetCurrentTime,
     pub gen_random_number: VfsGenerateRandomNumber,
     pub truncate: VfsTruncate,

--- a/fuzz/fuzz_targets/expression.rs
+++ b/fuzz/fuzz_targets/expression.rs
@@ -194,7 +194,7 @@ fn do_fuzz(expr: Expr) -> Result<Corpus, Box<dyn Error>> {
         loop {
             use turso_core::StepResult;
             match stmt.step()? {
-                StepResult::IO => stmt.run_once()?,
+                StepResult::IO => stmt.step()?,
                 StepResult::Row => {
                     let row = stmt.row().unwrap();
                     assert_eq!(row.len(), 1, "expr: {:?}", expr);

--- a/macros/src/ext/vfs_derive.rs
+++ b/macros/src/ext/vfs_derive.rs
@@ -16,7 +16,7 @@ pub fn derive_vfs_module(input: TokenStream) -> TokenStream {
     let unlock_fn_name = format_ident!("{}_unlock", struct_name);
     let sync_fn_name = format_ident!("{}_sync", struct_name);
     let size_fn_name = format_ident!("{}_size", struct_name);
-    let run_once_fn_name = format_ident!("{}_run_once", struct_name);
+    let step_fn_name = format_ident!("{}_step", struct_name);
     let generate_random_number_fn_name = format_ident!("{}_generate_random_number", struct_name);
     let get_current_time_fn_name = format_ident!("{}_get_current_time", struct_name);
 
@@ -38,7 +38,7 @@ pub fn derive_vfs_module(input: TokenStream) -> TokenStream {
                 sync: #sync_fn_name,
                 size: #size_fn_name,
                 truncate: #trunc_fn_name,
-                run_once: #run_once_fn_name,
+                step: #step_fn_name,
                 gen_random_number: #generate_random_number_fn_name,
                 current_time: #get_current_time_fn_name,
             };
@@ -62,7 +62,7 @@ pub fn derive_vfs_module(input: TokenStream) -> TokenStream {
                 sync: #sync_fn_name,
                 size: #size_fn_name,
                 truncate: #trunc_fn_name,
-                run_once: #run_once_fn_name,
+                step: #step_fn_name,
                 gen_random_number: #generate_random_number_fn_name,
                 current_time: #get_current_time_fn_name,
             };
@@ -124,12 +124,12 @@ pub fn derive_vfs_module(input: TokenStream) -> TokenStream {
         }
 
         #[no_mangle]
-        pub unsafe extern "C" fn #run_once_fn_name(ctx: *const ::std::ffi::c_void) -> ::turso_ext::ResultCode {
+        pub unsafe extern "C" fn #step_fn_name(ctx: *const ::std::ffi::c_void) -> ::turso_ext::ResultCode {
             if ctx.is_null() {
                 return ::turso_ext::ResultCode::Error;
             }
             let ctx = &mut *(ctx as *mut #struct_name);
-            if let Err(e) = <#struct_name as ::turso_ext::VfsExtension>::run_once(ctx) {
+            if let Err(e) = <#struct_name as ::turso_ext::VfsExtension>::step(ctx) {
                 return e;
             }
             ::turso_ext::ResultCode::OK

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -376,7 +376,7 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
 ///        Ok(TestFile { file })
 ///    }
 ///
-///    fn run_once(&self) -> Result<()> {
+///    fn step(&self) -> Result<()> {
 ///    // (optional) method to cycle/advance IO, if your extension is asynchronous
 ///        Ok(())
 ///    }

--- a/perf/latency/limbo/src/main.rs
+++ b/perf/latency/limbo/src/main.rs
@@ -75,7 +75,7 @@ fn main() {
                 }
             }
         }
-        io.run_once().unwrap();
+        io.step().unwrap();
     }
     hist.refresh();
     println!("count,p50,p90,p95,p99,p999,p9999,p99999");

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -469,7 +469,7 @@ impl Interaction {
                         out.push(r);
                     }
                     StepResult::IO => {
-                        rows.run_once().unwrap();
+                        rows.step().unwrap();
                     }
                     StepResult::Interrupt => {}
                     StepResult::Done => {
@@ -606,7 +606,7 @@ impl Interaction {
                         if syncing {
                             reopen_database(env);
                         } else {
-                            rows.run_once().unwrap();
+                            rows.step().unwrap();
                         }
                     }
                     StepResult::Done => {
@@ -671,7 +671,7 @@ impl Interaction {
                         out.push(r);
                     }
                     StepResult::IO => {
-                        rows.run_once()?;
+                        rows.step()?;
                         current_prob += incr;
                         if current_prob > 1.0 {
                             current_prob = 1.0;

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -261,7 +261,7 @@ fn limbo_integrity_check(conn: &Arc<Connection>) -> Result<()> {
                 result.push(val);
             }
             StepResult::IO => {
-                rows.run_once()?;
+                rows.step()?;
             }
             StepResult::Interrupt => {}
             StepResult::Done => {

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -257,7 +257,7 @@ pub unsafe extern "C" fn sqlite3_step(stmt: *mut sqlite3_stmt) -> ffi::c_int {
         if let Ok(result) = stmt.stmt.step() {
             match result {
                 turso_core::StepResult::IO => {
-                    stmt.stmt.run_once().unwrap();
+                    stmt.stmt.step().unwrap();
                     continue;
                 }
                 turso_core::StepResult::Done => return SQLITE_DONE,

--- a/tests/integration/functions/test_function_rowid.rs
+++ b/tests/integration/functions/test_function_rowid.rs
@@ -16,7 +16,7 @@ fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
         loop {
             match rows.step()? {
                 StepResult::IO => {
-                    rows.run_once()?;
+                    rows.step()?;
                 }
                 StepResult::Done => break,
                 _ => unreachable!(),
@@ -36,7 +36,7 @@ fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
                     }
                 }
                 StepResult::IO => {
-                    rows.run_once()?;
+                    rows.step()?;
                 }
                 StepResult::Interrupt => break,
                 StepResult::Done => break,
@@ -50,7 +50,7 @@ fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
         Ok(Some(ref mut rows)) => loop {
             match rows.step()? {
                 StepResult::IO => {
-                    rows.run_once()?;
+                    rows.step()?;
                 }
                 StepResult::Done => break,
                 _ => unreachable!(),
@@ -72,7 +72,7 @@ fn test_last_insert_rowid_basic() -> anyhow::Result<()> {
                     }
                 }
                 StepResult::IO => {
-                    rows.run_once()?;
+                    rows.step()?;
                 }
                 StepResult::Interrupt => break,
                 StepResult::Done => break,
@@ -101,7 +101,7 @@ fn test_integer_primary_key() -> anyhow::Result<()> {
         let mut insert_query = conn.query(query)?.unwrap();
         loop {
             match insert_query.step()? {
-                StepResult::IO => insert_query.run_once()?,
+                StepResult::IO => insert_query.step()?,
                 StepResult::Done => break,
                 _ => unreachable!(),
             }
@@ -117,7 +117,7 @@ fn test_integer_primary_key() -> anyhow::Result<()> {
                     rowids.push(*id);
                 }
             }
-            StepResult::IO => select_query.run_once()?,
+            StepResult::IO => select_query.step()?,
             StepResult::Interrupt | StepResult::Done => break,
             StepResult::Busy => panic!("Database is busy"),
         }

--- a/tests/integration/query_processing/test_btree.rs
+++ b/tests/integration/query_processing/test_btree.rs
@@ -435,7 +435,7 @@ fn write_at(io: &impl IO, file: Arc<dyn File>, offset: usize, data: &[u8]) {
     let buffer = Arc::new(RefCell::new(Buffer::new(Pin::new(data.to_vec()), drop_fn)));
     let result = file.pwrite(offset, buffer, completion).unwrap();
     while !result.is_completed() {
-        io.run_once().unwrap();
+        io.step().unwrap();
     }
 }
 

--- a/tests/integration/query_processing/test_multi_thread.rs
+++ b/tests/integration/query_processing/test_multi_thread.rs
@@ -22,7 +22,7 @@ fn test_schema_change() {
                 break row;
             }
             Ok(turso_core::StepResult::IO) => {
-                stmt.run_once().unwrap();
+                stmt.step().unwrap();
             }
             _ => panic!("unexpected step result"),
         }
@@ -58,7 +58,7 @@ fn test_create_multiple_connections() -> anyhow::Result<()> {
                                 panic!("unexpected row result");
                             }
                             StepResult::IO => {
-                                stmt.run_once().unwrap();
+                                stmt.step().unwrap();
                             }
                             StepResult::Done => {
                                 tracing::info!("inserted row {}", i);
@@ -91,7 +91,7 @@ fn test_create_multiple_connections() -> anyhow::Result<()> {
                     rows.push(row.get::<i64>(0).unwrap());
                 }
                 StepResult::IO => {
-                    stmt.run_once().unwrap();
+                    stmt.step().unwrap();
                 }
                 StepResult::Done => {
                     break;
@@ -156,7 +156,7 @@ fn test_reader_writer() -> anyhow::Result<()> {
                                 rows.push(x);
                             }
                             StepResult::IO => {
-                                stmt.run_once().unwrap();
+                                stmt.step().unwrap();
                             }
                             StepResult::Done => {
                                 rows.sort();

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -19,7 +19,7 @@ fn test_statement_reset_bind() -> anyhow::Result<()> {
                     turso_core::Value::Integer(1)
                 );
             }
-            StepResult::IO => stmt.run_once()?,
+            StepResult::IO => stmt.step()?,
             _ => break,
         }
     }
@@ -37,7 +37,7 @@ fn test_statement_reset_bind() -> anyhow::Result<()> {
                     turso_core::Value::Integer(2)
                 );
             }
-            StepResult::IO => stmt.run_once()?,
+            StepResult::IO => stmt.step()?,
             _ => break,
         }
     }
@@ -88,7 +88,7 @@ fn test_statement_bind() -> anyhow::Result<()> {
                 }
             }
             StepResult::IO => {
-                stmt.run_once()?;
+                stmt.step()?;
             }
             StepResult::Interrupt => break,
             StepResult::Done => break,
@@ -125,7 +125,7 @@ fn test_insert_parameter_remap() -> anyhow::Result<()> {
     }
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -150,7 +150,7 @@ fn test_insert_parameter_remap() -> anyhow::Result<()> {
                 // D = 22
                 assert_eq!(row.get::<&Value>(3).unwrap(), &Value::Integer(22));
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -196,7 +196,7 @@ fn test_insert_parameter_remap_all_params() -> anyhow::Result<()> {
     // execute the insert (no rows returned)
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -222,7 +222,7 @@ fn test_insert_parameter_remap_all_params() -> anyhow::Result<()> {
                 // D = 999
                 assert_eq!(row.get::<&Value>(3).unwrap(), &Value::Integer(999));
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -264,7 +264,7 @@ fn test_insert_parameter_multiple_remap_backwards() -> anyhow::Result<()> {
     // execute the insert (no rows returned)
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -290,7 +290,7 @@ fn test_insert_parameter_multiple_remap_backwards() -> anyhow::Result<()> {
                 // D = 999
                 assert_eq!(row.get::<&Value>(3).unwrap(), &Value::Integer(444));
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -331,7 +331,7 @@ fn test_insert_parameter_multiple_no_remap() -> anyhow::Result<()> {
     // execute the insert (no rows returned)
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -357,7 +357,7 @@ fn test_insert_parameter_multiple_no_remap() -> anyhow::Result<()> {
                 // D = 999
                 assert_eq!(row.get::<&Value>(3).unwrap(), &Value::Integer(444));
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -402,7 +402,7 @@ fn test_insert_parameter_multiple_row() -> anyhow::Result<()> {
     // execute the insert (no rows returned)
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -434,7 +434,7 @@ fn test_insert_parameter_multiple_row() -> anyhow::Result<()> {
                 );
                 i += 1;
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -450,7 +450,7 @@ fn test_bind_parameters_update_query() -> anyhow::Result<()> {
     let mut ins = conn.prepare("insert into test (a, b) values (3, 'test1');")?;
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -461,7 +461,7 @@ fn test_bind_parameters_update_query() -> anyhow::Result<()> {
     ins.bind_at(2.try_into()?, Value::build_text("test1"));
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -476,7 +476,7 @@ fn test_bind_parameters_update_query() -> anyhow::Result<()> {
                 assert_eq!(row.get::<&Value>(0).unwrap(), &Value::Integer(222));
                 assert_eq!(row.get::<&Value>(1).unwrap(), &Value::build_text("test1"),);
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -495,7 +495,7 @@ fn test_bind_parameters_update_query_multiple_where() -> anyhow::Result<()> {
     let mut ins = conn.prepare("insert into test (a, b, c, d) values (3, 'test1', 4, 5);")?;
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -507,7 +507,7 @@ fn test_bind_parameters_update_query_multiple_where() -> anyhow::Result<()> {
     ins.bind_at(3.try_into()?, Value::Integer(5));
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -524,7 +524,7 @@ fn test_bind_parameters_update_query_multiple_where() -> anyhow::Result<()> {
                 assert_eq!(row.get::<&Value>(2).unwrap(), &Value::Integer(4));
                 assert_eq!(row.get::<&Value>(3).unwrap(), &Value::Integer(5));
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -543,7 +543,7 @@ fn test_bind_parameters_update_rowid_alias() -> anyhow::Result<()> {
     let mut ins = conn.prepare("insert into test (id, name) values (1, 'test');")?;
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -558,7 +558,7 @@ fn test_bind_parameters_update_rowid_alias() -> anyhow::Result<()> {
                 assert_eq!(row.get::<&Value>(0).unwrap(), &Value::Integer(1));
                 assert_eq!(row.get::<&Value>(1).unwrap(), &Value::build_text("test"),);
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -568,7 +568,7 @@ fn test_bind_parameters_update_rowid_alias() -> anyhow::Result<()> {
     ins.bind_at(2.try_into()?, Value::Integer(1));
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -583,7 +583,7 @@ fn test_bind_parameters_update_rowid_alias() -> anyhow::Result<()> {
                 assert_eq!(row.get::<&Value>(0).unwrap(), &Value::Integer(1));
                 assert_eq!(row.get::<&Value>(1).unwrap(), &Value::build_text("updated"),);
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -618,7 +618,7 @@ fn test_bind_parameters_update_rowid_alias_seek_rowid() -> anyhow::Result<()> {
                     &Value::Integer(if i == 0 { 4 } else { 11 })
                 );
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -631,7 +631,7 @@ fn test_bind_parameters_update_rowid_alias_seek_rowid() -> anyhow::Result<()> {
     ins.bind_at(4.try_into()?, Value::Integer(5));
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -649,7 +649,7 @@ fn test_bind_parameters_update_rowid_alias_seek_rowid() -> anyhow::Result<()> {
                     &Value::build_text(if i == 0 { "updated" } else { "test" }),
                 );
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }
@@ -678,7 +678,7 @@ fn test_bind_parameters_delete_rowid_alias_seek_out_of_order() -> anyhow::Result
     ins.bind_at(4.try_into()?, Value::build_text("test"));
     loop {
         match ins.step()? {
-            StepResult::IO => ins.run_once()?,
+            StepResult::IO => ins.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
             _ => {}
@@ -693,7 +693,7 @@ fn test_bind_parameters_delete_rowid_alias_seek_out_of_order() -> anyhow::Result
                 let row = sel.row().unwrap();
                 assert_eq!(row.get::<&Value>(0).unwrap(), &Value::build_text("correct"),);
             }
-            StepResult::IO => sel.run_once()?,
+            StepResult::IO => sel.step()?,
             StepResult::Done | StepResult::Interrupt => break,
             StepResult::Busy => panic!("database busy"),
         }

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -44,7 +44,7 @@ fn test_simple_overflow_page() -> anyhow::Result<()> {
         Ok(Some(ref mut rows)) => loop {
             match rows.step()? {
                 StepResult::IO => {
-                    rows.run_once()?;
+                    rows.step()?;
                 }
                 StepResult::Done => break,
                 _ => unreachable!(),
@@ -70,7 +70,7 @@ fn test_simple_overflow_page() -> anyhow::Result<()> {
                     compare_string(&huge_text, text);
                 }
                 StepResult::IO => {
-                    rows.run_once()?;
+                    rows.step()?;
                 }
                 StepResult::Interrupt => break,
                 StepResult::Done => break,
@@ -112,7 +112,7 @@ fn test_sequential_overflow_page() -> anyhow::Result<()> {
             Ok(Some(ref mut rows)) => loop {
                 match rows.step()? {
                     StepResult::IO => {
-                        rows.run_once()?;
+                        rows.step()?;
                     }
                     StepResult::Done => break,
                     _ => unreachable!(),
@@ -140,7 +140,7 @@ fn test_sequential_overflow_page() -> anyhow::Result<()> {
                     current_index += 1;
                 }
                 StepResult::IO => {
-                    rows.run_once()?;
+                    rows.step()?;
                 }
                 StepResult::Interrupt => break,
                 StepResult::Done => break,
@@ -249,7 +249,7 @@ fn test_statement_reset() -> anyhow::Result<()> {
                 );
                 break;
             }
-            StepResult::IO => stmt.run_once()?,
+            StepResult::IO => stmt.step()?,
             _ => break,
         }
     }
@@ -266,7 +266,7 @@ fn test_statement_reset() -> anyhow::Result<()> {
                 );
                 break;
             }
-            StepResult::IO => stmt.run_once()?,
+            StepResult::IO => stmt.step()?,
             _ => break,
         }
     }
@@ -315,7 +315,7 @@ fn test_wal_restart() -> anyhow::Result<()> {
         let insert_query = format!("INSERT INTO test VALUES ({i})");
         run_query(tmp_db, conn, &insert_query)?;
         debug!("inserted {i}");
-        tmp_db.io.run_once()?;
+        tmp_db.io.step()?;
         Ok(())
     }
 
@@ -791,7 +791,7 @@ pub fn run_query_core(
         loop {
             match rows.step()? {
                 StepResult::IO => {
-                    rows.run_once()?;
+                    rows.step()?;
                 }
                 StepResult::Done => break,
                 StepResult::Row => {

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -46,7 +46,7 @@ fn test_wal_1_writer_1_reader() -> Result<()> {
                 match rows.step().unwrap() {
                     StepResult::Row => {}
                     StepResult::IO => {
-                        rows.run_once().unwrap();
+                        rows.step().unwrap();
                     }
                     StepResult::Interrupt => break,
                     StepResult::Done => break,
@@ -86,7 +86,7 @@ fn test_wal_1_writer_1_reader() -> Result<()> {
                             i += 1;
                         }
                         StepResult::IO => {
-                            rows.run_once().unwrap();
+                            rows.step().unwrap();
                         }
                         StepResult::Interrupt => break,
                         StepResult::Done => break,
@@ -126,8 +126,8 @@ pub(crate) fn execute_and_get_strings(conn: &Arc<Connection>, sql: &str) -> Resu
             }
             StepResult::Done => break,
             StepResult::Interrupt => break,
-            StepResult::IO => stmt.run_once()?,
-            StepResult::Busy => stmt.run_once()?,
+            StepResult::IO => stmt.step()?,
+            StepResult::Busy => stmt.step()?,
         }
     }
     Ok(result)
@@ -158,8 +158,8 @@ pub(crate) fn execute_and_get_ints(conn: &Arc<Connection>, sql: &str) -> Result<
             }
             StepResult::Done => break,
             StepResult::Interrupt => break,
-            StepResult::IO => stmt.run_once()?,
-            StepResult::Busy => stmt.run_once()?,
+            StepResult::IO => stmt.step()?,
+            StepResult::Busy => stmt.step()?,
         }
     }
     Ok(result)


### PR DESCRIPTION
The `run_once()` name is pretty confusing. What the method does is advance the I/O dispatcher by one step, whatever that means on a platform.