### PR TITLE
Simulator: Concurrent transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "blake3"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2338,7 @@ name = "limbo_sim"
 version = "0.2.0-pre.10"
 dependencies = [
  "anyhow",
+ "bitmaps",
  "chrono",
  "clap",
  "dirs 6.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ regex = "1.11.1"
 regex-syntax = { version = "0.8.5", default-features = false }
 similar = { version = "2.7.0" }
 similar-asserts = { version = "1.7.0" }
+bitmaps = { version = "3.2.1", default-features = false }
 
 [profile.dev.package.similar]
 opt-level = 3

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -47,3 +47,4 @@ indexmap = { workspace = true }
 either = "1.15.0"
 similar = { workspace = true }
 similar-asserts = { workspace = true }
+bitmaps = { workspace = true }

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -590,6 +590,7 @@ impl Display for Fault {
 pub struct Interaction {
     pub connection_index: usize,
     pub interaction: InteractionType,
+    pub ignore_error: bool,
 }
 
 impl Deref for Interaction {
@@ -611,6 +612,15 @@ impl Interaction {
         Self {
             connection_index,
             interaction,
+            ignore_error: false,
+        }
+    }
+
+    pub fn new_ignore_error(connection_index: usize, interaction: InteractionType) -> Self {
+        Self {
+            connection_index,
+            interaction,
+            ignore_error: true,
         }
     }
 }

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -371,6 +371,13 @@ impl Interactions {
             interactions,
         }
     }
+
+    pub fn get_extensional_queries(&mut self) -> Option<&mut Vec<Query>> {
+        match &mut self.interactions {
+            InteractionsType::Property(property) => property.get_extensional_queries(),
+            InteractionsType::Query(..) | InteractionsType::Fault(..) => None,
+        }
+    }
 }
 
 impl Deref for Interactions {

--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -476,7 +476,7 @@ impl Display for InteractionPlan {
                     writeln!(f, "-- FAULT '{fault}'")?;
                 }
                 InteractionsType::Query(query) => {
-                    writeln!(f, "{query};")?;
+                    writeln!(f, "{query}; -- {}", interactions.connection_index)?;
                 }
             }
         }
@@ -630,7 +630,7 @@ pub enum InteractionType {
 // FIXME: add the connection index here later
 impl Display for Interaction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.interaction)
+        write!(f, "{}; -- {}", self.interaction, self.connection_index)
     }
 }
 
@@ -638,13 +638,13 @@ impl Display for InteractionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Query(query) => write!(f, "{query}"),
-            Self::Assumption(assumption) => write!(f, "-- ASSUME {};", assumption.name),
+            Self::Assumption(assumption) => write!(f, "-- ASSUME {}", assumption.name),
             Self::Assertion(assertion) => {
                 write!(f, "-- ASSERT {};", assertion.name)
             }
