### PR TITLE
Fix page locked panic

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2048,6 +2048,9 @@ impl Statement {
             return res;
         }
         if res.is_err() {
+            if let Some(io) = &self.state.io_completions {
+                io.abort();
+            }
             let state = self.program.connection.transaction_state.get();
             if let TransactionState::Write { .. } = state {
                 let end_tx_res = self.pager.end_tx(true, &self.program.connection, true)?;

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -876,6 +876,7 @@ pub fn begin_read_page(
     let buf = Arc::new(buf);
     let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
         let Ok((mut buf, bytes_read)) = res else {
+            page.clear_locked();
             return;
         };
         let buf_len = buf.len();

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -915,6 +915,7 @@ impl Wal for WalFile {
         let frame = page.clone();
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
+                page.clear_locked();
                 return;
             };
             let buf_len = buf.len();

--- a/core/types.rs
+++ b/core/types.rs
@@ -2494,6 +2494,14 @@ impl IOCompletions {
             IOCompletions::Many(completions) => completions.iter().all(|c| c.finished()),
         }
     }
+
+    /// Send abort signal to completions
+    pub fn abort(&self) {
+        match self {
+            IOCompletions::Single(c) => c.abort(),
+            IOCompletions::Many(completions) => completions.iter().for_each(|c| c.abort()),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/core/types.rs
+++ b/core/types.rs
@@ -2488,10 +2488,10 @@ impl IOCompletions {
         }
     }
 
-    pub fn completed(&self) -> bool {
+    pub fn finished(&self) -> bool {
         match self {
-            IOCompletions::Single(c) => c.is_completed(),
-            IOCompletions::Many(completions) => completions.iter().all(|c| c.is_completed()),
+            IOCompletions::Single(c) => c.finished(),
+            IOCompletions::Many(completions) => completions.iter().all(|c| c.finished()),
         }
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -442,7 +442,7 @@ impl Program {
                 return Ok(StepResult::Interrupt);
             }
             if let Some(io) = &state.io_completions {
-                if !io.completed() {
+                if !io.finished() {
                     return Ok(StepResult::IO);
                 }
                 state.io_completions = None;


### PR DESCRIPTION
Clear locked pages when read completions callback fail. Also, we need to abort I/O Completions in `stmt.run_once()` so that we do not raise errors in `rollback` when clearing the page cache.

Fixes #2658
Fixes #2675
Fixes #2680
Fixes #2682