### PR TITLE
Use BufferPool owned by Database instead of a static global

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -326,7 +326,7 @@ pub enum Buffer {
 impl Debug for Buffer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Pooled(p) => write!(f, "{p:?}"),
+            Self::Pooled(p) => write!(f, "Pooled(len={})", p.logical_len()),
             Self::Heap(buf) => write!(f, "{buf:?}: {}", buf.len()),
         }
     }
@@ -362,7 +362,6 @@ impl Buffer {
     }
 
     pub fn new_pooled(buf: ArenaBuffer) -> Self {
-        tracing::trace!("new_pooled({:?})", buf);
         Self::Pooled(buf)
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3,7 +3,6 @@ use crate::function::AlterTableFunc;
 use crate::numeric::{NullableInteger, Numeric};
 use crate::schema::Table;
 use crate::storage::btree::{integrity_check, IntegrityCheckError, IntegrityCheckState};
-use crate::storage::buffer_pool::BUFFER_POOL;
 use crate::storage::database::DatabaseFile;
 use crate::storage::page_cache::DumbLruPageCache;
 use crate::storage::pager::{AtomicDbState, CreateBTreeFlags, DbState};
@@ -6779,7 +6778,7 @@ pub fn op_open_ephemeral(
                 .block(|| pager.with_header(|header| header.page_size))?
                 .get();
 
-            let buffer_pool = BUFFER_POOL.get().expect("Buffer pool not initialized");
+            let buffer_pool = program.connection._db.buffer_pool.clone();
             let page_cache = Arc::new(RwLock::new(DumbLruPageCache::default()));
 
             let pager = Rc::new(Pager::new(


### PR DESCRIPTION
## Problem

There are several problems with our current statically allocated `BufferPool`.

1. You cannot open two databases in the same process with different page sizes, because the `BufferPool`'s `Arena`s will be locked forever into the page size of the first database. This is the case regardless of whether the two `Database`s are open at the same time, or if the first is closed before the second is opened.

2. It is impossible to even write Rust tests for different page sizes because of this, assuming the test uses a single process.

## Solution

Make `Database` own `BufferPool` instead of it being statically allocated, so this problem goes away.

Note that I didn't touch the still statically-allocated `TEMP_BUFFER_CACHE`, because it should continue to work regardless of this change. It should only be a problem if the user has two or more databases with different page sizes open simultaneously, because `TEMP_BUFFER_CACHE` will only support one pool of a given page size at a time, so the rest of the allocations will go through the global allocator instead.

## Notes

I extracted this change out from #2569, because I didn't want it to be smuggled in without being reviewed as an individual piece.