### PR TITLE
Initial pass to support per page encryption

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,8 @@ jobs:
           python-version: "3.10"
       - name: Build
         run: cargo build --verbose
+      - name: Test Encryption
+        run: cargo test --features encryption --color=always --test integration_tests query_processing::encryption
       - name: Test
         env:
           RUST_LOG: ${{ runner.debug && 'turso_core::storage=trace' || '' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -771,6 +826,15 @@ name = "ctor-proc-macro"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "ctrlc"
@@ -1336,6 +1400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,6 +1753,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2436,6 +2519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,6 +2669,18 @@ dependencies = [
  "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3363,6 +3464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "supports-color"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,6 +3957,8 @@ dependencies = [
 name = "turso_core"
 version = "0.1.4-pre.10"
 dependencies = [
+ "aes",
+ "aes-gcm",
  "antithesis_sdk",
  "bitflags 2.9.0",
  "built",
@@ -4100,6 +4209,16 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/bindings/javascript/Cargo.toml
+++ b/bindings/javascript/Cargo.toml
@@ -16,5 +16,8 @@ napi = { version = "3.1.3", default-features = false, features = ["napi6"] }
 napi-derive = { version = "3.1.1", default-features = true }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
+[features]
+encryption = ["turso_core/encryption"]
+
 [build-dependencies]
 napi-build = "2.2.3"

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -561,7 +561,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
     fn read_page(
         &self,
         page_idx: usize,
-        #[cfg(feature = "encryption")] _key: Option<&turso_core::EncryptionKey>,
+        _key: Option<&turso_core::EncryptionKey>,
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
         let r = c.as_read();
@@ -578,7 +578,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         &self,
         page_idx: usize,
         buffer: Arc<turso_core::Buffer>,
-        #[cfg(feature = "encryption")] _key: Option<&turso_core::EncryptionKey>,
+        _key: Option<&turso_core::EncryptionKey>,
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
         let size = buffer.len();
@@ -588,13 +588,13 @@ impl turso_core::DatabaseStorage for DatabaseFile {
 
     fn write_pages(
         &self,
-        page_idx: usize,
+        first_page_idx: usize,
         page_size: usize,
         buffers: Vec<Arc<turso_core::Buffer>>,
-        #[cfg(feature = "encryption")] _key: Option<&turso_core::EncryptionKey>,
+        _key: Option<&turso_core::EncryptionKey>,
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
-        let pos = page_idx.saturating_sub(1) * page_size;
+        let pos = first_page_idx.saturating_sub(1) * page_size;
         let c = self.file.pwritev(pos, buffers, c)?;
         Ok(c)
     }

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -561,6 +561,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
     fn read_page(
         &self,
         page_idx: usize,
+        #[cfg(feature = "encryption")] _key: Option<&turso_core::EncryptionKey>,
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
         let r = c.as_read();
@@ -577,6 +578,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         &self,
         page_idx: usize,
         buffer: Arc<turso_core::Buffer>,
+        #[cfg(feature = "encryption")] _key: Option<&turso_core::EncryptionKey>,
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
         let size = buffer.len();
@@ -589,6 +591,7 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         page_idx: usize,
         page_size: usize,
         buffers: Vec<Arc<turso_core::Buffer>>,
+        #[cfg(feature = "encryption")] _key: Option<&turso_core::EncryptionKey>,
         c: turso_core::Completion,
     ) -> turso_core::Result<turso_core::Completion> {
         let pos = page_idx.saturating_sub(1) * page_size;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,6 +27,7 @@ omit_autovacuum = []
 simulator = ["fuzz", "serde"]
 serde = ["dep:serde"]
 series = []
+encryption = ["dep:aes-gcm", "dep:aes"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.5", optional = true }
@@ -73,6 +74,8 @@ uuid = { version = "1.11.0", features = ["v4", "v7"], optional = true }
 tempfile = "3.8.0"
 pack1 = { version = "1.0.0", features = ["bytemuck"] }
 bytemuck = "1.23.1"
+aes-gcm = { version = "0.10.3", optional = true }
+aes = { version = "0.8.4", optional = true }
 
 [build-dependencies]
 chrono = { version = "0.4.38", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ omit_autovacuum = []
 simulator = ["fuzz", "serde"]
 serde = ["dep:serde"]
 series = []
-encryption = ["dep:aes-gcm", "dep:aes"]
+encryption = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.5", optional = true }
@@ -74,8 +74,8 @@ uuid = { version = "1.11.0", features = ["v4", "v7"], optional = true }
 tempfile = "3.8.0"
 pack1 = { version = "1.0.0", features = ["bytemuck"] }
 bytemuck = "1.23.1"
-aes-gcm = { version = "0.10.3", optional = true }
-aes = { version = "0.8.4", optional = true }
+aes-gcm = { version = "0.10.3"}
+aes = { version = "0.8.4"}
 
 [build-dependencies]
 chrono = { version = "0.4.38", default-features = false }

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -280,6 +280,10 @@ impl ReadCompletion {
     pub fn callback(&self, bytes_read: Result<i32, CompletionError>) {
         (self.complete)(bytes_read.map(|b| (self.buf.clone(), b)));
     }
+
+    pub fn buf_arc(&self) -> Arc<Buffer> {
+        self.buf.clone()
+    }
 }
 
 pub struct WriteCompletion {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -76,7 +76,6 @@ use std::{
 };
 #[cfg(feature = "fs")]
 use storage::database::DatabaseFile;
-#[cfg(feature = "encryption")]
 pub use storage::encryption::EncryptionKey;
 use storage::page_cache::DumbLruPageCache;
 use storage::pager::{AtomicDbState, DbState};
@@ -427,7 +426,6 @@ impl Database {
             view_transaction_states: RefCell::new(HashMap::new()),
             metrics: RefCell::new(ConnectionMetrics::new()),
             is_nested_stmt: Cell::new(false),
-            #[cfg(feature = "encryption")]
             encryption_key: RefCell::new(None),
         });
         let builtin_syms = self.builtin_syms.borrow();
@@ -856,7 +854,6 @@ pub struct Connection {
     /// Whether the connection is executing a statement initiated by another statement.
     /// Generally this is only true for ParseSchema.
     is_nested_stmt: Cell<bool>,
-    #[cfg(feature = "encryption")]
     encryption_key: RefCell<Option<EncryptionKey>>,
 }
 
@@ -1932,7 +1929,6 @@ impl Connection {
         self.syms.borrow().vtab_modules.keys().cloned().collect()
     }
 
-    #[cfg(feature = "encryption")]
     pub fn set_encryption_key(&self, key: Option<EncryptionKey>) {
         tracing::trace!("setting encryption key for connection");
         *self.encryption_key.borrow_mut() = key.clone();

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -107,6 +107,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             &["query_only"],
         ),
         FreelistCount => Pragma::new(PragmaFlags::Result0, &["freelist_count"]),
+        EncryptionKey => Pragma::new(
+            PragmaFlags::Result0 | PragmaFlags::SchemaReq | PragmaFlags::NoColumns1,
+            &["key"],
+        ),
     }
 }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -8539,6 +8539,11 @@ mod tests {
             let c = Completion::new_write(move |_| {
                 let _ = _buf.clone();
             });
+            #[cfg(feature = "encryption")]
+            let _c = pager
+                .db_file
+                .write_page(current_page as usize, buf.clone(), None, c)?;
+            #[cfg(not(feature = "encryption"))]
             let _c = pager
                 .db_file
                 .write_page(current_page as usize, buf.clone(), c)?;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -8539,14 +8539,9 @@ mod tests {
             let c = Completion::new_write(move |_| {
                 let _ = _buf.clone();
             });
-            #[cfg(feature = "encryption")]
             let _c = pager
                 .db_file
                 .write_page(current_page as usize, buf.clone(), None, c)?;
-            #[cfg(not(feature = "encryption"))]
-            let _c = pager
-                .db_file
-                .write_page(current_page as usize, buf.clone(), c)?;
             pager.io.run_once()?;
 
             let (page, _c) = cursor.read_page(current_page as usize)?;

--- a/core/storage/encryption.rs
+++ b/core/storage/encryption.rs
@@ -1,0 +1,187 @@
+use crate::Result;
+use aes_gcm::{
+    aead::{Aead, AeadCore, KeyInit, OsRng},
+    Aes256Gcm, Key, Nonce,
+};
+use std::ops::Deref;
+
+pub const ENCRYPTION_METADATA_SIZE: usize = 28;
+pub const ENCRYPTED_PAGE_SIZE: usize = 4096;
+pub const ENCRYPTION_NONCE_SIZE: usize = 12;
+
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct EncryptionKey([u8; 32]);
+
+impl EncryptionKey {
+    pub fn new(key: [u8; 32]) -> Self {
+        Self(key)
+    }
+
+    pub fn from_string(s: &str) -> Self {
+        let mut key = [0u8; 32];
+        let bytes = s.as_bytes();
+        let len = bytes.len().min(32);
+        key[..len].copy_from_slice(&bytes[..len]);
+        Self(key)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Deref for EncryptionKey {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<[u8; 32]> for EncryptionKey {
+    fn as_ref(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for EncryptionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionKey")
+            .field("key", &"<encryption key redacted>")
+            .finish()
+    }
+}
+
+impl Drop for EncryptionKey {
+    fn drop(&mut self) {
+        // securely zero out the key bytes before dropping
+        for byte in self.0.iter_mut() {
+            unsafe {
+                std::ptr::write_volatile(byte, 0);
+            }
+        }
+    }
+}
+
+pub fn encrypt_page(page: &[u8], page_id: usize, key: &EncryptionKey) -> Result<Vec<u8>> {
+    if page_id == 1 {
+        tracing::debug!("skipping encryption for page 1 (database header)");
+        return Ok(page.to_vec());
+    }
+    tracing::debug!("encrypting page {}", page_id);
+    assert_eq!(
+        page.len(),
+        ENCRYPTED_PAGE_SIZE,
+        "Page data must be exactly {ENCRYPTED_PAGE_SIZE} bytes"
+    );
+    let reserved_bytes = &page[ENCRYPTED_PAGE_SIZE - ENCRYPTION_METADATA_SIZE..];
+    let reserved_bytes_zeroed = reserved_bytes.iter().all(|&b| b == 0);
+    assert!(
+        reserved_bytes_zeroed,
+        "last reserved bytes must be empty/zero, but found non-zero bytes"
+    );
+    let payload = &page[..ENCRYPTED_PAGE_SIZE - ENCRYPTION_METADATA_SIZE];
+    let (encrypted, nonce) = encrypt(payload, key)?;
+    assert_eq!(
+        encrypted.len(),
+        ENCRYPTED_PAGE_SIZE - nonce.len(),
+        "Encrypted page must be exactly {} bytes",
+        ENCRYPTED_PAGE_SIZE - nonce.len()
+    );
+    let mut result = Vec::with_capacity(ENCRYPTED_PAGE_SIZE);
+    result.extend_from_slice(&encrypted);
+    result.extend_from_slice(&nonce);
+    assert_eq!(
+        result.len(),
+        ENCRYPTED_PAGE_SIZE,
+        "Encrypted page must be exactly {ENCRYPTED_PAGE_SIZE} bytes"
+    );
+    Ok(result)
+}
+
+pub fn decrypt_page(encrypted_page: &[u8], page_id: usize, key: &EncryptionKey) -> Result<Vec<u8>> {
+    if page_id == 1 {
+        tracing::debug!("skipping decryption for page 1 (database header)");
+        return Ok(encrypted_page.to_vec());
+    }
+    tracing::debug!("decrypting page {}", page_id);
+    assert_eq!(
+        encrypted_page.len(),
+        ENCRYPTED_PAGE_SIZE,
+        "Encrypted page data must be exactly {ENCRYPTED_PAGE_SIZE} bytes"
+    );
+
+    let nonce_start = encrypted_page.len() - ENCRYPTION_NONCE_SIZE;
+    let payload = &encrypted_page[..nonce_start];
+    let nonce = &encrypted_page[nonce_start..];
+
+    let decrypted_data = decrypt(payload, nonce, key)?;
+    assert_eq!(
+        decrypted_data.len(),
+        ENCRYPTED_PAGE_SIZE - ENCRYPTION_METADATA_SIZE,
+        "Decrypted page data must be exactly {} bytes",
+        ENCRYPTED_PAGE_SIZE - ENCRYPTION_METADATA_SIZE
+    );
+    let mut result = Vec::with_capacity(ENCRYPTED_PAGE_SIZE);
+    result.extend_from_slice(&decrypted_data);
+    result.resize(ENCRYPTED_PAGE_SIZE, 0);
+    assert_eq!(
+        result.len(),
+        ENCRYPTED_PAGE_SIZE,
+        "Decrypted page data must be exactly {ENCRYPTED_PAGE_SIZE} bytes"
+    );
+    Ok(result)
+}
+
+fn encrypt(plaintext: &[u8], key: &EncryptionKey) -> Result<(Vec<u8>, Vec<u8>)> {
+    let key: &Key<Aes256Gcm> = key.as_ref().into();
+    let cipher = Aes256Gcm::new(key);
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let ciphertext = cipher.encrypt(&nonce, plaintext).unwrap();
+    Ok((ciphertext, nonce.to_vec()))
+}
+
+fn decrypt(ciphertext: &[u8], nonce: &[u8], key: &EncryptionKey) -> Result<Vec<u8>> {
+    let key: &Key<Aes256Gcm> = key.as_ref().into();
+    let cipher = Aes256Gcm::new(key);
+    let nonce = Nonce::from_slice(nonce);
+    let plaintext = cipher.decrypt(nonce, ciphertext).unwrap();
+    Ok(plaintext)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::Rng;
+
+    #[test]
+    fn test_encrypt_decrypt_round_trip() {
+        let mut rng = rand::thread_rng();
+        let data_size = ENCRYPTED_PAGE_SIZE - ENCRYPTION_METADATA_SIZE;
+
+        let page_data = {
+            let mut page = vec![0u8; ENCRYPTED_PAGE_SIZE];
+            page.iter_mut()
+                .take(data_size)
+                .for_each(|byte| *byte = rng.gen());
+            page
+        };
+
+        let key = EncryptionKey::from_string("alice and bob use encryption on database");
+
+        let page_id = 42;
+        let encrypted = encrypt_page(&page_data, page_id, &key).unwrap();
+        assert_eq!(encrypted.len(), ENCRYPTED_PAGE_SIZE);
+        assert_ne!(&encrypted[..data_size], &page_data[..data_size]);
+        assert_ne!(&encrypted[..], &page_data[..]);
+
+        let decrypted = decrypt_page(&encrypted, page_id, &key).unwrap();
+        assert_eq!(decrypted.len(), ENCRYPTED_PAGE_SIZE);
+        assert_eq!(decrypted, page_data);
+    }
+}

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -13,7 +13,6 @@
 pub(crate) mod btree;
 pub(crate) mod buffer_pool;
 pub(crate) mod database;
-#[cfg(feature = "encryption")]
 pub(crate) mod encryption;
 pub(crate) mod page_cache;
 #[allow(clippy::arc_with_non_send_sync)]

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -13,6 +13,8 @@
 pub(crate) mod btree;
 pub(crate) mod buffer_pool;
 pub(crate) mod database;
+#[cfg(feature = "encryption")]
+pub(crate) mod encryption;
 pub(crate) mod page_cache;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -309,6 +309,9 @@ impl Default for DatabaseHeader {
             page_size: Default::default(),
             write_version: Version::Wal,
             read_version: Version::Wal,
+            #[cfg(feature = "encryption")]
+            reserved_space: 28,
+            #[cfg(not(feature = "encryption"))]
             reserved_space: 0,
             max_embed_frac: 64,
             min_embed_frac: 32,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -59,6 +59,8 @@ use crate::storage::btree::offset::{
 use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_threshold_min};
 use crate::storage::buffer_pool::BufferPool;
 use crate::storage::database::DatabaseStorage;
+#[cfg(feature = "encryption")]
+use crate::storage::encryption::EncryptionKey;
 use crate::storage::pager::Pager;
 use crate::storage::wal::{PendingFlush, READMARK_NOT_USED};
 use crate::types::{RawSlice, RefValue, SerialType, SerialTypeKind, TextRef, TextSubtype};

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -59,7 +59,6 @@ use crate::storage::btree::offset::{
 use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_threshold_min};
 use crate::storage::buffer_pool::BufferPool;
 use crate::storage::database::DatabaseStorage;
-#[cfg(feature = "encryption")]
 use crate::storage::encryption::EncryptionKey;
 use crate::storage::pager::Pager;
 use crate::storage::wal::{PendingFlush, READMARK_NOT_USED};

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -11,9 +11,17 @@ use std::fmt::{Debug, Formatter};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::{cell::Cell, fmt, rc::Rc, sync::Arc};
 
+use self::sqlite3_ondisk::{checksum_wal, PageContent, WAL_MAGIC_BE, WAL_MAGIC_LE};
+use super::buffer_pool::BufferPool;
+use super::pager::{PageRef, Pager};
+use super::sqlite3_ondisk::{self, WalHeader};
 use crate::fast_lock::SpinLock;
 use crate::io::{File, IO};
 use crate::result::LimboResult;
+#[cfg(feature = "encryption")]
+use crate::storage::encryption::EncryptionKey;
+#[cfg(feature = "encryption")]
+use crate::storage::encryption::{decrypt_page, encrypt_page};
 use crate::storage::sqlite3_ondisk::{
     begin_read_wal_frame, begin_read_wal_frame_raw, finish_read_page, prepare_wal_frame,
     write_pages_vectored, PageSize, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
@@ -24,12 +32,6 @@ use crate::{
     LimboError, Result,
 };
 use crate::{Completion, Page};
-
-use self::sqlite3_ondisk::{checksum_wal, PageContent, WAL_MAGIC_BE, WAL_MAGIC_LE};
-
-use super::buffer_pool::BufferPool;
-use super::pager::{PageRef, Pager};
-use super::sqlite3_ondisk::{self, WalHeader};
 
 #[derive(Debug, Clone, Default)]
 pub struct CheckpointResult {
@@ -287,6 +289,9 @@ pub trait Wal: Debug {
     /// Return unique set of pages changed **after** frame_watermark position and until current WAL session max_frame_no
     fn changed_pages_after(&self, frame_watermark: u64) -> Result<Vec<u32>>;
 
+    #[cfg(feature = "encryption")]
+    fn set_encryption_key(&mut self, key: Option<EncryptionKey>);
+
     #[cfg(debug_assertions)]
     fn as_any(&self) -> &dyn std::any::Any;
 }
@@ -446,6 +451,9 @@ pub struct WalFile {
 
     /// Manages locks needed for checkpointing
     checkpoint_guard: Option<CheckpointLocks>,
+
+    #[cfg(feature = "encryption")]
+    encryption_key: RefCell<Option<EncryptionKey>>,
 }
 
 impl fmt::Debug for WalFile {
@@ -1226,6 +1234,11 @@ impl Wal for WalFile {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    #[cfg(feature = "encryption")]
+    fn set_encryption_key(&mut self, key: Option<EncryptionKey>) {
+        self.encryption_key.replace(key);
+    }
 }
 
 impl WalFile {
@@ -1265,6 +1278,8 @@ impl WalFile {
             prev_checkpoint: CheckpointResult::default(),
             checkpoint_guard: None,
             header: *header,
+            #[cfg(feature = "encryption")]
+            encryption_key: RefCell::new(None),
         }
     }
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -7,11 +7,16 @@ use std::sync::Arc;
 use turso_sqlite3_parser::ast::{self, ColumnDefinition, Expr, Literal, Name};
 use turso_sqlite3_parser::ast::{PragmaName, QualifiedName};
 
+use super::integrity_check::translate_integrity_check;
 use crate::pragma::pragma_for;
 use crate::schema::Schema;
+#[cfg(feature = "encryption")]
+use crate::storage::encryption::EncryptionKey;
 use crate::storage::pager::AutoVacuumMode;
+use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
+use crate::translate::emitter::TransactionMode;
 use crate::translate::schema::translate_create_table;
 use crate::util::{normalize_ident, parse_signed_number, parse_string, IOExt as _};
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
@@ -19,10 +24,6 @@ use crate::vdbe::insn::{Cookie, Insn};
 use crate::{bail_parse_error, CaptureDataChangesMode, LimboError, SymbolTable, Value};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
-
-use super::integrity_check::translate_integrity_check;
-use crate::storage::pager::Pager;
-use crate::translate::emitter::TransactionMode;
 
 fn list_pragmas(program: &mut ProgramBuilder) {
     for x in PragmaName::iter() {
@@ -309,6 +310,15 @@ fn update_pragma(
             connection,
             program,
         ),
+        PragmaName::EncryptionKey => {
+            #[cfg(feature = "encryption")]
+            {
+                let value = parse_string(&value)?;
+                let key = EncryptionKey::from_string(&value);
+                connection.set_encryption_key(Some(key));
+            }
+            Ok((program, TransactionMode::None))
+        }
     }
 }
 
@@ -564,6 +574,23 @@ fn query_pragma(
             program.emit_int(value as i64, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
+            Ok((program, TransactionMode::None))
+        }
+        PragmaName::EncryptionKey => {
+            #[cfg(feature = "encryption")]
+            {
+                let msg = {
+                    if connection.encryption_key.borrow().is_some() {
+                        "encryption key is set for this session"
+                    } else {
+                        "encryption key is not set for this session"
+                    }
+                };
+                let register = program.alloc_register();
+                program.emit_string8(msg.to_string(), register);
+                program.emit_result_row(register, 1);
+                program.add_pragma_result_column(pragma.to_string());
+            }
             Ok((program, TransactionMode::None))
         }
     }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -32,3 +32,6 @@ zerocopy = "0.8.26"
 test-log = { version = "0.2.17", features = ["trace"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing = "0.1.41"
+
+[features]
+encryption = ["turso_core/encryption"]

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -1,0 +1,70 @@
+use crate::common::{do_flush, TempDatabase};
+use crate::query_processing::test_write_path::{run_query, run_query_on_row};
+use rand::{rng, RngCore};
+use std::panic;
+use turso_core::Row;
+
+#[test]
+fn test_per_page_encryption() -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let db_name = format!("test-{}.db", rng().next_u32());
+    let tmp_db = TempDatabase::new(&db_name, false);
+    let db_path = tmp_db.path.clone();
+
+    {
+        let conn = tmp_db.connect_limbo();
+        run_query(
+            &tmp_db,
+            &conn,
+            "PRAGMA key = 'super secret key for encryption';",
+        )?;
+        run_query(
+            &tmp_db,
+            &conn,
+            "CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT);",
+        )?;
+        run_query(
+            &tmp_db,
+            &conn,
+            "INSERT INTO test (value) VALUES ('Hello, World!')",
+        )?;
+        let mut row_count = 0;
+        run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |row: &Row| {
+            assert_eq!(row.get::<i64>(0).unwrap(), 1);
+            assert_eq!(row.get::<String>(1).unwrap(), "Hello, World!");
+            row_count += 1;
+        })?;
+        assert_eq!(row_count, 1);
+        do_flush(&conn, &tmp_db)?;
+    }
+
+    {
+        // this should panik because we should not be able to access the encrypted database
+        // without the key
+        let conn = tmp_db.connect_limbo();
+        let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |_: &Row| {}).unwrap();
+        }));
+        assert!(
+            should_panic.is_err(),
+            "should panic when accessing encrypted DB without key"
+        );
+    }
+
+    {
+        // let's test the existing db with the key
+        let existing_db = TempDatabase::new_with_existent(&db_path, false);
+        let conn = existing_db.connect_limbo();
+        run_query(
+            &existing_db,
+            &conn,
+            "PRAGMA key = 'super secret key for encryption';",
+        )?;
+        run_query_on_row(&existing_db, &conn, "SELECT * FROM test", |row: &Row| {
+            assert_eq!(row.get::<i64>(0).unwrap(), 1);
+            assert_eq!(row.get::<String>(1).unwrap(), "Hello, World!");
+        })?;
+    }
+
+    Ok(())
+}

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -4,3 +4,6 @@ mod test_write_path;
 
 mod test_multi_thread;
 mod test_transactions;
+
+#[cfg(feature = "encryption")]
+mod encryption;

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1829,6 +1829,11 @@ pub enum PragmaName {
     IntegrityCheck,
     /// `journal_mode` pragma
     JournalMode,
+    /// encryption key for encrypted databases. This is just called `key` because most
+    /// extensions use this name instead of `encryption_key`.
+    #[strum(serialize = "key")]
+    #[cfg_attr(feature = "serde", serde(rename = "key"))]
+    EncryptionKey,
     /// Noop as per SQLite docs
     LegacyFileFormat,
     /// Set or get the maximum number of pages in the database file.


### PR DESCRIPTION
This patch adds support for per page encryption. The code is of alpha quality, was to test my hypothesis. All the encryption code is gated behind a `encryption` flag. To play with it, you can do:

```sh
cargo run --features encryption -- database.db

turso> PRAGMA key='turso_test_encryption_key_123456';

turso> CREATE TABLE t(v);
```

Right now, most stuff is hard coded. We use AES GCM 256. This information is not stored anywhere, but in future versions we will start saving this info in the file. When writing to disk, we will generate a cryptographically secure random salt, use that to encrypt the page. Then we will store the authentication tag and the salt in the page itself. To accommodate this encryption hardcodes reserved space of 28 bytes. 

Once the key is set in the connection, we propagate that information to pager and the WAL, to encrypt / decrypt when reading from disk.
