### PR TITLE
Differential testing fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,6 +74,8 @@ jobs:
         run: ./scripts/run-sim --maximum-tests 1000 --min-tick 10 --max-tick 50 --profile write_heavy loop -n 10 -s
       - name: Simulator Faultless
         run: ./scripts/run-sim --maximum-tests 1000 --min-tick 10 --max-tick 50 --profile faultless loop -n 10 -s
+      - name: Simulator Differential
+        run: ./scripts/run-sim --maximum-tests 1000 --differential loop -n 10 -s
 
   test-limbo:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1111,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encryption-throughput"
@@ -2171,6 +2189,8 @@ dependencies = [
  "schemars 1.0.4",
  "serde",
  "serde_json",
+ "similar",
+ "similar-asserts",
  "sql_generation",
  "strum",
  "tracing",
@@ -3538,6 +3558,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+dependencies = [
+ "console",
+ "similar",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,11 @@ tracing-appender = "0.2.3"
 env_logger = { version = "0.11.6", default-features = false }
 regex = "1.11.1"
 regex-syntax = { version = "0.8.5", default-features = false }
+similar = { version = "2.7.0" }
+similar-asserts = { version = "1.7.0" }
+
+[profile.dev.package.similar]
+opt-level = 3
 
 [profile.release]
 debug = "line-tables-only"

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -45,3 +45,5 @@ strum = { workspace = true }
 parking_lot = { workspace = true }
 indexmap = { workspace = true }
 either = "1.15.0"
+similar = { workspace = true }
+similar-asserts = { workspace = true }

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -1528,6 +1528,7 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats)> for Property {
             env.profile.experimental_mvcc,
         );
 
+        #[allow(clippy::type_complexity)]
         let choices: Vec<(_, Box<dyn Fn(&mut R) -> Property>)> = vec![
             (
                 if !env.opts.disable_insert_values_select {

--- a/simulator/runner/differential.rs
+++ b/simulator/runner/differential.rs
@@ -83,6 +83,7 @@ pub(crate) fn execute_interactions(
         last_execution.interaction_index = state.interaction_pointer;
 
         let mut turso_state = state.clone();
+        let mut rusqlite_state = state.clone();
 
         // first execute turso
         let turso_res = super::execution::execute_plan(
@@ -91,8 +92,6 @@ pub(crate) fn execute_interactions(
             turso_conn_state,
             &mut turso_state,
         );
-
-        let mut rusqlite_state = state.clone();
 
         // second execute rusqlite
         let rusqlite_res = super::execution::execute_plan(
@@ -112,7 +111,9 @@ pub(crate) fn execute_interactions(
             return ExecutionResult::new(history, Some(err));
         }
 
-        state.interaction_pointer += 1;
+        assert_eq!(turso_state, rusqlite_state);
+
+        *state = turso_state;
 
         // Check if the maximum time for the simulation has been reached
         if now.elapsed().as_secs() >= env.opts.max_time_simulation as u64 {

--- a/simulator/runner/doublecheck.rs
+++ b/simulator/runner/doublecheck.rs
@@ -142,7 +142,9 @@ pub(crate) fn execute_plans(
             return ExecutionResult::new(history, Some(err));
         }
 
-        state.interaction_pointer += 1;
+        assert_eq!(turso_state, doublecheck_state);
+
+        *state = turso_state;
 
         // Check if the maximum time for the simulation has been reached
         if now.elapsed().as_secs() >= env.opts.max_time_simulation as u64 {

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -269,7 +269,7 @@ impl SimulatorEnv {
     ) -> Self {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
-        let opts = SimulatorOpts {
+        let mut opts = SimulatorOpts {
             seed,
             ticks: rng.random_range(cli_opts.minimum_tests..=cli_opts.maximum_tests),
             max_tables: rng.random_range(0..128),
@@ -323,6 +323,8 @@ impl SimulatorEnv {
         if cli_opts.differential {
             // Disable faults when running against sqlite as we cannot control faults on it
             profile.io.enable = false;
+            // Disable limits due to differences in return order from turso and rusqlite
+            opts.disable_select_limit = true;
         }
 
         profile.validate().unwrap();

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -320,6 +320,10 @@ impl SimulatorEnv {
         if let Some(min_tick) = cli_opts.min_tick {
             profile.io.latency.min_tick = min_tick;
         }
+        if cli_opts.differential {
+            // Disable faults when running against sqlite as we cannot control faults on it
+            profile.io.enable = false;
+        }
 
         profile.validate().unwrap();
 


### PR DESCRIPTION
- Fixed some incorrect code when running interactions in differential testing. Instead of replacing the state that was used for running the interaction, I naively just incremented the interaction pointer.
- adjusted the comparison to check returned values without considering the order of the rows returned
- added differential testing to run in CI

Closes #3235 