### PR TITLE
core: Panic on fsync() error by default

### DIFF
--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -46,6 +46,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
                 | PragmaFlags::NoColumns1,
             &["cache_size"],
         ),
+        DataSyncRetry => Pragma::new(
+            PragmaFlags::Result0 | PragmaFlags::NoColumns1,
+            &["data_sync_retry"],
+        ),
         DatabaseList => Pragma::new(PragmaFlags::Result0, &["seq", "name", "file"]),
         Encoding => Pragma::new(
             PragmaFlags::Result0 | PragmaFlags::NoColumns1,

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1318,6 +1318,8 @@ pub enum PragmaName {
     #[strum(serialize = "cipher")]
     #[cfg_attr(feature = "serde", serde(rename = "cipher"))]
     EncryptionCipher,
+    /// Control fsync error retry behavior (0 = off/panic, 1 = on/retry)
+    DataSyncRetry,
     /// List databases
     DatabaseList,
     /// Encoding - only support utf8


### PR DESCRIPTION
Retrying fsync() on error was historically not safe ("fsyncgate") and Postgres still defaults to panicing on fsync(). Therefore, add a "data_sync_retry" pragma (disabled by default) and use it to determine whether to panic on fsync() error or not.