### PR TITLE
github: Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install cached dist
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The workflow needs `cargo` so let's make sure it's there.