### PR TITLE
turso-cdc: add "updates" column for cdc table

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -564,6 +564,9 @@ impl CaptureDataChangesMode {
             ))
         }
     }
+    pub fn has_updates(&self) -> bool {
+        matches!(self, CaptureDataChangesMode::Full { .. })
+    }
     pub fn has_after(&self) -> bool {
         matches!(
             self,

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -13,7 +13,7 @@ use crate::{
     LimboError, Result, SymbolTable,
 };
 
-use super::{schema::SQLITE_TABLEID, update::translate_update_with_after};
+use super::{schema::SQLITE_TABLEID, update::translate_update_for_schema_change};
 
 pub fn translate_alter_table(
     alter: (ast::QualifiedName, ast::AlterTableBody),
@@ -21,6 +21,7 @@ pub fn translate_alter_table(
     schema: &Schema,
     mut program: ProgramBuilder,
     connection: &Arc<crate::Connection>,
+    input: &str,
 ) -> Result<ProgramBuilder> {
     program.begin_write_operation();
     let (table_name, alter_table) = alter;
@@ -94,12 +95,13 @@ pub fn translate_alter_table(
                 unreachable!();
             };
 
-            translate_update_with_after(
+            translate_update_for_schema_change(
                 schema,
                 &mut update,
                 syms,
                 program,
                 connection,
+                input,
                 |program| {
                     let column_count = btree.columns.len();
                     let root_page = btree.root_page;
@@ -206,12 +208,13 @@ pub fn translate_alter_table(
                 unreachable!();
             };
 
-            translate_update_with_after(
+            translate_update_for_schema_change(
                 schema,
                 &mut update,
                 syms,
                 program,
                 connection,
+                input,
                 |program| {
                     program.emit_insn(Insn::SetCookie {
                         db: 0,

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -456,6 +456,7 @@ pub fn translate_drop_index(
             row_id_reg,
             before_record_reg,
             None,
+            None,
             SQLITE_TABLEID,
         )?;
     }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -571,6 +571,7 @@ pub fn translate_insert(
             rowid_and_columns_start_register,
             None,
             after_record_reg,
+            None,
             table_name.as_str(),
         )?;
     }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -98,7 +98,7 @@ pub fn translate(
             connection.clone(),
             program,
         )?,
-        stmt => translate_inner(schema, stmt, syms, program, &connection)?,
+        stmt => translate_inner(schema, stmt, syms, program, &connection, input)?,
     };
 
     program.epilogue(schema);
@@ -115,6 +115,7 @@ pub fn translate_inner(
     syms: &SymbolTable,
     program: ProgramBuilder,
     connection: &Arc<Connection>,
+    input: &str,
 ) -> Result<ProgramBuilder> {
     let is_write = matches!(
         stmt,
@@ -140,7 +141,7 @@ pub fn translate_inner(
 
     let mut program = match stmt {
         ast::Stmt::AlterTable(alter) => {
-            translate_alter_table(*alter, syms, schema, program, connection)?
+            translate_alter_table(*alter, syms, schema, program, connection, input)?
         }
         ast::Stmt::Analyze(_) => bail_parse_error!("ANALYZE not supported yet"),
         ast::Stmt::Attach { expr, db_name, key } => {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -397,6 +397,9 @@ pub struct UpdatePlan {
     pub indexes_to_update: Vec<Arc<Index>>,
     // If the table's rowid alias is used, gather all the target rowids into an ephemeral table, and then use that table as the single JoinedTable for the actual UPDATE loop.
     pub ephemeral_plan: Option<SelectPlan>,
+    // For ALTER TABLE turso-db emits appropriate DDL statement in the "updates" cell of CDC table
+    // This field is present only for update plan created for ALTER TABLE when CDC mode has "updates" values
+    pub cdc_update_alter_statement: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -692,6 +692,14 @@ fn turso_cdc_table_columns() -> Vec<ColumnDefinition> {
             }),
             constraints: vec![],
         },
+        ast::ColumnDefinition {
+            col_name: ast::Name::from_str("updates"),
+            col_type: Some(ast::Type {
+                name: "BLOB".to_string(),
+                size: None,
+            }),
+            constraints: vec![],
+        },
     ]
 }
 

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -268,6 +268,7 @@ pub fn emit_schema_entry(
             rowid_reg,
             None,
             after_record_reg,
+            None,
             SQLITE_TABLEID,
         )?;
     }
@@ -772,6 +773,7 @@ pub fn translate_drop_table(
             cdc_cursor_id,
             row_id_reg,
             before_record_reg,
+            None,
             None,
             SQLITE_TABLEID,
         )?;

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -44,6 +44,7 @@ fn test_cdc_simple_id() {
                 Value::Integer(10),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -51,6 +52,7 @@ fn test_cdc_simple_id() {
                 Value::Integer(1),
                 Value::Text("t".to_string()),
                 Value::Integer(5),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ]
@@ -99,6 +101,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -106,6 +109,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(1),
                 Value::Text("t".to_string()),
                 Value::Integer(3),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -117,6 +121,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(1),
                 Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
@@ -126,6 +131,7 @@ fn test_cdc_simple_before() {
                 Value::Integer(3),
                 Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(5),
@@ -134,6 +140,7 @@ fn test_cdc_simple_before() {
                 Value::Text("t".to_string()),
                 Value::Integer(1),
                 Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
+                Value::Null,
                 Value::Null,
             ]
         ]
@@ -165,6 +172,7 @@ fn test_cdc_simple_after() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -174,6 +182,7 @@ fn test_cdc_simple_after() {
                 Value::Integer(3),
                 Value::Null,
                 Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
@@ -183,6 +192,7 @@ fn test_cdc_simple_after() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
@@ -192,6 +202,7 @@ fn test_cdc_simple_after() {
                 Value::Integer(3),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(5),
@@ -199,6 +210,7 @@ fn test_cdc_simple_after() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(1),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ]
@@ -231,6 +243,7 @@ fn test_cdc_simple_full() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -240,6 +253,7 @@ fn test_cdc_simple_full() {
                 Value::Integer(3),
                 Value::Null,
                 Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
@@ -249,6 +263,12 @@ fn test_cdc_simple_full() {
                 Value::Integer(1),
                 Value::Blob(record([Value::Integer(1), Value::Integer(2)])),
                 Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
+                Value::Blob(record([
+                    Value::Integer(0),
+                    Value::Integer(1),
+                    Value::Null,
+                    Value::Integer(3)
+                ])),
             ],
             vec![
                 Value::Integer(4),
@@ -258,6 +278,7 @@ fn test_cdc_simple_full() {
                 Value::Integer(3),
                 Value::Blob(record([Value::Integer(3), Value::Integer(4)])),
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(5),
@@ -266,6 +287,7 @@ fn test_cdc_simple_full() {
                 Value::Text("t".to_string()),
                 Value::Integer(1),
                 Value::Blob(record([Value::Integer(1), Value::Integer(3)])),
+                Value::Null,
                 Value::Null,
             ]
         ]
@@ -307,6 +329,7 @@ fn test_cdc_crud() {
                 Value::Integer(20),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -314,6 +337,7 @@ fn test_cdc_crud() {
                 Value::Integer(1),
                 Value::Text("t".to_string()),
                 Value::Integer(10),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -325,6 +349,7 @@ fn test_cdc_crud() {
                 Value::Integer(5),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
@@ -332,6 +357,7 @@ fn test_cdc_crud() {
                 Value::Integer(0),
                 Value::Text("t".to_string()),
                 Value::Integer(5),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -343,6 +369,7 @@ fn test_cdc_crud() {
                 Value::Integer(10),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(6),
@@ -350,6 +377,7 @@ fn test_cdc_crud() {
                 Value::Integer(-1),
                 Value::Text("t".to_string()),
                 Value::Integer(20),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -361,6 +389,7 @@ fn test_cdc_crud() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(8),
@@ -370,6 +399,7 @@ fn test_cdc_crud() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(9),
@@ -377,6 +407,7 @@ fn test_cdc_crud() {
                 Value::Integer(1),
                 Value::Text("t".to_string()),
                 Value::Integer(2),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -422,6 +453,7 @@ fn test_cdc_failed_op() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -429,6 +461,7 @@ fn test_cdc_failed_op() {
                 Value::Integer(1),
                 Value::Text("t".to_string()),
                 Value::Integer(2),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -440,6 +473,7 @@ fn test_cdc_failed_op() {
                 Value::Integer(6),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
@@ -447,6 +481,7 @@ fn test_cdc_failed_op() {
                 Value::Integer(1),
                 Value::Text("t".to_string()),
                 Value::Integer(7),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -508,6 +543,7 @@ fn test_cdc_uncaptured_connection() {
                 Value::Integer(2),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -517,6 +553,7 @@ fn test_cdc_uncaptured_connection() {
                 Value::Integer(4),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
@@ -524,6 +561,7 @@ fn test_cdc_uncaptured_connection() {
                 Value::Integer(1),
                 Value::Text("t".to_string()),
                 Value::Integer(6),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -564,6 +602,7 @@ fn test_cdc_custom_table() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -571,6 +610,7 @@ fn test_cdc_custom_table() {
                 Value::Integer(1),
                 Value::Text("t".to_string()),
                 Value::Integer(2),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -611,6 +651,7 @@ fn test_cdc_ignore_changes_in_cdc_table() {
             Value::Integer(1),
             Value::Text("t".to_string()),
             Value::Integer(2),
+            Value::Null,
             Value::Null,
             Value::Null,
         ],]
@@ -654,6 +695,7 @@ fn test_cdc_transaction() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -663,6 +705,7 @@ fn test_cdc_transaction() {
                 Value::Integer(2),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
@@ -670,6 +713,7 @@ fn test_cdc_transaction() {
                 Value::Integer(1),
                 Value::Text("t".to_string()),
                 Value::Integer(3),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -681,6 +725,7 @@ fn test_cdc_transaction() {
                 Value::Integer(1),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(5),
@@ -688,6 +733,7 @@ fn test_cdc_transaction() {
                 Value::Integer(0),
                 Value::Text("q".to_string()),
                 Value::Integer(2),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ],
@@ -731,6 +777,7 @@ fn test_cdc_independent_connections() {
             Value::Integer(1),
             Value::Null,
             Value::Null,
+            Value::Null,
         ]]
     );
     let rows =
@@ -743,6 +790,7 @@ fn test_cdc_independent_connections() {
             Value::Integer(1),
             Value::Text("t".to_string()),
             Value::Integer(2),
+            Value::Null,
             Value::Null,
             Value::Null,
         ]]
@@ -796,6 +844,7 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
                 Value::Integer(2),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
@@ -803,6 +852,7 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
                 Value::Integer(-1),
                 Value::Text("custom_cdc2".to_string()),
                 Value::Integer(1),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ]
@@ -821,6 +871,7 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
                 Value::Integer(4),
                 Value::Null,
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
@@ -828,6 +879,7 @@ fn test_cdc_independent_connections_different_cdc_not_ignore() {
                 Value::Integer(-1),
                 Value::Text("custom_cdc1".to_string()),
                 Value::Integer(1),
+                Value::Null,
                 Value::Null,
                 Value::Null,
             ]
@@ -914,6 +966,7 @@ fn test_cdc_schema_changes() {
                         "CREATE TABLE t (x, y, z UNIQUE, q, PRIMARY KEY (x, y))".to_string()
                     )
                 ])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -929,6 +982,7 @@ fn test_cdc_schema_changes() {
                     Value::Integer(6),
                     Value::Text("CREATE TABLE q (a, b, c)".to_string())
                 ])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(3),
@@ -944,6 +998,7 @@ fn test_cdc_schema_changes() {
                     Value::Integer(7),
                     Value::Text("CREATE INDEX t_q ON t (q)".to_string())
                 ])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(4),
@@ -959,6 +1014,7 @@ fn test_cdc_schema_changes() {
                     Value::Integer(8),
                     Value::Text("CREATE INDEX q_abc ON q (a, b, c)".to_string())
                 ])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(5),
@@ -976,6 +1032,7 @@ fn test_cdc_schema_changes() {
                     )
                 ])),
                 Value::Null,
+                Value::Null,
             ],
             vec![
                 Value::Integer(6),
@@ -990,6 +1047,7 @@ fn test_cdc_schema_changes() {
                     Value::Integer(8),
                     Value::Text("CREATE INDEX q_abc ON q (a, b, c)".to_string())
                 ])),
+                Value::Null,
                 Value::Null,
             ]
         ]
@@ -1027,6 +1085,7 @@ fn test_cdc_schema_changes_alter_table() {
                         "CREATE TABLE t (x, y, z UNIQUE, q, PRIMARY KEY (x, y))".to_string()
                     )
                 ])),
+                Value::Null,
             ],
             vec![
                 Value::Integer(2),
@@ -1052,6 +1111,18 @@ fn test_cdc_schema_changes_alter_table() {
                         "CREATE TABLE t (x PRIMARY KEY, y PRIMARY KEY, z UNIQUE)".to_string()
                     )
                 ])),
+                Value::Blob(record([
+                    Value::Integer(0),
+                    Value::Integer(0),
+                    Value::Integer(0),
+                    Value::Integer(0),
+                    Value::Integer(1),
+                    Value::Null,
+                    Value::Null,
+                    Value::Null,
+                    Value::Null,
+                    Value::Text("ALTER TABLE t DROP COLUMN q".to_string())
+                ])),
             ],
             vec![
                 Value::Integer(3),
@@ -1076,6 +1147,18 @@ fn test_cdc_schema_changes_alter_table() {
                     Value::Text(
                         "CREATE TABLE t (x PRIMARY KEY, y PRIMARY KEY, z UNIQUE, t)".to_string()
                     )
+                ])),
+                Value::Blob(record([
+                    Value::Integer(0),
+                    Value::Integer(0),
+                    Value::Integer(0),
+                    Value::Integer(0),
+                    Value::Integer(1),
+                    Value::Null,
+                    Value::Null,
+                    Value::Null,
+                    Value::Null,
+                    Value::Text("ALTER TABLE t ADD COLUMN t".to_string())
                 ])),
             ],
         ]

--- a/tests/integration/query_processing/test_multi_thread.rs
+++ b/tests/integration/query_processing/test_multi_thread.rs
@@ -44,6 +44,41 @@ fn test_schema_reprepare() {
 }
 
 #[test]
+fn test_schema_reprepare_write() {
+    let tmp_db = TempDatabase::new_empty(false);
+    let conn1 = tmp_db.connect_limbo();
+    conn1.execute("CREATE TABLE t(x, y, z)").unwrap();
+    let conn2 = tmp_db.connect_limbo();
+    let mut stmt = conn2.prepare("INSERT INTO t(y, z) VALUES (1, 2)").unwrap();
+    let mut stmt2 = conn2.prepare("INSERT INTO t(y, z) VALUES (3, 4)").unwrap();
+    conn1.execute("ALTER TABLE t DROP COLUMN x").unwrap();
+
+    loop {
+        match stmt.step().unwrap() {
+            turso_core::StepResult::Done => {
+                break;
+            }
+            turso_core::StepResult::IO => {
+                stmt.run_once().unwrap();
+            }
+            step => panic!("unexpected step result {step:?}"),
+        }
+    }
+
+    loop {
+        match stmt2.step().unwrap() {
+            turso_core::StepResult::Done => {
+                break;
+            }
+            turso_core::StepResult::IO => {
+                stmt2.run_once().unwrap();
+            }
+            step => panic!("unexpected step result {step:?}"),
+        }
+    }
+}
+
+#[test]
 #[ignore]
 fn test_create_multiple_connections() -> anyhow::Result<()> {
     maybe_setup_tracing();


### PR DESCRIPTION
This PR adds new `updates` column to the CDC table. This column holds updated fields of the row in the following format:
```
[C boolean values where true set for changed columns]
[C values with updates where NULL is set for not-changed columns]
```

For example:
```
turso> UPDATE t SET y = 'turso', q = 'db' WHERE rowid = 1;
turso> SELECT bin_record_json_object('["x","y","z","q","x","y","z","q"]', updates) as updates FROM turso_cdc;
┌──────────────────────────────────────────────────────────────────┐
│ updates                                                          │
├──────────────────────────────────────────────────────────────────┤
│ {"x":0,"y":1,"z":0,"q":1,"x":null,"y":"turso","z":null,"q":"db"} │
└──────────────────────────────────────────────────────────────────┘
```

Also, this column works differently for `ALTER TABLE` statements where update value for `sql` will be equal to the original `ALTER TABLE`:
```
turso> ALTER TABLE t ADD COLUMN t;
turso> SELECT bin_record_json_object('["type","name","tbl_name","rootpage","sql","type","name","tbl_name","rootpage","sql"]', updates) as updates FROM turso_cdc WHERE rowid = 2;
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ updates                                                                                                                                           │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ {"type":0,"name":0,"tbl_name":0,"rootpage":0,"sql":1,"type":null,"name":null,"tbl_name":null,"rootpage":null,"sql":"ALTER TABLE t ADD COLUMN t;"} │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

This will help turso-db to implement logical replication which supports both column-level updates and schema changes