### PR TITLE
Remove RefCell from Buffer in IO trait methods and PageContents

### DIFF
--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -469,10 +469,10 @@ impl turso_core::DatabaseStorage for DatabaseFile {
     fn write_page(
         &self,
         page_idx: usize,
-        buffer: Arc<RefCell<turso_core::Buffer>>,
+        buffer: Arc<turso_core::Buffer>,
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
-        let size = buffer.borrow().len();
+        let size = buffer.len();
         let pos = (page_idx - 1) * size;
         self.file.pwrite(pos, buffer, c)
     }
@@ -481,7 +481,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         &self,
         page_idx: usize,
         page_size: usize,
-        buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
+        buffers: Vec<Arc<turso_core::Buffer>>,
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
         let pos = page_idx.saturating_sub(1) * page_size;

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -91,7 +91,7 @@ impl File for GenericFile {
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
         {
             let r = c.as_read();
-            let mut buf = r.buf_mut();
+            let mut buf = r.buf();
             let buf = buf.as_mut_slice();
             file.read_exact(buf)?;
         }
@@ -99,16 +99,10 @@ impl File for GenericFile {
         Ok(c)
     }
 
-    fn pwrite(
-        &self,
-        pos: usize,
-        buffer: Arc<RefCell<crate::Buffer>>,
-        c: Completion,
-    ) -> Result<Completion> {
+    fn pwrite(&self, pos: usize, buffer: Arc<crate::Buffer>, c: Completion) -> Result<Completion> {
         let mut file = self.file.borrow_mut();
         file.seek(std::io::SeekFrom::Start(pos as u64))?;
-        let buf = buffer.borrow();
-        let buf = buf.as_slice();
+        let buf = buffer.as_slice();
         file.write_all(buf)?;
         c.complete(buf.len() as i32);
         Ok(c)

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -298,6 +298,7 @@ impl Buffer {
         &self.data
     }
 
+    #[allow(clippy::mut_from_ref)]
     pub fn as_mut_slice(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.as_mut_ptr(), self.data.len()) }
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1146,7 +1146,7 @@ impl Connection {
 
         let content = page_ref.get_contents();
         // empty read - attempt to read absent page
-        if content.buffer.borrow().is_empty() {
+        if content.buffer.is_empty() {
             return Ok(false);
         }
         page.copy_from_slice(content.as_ptr());

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7350,10 +7350,7 @@ mod tests {
         let drop_fn = Rc::new(|_| {});
         let inner = PageContent::new(
             0,
-            Arc::new(RefCell::new(Buffer::new(
-                BufferData::new(vec![0; 4096]),
-                drop_fn,
-            ))),
+            Arc::new(Buffer::new(BufferData::new(vec![0; 4096]), drop_fn)),
         );
         page.get().contents.replace(inner);
         let page = Arc::new(BTreePageInner {
@@ -8644,15 +8641,14 @@ mod tests {
         while current_page <= 4 {
             let drop_fn = Rc::new(|_buf| {});
             #[allow(clippy::arc_with_non_send_sync)]
-            let buf = Arc::new(RefCell::new(Buffer::allocate(
+            let buf = Arc::new(Buffer::allocate(
                 pager
                     .io
                     .block(|| pager.with_header(|header| header.page_size))?
                     .get() as usize,
                 drop_fn,
-            )));
+            ));
             let c = Completion::new_write(|_| {});
-            #[allow(clippy::arc_with_non_send_sync)]
             let _c = pager
                 .db_file
                 .write_page(current_page as usize, buf.clone(), c)?;

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -1,6 +1,6 @@
 use crate::error::LimboError;
 use crate::{io::Completion, Buffer, Result};
-use std::{cell::RefCell, sync::Arc};
+use std::sync::Arc;
 use tracing::{instrument, Level};
 
 /// DatabaseStorage is an interface a database file that consists of pages.
@@ -10,17 +10,13 @@ use tracing::{instrument, Level};
 /// or something like a remote page server service.
 pub trait DatabaseStorage: Send + Sync {
     fn read_page(&self, page_idx: usize, c: Completion) -> Result<Completion>;
-    fn write_page(
-        &self,
-        page_idx: usize,
-        buffer: Arc<RefCell<Buffer>>,
-        c: Completion,
-    ) -> Result<Completion>;
+    fn write_page(&self, page_idx: usize, buffer: Arc<Buffer>, c: Completion)
+        -> Result<Completion>;
     fn write_pages(
         &self,
         first_page_idx: usize,
         page_size: usize,
-        buffers: Vec<Arc<RefCell<Buffer>>>,
+        buffers: Vec<Arc<Buffer>>,
         c: Completion,
     ) -> Result<Completion>;
     fn sync(&self, c: Completion) -> Result<Completion>;
@@ -56,10 +52,10 @@ impl DatabaseStorage for DatabaseFile {
     fn write_page(
         &self,
         page_idx: usize,
-        buffer: Arc<RefCell<Buffer>>,
+        buffer: Arc<Buffer>,
         c: Completion,
     ) -> Result<Completion> {
-        let buffer_size = buffer.borrow().len();
+        let buffer_size = buffer.len();
         assert!(page_idx > 0);
         assert!(buffer_size >= 512);
         assert!(buffer_size <= 65536);
@@ -72,7 +68,7 @@ impl DatabaseStorage for DatabaseFile {
         &self,
         page_idx: usize,
         page_size: usize,
-        buffers: Vec<Arc<RefCell<Buffer>>>,
+        buffers: Vec<Arc<Buffer>>,
         c: Completion,
     ) -> Result<Completion> {
         assert!(page_idx > 0);

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -626,7 +626,7 @@ mod tests {
     use crate::storage::pager::{Page, PageRef};
     use crate::storage::sqlite3_ondisk::PageContent;
     use std::ptr::NonNull;
-    use std::{cell::RefCell, num::NonZeroUsize, pin::Pin, rc::Rc, sync::Arc};
+    use std::{num::NonZeroUsize, pin::Pin, rc::Rc, sync::Arc};
 
     use lru::LruCache;
     use rand_chacha::{
@@ -646,7 +646,7 @@ mod tests {
             let buffer = Buffer::new(Pin::new(vec![0; 4096]), buffer_drop_fn);
             let page_content = PageContent {
                 offset: 0,
-                buffer: Arc::new(RefCell::new(buffer)),
+                buffer: Arc::new(buffer),
                 overflow_cells: Vec::new(),
             };
             page.get().contents = Some(page_content);

--- a/simulator/runner/file.rs
+++ b/simulator/runner/file.rs
@@ -173,7 +173,7 @@ impl File for SimulatorFile {
     fn pwrite(
         &self,
         pos: usize,
-        buffer: Arc<RefCell<turso_core::Buffer>>,
+        buffer: Arc<turso_core::Buffer>,
         c: turso_core::Completion,
     ) -> Result<turso_core::Completion> {
         self.nr_pwrite_calls.set(self.nr_pwrite_calls.get() + 1);
@@ -225,7 +225,7 @@ impl File for SimulatorFile {
     fn pwritev(
         &self,
         pos: usize,
-        buffers: Vec<Arc<RefCell<turso_core::Buffer>>>,
+        buffers: Vec<Arc<turso_core::Buffer>>,
         c: turso_core::Completion,
     ) -> Result<turso_core::Completion> {
         self.nr_pwrite_calls.set(self.nr_pwrite_calls.get() + 1);

--- a/tests/integration/query_processing/test_btree.rs
+++ b/tests/integration/query_processing/test_btree.rs
@@ -432,7 +432,7 @@ fn write_at(io: &impl IO, file: Arc<dyn File>, offset: usize, data: &[u8]) {
     let completion = Completion::new_write(|_| {});
     let drop_fn = Rc::new(move |_| {});
     #[allow(clippy::arc_with_non_send_sync)]
-    let buffer = Arc::new(RefCell::new(Buffer::new(Pin::new(data.to_vec()), drop_fn)));
+    let buffer = Arc::new(Buffer::new(Pin::new(data.to_vec()), drop_fn));
     let result = file.pwrite(offset, buffer, completion).unwrap();
     while !result.is_completed() {
         io.run_once().unwrap();

--- a/tests/integration/query_processing/test_btree.rs
+++ b/tests/integration/query_processing/test_btree.rs
@@ -1,5 +1,4 @@
 use std::{
-    cell::RefCell,
     collections::{HashMap, HashSet},
     path::Path,
     pin::Pin,


### PR DESCRIPTION
We are doing unsafe mut borrowing in `PageContent` currently, and when new BufferPool is merged, it will be all pointers into an arena anyway. We just need to be sure to clone the Arc and reference the buffers in the completion callbacks so they are ensured to live for async IO.


naturally in true spirit of all my previous PR's, I needed to introduce one while another is open that causes an absurd amount of conflicts.