### PR TITLE
page poisoning

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,6 +26,7 @@ omit_autovacuum = []
 simulator = ["fuzz", "serde"]
 serde = ["dep:serde"]
 series = []
+page-poisoning = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.5", optional = true }

--- a/core/build.rs
+++ b/core/build.rs
@@ -2,6 +2,15 @@ use std::fs;
 use std::path::PathBuf;
 
 fn main() {
+    // Enable page-poisoning by default ONLY in debug builds
+    #[cfg(debug_assertions)]
+    {
+        // Only enable if the feature is not explicitly set (either enabled or disabled)
+        if std::env::var("CARGO_FEATURE_PAGE_POISONING").is_err() {
+            println!("cargo:rustc-cfg=feature=\"page-poisoning\"");
+        }
+    }
+
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let built_file = out_dir.join("built.rs");
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -15,7 +15,7 @@ name = "limbo_sim"
 path = "main.rs"
 
 [dependencies]
-turso_core = { path = "../core", features = ["simulator"]}
+turso_core = { path = "../core", features = ["simulator", "page-poisoning"]}
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 log = "0.4.20"


### PR DESCRIPTION
Test that a page that is freed is not reused.
Enabled only explicitly through a feature. Enabled by default on debug builds.

This helped me find a nasty bug.