### PR TITLE
Fix: NULL values in group_concat()

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3744,13 +3744,18 @@ pub fn op_agg_step(
             if acc.to_string().is_empty() {
                 *acc = col;
             } else {
-                match delimiter {
-                    Register::Value(value) => {
-                        *acc += value;
+                match col {
+                    Value::Null => {}
+                    _ => {
+                        match delimiter {
+                            Register::Value(value) => {
+                                *acc += value;
+                            }
+                            _ => unreachable!(),
+                        }
+                        *acc += col;
                     }
-                    _ => unreachable!(),
                 }
-                *acc += col;
             }
         }
         #[cfg(feature = "json")]

--- a/testing/agg-functions.test
+++ b/testing/agg-functions.test
@@ -67,6 +67,11 @@ do_execsql_test_on_specific_db {:memory:} max-null-regression-test {
   SELECT max(a) FROM t;
 } {abc}
 
+do_execsql_test_on_specific_db {:memory:} group-concat-null-values-test {
+  CREATE TABLE t (a);
+  INSERT INTO t VALUES ('a'), (''), ('b'), (NULL), ('c');
+  SELECT group_concat(a) FROM t;
+} {a,,b,c}
 
 do_execsql_test select-max-text {
   SELECT max(first_name) FROM users;


### PR DESCRIPTION
Closes #3304. 
group_concat() now ignores null values.