### PR TITLE
fix(js): ensure optionalDependencies are included in published package.json

### DIFF
--- a/bindings/javascript/package.json
+++ b/bindings/javascript/package.json
@@ -58,5 +58,11 @@
       "browser": "./browser.js",
       "node": "./index.js"
     }
+  },
+  "optionalDependencies": {
+    "@tursodatabase/database-linux-x64-gnu": "0.1.4-pre.6",
+    "@tursodatabase/database-win32-x64-msvc": "0.1.4-pre.6",
+    "@tursodatabase/database-darwin-universal": "0.1.4-pre.6",
+    "@tursodatabase/database-wasm32-wasi": "0.1.4-pre.6"
   }
 }

--- a/bindings/javascript/package.json
+++ b/bindings/javascript/package.json
@@ -46,7 +46,7 @@
     "artifacts": "napi artifacts",
     "build": "npm exec tsc && napi build --platform --release --esm",
     "build:debug": "npm exec tsc && napi build --platform",
-    "prepublishOnly": "npm exec tsc && napi prepublish -t npm",
+    "prepublishOnly": "node scripts/copy-optional-deps.js && npm exec tsc && napi prepublish -t npm",
     "test": "true",
     "universal": "napi universalize",
     "version": "napi version"

--- a/bindings/javascript/scripts/copy-optional-deps.js
+++ b/bindings/javascript/scripts/copy-optional-deps.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+// Ruta al package.json
+const pkgPath = path.join(process.cwd(), 'package.json');
+
+// Leer el package.json actual
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+// Añadir optionalDependencies usando la misma versión del paquete
+pkg.optionalDependencies = {
+  '@tursodatabase/database-linux-x64-gnu': pkg.version,
+  '@tursodatabase/database-win32-x64-msvc': pkg.version,
+  '@tursodatabase/database-darwin-universal': pkg.version,
+  '@tursodatabase/database-wasm32-wasi': pkg.version,
+};
+
+// Guardar cambios en package.json
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+
+console.log('✅ optionalDependencies añadidos a package.json');


### PR DESCRIPTION
Currently, optionalDependencies are injected into package.json during prepublishOnly, but this modified file is never the one actually published to npm.
As a result, platform-specific binaries are missing from the published package, preventing them from being installed as optional dependencies.

Changes

Added a scripts/copy-optional-deps.js script to automatically copy optionalDependencies from the local package.json into the published one.

Updated prepublishOnly to run this script before publishing to npm.

Impact
This ensures that all platform-specific binaries (linux-x64-gnu, win32-x64-msvc, darwin-universal, wasm32-wasi) are included in the published package's optionalDependencies, allowing optional installation on all supported platforms.