### PR TITLE
Fix: read transaction cannot be allowed to start with a stale max frame

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -874,7 +874,9 @@ impl Wal for WalFile {
             }
         }
 
-        if best_idx == -1 {
+        if best_idx == -1 || best_mark != shared_max as u32 {
+            // If we cannot find a valid slot or the highest readmark has a stale max frame, we must return busy;
+            // otherwise we would not see some committed changes.
             return Ok((LimboResult::Busy, db_changed));
         }
 


### PR DESCRIPTION
If both of the following are true:

1. All read locks are already held
2. The highest readmark of any read lock is less than the committed max frame

Then we must return Busy to the reader, because otherwise they would begin a transaction with a stale local max frame, and thus not see some committed changes.

Closes #3016 