### PR TITLE
turso-sync: fix schema bug

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1218,6 +1218,7 @@ impl Connection {
         Ok(())
     }
 
+    /// Read schema version at current transaction
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
     pub fn read_schema_version(&self) -> Result<u32> {
         loop {
@@ -1232,6 +1233,10 @@ impl Connection {
         }
     }
 
+    /// Update schema version to the new value within opened write transaction
+    ///
+    /// New version of the schema must be strictly greater than previous one - otherwise method will panic
+    /// Write transaction must be opened in advance - otherwise method will panic
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
     pub fn write_schema_version(self: &Arc<Connection>, version: u32) -> Result<()> {
         let TransactionState::Write { .. } = self.transaction_state.get() else {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -849,6 +849,7 @@ impl Wal for WalFile {
         }
 
         // Snapshot is stale, give up and let caller retry from scratch
+        tracing::debug!("unable to upgrade transaction from read to write: snapshot is stale, give up and let caller retry from scratch");
         shared.write_lock.unlock();
         Ok(LimboResult::Busy)
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2062,6 +2062,11 @@ pub fn op_transaction(
             match res {
                 Ok(header_schema_cookie) => {
                     if header_schema_cookie != *schema_cookie {
+                        tracing::info!(
+                            "schema changed, force reprepare: {} != {}",
+                            header_schema_cookie,
+                            *schema_cookie
+                        );
                         return Err(LimboError::SchemaUpdated);
                     }
                 }

--- a/packages/turso-sync-engine/src/database_tape.rs
+++ b/packages/turso-sync-engine/src/database_tape.rs
@@ -60,9 +60,9 @@ pub(crate) async fn run_stmt_once<'a>(
     }
 }
 
-pub(crate) async fn run_stmt_expect_one_row<'a>(
-    coro: &'_ Coro,
-    stmt: &'a mut turso_core::Statement,
+pub(crate) async fn run_stmt_expect_one_row(
+    coro: &Coro,
+    stmt: &mut turso_core::Statement,
 ) -> Result<Option<Vec<turso_core::Value>>> {
     let Some(row) = run_stmt_once(coro, stmt).await? else {
         return Ok(None);
@@ -71,14 +71,14 @@ pub(crate) async fn run_stmt_expect_one_row<'a>(
     let None = run_stmt_once(coro, stmt).await? else {
         return Err(Error::DatabaseTapeError("single row expected".to_string()));
     };
-    return Ok(Some(values));
+    Ok(Some(values))
 }
 
 pub(crate) async fn run_stmt_ignore_rows(
     coro: &Coro,
     stmt: &mut turso_core::Statement,
 ) -> Result<()> {
-    while let Some(_) = run_stmt_once(coro, stmt).await? {}
+    while run_stmt_once(coro, stmt).await?.is_some() {}
     Ok(())
 }
 


### PR DESCRIPTION
This PR fixes few issues in turso-sync-engine implementation:

1. One step of `pull` implementation works like this:
   a. Start write WAL session
   b. Revert local changes in WAL
   c. Replay WAL frames from remote DB
   d. Replay WAL frames produced by local changes applied to the remote DB copy (`synced`)

My initial thinking was that by executing step (d) we will get the same schema as before (with same schema cookie) and everything will be fine. With more deep thinking we can see that it's not fine - as after step (d) tables created locally can change their root pages (if they were created locally, for example) - and DB will have "broken" schema

2. Sync engine execute few SQL statements and do not run them to completion - which basically created "orphaned" locks

In order to fix (1) I decided to introduce another `conn_raw_api` extension which allows to read and write schema cookie directly in the transaction. So, the process described above adds step (e) which set schema cookie to the value strictly greater than the value before.

In order to fix (2) I just fixed all places where statement were dropped before running to completion.

These fixes are merged together because I explored them by fixing one new test: `test_sync_single_db_many_pulls_big_payloads`