### PR TITLE
chore: use rusqlite 0.37 with bundled sqlite everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3267,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.34.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags 2.9.0",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ strum_macros = "0.26"
 serde = "1.0"
 serde_json = "1.0"
 anyhow = "1.0.98"
+rusqlite = { version = "0.37.0", features = ["bundled"] }
 
 [profile.release]
 debug = "line-tables-only"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -90,7 +90,7 @@ criterion = { version = "0.5", features = [
     "async_futures",
 ] }
 rstest = "0.18.2"
-rusqlite = "0.34.0"
+rusqlite.workspace = true
 quickcheck = { version = "1.0", default-features = false }
 quickcheck_macros = { version = "1.0", default-features = false }
 rand = "0.8.5" # Required for quickcheck

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1.4.1", features = ["derive"] }
 turso_core = { path = "../core", features = ["fuzz"] }
-rusqlite = { version = "0.34.0", features = ["bundled"] }
+rusqlite.workspace = true
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/perf/connection/rusqlite/Cargo.toml
+++ b/perf/connection/rusqlite/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 hdrhistogram = "7.5.2"
-rusqlite = "0.34.0"
+rusqlite.workspace = true
 
 [workspace]

--- a/perf/latency/rusqlite/Cargo.toml
+++ b/perf/latency/rusqlite/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 hdrhistogram = "7.5.2"
-rusqlite = "0.34.0"
+rusqlite.workspace = true
 
 [workspace]

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -29,7 +29,7 @@ clap = { version = "4.5", features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 notify = "8.0.0"
-rusqlite = { version = "0.34", features = ["bundled"] }
+rusqlite.workspace = true
 dirs = "6.0.0"
 chrono = { version = "0.4.40", features = ["serde"] }
 tracing = "0.1.41"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "0.10.1"
 turso_core = { path = "../core", features = ["conn_raw_api"] }
 turso = { path = "../bindings/rust", features = ["conn_raw_api"] }
 tokio = { version = "1.47", features = ["full"] }
-rusqlite = { version = "0.34", features = ["bundled"] }
+rusqlite.workspace = true
 tempfile = "3.0.7"
 log = "0.4.22"
 assert_cmd = "^2"


### PR DESCRIPTION
Use the same rusqlite version in every crate and use a bundled up-to-date sqlite version

(this is still me trying to figure out why sqlite in the insert benchmark doesn't seem to be fsyncing, even when instructed)