### PR TITLE
Fix clear_page_cache method and rollback

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -631,16 +631,6 @@ impl PageCache {
         self.capacity
     }
 
-    pub fn unset_dirty_all_pages(&mut self) {
-        let entries = &self.entries;
-        for entry in entries.iter() {
-            if entry.page.is_none() {
-                continue;
-            }
-            entry.page.as_ref().unwrap().clear_dirty();
-        }
-    }
-
     #[cfg(test)]
     fn verify_cache_integrity(&self) {
         let map = &self.map;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2122,20 +2122,14 @@ impl Pager {
         is_write: bool,
     ) -> Result<(), LimboError> {
         tracing::debug!(schema_did_change);
-        if is_write {
-            self.dirty_pages.borrow_mut().clear();
-        } else {
+        if !is_write {
             turso_assert!(
                 self.dirty_pages.borrow().is_empty(),
                 "dirty pages should be empty for read txn"
             );
         }
-        let mut cache = self.page_cache.write();
-
+        self.clear_page_cache();
         self.reset_internal_states();
-
-        cache.unset_dirty_all_pages();
-        cache.clear().expect("failed to clear page cache");
         if schema_did_change {
             connection.schema.replace(connection._db.clone_schema()?);
         }


### PR DESCRIPTION
Previously we were iterating over every entry in the page cache, clearing the dirty flag from each page.