### PR TITLE
perf: avoid constructing PageType in helper methods

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3325,7 +3325,7 @@ impl BTreeCursor {
                             parent_contents,
                             divider_cell_insert_idx_in_parent,
                             divider_cell_is_overflow_cell,
-                            &page,
+                            page,
                             usable_space,
                         );
                     }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -960,8 +960,7 @@ pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completio
     let page_id = page.get().id;
     tracing::trace!("begin_write_btree_page(page_id={})", page_id);
     let buffer = {
-        let page = page.get();
-        let contents = page.contents.as_ref().unwrap();
+        let contents = page.get_contents();
         contents.buffer.clone()
     };
 


### PR DESCRIPTION
I think the `try_into()` is probably expensive. we can use the fact that both interior page types are `<=5` to our advantage for a little perf boost in these hot path function calls

Based on #2836 (just to see aggregate perf difference in benchmarks)