### PR TITLE
Pass cipher and encrypt key through uri

### DIFF
--- a/core/util.rs
+++ b/core/util.rs
@@ -740,6 +740,8 @@ pub struct OpenOptions<'a> {
     pub cache: CacheMode,
     /// immutable=1|0 specifies that the database is stored on read-only media
     pub immutable: bool,
+    pub cipher: Option<String>,
+    pub hexkey: Option<String>,
 }
 
 pub const MEMORY_PATH: &str = ":memory:";
@@ -890,6 +892,8 @@ fn parse_query_params(query: &str, opts: &mut OpenOptions) -> Result<()> {
                 "cache" => opts.cache = decoded_value.as_str().into(),
                 "immutable" => opts.immutable = decoded_value == "1",
                 "vfs" => opts.vfs = Some(decoded_value),
+                "cipher" => opts.cipher = Some(decoded_value),
+                "hexkey" => opts.hexkey = Some(decoded_value),
                 _ => {}
             }
         }

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -503,11 +503,21 @@ $ openssl rand -hex 32
 
 Specify the key and cipher at the time of db creation to use encryption. Here is [sample test](https://github.com/tursodatabase/turso/blob/main/tests/integration/query_processing/encryption.rs):
 
+### Using PRAGMA
+
 ```shell
 $ cargo run --features encryption -- database.db
 
 PRAGMA cipher = 'aegis256'; -- or 'aes256gcm'
 PRAGMA hexkey = '2d7a30108d3eb3e45c90a732041fe54778bdcf707c76749fab7da335d1b39c1d';
+```
+
+### Using URI
+
+`file:<DATABASEFILE>?cipher=<CIPHER_NAME>&hexkey=<YOUR_32BYTE_HEX_KEY>`
+
+```shell
+$ cargo run --features encryption -- 'file:database.db?cipher=aegis256&hexkey=2d7a30108d3eb3e45c90a732041fe54778bdcf707c76749fab7da335d1b39c1d'
 ```
 
 ## Appendix A: Turso Internals


### PR DESCRIPTION
closes #2851 

```
turso on git uri-encrypt is pkg v0.1.4 via py v3.12.3 via rs v1.88.0 took 10s
x cargo run --features encryption -- 'file:database.db?cipher=aegis256&hexkey=2d7a30108d3eb3e45c90a732041fe54778bdcf707c76749fab7da335d1b39c1d'

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/tursodb 'file:database.db?cipher=aegis256&hexkey=2d7a30108d3eb3e45c90a732041fe54778bdcf707c76749fab7da335d1b39c1d'`
Turso v0.1.4
Enter ".help" for usage hints.
This software is ALPHA, only use for development, testing, and experimentation.
turso> select * from your_table;
Use .quit to exit or press Ctrl-C again to force quit.
turso> CREATE TABLE ligma (id INTEGER PRIMARY KEY, value TEXT);
INSERT INTO ligma (value) VALUES ('hello');
INSERT INTO ligma (value) VALUES ('bruh');
turso> select * from ligma;
┌────┬───────┐
│ id │ value │
├────┼───────┤
│  1 │ hello │
├────┼───────┤
│  2 │ bruh  │
└────┴───────┘
turso>
```

## file:

<img width="1914" height="96" alt="image" src="https://github.com/user-attachments/assets/cf4f0491-aeb0-47f9-b470-0dfe5f7ec2f2" />

## test:
```
running 1 test

thread 'query_processing::encryption::test_encryption_from_uri' panicked at core/storage/sqlite3_ondisk.rs:466:50:
called `Result::unwrap()` on an `Err` value: Corrupt("Invalid page type: 216")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test query_processing::encryption::test_encryption_from_uri ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 112 filtered out; finished in 0.04s

 ```

