### PR TITLE
for some reason a return IO in `allocate_page` as it creates an infinite

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1795,7 +1795,7 @@ impl Pager {
                         trunk_page,
                         current_db_size: new_db_size,
                     };
-                    return Ok(IOResult::IO);
+                    // return Ok(IOResult::IO);
                 }
                 AllocatePageState::SearchAvailableFreeListLeaf {
                     trunk_page,


### PR DESCRIPTION
I confess I am not sure what the problem is. I spent the better part of my day trying to understand why this was a problem. There is some very subtle reentrancy problem here. I don't know if when we call `fill_cell_payload` the usable size changes per call and this somehow affects this. I suggest we rollback this return statement for now just to avoid errors in CI