### PR TITLE
Add --keep-files flag to allow for inspection of files for successful simulator runs 

### DIFF
--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -717,6 +717,7 @@ fn reopen_database(env: &mut SimulatorEnv) {
             }
         }
         SimulationType::Default | SimulationType::Doublecheck => {
+            env.db = None;
             let db = match turso_core::Database::open_file(
                 env.io.clone(),
                 env.get_db_path().to_str().expect("path should be 'to_str'"),
@@ -734,11 +735,12 @@ fn reopen_database(env: &mut SimulatorEnv) {
                 }
             };
 
-            env.db = db;
+            env.db = Some(db);
 
             for _ in 0..num_conns {
-                env.connections
-                    .push(SimConnection::LimboConnection(env.db.connect().unwrap()));
+                env.connections.push(SimConnection::LimboConnection(
+                    env.db.as_ref().expect("db to be Some").connect().unwrap(),
+                ));
             }
         }
     };

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -136,7 +136,7 @@ fn testing_main(cli_opts: &SimulatorCLI) -> anyhow::Result<()> {
     println!("seed: {seed}");
     println!("path: {}", paths.base.display());
 
-    if result.is_ok() {
+    if !cli_opts.keep_files && result.is_ok() {
         paths.delete_all_files();
     }
 

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -129,6 +129,12 @@ pub struct SimulatorCLI {
     pub experimental_mvcc: bool,
     #[clap(long, help = "Disable experimental indexing feature")]
     pub disable_experimental_indexes: bool,
+    #[clap(
+        long,
+        help = "Keep all database and plan files",
+        default_value_t = false
+    )]
+    pub keep_files: bool,
 }
 
 #[derive(Parser, Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -123,8 +123,9 @@ fn execute_plan(
 
     if let SimConnection::Disconnected = connection {
         tracing::debug!("connecting {}", connection_index);
-        env.connections[connection_index] =
-            SimConnection::LimboConnection(env.db.connect().unwrap());
+        env.connections[connection_index] = SimConnection::LimboConnection(
+            env.db.as_ref().expect("db to be Some").connect().unwrap(),
+        );
     } else {
         tracing::debug!("connection {} already connected", connection_index);
         match execute_interaction(env, connection_index, interaction, &mut state.stack) {

--- a/simulator/runner/watch.rs
+++ b/simulator/runner/watch.rs
@@ -98,8 +98,9 @@ fn execute_plan(
 
     if let SimConnection::Disconnected = connection {
         tracing::debug!("connecting {}", connection_index);
-        env.connections[connection_index] =
-            SimConnection::LimboConnection(env.db.connect().unwrap());
+        env.connections[connection_index] = SimConnection::LimboConnection(
+            env.db.as_ref().expect("db to be Some").connect().unwrap(),
+        );
     } else {
         match execute_interaction(env, connection_index, interaction, &mut state.stack) {
             Ok(next_execution) => {


### PR DESCRIPTION
Also fixes an issue where since the old Database wasn't `Drop`d, it caused an issue with the static Registry :tm: that had broken `--doublecheck` mode. 