### PR TITLE
Add table name to the delete bytecode

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -634,6 +634,7 @@ fn emit_delete_insns(
 
         program.emit_insn(Insn::Delete {
             cursor_id: main_table_cursor_id,
+            table_name: table_reference.table.get_name().to_string(),
         });
     }
     if let Some(limit_ctx) = t_ctx.limit_ctx {
@@ -1175,7 +1176,10 @@ fn emit_update_insns(
         // Insert instruction to update the cell. We need to first delete the current cell
         // and later insert the updated record
         if has_user_provided_rowid {
-            program.emit_insn(Insn::Delete { cursor_id });
+            program.emit_insn(Insn::Delete {
+                cursor_id,
+                table_name: table_ref.table.get_name().to_string(),
+            });
         }
 
         program.emit_insn(Insn::Insert {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -462,6 +462,7 @@ pub fn translate_drop_index(
 
     program.emit_insn(Insn::Delete {
         cursor_id: sqlite_schema_cursor_id,
+        table_name: "sqlite_schema".to_string(),
     });
 
     program.resolve_label(next_label, program.offset());

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -779,6 +779,7 @@ pub fn translate_drop_table(
     }
     program.emit_insn(Insn::Delete {
         cursor_id: sqlite_schema_cursor_id_0,
+        table_name: SQLITE_TABLEID.to_string(),
     });
 
     program.resolve_label(next_label, program.offset());
@@ -978,6 +979,7 @@ pub fn translate_drop_table(
         });
         program.emit_insn(Insn::Delete {
             cursor_id: sqlite_schema_cursor_id_1,
+            table_name: SQLITE_TABLEID.to_string(),
         });
         program.emit_insn(Insn::Insert {
             cursor: sqlite_schema_cursor_id_1,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5216,7 +5216,13 @@ pub fn op_delete(
     pager: &Rc<Pager>,
     mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(Delete { cursor_id }, insn);
+    load_insn!(
+        Delete {
+            cursor_id,
+            table_name: _
+        },
+        insn
+    );
     {
         let mut cursor = state.get_cursor(*cursor_id);
         let cursor = cursor.as_btree_mut();

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1109,12 +1109,12 @@ pub fn insn_to_str(
                 flag.0 as u16,
                 format!("intkey=r[{key_reg}] data=r[{record_reg}]"),
             ),
-            Insn::Delete { cursor_id } => (
+            Insn::Delete { cursor_id, table_name } => (
                 "Delete",
                 *cursor_id as i32,
                 0,
                 0,
-                Value::build_text(""),
+                Value::build_text(table_name),
                 0,
                 "".to_string(),
             ),

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -745,6 +745,7 @@ pub enum Insn {
 
     Delete {
         cursor_id: CursorID,
+        table_name: String,
     },
 
     /// If P5 is not zero, then raise an SQLITE_CORRUPT_INDEX error if no matching index entry


### PR DESCRIPTION
When building views (soon), it will be important to know which table is being deleted. Getting from the cursor id is very cumbersome.

What we are doing here is symmetrical to op_insert, and sqlite also passes table information in one of the registers (p4)