### PR TITLE
WAL:minor checkpointing cleanups/optimizations

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -975,8 +975,8 @@ pub fn write_pages_vectored(
 
     // Create the atomic counters
     let runs_left = Arc::new(AtomicUsize::new(run_count));
+    flush.new_flush();
     let done = flush.done.clone();
-    done.store(false, Ordering::Release);
     // we know how many runs, but we don't know how many buffers per run, so we can only give an
     // estimate of the capacity
     const EST_BUFF_CAPACITY: usize = 32;


### PR DESCRIPTION
Small contribution to my current work on making checkpointing efficient.

We hold a write lock, and especially here on main there is no reason to mark the pages as dirty in the cache, so we can do away with that Vec<u64> and just track whether it's `Done`