### PR TITLE
Fix infinite loop when query starts comment token ("--")

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -499,33 +499,7 @@ impl Limbo {
                 return Ok(());
             }
         }
-        if line.trim_start().starts_with("--") {
-            if let Some(remaining) = line.split_once('\n') {
-                let after_comment = remaining.1.trim();
-                if !after_comment.is_empty() {
-                    if after_comment.ends_with(';') {
-                        self.run_query(after_comment);
-                        if self.opts.echo {
-                            let _ = self.writeln(after_comment);
-                        }
-                        let conn = self.conn.clone();
-                        let runner = conn.query_runner(after_comment.as_bytes());
-                        for output in runner {
-                            if let Err(e) = self.print_query_result(after_comment, output, None) {
-                                let _ = self.writeln(e.to_string());
-                            }
-                        }
-                        self.reset_input();
-                        return self.handle_input_line(after_comment);
-                    } else {
-                        self.set_multiline_prompt();
-                        let _ = self.reset_line(line);
-                        return Ok(());
-                    }
-                }
-            }
-            return Ok(());
-        }
+
         self.reset_line(line)?;
         if line.ends_with(';') {
             self.buffer_input(line);


### PR DESCRIPTION
fix #2937 , we dont need to check comment in cli because parser already handled it (i guest).

How to reproduce:
```sh
turso> --whatCREATE TABLE users (
    id INT PRIMARY KEY,
    first_name VARCHAR(50),
    age INT
);
```