### PR TITLE
sim: reduce frequency of compound selects and complex joins

### DIFF
--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -26,9 +26,9 @@ impl Arbitrary for Create {
 impl ArbitraryFrom<&Vec<Table>> for FromClause {
     fn arbitrary_from<R: Rng>(rng: &mut R, tables: &Vec<Table>) -> Self {
         let num_joins = match rng.gen_range(0..=100) {
-            0..=80 => 0,
-            81..=95 => 1,
-            96..=100 => 2,
+            0..=90 => 0,
+            91..=97 => 1,
+            98..=100 => 2,
             _ => unreachable!(),
         };
 

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -184,9 +184,9 @@ impl ArbitraryFrom<&SimulatorEnv> for Select {
         // Otherwise, we just have a single select with no compounds
         let num_compound_selects = if env.opts.experimental_indexes {
             match rng.gen_range(0..=100) {
-                0..=90 => 0,
-                91..=97 => 1,
-                98..=100 => 2,
+                0..=95 => 0,
+                96..=99 => 1,
+                100 => 2,
                 _ => unreachable!(),
             }
         } else {


### PR DESCRIPTION
we spend a shitload of time doing very complex selects in the simulator, and i'm not sure there has been a lot of gain from them. using up a lot of the runtime of a simulator run on these can mask other issues.