### PR TITLE
Fix: in UPDATE, insert rowid into index instead of NULL

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1000,10 +1000,17 @@ fn emit_update_insns(
 
         // copy each index column from the table's column registers into these scratch regs
         for (i, col) in index.columns.iter().enumerate() {
+            let col_in_table = table_ref
+                .columns()
+                .get(col.pos_in_table)
+                .expect("column index out of bounds");
             // copy from the table's column register over to the index's scratch register
-
             program.emit_insn(Insn::Copy {
-                src_reg: idx_cols_start_reg + col.pos_in_table,
+                src_reg: if col_in_table.is_rowid_alias {
+                    rowid_reg
+                } else {
+                    idx_cols_start_reg + col.pos_in_table
+                },
                 dst_reg: idx_start_reg + i,
                 extra_amount: 0,
             });


### PR DESCRIPTION
Same deal as #2700, except this time in UPDATE. Nothing tests this on `main` so not caught.

I will later put #2641 into mergeable condition so it will catch all of these going forward.