### PR TITLE
Fix column count in ImmutableRow

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -1280,7 +1280,7 @@ impl ImmutableRecord {
     pub fn column_count(&self) -> usize {
         let mut cursor = RecordCursor::new();
         cursor.parse_full_header(self).unwrap();
-        cursor.offsets.len()
+        cursor.serial_types.len()
     }
 }
 
@@ -3561,5 +3561,20 @@ mod tests {
             buf.len(),
             header_length + size_of::<i8>() + size_of::<f64>() + text.len()
         );
+    }
+
+    #[test]
+    fn test_column_count_matches_values_written() {
+        // Test with different numbers of values
+        for num_values in 1..=10 {
+            let values: Vec<Value> = (0..num_values).map(|i| Value::Integer(i as i64)).collect();
+
+            let record = ImmutableRecord::from_values(&values, values.len());
+            let cnt = record.column_count();
+            assert_eq!(
+                cnt, num_values,
+                "column_count should be {num_values}, not {cnt}"
+            );
+        }
     }
 }


### PR DESCRIPTION
When we create an ImmutableRow::from_value(), we are always adding a null padding at the end. We didn't notice this before, because a SQLite file with an extra column is as valid as any. But that column of course should not be there.

I traced this to column_count(), which is off by one. My understanding is that we should be returning based on serial_types, not offset.