### PR TITLE
Enable encryption option in Whopper 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,7 +248,7 @@ Note that exploration uses the `chaos` mode so if you need to reproduce a run, u
 SEED=1234 ./whopper/bin/run --mode chaos
 ```
 
-Both `explore` and `run` accept `--enable-checksums` flag to enable per page checksums.
+Both `explore` and `run` accept the `--enable-checksums` and `--enable-encryption` flags for per page checksums and encryption respectively.
 
 ## Python Bindings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,6 +4338,7 @@ version = "0.2.0-pre.3"
 dependencies = [
  "anyhow",
  "clap",
+ "hex",
  "memmap2",
  "rand 0.9.2",
  "rand_chacha 0.9.0",

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -40,7 +40,6 @@ pub mod numeric;
 mod numeric;
 
 use crate::storage::checksum::CHECKSUM_REQUIRED_RESERVED_BYTES;
-use crate::storage::encryption::CipherMode;
 use crate::translate::pragma::TURSO_CDC_DEFAULT_TABLE_NAME;
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
@@ -79,7 +78,7 @@ use std::{
 #[cfg(feature = "fs")]
 use storage::database::DatabaseFile;
 pub use storage::database::IOContext;
-pub use storage::encryption::{EncryptionContext, EncryptionKey};
+pub use storage::encryption::{CipherMode, EncryptionContext, EncryptionKey};
 use storage::page_cache::PageCache;
 use storage::pager::{AtomicDbState, DbState};
 use storage::sqlite3_ondisk::PageSize;

--- a/whopper/Cargo.toml
+++ b/whopper/Cargo.toml
@@ -25,6 +25,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 turso_core = { workspace = true, features = ["simulator"]}
 turso_parser = { workspace = true }
+hex = "0.4.3"
 
 [features]
 checksum = ["turso_core/checksum"]
+encryption = ["turso_core/encryption"]

--- a/whopper/bin/explore
+++ b/whopper/bin/explore
@@ -1,17 +1,33 @@
 #!/bin/bash
 
+# Usage: ./explore.sh [--enable-checksums|--enable-encryption] [other-args...]
+
 set -e
 
-# Check for special build time flags (e.g. `--enable-checksums`)
+# Check for special build time flags (e.g. `--enable-checksums`, `--enable-encryption`)
 FEATURES=""
 ARGS=()
+CHECKSUM_ENABLED=false
+ENCRYPTION_ENABLED=false
+
 for arg in "$@"; do
     if [[ "$arg" == "--enable-checksums" ]]; then
         FEATURES="--features checksum"
+        CHECKSUM_ENABLED=true
+    elif [[ "$arg" == "--enable-encryption" ]]; then
+        FEATURES="--features encryption"
+        ENCRYPTION_ENABLED=true
+        ARGS+=("$arg")
     else
         ARGS+=("$arg")
     fi
 done
+
+# check for incompatible options
+if [[ "$CHECKSUM_ENABLED" == true && "$ENCRYPTION_ENABLED" == true ]]; then
+    echo "Error: --enable-checksums and --enable-encryption are not compatible with each other"
+    exit 1
+fi
 
 cargo build $FEATURES -p turso_whopper
 

--- a/whopper/bin/run
+++ b/whopper/bin/run
@@ -1,17 +1,33 @@
 #!/bin/bash
 
+# Usage: ./run.sh [--enable-checksums|--enable-encryption] [other-args...]
+
 set -e
 
-# Check for special build time flags (e.g. `--enable-checksums`)
+# Check for special build time flags (e.g. `--enable-checksums`, `--enable-encryption`)
 FEATURES=""
 ARGS=()
+CHECKSUM_ENABLED=false
+ENCRYPTION_ENABLED=false
+
 for arg in "$@"; do
     if [[ "$arg" == "--enable-checksums" ]]; then
         FEATURES="--features checksum"
+        CHECKSUM_ENABLED=true
+    elif [[ "$arg" == "--enable-encryption" ]]; then
+        FEATURES="--features encryption"
+        ENCRYPTION_ENABLED=true
+        ARGS+=("$arg")
     else
         ARGS+=("$arg")
     fi
 done
+
+# check for incompatible options
+if [[ "$CHECKSUM_ENABLED" == true && "$ENCRYPTION_ENABLED" == true ]]; then
+    echo "Error: --enable-checksums and --enable-encryption are not compatible with each other"
+    exit 1
+fi
 
 cargo build $FEATURES -p turso_whopper
 


### PR DESCRIPTION
If encryption is arg is passed, then we run whopper tests with encryptions. We randomly generate cipher and key, and run whopper. They are also printed for debugging and analysis.

Also, updated the corresponding scripts. So now you can do: 

```bash
./whopper/bin/run --enable-encryption

or 

./whopper/bin/explore --enable-encryption
```