### PR TITLE
Remove duplicated attribute in `wal.rs`

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::arc_with_non_send_sync)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 use std::array;


### PR DESCRIPTION
Removed the redundant `#![allow(clippy::arc_with_non_send_sync)]` from wal.rs, since it’s already defined in `mod.rs`.