### PR TITLE
perf/throughput/turso: Don't interleave concurrent transactions in on…

### DIFF
--- a/perf/throughput/turso/src/main.rs
+++ b/perf/throughput/turso/src/main.rs
@@ -150,8 +150,6 @@ async fn worker_thread(
     mode: TransactionMode,
     think_ms: u64,
 ) -> Result<u64> {
-    let conn = db.connect()?;
-
     start_barrier.wait();
 
     let start_time = Instant::now();
@@ -160,7 +158,7 @@ async fn worker_thread(
     let mut tx_futs = vec![];
 
     for iteration in 0..iterations {
-        let conn = conn.clone();
+        let conn = db.connect()?;
         let total_inserts = Arc::clone(&total_inserts);
         let tx_fut = async move {
             let mut stmt = conn


### PR DESCRIPTION
…e connection

With BEGIN CONCURRENT, we cannot use the same connection all the time because there's no way for the transaction manager to know which transaction belongs to what "session" -- they're all individual statements executed in the context of the one connection.

Fixes #3093