### PR TITLE
reduce cloning `Arc<Page>`

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2243,7 +2243,7 @@ impl BTreeCursor {
                                     tracing::debug!("TableLeafCell: found exact match with cell_idx={cell_idx}, overwriting");
                                     self.has_record.set(true);
                                     *write_state = WriteState::Overwrite {
-                                        page: page,
+                                        page,
                                         cell_idx,
                                         state: Some(OverwriteCellState::AllocatePayload),
                                     };
@@ -2267,7 +2267,7 @@ impl BTreeCursor {
                                         panic!("expected write state");
                                     };
                                     *write_state = WriteState::Overwrite {
-                                        page: page,
+                                        page,
                                         cell_idx,
                                         state: Some(OverwriteCellState::AllocatePayload),
                                     };
@@ -2287,7 +2287,7 @@ impl BTreeCursor {
                         panic!("expected write state");
                     };
                     *write_state = WriteState::Insert {
-                        page: page,
+                        page,
                         cell_idx,
                         new_payload: Vec::with_capacity(record_values.len() + 4),
                         fill_cell_payload_state: FillCellPayloadState::Start,
@@ -2353,7 +2353,7 @@ impl BTreeCursor {
                             panic!("expected write state");
                         };
                         *write_state = WriteState::Overwrite {
-                            page: page,
+                            page,
                             cell_idx,
                             state: Some(state),
                         };
@@ -2536,7 +2536,7 @@ impl BTreeCursor {
                             overflow_cell.index
                         );
                     }
-                    self.pager.add_dirty(&parent_page);
+                    self.pager.add_dirty(parent_page);
                     let parent_contents = parent_page.get_contents();
                     let page_to_balance_idx = self.stack.current_cell_index() as usize;
 


### PR DESCRIPTION
only use `self.stack.top()` when we need to store `Arc<Page>` in struct

```sh
Execute `SELECT count() FROM users`/limbo_execute_select_count
                        time:   [5.3733 µs 5.3801 µs 5.3881 µs]
                        change: [-34.047% -33.949% -33.851%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
```