### PR TITLE
Add syntax highlighting for EXPLAIN and ANALYZE

### DIFF
--- a/cli/SQL.sublime-syntax
+++ b/cli/SQL.sublime-syntax
@@ -11,7 +11,7 @@ variables:
   simple_identifier_break: (?!\w)
 
   toplevel_reserved: |-
-    (?xi: alter | analyze | create | cross | delete | drop | from | grant | group | inner | insert | join
+    (?xi: alter | analyze | create | cross | delete | drop | explain | from | grant | group | inner | insert | join
     | left | on | order | outer | right | select | set | truncate | union
     | update | where )
   additional_toplevel_reserved: (?!)
@@ -75,6 +75,7 @@ contexts:
     - include: dml-statements
     - include: grant-statements
     - include: revoke-statements
+    - include: explain-statements
     - include: analyze-statements
     - include: other-statements
 
@@ -560,6 +561,12 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: meta.statement.revoke.sql
     - include: immediately-pop
+
+  ###[ EXPLAIN STATEMENTS ]######################################################
+
+  explain-statements:
+    - match: \b(?i:explain)\b
+      scope: keyword.other.ddl.sql
 
   ###[ ANALYZE STATEMENTS ]######################################################
 


### PR DESCRIPTION
I'm working on ANALYZE.  I'm using EXPLAIN.  The lack of highlighting for them in the CLI annoyed me a bit.

I don't think there's any tests for this?  I'm mostly at a "it seems to work for me".  I double checked that `EXPLAIN SELECT CASE 0 WHEN 0 THEN 0 ELSE 1` syntax highlights, to make sure  I didn't break the longer parsing (which I had).