### PR TITLE
Simulator should delete files after a successful run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ limbostress.log
 simulator.log
 **/*.txt
 profile.json.gz
+simulator-output/

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -136,6 +136,10 @@ fn testing_main(cli_opts: &SimulatorCLI) -> anyhow::Result<()> {
     println!("seed: {seed}");
     println!("path: {}", paths.base.display());
 
+    if result.is_ok() {
+        paths.delete_all_files();
+    }
+
     result
 }
 

--- a/simulator/runner/bugbase.rs
+++ b/simulator/runner/bugbase.rs
@@ -439,11 +439,6 @@ impl BugBase {
         &self.path
     }
 
-    /// Get the path to the database file for a given seed.
-    pub(crate) fn db_path(&self, seed: u64) -> PathBuf {
-        self.path.join(format!("{seed}/test.db"))
-    }
-
     /// Get paths to all the files for a given seed.
     pub(crate) fn paths(&self, seed: u64) -> Paths {
         let base = self.path.join(format!("{seed}/"));

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -124,6 +124,7 @@ impl SimulatorEnv {
         ) {
             Ok(db) => db,
             Err(e) => {
+                tracing::error!(%e);
                 panic!("error opening simulator test file {db_path:?}: {e:?}");
             }
         };
@@ -463,5 +464,14 @@ impl Paths {
     }
     pub(crate) fn plan(&self, type_: &SimulationType, phase: &SimulationPhase) -> PathBuf {
         self.path_(type_, phase).with_extension("sql")
+    }
+
+    pub fn delete_all_files(&self) {
+        if self.base.exists() {
+            let res = std::fs::remove_dir_all(&self.base);
+            if res.is_err() {
+                tracing::error!(error = %res.unwrap_err(),"failed to remove directory");
+            }
+        }
     }
 }


### PR DESCRIPTION
I was getting IO errors for too many files when running the simulator locally. It seemed that the simulator did not delete files after a successful run. After this change, I did not get anymore errors