### PR TITLE
js: fix types declaration

### DIFF
--- a/bindings/javascript/package.json
+++ b/bindings/javascript/package.json
@@ -15,11 +15,9 @@
   },
   "files": [
     "browser.js",
-    "index.d.ts",
     "index.js",
     "dist/**"
   ],
-  "types": "index.d.ts",
   "napi": {
     "binaryName": "turso",
     "targets": [
@@ -55,7 +53,6 @@
   "packageManager": "yarn@4.9.2",
   "imports": {
     "#entry-point": {
-      "types": "./index.d.ts",
       "browser": "./browser.js",
       "node": "./index.js"
     }

--- a/bindings/javascript/package.json
+++ b/bindings/javascript/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "browser.js",
+    "index.d.ts",
     "index.js",
     "dist/**"
   ],


### PR DESCRIPTION
The NPM distribution wasn't getting this file and thus types were missing.