### PR TITLE
Single quotes inside a string literal have to be doubled in `translate_alter_table`

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -80,7 +80,7 @@ pub fn translate_alter_table(
 
             btree.columns.remove(dropped_index);
 
-            let sql = btree.to_sql();
+            let sql = btree.to_sql().replace('\'', "''");
 
             let stmt = format!(
                 r#"

--- a/testing/alter_table.test
+++ b/testing/alter_table.test
@@ -46,34 +46,33 @@ do_execsql_test_on_specific_db {:memory:} alter-table-add-column-typed {
   "1|0"
 }
 
-# FIXME: #https://github.com/tursodatabase/turso/issues/2390
-#do_execsql_test_on_specific_db {:memory:} alter-table-add-column-default {
-#    CREATE TABLE test (a);
-#    INSERT INTO test VALUES (1), (2), (3);
-#
-#    ALTER TABLE test ADD b DEFAULT 0.1;
-#    ALTER TABLE test ADD c DEFAULT 'hello';
-#    SELECT * FROM test;
-#
-#    CREATE INDEX idx ON test (b);
-#    SELECT b, c FROM test WHERE b = 0.1;
-#
-#    ALTER TABLE test DROP a;
-#    SELECT * FROM test;
-#
-#} {
-#"1|0.1|hello"
-#"2|0.1|hello"
-#"3|0.1|hello"
-#
-#"0.1|hello"
-#"0.1|hello"
-#"0.1|hello"
+do_execsql_test_on_specific_db {:memory:} alter-table-add-column-default {
+    CREATE TABLE test (a);
+    INSERT INTO test VALUES (1), (2), (3);
 
-#"0.1|hello"
-#"0.1|hello"
-#"0.1|hello"
-#}
+    ALTER TABLE test ADD b DEFAULT 0.1;
+    ALTER TABLE test ADD c DEFAULT 'hello';
+    SELECT * FROM test;
+
+    CREATE INDEX idx ON test (b);
+    SELECT b, c FROM test WHERE b = 0.1;
+
+    ALTER TABLE test DROP a;
+    SELECT * FROM test;
+
+} {
+"1|0.1|hello"
+"2|0.1|hello"
+"3|0.1|hello"
+
+"0.1|hello"
+"0.1|hello"
+"0.1|hello"
+
+"0.1|hello"
+"0.1|hello"
+"0.1|hello"
+}
 
 do_execsql_test_on_specific_db {:memory:} alter-table-drop-column {
     CREATE TABLE t (a, b);


### PR DESCRIPTION
Close #2390

Single quotes inside a string literal have to be doubled