### PR TITLE
unify halts

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1911,9 +1911,16 @@ pub fn halt(
             )));
         }
     }
-    program
-        .commit_txn(pager.clone(), state, mv_store, false)
-        .map(Into::into)
+
+    let auto_commit = program.connection.auto_commit.get();
+    tracing::trace!("halt(auto_commit={})", auto_commit);
+    if auto_commit {
+        program
+            .commit_txn(pager.clone(), state, mv_store, false)
+            .map(Into::into)
+    } else {
+        Ok(InsnFunctionStepResult::Done)
+    }
 }
 
 pub fn op_halt(
@@ -1930,37 +1937,7 @@ pub fn op_halt(
         },
         insn
     );
-    if *err_code > 0 {
-        // invalidate page cache in case of error
-        pager.clear_page_cache();
-    }
-    match *err_code {
-        0 => {}
-        SQLITE_CONSTRAINT_PRIMARYKEY => {
-            return Err(LimboError::Constraint(format!(
-                "UNIQUE constraint failed: {description} (19)"
-            )));
-        }
-        SQLITE_CONSTRAINT_NOTNULL => {
-            return Err(LimboError::Constraint(format!(
-                "NOTNULL constraint failed: {description} (19)"
-            )));
-        }
-        _ => {
-            return Err(LimboError::Constraint(format!(
-                "undocumented halt error code {description}"
-            )));
-        }
-    }
-    let auto_commit = program.connection.auto_commit.get();
-    tracing::trace!("op_halt(auto_commit={})", auto_commit);
-    if auto_commit {
-        program
-            .commit_txn(pager.clone(), state, mv_store, false)
-            .map(Into::into)
-    } else {
-        Ok(InsnFunctionStepResult::Done)
-    }
+    halt(program, state, pager, mv_store, *err_code, description)
 }
 
 pub fn op_halt_if_null(


### PR DESCRIPTION
We have halt and op_halt, doing essentially the same thing.

This PR unifies them. There is a minor difference between them now in the way halt() handles auto-commit. My current understanding of the code is that what we have in halt *is a bug*, which is already one bad consequence of the duplication.