### PR TITLE
SQLite C API improvements: add basic bind and column functions

### DIFF
--- a/sqlite3/include/sqlite3.h
+++ b/sqlite3/include/sqlite3.h
@@ -44,6 +44,8 @@
 typedef struct sqlite3 sqlite3;
 
 typedef struct sqlite3_stmt sqlite3_stmt;
+typedef int64_t sqlite3_int64;
+typedef sqlite3_int64 sqlite_int64;
 
 typedef int (*exec_callback)(void *context, int n_column, char **argv, char **colv);
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -318,7 +318,7 @@ pub unsafe extern "C" fn sqlite3_reset(stmt: *mut sqlite3_stmt) -> ffi::c_int {
 pub unsafe extern "C" fn sqlite3_changes(db: *mut sqlite3) -> ffi::c_int {
     let db: &mut sqlite3 = &mut *db;
     let inner = db.inner.lock().unwrap();
-    return inner.conn.changes() as ffi::c_int;
+    inner.conn.changes() as ffi::c_int
 }
 
 #[no_mangle]
@@ -362,14 +362,14 @@ pub unsafe extern "C" fn sqlite3_get_autocommit(_db: *mut sqlite3) -> ffi::c_int
 pub unsafe extern "C" fn sqlite3_total_changes(db: *mut sqlite3) -> ffi::c_int {
     let db: &mut sqlite3 = &mut *db;
     let inner = db.inner.lock().unwrap();
-    return inner.conn.total_changes() as ffi::c_int;
+    inner.conn.total_changes() as ffi::c_int
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_last_insert_rowid(db: *mut sqlite3) -> ffi::c_int {
     let db: &mut sqlite3 = &mut *db;
     let inner = db.inner.lock().unwrap();
-    return inner.conn.last_insert_rowid() as ffi::c_int;
+    inner.conn.last_insert_rowid() as ffi::c_int
 }
 
 #[no_mangle]
@@ -486,7 +486,7 @@ pub unsafe extern "C" fn sqlite3_data_count(stmt: *mut sqlite3_stmt) -> ffi::c_i
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_bind_parameter_count(stmt: *mut sqlite3_stmt) -> ffi::c_int {
     let stmt = &*stmt;
-    return stmt.stmt.parameters_count() as ffi::c_int;
+    stmt.stmt.parameters_count() as ffi::c_int
 }
 
 #[no_mangle]
@@ -499,10 +499,9 @@ pub unsafe extern "C" fn sqlite3_bind_parameter_name(
 
     if let Some(val) = stmt.stmt.parameters().name(index) {
         let c_string = CString::new(val).expect("CString::new failed");
-        let c_ptr = c_string.into_raw();
-        return c_ptr;
+        c_string.into_raw()
     } else {
-        return std::ptr::null();
+        std::ptr::null()
     }
 }
 
@@ -519,7 +518,7 @@ pub unsafe extern "C" fn sqlite3_bind_null(stmt: *mut sqlite3_stmt, idx: ffi::c_
 
     stmt.stmt
         .bind_at(NonZero::new_unchecked(idx as usize), Value::Null);
-    return SQLITE_OK;
+    SQLITE_OK
 }
 
 #[no_mangle]
@@ -605,7 +604,7 @@ pub unsafe extern "C" fn sqlite3_column_type(
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_column_count(stmt: *mut sqlite3_stmt) -> ffi::c_int {
     let stmt = &mut *stmt;
-    return stmt.stmt.num_columns() as ffi::c_int;
+    stmt.stmt.num_columns() as ffi::c_int
 }
 
 #[no_mangle]
@@ -627,8 +626,7 @@ pub unsafe extern "C" fn sqlite3_column_name(
     let binding = stmt.stmt.get_column_name(idx).into_owned();
     let val = binding.as_str();
     let c_string = CString::new(val).expect("CString::new failed");
-    let c_ptr = c_string.into_raw();
-    c_ptr
+    c_string.into_raw()
 }
 
 #[no_mangle]

--- a/sqlite3/tests/Makefile
+++ b/sqlite3/tests/Makefile
@@ -1,0 +1,10 @@
+CC=gcc
+CFLAGS=-Wall -Wextra -g -I../include 
+TARGET=sqlite3-tests
+SRC=sqlite3_tests.c
+
+all:
+	$(CC) $(CFLAGS) -o $(TARGET) $(SRC) $(LIBS)
+
+clean:
+	rm -f $(TARGET)

--- a/sqlite3/tests/compat/mod.rs
+++ b/sqlite3/tests/compat/mod.rs
@@ -301,8 +301,7 @@ mod tests {
             let param_count = sqlite3_bind_parameter_count(stmt);
             assert_eq!(param_count, 2);
 
-            println!("parameter count {}", param_count);
-
+            println!("parameter count {param_count}");
             let name1 = sqlite3_bind_parameter_name(stmt, 1);
             assert!(!name1.is_null());
             let name1_str = std::ffi::CStr::from_ptr(name1).to_str().unwrap();
@@ -359,9 +358,8 @@ mod tests {
 
             let last_rowid = sqlite3_last_insert_rowid(db);
             assert!(last_rowid > 0);
-            println!("last insert rowid: {}", last_rowid);
-
-            let query = format!("SELECT value FROM test_rowid WHERE rowid = {}", last_rowid);
+            println!("last insert rowid: {last_rowid}");
+            let query = format!("SELECT value FROM test_rowid WHERE rowid = {last_rowid}");
             let query_cstring = std::ffi::CString::new(query).unwrap();
 
             let mut stmt = std::ptr::null_mut();

--- a/sqlite3/tests/sqlite3_tests.c
+++ b/sqlite3/tests/sqlite3_tests.c
@@ -1,0 +1,311 @@
+#include <assert.h>
+#include <math.h>
+#include <sqlite3.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+void test_sqlite3_changes();
+void test_sqlite3_bind_int64();
+void test_sqlite3_bind_double();
+void test_sqlite3_bind_parameter_name();
+void test_sqlite3_bind_parameter_count();
+void test_sqlite3_column_name();
+void test_sqlite3_last_insert_rowid();
+
+int main(void)
+{
+    test_sqlite3_changes();
+    test_sqlite3_bind_int64();
+    test_sqlite3_bind_double();
+    test_sqlite3_bind_parameter_name();
+    test_sqlite3_bind_parameter_count();
+    test_sqlite3_column_name();
+    test_sqlite3_last_insert_rowid();
+    return 0;
+}
+
+
+void test_sqlite3_changes()
+{
+    sqlite3 *db;
+    char *err_msg = NULL;
+    int rc;
+
+    rc = sqlite3_open("../../testing/testing.db", &db);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_exec(db,
+        "CREATE TABLE IF NOT EXISTS turso_test_changes (id INTEGER PRIMARY KEY, name TEXT);",
+        NULL, NULL, &err_msg);
+    assert(rc == SQLITE_OK);
+    if (err_msg) { sqlite3_free(err_msg); err_msg = NULL; }
+
+    rc = sqlite3_exec(db, "DELETE FROM turso_test_changes;", NULL, NULL, &err_msg);
+    assert(rc == SQLITE_OK);
+    if (err_msg) { sqlite3_free(err_msg); err_msg = NULL; }
+    
+    sqlite3_close(db);
+    rc = sqlite3_open("../../testing/testing.db", &db);
+    assert(rc == SQLITE_OK);
+
+    assert(sqlite3_changes(db) == 0);
+
+    rc = sqlite3_exec(db,
+        "INSERT INTO turso_test_changes (name) VALUES ('abc');",
+        NULL, NULL, &err_msg);
+    assert(rc == SQLITE_OK);
+    if (err_msg) { sqlite3_free(err_msg); err_msg = NULL; }
+    assert(sqlite3_changes(db) == 1);
+
+
+    rc = sqlite3_exec(db,
+        "INSERT INTO turso_test_changes (name) VALUES ('def'),('ghi'),('jkl');",
+        NULL, NULL, &err_msg);
+    assert(rc == SQLITE_OK);
+    if (err_msg) { sqlite3_free(err_msg); err_msg = NULL; }
+    assert(sqlite3_changes(db) == 3);
+
+    sqlite3_close(db);
+}
+
+
+void test_sqlite3_bind_int64()
+{
+    sqlite3 *db;
+    sqlite3_stmt *stmt;
+    char *err_msg = NULL;
+    int rc;
+
+    rc = sqlite3_open("../../testing/testing.db", &db);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_exec(db,
+        "CREATE TABLE IF NOT EXISTS turso_test_int64 (id INTEGER PRIMARY KEY, value INTEGER);",
+        NULL, NULL, &err_msg);
+    assert(rc == SQLITE_OK);
+    
+    if (err_msg) { sqlite3_free(err_msg); err_msg = NULL; }
+    rc = sqlite3_exec(db, "DELETE FROM turso_test_int64;", NULL, NULL, &err_msg);
+    assert(rc == SQLITE_OK);
+    if (err_msg) { sqlite3_free(err_msg); err_msg = NULL; }
+
+    rc = sqlite3_prepare_v2(db, "INSERT INTO turso_test_int64 (value) VALUES (?);", -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+    
+    sqlite_int64 big_value = (sqlite_int64)9223372036854775807LL;
+    rc = sqlite3_bind_int64(stmt, 1, big_value);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_DONE);
+
+    rc = sqlite3_finalize(stmt);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_prepare_v2(db, "SELECT value FROM turso_test_int64 LIMIT 1;", -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_ROW);
+
+    sqlite_int64 fetched = sqlite3_column_int64(stmt, 0);
+    assert(fetched == big_value);
+
+    printf("Inserted value: %lld, Fetched value: %lld\n", (long long)big_value, (long long)fetched);
+
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+}
+
+void test_sqlite3_bind_double()
+{
+    sqlite3 *db;
+    sqlite3_stmt *stmt;
+    char *err_msg = NULL;
+    int rc;
+
+    rc = sqlite3_open("../../testing/testing.db", &db);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_exec(db,
+        "CREATE TABLE IF NOT EXISTS turso_test_double (id INTEGER PRIMARY KEY, value REAL);",
+        NULL, NULL, &err_msg);
+    assert(rc == SQLITE_OK);
+    if (err_msg) { sqlite3_free(err_msg); err_msg = NULL; }
+
+    rc = sqlite3_exec(db, "DELETE FROM turso_test_double;", NULL, NULL, &err_msg);
+    assert(rc == SQLITE_OK);
+    if (err_msg) { sqlite3_free(err_msg); err_msg = NULL; }
+
+    rc = sqlite3_prepare_v2(db, "INSERT INTO turso_test_double (value) VALUES (?);", -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+
+    double big_value = 1234567890.123456;   
+    rc = sqlite3_bind_double(stmt, 1, big_value);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_DONE);
+
+    rc = sqlite3_finalize(stmt);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_prepare_v2(db, "SELECT value FROM turso_test_double LIMIT 1;", -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_ROW);
+
+    double fetched = sqlite3_column_double(stmt, 0);
+    assert(fabs(fetched - big_value) < 1e-9);
+
+    printf("Inserted value: %.15f, Fetched value: %.15f\n", big_value, fetched);
+
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+}
+
+
+void test_sqlite3_bind_parameter_name() {
+    sqlite3 *db;
+    sqlite3_stmt *stmt;
+    int rc;
+
+    rc = sqlite3_open(":memory:", &db);
+    assert(rc == SQLITE_OK);
+
+    const char *sql = "INSERT INTO test_parameter_name (value) VALUES (:val);";
+    rc = sqlite3_exec(db, "CREATE TABLE test_parameter_name (id INTEGER PRIMARY KEY, value INTEGER);", NULL, NULL, NULL);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+
+    const char *param_name = sqlite3_bind_parameter_name(stmt, 1);
+    assert(param_name != NULL);
+    printf("Parameter name: %s\n", param_name);
+    assert(strcmp(param_name, ":val") == 0);
+
+    const char *invalid_name = sqlite3_bind_parameter_name(stmt, 99);
+    assert(invalid_name == NULL);
+
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+}
+
+
+void test_sqlite3_bind_parameter_count() {
+    sqlite3 *db;
+    sqlite3_stmt *stmt;
+    int rc;
+
+    rc = sqlite3_open(":memory:", &db);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_exec(db, "CREATE TABLE test_parameter_count (id INTEGER PRIMARY KEY, value TEXT);", NULL, NULL, NULL);
+    assert(rc == SQLITE_OK);
+
+    const char *sql = "INSERT INTO test_parameter_count (id, value) VALUES (?1, ?2);";
+    rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+
+    int param_count = sqlite3_bind_parameter_count(stmt);
+    printf("Parameter count: %d\n", param_count);
+    assert(param_count == 2);  
+    sqlite3_finalize(stmt);
+
+    rc = sqlite3_prepare_v2(db, "SELECT * FROM test_parameter_count;", -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+    param_count = sqlite3_bind_parameter_count(stmt);
+    printf("Parameter count (no params): %d\n", param_count);
+    assert(param_count == 0);
+
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+}
+
+void test_sqlite3_column_name() {
+    sqlite3 *db;
+    sqlite3_stmt *stmt;
+    int rc;
+
+    rc = sqlite3_open(":memory:", &db);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_exec(db,
+        "CREATE TABLE test_column_name (id INTEGER PRIMARY KEY, name TEXT, age INTEGER);",
+        NULL, NULL, NULL);
+    assert(rc == SQLITE_OK);
+
+    const char *sql = "SELECT id, name AS full_name, age FROM test_column_name;";
+    rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+
+    int col_count = sqlite3_column_count(stmt);
+    assert(col_count == 3);
+
+    const char *col0 = sqlite3_column_name(stmt, 0);
+    const char *col1 = sqlite3_column_name(stmt, 1);
+    const char *col2 = sqlite3_column_name(stmt, 2);
+
+    printf("Column 0 name: %s\n", col0);
+    printf("Column 1 name: %s\n", col1);
+    printf("Column 2 name: %s\n", col2);
+
+    assert(strcmp(col0, "id") == 0);
+    assert(strcmp(col1, "full_name") == 0);  
+    assert(strcmp(col2, "age") == 0);
+
+    const char *invalid_col = sqlite3_column_name(stmt, 99);
+    assert(invalid_col == NULL);
+
+    sqlite3_finalize(stmt);
+    sqlite3_close(db);
+}
+
+
+void test_sqlite3_last_insert_rowid() {
+    sqlite3 *db;
+    sqlite3_stmt *stmt;
+    int rc;
+
+    rc = sqlite3_open(":memory:", &db);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_exec(db,
+        "CREATE TABLE test_last_insert (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);",
+        NULL, NULL, NULL);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_prepare_v2(db,
+        "INSERT INTO test_last_insert (name) VALUES ('first');",
+        -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_DONE);
+
+    sqlite3_finalize(stmt);
+
+    sqlite3_int64 rowid1 = sqlite3_last_insert_rowid(db);
+    printf("first: %lld\n", (long long)rowid1);
+    assert(rowid1 == 1);
+
+    rc = sqlite3_prepare_v2(db,
+        "INSERT INTO test_last_insert (name) VALUES ('second');",
+        -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_DONE);
+
+    sqlite3_finalize(stmt);
+
+    sqlite3_int64 rowid2 = sqlite3_last_insert_rowid(db);
+    printf("second: %lld\n", (long long)rowid2);
+    assert(rowid2 == 2);
+
+    sqlite3_close(db);
+}


### PR DESCRIPTION
Add support for more of the SQLite C API.

Bind functions:

* bind_parameter_count
* bind_parameter_name
* bind_null
* bind_int
* bind_int64
* bind_double

Column functions:

* column_count
* column_name
* column_int
* column_double
* last_insert_rowid