### PR TITLE
refactor/btree: don't clone WriteState in insert_into_page()

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4357,7 +4357,7 @@ impl BTreeCursor {
     }
 
     #[instrument(skip(self), level = Level::DEBUG)]
-    pub fn rowid(&mut self) -> Result<IOResult<Option<i64>>> {
+    pub fn rowid(&self) -> Result<IOResult<Option<i64>>> {
         if let Some(mv_cursor) = &self.mv_cursor {
             if self.has_record.get() {
                 let mut mv_cursor = mv_cursor.borrow_mut();

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5380,8 +5380,11 @@ impl BTreeCursor {
                     let new_payload = &mut *new_payload;
                     // if it all fits in local space and old_local_size is enough, do an in-place overwrite
                     if new_payload.len() == *old_local_size {
-                        let _res =
-                            self.overwrite_content(page_ref.clone(), *old_offset, new_payload)?;
+                        let _res = BTreeCursor::overwrite_content(
+                            page_ref.clone(),
+                            *old_offset,
+                            new_payload,
+                        )?;
                         return Ok(IOResult::Done(()));
                     }
 
@@ -5403,7 +5406,6 @@ impl BTreeCursor {
     }
 
     pub fn overwrite_content(
-        &mut self,
         page_ref: BTreePage,
         dest_offset: usize,
         new_payload: &[u8],


### PR DESCRIPTION
## Problem

Cloning `WriteState` was probably done for borrow checker reasons, but since `WriteState` has expanded to include buffers that must not be moved in memory, it has necessitated a really annoying workaround of wrapping the buffers in `Arc<Mutex>>` which is just completely wasteful.

## Fix

Do not clone `WriteState` in `insert_into_page()`, and instead work with the borrow checker a bit more. Note that `WriteState` still _implements_ `Clone` because it's also cloned in `balance_non_root()` - that can be a separate refactor.