### PR TITLE
core/io: Fix build on Android and iOS

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -506,15 +506,7 @@ cfg_block! {
         pub use PlatformIO as SyscallIO;
     }
 
-    #[cfg(any(target_os = "android", target_os = "ios"))] {
-        mod unix;
-        #[cfg(feature = "fs")]
-        pub use unix::UnixIO;
-        pub use unix::UnixIO as SyscallIO;
-        pub use unix::UnixIO as PlatformIO;
-    }
-
-     #[cfg(target_os = "windows")] {
+    #[cfg(target_os = "windows")] {
         mod windows;
         pub use windows::WindowsIO as PlatformIO;
          pub use PlatformIO as SyscallIO;


### PR DESCRIPTION
Commit ebe6aa0d28136753a03868c2990f714d1e1bbaf1 ("adjust cfg for unix and linux IO") adjusted the I/O conditional compilation, but forgot that Android and iOS are also part of Unix target family.

Fixes #2500