### PR TITLE
fix: normalize quotes in update

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -255,7 +255,8 @@ impl Schema {
     }
 
     pub fn table_has_indexes(&self, table_name: &str) -> bool {
-        self.has_indexes.contains(table_name)
+        let name = normalize_ident(table_name);
+        self.has_indexes.contains(&name)
     }
 
     pub fn table_set_has_index(&mut self, table_name: &str) {

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -132,6 +132,7 @@ pub fn prepare_update_plan(
         Some(table) => table,
         None => bail_parse_error!("Parse error: no such table: {}", table_name),
     };
+    let table_name = table.get_name();
     let iter_dir = body
         .order_by
         .first()
@@ -149,7 +150,7 @@ pub fn prepare_update_plan(
             Table::BTree(btree_table) => Table::BTree(btree_table.clone()),
             _ => unreachable!(),
         },
-        identifier: table_name.as_str().to_string(),
+        identifier: table_name.to_string(),
         internal_id: program.table_reference_counter.next(),
         op: build_scan_op(&table, iter_dir),
         join_info: None,
@@ -235,7 +236,7 @@ pub fn prepare_update_plan(
                 Table::BTree(btree_table) => Table::BTree(btree_table.clone()),
                 _ => unreachable!(),
             },
-            identifier: table_name.as_str().to_string(),
+            identifier: table_name.to_string(),
             internal_id,
             op: build_scan_op(&table, iter_dir),
             join_info: None,
@@ -334,7 +335,7 @@ pub fn prepare_update_plan(
 
     // Check what indexes will need to be updated by checking set_clauses and see
     // if a column is contained in an index.
-    let indexes = schema.get_indices(table_name.as_str());
+    let indexes = schema.get_indices(table_name);
     let rowid_alias_used = set_clauses
         .iter()
         .any(|(idx, _)| columns[*idx].is_rowid_alias);


### PR DESCRIPTION
fixes: #2744

```
turso> create table simple(x);
turso> insert into "simple"(x) values (1);
turso> select * from "simple";
┌───┐
│ x │
├───┤
│ 1 │
└───┘
turso> update "simple" set x = 3 where "simple"."x" = 1;
turso> select * from "simple";
┌───┐
│ x │
├───┤
│ 3 │
└───┘
turso>
```