### PR TITLE
Remove unnecessary argument from Pager::end_tx()

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1500,7 +1500,6 @@ impl Connection {
                     pager.end_tx(
                         true, // rollback = true for close
                         self,
-                        self.wal_auto_checkpoint_disabled.get(),
                     )
                 })?;
                 self.transaction_state.set(TransactionState::None);
@@ -2106,7 +2105,7 @@ impl Statement {
             }
             let state = self.program.connection.transaction_state.get();
             if let TransactionState::Write { .. } = state {
-                let end_tx_res = self.pager.end_tx(true, &self.program.connection, true)?;
+                let end_tx_res = self.pager.end_tx(true, &self.program.connection)?;
                 self.program
                     .connection
                     .transaction_state

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -546,7 +546,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         .end_tx(
                             false, // rollback = false since we're committing
                             &self.connection,
-                            self.connection.wal_auto_checkpoint_disabled.get(),
                         )
                         .map_err(|e| LimboError::InternalError(e.to_string()))
                         .unwrap();

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7915,10 +7915,7 @@ mod tests {
                     pager.deref(),
                 )
                 .unwrap();
-                pager
-                    .io
-                    .block(|| pager.end_tx(false, &conn, false))
-                    .unwrap();
+                pager.io.block(|| pager.end_tx(false, &conn)).unwrap();
                 pager.begin_read_tx().unwrap();
                 // FIXME: add sorted vector instead, should be okay for small amounts of keys for now :P, too lazy to fix right now
                 let _c = cursor.move_to_root().unwrap();
@@ -8063,10 +8060,7 @@ mod tests {
                 if let Some(c) = c {
                     pager.io.wait_for_completion(c).unwrap();
                 }
-                pager
-                    .io
-                    .block(|| pager.end_tx(false, &conn, false))
-                    .unwrap();
+                pager.io.block(|| pager.end_tx(false, &conn)).unwrap();
             }
 
             // Check that all keys can be found by seeking
@@ -8272,10 +8266,7 @@ mod tests {
                 if let Some(c) = c {
                     pager.io.wait_for_completion(c).unwrap();
                 }
-                pager
-                    .io
-                    .block(|| pager.end_tx(false, &conn, false))
-                    .unwrap();
+                pager.io.block(|| pager.end_tx(false, &conn)).unwrap();
             }
 
             // Final validation

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1026,7 +1026,6 @@ impl Pager {
         &self,
         rollback: bool,
         connection: &Connection,
-        wal_auto_checkpoint_disabled: bool,
     ) -> Result<IOResult<PagerCommitResult>> {
         if connection.is_nested_stmt.get() {
             // Parent statement will handle the transaction rollback.
@@ -1050,7 +1049,8 @@ impl Pager {
             self.rollback(schema_did_change, connection, is_write)?;
             return Ok(IOResult::Done(PagerCommitResult::Rollback));
         }
-        let commit_status = return_if_io!(self.commit_dirty_pages(wal_auto_checkpoint_disabled));
+        let commit_status =
+            return_if_io!(self.commit_dirty_pages(connection.wal_auto_checkpoint_disabled.get()));
         wal.borrow().end_write_tx();
         wal.borrow().end_read_tx();
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2170,7 +2170,7 @@ pub fn op_auto_commit(
     if *auto_commit != conn.auto_commit.get() {
         if *rollback {
             // TODO(pere): add rollback I/O logic once we implement rollback journal
-            return_if_io!(pager.end_tx(true, &conn, false));
+            return_if_io!(pager.end_tx(true, &conn));
             conn.transaction_state.replace(TransactionState::None);
             conn.auto_commit.replace(true);
         } else {


### PR DESCRIPTION
No need to pass `disable` flag to the `end_tx` method as it has that info from connection itself