### PR TITLE
core(datetime): added implementation of ceiling modifier to datetime

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -343,7 +343,7 @@ Modifiers:
 | TimeOffset     | Yes	 |                                 |
 | DateOffset	 | Yes   |                                 |
 | DateTimeOffset | Yes   |                                 |
-| Ceiling	     | No    |                                 |
+| Ceiling	     | Yes   |                                 |
 | Floor          | No    |                                 |
 | StartOfMonth	 | Yes	 |                                 |
 | StartOfYear	 | Yes	 |                                 |

--- a/testing/scalar-functions-datetime.test
+++ b/testing/scalar-functions-datetime.test
@@ -371,6 +371,26 @@ do_execsql_test datetime-with-multiple-modifiers {
 select datetime('2024-01-31', '+1 month', '+13 hours', '+5 minutes', '+62 seconds');
 } {{2024-03-02 13:06:02}}
 
+do_execsql_test datetime-with-modifier-ceiling {
+  SELECT datetime('2023-05-18 15:30:45', 'ceiling');
+} {{2023-05-18 15:30:45}}
+
+do_execsql_test datetime-with-modifier-ceiling-already-ceiled {
+  SELECT datetime('2023-05-18 23:59:59', 'ceiling');
+} {{2023-05-18 23:59:59}}
+
+do_execsql_test datetime-with-ceiling-modifier-invalid-input {
+  SELECT datetime('not-a-date', 'ceiling');
+} {{}}
+
+do_execsql_test datetime-with-ceiling-modifier-stacked {
+  SELECT datetime('2023-05-18 15:30:45', '+1 day', 'ceiling');
+} {{2023-05-19 15:30:45}}
+
+do_execsql_test date-with-ceiling-modifier-basic {
+  SELECT date('2023-05-18 15:30:45', 'ceiling');
+} {2023-05-18}
+
 do_execsql_test datetime-with-weekday {
   SELECT datetime('2023-05-18', 'weekday 3');
 } {{2023-05-24 00:00:00}}


### PR DESCRIPTION
#2677 

- Implements the modifier for Ceiling on the datetime object.
- Includes additional testing changes in testing/scalar-functions-datetime.test to test the sql functionality.