### PR TITLE
core/schema: Optimize get_dependent_materialized_views() when no views

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -178,6 +178,9 @@ impl Schema {
 
     /// Get all materialized views that depend on a given table
     pub fn get_dependent_materialized_views(&self, table_name: &str) -> Vec<String> {
+        if self.table_to_materialized_views.is_empty() {
+            return Vec::new();
+        }
         let table_name = normalize_ident(table_name);
         self.table_to_materialized_views
             .get(&table_name)


### PR DESCRIPTION
Eliminates get_dependent_materialized_views() overhead when there are no views. Note that we need to optimize the case when there are views as well because this ends up being pretty hot in write-intensive workloads.