### PR TITLE
clean `print_query_result`

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -798,7 +798,7 @@ impl Limbo {
                     }
 
                     if !table.is_empty() {
-                        write!(self, "{table}")?;
+                        writeln!(self, "{table}")?;
                     }
                 }
                 OutputMode::Line => {


### PR DESCRIPTION
different between output modes is how we handle `Ok(StepResult::Row)` so let introduce `row_step_result_query` macro to reduce duplicated code.