### PR TITLE
Fix segfault on schema update for virtual tables

### DIFF
--- a/core/ext/dynamic.rs
+++ b/core/ext/dynamic.rs
@@ -58,7 +58,7 @@ impl Connection {
                     LimboError::ExtensionError("Error locking extension libraries".to_string())
                 })?
                 .push((Arc::new(lib), api_ref));
-            {
+            if self.is_db_initialized() {
                 self.parse_schema_rows()?;
             }
             Ok(())

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -19,7 +19,7 @@ use turso_ext::{
     ExtensionApi, InitAggFunction, ResultCode, ScalarFunction, VTabKind, VTabModuleImpl,
 };
 pub use turso_ext::{FinalizeFunction, StepFunction, Value as ExtValue, ValueType as ExtValueType};
-pub use vtab_xconnect::{close, execute, prepare_stmt};
+pub use vtab_xconnect::{execute, prepare_stmt};
 
 /// The context passed to extensions to register with Core
 /// along with the function pointers

--- a/macros/src/ext/vtab_derive.rs
+++ b/macros/src/ext/vtab_derive.rs
@@ -49,7 +49,7 @@ pub fn derive_vtab_module(input: TokenStream) -> TokenStream {
             }
 
             #[no_mangle]
-            unsafe extern "C" fn #open_fn_name(table: *const ::std::ffi::c_void, conn: *mut ::turso_ext::Conn) -> *const ::std::ffi::c_void {
+            unsafe extern "C" fn #open_fn_name(table: *const ::std::ffi::c_void, conn: *const ::turso_ext::Conn) -> *const ::std::ffi::c_void {
                 if table.is_null() {
                     return ::std::ptr::null();
                 }


### PR DESCRIPTION
Closes #2478 
```console
turso>create table t(a,b);
turso>insert into t select 1,2 from generate_series(1,20);
turso>create index idxa on t(a);
turso>create index idxb on t(b);
# segfault
```
The issue was the `turso_ext::Conn` pointer was stored on the `VirtualTable`, which lives longer than necessary and the underlying core `Connection` is not guaranteed pinned. Moving the `turso_ext::Conn` on to the cursor fixes this issue because it's independent of the Schema.

This also fixes the issue that comes up when that issue is fixed, and some of the relevant code for this hadn't been updated when other surrounding changes had been made.