### PR TITLE
Reset interrupt count each time a new line is entered in CLI

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -580,6 +580,7 @@ impl Limbo {
             }
             return Ok(());
         }
+        self.reset_line(line)?;
         if line.ends_with(';') {
             self.buffer_input(line);
             let buff = self.input_buff.clone();
@@ -588,7 +589,6 @@ impl Limbo {
             self.buffer_input(format!("{line}\n").as_str());
             self.set_multiline_prompt();
         }
-        self.reset_line(line)?;
         Ok(())
     }
 


### PR DESCRIPTION
Resolves issue #1833.
**Before:**
<img width="581" height="92" alt="Screenshot 2025-08-11 at 9 07 21 PM" src="https://github.com/user-attachments/assets/eff4c919-ad54-4379-bbee-28eb3e4a375f" />
**After:**
<img width="563" height="118" alt="Screenshot 2025-08-11 at 9 07 27 PM" src="https://github.com/user-attachments/assets/f99f84a0-f5d3-4d70-9e08-1c3871fddda3" />
