### PR TITLE
Remove double indirection in the Parser

### DIFF
--- a/core/incremental/expr_compiler.rs
+++ b/core/incremental/expr_compiler.rs
@@ -67,7 +67,7 @@ fn transform_expr_for_dbsp(expr: &Expr, input_column_names: &[String]) -> Expr {
             distinctness: *distinctness,
             args: args
                 .iter()
-                .map(|arg| Box::new(transform_expr_for_dbsp(arg, input_column_names)))
+                .map(|arg| transform_expr_for_dbsp(arg, input_column_names))
                 .collect(),
             order_by: order_by.clone(),
             filter_over: filter_over.clone(),
@@ -75,7 +75,7 @@ fn transform_expr_for_dbsp(expr: &Expr, input_column_names: &[String]) -> Expr {
         Expr::Parenthesized(exprs) => Expr::Parenthesized(
             exprs
                 .iter()
-                .map(|e| Box::new(transform_expr_for_dbsp(e, input_column_names)))
+                .map(|e| transform_expr_for_dbsp(e, input_column_names))
                 .collect(),
         ),
         // For other expression types, keep as is

--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -368,13 +368,8 @@ impl ToTokens for SelectPlan {
         context: &C,
     ) -> Result<(), S::Error> {
         if !self.values.is_empty() {
-            ast::OneSelect::Values(
-                self.values
-                    .iter()
-                    .map(|values| values.iter().map(|v| Box::from(v.clone())).collect())
-                    .collect(),
-            )
-            .to_tokens_with_context(s, context)?;
+            ast::OneSelect::Values(self.values.iter().map(|values| values.to_vec()).collect())
+                .to_tokens_with_context(s, context)?;
         } else {
             s.append(TokenType::TK_SELECT, None)?;
             if self.distinctness.is_distinct() {
@@ -448,7 +443,7 @@ impl ToTokens for SelectPlan {
 
             s.comma(
                 self.order_by.iter().map(|(expr, order)| ast::SortedColumn {
-                    expr: expr.clone(),
+                    expr: expr.clone().into_boxed(),
                     order: Some(*order),
                     nulls: None,
                 }),
@@ -510,7 +505,7 @@ impl ToTokens for DeletePlan {
 
             s.comma(
                 self.order_by.iter().map(|(expr, order)| ast::SortedColumn {
-                    expr: expr.clone(),
+                    expr: expr.clone().into_boxed(),
                     order: Some(*order),
                     nulls: None,
                 }),
@@ -563,7 +558,7 @@ impl ToTokens for UpdatePlan {
 
                 ast::Set {
                     col_names: vec![ast::Name::new(col_name)],
-                    expr: set_expr.clone(),
+                    expr: set_expr.clone().into_boxed(),
                 }
             }),
             context,
@@ -591,7 +586,7 @@ impl ToTokens for UpdatePlan {
 
             s.comma(
                 self.order_by.iter().map(|(expr, order)| ast::SortedColumn {
-                    expr: expr.clone(),
+                    expr: expr.clone().into_boxed(),
                     order: Some(*order),
                     nulls: None,
                 }),

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -154,7 +154,7 @@ fn translate_in_list(
     program: &mut ProgramBuilder,
     referenced_tables: Option<&TableReferences>,
     lhs: &ast::Expr,
-    rhs: &[Box<ast::Expr>],
+    rhs: &[ast::Expr],
     not: bool,
     condition_metadata: ConditionMetadata,
     resolver: &Resolver,
@@ -1633,9 +1633,7 @@ pub fn translate_expr(
                                 );
                             }
 
-                            if let ast::Expr::Literal(ast::Literal::Numeric(ref value)) =
-                                args[1].as_ref()
-                            {
+                            if let ast::Expr::Literal(ast::Literal::Numeric(ref value)) = args[1] {
                                 if let Ok(probability) = value.parse::<f64>() {
                                     if !(0.0..=1.0).contains(&probability) {
                                         crate::bail_parse_error!(
@@ -2545,7 +2543,7 @@ fn translate_like_base(
 /// Returns the target register for the function.
 fn translate_function(
     program: &mut ProgramBuilder,
-    args: &[Box<ast::Expr>],
+    args: &[ast::Expr],
     referenced_tables: Option<&TableReferences>,
     resolver: &Resolver,
     target_register: usize,
@@ -2671,7 +2669,7 @@ pub fn unwrap_parens_owned(expr: ast::Expr) -> Result<(ast::Expr, usize)> {
         ast::Expr::Parenthesized(mut exprs) => match exprs.len() {
             1 => {
                 paren_count += 1;
-                let (expr, count) = unwrap_parens_owned(*exprs.pop().unwrap().clone())?;
+                let (expr, count) = unwrap_parens_owned(exprs.pop().unwrap().clone())?;
                 paren_count += count;
                 Ok((expr, paren_count))
             }

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -85,7 +85,7 @@ pub fn init_group_by<'a>(
     group_by: &'a GroupBy,
     plan: &SelectPlan,
     result_columns: &'a [ResultSetColumn],
-    order_by: &'a [(Box<ast::Expr>, ast::SortOrder)],
+    order_by: &'a [(ast::Expr, ast::SortOrder)],
 ) -> Result<()> {
     collect_non_aggregate_expressions(
         &mut t_ctx.non_aggregate_expressions,
@@ -238,13 +238,13 @@ fn collect_non_aggregate_expressions<'a>(
     group_by: &'a GroupBy,
     plan: &SelectPlan,
     root_result_columns: &'a [ResultSetColumn],
-    order_by: &'a [(Box<ast::Expr>, ast::SortOrder)],
+    order_by: &'a [(ast::Expr, ast::SortOrder)],
 ) -> Result<()> {
     let mut result_columns = Vec::new();
     for expr in root_result_columns
         .iter()
         .map(|col| &col.expr)
-        .chain(order_by.iter().map(|(e, _)| e.as_ref()))
+        .chain(order_by.iter().map(|(e, _)| e))
         .chain(group_by.having.iter().flatten())
     {
         collect_result_columns(expr, plan, &mut result_columns)?;

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -100,7 +100,7 @@ pub fn translate_insert(
 
     let root_page = btree_table.root_page;
 
-    let mut values: Option<Vec<Box<Expr>>> = None;
+    let mut values: Option<Vec<Expr>> = None;
     let inserting_multiple_rows = match &mut body {
         InsertBody::Select(select, _) => match &mut select.body.select {
             // TODO see how to avoid clone
@@ -110,11 +110,10 @@ pub fn translate_insert(
                 }
                 let mut param_idx = 1;
                 for expr in values_expr.iter_mut().flat_map(|v| v.iter_mut()) {
-                    match expr.as_mut() {
+                    match expr {
                         Expr::Id(name) => {
                             if name.is_double_quoted() {
-                                *expr =
-                                    Expr::Literal(ast::Literal::String(format!("{name}"))).into();
+                                *expr = Expr::Literal(ast::Literal::String(name.to_string()));
                             } else {
                                 // an INSERT INTO ... VALUES (...) cannot reference columns
                                 crate::bail_parse_error!("no such column: {name}");
@@ -838,7 +837,7 @@ fn translate_rows_multiple<'short, 'long: 'short>(
 #[allow(clippy::too_many_arguments)]
 fn translate_rows_single(
     program: &mut ProgramBuilder,
-    value: &[Box<Expr>],
+    value: &[Expr],
     insertion: &Insertion,
     resolver: &Resolver,
 ) -> Result<()> {

--- a/core/translate/optimizer/lift_common_subexpressions.rs
+++ b/core/translate/optimizer/lift_common_subexpressions.rs
@@ -104,7 +104,7 @@ pub(crate) fn lift_common_subexpressions_from_binary_or_terms(
             // If we unwrapped parentheses before, let's add them back.
             let mut top_level_expr = rebuild_and_expr_from_list(conjunct_list_for_or_branch);
             while num_unwrapped_parens > 0 {
-                top_level_expr = Expr::Parenthesized(vec![top_level_expr.into()]);
+                top_level_expr = Expr::Parenthesized(vec![top_level_expr]);
                 num_unwrapped_parens -= 1;
             }
             new_or_operands_for_original_term.push(top_level_expr);
@@ -246,13 +246,11 @@ mod tests {
         let or_expr = Expr::Binary(
             Box::new(ast::Expr::Parenthesized(vec![rebuild_and_expr_from_list(
                 vec![a_expr.clone(), x_expr.clone(), b_expr.clone()],
-            )
-            .into()])),
+            )])),
             Operator::Or,
             Box::new(ast::Expr::Parenthesized(vec![rebuild_and_expr_from_list(
                 vec![a_expr.clone(), y_expr.clone(), b_expr.clone()],
-            )
-            .into()])),
+            )])),
         );
 
         let mut where_clause = vec![WhereTerm {
@@ -275,9 +273,9 @@ mod tests {
         assert_eq!(
             nonconsumed_terms[0].expr,
             Expr::Binary(
-                Box::new(ast::Expr::Parenthesized(vec![x_expr.clone().into()])),
+                Box::new(ast::Expr::Parenthesized(vec![x_expr.clone()])),
                 Operator::Or,
-                Box::new(ast::Expr::Parenthesized(vec![y_expr.clone().into()]))
+                Box::new(ast::Expr::Parenthesized(vec![y_expr.clone()]))
             )
         );
         assert_eq!(nonconsumed_terms[1].expr, a_expr);
@@ -342,19 +340,16 @@ mod tests {
             Box::new(Expr::Binary(
                 Box::new(ast::Expr::Parenthesized(vec![rebuild_and_expr_from_list(
                     vec![a_expr.clone(), x_expr.clone()],
-                )
-                .into()])),
+                )])),
                 Operator::Or,
                 Box::new(ast::Expr::Parenthesized(vec![rebuild_and_expr_from_list(
                     vec![a_expr.clone(), y_expr.clone()],
-                )
-                .into()])),
+                )])),
             )),
             Operator::Or,
             Box::new(ast::Expr::Parenthesized(vec![rebuild_and_expr_from_list(
                 vec![a_expr.clone(), z_expr.clone()],
-            )
-            .into()])),
+            )])),
         );
 
         let mut where_clause = vec![WhereTerm {
@@ -377,12 +372,12 @@ mod tests {
             nonconsumed_terms[0].expr,
             Expr::Binary(
                 Box::new(Expr::Binary(
-                    Box::new(ast::Expr::Parenthesized(vec![x_expr.into()])),
+                    Box::new(ast::Expr::Parenthesized(vec![x_expr])),
                     Operator::Or,
-                    Box::new(ast::Expr::Parenthesized(vec![y_expr.into()])),
+                    Box::new(ast::Expr::Parenthesized(vec![y_expr])),
                 )),
                 Operator::Or,
-                Box::new(ast::Expr::Parenthesized(vec![z_expr.into()])),
+                Box::new(ast::Expr::Parenthesized(vec![z_expr])),
             )
         );
         assert_eq!(nonconsumed_terms[1].expr, a_expr);
@@ -419,9 +414,9 @@ mod tests {
         );
 
         let or_expr = Expr::Binary(
-            Box::new(ast::Expr::Parenthesized(vec![x_expr.into()])),
+            Box::new(ast::Expr::Parenthesized(vec![x_expr])),
             Operator::Or,
-            Box::new(ast::Expr::Parenthesized(vec![y_expr.into()])),
+            Box::new(ast::Expr::Parenthesized(vec![y_expr])),
         );
 
         let mut where_clause = vec![WhereTerm {
@@ -484,13 +479,11 @@ mod tests {
         let or_expr = Expr::Binary(
             Box::new(ast::Expr::Parenthesized(vec![rebuild_and_expr_from_list(
                 vec![a_expr.clone(), x_expr.clone()],
-            )
-            .into()])),
+            )])),
             Operator::Or,
             Box::new(ast::Expr::Parenthesized(vec![rebuild_and_expr_from_list(
                 vec![a_expr.clone(), y_expr.clone()],
-            )
-            .into()])),
+            )])),
         );
 
         let mut where_clause = vec![WhereTerm {
@@ -510,9 +503,9 @@ mod tests {
         assert_eq!(
             nonconsumed_terms[0].expr,
             Expr::Binary(
-                Box::new(ast::Expr::Parenthesized(vec![x_expr.into()])),
+                Box::new(ast::Expr::Parenthesized(vec![x_expr])),
                 Operator::Or,
-                Box::new(ast::Expr::Parenthesized(vec![y_expr.into()]))
+                Box::new(ast::Expr::Parenthesized(vec![y_expr]))
             )
         );
         assert_eq!(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -186,7 +186,7 @@ fn optimize_table_access(
     table_references: &mut TableReferences,
     available_indexes: &HashMap<String, Vec<Arc<Index>>>,
     where_clause: &mut [WhereTerm],
-    order_by: &mut Vec<(Box<ast::Expr>, SortOrder)>,
+    order_by: &mut Vec<(ast::Expr, SortOrder)>,
     group_by: &mut Option<GroupBy>,
 ) -> Result<Option<Vec<JoinOrderMember>>> {
     let access_methods_arena = RefCell::new(Vec::new());

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -71,7 +71,7 @@ impl OrderTarget {
 /// TODO: this does not currently handle the case where we definitely cannot eliminate
 /// the ORDER BY sorter, but we could still eliminate the GROUP BY sorter.
 pub fn compute_order_target(
-    order_by: &mut Vec<(Box<ast::Expr>, SortOrder)>,
+    order_by: &mut Vec<(ast::Expr, SortOrder)>,
     group_by_opt: Option<&mut GroupBy>,
 ) -> Option<OrderTarget> {
     match (order_by.is_empty(), group_by_opt) {
@@ -79,7 +79,7 @@ pub fn compute_order_target(
         (true, None) => None,
         // Only ORDER BY - we would like the joined result rows to be in the order specified by the ORDER BY
         (false, None) => OrderTarget::maybe_from_iterator(
-            order_by.iter().map(|(expr, order)| (expr.as_ref(), *order)),
+            order_by.iter().map(|(expr, order)| (expr, *order)),
             EliminatesSortBy::Order,
         ),
         // Only GROUP BY - we would like the joined result rows to be in the order specified by the GROUP BY

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -36,7 +36,7 @@ pub fn init_order_by(
     program: &mut ProgramBuilder,
     t_ctx: &mut TranslateCtx,
     result_columns: &[ResultSetColumn],
-    order_by: &[(Box<ast::Expr>, SortOrder)],
+    order_by: &[(ast::Expr, SortOrder)],
     referenced_tables: &TableReferences,
 ) -> Result<()> {
     let sort_cursor = program.alloc_cursor_id(CursorType::Sorter);
@@ -55,7 +55,7 @@ pub fn init_order_by(
      */
     let collations = order_by
         .iter()
-        .map(|(expr, _)| match expr.as_ref() {
+        .map(|(expr, _)| match expr {
             ast::Expr::Collate(_, collation_name) => {
                 CollationSeq::new(collation_name.as_str()).map(Some)
             }
@@ -324,7 +324,7 @@ pub struct OrderByRemapping {
 ///
 /// If any result columns can be skipped, this returns list of 2-tuples of (SkippedResultColumnIndex: usize, ResultColumnIndexInOrderBySorter: usize)
 pub fn order_by_deduplicate_result_columns(
-    order_by: &[(Box<ast::Expr>, SortOrder)],
+    order_by: &[(ast::Expr, SortOrder)],
     result_columns: &[ResultSetColumn],
 ) -> Vec<OrderByRemapping> {
     let mut result_column_remapping: Vec<OrderByRemapping> = Vec::new();

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -288,7 +288,7 @@ pub struct SelectPlan {
     /// group by clause
     pub group_by: Option<GroupBy>,
     /// order by clause
-    pub order_by: Vec<(Box<ast::Expr>, SortOrder)>,
+    pub order_by: Vec<(ast::Expr, SortOrder)>,
     /// all the aggregates collected from the result columns, order by, and (TODO) having clauses
     pub aggregates: Vec<Aggregate>,
     /// limit clause
@@ -376,7 +376,7 @@ pub struct DeletePlan {
     /// where clause split into a vec at 'AND' boundaries.
     pub where_clause: Vec<WhereTerm>,
     /// order by clause
-    pub order_by: Vec<(Box<ast::Expr>, SortOrder)>,
+    pub order_by: Vec<(ast::Expr, SortOrder)>,
     /// limit clause
     pub limit: Option<isize>,
     /// offset clause
@@ -391,9 +391,9 @@ pub struct DeletePlan {
 pub struct UpdatePlan {
     pub table_references: TableReferences,
     // (colum index, new value) pairs
-    pub set_clauses: Vec<(usize, Box<ast::Expr>)>,
+    pub set_clauses: Vec<(usize, ast::Expr)>,
     pub where_clause: Vec<WhereTerm>,
-    pub order_by: Vec<(Box<ast::Expr>, SortOrder)>,
+    pub order_by: Vec<(ast::Expr, SortOrder)>,
     pub limit: Option<isize>,
     pub offset: Option<isize>,
     // TODO: optional RETURNING clause

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -75,7 +75,7 @@ pub fn resolve_aggregates(
                         }
                         aggs.push(Aggregate {
                             func: f,
-                            args: args.iter().map(|arg| *arg.clone()).collect(),
+                            args: args.to_vec(),
                             original_expr: expr.clone(),
                             distinctness,
                         });
@@ -411,7 +411,7 @@ fn parse_table(
     vtab_predicates: &mut Vec<Expr>,
     qualified_name: &QualifiedName,
     maybe_alias: Option<&As>,
-    args: &[Box<Expr>],
+    args: &[Expr],
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
     let normalized_qualified_name = normalize_ident(qualified_name.name.as_str());
@@ -547,7 +547,7 @@ fn parse_table(
 }
 
 fn transform_args_into_where_terms(
-    args: &[Box<Expr>],
+    args: &[Expr],
     internal_id: TableInternalId,
     predicates: &mut Vec<Expr>,
     table: &Table,
@@ -567,7 +567,7 @@ fn transform_args_into_where_terms(
                 column: i,
                 is_rowid_alias: col.is_rowid_alias,
             };
-            let expr = match arg_expr.as_ref() {
+            let expr = match arg_expr {
                 Expr::Literal(Null) => Expr::IsNull(Box::new(column_expr)),
                 other => Expr::Binary(
                     column_expr.into(),

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -376,8 +376,7 @@ fn prepare_one_select_plan(
                                                 // COUNT() case
                                                 vec![ast::Expr::Literal(ast::Literal::Numeric(
                                                     "1".to_string(),
-                                                ))
-                                                .into()]
+                                                ))]
                                             }
                                             (true, _) => crate::bail_parse_error!(
                                                 "Aggregate function {} requires arguments",
@@ -388,7 +387,7 @@ fn prepare_one_select_plan(
 
                                         let agg = Aggregate {
                                             func: f,
-                                            args: agg_args.iter().map(|arg| *arg.clone()).collect(),
+                                            args: agg_args.to_vec(),
                                             original_expr: *expr.clone(),
                                             distinctness,
                                         };
@@ -448,10 +447,7 @@ fn prepare_one_select_plan(
                                             } else {
                                                 let agg = Aggregate {
                                                     func: AggFunc::External(f.func.clone().into()),
-                                                    args: args
-                                                        .iter()
-                                                        .map(|arg| *arg.clone())
-                                                        .collect(),
+                                                    args: args.to_vec(),
                                                     original_expr: *expr.clone(),
                                                     distinctness,
                                                 };
@@ -571,7 +567,7 @@ fn prepare_one_select_plan(
 
                 plan.group_by = Some(GroupBy {
                     sort_order: Some((0..group_by.exprs.len()).map(|_| SortOrder::Asc).collect()),
-                    exprs: group_by.exprs.iter().map(|expr| *expr.clone()).collect(),
+                    exprs: group_by.exprs.to_vec(),
                     having: if let Some(having) = group_by.having {
                         let mut predicates = vec![];
                         break_predicate_at_and_boundaries(&having, &mut predicates);
@@ -617,7 +613,7 @@ fn prepare_one_select_plan(
                 )?;
                 resolve_aggregates(schema, &o.expr, &mut plan.aggregates)?;
 
-                key.push((o.expr, o.order.unwrap_or(ast::SortOrder::Asc)));
+                key.push((*o.expr, o.order.unwrap_or(ast::SortOrder::Asc)));
             }
             plan.order_by = key;
 
@@ -651,10 +647,7 @@ fn prepare_one_select_plan(
                 contains_constant_false_condition: false,
                 query_destination,
                 distinctness: Distinctness::NonDistinct,
-                values: values
-                    .iter()
-                    .map(|values| values.iter().map(|value| *value.clone()).collect())
-                    .collect(),
+                values: values.iter().map(|values| values.to_vec()).collect(),
             };
 
             Ok(plan)

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -175,7 +175,7 @@ pub fn prepare_update_plan(
 
         let values = match set.expr.as_ref() {
             Expr::Parenthesized(vals) => vals.clone(),
-            expr => vec![expr.clone().into()],
+            expr => vec![expr.clone()],
         };
 
         if set.col_names.len() != values.len() {
@@ -213,7 +213,7 @@ pub fn prepare_update_plan(
     let order_by = body
         .order_by
         .iter()
-        .map(|o| (o.expr.clone(), o.order.unwrap_or(SortOrder::Asc)))
+        .map(|o| (*o.expr.clone(), o.order.unwrap_or(SortOrder::Asc)))
         .collect();
 
     // Sqlite determines we should create an ephemeral table if we do not have a FROM clause

--- a/core/util.rs
+++ b/core/util.rs
@@ -1190,8 +1190,8 @@ pub fn parse_pragma_bool(expr: &Expr) -> Result<bool> {
 }
 
 /// Extract column name from an expression (e.g., for SELECT clauses)
-pub fn extract_column_name_from_expr(expr: impl AsRef<ast::Expr>) -> Option<String> {
-    match expr.as_ref() {
+pub fn extract_column_name_from_expr(expr: &ast::Expr) -> Option<String> {
+    match expr {
         ast::Expr::Id(name) => Some(name.as_str().to_string()),
         ast::Expr::Qualified(_, name) => Some(name.as_str().to_string()),
         _ => None,
@@ -1435,7 +1435,7 @@ pub mod tests {
         let func1 = Expr::FunctionCall {
             name: Name::Ident("SUM".to_string()),
             distinctness: None,
-            args: vec![Expr::Id(Name::Ident("x".to_string())).into()],
+            args: vec![Expr::Id(Name::Ident("x".to_string()))],
             order_by: vec![],
             filter_over: FunctionTail {
                 filter_clause: None,
@@ -1445,7 +1445,7 @@ pub mod tests {
         let func2 = Expr::FunctionCall {
             name: Name::Ident("sum".to_string()),
             distinctness: None,
-            args: vec![Expr::Id(Name::Ident("x".to_string())).into()],
+            args: vec![Expr::Id(Name::Ident("x".to_string()))],
             order_by: vec![],
             filter_over: FunctionTail {
                 filter_clause: None,
@@ -1457,7 +1457,7 @@ pub mod tests {
         let func3 = Expr::FunctionCall {
             name: Name::Ident("SUM".to_string()),
             distinctness: Some(ast::Distinctness::Distinct),
-            args: vec![Expr::Id(Name::Ident("x".to_string())).into()],
+            args: vec![Expr::Id(Name::Ident("x".to_string()))],
             order_by: vec![],
             filter_over: FunctionTail {
                 filter_clause: None,
@@ -1472,7 +1472,7 @@ pub mod tests {
         let sum = Expr::FunctionCall {
             name: Name::Ident("SUM".to_string()),
             distinctness: None,
-            args: vec![Expr::Id(Name::Ident("x".to_string())).into()],
+            args: vec![Expr::Id(Name::Ident("x".to_string()))],
             order_by: vec![],
             filter_over: FunctionTail {
                 filter_clause: None,
@@ -1482,7 +1482,7 @@ pub mod tests {
         let sum_distinct = Expr::FunctionCall {
             name: Name::Ident("SUM".to_string()),
             distinctness: Some(ast::Distinctness::Distinct),
-            args: vec![Expr::Id(Name::Ident("x".to_string())).into()],
+            args: vec![Expr::Id(Name::Ident("x".to_string()))],
             order_by: vec![],
             filter_over: FunctionTail {
                 filter_clause: None,
@@ -1513,8 +1513,7 @@ pub mod tests {
             Box::new(Expr::Literal(Literal::Numeric("683".to_string()))),
             Add,
             Box::new(Expr::Literal(Literal::Numeric("799.0".to_string()))),
-        )
-        .into()]);
+        )]);
         let expr2 = Expr::Binary(
             Box::new(Expr::Literal(Literal::Numeric("799".to_string()))),
             Add,
@@ -1528,8 +1527,7 @@ pub mod tests {
             Box::new(Expr::Literal(Literal::Numeric("6".to_string()))),
             Add,
             Box::new(Expr::Literal(Literal::Numeric("7".to_string()))),
-        )
-        .into()]);
+        )]);
         let expr8 = Expr::Binary(
             Box::new(Expr::Literal(Literal::Numeric("6".to_string()))),
             Add,


### PR DESCRIPTION
Sometimes in the parser we had enum Variants that contained `Vec<Box<Expr>>` which is unnecessary and inefficient. 