### PR TITLE
Fix UPDATE: Do not use an index for iteration if that index is going to be updated

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -130,24 +130,32 @@ fn optimize_update_plan(plan: &mut UpdatePlan, schema: &Schema) -> Result<()> {
         &mut None,
     )?;
 
-    let table_ref = &mut plan.table_references.joined_tables_mut()[0];
     // It is not safe to use an index that is going to be updated as the iteration index for a table.
     // In these cases, we will fall back to a table scan.
     // FIXME: this should probably be incorporated into the optimizer itself, but it's a smaller fix this way.
-    if table_ref
-        .op
-        .index()
-        .is_some_and(|index| plan.indexes_to_update.iter().any(|i| Arc::ptr_eq(index, i)))
-    {
-        table_ref.op = Operation::Scan(Scan::BTreeTable {
-            iter_dir: IterationDirection::Forwards,
-            index: None,
-        });
-        // Revert the decision to use a WHERE clause term as an index constraint.
-        plan.where_clause
-            .iter_mut()
-            .for_each(|term| term.consumed = false);
+    let table_ref = &mut plan.table_references.joined_tables_mut()[0];
+
+    // No index, OK.
+    let Some(index) = table_ref.op.index() else {
+        return Ok(());
+    };
+    // Iteration index not affected by update, OK.
+    if !plan.indexes_to_update.iter().any(|i| Arc::ptr_eq(index, i)) {
+        return Ok(());
     }
+    // Fine to use index if we aren't going to be iterating over it, since it returns at most 1 row.
+    if table_ref.op.returns_max_1_row() {
+        return Ok(());
+    }
+    // Otherwise, fall back to a table scan.
+    table_ref.op = Operation::Scan(Scan::BTreeTable {
+        iter_dir: IterationDirection::Forwards,
+        index: None,
+    });
+    // Revert the decision to use a WHERE clause term as an index constraint.
+    plan.where_clause
+        .iter_mut()
+        .for_each(|term| term.consumed = false);
 
     Ok(())
 }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -762,6 +762,19 @@ impl Operation {
             Operation::Search(Search::Seek { index, .. }) => index.as_ref(),
         }
     }
+
+    pub fn returns_max_1_row(&self) -> bool {
+        match self {
+            Operation::Scan(_) => false,
+            Operation::Search(Search::RowidEq { .. }) => true,
+            Operation::Search(Search::Seek { index, seek_def }) => {
+                let Some(index) = index else {
+                    return false;
+                };
+                index.unique && seek_def.seek.as_ref().is_some_and(|seek| seek.op.eq_only())
+            }
+        }
+    }
 }
 
 impl JoinedTable {


### PR DESCRIPTION
Closes #2598

Forbids using an index as the iteration cursor for an `UPDATE` statement unless either of these is true:

1. The index is not affected by the `UPDATE` statement
2. The search condition on the index is guaranteed to return a maximum of 1 row, so no iteration will happen

### Note

I have created a follow-up issue about handling this a bit better: https://github.com/tursodatabase/turso/issues/2600