### PR TITLE
use a different seed for `gen_rng`

### DIFF
--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -264,7 +264,9 @@ impl SimulatorEnv {
     /// Rng only used for generating interactions. By having a separate Rng we can guarantee that a particular seed
     /// will always create the same interactions plan, regardless of the changes that happen in the Database code
     pub fn gen_rng(&self) -> ChaCha8Rng {
-        ChaCha8Rng::seed_from_u64(self.seed)
+        // Seed + 1 so that there is no relation with the original seed, and so we have no way to accidently generate
+        // the first Create statement twice in a row
+        ChaCha8Rng::seed_from_u64(self.seed + 1)
     }
 }
 


### PR DESCRIPTION
Because `InteractionPlan::init_plan` and `gen_rng` used an rng with the same seed initially, it could happen that we could create the first create query in `init_plan`, and then generate a `DoubleCreateFailure` property that would generate the exact same previous query, due to the seed being the same. The easy and quick fix is just to use different seeds. 

Closes #3330
Closes #3329 
Closes #3327 
Closes #3326
Closes #3325 
Closes #3324