### PR TITLE
Add short write fault injection to the simulator.

### DIFF
--- a/simulator/profiles/io.rs
+++ b/simulator/profiles/io.rs
@@ -65,6 +65,8 @@ pub struct FaultProfile {
     pub write: bool,
     #[garde(skip)]
     pub sync: bool,
+    #[garde(dive)]
+    pub short_write: ShortWriteProfile,
 }
 
 impl Default for FaultProfile {
@@ -74,6 +76,37 @@ impl Default for FaultProfile {
             read: true,
             write: true,
             sync: true,
+            short_write: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Validate)]
+#[serde(deny_unknown_fields, default)]
+pub struct ShortWriteProfile {
+    #[garde(skip)]
+    pub enable: bool,
+    #[garde(range(min = 0, max = 100))]
+    pub probability: usize,
+    #[garde(range(min = 1, max = 8192))]
+    /// Minimum bytes to write in a short write (must be at least 1)
+    pub min_bytes: usize,
+    #[garde(range(min = 1, max = 8192))]
+    /// Maximum bytes to subtract from full write (creates partial write)
+    pub max_bytes_short: usize,
+    #[garde(skip)]
+    /// Only apply short writes to WAL files (files ending with "-wal")
+    pub wal_only: bool,
+}
+
+impl Default for ShortWriteProfile {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            probability: 5,
+            min_bytes: 1,
+            max_bytes_short: 512,
+            wal_only: true,
         }
     }
 }

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -102,6 +102,7 @@ impl SimulatorEnv {
         self.rng = ChaCha8Rng::seed_from_u64(self.opts.seed);
 
         let latency_prof = &self.profile.io.latency;
+        let fault_prof = &self.profile.io.fault;
 
         let io: Arc<dyn SimIO> = if self.memory_io {
             Arc::new(MemorySimIO::new(
@@ -119,6 +120,7 @@ impl SimulatorEnv {
                     latency_prof.latency_probability,
                     latency_prof.min_tick,
                     latency_prof.max_tick,
+                    fault_prof.short_write.clone(),
                 )
                 .unwrap(),
             )
@@ -244,6 +246,7 @@ impl SimulatorEnv {
         profile.validate().unwrap();
 
         let latency_prof = &profile.io.latency;
+        let fault_prof = &profile.io.fault;
 
         let io: Arc<dyn SimIO> = if cli_opts.memory_io {
             Arc::new(MemorySimIO::new(
@@ -261,6 +264,7 @@ impl SimulatorEnv {
                     latency_prof.latency_probability,
                     latency_prof.min_tick,
                     latency_prof.max_tick,
+                    fault_prof.short_write.clone(),
                 )
                 .unwrap(),
             )

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -7,6 +7,7 @@ use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use turso_core::{Clock, IO, Instant, OpenFlags, PlatformIO, Result};
 
+use crate::profiles::io::ShortWriteProfile;
 use crate::runner::{SimIO, clock::SimulatorClock, file::SimulatorFile};
 
 pub(crate) struct SimulatorIO {
@@ -18,6 +19,7 @@ pub(crate) struct SimulatorIO {
     seed: u64,
     latency_probability: usize,
     clock: Arc<SimulatorClock>,
+    short_write_profile: ShortWriteProfile,
 }
 
 unsafe impl Send for SimulatorIO {}
@@ -30,6 +32,7 @@ impl SimulatorIO {
         latency_probability: usize,
         min_tick: u64,
         max_tick: u64,
+        short_write_profile: ShortWriteProfile,
     ) -> Result<Self> {
         let inner = Box::new(PlatformIO::new()?);
         let fault = Cell::new(false);
@@ -46,6 +49,7 @@ impl SimulatorIO {
             seed,
             latency_probability,
             clock: Arc::new(clock),
+            short_write_profile,
         })
     }
 }
@@ -111,6 +115,7 @@ impl IO for SimulatorIO {
             sync_completion: RefCell::new(None),
             queued_io: RefCell::new(Vec::new()),
             clock: self.clock.clone(),
+            short_write_profile: self.short_write_profile.clone(),
         });
         self.files.borrow_mut().push(file.clone());
         Ok(file)


### PR DESCRIPTION
This implements almost the same code as #3042. Just trying to help maintainers from doing this manual work : ) .I think this code was ready but was not merged due to the organization of the pull request and difficulties with communication. I have made this feature disabled by default. Please correct me if I am wrong.

fixes: #3099 