### PR TITLE
perf/btree: optimize op_column

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -100,6 +100,7 @@ pub trait Extendable<T> {
 }
 
 impl<T: AnyText> Extendable<T> for Text {
+    #[inline(always)]
     fn do_extend(&mut self, other: &T) {
         self.value.clear();
         self.value.extend_from_slice(other.as_ref().as_bytes());
@@ -108,6 +109,7 @@ impl<T: AnyText> Extendable<T> for Text {
 }
 
 impl<T: AnyBlob> Extendable<T> for Vec<u8> {
+    #[inline(always)]
     fn do_extend(&mut self, other: &T) {
         self.clear();
         self.extend_from_slice(other.as_slice());
@@ -136,6 +138,12 @@ impl AnyText for TextRef {
     }
 }
 
+impl AnyText for &str {
+    fn subtype(&self) -> TextSubtype {
+        TextSubtype::Text
+    }
+}
+
 pub trait AnyBlob {
     fn as_slice(&self) -> &[u8];
 }
@@ -149,6 +157,12 @@ impl AnyBlob for RawSlice {
 impl AnyBlob for Vec<u8> {
     fn as_slice(&self) -> &[u8] {
         self.as_slice()
+    }
+}
+
+impl AnyBlob for &[u8] {
+    fn as_slice(&self) -> &[u8] {
+        self
     }
 }
 


### PR DESCRIPTION
Mainly the performance impact here comes from removing some unnecessary checks and inlining `read_integer_fast()` directly into `op_column()`, but I also added some fiddly nano-optimizations for fun

On main, we are roughly 3.4x slower than sqlite on `SELECT * FROM users LIMIT 100`, and here we are roughly 3.2x slower, which ain't much, but it's honest work.

A more impactful optimization, but a much more annoying refactor, would be #2304 