### PR TITLE
Stop incrementing n_changes for idx delete

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5927,8 +5927,6 @@ pub fn op_idx_delete(
                 }
                 // Increment metrics for index write (delete is a write operation)
                 state.metrics.rows_written = state.metrics.rows_written.saturating_add(1);
-                let n_change = program.n_change.get();
-                program.n_change.set(n_change + 1);
                 state.pc += 1;
                 state.op_idx_delete_state = None;
                 return Ok(InsnFunctionStepResult::Step);


### PR DESCRIPTION
Previously we were emitting the following:
<img width="483" height="135" alt="image" src="https://github.com/user-attachments/assets/e12100ed-5815-4619-829a-3230eb8c8f7f" />

After:
<img width="484" height="310" alt="image" src="https://github.com/user-attachments/assets/28591f52-18b1-4060-8c92-7a3f7194fca0" />
