### PR TITLE
Reprepare fix on write statement

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -514,7 +514,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         .pager
                         .end_tx(
                             false, // rollback = false since we're committing
-                            false, // schema_did_change = false for now (could be improved)
                             &self.connection,
                             self.connection.wal_checkpoint_disabled.get(),
                         )

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7824,7 +7824,7 @@ mod tests {
                 )
                 .unwrap();
                 loop {
-                    match pager.end_tx(false, false, &conn, false).unwrap() {
+                    match pager.end_tx(false, &conn, false).unwrap() {
                         IOResult::Done(_) => break,
                         IOResult::IO => {
                             pager.io.run_once().unwrap();
@@ -7982,7 +7982,7 @@ mod tests {
                 .unwrap();
                 let _c = cursor.move_to_root().unwrap();
                 loop {
-                    match pager.end_tx(false, false, &conn, false).unwrap() {
+                    match pager.end_tx(false, &conn, false).unwrap() {
                         IOResult::Done(_) => break,
                         IOResult::IO => {
                             pager.io.run_once().unwrap();
@@ -8200,7 +8200,7 @@ mod tests {
 
                 let _c = cursor.move_to_root().unwrap();
                 loop {
-                    match pager.end_tx(false, false, &conn, false).unwrap() {
+                    match pager.end_tx(false, &conn, false).unwrap() {
                         IOResult::Done(_) => break,
                         IOResult::IO => {
                             pager.io.run_once().unwrap();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2090,6 +2090,11 @@ pub fn op_transaction(
             }
         }
 
+        // Transaction state should be updated before checking for Schema cookie so that the tx is ended properly on error
+        if updated {
+            conn.transaction_state.replace(new_transaction_state);
+        }
+
         // Check whether schema has changed if we are actually going to access the database.
         if !matches!(new_transaction_state, TransactionState::None) {
             let res = pager
@@ -2107,10 +2112,6 @@ pub fn op_transaction(
                     return Err(err);
                 }
             }
-        }
-
-        if updated {
-            conn.transaction_state.replace(new_transaction_state);
         }
     }
     state.pc += 1;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -412,8 +412,8 @@ impl Program {
             if self.connection.closed.get() {
                 // Connection is closed for whatever reason, rollback the transaction.
                 let state = self.connection.transaction_state.get();
-                if let TransactionState::Write { schema_did_change } = state {
-                    match pager.end_tx(true, schema_did_change, &self.connection, false)? {
+                if let TransactionState::Write { .. } = state {
+                    match pager.end_tx(true, &self.connection, false)? {
                         IOResult::IO => return Ok(StepResult::IO),
                         IOResult::Done(_) => {}
                     }
@@ -502,9 +502,7 @@ impl Program {
                 program_state.commit_state
             );
             if program_state.commit_state == CommitState::Committing {
-                let TransactionState::Write { schema_did_change } =
-                    connection.transaction_state.get()
-                else {
+                let TransactionState::Write { .. } = connection.transaction_state.get() else {
                     unreachable!("invalid state for write commit step")
                 };
                 self.step_end_write_txn(
@@ -512,18 +510,16 @@ impl Program {
                     &mut program_state.commit_state,
                     &connection,
                     rollback,
-                    schema_did_change,
                 )
             } else if auto_commit {
                 let current_state = connection.transaction_state.get();
                 tracing::trace!("Auto-commit state: {:?}", current_state);
                 match current_state {
-                    TransactionState::Write { schema_did_change } => self.step_end_write_txn(
+                    TransactionState::Write { .. } => self.step_end_write_txn(
                         &pager,
                         &mut program_state.commit_state,
                         &connection,
                         rollback,
-                        schema_did_change,
                     ),
                     TransactionState::Read => {
                         connection.transaction_state.replace(TransactionState::None);
@@ -551,11 +547,9 @@ impl Program {
         commit_state: &mut CommitState,
         connection: &Connection,
         rollback: bool,
-        schema_did_change: bool,
     ) -> Result<StepResult> {
         let cacheflush_status = pager.end_tx(
             rollback,
-            schema_did_change,
             connection,
             connection.wal_checkpoint_disabled.get(),
         )?;
@@ -809,20 +803,15 @@ pub fn handle_program_error(
         // Table locked errors, e.g. trying to checkpoint in an interactive transaction, do not cause a rollback.
         LimboError::TableLocked => {}
         _ => {
-            let state = connection.transaction_state.get();
-            if let TransactionState::Write { schema_did_change } = state {
-                loop {
-                    match pager.end_tx(true, schema_did_change, connection, false) {
-                        Ok(IOResult::IO) => connection.run_once()?,
-                        Ok(IOResult::Done(_)) => break,
-                        Err(e) => {
-                            tracing::error!("end_tx failed: {e}");
-                            break;
-                        }
+            loop {
+                match pager.end_tx(true, connection, false) {
+                    Ok(IOResult::IO) => connection.run_once()?,
+                    Ok(IOResult::Done(_)) => break,
+                    Err(e) => {
+                        tracing::error!("end_tx failed: {e}");
+                        break;
                     }
                 }
-            } else if let Err(e) = pager.end_read_tx() {
-                tracing::error!("end_read_tx failed: {e}");
             }
             connection.transaction_state.replace(TransactionState::None);
         }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -153,7 +153,7 @@ pub fn maybe_setup_tracing() {
     let _ = tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
-                .with_ansi(false)
+                .with_ansi(true)
                 .with_line_number(true)
                 .with_thread_ids(true),
         )

--- a/tests/integration/query_processing/test_multi_thread.rs
+++ b/tests/integration/query_processing/test_multi_thread.rs
@@ -196,3 +196,41 @@ fn test_reader_writer() -> anyhow::Result<()> {
     }
     Ok(())
 }
+
+#[test]
+fn test_schema_reprepare_write() {
+    maybe_setup_tracing();
+    let tmp_db = TempDatabase::new_empty(false);
+    let conn1 = tmp_db.connect_limbo();
+    conn1.execute("CREATE TABLE t(x, y, z)").unwrap();
+    let conn2 = tmp_db.connect_limbo();
+    let mut stmt = conn2.prepare("INSERT INTO t(y, z) VALUES (1, 2)").unwrap();
+    let mut stmt2 = conn2.prepare("INSERT INTO t(y, z) VALUES (3, 4)").unwrap();
+    conn1.execute("ALTER TABLE t DROP COLUMN x").unwrap();
+
+    tracing::info!("Executing Stmt 1");
+    loop {
+        match stmt.step().unwrap() {
+            turso_core::StepResult::Done => {
+                break;
+            }
+            turso_core::StepResult::IO => {
+                stmt.run_once().unwrap();
+            }
+            step => panic!("unexpected step result {step:?}"),
+        }
+    }
+
+    tracing::info!("Executing Stmt 2");
+    loop {
+        match stmt2.step().unwrap() {
+            turso_core::StepResult::Done => {
+                break;
+            }
+            turso_core::StepResult::IO => {
+                stmt2.run_once().unwrap();
+            }
+            step => panic!("unexpected step result {step:?}"),
+        }
+    }
+}


### PR DESCRIPTION
We have to update the Transaction State before checking for the Schema Cookie so that we can rollback the transaction later on correctly.

Closes #2535 