### PR TITLE
flake.nix: add uv dependency to nativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
             python3
             nodejs
             toolchain
+            uv
           ] ++ lib.optionals pkgs.stdenv.isDarwin [
             apple-sdk
           ];


### PR DESCRIPTION
`make test` fails when using the nix-shell environment due to `uv` not being included in the list of dependencies with

`make: uv: No such file or directory
make: *** [Makefile:55: uv-sync-test] Error 127`

simple fix adding it to `nativeBuildInputs` of the shell. after that runs as expected.