### PR TITLE
simulator: add race condition demo to simulator for testing page corruption

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,12 @@ jobs:
         run: ./scripts/run-sim --maximum-tests 1000 --min-tick 10 --max-tick 50 --profile write_heavy loop -n 10 -s
       - name: Simulator Faultless
         run: ./scripts/run-sim --maximum-tests 1000 --min-tick 10 --max-tick 50 --profile faultless loop -n 10 -s
+      - name: Race demo (in-memory corruption, expected panic)
+        continue-on-error: true
+        run: ./scripts/run-sim race-demo --rounds 1 --page-size 4096
+      - name: Race flush (persist corruption to WAL, expected panic)
+        continue-on-error: true
+        run: ./scripts/run-sim race-flush --path ./race_flush.db --page-size 4096 --page-idx 1
 
   test-limbo:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -78,8 +78,9 @@ use std::{
 use storage::database::DatabaseFile;
 pub use storage::database::IOContext;
 pub use storage::encryption::{EncryptionContext, EncryptionKey};
-use storage::page_cache::PageCache;
+pub use storage::page_cache::{PageCache, PageCacheKey};
 use storage::pager::{AtomicDbState, DbState};
+pub use storage::sqlite3_ondisk::PageContent;
 use storage::sqlite3_ondisk::PageSize;
 pub use storage::{
     buffer_pool::BufferPool,
@@ -942,6 +943,10 @@ impl Drop for Connection {
 }
 
 impl Connection {
+    #[cfg(feature = "simulator")]
+    pub fn pager_arc(&self) -> Rc<Pager> {
+        self.pager.borrow().clone()
+    }
     #[instrument(skip_all, level = Level::INFO)]
     pub fn prepare(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
         if self.closed.get() {

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -647,6 +647,11 @@ impl PageCache {
         self.capacity
     }
 
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     #[cfg(test)]
     fn verify_cache_integrity(&self) {
         let map = &self.map;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -562,6 +562,10 @@ enum FreePageState {
 }
 
 impl Pager {
+    #[cfg(feature = "simulator")]
+    pub fn page_cache_arc(&self) -> Arc<parking_lot::RwLock<PageCache>> {
+        self.page_cache.clone()
+    }
     pub fn new(
         db_file: Arc<dyn DatabaseStorage>,
         wal: Option<Rc<RefCell<dyn Wal>>>,

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -134,7 +134,8 @@ fn main() -> anyhow::Result<()> {
         }
     } else {
         banner();
-        testing_main(&cli_opts, &profile)
+        // Default to race-flush demo so it shows up in CI/CLI this is to just save time for reviewers so they dont have to run the race-demo
+        race_flush("./race_flush.db", 4096, 1)
     }
 }
 

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -134,8 +134,7 @@ fn main() -> anyhow::Result<()> {
         }
     } else {
         banner();
-        // Default to race-flush demo so it shows up in CI/CLI this is to just save time for reviewers so they dont have to run the race-demo
-        race_flush("./race_flush.db", 4096, 1)
+        testing_main(&cli_opts, &profile)
     }
 }
 

--- a/simulator/runner/cli.rs
+++ b/simulator/runner/cli.rs
@@ -173,6 +173,37 @@ pub enum SimulatorCommand {
     },
     /// Print profile Json Schema
     PrintSchema,
+    #[clap(about = "demonstrate concurrent page write corruption without panics")]
+    RaceDemo {
+        #[clap(
+            short = 'r',
+            long,
+            help = "number of race attempts to try",
+            default_value_t = 10
+        )]
+        rounds: usize,
+        #[clap(
+            short = 's',
+            long,
+            help = "size of the page buffer in bytes",
+            default_value_t = 4096
+        )]
+        page_size: usize,
+    },
+    #[clap(about = "race + flush to WAL to prove durability (will likely panic)")]
+    RaceFlush {
+        #[clap(
+            short = 'p',
+            long,
+            help = "database path to use",
+            default_value = "./race_flush.db"
+        )]
+        path: String,
+        #[clap(short = 's', long, help = "page size", default_value_t = 4096)]
+        page_size: usize,
+        #[clap(short = 'i', long, help = "page index to corrupt", default_value_t = 1)]
+        page_idx: usize,
+    },
 }
 
 impl SimulatorCLI {


### PR DESCRIPTION
- Two threads concurrently mutate the same Page buffer.
- Page is not Sync; mutations happen without synchronization.
- Core decoders read torn bytes and panic. (this is also in-memory corruption and panicks accordingly)
- Mark dirty + cacheflush writes corrupted bytes to WAL still. (race flush proves corrupted bytes are committed.)
- I didnt include the fix.

I added the each profile to be ran to github runners, it shows the same logs as my post below.