### PR TITLE
Don't allow duplicate columns and get column type as passed 

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1294,7 +1294,7 @@ impl From<&ColumnDefinition> for Column {
         let ty_str = value
             .col_type
             .as_ref()
-            .map(|t| t.to_string())
+            .map(|t| t.name.to_string())
             .unwrap_or_default();
 
         let hidden = ty_str.contains("HIDDEN");

--- a/testing/alter_table.test
+++ b/testing/alter_table.test
@@ -143,18 +143,6 @@ do_execsql_test_in_memory_any_error fail-alter-table-add-duplicate-column-case-i
     CREATE TABLE t1 (a);
     ALTER TABLE t1 ADD COLUMN A;
 }
-do_execsql_test_on_specific_db {:memory:} alter-table-add-column-type-should-be-same {
-    CREATE TABLE t1 (id integer);
-    ALTER TABLE t1 ADD COLUMN name varchar(255);
-    SELECT sql FROM sqlite_schema WHERE name = 't1';
-} { "CREATE TABLE t1 (id integer, name varchar (255))" }
-
-do_execsql_test_on_specific_db {:memory:} alter-table-add-column-type-should-be-same-2 {
-    CREATE TABLE t1 (a);
-    ALTER TABLE t1 ADD COLUMN price DECIMAL(10, 2);
-    SELECT sql FROM sqlite_schema WHERE name = 't1';
-} { "CREATE TABLE t1 (a, price DECIMAL (10, 2))" }
-
 
 do_execsql_test_in_memory_any_error fail-alter-table-drop-primary-key-column {
     CREATE TABLE t (a PRIMARY KEY, b);


### PR DESCRIPTION
fixes #3231 

```zsh

❯ sqlite3
SQLite version 3.50.4 2025-07-30 19:33:53
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite>   CREATE TABLE t1 (a);
    ALTER TABLE t1 ADD COLUMN a;
Parse error: duplicate column name: a
sqlite>   ALTER TABLE t1 ADD COLUMN name varchar(255);
    SELECT sql FROM sqlite_schema WHERE name = 't1';
CREATE TABLE t1 (a, name varchar(255))
sqlite>
```

```zsh
turso>
turso>  CREATE TABLE t1 (a);
    ALTER TABLE t1 ADD COLUMN a;
  x Parse error: duplicate column name: a

turso>  ALTER TABLE t1 ADD COLUMN name varchar(255);
    SELECT sql FROM sqlite_schema WHERE name = 't1';
┌─────────────────────────────────────────┐
│ sql                                     │
├─────────────────────────────────────────┤
│ CREATE TABLE t1 (a, name varchar (255)) │
└─────────────────────────────────────────┘
turso>
```