### PR TITLE
emit SetCookie when creating a view

### DIFF
--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -48,17 +48,18 @@ fn emit_create_view_program(
         where_clause: Some(format!("name = '{normalized_view_name}'")),
     });
 
-    // Populate materialized views if needed
-    if populate_materialized {
-        program.emit_insn(Insn::PopulateMaterializedViews);
-    }
-
     program.emit_insn(Insn::SetCookie {
         db: 0,
         cookie: Cookie::SchemaVersion,
         value: (schema.schema_version + 1) as i32,
         p5: 0,
     });
+
+    // Populate materialized views if needed
+    // Note: This must come after SetCookie since it may do I/O operations
+    if populate_materialized {
+        program.emit_insn(Insn::PopulateMaterializedViews);
+    }
 
     Ok(())
 }

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -53,6 +53,13 @@ fn emit_create_view_program(
         program.emit_insn(Insn::PopulateMaterializedViews);
     }
 
+    program.emit_insn(Insn::SetCookie {
+        db: 0,
+        cookie: Cookie::SchemaVersion,
+        value: (schema.schema_version + 1) as i32,
+        p5: 0,
+    });
+
     Ok(())
 }
 


### PR DESCRIPTION
SetCookie is necessary to invalidate prepared statements in the connection after DDL expressions.