### PR TITLE
fix(parameters): correct count() behavior for mixed parameter types

### DIFF
--- a/core/parameters.rs
+++ b/core/parameters.rs
@@ -11,7 +11,12 @@ pub enum Parameter {
 
 impl PartialEq for Parameter {
     fn eq(&self, other: &Self) -> bool {
-        self.index() == other.index()
+        match (self, other) {
+            (Parameter::Named(name1, idx1), Parameter::Named(name2, idx2)) => {
+                name1 == name2 && idx1 == idx2
+            }
+            _ => self.index() == other.index(),
+        }
     }
 }
 
@@ -120,5 +125,19 @@ impl Parameters {
                 index
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parameters_count() {
+        let mut params = Parameters::new();
+        params.push("?1");
+        params.push(":val");
+
+        assert_eq!(params.count(), 2);
     }
 }


### PR DESCRIPTION
Lately, while trying to replicate `sqlite3_bind_parameter_count()`, I noticed that our `Parameters::count()` is giving the wrong number when the SQL contains a mix of named and indexed parameters.


Right now, `Parameters::count()` doesn’t properly handle queries that mix named (`:val`) and indexed (`?1`) placeholders.

For example:
```sql
INSERT INTO test (id, value) VALUES (?1, :val);
```

Instead of counting 2 parameters like SQLite does, it only reports 1.

The issue comes from how PartialEq is implemented for Parameter, which makes different parameter types with the same index look like duplicates.
