### PR TITLE
add explicit usize type annotation to range iterator in test

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -2321,7 +2321,7 @@ mod tests {
         let mut small_vec = SmallVec::<i32, 4>::new();
         (0..8).for_each(|i| small_vec.push(i));
 
-        (0..8).for_each(|i| {
+        (0..8usize).for_each(|i| {
             assert_eq!(small_vec.get(i), Some(i as i32));
         });
 


### PR DESCRIPTION
very small fix when i was reading the codebase with rust-analyser while trying to find a bug for simulator.

original error:
`non-primitive cast: <Range<i32> as Iterator>::Item as i32 rust-analyzer E0605`