### PR TITLE
Btree cache usable space

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -1001,12 +1001,6 @@ impl std::fmt::Debug for ImmutableRecord {
     }
 }
 
-#[derive(PartialEq)]
-pub enum ParseRecordState {
-    Init,
-    Parsing { payload: Vec<u8> },
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Record {
     values: Vec<Value>,


### PR DESCRIPTION
Built on top of #2502 

```rust
    /// Cached value of the usable space of a BTree page, since it is very expensive to call in a hot loop via pager.usable_space().
    /// This is OK to cache because both 'PRAGMA page_size' and '.filectrl reserve_bytes' only have an effect on:
    /// 1. an uninitialized database,
    /// 2. an initialized database when the command is immediately followed by VACUUM.
    usable_space_cached: usize,
```