### PR TITLE
core/translate: remove unneessary agg clones

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -392,7 +392,7 @@ fn prepare_one_select_plan(
                                             original_expr: *expr.clone(),
                                             distinctness,
                                         };
-                                        aggregate_expressions.push(agg.clone());
+                                        aggregate_expressions.push(agg);
                                         plan.result_columns.push(ResultSetColumn {
                                             alias: maybe_alias.as_ref().map(|alias| match alias {
                                                 ast::As::Elided(alias) => {
@@ -455,7 +455,7 @@ fn prepare_one_select_plan(
                                                     original_expr: *expr.clone(),
                                                     distinctness,
                                                 };
-                                                aggregate_expressions.push(agg.clone());
+                                                aggregate_expressions.push(agg);
                                                 plan.result_columns.push(ResultSetColumn {
                                                     alias: maybe_alias.as_ref().map(|alias| {
                                                         match alias {
@@ -496,7 +496,7 @@ fn prepare_one_select_plan(
                                             original_expr: *expr.clone(),
                                             distinctness: Distinctness::NonDistinct,
                                         };
-                                        aggregate_expressions.push(agg.clone());
+                                        aggregate_expressions.push(agg);
                                         plan.result_columns.push(ResultSetColumn {
                                             alias: maybe_alias.as_ref().map(|alias| match alias {
                                                 ast::As::Elided(alias) => {


### PR DESCRIPTION
```
Prepare `SELECT first_name, count(1) FROM users GROUP BY first_name HAVING count(1) > 1 ORDER BY cou...
                        time:   [3.9978 µs 4.0085 µs 4.0193 µs]
                        change: [-5.0734% -4.6271% -4.1644%] (p = 0.00 < 0.05)
```