### PR TITLE
Fix column case sensitivity on strict table

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1762,10 +1762,10 @@ pub fn op_type_check(
                 return Ok(());
             }
             let col_affinity = col.affinity();
-            let ty_str = col.ty_str.as_str();
+            let ty_str = col.ty_str.to_ascii_uppercase();
             let applied = apply_affinity_char(reg, col_affinity);
             let value_type = reg.get_value().value_type();
-            match (ty_str, value_type) {
+            match (ty_str.as_str(), value_type) {
                 ("INTEGER" | "INT", ValueType::Integer) => {}
                 ("REAL", ValueType::Float) => {}
                 ("BLOB", ValueType::Blob) => {}

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1762,19 +1762,21 @@ pub fn op_type_check(
                 return Ok(());
             }
             let col_affinity = col.affinity();
-            let ty_str = col.ty_str.to_ascii_uppercase();
+            let ty_str = &col.ty_str;
             let applied = apply_affinity_char(reg, col_affinity);
             let value_type = reg.get_value().value_type();
-            match (ty_str.as_str(), value_type) {
-                ("INTEGER" | "INT", ValueType::Integer) => {}
-                ("REAL", ValueType::Float) => {}
-                ("BLOB", ValueType::Blob) => {}
-                ("TEXT", ValueType::Text) => {}
-                ("ANY", _) => {}
-                (t, v) => bail_constraint_error!(
+            match value_type {
+                ValueType::Integer
+                    if ty_str.eq_ignore_ascii_case("INTEGER")
+                        || ty_str.eq_ignore_ascii_case("INT") => {}
+                ValueType::Float if ty_str.eq_ignore_ascii_case("REAL") => {}
+                ValueType::Blob if ty_str.eq_ignore_ascii_case("BLOB") => {}
+                ValueType::Text if ty_str.eq_ignore_ascii_case("TEXT") => {}
+                _ if ty_str.eq_ignore_ascii_case("ANY") => {}
+                v => bail_constraint_error!(
                     "cannot store {} value in {} column {}.{} ({})",
                     v,
-                    t,
+                    ty_str,
                     &table_reference.name,
                     col.name.as_deref().unwrap_or(""),
                     SQLITE_CONSTRAINT

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -19,9 +19,9 @@ do_execsql_test_on_specific_db {:memory:} must-be-int-insert {
 4}
 
 do_execsql_test_on_specific_db {:memory:} strict-basic-creation {
-    CREATE TABLE test1 (id INTEGER, name TEXT, price REAL) STRICT;
-    INSERT INTO test1 VALUES(1, 'item1', 10.5);
-    SELECT * FROM test1;
+    create table test1 (id integer, name text, price real) strict;
+    insert into test1 values(1, 'item1', 10.5);
+    select * from test1;
 } {1|item1|10.5}
 
 do_execsql_test_in_memory_any_error  strict-require-datatype {


### PR DESCRIPTION
closes: #2822

```
turso> insert into strict_table values (1);
turso>
```