### PR TITLE
Pragma busy timeout

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -413,7 +413,7 @@ impl Connection {
             .inner
             .lock()
             .map_err(|e| Error::MutexError(e.to_string()))?;
-        conn.busy_timeout(duration);
+        conn.set_busy_timeout(duration);
         Ok(())
     }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2174,9 +2174,13 @@ impl Connection {
     /// 5. Step through query -> returns Busy -> return Busy to user
     ///
     /// This slight api change demonstrated a better throughtput in `perf/throughput/turso` benchmark
-    pub fn busy_timeout(&self, mut duration: Option<std::time::Duration>) {
+    pub fn set_busy_timeout(&self, mut duration: Option<std::time::Duration>) {
         duration = duration.filter(|duration| !duration.is_zero());
         self.busy_timeout.set(duration);
+    }
+
+    pub fn get_busy_timeout(&self) -> Option<std::time::Duration> {
+        self.busy_timeout.get()
     }
 }
 

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -102,6 +102,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["auto_vacuum"],
         ),
+        BusyTimeout => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["busy_timeout"],
+        ),
         IntegrityCheck => Pragma::new(
             PragmaFlags::NeedSchema | PragmaFlags::ReadOnly | PragmaFlags::Result0,
             &["message"],

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1312,6 +1312,8 @@ pub enum PragmaName {
     ApplicationId,
     /// set the autovacuum mode
     AutoVacuum,
+    /// set the busy_timeout
+    BusyTimeout,
     /// `cache_size` pragma
     CacheSize,
     /// encryption cipher algorithm name for encrypted databases

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1312,7 +1312,7 @@ pub enum PragmaName {
     ApplicationId,
     /// set the autovacuum mode
     AutoVacuum,
-    /// set the busy_timeout
+    /// set the busy_timeout (see https://www.sqlite.org/pragma.html#pragma_busy_timeout)
     BusyTimeout,
     /// `cache_size` pragma
     CacheSize,


### PR DESCRIPTION
Expose busy_timeout added in #3067 as a `PRAGMA busy_timeout=<ms duration>`

https://www.sqlite.org/pragma.html#pragma_busy_timeout