### PR TITLE
prevent modification to system tables.

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -41,6 +41,12 @@ use turso_parser::{
 const SCHEMA_TABLE_NAME: &str = "sqlite_schema";
 const SCHEMA_TABLE_NAME_ALT: &str = "sqlite_master";
 
+/// Check if a table name refers to a system table that should be protected from direct writes
+pub fn is_system_table(table_name: &str) -> bool {
+    let normalized = table_name.to_lowercase();
+    normalized == SCHEMA_TABLE_NAME || normalized == SCHEMA_TABLE_NAME_ALT
+}
+
 #[derive(Debug)]
 pub struct Schema {
     pub tables: HashMap<String, Arc<Table>>,

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -28,6 +28,12 @@ pub fn translate_alter_table(
         body: alter_table,
     } = alter;
     let table_name = table_name.name.as_str();
+
+    // Check if someone is trying to ALTER a system table
+    if crate::schema::is_system_table(table_name) {
+        crate::bail_parse_error!("table {} may not be modified", table_name);
+    }
+
     if schema.table_has_indexes(table_name) && !schema.indexes_enabled() {
         // Let's disable altering a table with indices altogether instead of checking column by
         // column to be extra safe.

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -23,6 +23,12 @@ pub fn translate_delete(
     connection: &Arc<crate::Connection>,
 ) -> Result<ProgramBuilder> {
     let tbl_name = normalize_ident(tbl_name.name.as_str());
+
+    // Check if this is a system table that should be protected from direct writes
+    if crate::schema::is_system_table(&tbl_name) {
+        crate::bail_parse_error!("table {} may not be modified", tbl_name);
+    }
+
     if schema.table_has_indexes(&tbl_name) && !schema.indexes_enabled() {
         // Let's disable altering a table with indices altogether instead of checking column by
         // column to be extra safe.

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -72,6 +72,12 @@ pub fn translate_insert(
         );
     }
     let table_name = &tbl_name.name;
+
+    // Check if this is a system table that should be protected from direct writes
+    if crate::schema::is_system_table(table_name.as_str()) {
+        crate::bail_parse_error!("table {} may not be modified", table_name);
+    }
+
     let table = match schema.get_table(table_name.as_str()) {
         Some(table) => table,
         None => crate::bail_parse_error!("no such table: {}", table_name),


### PR DESCRIPTION
SQLite does not allow us to modify system tables, but we do. Let's fix it.