### PR TITLE
docs: fix CLI command and add homebrew install instructions for MacOS

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -52,10 +52,16 @@ curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/tursodatabase/turso/releases/latest/download/turso_cli-installer.sh | sh
 ```
 
+Or alternatively, on MacOS, you can use Homebrew:
+
+```
+brew install turso
+```
+
 When you have the software installed, you can start a SQL shell as follows:
 
 ```console
-$ turso
+$ tursodb
 Turso
 Enter ".help" for usage hints.
 Connected to a transient in-memory database.


### PR DESCRIPTION
Hi there,

I wasn't able to run the Turso CLI locally following the manual in the docs (with both the release version and Homebrew). I found out that the right command is `tursodb` rather than just turso as specified in the cli/Cargo.toml.

This MR updates the docs and also mention the instruction to install it with Homebrew.

Demo:

<img width="629" height="129" alt="image" src="https://github.com/user-attachments/assets/3c684328-dab6-436a-bae6-4b6199f5b0b5" />
