### PR TITLE
Remove hardcoded flag usage in DBHeader for encryption

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -28,7 +28,7 @@ use super::btree::{btree_init_page, BTreePage};
 use super::page_cache::{CacheError, CacheResizeResult, DumbLruPageCache, PageCacheKey};
 use super::sqlite3_ondisk::begin_write_btree_page;
 use super::wal::CheckpointMode;
-use crate::storage::encryption::EncryptionKey;
+use crate::storage::encryption::{EncryptionKey, ENCRYPTION_METADATA_SIZE};
 
 /// SQLite's default maximum page count
 const DEFAULT_MAX_PAGE_COUNT: u32 = 0xfffffffe;
@@ -1683,6 +1683,11 @@ impl Pager {
 
                 assert_eq!(default_header.database_size.get(), 0);
                 default_header.database_size = 1.into();
+
+                // if a key is set, then we will reserve space for encryption metadata
+                if self.encryption_key.borrow().is_some() {
+                    default_header.reserved_space = ENCRYPTION_METADATA_SIZE as u8;
+                }
 
                 if let Some(size) = self.page_size.get() {
                     default_header.page_size = size;

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -308,9 +308,6 @@ impl Default for DatabaseHeader {
             page_size: Default::default(),
             write_version: Version::Wal,
             read_version: Version::Wal,
-            #[cfg(feature = "encryption")]
-            reserved_space: 28,
-            #[cfg(not(feature = "encryption"))]
             reserved_space: 0,
             max_embed_frac: 64,
             min_embed_frac: 32,


### PR DESCRIPTION
Previously, we just hardcoded the reserved space with encryption flag. This patch removes that and sets the reserved space if a key was specified during a creation of db