### PR TITLE
parser: fix incorrect LIMIT/OFFSET parsing of form LIMIT x,y

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -7585,8 +7585,8 @@ mod tests {
                     },
                     order_by: vec![],
                     limit: Some(Limit {
-                        expr: Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
-                        offset: Some(Box::new(Expr::Literal(Literal::Numeric("2".to_owned())))),
+                        expr: Box::new(Expr::Literal(Literal::Numeric("2".to_owned()))),
+                        offset: Some(Box::new(Expr::Literal(Literal::Numeric("1".to_owned())))),
                     }),
                 }))],
             ),

--- a/testing/offset.test
+++ b/testing/offset.test
@@ -45,3 +45,16 @@ do_execsql_test select-offset-subquery {
 5|Edward|15
 4|Jennifer|33
 3|Tommy|18}
+
+do_execsql_test_on_specific_db {:memory:} select-limit-comma-offset-equivalence {
+    CREATE TABLE nums (x INTEGER);
+    INSERT INTO nums VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+    SELECT x FROM nums ORDER BY x LIMIT 3 OFFSET 2;
+    SELECT x FROM nums ORDER BY x LIMIT 2,3;
+} {3
+4
+5
+3
+4
+5}
+


### PR DESCRIPTION
In this case x is the OFFSET and y is the LIMIT, not the other way around.

Closes #3303