-            Self::Fault(fault) => write!(f, "-- FAULT '{fault}';"),
+            Self::Fault(fault) => write!(f, "-- FAULT '{fault}'"),
             Self::FsyncQuery(query) => {
-                writeln!(f, "-- FSYNC QUERY;")?;
+                writeln!(f, "-- FSYNC QUERY")?;
                 writeln!(f, "{query};")?;
                 write!(f, "{query};")
             }

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -454,7 +454,7 @@ impl Property {
                                     Err(e) => {
                                         if e.to_string().to_lowercase().contains(&format!("table {table_name} already exists")) {
                                              // On error we rollback the transaction if there is any active here
-                                            Rollback.shadow(&mut env.get_conn_tables_mut(connection_index));
+                                            env.rollback_conn(connection_index);
                                             Ok(Ok(()))
                                         } else {
                                             Ok(Err(format!("expected table already exists error, got: {e}")))
@@ -808,7 +808,7 @@ impl Property {
                                 tracing::error!("Fault injection produced error: {err}");
 
                                 // On error we rollback the transaction if there is any active here
-                                Rollback.shadow(&mut env.get_conn_tables_mut(connection_index));
+                                env.rollback_conn(connection_index);
                                 Ok(Ok(()))
                             }
                         }

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -27,7 +27,7 @@ use super::plan::{Assertion, Interaction, InteractionStats, ResultSet};
 /// Properties are representations of executable specifications
 /// about the database behavior.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum Property {
+pub enum Property {
     /// Insert-Select is a property in which the inserted row
     /// must be in the resulting rows of a select query that has a
     /// where clause that matches the inserted row.

--- a/simulator/generation/property.rs
+++ b/simulator/generation/property.rs
@@ -472,7 +472,7 @@ impl Property {
                         .into_iter()
                         .map(|q| Interaction::new(connection_index, InteractionType::Query(q))),
                 );
-                interactions.push(Interaction::new(connection_index, cq2));
+                interactions.push(Interaction::new_ignore_error(connection_index, cq2));
                 interactions.push(Interaction::new(connection_index, assertion));
 
                 interactions

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -61,6 +61,14 @@ impl Query {
             Query::Begin(..) | Query::Commit(..) | Query::Rollback(..) => vec![],
         }
     }
+
+    #[inline]
+    pub fn is_transaction(&self) -> bool {
+        matches!(
+            self,
+            Self::Begin(..) | Self::Commit(..) | Self::Rollback(..)
+        )
+    }
 }
 
 impl Display for Query {

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -69,6 +69,14 @@ impl Query {
             Self::Begin(..) | Self::Commit(..) | Self::Rollback(..)
         )
     }
+
+    #[inline]
+    pub fn is_ddl(&self) -> bool {
+        matches!(
+            self,
+            Self::Create(..) | Self::CreateIndex(..) | Self::Drop(..)
+        )
+    }
 }
 
 impl Display for Query {

--- a/simulator/profiles/mod.rs
+++ b/simulator/profiles/mod.rs
@@ -28,7 +28,7 @@ pub struct Profile {
     #[garde(skip)]
     /// Experimental MVCC feature
     pub experimental_mvcc: bool,
-    #[garde(range(min = 1))]
+    #[garde(range(min = 1, max = 64))]
     pub max_connections: usize,
     #[garde(dive)]
     pub io: IOProfile,

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -10,9 +10,11 @@ use garde::Validate;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use sql_generation::generation::GenerationContext;
+use sql_generation::model::query::transaction::Rollback;
 use sql_generation::model::table::Table;
 use turso_core::Database;
 
+use crate::generation::Shadow;
 use crate::model::Query;
 use crate::profiles::Profile;
 use crate::runner::SimIO;
@@ -493,6 +495,11 @@ impl SimulatorEnv {
             )
         });
         self.connection_last_query.set(conn_index, value);
+    }
+
+    pub fn rollback_conn(&mut self, conn_index: usize) {
+        Rollback.shadow(&mut self.get_conn_tables_mut(conn_index));
+        self.update_conn_last_interaction(conn_index, Some(&Query::Rollback(Rollback)));
     }
 
     pub fn get_conn_tables<'a>(&'a self, conn_index: usize) -> ShadowTables<'a> {

