### PR TITLE
Fix is_nonnull returns true on 1 / 0

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -645,6 +645,7 @@ impl Optimizable for ast::Expr {
             Expr::Between {
                 lhs, start, end, ..
             } => lhs.is_nonnull(tables) && start.is_nonnull(tables) && end.is_nonnull(tables),
+            Expr::Binary(_, ast::Operator::Modulus | ast::Operator::Divide, _) => false, // 1 % 0, 1 / 0
             Expr::Binary(expr, _, expr1) => expr.is_nonnull(tables) && expr1.is_nonnull(tables),
             Expr::Case {
                 base,

--- a/testing/math.test
+++ b/testing/math.test
@@ -1445,3 +1445,9 @@ do_execsql_test unary-plus-noop-string {
 do_execsql_test unary-plus-noop-blob {
     SELECT typeof(+x'00') = 'blob'
 } { 1 }
+
+do_execsql_test_on_specific_db {:memory:} is-nonnull-divide-by-zero {
+    CREATE TABLE t (x PRIMARY KEY, y, z);
+    INSERT INTO t VALUES (37, -70, -196792117);
+    SELECT * FROM t WHERE  (1 / 0) >= -3289742039 < t.x;
+} {}


### PR DESCRIPTION
turso:
```sh
turso> CREATE TABLE t (x PRIMARY KEY, y, z);
turso> INSERT INTO t VALUES (37, -70, -196792117);
turso> SELECT * FROM t WHERE  (1 / 0) >= -3289742039 < t.x;
┌────┬─────┬────────────┐
│ x  │ y   │ z          │
├────┼─────┼────────────┤
│ 37 │ -70 │ -196792117 │
└────┴─────┴────────────┘
turso>
```

sqlite:
```sh
sqlite> CREATE TABLE t (x PRIMARY KEY, y, z);
sqlite> INSERT INTO t VALUES (37, -70, -196792117);
sqlite> SELECT * FROM t WHERE  (1 / 0) >= -3289742039 < t.x;
sqlite>
```