### PR TITLE
boxing all `Expr` in core

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2188,7 +2188,7 @@ impl Statement {
 
     pub fn get_column_type(&self, idx: usize) -> Option<String> {
         let column = &self.program.result_columns.get(idx).expect("No column");
-        match &column.expr {
+        match column.expr.as_ref() {
             turso_parser::ast::Expr::Column {
                 table,
                 column: column_idx,

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -99,7 +99,7 @@ pub fn prepare_delete_plan(
 
     // Parse the WHERE clause
     parse_where(
-        where_clause.as_deref(),
+        &where_clause,
         &mut table_references,
         None,
         &mut where_predicates,

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1333,7 +1333,7 @@ mod tests {
 
         // Create where clause that only references second column
         let where_clause = vec![WhereTerm {
-            expr: Expr::Binary(
+            expr: Box::new(Expr::Binary(
                 Box::new(Expr::Column {
                     database: None,
                     table: joined_tables[0].internal_id,
@@ -1342,7 +1342,7 @@ mod tests {
                 }),
                 ast::Operator::Equals,
                 Box::new(Expr::Literal(ast::Literal::Numeric(5.to_string()))),
-            ),
+            )),
             from_outer_join: None,
             consumed: false,
         }];
@@ -1425,7 +1425,7 @@ mod tests {
         // Create where clause that references first and third columns
         let where_clause = vec![
             WhereTerm {
-                expr: Expr::Binary(
+                expr: Box::new(Expr::Binary(
                     Box::new(Expr::Column {
                         database: None,
                         table: joined_tables[0].internal_id,
@@ -1434,12 +1434,12 @@ mod tests {
                     }),
                     ast::Operator::Equals,
                     Box::new(Expr::Literal(ast::Literal::Numeric(5.to_string()))),
-                ),
+                )),
                 from_outer_join: None,
                 consumed: false,
             },
             WhereTerm {
-                expr: Expr::Binary(
+                expr: Box::new(Expr::Binary(
                     Box::new(Expr::Column {
                         database: None,
                         table: joined_tables[0].internal_id,
@@ -1448,7 +1448,7 @@ mod tests {
                     }),
                     ast::Operator::Equals,
                     Box::new(Expr::Literal(ast::Literal::Numeric(7.to_string()))),
-                ),
+                )),
                 from_outer_join: None,
                 consumed: false,
             },
@@ -1536,7 +1536,7 @@ mod tests {
         // Create where clause: c1 = 5 AND c2 > 10 AND c3 = 7
         let where_clause = vec![
             WhereTerm {
-                expr: Expr::Binary(
+                expr: Box::new(Expr::Binary(
                     Box::new(Expr::Column {
                         database: None,
                         table: joined_tables[0].internal_id,
@@ -1545,12 +1545,12 @@ mod tests {
                     }),
                     ast::Operator::Equals,
                     Box::new(Expr::Literal(ast::Literal::Numeric(5.to_string()))),
-                ),
+                )),
                 from_outer_join: None,
                 consumed: false,
             },
             WhereTerm {
-                expr: Expr::Binary(
+                expr: Box::new(Expr::Binary(
                     Box::new(Expr::Column {
                         database: None,
                         table: joined_tables[0].internal_id,
@@ -1559,12 +1559,12 @@ mod tests {
                     }),
                     ast::Operator::Greater,
                     Box::new(Expr::Literal(ast::Literal::Numeric(10.to_string()))),
-                ),
+                )),
                 from_outer_join: None,
                 consumed: false,
             },
             WhereTerm {
-                expr: Expr::Binary(
+                expr: Box::new(Expr::Binary(
                     Box::new(Expr::Column {
                         database: None,
                         table: joined_tables[0].internal_id,
@@ -1573,7 +1573,7 @@ mod tests {
                     }),
                     ast::Operator::Equals,
                     Box::new(Expr::Literal(ast::Literal::Numeric(7.to_string()))),
-                ),
+                )),
                 from_outer_join: None,
                 consumed: false,
             },
@@ -1690,7 +1690,7 @@ mod tests {
     /// Creates a binary expression for a WHERE clause
     fn _create_binary_expr(lhs: Expr, op: Operator, rhs: Expr) -> WhereTerm {
         WhereTerm {
-            expr: Expr::Binary(Box::new(lhs), op, Box::new(rhs)),
+            expr: Box::new(Expr::Binary(Box::new(lhs), op, Box::new(rhs))),
             from_outer_join: None,
             consumed: false,
         }

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -84,7 +84,7 @@ pub fn compute_order_target(
         ),
         // Only GROUP BY - we would like the joined result rows to be in the order specified by the GROUP BY
         (true, Some(group_by)) => OrderTarget::maybe_from_iterator(
-            group_by.exprs.iter().map(|expr| (expr, SortOrder::Asc)),
+            group_by.exprs.iter().map(|expr| (expr.as_ref(), SortOrder::Asc)),
             EliminatesSortBy::Group,
         ),
         // Both ORDER BY and GROUP BY:
@@ -107,7 +107,7 @@ pub fn compute_order_target(
             // If not, let's try to target an ordering that matches the group by -- we don't care about ASC/DESC
             if !group_by_contains_all {
                 return OrderTarget::maybe_from_iterator(
-                    group_by.exprs.iter().map(|expr| (expr, SortOrder::Asc)),
+                    group_by.exprs.iter().map(|expr| (expr.as_ref(), SortOrder::Asc)),
                     EliminatesSortBy::Group,
                 );
             }
@@ -146,7 +146,7 @@ pub fn compute_order_target(
                             .expect("GROUP BY should have a sort order before optimization is run")
                             .iter(),
                     )
-                    .map(|(expr, dir)| (expr, *dir)),
+                    .map(|(expr, dir)| (expr.as_ref(), *dir)),
                 EliminatesSortBy::GroupByAndOrder,
             )
         }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -156,7 +156,7 @@ pub enum Plan {
         right_most: SelectPlan,
         limit: Option<isize>,
         offset: Option<isize>,
-        order_by: Option<Vec<(ast::Expr, SortOrder)>>,
+        order_by: Option<Vec<(Box<ast::Expr>, SortOrder)>>,
     },
     Delete(DeletePlan),
     Update(UpdatePlan),

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -450,7 +450,7 @@ fn prepare_one_select_plan(
                                                     original_expr: expr.clone(),
                                                     distinctness,
                                                 };
-                                                aggregate_expressions.push(agg.clone());
+                                                aggregate_expressions.push(agg);
                                                 plan.result_columns.push(ResultSetColumn {
                                                     alias: maybe_alias.as_ref().map(|alias| {
                                                         match alias {
@@ -491,7 +491,7 @@ fn prepare_one_select_plan(
                                             original_expr: expr.clone(),
                                             distinctness: Distinctness::NonDistinct,
                                         };
-                                        aggregate_expressions.push(agg.clone());
+                                        aggregate_expressions.push(agg);
                                         plan.result_columns.push(ResultSetColumn {
                                             alias: maybe_alias.as_ref().map(|alias| match alias {
                                                 ast::As::Elided(alias) => {

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -247,7 +247,7 @@ pub fn prepare_update_plan(
 
         // Parse the WHERE clause
         parse_where(
-            body.where_clause.as_deref(),
+            &body.where_clause,
             &mut table_references,
             Some(&result_columns),
             &mut where_clause,
@@ -280,10 +280,10 @@ pub fn prepare_update_plan(
         let mut ephemeral_plan = SelectPlan {
             table_references,
             result_columns: vec![ResultSetColumn {
-                expr: Expr::RowId {
+                expr: Box::new(Expr::RowId {
                     database: None,
                     table: internal_id,
-                },
+                }),
                 alias: None,
                 contains_aggregates: false,
             }],
@@ -322,7 +322,7 @@ pub fn prepare_update_plan(
     if ephemeral_plan.is_none() {
         // Parse the WHERE clause
         parse_where(
-            body.where_clause.as_deref(),
+            &body.where_clause,
             &mut table_references,
             Some(&result_columns),
             &mut where_clause,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -298,7 +298,7 @@ impl ProgramBuilder {
     pub fn add_pragma_result_column(&mut self, col_name: String) {
         // TODO figure out a better type definition for ResultSetColumn
         // or invent another way to set pragma result columns
-        let expr = ast::Expr::Id(ast::Name::Ident("".to_string()));
+        let expr = Box::new(ast::Expr::Id(ast::Name::Ident("".to_string())));
         self.result_columns.push(ResultSetColumn {
             expr,
             alias: Some(col_name),


### PR DESCRIPTION
depends on #2844

```sh
Prepare `SELECT first_name, count(1) FROM users GROUP BY first_name HAVING count(1) > 1 ORDER BY cou...
                        time:   [3.8178 µs 3.8258 µs 3.8341 µs]
                        change: [-9.7996% -9.4509% -9.0999%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild

Execute `SELECT * FROM users LIMIT ?`/limbo_execute_select_rows/1
                        time:   [482.22 ns 483.10 ns 483.98 ns]
                        change: [-2.8545% -2.5750% -2.2927%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Execute `SELECT * FROM users LIMIT ?`/limbo_execute_select_rows/10
                        time:   [2.3616 µs 2.3773 µs 2.3969 µs]
                        change: [-2.2609% -1.7715% -1.2770%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  6 (6.00%) high severe

Execute `SELECT * FROM users LIMIT ?`/limbo_execute_select_rows/50
                        time:   [10.581 µs 10.601 µs 10.621 µs]
                        change: [-2.0231% -1.7960% -1.5636%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Execute `SELECT * FROM users LIMIT ?`/limbo_execute_select_rows/100
                        time:   [20.531 µs 20.568 µs 20.607 µs]
                        change: [-3.8061% -3.5218% -3.2224%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

Execute `SELECT count() FROM users`/limbo_execute_select_count
                        time:   [12.586 µs 12.621 µs 12.663 µs]
                        change: [-3.8765% -3.5374% -3.2017%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

```