### PR TITLE
Wal checkpoint upper bound

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1439,8 +1439,12 @@ impl Pager {
             trace!(?state);
             match state {
                 CheckpointState::Checkpoint => {
-                    let res =
-                        return_if_io!(wal.borrow_mut().checkpoint(self, CheckpointMode::Passive));
+                    let res = return_if_io!(wal.borrow_mut().checkpoint(
+                        self,
+                        CheckpointMode::Passive {
+                            upper_bound_inclusive: None
+                        }
+                    ));
                     self.checkpoint_state
                         .replace(CheckpointState::SyncDbFile { res });
                 }
@@ -1487,7 +1491,9 @@ impl Pager {
             self.io.wait_for_completion(c)?;
         }
         if !wal_auto_checkpoint_disabled {
-            self.wal_checkpoint(CheckpointMode::Passive)?;
+            self.wal_checkpoint(CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            })?;
         }
         Ok(())
     }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -402,7 +402,9 @@ fn query_pragma(
                         LimboError::ParseError(format!("Unknown Checkpoint Mode: {e}"))
                     })?
                 }
-                _ => CheckpointMode::Passive,
+                _ => CheckpointMode::Passive {
+                    upper_bound_inclusive: None,
+                },
             };
 
             program.alloc_registers(2);

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -1345,9 +1345,13 @@ pub unsafe extern "C" fn sqlite3_wal_checkpoint_v2(
     let db: &mut sqlite3 = &mut *db;
     let db = db.inner.lock().unwrap();
     let chkptmode = match mode {
-        SQLITE_CHECKPOINT_PASSIVE => CheckpointMode::Passive,
+        SQLITE_CHECKPOINT_PASSIVE => CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
         SQLITE_CHECKPOINT_RESTART => CheckpointMode::Restart,
-        SQLITE_CHECKPOINT_TRUNCATE => CheckpointMode::Truncate,
+        SQLITE_CHECKPOINT_TRUNCATE => CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
         SQLITE_CHECKPOINT_FULL => CheckpointMode::Full,
         _ => return SQLITE_MISUSE, // Unsupported mode
     };

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use rusqlite::types::Value;
-use turso_core::types::WalFrameInfo;
+use turso_core::{types::WalFrameInfo, CheckpointMode, LimboError, StepResult};
 
 use crate::common::{limbo_exec_rows, rng_from_time, TempDatabase};
 
@@ -457,4 +457,84 @@ fn test_wal_api_revert_pages() {
         limbo_exec_rows(&db1, &conn1, "SELECT x, length(y) FROM t"),
         vec![] as Vec<Vec<Value>>,
     );
+}
+
+#[test]
+fn test_wal_upper_bound_passive() {
+    let db = TempDatabase::new_empty(false);
+    let writer = db.connect_limbo();
+
+    writer
+        .execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    let watermark0 = writer.wal_frame_count().unwrap();
+    writer
+        .execute("insert into test values (1, 'hello')")
+        .unwrap();
+    let watermark1 = writer.wal_frame_count().unwrap();
+    writer
+        .execute("insert into test values (2, 'turso')")
+        .unwrap();
+    let watermark2 = writer.wal_frame_count().unwrap();
+    let expected = vec![
+        vec![
+            turso_core::types::Value::Integer(1),
+            turso_core::types::Value::Text(turso_core::types::Text::new("hello")),
+        ],
+        vec![
+            turso_core::types::Value::Integer(2),
+            turso_core::types::Value::Text(turso_core::types::Text::new("turso")),
+        ],
+    ];
+
+    for (prefix, watermark) in [(0, watermark0), (1, watermark1), (2, watermark2)] {
+        let mode = CheckpointMode::Passive {
+            upper_bound_inclusive: Some(watermark),
+        };
+        writer.checkpoint(mode).unwrap();
+
+        let db_path_copy = format!("{}-{}-copy", db.path.to_str().unwrap(), watermark);
+        std::fs::copy(&db.path, db_path_copy.clone()).unwrap();
+        let db_copy = TempDatabase::new_with_existent(&PathBuf::from(db_path_copy), false);
+        let conn = db_copy.connect_limbo();
+        let mut stmt = conn.prepare("select * from test").unwrap();
+        let mut rows: Vec<Vec<turso_core::types::Value>> = Vec::new();
+        loop {
+            let result = stmt.step();
+            match result {
+                Ok(StepResult::Row) => {
+                    rows.push(stmt.row().unwrap().get_values().cloned().collect())
+                }
+                Ok(StepResult::IO) => db_copy.io.run_once().unwrap(),
+                Ok(StepResult::Done) => break,
+                result => panic!("unexpected step result: {result:?}"),
+            }
+        }
+        assert_eq!(rows, expected[0..prefix]);
+    }
+}
+
+#[test]
+fn test_wal_upper_bound_truncate() {
+    let db = TempDatabase::new_empty(false);
+    let writer = db.connect_limbo();
+
+    writer
+        .execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    writer
+        .execute("insert into test values (1, 'hello')")
+        .unwrap();
+    let watermark = writer.wal_frame_count().unwrap();
+    writer
+        .execute("insert into test values (2, 'turso')")
+        .unwrap();
+
+    let mode = CheckpointMode::Truncate {
+        upper_bound_inclusive: Some(watermark),
+    };
+    assert!(matches!(
+        writer.checkpoint(mode).err().unwrap(),
+        LimboError::Busy
+    ));
 }

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -476,7 +476,7 @@ fn test_wal_upper_bound_passive() {
         .execute("insert into test values (2, 'turso')")
         .unwrap();
     let watermark2 = writer.wal_frame_count().unwrap();
-    let expected = vec![
+    let expected = [
         vec![
             turso_core::types::Value::Integer(1),
             turso_core::types::Value::Text(turso_core::types::Text::new("hello")),

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -287,7 +287,9 @@ fn test_wal_checkpoint() -> anyhow::Result<()> {
     for i in 0..iterations {
         let insert_query = format!("INSERT INTO test VALUES ({i})");
         do_flush(&conn, &tmp_db)?;
-        conn.checkpoint(CheckpointMode::Passive)?;
+        conn.checkpoint(CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        })?;
         run_query(&tmp_db, &conn, &insert_query)?;
     }
 


### PR DESCRIPTION
This PR introduces optional upper_bound for PASSIVE and TRUNCATE checkpoint modes

This is needed for sync engine where we need to have control over WAL:
1. TRUNCATE with upper_bound used as a way to checkpoint WAL only if there were no frames written since sync-engine read max_frame_no
2. PASSIVE with upper_bound used to checkpoint only certain prefix of the WAL