### PR TITLE
Update stale in memory wal header after restarting log

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1698,7 +1698,12 @@ impl WalFile {
             }
         }
 
-        self.last_checksum = self.get_shared().last_checksum;
+        let (header, cksm) = {
+            let shared = self.get_shared();
+            (*shared.wal_header.lock(), shared.last_checksum)
+        };
+        self.last_checksum = cksm;
+        self.header = header;
         self.max_frame = 0;
         self.min_frame = 0;
         Ok(())


### PR DESCRIPTION
Currently during `Restart|Truncate` modes we properly restart the WAL header in the `WalFileShared`, but keep a stale one on the current `WalFile` instance.