### PR TITLE
Fix: Return Error if hexkey is different

### DIFF
--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -148,7 +148,7 @@ impl DatabaseStorage for DatabaseFile {
         let pos = (page_idx - 1) * buffer_size;
         let buffer = {
             if let Some(ctx) = io_ctx.encryption_context() {
-                encrypt_buffer(page_idx, buffer, ctx)
+                encrypt_buffer(page_idx, buffer, ctx)?
             } else {
                 buffer
             }
@@ -176,7 +176,7 @@ impl DatabaseStorage for DatabaseFile {
                     .into_iter()
                     .enumerate()
                     .map(|(i, buffer)| encrypt_buffer(first_page_idx + i, buffer, ctx))
-                    .collect::<Vec<_>>()
+                    .collect::<Result<Vec<_>>>()?
             } else {
                 buffers
             }
@@ -210,7 +210,11 @@ impl DatabaseFile {
     }
 }
 
-fn encrypt_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &EncryptionContext) -> Arc<Buffer> {
-    let encrypted_data = ctx.encrypt_page(buffer.as_slice(), page_idx).unwrap();
-    Arc::new(Buffer::new(encrypted_data.to_vec()))
+fn encrypt_buffer(
+    page_idx: usize,
+    buffer: Arc<Buffer>,
+    ctx: &EncryptionContext,
+) -> Result<Arc<Buffer>> {
+    let encrypted_data = ctx.encrypt_page(buffer.as_slice(), page_idx)?;
+    Ok(Arc::new(Buffer::new(encrypted_data.to_vec())))
 }

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod buffer_pool;
 pub mod database;
 pub(crate) mod encryption;
 pub(crate) mod page_cache;
+pub(crate) mod page_error_check;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;
 #[allow(dead_code)]

--- a/core/storage/page_error_check.rs
+++ b/core/storage/page_error_check.rs
@@ -1,0 +1,27 @@
+use crate::storage::pager::PageRef;
+use crate::{LimboError, Result};
+
+/// Check if a page has an error state (e.g., decryption failed) and return appropriate error
+pub fn check_page_error_state(page: &PageRef) -> Result<()> {
+    if page.has_error() {
+        return Err(LimboError::InternalError(format!(
+            "Page {} has error state (likely decryption failed)",
+            page.get().id
+        )));
+    }
+    Ok(())
+}
+
+/// Check if page is loaded and doesn't have error state, return appropriate error if not
+pub fn ensure_page_loaded_without_error(page: &PageRef) -> Result<()> {
+    check_page_error_state(page)?;
+    
+    if !page.is_loaded() {
+        return Err(LimboError::InternalError(format!(
+            "Page {} is not loaded",
+            page.get().id
+        )));
+    }
+    
+    Ok(())
+}


### PR DESCRIPTION
This is a fix to #2703 instead of panicking now it just returns an error.