### PR TITLE
Fix value conversion for function parameters

### DIFF
--- a/core/util.rs
+++ b/core/util.rs
@@ -1,5 +1,6 @@
 #![allow(unused)]
 use crate::incremental::view::IncrementalView;
+use crate::numeric::StrToF64;
 use crate::translate::expr::WalkControl;
 use crate::types::IOResult;
 use crate::{
@@ -1185,8 +1186,12 @@ pub fn parse_numeric_literal(text: &str) -> Result<Value> {
         return Ok(Value::Integer(int_value));
     }
 
-    let float_value = text.parse::<f64>()?;
-    Ok(Value::Float(float_value))
+    let Some(StrToF64::Fractional(float) | StrToF64::Decimal(float)) =
+        crate::numeric::str_to_f64(text)
+    else {
+        unreachable!();
+    };
+    Ok(Value::Float(float.into()))
 }
 
 pub fn parse_signed_number(expr: &Expr) -> Result<Value> {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.1.5-pre.3"
+version = "0.1.5"
 dependencies = [
  "aegis",
  "aes",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.1.5-pre.3"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "getrandom 0.3.1",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.1.5-pre.3"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.1.5-pre.3"
+version = "0.1.5"
 dependencies = [
  "bitflags",
  "miette",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sqlite3_parser"
-version = "0.1.5-pre.3"
+version = "0.1.5"
 dependencies = [
  "bitflags",
  "cc",


### PR DESCRIPTION
Value conversion to float for math functions work in a more strict way than general numeric conversion. For example, valid prefixes that can be converted to a integer, like `"44s"` will be converted to `Value::Null` instead of trying to recover like the math operators. 