### PR TITLE
Simulator Runtime generation

### DIFF
--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -216,7 +216,6 @@ impl InteractionPlan {
 
         // First create at least one table
         let create_query = Create::arbitrary(&mut env.rng.clone(), &env.connection_context(0));
-        env.committed_tables.push(create_query.table.clone());
 
         // initial query starts at 0th connection
         plan.plan.push(Interactions::new(
@@ -242,7 +241,6 @@ impl InteractionPlan {
                 Interactions::arbitrary_from(rng, conn_ctx, (env, self.stats(), conn_index))
             };
 
-            interactions.shadow(&mut env.get_conn_tables_mut(interactions.connection_index));
             let out_interactions = interactions.interactions();
             assert!(!out_interactions.is_empty());
             self.push(interactions);

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -256,6 +256,14 @@ fn run_simulator(
     let env = env.lock().unwrap();
     let plan = plan.lock().unwrap();
 
+    tracing::info!("{}", plan.stats());
+    std::fs::write(env.get_plan_path(), plan.to_string()).unwrap();
+    std::fs::write(
+        env.get_plan_path().with_extension("json"),
+        serde_json::to_string_pretty(&*plan).unwrap(),
+    )
+    .unwrap();
+
     // No doublecheck, run shrinking if panicking or found a bug.
     match &result {
         SandboxedResult::Correct => {
@@ -530,15 +538,6 @@ fn setup_simulation(
         tracing::info!("Generating database interaction plan...");
 
         let plan = InteractionPlan::init_plan(&mut env);
-
-        // TODO: move this code to the end of the simulation
-        tracing::info!("{}", plan.stats());
-        std::fs::write(env.get_plan_path(), plan.to_string()).unwrap();
-        std::fs::write(
-            env.get_plan_path().with_extension("json"),
-            serde_json::to_string_pretty(&plan).unwrap(),
-        )
-        .unwrap();
 
         (seed, env, plan)
     }

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -142,6 +142,8 @@ pub(crate) struct SimulatorEnv {
     pub(crate) io: Arc<dyn SimIO>,
     pub(crate) db: Option<Arc<Database>>,
     pub(crate) rng: ChaCha8Rng,
+
+    seed: u64,
     pub(crate) paths: Paths,
     pub(crate) type_: SimulationType,
     pub(crate) phase: SimulationPhase,
@@ -162,6 +164,7 @@ impl SimulatorEnv {
             io: self.io.clone(),
             db: self.db.clone(),
             rng: self.rng.clone(),
+            seed: self.seed,
             paths: self.paths.clone(),
             type_: self.type_,
             phase: self.phase,
@@ -256,6 +259,12 @@ impl SimulatorEnv {
 
     pub fn choose_conn(&self, rng: &mut impl Rng) -> usize {
         rng.random_range(0..self.connections.len())
+    }
+
+    /// Rng only used for generating interactions. By having a separate Rng we can guarantee that a particular seed
+    /// will always create the same interactions plan, regardless of the changes that happen in the Database code
+    pub fn gen_rng(&self) -> ChaCha8Rng {
+        ChaCha8Rng::seed_from_u64(self.seed)
     }
 }
 
@@ -373,6 +382,7 @@ impl SimulatorEnv {
             connections,
             paths,
             rng,
+            seed,
             io,
             db: Some(db),
             type_: simulation_type,

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -124,12 +124,11 @@ pub fn execute_plan(
     if let SimConnection::Disconnected = connection {
         tracing::debug!("connecting {}", connection_index);
         env.connect(connection_index);
+        Ok(ExecutionContinuation::Stay)
     } else {
         tracing::debug!("connection {} already connected", connection_index);
-        return execute_interaction(env, interaction, &mut conn_state.stack);
+        execute_interaction(env, interaction, &mut conn_state.stack)
     }
-
-    Ok(ExecutionContinuation::Stay)
 }
 
 /// The next point of control flow after executing an interaction.

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -7,7 +7,10 @@ use turso_core::{Connection, LimboError, Result, StepResult, Value};
 use crate::{
     generation::{
         Shadow as _,
-        plan::{ConnectionState, Interaction, InteractionPlanState, InteractionType, ResultSet},
+        plan::{
+            ConnectionState, Interaction, InteractionPlanIterator, InteractionPlanState,
+            InteractionType, ResultSet,
+        },
     },
     model::Query,
 };
@@ -55,7 +58,7 @@ impl ExecutionResult {
 
 pub(crate) fn execute_interactions(
     env: Arc<Mutex<SimulatorEnv>>,
-    interactions: Vec<Interaction>,
+    mut plan: impl InteractionPlanIterator,
     state: &mut InteractionPlanState,
     conn_states: &mut [ConnectionState],
     last_execution: Arc<Mutex<Execution>>,
@@ -67,14 +70,12 @@ pub(crate) fn execute_interactions(
 
     env.clear_tables();
 
+    let mut interaction = plan
+        .next(&mut env)
+        .expect("we should always have at least 1 interaction to start");
+
     for _tick in 0..env.opts.ticks {
         tracing::trace!("Executing tick {}", _tick);
-
-        if state.interaction_pointer >= interactions.len() {
-            break;
-        }
-
-        let interaction = &interactions[state.interaction_pointer];
 
         let connection_index = interaction.connection_index;
         let conn_state = &mut conn_states[connection_index];
@@ -86,11 +87,18 @@ pub(crate) fn execute_interactions(
         last_execution.connection_index = connection_index;
         last_execution.interaction_index = state.interaction_pointer;
         // Execute the interaction for the selected connection
-        match execute_plan(&mut env, interaction, conn_state, state) {
-            Ok(_) => {}
+        match execute_plan(&mut env, &interaction, conn_state) {
+            Ok(ExecutionContinuation::NextInteraction) => {
+                state.interaction_pointer += 1;
+                let Some(new_interaction) = plan.next(&mut env) else {
+                    break;
+                };
+                interaction = new_interaction;
+            }
             Err(err) => {
                 return ExecutionResult::new(history, Some(err));
             }
+            _ => {}
         }
         // Check if the maximum time for the simulation has been reached
         if now.elapsed().as_secs() >= env.opts.max_time_simulation as u64 {
@@ -110,8 +118,7 @@ pub fn execute_plan(
     env: &mut SimulatorEnv,
     interaction: &Interaction,
     conn_state: &mut ConnectionState,
-    state: &mut InteractionPlanState,
-) -> Result<()> {
+) -> Result<ExecutionContinuation> {
     let connection_index = interaction.connection_index;
     let connection = &mut env.connections[connection_index];
     if let SimConnection::Disconnected = connection {
@@ -119,24 +126,10 @@ pub fn execute_plan(
         env.connect(connection_index);
     } else {
         tracing::debug!("connection {} already connected", connection_index);
-        match execute_interaction(env, interaction, &mut conn_state.stack) {
-            Ok(next_execution) => {
-                tracing::debug!("connection {} processed", connection_index);
-                // Move to the next interaction or property
-                match next_execution {
-                    ExecutionContinuation::NextInteraction => {
-                        state.interaction_pointer += 1;
-                    }
-                }
-            }
-            Err(err) => {
-                tracing::error!("error {}", err);
-                return Err(err);
-            }
-        }
+        return execute_interaction(env, interaction, &mut conn_state.stack);
     }
 
-    Ok(())
+    Ok(ExecutionContinuation::Stay)
 }
 
 /// The next point of control flow after executing an interaction.
@@ -145,6 +138,8 @@ pub fn execute_plan(
 /// indicates the next step in the plan.
 #[derive(PartialEq, Debug)]
 pub(crate) enum ExecutionContinuation {
+    /// Stay in the current interaction
+    Stay,
     /// Default continuation, execute the next interaction.
     NextInteraction,
     //  /// Typically used in the case of preconditions failures, skip to the next property.

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -339,9 +339,9 @@ impl InteractionPlan {
         let last_execution = Arc::new(Mutex::new(*failing_execution));
         let result = SandboxedResult::from(
             std::panic::catch_unwind(|| {
-                let interactions = test_plan.interactions_list();
+                let plan = test_plan.static_iterator();
 
-                run_simulation(env.clone(), interactions, last_execution.clone())
+                run_simulation(env.clone(), plan, last_execution.clone())
             }),
             last_execution,
         );


### PR DESCRIPTION
Closes #3253 

Had to do some slight changes in how we shadow interactions and changed some of the execution code to accommodate both runtime generation and pre-run generation (pre-run generation is needed for instance when running the shrunk plans). This behavior is abstracted by the `InteractionPlanIterator` trait  