### PR TITLE
disable checkpoint: adjust semantic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,7 +4028,6 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "tracing-subscriber",
  "turso_core",
  "turso_node",
  "turso_sync_engine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,6 +4028,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "tracing-subscriber",
  "turso_core",
  "turso_node",
  "turso_sync_engine",

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1385,9 +1385,7 @@ impl Connection {
         if self.closed.get() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
-        self.pager
-            .borrow()
-            .wal_checkpoint(self.wal_checkpoint_disabled.get(), mode)
+        self.pager.borrow().wal_checkpoint(mode)
     }
 
     /// Close a connection and checkpoint.
@@ -1895,11 +1893,10 @@ impl Connection {
     pub fn copy_db(&self, file: &str) -> Result<()> {
         // use a new PlatformIO instance here to allow for copying in-memory databases
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new()?);
-        let disabled = false;
         // checkpoint so everything is in the DB file before copying
         self.pager
             .borrow_mut()
-            .wal_checkpoint(disabled, CheckpointMode::Truncate)?;
+            .wal_checkpoint(CheckpointMode::Truncate)?;
         self.pager.borrow_mut().db_file.copy_to(&*io, file)
     }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -502,7 +502,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         .end_tx(
                             false, // rollback = false since we're committing
                             &self.connection,
-                            self.connection.wal_checkpoint_disabled.get(),
+                            self.connection.wal_auto_checkpoint_disabled.get(),
                         )
                         .map_err(|e| LimboError::InternalError(e.to_string()))
                         .unwrap();

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1168,6 +1168,12 @@ impl Wal for WalFile {
         let page_size = self.page_size();
         let mut frame = vec![0u8; page_size as usize + WAL_FRAME_HEADER_SIZE];
         let mut seen = HashSet::new();
+        turso_assert!(
+            frame_count >= frame_watermark,
+            "frame_count must be not less than frame_watermark: {} vs {}",
+            frame_count,
+            frame_watermark
+        );
         let mut pages = Vec::with_capacity((frame_count - frame_watermark) as usize);
         for frame_no in frame_watermark + 1..=frame_count {
             let c = self.read_frame_raw(frame_no, &mut frame)?;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -581,7 +581,7 @@ impl Program {
         let cacheflush_status = pager.end_tx(
             rollback,
             connection,
-            connection.wal_checkpoint_disabled.get(),
+            connection.wal_auto_checkpoint_disabled.get(),
         )?;
         match cacheflush_status {
             IOResult::Done(_) => {

--- a/packages/turso-sync-engine/src/database_sync_operations.rs
+++ b/packages/turso-sync-engine/src/database_sync_operations.rs
@@ -37,13 +37,13 @@ pub enum WalPushResult {
 
 pub async fn connect(coro: &Coro, tape: &DatabaseTape) -> Result<Arc<turso_core::Connection>> {
     let conn = tape.connect(coro).await?;
-    conn.wal_disable_checkpoint();
+    conn.wal_auto_checkpoint_disable();
     Ok(conn)
 }
 
 pub fn connect_untracked(tape: &DatabaseTape) -> Result<Arc<turso_core::Connection>> {
     let conn = tape.connect_untracked()?;
-    conn.wal_disable_checkpoint();
+    conn.wal_auto_checkpoint_disable();
     Ok(conn)
 }
 

--- a/packages/turso-sync-engine/src/lib.rs
+++ b/packages/turso-sync-engine/src/lib.rs
@@ -18,7 +18,7 @@ pub type Result<T> = std::result::Result<T, errors::Error>;
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, sync::Arc};
+    use std::sync::Arc;
 
     use tokio::{select, sync::Mutex};
     use tracing_subscriber::EnvFilter;

--- a/packages/turso-sync-engine/src/lib.rs
+++ b/packages/turso-sync-engine/src/lib.rs
@@ -84,23 +84,12 @@ mod tests {
                 db: None,
             }
         }
-        pub async fn init(
-            &mut self,
-            local_path: PathBuf,
-            opts: DatabaseSyncEngineOpts,
-        ) -> Result<()> {
+        pub async fn init(&mut self, local_path: &str, opts: DatabaseSyncEngineOpts) -> Result<()> {
             let io = self.io.clone();
             let server = self.sync_server.clone();
             let db = self
                 .run(genawaiter::sync::Gen::new(|coro| async move {
-                    DatabaseSyncEngine::new(
-                        &coro,
-                        io,
-                        Arc::new(server),
-                        local_path.to_str().unwrap(),
-                        opts,
-                    )
-                    .await
+                    DatabaseSyncEngine::new(&coro, io, Arc::new(server), local_path, opts).await
                 }))
                 .await
                 .unwrap();

--- a/packages/turso-sync-engine/src/test_context.rs
+++ b/packages/turso-sync-engine/src/test_context.rs
@@ -77,6 +77,13 @@ impl TestContext {
         let delay = self.rng.lock().await.next_u64() % 1000;
         tokio::time::sleep(std::time::Duration::from_millis(delay)).await
     }
+    pub async fn random_sleep_n(&self, n: u64) {
+        let delay = {
+            let mut rng = self.rng.lock().await;
+            rng.next_u64() % 1000 * (rng.next_u64() % n + 1)
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(delay)).await
+    }
 
     pub async fn rng(&self) -> tokio::sync::MutexGuard<ChaCha8Rng> {
         self.rng.lock().await

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -1476,7 +1476,7 @@ pub unsafe extern "C" fn libsql_wal_disable_checkpoint(db: *mut sqlite3) -> ffi:
     }
     let db: &mut sqlite3 = &mut *db;
     let db = db.inner.lock().unwrap();
-    db.conn.wal_disable_checkpoint();
+    db.conn.wal_auto_checkpoint_disable();
     SQLITE_OK
 }
 


### PR DESCRIPTION
This PR change semantic of `wal_disable_checkpoint` flag and make it disable only "automatic" checkpoint behaviour which at the moment includes:
1. Checkpoint on shutdown
2. Checkpoint when WAL reach certain size

sync-engine needs checkpoint to be in full control but it also will issue `TRUNCATE` checkpoint at some certain moments of time - so complete disablement of checkpoints will not suffice.