### PR TITLE
Evaluate WHERE conditions after LEFT JOIN

### DIFF
--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -530,26 +530,6 @@ pub fn open_loop(
                         });
                     }
                 }
-
-                for cond in predicates
-                    .iter()
-                    .filter(|cond| cond.should_eval_at_loop(join_index, join_order))
-                {
-                    let jump_target_when_true = program.allocate_label();
-                    let condition_metadata = ConditionMetadata {
-                        jump_if_condition_is_true: false,
-                        jump_target_when_true,
-                        jump_target_when_false: next,
-                    };
-                    translate_condition_expr(
-                        program,
-                        table_references,
-                        &cond.expr,
-                        condition_metadata,
-                        &t_ctx.resolver,
-                    )?;
-                    program.preassign_label_to_next_insn(jump_target_when_true);
-                }
             }
             Operation::Search(search) => {
                 assert!(
@@ -645,27 +625,27 @@ pub fn open_loop(
                         }
                     }
                 }
-
-                for cond in predicates
-                    .iter()
-                    .filter(|cond| cond.should_eval_at_loop(join_index, join_order))
-                {
-                    let jump_target_when_true = program.allocate_label();
-                    let condition_metadata = ConditionMetadata {
-                        jump_if_condition_is_true: false,
-                        jump_target_when_true,
-                        jump_target_when_false: next,
-                    };
-                    translate_condition_expr(
-                        program,
-                        table_references,
-                        &cond.expr,
-                        condition_metadata,
-                        &t_ctx.resolver,
-                    )?;
-                    program.preassign_label_to_next_insn(jump_target_when_true);
-                }
             }
+        }
+
+        for cond in predicates
+            .iter()
+            .filter(|cond| cond.should_eval_at_loop(join_index, join_order))
+        {
+            let jump_target_when_true = program.allocate_label();
+            let condition_metadata = ConditionMetadata {
+                jump_if_condition_is_true: false,
+                jump_target_when_true,
+                jump_target_when_false: next,
+            };
+            translate_condition_expr(
+                program,
+                table_references,
+                &cond.expr,
+                condition_metadata,
+                &t_ctx.resolver,
+            )?;
+            program.preassign_label_to_next_insn(jump_target_when_true);
         }
 
         // Set the match flag to true if this is a LEFT JOIN.

--- a/testing/join.test
+++ b/testing/join.test
@@ -106,6 +106,25 @@ Jamie|coat
 Jamie|accessories
 Cindy|}
 
+# This test verifies that the WHERE clause is evaluated after the LEFT JOIN,
+# effectively filtering out rows where the right table has no match.
+do_execsql_test left-join-with-where-right-table {
+    select users.id, price
+    from users left join products on users.id = products.id
+    where products.price is not null
+    order by users.id;
+} {1|79.0
+2|82.0
+3|18.0
+4|25.0
+5|74.0
+6|70.0
+7|78.0
+8|82.0
+9|1.0
+10|33.0
+11|81.0}
+
 do_execsql_test left-join-row-id {
     select u.rowid, p.rowid from users u left join products as p on u.rowid = p.rowid where u.rowid >= 10 limit 5;
 } {10|10


### PR DESCRIPTION
This fix ensures that `WHERE` conditions are emitted after the `LEFT JOIN` match flag is set, so rows from the right table are properly filtered, even when they are `NULL` due to the outer join.

Previously, the query below would return rows where `products.price` was `NULL`:
```sql
SELECT users.id, price
FROM users
LEFT JOIN products ON users.id = products.id
WHERE products.price IS NOT NULL;
```