### PR TITLE
Fix two issues in simulator

### DIFF
--- a/simulator/generation/predicate/unary.rs
+++ b/simulator/generation/predicate/unary.rs
@@ -8,7 +8,7 @@ use crate::{
     generation::{backtrack, pick, predicate::SimplePredicate, ArbitraryFromMaybe},
     model::{
         query::predicate::Predicate,
-        table::{SimValue, Table},
+        table::{SimValue, TableContext},
     },
 };
 
@@ -99,10 +99,15 @@ impl ArbitraryFromMaybe<(&Vec<&SimValue>, bool)> for BitNotValue {
 
 // TODO: have some more complex generation with columns names here as well
 impl SimplePredicate {
-    /// Generates a true [ast::Expr::Unary] [SimplePredicate] from a [Table] for some values in the table
-    pub fn true_unary<R: rand::Rng>(rng: &mut R, table: &Table, row: &[SimValue]) -> Self {
+    /// Generates a true [ast::Expr::Unary] [SimplePredicate] from a [TableContext] for some values in the table
+    pub fn true_unary<R: rand::Rng, T: TableContext>(
+        rng: &mut R,
+        table: &T,
+        row: &[SimValue],
+    ) -> Self {
+        let columns = table.columns().collect::<Vec<_>>();
         // Pick a random column
-        let column_index = rng.gen_range(0..table.columns.len());
+        let column_index = rng.gen_range(0..columns.len());
         let column_value = &row[column_index];
         let num_retries = row.len();
         // Avoid creation of NULLs
@@ -160,10 +165,15 @@ impl SimplePredicate {
         ))
     }
 
-    /// Generates a false [ast::Expr::Unary] [SimplePredicate] from a [Table] for a row in the table
-    pub fn false_unary<R: rand::Rng>(rng: &mut R, table: &Table, row: &[SimValue]) -> Self {
+    /// Generates a false [ast::Expr::Unary] [SimplePredicate] from a [TableContext] for a row in the table
+    pub fn false_unary<R: rand::Rng, T: TableContext>(
+        rng: &mut R,
+        table: &T,
+        row: &[SimValue],
+    ) -> Self {
+        let columns = table.columns().collect::<Vec<_>>();
         // Pick a random column
-        let column_index = rng.gen_range(0..table.columns.len());
+        let column_index = rng.gen_range(0..columns.len());
         let column_value = &row[column_index];
         let num_retries = row.len();
         // Avoid creation of NULLs

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -1,12 +1,12 @@
 use crate::generation::{Arbitrary, ArbitraryFrom, ArbitrarySizedFrom, Shadow};
 use crate::model::query::predicate::Predicate;
 use crate::model::query::select::{
-    CompoundOperator, CompoundSelect, Distinctness, FromClause, JoinTable, JoinType, JoinedTable,
-    OrderBy, ResultColumn, SelectBody, SelectInner,
+    CompoundOperator, CompoundSelect, Distinctness, FromClause, OrderBy, ResultColumn, SelectBody,
+    SelectInner,
 };
 use crate::model::query::update::Update;
 use crate::model::query::{Create, Delete, Drop, Insert, Query, Select};
-use crate::model::table::{SimValue, Table};
+use crate::model::table::{JoinTable, JoinType, JoinedTable, SimValue, Table, TableContext};
 use crate::SimulatorEnv;
 use itertools::Itertools;
 use rand::Rng;
@@ -39,27 +39,32 @@ impl ArbitraryFrom<&Vec<Table>> for FromClause {
 
         let name = table.name.clone();
 
+        let mut table_context = JoinTable {
+            tables: Vec::new(),
+            rows: Vec::new(),
+        };
+
         let joins: Vec<_> = (0..num_joins)
             .filter_map(|_| {
                 if tables.is_empty() {
                     return None;
                 }
                 let join_table = pick(&tables, rng).clone();
+                let joined_table_name = join_table.name.clone();
+
                 tables.retain(|t| t.name != join_table.name);
-                table = JoinTable {
-                    tables: vec![table.clone(), join_table.clone()],
-                    rows: table
-                        .rows
-                        .iter()
-                        .cartesian_product(join_table.rows.iter())
-                        .map(|(t_row, j_row)| {
-                            let mut row = t_row.clone();
-                            row.extend(j_row.clone());
-                            row
-                        })
-                        .collect(),
-                }
-                .into_table();
+                table_context.rows = table_context
+                    .rows
+                    .iter()
+                    .cartesian_product(join_table.rows.iter())
+                    .map(|(t_row, j_row)| {
+                        let mut row = t_row.clone();
+                        row.extend(j_row.clone());
+                        row
+                    })
+                    .collect();
+                // TODO: inneficient. use a Deque to push_front?
+                table_context.tables.insert(0, join_table);
                 for row in &mut table.rows {
                     assert_eq!(
                         row.len(),
@@ -70,7 +75,7 @@ impl ArbitraryFrom<&Vec<Table>> for FromClause {
 
                 let predicate = Predicate::arbitrary_from(rng, &table);
                 Some(JoinedTable {
-                    table: join_table.name.clone(),
+                    table: joined_table_name,
                     join_type: JoinType::Inner,
                     on: predicate,
                 })
@@ -87,8 +92,8 @@ impl ArbitraryFrom<&SimulatorEnv> for SelectInner {
         // todo: this is a temporary hack because env is not separated from the tables
         let join_table = from
             .shadow(&mut tables)
-            .expect("Failed to shadow FromClause")
-            .into_table();
+            .expect("Failed to shadow FromClause");
+        let cuml_col_count = join_table.columns().count();
 
         let order_by = 'order_by: {
             if rng.gen_bool(0.3) {
@@ -98,7 +103,6 @@ impl ArbitraryFrom<&SimulatorEnv> for SelectInner {
                     .map(|j| j.table.clone())
                     .chain(std::iter::once(from.table.clone()))
                     .collect::<Vec<_>>();
-                let cuml_col_count = join_table.columns.len();
                 let order_by_col_count =
                     (rng.gen::<f64>() * rng.gen::<f64>() * (cuml_col_count as f64)) as usize; // skew towards 0
                 if order_by_col_count == 0 {


### PR DESCRIPTION
## 1. select equal number of columns per compound subselect in simulator

#2609 fixed compound selects incorrectly, introducing another bug: now the sim can SELECT a different number of columns per subselect, which is illegal. this PR forces the sim to select the same number of cols per subselect.

Depends on #2614 , otherwise the sim constantly fails whenever it decides to do a compound select with DISTINCT.

Closes #2611 

## 2. introduce TableContext for the simulator to properly generate predicates for Joins

The simulator has a construct called `JoinTable` which is really a `JoinContext` that includes all the columns from the so-far joined tables, so that the next table to be joined can refer to columns from any of those tables. @pedrocarlo 's commit fixes an issue where `JoinTable` would incorrectly generate predicates with empty table names. Related: #2618 