### PR TITLE
bindings/rust: Add `Connection::last_insert_rowid()` method

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -318,6 +318,12 @@ impl Connection {
         Ok(())
     }
 
+    /// Returns the rowid of the last row inserted.
+    pub fn last_insert_rowid(&self) -> i64 {
+        let conn = self.inner.lock().unwrap();
+        conn.last_insert_rowid()
+    }
+
     /// Flush dirty pages to disk.
     /// This will write the dirty pages to the WAL.
     pub fn cacheflush(&self) -> Result<()> {

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -12,27 +12,32 @@ async fn test_rows_next() {
     conn.execute("INSERT INTO test (x) VALUES (1)", ())
         .await
         .unwrap();
+    assert_eq!(conn.last_insert_rowid(), 1);
     conn.execute("INSERT INTO test (x) VALUES (2)", ())
         .await
         .unwrap();
+    assert_eq!(conn.last_insert_rowid(), 2);
     conn.execute(
         "INSERT INTO test (x) VALUES (:x)",
         vec![(":x".to_string(), Value::Integer(3))],
     )
     .await
     .unwrap();
+    assert_eq!(conn.last_insert_rowid(), 3);
     conn.execute(
         "INSERT INTO test (x) VALUES (@x)",
         vec![("@x".to_string(), Value::Integer(4))],
     )
     .await
     .unwrap();
+    assert_eq!(conn.last_insert_rowid(), 4);
     conn.execute(
         "INSERT INTO test (x) VALUES ($x)",
         vec![("$x".to_string(), Value::Integer(5))],
     )
     .await
     .unwrap();
+    assert_eq!(conn.last_insert_rowid(), 5);
     let mut res = conn.query("SELECT * FROM test", ()).await.unwrap();
     assert_eq!(
         res.next().await.unwrap().unwrap().get_value(0).unwrap(),


### PR DESCRIPTION
Fixes #2670