### PR TITLE
Add support for PRAGMA freelist_count

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -126,7 +126,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | PRAGMA foreign_key_check         | No         |                                              |
 | PRAGMA foreign_key_list          | No         |                                              |
 | PRAGMA foreign_keys              | No         |                                              |
-| PRAGMA freelist_count            | No         |                                              |
+| PRAGMA freelist_count            | Yes        |                                              |
 | PRAGMA full_column_names         | Not Needed | deprecated in SQLite                         |
 | PRAGMA fullsync                  | No         |                                              |
 | PRAGMA function_list             | No         |                                              |
@@ -140,7 +140,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | PRAGMA journal_mode              | Yes        |                                              |
 | PRAGMA journal_size_limit        | No         |                                              |
 | PRAGMA legacy_alter_table        | No         |                                              |
-| PRAGMA legacy_file_format         | Yes        |                                              |
+| PRAGMA legacy_file_format        | Yes        |                                              |
 | PRAGMA locking_mode              | No         |                                              |
 | PRAGMA max_page_count            | Yes        |                                              |
 | PRAGMA mmap_size                 | No         |                                              |

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -102,6 +102,7 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::Result0 | PragmaFlags::NoColumns1,
             &["query_only"],
         ),
+        FreelistCount => Pragma::new(PragmaFlags::Result0, &["freelist_count"]),
     }
 }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1625,6 +1625,12 @@ impl Pager {
         Ok(checkpoint_result)
     }
 
+    pub fn freepage_list(&self) -> u32 {
+        self.io
+            .block(|| HeaderRefMut::from_pager(self))
+            .map(|header_ref| header_ref.borrow_mut().freelist_pages.into())
+            .unwrap_or(0)
+    }
     // Providing a page is optional, if provided it will be used to avoid reading the page from disk.
     // This is implemented in accordance with sqlite freepage2() function.
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -300,6 +300,14 @@ fn update_pragma(
             connection,
             program,
         ),
+        PragmaName::FreelistCount => query_pragma(
+            PragmaName::FreelistCount,
+            schema,
+            Some(value),
+            pager,
+            connection,
+            program,
+        ),
     }
 }
 
@@ -560,6 +568,14 @@ fn query_pragma(
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
 
+            Ok((program, TransactionMode::None))
+        }
+        PragmaName::FreelistCount => {
+            let value = pager.freepage_list();
+            let register = program.alloc_register();
+            program.emit_int(value as i64, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
             Ok((program, TransactionMode::None))
         }
     }

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1804,6 +1804,8 @@ pub enum PragmaName {
     DatabaseList,
     /// Encoding - only support utf8
     Encoding,
+    /// Current free page count.
+    FreelistCount,
     /// Run integrity check on the database file
     IntegrityCheck,
     /// `journal_mode` pragma
@@ -1828,8 +1830,6 @@ pub enum PragmaName {
     UserVersion,
     /// trigger a checkpoint to run on database(s) if WAL is enabled
     WalCheckpoint,
-    /// Current free page count.
-    FreelistCount,
 }
 
 /// `CREATE TRIGGER` time

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1828,6 +1828,8 @@ pub enum PragmaName {
     UserVersion,
     /// trigger a checkpoint to run on database(s) if WAL is enabled
     WalCheckpoint,
+    /// Current free page count.
+    FreelistCount,
 }
 
 /// `CREATE TRIGGER` time


### PR DESCRIPTION
Implements `PRAGMA freelist_count` to return the current number of free pages in the database.