### PR TITLE
 core/translate: parse_table remove unnecessary clone of table name 

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -417,7 +417,7 @@ fn parse_table(
 ) -> Result<()> {
     let normalized_qualified_name = normalize_ident(qualified_name.name.as_str());
     let database_id = connection.resolve_database_id(qualified_name)?;
-    let table_name = qualified_name.name.clone();
+    let table_name = &qualified_name.name;
 
     // Check if the FROM clause table is referring to a CTE in the current scope.
     if let Some(cte_idx) = ctes


### PR DESCRIPTION
```

Benchmarking Prepare `SELECT first_name, count(1) FROM users GROUP BY first_name HAVING count(1) > 1 ORDER BY cou...: Collecting 100 samples in estimated 5.008
Prepare `SELECT first_name, count(1) FROM users GROUP BY first_name HAVING count(1) > 1 ORDER BY cou...
                        time:   [4.0081 µs 4.0223 µs 4.0364 µs]
                        change: [-2.9298% -2.2538% -1.6786%] (p = 0.00 < 0.05)
                        Performance has improved.
                        ```