### PR TITLE
core/mvcc/logical-log: on disk format for logical log

### DIFF
--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -83,8 +83,8 @@ impl LogRecordType {
     ///
     /// Insert:
     /// * Payload length -> u64
-    /// * Data size -> varint
     /// * Rowid -> varint
+    /// * Data size -> varint
     /// * Data -> [u8] (data size length)
     fn serialize(&self, buffer: &mut Vec<u8>, row_version: &RowVersion) {
         buffer.extend_from_slice(&row_version.row.id.table_id.to_be_bytes());

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1,6 +1,9 @@
 use crate::{
-    mvcc::database::LogRecord, turso_assert, types::IOCompletions, Buffer, Completion,
-    CompletionError, Result,
+    mvcc::database::{LogRecord, RowVersion},
+    storage::sqlite3_ondisk::{write_varint, write_varint_to_vec},
+    turso_assert,
+    types::IOCompletions,
+    Buffer, Completion, CompletionError, Result,
 };
 use std::sync::Arc;
 
@@ -14,6 +17,81 @@ pub struct LogicalLog {
 const TOMBSTONE: u8 = 1;
 const NOT_TOMBSTONE: u8 = 0;
 
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum LogRowType {
+    Delete = 0,
+    Insert = 1,
+}
+
+impl LogRowType {
+    fn from_row_version(row_version: &RowVersion) -> Self {
+        if row_version.end.is_some() {
+            Self::Delete
+        } else {
+            Self::Insert
+        }
+    }
+
+    #[allow(dead_code)]
+    fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(LogRowType::Delete),
+            1 => Some(LogRowType::Insert),
+            _ => None,
+        }
+    }
+
+    fn as_u8(&self) -> u8 {
+        *self as u8
+    }
+
+    /// Serialize a row_version into on disk format.
+    /// Format of a "row" (maybe we could change the name because row is not general enough for
+    /// future type of values):
+    ///
+    /// * table_id (root page) -> u64
+    /// * row type -> u8
+    ///
+    /// (by row type)
+    /// Delete:
+    /// * Payload length -> u64
+    /// * Rowid -> varint
+    ///
+    /// Insert:
+    /// * Payload length -> u64
+    /// * Data size -> varint
+    /// * Rowid -> varint
+    /// * Data -> [u8] (data size length)
+    fn serialize(&self, buffer: &mut Vec<u8>, row_version: &RowVersion) {
+        buffer.extend_from_slice(&row_version.row.id.table_id.to_be_bytes());
+        buffer.extend_from_slice(&self.as_u8().to_be_bytes());
+        let size_before_payload = buffer.len();
+        match self {
+            LogRowType::Delete => {
+                write_varint_to_vec(row_version.row.id.row_id as u64, buffer);
+            }
+            LogRowType::Insert => {
+                write_varint_to_vec(row_version.row.id.row_id as u64, buffer);
+                write_varint_to_vec(row_version.row.column_count as u64, buffer);
+
+                let data = &row_version.row.data;
+                // Maybe this isn't needed? We already might infer data size with payload size
+                // anyways.
+                write_varint_to_vec(data.len() as u64, buffer);
+                buffer.extend_from_slice(data);
+            }
+        }
+        // FIXME: remove shifting of bytes that we do by inserting payload sizes before everything
+        // Should payload_size be varint?
+        let payload_size = (buffer.len() - size_before_payload) as u64;
+        buffer.splice(
+            size_before_payload..size_before_payload,
+            payload_size.to_be_bytes(),
+        );
+    }
+}
+
 impl LogicalLog {
     pub fn new(file: Arc<dyn File>) -> Self {
         Self { file, offset: 0 }
@@ -23,17 +101,10 @@ impl LogicalLog {
         let mut buffer = Vec::new();
         buffer.extend_from_slice(&tx.tx_timestamp.to_be_bytes());
         tx.row_versions.iter().for_each(|row_version| {
-            let data = &row_version.row.data;
-            buffer.extend_from_slice(&row_version.row.id.table_id.to_be_bytes());
-            buffer.extend_from_slice(&row_version.row.id.row_id.to_be_bytes());
-            if row_version.end.is_some() {
-                buffer.extend_from_slice(&TOMBSTONE.to_be_bytes());
-            } else {
-                buffer.extend_from_slice(&NOT_TOMBSTONE.to_be_bytes());
-                buffer.extend_from_slice(&row_version.row.column_count.to_be_bytes());
-                buffer.extend_from_slice(data);
-            }
+            let row_type = LogRowType::from_row_version(row_version);
+            row_type.serialize(&mut buffer, row_version);
         });
+
         let buffer = Arc::new(Buffer::new(buffer));
         let c = Completion::new_write({
             let buffer = buffer.clone();

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -96,7 +96,6 @@ impl LogRowType {
             }
             LogRowType::Insert => {
                 write_varint_to_vec(row_version.row.id.row_id as u64, buffer);
-                write_varint_to_vec(row_version.row.column_count as u64, buffer);
 
                 let data = &row_version.row.data;
                 // Maybe this isn't needed? We already might infer data size with payload size

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -43,24 +43,24 @@ impl LogHeader {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum LogRecordType {
-    Delete = 0,
-    Insert = 1,
+    DeleteRow = 0,
+    InsertRow = 1,
 }
 
 impl LogRecordType {
     fn from_row_version(row_version: &RowVersion) -> Self {
         if row_version.end.is_some() {
-            Self::Delete
+            Self::DeleteRow
         } else {
-            Self::Insert
+            Self::InsertRow
         }
     }
 
     #[allow(dead_code)]
     fn from_u8(value: u8) -> Option<Self> {
         match value {
-            0 => Some(LogRecordType::Delete),
-            1 => Some(LogRecordType::Insert),
+            0 => Some(LogRecordType::DeleteRow),
+            1 => Some(LogRecordType::InsertRow),
             _ => None,
         }
     }
@@ -91,10 +91,10 @@ impl LogRecordType {
         buffer.extend_from_slice(&self.as_u8().to_be_bytes());
         let size_before_payload = buffer.len();
         match self {
-            LogRecordType::Delete => {
+            LogRecordType::DeleteRow => {
                 write_varint_to_vec(row_version.row.id.row_id as u64, buffer);
             }
-            LogRecordType::Insert => {
+            LogRecordType::InsertRow => {
                 write_varint_to_vec(row_version.row.id.row_id as u64, buffer);
 
                 let data = &row_version.row.data;

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -42,12 +42,12 @@ impl LogHeader {
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum LogRowType {
+enum LogRecordType {
     Delete = 0,
     Insert = 1,
 }
 
-impl LogRowType {
+impl LogRecordType {
     fn from_row_version(row_version: &RowVersion) -> Self {
         if row_version.end.is_some() {
             Self::Delete
@@ -59,8 +59,8 @@ impl LogRowType {
     #[allow(dead_code)]
     fn from_u8(value: u8) -> Option<Self> {
         match value {
-            0 => Some(LogRowType::Delete),
-            1 => Some(LogRowType::Insert),
+            0 => Some(LogRecordType::Delete),
+            1 => Some(LogRecordType::Insert),
             _ => None,
         }
     }
@@ -91,10 +91,10 @@ impl LogRowType {
         buffer.extend_from_slice(&self.as_u8().to_be_bytes());
         let size_before_payload = buffer.len();
         match self {
-            LogRowType::Delete => {
+            LogRecordType::Delete => {
                 write_varint_to_vec(row_version.row.id.row_id as u64, buffer);
             }
-            LogRowType::Insert => {
+            LogRecordType::Insert => {
                 write_varint_to_vec(row_version.row.id.row_id as u64, buffer);
 
                 let data = &row_version.row.data;
@@ -141,7 +141,7 @@ impl LogicalLog {
 
         // 3. Serialize rows
         tx.row_versions.iter().for_each(|row_version| {
-            let row_type = LogRowType::from_row_version(row_version);
+            let row_type = LogRecordType::from_row_version(row_version);
             row_type.serialize(&mut buffer, row_version);
         });
 


### PR DESCRIPTION
This format is based on previous discussions:
1. Log header
```rust
/// Log's Header, this will be the 64 bytes in any logical log file.
/// Log header is 64 bytes at maximum, fields added must not exceed that size. If it doesn't exceed
/// it, any bytes missing will be padded with zeroes.
struct LogHeader {
    version: u8,
    salt: u64,
    encrypted: u8, // 0 is no
}
```

2. Transaction format:
* Transaction id
* Checksum u64
* Byte size of all rows combined
* Rows
* End marker (offset position after appending buffer) 

3. Row format:
```rust
    /// Serialize a row_version into on disk format.
    /// Format of a "row" (maybe we could change the name because row is not general enough for
    /// future type of values):
    ///
    /// * table_id (root page) -> u64
    /// * row type -> u8
    ///
    /// (by row type)
    /// Delete:
    /// * Payload length -> u64
    /// * Rowid -> varint
    ///
    /// Insert:
    /// * Payload length -> u64
    /// * Data size -> varint
    /// * Rowid -> varint
    /// * Data -> [u8] (data size length)
    fn serialize(&self, buffer: &mut Vec<u8>, row_version: &RowVersion) {

```