### PR TITLE
translate: disable support for UPDATE ... ORDER BY

### DIFF
--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -122,6 +122,11 @@ pub fn prepare_update_plan(
     {
         bail_parse_error!("INDEXED BY clause is not supported in UPDATE");
     }
+
+    if !body.order_by.is_empty() {
+        bail_parse_error!("ORDER BY is not supported in UPDATE");
+    }
+
     let table_name = &body.tbl_name.name;
 
     // Check if this is a system table that should be protected from direct writes


### PR DESCRIPTION
we haven't really tested this at all, and it clearly doesn't work, as per #3315.

best to disable it for the time being, especially since vanilla SQLite doesn't support this syntax unless you compile it with a flag.