--- a/simulator/runner/execution.rs
+++ b/simulator/runner/execution.rs
@@ -344,10 +344,6 @@ fn execute_query_rusqlite(
     query: &Query,
 ) -> rusqlite::Result<Vec<Vec<SimValue>>> {
     match query {
-        Query::Create(create) => {
-            connection.execute(create.to_string().as_str(), ())?;
-            Ok(vec![])
-        }
         Query::Select(select) => {
             let mut stmt = connection.prepare(select.to_string().as_str())?;
             let columns = stmt.column_count();
@@ -372,36 +368,8 @@ fn execute_query_rusqlite(
             }
             Ok(result)
         }
-        Query::Insert(insert) => {
-            connection.execute(insert.to_string().as_str(), ())?;
-            Ok(vec![])
-        }
-        Query::Delete(delete) => {
-            connection.execute(delete.to_string().as_str(), ())?;
-            Ok(vec![])
-        }
-        Query::Drop(drop) => {
-            connection.execute(drop.to_string().as_str(), ())?;
-            Ok(vec![])
-        }
-        Query::Update(update) => {
-            connection.execute(update.to_string().as_str(), ())?;
-            Ok(vec![])
-        }
-        Query::CreateIndex(create_index) => {
-            connection.execute(create_index.to_string().as_str(), ())?;
-            Ok(vec![])
-        }
-        Query::Begin(begin) => {
-            connection.execute(begin.to_string().as_str(), ())?;
-            Ok(vec![])
-        }
-        Query::Commit(commit) => {
-            connection.execute(commit.to_string().as_str(), ())?;
-            Ok(vec![])
-        }
-        Query::Rollback(rollback) => {
-            connection.execute(rollback.to_string().as_str(), ())?;
+        _ => {
+            connection.execute(query.to_string().as_str(), ())?;
             Ok(vec![])
         }
     }

--- a/simulator/shrink/plan.rs
+++ b/simulator/shrink/plan.rs
@@ -1,3 +1,5 @@
+use indexmap::IndexSet;
+
 use crate::{
     SandboxedResult, SimulatorEnv,
     generation::{
@@ -12,6 +14,17 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
+
+fn retain_relevant_queries(
+    extensional_queries: &mut Vec<Query>,
+    depending_tables: &IndexSet<String>,
+) {
+    extensional_queries.retain(|query| {
+        query.is_transaction()
+            || (!matches!(query, Query::Select(..))
+                && query.uses().iter().any(|t| depending_tables.contains(t)))
+    });
+}
 
 impl InteractionPlan {
     /// Create a smaller interaction plan by deleting a property
@@ -64,134 +77,7 @@ impl InteractionPlan {
 
         // means we errored in some fault on transaction statement so just maintain the statements from before the failing one
         if !depending_tables.is_empty() {
-            let mut idx = 0;
-            // Remove all properties that do not use the failing tables
-            plan.plan.retain_mut(|interactions| {
-                let retain = if idx == secondary_interactions_index {
-                    if let InteractionsType::Property(
-                        Property::FsyncNoWait { tables, .. } | Property::FaultyQuery { tables, .. },
-                    ) = &mut interactions.interactions
-                    {
-                        tables.retain(|table| depending_tables.contains(table));
-                    }
-                    true
-                } else if matches!(
-                    interactions.interactions,
-                    InteractionsType::Query(Query::Begin(..))
-                        | InteractionsType::Query(Query::Commit(..))
-                        | InteractionsType::Query(Query::Rollback(..))
-                ) {
-                    true
-                } else {
-                    let mut has_table = interactions
-                        .uses()
-                        .iter()
-                        .any(|t| depending_tables.contains(t));
-
-                    if has_table {
-                        // Remove the extensional parts of the properties
-                        if let InteractionsType::Property(p) = &mut interactions.interactions {
-                            match p {
-                                Property::InsertValuesSelect { queries, .. }
-                                | Property::DoubleCreateFailure { queries, .. }
-                                | Property::DeleteSelect { queries, .. }
-                                | Property::DropSelect { queries, .. } => {
-                                    queries.clear();
-                                }
-                                Property::FsyncNoWait { tables, query }
-                                | Property::FaultyQuery { tables, query } => {
-                                    if !query.uses().iter().any(|t| depending_tables.contains(t)) {
-                                        tables.clear();
-                                    } else {
-                                        tables.retain(|table| depending_tables.contains(table));
-                                    }
-                                }
-                                Property::SelectLimit { .. }
-                                | Property::SelectSelectOptimizer { .. }
-                                | Property::WhereTrueFalseNull { .. }
-                                | Property::UNIONAllPreservesCardinality { .. }
-                                | Property::ReadYourUpdatesBack { .. }
-                                | Property::TableHasExpectedContent { .. } => {}
-                            }
-                        }
-                        // Check again after query clear if the interactions still uses the failing table
-                        has_table = interactions
-                            .uses()
-                            .iter()
-                            .any(|t| depending_tables.contains(t));
-                    }
-                    let is_fault = matches!(interactions.interactions, InteractionsType::Fault(..));
-                    is_fault
-                        || (has_table
-                            && !matches!(
-                                interactions.interactions,
-                                InteractionsType::Query(Query::Select(_))
-                                    | InteractionsType::Property(Property::SelectLimit { .. })
-                                    | InteractionsType::Property(
-                                        Property::SelectSelectOptimizer { .. }
-                                    )
-                            ))
-                };
-                idx += 1;
-                retain
-            });
-
-            // Comprises of idxs of Begin interactions
-            let mut begin_idx: HashMap<usize, Vec<usize>> = HashMap::new();
-            // Comprises of idxs of Commit and Rollback intereactions
-            let mut end_tx_idx: HashMap<usize, Vec<usize>> = HashMap::new();
-
-            for (idx, interactions) in plan.plan.iter().enumerate() {
-                match &interactions.interactions {
-                    InteractionsType::Query(Query::Begin(..)) => {
-                        begin_idx
-                            .entry(interactions.connection_index)
-                            .or_insert_with(|| vec![idx]);
-                    }
-                    InteractionsType::Query(Query::Commit(..))
-                    | InteractionsType::Query(Query::Rollback(..)) => {
-                        let last_begin = begin_idx
-                            .get(&interactions.connection_index)
-                            .and_then(|list| list.last())
-                            .unwrap()
-                            + 1;
-                        if last_begin == idx {
-                            end_tx_idx
-                                .entry(interactions.connection_index)
-                                .or_insert_with(|| vec![idx]);
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            // remove interactions if its just a Begin Commit/Rollback with no queries in the middle
-            let mut range_transactions = end_tx_idx
-                .into_iter()
-                .map(|(conn_index, list)| (conn_index, list.into_iter().peekable()))
-                .collect::<HashMap<_, _>>();
-            let mut idx = 0;
-            plan.plan.retain_mut(|interactions| {
-                let mut retain = true;
-
-                let iter = range_transactions.get_mut(&interactions.connection_index);
-
-                if let Some(iter) = iter {
-                    if let Some(txn_interaction_idx) = iter.peek().copied() {
-                        if txn_interaction_idx == idx {
-                            iter.next();
-                        }
-                        if txn_interaction_idx == idx
-                            || txn_interaction_idx.saturating_sub(1) == idx
-                        {
-                            retain = false;
-                        }
-                    }
-                }
-
-                idx += 1;
-                retain
-            });
+            plan.remove_properties(&depending_tables, secondary_interactions_index);
         }
 
         let after = plan.len();
@@ -204,6 +90,166 @@ impl InteractionPlan {
 
         plan
     }
+
+    /// Remove all properties that do not use the failing tables
+    fn remove_properties(
+        &mut self,
+        depending_tables: &IndexSet<String>,
+        failing_interaction_index: usize,
+    ) {
+        let mut idx = 0;
+        // Remove all properties that do not use the failing tables
+        self.plan.retain_mut(|interactions| {
+            let retain = if idx == failing_interaction_index {
+                if let InteractionsType::Property(
+                    Property::FsyncNoWait { tables, .. } | Property::FaultyQuery { tables, .. },
+                ) = &mut interactions.interactions
+                {
+                    tables.retain(|table| depending_tables.contains(table));
+                }
+                true
+            } else {
+                let mut has_table = interactions
+                    .uses()
+                    .iter()
+                    .any(|t| depending_tables.contains(t));
+
+                if has_table {
+                    // will contain extensional queries that reference the depending tables
+                    let mut extensional_queries = Vec::new();
+
+                    // Remove the extensional parts of the properties
+                    if let InteractionsType::Property(p) = &mut interactions.interactions {
+                        match p {
+                            Property::InsertValuesSelect { queries, .. }
+                            | Property::DoubleCreateFailure { queries, .. }
+                            | Property::DeleteSelect { queries, .. }
+                            | Property::DropSelect { queries, .. }
+                            | Property::Queries { queries } => {
+                                extensional_queries.append(queries);
+                            }
+                            Property::FsyncNoWait { tables, query }
+                            | Property::FaultyQuery { tables, query } => {
+                                if !query.uses().iter().any(|t| depending_tables.contains(t)) {
+                                    tables.clear();
+                                } else {
+                                    tables.retain(|table| depending_tables.contains(table));
+                                }
+                            }
+                            Property::SelectLimit { .. }
+                            | Property::SelectSelectOptimizer { .. }
+                            | Property::WhereTrueFalseNull { .. }
+                            | Property::UNIONAllPreservesCardinality { .. }
+                            | Property::ReadYourUpdatesBack { .. }
+                            | Property::TableHasExpectedContent { .. } => {}
+                        }
+                    }
+                    // Check again after query clear if the interactions still uses the failing table
+                    has_table = interactions
+                        .uses()
+                        .iter()
+                        .any(|t| depending_tables.contains(t));
+
+                    // means the queries in the original property are present in the depending tables regardless of the extensional queries
+                    if has_table {
+                        if let Some(queries) = interactions.get_extensional_queries() {
+                            retain_relevant_queries(&mut extensional_queries, depending_tables);
+                            queries.append(&mut extensional_queries);
+                        }
+                    } else {
+                        // original property without extensional queries does not reference the tables so convert the property to
+                        // `Property::Queries` if `extensional_queries` is not empty
+                        retain_relevant_queries(&mut extensional_queries, depending_tables);
+                        if !extensional_queries.is_empty() {
+                            has_table = true;
+                            *interactions = Interactions::new(
+                                interactions.connection_index,
+                                InteractionsType::Property(Property::Queries {
+                                    queries: extensional_queries,
+                                }),
+                            );
+                        }
+                    }
+                }
+                let is_fault = matches!(interactions.interactions, InteractionsType::Fault(..));
+                let is_transaction = matches!(
+                    interactions.interactions,
+                    InteractionsType::Query(Query::Begin(..))
+                        | InteractionsType::Query(Query::Commit(..))
+                        | InteractionsType::Query(Query::Rollback(..))
+                );
+                is_fault
+                    || is_transaction
+                    || (has_table
+                        && !matches!(
+                            interactions.interactions,
+                            InteractionsType::Query(Query::Select(_))
+                                | InteractionsType::Property(Property::SelectLimit { .. })
+                                | InteractionsType::Property(
+                                    Property::SelectSelectOptimizer { .. }
+                                )
+                        ))
+            };
+            idx += 1;
+            retain
+        });
+
+        // Comprises of idxs of Begin interactions
+        let mut begin_idx: HashMap<usize, Vec<usize>> = HashMap::new();
+        // Comprises of idxs of Commit and Rollback intereactions
+        let mut end_tx_idx: HashMap<usize, Vec<usize>> = HashMap::new();
+
+        for (idx, interactions) in self.plan.iter().enumerate() {
+            match &interactions.interactions {
+                InteractionsType::Query(Query::Begin(..)) => {
+                    begin_idx
+                        .entry(interactions.connection_index)
+                        .or_insert_with(|| vec![idx]);
+                }
+                InteractionsType::Query(Query::Commit(..))
+                | InteractionsType::Query(Query::Rollback(..)) => {
+                    let last_begin = begin_idx
+                        .get(&interactions.connection_index)
+                        .and_then(|list| list.last())
+                        .unwrap()
+                        + 1;
+                    if last_begin == idx {
+                        end_tx_idx
+                            .entry(interactions.connection_index)
+                            .or_insert_with(|| vec![idx]);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // remove interactions if its just a Begin Commit/Rollback with no queries in the middle
+        let mut range_transactions = end_tx_idx
+            .into_iter()
+            .map(|(conn_index, list)| (conn_index, list.into_iter().peekable()))
+            .collect::<HashMap<_, _>>();
+        let mut idx = 0;
+        self.plan.retain_mut(|interactions| {
+            let mut retain = true;
+
+            let iter = range_transactions.get_mut(&interactions.connection_index);
+
+            if let Some(iter) = iter {
+                if let Some(txn_interaction_idx) = iter.peek().copied() {
+                    if txn_interaction_idx == idx {
+                        iter.next();
+                    }
+                    if txn_interaction_idx == idx || txn_interaction_idx.saturating_sub(1) == idx {
+                        retain = false;
+                    }
+                }
+            }
+
+            idx += 1;
+            retain
+        });
+    }
+
     /// Create a smaller interaction plan by deleting a property
     pub(crate) fn brute_shrink_interaction_plan(
         &self,
@@ -265,7 +311,8 @@ impl InteractionPlan {
                     Property::InsertValuesSelect { queries, .. }
                     | Property::DoubleCreateFailure { queries, .. }
                     | Property::DeleteSelect { queries, .. }
-                    | Property::DropSelect { queries, .. } => {
+                    | Property::DropSelect { queries, .. }
+                    | Property::Queries { queries } => {
                         let mut temp_plan = InteractionPlan::new_with(
                             queries
                                 .iter()


### PR DESCRIPTION
Depends on #3272.

First big step towards: #1851 

- Add ignore error flag to `Interaction` to ignore parse errors when needed, and still properly report other errors from intermediate queries.
- adjusted shrinking to accommodate transaction statements from different connections and properly remove extensional queries from some properties
- MVCC: generates `Begin Concurrent` and `Commit` statements that are interleaved to test snapshot isolation between connection transactions. 
- MVCC: if the next interactions are going to contain a DDL statement, we first commit all transaction and execute the DDL statements serially
