### PR TITLE
wal-api: allow to mix frames insert with SQL execution

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -234,12 +234,12 @@ impl Connection {
     }
 
     #[cfg(feature = "conn_raw_api")]
-    pub fn wal_insert_end(&self) -> Result<()> {
+    pub fn wal_insert_end(&self, force_commit: bool) -> Result<()> {
         let conn = self
             .inner
             .lock()
             .map_err(|e| Error::MutexError(e.to_string()))?;
-        conn.wal_insert_end()
+        conn.wal_insert_end(force_commit)
             .map_err(|e| Error::WalOperationError(format!("wal_insert_end failed: {e}")))
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -298,7 +298,7 @@ impl Database {
         Ok(db)
     }
 
-    #[allow(clippy::arc_with_non_send_sync)]
+    #[allow(clippy::arc_with_non_send_sync, clippy::too_many_arguments)]
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
     pub fn open_with_flags_bypass_registry(
         io: Arc<dyn IO>,
@@ -322,7 +322,7 @@ impl Database {
         )
     }
 
-    #[allow(clippy::arc_with_non_send_sync)]
+    #[allow(clippy::arc_with_non_send_sync, clippy::too_many_arguments)]
     fn open_with_flags_bypass_registry_internal(
         io: Arc<dyn IO>,
         path: &str,

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -12,7 +12,7 @@
 //! for the database, also either local or remote.
 pub(crate) mod btree;
 pub(crate) mod buffer_pool;
-pub(crate) mod database;
+pub mod database;
 pub(crate) mod encryption;
 pub(crate) mod page_cache;
 #[allow(clippy::arc_with_non_send_sync)]

--- a/sync/engine/src/wal_session.rs
+++ b/sync/engine/src/wal_session.rs
@@ -40,7 +40,7 @@ impl WalSession {
     }
     pub fn end(&mut self) -> Result<()> {
         assert!(self.in_txn);
-        self.conn.wal_insert_end()?;
+        self.conn.wal_insert_end(false)?;
         self.in_txn = false;
         Ok(())
     }

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -657,7 +657,7 @@ fn test_wal_revert_change_db_size() {
             continue;
         }
         let info = WalFrameInfo {
-            page_no: page_no,
+            page_no,
             db_size: if page_no == 2 { 2 } else { 0 },
         };
         info.put_to_frame_header(&mut frame);

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -784,7 +784,7 @@ fn test_wal_api_insert_exec_mix() {
         }
         let info = WalFrameInfo {
             db_size: 0,
-            page_no: page_no,
+            page_no,
         };
         info.put_to_frame_header(&mut frame);
         frames.push(frame);
@@ -824,7 +824,7 @@ fn test_wal_api_insert_exec_mix() {
         vec![
             vec![
                 turso_core::types::Value::Integer(1),
-                turso_core::types::Value::Integer(1 * 4096),
+                turso_core::types::Value::Integer(4096),
             ],
             vec![
                 turso_core::types::Value::Integer(3),
@@ -922,7 +922,7 @@ fn test_db_share_same_file() {
         rows,
         vec![vec![
             turso_core::types::Value::Integer(1),
-            turso_core::types::Value::Integer(1 * 4096),
+            turso_core::types::Value::Integer(4096),
         ]]
     );
 }

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -275,7 +275,6 @@ fn test_statement_reset() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_wal_checkpoint() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
     let tmp_db =


### PR DESCRIPTION
This PR make it possible to do 2 pretty crazy things with turso-db:
1. Now we can mix WAL frames inserts with SQL execution within same transaction. This will allow sync engine to execute rebase of local changes within atomically over main database file (the operation first require us to push new frames to physically revert local changes and then we need to replay local logical changes on top of the modified DB state)
2. Under `conn_raw_api` Cargo feature turso-db now expose method which allow caller to specify WAL file path. This dangerous capability exposed for sync-engine which maintain 2 databases: main one and "revert"-DB which shares same DB file but has it's own separate WAL. As sync-engine has full control over checkpoint - it can guarantee that DB file will be consistent with both main and "revert" DB WALs.