### PR TITLE
Fix missing functions after revert

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -476,6 +476,76 @@ pub enum Expr {
     Variable(String),
 }
 
+impl Expr {
+    pub fn into_boxed(self) -> Box<Expr> {
+        Box::new(self)
+    }
+
+    pub fn unary(operator: UnaryOperator, expr: Expr) -> Expr {
+        Expr::Unary(operator, Box::new(expr))
+    }
+
+    pub fn binary(lhs: Expr, operator: Operator, rhs: Expr) -> Expr {
+        Expr::Binary(Box::new(lhs), operator, Box::new(rhs))
+    }
+
+    pub fn not_null(expr: Expr) -> Expr {
+        Expr::NotNull(Box::new(expr))
+    }
+
+    pub fn between(lhs: Expr, not: bool, start: Expr, end: Expr) -> Expr {
+        Expr::Between {
+            lhs: Box::new(lhs),
+            not,
+            start: Box::new(start),
+            end: Box::new(end),
+        }
+    }
+
+    pub fn in_select(lhs: Expr, not: bool, select: Select) -> Expr {
+        Expr::InSelect {
+            lhs: Box::new(lhs),
+            not,
+            rhs: select,
+        }
+    }
+
+    pub fn like(
+        lhs: Expr,
+        not: bool,
+        operator: LikeOperator,
+        rhs: Expr,
+        escape: Option<Expr>,
+    ) -> Expr {
+        Expr::Like {
+            lhs: Box::new(lhs),
+            not,
+            op: operator,
+            rhs: Box::new(rhs),
+            escape: escape.map(Box::new),
+        }
+    }
+
+    pub fn is_null(expr: Expr) -> Expr {
+        Expr::IsNull(Box::new(expr))
+    }
+
+    pub fn collate(expr: Expr, name: Name) -> Expr {
+        Expr::Collate(Box::new(expr), name)
+    }
+
+    pub fn cast(expr: Expr, type_name: Option<Type>) -> Expr {
+        Expr::Cast {
+            expr: Box::new(expr),
+            type_name,
+        }
+    }
+
+    pub fn raise(resolve_type: ResolveType, expr: Option<Expr>) -> Expr {
+        Expr::Raise(resolve_type, expr.map(Box::new))
+    }
+}
+
 /// SQL literal
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/simulator-docker-runner/Dockerfile.simulator
+++ b/simulator-docker-runner/Dockerfile.simulator
@@ -26,6 +26,7 @@ COPY stress ./stress/
 COPY tests ./tests/
 COPY packages ./packages/
 COPY testing/sqlite_test_ext ./testing/sqlite_test_ext
+COPY sql_generation ./sql_generation/
 RUN cargo chef prepare --bin limbo_sim --recipe-path recipe.json
 
 #
@@ -43,6 +44,7 @@ COPY --from=planner /app/macros ./macros/
 COPY --from=planner /app/parser ./parser/
 COPY --from=planner /app/simulator ./simulator/
 COPY --from=planner /app/packages ./packages/
+COPY --from=planner /app/sql_generation ./sql_generation/
 
 RUN cargo build --bin limbo_sim --release
 

--- a/sql_generation/model/query/predicate.rs
+++ b/sql_generation/model/query/predicate.rs
@@ -71,7 +71,7 @@ impl Predicate {
     }
 
     pub fn parens(self) -> Self {
-        let expr = ast::Expr::Parenthesized(vec![self.0]);
+        let expr = ast::Expr::Parenthesized(vec![Box::new(self.0)]);
         Self(expr)
     }
 


### PR DESCRIPTION
When we reverted the #2789 , we had already merged #2793 . That Pr used some helper methods that were created in #2789. So I just added them back here + fixed the simulator dockerfile.