### PR TITLE
Parse booleans to integer literals in expressions

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -15,6 +15,9 @@ use crate::lexer::{Lexer, Token};
 use crate::token::TokenType::{self, *};
 use crate::Result;
 
+const TRUE_LIT: &str = "TRUE";
+const FALSE_LIT: &str = "FALSE";
+
 macro_rules! peek_expect {
     ( $parser:expr, $( $x:ident ),* $(,)?) => {
         {
@@ -1545,7 +1548,25 @@ impl<'a> Parser<'a> {
                         Name::Ident(s) => Literal::String(s),
                     })))
                 } else {
-                    Ok(Box::new(Expr::Id(name)))
+                    match name {
+                        Name::Ident(s) => {
+                            let ident = s.to_ascii_uppercase();
+                            match ident.as_str() {
+                                TRUE_LIT => {
+                                    return Ok(Box::new(Expr::Literal(Literal::Numeric(
+                                        "1".into(),
+                                    ))))
+                                }
+                                FALSE_LIT => {
+                                    return Ok(Box::new(Expr::Literal(Literal::Numeric(
+                                        "0".into(),
+                                    ))))
+                                }
+                                _ => return Ok(Box::new(Expr::Id(Name::Ident(s)))),
+                            }
+                        }
+                        _ => Ok(Box::new(Expr::Id(name))),
+                    }
                 }
             }
         }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1549,22 +1549,15 @@ impl<'a> Parser<'a> {
                     })))
                 } else {
                     match name {
-                        Name::Ident(s) => {
-                            let ident = s.to_ascii_uppercase();
-                            match ident.as_str() {
-                                TRUE_LIT => {
-                                    return Ok(Box::new(Expr::Literal(Literal::Numeric(
-                                        "1".into(),
-                                    ))))
-                                }
-                                FALSE_LIT => {
-                                    return Ok(Box::new(Expr::Literal(Literal::Numeric(
-                                        "0".into(),
-                                    ))))
-                                }
-                                _ => return Ok(Box::new(Expr::Id(Name::Ident(s)))),
+                        Name::Ident(s) => match s.as_str() {
+                            s if s.eq_ignore_ascii_case(TRUE_LIT) => {
+                                return Ok(Box::new(Expr::Literal(Literal::Numeric("1".into()))))
                             }
-                        }
+                            s if s.eq_ignore_ascii_case(FALSE_LIT) => {
+                                return Ok(Box::new(Expr::Literal(Literal::Numeric("0".into()))))
+                            }
+                            _ => return Ok(Box::new(Expr::Id(Name::Ident(s)))),
+                        },
                         _ => Ok(Box::new(Expr::Id(name))),
                     }
                 }

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -623,3 +623,13 @@ do_execsql_test_on_specific_db {:memory:} returning-false-literal {
     CREATE TABLE test (id INTEGER, value TEXT);
     INSERT INTO test (id, value) VALUES (1, false) RETURNING id, value;
 } {1|0}
+
+do_execsql_test_on_specific_db {:memory:} boolean-literal-edgecase {
+    CREATE TABLE true (id INTEGER, value TEXT);
+    INSERT INTO true (id, value) VALUES (1, true) RETURNING id, value;
+} {1|1}
+
+do_execsql_test_on_specific_db {:memory:} boolean-literal-edgecase-false {
+    CREATE TABLE false (id INTEGER, true TEXT);
+    INSERT INTO false (id, true) VALUES (1, false) RETURNING id, false;
+} {1|0}

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -613,3 +613,13 @@ do_execsql_test_in_memory_error_content  null-insert-in-nulltype-column-notnull-
     CREATE TABLE test (id INTEGER,name NULL NOT NULL);
     INSERT INTO test (id, name) VALUES (1, NULL);
 } {NOT NULL constraint failed}
+
+do_execsql_test_on_specific_db {:memory:} returning-true-literal {
+    CREATE TABLE test (id INTEGER, value TEXT);
+    INSERT INTO test (id, value) VALUES (1, true) RETURNING id, value;
+} {1|1}
+
+do_execsql_test_on_specific_db {:memory:} returning-false-literal {
+    CREATE TABLE test (id INTEGER, value TEXT);
+    INSERT INTO test (id, value) VALUES (1, false) RETURNING id, value;
+} {1|0}

--- a/testing/null.test
+++ b/testing/null.test
@@ -18,3 +18,11 @@ do_execsql_test notnull {
 do_execsql_test not-null {
     select null not null, 'hi' not null;
 } {0|1}
+
+do_execsql_test sel-true {
+	select true;
+}{1}
+
+do_execsql_test sel-false {
+	select false;
+}{0}

--- a/testing/null.test
+++ b/testing/null.test
@@ -21,8 +21,8 @@ do_execsql_test not-null {
 
 do_execsql_test sel-true {
 	select true;
-}{1}
+} {1}
 
 do_execsql_test sel-false {
 	select false;
-}{0}
+} {0}


### PR DESCRIPTION
Adds tests for edgecases for the insane cases where someone might want to name a table `true` :)

 