### PR TITLE
core/vdbe: Don't automatically rollback on write-write conflict

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1076,7 +1076,7 @@ pub fn handle_program_error(
         // Table locked errors, e.g. trying to checkpoint in an interactive transaction, do not cause a rollback.
         LimboError::TableLocked => {}
         // Busy errors do not cause a rollback.
-        LimboError::Busy => {}
+        LimboError::Busy | LimboError::WriteWriteConflict => {}
         _ => {
             if let Some(mv_store) = mv_store {
                 if let Some((tx_id, _)) = connection.mv_tx.get() {


### PR DESCRIPTION
We don't rollback if there's a snapshot error on a transaction either, so let's not automatically rollback on write-write conflict either.