### PR TITLE
simulator: Fix shrinking

### DIFF
--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -30,7 +30,7 @@ use super::property::{Property, remaining};
 
 pub(crate) type ResultSet = Result<Vec<Vec<SimValue>>>;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct InteractionPlan {
     pub(crate) plan: Vec<Interactions>,
 }

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -1,5 +1,3 @@
-use indexmap::IndexSet;
-
 use crate::{
     SandboxedResult, SimulatorEnv,
     generation::{
@@ -19,12 +17,13 @@ impl InteractionPlan {
         // - Shrink to multiple values by removing random interactions
         // - Shrink properties by removing their extensions, or shrinking their values
         let mut plan = self.clone();
-        // let failing_property = &self.plan[failing_execution.interaction_index];
-        let mut depending_tables = IndexSet::new();
 
         let all_interactions = self.interactions_list_with_secondary_index();
-        // Index of the parent property where the interaction originated from
         let secondary_interactions_index = all_interactions[failing_execution.interaction_index].0;
+
+        // Index of the parent property where the interaction originated from
+        let failing_property = &self.plan[secondary_interactions_index];
+        let mut depending_tables = failing_property.dependencies();
 
         {
             let mut idx = failing_execution.interaction_index;


### PR DESCRIPTION
When shrinking, the depending table should first start with the dependencies from the overall property first. I broke this in my previous Sim Connections PR.