### PR TITLE
use state machine for NoConflict opcode

### DIFF
--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -771,11 +771,17 @@ pub enum Insn {
         reg: usize,
     },
 
-    /// If P4==0 then register P3 holds a blob constructed by [MakeRecord](https://sqlite.org/opcode.html#MakeRecord). If P4>0 then register P3 is the first of P4 registers that form an unpacked record.\
+    /// If P4==0 then register P3 holds a blob constructed by [MakeRecord](https://sqlite.org/opcode.html#MakeRecord).
+    /// If P4>0 then register P3 is the first of P4 registers that form an unpacked record.
     ///
-    /// Cursor P1 is on an index btree. If the record identified by P3 and P4 contains any NULL value, jump immediately to P2. If all terms of the record are not-NULL then a check is done to determine if any row in the P1 index btree has a matching key prefix. If there are no matches, jump immediately to P2. If there is a match, fall through and leave the P1 cursor pointing to the matching row.\
+    /// Cursor P1 is on an index btree. If the record identified by P3 and P4 contains any NULL value, jump immediately
+    /// to P2. If all terms of the record are not-NULL then a check is done to determine if any row in the P1 index
+    /// btree has a matching key prefix. If there are no matches, jump immediately to P2. If there is a match, fall
+    /// through and leave the P1 cursor pointing to the matching row.\
     ///
-    /// This opcode is similar to [NotFound](https://sqlite.org/opcode.html#NotFound) with the exceptions that the branch is always taken if any part of the search key input is NULL.
+    /// This opcode is similar to [NotFound](https://sqlite.org/opcode.html#NotFound) with the exceptions that the
+    /// branch is always taken if any part of the search key input is NULL.
+    //TODO this one
     NoConflict {
         cursor_id: CursorID,     // P1 index cursor
         target_pc: BranchOffset, // P2 jump target

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -781,7 +781,6 @@ pub enum Insn {
     ///
     /// This opcode is similar to [NotFound](https://sqlite.org/opcode.html#NotFound) with the exceptions that the
     /// branch is always taken if any part of the search key input is NULL.
-    //TODO this one
     NoConflict {
         cursor_id: CursorID,     // P1 index cursor
         target_pc: BranchOffset, // P2 jump target

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -31,7 +31,9 @@ use crate::{
     storage::sqlite3_ondisk::SmallVec,
     translate::plan::TableReferences,
     types::{IOResult, RawSlice, TextRef},
-    vdbe::execute::{OpIdxInsertState, OpInsertState, OpNewRowidState, OpSeekState},
+    vdbe::execute::{
+        OpIdxInsertState, OpInsertState, OpNewRowidState, OpNoConflictState, OpSeekState,
+    },
     RefValue,
 };
 
@@ -256,6 +258,7 @@ pub struct ProgramState {
     op_new_rowid_state: OpNewRowidState,
     op_idx_insert_state: OpIdxInsertState,
     op_insert_state: OpInsertState,
+    op_no_conflict_state: OpNoConflictState,
     seek_state: OpSeekState,
 }
 
@@ -286,6 +289,7 @@ impl ProgramState {
             op_new_rowid_state: OpNewRowidState::Start,
             op_idx_insert_state: OpIdxInsertState::SeekIfUnique,
             op_insert_state: OpInsertState::Insert,
+            op_no_conflict_state: OpNoConflictState::Start,
             seek_state: OpSeekState::Start,
         }
     }


### PR DESCRIPTION
This will save some work when yielding to IO. Previously, on every invocation, if the record was a packed record, we parsed it and iterated through the values to check for nulls. Now, the pre-seeking work is done only once.