### PR TITLE
fix pragma table_info for views

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -451,6 +451,10 @@ fn query_pragma(
                 } else if let Some(view_mutex) = schema.get_materialized_view(&name) {
                     let view = view_mutex.lock().unwrap();
                     emit_columns_for_table_info(&mut program, &view.columns, base_reg);
+                } else if let Some(view) = schema.get_view(&name) {
+                    if let Some(ref columns) = view.columns {
+                        emit_columns_for_table_info(&mut program, columns, base_reg);
+                    }
                 }
             }
             let col_names = ["cid", "name", "type", "notnull", "dflt_value", "pk"];

--- a/core/util.rs
+++ b/core/util.rs
@@ -216,20 +216,30 @@ pub fn parse_schema_rows(
                                 }
                                 Stmt::CreateView {
                                     view_name: _,
-                                    columns,
+                                    columns: column_names,
                                     select,
                                     ..
                                 } => {
+                                    // Extract actual columns from the SELECT statement
+                                    let view_columns = extract_view_columns(&select, schema);
+
+                                    // If column names were provided in CREATE VIEW (col1, col2, ...),
+                                    // use them to rename the columns
+                                    let mut final_columns = view_columns;
+                                    if let Some(ref names) = column_names {
+                                        for (i, indexed_col) in names.iter().enumerate() {
+                                            if let Some(col) = final_columns.get_mut(i) {
+                                                col.name = Some(indexed_col.col_name.to_string());
+                                            }
+                                        }
+                                    }
+
                                     // Create regular view
                                     let view = View {
                                         name: name.to_string(),
                                         sql: sql.to_string(),
                                         select_stmt: *select,
-                                        columns: columns.map(|cols| {
-                                            cols.into_iter()
-                                                .map(|c| c.col_name.to_string())
-                                                .collect()
-                                        }),
+                                        columns: Some(final_columns),
                                     };
                                     schema.add_view(view);
                                 }


### PR DESCRIPTION
We were not generating table_info for views. This PR fixes it.  We were so far storing columns as strings with just their names - since this is all we needed - but we will move now to store Columns. We need to convert the names to Column anyway for table_info to work.