### PR TITLE
Fail simulator on parse errors

### DIFF
--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -451,6 +451,9 @@ impl Interaction {
                     &query_str[0..query_str.len().min(4096)],
                     err
                 );
+                if let Some(turso_core::LimboError::ParseError(e)) = err {
+                    panic!("Unexpected parse error: {e}");
+                }
                 return Err(err.unwrap());
             }
             let rows = rows?;

--- a/simulator/generation/query.rs
+++ b/simulator/generation/query.rs
@@ -237,11 +237,19 @@ impl ArbitraryFrom<&SimulatorEnv> for Select {
 
         let num_result_columns = rng.gen_range(1..=min_column_count_across_tables);
 
-        let first = SelectInner::arbitrary_sized_from(rng, env, num_result_columns);
+        let mut first = SelectInner::arbitrary_sized_from(rng, env, num_result_columns);
 
-        let rest: Vec<SelectInner> = (0..num_compound_selects)
+        let mut rest: Vec<SelectInner> = (0..num_compound_selects)
             .map(|_| SelectInner::arbitrary_sized_from(rng, env, num_result_columns))
             .collect();
+
+        if !rest.is_empty() {
+            // ORDER BY is not supported in compound selects yet
+            first.order_by = None;
+            for s in &mut rest {
+                s.order_by = None;
+            }
+        }
 
         Self {
             body: SelectBody {


### PR DESCRIPTION
Closes #2618 (sufficiently for now, IMO)

Prevents simulator from creating malformed queries which we don't notice (ref e.g. #2609 , #2611, #2616)