### PR TITLE
core: few micro-performance changes

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -157,6 +157,15 @@ impl Schema {
             .unwrap_or_default()
     }
 
+    /// Get all materialized views that depend on a given table, skip normalizing ident.
+    /// We are basically assuming we already normalized the ident.
+    pub fn get_dependent_materialized_views_unnormalized(
+        &self,
+        table_name: &str,
+    ) -> Option<Vec<String>> {
+        self.table_to_materialized_views.get(table_name).cloned()
+    }
+
     /// Populate all materialized views by scanning their source tables
     /// Returns IOResult to support async execution
     pub fn populate_materialized_views(

--- a/core/storage/buffer_pool.rs
+++ b/core/storage/buffer_pool.rs
@@ -128,13 +128,13 @@ impl BufferPool {
     /// 3MB Default size for each `Arena`. Any higher and
     /// it will fail to register the second arena with io_uring due
     /// to `RL_MEMLOCK` limit for un-privileged processes being 8MB total.
-    pub const DEFAULT_ARENA_SIZE: usize = 3 * 1024 * 1024;
+    pub const DEFAULT_ARENA_SIZE: usize = 64 * 1024 * 1024;
     /// 1MB size For testing/CI
     pub const TEST_ARENA_SIZE: usize = 1024 * 1024;
     /// 4KB default page_size
     pub const DEFAULT_PAGE_SIZE: usize = 4096;
-    /// Maximum size for each Arena (64MB total)
-    const MAX_ARENA_SIZE: usize = 32 * 1024 * 1024;
+    /// Maximum size for each Arena (128MB total)
+    const MAX_ARENA_SIZE: usize = 128 * 1024 * 1024;
     /// 64kb Minimum arena size
     const MIN_ARENA_SIZE: usize = 1024 * 64;
     fn new(arena_size: usize) -> Self {

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -9,8 +9,7 @@ use crate::turso_assert;
 use super::pager::PageRef;
 
 /// FIXME: https://github.com/tursodatabase/turso/issues/1661
-const DEFAULT_PAGE_CACHE_SIZE_IN_PAGES_MAKE_ME_SMALLER_ONCE_WAL_SPILL_IS_IMPLEMENTED: usize =
-    100000;
+const DEFAULT_PAGE_CACHE_SIZE_IN_PAGES_MAKE_ME_SMALLER_ONCE_WAL_SPILL_IS_IMPLEMENTED: usize = 2000;
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone)]
 pub struct PageCacheKey {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -71,7 +71,7 @@ pub fn translate_insert(
             "INSERT to table with indexes is disabled. Omit the `--experimental-indexes=false` flag to enable this feature."
         );
     }
-    let table_name = &tbl_name.name;
+    let table_name = normalize_ident(&tbl_name.name.to_string());
     let table = match schema.get_table(table_name.as_str()) {
         Some(table) => table,
         None => crate::bail_parse_error!("no such table: {}", table_name),
@@ -114,7 +114,7 @@ pub fn translate_insert(
                         Expr::Id(name) => {
                             if name.is_double_quoted() {
                                 *expr =
-                                    Expr::Literal(ast::Literal::String(format!("{name}"))).into();
+                                    Expr::Literal(ast::Literal::String(name.to_string())).into();
                             } else {
                                 // an INSERT INTO ... VALUES (...) cannot reference columns
                                 crate::bail_parse_error!("no such column: {name}");
@@ -509,7 +509,7 @@ pub fn translate_insert(
         key_reg: insertion.key_register(),
         record_reg: insertion.record_register(),
         flag: InsertFlags::new(),
-        table_name: table_name.to_string(),
+        table_name: table_name.clone(),
     });
 
     // Emit update in the CDC table if necessary (after the INSERT updated the table)


### PR DESCRIPTION
1. Changed arena size to be bigger, since we don't split arena per connection and instead we share it, a single connection can overload other connections and induce unwanted heap allocated buffers. I'm not a fan of sharing an arena because that is a bit paradoxical to what an arena really prefers.
2. `get_dependent_materialized_views` follows the pattern of having to normalize table name every time, this is unecessary if we already make it so `translate` provides the normalized ident on translation time.
3. there was a dumb `format!("{name}")`