### PR TITLE
Avoid allocating and then immediately fallbacking errors in affinity

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1306,16 +1306,14 @@ impl Affinity {
         }
     }
 
-    pub fn from_char(char: char) -> Result<Self> {
+    pub fn from_char(char: char) -> Self {
         match char {
-            SQLITE_AFF_INTEGER => Ok(Affinity::Integer),
-            SQLITE_AFF_TEXT => Ok(Affinity::Text),
-            SQLITE_AFF_NONE => Ok(Affinity::Blob),
-            SQLITE_AFF_REAL => Ok(Affinity::Real),
-            SQLITE_AFF_NUMERIC => Ok(Affinity::Numeric),
-            _ => Err(LimboError::InternalError(format!(
-                "Invalid affinity character: {char}"
-            ))),
+            SQLITE_AFF_INTEGER => Affinity::Integer,
+            SQLITE_AFF_TEXT => Affinity::Text,
+            SQLITE_AFF_NONE => Affinity::Blob,
+            SQLITE_AFF_REAL => Affinity::Real,
+            SQLITE_AFF_NUMERIC => Affinity::Numeric,
+            _ => Affinity::Blob,
         }
     }
 
@@ -1323,7 +1321,7 @@ impl Affinity {
         self.aff_mask() as u8
     }
 
-    pub fn from_char_code(code: u8) -> Result<Self, LimboError> {
+    pub fn from_char_code(code: u8) -> Self {
         Self::from_char(code as char)
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7236,7 +7236,7 @@ pub fn op_affinity(
     for (i, affinity_char) in affinities.chars().enumerate().take(count.get()) {
         let reg_index = *start_reg + i;
 
-        let affinity = Affinity::from_char(affinity_char)?;
+        let affinity = Affinity::from_char(affinity_char);
 
         apply_affinity_char(&mut state.registers[reg_index], affinity);
     }

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -52,7 +52,7 @@ impl CmpInsFlags {
 
     pub fn get_affinity(&self) -> Affinity {
         let aff_code = (self.0 & Self::AFFINITY_MASK) as u8;
-        Affinity::from_char_code(aff_code).unwrap_or(Affinity::Blob)
+        Affinity::from_char_code(aff_code)
     }
 }
 


### PR DESCRIPTION
On the syscall IO backend, on TPC-H query 12, the _dominating_ part of the stack trace is trying to construct affinities from a character, failing, allocating an error&string, and then immediately falling back to Blob affinity and dropping the error&string.

Since I'm on vacation I won't spend cycles on figuring out why we are passing an incorrect affinity in `flags.get_affinity()` and instead make this lazy PR just to improve performance and stop doing silly things :]