### PR TITLE
fix/sim: prevent sim from trying to create an existing table or index

### DIFF
--- a/simulator/generation/table.rs
+++ b/simulator/generation/table.rs
@@ -42,6 +42,7 @@ impl Arbitrary for Table {
             rows: Vec::new(),
             name,
             columns,
+            indexes: vec![],
         }
     }
 }

--- a/simulator/model/query/create_index.rs
+++ b/simulator/model/query/create_index.rs
@@ -30,9 +30,13 @@ pub(crate) struct CreateIndex {
 
 impl Shadow for CreateIndex {
     type Result = Vec<Vec<SimValue>>;
-    fn shadow(&self, _env: &mut SimulatorTables) -> Vec<Vec<SimValue>> {
-        // CREATE INDEX doesn't require any shadowing; we don't need to keep track
-        // in the simulator what indexes exist.
+    fn shadow(&self, env: &mut SimulatorTables) -> Vec<Vec<SimValue>> {
+        env.tables
+            .iter_mut()
+            .find(|t| t.name == self.table_name)
+            .unwrap()
+            .indexes
+            .push(self.index_name.clone());
         vec![]
     }
 }

--- a/simulator/model/table.rs
+++ b/simulator/model/table.rs
@@ -45,6 +45,7 @@ pub(crate) struct Table {
     pub(crate) name: String,
     pub(crate) columns: Vec<Column>,
     pub(crate) rows: Vec<Vec<SimValue>>,
+    pub(crate) indexes: Vec<String>,
 }
 
 impl Table {
@@ -53,6 +54,7 @@ impl Table {
             rows,
             name: "".to_string(),
             columns: vec![],
+            indexes: vec![],
         }
     }
 }


### PR DESCRIPTION
We recently merged a change that panics the sim on parse errors, because not doing so has masked many scenarios where the sim unintentionally creates incorrect sql and we just ignore it.

The aforementioned change also surfaced that the sim can try to create a table that already exists, which now makes us panic and fail the sim. So in this PR, we make sure that doesn't happen.

We already have Property::DoubleCreateFailure to assert that the same table cannot be created twice, so this should not hide any bugs.