### PR TITLE
simulator: write_frame_raw corrupts file confirmed by sqlite

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,6 +74,8 @@ jobs:
         run: ./scripts/run-sim --maximum-tests 1000 --min-tick 10 --max-tick 50 --profile write_heavy loop -n 10 -s
       - name: Simulator Faultless
         run: ./scripts/run-sim --maximum-tests 1000 --min-tick 10 --max-tick 50 --profile faultless loop -n 10 -s
+      - name: Simulator WALCorruption (Shouldn't have happened.)
+        run: cargo run --bin limbo_sim -- --profile ./simulator/profiles/wal_corruption_test.json --differential
 
   test-limbo:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/simulator/profiles/wal_corruption_test.json
+++ b/simulator/profiles/wal_corruption_test.json
@@ -10,12 +10,6 @@
   },
   "io": {
     "enable": true,
-    "fault": {
-      "enable": true,
-      "write": true,
-      "read": true,
-      "sync": true
-    },
     "latency": {
       "enable": true,
       "latency_probability": 25,

--- a/simulator/profiles/wal_corruption_test.json
+++ b/simulator/profiles/wal_corruption_test.json
@@ -1,0 +1,27 @@
+{
+  "query": {
+    "select_weight": 40,
+    "insert_weight": 40,
+    "update_weight": 10,
+    "delete_weight": 10,
+    "create_table_weight": 5,
+    "create_index_weight": 3,
+    "drop_table_weight": 2
+  },
+  "io": {
+    "enable": true,
+    "fault": {
+      "enable": true,
+      "write": true,
+      "read": true,
+      "sync": true
+    },
+    "latency": {
+      "enable": true,
+      "latency_probability": 25,
+      "min_tick": 1,
+      "max_tick": 15
+    }
+  },
+  "experimental_mvcc": false
+}


### PR DESCRIPTION
this shouldn't happen at all, just giving a profile json and added to github runners for you guys to see.

results:
```
ERROR limbo_sim::runner::differential: 252: returned values from limbo and rusqlite results do not match
 INFO limbo_sim::runner::differential: 56: Simulation completed
 INFO limbo_sim: 385: shrinking succeeded, reduced the plan from 3984 to 22
 WARN limbo_sim::runner::bugbase: 332: Bug with seed 17388185823909721069 is already loaded, returning the existing plan
seed: 17388185823909721069
path: /home/denizhan/Documents/projects/tursodatabase/turso/.bugbase/17388185823909721069/
Error: failed with error: 'InternalError("returned values from limbo and rusqlite results do not match")'

Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::msg
             at /home/denizhan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.98/src/backtrace.rs:27:14
   1: limbo_sim::run_simulator
             at ./simulator/main.rs:399:29
   2: limbo_sim::testing_main
             at ./simulator/main.rs:144:18
   3: limbo_sim::main
             at ./simulator/main.rs:117:9
   4: core::ops::function::FnOnce::call_once
             at /home/denizhan/.rustup/toolchains/1.88.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
   5: std::sys::backtrace::__rust_begin_short_backtrace
             at /home/denizhan/.rustup/toolchains/1.88.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18
   6: std::rt::lang_start::{{closure}}
             at /home/denizhan/.rustup/toolchains/1.88.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:199:18
   7: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/ops/function.rs:284:13
   8: std::panicking::try::do_call
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:589:40
   9: std::panicking::try
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:552:19
  10: std::panic::catch_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panic.rs:359:14
  11: std::rt::lang_start_internal::{{closure}}
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/rt.rs:168:24
  12: std::panicking::try::do_call
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:589:40
  13: std::panicking::try
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:552:19
  14: std::panic::catch_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panic.rs:359:14
  15: std::rt::lang_start_internal
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/rt.rs:164:5
  16: std::rt::lang_start
             at /home/denizhan/.rustup/toolchains/1.88.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:198:5
  17: main
  18: <unknown>
  19: __libc_start_main
  20: _start
```
