### PR TITLE
Handle case where null flag is set in op_column

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1455,13 +1455,16 @@ pub fn op_column(
                 index_cursor_id,
                 table_cursor_id,
             } => {
-                let rowid = {
+                let Some(rowid) = ({
                     let index_cursor = state.get_cursor(index_cursor_id);
                     let index_cursor = index_cursor.as_btree_mut();
                     return_if_io!(index_cursor.rowid())
+                }) else {
+                    state.registers[*dest] = Register::Value(Value::Null);
+                    break 'outer;
                 };
                 state.op_column_state = OpColumnState::Seek {
-                    rowid: rowid.unwrap(),
+                    rowid,
                     table_cursor_id,
                 };
             }

--- a/testing/join.test
+++ b/testing/join.test
@@ -329,3 +329,13 @@ do_execsql_test_on_specific_db {:memory:} next-crash {
   select a.x, b.x, c.x from a left join b on a.y=b.x left join c on b.y=c.x;
 } {1||
 2||}
+
+# regression test for crash in op_column
+do_execsql_test_on_specific_db {:memory:} left-join-column-crash {
+    create table a(x int primary key,y);
+    create table b(x int primary key,y);
+    insert into a values (1,1),(2,2);
+    insert into b values (3,3),(4,4);
+    select * from a left join b on a.x < 2 where a.x < 3 and b.x < 12;
+} {1|1|3|3
+1|1|4|4}


### PR DESCRIPTION
current code is incorrectly assuming that `index_cursor.rowid()` always finds a rowid, but this is not the case when `NullRow` has previously been called.