### PR TITLE
sqlite3: Fix compatibility test error by canonicalizing path

### DIFF
--- a/sqlite3/tests/compat/mod.rs
+++ b/sqlite3/tests/compat/mod.rs
@@ -1247,8 +1247,10 @@ mod tests {
             // Test with "main" database name
             let filename = sqlite3_db_filename(db, c"main".as_ptr());
             assert!(!filename.is_null());
-            let filename_str = std::ffi::CStr::from_ptr(filename).to_str().unwrap();
-            assert_eq!(filename_str, temp_file.path().to_str().unwrap());
+            let filename_pathbuf =
+                std::fs::canonicalize(std::ffi::CStr::from_ptr(filename).to_str().unwrap())
+                    .unwrap();
+            assert_eq!(filename_pathbuf, temp_file.path().canonicalize().unwrap());
 
             // Test with NULL database name (defaults to main)
             let filename_default = sqlite3_db_filename(db, ptr::null());


### PR DESCRIPTION
Use canonical path to fix temp path on macOS ; rename to resolve binding connascence. Fixes:
```
---- tests::test_sqlite3_db_filename stdout ----

thread 'tests::test_sqlite3_db_filename' (62061) panicked at sqlite3/tests/compat/mod.rs:1251:13:
assertion `left == right` failed
  left: "/private/var/folders/w5/21g61wls7ksd3z8cxrj41s1c0000gn/T/.tmpNcCUO2.db"
 right: "/var/folders/w5/21g61wls7ksd3z8cxrj41s1c0000gn/T/.tmpNcCUO2.db"
```
