### PR TITLE
sync-engine: avoid unnecessary WAL push

### DIFF
--- a/packages/turso-sync-engine/src/database_sync_engine.rs
+++ b/packages/turso-sync-engine/src/database_sync_engine.rs
@@ -221,6 +221,8 @@ impl<C: ProtocolIO> DatabaseSyncEngine<C> {
         transfer_logical_changes(coro, &self.draft_tape, &synced, client_id, false).await?;
 
         self.push_synced_to_remote(coro).await?;
+
+        self.reset_synced_if_dirty(coro).await?;
         Ok(())
     }
 
@@ -772,7 +774,7 @@ pub mod tests {
                 .await
                 .unwrap();
 
-            runner.pull().await.unwrap();
+            runner.sync().await.unwrap();
 
             // create connection in outer scope in order to prevent Database from being dropped in between of pull operations
             let conn = runner.connect().await.unwrap();
@@ -791,7 +793,7 @@ pub mod tests {
                 }
 
                 tracing::info!("pull attempt={}", attempt);
-                runner.pull().await.unwrap();
+                runner.sync().await.unwrap();
 
                 let expected = expected
                     .iter()

--- a/packages/turso-sync-engine/src/database_tape.rs
+++ b/packages/turso-sync-engine/src/database_tape.rs
@@ -167,12 +167,14 @@ impl DatabaseTape {
         opts: DatabaseReplaySessionOpts,
     ) -> Result<DatabaseReplaySession> {
         tracing::debug!("opening replay session");
+        let conn = self.connect(coro).await?;
+        conn.execute("BEGIN IMMEDIATE")?;
         Ok(DatabaseReplaySession {
-            conn: self.connect(coro).await?,
+            conn,
             cached_delete_stmt: HashMap::new(),
             cached_insert_stmt: HashMap::new(),
             cached_update_stmt: HashMap::new(),
-            in_txn: false,
+            in_txn: true,
             opts,
         })
     }
@@ -407,7 +409,7 @@ impl DatabaseChangesIterator {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DatabaseReplaySessionOpts {
     pub use_implicit_rowid: bool,
 }

--- a/packages/turso-sync-engine/src/test_sync_server.rs
+++ b/packages/turso-sync-engine/src/test_sync_server.rs
@@ -313,6 +313,7 @@ impl TestSyncServer {
     pub async fn execute(&self, sql: &str, params: impl turso::IntoParams) -> Result<()> {
         let conn = self.db.connect()?;
         conn.execute(sql, params).await?;
+        tracing::debug!("sync_frames_from_conn after execute");
         self.sync_frames_from_conn(&conn).await?;
         Ok(())
     }


### PR DESCRIPTION
This PR ignores changes from `TURSO_SYNC_TABLE_NAME` meta table in order to not generate unnecessary push commands when nothing actually changed on the client side.