### PR TITLE
perf/btree: skip seek in move_to_rightmost() if we are already on rightmost page

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5509,10 +5509,6 @@ pub fn op_new_rowid(
                 let current_max = {
                     let mut cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut();
-
-                    // Move to last record
-                    return_if_io!(cursor.seek_to_last());
-
                     return_if_io!(cursor.rowid())
                 };
 


### PR DESCRIPTION
## Background

When we get a new rowid using `op_new_rowid()`, we move to the end of the btree to look at what the maximum rowid currently is, and then increment it by one.

This requires a btree seek.

## Problem

If we were already on the rightmost page, this is a lot of unnecessary work, including potentially a few page reads from disk (although to be fair the ancestor pages are very likely to be in cache at this point.)

## Fix

Cache the rightmost page id whenever we enter it in `move_to_rightmost()`, and invalidate it whenever we do a balancing operation.

## Local benchmark results

```sql
Insert rows in batches/limbo_insert_1_rows
                        time:   [23.333 µs 27.718 µs 35.801 µs]
                        change: [-7.7924% +0.8805% +12.841%] (p = 0.91 > 0.05)
                        No change in performance detected.
Insert rows in batches/limbo_insert_10_rows
                        time:   [38.204 µs 38.381 µs 38.568 µs]
                        change: [-8.7188% -7.4786% -6.1955%] (p = 0.00 < 0.05)
                        Performance has improved.
Insert rows in batches/limbo_insert_100_rows
                        time:   [158.39 µs 165.06 µs 178.37 µs]
                        change: [-21.000% -18.789% -15.666%] (p = 0.00 < 0.05)
                        Performance has improved.