### PR TITLE
translate/emitter: Implement partial indexes

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -164,3 +164,4 @@ impl From<turso_ext::ResultCode> for LimboError {
 pub const SQLITE_CONSTRAINT: usize = 19;
 pub const SQLITE_CONSTRAINT_PRIMARYKEY: usize = SQLITE_CONSTRAINT | (6 << 8);
 pub const SQLITE_CONSTRAINT_NOTNULL: usize = SQLITE_CONSTRAINT | (5 << 8);
+pub const SQLITE_CONSTRAINT_UNIQUE: usize = 2067;

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -69,6 +69,7 @@ pub fn create_dbsp_state_index(root_page: usize) -> Index {
         unique: true,
         ephemeral: false,
         has_rowid: true,
+        where_clause: None,
     }
 }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,8 +1,6 @@
 use crate::function::Func;
 use crate::incremental::view::IncrementalView;
-use crate::translate::emitter::Resolver;
 use crate::translate::expr::{bind_and_rewrite_expr, walk_expr, ParamState, WalkControl};
-use crate::translate::optimizer::Optimizable;
 use parking_lot::RwLock;
 
 /// Simple view structure for non-materialized views

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -8565,6 +8565,7 @@ mod tests {
                 .unwrap() as usize;
             let index_def = Index {
                 name: "testindex".to_string(),
+                where_clause: None,
                 columns: (0..10)
                     .map(|i| IndexColumn {
                         name: format!("test{i}"),
@@ -8726,6 +8727,7 @@ mod tests {
                 .unwrap() as usize;
             let index_def = Index {
                 name: "testindex".to_string(),
+                where_clause: None,
                 columns: vec![IndexColumn {
                     name: "testcol".to_string(),
                     order: SortOrder::Asc,

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -401,6 +401,7 @@ fn create_dedupe_index(
         table_name: String::new(),
         unique: false,
         has_rowid: false,
+        where_clause: None,
     });
     let cursor_id = program.alloc_cursor_id(CursorType::BTreeIndex(dedupe_index.clone()));
     program.emit_insn(Insn::OpenEphemeral {

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -66,7 +66,7 @@ pub fn translate_delete(
         approx_num_labels: 0,
     };
     program.extend(&opts);
-    emit_program(&mut program, delete_plan, schema, syms, |_| {})?;
+    emit_program(connection, &mut program, delete_plan, schema, syms, |_| {})?;
     Ok(program)
 }
 

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -96,7 +96,7 @@ pub fn prepare_delete_plan(
     } else {
         crate::bail_parse_error!("Table is neither a virtual table nor a btree table");
     };
-    let indexes = schema.get_indices(table.get_name()).to_vec();
+    let indexes = schema.get_indices(table.get_name()).cloned().collect();
     let joined_tables = vec![JoinedTable {
         op: Operation::default_scan_for(&table),
         table,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -577,7 +577,6 @@ fn emit_delete_insns(
                 let where_copy = index
                     .bind_where_expr(Some(table_references), connection)
                     .expect("where clause to exist");
-                let where_result_reg = program.alloc_register();
                 let skip_label = program.allocate_label();
                 translate_condition_expr(
                     program,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1778,7 +1778,7 @@ fn rewrite_where_for_update_registers(
                 if let Some((idx, _)) = columns.iter().enumerate().find(|(_, c)| {
                     c.name
                         .as_ref()
-                        .map_or(false, |n| n.eq_ignore_ascii_case(&normalized))
+                        .is_some_and(|n| n.eq_ignore_ascii_case(&normalized))
                 }) {
                     *e = Expr::Register(columns_start_reg + idx);
                 }
@@ -1790,7 +1790,7 @@ fn rewrite_where_for_update_registers(
                 } else if let Some((idx, _)) = columns.iter().enumerate().find(|(_, c)| {
                     c.name
                         .as_ref()
-                        .map_or(false, |n| n.eq_ignore_ascii_case(&normalized))
+                        .is_some_and(|n| n.eq_ignore_ascii_case(&normalized))
                 }) {
                     *e = Expr::Register(columns_start_reg + idx);
                 }

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,8 +1,14 @@
 use std::sync::Arc;
 
+use crate::schema::Table;
 use crate::translate::emitter::{
     emit_cdc_full_record, emit_cdc_insns, prepare_cdc_if_necessary, OperationMode, Resolver,
 };
+use crate::translate::expr::{bind_and_rewrite_expr, translate_expr, ParamState};
+use crate::translate::plan::{
+    ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReferences,
+};
+use crate::vdbe::builder::CursorKey;
 use crate::vdbe::insn::{CmpInsFlags, Cookie};
 use crate::SymbolTable;
 use crate::{
@@ -18,6 +24,7 @@ use turso_parser::ast::{self, Expr, SortOrder, SortedColumn};
 
 use super::schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID};
 
+#[allow(clippy::too_many_arguments)]
 pub fn translate_create_index(
     unique_if_not_exists: (bool, bool),
     idx_name: &str,
@@ -26,6 +33,8 @@ pub fn translate_create_index(
     schema: &Schema,
     syms: &SymbolTable,
     mut program: ProgramBuilder,
+    connection: &Arc<crate::Connection>,
+    mut where_clause: Option<Box<Expr>>,
 ) -> crate::Result<ProgramBuilder> {
     if !schema.indexes_enabled() {
         crate::bail_parse_error!(
@@ -75,6 +84,8 @@ pub fn translate_create_index(
         unique: unique_if_not_exists.0,
         ephemeral: false,
         has_rowid: tbl.has_rowid,
+        where_clause: where_clause.clone(), // store the *original* where clause, because we need to rewrite it
+                                            // before translating, and it cannot reference a table alias
     });
 
     // Allocate the necessary cursors:
@@ -87,12 +98,42 @@ pub fn translate_create_index(
     let sqlite_table = schema.get_btree_table(SQLITE_TABLEID).unwrap();
     let sqlite_schema_cursor_id =
         program.alloc_cursor_id(CursorType::BTreeTable(sqlite_table.clone()));
+    let table_ref = program.table_reference_counter.next();
     let btree_cursor_id = program.alloc_cursor_id(CursorType::BTreeIndex(idx.clone()));
-    let table_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(tbl.clone()));
+    let table_cursor_id = program.alloc_cursor_id_keyed(
+        CursorKey::table(table_ref),
+        CursorType::BTreeTable(tbl.clone()),
+    );
     let sorter_cursor_id = program.alloc_cursor_id(CursorType::Sorter);
     let pseudo_cursor_id = program.alloc_cursor_id(CursorType::Pseudo(PseudoCursorType {
         column_count: tbl.columns.len(),
     }));
+
+    let mut table_references = TableReferences::new(
+        vec![JoinedTable {
+            op: Operation::Scan(Scan::BTreeTable {
+                iter_dir: IterationDirection::Forwards,
+                index: None,
+            }),
+            table: Table::BTree(tbl.clone()),
+            identifier: tbl_name.clone(),
+            internal_id: table_ref,
+            join_info: None,
+            col_used_mask: ColumnUsedMask::default(),
+            database_id: 0,
+        }],
+        vec![],
+    );
+    let mut param_state = ParamState::default();
+    if let Some(where_clause) = where_clause.as_mut() {
+        bind_and_rewrite_expr(
+            where_clause,
+            Some(&mut table_references),
+            None,
+            connection,
+            &mut param_state,
+        )?;
+    }
 
     // Create a new B-Tree and store the root page index in a register
     let root_page_reg = program.alloc_register();
@@ -108,7 +149,13 @@ pub fn translate_create_index(
         root_page: RegisterOrLiteral::Literal(sqlite_table.root_page),
         db: 0,
     });
-    let sql = create_idx_stmt_to_sql(&tbl_name, &idx_name, unique_if_not_exists, &columns);
+    let sql = create_idx_stmt_to_sql(
+        &tbl_name,
+        &idx_name,
+        unique_if_not_exists,
+        &columns,
+        &idx.where_clause.clone(),
+    );
     let resolver = Resolver::new(schema, syms);
     let cdc_table = prepare_cdc_if_necessary(&mut program, schema, SQLITE_TABLEID)?;
     emit_schema_entry(
@@ -159,6 +206,25 @@ pub fn translate_create_index(
     // emit MakeRecord (index key + rowid) into record_reg.
     //
     // Then insert the record into the sorter
+    let mut skip_row_label = None;
+    if let Some(where_clause) = where_clause {
+        let reg = program.alloc_register();
+        let label = program.allocate_label();
+        let pr = translate_expr(
+            &mut program,
+            Some(&table_references),
+            &where_clause,
+            reg,
+            &resolver,
+        )?;
+        program.emit_insn(Insn::IfNot {
+            reg: pr,
+            target_pc: label,
+            jump_if_null: true,
+        });
+        skip_row_label = Some(label);
+    }
+
     let start_reg = program.alloc_registers(columns.len() + 1);
     for (i, (col, _)) in columns.iter().enumerate() {
         program.emit_column_or_rowid(table_cursor_id, col.0, start_reg + i);
@@ -181,6 +247,9 @@ pub fn translate_create_index(
         record_reg,
     });
 
+    if let Some(skip_row_label) = skip_row_label {
+        program.resolve_label(skip_row_label, program.offset());
+    }
     program.emit_insn(Insn::Next {
         cursor_id: table_cursor_id,
         pc_if_next: loop_start_label,
@@ -285,6 +354,7 @@ fn create_idx_stmt_to_sql(
     idx_name: &str,
     unique_if_not_exists: (bool, bool),
     cols: &[((usize, &Column), SortOrder)],
+    where_clause: &Option<Box<Expr>>,
 ) -> String {
     let mut sql = String::with_capacity(128);
     sql.push_str("CREATE ");
@@ -309,6 +379,10 @@ fn create_idx_stmt_to_sql(
         }
     }
     sql.push(')');
+    if let Some(where_clause) = where_clause {
+        sql.push_str(" WHERE ");
+        sql.push_str(&where_clause.to_string());
+    }
     sql
 }
 

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -5,7 +5,7 @@ use crate::translate::emitter::{
     emit_cdc_full_record, emit_cdc_insns, prepare_cdc_if_necessary, OperationMode, Resolver,
 };
 use crate::translate::expr::{
-    bind_and_rewrite_expr, translate_condition_expr, translate_expr, ConditionMetadata, ParamState,
+    bind_and_rewrite_expr, translate_condition_expr, ConditionMetadata, ParamState,
 };
 use crate::translate::plan::{
     ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReferences,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1,18 +1,20 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use turso_parser::ast::{
     self, Expr, InsertBody, OneSelect, QualifiedName, ResolveType, ResultColumn, Upsert, UpsertDo,
     With,
 };
 
-use crate::error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY};
-use crate::schema::{self, Table};
+use crate::error::{
+    SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE,
+};
+use crate::schema::{self, Index, Table};
 use crate::translate::emitter::{
     emit_cdc_insns, emit_cdc_patch_record, prepare_cdc_if_necessary, OperationMode,
 };
 use crate::translate::expr::{
-    bind_and_rewrite_expr, emit_returning_results, process_returning_clause,
-    translate_condition_expr, walk_expr_mut, ConditionMetadata, ParamState,
-    ReturningValueRegisters, WalkControl,
+    bind_and_rewrite_expr, emit_returning_results, process_returning_clause, walk_expr_mut,
+    ParamState, ReturningValueRegisters, WalkControl,
 };
 use crate::translate::plan::TableReferences;
 use crate::translate::planner::ROWID;
@@ -351,6 +353,7 @@ pub fn translate_insert(
             program.alloc_cursor_id(CursorType::BTreeTable(btree_table.clone())),
         ),
     };
+    let has_upsert = upsert_opt.is_some();
 
     // Set up the program to return result columns if RETURNING is specified
     if !result_columns.is_empty() {
@@ -372,6 +375,9 @@ pub fn translate_insert(
         .collect::<Vec<(&String, usize, usize)>>();
 
     let insertion = build_insertion(&mut program, &table, &columns, num_values)?;
+
+    let upsert_entry = program.allocate_label();
+    let conflict_rowid_reg = program.alloc_register();
 
     if inserting_multiple_rows {
         translate_rows_multiple(
@@ -444,41 +450,20 @@ pub fn translate_insert(
         // Conflict on rowid: attempt to route through UPSERT if it targets the PK, otherwise raise constraint.
         // emit Halt for every case *except* when upsert handles the conflict
         'emit_halt: {
-            if let (Some(ref mut upsert), Some(ref target)) =
-                (upsert_opt.as_mut(), resolved_upsert.as_ref())
-            {
+            if let (Some(_), Some(ref target)) = (upsert_opt.as_mut(), resolved_upsert.as_ref()) {
                 if matches!(
                     target,
                     ResolvedUpsertTarget::CatchAll | ResolvedUpsertTarget::PrimaryKey
                 ) {
-                    match upsert.do_clause {
-                        UpsertDo::Nothing => {
-                            program.emit_insn(Insn::Goto {
-                                target_pc: row_done_label,
-                            });
-                        }
-                        UpsertDo::Set {
-                            ref mut sets,
-                            ref mut where_clause,
-                        } => {
-                            let mut rewritten_sets = collect_set_clauses_for_upsert(&table, sets)?;
-                            emit_upsert(
-                                &mut program,
-                                schema,
-                                &table,
-                                &insertion,
-                                cursor_id,
-                                insertion.key_register(),
-                                &mut rewritten_sets,
-                                where_clause,
-                                &resolver,
-                                &idx_cursors,
-                                &mut result_columns,
-                                cdc_table.as_ref().map(|c| c.0),
-                                row_done_label,
-                            )?;
-                        }
-                    }
+                    // PK conflict: the conflicting rowid is exactly the attempted key
+                    program.emit_insn(Insn::Copy {
+                        src_reg: insertion.key_register(),
+                        dst_reg: conflict_rowid_reg,
+                        extra_amount: 0,
+                    });
+                    program.emit_insn(Insn::Goto {
+                        target_pc: upsert_entry,
+                    });
                     break 'emit_halt;
                 }
             }
@@ -507,6 +492,18 @@ pub fn translate_insert(
         _ => (),
     }
 
+    // We need to separate index handling and insertion into a `preflight` and a
+    // `commit` phase, because in UPSERT mode we might need to skip the actual insertion, as we can
+    // have a naked ON CONFLICT DO NOTHING, so if we eagerly insert any indexes, we could insert
+    // invalid index entries before we hit a conflict down the line.
+    //
+    // Preflight phase: evaluate each applicable UNIQUE constraint and probe with NoConflict.
+    // If any probe hits:
+    // DO NOTHING -> jump to row_done_label.
+    //
+    // DO UPDATE (matching target) -> fetch conflicting rowid and jump to `upsert_entry`.
+    //
+    // otherwise, raise SQLITE_CONSTRAINT_UNIQUE
     for index in schema.get_indices(table_name.as_str()) {
         let column_mappings = index
             .columns
@@ -519,29 +516,25 @@ pub fn translate_insert(
             .map(|(_, _, c_id)| *c_id)
             .expect("no cursor found for index");
 
-        let skip_index_label = if let Some(where_clause) = &index.where_clause {
-            // Clone and rewrite WHERE to use insertion registers
+        let maybe_skip_probe_label = if let Some(where_clause) = &index.where_clause {
             let mut where_for_eval = where_clause.as_ref().clone();
             rewrite_partial_index_where(&mut where_for_eval, &insertion)?;
-
-            // Evaluate rewritten WHERE clause
-            let skip_label = program.allocate_label();
-            // We can use an empty TableReferences here because we shouldn't have any
-            // Expr::Column's in the partial index WHERE clause after rewriting it to use
-            // regsisters
-            let table_references = TableReferences::new_empty();
-            translate_condition_expr(
+            let reg = program.alloc_register();
+            translate_expr_no_constant_opt(
                 &mut program,
-                &table_references,
+                Some(&TableReferences::new_empty()),
                 &where_for_eval,
-                ConditionMetadata {
-                    jump_if_condition_is_true: false,
-                    jump_target_when_false: skip_label,
-                    jump_target_when_true: BranchOffset::Placeholder,
-                },
+                reg,
                 &resolver,
+                NoConstantOptReason::RegisterReuse,
             )?;
-            Some(skip_label)
+            let lbl = program.allocate_label();
+            program.emit_insn(Insn::IfNot {
+                reg,
+                target_pc: lbl,
+                jump_if_null: true,
+            });
+            Some(lbl)
         } else {
             None
         };
@@ -550,6 +543,7 @@ pub fn translate_insert(
         // allocate scratch registers for the index columns plus rowid
         let idx_start_reg = program.alloc_registers(num_cols + 1);
 
+        // build unpacked key [idx_start_reg .. idx_start_reg+num_cols-1], and rowid in last reg,
         // copy each index column from the table's column registers into these scratch regs
         for (i, column_mapping) in column_mappings.clone().enumerate() {
             // copy from the table's column register over to the index's scratch register
@@ -571,104 +565,131 @@ pub fn translate_insert(
             extra_amount: 0,
         });
 
-        let record_reg = program.alloc_register();
-        program.emit_insn(Insn::MakeRecord {
-            start_reg: idx_start_reg,
-            count: num_cols + 1,
-            dest_reg: record_reg,
-            index_name: Some(index.name.clone()),
-            affinity_str: None,
-        });
-
         if index.unique {
-            let label_idx_insert = program.allocate_label();
-            program.emit_insn(Insn::NoConflict {
-                cursor_id: idx_cursor_id,
-                target_pc: label_idx_insert,
-                record_reg: idx_start_reg,
-                num_regs: num_cols,
+            let aff = index
+                .columns
+                .iter()
+                .map(|ic| table.columns()[ic.pos_in_table].affinity().aff_mask())
+                .collect::<String>();
+            program.emit_insn(Insn::Affinity {
+                start_reg: idx_start_reg,
+                count: NonZeroUsize::new(num_cols).expect("nonzero col count"),
+                affinities: aff,
             });
-            let column_names = index.columns.iter().enumerate().fold(
-                String::with_capacity(50),
-                |mut accum, (idx, column)| {
-                    if idx > 0 {
-                        accum.push_str(", ");
-                    }
-                    accum.push_str(table_name.as_str());
-                    accum.push('.');
-                    accum.push_str(&column.name);
-                    accum
-                },
-            );
-            // again, emit halt for every case *except* when upsert handles the conflict
-            'emit_halt: {
-                if let (Some(ref mut upsert), Some(ref target)) =
-                    (upsert_opt.as_mut(), resolved_upsert.as_ref())
+
+            if has_upsert {
+                let next_check = program.allocate_label();
+                program.emit_insn(Insn::NoConflict {
+                    cursor_id: idx_cursor_id,
+                    target_pc: next_check,
+                    record_reg: idx_start_reg,
+                    num_regs: num_cols,
+                });
+
+                // Conflict detected, figure out if this UPSERT handles the conflict
+                let upsert_matches_this_index = if let (Some(_u), Some(ref target)) =
+                    (upsert_opt.as_ref(), resolved_upsert.as_ref())
                 {
-                    if match target {
+                    match target {
                         ResolvedUpsertTarget::CatchAll => true,
                         ResolvedUpsertTarget::Index(tgt) => Arc::ptr_eq(tgt, index),
+                        // note: PK handled earlier by rowid path; this is a secondary index
                         ResolvedUpsertTarget::PrimaryKey => false,
-                    } {
-                        match upsert.do_clause {
-                            UpsertDo::Nothing => {
-                                program.emit_insn(Insn::Goto {
-                                    target_pc: row_done_label,
-                                });
-                            }
-                            UpsertDo::Set {
-                                ref mut sets,
-                                ref mut where_clause,
-                            } => {
-                                let mut rewritten_sets =
-                                    collect_set_clauses_for_upsert(&table, sets)?;
-                                let conflict_rowid_reg = program.alloc_register();
-                                program.emit_insn(Insn::IdxRowId {
-                                    cursor_id: idx_cursor_id,
-                                    dest: conflict_rowid_reg,
-                                });
-                                emit_upsert(
-                                    &mut program,
-                                    schema,
-                                    &table,
-                                    &insertion,
-                                    cursor_id,
-                                    conflict_rowid_reg,
-                                    &mut rewritten_sets,
-                                    where_clause,
-                                    &resolver,
-                                    &idx_cursors,
-                                    &mut result_columns,
-                                    cdc_table.as_ref().map(|c| c.0),
-                                    row_done_label,
-                                )?;
-                            }
-                        }
-                        break 'emit_halt;
                     }
+                } else {
+                    false
+                };
+
+                if upsert_matches_this_index {
+                    // Distinguish DO NOTHING vs DO UPDATE
+                    match upsert_opt.as_ref().unwrap().do_clause {
+                        UpsertDo::Nothing => {
+                            // Bail out without writing anything
+                            program.emit_insn(Insn::Goto {
+                                target_pc: row_done_label,
+                            });
+                        }
+                        UpsertDo::Set { .. } => {
+                            // Route to DO UPDATE: capture conflicting rowid then jump
+                            program.emit_insn(Insn::IdxRowId {
+                                cursor_id: idx_cursor_id,
+                                dest: conflict_rowid_reg,
+                            });
+                            program.emit_insn(Insn::Goto {
+                                target_pc: upsert_entry,
+                            });
+                        }
+                    }
+                } else {
+                    // No matching UPSERT handler so we emit constraint error
+                    program.emit_insn(Insn::Halt {
+                        err_code: SQLITE_CONSTRAINT_UNIQUE,
+                        description: format_unique_violation_desc(table_name.as_str(), index),
+                    });
                 }
-                // No matching UPSERT rule: unique constraint violation.
+
+                // continue preflight with next constraint
+                program.preassign_label_to_next_insn(next_check);
+            } else {
+                // No UPSERT fast-path: probe and immediately insert
+                let ok = program.allocate_label();
+                program.emit_insn(Insn::NoConflict {
+                    cursor_id: idx_cursor_id,
+                    target_pc: ok,
+                    record_reg: idx_start_reg,
+                    num_regs: num_cols,
+                });
+                // Unique violation without ON CONFLICT clause -> error
                 program.emit_insn(Insn::Halt {
-                    err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
-                    description: column_names,
+                    err_code: SQLITE_CONSTRAINT_UNIQUE,
+                    description: format_unique_violation_desc(table_name.as_str(), index),
+                });
+                program.preassign_label_to_next_insn(ok);
+
+                // In the non-UPSERT case, we insert the index
+                let record_reg = program.alloc_register();
+                program.emit_insn(Insn::MakeRecord {
+                    start_reg: idx_start_reg,
+                    count: num_cols + 1,
+                    dest_reg: record_reg,
+                    index_name: Some(index.name.clone()),
+                    affinity_str: None,
+                });
+                program.emit_insn(Insn::IdxInsert {
+                    cursor_id: idx_cursor_id,
+                    record_reg,
+                    unpacked_start: Some(idx_start_reg),
+                    unpacked_count: Some((num_cols + 1) as u16),
+                    flags: IdxInsertFlags::new().nchange(true),
                 });
             }
-            program.resolve_label(label_idx_insert, program.offset());
+        } else {
+            // Non-unique index: in UPSERT mode we postpone writes to commit phase.
+            if !has_upsert {
+                // eager insert for non-unique, no UPSERT
+                let record_reg = program.alloc_register();
+                program.emit_insn(Insn::MakeRecord {
+                    start_reg: idx_start_reg,
+                    count: num_cols + 1,
+                    dest_reg: record_reg,
+                    index_name: Some(index.name.clone()),
+                    affinity_str: None,
+                });
+                program.emit_insn(Insn::IdxInsert {
+                    cursor_id: idx_cursor_id,
+                    record_reg,
+                    unpacked_start: Some(idx_start_reg),
+                    unpacked_count: Some((num_cols + 1) as u16),
+                    flags: IdxInsertFlags::new().nchange(true),
+                });
+            }
         }
-        // now do the actual index insertion using the unpacked registers
-        program.emit_insn(Insn::IdxInsert {
-            cursor_id: idx_cursor_id,
-            record_reg,
-            unpacked_start: Some(idx_start_reg), // TODO: enable optimization
-            unpacked_count: Some((num_cols + 1) as u16),
-            // TODO: figure out how to determine whether or not we need to seek prior to insert.
-            flags: IdxInsertFlags::new().nchange(true),
-        });
-        if let Some(skip_label) = skip_index_label {
-            program.resolve_label(skip_label, program.offset());
+
+        // Close the partial-index skip (preflight)
+        if let Some(lbl) = maybe_skip_probe_label {
+            program.resolve_label(lbl, program.offset());
         }
     }
-
     for column_mapping in insertion
         .col_mappings
         .iter()
@@ -705,6 +726,7 @@ pub fn translate_insert(
             },
         });
     }
+
     // Create and insert the record
     let affinity_str = insertion
         .col_mappings
@@ -719,6 +741,87 @@ pub fn translate_insert(
         index_name: None,
         affinity_str: Some(affinity_str),
     });
+
+    if has_upsert {
+        // COMMIT PHASE: no preflight jumps happened; emit the actual index writes now
+        // We re-check partial-index predicates against the NEW image, produce packed records,
+        // and insert into all applicable indexes, we do not re-probe uniqueness here, as preflight
+        // already guaranteed non-conflict.
+        for index in schema.get_indices(table_name.as_str()) {
+            let idx_cursor_id = idx_cursors
+                .iter()
+                .find(|(name, _, _)| *name == &index.name)
+                .map(|(_, _, c_id)| *c_id)
+                .expect("no cursor found for index");
+
+            // Re-evaluate partial predicate on the would-be inserted image
+            let commit_skip_label = if let Some(where_clause) = &index.where_clause {
+                let mut where_for_eval = where_clause.as_ref().clone();
+                rewrite_partial_index_where(&mut where_for_eval, &insertion)?;
+                let reg = program.alloc_register();
+                translate_expr_no_constant_opt(
+                    &mut program,
+                    Some(&TableReferences::new_empty()),
+                    &where_for_eval,
+                    reg,
+                    &resolver,
+                    NoConstantOptReason::RegisterReuse,
+                )?;
+                let lbl = program.allocate_label();
+                program.emit_insn(Insn::IfNot {
+                    reg,
+                    target_pc: lbl,
+                    jump_if_null: true,
+                });
+                Some(lbl)
+            } else {
+                None
+            };
+
+            let num_cols = index.columns.len();
+            let idx_start_reg = program.alloc_registers(num_cols + 1);
+
+            // Build [key cols..., rowid] from insertion registers
+            for (i, idx_col) in index.columns.iter().enumerate() {
+                let Some(cm) = insertion.get_col_mapping_by_name(&idx_col.name) else {
+                    return Err(crate::LimboError::PlanningError(
+                        "Column not found in INSERT (commit phase)".to_string(),
+                    ));
+                };
+                program.emit_insn(Insn::Copy {
+                    src_reg: cm.register,
+                    dst_reg: idx_start_reg + i,
+                    extra_amount: 0,
+                });
+            }
+            program.emit_insn(Insn::Copy {
+                src_reg: insertion.key_register(),
+                dst_reg: idx_start_reg + num_cols,
+                extra_amount: 0,
+            });
+
+            let record_reg = program.alloc_register();
+            program.emit_insn(Insn::MakeRecord {
+                start_reg: idx_start_reg,
+                count: num_cols + 1,
+                dest_reg: record_reg,
+                index_name: Some(index.name.clone()),
+                affinity_str: None,
+            });
+            program.emit_insn(Insn::IdxInsert {
+                cursor_id: idx_cursor_id,
+                record_reg,
+                unpacked_start: Some(idx_start_reg),
+                unpacked_count: Some((num_cols + 1) as u16),
+                flags: IdxInsertFlags::new().nchange(true),
+            });
+
+            if let Some(lbl) = commit_skip_label {
+                program.resolve_label(lbl, program.offset());
+            }
+        }
+    }
+
     program.emit_insn(Insn::Insert {
         cursor: cursor_id,
         key_reg: insertion.key_register(),
@@ -763,6 +866,45 @@ pub fn translate_insert(
         };
 
         emit_returning_results(&mut program, &result_columns, &value_registers)?;
+    }
+    program.emit_insn(Insn::Goto {
+        target_pc: row_done_label,
+    });
+
+    // Normal INSERT path is done above
+    // Any conflict routed to UPSERT jumps past all that to here:
+    program.preassign_label_to_next_insn(upsert_entry);
+    if let (Some(mut upsert), Some(_)) = (upsert_opt.take(), resolved_upsert.clone()) {
+        // Only DO UPDATE (SET ...); DO NOTHING should have already jumped to row_done_label earlier.
+        if let UpsertDo::Set {
+            ref mut sets,
+            ref mut where_clause,
+        } = upsert.do_clause
+        {
+            // Normalize SET pairs once
+            let mut rewritten_sets = collect_set_clauses_for_upsert(&table, sets)?;
+
+            emit_upsert(
+                &mut program,
+                schema,
+                &table,
+                &insertion,
+                cursor_id,
+                conflict_rowid_reg,
+                &mut rewritten_sets,
+                where_clause,
+                &resolver,
+                &idx_cursors,
+                &mut result_columns,
+                cdc_table.as_ref().map(|c| c.0),
+                row_done_label,
+            )?;
+        } else {
+            // UpsertDo::Nothing case
+            program.emit_insn(Insn::Goto {
+                target_pc: row_done_label,
+            });
+        }
     }
 
     if inserting_multiple_rows {
@@ -1231,11 +1373,52 @@ fn translate_virtual_table_insert(
     Ok(program)
 }
 
+#[inline]
+/// Build the UNIQUE constraint error description to match sqlite
+/// single column: `t.c1`
+/// multi-column:  `t.(k, c1)`
+pub fn format_unique_violation_desc(table_name: &str, index: &Index) -> String {
+    if index.columns.len() == 1 {
+        let mut s = String::with_capacity(table_name.len() + 1 + index.columns[0].name.len());
+        s.push_str(table_name);
+        s.push('.');
+        s.push_str(&index.columns[0].name);
+        s
+    } else {
+        let mut s = String::with_capacity(table_name.len() + 3 + 4 * index.columns.len());
+        s.push_str(table_name);
+        s.push_str(".(");
+        s.push_str(
+            &index
+                .columns
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        s.push(')');
+        s
+    }
+}
+
 /// Rewrite WHERE clause for partial index to reference insertion registers
 pub fn rewrite_partial_index_where(
     expr: &mut ast::Expr,
     insertion: &Insertion,
 ) -> crate::Result<WalkControl> {
+    let col_reg = |name: &str| -> Option<usize> {
+        if name.eq_ignore_ascii_case("rowid") {
+            Some(insertion.key_register())
+        } else if let Some(c) = insertion.get_col_mapping_by_name(name) {
+            if c.column.is_rowid_alias {
+                Some(insertion.key_register())
+            } else {
+                Some(c.register)
+            }
+        } else {
+            None
+        }
+    };
     walk_expr_mut(
         expr,
         &mut |e: &mut ast::Expr| -> crate::Result<WalkControl> {
@@ -1243,32 +1426,15 @@ pub fn rewrite_partial_index_where(
                 // NOTE: should not have ANY Expr::Columns bound to the expr
                 Expr::Id(ast::Name::Ident(name)) | Expr::Id(ast::Name::Quoted(name)) => {
                     let normalized = normalize_ident(name.as_str());
-                    if normalized.eq_ignore_ascii_case("rowid") {
-                        *e = Expr::Register(insertion.key_register());
-                    } else if let Some(col_mapping) = insertion.get_col_mapping_by_name(&normalized)
-                    {
-                        if col_mapping.column.is_rowid_alias {
-                            *e = Expr::Register(insertion.key_register());
-                        } else {
-                            *e = Expr::Register(col_mapping.register);
-                        }
+                    if let Some(reg) = col_reg(&normalized) {
+                        *e = Expr::Register(reg);
                     }
                 }
                 Expr::Qualified(_, col) | Expr::DoublyQualified(_, _, col) => {
                     let normalized = normalize_ident(col.as_str());
-                    if normalized.eq_ignore_ascii_case("rowid") {
-                        *e = Expr::Register(insertion.key_register());
-                    } else if let Some(col_mapping) = insertion.get_col_mapping_by_name(&normalized)
-                    {
-                        if col_mapping.column.is_rowid_alias {
-                            *e = Expr::Register(insertion.key_register());
-                        } else {
-                            *e = Expr::Register(col_mapping.register);
-                        }
+                    if let Some(reg) = col_reg(&normalized) {
+                        *e = Expr::Register(reg);
                     }
-                }
-                Expr::RowId { .. } => {
-                    *e = Expr::Register(insertion.key_register());
                 }
                 _ => {}
             }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -364,7 +364,6 @@ pub fn translate_insert(
     // (idx name, root_page, idx cursor id)
     let idx_cursors = schema
         .get_indices(table_name.as_str())
-        .iter()
         .map(|idx| {
             (
                 &idx.name,

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -93,6 +93,7 @@ pub fn init_distinct(program: &mut ProgramBuilder, plan: &SelectPlan) -> Distinc
             .collect(),
         unique: false,
         has_rowid: false,
+        where_clause: None,
     });
     let cursor_id = program.alloc_cursor_id(CursorType::BTreeIndex(index.clone()));
     let ctx = DistinctCtx {
@@ -166,6 +167,7 @@ pub fn init_loop(
             }],
             has_rowid: false,
             unique: false,
+            where_clause: None,
         });
         let cursor_id = program.alloc_cursor_id(CursorType::BTreeIndex(index.clone()));
         if group_by.is_none() {

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -163,20 +163,17 @@ pub fn translate_inner(
             tbl_name,
             columns,
             where_clause,
-        } => {
-            if where_clause.is_some() {
-                bail_parse_error!("Partial indexes are not supported");
-            }
-            translate_create_index(
-                (unique, if_not_exists),
-                idx_name.name.as_str(),
-                tbl_name.as_str(),
-                &columns,
-                schema,
-                syms,
-                program,
-            )?
-        }
+        } => translate_create_index(
+            (unique, if_not_exists),
+            idx_name.name.as_str(),
+            tbl_name.as_str(),
+            &columns,
+            schema,
+            syms,
+            program,
+            connection,
+            where_clause,
+        )?,
         ast::Stmt::CreateTable {
             temporary,
             if_not_exists,

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1,4 +1,8 @@
-use std::{cmp::Ordering, collections::HashMap, sync::Arc};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
 
 use crate::{
     schema::{Column, Index},
@@ -175,7 +179,7 @@ fn estimate_selectivity(column: &Column, op: ast::Operator) -> f64 {
 pub fn constraints_from_where_clause(
     where_clause: &[WhereTerm],
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, Vec<Arc<Index>>>,
+    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
 ) -> Result<Vec<TableConstraints>> {
     let mut constraints = Vec::new();
 
@@ -315,7 +319,7 @@ pub fn constraints_from_where_clause(
             }
             for index in available_indexes
                 .get(table_reference.table.get_name())
-                .unwrap_or(&Vec::new())
+                .unwrap_or(&VecDeque::new())
             {
                 if let Some(position_in_index) =
                     index.column_table_pos_to_index_pos(constraint.table_col_pos)

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -7,6 +7,7 @@ use crate::{
         plan::{JoinOrderMember, TableReferences, WhereTerm},
         planner::{table_mask_from_expr, TableMask},
     },
+    util::exprs_are_equivalent,
     Result,
 };
 use turso_ext::{ConstraintInfo, ConstraintOp};
@@ -319,26 +320,21 @@ pub fn constraints_from_where_clause(
                 if let Some(position_in_index) =
                     index.column_table_pos_to_index_pos(constraint.table_col_pos)
                 {
-                    let index_candidate = cs
-                        .candidates
-                        .iter_mut()
-                        .find_map(|candidate| {
-                            if candidate
-                                .index
-                                .as_ref()
-                                .is_some_and(|i| Arc::ptr_eq(index, i))
-                            {
-                                Some(candidate)
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap();
-                    index_candidate.refs.push(ConstraintRef {
-                        constraint_vec_pos: i,
-                        index_col_pos: position_in_index,
-                        sort_order: index.columns[position_in_index].order,
-                    });
+                    if let Some(index_candidate) = cs.candidates.iter_mut().find_map(|candidate| {
+                        if candidate.index.as_ref().is_some_and(|i| {
+                            Arc::ptr_eq(index, i) && can_use_partial_index(index, where_clause)
+                        }) {
+                            Some(candidate)
+                        } else {
+                            None
+                        }
+                    }) {
+                        index_candidate.refs.push(ConstraintRef {
+                            constraint_vec_pos: i,
+                            index_col_pos: position_in_index,
+                            sort_order: index.columns[position_in_index].order,
+                        });
+                    }
                 }
             }
         }
@@ -401,6 +397,21 @@ pub fn usable_constraints_for_join_order<'a>(
         usable_until += 1;
     }
     &refs[..usable_until]
+}
+
+fn can_use_partial_index(index: &Index, query_where_clause: &[WhereTerm]) -> bool {
+    let Some(index_where) = &index.where_clause else {
+        // Full index, always usable
+        return true;
+    };
+    // Check if query WHERE contains the exact same predicate
+    for term in query_where_clause {
+        if exprs_are_equivalent(&term.expr, index_where.as_ref()) {
+            return true;
+        }
+    }
+    // TODO: do better to determine if we should use partial index
+    false
 }
 
 pub fn convert_to_vtab_constraint(

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -361,6 +361,15 @@ pub fn constraints_from_where_clause(
                 candidate.refs.truncate(first_inequality + 1);
             }
         }
+        cs.candidates.retain(|c| {
+            if let Some(idx) = &c.index {
+                if idx.where_clause.is_some() && c.refs.is_empty() {
+                    // prevent a partial index from even being considered as a scan driver.
+                    return false;
+                }
+            }
+            true
+        });
         constraints.push(cs);
     }
 

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -501,7 +501,7 @@ fn generate_join_bitmasks(table_number_max_exclusive: usize, how_many: usize) ->
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{collections::VecDeque, sync::Arc};
 
     use turso_parser::ast::{self, Expr, Operator, SortOrder, TableInternalId};
 
@@ -677,7 +677,7 @@ mod tests {
             root_page: 1,
             has_rowid: true,
         });
-        available_indexes.insert("test_table".to_string(), vec![index]);
+        available_indexes.insert("test_table".to_string(), VecDeque::from([index]));
 
         let table_constraints =
             constraints_from_where_clause(&where_clause, &table_references, &available_indexes)
@@ -747,7 +747,7 @@ mod tests {
             root_page: 1,
             has_rowid: true,
         });
-        available_indexes.insert("table1".to_string(), vec![index1]);
+        available_indexes.insert("table1".to_string(), VecDeque::from([index1]));
 
         // SELECT * FROM table1 JOIN table2 WHERE table1.id = table2.id
         // expecting table2 to be chosen first due to the index on table1.id
@@ -865,7 +865,7 @@ mod tests {
                     root_page: 1,
                     has_rowid: true,
                 });
-                available_indexes.insert(table_name.to_string(), vec![index]);
+                available_indexes.insert(table_name.to_string(), VecDeque::from([index]));
             });
         let customer_id_idx = Arc::new(Index {
             name: "orders_customer_id_idx".to_string(),
@@ -902,10 +902,10 @@ mod tests {
 
         available_indexes
             .entry("orders".to_string())
-            .and_modify(|v| v.push(customer_id_idx));
+            .and_modify(|v| v.push_front(customer_id_idx));
         available_indexes
             .entry("order_items".to_string())
-            .and_modify(|v| v.push(order_id_idx));
+            .and_modify(|v| v.push_front(order_id_idx));
 
         // SELECT * FROM orders JOIN customers JOIN order_items
         // WHERE orders.customer_id = customers.id AND orders.id = order_items.order_id AND customers.id = 42
@@ -1324,7 +1324,7 @@ mod tests {
         });
 
         let mut available_indexes = HashMap::new();
-        available_indexes.insert("t1".to_string(), vec![index]);
+        available_indexes.insert("t1".to_string(), VecDeque::from([index]));
 
         let table = Table::BTree(table);
         joined_tables.push(JoinedTable {
@@ -1416,7 +1416,7 @@ mod tests {
             ephemeral: false,
             has_rowid: true,
         });
-        available_indexes.insert("t1".to_string(), vec![index]);
+        available_indexes.insert("t1".to_string(), VecDeque::from([index]));
 
         let table = Table::BTree(table);
         joined_tables.push(JoinedTable {
@@ -1528,7 +1528,7 @@ mod tests {
             has_rowid: true,
             unique: false,
         });
-        available_indexes.insert("t1".to_string(), vec![index]);
+        available_indexes.insert("t1".to_string(), VecDeque::from([index]));
 
         let table = Table::BTree(table);
         joined_tables.push(JoinedTable {

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -664,6 +664,7 @@ mod tests {
         let index = Arc::new(Index {
             name: "sqlite_autoindex_test_table_1".to_string(),
             table_name: "test_table".to_string(),
+            where_clause: None,
             columns: vec![IndexColumn {
                 name: "id".to_string(),
                 order: SortOrder::Asc,
@@ -733,6 +734,7 @@ mod tests {
         let index1 = Arc::new(Index {
             name: "index1".to_string(),
             table_name: "table1".to_string(),
+            where_clause: None,
             columns: vec![IndexColumn {
                 name: "id".to_string(),
                 order: SortOrder::Asc,
@@ -849,6 +851,7 @@ mod tests {
                 let index_name = format!("sqlite_autoindex_{table_name}_1");
                 let index = Arc::new(Index {
                     name: index_name,
+                    where_clause: None,
                     table_name: table_name.to_string(),
                     columns: vec![IndexColumn {
                         name: "id".to_string(),
@@ -867,6 +870,7 @@ mod tests {
         let customer_id_idx = Arc::new(Index {
             name: "orders_customer_id_idx".to_string(),
             table_name: "orders".to_string(),
+            where_clause: None,
             columns: vec![IndexColumn {
                 name: "customer_id".to_string(),
                 order: SortOrder::Asc,
@@ -882,6 +886,7 @@ mod tests {
         let order_id_idx = Arc::new(Index {
             name: "order_items_order_id_idx".to_string(),
             table_name: "order_items".to_string(),
+            where_clause: None,
             columns: vec![IndexColumn {
                 name: "order_id".to_string(),
                 order: SortOrder::Asc,
@@ -1295,6 +1300,7 @@ mod tests {
         let index = Arc::new(Index {
             name: "idx_xy".to_string(),
             table_name: "t1".to_string(),
+            where_clause: None,
             columns: vec![
                 IndexColumn {
                     name: "x".to_string(),
@@ -1381,6 +1387,7 @@ mod tests {
         let index = Arc::new(Index {
             name: "idx1".to_string(),
             table_name: "t1".to_string(),
+            where_clause: None,
             columns: vec![
                 IndexColumn {
                     name: "c1".to_string(),
@@ -1492,6 +1499,7 @@ mod tests {
         let index = Arc::new(Index {
             name: "idx1".to_string(),
             table_name: "t1".to_string(),
+            where_clause: None,
             columns: vec![
                 IndexColumn {
                     name: "c1".to_string(),

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1,4 +1,9 @@
-use std::{cell::RefCell, cmp::Ordering, collections::HashMap, sync::Arc};
+use std::{
+    cell::RefCell,
+    cmp::Ordering,
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
 
 use constraints::{
     constraints_from_where_clause, usable_constraints_for_join_order, Constraint, ConstraintRef,
@@ -178,7 +183,7 @@ fn optimize_subqueries(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
 fn optimize_table_access(
     schema: &Schema,
     table_references: &mut TableReferences,
-    available_indexes: &HashMap<String, Vec<Arc<Index>>>,
+    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
     where_clause: &mut [WhereTerm],
     order_by: &mut Vec<(Box<ast::Expr>, SortOrder)>,
     group_by: &mut Option<GroupBy>,

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -899,6 +899,7 @@ fn ephemeral_index_build(
         ephemeral: true,
         table_name: table_reference.table.get_name().to_string(),
         root_page: 0,
+        where_clause: None,
         has_rowid: table_reference
             .table
             .btree()

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -577,6 +577,12 @@ impl TableReferences {
             outer_query_refs,
         }
     }
+    pub fn new_empty() -> Self {
+        Self {
+            joined_tables: Vec::new(),
+            outer_query_refs: Vec::new(),
+        }
+    }
 
     pub fn is_empty(&self) -> bool {
         self.joined_tables.is_empty() && self.outer_query_refs.is_empty()

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -82,7 +82,7 @@ pub fn translate_select(
     };
 
     program.extend(&opts);
-    emit_program(&mut program, select_plan, schema, syms, |_| {})?;
+    emit_program(connection, &mut program, select_plan, schema, syms, |_| {})?;
     Ok(TranslateSelectResult {
         program,
         num_result_cols,

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -377,12 +377,11 @@ pub fn prepare_update_plan(
         .any(|(idx, _)| columns[*idx].is_rowid_alias);
     let indexes_to_update = if rowid_alias_used {
         // If the rowid alias is used in the SET clause, we need to update all indexes
-        indexes.to_vec()
+        indexes.cloned().collect()
     } else {
         // otherwise we need to update the indexes whose columns are set in the SET clause,
         // or if the colunns used in the partial index WHERE clause are being updated
         indexes
-            .iter()
             .filter_map(|idx| {
                 let mut needs = idx
                     .columns

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::schema::{BTreeTable, Column, Type};
-use crate::translate::expr::{bind_and_rewrite_expr, ParamState};
+use crate::translate::expr::{bind_and_rewrite_expr, walk_expr, ParamState, WalkControl};
 use crate::translate::optimizer::optimize_select_plan;
 use crate::translate::plan::{Operation, QueryDestination, Scan, Search, SelectPlan};
 use crate::translate::planner::parse_limit;
@@ -62,14 +62,13 @@ pub fn translate_update(
 ) -> crate::Result<ProgramBuilder> {
     let mut plan = prepare_update_plan(&mut program, schema, body, connection, false)?;
     optimize_plan(&mut plan, schema)?;
-    // TODO: freestyling these numbers
     let opts = ProgramBuilderOpts {
         num_cursors: 1,
         approx_num_insns: 20,
         approx_num_labels: 4,
     };
     program.extend(&opts);
-    emit_program(&mut program, plan, schema, syms, |_| {})?;
+    emit_program(connection, &mut program, plan, schema, syms, |_| {})?;
     Ok(program)
 }
 
@@ -97,7 +96,7 @@ pub fn translate_update_for_schema_change(
         approx_num_labels: 4,
     };
     program.extend(&opts);
-    emit_program(&mut program, plan, schema, syms, after)?;
+    emit_program(connection, &mut program, plan, schema, syms, after)?;
     Ok(program)
 }
 
@@ -372,6 +371,7 @@ pub fn prepare_update_plan(
     // Check what indexes will need to be updated by checking set_clauses and see
     // if a column is contained in an index.
     let indexes = schema.get_indices(table_name);
+    let updated_cols: HashSet<usize> = set_clauses.iter().map(|(i, _)| *i).collect();
     let rowid_alias_used = set_clauses
         .iter()
         .any(|(idx, _)| columns[*idx].is_rowid_alias);
@@ -382,14 +382,37 @@ pub fn prepare_update_plan(
         // otherwise we need to update the indexes whose columns are set in the SET clause
         indexes
             .iter()
-            .filter(|index| {
-                index.columns.iter().any(|index_column| {
-                    set_clauses
-                        .iter()
-                        .any(|(set_index_column, _)| index_column.pos_in_table == *set_index_column)
-                })
+            .filter_map(|idx| {
+                let mut needs = idx
+                    .columns
+                    .iter()
+                    .any(|c| updated_cols.contains(&c.pos_in_table));
+
+                if !needs {
+                    if let Some(w) = &idx.where_clause {
+                        // Bind once so names→positions are resolved exactly like execution.
+                        let mut where_copy = w.as_ref().clone();
+                        let mut param = ParamState::disallow();
+                        let mut tr =
+                            TableReferences::new(table_references.joined_tables().to_vec(), vec![]);
+                        bind_and_rewrite_expr(
+                            &mut where_copy,
+                            Some(&mut tr),
+                            None,
+                            connection,
+                            &mut param,
+                        )
+                        .expect("bind where");
+                        let cols_used = collect_cols_used_in_expr(&where_copy);
+                        needs = cols_used.iter().any(|c| updated_cols.contains(c));
+                    }
+                }
+                if needs {
+                    Some(idx.clone())
+                } else {
+                    None
+                }
             })
-            .cloned()
             .collect()
     };
 
@@ -421,4 +444,16 @@ fn build_scan_op(table: &Table, iter_dir: IterationDirection) -> Operation {
         Table::Virtual(_) => Operation::default_scan_for(table),
         _ => unreachable!(),
     }
+}
+
+fn collect_cols_used_in_expr(expr: &Expr) -> HashSet<usize> {
+    let mut acc = HashSet::new();
+    let _ = walk_expr(expr, &mut |expr| match expr {
+        Expr::Column { column, .. } => {
+            acc.insert(*column);
+            Ok(WalkControl::Continue)
+        }
+        _ => Ok(WalkControl::Continue),
+    });
+    acc
 }

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -395,13 +395,14 @@ pub fn prepare_update_plan(
                         let mut param = ParamState::disallow();
                         let mut tr =
                             TableReferences::new(table_references.joined_tables().to_vec(), vec![]);
-                        let _ = bind_and_rewrite_expr(
+                        bind_and_rewrite_expr(
                             &mut where_copy,
                             Some(&mut tr),
                             None,
                             connection,
                             &mut param,
-                        );
+                        )
+                        .ok()?;
                         let cols_used = collect_cols_used_in_expr(&where_copy);
                         // if any of the columns used in the partial index WHERE clause is being
                         // updated, we need to update this index
@@ -447,6 +448,8 @@ fn build_scan_op(table: &Table, iter_dir: IterationDirection) -> Operation {
     }
 }
 
+/// Returns a set of column indices used in the expression.
+/// *Must* be used on an Expr already processed by `bind_and_rewrite_expr`
 fn collect_cols_used_in_expr(expr: &Expr) -> HashSet<usize> {
     let mut acc = HashSet::new();
     let _ = walk_expr(expr, &mut |expr| match expr {

--- a/core/util.rs
+++ b/core/util.rs
@@ -333,8 +333,6 @@ pub fn check_literal_equivalency(lhs: &Literal, rhs: &Literal) -> bool {
 /// This function is used to determine whether two expressions are logically
 /// equivalent in the context of queries, even if their representations
 /// differ. e.g.: `SUM(x)` and `sum(x)`, `x + y` and `y + x`
-///
-/// *Note*: doesn't attempt to evaluate/compute "constexpr" results
 pub fn exprs_are_equivalent(expr1: &Expr, expr2: &Expr) -> bool {
     match (expr1, expr2) {
         (

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1,4 +1,5 @@
 #![allow(unused_variables)]
+use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::AlterTableFunc;
 use crate::numeric::{NullableInteger, Numeric};
 use crate::schema::Table;
@@ -2092,6 +2093,11 @@ pub fn halt(
         SQLITE_CONSTRAINT_NOTNULL => {
             return Err(LimboError::Constraint(format!(
                 "NOT NULL constraint failed: {description} (19)"
+            )));
+        }
+        SQLITE_CONSTRAINT_UNIQUE => {
+            return Err(LimboError::Constraint(format!(
+                "UNIQUE constraint failed: {description} (19)"
             )));
         }
         _ => {

--- a/testing/all.test
+++ b/testing/all.test
@@ -43,3 +43,4 @@ source $testdir/views.test
 source $testdir/vtab.test
 source $testdir/upsert.test
 source $testdir/window.test
+source $testdir/partial_idx.test

--- a/testing/partial_idx.test
+++ b/testing/partial_idx.test
@@ -230,3 +230,139 @@ do_execsql_test_on_specific_db {:memory:} partial-index-delete-complex-where {
     INSERT INTO complex_del VALUES (5, 12, 18, 'dup');
     SELECT COUNT(*) FROM complex_del WHERE c = 'dup';
 } {3}
+
+
+# Entering predicate via UPDATE should conflict with an existing in-predicate key
+do_execsql_test_in_memory_error_content partial-index-update-enter-conflict-1 {
+    CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
+    CREATE UNIQUE INDEX idx_expensive ON products(sku) WHERE price > 100;
+    INSERT INTO products VALUES (1, 'ABC123', 50);
+    INSERT INTO products VALUES (2, 'ABC123', 150);
+    UPDATE products SET price = 200 WHERE id = 1;
+} {UNIQUE constraint failed: products.sku (19)}
+
+# Staying in predicate but changing key to a conflicting key should fail
+do_execsql_test_in_memory_error_content partial-index-update-change-key-conflict {
+    CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
+    CREATE UNIQUE INDEX idx_expensive ON products(sku) WHERE price > 100;
+    INSERT INTO products VALUES (1, 'ABC123', 150);
+    INSERT INTO products VALUES (2, 'XYZ789', 200);
+    UPDATE products SET sku = 'XYZ789' WHERE id = 1;
+} {UNIQUE constraint failed: products.sku (19)}
+
+# Exiting predicate via UPDATE should remove index entry; then re-entering later may fail
+do_execsql_test_in_memory_error_content partial-index-update-exit-then-reenter {
+    CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
+    CREATE UNIQUE INDEX idx_expensive ON products(sku) WHERE price > 100;
+    INSERT INTO products VALUES (1, 'ABC123', 150);
+    UPDATE products SET price = 50 WHERE id = 1;
+    INSERT INTO products VALUES (2, 'ABC123', 200);
+    UPDATE products SET price = 300 WHERE id = 1;
+} {UNIQUE constraint failed: products.sku (19)}
+
+# Multi-row UPDATE causing multiple rows to enter predicate together should conflict
+do_execsql_test_in_memory_error_content partial-index-update-multirow-conflict {
+    CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
+    CREATE UNIQUE INDEX idx_expensive ON products(sku) WHERE price > 100;
+    INSERT INTO products VALUES (1, 'ABC123', 50);
+    INSERT INTO products VALUES (2, 'ABC123', 150);
+    INSERT INTO products VALUES (3, 'ABC123', 75);
+    UPDATE products SET price = 150 WHERE sku = 'ABC123';
+} {UNIQUE constraint failed: products.sku (19)}
+
+# Update of unrelated columns should not affect partial index membership
+do_execsql_test_on_specific_db {:memory:} partial-index-update-unrelated-column {
+    CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, status TEXT, note TEXT);
+    CREATE UNIQUE INDEX idx_active_email ON users(email) WHERE status = 'active';
+    INSERT INTO users VALUES (1, 'u@test.com', 'active',  'n1');
+    INSERT INTO users VALUES (2, 'u@test.com', 'inactive','n2');
+    UPDATE users SET note = 'changed' WHERE id = 2;
+    SELECT id,email,status,note FROM users ORDER BY id;
+} {1|u@test.com|active|n1
+2|u@test.com|inactive|changed}
+
+# NULL -> NOT NULL transition enters predicate and may conflict
+do_execsql_test_in_memory_error_content partial-index-update-null-enters-conflict {
+    CREATE TABLE items (id INTEGER PRIMARY KEY, code TEXT, category TEXT);
+    CREATE UNIQUE INDEX idx_categorized ON items(code) WHERE category IS NOT NULL;
+    INSERT INTO items VALUES (1,'CODE1','electronics');
+    INSERT INTO items VALUES (2,'CODE1',NULL);
+    UPDATE items SET category = 'x' WHERE id = 2;
+} {UNIQUE constraint failed: items.code (19)}
+
+# Function predicate: UPDATE causes entry into predicate -> conflict
+do_execsql_test_in_memory_error_content partial-index-update-function-enters {
+    CREATE TABLE docs (id INTEGER PRIMARY KEY, title TEXT);
+    CREATE UNIQUE INDEX idx_lower_title ON docs(title) WHERE LOWER(title) = title;
+    INSERT INTO docs VALUES (1, 'lowercase');
+    INSERT INTO docs VALUES (2, 'UPPERCASE');
+    UPDATE docs SET title = 'lowercase' WHERE id = 2;
+} {UNIQUE constraint failed: docs.title (19)}
+
+# Multi-column unique key with partial predicate: conflict on UPDATE entering predicate
+do_execsql_test_in_memory_error_content partial-index-update-multicol-enter-conflict {
+    CREATE TABLE inv (id INTEGER PRIMARY KEY, sku TEXT, region TEXT, price INT);
+    CREATE UNIQUE INDEX idx_sr ON inv(sku,region) WHERE price > 100;
+    INSERT INTO inv VALUES (1,'A','US', 50);
+    INSERT INTO inv VALUES (2,'A','US',150);
+    INSERT INTO inv VALUES (3,'A','EU',150);
+    UPDATE inv SET price = 200 WHERE id = 1;
+} {UNIQUE constraint failed: inv.sku, inv.region (19)}
+
+# Staying in predicate but changing second key part to collide should fail
+do_execsql_test_in_memory_error_content partial-index-update-multicol-change-second {
+    CREATE TABLE inv2 (id INTEGER PRIMARY KEY, sku TEXT, region TEXT, price INT);
+    CREATE UNIQUE INDEX idx_sr2 ON inv2(sku,region) WHERE price > 100;
+    INSERT INTO inv2 VALUES (1,'A','US',150);
+    INSERT INTO inv2 VALUES (2,'A','EU',150);
+    UPDATE inv2 SET region = 'US' WHERE id = 2;
+} {UNIQUE constraint failed: inv2.sku, inv2.region (19)}
+
+# UPDATE that leaves predicate and then changes key should be allowed, then re-entering may fail
+do_execsql_test_in_memory_error_content partial-index-update-exit-change-key-reenter {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT, b INT);
+    CREATE UNIQUE INDEX idx_a ON t(a) WHERE b > 0;
+    INSERT INTO t VALUES (1,'K', 10);
+    INSERT INTO t VALUES (2,'X', 10);
+    UPDATE t SET b = 0       WHERE id = 1;
+    UPDATE t SET a = 'X'     WHERE id = 1;
+    UPDATE t SET b = 5       WHERE id = 1;
+} {UNIQUE constraint failed: t.a (19)}
+
+# Rowid (INTEGER PRIMARY KEY) change while in predicate should not self-conflict
+do_execsql_test_on_specific_db {:memory:} partial-index-update-rowid-no-self-conflict {
+    CREATE TABLE rowid_test (id INTEGER PRIMARY KEY, val TEXT, flag INT);
+    CREATE UNIQUE INDEX idx_flagged ON rowid_test(val) WHERE flag = 1;
+    INSERT INTO rowid_test VALUES (1,'v',1);
+    UPDATE rowid_test SET id = 9 WHERE id = 1;
+    SELECT id,val,flag FROM rowid_test ORDER BY id;
+} {9|v|1}
+
+# Batch UPDATE that toggles predicate truth for multiple rows; ensure net uniqueness is enforced
+do_execsql_test_in_memory_error_content partial-index-update-batch-crossing {
+    CREATE TABLE p (id INTEGER PRIMARY KEY, k TEXT, x INT);
+    CREATE UNIQUE INDEX idx_k ON p(k) WHERE x > 0;
+    INSERT INTO p VALUES (1,'A', 1);
+    INSERT INTO p VALUES (2,'A', 0);
+    INSERT INTO p VALUES (3,'A', 0);
+    UPDATE p SET x = CASE id WHEN 1 THEN 0 ELSE 1 END;
+} {UNIQUE constraint failed: p.k (19)}
+
+# UPDATE with WHERE predicate true, but changing to a unique new key while staying in predicate
+do_execsql_test_on_specific_db {:memory:} partial-index-update-stay-in-predicate-change-to-unique {
+    CREATE TABLE q (id INTEGER PRIMARY KEY, k TEXT, x INT);
+    CREATE UNIQUE INDEX idx_kx ON q(k) WHERE x > 0;
+    INSERT INTO q VALUES (1,'A',1);
+    INSERT INTO q VALUES (2,'B',1);
+    UPDATE q SET k='C' WHERE id=1;   -- stays in predicate, key now unique
+    SELECT id,k,x FROM q ORDER BY id;
+} {1|C|1
+2|B|1}
+
+do_execsql_test_in_memory_error_content partial-index-update-only-predicate-col-error {
+    CREATE TABLE r2 (id INTEGER PRIMARY KEY, k TEXT, x INT);
+    CREATE UNIQUE INDEX idx_k ON r2(k) WHERE x > 0;
+    INSERT INTO r2 VALUES (1,'A',0);
+    INSERT INTO r2 VALUES (2,'A',1);
+    UPDATE r2 SET x = 1 WHERE id = 1;
+} {UNIQUE constraint failed: r2.k (19)}

--- a/testing/partial_idx.test
+++ b/testing/partial_idx.test
@@ -153,3 +153,80 @@ do_execsql_test_on_specific_db {:memory:} partial-index-delete {
     SELECT id, sku, price FROM products WHERE price > 100 ORDER BY id;
 } {5|ABC123|500
 6|XYZ789|600}
+
+do_execsql_test_on_specific_db {:memory:} partial-index-delete-function-where {
+    CREATE TABLE func_del (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE UNIQUE INDEX idx_lower ON func_del(name) WHERE LOWER(name) = name;
+    
+    INSERT INTO func_del VALUES (1, 'lowercase');
+    INSERT INTO func_del VALUES (2, 'UPPERCASE');
+    INSERT INTO func_del VALUES (3, 'MixedCase');
+    DELETE FROM func_del WHERE LOWER(name) = name;
+
+    -- Should be able to insert lowercase now
+    INSERT INTO func_del VALUES (4, 'lowercase');
+    INSERT INTO func_del VALUES (5, 'another');
+    SELECT id, name FROM func_del ORDER BY id;
+} {2|UPPERCASE
+3|MixedCase
+4|lowercase
+5|another}
+
+do_execsql_test_in_memory_error_content partial-index-delete-all {
+    CREATE TABLE del_all (id INTEGER PRIMARY KEY, val TEXT, flag INTEGER);
+    CREATE UNIQUE INDEX idx_all ON del_all(val) WHERE flag = 1;
+    INSERT INTO del_all VALUES (1, 'test', 1), (2, 'test', 0), (3, 'other', 1);
+    DELETE FROM del_all;
+    -- Should be able to insert anything now
+    INSERT INTO del_all VALUES (4, 'test', 1);
+    INSERT INTO del_all VALUES (5, 'test', 1);
+} {UNIQUE constraint failed: idx_all.val (19)}
+
+do_execsql_test_on_specific_db {:memory:} partial-index-delete-cascade-scenario {
+    CREATE TABLE parent_del (id INTEGER PRIMARY KEY, status TEXT);
+    CREATE TABLE child_del (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT, active INTEGER);
+    CREATE UNIQUE INDEX idx_active_child ON child_del(name) WHERE active = 1;
+    
+    INSERT INTO parent_del VALUES (1, 'active'), (2, 'inactive');
+    INSERT INTO child_del VALUES (1, 1, 'child1', 1);
+    INSERT INTO child_del VALUES (2, 1, 'child2', 1);
+    INSERT INTO child_del VALUES (3, 2, 'child1', 0);
+    -- Simulate cascade by deleting children of parent 1
+    DELETE FROM child_del WHERE parent_id = 1;
+    -- Should now allow these since active children are gone
+    INSERT INTO child_del VALUES (4, 2, 'child1', 1);
+    INSERT INTO child_del VALUES (5, 2, 'child2', 1);
+    SELECT COUNT(*) FROM child_del WHERE active = 1;
+} {2}
+
+do_execsql_test_on_specific_db {:memory:} partial-index-delete-null-where {
+    CREATE TABLE null_del (id INTEGER PRIMARY KEY, code TEXT, category TEXT);
+    CREATE UNIQUE INDEX idx_with_category ON null_del(code) WHERE category IS NOT NULL;
+    INSERT INTO null_del VALUES (1, 'CODE1', 'cat1');
+    INSERT INTO null_del VALUES (2, 'CODE1', NULL);
+    INSERT INTO null_del VALUES (3, 'CODE2', 'cat2');
+    INSERT INTO null_del VALUES (4, 'CODE1', NULL);
+    -- Delete the one with category
+    DELETE FROM null_del WHERE code = 'CODE1' AND category IS NOT NULL;
+    -- Should allow this now
+    INSERT INTO null_del VALUES (5, 'CODE1', 'cat3');
+    
+    SELECT id, code, category FROM null_del WHERE code = 'CODE1' ORDER BY id;
+} {2|CODE1|
+4|CODE1|
+5|CODE1|cat3}
+
+do_execsql_test_on_specific_db {:memory:} partial-index-delete-complex-where {
+    CREATE TABLE complex_del (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, c TEXT);
+    CREATE UNIQUE INDEX idx_complex ON complex_del(c) WHERE a > 10 AND b < 20;
+    INSERT INTO complex_del VALUES (1, 15, 10, 'dup');
+    INSERT INTO complex_del VALUES (2, 5, 15, 'dup');
+    INSERT INTO complex_del VALUES (3, 15, 25, 'dup');
+    INSERT INTO complex_del VALUES (4, 20, 10, 'unique');
+    -- Delete the one entry that's actually in the partial index
+    DELETE FROM complex_del WHERE a > 10 AND b < 20;
+    
+    -- Should now allow this since we deleted the conflicting entry
+    INSERT INTO complex_del VALUES (5, 12, 18, 'dup');
+    SELECT COUNT(*) FROM complex_del WHERE c = 'dup';
+} {3}

--- a/testing/partial_idx.test
+++ b/testing/partial_idx.test
@@ -21,7 +21,7 @@ do_execsql_test_in_memory_error_content partial-index-unique-violation {
     INSERT INTO users VALUES (2, 'user@test.com', 'inactive');
     INSERT INTO users VALUES (3, 'user@test.com', 'deleted');
     INSERT INTO users VALUES (4, 'user@test.com', 'active');
-} {UNIQUE constraint failed: idx_active_email.email (19)}
+} {UNIQUE constraint failed: users.email (19)}
 
 do_execsql_test_on_specific_db {:memory:} partial-index-expression-where {
     CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
@@ -45,7 +45,7 @@ do_execsql_test_in_memory_error_content partial-index-expensive-violation {
     INSERT INTO products VALUES (4, 'ABC123', 75);
     INSERT INTO products VALUES (5, 'ABC123', 250);
 	-- should fail with unique sku where price > 100
-} {UNIQUE constraint failed: idx_expensive.sku (19)}
+} {UNIQUE constraint failed: products.sku (19)}
 
 do_execsql_test_in_memory_error_content partial-index-expensive-violation-update {
     CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
@@ -78,7 +78,7 @@ do_execsql_test_in_memory_error_content partial-index-function-where {
     INSERT INTO docs VALUES (1, 'lowercase');
     INSERT INTO docs VALUES (2, 'UPPERCASE');
     INSERT INTO docs VALUES (3, 'lowercase');
-} {UNIQUE constraint failed: idx_lower_title.title (19)}
+} {UNIQUE constraint failed: docs.title (19)}
 
 do_execsql_test_on_specific_db {:memory:} partial-index-multiple { 
     CREATE TABLE tasks (id INTEGER PRIMARY KEY, name TEXT, priority INTEGER, status TEXT);
@@ -107,7 +107,7 @@ do_execsql_test_in_memory_error_content partial-index-function-where {
     INSERT INTO tasks VALUES (4, 'task2', 1, 'done');
 	INSERT INTO tasks VALUES (5, 'task1', 1, 'pending');
 	--  should fail for unique name where priority = 1
-} {UNIQUE constraint failed: idx_urgent.name (19)}
+} {UNIQUE constraint failed: tasks.name (19)}
 
 do_execsql_test_in_memory_error_content partial-index-function-where-2 {
     CREATE TABLE tasks (id INTEGER PRIMARY KEY, name TEXT, priority INTEGER, status TEXT);
@@ -119,7 +119,7 @@ do_execsql_test_in_memory_error_content partial-index-function-where-2 {
     INSERT INTO tasks VALUES (4, 'task2', 1, 'done');
 	INSERT INTO tasks VALUES (6, 'task1', 2, 'done');
 	 -- should fail for unique name where status = 'done'
-} {UNIQUE constraint failed: idx_completed.name (19)}
+} {UNIQUE constraint failed: tasks.name (19)}
 
 do_execsql_test_on_specific_db {:memory:} partial-index-update-rowid {
     CREATE TABLE rowid_test (id INTEGER PRIMARY KEY, val TEXT, flag INTEGER);
@@ -138,7 +138,7 @@ do_execsql_test_in_memory_error_content partial-index-update-complex {
     INSERT INTO complex VALUES (2, 'dup', 15, 'inactive');
     INSERT INTO complex VALUES (3, 'dup', 15, 'active');
     INSERT INTO complex VALUES (4, 'dup', 20, 'active');
-} {UNIQUE constraint failed: idx_complex.a (19)}
+} {UNIQUE constraint failed: complex.a (19)}
 
 do_execsql_test_on_specific_db {:memory:} partial-index-delete {
 	CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
@@ -180,7 +180,7 @@ do_execsql_test_in_memory_error_content partial-index-delete-all {
     -- Should be able to insert anything now
     INSERT INTO del_all VALUES (4, 'test', 1);
     INSERT INTO del_all VALUES (5, 'test', 1);
-} {UNIQUE constraint failed: idx_all.val (19)}
+} {UNIQUE constraint failed: del_all.val (19)}
 
 do_execsql_test_on_specific_db {:memory:} partial-index-delete-cascade-scenario {
     CREATE TABLE parent_del (id INTEGER PRIMARY KEY, status TEXT);

--- a/testing/partial_idx.test
+++ b/testing/partial_idx.test
@@ -1,0 +1,155 @@
+#!/usr/bin/env tclsh
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/sqlite3/tester.tcl
+
+do_execsql_test_on_specific_db {:memory:} partial-index-unique-basic {
+    CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, status TEXT);
+    CREATE UNIQUE INDEX idx_active_email ON users(email) WHERE status = 'active';
+    INSERT INTO users VALUES (1, 'user@test.com', 'active');
+    INSERT INTO users VALUES (2, 'user@test.com', 'inactive');
+    INSERT INTO users VALUES (3, 'user@test.com', 'deleted');
+    SELECT id, email, status FROM users ORDER BY id;
+} {1|user@test.com|active
+2|user@test.com|inactive
+3|user@test.com|deleted}
+
+do_execsql_test_in_memory_error_content partial-index-unique-violation {
+    CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, status TEXT);
+    CREATE UNIQUE INDEX idx_active_email ON users(email) WHERE status = 'active';
+    INSERT INTO users VALUES (1, 'user@test.com', 'active');
+    INSERT INTO users VALUES (2, 'user@test.com', 'inactive');
+    INSERT INTO users VALUES (3, 'user@test.com', 'deleted');
+    INSERT INTO users VALUES (4, 'user@test.com', 'active');
+} {UNIQUE constraint failed: idx_active_email.email (19)}
+
+do_execsql_test_on_specific_db {:memory:} partial-index-expression-where {
+    CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
+    CREATE UNIQUE INDEX idx_expensive ON products(sku) WHERE price > 100;
+    INSERT INTO products VALUES (1, 'ABC123', 50);
+    INSERT INTO products VALUES (2, 'ABC123', 150);
+    INSERT INTO products VALUES (3, 'XYZ789', 200);
+    INSERT INTO products VALUES (4, 'ABC123', 75);
+    SELECT id, sku, price FROM products ORDER BY id;
+} {1|ABC123|50
+2|ABC123|150
+3|XYZ789|200
+4|ABC123|75}
+
+do_execsql_test_in_memory_error_content partial-index-expensive-violation {
+    CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
+    CREATE UNIQUE INDEX idx_expensive ON products(sku) WHERE price > 100;
+    INSERT INTO products VALUES (1, 'ABC123', 50);
+    INSERT INTO products VALUES (2, 'ABC123', 150);
+    INSERT INTO products VALUES (3, 'XYZ789', 200);
+    INSERT INTO products VALUES (4, 'ABC123', 75);
+    INSERT INTO products VALUES (5, 'ABC123', 250);
+	-- should fail with unique sku where price > 100
+} {UNIQUE constraint failed: idx_expensive.sku (19)}
+
+do_execsql_test_in_memory_error_content partial-index-expensive-violation-update {
+    CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
+    CREATE UNIQUE INDEX idx_expensive ON products(sku) WHERE price > 100;
+    INSERT INTO products VALUES (1, 'ABC123', 50);
+    INSERT INTO products VALUES (2, 'ABC123', 150);
+    INSERT INTO products VALUES (3, 'XYZ789', 200);
+    INSERT INTO products VALUES (4, 'ABC123', 75);
+	UPDATE products SET price = 300 WHERE id = 1;
+	-- should fail with unique sku where price > 100
+} {UNIQUE constraint failed: products.sku (19)}
+
+do_execsql_test_on_specific_db {:memory:} partial-index-null-where {
+    CREATE TABLE items (id INTEGER PRIMARY KEY, code TEXT, category TEXT);
+    CREATE UNIQUE INDEX idx_categorized ON items(code) WHERE category IS NOT NULL;
+    INSERT INTO items VALUES (1, 'ITEM1', 'electronics');
+    INSERT INTO items VALUES (2, 'ITEM1', NULL);
+    INSERT INTO items VALUES (3, 'ITEM1', NULL);
+    INSERT INTO items VALUES (4, 'ITEM2', 'books');
+    SELECT id, code, category FROM items ORDER BY id;
+} {1|ITEM1|electronics
+2|ITEM1|
+3|ITEM1|
+4|ITEM2|books}
+
+
+do_execsql_test_in_memory_error_content partial-index-function-where {
+ CREATE TABLE docs (id INTEGER PRIMARY KEY, title TEXT);
+    CREATE UNIQUE INDEX idx_lower_title ON docs(title) WHERE LOWER(title) = title;
+    INSERT INTO docs VALUES (1, 'lowercase');
+    INSERT INTO docs VALUES (2, 'UPPERCASE');
+    INSERT INTO docs VALUES (3, 'lowercase');
+} {UNIQUE constraint failed: idx_lower_title.title (19)}
+
+do_execsql_test_on_specific_db {:memory:} partial-index-multiple { 
+    CREATE TABLE tasks (id INTEGER PRIMARY KEY, name TEXT, priority INTEGER, status TEXT);
+    CREATE UNIQUE INDEX idx_urgent ON tasks(name) WHERE priority = 1;
+    CREATE UNIQUE INDEX idx_completed ON tasks(name) WHERE status = 'done';
+    
+    INSERT INTO tasks VALUES (1, 'task1', 1, 'open');
+    INSERT INTO tasks VALUES (2, 'task1', 2, 'open');
+    INSERT INTO tasks VALUES (3, 'task1', 3, 'done');
+    INSERT INTO tasks VALUES (4, 'task2', 1, 'done');
+    
+    SELECT id, name, priority, status FROM tasks ORDER BY id;
+} {1|task1|1|open
+2|task1|2|open
+3|task1|3|done
+4|task2|1|done}
+
+do_execsql_test_in_memory_error_content partial-index-function-where {
+    CREATE TABLE tasks (id INTEGER PRIMARY KEY, name TEXT, priority INTEGER, status TEXT);
+    CREATE UNIQUE INDEX idx_urgent ON tasks(name) WHERE priority = 1;
+    CREATE UNIQUE INDEX idx_completed ON tasks(name) WHERE status = 'done';
+    
+    INSERT INTO tasks VALUES (1, 'task1', 1, 'open');
+    INSERT INTO tasks VALUES (2, 'task1', 2, 'open');
+    INSERT INTO tasks VALUES (3, 'task1', 3, 'done');
+    INSERT INTO tasks VALUES (4, 'task2', 1, 'done');
+	INSERT INTO tasks VALUES (5, 'task1', 1, 'pending');
+	--  should fail for unique name where priority = 1
+} {UNIQUE constraint failed: idx_urgent.name (19)}
+
+do_execsql_test_in_memory_error_content partial-index-function-where-2 {
+    CREATE TABLE tasks (id INTEGER PRIMARY KEY, name TEXT, priority INTEGER, status TEXT);
+    CREATE UNIQUE INDEX idx_urgent ON tasks(name) WHERE priority = 1;
+    CREATE UNIQUE INDEX idx_completed ON tasks(name) WHERE status = 'done';
+    INSERT INTO tasks VALUES (1, 'task1', 1, 'open');
+    INSERT INTO tasks VALUES (2, 'task1', 2, 'open');
+    INSERT INTO tasks VALUES (3, 'task1', 3, 'done');
+    INSERT INTO tasks VALUES (4, 'task2', 1, 'done');
+	INSERT INTO tasks VALUES (6, 'task1', 2, 'done');
+	 -- should fail for unique name where status = 'done'
+} {UNIQUE constraint failed: idx_completed.name (19)}
+
+do_execsql_test_on_specific_db {:memory:} partial-index-update-rowid {
+    CREATE TABLE rowid_test (id INTEGER PRIMARY KEY, val TEXT, flag INTEGER);
+    CREATE UNIQUE INDEX idx_flagged ON rowid_test(val) WHERE flag = 1;
+    INSERT INTO rowid_test VALUES (1, 'test', 1);
+    INSERT INTO rowid_test VALUES (2, 'test', 0);
+    UPDATE rowid_test SET id = 10 WHERE id = 1;
+    SELECT id, val, flag FROM rowid_test ORDER BY id;
+} {2|test|0
+10|test|1}
+
+do_execsql_test_in_memory_error_content partial-index-update-complex {
+	CREATE TABLE complex (id INTEGER PRIMARY KEY, a TEXT, b INTEGER, c TEXT);
+    CREATE UNIQUE INDEX idx_complex ON complex(a) WHERE b > 10 AND c = 'active';
+    INSERT INTO complex VALUES (1, 'dup', 5, 'active');
+    INSERT INTO complex VALUES (2, 'dup', 15, 'inactive');
+    INSERT INTO complex VALUES (3, 'dup', 15, 'active');
+    INSERT INTO complex VALUES (4, 'dup', 20, 'active');
+} {UNIQUE constraint failed: idx_complex.a (19)}
+
+do_execsql_test_on_specific_db {:memory:} partial-index-delete {
+	CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
+    CREATE UNIQUE INDEX idx_expensive ON products(sku) WHERE price > 100;
+    INSERT INTO products VALUES (1, 'ABC123', 50);
+    INSERT INTO products VALUES (2, 'ABC123', 150);
+    INSERT INTO products VALUES (3, 'XYZ789', 200);
+    INSERT INTO products VALUES (4, 'ABC123', 75);
+    DELETE FROM products WHERE price > 100;
+    INSERT INTO products VALUES (5, 'ABC123', 500);
+    INSERT INTO products VALUES (6, 'XYZ789', 600);
+    SELECT id, sku, price FROM products WHERE price > 100 ORDER BY id;
+} {5|ABC123|500
+6|XYZ789|600}

--- a/testing/partial_idx.test
+++ b/testing/partial_idx.test
@@ -366,3 +366,207 @@ do_execsql_test_in_memory_error_content partial-index-update-only-predicate-col-
     INSERT INTO r2 VALUES (2,'A',1);
     UPDATE r2 SET x = 1 WHERE id = 1;
 } {UNIQUE constraint failed: r2.k (19)}
+
+
+do_execsql_test_on_specific_db {:memory:} partial-index-multi-predicate-references {
+    CREATE TABLE r2 (id INTEGER PRIMARY KEY, k TEXT, x INT);
+    CREATE UNIQUE INDEX idx_k ON r2(k) WHERE x < 10 AND id > 10;
+    INSERT INTO r2 (k,x) VALUES ('A',1), ('A',2), ('A',3), ('A',4), ('A',5), ('A',6), ('A',7), ('A',8), ('A', 9), ('A', 10), ('A', 10);
+	-- now `id` will be greater than 10, so anything added with k='A' and x<10 should conflict
+    INSERT INTO r2 (k,x) VALUES ('A',11);
+	INSERT INTO r2 (k,x) VALUES ('A',12);
+	SELECT id FROM r2 ORDER BY id DESC LIMIT 1;
+} {13}
+
+do_execsql_test_in_memory_error_content partial-index-multi-predicate-references-rowid-alais {
+    CREATE TABLE r2 (id INTEGER PRIMARY KEY, k TEXT, x INT);
+    CREATE UNIQUE INDEX idx_k ON r2(k) WHERE x < 10 AND id > 10;
+    INSERT INTO r2 (k,x) VALUES ('A',1), ('A',2), ('A',3), ('A',4), ('A',5), ('A',6), ('A',7), ('A',8), ('A', 9), ('A', 10), ('A', 10);
+	-- now `id` will be greater than 10, so anything added with k='A' and x<10 should conflict
+    INSERT INTO r2 (k,x) VALUES ('A',11);
+	INSERT INTO r2 (k,x) VALUES ('A',12);
+	INSERT INTO r2 (k,x) VALUES ('A', 3);
+	INSERT INTO r2 (k,x) VALUES ('A', 9);
+	 -- should fail now
+} {UNIQUE constraint failed: r2.k (19)}
+
+
+do_execsql_test_in_memory_any_error upsert-partial-donothing-basic {
+  CREATE TABLE u1(id INTEGER PRIMARY KEY, email TEXT, status TEXT, note TEXT);
+  CREATE UNIQUE INDEX idx_active_email ON u1(email) WHERE status='active';
+  INSERT INTO u1(email,status,note)
+    VALUES('a@test','active','n3')
+    ON CONFLICT(email) DO NOTHING;
+}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-doupdate-basic {
+  CREATE TABLE u2(id INTEGER PRIMARY KEY, email TEXT, status TEXT, note TEXT);
+  CREATE UNIQUE INDEX idx_active_email ON u2(email) WHERE status='active';
+
+  INSERT INTO u2 VALUES (1,'a@test','active','n1');
+
+  INSERT INTO u2(email,status,note)
+    VALUES('a@test','active','nNEW')
+    ON CONFLICT DO UPDATE SET note=excluded.note;
+
+  SELECT id,email,status,note FROM u2;
+} {1|a@test|active|nNEW}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-doupdate-leave-predicate {
+  CREATE TABLE u3(id INTEGER PRIMARY KEY, email TEXT, status TEXT);
+  CREATE UNIQUE INDEX idx_active_email ON u3(email) WHERE status='active';
+
+  INSERT INTO u3 VALUES (1,'a@test','active');
+
+  INSERT INTO u3(email,status)
+    VALUES('a@test','active')
+    ON CONFLICT DO UPDATE SET status='inactive';
+
+  -- After update, the conflicting row no longer participates in idx predicate.
+  -- Insert should now succeed for active variant.
+  INSERT INTO u3 VALUES (2,'a@test','active');
+
+  SELECT id,email,status FROM u3 ORDER BY id;
+} {1|a@test|inactive 2|a@test|active}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-doupdate-where-skip {
+  CREATE TABLE u4(id INTEGER PRIMARY KEY, email TEXT, status TEXT, hits INT DEFAULT 0);
+  CREATE UNIQUE INDEX idx_active_email ON u4(email) WHERE status='active';
+
+  INSERT INTO u4 VALUES(1,'a@test','active',5);
+
+  INSERT INTO u4(email,status)
+    VALUES('a@test','active')
+    ON CONFLICT DO UPDATE SET hits=hits+1 WHERE excluded.status='inactive';
+
+  -- filter false => no UPDATE; constraint remains => INSERT must be suppressed,
+  -- SQLite semantics: when WHERE is false, the UPSERT does nothing (no row added).
+  SELECT id,email,status,hits FROM u4 ORDER BY id;
+} {1|a@test|active|5}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-omitted-target-matches {
+  CREATE TABLE u6(id INTEGER PRIMARY KEY, email TEXT, status TEXT, n INT);
+  CREATE UNIQUE INDEX idx_active_email ON u6(email) WHERE status='active';
+  INSERT INTO u6 VALUES (1,'a@test','active',0);
+
+  INSERT INTO u6(email,status,n)
+    VALUES('a@test','active',10)
+    ON CONFLICT DO UPDATE SET n = excluded.n;
+
+  SELECT id,email,status,n FROM u6;
+} {1|a@test|active|10}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-multicol-leave-predicate {
+  CREATE TABLE m2(id INTEGER PRIMARY KEY, sku TEXT, region TEXT, price INT);
+  CREATE UNIQUE INDEX idx_sr ON m2(sku,region) WHERE price > 100;
+
+  INSERT INTO m2 VALUES(1,'A','US',150);
+
+  INSERT INTO m2(sku,region,price)
+    VALUES('A','US',150)
+    ON CONFLICT DO UPDATE SET price=50;
+
+  -- Now predicate false; insert another high-price duplicate should succeed
+  INSERT INTO m2 VALUES(2,'A','US',200);
+
+  SELECT id,sku,region,price FROM m2 ORDER BY id;
+} {1|A|US|50 2|A|US|200}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-func-predicate {
+  CREATE TABLE d1(id INTEGER PRIMARY KEY, title TEXT, n INT DEFAULT 0);
+  CREATE UNIQUE INDEX idx_lower_title ON d1(title) WHERE LOWER(title)=title;
+
+  INSERT INTO d1 VALUES(1,'lower',0);
+
+  INSERT INTO d1(title)
+    VALUES('lower')
+    ON CONFLICT DO UPDATE SET n = n+1;
+
+  SELECT id,title,n FROM d1;
+} {1|lower|1}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-rowid-predicate {
+  CREATE TABLE r1(id INTEGER PRIMARY KEY, k TEXT, x INT, hits INT DEFAULT 0);
+  CREATE UNIQUE INDEX idx_k ON r1(k) WHERE x < 10 AND id > 10;
+
+  -- create ids 1..12, with ('A', >=10) rows to push rowid>10
+  INSERT INTO r1(k,x) VALUES('A',10),('A',10),('A',10),('A',10),('A',10),
+                            ('A',10),('A',10),('A',10),('A',10),('A',10),('A',11),('A',12);
+
+  -- Now conflict for ('A', 5) is against partial index (id>10 & x<10)
+  INSERT INTO r1(k,x,hits)
+    VALUES('A',5,1)
+    ON CONFLICT DO UPDATE SET hits = hits + excluded.hits;
+
+  SELECT k, SUM(hits) FROM r1 GROUP BY k;
+} {A|1}
+
+# EXCLUDED usage inside DO UPDATE stays within predicate and changes key
+do_execsql_test_on_specific_db {:memory:} upsert-partial-excluded-rewrite {
+  CREATE TABLE ex1(id INTEGER PRIMARY KEY, a TEXT, b INT, c TEXT);
+  CREATE UNIQUE INDEX idx_a ON ex1(a) WHERE b>0;
+
+  INSERT INTO ex1 VALUES(1,'X',1,'old');
+
+  INSERT INTO ex1(a,b,c)
+    VALUES('X',1,'new')
+    ON CONFLICT DO UPDATE SET c = excluded.c, b = excluded.b;
+
+  SELECT id,a,b,c FROM ex1;
+} {1|X|1|new}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-stay-change-to-unique {
+  CREATE TABLE s1(id INTEGER PRIMARY KEY, a TEXT, flag INT);
+  CREATE UNIQUE INDEX idx_a ON s1(a) WHERE flag=1;
+
+  INSERT INTO s1 VALUES(1,'K',1);
+
+  INSERT INTO s1(a,flag)
+    VALUES('K',1)
+    ON CONFLICT DO UPDATE SET a='K2';
+
+  SELECT id,a,flag FROM s1;
+} {1|K2|1}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-toggle-predicate {
+  CREATE TABLE tgl(id INTEGER PRIMARY KEY, k TEXT, x INT);
+  CREATE UNIQUE INDEX idx_k ON tgl(k) WHERE x>0;
+
+  INSERT INTO tgl VALUES(1,'A',1);
+
+  -- Conflicts on 'A', flips x to 0 (leaves predicate)
+  INSERT INTO tgl(k,x)
+    VALUES('A',1)
+    ON CONFLICT DO UPDATE SET x=0;
+
+  -- Now another 'A' with x>0 should insert
+  INSERT INTO tgl VALUES(2,'A',5);
+
+  SELECT id,k,x FROM tgl ORDER BY id;
+} {1|A|0 2|A|5}
+
+do_execsql_test_in_memory_error_content upsert-partial-target-pk-only {
+  CREATE TABLE pko(id INTEGER PRIMARY KEY, k TEXT, x INT);
+  CREATE UNIQUE INDEX idx_k ON pko(k) WHERE x>0;
+
+  INSERT INTO pko VALUES(1,'A',1);
+
+  -- Target PK only; conflict is on idx_k, so DO UPDATE must NOT fire and error is raised
+  INSERT INTO pko(id,k,x)
+    VALUES(2,'A',1)
+    ON CONFLICT(id) DO UPDATE SET x=99;
+} {UNIQUE constraint failed: pko.k (19)}
+
+do_execsql_test_on_specific_db {:memory:} upsert-partial-omitted-no-conflict {
+  CREATE TABLE insfree(id INTEGER PRIMARY KEY, k TEXT, x INT);
+  CREATE UNIQUE INDEX idx_k ON insfree(k) WHERE x>0;
+
+  INSERT INTO insfree VALUES(1,'A',1);
+
+  -- x=0 => not in predicate, so no conflict; row must be inserted
+  INSERT INTO insfree(k,x)
+    VALUES('A',0)
+    ON CONFLICT DO NOTHING;
+
+  SELECT COUNT(*) FROM insfree WHERE k='A';
+} {2}

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -676,6 +676,7 @@ mod tests {
             "ss", "tt", "uu", "vv", "ww", "xx", "yy", "zz",
         ];
         for outer in 0..OUTER_ITERS {
+            println!("");
             println!(
                 "partial_index_mutation_and_upsert_fuzz iteration {}/{}",
                 outer + 1,
@@ -696,6 +697,7 @@ mod tests {
                 cols.push(format!("c{i} INT"));
             }
             let create = format!("CREATE TABLE t ({})", cols.join(", "));
+            println!("{create};");
             limbo_exec_rows(&limbo_db, &limbo_conn, &create);
             sqlite.execute(&create, rusqlite::params![]).unwrap();
 
@@ -780,6 +782,7 @@ mod tests {
                 );
                 idx_ddls.push(ddl.clone());
                 // Create in both engines
+                println!("{ddl};");
                 limbo_exec_rows(&limbo_db, &limbo_conn, &ddl);
                 sqlite.execute(&ddl, rusqlite::params![]).unwrap();
             }
@@ -930,6 +933,7 @@ mod tests {
 
                 match (sqlite_res, limbo_res) {
                     (Ok(_), Ok(_)) => {
+                        println!("{stmt};");
                         // Compare canonical table state
                         let verify = format!(
                             "SELECT id, k{} FROM t ORDER BY id, k{}",
@@ -953,6 +957,7 @@ mod tests {
                     }
                     // Mismatch: dump context
                     (ok_sqlite, ok_turso) => {
+                        println!("{stmt};");
                         eprintln!("Schema: {create};");
                         for d in idx_ddls.iter() {
                             eprintln!("{d};");

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -676,7 +676,7 @@ mod tests {
             "ss", "tt", "uu", "vv", "ww", "xx", "yy", "zz",
         ];
         for outer in 0..OUTER_ITERS {
-            println!("");
+            println!(" ");
             println!(
                 "partial_index_mutation_and_upsert_fuzz iteration {}/{}",
                 outer + 1,

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -657,6 +657,291 @@ mod tests {
     }
 
     #[test]
+    pub fn partial_index_mutation_and_upsert_fuzz() {
+        let _ = env_logger::try_init();
+        const OUTER_ITERS: usize = 5;
+        const INNER_ITERS: usize = 200;
+
+        let (mut rng, seed) = if std::env::var("SEED").is_ok() {
+            let seed = std::env::var("SEED").unwrap().parse::<u64>().unwrap();
+            (ChaCha8Rng::seed_from_u64(seed), seed)
+        } else {
+            rng_from_time()
+        };
+        println!("partial_index_mutation_and_upsert_fuzz seed: {seed}");
+        // we want to hit unique constraints fairly often so limit the insert values
+        const K_POOL: [&str; 35] = [
+            "a", "aa", "abc", "A", "B", "zzz", "foo", "bar", "baz", "fizz", "buzz", "bb", "cc",
+            "dd", "ee", "ff", "gg", "hh", "jj", "kk", "ll", "mm", "nn", "oo", "pp", "qq", "rr",
+            "ss", "tt", "uu", "vv", "ww", "xx", "yy", "zz",
+        ];
+        for outer in 0..OUTER_ITERS {
+            println!(
+                "partial_index_mutation_and_upsert_fuzz iteration {}/{}",
+                outer + 1,
+                OUTER_ITERS
+            );
+
+            // Columns: id (rowid PK), plus a few data columns we can reference in predicates/keys.
+            let limbo_db = TempDatabase::new_empty(true);
+            let sqlite_db = TempDatabase::new_empty(true);
+            let limbo_conn = limbo_db.connect_limbo();
+            let sqlite = rusqlite::Connection::open(sqlite_db.path.clone()).unwrap();
+
+            let num_cols = rng.random_range(2..=4);
+            // We'll always include a TEXT "k" and a couple INT columns to give predicates variety.
+            // Build: id INTEGER PRIMARY KEY, k TEXT, c0 INT, c1 INT, ...
+            let mut cols: Vec<String> = vec!["id INTEGER PRIMARY KEY".into(), "k TEXT".into()];
+            for i in 0..(num_cols - 1) {
+                cols.push(format!("c{i} INT"));
+            }
+            let create = format!("CREATE TABLE t ({})", cols.join(", "));
+            limbo_exec_rows(&limbo_db, &limbo_conn, &create);
+            sqlite.execute(&create, rusqlite::params![]).unwrap();
+
+            // Helper to list usable columns for keys/predicates
+            let int_cols: Vec<String> = (0..(num_cols - 1)).map(|i| format!("c{i}")).collect();
+            let functions = ["lower", "upper", "length"];
+
+            let num_pidx = rng.random_range(0..=3);
+            let mut idx_ddls: Vec<String> = Vec::new();
+            for i in 0..num_pidx {
+                // Pick 1 or 2 key columns; always include "k" sometimes to get frequent conflicts.
+                let mut key_cols = Vec::new();
+                if rng.random_bool(0.7) {
+                    key_cols.push("k".to_string());
+                }
+                if key_cols.is_empty() || rng.random_bool(0.5) {
+                    // Add one INT col to make compound keys common
+                    if !int_cols.is_empty() {
+                        let c = int_cols[rng.random_range(0..int_cols.len())].clone();
+                        if !key_cols.contains(&c) {
+                            key_cols.push(c);
+                        }
+                    }
+                }
+                // Ensure at least one key column
+                if key_cols.is_empty() {
+                    key_cols.push("k".to_string());
+                }
+                // Build a simple deterministic partial predicate:
+                // Examples:
+                //   c0 > 10 AND c1 < 50
+                //   c0 IS NOT NULL
+                //   id > 5 AND c0 >= 0
+                //   lower(k) = k
+                let pred = {
+                    // parts we can AND/OR (we’ll only AND for stability)
+                    let mut parts: Vec<String> = Vec::new();
+
+                    // Maybe include rowid (id) bound
+                    if rng.random_bool(0.4) {
+                        let n = rng.random_range(0..20);
+                        let op = *["<", "<=", ">", ">="].choose(&mut rng).unwrap();
+                        parts.push(format!("id {op} {n}"));
+                    }
+
+                    // Maybe include int column comparison
+                    if !int_cols.is_empty() && rng.random_bool(0.8) {
+                        let c = &int_cols[rng.random_range(0..int_cols.len())];
+                        match rng.random_range(0..3) {
+                            0 => parts.push(format!("{c} IS NOT NULL")),
+                            1 => {
+                                let n = rng.random_range(-10..=20);
+                                let op = *["<", "<=", "=", ">=", ">"].choose(&mut rng).unwrap();
+                                parts.push(format!("{c} {op} {n}"));
+                            }
+                            _ => {
+                                let n = rng.random_range(0..=1);
+                                parts.push(format!(
+                                    "{c} IS {}",
+                                    if n == 0 { "NULL" } else { "NOT NULL" }
+                                ));
+                            }
+                        }
+                    }
+
+                    if rng.random_bool(0.2) {
+                        parts.push(format!("{}(k) = k", functions.choose(&mut rng).unwrap()));
+                    }
+                    // Guarantee at least one part
+                    if parts.is_empty() {
+                        parts.push("1".to_string());
+                    }
+                    parts.join(" AND ")
+                };
+
+                let ddl = format!(
+                    "CREATE UNIQUE INDEX idx_p{}_{} ON t({}) WHERE {}",
+                    outer,
+                    i,
+                    key_cols.join(","),
+                    pred
+                );
+                idx_ddls.push(ddl.clone());
+                // Create in both engines
+                limbo_exec_rows(&limbo_db, &limbo_conn, &ddl);
+                sqlite.execute(&ddl, rusqlite::params![]).unwrap();
+            }
+
+            let seed_rows = rng.random_range(10..=80);
+            for _ in 0..seed_rows {
+                let k = *K_POOL.choose(&mut rng).unwrap();
+                let mut vals: Vec<String> = vec!["NULL".into(), format!("'{k}'")]; // id NULL -> auto
+                for _ in 0..(num_cols - 1) {
+                    // bias a bit toward small ints & NULL to make predicate flipping common
+                    let v = match rng.random_range(0..6) {
+                        0 => "NULL".into(),
+                        _ => rng.random_range(-5..=15).to_string(),
+                    };
+                    vals.push(v);
+                }
+                let ins = format!("INSERT INTO t VALUES ({})", vals.join(", "));
+                // Execute on both; ignore errors due to partial unique conflicts (keep seeding going)
+                let _ = sqlite.execute(&ins, rusqlite::params![]);
+                let _ = limbo_exec_rows_fallible(&limbo_db, &limbo_conn, &ins);
+            }
+
+            for _ in 0..INNER_ITERS {
+                let action = rng.random_range(0..4); // 0: INSERT, 1: UPDATE, 2: DELETE, 3: UPSERT (catch-all)
+                let stmt = match action {
+                    // INSERT
+                    0 => {
+                        let k = *K_POOL.choose(&mut rng).unwrap();
+                        let mut cols_list = vec!["k".to_string()];
+                        let mut vals_list = vec![format!("'{k}'")];
+                        for i in 0..(num_cols - 1) {
+                            if rng.random_bool(0.8) {
+                                cols_list.push(format!("c{i}"));
+                                vals_list.push(if rng.random_bool(0.15) {
+                                    "NULL".into()
+                                } else {
+                                    rng.random_range(-5..=15).to_string()
+                                });
+                            }
+                        }
+                        format!(
+                            "INSERT INTO t({}) VALUES({})",
+                            cols_list.join(","),
+                            vals_list.join(",")
+                        )
+                    }
+
+                    // UPDATE (randomly touch either key or predicate column)
+                    1 => {
+                        // choose a column
+                        let col_pick = if rng.random_bool(0.5) {
+                            "k".to_string()
+                        } else {
+                            format!("c{}", rng.random_range(0..(num_cols - 1)))
+                        };
+                        let new_val = if col_pick == "k" {
+                            format!("'{}'", K_POOL.choose(&mut rng).unwrap())
+                        } else if rng.random_bool(0.2) {
+                            "NULL".into()
+                        } else {
+                            rng.random_range(-5..=15).to_string()
+                        };
+                        // predicate to affect some rows
+                        let wc = if rng.random_bool(0.6) {
+                            let pred_col = format!("c{}", rng.random_range(0..(num_cols - 1)));
+                            let op = *["<", "<=", "=", ">=", ">"].choose(&mut rng).unwrap();
+                            let n = rng.random_range(-5..=15);
+                            format!("WHERE {pred_col} {op} {n}")
+                        } else {
+                            // toggle rows by id parity
+                            "WHERE (id % 2) = 0".into()
+                        };
+                        format!("UPDATE t SET {col_pick} = {new_val} {wc}")
+                    }
+
+                    // DELETE
+                    2 => {
+                        let wc = if rng.random_bool(0.5) {
+                            // delete rows inside partial predicate zones
+                            match int_cols.len() {
+                                0 => "WHERE lower(k) = k".to_string(),
+                                _ => {
+                                    let c = &int_cols[rng.random_range(0..int_cols.len())];
+                                    let n = rng.random_range(-5..=15);
+                                    let op = *["<", "<=", "=", ">=", ">"].choose(&mut rng).unwrap();
+                                    format!("WHERE {c} {op} {n}")
+                                }
+                            }
+                        } else {
+                            "WHERE id % 3 = 1".to_string()
+                        };
+                        format!("DELETE FROM t {wc}")
+                    }
+
+                    // UPSERT catch-all is allowed even if only partial unique constraints exist
+                    3 => {
+                        let k = *K_POOL.choose(&mut rng).unwrap();
+                        let mut cols_list = vec!["k".to_string()];
+                        let mut vals_list = vec![format!("'{k}'")];
+                        for i in 0..(num_cols - 1) {
+                            if rng.random_bool(0.8) {
+                                cols_list.push(format!("c{i}"));
+                                vals_list.push(if rng.random_bool(0.2) {
+                                    "NULL".into()
+                                } else {
+                                    rng.random_range(-5..=15).to_string()
+                                });
+                            }
+                        }
+                        format!(
+                            "INSERT INTO t({}) VALUES({}) ON CONFLICT DO NOTHING",
+                            cols_list.join(","),
+                            vals_list.join(",")
+                        )
+                    }
+                    _ => unreachable!(),
+                };
+
+                // Execute on SQLite first; capture success/error, then run on turso and demand same outcome.
+                let sqlite_res = sqlite.execute(&stmt, rusqlite::params![]);
+                let limbo_res = limbo_exec_rows_fallible(&limbo_db, &limbo_conn, &stmt);
+
+                match (sqlite_res, limbo_res) {
+                    (Ok(_), Ok(_)) => {
+                        // Compare canonical table state
+                        let verify = format!(
+                            "SELECT id, k{} FROM t ORDER BY id, k{}",
+                            (0..(num_cols - 1))
+                                .map(|i| format!(", c{i}"))
+                                .collect::<String>(),
+                            (0..(num_cols - 1))
+                                .map(|i| format!(", c{i}"))
+                                .collect::<String>(),
+                        );
+                        let s = sqlite_exec_rows(&sqlite, &verify);
+                        let l = limbo_exec_rows(&limbo_db, &limbo_conn, &verify);
+                        assert_eq!(
+                            l, s,
+                            "stmt: {stmt}, seed: {seed}, create: {create}, idx: {idx_ddls:?}"
+                        );
+                    }
+                    (Err(_), Err(_)) => {
+                        // Both errored
+                        continue;
+                    }
+                    // Mismatch: dump context
+                    (ok_sqlite, ok_turso) => {
+                        eprintln!("Schema: {create};");
+                        for d in idx_ddls.iter() {
+                            eprintln!("{d};");
+                        }
+                        panic!(
+                            "DML outcome mismatch (sqlite: {ok_sqlite:?}, turso ok: {ok_turso:?}) \n
+                         stmt: {stmt}, seed: {seed}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     pub fn compound_select_fuzz() {
         let _ = env_logger::try_init();
         let (mut rng, seed) = rng_from_time();


### PR DESCRIPTION
This PR adds support for partial indexes, e.g. `CREATE INDEX` with a provided predicate
```sql
CREATE UNIQUE INDEX idx_expensive ON products(sku) where price > 100;
```

The PR does not yet implement support for using the partial indexes in the optimizer.

 