### PR TITLE
Remove Result from signature

### DIFF
--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -909,12 +909,13 @@ impl Jsonb {
         }
     }
 
-    pub fn to_string(&self) -> Result<String> {
+    #[expect(clippy::inherent_to_string)]
+    pub fn to_string(&self) -> String {
         let mut result = String::with_capacity(self.data.len() * 2);
 
-        self.write_to_string(&mut result, JsonIndentation::None)?;
+        self.write_to_string(&mut result, JsonIndentation::None);
 
-        Ok(result)
+        result
     }
 
     pub fn to_string_pretty(&self, indentation: Option<&str>) -> Result<String> {
@@ -924,16 +925,15 @@ impl Jsonb {
         } else {
             JsonIndentation::Indentation(Cow::Borrowed("    "))
         };
-        self.write_to_string(&mut result, ind)?;
+        self.write_to_string(&mut result, ind);
 
         Ok(result)
     }
 
-    fn write_to_string(&self, string: &mut String, indentation: JsonIndentation) -> Result<()> {
+    fn write_to_string(&self, string: &mut String, indentation: JsonIndentation) {
         let cursor = 0;
         let ind = indentation;
         let _ = self.serialize_value(string, cursor, 0, &ind);
-        Ok(())
     }
 
     fn serialize_value(
@@ -3093,7 +3093,7 @@ mod tests {
         jsonb.data.push(ElementType::NULL as u8);
 
         // Test serialization
-        let json_str = jsonb.to_string().unwrap();
+        let json_str = jsonb.to_string();
         assert_eq!(json_str, "null");
 
         // Test round-trip
@@ -3106,12 +3106,12 @@ mod tests {
         // True
         let mut jsonb_true = Jsonb::new(10, None);
         jsonb_true.data.push(ElementType::TRUE as u8);
-        assert_eq!(jsonb_true.to_string().unwrap(), "true");
+        assert_eq!(jsonb_true.to_string(), "true");
 
         // False
         let mut jsonb_false = Jsonb::new(10, None);
         jsonb_false.data.push(ElementType::FALSE as u8);
-        assert_eq!(jsonb_false.to_string().unwrap(), "false");
+        assert_eq!(jsonb_false.to_string(), "false");
 
         // Round-trip
         let true_parsed = Jsonb::from_str("true").unwrap();
@@ -3125,15 +3125,15 @@ mod tests {
     fn test_integer_serialization() {
         // Standard integer
         let parsed = Jsonb::from_str("42").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "42");
+        assert_eq!(parsed.to_string(), "42");
 
         // Negative integer
         let parsed = Jsonb::from_str("-123").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "-123");
+        assert_eq!(parsed.to_string(), "-123");
 
         // Zero
         let parsed = Jsonb::from_str("0").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "0");
+        assert_eq!(parsed.to_string(), "0");
 
         // Verify correct type
         let header = JsonbHeader::from_slice(0, &parsed.data).unwrap().0;
@@ -3144,15 +3144,15 @@ mod tests {
     fn test_json5_integer_serialization() {
         // Hexadecimal notation
         let parsed = Jsonb::from_str("0x1A").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "26"); // Should convert to decimal
+        assert_eq!(parsed.to_string(), "26"); // Should convert to decimal
 
         // Positive sign (JSON5)
         let parsed = Jsonb::from_str("+42").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "42");
+        assert_eq!(parsed.to_string(), "42");
 
         // Negative hexadecimal
         let parsed = Jsonb::from_str("-0xFF").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "-255");
+        assert_eq!(parsed.to_string(), "-255");
 
         // Verify correct type
         let header = JsonbHeader::from_slice(0, &parsed.data).unwrap().0;
@@ -3163,15 +3163,15 @@ mod tests {
     fn test_float_serialization() {
         // Standard float
         let parsed = Jsonb::from_str("3.14159").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "3.14159");
+        assert_eq!(parsed.to_string(), "3.14159");
 
         // Negative float
         let parsed = Jsonb::from_str("-2.718").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "-2.718");
+        assert_eq!(parsed.to_string(), "-2.718");
 
         // Scientific notation
         let parsed = Jsonb::from_str("6.022e23").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "6.022e23");
+        assert_eq!(parsed.to_string(), "6.022e23");
 
         // Verify correct type
         let header = JsonbHeader::from_slice(0, &parsed.data).unwrap().0;
@@ -3182,23 +3182,23 @@ mod tests {
     fn test_json5_float_serialization() {
         // Leading decimal point
         let parsed = Jsonb::from_str(".123").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "0.123");
+        assert_eq!(parsed.to_string(), "0.123");
 
         // Trailing decimal point
         let parsed = Jsonb::from_str("42.").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "42.0");
+        assert_eq!(parsed.to_string(), "42.0");
 
         // Plus sign in exponent
         let parsed = Jsonb::from_str("1.5e+10").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "1.5e+10");
+        assert_eq!(parsed.to_string(), "1.5e+10");
 
         // Infinity
         let parsed = Jsonb::from_str("Infinity").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "9e999");
