### PR TITLE
perf/pager: dont clear page cache on commit

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1170,11 +1170,6 @@ impl Pager {
                     let is_last_frame = current_page_to_append_idx
                         == self.commit_info.borrow().dirty_pages.len() - 1;
                     if is_last_frame {
-                        // Let's clear the page cache now
-                        {
-                            let mut cache = self.page_cache.write();
-                            cache.clear().unwrap();
-                        }
                         self.dirty_pages.borrow_mut().clear();
                         self.commit_info.borrow_mut().state = CommitState::SyncWal;
                     } else {


### PR DESCRIPTION
This should be safe to do as:

1. page cache is private per connection
2. since this connection wrote the flushed pages/frames, they are up to date from its perspective
3. multiple concurrent statements inside one connection are not snapshot-transactional even in sqlite