### PR TITLE
Move common dependencies to workspace 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,12 +123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,9 +314,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
 ]
@@ -466,11 +460,10 @@ checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -518,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -528,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -552,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -666,7 +659,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "ctor 0.5.0",
- "env_logger 0.10.2",
+ "env_logger 0.11.7",
  "log",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -796,7 +789,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -1120,7 +1113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]
@@ -1129,11 +1121,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1145,7 +1134,6 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "jiff",
  "log",
 ]
 
@@ -1514,7 +1502,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5220b8ba44c68a9a7f7a7659e864dd73692e417ef0211bea133c7b74e031eeb9"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "libc",
  "libgit2-sys",
  "log",
@@ -1604,12 +1592,6 @@ dependencies = [
  "fnv",
  "itoa",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "iana-time-zone"
@@ -1793,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1815,7 +1797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "is-terminal",
  "itoa",
  "log",
@@ -1832,7 +1814,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "inotify-sys",
  "libc",
 ]
@@ -1861,7 +1843,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f96dfbc20c12b9b4f12eef60472d8c29b9c3f29463570dcb47e4a48551168"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -1927,30 +1909,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
 
 [[package]]
 name = "jni"
@@ -2089,7 +2047,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "libc",
  "redox_syscall",
 ]
@@ -2182,10 +2140,10 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 6.0.0",
- "env_logger 0.10.2",
+ "env_logger 0.11.7",
  "garde",
  "hex",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "json5",
  "log",
@@ -2399,7 +2357,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96671d5c84cee3ae4cab96386b9f953b22569ece9677b9fdd1492550a165eca5"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "ctor 0.4.2",
  "napi-build",
  "napi-sys",
@@ -2475,7 +2433,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2493,7 +2451,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -2578,7 +2536,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2680,7 +2638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "ucd-trie",
 ]
 
