### PR TITLE
Handle single, double and unquoted strings in values clause

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -2715,11 +2715,6 @@ pub fn sanitize_double_quoted_string(input: &str) -> String {
     input[1..input.len() - 1].replace("\"\"", "\"").to_string()
 }
 
-/// Checks if an identifier represents a double-quoted string that should get fallback behavior
-pub fn is_double_quoted_identifier(id_str: &str) -> bool {
-    id_str.len() >= 2 && id_str.starts_with('"') && id_str.ends_with('"')
-}
-
 /// Returns the components of a binary expression
 /// e.g. t.x = 5 -> Some((t.x, =, 5))
 pub fn as_binary_components(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -14,9 +14,8 @@ use crate::{
     parameters::PARAM_PREFIX,
     schema::{Index, IndexColumn, Schema, Table},
     translate::{
-        expr::is_double_quoted_identifier, expr::walk_expr_mut,
-        optimizer::access_method::AccessMethodParams, optimizer::constraints::TableConstraints,
-        plan::Scan, plan::TerminationKey,
+        expr::walk_expr_mut, optimizer::access_method::AccessMethodParams,
+        optimizer::constraints::TableConstraints, plan::Scan, plan::TerminationKey,
     },
     types::SeekOp,
     LimboError, Result,
@@ -701,7 +700,7 @@ impl Optimizable for ast::Expr {
             Expr::FunctionCallStar { .. } => false,
             Expr::Id(id) => {
                 // If we got here with an id, this has to be double-quotes identifier
-                assert!(is_double_quoted_identifier(id.as_str()));
+                assert!(id.is_double_quoted());
                 true
             }
             Expr::Column { .. } => false,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -205,7 +205,7 @@ pub fn bind_column_references(
                 }
                 // SQLite behavior: Only double-quoted identifiers get fallback to string literals
                 // Single quotes are handled as literals earlier, unquoted identifiers must resolve to columns
-                if crate::translate::expr::is_double_quoted_identifier(id.as_str()) {
+                if id.is_double_quoted() {
                     // Convert failed double-quoted identifier to string literal
                     *expr = Expr::Literal(Literal::String(id.as_str().to_string()));
                     Ok(())

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -1,6 +1,7 @@
 #!/usr/bin/env tclsh
 set testdir [file dirname $argv0]
 source $testdir/tester.tcl
+source $testdir/sqlite3/tester.tcl
 
 do_execsql_test_on_specific_db {:memory:} basic-insert {
     create table temp (t1 integer, primary key (t1));
@@ -582,3 +583,15 @@ do_execsql_test_on_specific_db {:memory:} returning-null-values {
     CREATE TABLE test (id INTEGER, name TEXT, value INTEGER);
     INSERT INTO test (id, name, value) VALUES (1, NULL, NULL) RETURNING id, name, value;
 } {1||}
+
+do_catchsql_test unknown-identifier-in-values-clause {
+  DROP TABLE IF EXISTS tt;
+  CREATE TABLE tt (x);
+  INSERT INTO tt VALUES(asdf);
+} {1 {no such column: asdf}}
+
+do_catchsql_test unknown-backtick-identifier-in-values-clause {
+  DROP TABLE IF EXISTS tt;
+  CREATE TABLE tt (x);
+  INSERT INTO tt VALUES(`asdf`);
+} {1 {no such column: `asdf`}}

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1178,6 +1178,14 @@ impl Name {
             _ => Name::Ident(s.to_string()),
         }
     }
+
+    /// Checks if a name represents a double-quoted string that should get fallback behavior
+    pub fn is_double_quoted(&self) -> bool {
+        if let Self::Quoted(ident) = self {
+            return ident.starts_with("\"");
+        }
+        false
+    }
 }
 
 struct QuotedIterator<'s>(Bytes<'s>, u8);


### PR DESCRIPTION
I'm not sure how much this will clash with @TcMits's parser rewrite, hopefully not too much. If it does and we eventually have to remove it, at least we'll have two new regression tests.

Closes https://github.com/tursodatabase/turso/issues/2484