### PR TITLE
introduce package.json for separate *-browser package (both database and sync)

### DIFF
--- a/.github/workflows/napi-sync.yml
+++ b/.github/workflows/napi-sync.yml
@@ -172,11 +172,13 @@ jobs:
           if git log -1 --pretty=%B | grep "^Turso [0-9]\+\.[0-9]\+\.[0-9]\+$";
           then
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish --access public
+            make publish-native
+            make publish-browser
           elif git log -1 --pretty=%B | grep "^Turso [0-9]\+\.[0-9]\+\.[0-9]\+";
           then
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish --tag next --access public
+            make publish-native-next
+            make publish-browser-next
           else
             echo "Not a release, skipping publish"
           fi

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -172,11 +172,13 @@ jobs:
           if git log -1 --pretty=%B | grep "^Turso [0-9]\+\.[0-9]\+\.[0-9]\+$";
           then
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish --access public
+            make publish-native
+            make publish-browser
           elif git log -1 --pretty=%B | grep "^Turso [0-9]\+\.[0-9]\+\.[0-9]\+";
           then
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish --tag next --access public
+            make publish-native-next
+            make publish-browser-next
           else
             echo "Not a release, skipping publish"
           fi

--- a/bindings/javascript/.gitignore
+++ b/bindings/javascript/.gitignore
@@ -196,3 +196,5 @@ Cargo.lock
 
 *.node
 *.wasm
+
+package.native.json

--- a/bindings/javascript/Makefile
+++ b/bindings/javascript/Makefile
@@ -1,25 +1,20 @@
 pack-native:
-	npm publish --dry-run
-	npm pack
+	npm publish --dry-run && npm pack
 pack-browser:
 	cp package.json package.native.json
 	cp package.browser.json package.json
-	npm publish --dry-run
-	npm pack
-	cp package.native.json package.json
+	npm publish --dry-run && npm pack; cp package.native.json package.json
 
 publish-native:
 	npm publish --access public
 publish-browser:
 	cp package.json package.native.json
 	cp package.browser.json package.json
-	npm publish --access public
-	cp package.native.json package.json
+	npm publish --access public; cp package.native.json package.json
 
 publish-native-next:
 	npm publish --tag next --access public
 publish-browser-next:
 	cp package.json package.native.json
 	cp package.browser.json package.json
-	npm publish --tag next --access public
-	cp package.native.json package.json
+	npm publish --tag next --access public; cp package.native.json package.json

--- a/bindings/javascript/Makefile
+++ b/bindings/javascript/Makefile
@@ -1,0 +1,25 @@
+pack-native:
+	npm publish --dry-run
+	npm pack
+pack-browser:
+	cp package.json package.native.json
+	cp package.browser.json package.json
+	npm publish --dry-run
+	npm pack
+	cp package.native.json package.json
+
+publish-native:
+	npm publish --access public
+publish-browser:
+	cp package.json package.native.json
+	cp package.browser.json package.json
+	npm publish --access public
+	cp package.native.json package.json
+
+publish-native-next:
+	npm publish --tag next --access public
+publish-browser-next:
+	cp package.json package.native.json
+	cp package.browser.json package.json
+	npm publish --tag next --access public
+	cp package.native.json package.json

--- a/bindings/javascript/package.browser.json
+++ b/bindings/javascript/package.browser.json
@@ -1,0 +1,59 @@
+{
+  "name": "@tursodatabase/database-browser",
+  "version": "0.1.5-pre.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/turso"
+  },
+  "description": "The Turso database library specifically for browser/web environment",
+  "module": "./dist/promise.js",
+  "main": "./dist/promise.js",
+  "type": "module",
+  "exports": {
+    ".": "./dist/promise.js",
+    "./compat": "./dist/compat.js"
+  },
+  "files": [
+    "browser.js",
+    "index.js",
+    "index.d.ts",
+    "dist/**"
+  ],
+  "types": "index.d.ts",
+  "napi": {
+    "binaryName": "turso",
+    "targets": [
+      "wasm32-wasip1-threads"
+    ]
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@napi-rs/cli": "^3.0.4",
+    "@napi-rs/wasm-runtime": "^1.0.1",
+    "ava": "^6.0.1",
+    "better-sqlite3": "^11.9.1",
+    "typescript": "^5.9.2"
+  },
+  "ava": {
+    "timeout": "3m"
+  },
+  "engines": {
+    "node": ">= 10"
+  },
+  "scripts": {
+    "artifacts": "napi artifacts",
+    "build": "npm exec tsc && napi build --platform --release --esm",
+    "build:debug": "npm exec tsc && napi build --platform",
+    "prepublishOnly": "npm exec tsc && napi prepublish -t npm",
+    "test": "true",
+    "universal": "napi universalize",
+    "version": "napi version"
+  },
+  "packageManager": "yarn@4.9.2",
+  "imports": {
+    "#entry-point": {
+      "types": "./index.d.ts",
+      "browser": "./browser.js"
+    }
+  }
+}

--- a/bindings/javascript/package.browser.json
+++ b/bindings/javascript/package.browser.json
@@ -44,7 +44,7 @@
     "artifacts": "napi artifacts",
     "build": "npm exec tsc && napi build --platform --release --esm",
     "build:debug": "npm exec tsc && napi build --platform",
