### PR TITLE
perf/throughput/turso: Don't execute futures serially

### DIFF
--- a/perf/throughput/turso/Cargo.lock
+++ b/perf/throughput/turso/Cargo.lock
@@ -348,7 +348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -413,6 +413,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -906,6 +995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,8 +1081,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -997,7 +1102,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1007,6 +1122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1336,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "turso"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.3"
 dependencies = [
  "thiserror 2.0.16",
  "turso_core",
@@ -1344,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.3"
 dependencies = [
  "aegis",
  "aes",
@@ -1368,7 +1492,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "polling",
- "rand",
+ "rand 0.8.5",
  "regex",
  "regex-syntax",
  "rustix",
@@ -1382,13 +1506,14 @@ dependencies = [
  "turso_macros",
  "turso_parser",
  "turso_sqlite3_parser",
+ "twox-hash",
  "uncased",
  "uuid",
 ]
 
 [[package]]
 name = "turso_ext"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.3"
 dependencies = [
  "chrono",
  "getrandom 0.3.3",
@@ -1397,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1406,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.3"
 dependencies = [
  "bitflags",
  "miette",
@@ -1418,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sqlite3_parser"
-version = "0.2.0-pre.1"
+version = "0.2.0-pre.3"
 dependencies = [
  "bitflags",
  "cc",
@@ -1430,6 +1555,15 @@ dependencies = [
  "smallvec",
  "strum",
  "strum_macros",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -1822,6 +1956,7 @@ name = "write-throughput"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "futures",
  "tokio",
  "turso",
 ]

--- a/perf/throughput/turso/Cargo.toml
+++ b/perf/throughput/turso/Cargo.toml
@@ -11,3 +11,4 @@ path = "src/main.rs"
 turso = { path = "../../../bindings/rust" }
 clap = { version = "4.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
+futures = "0.3"

--- a/perf/throughput/turso/src/main.rs
+++ b/perf/throughput/turso/src/main.rs
@@ -196,8 +196,9 @@ async fn worker_thread(
         };
     }
 
-    for tx_fut in tx_futs {
-        tx_fut.await?;
+    let results = futures::future::join_all(tx_futs).await;
+    for result in results {
+        result?;
     }
 
     let elapsed = start_time.elapsed();


### PR DESCRIPTION
Looping through the futures means we're essentially executing them serially.