### PR TITLE
Improve encryption API

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1971,7 +1971,7 @@ impl Connection {
     }
 
     pub fn get_encryption_cipher_mode(&self) -> Option<CipherMode> {
-        self.encryption_cipher.borrow().clone()
+        *self.encryption_cipher.borrow()
     }
 
     // if both key and cipher are set, set encryption context on pager
@@ -1980,7 +1980,7 @@ impl Connection {
         let Some(key) = key_ref.as_ref() else {
             return;
         };
-        let Some(cipher) = self.encryption_cipher.borrow().clone() else {
+        let Some(cipher) = *self.encryption_cipher.borrow() else {
             return;
         };
         tracing::trace!("setting encryption ctx for connection");

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -111,6 +111,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::Result0 | PragmaFlags::SchemaReq | PragmaFlags::NoColumns1,
             &["hexkey"],
         ),
+        EncryptionCipher => Pragma::new(
+            PragmaFlags::Result0 | PragmaFlags::SchemaReq | PragmaFlags::NoColumns1,
+            &["cipher"],
+        ),
     }
 }
 

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -109,7 +109,7 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
         FreelistCount => Pragma::new(PragmaFlags::Result0, &["freelist_count"]),
         EncryptionKey => Pragma::new(
             PragmaFlags::Result0 | PragmaFlags::SchemaReq | PragmaFlags::NoColumns1,
-            &["key"],
+            &["hexkey"],
         ),
     }
 }

--- a/core/storage/encryption.rs
+++ b/core/storage/encryption.rs
@@ -26,6 +26,19 @@ impl EncryptionKey {
         Self(key)
     }
 
+    pub fn from_hex_string(s: &str) -> Result<Self> {
+        let hex_str = s.trim();
+        let bytes = hex::decode(hex_str)
+            .map_err(|e| LimboError::InvalidArgument(format!("Invalid hex string: {}", e)))?;
+        let key: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+            LimboError::InvalidArgument(format!(
+                "Hex string must decode to exactly 32 bytes, got {}",
+                v.len()
+            ))
+        })?;
+        Ok(Self(key))
+    }
+
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }

