### PR TITLE
refactor/perf: remove BTreePageInner

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3325,7 +3325,7 @@ impl BTreeCursor {
                             parent_contents,
                             divider_cell_insert_idx_in_parent,
                             divider_cell_is_overflow_cell,
-                            &page,
+                            page,
                             usable_space,
                         );
                     }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -960,8 +960,7 @@ pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completio
     let page_id = page.get().id;
     tracing::trace!("begin_write_btree_page(page_id={})", page_id);
     let buffer = {
-        let page = page.get();
-        let contents = page.contents.as_ref().unwrap();
+        let contents = page.get_contents();
         contents.buffer.clone()
     };
 


### PR DESCRIPTION
it wasn't used for anything. no more `page.get().get().id`.

i did this simply to clean up the code (we haven't needed BTreePageInner in probably at least 8 months or more?), but it also:

- makes practically every tpc-h query faster due to removing indirection and refcell runtime borrowing every time the btree stack is accessed etc
- makes every SELECT * FROM users bench query faster
- drops the count() benchmark runtime by like half