### PR TITLE
Implement normal views

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -43,7 +43,6 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 * ⛔️ Concurrent access from multiple processes is not supported.
 * ⛔️ Savepoints are not supported.
 * ⛔️ Triggers are not supported.
-* ⛔️ Views are not supported.
 * ⛔️ Vacuum is not supported.
 
 ## SQLite query language
@@ -61,14 +60,14 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | CREATE TABLE              | Partial |                                                                                   |
 | CREATE TABLE ... STRICT   | Yes     |                                                                                   |
 | CREATE TRIGGER            | No      |                                                                                   |
-| CREATE VIEW               | No      |                                                                                   |
+| CREATE VIEW               | Yes     |                                                                                   |
 | CREATE VIRTUAL TABLE      | Yes     |                                                                                   |
 | DELETE                    | Yes     |                                                                                   |
 | DETACH DATABASE           | Yes     |                                                                                   |
 | DROP INDEX                | Partial | Disabled by default.                                                              |
 | DROP TABLE                | Yes     |                                                                                   |
 | DROP TRIGGER              | No      |                                                                                   |
-| DROP VIEW                 | No      |                                                                                   |
+| DROP VIEW                 | Yes     |                                                                                   |
 | END TRANSACTION           | Partial | Alias for `COMMIT TRANSACTION`                                                    |
 | EXPLAIN                   | Yes     |                                                                                   |
 | INDEXED BY                | No      |                                                                                   |

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -190,9 +190,20 @@ pub fn translate_inner(
             program,
         )?,
         ast::Stmt::CreateTrigger { .. } => bail_parse_error!("CREATE TRIGGER not supported yet"),