--- a/core/storage/encryption.rs
+++ b/core/storage/encryption.rs
@@ -21,7 +21,7 @@ impl EncryptionKey {
     pub fn from_hex_string(s: &str) -> Result<Self> {
         let hex_str = s.trim();
         let bytes = hex::decode(hex_str)
-            .map_err(|e| LimboError::InvalidArgument(format!("Invalid hex string: {}", e)))?;
+            .map_err(|e| LimboError::InvalidArgument(format!("Invalid hex string: {e}")))?;
         let key: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
             LimboError::InvalidArgument(format!(
                 "Hex string must decode to exactly 32 bytes, got {}",
@@ -142,8 +142,7 @@ impl TryFrom<&str> for CipherMode {
             "aes256gcm" | "aes-256-gcm" | "aes_256_gcm" => Ok(CipherMode::Aes256Gcm),
             "aegis256" | "aegis-256" | "aegis_256" => Ok(CipherMode::Aegis256),
             _ => Err(LimboError::InvalidArgument(format!(
-                "Unknown cipher name: {}",
-                s
+                "Unknown cipher name: {s}"
             ))),
         }
     }

--- a/core/storage/encryption.rs
+++ b/core/storage/encryption.rs
@@ -134,6 +134,30 @@ pub enum CipherMode {
     Aegis256,
 }
 
+impl TryFrom<&str> for CipherMode {
+    type Error = LimboError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s.to_lowercase().as_str() {
+            "aes256gcm" | "aes-256-gcm" | "aes_256_gcm" => Ok(CipherMode::Aes256Gcm),
+            "aegis256" | "aegis-256" | "aegis_256" => Ok(CipherMode::Aegis256),
+            _ => Err(LimboError::InvalidArgument(format!(
+                "Unknown cipher name: {}",
+                s
+            ))),
+        }
+    }
+}
+
+impl std::fmt::Display for CipherMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CipherMode::Aes256Gcm => write!(f, "aes256gcm"),
+            CipherMode::Aegis256 => write!(f, "aegis256"),
+        }
+    }
+}
+
 impl CipherMode {
     /// Every cipher requires a specific key size. For 256-bit algorithms, this is 32 bytes.
     /// For 128-bit algorithms, it would be 16 bytes, etc.

--- a/core/storage/encryption.rs
+++ b/core/storage/encryption.rs
@@ -18,14 +18,6 @@ impl EncryptionKey {
         Self(key)
     }
 
-    pub fn from_string(s: &str) -> Self {
-        let mut key = [0u8; 32];
-        let bytes = s.as_bytes();
-        let len = bytes.len().min(32);
-        key[..len].copy_from_slice(&bytes[..len]);
-        Self(key)
-    }
-
     pub fn from_hex_string(s: &str) -> Result<Self> {
         let hex_str = s.trim();
         let bytes = hex::decode(hex_str)
@@ -379,6 +371,13 @@ mod tests {
     use super::*;
     use rand::Rng;
 
+    fn generate_random_hex_key() -> String {
+        let mut rng = rand::thread_rng();
+        let mut bytes = [0u8; 32];
+        rng.fill(&mut bytes);
+        hex::encode(bytes)
+    }
+
     #[test]
     #[cfg(feature = "encryption")]
     fn test_aes_encrypt_decrypt_round_trip() {
@@ -395,7 +394,7 @@ mod tests {
             page
         };
 
-        let key = EncryptionKey::from_string("alice and bob use encryption on database");
+        let key = EncryptionKey::from_hex_string(&generate_random_hex_key()).unwrap();
         let ctx = EncryptionContext::new(CipherMode::Aes256Gcm, &key).unwrap();
 
         let page_id = 42;
@@ -412,7 +411,7 @@ mod tests {
     #[test]
     #[cfg(feature = "encryption")]
     fn test_aegis256_cipher_wrapper() {
-        let key = EncryptionKey::from_string("alice and bob use AEGIS-256 here!");
+        let key = EncryptionKey::from_hex_string(&generate_random_hex_key()).unwrap();
         let cipher = Aegis256Cipher::new(&key);
 
         let plaintext = b"Hello, AEGIS-256!";
@@ -429,7 +428,7 @@ mod tests {
     #[test]
     #[cfg(feature = "encryption")]
     fn test_aegis256_raw_encryption() {
-        let key = EncryptionKey::from_string("alice and bob use AEGIS-256 here!");
+        let key = EncryptionKey::from_hex_string(&generate_random_hex_key()).unwrap();
         let ctx = EncryptionContext::new(CipherMode::Aegis256, &key).unwrap();
 
         let plaintext = b"Hello, AEGIS-256!";
@@ -458,7 +457,7 @@ mod tests {
             page
         };
 
-        let key = EncryptionKey::from_string("alice and bob use AEGIS-256 for pages!");
+        let key = EncryptionKey::from_hex_string(&generate_random_hex_key()).unwrap();
         let ctx = EncryptionContext::new(CipherMode::Aegis256, &key).unwrap();
 
         let page_id = 42;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2109,8 +2109,8 @@ impl Pager {
         Ok(IOResult::Done(f(header)))
     }
 
-    pub fn set_encryption_context(&self, key: &EncryptionKey) {
-        let encryption_ctx = EncryptionContext::new(CipherMode::Aegis256, key).unwrap();
+    pub fn set_encryption_context(&self, cipher_mode: CipherMode, key: &EncryptionKey) {
+        let encryption_ctx = EncryptionContext::new(cipher_mode, key).unwrap();
         self.encryption_ctx.replace(Some(encryption_ctx.clone()));
         let Some(wal) = self.wal.as_ref() else { return };
         wal.borrow_mut().set_encryption_context(encryption_ctx)

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -314,7 +314,7 @@ fn update_pragma(
         ),
         PragmaName::EncryptionKey => {
             let value = parse_string(&value)?;
-            let key = EncryptionKey::from_string(&value);
+            let key = EncryptionKey::from_hex_string(&value)?;
             connection.set_encryption_key(key);
             Ok((program, TransactionMode::None))
         }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1221,10 +1221,9 @@ pub enum PragmaName {
     IntegrityCheck,
     /// `journal_mode` pragma
     JournalMode,
-    /// encryption key for encrypted databases. This is just called `key` because most
-    /// extensions use this name instead of `encryption_key`.
-    #[strum(serialize = "key")]
-    #[cfg_attr(feature = "serde", serde(rename = "key"))]
+    /// encryption key for encrypted databases, specified as hexadecimal string.
+    #[strum(serialize = "hexkey")]
+    #[cfg_attr(feature = "serde", serde(rename = "hexkey"))]
     EncryptionKey,
     /// Noop as per SQLite docs
     LegacyFileFormat,

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1211,6 +1211,10 @@ pub enum PragmaName {
     AutoVacuum,
     /// `cache_size` pragma
     CacheSize,
+    /// encryption cipher algorithm name for encrypted databases
+    #[strum(serialize = "cipher")]
+    #[cfg_attr(feature = "serde", serde(rename = "cipher"))]
+    EncryptionCipher,
     /// List databases
     DatabaseList,
     /// Encoding - only support utf8

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -16,7 +16,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         run_query(
             &tmp_db,
             &conn,
-            "PRAGMA hexkey = 'super secret key for encryption';",
+            "PRAGMA hexkey = 'b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327';",
         )?;
         run_query(
             &tmp_db,
@@ -58,7 +58,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         run_query(
             &existing_db,
             &conn,
-            "PRAGMA hexkey = 'super secret key for encryption';",
+            "PRAGMA hexkey = 'b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327';",
         )?;
         run_query_on_row(&existing_db, &conn, "SELECT * FROM test", |row: &Row| {
             assert_eq!(row.get::<i64>(0).unwrap(), 1);

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -16,7 +16,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         run_query(
             &tmp_db,
             &conn,
-            "PRAGMA key = 'super secret key for encryption';",
+            "PRAGMA hexkey = 'super secret key for encryption';",
         )?;
         run_query(
             &tmp_db,
@@ -58,7 +58,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         run_query(
             &existing_db,
             &conn,
-            "PRAGMA key = 'super secret key for encryption';",
+            "PRAGMA hexkey = 'super secret key for encryption';",
         )?;
         run_query_on_row(&existing_db, &conn, "SELECT * FROM test", |row: &Row| {
             assert_eq!(row.get::<i64>(0).unwrap(), 1);

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -18,6 +18,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
             &conn,
             "PRAGMA hexkey = 'b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327';",
         )?;
+        run_query(&tmp_db, &conn, "PRAGMA cipher = 'aegis256';")?;
         run_query(
             &tmp_db,
             &conn,
@@ -55,6 +56,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         // let's test the existing db with the key
         let existing_db = TempDatabase::new_with_existent(&db_path, false);
         let conn = existing_db.connect_limbo();
+        run_query(&tmp_db, &conn, "PRAGMA cipher = 'aegis256';")?;
         run_query(
             &existing_db,
             &conn,

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -50,6 +50,62 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
             should_panic.is_err(),
             "should panic when accessing encrypted DB without key"
         );
+
+        // it should also panic if we specify either only key or cipher
+        let conn = tmp_db.connect_limbo();
+        let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            run_query(&tmp_db, &conn, "PRAGMA cipher = 'aegis256';").unwrap();
+            run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |_: &Row| {}).unwrap();
+        }));
+        assert!(
+            should_panic.is_err(),
+            "should panic when accessing encrypted DB without key"
+        );
+
+        let conn = tmp_db.connect_limbo();
+        let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            run_query(
+                &tmp_db,
+                &conn,
+                "PRAGMA hexkey = 'b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327';",
+            ).unwrap();
+            run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |_: &Row| {}).unwrap();
+        }));
+        assert!(
+            should_panic.is_err(),
+            "should panic when accessing encrypted DB without cipher name"
+        );
+
+        // it should panic if we specify wrong cipher or key
+        let conn = tmp_db.connect_limbo();
+        let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            run_query(
+                &tmp_db,
+                &conn,
+                "PRAGMA hexkey = 'b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327';",
+            ).unwrap();
+            run_query(&tmp_db, &conn, "PRAGMA cipher = 'aes256gcm';").unwrap();
+            run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |_: &Row| {}).unwrap();
+        }));
+        assert!(
+            should_panic.is_err(),
+            "should panic when accessing encrypted DB with incorrect cipher"
+        );
+
+        let conn = tmp_db.connect_limbo();
+        let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            run_query(&tmp_db, &conn, "PRAGMA cipher = 'aegis256';").unwrap();
+            run_query(
+                &tmp_db,
+                &conn,
+                "PRAGMA hexkey = 'b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76377';",
+            ).unwrap();
+            run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |_: &Row| {}).unwrap();
+        }));
+        assert!(
+            should_panic.is_err(),
+            "should panic when accessing encrypted DB with incorrect key"
+        );
     }
 
     {


### PR DESCRIPTION
This patch brings a bunch of quality of life improvements to encryption:

1. Previously, we just let any string to be used as a key. I have updated the `PRAGMA hexkey=''` to get the key in hex. I have also renamed from `key`, because that will be used to get passphrase 
2. Added `PRAGMA cipher` so that now users can select which cipher they want to use (for now, either `aegis256` or `aes256gcm`)
3. We now set the encryption context when both cipher and key are set

I also updated tests to reflect this. 