### PR TITLE
Small fixes

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -757,7 +757,6 @@ impl BTreeCursor {
                 continue;
             }
             if contents.is_leaf() {
-                self.going_upwards = false;
                 return Ok(IOResult::Done(true));
             }
 
@@ -5998,9 +5997,6 @@ impl PageStack {
         assert!(current > 0);
         self.node_states[current] = BTreeNodeState::default();
         self.stack[current] = None;
-        // cell_count must be unset for last stack page by default
-        // (otherwise caller can think that he is at the leaf and enable hot-path optimization)
-        self.node_states[current - 1].cell_count = None;
         self.current_page -= 1;
     }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5938,7 +5938,7 @@ impl PageStack {
         // Pin the page to prevent it from being evicted while on the stack
         page.pin();
 
-        self.stack[current] = Some(page.clone());
+        self.stack[current] = Some(page);
         self.node_states[current] = BTreeNodeState {
             cell_idx: starting_cell_idx,
             cell_count: None, // we don't know the cell count yet, so we set it to None. any code pushing a child page onto the stack MUST set the parent page's cell_count.
@@ -6019,8 +6019,7 @@ impl PageStack {
     #[inline(always)]
     fn current(&self) -> usize {
         assert!(self.current_page >= 0);
-        let current = self.current_page as usize;
-        current
+        self.current_page as usize
     }
 
     /// Cell index of the current page
@@ -6052,14 +6051,9 @@ impl PageStack {
 
     /// Advance the current cell index of the current page to the next cell.
     /// We usually advance after going traversing a new page
-    // #[instrument(skip(self), level = Level::DEBUG, name = "pagestack::advance",)]
     #[inline(always)]
     fn advance(&mut self) {
         let current = self.current();
-        // tracing::trace!(
-        //     curr_cell_index = self.node_states[current].cell_idx,
-        //     node_states = ?self.node_states.iter().map(|state| state.cell_idx).collect::<Vec<_>>(),
-        // );
         self.node_states[current].cell_idx += 1;
     }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5314,7 +5314,7 @@ impl BTreeCursor {
             self.context = None;
             self.valid_state = CursorValidState::Valid;
             return Ok(IOResult::Done(()));
-        };
+        }
         let ctx = self.context.take().unwrap();
         let seek_key = match ctx.key {
             CursorContextKey::TableRowId(rowid) => SeekKey::TableRowId(rowid),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -415,8 +415,13 @@ impl Register {
 macro_rules! must_be_btree_cursor {
     ($cursor_id:expr, $cursor_ref:expr, $state:expr, $insn_name:expr) => {{
         let (_, cursor_type) = $cursor_ref.get($cursor_id).unwrap();
-        if matches!(cursor_type, CursorType::BTreeTable(_) | CursorType::BTreeIndex(_)) | CursorType::Materialized(_, _) {
-            $state.get_cursor($cursor_id)
+        if matches!(
+            cursor_type,
+            CursorType::BTreeTable(_)
+                | CursorType::BTreeIndex(_)
+                | CursorType::MaterializedView(_, _)
+        ) {
+            $crate::get_cursor!($state, $cursor_id)
         } else {
             panic!("{} on unexpected cursor", $insn_name)
         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -415,15 +415,11 @@ impl Register {
 macro_rules! must_be_btree_cursor {
     ($cursor_id:expr, $cursor_ref:expr, $state:expr, $insn_name:expr) => {{
         let (_, cursor_type) = $cursor_ref.get($cursor_id).unwrap();
-        let cursor = match cursor_type {
-            CursorType::BTreeTable(_) => $crate::get_cursor!($state, $cursor_id),
-            CursorType::BTreeIndex(_) => $crate::get_cursor!($state, $cursor_id),
-            CursorType::MaterializedView(_, _) => $crate::get_cursor!($state, $cursor_id),
-            CursorType::Pseudo(_) => panic!("{} on pseudo cursor", $insn_name),
-            CursorType::Sorter => panic!("{} on sorter cursor", $insn_name),
-            CursorType::VirtualTable(_) => panic!("{} on virtual table cursor", $insn_name),
-        };
-        cursor
+        if matches!(cursor_type, CursorType::BTreeTable(_) | CursorType::BTreeIndex(_)) | CursorType::Materialized(_, _) {
+            $state.get_cursor($cursor_id)
+        } else {
+            panic!("{} on unexpected cursor", $insn_name)
+        }
     }};
 }
 
@@ -471,6 +467,7 @@ impl Program {
         mv_store: Option<Arc<MvStore>>,
         pager: Rc<Pager>,
     ) -> Result<StepResult> {
+        let enable_tracing = tracing::enabled!(tracing::Level::TRACE);
         loop {
             if self.connection.closed.get() {
                 // Connection is closed for whatever reason, rollback the transaction.
@@ -497,7 +494,9 @@ impl Program {
             // invalidate row
             let _ = state.result_row.take();
             let (insn, insn_function) = &self.insns[state.pc as usize];
-            trace_insn(self, state.pc as InsnReference, insn);
+            if enable_tracing {
+                trace_insn(self, state.pc as InsnReference, insn);
+            }
             // Always increment VM steps for every loop iteration
             state.metrics.vm_steps = state.metrics.vm_steps.saturating_add(1);
 
@@ -832,9 +831,6 @@ pub fn registers_to_ref_values(registers: &[Register]) -> Vec<RefValue> {
 
 #[instrument(skip(program), level = Level::DEBUG)]
 fn trace_insn(program: &Program, addr: InsnReference, insn: &Insn) {
-    if !tracing::enabled!(tracing::Level::TRACE) {
-        return;
-    }
     tracing::trace!(
         "\n{}",
         explain::insn_to_str(

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -64,9 +64,6 @@ impl TempDatabase {
     }
 
     pub fn new_with_rusqlite(table_sql: &str, enable_indexes: bool) -> Self {
-        let _ = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::TRACE)
-            .finish();
         let mut path = TempDir::new().unwrap().keep();
         path.push("test.db");
         {

--- a/tests/integration/functions/mod.rs
+++ b/tests/integration/functions/mod.rs
@@ -1,16 +1,3 @@
 mod test_cdc;
 mod test_function_rowid;
 mod test_wal_api;
-
-#[cfg(test)]
-mod tests {
-    use tracing_subscriber::EnvFilter;
-
-    #[ctor::ctor]
-    fn init() {
-        tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .with_ansi(false)
-            .init();
-    }
-}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -5,3 +5,16 @@ mod fuzz_transaction;
 mod pragma;
 mod query_processing;
 mod wal;
+
+#[cfg(test)]
+mod tests {
+    use tracing_subscriber::EnvFilter;
+
+    #[ctor::ctor]
+    fn init() {
+        tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_ansi(false)
+            .init();
+    }
+}


### PR DESCRIPTION
Attempt to improve performance of `SELECT COUNT(*) FROM t WHERE 1 = 1` (redundant filter added to force sqlite and tursodb to iterate over rows instead of applying count optimization).

Before that PR turso with hot cache runs for ~440ms.

After that PR turso with hot cache runs for ~200ms.

This PR eliminates small things on a hot path and also introduce separate flow for `get_next_record` which just increment cell idx if its safe to do that - without much additional overhead.

Also, this PR eliminates RefCell/Cell from PageStack because there were completely unnecessary.