### PR TITLE
[*.rs] Resolve warnings (mostly "hiding a lifetime that's elided elsewhere is confusing")

### DIFF
--- a/core/fast_lock.rs
+++ b/core/fast_lock.rs
@@ -45,7 +45,7 @@ impl<T> SpinLock<T> {
         }
     }
 
-    pub fn lock(&self) -> SpinLockGuard<T> {
+    pub fn lock(&self) -> SpinLockGuard<'_, T> {
         while self.locked.swap(true, Ordering::Acquire) {
             std::hint::spin_loop();
         }

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -2050,13 +2050,13 @@ impl AggregateOperator {
             .join(",")
     }
 
-    fn seek_key_from_str(&self, group_key_str: &str) -> SeekKey {
+    fn seek_key_from_str(&self, group_key_str: &str) -> SeekKey<'_> {
         // Calculate the composite key for seeking
         let key_i64 = self.generate_storage_key(group_key_str);
         SeekKey::TableRowId(key_i64)
     }
 
-    fn seek_key(&self, row: HashableRow) -> SeekKey {
+    fn seek_key(&self, row: HashableRow) -> SeekKey<'_> {
         // Extract group key for first row
         let group_key = self.extract_group_key(&row.values);
         let group_key_str = Self::group_key_to_string(&group_key);

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -540,7 +540,7 @@ pub fn json_type(value: &Value, path: Option<&Value>) -> crate::Result<Value> {
     }
 }
 
-fn json_path_from_db_value(path: &Value, strict: bool) -> crate::Result<Option<JsonPath>> {
+fn json_path_from_db_value(path: &Value, strict: bool) -> crate::Result<Option<JsonPath<'_>>> {
     let json_path = if strict {
         match path {
             Value::Text(t) => json_path(t.as_str())?,

--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -38,7 +38,7 @@ impl InternalVirtualTable for JsonEachVirtualTable {
     fn open(
         &self,
         _conn: Arc<Connection>,
-    ) -> crate::Result<std::sync::Arc<RwLock<(dyn InternalVirtualTableCursor + 'static)>>> {
+    ) -> crate::Result<std::sync::Arc<RwLock<dyn InternalVirtualTableCursor + 'static>>> {
         Ok(Arc::new(RwLock::new(JsonEachCursor::default())))
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2452,7 +2452,7 @@ impl Statement {
         }
     }
 
-    pub fn get_column_name(&self, idx: usize) -> Cow<str> {
+    pub fn get_column_name(&self, idx: usize) -> Cow<'_, str> {
         match self.query_mode {
             QueryMode::Normal => {
                 let column = &self.program.result_columns.get(idx).expect("No column");
@@ -2466,7 +2466,7 @@ impl Statement {
         }
     }
 
-    pub fn get_column_table_name(&self, idx: usize) -> Option<Cow<str>> {
+    pub fn get_column_table_name(&self, idx: usize) -> Option<Cow<'_, str>> {
         let column = &self.program.result_columns.get(idx).expect("No column");
         match &column.expr {
             turso_parser::ast::Expr::Column { table, .. } => self

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4633,7 +4633,7 @@ impl BTreeCursor {
     /// If record was not parsed yet, then we have to parse it and in case of I/O we yield control
     /// back.
     #[instrument(skip(self), level = Level::DEBUG)]
-    pub fn record(&self) -> Result<IOResult<Option<Ref<ImmutableRecord>>>> {
+    pub fn record(&self) -> Result<IOResult<Option<Ref<'_, ImmutableRecord>>>> {
         if !self.has_record.get() && self.mv_cursor.is_none() {
             return Ok(IOResult::Done(None));
         }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1638,11 +1638,11 @@ impl WalFile {
         WAL_HEADER_SIZE as u64 + page_offset
     }
 
-    fn get_shared_mut(&self) -> parking_lot::RwLockWriteGuard<WalFileShared> {
+    fn get_shared_mut(&self) -> parking_lot::RwLockWriteGuard<'_, WalFileShared> {
         self.shared.write()
     }
 
-    fn get_shared(&self) -> parking_lot::RwLockReadGuard<WalFileShared> {
+    fn get_shared(&self) -> parking_lot::RwLockReadGuard<'_, WalFileShared> {
         self.shared.read()
     }
 


### PR DESCRIPTION
Nothing fancy yet, assuming you merge this I'll do this one next:
```
warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
   --> core/types.rs:403:5
    |
398 | #[derive(Debug, Clone, PartialEq)]
    |                        --------- in this derive macro expansion
...
402 |     pub step_fn: StepFunction,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
403 |     pub finalize_fn: FinalizeFunction,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the address of the same function can vary between different codegen units
    = note: furthermore, different functions could have the same address after being merged together
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
```

And fix a test failure that I resolved in Python (specific to macOS hosts). Basically this PR is putting my toe in the water to see how open you are to contribs!