### PR TITLE
Direct schema mutation – add `RenameTable` instruction

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -7,7 +7,7 @@ use crate::{
     schema::{Column, Schema},
     util::normalize_ident,
     vdbe::{
-        builder::ProgramBuilder,
+        builder::{CursorType, ProgramBuilder},
         insn::{Cookie, Insn, RegisterOrLiteral},
     },
     LimboError, Result, SymbolTable,
@@ -106,9 +106,7 @@ pub fn translate_alter_table(
                     let root_page = btree.root_page;
                     let table_name = btree.name.clone();
 
-                    let cursor_id = program.alloc_cursor_id(
-                        crate::vdbe::builder::CursorType::BTreeTable(original_btree),
-                    );
+                    let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(original_btree));
 
                     program.emit_insn(Insn::OpenWrite {
                         cursor_id,
@@ -248,9 +246,7 @@ pub fn translate_alter_table(
                 .get_btree_table(SQLITE_TABLEID)
                 .expect("sqlite_schema should be on schema");
 
-            let cursor_id = program.alloc_cursor_id(crate::vdbe::builder::CursorType::BTreeTable(
-                sqlite_schema.clone(),
-            ));
+            let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(sqlite_schema.clone()));
 
             program.emit_insn(Insn::OpenWrite {
                 cursor_id,
@@ -335,9 +331,7 @@ pub fn translate_alter_table(
                 .get_btree_table(SQLITE_TABLEID)
                 .expect("sqlite_schema should be on schema");
 
-            let cursor_id = program.alloc_cursor_id(crate::vdbe::builder::CursorType::BTreeTable(
-                sqlite_schema.clone(),
-            ));
+            let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(sqlite_schema.clone()));
 
             program.emit_insn(Insn::OpenWrite {
                 cursor_id,
@@ -398,9 +392,9 @@ pub fn translate_alter_table(
                 p5: 0,
             });
 
-            program.emit_insn(Insn::ParseSchema {
-                db: usize::MAX, // TODO: This value is unused, change when we do something with it
-                where_clause: None,
+            program.emit_insn(Insn::RenameTable {
+                from: table_name.to_owned(),
+                to: new_name.to_owned(),
             });
 
             program.epilogue(TransactionMode::Write);

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1627,6 +1627,15 @@ pub fn insn_to_str(
                 0,
                 format!("affinity(r[{}]={:?})", *reg, affinity),
             ),
+            Insn::RenameTable { from, to } => (
+                "RenameTable",
+                0,
+                0,
+                0,
+                Value::build_text(""),
+                0,
+                format!("rename_table({from}, {to})"),
+            ),
         };
     format!(
         "{:<4}  {:<17}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1004,6 +1004,10 @@ pub enum Insn {
         roots: Vec<usize>,
         message_register: usize,
     },
+    RenameTable {
+        from: String,
+        to: String,
+    },
 }
 
 impl Insn {
@@ -1132,6 +1136,7 @@ impl Insn {
             Insn::IdxDelete { .. } => execute::op_idx_delete,
             Insn::Count { .. } => execute::op_count,
             Insn::IntegrityCk { .. } => execute::op_integrity_check,
+            Insn::RenameTable { .. } => execute::op_rename_table,
         }
     }
 }


### PR DESCRIPTION
Resolves #2378.

```
`ALTER TABLE _ RENAME TO _`/limbo_rename_table/
                        time:   [53.401 ms 55.767 ms 58.473 ms]
                        change: [-9.1755% -3.0960% +3.4253%] (p = 0.33 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking `ALTER TABLE _ RENAME TO _`/sqlite_rename_table/: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.3s, or reduce sample count to 90.
`ALTER TABLE _ RENAME TO _`/sqlite_rename_table/
                        time:   [58.217 ms 59.116 ms 60.235 ms]
                        change: [-0.2631% +1.4193% +3.5706%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe
  ```