### PR TITLE
translate/optimize: centralize AST/expr traversal

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -3250,6 +3250,10 @@ where
     Ok(WalkControl::Continue)
 }
 
+/// Context needed to walk all expressions in a INSERT|UPDATE|SELECT|DELETE body,
+/// in the order they are encountered, to ensure that the parameters are rewritten from
+/// anonymous ("?") to our internal named scheme so when the columns are re-ordered we are able
+/// to bind the proper parameter values.
 pub struct ParamState {
     /// ALWAYS starts at 1
     pub next_param_idx: usize,
@@ -3261,6 +3265,9 @@ impl Default for ParamState {
     }
 }
 
+/// Rewrite ast::Expr in place, binding Column references/rewriting Expr::Id -> Expr::Column
+/// using the provided TableReferences, and replacing anonymous parameters with internal named
+/// ones, as well as normalizing any DoublyQualified/Qualified quoted identifiers.
 pub fn bind_and_rewrite_expr<'a>(
     top_level_expr: &mut ast::Expr,
     mut referenced_tables: Option<&'a mut TableReferences>,

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use tracing::{instrument, Level};
-use turso_parser::ast::{self, As, Expr, TableInternalId, UnaryOperator};
+use turso_parser::ast::{self, As, Expr, UnaryOperator};
 
 use super::emitter::Resolver;
 use super::optimizer::Optimizable;

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -3300,7 +3300,6 @@ pub fn bind_and_rewrite_expr<'a>(
                         ast::Name::Ident(normalize_ident(c.as_str())),
                     );
                 }
