### PR TITLE
translate: implement Sequence opcode and fix sort order

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -539,7 +539,8 @@ Modifiers:
 | SeekLt         | Yes    |         |
 | SeekRowid      | Yes    |         |
 | SeekEnd        | Yes    |         |
-| Sequence       | No     |         |
+| Sequence       | Yes    |         |
+| SequenceTest   | Yes    |         |
 | SetCookie      | Yes    |         |
 | ShiftLeft      | Yes    |         |
 | ShiftRight     | Yes    |         |

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -299,6 +299,8 @@ pub fn emit_query<'a>(
             &plan.result_columns,
             &plan.order_by,
             &plan.table_references,
+            plan.group_by.is_some(),
+            &plan.aggregates,
         )?;
     }
 

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -858,15 +858,7 @@ fn emit_loop_source(
             Ok(())
         }
         LoopEmitTarget::OrderBySorter => {
-            order_by_sorter_insert(
-                program,
-                &t_ctx.resolver,
-                t_ctx
-                    .meta_sort
-                    .as_ref()
-                    .expect("sort metadata must exist for ORDER BY"),
-                plan,
-            )?;
+            order_by_sorter_insert(program, t_ctx, plan)?;
 
             if let Distinctness::Distinct { ctx } = &plan.distinctness {
                 let distinct_ctx = ctx.as_ref().expect("distinct context must exist");

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -3,7 +3,7 @@ use turso_parser::ast::{self, SortOrder};
 use crate::{
     emit_explain,
     schema::PseudoCursorType,
-    translate::collate::CollationSeq,
+    translate::{collate::CollationSeq, group_by::is_orderby_agg_or_const, plan::Aggregate},
     util::exprs_are_equivalent,
     vdbe::{
         builder::{CursorType, ProgramBuilder},
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use super::{
-    emitter::{Resolver, TranslateCtx},
+    emitter::TranslateCtx,
     expr::translate_expr,
     plan::{Distinctness, ResultSetColumn, SelectPlan, TableReferences},
     result_row::{emit_offset, emit_result_row_and_limit},
@@ -30,6 +30,11 @@ pub struct SortMetadata {
     // This vector holds the indexes of the result columns in the ORDER BY sorter.
     // This vector must be the same length as the result columns.
     pub remappings: Vec<OrderByRemapping>,
+    /// Whether we append an extra ascending "Sequence" key to the ORDER BY sort keys.
+    /// This is used *only* when a GROUP BY is present *and* ORDER BY is not purely
+    /// aggregates/constants, so that rows that tie on ORDER BY terms are output in
+    /// the same relative order the underlying row stream produced them.
+    pub has_sequence: bool,
 }
 
 /// Initialize resources needed for ORDER BY processing
@@ -39,12 +44,21 @@ pub fn init_order_by(
     result_columns: &[ResultSetColumn],
     order_by: &[(Box<ast::Expr>, SortOrder)],
     referenced_tables: &TableReferences,
+    has_group_by: bool,
+    aggregates: &[Aggregate],
 ) -> Result<()> {
     let sort_cursor = program.alloc_cursor_id(CursorType::Sorter);
+    let only_aggs = order_by
+        .iter()
+        .all(|(e, _)| is_orderby_agg_or_const(e, aggregates));
+
+    // only emit sequence column if we have GROUP BY and ORDER BY is not only aggregates or constants
+    let has_sequence = has_group_by && !only_aggs;
     t_ctx.meta_sort = Some(SortMetadata {
         sort_cursor,
         reg_sorter_data: program.alloc_register(),
-        remappings: order_by_deduplicate_result_columns(order_by, result_columns),
+        remappings: order_by_deduplicate_result_columns(order_by, result_columns, has_sequence),
+        has_sequence,
     });
 
     /*
@@ -54,7 +68,7 @@ pub fn init_order_by(
      * then the collating sequence of the column is used to determine sort order.
      * If the expression is not a column and has no COLLATE clause, then the BINARY collating sequence is used.
      */
-    let collations = order_by
+    let mut collations = order_by
         .iter()
         .map(|(expr, _)| match expr.as_ref() {
             ast::Expr::Collate(_, collation_name) => {
@@ -72,10 +86,24 @@ pub fn init_order_by(
             _ => Ok(Some(CollationSeq::default())),
         })
         .collect::<Result<Vec<_>>>()?;
+
+    if has_sequence {
+        // sequence column uses BINARY collation
+        collations.push(Some(CollationSeq::default()));
+    }
+    let key_len = order_by.len() + if has_sequence { 1 } else { 0 };
+
     program.emit_insn(Insn::SorterOpen {
         cursor_id: sort_cursor,
-        columns: order_by.len(),
-        order: order_by.iter().map(|(_, direction)| *direction).collect(),
+        columns: key_len,
+        order: {
+            let mut ord: Vec<SortOrder> = order_by.iter().map(|(_, d)| *d).collect();
+            if has_sequence {
+                // sequence is ascending tiebreaker
+                ord.push(SortOrder::Asc);
+            }
+            ord
+        },
         collations,
     });
     Ok(())
@@ -98,9 +126,12 @@ pub fn emit_order_by(
         sort_cursor,
         reg_sorter_data,
         ref remappings,
+        has_sequence,
     } = *t_ctx.meta_sort.as_ref().unwrap();
-    let sorter_column_count =
-        order_by.len() + remappings.iter().filter(|r| !r.deduplicated).count();
+
+    let sorter_column_count = order_by.len()
+        + if has_sequence { 1 } else { 0 }
+        + remappings.iter().filter(|r| !r.deduplicated).count();
 
     // TODO: we need to know how many indices used for sorting
     // to emit correct explain output.
@@ -142,10 +173,11 @@ pub fn emit_order_by(
     let start_reg = t_ctx.reg_result_cols_start.unwrap();
     for i in 0..result_columns.len() {
         let reg = start_reg + i;
-        let column_idx = remappings
+        let remapping = remappings
             .get(i)
-            .expect("remapping must exist for all result columns")
-            .orderby_sorter_idx;
+            .expect("remapping must exist for all result columns");
+
+        let column_idx = remapping.orderby_sorter_idx;
         program.emit_column_or_rowid(cursor_id, column_idx, reg);
     }
 
@@ -170,10 +202,11 @@ pub fn emit_order_by(
 /// Emits the bytecode for inserting a row into an ORDER BY sorter.
 pub fn order_by_sorter_insert(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
-    sort_metadata: &SortMetadata,
+    t_ctx: &TranslateCtx,
     plan: &SelectPlan,
 ) -> Result<()> {
+    let resolver = &t_ctx.resolver;
+    let sort_metadata = t_ctx.meta_sort.as_ref().expect("sort metadata must exist");
     let order_by = &plan.order_by;
     let order_by_len = order_by.len();
     let result_columns = &plan.result_columns;
@@ -185,19 +218,49 @@ pub fn order_by_sorter_insert(
 
     // The ORDER BY sorter has the sort keys first, then the result columns.
     let orderby_sorter_column_count =
-        order_by_len + result_columns.len() - result_columns_to_skip_len;
+        order_by_len + if sort_metadata.has_sequence { 1 } else { 0 } + result_columns.len()
+            - result_columns_to_skip_len;
+
     let start_reg = program.alloc_registers(orderby_sorter_column_count);
     for (i, (expr, _)) in order_by.iter().enumerate() {
         let key_reg = start_reg + i;
-        translate_expr(
-            program,
-            Some(&plan.table_references),
-            expr,
-            key_reg,
-            resolver,
-        )?;
+
+        // Check if this ORDER BY expression matches a finalized aggregate
+        if let Some(agg_idx) = plan
+            .aggregates
+            .iter()
+            .position(|agg| exprs_are_equivalent(&agg.original_expr, expr))
+        {
+            // This ORDER BY expression is an aggregate, so copy from register
+            let agg_start_reg = t_ctx
+                .reg_agg_start
+                .expect("aggregate registers must be initialized");
+            let src_reg = agg_start_reg + agg_idx;
+            program.emit_insn(Insn::Copy {
+                src_reg,
+                dst_reg: key_reg,
+                extra_amount: 0,
+            });
+        } else {
+            // Not an aggregate, translate normally
+            translate_expr(
+                program,
+                Some(&plan.table_references),
+                expr,
+                key_reg,
+                resolver,
+            )?;
+        }
     }
     let mut cur_reg = start_reg + order_by_len;
+    if sort_metadata.has_sequence {
+        program.emit_insn(Insn::Sequence {
+            cursor_id: sort_metadata.sort_cursor,
+            target_reg: cur_reg,
+        });
+        cur_reg += 1;
+    }
+
     for (i, rc) in result_columns.iter().enumerate() {
         // If the result column is an exact duplicate of a sort key, we skip it.
         if sort_metadata
@@ -251,12 +314,12 @@ pub fn order_by_sorter_insert(
             let reordered_start_reg = program.alloc_registers(result_columns.len());
 
             for (select_idx, _rc) in result_columns.iter().enumerate() {
-                let src_reg = sort_metadata
+                let remapping = sort_metadata
                     .remappings
                     .get(select_idx)
-                    .map(|r| start_reg + r.orderby_sorter_idx)
                     .expect("remapping must exist for all result columns");
 
+                let src_reg = start_reg + remapping.orderby_sorter_idx;
                 let dst_reg = reordered_start_reg + select_idx;
 
                 program.emit_insn(Insn::Copy {
@@ -336,11 +399,13 @@ pub struct OrderByRemapping {
 pub fn order_by_deduplicate_result_columns(
     order_by: &[(Box<ast::Expr>, SortOrder)],
     result_columns: &[ResultSetColumn],
+    has_sequence: bool,
 ) -> Vec<OrderByRemapping> {
     let mut result_column_remapping: Vec<OrderByRemapping> = Vec::new();
     let order_by_len = order_by.len();
+    let sequence_offset = if has_sequence { 1 } else { 0 };
 
-    let mut i = 0;
+    let mut non_dedup_count = 0;
     for rc in result_columns.iter() {
         let found = order_by
             .iter()
@@ -352,14 +417,11 @@ pub fn order_by_deduplicate_result_columns(
                 deduplicated: true,
             });
         } else {
-            // This result column is not a duplicate of any ORDER BY key, so its sorter
-            // index comes after all ORDER BY entries (hence the +order_by_len). The
-            // counter `i` tracks how many such non-duplicate result columns we've seen.
             result_column_remapping.push(OrderByRemapping {
-                orderby_sorter_idx: i + order_by_len,
+                orderby_sorter_idx: order_by_len + sequence_offset + non_dedup_count,
                 deduplicated: false,
             });
-            i += 1;
+            non_dedup_count += 1;
         }
     }
 

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -4,6 +4,7 @@ use super::plan::{
     Search, TableReferences, WhereTerm, Window,
 };
 use crate::schema::Table;
+use crate::translate::emitter::Resolver;
 use crate::translate::expr::{bind_and_rewrite_expr, ParamState};
 use crate::translate::group_by::compute_group_by_sort_order;
 use crate::translate::optimizer::optimize_plan;
@@ -20,7 +21,7 @@ use crate::{schema::Schema, vdbe::builder::ProgramBuilder, Result};
 use crate::{Connection, SymbolTable};
 use std::sync::Arc;
 use turso_parser::ast::ResultColumn;
-use turso_parser::ast::{self, CompoundSelect, Expr, SortOrder};
+use turso_parser::ast::{self, CompoundSelect, Expr};
 
 pub struct TranslateSelectResult {
     pub program: ProgramBuilder,
@@ -495,6 +496,7 @@ fn prepare_one_select_plan(
                     &group_by.exprs,
                     &plan.order_by,
                     &plan.aggregates,
+                    &Resolver::new(schema, syms),
                 ));
             }
 

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -1013,15 +1013,7 @@ fn emit_return_buffered_rows(
             )?;
         }
         false => {
-            order_by_sorter_insert(
-                program,
-                &t_ctx.resolver,
-                t_ctx
-                    .meta_sort
-                    .as_ref()
-                    .expect("sort metadata must exist for ORDER BY"),
-                plan,
-            )?;
+            order_by_sorter_insert(program, t_ctx, plan)?;
         }
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5345,6 +5345,49 @@ pub fn op_function(
     Ok(InsnFunctionStepResult::Step)
 }
 
+pub fn op_sequence(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    pager: &Arc<Pager>,
+    mv_store: Option<&Arc<MvStore>>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(
+        Sequence {
+            cursor_id,
+            target_reg
+        },
+        insn
+    );
+    let cursor = state.get_cursor(*cursor_id).as_sorter_mut();
+    let seq_num = cursor.next_sequence();
+    state.registers[*target_reg] = Register::Value(Value::Integer(seq_num));
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
+pub fn op_sequence_test(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    pager: &Arc<Pager>,
+    mv_store: Option<&Arc<MvStore>>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(
+        SequenceTest {
+            cursor_id,
+            target_pc,
+            value_reg
+        },
+        insn
+    );
+    let cursor = state.get_cursor(*cursor_id).as_sorter_mut();
+    if cursor.seq_beginning() {
+        state.pc = target_pc.as_offset_int();
+    }
+    Ok(InsnFunctionStepResult::Step)
+}
+
 pub fn op_init_coroutine(
     program: &Program,
     state: &mut ProgramState,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1759,6 +1759,24 @@ pub fn insn_to_row(
                 0,
                 String::new(),
             ),
+        Insn::Sequence{ cursor_id, target_reg} => (
+                "Sequence",
+                *cursor_id as i32,
+                *target_reg as i32,
+                0,
+                Value::build_text(""),
+                0,
+                String::new(),
+          ),
+        Insn::SequenceTest{ cursor_id, target_pc, value_reg } => (
+            "SequenceTest",
+              *cursor_id as i32,
+            target_pc.as_debug_int(),
+            *value_reg as i32,
+            Value::build_text(""),
+            0,
+            String::new(),
+        ),
         }
 }
 

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1126,6 +1126,20 @@ pub enum Insn {
         target_pc: BranchOffset,
     },
 
+    /// Find the next available sequence number for cursor P1. Write the sequence number into register P2.
+    /// The sequence number on the cursor is incremented after this instruction.
+    Sequence {
+        cursor_id: CursorID,
+        target_reg: usize,
+    },
+
+    /// P1 is a sorter cursor. If the sequence counter is currently zero, jump to P2. Regardless of whether or not the jump is taken, increment the the sequence value.
+    SequenceTest {
+        cursor_id: CursorID,
+        target_pc: BranchOffset,
+        value_reg: usize,
+    },
+
     // OP_Explain
     Explain {
         p1: usize,         // P1: address of instruction
@@ -1295,6 +1309,8 @@ impl InsnVariants {
             InsnVariants::IfNeg => execute::op_if_neg,
             InsnVariants::Explain => execute::op_noop,
             InsnVariants::OpenDup => execute::op_open_dup,
+            InsnVariants::Sequence => execute::op_sequence,
+            InsnVariants::SequenceTest => execute::op_sequence_test,
         }
     }
 }

--- a/testing/groupby.test
+++ b/testing/groupby.test
@@ -326,3 +326,23 @@ sneakers|sneakers|sneakers
 boots|boots|boots
 coat|coat|coat
 accessories|accessories|accessories}
+
+# make sure we return the group by key sorted DESC when the order by has only an aggregate term
+do_execsql_test proper-sort-order {
+	SELECT u.first_name, COUNT(*) AS c
+	FROM users u
+	JOIN products p ON p.id = u.id
+	GROUP BY u.first_name
+	ORDER BY c DESC;
+} {Travis|1
+Tommy|1
+Rachel|1
+Nicholas|1
+Matthew|1
+Jennifer|1
+Jamie|1
+Edward|1
+Daniel|1
+Cindy|1
+Aimee|1}
+


### PR DESCRIPTION
This PR implements the `Sequence` and `SequenceTest` opcodes, although does not yet add plumbing to emit the latter.

SQLite has two distinct mechanisms that determine the final row order with aggregates:

Traversal order of GROUP BY, and ORDER BY tiebreaking. When ORDER BY contains only aggregate expressions and/or constants, SQLite has no extra tiebreak key, but when ORDER BY mixes aggregate and non-aggregate terms, SQLite adds an implicit, stable row `sequence` so “ties” respect the input order.

```sql
SELECT u.first_name, COUNT(*) AS c
FROM users u
JOIN orders o ON o.user_id = u.id
GROUP BY u.first_name
ORDER BY c DESC;
```

Because ORDER BY has only an aggregate (COUNT(*) DESC) and no non-aggregate terms, it does not use a sequence tiebreaker and instead relies on the GROUP BY traversal order. SQLite traverses the group key (u.first_name) in DESC order in this case, so ties on c naturally appear with group keys in descending order.

Previously tursodb would return the group key sorted in ASC order.
