### PR TITLE
turso-sync: support checkpoint

### DIFF
--- a/packages/turso-sync-engine/src/database_sync_engine.rs
+++ b/packages/turso-sync-engine/src/database_sync_engine.rs
@@ -565,7 +565,7 @@ pub mod tests {
 
     #[test]
     pub fn test_sync_single_db_many_pulls_big_payloads() {
-        deterministic_runtime(async || {
+                deterministic_runtime(async || {
             let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
             let dir = tempfile::TempDir::new().unwrap();
             let server_path = dir.path().join("server.db");
@@ -579,6 +579,7 @@ pub mod tests {
                 client_name: "id-1".to_string(),
                 wal_pull_batch_size: 1,
             };
+
             runner.init(local_path, opts).await.unwrap();
 
             protocol
@@ -619,6 +620,55 @@ pub mod tests {
                     expected
                 );
             }
+        });
+    }
+    
+    #[test]
+    pub fn test_sync_single_db_checkpoint() {
+        deterministic_runtime(async || {
+            let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+            let dir = tempfile::TempDir::new().unwrap();
+            let server_path = dir.path().join("server.db");
+            let ctx = Arc::new(TestContext::new(seed_u64()));
+            let protocol = TestProtocolIo::new(ctx.clone(), &server_path)
+                .await
+                .unwrap();
+            let mut runner = TestRunner::new(ctx.clone(), io, protocol.clone());
+            let local_path = dir.path().join("local.db");
+            let opts = DatabaseSyncEngineOpts {
+                client_name: "id-1".to_string(),
+                wal_pull_batch_size: 1,
+            };
+            runner.init(local_path, opts).await.unwrap();
+
+            protocol
+                .server
+                .execute("CREATE TABLE t(x INTEGER PRIMARY KEY)", ())
+                .await
+                .unwrap();
+            protocol
+                .server
+                .execute("INSERT INTO t VALUES (1)", ())
+                .await
+                .unwrap();
+            protocol.server.checkpoint().await.unwrap();
+            protocol
+                .server
+                .execute("INSERT INTO t VALUES (2)", ())
+                .await
+                .unwrap();
+
+            let conn = runner.connect().await.unwrap();
+
+            runner.pull().await.unwrap();
+
+            assert_eq!(
+                query_rows(&conn, "SELECT * FROM t").await.unwrap(),
+                vec![
+                    vec![turso::Value::Integer(1)],
+                    vec![turso::Value::Integer(2)]
+                ]
+            );
         });
     }
 

--- a/packages/turso-sync-engine/src/database_sync_engine.rs
+++ b/packages/turso-sync-engine/src/database_sync_engine.rs
@@ -179,7 +179,7 @@ impl<C: ProtocolIO> DatabaseSyncEngine<C> {
                     &self.meta_path,
                     &mut self.meta,
                     |m| {
-                        m.synced_generation = m.synced_generation + 1;
+                        m.synced_generation += 1;
                         m.synced_frame_no = Some(0);
                         m.synced_wal_match_watermark = 0;
                     },


### PR DESCRIPTION
remote protocol can require client to perform checkpoint of the WAL. This PR supports that need in the sync-engine implementation