### PR TITLE
Enhancement to Sim Snapshot isolation code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,6 +2140,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 6.0.0",
+ "either",
  "env_logger 0.11.7",
  "garde",
  "hex",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -44,3 +44,4 @@ json5 = { version = "0.4.1" }
 strum = { workspace = true }
 parking_lot = { workspace = true }
 indexmap = { workspace = true }
+either = "1.15.0"

--- a/simulator/generation/mod.rs
+++ b/simulator/generation/mod.rs
@@ -1,5 +1,3 @@
-use sql_generation::generation::GenerationContext;
-
 use crate::runner::env::ShadowTablesMut;
 
 pub mod plan;
@@ -18,18 +16,4 @@ pub mod query;
 pub(crate) trait Shadow {
     type Result;
     fn shadow(&self, tables: &mut ShadowTablesMut<'_>) -> Self::Result;
-}
-
-/// Generation context that will always panic when called
-/// This is meant to be used when want to ensure that no downstream arbitrary fn will use this context
-pub struct PanicGenerationContext;
-
-impl GenerationContext for PanicGenerationContext {
-    fn tables(&self) -> &Vec<sql_generation::model::table::Table> {
-        unimplemented!("you are not supposed to use this context")
-    }
-
-    fn opts(&self) -> &sql_generation::generation::Opts {
-        unimplemented!("you are not supposed to use this context")
-    }
 }

--- a/simulator/generation/mod.rs
+++ b/simulator/generation/mod.rs
@@ -1,6 +1,6 @@
 use sql_generation::generation::GenerationContext;
 
-use crate::runner::env::{SimulatorEnv, SimulatorTables};
+use crate::runner::env::SimulatorTables;
 
 pub mod plan;
 pub mod property;
@@ -20,22 +20,16 @@ pub(crate) trait Shadow {
     fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result;
 }
 
-impl GenerationContext for SimulatorEnv {
+/// Generation context that will always panic when called
+/// This is meant to be used when want to ensure that no downstream arbitrary fn will use this context
+pub struct PanicGenerationContext;
+
+impl GenerationContext for PanicGenerationContext {
     fn tables(&self) -> &Vec<sql_generation::model::table::Table> {
-        &self.tables.tables
+        unimplemented!("you are not supposed to use this context")
     }
 
     fn opts(&self) -> &sql_generation::generation::Opts {
-        &self.profile.query.gen_opts
-    }
-}
-
-impl GenerationContext for &mut SimulatorEnv {
-    fn tables(&self) -> &Vec<sql_generation::model::table::Table> {
-        &self.tables.tables
-    }
-
-    fn opts(&self) -> &sql_generation::generation::Opts {
-        &self.profile.query.gen_opts
+        unimplemented!("you are not supposed to use this context")
     }
 }

--- a/simulator/generation/mod.rs
+++ b/simulator/generation/mod.rs
@@ -1,6 +1,6 @@
 use sql_generation::generation::GenerationContext;
 
-use crate::runner::env::SimulatorTables;
+use crate::runner::env::ShadowTablesMut;
 
 pub mod plan;
 pub mod property;
@@ -17,7 +17,7 @@ pub mod query;
 /// might return a vector of rows that were inserted into the table.
 pub(crate) trait Shadow {
     type Result;
-    fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result;
+    fn shadow(&self, tables: &mut ShadowTablesMut<'_>) -> Self::Result;
 }
 
 /// Generation context that will always panic when called

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -1006,7 +1006,12 @@ impl ArbitraryFrom<(&SimulatorEnv, InteractionStats)> for Interactions {
         _context: &C,
         (env, stats): (&SimulatorEnv, InteractionStats),
     ) -> Self {
-        let remaining_ = remaining(env.opts.max_interactions, &env.profile.query, &stats);
+        let remaining_ = remaining(
+            env.opts.max_interactions,
+            &env.profile.query,
+            &stats,
+            env.profile.experimental_mvcc,
+        );
         let conn_index = env.choose_conn(rng);
         frequency(
             vec![

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -225,11 +225,7 @@ impl InteractionPlan {
         ));
 
         while plan.len() < num_interactions {
-            tracing::debug!(
-                "Generating interaction {}/{}",
-                plan.len(),
-                num_interactions
-            );
+            tracing::debug!("Generating interaction {}/{}", plan.len(), num_interactions);
             let interactions =
                 Interactions::arbitrary_from(rng, &PanicGenerationContext, (env, plan.stats()));
             interactions.shadow(env.get_conn_tables_mut(interactions.connection_index));

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -1176,8 +1176,10 @@ fn property_insert_values_select<R: rand::Rng>(
     // - [x] The inserted row will not be updated.
     // - [ ] The table `t` will not be renamed, dropped, or altered. (todo: add this constraint once ALTER or DROP is implemented)
     if let Some(ref interactive) = interactive {
-        queries.push(Query::Begin(Begin {
-            immediate: interactive.start_with_immediate,
+        queries.push(Query::Begin(if interactive.start_with_immediate {
+            Begin::Immediate
+        } else {
+            Begin::Deferred
         }));
     }
     for _ in 0..rng.random_range(0..3) {

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -226,7 +226,8 @@ impl Property {
                 let assumption = InteractionType::Assumption(Assertion::new(
                     format!("table {} exists", table.clone()),
                     move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
-                        if env.tables.iter().any(|t| t.name == table_name) {
+                        let conn_tables = env.get_conn_tables(connection_index);
+                        if conn_tables.iter().any(|t| t.name == table_name) {
                             Ok(Ok(()))
                         } else {
                             Ok(Err(format!("table {table_name} does not exist")))
@@ -246,8 +247,8 @@ impl Property {
                         let Ok(rows) = rows else {
                             return Ok(Err(format!("expected rows but got error: {rows:?}")));
                         };
-                        let sim_table = env
-                            .tables
+                        let conn_tables = env.get_conn_tables(connection_index);
+                        let sim_table = conn_tables
                             .iter()
                             .find(|t| t.name == table)
                             .expect("table should be in enviroment");
@@ -283,7 +284,8 @@ impl Property {
                 let assumption = InteractionType::Assumption(Assertion::new(
                     format!("table {} exists", table.clone()),
                     move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
-                        if env.tables.iter().any(|t| t.name == table.clone()) {
+                        let conn_tables = env.get_conn_tables(connection_index);
+                        if conn_tables.iter().any(|t| t.name == table.clone()) {
                             Ok(Ok(()))
                         } else {
                             Ok(Err(format!("table {} does not exist", table.clone())))
@@ -360,7 +362,8 @@ impl Property {
                     {
                         let table_name = table.clone();
                         move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
-                            if env.tables.iter().any(|t| t.name == table_name) {
+                            let conn_tables = env.get_conn_tables(connection_index);
+                            if conn_tables.iter().any(|t| t.name == table_name) {
                                 Ok(Ok(()))
                             } else {
                                 Ok(Err(format!("table {table_name} does not exist")))
@@ -429,7 +432,8 @@ impl Property {
                 let assumption = InteractionType::Assumption(Assertion::new(
                     "Double-Create-Failure should not be called on an existing table".to_string(),
                     move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
-                        if !env.tables.iter().any(|t| t.name == table_name) {
+                        let conn_tables = env.get_conn_tables(connection_index);
+                        if !conn_tables.iter().any(|t| t.name == table_name) {
                             Ok(Ok(()))
                         } else {
                             Ok(Err(format!("table {table_name} already exists")))
@@ -484,15 +488,16 @@ impl Property {
                     {
                         let table_name = select.dependencies();
                         move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
+                            let conn_tables = env.get_conn_tables(connection_index);
                             if table_name
                                 .iter()
-                                .all(|table| env.tables.iter().any(|t| t.name == *table))
+                                .all(|table| conn_tables.iter().any(|t| t.name == *table))
                             {
                                 Ok(Ok(()))
                             } else {
                                 let missing_tables = table_name
                                     .iter()
-                                    .filter(|t| !env.tables.iter().any(|t2| t2.name == **t))
+                                    .filter(|t| !conn_tables.iter().any(|t2| t2.name == **t))
                                     .collect::<Vec<&String>>();
                                 Ok(Err(format!("missing tables: {missing_tables:?}")))
                             }
@@ -544,12 +549,13 @@ impl Property {
                     {
                         let table = table.clone();
                         move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
-                            if env.tables.iter().any(|t| t.name == table) {
+                            let conn_tables = env.get_conn_tables(connection_index);
+                            if conn_tables.iter().any(|t| t.name == table) {
                                 Ok(Ok(()))
                             } else {
                                 {
                                     let available_tables: Vec<String> =
-                                        env.tables.iter().map(|t| t.name.clone()).collect();
+                                        conn_tables.iter().map(|t| t.name.clone()).collect();
                                     Ok(Err(format!(
                                         "table \'{table}\' not found. Available tables: {available_tables:?}"
                                     )))
@@ -617,12 +623,13 @@ impl Property {
                     {
                         let table = table.clone();
                         move |_, env: &mut SimulatorEnv| {
-                            if env.tables.iter().any(|t| t.name == table) {
+                            let conn_tables = env.get_conn_tables(connection_index);
+                            if conn_tables.iter().any(|t| t.name == table) {
                                 Ok(Ok(()))
                             } else {
                                 {
                                     let available_tables: Vec<String> =
-                                        env.tables.iter().map(|t| t.name.clone()).collect();
+                                        conn_tables.iter().map(|t| t.name.clone()).collect();
                                     Ok(Err(format!(
                                         "table \'{table}\' not found. Available tables: {available_tables:?}"
                                     )))
@@ -684,12 +691,13 @@ impl Property {
                     {
                         let table = table.clone();
                         move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
-                            if env.tables.iter().any(|t| t.name == table) {
+                            let conn_tables = env.get_conn_tables(connection_index);
+                            if conn_tables.iter().any(|t| t.name == table) {
                                 Ok(Ok(()))
                             } else {
                                 {
                                     let available_tables: Vec<String> =
-                                        env.tables.iter().map(|t| t.name.clone()).collect();
+                                        conn_tables.iter().map(|t| t.name.clone()).collect();
                                     Ok(Err(format!(
                                         "table \'{table}\' not found. Available tables: {available_tables:?}"
                                     )))
@@ -788,7 +796,8 @@ impl Property {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(_) => {
-                                let _ = query_clone.shadow(&mut env.tables);
+                                let _ =
+                                    query_clone.shadow(env.get_conn_tables_mut(connection_index));
                                 Ok(Ok(()))
                             }
                             Err(err) => {
@@ -821,15 +830,16 @@ impl Property {
                     {
                         let tables = select.dependencies();
                         move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
+                            let conn_tables = env.get_conn_tables(connection_index);
                             if tables
                                 .iter()
-                                .all(|table| env.tables.iter().any(|t| t.name == *table))
+                                .all(|table| conn_tables.iter().any(|t| t.name == *table))
                             {
                                 Ok(Ok(()))
                             } else {
                                 let missing_tables = tables
                                     .iter()
-                                    .filter(|t| !env.tables.iter().any(|t2| t2.name == **t))
+                                    .filter(|t| !conn_tables.iter().any(|t2| t2.name == **t))
                                     .collect::<Vec<&String>>();
                                 Ok(Err(format!("missing tables: {missing_tables:?}")))
                             }
@@ -1030,7 +1040,7 @@ fn assert_all_table_values(
         let assertion = InteractionType::Assertion(Assertion::new(format!("table {table} should contain all of its expected values"), {
                 let table = table.clone();
                 move |stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
-                    let table = env.tables.iter().find(|t| t.name == table).ok_or_else(|| {
+                    let table = env.get_conn_tables(connection_index).iter().find(|t| t.name == table).ok_or_else(|| {
                         LimboError::InternalError(format!(
                             "table {table} should exist in simulator env"
                         ))
@@ -1140,14 +1150,14 @@ pub(crate) fn remaining(
 
 fn property_insert_values_select<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
     remaining: &Remaining,
+    ctx: &impl GenerationContext,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(ctx.tables(), rng);
     // Generate rows to insert
     let rows = (0..rng.random_range(1..=5))
-        .map(|_| Vec::<SimValue>::arbitrary_from(rng, env, table))
+        .map(|_| Vec::<SimValue>::arbitrary_from(rng, ctx, table))
         .collect::<Vec<_>>();
 
     // Pick a random row to select
@@ -1183,7 +1193,7 @@ fn property_insert_values_select<R: rand::Rng>(
         }));
     }
     for _ in 0..rng.random_range(0..3) {
-        let query = Query::arbitrary_from(rng, env, remaining);
+        let query = Query::arbitrary_from(rng, ctx, remaining);
         match &query {
             Query::Delete(Delete {
                 table: t,
@@ -1226,7 +1236,7 @@ fn property_insert_values_select<R: rand::Rng>(
     // Select the row
     let select_query = Select::simple(
         table.name.clone(),
-        Predicate::arbitrary_from(rng, env, (table, &row)),
+        Predicate::arbitrary_from(rng, ctx, (table, &row)),
     );
 
     Property::InsertValuesSelect {
@@ -1238,9 +1248,12 @@ fn property_insert_values_select<R: rand::Rng>(
     }
 }
 
-fn property_read_your_updates_back<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Property {
+fn property_read_your_updates_back<R: rand::Rng>(
+    rng: &mut R,
+    ctx: &impl GenerationContext,
+) -> Property {
     // e.g. UPDATE t SET a=1, b=2 WHERE c=1;
-    let update = Update::arbitrary(rng, env);
+    let update = Update::arbitrary(rng, ctx);
     // e.g. SELECT a, b FROM t WHERE c=1;
     let select = Select::single(
         update.table().to_string(),
@@ -1257,22 +1270,25 @@ fn property_read_your_updates_back<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv
     Property::ReadYourUpdatesBack { update, select }
 }
 
-fn property_table_has_expected_content<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Property {
+fn property_table_has_expected_content<R: rand::Rng>(
+    rng: &mut R,
+    ctx: &impl GenerationContext,
+) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(ctx.tables(), rng);
     Property::TableHasExpectedContent {
         table: table.name.clone(),
     }
 }
 
-fn property_select_limit<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Property {
+fn property_select_limit<R: rand::Rng>(rng: &mut R, ctx: &impl GenerationContext) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(ctx.tables(), rng);
     // Select the table
     let select = Select::single(
         table.name.clone(),
         vec![ResultColumn::Star],
-        Predicate::arbitrary_from(rng, env, table),
+        Predicate::arbitrary_from(rng, ctx, table),
         Some(rng.random_range(1..=5)),
         Distinctness::All,
     );
@@ -1281,11 +1297,11 @@ fn property_select_limit<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Prope
 
 fn property_double_create_failure<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
     remaining: &Remaining,
+    ctx: &impl GenerationContext,
 ) -> Property {
     // Create the table
-    let create_query = Create::arbitrary(rng, env);
+    let create_query = Create::arbitrary(rng, ctx);
     let table = &create_query.table;
 
     // Create random queries respecting the constraints
@@ -1294,7 +1310,7 @@ fn property_double_create_failure<R: rand::Rng>(
     // - [x] There will be no errors in the middle interactions.(best effort)
     // - [ ] Table `t` will not be renamed or dropped.(todo: add this constraint once ALTER or DROP is implemented)
     for _ in 0..rng.random_range(0..3) {
-        let query = Query::arbitrary_from(rng, env, remaining);
+        let query = Query::arbitrary_from(rng, ctx, remaining);
         if let Query::Create(Create { table: t }) = &query {
             // There will be no errors in the middle interactions.
             // - Creating the same table is an error
@@ -1313,13 +1329,13 @@ fn property_double_create_failure<R: rand::Rng>(
 
 fn property_delete_select<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
     remaining: &Remaining,
+    ctx: &impl GenerationContext,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(ctx.tables(), rng);
     // Generate a random predicate
-    let predicate = Predicate::arbitrary_from(rng, env, table);
+    let predicate = Predicate::arbitrary_from(rng, ctx, table);
 
     // Create random queries respecting the constraints
     let mut queries = Vec::new();
@@ -1327,7 +1343,7 @@ fn property_delete_select<R: rand::Rng>(
     // - [x] A row that holds for the predicate will not be inserted.
     // - [ ] The table `t` will not be renamed, dropped, or altered. (todo: add this constraint once ALTER or DROP is implemented)
     for _ in 0..rng.random_range(0..3) {
-        let query = Query::arbitrary_from(rng, env, remaining);
+        let query = Query::arbitrary_from(rng, ctx, remaining);
         match &query {
             Query::Insert(Insert::Values { table: t, values }) => {
                 // A row that holds for the predicate will not be inserted.
@@ -1371,18 +1387,18 @@ fn property_delete_select<R: rand::Rng>(
 
 fn property_drop_select<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
     remaining: &Remaining,
+    ctx: &impl GenerationContext,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(ctx.tables(), rng);
 
     // Create random queries respecting the constraints
     let mut queries = Vec::new();
     // - [x] There will be no errors in the middle interactions. (this constraint is impossible to check, so this is just best effort)
     // - [-] The table `t` will not be created, no table will be renamed to `t`. (todo: update this constraint once ALTER is implemented)
     for _ in 0..rng.random_range(0..3) {
-        let query = Query::arbitrary_from(rng, env, remaining);
+        let query = Query::arbitrary_from(rng, ctx, remaining);
         if let Query::Create(Create { table: t }) = &query {
             // - The table `t` will not be created
             if t.name == table.name {
@@ -1394,7 +1410,7 @@ fn property_drop_select<R: rand::Rng>(
 
     let select = Select::simple(
         table.name.clone(),
-        Predicate::arbitrary_from(rng, env, table),
+        Predicate::arbitrary_from(rng, ctx, table),
     );
 
     Property::DropSelect {
@@ -1404,11 +1420,14 @@ fn property_drop_select<R: rand::Rng>(
     }
 }
 
-fn property_select_select_optimizer<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Property {
+fn property_select_select_optimizer<R: rand::Rng>(
+    rng: &mut R,
+    ctx: &impl GenerationContext,
+) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(ctx.tables(), rng);
     // Generate a random predicate
-    let predicate = Predicate::arbitrary_from(rng, env, table);
+    let predicate = Predicate::arbitrary_from(rng, ctx, table);
     // Transform into a Binary predicate to force values to be casted to a bool
     let expr = ast::Expr::Binary(
         Box::new(predicate.0),
@@ -1422,12 +1441,15 @@ fn property_select_select_optimizer<R: rand::Rng>(rng: &mut R, env: &SimulatorEn
     }
 }
 
-fn property_where_true_false_null<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv) -> Property {
+fn property_where_true_false_null<R: rand::Rng>(
+    rng: &mut R,
+    ctx: &impl GenerationContext,
+) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(ctx.tables(), rng);
     // Generate a random predicate
-    let p1 = Predicate::arbitrary_from(rng, env, table);
-    let p2 = Predicate::arbitrary_from(rng, env, table);
+    let p1 = Predicate::arbitrary_from(rng, ctx, table);
+    let p2 = Predicate::arbitrary_from(rng, ctx, table);
 
     // Create the select query
     let select = Select::simple(table.name.clone(), p1);
@@ -1440,13 +1462,13 @@ fn property_where_true_false_null<R: rand::Rng>(rng: &mut R, env: &SimulatorEnv)
 
 fn property_union_all_preserves_cardinality<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
+    ctx: &impl GenerationContext,
 ) -> Property {
     // Get a random table
-    let table = pick(&env.tables, rng);
+    let table = pick(ctx.tables(), rng);
     // Generate a random predicate
-    let p1 = Predicate::arbitrary_from(rng, env, table);
-    let p2 = Predicate::arbitrary_from(rng, env, table);
+    let p1 = Predicate::arbitrary_from(rng, ctx, table);
+    let p2 = Predicate::arbitrary_from(rng, ctx, table);
 
     // Create the select query
     let select = Select::single(
@@ -1465,33 +1487,34 @@ fn property_union_all_preserves_cardinality<R: rand::Rng>(
 
 fn property_fsync_no_wait<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
     remaining: &Remaining,
+    ctx: &impl GenerationContext,
 ) -> Property {
     Property::FsyncNoWait {
-        query: Query::arbitrary_from(rng, env, remaining),
-        tables: env.tables.iter().map(|t| t.name.clone()).collect(),
+        query: Query::arbitrary_from(rng, ctx, remaining),
+        tables: ctx.tables().iter().map(|t| t.name.clone()).collect(),
     }
 }
 
 fn property_faulty_query<R: rand::Rng>(
     rng: &mut R,
-    env: &SimulatorEnv,
     remaining: &Remaining,
+    ctx: &impl GenerationContext,
 ) -> Property {
     Property::FaultyQuery {
-        query: Query::arbitrary_from(rng, env, remaining),
-        tables: env.tables.iter().map(|t| t.name.clone()).collect(),
+        query: Query::arbitrary_from(rng, ctx, remaining),
+        tables: ctx.tables().iter().map(|t| t.name.clone()).collect(),
     }
 }
 
-impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
+impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats, usize)> for Property {
     fn arbitrary_from<R: rand::Rng, C: GenerationContext>(
         rng: &mut R,
-        context: &C,
-        (env, stats): (&SimulatorEnv, &InteractionStats),
+        _context: &C,
+        (env, stats, conn_index): (&SimulatorEnv, &InteractionStats, usize),
     ) -> Self {
-        let opts = context.opts();
+        let conn_ctx = &env.connection_context(conn_index);
+        let opts = conn_ctx.opts();
         let remaining_ = remaining(env.opts.max_interactions, &env.profile.query, stats);
 
         frequency(
@@ -1502,15 +1525,17 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_insert_values_select(rng, env, &remaining_)),
+                    Box::new(|rng: &mut R| {
+                        property_insert_values_select(rng, &remaining_, conn_ctx)
+                    }),
                 ),
                 (
                     remaining_.select,
-                    Box::new(|rng: &mut R| property_table_has_expected_content(rng, env)),
+                    Box::new(|rng: &mut R| property_table_has_expected_content(rng, conn_ctx)),
                 ),
                 (
                     u32::min(remaining_.select, remaining_.insert),
-                    Box::new(|rng: &mut R| property_read_your_updates_back(rng, env)),
+                    Box::new(|rng: &mut R| property_read_your_updates_back(rng, conn_ctx)),
                 ),
                 (
                     if !env.opts.disable_double_create_failure {
@@ -1518,7 +1543,9 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_double_create_failure(rng, env, &remaining_)),
+                    Box::new(|rng: &mut R| {
+                        property_double_create_failure(rng, &remaining_, conn_ctx)
+                    }),
                 ),
                 (
                     if !env.opts.disable_select_limit {
@@ -1526,7 +1553,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_select_limit(rng, env)),
+                    Box::new(|rng: &mut R| property_select_limit(rng, conn_ctx)),
                 ),
                 (
                     if !env.opts.disable_delete_select {
@@ -1534,7 +1561,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_delete_select(rng, env, &remaining_)),
+                    Box::new(|rng: &mut R| property_delete_select(rng, &remaining_, conn_ctx)),
                 ),
                 (
                     if !env.opts.disable_drop_select {
@@ -1543,7 +1570,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_drop_select(rng, env, &remaining_)),
+                    Box::new(|rng: &mut R| property_drop_select(rng, &remaining_, conn_ctx)),
                 ),
                 (
                     if !env.opts.disable_select_optimizer {
@@ -1551,7 +1578,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_select_select_optimizer(rng, env)),
+                    Box::new(|rng: &mut R| property_select_select_optimizer(rng, conn_ctx)),
                 ),
                 (
                     if opts.indexes && !env.opts.disable_where_true_false_null {
@@ -1559,7 +1586,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_where_true_false_null(rng, env)),
+                    Box::new(|rng: &mut R| property_where_true_false_null(rng, conn_ctx)),
                 ),
                 (
                     if opts.indexes && !env.opts.disable_union_all_preserves_cardinality {
@@ -1567,7 +1594,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_union_all_preserves_cardinality(rng, env)),
+                    Box::new(|rng: &mut R| property_union_all_preserves_cardinality(rng, conn_ctx)),
                 ),
                 (
                     if env.profile.io.enable && !env.opts.disable_fsync_no_wait {
@@ -1575,7 +1602,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_fsync_no_wait(rng, env, &remaining_)),
+                    Box::new(|rng: &mut R| property_fsync_no_wait(rng, &remaining_, conn_ctx)),
                 ),
                 (
                     if env.profile.io.enable
@@ -1586,7 +1613,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
                     } else {
                         0
                     },
-                    Box::new(|rng: &mut R| property_faulty_query(rng, env, &remaining_)),
+                    Box::new(|rng: &mut R| property_faulty_query(rng, &remaining_, conn_ctx)),
                 ),
             ],
             rng,

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -796,8 +796,8 @@ impl Property {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(_) => {
-                                let _ =
-                                    query_clone.shadow(env.get_conn_tables_mut(connection_index));
+                                let _ = query_clone
+                                    .shadow(&mut env.get_conn_tables_mut(connection_index));
                                 Ok(Ok(()))
                             }
                             Err(err) => {
@@ -1040,7 +1040,8 @@ fn assert_all_table_values(
         let assertion = InteractionType::Assertion(Assertion::new(format!("table {table} should contain all of its expected values"), {
                 let table = table.clone();
                 move |stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
-                    let table = env.get_conn_tables(connection_index).iter().find(|t| t.name == table).ok_or_else(|| {
+                    let conn_ctx = env.get_conn_tables(connection_index);
+                    let table = conn_ctx.iter().find(|t| t.name == table).ok_or_else(|| {
                         LimboError::InternalError(format!(
                             "table {table} should exist in simulator env"
                         ))

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -1514,13 +1514,12 @@ fn property_faulty_query<R: rand::Rng>(
     }
 }
 
-impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats, usize)> for Property {
+impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
     fn arbitrary_from<R: rand::Rng, C: GenerationContext>(
         rng: &mut R,
-        _context: &C,
-        (env, stats, conn_index): (&SimulatorEnv, &InteractionStats, usize),
+        conn_ctx: &C,
+        (env, stats): (&SimulatorEnv, &InteractionStats),
     ) -> Self {
-        let conn_ctx = &env.connection_context(conn_index);
         let opts = conn_ctx.opts();
         let remaining_ = remaining(
             env.opts.max_interactions,

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -330,7 +330,7 @@ fn run_simulator(
                         tracing::trace!(
                             "adding bug to bugbase, seed: {}, plan: {}, error: {}",
                             env.opts.seed,
-                            plan.plan.len(),
+                            plan.len(),
                             error
                         );
                         bugbase
@@ -361,8 +361,8 @@ fn run_simulator(
 
                         tracing::info!(
                             "shrinking succeeded, reduced the plan from {} to {}",
-                            plan.plan.len(),
-                            final_plan.plan.len()
+                            plan.len(),
+                            final_plan.len()
                         );
                         // Save the shrunk database
                         if let Some(bugbase) = bugbase.as_deref_mut() {

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -358,6 +358,8 @@ impl Shadow for Select {
 impl Shadow for Begin {
     type Result = Vec<Vec<SimValue>>;
     fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result {
+        // FIXME: currently the snapshot is taken eagerly
+        // this is wrong for Deffered transactions
         tables.snapshot = Some(tables.tables.clone());
         vec![]
     }

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -15,7 +15,7 @@ use sql_generation::model::{
 };
 use turso_parser::ast::Distinctness;
 
-use crate::{generation::Shadow, runner::env::SimulatorTables};
+use crate::{generation::Shadow, runner::env::ShadowTablesMut};
 
 // This type represents the potential queries on the database.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,7 +83,7 @@ impl Display for Query {
 impl Shadow for Query {
     type Result = anyhow::Result<Vec<Vec<SimValue>>>;
 
-    fn shadow(&self, env: &mut SimulatorTables) -> Self::Result {
+    fn shadow(&self, env: &mut ShadowTablesMut) -> Self::Result {
         match self {
             Query::Create(create) => create.shadow(env),
             Query::Insert(insert) => insert.shadow(env),
@@ -102,7 +102,7 @@ impl Shadow for Query {
 impl Shadow for Create {
     type Result = anyhow::Result<Vec<Vec<SimValue>>>;
 
-    fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result {
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         if !tables.iter().any(|t| t.name == self.table.name) {
             tables.push(self.table.clone());
             Ok(vec![])
@@ -117,9 +117,8 @@ impl Shadow for Create {
 
 impl Shadow for CreateIndex {
     type Result = Vec<Vec<SimValue>>;
-    fn shadow(&self, env: &mut SimulatorTables) -> Vec<Vec<SimValue>> {
-        env.tables
-            .iter_mut()
+    fn shadow(&self, env: &mut ShadowTablesMut) -> Vec<Vec<SimValue>> {
+        env.iter_mut()
             .find(|t| t.name == self.table_name)
             .unwrap()
             .indexes
@@ -131,8 +130,8 @@ impl Shadow for CreateIndex {
 impl Shadow for Delete {
     type Result = anyhow::Result<Vec<Vec<SimValue>>>;
 
-    fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result {
-        let table = tables.tables.iter_mut().find(|t| t.name == self.table);
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
+        let table = tables.iter_mut().find(|t| t.name == self.table);
 
         if let Some(table) = table {
             // If the table exists, we can delete from it
@@ -153,7 +152,7 @@ impl Shadow for Delete {
 impl Shadow for Drop {
     type Result = anyhow::Result<Vec<Vec<SimValue>>>;
 
-    fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result {
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         if !tables.iter().any(|t| t.name == self.table) {
             // If the table does not exist, we return an error
             return Err(anyhow::anyhow!(
@@ -162,7 +161,7 @@ impl Shadow for Drop {
             ));
         }
 
-        tables.tables.retain(|t| t.name != self.table);
+        tables.retain(|t| t.name != self.table);
 
         Ok(vec![])
     }
@@ -171,10 +170,10 @@ impl Shadow for Drop {
 impl Shadow for Insert {
     type Result = anyhow::Result<Vec<Vec<SimValue>>>;
 
-    fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result {
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         match self {
             Insert::Values { table, values } => {
-                if let Some(t) = tables.tables.iter_mut().find(|t| &t.name == table) {
+                if let Some(t) = tables.iter_mut().find(|t| &t.name == table) {
                     t.rows.extend(values.clone());
                 } else {
                     return Err(anyhow::anyhow!(
@@ -185,7 +184,7 @@ impl Shadow for Insert {
             }
             Insert::Select { table, select } => {
                 let rows = select.shadow(tables)?;
-                if let Some(t) = tables.tables.iter_mut().find(|t| &t.name == table) {
+                if let Some(t) = tables.iter_mut().find(|t| &t.name == table) {
                     t.rows.extend(rows);
                 } else {
                     return Err(anyhow::anyhow!(
@@ -202,9 +201,7 @@ impl Shadow for Insert {
 
 impl Shadow for FromClause {
     type Result = anyhow::Result<JoinTable>;
-    fn shadow(&self, env: &mut SimulatorTables) -> Self::Result {
-        let tables = &mut env.tables;
-
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         let first_table = tables
             .iter()
             .find(|t| t.name == self.table)
@@ -259,7 +256,7 @@ impl Shadow for FromClause {
 impl Shadow for SelectInner {
     type Result = anyhow::Result<JoinTable>;
 
-    fn shadow(&self, env: &mut SimulatorTables) -> Self::Result {
+    fn shadow(&self, env: &mut ShadowTablesMut) -> Self::Result {
         if let Some(from) = &self.from {
             let mut join_table = from.shadow(env)?;
             let col_count = join_table.columns().count();
@@ -327,7 +324,7 @@ impl Shadow for SelectInner {
 impl Shadow for Select {
     type Result = anyhow::Result<Vec<Vec<SimValue>>>;
 
-    fn shadow(&self, env: &mut SimulatorTables) -> Self::Result {
+    fn shadow(&self, env: &mut ShadowTablesMut) -> Self::Result {
         let first_result = self.body.select.shadow(env)?;
 
         let mut rows = first_result.rows;
@@ -357,28 +354,26 @@ impl Shadow for Select {
 
 impl Shadow for Begin {
     type Result = Vec<Vec<SimValue>>;
-    fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result {
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         // FIXME: currently the snapshot is taken eagerly
         // this is wrong for Deffered transactions
-        tables.snapshot = Some(tables.tables.clone());
+        tables.create_snapshot();
         vec![]
     }
 }
 
 impl Shadow for Commit {
     type Result = Vec<Vec<SimValue>>;
-    fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result {
-        tables.snapshot = None;
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
+        tables.apply_snapshot();
         vec![]
     }
 }
 
 impl Shadow for Rollback {
     type Result = Vec<Vec<SimValue>>;
-    fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result {
-        if let Some(tables_) = tables.snapshot.take() {
-            tables.tables = tables_;
-        }
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
+        tables.delete_snapshot();
         vec![]
     }
 }
@@ -386,8 +381,8 @@ impl Shadow for Rollback {
 impl Shadow for Update {
     type Result = anyhow::Result<Vec<Vec<SimValue>>>;
 
-    fn shadow(&self, tables: &mut SimulatorTables) -> Self::Result {
-        let table = tables.tables.iter_mut().find(|t| t.name == self.table);
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
+        let table = tables.iter_mut().find(|t| t.name == self.table);
 
         let table = if let Some(table) = table {
             table

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -59,8 +59,8 @@ pub(crate) fn execute_interactions(
     let mut env = env.lock().unwrap();
     let mut rusqlite_env = rusqlite_env.lock().unwrap();
 
-    env.tables.clear();
-    rusqlite_env.tables.clear();
+    env.clear_tables();
+    rusqlite_env.clear_tables();
 
     let now = std::time::Instant::now();
 

--- a/simulator/runner/doublecheck.rs
+++ b/simulator/runner/doublecheck.rs
@@ -89,8 +89,8 @@ pub(crate) fn execute_plans(
     let mut env = env.lock().unwrap();
     let mut doublecheck_env = doublecheck_env.lock().unwrap();
 
-    env.tables.clear();
-    doublecheck_env.tables.clear();
+    env.clear_tables();
+    doublecheck_env.clear_tables();
 
     let now = std::time::Instant::now();
 

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -65,7 +65,7 @@ pub(crate) fn execute_interactions(
     env.clear_poison();
     let mut env = env.lock().unwrap();
 
-    env.tables.clear();
+    env.clear_tables();
 
     for _tick in 0..env.opts.ticks {
         tracing::trace!("Executing tick {}", _tick);

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -230,7 +230,7 @@ pub fn execute_interaction_turso(
             limbo_integrity_check(&conn)?;
         }
     }
-    let _ = interaction.shadow(&mut env.tables);
+    let _ = interaction.shadow(env.get_conn_tables_mut(interaction.connection_index));
     Ok(ExecutionContinuation::NextInteraction)
 }
 
@@ -323,7 +323,7 @@ fn execute_interaction_rusqlite(
         }
     }
 
-    let _ = interaction.shadow(&mut env.tables);
+    let _ = interaction.shadow(env.get_conn_tables_mut(interaction.connection_index));
     Ok(ExecutionContinuation::NextInteraction)
 }
 

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -186,7 +186,10 @@ pub fn execute_interaction_turso(
                 tracing::error!(?results);
             }
             stack.push(results);
-            limbo_integrity_check(conn)?;
+            // TODO: skip integrity check with mvcc
+            if !env.profile.experimental_mvcc {
+                limbo_integrity_check(conn)?;
+            }
         }
         InteractionType::FsyncQuery(query) => {
             let results = interaction.execute_fsync_query(conn.clone(), env);
@@ -227,7 +230,10 @@ pub fn execute_interaction_turso(
             stack.push(results);
             // Reset fault injection
             env.io.inject_fault(false);
-            limbo_integrity_check(&conn)?;
+            // TODO: skip integrity check with mvcc
+            if !env.profile.experimental_mvcc {
+                limbo_integrity_check(&conn)?;
+            }
         }
     }
     let _ = interaction.shadow(env.get_conn_tables_mut(interaction.connection_index));

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -236,7 +236,7 @@ pub fn execute_interaction_turso(
             }
         }
     }
-    let _ = interaction.shadow(env.get_conn_tables_mut(interaction.connection_index));
+    let _ = interaction.shadow(&mut env.get_conn_tables_mut(interaction.connection_index));
     Ok(ExecutionContinuation::NextInteraction)
 }
 
@@ -329,7 +329,7 @@ fn execute_interaction_rusqlite(
         }
     }
 
-    let _ = interaction.shadow(env.get_conn_tables_mut(interaction.connection_index));
+    let _ = interaction.shadow(&mut env.get_conn_tables_mut(interaction.connection_index));
     Ok(ExecutionContinuation::NextInteraction)
 }
 

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -33,7 +33,7 @@ impl InteractionPlan {
                     break;
                 }
                 match &all_interactions[idx].1.interaction {
-                    InteractionType::Query(query) => {
+                    InteractionType::Query(query) | InteractionType::FaultyQuery(query) => {
                         depending_tables = query.dependencies();
                         break;
                     }

--- a/sql_generation/model/query/transaction.rs
+++ b/sql_generation/model/query/transaction.rs
@@ -3,8 +3,10 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Begin {
-    pub immediate: bool,
+pub enum Begin {
+    Deferred,
+    Immediate,
+    Concurrent,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -15,7 +17,12 @@ pub struct Rollback;
 
 impl Display for Begin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "BEGIN {}", if self.immediate { "IMMEDIATE" } else { "" })
+        let keyword = match self {
+            Begin::Deferred => "",
+            Begin::Immediate => "IMMEDIATE",
+            Begin::Concurrent => "CONCURRENT",
+        };
+        write!(f, "BEGIN {keyword}")
     }
 }
 


### PR DESCRIPTION
- Made the code around snapshot isolation more ergonomic with each connections having its own transaction state. Also when shadowing, we pass a ShadowTablesMut object that dynamically uses the committed tables or the connection tables depending on the transaction state. 
- added begin concurrent transaction before every property when mvcc is enabled (this is just so we can have some mvcc code be tested using the simulator under Begin Concurrent, I have not yet implemented the logic to have concurrent transactions in the simulator)
- some small enhancements to shrinking

TODOs
- have proper logic to have concurrent transactions without WriteWrite conflicts. This means when generating the plans we need to make sure that we do not generate rows that will conflict with rows in other transactions. This is slightly more powerful than what we do in the fuzzer, as we just have `WriteWriteConflict` as an acceptable error there. By baking this `NoConflict` approach to the simulator, we can continuously test the what does not trigger a WriteWriteConflict and snapshot isolation.