### PR TITLE
core/printf: support for more basic substitution types

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -350,6 +350,13 @@ impl Value {
         }
     }
 
+    pub fn as_uint(&self) -> u64 {
+        match self {
+            Value::Integer(i) => (*i).cast_unsigned(),
+            _ => 0,
+        }
+    }
+
     pub fn from_text(text: &str) -> Self {
         Value::Text(Text::new(text))
     }


### PR DESCRIPTION
Some progress working on `printf` support.
(relevant issue https://github.com/tursodatabase/turso/issues/885)

Implementation of the basic substitution types cited in the `TODO` comment on the beginning of the file (%i, %x, %X, %o, %e, %E, %c). There are some others in the sqlite spec which I will implement in a future PR.

I tried to pay attention to the specific behaviors from sqlite as much as possible while testing this, but if there's something I missed please tell me.

Also, I see this code needs to be reorganized already, I'm still thinking on the best approach to do that without affecting the ergonomics of new implementations, I'm still learning Rust so this is not obvious for me right now. I'm open to suggestions about it.