### PR TITLE
UNIQUE constraint errors should not abort txn

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1917,10 +1917,6 @@ pub fn halt(
     err_code: usize,
     description: &str,
 ) -> Result<InsnFunctionStepResult> {
-    if err_code > 0 {
-        // invalidate page cache in case of error
-        pager.clear_page_cache();
-    }
     match err_code {
         0 => {}
         SQLITE_CONSTRAINT_PRIMARYKEY => {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -858,6 +858,8 @@ pub fn handle_program_error(
         LimboError::TxError(_) => {}
         // Table locked errors, e.g. trying to checkpoint in an interactive transaction, do not cause a rollback.
         LimboError::TableLocked => {}
+        // Table constraints, e.g NOT NULL, UNIQUE etc. Check issue #2713
+        LimboError::Constraint(_) => {}
         _ => {
             pager
                 .io


### PR DESCRIPTION
Closes #2713

SQLite doesn't invalidate the page cache in case of a constraint error. In fact, it only invalidate it for the following errors:

SQLITE_NOMEM SQLITE_IOERR SQLITE_FULL SQLITE_INTERRUPT

Check:
https://github.com/sqlite/sqlite/blob/a939a635a2c8f857663ea197be81d19c4a4351d1/src/vdbeaux.c#L3311