### PR TITLE
Properly implement `.clone` CLI command

### DIFF
--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -530,12 +530,4 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         let c = self.file.truncate(len, c)?;
         Ok(c)
     }
-    fn copy_to(
-        &self,
-        src_io: &dyn turso_core::IO,
-        dest_io: &dyn turso_core::IO,
-        path: &str,
-    ) -> turso_core::Result<()> {
-        self.file.copy_to(src_io, dest_io, path)
-    }
 }

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -530,7 +530,12 @@ impl turso_core::DatabaseStorage for DatabaseFile {
         let c = self.file.truncate(len, c)?;
         Ok(c)
     }
-    fn copy_to(&self, io: &dyn turso_core::IO, path: &str) -> turso_core::Result<()> {
-        self.file.copy_to(io, path)
+    fn copy_to(
+        &self,
+        src_io: &dyn turso_core::IO,
+        dest_io: &dyn turso_core::IO,
+        path: &str,
+    ) -> turso_core::Result<()> {
+        self.file.copy_to(src_io, dest_io, path)
     }
 }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1450,7 +1450,7 @@ impl Limbo {
                         writeln!(
                             out,
                             "INSERT INTO sqlite_sequence(name,seq) VALUES({},{});",
-                            quote_ident(name),
+                            sql_quote_string(name),
                             seq
                         )?;
                     }
@@ -1542,6 +1542,18 @@ fn quote_ident(s: &str) -> String {
     out
 }
 
