### PR TITLE
Unify handling of grouped and ungrouped aggregations

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -155,14 +155,12 @@ pub fn translate_aggregation_step(
             target_register
         }
         AggFunc::Count | AggFunc::Count0 => {
-            let expr_reg = if agg.args.is_empty() {
-                program.alloc_register()
-            } else {
-                let expr = &agg.args[0];
-                let expr_reg = program.alloc_register();
-                let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
-                expr_reg
-            };
+            if agg.args.len() != 1 {
+                crate::bail_parse_error!("count bad number of arguments");
+            }
+            let expr = &agg.args[0];
+            let expr_reg = program.alloc_register();
+            let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
             handle_distinct(program, agg, expr_reg);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -61,7 +61,7 @@ pub fn emit_ungrouped_aggregation<'a>(
     Ok(())
 }
 
-fn emit_collseq_if_needed(
+pub fn emit_collseq_if_needed(
     program: &mut ProgramBuilder,
     referenced_tables: &TableReferences,
     expr: &ast::Expr,

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -479,7 +479,11 @@ impl<'a> GroupByAggArgumentSource<'a> {
                 dest_reg_start,
                 ..
             } => {
-                program.emit_column_or_rowid(*cursor_id, *col_start, dest_reg_start + arg_idx);
+                program.emit_column_or_rowid(
+                    *cursor_id,
+                    *col_start + arg_idx,
+                    dest_reg_start + arg_idx,
+                );
                 Ok(dest_reg_start + arg_idx)
             }
             GroupByAggArgumentSource::Register {

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     Result,
 };
-
+use crate::translate::aggregation::emit_collseq_if_needed;
 use super::{
     aggregation::handle_distinct,
     emitter::{Resolver, TranslateCtx},
@@ -991,6 +991,8 @@ pub fn translate_aggregation_step_groupby(
             }
             let expr_reg = agg_arg_source.translate(program, 0)?;
             handle_distinct(program, agg_arg_source.aggregate(), expr_reg);
+            let expr = &agg_arg_source.args()[0];
+            emit_collseq_if_needed(program, referenced_tables, expr);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -1005,6 +1007,8 @@ pub fn translate_aggregation_step_groupby(
             }
             let expr_reg = agg_arg_source.translate(program, 0)?;
             handle_distinct(program, agg_arg_source.aggregate(), expr_reg);
+            let expr = &agg_arg_source.args()[0];
+            emit_collseq_if_needed(program, referenced_tables, expr);
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -928,6 +928,9 @@ pub fn translate_aggregation_step_groupby(
             target_register
         }
         AggFunc::Count | AggFunc::Count0 => {
+            if num_args != 1 {
+                crate::bail_parse_error!("count bad number of arguments");
+            }
             let expr_reg = agg_arg_source.translate(program, 0)?;
             handle_distinct(program, agg_arg_source.aggregate(), expr_reg);
             program.emit_insn(Insn::AggStep {

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use super::{
-    aggregation::translate_aggregation_step,
+    aggregation::{translate_aggregation_step, AggArgumentSource},
     emitter::{OperationMode, TranslateCtx},
     expr::{
         translate_condition_expr, translate_expr, translate_expr_no_constant_opt,
@@ -868,7 +868,7 @@ fn emit_loop_source(
                 translate_aggregation_step(
                     program,
                     &plan.table_references,
-                    agg,
+                    AggArgumentSource::new_from_expression(agg),
                     reg,
                     &t_ctx.resolver,
                 )?;

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -73,12 +73,7 @@ pub fn resolve_aggregates(
                                 "DISTINCT aggregate functions must have exactly one argument"
                             );
                         }
-                        aggs.push(Aggregate {
-                            func: f,
-                            args: args.iter().map(|arg| *arg.clone()).collect(),
-                            original_expr: expr.clone(),
-                            distinctness,
-                        });
+                        aggs.push(Aggregate::new(f, args, expr, distinctness));
                         contains_aggregates = true;
                     }
                     _ => {
@@ -95,12 +90,7 @@ pub fn resolve_aggregates(
                     );
                 }
                 if let Ok(Func::Agg(f)) = Func::resolve_function(name.as_str(), 0) {
-                    aggs.push(Aggregate {
-                        func: f,
-                        args: vec![],
-                        original_expr: expr.clone(),
-                        distinctness: Distinctness::NonDistinct,
-                    });
+                    aggs.push(Aggregate::new(f, &[], expr, Distinctness::NonDistinct));
                     contains_aggregates = true;
                 }
             }

--- a/testing/agg-functions.test
+++ b/testing/agg-functions.test
@@ -144,3 +144,34 @@ do_execsql_test select-agg-json-array-object {
 do_execsql_test select-distinct-agg-functions {
 SELECT sum(distinct age), count(distinct age), avg(distinct age) FROM users;
 } {5050|100|50.5}
+
+do_execsql_test select-json-group-object {
+  select price,
+         json_group_object(cast (id as text), name)
+  from products
+  group by price
+  order by price;
+} {1.0|{"9":"boots"}
+18.0|{"3":"shirt"}
+25.0|{"4":"sweater"}
+33.0|{"10":"coat"}
+70.0|{"6":"shorts"}
+74.0|{"5":"sweatshirt"}
+78.0|{"7":"jeans"}
+79.0|{"1":"hat"}
+81.0|{"11":"accessories"}
+82.0|{"2":"cap","8":"sneakers"}}
+
+do_execsql_test select-json-group-object-no-sorting-required {
+  select age,
+         json_group_object(cast (id as text), first_name)
+  from users
+  where first_name like 'Am%'
+  group by age
+  order by age
+  limit 5;
+} {1|{"6737":"Amy"}
+2|{"2297":"Amy","3580":"Amanda"}
+3|{"3437":"Amanda"}
+5|{"2378":"Amy","3227":"Amy","5605":"Amanda"}
+7|{"2454":"Amber"}}

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -7,22 +7,22 @@ from cli_tests.test_turso_cli import TestTursoShell
 sqlite_exec = "./scripts/limbo-sqlite3"
 sqlite_flags = os.getenv("SQLITE_FLAGS", "-q").split(" ")
 
-test_data = """CREATE TABLE numbers ( id INTEGER PRIMARY KEY, value FLOAT NOT NULL);
-INSERT INTO numbers (value) VALUES (1.0);
-INSERT INTO numbers (value) VALUES (2.0);
-INSERT INTO numbers (value) VALUES (3.0);
-INSERT INTO numbers (value) VALUES (4.0);
-INSERT INTO numbers (value) VALUES (5.0);
-INSERT INTO numbers (value) VALUES (6.0);
-INSERT INTO numbers (value) VALUES (7.0);
-CREATE TABLE test (value REAL, percent REAL);
-INSERT INTO test values (10, 25);
-INSERT INTO test values (20, 25);
-INSERT INTO test values (30, 25);
-INSERT INTO test values (40, 25);
-INSERT INTO test values (50, 25);
-INSERT INTO test values (60, 25);
-INSERT INTO test values (70, 25);
+test_data = """CREATE TABLE numbers ( id INTEGER PRIMARY KEY, value FLOAT NOT NULL, category TEXT DEFAULT 'A');
+INSERT INTO numbers (value, category) VALUES (1.0, 'A');
+INSERT INTO numbers (value, category) VALUES (2.0, 'A');
+INSERT INTO numbers (value, category) VALUES (3.0, 'A');
+INSERT INTO numbers (value, category) VALUES (4.0, 'B');
+INSERT INTO numbers (value, category) VALUES (5.0, 'B');
+INSERT INTO numbers (value, category) VALUES (6.0, 'B');
+INSERT INTO numbers (value, category) VALUES (7.0, 'B');
+CREATE TABLE test (value REAL, percent REAL, category TEXT);
+INSERT INTO test values (10, 25, 'A');
+INSERT INTO test values (20, 25, 'A');
+INSERT INTO test values (30, 25, 'B');
+INSERT INTO test values (40, 25, 'C');
+INSERT INTO test values (50, 25, 'C');
+INSERT INTO test values (60, 25, 'C');
+INSERT INTO test values (70, 25, 'D');
 """
 
 
@@ -171,6 +171,39 @@ def test_aggregates():
     )
     limbo.run_test_fn("SELECT percentile_cont(value, 0.25) from test;", validate_percentile1)
     limbo.run_test_fn("SELECT percentile_disc(value, 0.55) from test;", validate_percentile_disc)
+    limbo.quit()
+
+
+def test_grouped_aggregates():
+    limbo = TestTursoShell(init_commands=test_data)
+    extension_path = "./target/debug/liblimbo_percentile"
+    limbo.execute_dot(f".load {extension_path}")
+
+    limbo.run_test_fn(
+        "SELECT median(value) FROM numbers GROUP BY category;",
+        lambda res: "2.0\n5.5" == res,
+        "median aggregate function works",
+    )
+    limbo.run_test_fn(
+        "SELECT percentile(value, percent) FROM test GROUP BY category;",
+        lambda res: "12.5\n30.0\n45.0\n70.0" == res,
+        "grouped aggregate percentile function with 2 arguments works",
+    )
+    limbo.run_test_fn(
+        "SELECT percentile(value, 55) FROM test GROUP BY category;",
+        lambda res: "15.5\n30.0\n51.0\n70.0" == res,
+        "grouped aggregate percentile function with 1 argument works",
+    )
+    limbo.run_test_fn(
+        "SELECT percentile_cont(value, 0.25) FROM test GROUP BY category;",
+        lambda res: "12.5\n30.0\n45.0\n70.0" == res,
+        "grouped aggregate percentile_cont function works",
+    )
+    limbo.run_test_fn(
+        "SELECT percentile_disc(value, 0.55) FROM test GROUP BY category;",
+        lambda res: "10.0\n30.0\n50.0\n70.0" == res,
+        "grouped aggregate percentile_disc function works",
+    )
     limbo.quit()
 
 
@@ -770,6 +803,7 @@ def main():
         test_regexp()
         test_uuid()
         test_aggregates()
+        test_grouped_aggregates()
         test_crypto()
         test_series()
         test_ipaddr()

--- a/testing/collate.test
+++ b/testing/collate.test
@@ -74,3 +74,31 @@ do_execsql_test_on_specific_db {:memory:} collate_aggregation_explicit_nocase {
     insert into fruits(name) values ('Apple') ,('banana') ,('CHERRY');
     select max(name collate nocase) from fruits;
 } {CHERRY}
+
+do_execsql_test_on_specific_db {:memory:} collate_grouped_aggregation_default_binary {
+    create table fruits(name collate binary, category text);
+    insert into fruits(name, category) values ('Apple', 'A'), ('banana', 'A'), ('CHERRY', 'B'), ('blueberry', 'B');
+    select max(name) from fruits group by category;
+} {banana
+blueberry}
+
+do_execsql_test_on_specific_db {:memory:} collate_grouped_aggregation_default_nocase {
+    create table fruits(name collate nocase, category text);
+    insert into fruits(name, category) values ('Apple', 'A'), ('banana', 'A'), ('CHERRY', 'B'), ('blueberry', 'B');
+    select max(name) from fruits group by category;
+} {banana
+CHERRY}
+
+do_execsql_test_on_specific_db {:memory:} collate_grouped_aggregation_explicit_binary {
+    create table fruits(name collate nocase, category text);
+    insert into fruits(name, category) values ('Apple', 'A'), ('banana', 'A'), ('CHERRY', 'B'), ('blueberry', 'B');
+    select max(name collate binary) from fruits group by category;
+} {banana
+blueberry}
+
+do_execsql_test_on_specific_db {:memory:} collate_groupped_aggregation_explicit_nocase {
+    create table fruits(name collate binary, category text);
+    insert into fruits(name, category) values ('Apple', 'A'), ('banana', 'A'), ('CHERRY', 'B'), ('blueberry', 'B');
+    select max(name collate nocase) from fruits group by category;
+} {banana
+CHERRY}

--- a/testing/groupby.test
+++ b/testing/groupby.test
@@ -145,6 +145,18 @@ do_execsql_test group_by_count_star {
   select u.first_name, count(*) from users u group by u.first_name limit 1;
 } {Aaron|41}
 
+do_execsql_test group_by_count_star_in_expression {
+  select u.first_name, count(*) % 3 from users u group by u.first_name order by u.first_name limit 3;
+} {Aaron|2
+Abigail|1
+Adam|0}
+
+do_execsql_test group_by_count_no_args_in_expression {
+  select u.first_name, count() % 3 from users u group by u.first_name order by u.first_name limit 3;
+} {Aaron|2
+Abigail|1
+Adam|0}
+
 do_execsql_test having {
   select u.first_name, round(avg(u.age)) from users u group by u.first_name having avg(u.age) > 97 order by avg(u.age) desc limit 5;
 } {Nina|100.0


### PR DESCRIPTION
The initial commits fix issues and plug gaps between ungrouped and grouped aggregations.
The final commit consolidates the code that emits `AggStep` to prevent future disparities between the two.