### PR TITLE
Direct schema mutation – add `DropColumn` instruction

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -116,6 +116,142 @@ fn bench_alter(criterion: &mut Criterion) {
     }
 
     group.finish();
+
+    let mut group = criterion.benchmark_group("`ALTER TABLE _ RENAME COLUMN _ TO _`");
+
+    group.bench_function(BenchmarkId::new("limbo_rename_column", ""), |b| {
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false, false).unwrap();
+        let conn = db.connect().unwrap();
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    conn.execute("CREATE TABLE x(a)").unwrap();
+                    let elapsed = {
+                        let start = Instant::now();
+                        conn.execute("ALTER TABLE x RENAME COLUMN a TO b").unwrap();
+                        start.elapsed()
+                    };
+                    conn.execute("DROP TABLE x").unwrap();
+                    elapsed
+                })
+                .sum()
+        });
+    });
+
+    if enable_rusqlite {
+        group.bench_function(BenchmarkId::new("sqlite_rename_column", ""), |b| {
+            let conn = rusqlite::Connection::open("../testing/schema_5k.db").unwrap();
+            b.iter_custom(|iters| {
+                (0..iters)
+                    .map(|_| {
+                        conn.execute("CREATE TABLE x(a)", ()).unwrap();
+                        let elapsed = {
+                            let start = Instant::now();
+                            conn.execute("ALTER TABLE x RENAME COLUMN a TO b", ())
+                                .unwrap();
+                            start.elapsed()
+                        };
+                        conn.execute("DROP TABLE x", ()).unwrap();
+                        elapsed
+                    })
+                    .sum()
+            });
+        });
+    }
+
+    group.finish();
+
+    let mut group = criterion.benchmark_group("`ALTER TABLE _ ADD COLUMN _`");
+
+    group.bench_function(BenchmarkId::new("limbo_add_column", ""), |b| {
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false, false).unwrap();
+        let conn = db.connect().unwrap();
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    conn.execute("CREATE TABLE x(a)").unwrap();
+                    let elapsed = {
+                        let start = Instant::now();
+                        conn.execute("ALTER TABLE x ADD COLUMN b").unwrap();
+                        start.elapsed()
+                    };
+                    conn.execute("DROP TABLE x").unwrap();
+                    elapsed
+                })
+                .sum()
+        });
+    });
+
+    if enable_rusqlite {
+        group.bench_function(BenchmarkId::new("sqlite_add_column", ""), |b| {
+            let conn = rusqlite::Connection::open("../testing/schema_5k.db").unwrap();
+            b.iter_custom(|iters| {
+                (0..iters)
+                    .map(|_| {
+                        conn.execute("CREATE TABLE x(a)", ()).unwrap();
+                        let elapsed = {
+                            let start = Instant::now();
+                            conn.execute("ALTER TABLE x ADD COLUMN b", ()).unwrap();
+                            start.elapsed()
+                        };
+                        conn.execute("DROP TABLE x", ()).unwrap();
+                        elapsed
+                    })
+                    .sum()
+            });
+        });
+    }
+
+    group.finish();
+
+    let mut group = criterion.benchmark_group("`ALTER TABLE _ DROP COLUMN _`");
+
+    group.bench_function(BenchmarkId::new("limbo_drop_column", ""), |b| {
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false, false).unwrap();
+        let conn = db.connect().unwrap();
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    conn.execute("CREATE TABLE x(a, b)").unwrap();
+                    let elapsed = {
+                        let start = Instant::now();
+                        conn.execute("ALTER TABLE x DROP COLUMN b").unwrap();
+                        start.elapsed()
+                    };
+                    conn.execute("DROP TABLE x").unwrap();
+                    elapsed
+                })
+                .sum()
+        });
+    });
+
+    if enable_rusqlite {
+        group.bench_function(BenchmarkId::new("sqlite_drop_column", ""), |b| {
+            let conn = rusqlite::Connection::open("../testing/schema_5k.db").unwrap();
+            b.iter_custom(|iters| {
+                (0..iters)
+                    .map(|_| {
+                        conn.execute("CREATE TABLE x(a, b)", ()).unwrap();
+                        let elapsed = {
+                            let start = Instant::now();
+                            conn.execute("ALTER TABLE x DROP COLUMN b", ()).unwrap();
+                            start.elapsed()
+                        };
+                        conn.execute("DROP TABLE x", ()).unwrap();
+                        elapsed
+                    })
+                    .sum()
+            });
+        });
+    }
+
+    group.finish();
 }
 
 fn bench_prepare_query(criterion: &mut Criterion) {

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -153,9 +153,9 @@ pub fn translate_alter_table(
                         p5: 0,
                     });
 
-                    program.emit_insn(Insn::ParseSchema {
-                        db: usize::MAX, // TODO: This value is unused, change when we do something with it
-                        where_clause: None,
+                    program.emit_insn(Insn::DropColumn {
+                        table: table_name,
+                        column_index: dropped_index,
                     })
                 },
             )?

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1636,6 +1636,15 @@ pub fn insn_to_str(
                 0,
                 format!("rename_table({from}, {to})"),
             ),
+            Insn::DropColumn { table, column_index } => (
+                "DropColumn",
+                0,
+                0,
+                0,
+                Value::build_text(""),
+                0,
+                format!("drop_column({table}, {column_index})"),
+            ),
             Insn::CollSeq { reg, collation } => (
                 "CollSeq",
                 reg.unwrap_or(0) as i32,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1030,6 +1030,10 @@ pub enum Insn {
         from: String,
         to: String,
     },
+    DropColumn {
+        table: String,
+        column_index: usize,
+    },
 }
 
 impl Insn {
@@ -1160,6 +1164,7 @@ impl Insn {
             Insn::Count { .. } => execute::op_count,
             Insn::IntegrityCk { .. } => execute::op_integrity_check,
             Insn::RenameTable { .. } => execute::op_rename_table,
+            Insn::DropColumn { .. } => execute::op_drop_column,
         }
     }
 }


### PR DESCRIPTION
**86%** performance improvement. We are **25x** faster than SQLite. 

<img width="953" height="511" alt="image" src="https://github.com/user-attachments/assets/fd717d1e-bbbe-4959-ae48-41afc73e5e9f" />

```
ALTER TABLE _ DROP COLUMN _`/limbo_drop_column/
                        time:   [1.8821 ms 1.8929 ms 1.9047 ms]
                        change: [-86.850% -86.733% -86.614%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking `ALTER TABLE _ DROP COLUMN _`/sqlite_drop_column/: Warming up for 3.0000 s

`ALTER TABLE _ DROP COLUMN _`/sqlite_drop_column/
                        time:   [46.227 ms 46.258 ms 46.291 ms]
                        change: [-1.3202% -1.0505% -0.8109%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  10 (10.00%) high mild
  5 (5.00%) high severe
  ```