### PR TITLE
Reimplement LimboRwLock in the WAL

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -181,12 +181,11 @@ impl TursoRwLock {
             let cur = self.0.fetch_and(!Self::WRITER, Ordering::Release);
             turso_assert!(!Self::has_readers(cur), "write lock was held with readers");
         } else {
-            // drop one reader, last reader leaves value intact
-            let prev = self.0.fetch_sub(Self::READER_INC, Ordering::Release);
             turso_assert!(
-                (prev & Self::READER_COUNT_MASK) >= Self::READER_INC,
-                "unlock called with no readers"
+                Self::has_readers(cur),
+                "unlock called with no readers or writers"
             );
+            self.0.fetch_sub(Self::READER_INC, Ordering::Release);
         }
     }
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -88,7 +88,7 @@ pub enum CheckpointMode {
 /// atomically together while sitting in a single cpu cache line.
 ///
 /// # Memory Layout:
-/// ```
+/// ```ignore
 /// [63:32] Value bits    - 32 bits for stored value
 /// [31:1]  Reader count  - 31 bits for reader count
 /// [0]     Writer bit    - 1 bit indicating exclusive write lock


### PR DESCRIPTION
This PR rewrites the `LimboRwLock`, which previously used 3 separate `AtomicU32` values to store the lock state, in favor of a single, packed, cache friendly `AtomicU64`.

The previous impl has some complexity and rather hairy edge cases/issues because we are not updating the lock state together. This PR also adjusts it to use `Acquire`/`Release` for `load`/`store` operations, and tries to improve the API of using the locks.