-    "prepublishOnly": "npm exec tsc && napi prepublish -t npm",
+    "prepublishOnly": "npm exec tsc && napi prepublish -t npm --skip-optional-publish",
     "test": "true",
     "universal": "napi universalize",
     "version": "napi version"

--- a/sync/javascript/.gitignore
+++ b/sync/javascript/.gitignore
@@ -134,3 +134,5 @@ Cargo.lock
 *-draft
 *-synced
 *-info
+
+package.native.json

--- a/sync/javascript/Makefile
+++ b/sync/javascript/Makefile
@@ -1,25 +1,20 @@
 pack-native:
-	npm publish --dry-run
-	npm pack
+	npm publish --dry-run && npm pack
 pack-browser:
 	cp package.json package.native.json
 	cp package.browser.json package.json
-	npm publish --dry-run
-	npm pack
-	cp package.native.json package.json
+	npm publish --dry-run && npm pack; cp package.native.json package.json
 
 publish-native:
 	npm publish --access public
 publish-browser:
 	cp package.json package.native.json
 	cp package.browser.json package.json
-	npm publish --access public
-	cp package.native.json package.json
+	npm publish --access public; cp package.native.json package.json
 
 publish-native-next:
 	npm publish --tag next --access public
 publish-browser-next:
 	cp package.json package.native.json
 	cp package.browser.json package.json
-	npm publish --tag next --access public
-	cp package.native.json package.json
+	npm publish --tag next --access public; cp package.native.json package.json

--- a/sync/javascript/Makefile
+++ b/sync/javascript/Makefile
@@ -1,0 +1,25 @@
+pack-native:
+	npm publish --dry-run
+	npm pack
+pack-browser:
+	cp package.json package.native.json
+	cp package.browser.json package.json
+	npm publish --dry-run
+	npm pack
+	cp package.native.json package.json
+
+publish-native:
+	npm publish --access public
+publish-browser:
+	cp package.json package.native.json
+	cp package.browser.json package.json
+	npm publish --access public
+	cp package.native.json package.json
+
+publish-native-next:
+	npm publish --tag next --access public
+publish-browser-next:
+	cp package.json package.native.json
+	cp package.browser.json package.json
+	npm publish --tag next --access public
+	cp package.native.json package.json

--- a/sync/javascript/package.browser.json
+++ b/sync/javascript/package.browser.json
@@ -39,7 +39,7 @@
     "artifacts": "napi artifacts",
     "build": "npm exec tsc && napi build --platform --release --esm",
     "build:debug": "npm exec tsc && napi build --platform",
-    "prepublishOnly": "npm exec tsc && napi prepublish -t npm",
+    "prepublishOnly": "npm exec tsc && napi prepublish -t npm --skip-optional-publish",
     "test": "true",
     "universal": "napi universalize",
     "version": "napi version"

--- a/sync/javascript/package.browser.json
+++ b/sync/javascript/package.browser.json
@@ -1,0 +1,57 @@
+{
+  "name": "@tursodatabase/sync-browser",
+  "version": "0.1.5-pre.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/turso"
+  },
+  "description": "Sync engine for the Turso database library specifically for browser/web environment",
+  "module": "./dist/sync_engine.js",
+  "main": "./dist/sync_engine.js",
+  "type": "module",
+  "exports": "./dist/sync_engine.js",
+  "files": [
+    "browser.js",
+    "dist/**"
+  ],
+  "types": "./dist/sync_engine.d.ts",
+  "napi": {
+    "binaryName": "turso-sync-js",
+    "targets": [
+      "wasm32-wasip1-threads"
+    ]
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@napi-rs/cli": "^3.0.4",
+    "@napi-rs/wasm-runtime": "^1.0.1",
+    "@types/node": "^24.2.0",
+    "ava": "^6.0.1",
+    "typescript": "^5.9.2"
+  },
+  "ava": {
+    "timeout": "3m"
+  },
+  "engines": {
+    "node": ">= 10"
+  },
+  "scripts": {
+    "artifacts": "napi artifacts",
+    "build": "npm exec tsc && napi build --platform --release --esm",
+    "build:debug": "npm exec tsc && napi build --platform",
+    "prepublishOnly": "npm exec tsc && napi prepublish -t npm",
+    "test": "true",
+    "universal": "napi universalize",
+    "version": "napi version"
+  },
+  "packageManager": "yarn@4.9.2",
+  "imports": {
+    "#entry-point": {
+      "types": "./index.d.ts",
+      "browser": "./browser.js"
+    }
+  },
+  "dependencies": {
+    "@tursodatabase/database": "~0.1.4-pre.5"
+  }
+}


### PR DESCRIPTION
This PR introduces separate `package.browser.json` file for `*-browser` npm packages (`@tursodatabase/sync-browser` and `@tursodatabase/database-browser`).

The packages are nearly identical and the only change is `package.json` content (browser package mentions only WASM optional dependency which shouldn't confuse NPM and force it to download WASM dep package instead of native one).

Due to that, innocent "hack" is implemented which swap `package.json` with `package.browser.json` before publish of `browser` package.