### PR TITLE
 core/mvcc: update on insert when rowid already exists 

### DIFF
--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -36,7 +36,8 @@ fn bench(c: &mut Criterion) {
         b.to_async(FuturesExecutor).iter(|| async {
             let conn = db.conn.clone();
             let tx_id = db.mvcc_store.begin_tx(conn.get_pager().clone());
-            db.mvcc_store.rollback_tx(tx_id, conn.get_pager().clone())
+            db.mvcc_store
+                .rollback_tx(tx_id, conn.get_pager().clone(), &conn, false, false)
         })
     });
 
@@ -109,7 +110,6 @@ fn bench(c: &mut Criterion) {
                         data: record_data.clone(),
                         column_count: 1,
                     },
-                    conn.get_pager().clone(),
                 )
                 .unwrap();
             let mv_store = &db.mvcc_store;
@@ -186,7 +186,6 @@ fn bench(c: &mut Criterion) {
                         data: record_data.clone(),
                         column_count: 1,
                     },
-                    conn.get_pager().clone(),
                 )
                 .unwrap();
         })

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -17,7 +17,6 @@ enum CursorPosition {
     /// We have reached the end of the table.
     End,
 }
-#[derive(Debug)]
 pub struct MvccLazyCursor<Clock: LogicalClock> {
     pub db: Arc<MvStore<Clock>>,
     current_pos: CursorPosition,
@@ -253,3 +252,13 @@ impl<Clock: LogicalClock> MvccLazyCursor<Clock> {
     }
 }
 
+impl<Clock: LogicalClock> Debug for MvccLazyCursor<Clock> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MvccLazyCursor")
+            .field("db", &"...")
+            .field("current_pos", &self.current_pos)
+            .field("table_id", &self.table_id)
+            .field("tx_id", &self.tx_id)
+            .finish()
+    }
+}

--- a/core/mvcc/mod.rs
+++ b/core/mvcc/mod.rs
@@ -134,8 +134,7 @@ mod tests {
                         row_id: id,
                     };
                     let row = generate_simple_string_row(1, id.row_id, &format!("{prefix} @{tx}"));
-                    if let Err(e) = mvcc_store.upsert(tx, row.clone(), conn.pager.borrow().clone())
-                    {
+                    if let Err(e) = mvcc_store.upsert(tx, row.clone()) {
                         tracing::trace!("upsert failed: {e}");
                         failed_upserts += 1;
                         continue;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4423,7 +4423,7 @@ impl BTreeCursor {
     pub fn delete(&mut self) -> Result<IOResult<()>> {
         if let Some(mv_cursor) = &self.mv_cursor {
             let rowid = mv_cursor.borrow_mut().current_row_id().unwrap();
-            mv_cursor.borrow_mut().delete(rowid, self.pager.clone())?;
+            mv_cursor.borrow_mut().delete(rowid)?;
             return Ok(IOResult::Done(()));
         }
 


### PR DESCRIPTION
Two important things are implemented here:

1. When inserting a row, we need to make sure we are either updating it, or
inserting a new one. This is important because update takes care of
deleting previous version, if not, we would have two valid versions.
2. This adds a bool flag to keep track whether a connections was commiting
a transaction. If this is the case we need to supply `is_write` flag to
rollback as transactions in MVCC do not start pager write transaction
until commit starts.

Other minor changes:
* Support for rollback with schema changes and ongoing transsaction commit.
* Remove pager from MVCC cursor's api.