### PR TITLE
 core/vdbe: op_insert split into callback chain 

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -33,7 +33,7 @@ use crate::{
     },
 };
 use std::env::temp_dir;
-use std::ops::{ControlFlow, DerefMut};
+use std::ops::DerefMut;
 use std::{
     borrow::BorrowMut,
     rc::Rc,
@@ -5138,25 +5138,6 @@ pub fn op_yield(
 pub struct OpInsertState {
     pub step_fn: Option<InsertStepFn>,
     pub old_record: Option<(i64, Vec<Value>)>,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum OpInsertSubState {
-    /// If this insert overwrites a record, capture the old record for incremental view maintenance.
-    MaybeCaptureRecord,
-    /// Seek to the correct position if needed.
-    /// In a table insert, if the caller does not pass InsertFlags::REQUIRE_SEEK, they must ensure that a seek has already happened to the correct location.
-    /// This typically happens by invoking either Insn::NewRowid or Insn::NotExists, because:
-    /// 1. op_new_rowid() seeks to the end of the table, which is the correct insertion position.
-    /// 2. op_not_exists() seeks to the position in the table where the target rowid would be inserted.
-    Seek,
-    /// Insert the row into the table.
-    Insert,
-    /// Updating last_insert_rowid may return IO, so we need a separate state for it so that we don't
-    /// start inserting the same row multiple times.
-    UpdateLastRowid,
-    /// If there are dependent incremental views, apply the change.
-    ApplyViewChange,
 }
 
 type InsertStepFn = fn(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     types::{IOCompletions, IOResult, RawSlice, TextRef},
     vdbe::execute::{
         OpColumnState, OpDeleteState, OpDeleteSubState, OpIdxInsertState, OpInsertState,
-        OpInsertSubState, OpNewRowidState, OpNoConflictState, OpRowIdState, OpSeekState,
+        OpNewRowidState, OpNoConflictState, OpRowIdState, OpSeekState,
     },
     vdbe::metrics::StatementMetrics,
     IOExt, RefValue,


### PR DESCRIPTION
Guess who's back... the _wanna be state machine killer_... This is a love story based on @penberg's love for callbacks instead of state machines. State machines with `match` statements are somewhat nice because you can quickly look at the statement and know which are the states. Sadly, they are sometimes slow because they can have huge stack sizes and sometimes it is hard to judge what will be the next state. Did we solve this with this? No idea. But it would be good for all of us to gather and discuss wether this is worth it to expand.

The basic idea is that a state machine is only ecoded with a _step function_ (`step_fn`) which we will call in a loop until this function is `None`, meaning we reached a terminal state. In the loop that calls `step_fn` we first take ownership of it and then call, so that any `step_fn` must refill `step_fn` in order for the loop to advance:

```rust
    fn insert_into_page(&mut self, bkey: &BTreeKey) -> Result<IOResult<()>> {
        if let CursorState::None = &self.state {
            self.state = CursorState::Write(WriteState {
                step_fn: Some(BTreeCursor::insert_into_page_start),
                sub_state: None,
            });
        }
        loop {
            let CursorState::Write(WriteState { step_fn, .. }) = &self.state else {
                panic!("expected write state");
            };
            if let Some(step_fn) = step_fn {
                let pager = self.pager.clone();
                return_if_io!(step_fn(self, bkey, &pager));
            } else {
                break;
            }
        }
```

For example the first state is `BTreeCursor::insert_into_page_start`. This function/state will internally set next function if it requires to continue:
```rust
                        write_state.step_fn = Some(BTreeCursor::insert_into_page_overwrite);
                        write_state.sub_state = Some(WriteSubState::Overwrite {
                            page: page.clone(),
                            cell_idx,
                            state: Some(OverwriteCellState::AllocatePayload),
                        });
                        return Ok(IOResult::Done(()));
                        ```

