### PR TITLE
core: Use sequential consistency for atomics by default

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -41,7 +41,7 @@ pub trait File: Send + Sync {
                         // reference buffer in callback to ensure alive for async io
                         let _buf = _cloned.clone();
                         // accumulate bytes actually reported by the backend
-                        total_written.fetch_add(n as usize, Ordering::Relaxed);
+                        total_written.fetch_add(n as usize, Ordering::SeqCst);
                         if outstanding.fetch_sub(1, Ordering::AcqRel) == 1 {
                             // last one finished
                             c_main.complete(total_written.load(Ordering::Acquire) as i32);

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -618,8 +618,8 @@ impl PageCache {
                     "slot={}, page={:?}, flags={}, pin_count={}, ref_bit={:?}",
                     i,
                     entry_opt.key,
-                    page.get().flags.load(Ordering::Relaxed),
-                    page.get().pin_count.load(Ordering::Relaxed),
+                    page.get().flags.load(Ordering::SeqCst),
+                    page.get().pin_count.load(Ordering::SeqCst),
                     entry_opt.ref_bit,
                 );
             }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -268,7 +268,7 @@ impl Page {
     pub fn try_unpin(&self) -> bool {
         self.get()
             .pin_count
-            .fetch_update(Ordering::Release, Ordering::Relaxed, |current| {
+            .fetch_update(Ordering::Release, Ordering::SeqCst, |current| {
                 if current == 0 {
                     None
                 } else {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -996,7 +996,7 @@ pub fn write_pages_vectored(
     done_flag: Arc<AtomicBool>,
 ) -> Result<Vec<Completion>> {
     if batch.is_empty() {
-        done_flag.store(true, Ordering::Relaxed);
+        done_flag.store(true, Ordering::SeqCst);
         return Ok(Vec::new());
     }
 

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -223,7 +223,7 @@ impl Clone for ExtVirtualTable {
     fn clone(&self) -> Self {
         Self {
             implementation: self.implementation.clone(),
-            table_ptr: AtomicPtr::new(self.table_ptr.load(std::sync::atomic::Ordering::Relaxed)),
+            table_ptr: AtomicPtr::new(self.table_ptr.load(std::sync::atomic::Ordering::SeqCst)),
         }
     }
 }
@@ -289,7 +289,7 @@ impl ExtVirtualTable {
         // store the leaked connection pointer on the table so it can be freed on drop
         let Some(cursor) = NonNull::new(unsafe {
             (self.implementation.open)(
-                self.table_ptr.load(std::sync::atomic::Ordering::Relaxed) as *const c_void,
+                self.table_ptr.load(std::sync::atomic::Ordering::SeqCst) as *const c_void,
                 ext_conn_ptr.as_ptr(),
             ) as *mut c_void
         }) else {
@@ -304,7 +304,7 @@ impl ExtVirtualTable {
         let newrowid = 0i64;
         let rc = unsafe {
             (self.implementation.update)(
-                self.table_ptr.load(std::sync::atomic::Ordering::Relaxed) as *const c_void,
+                self.table_ptr.load(std::sync::atomic::Ordering::SeqCst) as *const c_void,
                 arg_count as i32,
                 ext_args.as_ptr(),
                 &newrowid as *const _ as *mut i64,
@@ -325,7 +325,7 @@ impl ExtVirtualTable {
     fn destroy(&self) -> crate::Result<()> {
         let rc = unsafe {
             (self.implementation.destroy)(
-                self.table_ptr.load(std::sync::atomic::Ordering::Relaxed) as *const c_void
+                self.table_ptr.load(std::sync::atomic::Ordering::SeqCst) as *const c_void
             )
         };
         match rc {


### PR DESCRIPTION
We use relaxed ordering in a lot of places where we really need to ensure all CPUs see the write. Switch to sequential consistency, unless acquire/release is explicitly used. If there are places that can be optimized, we can switch to relaxed case-by-case, but have a comment explaning *why* it is safe.