### PR TITLE
Enable checksum tests if checksum feature is on

### DIFF
--- a/core/storage/checksum.rs
+++ b/core/storage/checksum.rs
@@ -107,6 +107,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "checksum")]
     fn test_add_checksum_to_page() {
         let ctx = ChecksumContext::new();
         let mut page = get_random_page();
@@ -135,6 +136,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "checksum")]
     fn test_verify_and_strip_checksum_mismatch() {
         let ctx = ChecksumContext::new();
         let mut page = get_random_page();
@@ -160,6 +162,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "checksum")]
     fn test_verify_and_strip_checksum_corrupted_checksum() {
         let ctx = ChecksumContext::new();
         let mut page = get_random_page();


### PR DESCRIPTION
These tests fail if checksum feature is turned off.