### PR TITLE
Fix non-4096 page sizes

### DIFF
--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -474,12 +474,6 @@ impl DatabaseFile {
 
 impl turso_core::DatabaseStorage for DatabaseFile {
     fn read_header(&self, c: turso_core::Completion) -> turso_core::Result<turso_core::Completion> {
-        let r = c.as_read();
-        let size = r.buf().len();
-        assert!(
-            size == 100,
-            "the size of the database header must be 100 bytes, got {size}"
-        );
         self.file.pread(0, c)
     }
     fn read_page(

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -473,6 +473,15 @@ impl DatabaseFile {
 }
 
 impl turso_core::DatabaseStorage for DatabaseFile {
+    fn read_header(&self, c: turso_core::Completion) -> turso_core::Result<turso_core::Completion> {
+        let r = c.as_read();
+        let size = r.buf().len();
+        assert!(
+            size == 100,
+            "the size of the database header must be 100 bytes, got {size}"
+        );
+        self.file.pread(0, c)
+    }
     fn read_page(
         &self,
         page_idx: usize,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -470,9 +470,10 @@ impl Database {
         if let Some(shared_wal) = maybe_shared_wal {
             let size_in_wal = shared_wal.page_size();
             if size_in_wal != 0 {
-                return Ok(PageSize::new(size_in_wal).unwrap_or_else(|| {
-                    panic!("invalid page size in WAL: {size_in_wal}");
-                }));
+                let Some(page_size) = PageSize::new(size_in_wal) else {
+                    bail_corrupt_error!("invalid page size in WAL: {size_in_wal}");
+                };
+                return Ok(page_size);
             }
         }
         if self.db_state.is_initialized() {
@@ -481,9 +482,10 @@ impl Database {
             let Some(size) = requested_page_size else {
                 return Ok(PageSize::default());
             };
-            Ok(PageSize::new(size as u32).unwrap_or_else(|| {
-                panic!("invalid requested page size: {size}");
-            }))
+            let Some(page_size) = PageSize::new(size as u32) else {
+                bail_corrupt_error!("invalid requested page size: {size}");
+            };
+            Ok(page_size)
         }
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -449,9 +449,7 @@ impl Database {
         let c = self.db_file.read_header(c)?;
         self.io.wait_for_completion(c)?;
         let page_size = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
-        let Some(page_size) = PageSize::new(page_size as u32) else {
-            bail_corrupt_error!("invalid page size in DB header: {page_size}");
-        };
+        let page_size = PageSize::new_from_header_u16(page_size)?;
         Ok(page_size)
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -391,8 +391,7 @@ impl Database {
         let page_size = pager
             .io
             .block(|| pager.with_header(|header| header.page_size))
-            .unwrap_or_default()
-            .get();
+            .unwrap_or_default();
 
         let default_cache_size = pager
             .io
@@ -784,7 +783,7 @@ pub struct Connection {
     cache_size: Cell<i32>,
     /// page size used for an uninitialized database or the next vacuum command.
     /// it's not always equal to the current page size of the database
-    page_size: Cell<u32>,
+    page_size: Cell<PageSize>,
     /// Disable automatic checkpoint behaviour when DB is shutted down or WAL reach certain size
     /// Client still can manually execute PRAGMA wal_checkpoint(...) commands
     wal_auto_checkpoint_disabled: Cell<bool>,
@@ -1439,7 +1438,7 @@ impl Connection {
     pub fn set_capture_data_changes(&self, opts: CaptureDataChangesMode) {
         self.capture_data_changes.replace(opts);
     }
-    pub fn get_page_size(&self) -> u32 {
+    pub fn get_page_size(&self) -> PageSize {
         self.page_size.get()
     }
 
@@ -1481,7 +1480,7 @@ impl Connection {
             return Ok(());
         };
 
-        self.page_size.set(size.get());
+        self.page_size.set(size);
         if self._db.db_state.get() != DbState::Uninitialized {
             return Ok(());
         }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -8469,7 +8469,7 @@ mod tests {
         ));
 
         let wal_file = io.open_file("test.wal", OpenFlags::Create, false).unwrap();
-        let wal_shared = WalFileShared::new_shared(page_size as u32, &io, wal_file).unwrap();
+        let wal_shared = WalFileShared::new_shared(wal_file).unwrap();
         let wal = Rc::new(RefCell::new(WalFile::new(
             io.clone(),
             wal_shared,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5261,7 +5261,13 @@ impl BTreeCursor {
 
     fn get_immutable_record_or_create(&self) -> std::cell::RefMut<'_, Option<ImmutableRecord>> {
         if self.reusable_immutable_record.borrow().is_none() {
-            let record = ImmutableRecord::new(4096);
+            let page_size = self
+                .pager
+                .page_size
+                .get()
+                .expect("page size is not set")
+                .get();
+            let record = ImmutableRecord::new(page_size as usize);
             self.reusable_immutable_record.replace(Some(record));
         }
         self.reusable_immutable_record.borrow_mut()

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -40,12 +40,6 @@ unsafe impl Sync for DatabaseFile {}
 impl DatabaseStorage for DatabaseFile {
     #[instrument(skip_all, level = Level::DEBUG)]
     fn read_header(&self, c: Completion) -> Result<Completion> {
-        let r = c.as_read();
-        let size = r.buf().len();
-        assert!(
-            size == 100,
-            "the size of the database header must be 100 bytes, got {size}"
-        );
         self.file.pread(0, c)
     }
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1147,7 +1147,11 @@ impl Pager {
                 );
                 page
             };
-            let c = wal.borrow_mut().append_frame(page.clone(), 0)?;
+            let c = wal.borrow_mut().append_frame(
+                page.clone(),
+                self.page_size.get().expect("page size not set"),
+                0,
+            )?;
             // TODO: invalidade previous completions if this one fails
             completions.push(c);
         }
@@ -1207,7 +1211,11 @@ impl Pager {
                         };
 
                         // TODO: invalidade previous completions on error here
-                        let c = wal.borrow_mut().append_frame(page.clone(), db_size)?;
+                        let c = wal.borrow_mut().append_frame(
+                            page.clone(),
+                            self.page_size.get().expect("page size not set"),
+                            db_size,
+                        )?;
                         completions.push(c);
                     }
                     self.dirty_pages.borrow_mut().clear();
@@ -2214,8 +2222,6 @@ mod ptrmap_tests {
         let wal = Rc::new(RefCell::new(WalFile::new(
             io.clone(),
             WalFileShared::new_shared(
-                page_size,
-                &io,
                 io.open_file("test.db-wal", OpenFlags::Create, false)
                     .unwrap(),
             )

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -85,11 +85,15 @@ pub const LEFT_CHILD_PTR_SIZE_BYTES: usize = 4;
 pub struct PageSize(U16BE);
 
 impl PageSize {
+    pub const ALIAS_64K: u32 = 1;
     pub const MIN: u32 = 512;
     pub const MAX: u32 = 65536;
     pub const DEFAULT: u16 = 4096;
 
     pub const fn new(size: u32) -> Option<Self> {
+        if size == Self::ALIAS_64K {
+            return Some(Self(U16BE::new(1)));
+        }
         if size < PageSize::MIN || size > PageSize::MAX {
             return None;
         }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -947,7 +947,7 @@ pub fn write_pages_vectored(
     // batch item array is already sorted by id, so we just need to find contiguous ranges of page_id's
     // to submit as `writev`/write_pages calls.
 
-    let page_sz = pager.page_size.get().unwrap_or(PageSize::DEFAULT as u32) as usize;
+    let page_sz = pager.page_size.get().expect("page size is not set").get() as usize;
 
     // Count expected number of runs to create the atomic counter we need to track each batch
     let mut run_count = 0;

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -62,7 +62,7 @@ use crate::storage::database::DatabaseStorage;
 use crate::storage::pager::Pager;
 use crate::storage::wal::{PendingFlush, READMARK_NOT_USED};
 use crate::types::{RawSlice, RefValue, SerialType, SerialTypeKind, TextRef, TextSubtype};
-use crate::{turso_assert, File, Result, WalFileShared};
+use crate::{bail_corrupt_error, turso_assert, File, Result, WalFileShared};
 use std::cell::{RefCell, UnsafeCell};
 use std::collections::{BTreeMap, HashMap};
 use std::mem::MaybeUninit;
@@ -85,15 +85,12 @@ pub const LEFT_CHILD_PTR_SIZE_BYTES: usize = 4;
 pub struct PageSize(U16BE);
 
 impl PageSize {
-    pub const ALIAS_64K: u32 = 1;
     pub const MIN: u32 = 512;
     pub const MAX: u32 = 65536;
     pub const DEFAULT: u16 = 4096;
 
+    /// Interpret a user-provided u32 as either a valid page size or None.
     pub const fn new(size: u32) -> Option<Self> {
-        if size == Self::ALIAS_64K {
-            return Some(Self(U16BE::new(1)));
-        }
         if size < PageSize::MIN || size > PageSize::MAX {
             return None;
         }
@@ -104,10 +101,26 @@ impl PageSize {
         }
 
         if size == PageSize::MAX {
+            // Internally, the value 1 represents 65536, since the on-disk value of the page size in the DB header is 2 bytes.
             return Some(Self(U16BE::new(1)));
         }
 
         Some(Self(U16BE::new(size as u16)))
+    }
+
+    /// Interpret a u16 on disk (DB file header) as either a valid page size or
+    /// return a corrupt error.
+    pub fn new_from_header_u16(value: u16) -> Result<Self> {
+        match value {
+            1 => Ok(Self(U16BE::new(1))),
+            n => {
+                let Some(size) = Self::new(n as u32) else {
+                    bail_corrupt_error!("invalid page size in database header: {n}");
+                };
+
+                Ok(size)
+            }
+        }
     }
 
     pub const fn get(self) -> u32 {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1313,9 +1313,8 @@ impl WalFile {
             if hdr.page_size == 0 {
                 hdr.page_size = page_size.get();
             }
-            if hdr.salt_1 == 0 {
+            if hdr.salt_1 == 0 && hdr.salt_2 == 0 {
                 hdr.salt_1 = self.io.generate_random_number() as u32;
-                turso_assert!(hdr.salt_2 == 0, "salt_2 must be zero");
                 hdr.salt_2 = self.io.generate_random_number() as u32;
             }
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -484,7 +484,7 @@ fn query_pragma(
                 pager
                     .io
                     .block(|| pager.with_header(|header| header.page_size.get()))
-                    .unwrap_or(connection.get_page_size()) as i64,
+                    .unwrap_or(connection.get_page_size().get()) as i64,
                 register,
             );
             program.emit_result_row(register, 1);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6785,8 +6785,9 @@ pub fn op_open_ephemeral(
             let page_size = pager
                 .io
                 .block(|| pager.with_header(|header| header.page_size))
-                .unwrap_or_default()
-                .get() as usize;
+                .unwrap_or_default();
+
+            pager.page_size.set(Some(page_size));
 
             state.op_open_ephemeral_state = OpOpenEphemeralState::StartingTxn { pager };
         }

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -57,3 +57,107 @@ fn test_pragma_module_list_generate_series() {
 
     assert!(found, "generate_series should appear in module_list");
 }
+
+#[test]
+fn test_pragma_page_sizes_without_writes_persists() {
+    for test_page_size in [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536] {
+        let db = TempDatabase::new_empty(false);
+        {
+            let conn = db.connect_limbo();
+            let pragma_query = format!("PRAGMA page_size={test_page_size}");
+            conn.execute(&pragma_query).unwrap();
+            conn.execute("PRAGMA user_version=1").unwrap(); // even sqlite behavior is that just changing page_size pragma doesn't persist it, so we do this to make a minimal persistent change
+        }
+
+        let conn = db.connect_limbo();
+        let mut rows = conn.query("PRAGMA page_size").unwrap().unwrap();
+        let StepResult::Row = rows.step().unwrap() else {
+            panic!("expected row");
+        };
+        let row = rows.row().unwrap();
+        let Value::Integer(page_size) = row.get_value(0) else {
+            panic!("expected integer value");
+        };
+        assert_eq!(*page_size, test_page_size);
+
+        // Reopen database and verify page size
+        let db = TempDatabase::new_with_existent(&db.path, false);
+        let conn = db.connect_limbo();
+        let mut rows = conn.query("PRAGMA page_size").unwrap().unwrap();
+        let StepResult::Row = rows.step().unwrap() else {
+            panic!("expected row");
+        };
+        let row = rows.row().unwrap();
+        let Value::Integer(page_size) = row.get_value(0) else {
+            panic!("expected integer value");
+        };
+        assert_eq!(*page_size, test_page_size);
+    }
+}
+
+#[test]
+fn test_pragma_page_sizes_with_writes_persists() {
+    for test_page_size in [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536] {
+        let db = TempDatabase::new_empty(false);
+        {
+            {
+                let conn = db.connect_limbo();
+                let pragma_query = format!("PRAGMA page_size={test_page_size}");
+                conn.execute(&pragma_query).unwrap();
+
+                // Create table and insert data
+                conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+                    .unwrap();
+                conn.execute("INSERT INTO test (id, value) VALUES (1, 'test data')")
+                    .unwrap();
+                let mut page_size = conn.pragma_query("page_size").unwrap();
+                let mut page_size = page_size.pop().unwrap();
+                let page_size = page_size.pop().unwrap();
+                let Value::Integer(page_size) = page_size else {
+                    panic!("expected integer value");
+                };
+                assert_eq!(page_size, test_page_size);
+            } // Connection is dropped here
+
+            // Reopen database and verify page size and data
+            let conn = db.connect_limbo();
+
+            // Check page size is still test_page_size
+            let mut page_size = conn.pragma_query("page_size").unwrap();
+            let mut page_size = page_size.pop().unwrap();
+            let page_size = page_size.pop().unwrap();
+            let Value::Integer(page_size) = page_size else {
+                panic!("expected integer value");
+            };
+            assert_eq!(page_size, test_page_size);
+
+            // Verify data can still be read
+            let mut rows = conn
+                .query("SELECT value FROM test WHERE id = 1")
+                .unwrap()
+                .unwrap();
+            loop {
+                if let StepResult::Row = rows.step().unwrap() {
+                    let row = rows.row().unwrap();
+                    let Value::Text(value) = row.get_value(0) else {
+                        panic!("expected text value");
+                    };
+                    assert_eq!(value.as_str(), "test data");
+                    break;
+                }
+                rows.run_once().unwrap();
+            }
+        }
+
+        // Drop the db and reopen it, and verify the same
+        let db = TempDatabase::new_with_existent(&db.path, false);
+        let conn = db.connect_limbo();
+        let mut page_size = conn.pragma_query("page_size").unwrap();
+        let mut page_size = page_size.pop().unwrap();
+        let page_size = page_size.pop().unwrap();
+        let Value::Integer(page_size) = page_size else {
+            panic!("expected integer value");
+        };
+        assert_eq!(page_size, test_page_size);
+    }
+}

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -110,6 +110,9 @@ fn test_pragma_page_sizes_with_writes_persists() {
                     .unwrap();
                 conn.execute("INSERT INTO test (id, value) VALUES (1, 'test data')")
                     .unwrap();
+                // Insert a big blob just as a small smoke test that our btree handles this well with different page sizes.
+                conn.execute("INSERT INTO test (id, value) VALUES (2, randomblob(1024*1024))")
+                    .unwrap();
                 let mut page_size = conn.pragma_query("page_size").unwrap();
                 let mut page_size = page_size.pop().unwrap();
                 let page_size = page_size.pop().unwrap();


### PR DESCRIPTION
Closes #2555 

## Problem

The main problem we had with the current implementation of `init_pager()` was that the WAL header was eagerly allocated and written to disk with a page size, and a potential already-set page size on an initialized database was not checked. Given this scenario:

- Initialized database with e.g. page size 512 but no WAL
- Tursodb connects to DB

It would not check the database file for the page size and instead would initialize the WAL header with the default 4096 page size, plus initialize the `BufferPool` similarly with the wrong size, and then panic when reading pages from the DB, expecting to read `4096` instead of `512`, as demonstrated in the reproduction of #2555.

## Fix

1. Add `Database::read_page_size_from_db_header()` method that can be used in the above cases
2. Initialize the WAL header lazily during the first frame append, using the existing `WalFile::ensure_header_if_needed()` method, removing the need to eagerly pass `page_size` when constructing the in-memory `WalFileShared` structure.

## Reader notes

This PR follows a fairly logical commit-by-commit structure so you'll preferably want to read it that way.