### PR TITLE
hind dangerous methods behind conn_raw_api feature

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -11,6 +11,7 @@ description = "Turso Rust API"
 
 [features]
 default = ["experimental_indexes"]
+conn_raw_api = ["turso_core/conn_raw_api"]
 experimental_indexes = []
 antithesis = ["turso_core/antithesis"]
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -38,7 +38,8 @@ pub mod transaction;
 pub mod value;
 
 use transaction::TransactionBehavior;
-use turso_core::types::WalInsertInfo;
+#[cfg(feature = "conn_raw_api")]
+use turso_core::types::WalFrameInfo;
 pub use value::Value;
 
 pub use params::params_from_iter;
@@ -181,6 +182,7 @@ impl Connection {
         stmt.execute(params).await
     }
 
+    #[cfg(feature = "conn_raw_api")]
     pub fn wal_frame_count(&self) -> Result<u64> {
         let conn = self
             .inner
@@ -190,6 +192,7 @@ impl Connection {
             .map_err(|e| Error::WalOperationError(format!("wal_insert_begin failed: {e}")))
     }
 
+    #[cfg(feature = "conn_raw_api")]
     pub fn wal_insert_begin(&self) -> Result<()> {
         let conn = self
             .inner
@@ -199,6 +202,7 @@ impl Connection {
             .map_err(|e| Error::WalOperationError(format!("wal_insert_begin failed: {e}")))
     }
 
+    #[cfg(feature = "conn_raw_api")]
     pub fn wal_insert_end(&self) -> Result<()> {
         let conn = self
             .inner
@@ -208,7 +212,8 @@ impl Connection {
             .map_err(|e| Error::WalOperationError(format!("wal_insert_end failed: {e}")))
     }
 
-    pub fn wal_insert_frame(&self, frame_no: u32, frame: &[u8]) -> Result<WalInsertInfo> {
+    #[cfg(feature = "conn_raw_api")]
+    pub fn wal_insert_frame(&self, frame_no: u32, frame: &[u8]) -> Result<WalFrameInfo> {
         let conn = self
             .inner
             .lock()
@@ -217,6 +222,7 @@ impl Connection {
             .map_err(|e| Error::WalOperationError(format!("wal_insert_frame failed: {e}")))
     }
 
+    #[cfg(feature = "conn_raw_api")]
     pub fn wal_get_frame(&self, frame_no: u32, frame: &mut [u8]) -> Result<()> {
         let conn = self
             .inner

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,8 +14,9 @@ name = "turso_core"
 path = "lib.rs"
 
 [features]
-antithesis = ["dep:antithesis_sdk"]
 default = ["fs", "uuid", "time", "json", "series"]
+antithesis = ["dep:antithesis_sdk"]
+conn_raw_api = []
 fs = ["turso_ext/vfs"]
 json = []
 uuid = ["dep:uuid"]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -6,7 +6,7 @@ use crate::storage::sqlite3_ondisk::{
     self, parse_wal_frame_header, DatabaseHeader, PageContent, PageSize, PageType,
 };
 use crate::storage::wal::{CheckpointResult, Wal};
-use crate::types::{IOResult, WalInsertInfo};
+use crate::types::{IOResult, WalFrameInfo};
 use crate::util::IOExt as _;
 use crate::{return_if_io, Completion, TransactionState};
 use crate::{turso_assert, Buffer, Connection, LimboError, Result};
@@ -1290,7 +1290,7 @@ impl Pager {
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn wal_insert_frame(&self, frame_no: u32, frame: &[u8]) -> Result<WalInsertInfo> {
+    pub fn wal_insert_frame(&self, frame_no: u32, frame: &[u8]) -> Result<WalFrameInfo> {
         let Some(wal) = self.wal.as_ref() else {
             return Err(LimboError::InternalError(
                 "wal_insert_frame() called on database without WAL".to_string(),
@@ -1323,9 +1323,9 @@ impl Pager {
             }
             self.dirty_pages.borrow_mut().clear();
         }
-        Ok(WalInsertInfo {
-            page_no: header.page_number as usize,
-            is_commit: header.is_commit_frame(),
+        Ok(WalFrameInfo {
+            page_no: header.page_number,
+            db_size: header.db_size,
         })
     }
 

--- a/core/types.rs
+++ b/core/types.rs
@@ -2590,9 +2590,15 @@ pub struct DatabaseChange {
 }
 
 #[derive(Debug)]
-pub struct WalInsertInfo {
-    pub page_no: usize,
-    pub is_commit: bool,
+pub struct WalFrameInfo {
+    pub page_no: u32,
+    pub db_size: u32,
+}
+
+impl WalFrameInfo {
+    pub fn is_commit_frame(&self) -> bool {
+        self.db_size > 0
+    }
 }
 
 #[cfg(test)]

--- a/packages/turso-sync/Cargo.toml
+++ b/packages/turso-sync/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-turso_core = { workspace = true }
-turso = { workspace = true }
+turso_core = { workspace = true, features = ["conn_raw_api"] }
+turso = { workspace = true, features = ["conn_raw_api"] }
 thiserror = "2.0.12"
 tracing = "0.1.41"
 hyper = { version = "1.6.0", features = ["client", "http1"] }

--- a/packages/turso-sync/src/database_inner.rs
+++ b/packages/turso-sync/src/database_inner.rs
@@ -369,8 +369,8 @@ impl<S: SyncServer, F: Filesystem> DatabaseInner<S, F> {
                     if !wal_session.in_txn() {
                         wal_session.begin()?;
                     }
-                    let wal_insert_info = clean_conn.wal_insert_frame(frame_no as u32, &buffer)?;
-                    if wal_insert_info.is_commit {
+                    let wal_frame_info = clean_conn.wal_insert_frame(frame_no as u32, &buffer)?;
+                    if wal_frame_info.is_commit_frame() {
                         wal_session.end()?;
                         // transaction boundary reached - it's safe to commit progress
                         self.meta = Some(self.write_meta(|m| m.synced_frame_no = frame_no).await?);

--- a/sqlite3/Cargo.toml
+++ b/sqlite3/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [dependencies]
 env_logger = { version = "0.11.3", default-features = false }
 libc = "0.2.169"
-turso_core = { path = "../core" }
+turso_core = { path = "../core", features = ["conn_raw_api"] }
 tracing = "0.1.41"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }


### PR DESCRIPTION
WAL API shouldn't be exposed by default because this is relatively dangerous API which we use internally and ordinary users shouldn't not be interested in it.