### PR TITLE
core/printf: support for the %i operand

### DIFF
--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -28,7 +28,7 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
                 result.push('%');
                 continue;
             }
-            Some('d') => {
+            Some('d') | Some('i') => {
                 if args_index >= values.len() {
                     return Err(LimboError::InvalidArgument("not enough arguments".into()));
                 }
@@ -152,6 +152,7 @@ mod tests {
                 vec![text("Number: %d"), text("not a number")],
                 text("Number: 0"),
             ),
+            (vec![text("Number: %i"), integer(42)], text("Number: 42")),
         ];
         for (input, output) in test_cases {
             assert_eq!(exec_printf(&input).unwrap(), *output.get_owned_value())


### PR DESCRIPTION
This continues the work for `printf` support from from tthe issue https://github.com/tursodatabase/turso/issues/885.

This PR adds support for `%i` operands in the printf function. An example of a command that works now and didn't before:

```sql
SELECT PRINTF("Decimals: %d %i", 200, 300);
```

This is Just an initial very simple contribution to get my feet wet and learn the basics about the project and how contributions here work. I intend to do something more meaningful in next contributions. Probably will try to finish support for missing `printf` functionality also.