### PR TITLE
bindings/javascript: Reduce VM/native crossing overhead

### DIFF
--- a/bindings/javascript/index.d.ts
+++ b/bindings/javascript/index.d.ts
@@ -94,8 +94,17 @@ export declare class Statement {
    * * `value` - The value to bind.
    */
   bindAt(index: number, value: unknown): void
-  step(): unknown
+  /**
+   * Step the statement and return result code:
+   * 1 = Row available, 2 = Done, 3 = I/O needed
+   */
+  step(): number
+  /** Get the current row data according to the presentation mode */
+  row(): unknown
+  /** Sets the presentation mode to raw. */
   raw(raw?: boolean | undefined | null): void
+  /** Sets the presentation mode to pluck. */
   pluck(pluck?: boolean | undefined | null): void
+  /** Finalizes the statement. */
   finalize(): void
 }

--- a/bindings/javascript/promise.js
+++ b/bindings/javascript/promise.js
@@ -5,6 +5,11 @@ const { bindParams } = require("./bind.js");
 
 const SqliteError = require("./sqlite-error.js");
 
+// Step result constants
+const STEP_ROW = 1;
+const STEP_DONE = 2;
+const STEP_IO = 3;
+
 const convertibleErrorTypes = { TypeError };
 const CONVERTIBLE_ERROR_PREFIX = "[TURSO_CONVERT_TYPE]";
 
@@ -258,13 +263,17 @@ class Statement {
     bindParams(this.stmt, bindParameters);
     
     while (true) {
-      const result = this.stmt.step();
-      if (result.io) {
+      const stepResult = this.stmt.step();
+      if (stepResult === STEP_IO) {
         await this.db.db.ioLoopAsync();
         continue;
       }
-      if (result.done) {
+      if (stepResult === STEP_DONE) {
         break;
+      }
+      if (stepResult === STEP_ROW) {
+        // For run(), we don't need the row data, just continue
+        continue;
       }
     }
     
@@ -284,15 +293,17 @@ class Statement {
     bindParams(this.stmt, bindParameters);
     
     while (true) {
-      const result = this.stmt.step();
-      if (result.io) {
+      const stepResult = this.stmt.step();
+      if (stepResult === STEP_IO) {
         await this.db.db.ioLoopAsync();
         continue;
       }
-      if (result.done) {
+      if (stepResult === STEP_DONE) {
         return undefined;
       }
-      return result.value;
+      if (stepResult === STEP_ROW) {
+        return this.stmt.row();
+      }
     }
   }
 
@@ -316,15 +327,17 @@ class Statement {
     const rows = [];
     
     while (true) {
-      const result = this.stmt.step();
-      if (result.io) {
+      const stepResult = this.stmt.step();
+      if (stepResult === STEP_IO) {
         await this.db.db.ioLoopAsync();
         continue;
       }
-      if (result.done) {
+      if (stepResult === STEP_DONE) {
         break;
       }
-      rows.push(result.value);
+      if (stepResult === STEP_ROW) {
+        rows.push(this.stmt.row());
+      }
     }
     return rows;
   }


### PR DESCRIPTION
Before:

```
penberg@vonneumann perf % node perf-turso.js
cpu: Apple M1
runtime: node v22.16.0 (arm64-darwin)

benchmark                            time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------------- -----------------------------
• Statement
----------------------------------------------------------------------- -----------------------------
Statement.get() bind parameters   1'525 ns/iter   (1'482 ns … 1'720 ns)  1'534 ns  1'662 ns  1'720 ns

summary for Statement
  Statement.get() bind parameters
penberg@vonneumann perf % bun perf-turso.js
cpu: Apple M1
runtime: bun 1.2.15 (arm64-darwin)

benchmark                            time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------------- -----------------------------
• Statement
----------------------------------------------------------------------- -----------------------------
Statement.get() bind parameters   1'198 ns/iter   (1'157 ns … 1'495 ns)  1'189 ns  1'456 ns  1'495 ns

summary for Statement
  Statement.get() bind parameters
```

After:

```

benchmark                            time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------------- -----------------------------
• Statement
----------------------------------------------------------------------- -----------------------------
Statement.get() bind parameters   1'206 ns/iter   (1'180 ns … 1'402 ns)  1'208 ns  1'365 ns  1'402 ns

summary for Statement
  Statement.get() bind parameters
penberg@vonneumann perf % bun perf-turso.js
cpu: Apple M1
runtime: bun 1.2.15 (arm64-darwin)

benchmark                            time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------------- -----------------------------
• Statement
----------------------------------------------------------------------- -----------------------------
Statement.get() bind parameters   1'019 ns/iter     (980 ns … 1'360 ns)  1'005 ns  1'270 ns  1'360 ns

summary for Statement
  Statement.get() bind parameters
```