+        assert_eq!(parsed.to_string(), "9e999");
 
         // Negative Infinity
         let parsed = Jsonb::from_str("-Infinity").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "-9e999");
+        assert_eq!(parsed.to_string(), "-9e999");
 
         // Verify correct type
         let header = JsonbHeader::from_slice(0, &parsed.data).unwrap().0;
@@ -3209,15 +3209,15 @@ mod tests {
     fn test_string_serialization() {
         // Simple string
         let parsed = Jsonb::from_str(r#""hello world""#).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#""hello world""#);
+        assert_eq!(parsed.to_string(), r#""hello world""#);
 
         // String with escaped characters
         let parsed = Jsonb::from_str(r#""hello\nworld""#).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#""hello\nworld""#);
+        assert_eq!(parsed.to_string(), r#""hello\nworld""#);
 
         // Unicode escape
         let parsed = Jsonb::from_str(r#""hello\u0020world""#).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#""hello\u0020world""#);
+        assert_eq!(parsed.to_string(), r#""hello\u0020world""#);
 
         // Verify correct type
         let header = JsonbHeader::from_slice(0, &parsed.data).unwrap().0;
@@ -3228,11 +3228,11 @@ mod tests {
     fn test_json5_string_serialization() {
         // Single quotes
         let parsed = Jsonb::from_str("'hello world'").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#""hello world""#);
+        assert_eq!(parsed.to_string(), r#""hello world""#);
 
         // Hex escape
         let parsed = Jsonb::from_str(r#"'\x41\x42\x43'"#).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#""\u0041\u0042\u0043""#);
+        assert_eq!(parsed.to_string(), r#""\u0041\u0042\u0043""#);
 
         // Multiline string with line continuation
         let parsed = Jsonb::from_str(
@@ -3240,11 +3240,11 @@ mod tests {
 world""#,
         )
         .unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#""hello world""#);
+        assert_eq!(parsed.to_string(), r#""hello world""#);
 
         // Escaped single quote
         let parsed = Jsonb::from_str(r#"'Don\'t worry'"#).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#""Don't worry""#);
+        assert_eq!(parsed.to_string(), r#""Don't worry""#);
 
         // Verify correct type
         let header = JsonbHeader::from_slice(0, &parsed.data).unwrap().0;
@@ -3255,20 +3255,20 @@ world""#,
     fn test_array_serialization() {
         // Empty array
         let parsed = Jsonb::from_str("[]").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "[]");
+        assert_eq!(parsed.to_string(), "[]");
 
         // Simple array
         let parsed = Jsonb::from_str("[1,2,3]").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "[1,2,3]");
+        assert_eq!(parsed.to_string(), "[1,2,3]");
 
         // Nested array
         let parsed = Jsonb::from_str("[[1,2],[3,4]]").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "[[1,2],[3,4]]");
+        assert_eq!(parsed.to_string(), "[[1,2],[3,4]]");
 
         // Mixed types array
         let parsed = Jsonb::from_str(r#"[1,"text",true,null,{"key":"value"}]"#).unwrap();
         assert_eq!(
-            parsed.to_string().unwrap(),
+            parsed.to_string(),
             r#"[1,"text",true,null,{"key":"value"}]"#
         );
 
@@ -3281,44 +3281,41 @@ world""#,
     fn test_json5_array_serialization() {
         // Trailing comma
         let parsed = Jsonb::from_str("[1,2,3,]").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "[1,2,3]");
+        assert_eq!(parsed.to_string(), "[1,2,3]");
 
         // Comments in array
         let parsed = Jsonb::from_str("[1,/* comment */2,3]").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "[1,2,3]");
+        assert_eq!(parsed.to_string(), "[1,2,3]");
 
         // Line comment in array
         let parsed = Jsonb::from_str("[1,// line comment\n2,3]").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "[1,2,3]");
+        assert_eq!(parsed.to_string(), "[1,2,3]");
     }
 
     #[test]
     fn test_object_serialization() {
         // Empty object
         let parsed = Jsonb::from_str("{}").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "{}");
+        assert_eq!(parsed.to_string(), "{}");
 
         // Simple object
         let parsed = Jsonb::from_str(r#"{"key":"value"}"#).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#"{"key":"value"}"#);
+        assert_eq!(parsed.to_string(), r#"{"key":"value"}"#);
 
         // Multiple properties
         let parsed = Jsonb::from_str(r#"{"a":1,"b":2,"c":3}"#).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#"{"a":1,"b":2,"c":3}"#);
+        assert_eq!(parsed.to_string(), r#"{"a":1,"b":2,"c":3}"#);
 
         // Nested object
         let parsed = Jsonb::from_str(r#"{"outer":{"inner":"value"}}"#).unwrap();
-        assert_eq!(
-            parsed.to_string().unwrap(),
-            r#"{"outer":{"inner":"value"}}"#
-        );
+        assert_eq!(parsed.to_string(), r#"{"outer":{"inner":"value"}}"#);
 
         // Mixed values
         let parsed =
             Jsonb::from_str(r#"{"str":"text","num":42,"bool":true,"null":null,"arr":[1,2]}"#)
                 .unwrap();
         assert_eq!(
-            parsed.to_string().unwrap(),
+            parsed.to_string(),
             r#"{"str":"text","num":42,"bool":true,"null":null,"arr":[1,2]}"#
         );
 
@@ -3331,19 +3328,19 @@ world""#,
     fn test_json5_object_serialization() {
         // Unquoted keys
         let parsed = Jsonb::from_str("{key:\"value\"}").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#"{"key":"value"}"#);
+        assert_eq!(parsed.to_string(), r#"{"key":"value"}"#);
 
         // Trailing comma
         let parsed = Jsonb::from_str(r#"{"a":1,"b":2,}"#).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#"{"a":1,"b":2}"#);
+        assert_eq!(parsed.to_string(), r#"{"a":1,"b":2}"#);
 
         // Comments in object
         let parsed = Jsonb::from_str(r#"{"a":1,/*comment*/"b":2}"#).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#"{"a":1,"b":2}"#);
+        assert_eq!(parsed.to_string(), r#"{"a":1,"b":2}"#);
 
         // Single quotes for keys and values
         let parsed = Jsonb::from_str("{'a':'value'}").unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#"{"a":"value"}"#);
+        assert_eq!(parsed.to_string(), r#"{"a":"value"}"#);
     }
 
     #[test]
@@ -3366,8 +3363,8 @@ world""#,
 
         let parsed = Jsonb::from_str(complex_json).unwrap();
         // Round-trip test
-        let reparsed = Jsonb::from_str(&parsed.to_string().unwrap()).unwrap();
-        assert_eq!(parsed.to_string().unwrap(), reparsed.to_string().unwrap());
+        let reparsed = Jsonb::from_str(&parsed.to_string()).unwrap();
+        assert_eq!(parsed.to_string(), reparsed.to_string());
     }
 
     #[test]
@@ -3486,11 +3483,11 @@ world""#,
     fn test_unicode_escapes() {
         // Basic unicode escape
         let parsed = Jsonb::from_str(r#""\u00A9""#).unwrap(); // Copyright symbol
-        assert_eq!(parsed.to_string().unwrap(), r#""\u00A9""#);
+        assert_eq!(parsed.to_string(), r#""\u00A9""#);
 
         // Non-BMP character (surrogate pair)
         let parsed = Jsonb::from_str(r#""\uD83D\uDE00""#).unwrap(); // Smiley emoji
-        assert_eq!(parsed.to_string().unwrap(), r#""\uD83D\uDE00""#);
+        assert_eq!(parsed.to_string(), r#""\uD83D\uDE00""#);
     }
 
     #[test]
@@ -3503,7 +3500,7 @@ world""#,
         }"#,
         )
         .unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#"{"key":"value"}"#);
+        assert_eq!(parsed.to_string(), r#"{"key":"value"}"#);
 
         // Block comments
         let parsed = Jsonb::from_str(
@@ -3514,7 +3511,7 @@ world""#,
         }"#,
         )
         .unwrap();
-        assert_eq!(parsed.to_string().unwrap(), r#"{"key":"value"}"#);
+        assert_eq!(parsed.to_string(), r#"{"key":"value"}"#);
 
         // Comments inside array
         let parsed = Jsonb::from_str(
@@ -3522,7 +3519,7 @@ world""#,
                                        2, /* Another comment */ 3]"#,
         )
         .unwrap();
-        assert_eq!(parsed.to_string().unwrap(), "[1,2,3]");
+        assert_eq!(parsed.to_string(), "[1,2,3]");
     }
 
     #[test]
@@ -3540,7 +3537,7 @@ world""#,
 
         let parsed = Jsonb::from_str(json_with_whitespace).unwrap();
         assert_eq!(
-            parsed.to_string().unwrap(),
+            parsed.to_string(),
             r#"{"key1":"value1","key2":[1,2,3],"key3":{"nested":true}}"#
         );
     }
@@ -3554,7 +3551,7 @@ world""#,
 
         // Create a new Jsonb from the binary data
         let from_binary = Jsonb::new(0, Some(&binary_data));
-        assert_eq!(from_binary.to_string().unwrap(), original);
+        assert_eq!(from_binary.to_string(), original);
     }
 
     #[test]
@@ -3570,8 +3567,8 @@ world""#,
         large_array.push(']');
 
         let parsed = Jsonb::from_str(&large_array).unwrap();
-        assert!(parsed.to_string().unwrap().starts_with("[0,1,2,"));
-        assert!(parsed.to_string().unwrap().ends_with("998,999]"));
+        assert!(parsed.to_string().starts_with("[0,1,2,"));
+        assert!(parsed.to_string().ends_with("998,999]"));
     }
 
     #[test]
@@ -3600,7 +3597,7 @@ world""#,
         }"#;
 
         let parsed = Jsonb::from_str(json).unwrap();
-        let result = parsed.to_string().unwrap();
+        let result = parsed.to_string();
 
         assert!(result.contains(r#""escaped_quotes":"He said \"Hello\"""#));
         assert!(result.contains(r#""backslashes":"C:\\Windows\\System32""#));
@@ -3767,7 +3764,7 @@ mod path_operations_tests {
         assert!(result.is_ok());
 
         // Verify the value was updated
-        let updated_json = jsonb.to_string().unwrap();
+        let updated_json = jsonb.to_string();
         assert_eq!(updated_json, r#"{"name":"Jane","age":30}"#);
     }
 
@@ -3791,7 +3788,7 @@ mod path_operations_tests {
         assert!(result.is_ok());
 
         // Verify the value was inserted
-        let updated_json = jsonb.to_string().unwrap();
+        let updated_json = jsonb.to_string();
         assert_eq!(updated_json, r#"{"name":"John","age":30}"#);
     }
 
@@ -3814,7 +3811,7 @@ mod path_operations_tests {
         assert!(result.is_ok());
 
         // Verify the property was deleted
-        let updated_json = jsonb.to_string().unwrap();
+        let updated_json = jsonb.to_string();
         assert_eq!(updated_json, r#"{"name":"John"}"#);
     }
 
@@ -3839,7 +3836,7 @@ mod path_operations_tests {
         assert!(result.is_ok());
 
         // Verify the value was replaced
-        let updated_json = jsonb.to_string().unwrap();
+        let updated_json = jsonb.to_string();
         assert_eq!(updated_json, r#"{"items":[10,50,30]}"#);
     }
 
@@ -3863,7 +3860,7 @@ mod path_operations_tests {
 
         // Get the search result
         let search_result = operation.result();
-        let result_str = search_result.to_string().unwrap();
+        let result_str = search_result.to_string();
 
         // Verify the search found the correct value
         assert_eq!(result_str, r#"{"name":"John","age":30}"#);
@@ -3912,7 +3909,7 @@ mod path_operations_tests {
         assert!(result.is_ok());
 
         // Verify the deep value was updated
-        let updated_json = jsonb.to_string().unwrap();
+        let updated_json = jsonb.to_string();
         assert_eq!(
             updated_json,
             r#"{"level1":{"level2":{"level3":{"value":100}}}}"#
@@ -3953,7 +3950,7 @@ mod path_operations_tests {
         let result = jsonb.operate_on_path(&path, &mut operation);
         assert!(result.is_ok());
 
-        let updated_json = jsonb.to_string().unwrap();
+        let updated_json = jsonb.to_string();
         assert_eq!(updated_json, r#"{"name":"John","age":30}"#);
 
         // 3. InsertNew mode - should fail when path already exists
@@ -3991,7 +3988,7 @@ mod path_operations_tests {
         let result = jsonb.operate_on_path(&path, &mut operation);
         assert!(result.is_ok());
 
-        let updated_json = jsonb.to_string().unwrap();
+        let updated_json = jsonb.to_string();
         assert_eq!(updated_json, r#"{"name":"John","age":31,"surname":"Doe"}"#);
     }
 }

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -44,7 +44,7 @@ pub fn get_json(json_value: &Value, indent: Option<&str>) -> crate::Result<Value
             let json_val = convert_dbtype_to_jsonb(json_value, Conv::Strict)?;
             let json = match indent {
                 Some(indent) => json_val.to_string_pretty(Some(indent))?,
-                None => json_val.to_string()?,
+                None => json_val.to_string(),
             };
 
             Ok(Value::Text(Text::json(json)))
@@ -53,7 +53,7 @@ pub fn get_json(json_value: &Value, indent: Option<&str>) -> crate::Result<Value
             let jsonbin = Jsonb::new(b.len(), Some(b));
             jsonbin.element_type()?;
             Ok(Value::Text(Text {
-                value: jsonbin.to_string()?.into_bytes(),
+                value: jsonbin.to_string().into_bytes(),
                 subtype: TextSubtype::Json,
             }))
         }
@@ -285,7 +285,7 @@ pub fn json_arrow_extract(
         let res = json.operate_on_path(&path, &mut op);
         let extracted = op.result();
         if res.is_ok() {
-            Ok(Value::Text(Text::json(extracted.to_string()?)))
+            Ok(Value::Text(Text::json(extracted.to_string())))
         } else {
             Ok(Value::Null)
         }
@@ -438,7 +438,7 @@ pub fn json_string_to_db_type(
     element_type: ElementType,
     flag: OutputVariant,
 ) -> crate::Result<Value> {
-    let mut json_string = json.to_string()?;
+    let mut json_string = json.to_string();
     if matches!(flag, OutputVariant::Binary) {
         return Ok(Value::Blob(json.data()));
     }


### PR DESCRIPTION
This PR removes `Result<()>` from `Jsonb::write_to_string()`, since it wasn't required. The method now returns `()`.