### PR TITLE
Fix `sim-schema` command 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,5 +203,6 @@ endif
 .PHONY: merge-pr
 
 sim-schema: 
+	mkdir -p  simulator/configs/custom
 	cargo run -p limbo_sim -- print-schema > simulator/configs/custom/profile-schema.json
 


### PR DESCRIPTION
Create the directory to store the schema if it does not exists