### PR TITLE
Fix read_entire_wal_dumb: incrementally build the frame cache

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1638,7 +1638,6 @@ pub fn build_shared_wal(
         l.unlock();
     }
 
-    #[allow(clippy::arc_with_non_send_sync)]
     let wal_file_shared = Arc::new(RwLock::new(WalFileShared {
         enabled: AtomicBool::new(true),
         wal_header: header.clone(),
@@ -1964,7 +1963,6 @@ pub fn begin_read_wal_frame_raw(
 ) -> Result<Completion> {
     tracing::trace!("begin_read_wal_frame_raw(offset={})", offset);
     let buf = Arc::new(buffer_pool.get_wal_frame());
-    #[allow(clippy::arc_with_non_send_sync)]
     let c = Completion::new_read(buf, complete);
     let c = io.pread(offset, c)?;
     Ok(c)

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -553,7 +553,6 @@ impl fmt::Debug for OngoingCheckpoint {
     }
 }
 
-#[allow(dead_code)]
 pub struct WalFile {
     io: Arc<dyn IO>,
     buffer_pool: Arc<BufferPool>,
@@ -660,7 +659,6 @@ impl fmt::Debug for WalFile {
 // TODO(pere): lock only important parts + pin WalFileShared
 /// WalFileShared is the part of a WAL that will be shared between threads. A wal has information
 /// that needs to be communicated between threads so this struct does the job.
-#[allow(dead_code)]
 pub struct WalFileShared {
     pub enabled: AtomicBool,
     pub wal_header: Arc<SpinLock<WalHeader>>,


### PR DESCRIPTION
closes #2240

Incrementally build the frame cache by reading the WAL file in chunks instead of reading the entire file into memory.

<img width="247" height="254" alt="image" src="https://github.com/user-attachments/assets/803645ab-002a-4efd-ac47-b2f690e63fc7" />