@@ -2742,7 +2700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
 dependencies = [
  "base64",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "quick-xml 0.32.0",
  "serde",
  "time",
@@ -2808,15 +2766,6 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "powerfmt"
@@ -3160,7 +3109,7 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3182,7 +3131,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3308,7 +3257,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3353,7 +3302,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3366,7 +3315,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
@@ -3385,7 +3334,7 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -3625,7 +3574,7 @@ dependencies = [
  "anyhow",
  "garde",
  "hex",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -3815,15 +3764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3882,11 +3822,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -3902,9 +3842,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4018,7 +3958,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4040,7 +3980,7 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4131,10 +4071,10 @@ dependencies = [
 name = "turso"
 version = "0.2.0-pre.3"
 dependencies = [
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "turso_core",
 ]
@@ -4144,7 +4084,7 @@ name = "turso-java"
 version = "0.2.0-pre.3"
 dependencies = [
  "jni",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "turso_core",
 ]
 
@@ -4160,7 +4100,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "dirs 5.0.1",
- "env_logger 0.10.2",
+ "env_logger 0.11.7",
  "libc",
  "limbo_completion",
  "miette",
@@ -4189,7 +4129,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "antithesis_sdk",
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "built",
  "bytemuck",
  "cfg_block",
@@ -4229,12 +4169,11 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "test-log",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tracing",
  "turso_ext",
  "turso_macros",
  "turso_parser",
- "turso_sqlite3_parser",
  "twox-hash",
  "uncased",
  "uuid",
@@ -4293,7 +4232,7 @@ dependencies = [
 name = "turso_parser"
 version = "0.2.0-pre.3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "criterion",
  "fallible-iterator",
  "miette",
@@ -4301,7 +4240,7 @@ dependencies = [
  "serde",
  "strum",
  "strum_macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "turso_macros",
 ]
 
@@ -4322,11 +4261,11 @@ dependencies = [
 name = "turso_sqlite3_parser"
 version = "0.2.0-pre.3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "cc",
  "env_logger 0.11.7",
  "fallible-iterator",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "log",
  "memchr",
  "miette",
@@ -4369,7 +4308,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4742,9 +4681,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -4975,7 +4914,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,11 +71,30 @@ mimalloc = { version = "0.1.47", default-features = false }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 itertools = "0.14.0"
 rand = "0.9.2"
+rand_chacha = "0.9.0"
 tracing = "0.1.41"
 schemars = "1.0.4"
 garde = "0.22"
 parking_lot = "0.12.4"
 tokio = { version = "1.0", default-features = false }
+tracing-subscriber = "0.3.20"
+futures = "0.3"
+clap = "4.5.47"
+thiserror = "2.0.16"
+tempfile = "3.20.0"
+indexmap = "2.11.1"
+miette = "7.6.0"
+bitflags = "2.9.4"
+fallible-iterator = "0.3.0"
+criterion = "0.5"
+chrono = { version = "0.4.42", default-features = false }
+hex = "0.4"
+antithesis_sdk = "0.2"
+cfg-if = "1.0.0"
+tracing-appender = "0.2.3"
+env_logger = { version = "0.11.6", default-features = false }
+regex = "1.11.1"
+regex-syntax = { version = "0.8.5", default-features = false }
 
 [profile.release]
 debug = "line-tables-only"

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 path = "rs_src/lib.rs"
 
 [dependencies]
-turso_core = { path = "../../core", features = ["io_uring"] }
+turso_core = { workspace = true, features = ["io_uring"] }
 jni = "0.21.1"
-thiserror = "2.0.9"
+thiserror = { workspace = true }

--- a/bindings/javascript/Cargo.toml
+++ b/bindings/javascript/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 turso_core = { workspace = true }
 napi = { version = "3.1.3", default-features = false, features = ["napi6"] }
 napi-derive = { version = "3.1.1", default-features = true }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing.workspace = true
 
 [features]

--- a/bindings/javascript/sync/Cargo.toml
+++ b/bindings/javascript/sync/Cargo.toml
@@ -17,7 +17,7 @@ turso_sync_engine = { workspace = true }
 turso_core = { workspace = true }
 turso_node = { workspace = true }
 genawaiter = { version = "0.99.1", default-features = false }
-tracing-subscriber = "0.3.19"
+tracing-subscriber = { workspace = true }
 
 [build-dependencies]
 napi-build = "2.2.3"

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -18,10 +18,10 @@ tracing_release = ["turso_core/tracing_release"]
 
 [dependencies]
 turso_core = { workspace = true, features = ["io_uring"] }
-thiserror = "2.0.9"
+thiserror = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.20.0"
-tokio = { version = "1.29.1", features = ["full"] }
-rand = "0.8.5"
-rand_chacha = "0.3.1"
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+rand = { workspace = true }
+rand_chacha = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,27 +19,27 @@ path = "main.rs"
 
 [dependencies]
 anyhow.workspace = true
-cfg-if = "1.0.0"
-clap = { version = "4.5.31", features = ["derive"] }
+cfg-if = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 clap_complete = { version = "=4.5.47", features = ["unstable-dynamic"] }
 comfy-table = "7.1.4"
 csv = "1.3.1"
 ctrlc = "3.4.4"
 dirs = "5.0.1"
-env_logger = "0.10.1"
+env_logger = { workspace = true }
 libc = "0.2.172"
 turso_core = { path = "../core", default-features = true, features = [] }
 limbo_completion = { path = "../extensions/completion", features = ["static"] }
-miette = { version = "7.4.0", features = ["fancy"] }
+miette = { workspace = true, features = ["fancy"] }
 nu-ansi-term = {version = "0.50.1", features = ["serde", "derive_serde_style"]}
 rustyline = { version = "15.0.0", default-features = true, features = [
     "derive",
 ] }
 shlex = "1.3.0"
 syntect = { git = "https://github.com/trishume/syntect.git", rev = "64644ffe064457265cbcee12a0c1baf9485ba6ee" }
-tracing = "0.1.41"
-tracing-appender = "0.2.3"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 toml = {version = "0.8.20", features = ["preserve_order"]}
 schemars = {version = "0.8.22", features = ["preserve_order"]}
 serde = { workspace = true, features = ["derive"]}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,36 +44,35 @@ libc = { version = "0.2.172" }
 libloading = "0.8.6"
 
 [dependencies]
-antithesis_sdk = { version = "0.2.5", optional = true }
+antithesis_sdk = { workspace = true, optional = true }
 turso_ext = { workspace = true, features = ["core_only"] }
 cfg_block = "0.1.1"
-fallible-iterator = "0.3.0"
-hex = "0.4.3"
-turso_sqlite3_parser = { workspace = true }
-thiserror = "1.0.61"
+fallible-iterator = { workspace = true }
+hex = { workspace = true }
+thiserror = { workspace = true }
 getrandom = { version = "0.2.15" }
-regex = "1.11.1"
-regex-syntax = { version = "0.8.5", default-features = false, features = [
+regex = { workspace = true }
+regex-syntax = { workspace = true, default-features = false, features = [
     "unicode",
 ] }
-chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
+chrono = { workspace = true, default-features = false, features = ["clock"] }
 julian_day_converter = "0.4.5"
 rand = "0.8.5"
 libm = "0.2"
 turso_macros = { workspace = true }
-miette = "7.6.0"
+miette = { workspace = true }
 strum = { workspace = true }
 parking_lot = { workspace = true }
 crossbeam-skiplist = "0.1.3"
-tracing = "0.1.41"
+tracing = { workspace = true }
 ryu = "1.0.19"
 uncased = "0.9.10"
 strum_macros = { workspace = true }
-bitflags = "2.9.0"
+bitflags = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 paste = "1.0.15"
 uuid = { version = "1.11.0", features = ["v4", "v7"], optional = true }
-tempfile = "3.8.0"
+tempfile = { workspace = true }
 pack1 = { version = "1.0.0", features = ["bytemuck"] }
 bytemuck = "1.23.1"
 aes-gcm = { version = "0.10.3"}
@@ -83,7 +82,7 @@ aegis = "0.9.0"
 twox-hash = "2.1.1"
 
 [build-dependencies]
-chrono = { version = "0.4.38", default-features = false }
+chrono = { workspace = true, default-features = false }
 built = { version = "0.7.5", features = ["git2", "chrono"] }
 
 [target.'cfg(not(target_family = "windows"))'.dev-dependencies]
@@ -91,7 +90,7 @@ pprof = { version = "0.14.0", features = ["criterion", "flamegraph"] }
 
 [dev-dependencies]
 memory-stats = "1.2.0"
-criterion = { version = "0.5", features = [
+criterion = { workspace = true, features = [
     "html_reports",
     "async",
     "async_futures",
@@ -101,11 +100,11 @@ rusqlite.workspace = true
 quickcheck = { version = "1.0", default-features = false }
 quickcheck_macros = { version = "1.0", default-features = false }
 rand = "0.8.5" # Required for quickcheck
-rand_chacha = "0.9.0"
-env_logger = "0.11.6"
+rand_chacha = { workspace = true }
+env_logger = { workspace = true }
 test-log = { version = "0.2.17", features = ["trace"] }
 sorted-vec = "0.8.6"
-mimalloc = { version = "0.1.46", default-features = false }
+mimalloc = { workspace = true, default-features = false }
 
 [[bench]]
 name = "benchmark"

--- a/extensions/core/Cargo.toml
+++ b/extensions/core/Cargo.toml
@@ -16,4 +16,4 @@ static = []
 turso_macros = { workspace = true }
 
 getrandom = "0.3.1"
-chrono = "0.4.40"
+chrono = { workspace = true, default-features = true }

--- a/extensions/csv/Cargo.toml
+++ b/extensions/csv/Cargo.toml
@@ -18,7 +18,7 @@ turso_ext = { workspace = true, features = ["static"] }
 csv = "1.3.1"
 
 [dev-dependencies]
-tempfile = "3.19.1"
+tempfile = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 mimalloc = { version = "0.1", default-features = false }

--- a/extensions/regexp/Cargo.toml
+++ b/extensions/regexp/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 turso_ext = { workspace = true, features = ["static"] }
-regex = "1.11.1"
+regex = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 mimalloc = { version = "0.1", default-features = false }

--- a/extensions/tests/Cargo.toml
+++ b/extensions/tests/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 static= [ "turso_ext/static" ]
 
 [dependencies]
-env_logger = "0.11.6"
+env_logger = { workspace = true }
 lazy_static = "1.5.0"
 turso_ext = { workspace = true, features = ["static", "vfs"] }
 log = "0.4.26"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -15,17 +15,17 @@ default = []
 serde = ["dep:serde", "bitflags/serde"]
 
 [dependencies]
-bitflags = "2.0"
-miette = "7.4.0"
+bitflags = { workspace = true }
+miette = { workspace = true }
 strum = { workspace = true }
 strum_macros = {workspace = true }
 serde = { workspace = true , optional = true, features = ["derive"] }
-thiserror = "1.0.61"
+thiserror = { workspace = true }
 turso_macros = { workspace = true }
 
 [dev-dependencies]
-fallible-iterator = "0.3"
-criterion = { version = "0.5", features = ["html_reports" ] }
+fallible-iterator = { workspace = true }
+criterion = { workspace = true, features = ["html_reports" ] }
 
 [target.'cfg(not(target_family = "windows"))'.dev-dependencies]
 pprof = { version = "0.14.0", features = ["criterion", "flamegraph"] }

--- a/perf/throughput/rusqlite/Cargo.toml
+++ b/perf/throughput/rusqlite/Cargo.toml
@@ -9,4 +9,4 @@ path = "src/main.rs"
 
 [dependencies]
 rusqlite = { workspace = true }
-clap = { version = "4.0", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }

--- a/perf/throughput/turso/Cargo.toml
+++ b/perf/throughput/turso/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 turso = { workspace = true }
-clap = { version = "4.0", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, default-features = true, features = ["full"] }
-futures = "0.3"
-tracing-subscriber = "0.3.20"
+futures = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -15,27 +15,27 @@ name = "limbo_sim"
 path = "main.rs"
 
 [dependencies]
-turso_core = { path = "../core", features = ["simulator"]}
+turso_core = { workspace = true, features = ["simulator"]}
 rand = { workspace = true }
-rand_chacha = "0.9.0"
+rand_chacha = { workspace = true }
 log = "0.4.20"
-env_logger = "0.10.1"
-regex = "1.11.1"
-regex-syntax = { version = "0.8.5", default-features = false, features = [
+env_logger = { workspace = true }
+regex = { workspace = true }
+regex-syntax = { workspace = true, default-features = false, features = [
     "unicode",
 ] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 notify = "8.0.0"
 rusqlite.workspace = true
 dirs = "6.0.0"
-chrono = { version = "0.4.40", features = ["serde"] }
+chrono = { workspace = true, default-features = true, features = ["serde"] }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow.workspace = true
-hex = "0.4.3"
-itertools = "0.14.0"
+hex = { workspace = true }
+itertools = { workspace = true }
 sql_generation = { workspace = true }
 turso_parser = { workspace = true }
 schemars = { workspace = true }
@@ -43,4 +43,4 @@ garde = { workspace = true, features = ["derive", "serde"] }
 json5 = { version = "0.4.1" }
 strum = { workspace = true }
 parking_lot = { workspace = true }
-indexmap = "2.10.0"
+indexmap = { workspace = true }

--- a/sql_generation/Cargo.toml
+++ b/sql_generation/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 path = "lib.rs"
 
 [dependencies]
-hex = "0.4.3"
+hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 turso_core = { workspace = true, features = ["simulator"] }
 turso_parser = { workspace = true, features = ["serde"] }
@@ -21,7 +21,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 schemars = { workspace = true }
 garde = { workspace = true, features = ["derive", "serde"] }
-indexmap = { version = "2.11.0" }
+indexmap = { workspace = true }
 
 [dev-dependencies]
-rand_chacha = "0.9.0"
+rand_chacha = { workspace = true }

--- a/sqlite3/Cargo.toml
+++ b/sqlite3/Cargo.toml
@@ -22,15 +22,15 @@ doc = false
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
-env_logger = { version = "0.11.3", default-features = false }
+env_logger = { workspace = true, default-features = false }
 libc = "0.2.169"
-turso_core = { path = "../core", features = ["conn_raw_api"] }
-tracing = "0.1.41"
-tracing-appender = "0.2.3"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+turso_core = { workspace = true, features = ["conn_raw_api"] }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]
-tempfile = "3.8.0"
+tempfile = { workspace = true }
 
 [package.metadata.capi.header]
 name = "sqlite3.h"

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -21,12 +21,12 @@ experimental_indexes = []
 
 [dependencies]
 anarchist-readable-name-generator-lib = "0.1.0"
-antithesis_sdk = "0.2.5"
-clap = { version = "4.5", features = ["derive"] }
-hex = "0.4"
-tempfile = "3.20.0"
-tokio = { version = "1.29.1", features = ["full"] }
-tracing = "0.1.41"
-tracing-appender = "0.2.3"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-turso = { path = "../bindings/rust" }
+antithesis_sdk = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+hex = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+turso = { workspace = true }

--- a/sync/engine/Cargo.toml
+++ b/sync/engine/Cargo.toml
@@ -22,11 +22,11 @@ roaring = "0.11.2"
 
 [dev-dependencies]
 ctor = "0.4.2"
-tempfile = "3.20.0"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread", "test-util"] }
+tempfile = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 uuid = "1.17.0"
-rand = "0.9.2"
-rand_chacha = "0.9.0"
+rand = { workspace = true }
+rand_chacha = { workspace = true }
 turso = { workspace = true, features = ["conn_raw_api"] }
-futures = "0.3.31"
+futures = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,24 +16,24 @@ path = "integration/mod.rs"
 
 [dependencies]
 anyhow.workspace = true
-env_logger = "0.10.1"
-turso_core = { path = "../core", features = ["conn_raw_api"] }
-turso = { path = "../bindings/rust", features = ["conn_raw_api"] }
-tokio = { version = "1.47", features = ["full"] }
+env_logger = { workspace = true }
+turso_core = { workspace = true, features = ["conn_raw_api"] }
+turso = { workspace = true, features = ["conn_raw_api"] }
+tokio = { workspace = true, features = ["full"] }
 rusqlite.workspace = true
-tempfile = "3.0.7"
+tempfile = { workspace = true }
 log = "0.4.22"
 assert_cmd = "^2"
-rand_chacha = "0.9.0"
-rand = "0.9.0"
+rand_chacha = { workspace = true }
+rand = { workspace = true }
 zerocopy = "0.8.26"
 ctor = "0.5.0"
 twox-hash = "2.1.1"
 
 [dev-dependencies]
 test-log = { version = "0.2.17", features = ["trace"] }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-tracing = "0.1.41"
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing = { workspace = true }
 
 [features]
 encryption = ["turso_core/encryption"]

--- a/vendored/sqlite3-parser/Cargo.toml
+++ b/vendored/sqlite3-parser/Cargo.toml
@@ -27,17 +27,17 @@ serde = ["dep:serde", "indexmap/serde", "bitflags/serde"]
 [dependencies]
 log = "0.4.22"
 memchr = "2.0"
-fallible-iterator = "0.3"
-bitflags = "2.0"
-indexmap = "2.0"
-miette = "7.4.0"
+fallible-iterator = { workspace = true }
+bitflags = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
 strum = { workspace = true }
 strum_macros = {workspace = true }
 serde = { workspace = true , optional = true, features = ["derive"] }
 smallvec = { version = "1.15.1", features = ["const_generics"] }
 
 [dev-dependencies]
-env_logger = { version = "0.11", default-features = false }
+env_logger = { workspace = true, default-features = false }
 
 [build-dependencies]
 cc = "1.0"

--- a/vendored/sqlite3-parser/sqlparser_bench/Cargo.toml
+++ b/vendored/sqlite3-parser/sqlparser_bench/Cargo.toml
@@ -9,10 +9,10 @@ turso_sqlite3_parser = { path = "..", default-features = false, features = [
     "YYNOERRORRECOVERY",
     "NDEBUG",
 ] }
-fallible-iterator = "0.3"
+fallible-iterator = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = { workspace = true }
 
 [[bench]]
 name = "sqlparser_bench"

--- a/whopper/Cargo.toml
+++ b/whopper/Cargo.toml
@@ -16,14 +16,14 @@ path = "main.rs"
 
 [dependencies]
 anyhow.workspace = true
-clap = { version = "4.5", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 memmap2 = "0.9"
 rand = { workspace = true }
-rand_chacha = "0.9.0"
+rand_chacha = { workspace = true }
 sql_generation = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-turso_core = { path = "../core", features = ["simulator"]}
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+turso_core = { workspace = true, features = ["simulator"]}
 turso_parser = { workspace = true }
 
 [features]


### PR DESCRIPTION
This removes 4 crates from the `cargo build` and tries to ensure that in the future we avoid the same crates with different versions.