### PR TITLE
Fix: return NULL for rowid() when cursor's null flag is on

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4320,6 +4320,9 @@ impl BTreeCursor {
                 return Ok(IOResult::Done(None));
             }
         }
+        if self.get_null_flag() {
+            return Ok(IOResult::Done(None));
+        }
         if self.has_record.get() {
             let page = self.stack.top();
             let page = page.get();


### PR DESCRIPTION
Fixes TPC-H query 13 from returning an incorrect result. In this specific case, we were returning non-null `IdxRowid` values for the right-hand side table even when there was no match with the left-hand side table, meaning the join produced matches even in cases where there shouldn't have been any.

Closes #2794