### PR TITLE
Use SQL over HTTP batch statements for sync push

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -190,6 +190,41 @@ jobs:
         shell: bash
       - name: Test bindings
         run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim yarn workspace @tursodatabase/database test
+  test-db-browser-binding:
+    name: Test DB bindings on browser@${{ matrix.node }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - "20"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: useblacksmith/setup-node@v5
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Build common
+        run: yarn workspace @tursodatabase/database-common build
+      - name: Build browser-common
+        run: yarn workspace @tursodatabase/database-browser-common build
+      - name: Install playwright with deps
+        run: yarn workspace @tursodatabase/database-browser playwright install --with-deps
+      - name: Download all DB artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: bindings/javascript
+          merge-multiple: true
+          pattern: 'db*'
+      - name: List packages
+        run: ls -R .
+        shell: bash
+      - name: Test bindings
+        run: yarn workspace @tursodatabase/database-browser test
   publish:
     name: Publish
     runs-on: ubuntu-latest
@@ -198,6 +233,7 @@ jobs:
       id-token: write
     needs:
       - test-db-linux-x64-gnu-binding
+      - test-db-browser-binding
     steps:
       - uses: actions/checkout@v4
       - name: Setup node

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -1180,17 +1180,13 @@ async fn sql_execute_http<C: ProtocolIO, Ctx>(
                     results.push(execute.result);
                 }
                 server_proto::StreamResponse::Batch(batch) => {
-                    for error in batch.result.step_errors {
-                        if let Some(error) = error {
-                            return Err(Error::DatabaseSyncEngineError(format!(
-                                "failed to execute sql: {error:?}"
-                            )));
-                        }
+                    if let Some(error) = batch.result.step_errors.into_iter().flatten().next() {
+                        return Err(Error::DatabaseSyncEngineError(format!(
+                            "failed to execute sql: {error:?}"
+                        )));
                     }
-                    for result in batch.result.step_results {
-                        if let Some(result) = result {
-                            results.push(result);
-                        }
+                    for result in batch.result.step_results.into_iter().flatten() {
+                        results.push(result);
                     }
                 }
             },


### PR DESCRIPTION
Use SQL over HTTP batch statement in the push logic of sync-engine with additional condition for `!auto_commit` for every step except from initial `BEGIN` of txn.

This is needed to avoid non-transactional update if SQLite will decide to close transaction due to some error and reset state to autocommit mode.