### PR TITLE
cdc: emit entries for schema changes

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -586,7 +586,7 @@ fn emit_delete_insns(
             let before_record_reg = if cdc_has_before {
                 Some(emit_cdc_full_record(
                     program,
-                    &table_reference.table.columns(),
+                    table_reference.table.columns(),
                     main_table_cursor_id,
                     rowid_reg,
                 ))
@@ -1163,7 +1163,7 @@ fn emit_update_insns(
         let cdc_before_reg = if program.capture_data_changes_mode().has_before() {
             Some(emit_cdc_full_record(
                 program,
-                &table_ref.table.columns(),
+                table_ref.table.columns(),
                 cursor_id,
                 cdc_rowid_before_reg.expect("cdc_rowid_before_reg must be set"),
             ))
@@ -1302,7 +1302,7 @@ pub fn prepare_cdc_if_necessary(
     };
     let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(cdc_btree.clone()));
     program.emit_insn(Insn::OpenWrite {
-        cursor_id: cursor_id,
+        cursor_id,
         root_page: cdc_btree.root_page.into(),
         db: 0, // todo(sivukhin): fix DB number when write will be supported for ATTACH
     });

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -124,7 +124,7 @@ pub fn translate_insert(
     let halt_label = program.allocate_label();
     let loop_start_label = program.allocate_label();
 
-    let cdc_table = prepare_cdc_if_necessary(&mut program, schema, &table)?;
+    let cdc_table = prepare_cdc_if_necessary(&mut program, schema, table.get_name())?;
 
     // Process RETURNING clause using shared module
     let (result_columns, _) = if let Some(returning) = &mut returning {
@@ -348,14 +348,6 @@ pub fn translate_insert(
             rowid_and_columns_start_register,
             &resolver,
         )?;
-    }
-    // Open turso_cdc table btree for writing if necessary
-    if let Some((cdc_cursor_id, cdc_btree)) = &cdc_table {
-        program.emit_insn(Insn::OpenWrite {
-            cursor_id: *cdc_cursor_id,
-            root_page: cdc_btree.root_page.into(),
-            db: 0,
-        });
     }
 
     // Open all the index btrees for writing

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -6,7 +6,9 @@ use turso_sqlite3_parser::ast::{
 
 use crate::error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY};
 use crate::schema::{self, IndexColumn, Table};
-use crate::translate::emitter::{emit_cdc_insns, emit_cdc_patch_record, OperationMode};
+use crate::translate::emitter::{
+    emit_cdc_insns, emit_cdc_patch_record, prepare_cdc_if_necessary, OperationMode,
+};
 use crate::translate::expr::{
     emit_returning_results, process_returning_clause, ReturningValueRegisters,
 };
@@ -122,25 +124,7 @@ pub fn translate_insert(
     let halt_label = program.allocate_label();
     let loop_start_label = program.allocate_label();
 
-    let cdc_table = program.capture_data_changes_mode().table();
-    let cdc_table = if let Some(cdc_table) = cdc_table {
-        if table.get_name() != cdc_table {
-            let Some(turso_cdc_table) = schema.get_table(cdc_table) else {
-                crate::bail_parse_error!("no such table: {}", cdc_table);
-            };
-            let Some(cdc_btree) = turso_cdc_table.btree().clone() else {
-                crate::bail_parse_error!("no such table: {}", cdc_table);
-            };
-            Some((
-                program.alloc_cursor_id(CursorType::BTreeTable(cdc_btree.clone())),
-                cdc_btree,
-            ))
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    let cdc_table = prepare_cdc_if_necessary(&mut program, schema, &table)?;
 
     // Process RETURNING clause using shared module
     let (result_columns, _) = if let Some(returning) = &mut returning {

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -124,7 +124,8 @@ pub fn init_loop(
     ) {
         assert!(tables.joined_tables().len() == 1);
         let changed_table = &tables.joined_tables()[0].table;
-        let prepared = prepare_cdc_if_necessary(program, t_ctx.resolver.schema, &changed_table)?;
+        let prepared =
+            prepare_cdc_if_necessary(program, t_ctx.resolver.schema, changed_table.get_name())?;
         if let Some((cdc_cursor_id, _)) = prepared {
             t_ctx.cdc_cursor_id = Some(cdc_cursor_id);
         }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -91,6 +91,7 @@ pub fn translate(
         // There can be no nesting with pragma, so lift it up here
         ast::Stmt::Pragma(name, body) => pragma::translate_pragma(
             schema,
+            syms,
             &name,
             body.map(|b| *b),
             pager,
@@ -158,6 +159,7 @@ pub fn translate_inner(
             tbl_name.as_str(),
             &columns,
             schema,
+            syms,
             program,
         )?,
         ast::Stmt::CreateTable {
@@ -165,7 +167,15 @@ pub fn translate_inner(
             if_not_exists,
             tbl_name,
             body,
-        } => translate_create_table(tbl_name, temporary, *body, if_not_exists, schema, program)?,
+        } => translate_create_table(
+            tbl_name,
+            temporary,
+            *body,
+            if_not_exists,
+            schema,
+            syms,
+            program,
+        )?,
         ast::Stmt::CreateTrigger { .. } => bail_parse_error!("CREATE TRIGGER not supported yet"),
         ast::Stmt::CreateView { .. } => bail_parse_error!("CREATE VIEW not supported yet"),
         ast::Stmt::CreateVirtualTable(vtab) => {
@@ -194,11 +204,11 @@ pub fn translate_inner(
         ast::Stmt::DropIndex {
             if_exists,
             idx_name,
-        } => translate_drop_index(idx_name.name.as_str(), if_exists, schema, program)?,
+        } => translate_drop_index(idx_name.name.as_str(), if_exists, schema, syms, program)?,
         ast::Stmt::DropTable {
             if_exists,
             tbl_name,
-        } => translate_drop_table(tbl_name, if_exists, schema, program)?,
+        } => translate_drop_table(tbl_name, if_exists, schema, syms, program)?,
         ast::Stmt::DropTrigger { .. } => bail_parse_error!("DROP TRIGGER not supported yet"),
         ast::Stmt::DropView { .. } => bail_parse_error!("DROP VIEW not supported yet"),
         ast::Stmt::Pragma(..) => {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -194,6 +194,7 @@ impl SchemaEntryType {
 }
 pub const SQLITE_TABLEID: &str = "sqlite_schema";
 
+#[allow(clippy::too_many_arguments)]
 pub fn emit_schema_entry(
     program: &mut ProgramBuilder,
     resolver: &Resolver,

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -18,9 +18,9 @@ fn replace_column_with_null(rows: Vec<Vec<Value>>, column: usize) -> Vec<Vec<Val
 fn test_cdc_simple_id() {
     let db = TempDatabase::new_empty(false);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
-        .unwrap();
     conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
+        .unwrap();
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (10, 10), (5, 1)")
         .unwrap();
@@ -78,9 +78,9 @@ fn record<const N: usize>(values: [Value; N]) -> Vec<u8> {
 fn test_cdc_simple_before() {
     let db = TempDatabase::new_empty(false);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('before')")
-        .unwrap();
     conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
+        .unwrap();
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('before')")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (1, 2), (3, 4)").unwrap();
     conn.execute("UPDATE t SET y = 3 WHERE x = 1").unwrap();
@@ -144,9 +144,9 @@ fn test_cdc_simple_before() {
 fn test_cdc_simple_after() {
     let db = TempDatabase::new_empty(false);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('after')")
-        .unwrap();
     conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
+        .unwrap();
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('after')")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (1, 2), (3, 4)").unwrap();
     conn.execute("UPDATE t SET y = 3 WHERE x = 1").unwrap();
@@ -210,9 +210,9 @@ fn test_cdc_simple_after() {
 fn test_cdc_simple_full() {
     let db = TempDatabase::new_empty(false);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('full')")
-        .unwrap();
     conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
+        .unwrap();
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('full')")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (1, 2), (3, 4)").unwrap();
     conn.execute("UPDATE t SET y = 3 WHERE x = 1").unwrap();
@@ -276,9 +276,9 @@ fn test_cdc_simple_full() {
 fn test_cdc_crud() {
     let db = TempDatabase::new_empty(false);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
-        .unwrap();
     conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
+        .unwrap();
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (20, 20), (10, 10), (5, 1)")
         .unwrap();
@@ -388,9 +388,9 @@ fn test_cdc_crud() {
 fn test_cdc_failed_op() {
     let db = TempDatabase::new_empty(true);
     let conn = db.connect_limbo();
-    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
-        .unwrap();
     conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
+        .unwrap();
+    conn.execute("PRAGMA unstable_capture_data_changes_conn('id')")
         .unwrap();
     conn.execute("INSERT INTO t VALUES (1, 10), (2, 20)")
         .unwrap();
@@ -701,13 +701,13 @@ fn test_cdc_independent_connections() {
     let conn1 = db.connect_limbo();
     let conn2 = db.connect_limbo();
     conn1
+        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
+        .unwrap();
+    conn1
         .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc1')")
         .unwrap();
     conn2
         .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc2')")
-        .unwrap();
-    conn1
-        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn2.execute("INSERT INTO t VALUES (2, 20)").unwrap();
@@ -755,13 +755,13 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
     let conn1 = db.connect_limbo();
     let conn2 = db.connect_limbo();
     conn1
+        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
+        .unwrap();
+    conn1
         .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc1')")
         .unwrap();
     conn2
         .execute("PRAGMA unstable_capture_data_changes_conn('id,custom_cdc2')")
-        .unwrap();
-    conn1
-        .execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
         .unwrap();
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     conn1.execute("INSERT INTO t VALUES (2, 20)").unwrap();


### PR DESCRIPTION
This PR emit CDC entries as changes in `sqlite_schema` table for DDL statements: `CREATE TABLE` / `CREATE INDEX` / etc.

The logic is a bit tricky as under the hood `turso` can do some implicit DDL operations like:
1. Creating auto-indexes in case of `CREATE TABLE`
2. Deletion of all attached indices in case of `DROP TABLE`

```
turso> PRAGMA unstable_capture_data_changes_conn('full');
turso> CREATE TABLE t(x, y, z UNIQUE, q, PRIMARY KEY (x, y));
turso> CREATE INDEX t_xy ON t(x, y);
turso> CREATE TABLE q(a, b, c);
turso> ALTER TABLE q DROP COLUMN b;

turso> SELECT
change_id, 
id,
change_type, 
table_name,
bin_record_json_object(table_columns_json_array(table_name), before) AS before,
bin_record_json_object(table_columns_json_array(table_name), after) AS after
FROM turso_cdc;
┌───────────┬────┬─────────────┬───────────────┬─────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────┐
│ change_id │ id │ change_type │ table_name    │ before                                                              │ after                                                               │
├───────────┼────┼─────────────┼───────────────┼─────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│         1 │  2 │           1 │ sqlite_schema │                                                                     │ {"type":"table","name":"t","tbl_name":"t","rootpage":3,"sql":"CREA… │
├───────────┼────┼─────────────┼───────────────┼─────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│         2 │  5 │           1 │ sqlite_schema │                                                                     │ {"type":"index","name":"t_xy","tbl_name":"t","rootpage":6,"sql":"C… │
├───────────┼────┼─────────────┼───────────────┼─────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│         3 │  6 │           1 │ sqlite_schema │                                                                     │ {"type":"table","name":"q","tbl_name":"q","rootpage":7,"sql":"CREA… │
├───────────┼────┼─────────────┼───────────────┼─────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
│         4 │  6 │           0 │ sqlite_schema │ {"type":"table","name":"q","tbl_name":"q","rootpage":7,"sql":"CREA… │ {"type":"table","name":"q","tbl_name":"q","rootpage":7,"sql":"CREA… │
└───────────┴────┴─────────────┴───────────────┴─────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────┘
```

For now, CDC capture only all explicit operations and ignore all implicit operations. The reasoning for that is that one use case for CDC is to apply logical changes as is with simple SQL statements - but if implicit operations will be logged to the CDC table too - we can have hard times using simple SQL statement (for example, creation of `autoindices` will always work; implicit deletion of indices for `DROP TABLE` also can lead to some troubles and force us to is `DROP INDEX IF EXISTS ...` statements + we will need to filter out autoindices in this case too).

Also, to simplify PR, for now `DatabaseTape` from `turso-sync` package just ignore all schema changes from CDC table.