### PR TITLE
Remove Clone impl for Buffer and PageContent

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -270,7 +270,6 @@ pub type BufferData = Pin<Vec<u8>>;
 
 pub type BufferDropFn = Rc<dyn Fn(BufferData)>;
 
-#[derive(Clone)]
 pub struct Buffer {
     data: ManuallyDrop<BufferData>,
     drop: BufferDropFn,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -434,17 +434,6 @@ pub struct PageContent {
     pub overflow_cells: Vec<OverflowCell>,
 }
 
-impl Clone for PageContent {
-    fn clone(&self) -> Self {
-        #[allow(clippy::arc_with_non_send_sync)]
-        Self {
-            offset: self.offset,
-            buffer: Arc::new(RefCell::new((*self.buffer.borrow()).clone())),
-            overflow_cells: self.overflow_cells.clone(),
-        }
-    }
-}
-
 impl PageContent {
     pub fn new(offset: usize, buffer: Arc<RefCell<Buffer>>) -> Self {
         Self {


### PR DESCRIPTION
After #2258, we no longer need to clone/deep copy `PageContent` or `Buffer`.

We can remove the implementation to make any copying of page data explicit.