### PR TITLE
core/storage: Micro-optimize Pager::commit_dirty_pages()

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1435,11 +1435,11 @@ impl Pager {
                 }
             }
         };
-
-        let now = self.io.now();
         tracing::debug!(
             "total time flushing cache: {} ms",
-            now.to_system_time()
+            self.io
+                .now()
+                .to_system_time()
                 .duration_since(self.commit_info.time.get().to_system_time())
                 .unwrap()
                 .as_millis()


### PR DESCRIPTION
There's no need to call io.now() unless debug tracing is on. Let's micro-optimize commit_dirty_pages() to avoid the unnecessary call.