+fn sql_quote_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push('\'');
+        } // escape as ''
+        out.push(ch);
+    }
+    out.push('\'');
+    out
+}
 impl Drop for Limbo {
     fn drop(&mut self) {
         self.save_history()

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -58,44 +58,6 @@ pub trait File: Send + Sync {
     }
     fn size(&self) -> Result<u64>;
     fn truncate(&self, len: usize, c: Completion) -> Result<Completion>;
-    fn copy_to(&self, src_io: &dyn IO, dest_io: &dyn IO, path: &str) -> Result<()> {
-        // Open or create the destination file
-        let dest_file = dest_io.open_file(path, OpenFlags::Create, false)?;
-        // Get the size of the source file
-        let file_size = self.size()? as usize;
-        if file_size == 0 {
-            return Ok(());
-        }
-
-        // use 1MB chunk size
-        const BUFFER_SIZE: usize = 1024 * 1024;
-        let mut pos = 0;
-
-        while pos < file_size {
-            let chunk_size = (file_size - pos).min(BUFFER_SIZE);
-            // Read from source
-            let read_buffer = Arc::new(Buffer::new_temporary(chunk_size));
-            let read_completion = self.pread(
-                pos,
-                Completion::new_read(read_buffer.clone(), move |_, _| {}),
-            )?;
-
-            // Wait for read to complete
-            src_io.wait_for_completion(read_completion)?;
-
-            // Write to destination
-            let write_completion =
-                dest_file.pwrite(pos, read_buffer, Completion::new_write(|_| {}))?;
-            dest_io.wait_for_completion(write_completion)?;
-
-            pos += chunk_size;
-        }
-        let sync_completion = dest_file.sync(Completion::new_sync(|_| {}))?;
-
-        dest_io.wait_for_completion(sync_completion)?;
-
-        Ok(())
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1913,48 +1913,6 @@ impl Connection {
         self.query_only.set(value);
     }
 
-    #[cfg(feature = "fs")]
-    /// Copy the current Database and write out to a new file.
-    /// TODO: sqlite3 instead essentially does the equivalent of
-    /// `.dump` and creates a new .db file from that.
-    ///
-    /// Because we are instead making a copy of the File, as a side-effect we are
-    /// also having to checkpoint the database.
-    pub fn copy_db(&self, file: &str) -> Result<()> {
-        if !self.is_db_initialized() {
-            return Err(LimboError::Page1NotAlloc);
-        }
-        let pager = self.pager.borrow();
-        if let Some(wal) = pager.wal.as_ref() {
-            let checkpoint_result = self
-                ._db
-                .io
-                .block(|| wal.borrow_mut().checkpoint(&pager, CheckpointMode::Full))?;
-
-            if checkpoint_result.everything_backfilled() {
-                let c = Completion::new_sync(|_| {});
-                let c = pager.db_file.sync(c)?;
-                // sync the db file to ensure checkpointed frames were flushed.
-                self._db.io.wait_for_completion(c)?;
-
-                // CheckpointResult here still holds the checkpoint/writer lock until it goes out of scope,
-                // so it's safe to copy from file.
-
-                let src_io = self._db.io.clone();
-                // use a new PlatformIO instance as the dest_io when copying the file to account that src could be memory
-                let dest_io: Arc<dyn IO> = Arc::new(PlatformIO::new()?);
-                pager.db_file.copy_to(&*src_io, &*dest_io, file)?;
-                return Ok(());
-            } else {
-                // unable to backfill all frames to the db file, so we cannot support copying file
-                return Err(LimboError::Busy);
-            }
-        }
-        Err(LimboError::InternalError(
-            "not yet supported for DB's without WAL".into(),
-        ))
-    }
-
     /// Creates a HashSet of modules that have been loaded
     pub fn get_syms_vtab_mods(&self) -> std::collections::HashSet<String> {
         self.syms.borrow().vtab_modules.keys().cloned().collect()

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -23,7 +23,7 @@ pub trait DatabaseStorage: Send + Sync {
     fn sync(&self, c: Completion) -> Result<Completion>;
     fn size(&self) -> Result<u64>;
     fn truncate(&self, len: usize, c: Completion) -> Result<Completion>;
-    fn copy_to(&self, io: &dyn crate::IO, path: &str) -> Result<()>;
+    fn copy_to(&self, src_io: &dyn crate::IO, dest_io: &dyn crate::IO, path: &str) -> Result<()>;
 }
 
 #[cfg(feature = "fs")]
@@ -103,8 +103,8 @@ impl DatabaseStorage for DatabaseFile {
     }
 
     #[instrument(skip_all, level = Level::INFO)]
-    fn copy_to(&self, io: &dyn crate::IO, path: &str) -> Result<()> {
-        self.file.copy_to(io, path)
+    fn copy_to(&self, src_io: &dyn crate::IO, dest_io: &dyn crate::IO, path: &str) -> Result<()> {
+        self.file.copy_to(src_io, dest_io, path)
     }
 }
 

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -23,7 +23,6 @@ pub trait DatabaseStorage: Send + Sync {
     fn sync(&self, c: Completion) -> Result<Completion>;
     fn size(&self) -> Result<u64>;
     fn truncate(&self, len: usize, c: Completion) -> Result<Completion>;
-    fn copy_to(&self, src_io: &dyn crate::IO, dest_io: &dyn crate::IO, path: &str) -> Result<()>;
 }
 
 #[cfg(feature = "fs")]
@@ -100,11 +99,6 @@ impl DatabaseStorage for DatabaseFile {
     fn truncate(&self, len: usize, c: Completion) -> Result<Completion> {
         let c = self.file.truncate(len, c)?;
         Ok(c)
-    }
-
-    #[instrument(skip_all, level = Level::INFO)]
-    fn copy_to(&self, src_io: &dyn crate::IO, dest_io: &dyn crate::IO, path: &str) -> Result<()> {
-        self.file.copy_to(src_io, dest_io, path)
     }
 }
 

--- a/testing/cli_tests/cli_test_cases.py
+++ b/testing/cli_tests/cli_test_cases.py
@@ -318,13 +318,13 @@ def test_copy_db_file():
         os.unlink(Path(testpath))
         time.sleep(0.2)  # make sure closed
     time.sleep(0.3)
-    turso = TestTursoShell(init_commands="", flags=f" {testpath}")
+    turso = TestTursoShell(init_commands="")
     turso.execute_dot("create table testing(a,b,c);")
     turso.run_test_fn(".schema", lambda x: "CREATE TABLE testing (a, b, c)" in x, "test-database-has-expected-schema")
     for i in range(100):
         turso.execute_dot(f"insert into testing (a,b,c) values ({i},{i + 1}, {i + 2});")
     turso.run_test_fn("SELECT COUNT(*) FROM testing;", lambda x: "100" == x, "test-database-has-expected-count")
-    turso.execute_dot(f".clone {testpath}")
+    turso.run_test_fn(f".clone {testpath}", lambda res: "testing... done" in res)
 
     turso.execute_dot(f".open {testpath}")
     turso.run_test_fn(".schema", lambda x: "CREATE TABLE testing" in x, "test-copied-database-has-expected-schema")
@@ -342,7 +342,7 @@ def test_copy_memory_db_to_file():
     turso.execute_dot("create table testing(a,b,c);")
     for i in range(100):
         turso.execute_dot(f"insert into testing (a, b, c) values ({i},{i + 1}, {i + 2});")
-    turso.execute_dot(f".clone {testpath}")
+    turso.run_test_fn(f".clone {testpath}", lambda res: "testing... done" in res)
     turso.quit()
     time.sleep(0.3)
     sqlite = TestTursoShell(exec_name="sqlite3", flags=f" {testpath}")


### PR DESCRIPTION
Closes #2588 

SQLite internally implements `.clone` by doing something like piping `.dump` into a new connection to a database attached to the file you want. This PR implements that by adding an `ApplyWriter` that implements `std::fmt::Write`, and refactors our current `.dump` plumbing to work with any `Write` interface, so we can `.dump` to stdout or `.dump` to a new connection, therefore cloning the database.
