### PR TITLE
stress: Retry sync on error to avoid a panic

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -488,6 +488,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let plan = plan.clone();
         let conn = db.lock().await.connect()?;
 
+        conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
+
         // Apply each DDL statement individually
         for stmt in &plan.ddl_statements {
             if opts.verbose {


### PR DESCRIPTION
We now panic on fsync error by default to be safe against fsyncgate. However, no reason to do that in the stress tester, especially since we test out of disk space errors under Antithesis.