### PR TITLE
add .envrc for direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+# shellcheck shell=bash
+use flake
+watch_file rust-toolchain.toml


### PR DESCRIPTION
https://direnv.net/ is great DX. It autoloads environments when you cd into a directory, and it has editor support via plugins.

with this PR:

```sh
 $ direnv allow
direnv: loading ~/Projects/turso/.envrc
direnv: using flake
[1.0/0.0 MiB DL] downloading 'https://github.com/oxalica/rust-overlay/archive/dc221f842e9ddc8c0416beae8d77f2ea356b91ae.tar.gz'direnv: ([/nix/store/qj6a7xr3knnl5wjs3rvr8ajbjkxbn32f-direnv-2.37.1/bin/direnv export bash]) is taking a while to execute. Use CTRL-C to give up.
direnv: export +AR +AR_FOR_BUILD +AS +AS_FOR_BUILD +CC +CC_FOR_BUILD +CONFIG_SHELL +CXX +CXX_FOR_BUILD +DETERMINISTIC_BUILD +HOST_PATH +IN_NIX_SHELL +LD +LD_FOR_BUILD +NIX_BINTOOLS +NIX_BINTOOLS_FOR_BUILD +NIX_BINTOOLS_WRAPPER_TARGET_BUILD_x86_64_unknown_linux_gnu +NIX_BINTOOLS_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu +NIX_BUILD_CORES +NIX_BUILD_TOP +NIX_CC +NIX_CC_FOR_BUILD +NIX_CC_WRAPPER_TARGET_BUILD_x86_64_unknown_linux_gnu +NIX_CC_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu +NIX_CFLAGS_COMPILE +NIX_CFLAGS_COMPILE_FOR_BUILD +NIX_ENFORCE_NO_NATIVE +NIX_HARDENING_ENABLE +NIX_LDFLAGS +NIX_LDFLAGS_FOR_BUILD +NIX_STORE +NM +NM_FOR_BUILD +NODE_PATH +OBJCOPY +OBJCOPY_FOR_BUILD +OBJDUMP +OBJDUMP_FOR_BUILD +PYTHONHASHSEED +PYTHONNOUSERSITE +PYTHONPATH +RANLIB +RANLIB_FOR_BUILD +READELF +READELF_FOR_BUILD +SIZE +SIZE_FOR_BUILD +SOURCE_DATE_EPOCH +STRINGS +STRINGS_FOR_BUILD +STRIP +STRIP_FOR_BUILD +TEMP +TEMPDIR +TMP +TMPDIR +_PYTHON_HOST_PLATFORM +_PYTHON_SYSCONFIGDATA_NAME +__structuredAttrs +buildInputs +buildPhase +builder +cmakeFlags +configureFlags +depsBuildBuild +depsBuildBuildPropagated +depsBuildTarget +depsBuildTargetPropagated +depsHostHost +depsHostHostPropagated +depsTargetTarget +depsTargetTargetPropagated +doCheck +doInstallCheck +dontAddDisableDepTrack +mesonFlags +name +nativeBuildInputs +out +outputs +patches +phases +preferLocalBuild +propagatedBuildInputs +propagatedNativeBuildInputs +shell +shellHook +stdenv +strictDeps +system ~PATH ~XDG_DATA_DIRS

 $ type cargo
cargo is /nix/store/g1n522yqac9afjxaivljrp9sklks0g9q-rust-default-1.88.0/bin/cargo

 $ cd ..
direnv: unloading

 $ type cargo
bash: type: cargo: not found

 $ cd -
/home/wmertens/Projects/turso
direnv: loading ~/Projects/turso/.envrc
direnv: using flake
direnv: export +AR +AR_FOR_BUILD +AS +AS_FOR_BUILD +CC +CC_FOR_BUILD +CONFIG_SHELL +CXX +CXX_FOR_BUILD +DETERMINISTIC_BUILD +HOST_PATH +IN_NIX_SHELL +LD +LD_FOR_BUILD +NIX_BINTOOLS +NIX_BINTOOLS_FOR_BUILD +NIX_BINTOOLS_WRAPPER_TARGET_BUILD_x86_64_unknown_linux_gnu +NIX_BINTOOLS_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu +NIX_BUILD_CORES +NIX_BUILD_TOP +NIX_CC +NIX_CC_FOR_BUILD +NIX_CC_WRAPPER_TARGET_BUILD_x86_64_unknown_linux_gnu +NIX_CC_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu +NIX_CFLAGS_COMPILE +NIX_CFLAGS_COMPILE_FOR_BUILD +NIX_ENFORCE_NO_NATIVE +NIX_HARDENING_ENABLE +NIX_LDFLAGS +NIX_LDFLAGS_FOR_BUILD +NIX_STORE +NM +NM_FOR_BUILD +NODE_PATH +OBJCOPY +OBJCOPY_FOR_BUILD +OBJDUMP +OBJDUMP_FOR_BUILD +PYTHONHASHSEED +PYTHONNOUSERSITE +PYTHONPATH +RANLIB +RANLIB_FOR_BUILD +READELF +READELF_FOR_BUILD +SIZE +SIZE_FOR_BUILD +SOURCE_DATE_EPOCH +STRINGS +STRINGS_FOR_BUILD +STRIP +STRIP_FOR_BUILD +TEMP +TEMPDIR +TMP +TMPDIR +_PYTHON_HOST_PLATFORM +_PYTHON_SYSCONFIGDATA_NAME +__structuredAttrs +buildInputs +buildPhase +builder +cmakeFlags +configureFlags +depsBuildBuild +depsBuildBuildPropagated +depsBuildTarget +depsBuildTargetPropagated +depsHostHost +depsHostHostPropagated +depsTargetTarget +depsTargetTargetPropagated +doCheck +doInstallCheck +dontAddDisableDepTrack +mesonFlags +name +nativeBuildInputs +out +outputs +patches +phases +preferLocalBuild +propagatedBuildInputs +propagatedNativeBuildInputs +shell +shellHook +stdenv +strictDeps +system ~PATH ~XDG_DATA_DIRS

 $ type cargo
cargo is /nix/store/g1n522yqac9afjxaivljrp9sklks0g9q-rust-default-1.88.0/bin/cargo
```