### PR TITLE
Do not begin or end transactions in nested statement

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -962,6 +962,10 @@ impl Pager {
         connection: &Connection,
         wal_auto_checkpoint_disabled: bool,
     ) -> Result<IOResult<PagerCommitResult>> {
+        if connection.is_nested_stmt.get() {
+            // Parent statement will handle the transaction rollback.
+            return Ok(IOResult::Done(PagerCommitResult::Rollback));
+        }
         tracing::trace!("end_tx(rollback={})", rollback);
         let Some(wal) = self.wal.as_ref() else {
             // TODO: Unsure what the semantics of "end_tx" is for in-memory databases, ephemeral tables and ephemeral indexes.

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -645,6 +645,9 @@ impl Interaction {
                     &query_str[0..query_str.len().min(4096)],
                     err
                 );
+                if let Some(turso_core::LimboError::ParseError(e)) = err {
+                    panic!("Unexpected parse error: {e}");
+                }
                 return Err(err.unwrap());
             }
             let mut rows = rows.unwrap().unwrap();

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -16,7 +16,6 @@ use crate::{
             Create, Delete, Drop, Insert, Query, Select,
         },
         table::SimValue,
-        FAULT_ERROR_MSG,
     },
     runner::env::SimulatorEnv,
 };
@@ -752,12 +751,10 @@ impl Property {
                                 Ok(Ok(()))
                             }
                             Err(err) => {
-                                let msg = format!("{err}");
-                                if msg.contains(FAULT_ERROR_MSG) {
-                                    Ok(Ok(()))
-                                } else {
-                                    Err(LimboError::InternalError(msg))
-                                }
+                                // We cannot make any assumptions about the error content; all we are about is, if the statement errored,
+                                // we don't shadow the results into the simulator env, i.e. we assume whatever the statement did was rolled back.
+                                tracing::error!("Fault injection produced error: {err}");
+                                Ok(Ok(()))
                             }
                         }
                     }),


### PR DESCRIPTION
Closes #2657 
Closes #2659 
Closes #2660 
Closes #2661

1. In simulator, do not assume every error that happens after fault injection has the literal error message `"Injected fault"`. If an error happened, all we need to do is not shadow the query into the in-memory simulator environment -- in other words, we assume whatever the statement did failed and was rolled back.

2. Do not begin or end transactions inside a nested statement. Nested statements generally only occur when `ParseSchema` is invoked, which runs the equivalent of `SELECT * FROM sqlite_schema`. This does not need a new transaction nor does it need to end the transaction on error, since the parent statement will handle it.