### PR TITLE
core/btree: fix re-entrancy bug in insert_into_page()

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -2466,6 +2466,12 @@ pub enum IOResult<T> {
     IO,
 }
 
+impl<T> IOResult<T> {
+    pub fn is_io(&self) -> bool {
+        matches!(self, IOResult::IO)
+    }
+}
+
 /// Evaluate a Result<IOResult<T>>, if IO return IO.
 #[macro_export]
 macro_rules! return_if_io {


### PR DESCRIPTION
## Background

We currently clone `WriteState` on every iteration of `insert_into_page()`,
presumably for _Borrow Checker Reasons (tm)_.

## Problem

There was a bug in `WriteState::Insert` handling where if `fill_cell_payload()`
returned IO, the `fill_cell_payload_state` was not updated in
`write_info.state`, leading to an infinite loop of allocating new pages. Further, the `new_payload` vector was also always deep-cloned.

## Fix

Update the state if `fill_cell_payload()` returns IO. Because of `WriteState` cloning we also need to `Arc<Mutex>` wrap the vector so that the underlying data buffer doesn't get cloned the next time `WriteState` gets cloned, since `fill_cell_payload` relies on raw pointers to work. Left a couple of prominent FIXMEs about this.

## Notes

This bug was surfaced by, but not caused by, https://github.com/tursodatabase/turso/pull/2400.