### PR TITLE
MVCC: support alter table

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1357,11 +1357,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             }
         }
 
-        if connection.schema.borrow().schema_version
+        if connection.schema.read().schema_version
             > connection.db.schema.lock().unwrap().schema_version
         {
             // Connection made schema changes during tx and rolled back -> revert connection-local schema.
-            connection.schema.replace(connection.db.clone_schema()?);
+            *connection.schema.write() = connection.db.clone_schema()?;
         }
 
         let tx = tx_unlocked.value();

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1340,7 +1340,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     }
 
     /// Returns true if the given transaction is the exclusive transaction.
-    fn is_exclusive_tx(&self, tx_id: &TxID) -> bool {
+    pub fn is_exclusive_tx(&self, tx_id: &TxID) -> bool {
         self.exclusive_tx.read().as_ref() == Some(tx_id)
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2282,14 +2282,6 @@ pub fn op_transaction_inner(
                     // Programs can run Transaction twice, first with read flag and then with write flag. So a single txid is enough
                     // for both.
                     if program.connection.mv_tx.get().is_none() {
-                        // We allocate the first page lazily in the first transaction.
-                        // TODO: when we fix MVCC enable schema cookie detection for reprepare statements
-                        // let header_schema_cookie = pager
-                        //     .io
-                        //     .block(|| pager.with_header(|header| header.schema_cookie.get()))?;
-                        // if header_schema_cookie != *schema_cookie {
-                        //     return Err(LimboError::SchemaUpdated);
-                        // }
                         let tx_id = match tx_mode {
                             TransactionMode::None
                             | TransactionMode::Read

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2451,6 +2451,11 @@ pub fn op_auto_commit(
                     "cannot commit - no transaction is active".to_string(),
                 ));
             }
+        } else {
+            let is_begin = !*auto_commit && !*rollback;
+            return Err(LimboError::TxError(
+                "cannot use BEGIN after BEGIN CONCURRENT".to_string(),
+            ));
         }
     }
 

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -305,20 +305,6 @@ fn test_mvcc_update_basic() {
 }
 
 #[test]
-fn test_mvcc_begin_concurrent_smoke() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_begin_concurrent_smoke.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
-    let conn1 = tmp_db.connect_limbo();
-    conn1.execute("BEGIN CONCURRENT").unwrap();
-    conn1
-        .execute("CREATE TABLE test (id INTEGER, value TEXT)")
-        .unwrap();
-    conn1.execute("COMMIT").unwrap();
-}
-
-#[test]
 fn test_mvcc_concurrent_insert_basic() {
     let tmp_db = TempDatabase::new_with_opts(
         "test_mvcc_update_basic.db",


### PR DESCRIPTION
Changes ALTER TABLE operations to use only MV store and not go through pager, because pager is only used during checkpoint. 

- Exclusive transaction is required for DDL operations: trying to execute one inside a `BEGIN CONCURRENT` transaction will return an error. It's simply too complicated for now to try to make them concurrently transactional.
- Not doing schema changes via pager means that in MV rollback, the connection must rollback its private schema separately, since pager rollback is not invoked.
- To simplify MVCC semantics, if any transaction committed a schema change after a transaction started, it cannot commit and will abort with `SchemaUpdated` error
- To mimic regular SQLite transaction behavior, if a transaction tries to promote to exclusive transaction, it will fail with `Busy` error if there were any committed transactions after the read transaction started.