### PR TITLE
github: Drop macOS/x86-64 configuration

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -26,9 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-13
-            target: x86_64-apple-darwin
-            build: yarn build --target x86_64-apple-darwin
           - host: windows-latest
             build: |
               yarn build --target x86_64-pc-windows-msvc
@@ -113,38 +110,6 @@ jobs:
             bindings/javascript/${{ env.APP_NAME }}.*.node
             bindings/javascript/${{ env.APP_NAME }}.*.wasm
           if-no-files-found: error
-  test-macOS-windows-binding:
-    name: Test bindings on ${{ matrix.settings.target }} - node@${{ matrix.node }}
-    needs:
-      - build
-    strategy:
-      fail-fast: false
-      matrix:
-        settings:
-          - host: macos-13
-            target: x86_64-apple-darwin
-        node:
-          - "20"
-    runs-on: ${{ matrix.settings.host }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-          architecture: x64
-      - name: Install dependencies
-        run: yarn install
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: bindings-${{ matrix.settings.target }}
-          path: bindings/javascript
-      - name: List packages
-        run: ls -R .
-        shell: bash
-      - name: Test bindings
-        run: yarn test
   test-linux-x64-gnu-binding:
     name: Test bindings on Linux-x64-gnu - node@${{ matrix.node }}
     needs:
@@ -217,7 +182,6 @@ jobs:
       contents: read
       id-token: write
     needs:
-      - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
       - universal-macOS
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -110,35 +110,6 @@ jobs:
           name: wheels-linux
           path: bindings/python/dist
 
-  macos-x86_64:
-    runs-on: macos-13
-    defaults:
-      run:
-        working-directory: ${{ env.working-directory }}
-    strategy:
-      matrix:
-        target: [x86_64]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        env:
-          CXX: clang++
-          CC: clang
-        with:
-          working-directory: ${{ env.working-directory }}
-          target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
-          sccache: 'true'
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-x86
-          path: bindings/python/dist
-
   macos-arm64:
     runs-on: macos-14
     defaults:
@@ -191,7 +162,7 @@ jobs:
     name: Release
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, macos-arm64, macos-x86_64, sdist]
+    needs: [linux, macos-arm64, sdist]
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
GitHub seems to have a lot of capacity issues with Intel macOS runners so let's just drop them.