### PR TITLE
translate: return parse error for unsupported join types

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -996,6 +996,12 @@ fn parse_join(
 
     let (outer, natural) = match join_operator {
         ast::JoinOperator::TypedJoin(Some(join_type)) => {
+            if join_type.contains(JoinType::RIGHT) {
+                crate::bail_parse_error!("RIGHT JOIN is not supported");
+            }
+            if join_type.contains(JoinType::CROSS) {
+                crate::bail_parse_error!("CROSS JOIN is not supported");
+            }
             let is_outer = join_type.contains(JoinType::OUTER);
             let is_natural = join_type.contains(JoinType::NATURAL);
             (is_outer, is_natural)


### PR DESCRIPTION
We were silently ignoring these before