### PR TITLE
fix/core/translate: ALTER TABLE DROP COLUMN: ensure schema cookie is updated even when target table is empty

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -139,12 +139,6 @@ pub fn translate_alter_table(
                             dest_reg: record,
                             index_name: None,
                         });
-                        program.emit_insn(Insn::SetCookie {
-                            db: 0,
-                            cookie: Cookie::SchemaVersion,
-                            value: schema.schema_version as i32 + 1,
-                            p5: 0,
-                        });
 
                         program.emit_insn(Insn::Insert {
                             cursor: cursor_id,
@@ -153,6 +147,13 @@ pub fn translate_alter_table(
                             flag: crate::vdbe::insn::InsertFlags(0),
                             table_name: table_name.clone(),
                         });
+                    });
+
+                    program.emit_insn(Insn::SetCookie {
+                        db: 0,
+                        cookie: Cookie::SchemaVersion,
+                        value: schema.schema_version as i32 + 1,
+                        p5: 0,
                     });
 
                     program.emit_insn(Insn::ParseSchema {


### PR DESCRIPTION
Closes #2431 
Discovered while fuzzing #2086 

## What

We update `schema_version` whenever the schema changes

## Problem

Probably unintentionally, we were calling `SetCookie` in a loop for each row in the target table, instead of only once at the end. This means 2 things:

- For large `n`, this is a lot of unnecessary instructions
- For `n==0`, `SetCookie` doesn't get called at all -> the schema won't get marked as having been updated -> conns can operate on a stale schema

## Fix

Lift `SetCookie` out of the loop