-        ast::Stmt::CreateView { .. } => {
-            bail_parse_error!("CREATE VIEW not supported yet.")
-        }
+        ast::Stmt::CreateView {
+            view_name,
+            select,
+            columns,
+            ..
+        } => view::translate_create_view(
+            schema,
+            view_name.name.as_str(),
+            &select,
+            columns.as_ref(),
+            connection.clone(),
+            syms,
+            program,
+        )?,
         ast::Stmt::CreateMaterializedView {
             view_name, select, ..
         } => view::translate_create_materialized_view(
@@ -249,13 +260,7 @@ pub fn translate_inner(
         ast::Stmt::DropView {
             if_exists,
             view_name,
-        } => view::translate_drop_view(
-            schema,
-            view_name.name.as_str(),
-            if_exists,
-            connection.clone(),
-            program,
-        )?,
+        } => view::translate_drop_view(schema, view_name.name.as_str(), if_exists, program)?,
         ast::Stmt::Pragma(..) => {
             bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")
         }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -470,7 +470,9 @@ fn parse_table(
         return Ok(());
     };
 
-    let view = connection.with_schema(database_id, |schema| schema.get_view(table_name.as_str()));
+    let view = connection.with_schema(database_id, |schema| {
+        schema.get_materialized_view(table_name.as_str())
+    });
     if let Some(view) = view {
         // Create a virtual table wrapper for the view
         // We'll use the view's columns from the schema

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -448,7 +448,7 @@ fn query_pragma(
             if let Some(name) = name {
                 if let Some(table) = schema.get_table(&name) {
                     emit_columns_for_table_info(&mut program, table.columns(), base_reg);
-                } else if let Some(view_mutex) = schema.get_view(&name) {
+                } else if let Some(view_mutex) = schema.get_materialized_view(&name) {
                     let view = view_mutex.lock().unwrap();
                     emit_columns_for_table_info(&mut program, &view.columns, base_reg);
                 }

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -27,7 +27,10 @@ pub fn translate_create_materialized_view(
     let normalized_view_name = normalize_ident(view_name);
 
     // Check if view already exists
-    if schema.get_view(&normalized_view_name).is_some() {
+    if schema
+        .get_materialized_view(&normalized_view_name)
+        .is_some()
+    {
         return Err(crate::LimboError::ParseError(format!(
             "View {normalized_view_name} already exists"
         )));
@@ -71,8 +74,8 @@ pub fn translate_create_materialized_view(
         where_clause: Some(format!("name = '{normalized_view_name}'")),
     });
 
-    // Populate the new view
-    program.emit_insn(Insn::PopulateViews);
+    // Populate the new materialized view
+    program.emit_insn(Insn::PopulateMaterializedViews);
 
     program.epilogue(schema);
     Ok(program)
@@ -104,7 +107,9 @@ pub fn translate_drop_view(
     let normalized_view_name = normalize_ident(view_name);
 
     // Check if view exists
-    let view_exists = schema.get_view(&normalized_view_name).is_some();
+    let view_exists = schema
+        .get_materialized_view(&normalized_view_name)
+        .is_some();
 
     if !view_exists && !if_exists {
         return Err(crate::LimboError::ParseError(format!(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6314,7 +6314,7 @@ pub fn op_drop_view(
     }
     let conn = program.connection.clone();
     conn.with_schema_mut(|schema| {
-        schema.remove_view(view_name);
+        schema.remove_view(view_name)?;
         Ok::<(), crate::LimboError>(())
     })?;
     state.pc += 1;

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1337,8 +1337,8 @@ pub fn insn_to_str(
                 0,
                 where_clause.clone().unwrap_or("NULL".to_string()),
             ),
-            Insn::PopulateViews => (
-                "PopulateViews",
+            Insn::PopulateMaterializedViews => (
+                "PopulateMaterializedViews",
                 0,
                 0,
                 0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -897,8 +897,8 @@ pub enum Insn {
         where_clause: Option<String>,
     },
 
-    /// Populate all views after schema parsing
-    PopulateViews,
+    /// Populate all materialized views after schema parsing
+    PopulateMaterializedViews,
 
     /// Place the result of lhs >> rhs in dest register.
     ShiftRight {
@@ -1185,7 +1185,7 @@ impl Insn {
             Insn::IsNull { .. } => execute::op_is_null,
             Insn::CollSeq { .. } => execute::op_coll_seq,
             Insn::ParseSchema { .. } => execute::op_parse_schema,
-            Insn::PopulateViews => execute::op_populate_views,
+            Insn::PopulateMaterializedViews => execute::op_populate_materialized_views,
             Insn::ShiftRight { .. } => execute::op_shift_right,
             Insn::ShiftLeft { .. } => execute::op_shift_left,
             Insn::AddImm { .. } => execute::op_add_imm,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -476,7 +476,7 @@ impl Program {
             let schema = self.connection.schema.borrow();
 
             for (view_name, tx_state) in tx_states.iter() {
-                if let Some(view_mutex) = schema.get_view(view_name) {
+                if let Some(view_mutex) = schema.get_materialized_view(view_name) {
                     let mut view = view_mutex.lock().unwrap();
                     view.merge_delta(&tx_state.delta);
                 }

--- a/testing/all.test
+++ b/testing/all.test
@@ -39,3 +39,4 @@ source $testdir/collate.test
 source $testdir/values.test
 source $testdir/integrity_check.test
 source $testdir/rollback.test
+source $testdir/views.test

--- a/testing/views.test
+++ b/testing/views.test
@@ -1,0 +1,231 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+do_execsql_test_on_specific_db {:memory:} view-basic-filtering {
+    CREATE TABLE products(id INTEGER, name TEXT, price INTEGER, category TEXT);
+    INSERT INTO products VALUES
+        (1, 'Laptop', 1200, 'Electronics'),
+        (2, 'Mouse', 25, 'Electronics'),
+        (3, 'Desk', 350, 'Furniture'),
+        (4, 'Chair', 150, 'Furniture'),
+        (5, 'Monitor', 400, 'Electronics'),
+        (6, 'Keyboard', 75, 'Electronics');
+
+    CREATE VIEW expensive_electronics AS
+        SELECT id, name, price
+        FROM products
+        WHERE category = 'Electronics' AND price > 100;
+
+    SELECT * FROM expensive_electronics ORDER BY price;
+} {5|Monitor|400
+1|Laptop|1200}
+
+do_execsql_test_on_specific_db {:memory:} view-aggregation-groupby {
+    CREATE TABLE sales(product_id INTEGER, quantity INTEGER, day INTEGER);
+    INSERT INTO sales VALUES
+        (1, 2, 1),
+        (2, 5, 1),
+        (1, 1, 2),
+        (3, 1, 2),
+        (2, 3, 3),
+        (1, 1, 3);
+
+    CREATE VIEW daily_sales AS
+        SELECT day,
+               COUNT(*) as transactions,
+               SUM(quantity) as total_items
+        FROM sales
+        GROUP BY day;
+
+    SELECT * FROM daily_sales ORDER BY day;
+} {1|2|7
+2|2|2
+3|2|4}
+
+do_execsql_test_on_specific_db {:memory:} view-with-join {
+    CREATE TABLE employees(id INTEGER, name TEXT, dept_id INTEGER);
+    CREATE TABLE departments(id INTEGER, name TEXT, budget INTEGER);
+
+    INSERT INTO employees VALUES
+        (1, 'Alice', 1),
+        (2, 'Bob', 2),
+        (3, 'Charlie', 1),
+        (4, 'Diana', 3),
+        (5, 'Eve', 2);
+
+    INSERT INTO departments VALUES
+        (1, 'Engineering', 500000),
+        (2, 'Sales', 300000),
+        (3, 'HR', 150000);
+
+    CREATE VIEW employee_dept AS
+        SELECT e.id,
+               e.name as emp_name,
+               d.name as dept_name,
+               d.budget
+        FROM employees e
+        JOIN departments d ON e.dept_id = d.id;
+
+    SELECT emp_name, dept_name FROM employee_dept WHERE budget > 200000 ORDER BY emp_name;
+} {Alice|Engineering
+Bob|Sales
+Charlie|Engineering
+Eve|Sales}
+
+do_execsql_test_on_specific_db {:memory:} view-composition-with-functions {
+    CREATE TABLE numbers(value INTEGER);
+    INSERT INTO numbers VALUES (10), (20), (30), (40), (50);
+
+    CREATE VIEW stats AS
+        SELECT
+            SUM(value) as total,
+            COUNT(*) as cnt,
+            AVG(value) as average
+        FROM numbers
+        WHERE value > 15;
+
+    SELECT
+        total,
+        total * 2 as doubled,
+        cnt,
+        LENGTH(CAST(total AS TEXT)) as total_digits
+    FROM stats;
+} {140|280|4|3}
+
+do_execsql_test_on_specific_db {:memory:} view-referencing-view {
+    CREATE TABLE orders(
+        order_id INTEGER,
+        customer_id INTEGER,
+        quantity INTEGER,
+        price INTEGER
+    );
+
+    INSERT INTO orders VALUES
+        (1, 101, 2, 50),
+        (2, 102, 1, 75),
+        (3, 101, 3, 25),
+        (4, 103, 1, 50),
+        (5, 102, 2, 25),
+        (6, 101, 1, 75);
+
+    CREATE VIEW order_totals AS
+        SELECT
+            order_id,
+            customer_id,
+            quantity * price as total_amount
+        FROM orders;
+
+    CREATE VIEW customer_summary AS
+        SELECT
+            customer_id,
+            COUNT(*) as num_orders,
+            SUM(total_amount) as total_spent
+        FROM order_totals
+        GROUP BY customer_id;
+
+    SELECT
+        customer_id,
+        num_orders,
+        total_spent
+    FROM customer_summary
+    WHERE total_spent > 100
+    ORDER BY customer_id;
+} {101|3|250
+102|2|125}
+
+do_execsql_test_on_specific_db {:memory:} view-case-expression {
+    CREATE TABLE transactions(
+        id INTEGER,
+        account_id INTEGER,
+        type TEXT,
+        amount INTEGER
+    );
+
+    INSERT INTO transactions VALUES
+        (1, 1001, 'D', 1000),
+        (2, 1001, 'W', 200),
+        (3, 1002, 'D', 500),
+        (4, 1001, 'D', 300),
+        (5, 1002, 'W', 100),
+        (6, 1003, 'D', 750),
+        (7, 1002, 'D', 200),
+        (8, 1003, 'W', 250);
+
+    CREATE VIEW account_balance AS
+        SELECT
+            account_id,
+            SUM(CASE WHEN type = 'D' THEN amount ELSE -amount END) as balance,
+            COUNT(CASE WHEN type = 'D' THEN 1 END) as deposits,
+            COUNT(CASE WHEN type = 'W' THEN 1 END) as withdrawals
+        FROM transactions
+        GROUP BY account_id;
+
+    SELECT
+        account_id,
+        balance,
+        deposits + withdrawals as total_txns
+    FROM account_balance
+    WHERE balance > 500
+    ORDER BY account_id;
+} {1001|1100|3
+1002|600|3}
+
+do_execsql_test_on_specific_db {:memory:} view-drop-and-recreate {
+    CREATE TABLE data(x INTEGER, y INTEGER);
+    INSERT INTO data VALUES (1, 10), (2, 20), (3, 30);
+
+    CREATE VIEW simple AS SELECT x, y * 2 as doubled FROM data;
+    SELECT * FROM simple WHERE x > 1 ORDER BY x;
+} {2|40
+3|60}
+
+do_execsql_test_on_specific_db {:memory:} view-recreate-after-drop {
+    CREATE TABLE data(x INTEGER, y INTEGER);
+    INSERT INTO data VALUES (1, 10), (2, 20), (3, 30);
+
+    CREATE VIEW simple AS SELECT x, y * 2 as doubled FROM data;
+    DROP VIEW simple;
+
+    CREATE VIEW simple AS SELECT x + 1 as modified_x, y FROM data WHERE x > 1;
+    SELECT * FROM simple ORDER BY modified_x;
+} {3|20
+4|30}
+
+
+do_execsql_test_on_specific_db {:memory:} view-arithmetic-expression {
+    CREATE TABLE nums(a INTEGER, b INTEGER);
+    INSERT INTO nums VALUES (10, 5), (20, 8), (30, 12);
+
+    CREATE VIEW sums AS
+        SELECT SUM(a) as sum_a, SUM(b) as sum_b
+        FROM nums;
+
+    SELECT
+        sum_a,
+        sum_b,
+        sum_a + sum_b as total,
+        sum_a - sum_b as diff,
+        (sum_a * 100) / (sum_a + sum_b) as percentage_a
+    FROM sums;
+} {60|25|85|35|70}
+
+do_execsql_test_on_specific_db {:memory:} view-with-having {
+    CREATE TABLE product_sales(product TEXT, region TEXT, units INTEGER);
+    INSERT INTO product_sales VALUES
+        ('A', 'North', 100),
+        ('A', 'South', 150),
+        ('B', 'North', 80),
+        ('B', 'South', 60),
+        ('C', 'North', 200),
+        ('C', 'South', 180);
+
+    CREATE VIEW high_volume_products AS
+        SELECT product, SUM(units) as total_units
+        FROM product_sales
+        GROUP BY product
+        HAVING SUM(units) > 200;
+
+    SELECT * FROM high_volume_products ORDER BY total_units DESC;
+} {C|380
+A|250}


### PR DESCRIPTION
Now that we actually implemented the statement parsing around views, implementing normal SQLite views is relatively trivial, as they are just an alias to a query.

We'll implement them now to get them out of the way, and then I'll go back to DBSP