### PR TITLE
Wal api checkpoint seq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,7 @@ version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "ctor 0.5.0",
  "env_logger 0.10.2",
  "log",
  "rand 0.9.2",
@@ -817,8 +818,18 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4735f265ba6a1188052ca32d461028a7d1125868be18e287e756019da7607b5"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "ctor-proc-macro 0.0.5",
+ "dtor 0.0.6",
+]
+
+[[package]]
+name = "ctor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+dependencies = [
+ "ctor-proc-macro 0.0.6",
+ "dtor 0.1.0",
 ]
 
 [[package]]
@@ -826,6 +837,12 @@ name = "ctor-proc-macro"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "ctr"
@@ -1016,7 +1033,16 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
 dependencies = [
- "dtor-proc-macro",
+ "dtor-proc-macro 0.0.5",
+]
+
+[[package]]
+name = "dtor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
+dependencies = [
+ "dtor-proc-macro 0.0.6",
 ]
 
 [[package]]
@@ -1024,6 +1050,12 @@ name = "dtor-proc-macro"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dyn-clone"
@@ -2308,7 +2340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96671d5c84cee3ae4cab96386b9f953b22569ece9677b9fdd1492550a165eca5"
 dependencies = [
  "bitflags 2.9.0",
- "ctor",
+ "ctor 0.4.2",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
@@ -2328,7 +2360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e61844e0c0bb81e711f2084abe7cff187b03ca21ff8b000cb59bbda61e15a9"
 dependencies = [
  "convert_case",
- "ctor",
+ "ctor 0.4.2",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -4126,7 +4158,7 @@ version = "0.1.4"
 dependencies = [
  "base64",
  "bytes",
- "ctor",
+ "ctor 0.4.2",
  "futures",
  "genawaiter",
  "http",

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -191,8 +191,9 @@ impl Connection {
             .inner
             .lock()
             .map_err(|e| Error::MutexError(e.to_string()))?;
-        conn.wal_frame_count()
+        conn.wal_state()
             .map_err(|e| Error::WalOperationError(format!("wal_insert_begin failed: {e}")))
+            .map(|state| state.max_frame)
     }
 
     #[cfg(feature = "conn_raw_api")]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -44,7 +44,7 @@ use crate::incremental::view::ViewTransactionState;
 use crate::translate::optimizer::optimize_plan;
 use crate::translate::pragma::TURSO_CDC_DEFAULT_TABLE_NAME;
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
-use crate::types::WalFrameInfo;
+use crate::types::{WalFrameInfo, WalState};
 #[cfg(feature = "fs")]
 use crate::util::{OpenMode, OpenOptions};
 use crate::vdbe::metrics::ConnectionMetrics;
@@ -1340,8 +1340,8 @@ impl Connection {
     }
 
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
-    pub fn wal_frame_count(&self) -> Result<u64> {
-        self.pager.borrow().wal_frame_count()
+    pub fn wal_state(&self) -> Result<WalState> {
+        self.pager.borrow().wal_state()
     }
 
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -8,7 +8,7 @@ use crate::storage::{
     },
     wal::{CheckpointResult, Wal},
 };
-use crate::types::IOCompletions;
+use crate::types::{IOCompletions, WalState};
 use crate::util::IOExt as _;
 use crate::{io_yield_many, io_yield_one};
 use crate::{
@@ -1202,13 +1202,16 @@ impl Pager {
         page.set_dirty();
     }
 
-    pub fn wal_frame_count(&self) -> Result<u64> {
+    pub fn wal_state(&self) -> Result<WalState> {
         let Some(wal) = self.wal.as_ref() else {
             return Err(LimboError::InternalError(
-                "wal_frame_count() called on database without WAL".to_string(),
+                "wal_state() called on database without WAL".to_string(),
             ));
         };
-        Ok(wal.borrow().get_max_frame())
+        Ok(WalState {
+            checkpoint_seq_no: wal.borrow().get_checkpoint_seq(),
+            max_frame: wal.borrow().get_max_frame(),
+        })
     }
 
     /// Flush all dirty pages to disk.

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1439,8 +1439,12 @@ impl Pager {
             trace!(?state);
             match state {
                 CheckpointState::Checkpoint => {
-                    let res =
-                        return_if_io!(wal.borrow_mut().checkpoint(self, CheckpointMode::Passive));
+                    let res = return_if_io!(wal.borrow_mut().checkpoint(
+                        self,
+                        CheckpointMode::Passive {
+                            upper_bound_inclusive: None
+                        }
+                    ));
                     self.checkpoint_state
                         .replace(CheckpointState::SyncDbFile { res });
                 }
@@ -1487,7 +1491,9 @@ impl Pager {
             self.io.wait_for_completion(c)?;
         }
         if !wal_auto_checkpoint_disabled {
-            self.wal_checkpoint(CheckpointMode::Passive)?;
+            self.wal_checkpoint(CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            })?;
         }
         Ok(())
     }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1552,21 +1552,6 @@ impl WalFile {
                         max_frame = max_frame.min(upper_bound);
                     }
 
-                    if max_frame <= nbackfills {
-                        tracing::debug!(
-                            "no need in checkpoint: max_frame={}, nbackfills={}, prev={:?}",
-                            max_frame,
-                            nbackfills,
-                            self.prev_checkpoint
-                        );
-                        return Ok(IOResult::Done(CheckpointResult {
-                            num_attempted: self.prev_checkpoint.num_attempted,
-                            num_backfilled: self.prev_checkpoint.num_backfilled,
-                            max_frame: nbackfills,
-                            maybe_guard: None,
-                        }));
-                    }
-
                     self.ongoing_checkpoint.max_frame = max_frame;
                     self.ongoing_checkpoint.min_frame = nbackfills + 1;
                     let to_checkpoint = {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2211,7 +2211,7 @@ pub mod test {
         );
         drop(wal);
 
-        assert_eq!(pager.wal_frame_count().unwrap(), 0);
+        assert_eq!(pager.wal_state().unwrap().max_frame, 0);
 
         tracing::info!("wal filepath: {walpath:?}, size: {}", stat.len());
         let meta_after = std::fs::metadata(&walpath).unwrap();

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1106,7 +1106,8 @@ impl Wal for WalFile {
         };
         self.ensure_header_if_needed(page_size)?;
         tracing::debug!("write_raw_frame({})", frame_id);
-        if page.len() != self.page_size() as usize {
+        // if page_size wasn't initialized before - we will initialize it during that raw write
+        if self.page_size() != 0 && page.len() != self.page_size() as usize {
             return Err(LimboError::InvalidArgument(format!(
                 "unexpected page size in frame: got={}, expected={}",
                 page.len(),

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -289,6 +289,7 @@ pub trait Wal: Debug {
     fn sync(&mut self) -> Result<Completion>;
     fn is_syncing(&self) -> bool;
     fn get_max_frame_in_wal(&self) -> u64;
+    fn get_checkpoint_seq(&self) -> u32;
     fn get_max_frame(&self) -> u64;
     fn get_min_frame(&self) -> u64;
     fn rollback(&mut self) -> Result<()>;
@@ -1301,6 +1302,10 @@ impl Wal for WalFile {
 
     fn get_max_frame_in_wal(&self) -> u64 {
         self.get_shared().max_frame.load(Ordering::Acquire)
+    }
+
+    fn get_checkpoint_seq(&self) -> u32 {
+        self.header.checkpoint_seq
     }
 
     fn get_max_frame(&self) -> u64 {

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -402,7 +402,9 @@ fn query_pragma(
                         LimboError::ParseError(format!("Unknown Checkpoint Mode: {e}"))
                     })?
                 }
-                _ => CheckpointMode::Passive,
+                _ => CheckpointMode::Passive {
+                    upper_bound_inclusive: None,
+                },
             };
 
             program.alloc_registers(2);

--- a/core/types.rs
+++ b/core/types.rs
@@ -2646,9 +2646,20 @@ pub struct WalFrameInfo {
     pub db_size: u32,
 }
 
+#[derive(Debug)]
+pub struct WalState {
+    pub checkpoint_seq_no: u32,
+    pub max_frame: u64,
+}
+
 impl WalFrameInfo {
     pub fn is_commit_frame(&self) -> bool {
         self.db_size > 0
+    }
+    pub fn from_frame_header(frame: &[u8]) -> Self {
+        let page_no = u32::from_be_bytes(frame[0..4].try_into().unwrap());
+        let db_size = u32::from_be_bytes(frame[4..8].try_into().unwrap());
+        Self { page_no, db_size }
     }
     pub fn put_to_frame_header(&self, frame: &mut [u8]) {
         frame[0..4].copy_from_slice(&self.page_no.to_be_bytes());

--- a/core/types.rs
+++ b/core/types.rs
@@ -2646,7 +2646,7 @@ pub struct WalFrameInfo {
     pub db_size: u32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct WalState {
     pub checkpoint_seq_no: u32,
     pub max_frame: u64,

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -1404,8 +1404,8 @@ pub unsafe extern "C" fn libsql_wal_frame_count(
     }
     let db: &mut sqlite3 = &mut *db;
     let db = db.inner.lock().unwrap();
-    let frame_count = match db.conn.wal_frame_count() {
-        Ok(count) => count as u32,
+    let frame_count = match db.conn.wal_state() {
+        Ok(state) => state.max_frame as u32,
         Err(_) => return SQLITE_ERROR,
     };
     *p_frame_count = frame_count;

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -1345,9 +1345,13 @@ pub unsafe extern "C" fn sqlite3_wal_checkpoint_v2(
     let db: &mut sqlite3 = &mut *db;
     let db = db.inner.lock().unwrap();
     let chkptmode = match mode {
-        SQLITE_CHECKPOINT_PASSIVE => CheckpointMode::Passive,
+        SQLITE_CHECKPOINT_PASSIVE => CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
         SQLITE_CHECKPOINT_RESTART => CheckpointMode::Restart,
-        SQLITE_CHECKPOINT_TRUNCATE => CheckpointMode::Truncate,
+        SQLITE_CHECKPOINT_TRUNCATE => CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
         SQLITE_CHECKPOINT_FULL => CheckpointMode::Full,
         _ => return SQLITE_MISUSE, // Unsupported mode
     };

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -349,7 +349,7 @@ impl<C: ProtocolIO> DatabaseSyncEngine<C> {
         // todo(sivukhin): push frames in multiple batches
         let generation = self.meta().synced_generation;
         let start_frame = self.meta().synced_frame_no.unwrap_or(0) + 1;
-        let end_frame = wal.conn().wal_frame_count()? + 1;
+        let end_frame = wal.conn().wal_state()?.max_frame + 1;
         match wal_push(
             coro,
             self.protocol.as_ref(),

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -1074,15 +1074,15 @@ pub mod tests {
             let conn1 = db1.connect(&coro).await?;
             conn1.execute("CREATE TABLE t(x, y)")?;
             conn1.execute("INSERT INTO t VALUES (1, 2)")?;
-            let conn1_match_watermark = conn1.wal_frame_count().unwrap();
+            let conn1_match_watermark = conn1.wal_state().unwrap().max_frame;
             conn1.execute("INSERT INTO t VALUES (3, 4)")?;
-            let conn1_sync_watermark = conn1.wal_frame_count().unwrap();
+            let conn1_sync_watermark = conn1.wal_state().unwrap().max_frame;
             conn1.execute("INSERT INTO t VALUES (5, 6)")?;
 
             let conn2 = db2.connect(&coro).await?;
             conn2.execute("CREATE TABLE t(x, y)")?;
             conn2.execute("INSERT INTO t VALUES (1, 2)")?;
-            let conn2_match_watermark = conn2.wal_frame_count().unwrap();
+            let conn2_match_watermark = conn2.wal_state().unwrap().max_frame;
             conn2.execute("INSERT INTO t VALUES (5, 6)")?;
 
             // db1 WAL frames: [A1 A2] [A3] [A4] (sync_watermark) [A5]

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -746,7 +746,7 @@ pub async fn transfer_physical_changes(
     let mut source_session = WalSession::new(source_conn.clone());
     source_session.begin()?;
 
-    let source_frames_count = source_conn.wal_frame_count()?;
+    let source_frames_count = source_conn.wal_state()?.max_frame;
     assert!(
         source_frames_count >= source_wal_match_watermark,
         "watermark can't be greater than current frames count: {source_frames_count} vs {source_wal_match_watermark}",

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -191,7 +191,7 @@ pub struct DatabaseWalSession {
 impl DatabaseWalSession {
     pub async fn new(coro: &Coro, wal_session: WalSession) -> Result<Self> {
         let conn = wal_session.conn();
-        let frames_count = conn.wal_frame_count()?;
+        let frames_count = conn.wal_state()?.max_frame;
         let mut page_size_stmt = conn.prepare("PRAGMA page_size")?;
         let Some(row) = run_stmt_expect_one_row(coro, &mut page_size_stmt).await? else {
             return Err(Error::DatabaseTapeError(
@@ -217,7 +217,7 @@ impl DatabaseWalSession {
     }
 
     pub fn frames_count(&self) -> Result<u64> {
-        Ok(self.wal_session.conn().wal_frame_count()?)
+        Ok(self.wal_session.conn().wal_state()?.max_frame)
     }
 
     pub fn append_page(&mut self, page_no: u32, page: &[u8]) -> Result<()> {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,6 +27,7 @@ assert_cmd = "^2"
 rand_chacha = "0.9.0"
 rand = "0.9.0"
 zerocopy = "0.8.26"
+ctor = "0.5.0"
 
 [dev-dependencies]
 test-log = { version = "0.2.17", features = ["trace"] }

--- a/tests/integration/functions/mod.rs
+++ b/tests/integration/functions/mod.rs
@@ -1,3 +1,16 @@
 mod test_cdc;
 mod test_function_rowid;
 mod test_wal_api;
+
+#[cfg(test)]
+mod tests {
+    use tracing_subscriber::EnvFilter;
+
+    #[ctor::ctor]
+    fn init() {
+        tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_ansi(false)
+            .init();
+    }
+}

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use rusqlite::types::Value;
-use turso_core::types::WalFrameInfo;
+use turso_core::{types::WalFrameInfo, CheckpointMode, LimboError, StepResult};
 
 use crate::common::{limbo_exec_rows, rng_from_time, TempDatabase};
 
@@ -457,4 +457,84 @@ fn test_wal_api_revert_pages() {
         limbo_exec_rows(&db1, &conn1, "SELECT x, length(y) FROM t"),
         vec![] as Vec<Vec<Value>>,
     );
+}
+
+#[test]
+fn test_wal_upper_bound_passive() {
+    let db = TempDatabase::new_empty(false);
+    let writer = db.connect_limbo();
+
+    writer
+        .execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    let watermark0 = writer.wal_frame_count().unwrap();
+    writer
+        .execute("insert into test values (1, 'hello')")
+        .unwrap();
+    let watermark1 = writer.wal_frame_count().unwrap();
+    writer
+        .execute("insert into test values (2, 'turso')")
+        .unwrap();
+    let watermark2 = writer.wal_frame_count().unwrap();
+    let expected = vec![
+        vec![
+            turso_core::types::Value::Integer(1),
+            turso_core::types::Value::Text(turso_core::types::Text::new("hello")),
+        ],
+        vec![
+            turso_core::types::Value::Integer(2),
+            turso_core::types::Value::Text(turso_core::types::Text::new("turso")),
+        ],
+    ];
+
+    for (prefix, watermark) in [(0, watermark0), (1, watermark1), (2, watermark2)] {
+        let mode = CheckpointMode::Passive {
+            upper_bound_inclusive: Some(watermark),
+        };
+        writer.checkpoint(mode).unwrap();
+
+        let db_path_copy = format!("{}-{}-copy", db.path.to_str().unwrap(), watermark);
+        std::fs::copy(&db.path, db_path_copy.clone()).unwrap();
+        let db_copy = TempDatabase::new_with_existent(&PathBuf::from(db_path_copy), false);
+        let conn = db_copy.connect_limbo();
+        let mut stmt = conn.prepare("select * from test").unwrap();
+        let mut rows: Vec<Vec<turso_core::types::Value>> = Vec::new();
+        loop {
+            let result = stmt.step();
+            match result {
+                Ok(StepResult::Row) => {
+                    rows.push(stmt.row().unwrap().get_values().cloned().collect())
+                }
+                Ok(StepResult::IO) => db_copy.io.run_once().unwrap(),
+                Ok(StepResult::Done) => break,
+                result => panic!("unexpected step result: {result:?}"),
+            }
+        }
+        assert_eq!(rows, expected[0..prefix]);
+    }
+}
+
+#[test]
+fn test_wal_upper_bound_truncate() {
+    let db = TempDatabase::new_empty(false);
+    let writer = db.connect_limbo();
+
+    writer
+        .execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    writer
+        .execute("insert into test values (1, 'hello')")
+        .unwrap();
+    let watermark = writer.wal_frame_count().unwrap();
+    writer
+        .execute("insert into test values (2, 'turso')")
+        .unwrap();
+
+    let mode = CheckpointMode::Truncate {
+        upper_bound_inclusive: Some(watermark),
+    };
+    assert!(matches!(
+        writer.checkpoint(mode).err().unwrap(),
+        LimboError::Busy
+    ));
 }

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -476,7 +476,7 @@ fn test_wal_upper_bound_passive() {
         .execute("insert into test values (2, 'turso')")
         .unwrap();
     let watermark2 = writer.wal_frame_count().unwrap();
-    let expected = vec![
+    let expected = [
         vec![
             turso_core::types::Value::Integer(1),
             turso_core::types::Value::Text(turso_core::types::Text::new("hello")),

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -287,7 +287,9 @@ fn test_wal_checkpoint() -> anyhow::Result<()> {
     for i in 0..iterations {
         let insert_query = format!("INSERT INTO test VALUES ({i})");
         do_flush(&conn, &tmp_db)?;
-        conn.checkpoint(CheckpointMode::Passive)?;
+        conn.checkpoint(CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        })?;
         run_query(&tmp_db, &conn, &insert_query)?;
     }
 


### PR DESCRIPTION
This PR adds information about checkpoint sequence number to the WAL raw API. Will be used in the sync engine.

Depends on the #2699 