### PR TITLE
fix/sim: fix incorrect implementation of compound SELECT generation

### DIFF
--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -177,8 +177,6 @@ impl ArbitraryFrom<&SimulatorEnv> for SelectFree {
 
 impl ArbitraryFrom<&SimulatorEnv> for Select {
     fn arbitrary_from<R: Rng>(rng: &mut R, env: &SimulatorEnv) -> Self {
-        let table = pick(&env.tables, rng);
-
         // Generate a number of selects based on the query size
         // If experimental indexes are enabled, we can have selects with compounds
         // Otherwise, we just have a single select with no compounds
@@ -196,11 +194,7 @@ impl ArbitraryFrom<&SimulatorEnv> for Select {
         let first = SelectInner::arbitrary_from(rng, env);
 
         let rest: Vec<SelectInner> = (0..num_compound_selects)
-            .map(|_| {
-                let mut select = first.clone();
-                select.where_clause = Predicate::arbitrary_from(rng, table);
-                select
-            })
+            .map(|_| SelectInner::arbitrary_from(rng, env))
             .collect();
 
         Self {


### PR DESCRIPTION
## Problem:

sim was generating compound selects like this:

- pick a random `table`
- create a random single SELECT
- create `n` random compound SELECTs (UNION ALL etc)

assign a WHERE clause to the compound selects that always has a condition based on `table`

```
SELECT a FROM foo where foo.a > 100 UNION ALL SELECT b FROM bar WHERE unrelated.c = 5
```

## Solution:

Don't base the WHERE clause on a table that might not be referenced in the query.

Again, the only reason this wasn't caught before was because `FaultyQuery` and `FsyncNoWait` are the only paths where this is actually tested with an assertion, and those are both disabled