-                // Expand BETWEEN to binary ops (kept identical to your logic).
                 ast::Expr::Between {
                     lhs,
                     not,

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -3272,6 +3272,12 @@ pub fn bind_and_rewrite_expr<'a>(
         top_level_expr,
         &mut |expr: &mut ast::Expr| -> Result<WalkControl> {
             match expr {
+                ast::Expr::Id(ast::Name::Ident(n)) if n.eq_ignore_ascii_case("true") => {
+                    *expr = ast::Expr::Literal(ast::Literal::Numeric("1".to_string()));
+                }
+                ast::Expr::Id(ast::Name::Ident(n)) if n.eq_ignore_ascii_case("false") => {
+                    *expr = ast::Expr::Literal(ast::Literal::Numeric("0".to_string()));
+                }
                 // Rewrite anonymous variables in encounter order.
                 ast::Expr::Variable(var) if var.is_empty() => {
                     *expr = ast::Expr::Variable(format!(

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -4,11 +4,12 @@ use super::plan::{
     Search, TableReferences, WhereTerm, Window,
 };
 use crate::schema::Table;
+use crate::translate::expr::{bind_and_rewrite_expr, ParamState};
 use crate::translate::optimizer::optimize_plan;
 use crate::translate::plan::{GroupBy, Plan, ResultSetColumn, SelectPlan};
 use crate::translate::planner::{
-    bind_column_references, break_predicate_at_and_boundaries, parse_from, parse_limit,
-    parse_where, resolve_window_and_aggregate_functions,
+    break_predicate_at_and_boundaries, parse_from, parse_limit, parse_where,
+    resolve_window_and_aggregate_functions,
 };
 use crate::translate::window::plan_windows;
 use crate::util::normalize_ident;
@@ -98,6 +99,7 @@ pub fn prepare_select_plan(
     connection: &Arc<crate::Connection>,
 ) -> Result<Plan> {
     let compounds = select.body.compounds;
+    let mut param_ctx = ParamState::default();
     match compounds.is_empty() {
         true => Ok(Plan::Select(prepare_one_select_plan(
             schema,
@@ -110,6 +112,7 @@ pub fn prepare_select_plan(
             table_ref_counter,
             query_destination,
             connection,
+            &mut param_ctx,
         )?)),
         false => {
             let mut last = prepare_one_select_plan(
@@ -123,6 +126,7 @@ pub fn prepare_select_plan(
                 table_ref_counter,
                 query_destination.clone(),
                 connection,
+                &mut param_ctx,
             )?;
 
             let mut left = Vec::with_capacity(compounds.len());
@@ -139,6 +143,7 @@ pub fn prepare_select_plan(
                     table_ref_counter,
                     query_destination.clone(),
                     connection,
+                    &mut param_ctx,
                 )?;
             }
 
@@ -149,9 +154,9 @@ pub fn prepare_select_plan(
                     crate::bail_parse_error!("SELECTs to the left and right of {} do not have the same number of result columns", operator);
                 }
             }
-            let (limit, offset) = select
-                .limit
-                .map_or(Ok((None, None)), |mut l| parse_limit(&mut l, connection))?;
+            let (limit, offset) = select.limit.map_or(Ok((None, None)), |mut l| {
+                parse_limit(&mut l, connection, &mut param_ctx)
+            })?;
 
             // FIXME: handle ORDER BY for compound selects
             if !select.order_by.is_empty() {
@@ -184,6 +189,7 @@ fn prepare_one_select_plan(
     table_ref_counter: &mut TableRefIdCounter,
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
+    param_ctx: &mut ParamState,
 ) -> Result<SelectPlan> {
     match select {
         ast::OneSelect::Select {
@@ -255,7 +261,6 @@ fn prepare_one_select_plan(
                     })
                     .sum(),
             );
-
             let mut plan = SelectPlan {
                 join_order: table_references
                     .joined_tables()
@@ -288,19 +293,21 @@ fn prepare_one_select_plan(
                 let mut window = Window::new(Some(name), &window_def.window)?;
 
                 for expr in window.partition_by.iter_mut() {
-                    bind_column_references(
+                    bind_and_rewrite_expr(
                         expr,
-                        &mut plan.table_references,
-                        Some(&plan.result_columns),
+                        Some(&mut plan.table_references),
+                        None,
                         connection,
+                        param_ctx,
                     )?;
                 }
                 for (expr, _) in window.order_by.iter_mut() {
-                    bind_column_references(
+                    bind_and_rewrite_expr(
                         expr,
-                        &mut plan.table_references,
-                        Some(&plan.result_columns),
+                        Some(&mut plan.table_references),
+                        None,
                         connection,
+                        param_ctx,
                     )?;
                 }
 
@@ -357,11 +364,12 @@ fn prepare_one_select_plan(
                         }
                     }
                     ResultColumn::Expr(ref mut expr, maybe_alias) => {
-                        bind_column_references(
+                        bind_and_rewrite_expr(
                             expr,
-                            &mut plan.table_references,
-                            Some(&plan.result_columns),
+                            Some(&mut plan.table_references),
+                            None,
                             connection,
+                            param_ctx,
                         )?;
                         let contains_aggregates = resolve_window_and_aggregate_functions(
                             schema,
@@ -385,7 +393,12 @@ fn prepare_one_select_plan(
             // This step can only be performed at this point, because all table references are now available.
             // Virtual table predicates may depend on column bindings from tables to the right in the join order,
             // so we must wait until the full set of references has been collected.
-            add_vtab_predicates_to_where_clause(&mut vtab_predicates, &mut plan, connection)?;
+            add_vtab_predicates_to_where_clause(
+                &mut vtab_predicates,
+                &mut plan,
+                connection,
+                param_ctx,
+            )?;
 
             // Parse the actual WHERE clause and add its conditions to the plan WHERE clause that already contains the join conditions.
             parse_where(
@@ -394,16 +407,18 @@ fn prepare_one_select_plan(
                 Some(&plan.result_columns),
                 &mut plan.where_clause,
                 connection,
+                param_ctx,
             )?;
 
             if let Some(mut group_by) = group_by {
                 for expr in group_by.exprs.iter_mut() {
                     replace_column_number_with_copy_of_column_expr(expr, &plan.result_columns)?;
-                    bind_column_references(
+                    bind_and_rewrite_expr(
                         expr,
-                        &mut plan.table_references,
-                        Some(&plan.result_columns),
+                        Some(&mut plan.table_references),
+                        Some(&mut plan.result_columns),
                         connection,
+                        param_ctx,
                     )?;
                 }
 
@@ -414,11 +429,12 @@ fn prepare_one_select_plan(
                         let mut predicates = vec![];
                         break_predicate_at_and_boundaries(&having, &mut predicates);
                         for expr in predicates.iter_mut() {
-                            bind_column_references(
+                            bind_and_rewrite_expr(
                                 expr,
-                                &mut plan.table_references,
-                                Some(&plan.result_columns),
+                                Some(&mut plan.table_references),
+                                Some(&mut plan.result_columns),
                                 connection,
+                                param_ctx,
                             )?;
                             let contains_aggregates = resolve_window_and_aggregate_functions(
                                 schema,
@@ -452,11 +468,12 @@ fn prepare_one_select_plan(
             for mut o in order_by {
                 replace_column_number_with_copy_of_column_expr(&mut o.expr, &plan.result_columns)?;
 
-                bind_column_references(
+                bind_and_rewrite_expr(
                     &mut o.expr,
-                    &mut plan.table_references,
-                    Some(&plan.result_columns),
+                    Some(&mut plan.table_references),
+                    Some(&mut plan.result_columns),
                     connection,
+                    param_ctx,
                 )?;
                 resolve_window_and_aggregate_functions(
                     schema,
@@ -471,8 +488,9 @@ fn prepare_one_select_plan(
             plan.order_by = key;
 
             // Parse the LIMIT/OFFSET clause
-            (plan.limit, plan.offset) =
-                limit.map_or(Ok((None, None)), |mut l| parse_limit(&mut l, connection))?;
+            (plan.limit, plan.offset) = limit.map_or(Ok((None, None)), |mut l| {
+                parse_limit(&mut l, connection, param_ctx)
+            })?;
 
             if !windows.is_empty() {
                 plan_windows(schema, syms, &mut plan, table_ref_counter, &mut windows)?;
@@ -521,13 +539,15 @@ fn add_vtab_predicates_to_where_clause(
     vtab_predicates: &mut Vec<Expr>,
     plan: &mut SelectPlan,
     connection: &Arc<Connection>,
+    param_ctx: &mut ParamState,
 ) -> Result<()> {
     for expr in vtab_predicates.iter_mut() {
-        bind_column_references(
+        bind_and_rewrite_expr(
             expr,
-            &mut plan.table_references,
+            Some(&mut plan.table_references),
             Some(&plan.result_columns),
             connection,
+            param_ctx,
         )?;
     }
     for expr in vtab_predicates.drain(..) {

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -236,6 +236,7 @@ fn prepare_one_select_plan(
                 &mut table_references,
                 table_ref_counter,
                 connection,
+                param_ctx,
             )?;
 
             // Preallocate space for the result columns

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -417,7 +417,7 @@ fn prepare_one_select_plan(
                     bind_and_rewrite_expr(
                         expr,
                         Some(&mut plan.table_references),
-                        Some(&mut plan.result_columns),
+                        Some(&plan.result_columns),
                         connection,
                         param_ctx,
                     )?;
@@ -433,7 +433,7 @@ fn prepare_one_select_plan(
                             bind_and_rewrite_expr(
                                 expr,
                                 Some(&mut plan.table_references),
-                                Some(&mut plan.result_columns),
+                                Some(&plan.result_columns),
                                 connection,
                                 param_ctx,
                             )?;
@@ -472,7 +472,7 @@ fn prepare_one_select_plan(
                 bind_and_rewrite_expr(
                     &mut o.expr,
                     Some(&mut plan.table_references),
-                    Some(&mut plan.result_columns),
+                    Some(&plan.result_columns),
                     connection,
                     param_ctx,
                 )?;

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::schema::{BTreeTable, Column, Type};
+use crate::translate::expr::{bind_and_rewrite_expr, ParamState};
 use crate::translate::optimizer::optimize_select_plan;
 use crate::translate::plan::{Operation, QueryDestination, Scan, Search, SelectPlan};
 use crate::translate::planner::parse_limit;
@@ -22,7 +23,7 @@ use super::plan::{
     ColumnUsedMask, IterationDirection, JoinedTable, Plan, ResultSetColumn, TableReferences,
     UpdatePlan,
 };
-use super::planner::{bind_column_references, parse_where};
+use super::planner::parse_where;
 /*
 * Update is simple. By default we scan the table, and for each row, we check the WHERE
 * clause. If it evaluates to true, we build the new record with the updated value and insert.
@@ -90,7 +91,6 @@ pub fn translate_update_for_schema_change(
     }
 
     optimize_plan(&mut plan, schema)?;
-    // TODO: freestyling these numbers
     let opts = ProgramBuilderOpts {
         num_cursors: 1,
         approx_num_insns: 20,
@@ -181,11 +181,18 @@ pub fn prepare_update_plan(
         .collect();
 
     let mut set_clauses = Vec::with_capacity(body.sets.len());
+    let mut param_idx = ParamState::default();
 
     // Process each SET assignment and map column names to expressions
     // e.g the statement `SET x = 1, y = 2, z = 3` has 3 set assigments
     for set in &mut body.sets {
-        bind_column_references(&mut set.expr, &mut table_references, None, connection)?;
+        bind_and_rewrite_expr(
+            &mut set.expr,
+            Some(&mut table_references),
+            None,
+            connection,
+            &mut param_idx,
+        )?;
 
         let values = match set.expr.as_ref() {
             Expr::Parenthesized(vals) => vals.clone(),
@@ -222,12 +229,22 @@ pub fn prepare_update_plan(
         body.tbl_name.name.as_str(),
         program,
         connection,
+        &mut param_idx,
     )?;
 
     let order_by = body
         .order_by
-        .iter()
-        .map(|o| (o.expr.clone(), o.order.unwrap_or(SortOrder::Asc)))
+        .iter_mut()
+        .map(|o| {
+            let _ = bind_and_rewrite_expr(
+                &mut o.expr,
+                Some(&mut table_references),
+                Some(&result_columns),
+                connection,
+                &mut param_idx,
+            );
+            (o.expr.clone(), o.order.unwrap_or(SortOrder::Asc))
+        })
         .collect();
 
     // Sqlite determines we should create an ephemeral table if we do not have a FROM clause
@@ -266,6 +283,7 @@ pub fn prepare_update_plan(
             Some(&result_columns),
             &mut where_clause,
             connection,
+            &mut param_idx,
         )?;
 
         let table = Arc::new(BTreeTable {
@@ -342,14 +360,14 @@ pub fn prepare_update_plan(
             Some(&result_columns),
             &mut where_clause,
             connection,
+            &mut param_idx,
         )?;
     };
 
     // Parse the LIMIT/OFFSET clause
-    let (limit, offset) = body
-        .limit
-        .as_mut()
-        .map_or(Ok((None, None)), |l| parse_limit(l, connection))?;
+    let (limit, offset) = body.limit.as_mut().map_or(Ok((None, None)), |l| {
+        parse_limit(l, connection, &mut param_idx)
+    })?;
 
     // Check what indexes will need to be updated by checking set_clauses and see
     // if a column is contained in an index.


### PR DESCRIPTION
Previously we were rewriting/traversing the AST in a couple different places, each of these added kinda ad-hoc as we needed them. This attempts to do the binding of column references as well as the rewriting of anonymous `Expr::Variable` -> `__param_N` that we use to maintain the order of bound variables, also normalizes the Qualified Name's.

Also we previously weren't accepting Variable (or at least they wouldn't work) in places like `LIMIT ? OFFSET ?`, which this PR adds.


I kinda want to keep refactoring translation a bit, and try to break plan building up into more easy-to-digest chunks.. but I will resist the urge right now as it's definitely not high priority pre-beta 