### PR TITLE
Optimize range scans

### DIFF
--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -1126,7 +1126,7 @@ fn emit_seek(
     loop_end: BranchOffset,
     is_index: bool,
 ) -> Result<()> {
-    if seek_def.prefix.len() == 0 && matches!(seek_def.start.last_component, SeekKeyComponent::None)
+    if seek_def.prefix.is_empty() && matches!(seek_def.start.last_component, SeekKeyComponent::None)
     {
         // If there is no seek key, we start from the first or last row of the index,
         // depending on the iteration direction.
@@ -1231,7 +1231,7 @@ fn emit_seek_termination(
     loop_end: BranchOffset,
     is_index: bool,
 ) -> Result<()> {
-    if seek_def.prefix.len() == 0 && matches!(seek_def.end.last_component, SeekKeyComponent::None) {
+    if seek_def.prefix.is_empty() && matches!(seek_def.end.last_component, SeekKeyComponent::None) {
         program.preassign_label_to_next_insn(loop_start);
         return Ok(());
     };

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -1238,7 +1238,7 @@ fn emit_seek_termination(
 
     // For all index key values apart from the last one, we are guaranteed to use the same values
     // as these values were emited from common prefix, so we don't need to emit them again.
-        
+
     let num_regs = seek_def.size(&seek_def.end);
     let last_reg = start_reg + seek_def.prefix.len();
     match &seek_def.end.last_component {

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -59,9 +59,9 @@ pub enum AccessMethodParams {
 }
 
 /// Return the best [AccessMethod] for a given join order.
-pub fn find_best_access_method_for_join_order<'a>(
+pub fn find_best_access_method_for_join_order(
     rhs_table: &JoinedTable,
-    rhs_constraints: &'a TableConstraints,
+    rhs_constraints: &'_ TableConstraints,
     join_order: &[JoinOrderMember],
     maybe_order_target: Option<&OrderTarget>,
     input_cardinality: f64,

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -4,7 +4,7 @@ use turso_ext::{ConstraintInfo, ConstraintUsage, ResultCode};
 use turso_parser::ast::SortOrder;
 
 use crate::translate::optimizer::constraints::{
-    convert_to_vtab_constraint, RangeConstraintRef, Constraint,
+    convert_to_vtab_constraint, Constraint, RangeConstraintRef,
 };
 use crate::{
     schema::{Index, Table},

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -58,17 +58,17 @@ pub enum BinaryExprSide {
 }
 
 impl Constraint {
-    /// Get the constraining expression, e.g. '2+3' from 't.x = 2+3'
-    pub fn get_constraining_expr(&self, where_clause: &[WhereTerm]) -> ast::Expr {
+    /// Get the constraining expression and operator, e.g. ('>=', '2+3') from 't.x >= 2+3'
+    pub fn get_constraining_expr(&self, where_clause: &[WhereTerm]) -> (ast::Operator, ast::Expr) {
         let (idx, side) = self.where_clause_pos;
         let where_term = &where_clause[idx];
         let Ok(Some((lhs, _, rhs))) = as_binary_components(&where_term.expr) else {
             panic!("Expected a valid binary expression");
         };
         if side == BinaryExprSide::Lhs {
-            lhs.clone()
+            (self.operator, lhs.clone())
         } else {
-            rhs.clone()
+            (self.operator, rhs.clone())
         }
     }
 }
@@ -84,19 +84,6 @@ pub struct ConstraintRef {
     pub index_col_pos: usize,
     /// The sort order of the constrained column in the index. Always ascending for rowid indices.
     pub sort_order: SortOrder,
-}
-
-impl ConstraintRef {
-    /// Convert the constraint to a column usable in a [crate::translate::plan::SeekDef::key].
-    pub fn as_seek_key_column(
-        &self,
-        constraints: &[Constraint],
-        where_clause: &[WhereTerm],
-    ) -> (ast::Expr, SortOrder) {
-        let constraint = &constraints[self.constraint_vec_pos];
-        let constraining_expr = constraint.get_constraining_expr(where_clause);
-        (constraining_expr, self.sort_order)
-    }
 }
 
 /// A collection of [ConstraintRef]s for a given index, or if index is None, for the table's rowid index.
@@ -128,6 +115,7 @@ pub struct ConstraintUseCandidate {
     /// The index that may be used to satisfy the constraints. If none, the table's rowid index is used.
     pub index: Option<Arc<Index>>,
     /// References to the constraints that may be used as an access path for the index.
+    /// Refs are sorted by [ConstraintRef::index_col_pos]
     pub refs: Vec<ConstraintRef>,
 }
 
@@ -171,6 +159,9 @@ fn estimate_selectivity(column: &Column, op: ast::Operator) -> f64 {
 
 /// Precompute all potentially usable [Constraints] from a WHERE clause.
 /// The resulting list of [TableConstraints] is then used to evaluate the best access methods for various join orders.
+///
+/// This method do not perform much filtering of constraints and delegate this tasks to the consumers of the method
+/// Consumers must inspect [TableConstraints] and its candidates and pick best constraints for optimized access
 pub fn constraints_from_where_clause(
     where_clause: &[WhereTerm],
     table_references: &TableReferences,
@@ -346,29 +337,92 @@ pub fn constraints_from_where_clause(
         for candidate in cs.candidates.iter_mut() {
             // Sort by index_col_pos, ascending -- index columns must be consumed in contiguous order.
             candidate.refs.sort_by_key(|cref| cref.index_col_pos);
-            // Deduplicate by position, keeping first occurrence (which will be equality if one exists, since the constraints vec is sorted that way)
-            candidate.refs.dedup_by_key(|cref| cref.index_col_pos);
-            // Truncate at first gap in positions -- again, index columns must be consumed in contiguous order.
-            let contiguous_len = candidate
-                .refs
-                .iter()
-                .enumerate()
-                .take_while(|(i, cref)| cref.index_col_pos == *i)
-                .count();
-            candidate.refs.truncate(contiguous_len);
-
-            // Truncate after the first inequality, since the left-prefix rule of indexes requires that all constraints but the last one must be equalities;
-            // again see: https://www.solarwinds.com/blog/the-left-prefix-index-rule
-            if let Some(first_inequality) = candidate.refs.iter().position(|cref| {
-                cs.constraints[cref.constraint_vec_pos].operator != ast::Operator::Equals
-            }) {
-                candidate.refs.truncate(first_inequality + 1);
-            }
         }
         constraints.push(cs);
     }
 
     Ok(constraints)
+}
+
+#[derive(Clone, Debug)]
+/// A reference to a [Constraint]s in a [TableConstraints] for single column.
+///
+/// This is specialized version of [ConstraintRef] which specifically holds range-like constraints:
+/// - x = 10 (eq is set)
+/// - x >= 10, x > 10 (lower_bound is set)
+/// - x <= 10, x < 10 (upper_bound is set)
+/// - x > 10 AND x < 20 (both lower_bound and upper_bound are set)
+///
+/// eq, lower_bound and upper_bound holds None or position of the constraint in the [Constraint] array
+pub struct RangeConstraintRef {
+    /// position of the column in the table definition
+    pub table_col_pos: usize,
+    /// position of the column in the index definition
+    pub index_col_pos: usize,
+    /// sort order for the column in the index definition
+    pub sort_order: SortOrder,
+    /// equality constraint
+    pub eq: Option<usize>,
+    /// lower bound constraint (either > or >=)
+    pub lower_bound: Option<usize>,
+    /// upper bound constraint (either < or <=)
+    pub upper_bound: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+/// Represent seek range which can be used in query planning to emit range scan over table or index
+pub struct SeekRangeConstraint {
+    pub sort_order: SortOrder,
+    pub eq: Option<(ast::Operator, ast::Expr)>,
+    pub lower_bound: Option<(ast::Operator, ast::Expr)>,
+    pub upper_bound: Option<(ast::Operator, ast::Expr)>,
+}
+
+impl SeekRangeConstraint {
+    pub fn new_eq(sort_order: SortOrder, eq: (ast::Operator, ast::Expr)) -> Self {
+        Self {
+            sort_order,
+            eq: Some(eq),
+            lower_bound: None,
+            upper_bound: None,
+        }
+    }
+    pub fn new_range(
+        sort_order: SortOrder,
+        lower_bound: Option<(ast::Operator, ast::Expr)>,
+        upper_bound: Option<(ast::Operator, ast::Expr)>,
+    ) -> Self {
+        assert!(lower_bound.is_some() || upper_bound.is_some());
+        Self {
+            sort_order,
+            eq: None,
+            lower_bound,
+            upper_bound,
+        }
+    }
+}
+
+impl RangeConstraintRef {
+    /// Convert the [RangeConstraintRef] to a [SeekRangeConstraint] usable in a [crate::translate::plan::SeekDef::key].
+    pub fn as_seek_range_constraint(
+        &self,
+        constraints: &[Constraint],
+        where_clause: &[WhereTerm],
+    ) -> SeekRangeConstraint {
+        if let Some(eq) = self.eq {
+            return SeekRangeConstraint::new_eq(
+                self.sort_order,
+                constraints[eq].get_constraining_expr(where_clause),
+            );
+        }
+        SeekRangeConstraint::new_range(
+            self.sort_order,
+            self.lower_bound
+                .map(|x| constraints[x].get_constraining_expr(where_clause)),
+            self.upper_bound
+                .map(|x| constraints[x].get_constraining_expr(where_clause)),
+        )
+    }
 }
 
 /// Find which [Constraint]s are usable for a given join order.
@@ -379,28 +433,88 @@ pub fn usable_constraints_for_join_order<'a>(
     constraints: &'a [Constraint],
     refs: &'a [ConstraintRef],
     join_order: &[JoinOrderMember],
-) -> &'a [ConstraintRef] {
+) -> Vec<RangeConstraintRef> {
+    debug_assert!(refs.is_sorted_by_key(|x| x.index_col_pos));
+
     let table_idx = join_order.last().unwrap().original_idx;
-    let mut usable_until = 0;
+    let lhs_mask = TableMask::from_table_number_iter(
+        join_order
+            .iter()
+            .take(join_order.len() - 1)
+            .map(|j| j.original_idx),
+    );
+    let mut usable: Vec<RangeConstraintRef> = Vec::new();
+    let mut last_column_pos = 0;
     for cref in refs.iter() {
         let constraint = &constraints[cref.constraint_vec_pos];
         let other_side_refers_to_self = constraint.lhs_mask.contains_table(table_idx);
         if other_side_refers_to_self {
             break;
         }
-        let lhs_mask = TableMask::from_table_number_iter(
-            join_order
-                .iter()
-                .take(join_order.len() - 1)
-                .map(|j| j.original_idx),
-        );
         let all_required_tables_are_on_left_side = lhs_mask.contains_all(&constraint.lhs_mask);
         if !all_required_tables_are_on_left_side {
             break;
         }
-        usable_until += 1;
+        if Some(cref.index_col_pos) == usable.last().map(|x| x.index_col_pos) {
+            assert_eq!(cref.sort_order, usable.last().unwrap().sort_order);
+            assert_eq!(cref.index_col_pos, usable.last().unwrap().index_col_pos);
+            assert_eq!(
+                constraints[cref.constraint_vec_pos].table_col_pos,
+                usable.last().unwrap().table_col_pos
+            );
+            // if we already have eq constraint - we must not add anything to it
+            // otherwise, we can incorrectly consume filters which will not be used in the access path
+            if usable.last().unwrap().eq.is_some() {
+                continue;
+            }
+            match constraints[cref.constraint_vec_pos].operator {
+                ast::Operator::Greater | ast::Operator::GreaterEquals => {
+                    usable.last_mut().unwrap().lower_bound = Some(cref.constraint_vec_pos);
+                }
+                ast::Operator::Less | ast::Operator::LessEquals => {
+                    usable.last_mut().unwrap().upper_bound = Some(cref.constraint_vec_pos);
+                }
+                _ => {}
+            }
+            continue;
+        }
+        if cref.index_col_pos != last_column_pos {
+            break;
+        }
+        if usable.last().is_some_and(|x| x.eq.is_none()) {
+            break;
+        }
+        let constraint_group = match constraints[cref.constraint_vec_pos].operator {
+            ast::Operator::Equals => RangeConstraintRef {
+                table_col_pos: constraints[cref.constraint_vec_pos].table_col_pos,
+                index_col_pos: cref.index_col_pos,
+                sort_order: cref.sort_order,
+                eq: Some(cref.constraint_vec_pos),
+                lower_bound: None,
+                upper_bound: None,
+            },
+            ast::Operator::Greater | ast::Operator::GreaterEquals => RangeConstraintRef {
+                table_col_pos: constraints[cref.constraint_vec_pos].table_col_pos,
+                index_col_pos: cref.index_col_pos,
+                sort_order: cref.sort_order,
+                eq: None,
+                lower_bound: Some(cref.constraint_vec_pos),
+                upper_bound: None,
+            },
+            ast::Operator::Less | ast::Operator::LessEquals => RangeConstraintRef {
+                table_col_pos: constraints[cref.constraint_vec_pos].table_col_pos,
+                index_col_pos: cref.index_col_pos,
+                sort_order: cref.sort_order,
+                eq: None,
+                lower_bound: None,
+                upper_bound: Some(cref.constraint_vec_pos),
+            },
+            _ => continue,
+        };
+        usable.push(constraint_group);
+        last_column_pos += 1;
     }
-    &refs[..usable_until]
+    usable
 }
 
 pub fn convert_to_vtab_constraint(

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -49,7 +49,7 @@ pub fn join_lhs_and_rhs<'a>(
     rhs_constraints: &'a TableConstraints,
     join_order: &[JoinOrderMember],
     maybe_order_target: Option<&OrderTarget>,
-    access_methods_arena: &'a RefCell<Vec<AccessMethod<'a>>>,
+    access_methods_arena: &'a RefCell<Vec<AccessMethod>>,
     cost_upper_bound: Cost,
 ) -> Result<Option<JoinN>> {
     // The input cardinality for this join is the output cardinality of the previous join.
@@ -125,7 +125,7 @@ pub fn compute_best_join_order<'a>(
     joined_tables: &[JoinedTable],
     maybe_order_target: Option<&OrderTarget>,
     constraints: &'a [TableConstraints],
-    access_methods_arena: &'a RefCell<Vec<AccessMethod<'a>>>,
+    access_methods_arena: &'a RefCell<Vec<AccessMethod>>,
 ) -> Result<Option<BestJoinOrderResult>> {
     // Skip work if we have no tables to consider.
     if joined_tables.is_empty() {
@@ -403,7 +403,7 @@ pub fn compute_best_join_order<'a>(
 pub fn compute_naive_left_deep_plan<'a>(
     joined_tables: &[JoinedTable],
     maybe_order_target: Option<&OrderTarget>,
-    access_methods_arena: &'a RefCell<Vec<AccessMethod<'a>>>,
+    access_methods_arena: &'a RefCell<Vec<AccessMethod>>,
     constraints: &'a [TableConstraints],
 ) -> Result<Option<JoinN>> {
     let n = joined_tables.len();
@@ -509,9 +509,11 @@ mod tests {
     use crate::{
         schema::{BTreeTable, Column, Index, IndexColumn, Table, Type},
         translate::{
-            optimizer::access_method::AccessMethodParams,
-            optimizer::constraints::{
-                constraints_from_where_clause, BinaryExprSide, ConstraintRef,
+            optimizer::{
+                access_method::AccessMethodParams,
+                constraints::{
+                    constraints_from_where_clause, BinaryExprSide, RangeConstraintRef,
+                },
             },
             plan::{
                 ColumnUsedMask, IterationDirection, JoinInfo, Operation, TableReferences, WhereTerm,
@@ -632,8 +634,7 @@ mod tests {
         assert!(iter_dir == IterationDirection::Forwards);
         assert!(constraint_refs.len() == 1);
         assert!(
-            table_constraints[0].constraints[constraint_refs[0].constraint_vec_pos]
-                .where_clause_pos
+            table_constraints[0].constraints[constraint_refs[0].eq.unwrap()].where_clause_pos
                 == (0, BinaryExprSide::Rhs)
         );
     }
@@ -700,8 +701,7 @@ mod tests {
         assert!(index.as_ref().unwrap().name == "sqlite_autoindex_test_table_1");
         assert!(constraint_refs.len() == 1);
         assert!(
-            table_constraints[0].constraints[constraint_refs[0].constraint_vec_pos]
-                .where_clause_pos
+            table_constraints[0].constraints[constraint_refs[0].eq.unwrap()].where_clause_pos
                 == (0, BinaryExprSide::Rhs)
         );
     }
@@ -782,8 +782,7 @@ mod tests {
         assert!(index.as_ref().unwrap().name == "index1");
         assert!(constraint_refs.len() == 1);
         assert!(
-            table_constraints[TABLE1].constraints[constraint_refs[0].constraint_vec_pos]
-                .where_clause_pos
+            table_constraints[TABLE1].constraints[constraint_refs[0].eq.unwrap()].where_clause_pos
                 == (0, BinaryExprSide::Rhs)
         );
     }
@@ -955,8 +954,8 @@ mod tests {
         assert!(iter_dir == IterationDirection::Forwards);
         assert!(index.as_ref().unwrap().name == "sqlite_autoindex_customers_1");
         assert!(constraint_refs.len() == 1);
-        let constraint = &table_constraints[TABLE_NO_CUSTOMERS].constraints
-            [constraint_refs[0].constraint_vec_pos];
+        let constraint =
+            &table_constraints[TABLE_NO_CUSTOMERS].constraints[constraint_refs[0].eq.unwrap()];
         assert!(constraint.lhs_mask.is_empty());
 
         let access_method = &access_methods_arena.borrow()[best_plan.data[1].1];
@@ -965,7 +964,7 @@ mod tests {
         assert!(index.as_ref().unwrap().name == "orders_customer_id_idx");
         assert!(constraint_refs.len() == 1);
         let constraint =
-            &table_constraints[TABLE_NO_ORDERS].constraints[constraint_refs[0].constraint_vec_pos];
+            &table_constraints[TABLE_NO_ORDERS].constraints[constraint_refs[0].eq.unwrap()];
         assert!(constraint.lhs_mask.contains_table(TABLE_NO_CUSTOMERS));
 
         let access_method = &access_methods_arena.borrow()[best_plan.data[2].1];
@@ -973,8 +972,8 @@ mod tests {
         assert!(iter_dir == IterationDirection::Forwards);
         assert!(index.as_ref().unwrap().name == "order_items_order_id_idx");
         assert!(constraint_refs.len() == 1);
-        let constraint = &table_constraints[TABLE_NO_ORDER_ITEMS].constraints
-            [constraint_refs[0].constraint_vec_pos];
+        let constraint =
+            &table_constraints[TABLE_NO_ORDER_ITEMS].constraints[constraint_refs[0].eq.unwrap()];
         assert!(constraint.lhs_mask.contains_table(TABLE_NO_ORDERS));
     }
 
@@ -1182,8 +1181,8 @@ mod tests {
             assert!(iter_dir == IterationDirection::Forwards);
             assert!(index.is_none());
             assert!(constraint_refs.len() == 1);
-            let constraint = &table_constraints[*table_number].constraints
-                [constraint_refs[0].constraint_vec_pos];
+            let constraint =
+                &table_constraints[*table_number].constraints[constraint_refs[0].eq.unwrap()];
             assert!(constraint.lhs_mask.contains_table(FACT_TABLE_IDX));
             assert!(constraint.operator == ast::Operator::Equals);
         }
@@ -1275,7 +1274,7 @@ mod tests {
             assert!(iter_dir == IterationDirection::Forwards);
             assert!(index.is_none());
             assert!(constraint_refs.len() == 1);
-            let constraint = &table_constraints.constraints[constraint_refs[0].constraint_vec_pos];
+            let constraint = &table_constraints.constraints[constraint_refs[0].eq.unwrap()];
             assert!(constraint.lhs_mask.contains_table(i - 1));
             assert!(constraint.operator == ast::Operator::Equals);
         }
@@ -1474,7 +1473,7 @@ mod tests {
         let (_, index, constraint_refs) = _as_btree(access_method);
         assert!(index.as_ref().is_some_and(|i| i.name == "idx1"));
         assert!(constraint_refs.len() == 1);
-        let constraint = &table_constraints[0].constraints[constraint_refs[0].constraint_vec_pos];
+        let constraint = &table_constraints[0].constraints[constraint_refs[0].eq.unwrap()];
         assert!(constraint.operator == ast::Operator::Equals);
         assert!(constraint.table_col_pos == 0); // c1
     }
@@ -1600,10 +1599,10 @@ mod tests {
         let (_, index, constraint_refs) = _as_btree(access_method);
         assert!(index.as_ref().is_some_and(|i| i.name == "idx1"));
         assert!(constraint_refs.len() == 2);
-        let constraint = &table_constraints[0].constraints[constraint_refs[0].constraint_vec_pos];
+        let constraint = &table_constraints[0].constraints[constraint_refs[0].eq.unwrap()];
         assert!(constraint.operator == ast::Operator::Equals);
         assert!(constraint.table_col_pos == 0); // c1
-        let constraint = &table_constraints[0].constraints[constraint_refs[1].constraint_vec_pos];
+        let constraint = &table_constraints[0].constraints[constraint_refs[1].lower_bound.unwrap()];
         assert!(constraint.operator == ast::Operator::Greater);
         assert!(constraint.table_col_pos == 1); // c2
     }
@@ -1701,9 +1700,13 @@ mod tests {
         Expr::Literal(ast::Literal::Numeric(value.to_string()))
     }
 
-    fn _as_btree<'a>(
-        access_method: &AccessMethod<'a>,
-    ) -> (IterationDirection, Option<Arc<Index>>, &'a [ConstraintRef]) {
+    fn _as_btree(
+        access_method: &AccessMethod,
+    ) -> (
+        IterationDirection,
+        Option<Arc<Index>>,
+        &'_ [RangeConstraintRef],
+    ) {
         match &access_method.params {
             AccessMethodParams::BTreeTable {
                 iter_dir,

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -511,9 +511,7 @@ mod tests {
         translate::{
             optimizer::{
                 access_method::AccessMethodParams,
-                constraints::{
-                    constraints_from_where_clause, BinaryExprSide, RangeConstraintRef,
-                },
+                constraints::{constraints_from_where_clause, BinaryExprSide, RangeConstraintRef},
             },
             plan::{
                 ColumnUsedMask, IterationDirection, JoinInfo, Operation, TableReferences, WhereTerm,

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -14,8 +14,12 @@ use crate::{
     parameters::PARAM_PREFIX,
     schema::{Index, IndexColumn, Schema, Table},
     translate::{
-        expr::walk_expr_mut, optimizer::access_method::AccessMethodParams,
-        optimizer::constraints::TableConstraints, plan::Scan, plan::TerminationKey,
+        expr::walk_expr_mut,
+        optimizer::{
+            access_method::AccessMethodParams,
+            constraints::{RangeConstraintRef, SeekRangeConstraint, TableConstraints},
+        },
+        plan::{Scan, SeekKeyComponent},
     },
     types::SeekOp,
     LimboError, Result,
@@ -326,31 +330,33 @@ fn optimize_table_access(
                         });
                         continue;
                     }
-                    let ephemeral_index = ephemeral_index_build(
-                        &joined_tables[table_idx],
-                        &table_constraints.constraints,
-                        usable_constraint_refs,
-                    );
+                    let ephemeral_index =
+                        ephemeral_index_build(&joined_tables[table_idx], &usable_constraint_refs);
                     let ephemeral_index = Arc::new(ephemeral_index);
                     joined_tables[table_idx].op = Operation::Search(Search::Seek {
                         index: Some(ephemeral_index),
                         seek_def: build_seek_def_from_constraints(
                             &table_constraints.constraints,
-                            usable_constraint_refs,
+                            &usable_constraint_refs,
                             *iter_dir,
                             where_clause,
                         )?,
                     });
                 } else {
                     for cref in constraint_refs.iter() {
-                        let constraint =
-                            &constraints_per_table[table_idx].constraints[cref.constraint_vec_pos];
-                        assert!(
-                            !where_clause[constraint.where_clause_pos.0].consumed,
-                            "trying to consume a where clause term twice: {:?}",
-                            where_clause[constraint.where_clause_pos.0]
-                        );
-                        where_clause[constraint.where_clause_pos.0].consumed = true;
+                        for constraint_vec_pos in &[cref.eq, cref.lower_bound, cref.upper_bound] {
+                            let Some(constraint_vec_pos) = constraint_vec_pos else {
+                                continue;
+                            };
+                            let constraint =
+                                &constraints_per_table[table_idx].constraints[*constraint_vec_pos];
+                            assert!(
+                                !where_clause[constraint.where_clause_pos.0].consumed,
+                                "trying to consume a where clause term twice: {:?}",
+                                where_clause[constraint.where_clause_pos.0]
+                            );
+                            where_clause[constraint.where_clause_pos.0].consumed = true;
+                        }
                     }
                     if let Some(index) = &index {
                         joined_tables[table_idx].op = Operation::Search(Search::Seek {
@@ -368,13 +374,14 @@ fn optimize_table_access(
                         constraint_refs.len() == 1,
                         "expected exactly one constraint for rowid seek, got {constraint_refs:?}"
                     );
-                    let constraint = &constraints_per_table[table_idx].constraints
-                        [constraint_refs[0].constraint_vec_pos];
-                    joined_tables[table_idx].op = match constraint.operator {
-                        ast::Operator::Equals => Operation::Search(Search::RowidEq {
-                            cmp_expr: constraint.get_constraining_expr(where_clause),
-                        }),
-                        _ => Operation::Search(Search::Seek {
+                    joined_tables[table_idx].op = if let Some(eq) = constraint_refs[0].eq {
+                        Operation::Search(Search::RowidEq {
+                            cmp_expr: constraints_per_table[table_idx].constraints[eq]
+                                .get_constraining_expr(where_clause)
+                                .1,
+                        })
+                    } else {
+                        Operation::Search(Search::Seek {
                             index: None,
                             seek_def: build_seek_def_from_constraints(
                                 &constraints_per_table[table_idx].constraints,
@@ -382,7 +389,7 @@ fn optimize_table_access(
                                 *iter_dir,
                                 where_clause,
                             )?,
-                        }),
+                        })
                     };
                 }
             }
@@ -454,7 +461,7 @@ fn build_vtab_scan_op(
         if usage.omit {
             where_clause[constraint.where_clause_pos.0].consumed = true;
         }
-        let expr = constraint.get_constraining_expr(where_clause);
+        let (_, expr) = constraint.get_constraining_expr(where_clause);
         constraints[zero_based_argv_index] = Some(expr);
         arg_count += 1;
     }
@@ -867,8 +874,7 @@ impl Optimizable for ast::Expr {
 
 fn ephemeral_index_build(
     table_reference: &JoinedTable,
-    constraints: &[Constraint],
-    constraint_refs: &[ConstraintRef],
+    constraint_refs: &[RangeConstraintRef],
 ) -> Index {
     let mut ephemeral_columns: Vec<IndexColumn> = table_reference
         .columns()
@@ -889,11 +895,11 @@ fn ephemeral_index_build(
         let a_constraint = constraint_refs
             .iter()
             .enumerate()
-            .find(|(_, c)| constraints[c.constraint_vec_pos].table_col_pos == a.pos_in_table);
+            .find(|(_, c)| c.table_col_pos == a.pos_in_table);
         let b_constraint = constraint_refs
             .iter()
             .enumerate()
-            .find(|(_, c)| constraints[c.constraint_vec_pos].table_col_pos == b.pos_in_table);
+            .find(|(_, c)| c.table_col_pos == b.pos_in_table);
         match (a_constraint, b_constraint) {
             (Some(_), None) => Ordering::Less,
             (None, Some(_)) => Ordering::Greater,
@@ -924,7 +930,7 @@ fn ephemeral_index_build(
 /// Build a [SeekDef] for a given list of [Constraint]s
 pub fn build_seek_def_from_constraints(
     constraints: &[Constraint],
-    constraint_refs: &[ConstraintRef],
+    constraint_refs: &[RangeConstraintRef],
     iter_dir: IterationDirection,
     where_clause: &[WhereTerm],
 ) -> Result<SeekDef> {
@@ -935,471 +941,289 @@ pub fn build_seek_def_from_constraints(
     // Extract the key values and operators
     let key = constraint_refs
         .iter()
-        .map(|cref| cref.as_seek_key_column(constraints, where_clause))
+        .map(|cref| cref.as_seek_range_constraint(constraints, where_clause))
         .collect();
 
-    // We know all but potentially the last term is an equality, so we can use the operator of the last term
-    // to form the SeekOp
-    let op = constraints[constraint_refs.last().unwrap().constraint_vec_pos].operator;
-
-    let seek_def = build_seek_def(op, iter_dir, key)?;
+    let seek_def = build_seek_def(iter_dir, key)?;
     Ok(seek_def)
 }
 
-/// Build a [SeekDef] for a given comparison operator and index key.
+/// Build a [SeekDef] for a given [SeekRangeConstraint] and [IterationDirection].
 /// To be usable as a seek key, all but potentially the last term must be equalities.
-/// The last term can be a nonequality.
-/// The comparison operator referred to by `op` is the operator of the last term.
+/// The last term can be a nonequality (range with potentially one unbounded range).
 ///
 /// There are two parts to the seek definition:
-/// 1. The [SeekKey], which specifies the key that we will use to seek to the first row that matches the index key.
-/// 2. The [TerminationKey], which specifies the key that we will use to terminate the index scan that follows the seek.
+/// 1. start [SeekKey], which specifies the key that we will use to seek to the first row that matches the index key.
+/// 2. end [SeekKey], which specifies the key that we will use to terminate the index scan that follows the seek.
 ///
-/// There are some nuances to how, and which parts of, the index key can be used in the [SeekKey] and [TerminationKey],
+/// There are some nuances to how, and which parts of, the index key can be used in the start and end [SeekKey]s,
 /// depending on the operator and iteration order. This function explains those nuances inline when dealing with
 /// each case.
 ///
 /// But to illustrate the general idea, consider the following examples:
 ///
 /// 1. For example, having two conditions like (x>10 AND y>20) cannot be used as a valid [SeekKey] GT(x:10, y:20)
-///    because the first row greater than (x:10, y:20) might be (x:10, y:21), which does not satisfy the where clause.
+///    because the first row greater than (x:10, y:20) might be (x:11, y:19), which does not satisfy the where clause.
 ///    In this case, only GT(x:10) must be used as the [SeekKey], and rows with y <= 20 must be filtered as a regular condition expression for each value of x.
 ///
 /// 2. In contrast, having (x=10 AND y>20) forms a valid index key GT(x:10, y:20) because after the seek, we can simply terminate as soon as x > 10,
-///    i.e. use GT(x:10, y:20) as the [SeekKey] and GT(x:10) as the [TerminationKey].
+///    i.e. use GT(x:10, y:20) as the start [SeekKey] and GT(x:10) as the end.
 ///
 /// The preceding examples are for an ascending index. The logic is similar for descending indexes, but an important distinction is that
 /// since a descending index is laid out in reverse order, the comparison operators are reversed, e.g. LT becomes GT, LE becomes GE, etc.
 /// So when you see e.g. a SeekOp::GT below for a descending index, it actually means that we are seeking the first row where the index key is LESS than the seek key.
 ///
 fn build_seek_def(
-    op: ast::Operator,
     iter_dir: IterationDirection,
-    key: Vec<(ast::Expr, SortOrder)>,
+    mut key: Vec<SeekRangeConstraint>,
 ) -> Result<SeekDef> {
-    let key_len = key.len();
-    let sort_order_of_last_key = key.last().unwrap().1;
+    assert!(key.len() >= 1);
+    let last = key.last().unwrap();
+
+    // if we searching for exact key - emit definition immediately with prefix as a full key
+    if last.eq.is_some() {
+        return Ok(SeekDef {
+            prefix: key,
+            iter_dir,
+            start: SeekKey {
+                last_component: SeekKeyComponent::None,
+                op: SeekOp::GE { eq_only: true },
+            },
+            end: SeekKey {
+                last_component: SeekKeyComponent::None,
+                op: SeekOp::GT,
+            },
+        });
+    }
+    assert!(last.lower_bound.is_some() || last.upper_bound.is_some());
+
+    // pop last key as we will do some form of range search
+    let last = key.pop().unwrap();
+
+    // after that all key components must be equality constraints
+    debug_assert!(key.iter().all(|k| k.eq.is_some()));
 
     // For the commented examples below, keep in mind that since a descending index is laid out in reverse order, the comparison operators are reversed, e.g. LT becomes GT, LE becomes GE, etc.
     // Also keep in mind that index keys are compared based on the number of columns given, so for example:
     // - if key is GT(x:10), then (x=10, y=usize::MAX) is not GT because only X is compared. (x=11, y=<any>) is GT.
     // - if key is GT(x:10, y:20), then (x=10, y=21) is GT because both X and Y are compared.
     // - if key is GT(x:10, y:NULL), then (x=10, y=0) is GT because NULL is always LT in index key comparisons.
-    Ok(match (iter_dir, op) {
-        // Forwards, EQ:
-        // Example: (x=10 AND y=20)
-        // Seek key: start from the first GE(x:10, y:20)
-        // Termination key: end at the first GT(x:10, y:20)
-        // Ascending vs descending doesn't matter because all the comparisons are equalities.
-        (IterationDirection::Forwards, ast::Operator::Equals) => SeekDef {
-            key,
-            iter_dir,
-            seek: Some(SeekKey {
-                len: key_len,
-                null_pad: false,
-                op: SeekOp::GE { eq_only: true },
-            }),
-            termination: Some(TerminationKey {
-                len: key_len,
-                null_pad: false,
-                op: SeekOp::GT,
-            }),
-        },
-        // Forwards, GT:
-        // Ascending index example: (x=10 AND y>20)
-        // Seek key: start from the first GT(x:10, y:20), e.g. (x=10, y=21)
-        // Termination key: end at the first GT(x:10), e.g. (x=11, y=0)
-        //
-        // Descending index example: (x=10 AND y>20)
-        // Seek key: start from the first LE(x:10), e.g. (x=10, y=usize::MAX), so reversed -> GE(x:10)
-        // Termination key: end at the first LE(x:10, y:20), e.g. (x=10, y=20) so reversed -> GE(x:10, y:20)
-        (IterationDirection::Forwards, ast::Operator::Greater) => {
-            let (seek_key_len, termination_key_len, seek_op, termination_op) =
-                if sort_order_of_last_key == SortOrder::Asc {
-                    (key_len, key_len - 1, SeekOp::GT, SeekOp::GT)
-                } else {
-                    (
-                        key_len - 1,
-                        key_len,
-                        SeekOp::LE { eq_only: false }.reverse(),
-                        SeekOp::LE { eq_only: false }.reverse(),
-                    )
-                };
+    Ok(match iter_dir {
+        IterationDirection::Forwards => {
+            let (start, end) = match last.sort_order {
+                SortOrder::Asc => {
+                    let start = match last.lower_bound {
+                        // Forwards, Asc, GT: (x=10 AND y>20)
+                        // Start key: start from the first GT(x:10, y:20)
+                        Some((ast::Operator::Greater, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::GT,
+                        },
+                        // Forwards, Asc, GE: (x=10 AND y>=20)
+                        // Start key: start from the first GE(x:10, y:20)
+                        Some((ast::Operator::GreaterEquals, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::GE { eq_only: false },
+                        },
+                        // Forwards, Asc, None, (x=10 AND y<30)
+                        // Start key: start from the first GE(x:10)
+                        None => SeekKey {
+                            last_component: SeekKeyComponent::None,
+                            op: SeekOp::GE { eq_only: false },
+                        },
+                        Some((op, _)) => {
+                            crate::bail_parse_error!("build_seek_def: invalid operator: {:?}", op,)
+                        }
+                    };
+                    let end = match last.upper_bound {
+                        // Forwards, Asc, LT, (x=10 AND y<30)
+                        // End key: end at first GE(x:10, y:30)
+                        Some((ast::Operator::Less, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::GE { eq_only: false },
+                        },
+                        // Forwards, Asc, LE, (x=10 AND y<=30)
+                        // End key: end at first GT(x:10, y:30)
+                        Some((ast::Operator::LessEquals, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::GT,
+                        },
+                        // Forwards, Asc, None, (x=10 AND y>20)
+                        // End key: end at first GT(x:10)
+                        None => SeekKey {
+                            last_component: SeekKeyComponent::None,
+                            op: SeekOp::GT,
+                        },
+                        Some((op, _)) => {
+                            crate::bail_parse_error!("build_seek_def: invalid operator: {:?}", op,)
+                        }
+                    };
+                    (start, end)
+                }
+                SortOrder::Desc => {
+                    let start = match last.upper_bound {
+                        // Forwards, Desc, LT: (x=10 AND y<30)
+                        // Start key: start from the first GT(x:10, y:30)
+                        Some((ast::Operator::Less, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::GT,
+                        },
+                        // Forwards, Desc, LE: (x=10 AND y<=30)
+                        // Start key: start from the first GE(x:10, y:30)
+                        Some((ast::Operator::LessEquals, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::GE { eq_only: false },
+                        },
+                        // Forwards, Desc, None: (x=10 AND y>20)
+                        // Start key: start from the first GE(x:10)
+                        None => SeekKey {
+                            last_component: SeekKeyComponent::None,
+                            op: SeekOp::GE { eq_only: false },
+                        },
+                        Some((op, _)) => {
+                            crate::bail_parse_error!("build_seek_def: invalid operator: {:?}", op,)
+                        }
+                    };
+                    let end = match last.lower_bound {
+                        // Forwards, Asc, GT, (x=10 AND y>20)
+                        // End key: end at first GE(x:10, y:20)
+                        Some((ast::Operator::Greater, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::GE { eq_only: false },
+                        },
+                        // Forwards, Asc, GE, (x=10 AND y>=20)
+                        // End key: end at first GT(x:10, y:20)
+                        Some((ast::Operator::GreaterEquals, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::GT,
+                        },
+                        // Forwards, Asc, None, (x=10 AND y<30)
+                        // End key: end at first GT(x:10)
+                        None => SeekKey {
+                            last_component: SeekKeyComponent::None,
+                            op: SeekOp::GT,
+                        },
+                        Some((op, _)) => {
+                            crate::bail_parse_error!("build_seek_def: invalid operator: {:?}", op,)
+                        }
+                    };
+                    (start, end)
+                }
+            };
             SeekDef {
-                key,
+                prefix: key,
                 iter_dir,
-                seek: if seek_key_len > 0 {
-                    Some(SeekKey {
-                        len: seek_key_len,
-                        op: seek_op,
-                        null_pad: false,
-                    })
-                } else {
-                    None
-                },
-                termination: if termination_key_len > 0 {
-                    Some(TerminationKey {
-                        len: termination_key_len,
-                        op: termination_op,
-                        null_pad: false,
-                    })
-                } else {
-                    None
-                },
+                start,
+                end,
             }
         }
-        // Forwards, GE:
-        // Ascending index example: (x=10 AND y>=20)
-        // Seek key: start from the first GE(x:10, y:20), e.g. (x=10, y=20)
-        // Termination key: end at the first GT(x:10), e.g. (x=11, y=0)
-        //
-        // Descending index example: (x=10 AND y>=20)
-        // Seek key: start from the first LE(x:10), e.g. (x=10, y=usize::MAX), so reversed -> GE(x:10)
-        // Termination key: end at the first LT(x:10, y:20), e.g. (x=10, y=19), so reversed -> GT(x:10, y:20)
-        (IterationDirection::Forwards, ast::Operator::GreaterEquals) => {
-            let (seek_key_len, termination_key_len, seek_op, termination_op) =
-                if sort_order_of_last_key == SortOrder::Asc {
-                    (
-                        key_len,
-                        key_len - 1,
-                        SeekOp::GE { eq_only: false },
-                        SeekOp::GT,
-                    )
-                } else {
-                    (
-                        key_len - 1,
-                        key_len,
-                        SeekOp::LE { eq_only: false }.reverse(),
-                        SeekOp::LT.reverse(),
-                    )
-                };
+        IterationDirection::Backwards => {
+            let (start, end) = match last.sort_order {
+                SortOrder::Asc => {
+                    let start = match last.upper_bound {
+                        // Backwards, Asc, LT: (x=10 AND y<30)
+                        // Start key: start from the first LT(x:10, y:30)
+                        Some((ast::Operator::Less, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::LT,
+                        },
+                        // Backwards, Asc, LT: (x=10 AND y<=30)
+                        // Start key: start from the first LE(x:10, y:30)
+                        Some((ast::Operator::LessEquals, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::LE { eq_only: false },
+                        },
+                        // Backwards, Asc, None: (x=10 AND y>20)
+                        // Start key: start from the first LE(x:10)
+                        None => SeekKey {
+                            last_component: SeekKeyComponent::None,
+                            op: SeekOp::LE { eq_only: false },
+                        },
+                        Some((op, _)) => {
+                            crate::bail_parse_error!("build_seek_def: invalid operator: {:?}", op)
+                        }
+                    };
+                    let end = match last.lower_bound {
+                        // Backwards, Asc, GT, (x=10 AND y>20)
+                        // End key: end at first LE(x:10, y:20)
+                        Some((ast::Operator::Greater, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::LE { eq_only: false },
+                        },
+                        // Backwards, Asc, GT, (x=10 AND y>=20)
+                        // End key: end at first LT(x:10, y:20)
+                        Some((ast::Operator::GreaterEquals, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::LT,
+                        },
+                        // Backwards, Asc, None, (x=10 AND y<30)
+                        // End key: end at first LT(x:10)
+                        None => SeekKey {
+                            last_component: SeekKeyComponent::None,
+                            op: SeekOp::GT,
+                        },
+                        Some((op, _)) => {
+                            crate::bail_parse_error!("build_seek_def: invalid operator: {:?}", op,)
+                        }
+                    };
+                    (start, end)
+                }
+                SortOrder::Desc => {
+                    let start = match last.lower_bound {
+                        // Backwards, Desc, LT: (x=10 AND y>20)
+                        // Start key: start from the first LT(x:10, y:20)
+                        Some((ast::Operator::Greater, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::LT,
+                        },
+                        // Backwards, Desc, LE: (x=10 AND y>=20)
+                        // Start key: start from the first LE(x:10, y:20)
+                        Some((ast::Operator::GreaterEquals, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::LE { eq_only: false },
+                        },
+                        // Backwards, Desc, LE: (x=10 AND y<30)
+                        // Start key: start from the first LE(x:10)
+                        None => SeekKey {
+                            last_component: SeekKeyComponent::None,
+                            op: SeekOp::LE { eq_only: false },
+                        },
+                        Some((op, _)) => {
+                            crate::bail_parse_error!("build_seek_def: invalid operator: {:?}", op,)
+                        }
+                    };
+                    let end = match last.upper_bound {
+                        // Backwards, Desc, LT, (x=10 AND y<30)
+                        // End key: end at first LE(x:10, y:30)
+                        Some((ast::Operator::Less, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::LE { eq_only: false },
+                        },
+                        // Backwards, Desc, LT, (x=10 AND y<=30)
+                        // End key: end at first LT(x:10, y:30)
+                        Some((ast::Operator::LessEquals, bound)) => SeekKey {
+                            last_component: SeekKeyComponent::Expr(bound),
+                            op: SeekOp::LT,
+                        },
+                        // Backwards, Desc, LT, (x=10 AND y>20)
+                        // End key: end at first LT(x:10)
+                        None => SeekKey {
+                            last_component: SeekKeyComponent::None,
+                            op: SeekOp::LT,
+                        },
+                        Some((op, _)) => {
+                            crate::bail_parse_error!("build_seek_def: invalid operator: {:?}", op,)
+                        }
+                    };
+                    (start, end)
+                }
+            };
             SeekDef {
-                key,
+                prefix: key,
                 iter_dir,
-                seek: if seek_key_len > 0 {
-                    Some(SeekKey {
-                        len: seek_key_len,
-                        op: seek_op,
-                        null_pad: false,
-                    })
-                } else {
-                    None
-                },
-                termination: if termination_key_len > 0 {
-                    Some(TerminationKey {
-                        len: termination_key_len,
-                        op: termination_op,
-                        null_pad: false,
-                    })
-                } else {
-                    None
-                },
+                start,
+                end,
             }
-        }
-        // Forwards, LT:
-        // Ascending index example: (x=10 AND y<20)
-        // Seek key: start from the first GT(x:10, y: NULL), e.g. (x=10, y=0)
-        // Termination key: end at the first GE(x:10, y:20), e.g. (x=10, y=20)
-        //
-        // Descending index example: (x=10 AND y<20)
-        // Seek key: start from the first LT(x:10, y:20), e.g. (x=10, y=19) so reversed -> GT(x:10, y:20)
-        // Termination key: end at the first LT(x:10), e.g. (x=9, y=usize::MAX), so reversed -> GE(x:10, NULL); i.e. GE the smallest possible (x=10, y) combination (NULL is always LT)
-        (IterationDirection::Forwards, ast::Operator::Less) => {
-            let (seek_key_len, termination_key_len, seek_op, termination_op) =
-                if sort_order_of_last_key == SortOrder::Asc {
-                    (
-                        key_len - 1,
-                        key_len,
-                        SeekOp::GT,
-                        SeekOp::GE { eq_only: false },
-                    )
-                } else {
-                    (
-                        key_len,
-                        key_len - 1,
-                        SeekOp::GT,
-                        SeekOp::GE { eq_only: false },
-                    )
-                };
-            SeekDef {
-                key,
-                iter_dir,
-                seek: if seek_key_len > 0 {
-                    Some(SeekKey {
-                        len: seek_key_len,
-                        op: seek_op,
-                        null_pad: sort_order_of_last_key == SortOrder::Asc,
-                    })
-                } else {
-                    None
-                },
-                termination: if termination_key_len > 0 {
-                    Some(TerminationKey {
-                        len: termination_key_len,
-                        op: termination_op,
-                        null_pad: sort_order_of_last_key == SortOrder::Desc,
-                    })
-                } else {
-                    None
-                },
-            }
-        }
-        // Forwards, LE:
-        // Ascending index example: (x=10 AND y<=20)
-        // Seek key: start from the first GE(x:10, y:NULL), e.g. (x=10, y=0)
-        // Termination key: end at the first GT(x:10, y:20), e.g. (x=10, y=21)
-        //
-        // Descending index example: (x=10 AND y<=20)
-        // Seek key: start from the first LE(x:10, y:20), e.g. (x=10, y=20) so reversed -> GE(x:10, y:20)
-        // Termination key: end at the first LT(x:10), e.g. (x=9, y=usize::MAX), so reversed -> GE(x:10, NULL); i.e. GE the smallest possible (x=10, y) combination (NULL is always LT)
-        (IterationDirection::Forwards, ast::Operator::LessEquals) => {
-            let (seek_key_len, termination_key_len, seek_op, termination_op) =
-                if sort_order_of_last_key == SortOrder::Asc {
-                    (key_len - 1, key_len, SeekOp::GT, SeekOp::GT)
-                } else {
-                    (
-                        key_len,
-                        key_len - 1,
-                        SeekOp::LE { eq_only: false }.reverse(),
-                        SeekOp::LE { eq_only: false }.reverse(),
-                    )
-                };
-            SeekDef {
-                key,
-                iter_dir,
-                seek: if seek_key_len > 0 {
-                    Some(SeekKey {
-                        len: seek_key_len,
-                        op: seek_op,
-                        null_pad: sort_order_of_last_key == SortOrder::Asc,
-                    })
-                } else {
-                    None
-                },
-                termination: if termination_key_len > 0 {
-                    Some(TerminationKey {
-                        len: termination_key_len,
-                        op: termination_op,
-                        null_pad: sort_order_of_last_key == SortOrder::Desc,
-                    })
-                } else {
-                    None
-                },
-            }
-        }
-        // Backwards, EQ:
-        // Example: (x=10 AND y=20)
-        // Seek key: start from the last LE(x:10, y:20)
-        // Termination key: end at the first LT(x:10, y:20)
-        // Ascending vs descending doesn't matter because all the comparisons are equalities.
-        (IterationDirection::Backwards, ast::Operator::Equals) => SeekDef {
-            key,
-            iter_dir,
-            seek: Some(SeekKey {
-                len: key_len,
-                op: SeekOp::LE { eq_only: true },
-                null_pad: false,
-            }),
-            termination: Some(TerminationKey {
-                len: key_len,
-                op: SeekOp::LT,
-                null_pad: false,
-            }),
-        },
-        // Backwards, LT:
-        // Ascending index example: (x=10 AND y<20)
-        // Seek key: start from the last LT(x:10, y:20), e.g. (x=10, y=19)
-        // Termination key: end at the first LE(x:10, NULL), e.g. (x=9, y=usize::MAX)
-        //
-        // Descending index example: (x=10 AND y<20)
-        // Seek key: start from the last GT(x:10, y:NULL), e.g. (x=10, y=0) so reversed -> LT(x:10, NULL)
-        // Termination key: end at the first GE(x:10, y:20), e.g. (x=10, y=20) so reversed -> LE(x:10, y:20)
-        (IterationDirection::Backwards, ast::Operator::Less) => {
-            let (seek_key_len, termination_key_len, seek_op, termination_op) =
-                if sort_order_of_last_key == SortOrder::Asc {
-                    (
-                        key_len,
-                        key_len - 1,
-                        SeekOp::LT,
-                        SeekOp::LE { eq_only: false },
-                    )
-                } else {
-                    (
-                        key_len - 1,
-                        key_len,
-                        SeekOp::GT.reverse(),
-                        SeekOp::GE { eq_only: false }.reverse(),
-                    )
-                };
-            SeekDef {
-                key,
-                iter_dir,
-                seek: if seek_key_len > 0 {
-                    Some(SeekKey {
-                        len: seek_key_len,
-                        op: seek_op,
-                        null_pad: sort_order_of_last_key == SortOrder::Desc,
-                    })
-                } else {
-                    None
-                },
-                termination: if termination_key_len > 0 {
-                    Some(TerminationKey {
-                        len: termination_key_len,
-                        op: termination_op,
-                        null_pad: sort_order_of_last_key == SortOrder::Asc,
-                    })
-                } else {
-                    None
-                },
-            }
-        }
-        // Backwards, LE:
-        // Ascending index example: (x=10 AND y<=20)
-        // Seek key: start from the last LE(x:10, y:20), e.g. (x=10, y=20)
-        // Termination key: end at the first LT(x:10, NULL), e.g. (x=9, y=usize::MAX)
-        //
-        // Descending index example: (x=10 AND y<=20)
-        // Seek key: start from the last GT(x:10, NULL), e.g. (x=10, y=0) so reversed -> LT(x:10, NULL)
-        // Termination key: end at the first GT(x:10, y:20), e.g. (x=10, y=21) so reversed -> LT(x:10, y:20)
-        (IterationDirection::Backwards, ast::Operator::LessEquals) => {
-            let (seek_key_len, termination_key_len, seek_op, termination_op) =
-                if sort_order_of_last_key == SortOrder::Asc {
-                    (
-                        key_len,
-                        key_len - 1,
-                        SeekOp::LE { eq_only: false },
-                        SeekOp::LE { eq_only: false },
-                    )
-                } else {
-                    (
-                        key_len - 1,
-                        key_len,
-                        SeekOp::GT.reverse(),
-                        SeekOp::GT.reverse(),
-                    )
-                };
-            SeekDef {
-                key,
-                iter_dir,
-                seek: if seek_key_len > 0 {
-                    Some(SeekKey {
-                        len: seek_key_len,
-                        op: seek_op,
-                        null_pad: sort_order_of_last_key == SortOrder::Desc,
-                    })
-                } else {
-                    None
-                },
-                termination: if termination_key_len > 0 {
-                    Some(TerminationKey {
-                        len: termination_key_len,
-                        op: termination_op,
-                        null_pad: sort_order_of_last_key == SortOrder::Asc,
-                    })
-                } else {
-                    None
-                },
-            }
-        }
-        // Backwards, GT:
-        // Ascending index example: (x=10 AND y>20)
-        // Seek key: start from the last LE(x:10), e.g. (x=10, y=usize::MAX)
-        // Termination key: end at the first LE(x:10, y:20), e.g. (x=10, y=20)
-        //
-        // Descending index example: (x=10 AND y>20)
-        // Seek key: start from the last GT(x:10, y:20), e.g. (x=10, y=21) so reversed -> LT(x:10, y:20)
-        // Termination key: end at the first GT(x:10), e.g. (x=11, y=0) so reversed -> LT(x:10)
-        (IterationDirection::Backwards, ast::Operator::Greater) => {
-            let (seek_key_len, termination_key_len, seek_op, termination_op) =
-                if sort_order_of_last_key == SortOrder::Asc {
-                    (
-                        key_len - 1,
-                        key_len,
-                        SeekOp::LE { eq_only: false },
-                        SeekOp::LE { eq_only: false },
-                    )
-                } else {
-                    (
-                        key_len,
-                        key_len - 1,
-                        SeekOp::GT.reverse(),
-                        SeekOp::GT.reverse(),
-                    )
-                };
-            SeekDef {
-                key,
-                iter_dir,
-                seek: if seek_key_len > 0 {
-                    Some(SeekKey {
-                        len: seek_key_len,
-                        op: seek_op,
-                        null_pad: false,
-                    })
-                } else {
-                    None
-                },
-                termination: if termination_key_len > 0 {
-                    Some(TerminationKey {
-                        len: termination_key_len,
-                        op: termination_op,
-                        null_pad: false,
-                    })
-                } else {
-                    None
-                },
-            }
-        }
-        // Backwards, GE:
-        // Ascending index example: (x=10 AND y>=20)
-        // Seek key: start from the last LE(x:10), e.g. (x=10, y=usize::MAX)
-        // Termination key: end at the first LT(x:10, y:20), e.g. (x=10, y=19)
-        //
-        // Descending index example: (x=10 AND y>=20)
-        // Seek key: start from the last GE(x:10, y:20), e.g. (x=10, y=20) so reversed -> LE(x:10, y:20)
-        // Termination key: end at the first GT(x:10), e.g. (x=11, y=0) so reversed -> LT(x:10)
-        (IterationDirection::Backwards, ast::Operator::GreaterEquals) => {
-            let (seek_key_len, termination_key_len, seek_op, termination_op) =
-                if sort_order_of_last_key == SortOrder::Asc {
-                    (
-                        key_len - 1,
-                        key_len,
-                        SeekOp::LE { eq_only: false },
-                        SeekOp::LT,
-                    )
-                } else {
-                    (
-                        key_len,
-                        key_len - 1,
-                        SeekOp::GE { eq_only: false }.reverse(),
-                        SeekOp::GT.reverse(),
-                    )
-                };
-            SeekDef {
-                key,
-                iter_dir,
-                seek: if seek_key_len > 0 {
-                    Some(SeekKey {
-                        len: seek_key_len,
-                        op: seek_op,
-                        null_pad: false,
-                    })
-                } else {
-                    None
-                },
-                termination: if termination_key_len > 0 {
-                    Some(TerminationKey {
-                        len: termination_key_len,
-                        op: termination_op,
-                        null_pad: false,
-                    })
-                } else {
-                    None
-                },
-            }
-        }
-        (_, op) => {
-            crate::bail_parse_error!("build_seek_def: invalid operator: {:?}", op,)
         }
     })
 }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -977,7 +977,7 @@ fn build_seek_def(
     iter_dir: IterationDirection,
     mut key: Vec<SeekRangeConstraint>,
 ) -> Result<SeekDef> {
-    assert!(key.len() >= 1);
+    assert!(!key.is_empty());
     let last = key.last().unwrap();
 
     // if we searching for exact key - emit definition immediately with prefix as a full key

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -731,6 +731,7 @@ impl ColumnUsedMask {
 }
 
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Operation {
     // Scan operation
     // This operation is used to scan a table.
@@ -958,6 +959,7 @@ pub struct SeekDef {
     /// For example, given:
     /// - CREATE INDEX i ON t (x, y desc)
     /// - SELECT * FROM t WHERE x = 1 AND y >= 30
+    ///
     /// Then, prefix=[(eq=1, ASC)], start=Some((ge, Expr(30))), end=Some((gt, Sentinel))
     pub prefix: Vec<SeekRangeConstraint>,
     /// The condition to use when seeking. See [SeekKey] for more details.
@@ -998,7 +1000,7 @@ impl<'a> Iterator for SeekDefKeyIterator<'a> {
 impl SeekDef {
     /// returns amount of values in the given seek key
     /// - so, for SELECT * FROM t WHERE x = 10 AND y = 20 AND y >= 30 there will be 3 values (10, 20, 30)
-    pub fn size<'a>(&self, key: &'a SeekKey) -> usize {
+    pub fn size(&self, key: &'_ SeekKey) -> usize {
         self.prefix.len()
             + match key.last_component {
                 SeekKeyComponent::Expr(_) => 1,
@@ -1058,7 +1060,7 @@ pub enum Scan {
 
 /// An enum that represents a search operation that can be used to search for a row in a table using an index
 /// (i.e. a primary key or a secondary index)
-#[allow(clippy::enum_variant_names)]
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum Search {
     /// A rowid equality point lookup. This is a special case that uses the SeekRowid bytecode instruction and does not loop.

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -985,7 +985,6 @@ impl<'a> Iterator for SeekDefKeyIterator<'a> {
         } else if self.pos == self.seek_def.prefix.len() {
             match &self.seek_key.last_component {
                 SeekKeyComponent::Expr(expr) => Some(SeekKeyComponent::Expr(expr)),
-                SeekKeyComponent::Sentinel => Some(SeekKeyComponent::Sentinel),
                 SeekKeyComponent::None => None,
             }
         } else {
@@ -1002,7 +1001,7 @@ impl SeekDef {
     pub fn size<'a>(&self, key: &'a SeekKey) -> usize {
         self.prefix.len()
             + match key.last_component {
-                SeekKeyComponent::Expr(_) | SeekKeyComponent::Sentinel => 1,
+                SeekKeyComponent::Expr(_) => 1,
                 SeekKeyComponent::None => 0,
             }
     }
@@ -1020,7 +1019,6 @@ impl SeekDef {
 #[derive(Debug, Clone)]
 pub enum SeekKeyComponent<E> {
     Expr(E),
-    Sentinel,
     None,
 }
 

--- a/testing/select.test
+++ b/testing/select.test
@@ -714,6 +714,176 @@ do_execsql_test_on_specific_db {:memory:} select-no-match-in-leaf-page {
 2
 2}
 
+do_execsql_test_on_specific_db {:memory:} select-range-search-count-asc-index {
+    CREATE TABLE t (a, b);
+    CREATE INDEX t_idx ON t(a, b);
+    insert into t values (1, 1);
+    insert into t values (1, 2);
+    insert into t values (1, 3);
+    insert into t values (1, 4);
+    insert into t values (1, 5);
+    insert into t values (1, 6);
+    insert into t values (2, 1);
+    insert into t values (2, 2);
+    insert into t values (2, 3);
+    insert into t values (2, 4);
+    insert into t values (2, 5);
+    insert into t values (2, 6);
+    select count(*) from t where a = 1 AND b >= 2 ORDER BY a ASC, b ASC;
+    select count(*) from t where a = 1 AND b > 2 ORDER BY a ASC, b ASC;
+    select count(*) from t where a = 1 AND b <= 4 ORDER BY a ASC, b ASC;
+    select count(*) from t where a = 1 AND b < 4 ORDER BY a ASC, b ASC;
+    select count(*) from t where a = 1 AND b >= 2 AND b <= 4 ORDER BY a ASC, b ASC;
+    select count(*) from t where a = 1 AND b > 2 AND b <= 4 ORDER BY a ASC, b ASC;
+    select count(*) from t where a = 1 AND b >= 2 AND b < 4 ORDER BY a ASC, b ASC;
+    select count(*) from t where a = 1 AND b > 2 AND b < 4 ORDER BY a ASC, b ASC;
+    
+    select count(*) from t where a = 1 AND b >= 2 ORDER BY a DESC, b DESC;
+    select count(*) from t where a = 1 AND b > 2 ORDER BY a DESC, b DESC;
+    select count(*) from t where a = 1 AND b <= 4 ORDER BY a DESC, b DESC;
+    select count(*) from t where a = 1 AND b < 4 ORDER BY a DESC, b DESC;
+    select count(*) from t where a = 1 AND b >= 2 AND b <= 4 ORDER BY a DESC, b DESC;
+    select count(*) from t where a = 1 AND b > 2 AND b <= 4 ORDER BY a DESC, b DESC;
+    select count(*) from t where a = 1 AND b >= 2 AND b < 4 ORDER BY a DESC, b DESC;
+    select count(*) from t where a = 1 AND b > 2 AND b < 4 ORDER BY a DESC, b DESC;
+} {5
+4
+4
+3
+3
+2
+2
+1
+5
+4
+4
+3
+3
+2
+2
+1}
+
+do_execsql_test_on_specific_db {:memory:} select-range-search-count-desc-index {
+    CREATE TABLE t (a, b);
+    CREATE INDEX t_idx ON t(a, b DESC);
+    insert into t values (1, 1);
+    insert into t values (1, 2);
+    insert into t values (1, 3);
+    insert into t values (1, 4);
+    insert into t values (1, 5);
+    insert into t values (1, 6);
+    insert into t values (2, 1);
+    insert into t values (2, 2);
+    insert into t values (2, 3);
+    insert into t values (2, 4);
+    insert into t values (2, 5);
+    insert into t values (2, 6);
+    select count(*) from t where a = 1 AND b >= 2 ORDER BY a ASC, b DESC;
+    select count(*) from t where a = 1 AND b > 2 ORDER BY a ASC, b DESC;
+    select count(*) from t where a = 1 AND b <= 4 ORDER BY a ASC, b DESC;
+    select count(*) from t where a = 1 AND b < 4 ORDER BY a ASC, b DESC;
+    select count(*) from t where a = 1 AND b >= 2 AND b <= 4 ORDER BY a ASC, b DESC;
+    select count(*) from t where a = 1 AND b > 2 AND b <= 4 ORDER BY a ASC, b DESC;
+    select count(*) from t where a = 1 AND b >= 2 AND b < 4 ORDER BY a ASC, b DESC;
+    select count(*) from t where a = 1 AND b > 2 AND b < 4 ORDER BY a ASC, b DESC;
+    
+    select count(*) from t where a = 1 AND b >= 2 ORDER BY a DESC, b ASC;
+    select count(*) from t where a = 1 AND b > 2 ORDER BY a DESC, b ASC;
+    select count(*) from t where a = 1 AND b <= 4 ORDER BY a DESC, b ASC;
+    select count(*) from t where a = 1 AND b < 4 ORDER BY a DESC, b ASC;
+    select count(*) from t where a = 1 AND b >= 2 AND b <= 4 ORDER BY a DESC, b ASC;
+    select count(*) from t where a = 1 AND b > 2 AND b <= 4 ORDER BY a DESC, b ASC;
+    select count(*) from t where a = 1 AND b >= 2 AND b < 4 ORDER BY a DESC, b ASC;
+    select count(*) from t where a = 1 AND b > 2 AND b < 4 ORDER BY a DESC, b ASC;
+} {5
+4
+4
+3
+3
+2
+2
+1
+5
+4
+4
+3
+3
+2
+2
+1}
+
+do_execsql_test_on_specific_db {:memory:} select-range-search-scan-asc-index {
+    CREATE TABLE t (a, b);
+    CREATE INDEX t_idx ON t(a, b);
+    insert into t values (1, 1);
+    insert into t values (1, 2);
+    insert into t values (1, 3);
+    insert into t values (1, 4);
+    insert into t values (1, 5);
+    insert into t values (1, 6);
+    insert into t values (2, 1);
+    insert into t values (2, 2);
+    insert into t values (2, 3);
+    insert into t values (2, 4);
+    insert into t values (2, 5);
+    insert into t values (2, 6);
+    select * from t where a = 1 AND b > 1 AND b < 6 ORDER BY a ASC, b ASC;
+    select * from t where a = 2 AND b > 1 AND b < 6 ORDER BY a DESC, b DESC;
+    select * from t where a = 1 AND b > 1 AND b < 6 ORDER BY a DESC, b ASC;
+    select * from t where a = 2 AND b > 1 AND b < 6 ORDER BY a ASC, b DESC;
+} {1|2
+1|3
+1|4
+1|5
+2|5
+2|4
+2|3
+2|2
+1|2
+1|3
+1|4
+1|5
+2|5
+2|4
+2|3
+2|2}
+
+do_execsql_test_on_specific_db {:memory:} select-range-search-scan-desc-index {
+    CREATE TABLE t (a, b);
+    CREATE INDEX t_idx ON t(a, b DESC);
+    insert into t values (1, 1);
+    insert into t values (1, 2);
+    insert into t values (1, 3);
+    insert into t values (1, 4);
+    insert into t values (1, 5);
+    insert into t values (1, 6);
+    insert into t values (2, 1);
+    insert into t values (2, 2);
+    insert into t values (2, 3);
+    insert into t values (2, 4);
+    insert into t values (2, 5);
+    insert into t values (2, 6);
+    select * from t where a = 1 AND b > 1 AND b < 6 ORDER BY a ASC, b ASC;
+    select * from t where a = 2 AND b > 1 AND b < 6 ORDER BY a DESC, b DESC;
+    select * from t where a = 1 AND b > 1 AND b < 6 ORDER BY a DESC, b ASC;
+    select * from t where a = 2 AND b > 1 AND b < 6 ORDER BY a ASC, b DESC;
+} {1|2
+1|3
+1|4
+1|5
+2|5
+2|4
+2|3
+2|2
+1|2
+1|3
+1|4
+1|5
+2|5
+2|4
+2|3
+2|2}
+
 # Regression tests for double-quoted strings in SELECT statements
 do_execsql_test_skip_lines_on_specific_db 1 {:memory:} select-double-quotes-values {
     .dbconfig dqs_dml on


### PR DESCRIPTION
This PR optimizes range scans for table/indices when both lower and upper bounds are set (`e.g. SELECT * FROM t WHERE x = ? AND y >= ? AND y <= ?`)

**Before**:
```
turso> .timer on
turso> select count(*) from t where x >= 512 and x <= 600;
┌───────────┐
│ count (*) │
├───────────┤
│        89 │
└───────────┘
Command stats:
----------------------------
total: 2.394466836 s (this includes parsing/coloring of cli app)
```


**After** (x2265 faster :wink:):
```
turso> .timer on
turso> select count(*) from t where x >= 512 and x <= 600;
┌───────────┐
│ count (*) │
├───────────┤
│        89 │
└───────────┘
Command stats:
----------------------------
total: 883 us (this includes parsing/coloring of cli app)
```

