### PR TITLE
More mvcc fixes 2

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -40,7 +40,6 @@ pub mod numeric;
 #[cfg(not(feature = "fuzz"))]
 mod numeric;
 
-use crate::incremental::view::AllViewsTxState;
 use crate::storage::checksum::CHECKSUM_REQUIRED_RESERVED_BYTES;
 use crate::storage::encryption::CipherMode;
 use crate::translate::pragma::TURSO_CDC_DEFAULT_TABLE_NAME;
@@ -50,6 +49,7 @@ use crate::types::{WalFrameInfo, WalState};
 use crate::util::{OpenMode, OpenOptions};
 use crate::vdbe::metrics::ConnectionMetrics;
 use crate::vtab::VirtualTable;
+use crate::{incremental::view::AllViewsTxState, translate::emitter::TransactionMode};
 use core::str;
 pub use error::{CompletionError, LimboError};
 pub use io::clock::{Clock, Instant};
@@ -477,7 +477,7 @@ impl Database {
             closed: Cell::new(false),
             attached_databases: RefCell::new(DatabaseCatalog::new()),
             query_only: Cell::new(false),
-            mv_tx_id: Cell::new(None),
+            mv_tx: Cell::new(None),
             view_transaction_states: AllViewsTxState::new(),
             metrics: RefCell::new(ConnectionMetrics::new()),
             is_nested_stmt: Cell::new(false),
@@ -961,7 +961,7 @@ pub struct Connection {
     /// Attached databases
     attached_databases: RefCell<DatabaseCatalog>,
     query_only: Cell<bool>,
-    pub(crate) mv_tx_id: Cell<Option<crate::mvcc::database::TxID>>,
+    pub(crate) mv_tx: Cell<Option<(crate::mvcc::database::TxID, TransactionMode)>>,
 
     /// Per-connection view transaction states for uncommitted changes. This represents
     /// one entry per view that was touched in the transaction.
@@ -2145,8 +2145,8 @@ impl Statement {
         self.program.n_change.get()
     }
 
-    pub fn set_mv_tx_id(&mut self, mv_tx_id: Option<u64>) {
-        self.program.connection.mv_tx_id.set(mv_tx_id);
+    pub fn set_mv_tx(&mut self, mv_tx: Option<(u64, TransactionMode)>) {
+        self.program.connection.mv_tx.set(mv_tx);
     }
 
     pub fn interrupt(&mut self) {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -464,7 +464,6 @@ impl Database {
             ),
             database_schemas: RefCell::new(std::collections::HashMap::new()),
             auto_commit: Cell::new(true),
-            mv_transactions: RefCell::new(Vec::new()),
             transaction_state: Cell::new(TransactionState::None),
             last_insert_rowid: Cell::new(0),
             last_change: Cell::new(0),
@@ -944,8 +943,6 @@ pub struct Connection {
     database_schemas: RefCell<std::collections::HashMap<usize, Arc<Schema>>>,
     /// Whether to automatically commit transaction
     auto_commit: Cell<bool>,
-    /// Transactions that are in progress.
-    mv_transactions: RefCell<Vec<crate::mvcc::database::TxID>>,
     transaction_state: Cell<TransactionState>,
     last_insert_rowid: Cell<i64>,
     last_change: Cell<i64>,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1093,7 +1093,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 if is_write_write_conflict(&self.txs, tx, rv) {
                     drop(row_versions);
                     drop(row_versions_opt);
-                    self.rollback_tx(tx_id, pager);
                     return Err(LimboError::WriteWriteConflict);
                 }
 

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -185,7 +185,7 @@ pub enum OperationMode {
     DELETE,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// Sqlite always considers Read transactions implicit
 pub enum TransactionMode {
     None,

--- a/core/util.rs
+++ b/core/util.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 use crate::incremental::view::IncrementalView;
 use crate::numeric::StrToF64;
+use crate::translate::emitter::TransactionMode;
 use crate::translate::expr::WalkControl;
 use crate::types::IOResult;
 use crate::{
@@ -150,10 +151,10 @@ pub fn parse_schema_rows(
     mut rows: Statement,
     schema: &mut Schema,
     syms: &SymbolTable,
-    mv_tx_id: Option<u64>,
+    mv_tx: Option<(u64, TransactionMode)>,
     mut existing_views: HashMap<String, Arc<Mutex<IncrementalView>>>,
 ) -> Result<()> {
-    rows.set_mv_tx_id(mv_tx_id);
+    rows.set_mv_tx(mv_tx);
     // TODO: if we IO, this unparsed indexes is lost. Will probably need some state between
     // IO runs
     let mut from_sql_indexes = Vec::with_capacity(10);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2174,7 +2174,6 @@ pub fn op_transaction(
                     return_if_io!(mv_store.begin_exclusive_tx(pager.clone(), None))
                 }
             };
-            conn.mv_transactions.borrow_mut().push(tx_id);
             program.connection.mv_tx_id.set(Some(tx_id));
         } else if updated
             && matches!(new_transaction_state, TransactionState::Write { .. })

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2181,7 +2181,7 @@ pub fn op_transaction(
             let actual_tx_mode = if mv_tx_mode == TransactionMode::Concurrent {
                 TransactionMode::Concurrent
             } else {
-                TransactionMode::Write
+                *tx_mode
             };
             if matches!(new_transaction_state, TransactionState::Write { .. })
                 && matches!(actual_tx_mode, TransactionMode::Write)

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1080,6 +1080,9 @@ pub fn handle_program_error(
         _ => {
             if let Some(mv_store) = mv_store {
                 if let Some((tx_id, _)) = connection.mv_tx.get() {
+                    connection.mv_tx.set(None);
+                    connection.transaction_state.replace(TransactionState::None);
+                    connection.auto_commit.replace(true);
                     mv_store.rollback_tx(tx_id, pager.clone());
                 }
             } else {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1082,6 +1082,8 @@ pub fn handle_program_error(
         LimboError::TxError(_) => {}
         // Table locked errors, e.g. trying to checkpoint in an interactive transaction, do not cause a rollback.
         LimboError::TableLocked => {}
+        // Busy errors do not cause a rollback.
+        LimboError::Busy => {}
         _ => {
             if let Some(mv_store) = mv_store {
                 if let Some(tx_id) = connection.mv_tx_id.get() {


### PR DESCRIPTION
based on #3110 

    mvcc: properly remove mutations of rolled back tx
    
    mvstore was not removing deletions made by a tx that rolled back.
    deletions are removed by clearing the `end` mark from the row
    version.

---

    mvcc: properly clear tx states when mvcc tx rolls back

---

    mvcc: don't double-rollback on write-write-conflict
    
    handle_program_error() already rolls back if this error happens.
    double rollback causes a crash.