### PR TITLE
Use vectored I/O for appending WAL frames

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1291,7 +1291,12 @@ impl Pager {
         if !pages.is_empty() {
             let c = wal
                 .borrow_mut()
-                .append_frames_vectored(pages, page_sz, commit_frame)?;
+                .append_frames_vectored(pages, page_sz, commit_frame)
+                .inspect_err(|_| {
+                    for c in completions.iter() {
+                        c.abort();
+                    }
+                })?;
             completions.push(c);
         }
         Ok(completions)

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1442,9 +1442,9 @@ impl Wal for WalFile {
             let plain = page.get_contents().as_ptr();
 
             let data_to_write: std::borrow::Cow<[u8]> = {
-                let key = self.encryption_key.borrow();
-                if let Some(k) = key.as_ref() {
-                    Cow::Owned(encrypt_page(plain, page_id as usize, k)?)
+                let ectx = self.encryption_ctx.borrow();
+                if let Some(ctx) = ectx.as_ref() {
+                    Cow::Owned(ctx.encrypt_page(plain, page_id as usize)?)
                 } else {
                     Cow::Borrowed(plain)
                 }


### PR DESCRIPTION
This PR adds a method `append_frames_vectored` that takes N frames and optionally the `db size` which will need to be set for the last (commit) frame, and it calculates the checksums and submits them as a single `pwritev` call, drastically reducing the number of syscalls needed for each write operation.