### PR TITLE
stress: Retry sync on error to avoid a panic, take 2

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -519,6 +519,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
         let handle = tokio::spawn(async move {
             let mut conn = db.lock().await.connect()?;
+
+            conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
+
             println!("\rExecuting queries...");
             for query_index in 0..nr_iterations {
                 if gen_bool(0.0) {


### PR DESCRIPTION
Commit eeab6d5ce ("stress: Retry sync on error to avoid a panic") only enabled sync retry in the schema creation path. Let's add it to the stress test loop too.

Spotted during Antithesis runs.