### PR TITLE
extend raw WAL API with few more methods

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -193,6 +193,33 @@ impl Connection {
     }
 
     #[cfg(feature = "conn_raw_api")]
+    pub fn try_wal_watermark_read_page(
+        &self,
+        page_idx: u32,
+        page: &mut [u8],
+        frame_watermark: Option<u64>,
+    ) -> Result<bool> {
+        let conn = self
+            .inner
+            .lock()
+            .map_err(|e| Error::MutexError(e.to_string()))?;
+        conn.try_wal_watermark_read_page(page_idx, page, frame_watermark)
+            .map_err(|e| {
+                Error::WalOperationError(format!("try_wal_watermark_read_page failed: {e}"))
+            })
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    pub fn wal_changed_pages_after(&self, frame_watermark: u64) -> Result<Vec<u32>> {
+        let conn = self
+            .inner
+            .lock()
+            .map_err(|e| Error::MutexError(e.to_string()))?;
+        conn.wal_changed_pages_after(frame_watermark)
+            .map_err(|e| Error::WalOperationError(format!("wal_changed_pages_after failed: {e}")))
+    }
+
+    #[cfg(feature = "conn_raw_api")]
     pub fn wal_insert_begin(&self) -> Result<()> {
         let conn = self
             .inner
@@ -213,7 +240,7 @@ impl Connection {
     }
 
     #[cfg(feature = "conn_raw_api")]
-    pub fn wal_insert_frame(&self, frame_no: u32, frame: &[u8]) -> Result<WalFrameInfo> {
+    pub fn wal_insert_frame(&self, frame_no: u64, frame: &[u8]) -> Result<WalFrameInfo> {
         let conn = self
             .inner
             .lock()
@@ -223,7 +250,7 @@ impl Connection {
     }
 
     #[cfg(feature = "conn_raw_api")]
-    pub fn wal_get_frame(&self, frame_no: u32, frame: &mut [u8]) -> Result<()> {
+    pub fn wal_get_frame(&self, frame_no: u64, frame: &mut [u8]) -> Result<WalFrameInfo> {
         let conn = self
             .inner
             .lock()

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1141,6 +1141,8 @@ impl Connection {
         Ok(())
     }
 
+    /// Try to read page with given ID with fixed WAL watermark position
+    /// This method return false if page is not found (so, this is probably new page created after watermark position which wasn't checkpointed to the DB file yet)
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
     pub fn try_wal_watermark_read_page(
         &self,
@@ -1161,6 +1163,8 @@ impl Connection {
         Ok(true)
     }
 
+    /// Return unique set of page numbers changes after WAL watermark position in the current WAL session
+    /// (so, if concurrent connection wrote something to the WAL - this method will not see this change)
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
     pub fn wal_changed_pages_after(&self, frame_watermark: u64) -> Result<Vec<u32>> {
         self.pager.borrow().wal_changed_pages_after(frame_watermark)

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -929,7 +929,7 @@ impl Pager {
         Ok(())
     }
 
-    /// Reads a page from disk bypassing page-cache
+    /// Reads a page from disk (either WAL or DB file) bypassing page-cache
     #[tracing::instrument(skip_all, level = Level::DEBUG)]
     pub fn read_page_no_cache(
         &self,

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -860,6 +860,11 @@ impl Wal for WalFile {
             "unexpected use of frame_watermark optional argument"
         );
 
+        turso_assert!(
+            frame_watermark.unwrap_or(0) <= self.max_frame,
+            "frame_watermark must be <= than current WAL max_frame value"
+        );
+
         // if we are holding read_lock 0, skip and read right from db file.
         if self.max_frame_read_lock_index.get() == 0 {
             return Ok(None);

--- a/core/types.rs
+++ b/core/types.rs
@@ -2599,6 +2599,10 @@ impl WalFrameInfo {
     pub fn is_commit_frame(&self) -> bool {
         self.db_size > 0
     }
+    pub fn put_to_frame_header(&self, frame: &mut [u8]) {
+        frame[0..4].copy_from_slice(&self.page_no.to_be_bytes());
+        frame[4..8].copy_from_slice(&self.db_size.to_be_bytes());
+    }
 }
 
 #[cfg(test)]

--- a/packages/turso-sync/src/database_inner.rs
+++ b/packages/turso-sync/src/database_inner.rs
@@ -369,7 +369,7 @@ impl<S: SyncServer, F: Filesystem> DatabaseInner<S, F> {
                     if !wal_session.in_txn() {
                         wal_session.begin()?;
                     }
-                    let wal_frame_info = clean_conn.wal_insert_frame(frame_no as u32, &buffer)?;
+                    let wal_frame_info = clean_conn.wal_insert_frame(frame_no as u64, &buffer)?;
                     if wal_frame_info.is_commit_frame() {
                         wal_session.end()?;
                         // transaction boundary reached - it's safe to commit progress
@@ -437,7 +437,7 @@ impl<S: SyncServer, F: Filesystem> DatabaseInner<S, F> {
 
             let mut buffer = [0u8; FRAME_SIZE];
             for frame_no in (frame_no + 1)..=clean_frames {
-                clean_conn.wal_get_frame(frame_no as u32, &mut buffer)?;
+                clean_conn.wal_get_frame(frame_no as u64, &mut buffer)?;
                 frames.extend_from_slice(&buffer);
                 frames_cnt += 1;
             }

--- a/packages/turso-sync/src/sync_server/test.rs
+++ b/packages/turso-sync/src/sync_server/test.rs
@@ -185,7 +185,7 @@ impl SyncServer for TestSyncServer {
                 session.in_txn = true;
             }
             let frame = &frames[offset..offset + FRAME_SIZE];
-            match session.conn.wal_insert_frame(frame_no as u32, frame) {
+            match session.conn.wal_insert_frame(frame_no as u64, frame) {
                 Ok(info) => {
                     if info.is_commit_frame() {
                         if session.in_txn {
@@ -276,7 +276,7 @@ impl TestSyncServer {
         let wal_frame_count = conn.wal_frame_count()?;
         tracing::debug!("conn frames count: {}", wal_frame_count);
         for frame_no in last_frame..=wal_frame_count as usize {
-            conn.wal_get_frame(frame_no as u32, &mut frame)?;
+            conn.wal_get_frame(frame_no as u64, &mut frame)?;
             tracing::debug!("push local frame {}", frame_no);
             generation.frames.push(frame.to_vec());
         }

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -1213,8 +1213,8 @@ pub unsafe extern "C" fn libsql_wal_get_frame(
     let db: &mut sqlite3 = &mut *db;
     let db = db.inner.lock().unwrap();
     let frame = std::slice::from_raw_parts_mut(p_frame, frame_len as usize);
-    match db.conn.wal_get_frame(frame_no, frame) {
-        Ok(()) => SQLITE_OK,
+    match db.conn.wal_get_frame(frame_no as u64, frame) {
+        Ok(..) => SQLITE_OK,
         Err(_) => SQLITE_ERROR,
     }
 }
@@ -1250,7 +1250,7 @@ pub unsafe extern "C" fn libsql_wal_insert_frame(
     let db: &mut sqlite3 = &mut *db;
     let db = db.inner.lock().unwrap();
     let frame = std::slice::from_raw_parts(p_frame, frame_len as usize);
-    match db.conn.wal_insert_frame(frame_no, frame) {
+    match db.conn.wal_insert_frame(frame_no as u64, frame) {
         Ok(_) => SQLITE_OK,
         Err(LimboError::Conflict(..)) => {
             if !p_conflict.is_null() {

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -393,7 +393,7 @@ fn revert_to(conn: &Arc<turso_core::Connection>, frame_watermark: u64) -> turso_
         if !has_page {
             continue;
         }
-        frames.push((page_id, frame.clone()));
+        frames.push((page_id, frame));
     }
 
     let mut frame_no = conn.wal_frame_count().unwrap();


### PR DESCRIPTION
This PR extends raw WAL API with few methods which will be helpful for offline-sync:

1. `try_wal_watermark_read_page` - try to read page from the DB with given WAL watermark value\
    * Usually, WAL max_frame is set automatically to the latest value (`shared.max_frame`) when transaction is started and then this "watermark" is preserved throughout whole transaction
    * New method allows to simulate "read from the past" by controlling frame watermark explicitly
    * There is an alternative to implement some API like `start_read_session(frame_watermark: u64)` - but I decided to expose just single method to simplify the logic and reduce "surface" of actions which can be executed in this "controllable" manner
    * Also, for simplicity, now `try_wal_watermark_read_page` always read data from disk and bypass any cached values (and also do not populate the cache)
2. `wal_changed_pages_after` - return set of unique pages changed after watermark WAL position in the current WAL session

With these 2 methods we can implement `REVERT frame_watermark` logic which will just fetch all changed pages first, and then revert them to the previous value by using `try_wal_watermark_read_page` and `wal_insert_frame` methods (see `test_wal_api_revert_pages` test).

Note, that if there were schema changes - than `REVERT` logic described above can bring connection to the inconsistent state, as it will preserve schema information in memory and will still think that table exist (while it can be reverted). This should be considered by any consumer of this new methods.
