### PR TITLE
Fix CREATE INDEX with quoted identifiers

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -911,7 +911,7 @@ impl<'a> Parser<'a> {
     fn parse_fullname(&mut self, allow_alias: bool) -> Result<QualifiedName> {
         let first_name = self.parse_nm()?;
 
-        let secone_name = if let Some(tok) = self.peek()? {
+        let second_name = if let Some(tok) = self.peek()? {
             if tok.token_type == Some(TK_DOT) {
                 eat_assert!(self, TK_DOT);
                 Some(self.parse_nm()?)
@@ -937,10 +937,10 @@ impl<'a> Parser<'a> {
             None
         };
 
-        if let Some(secone_name) = secone_name {
+        if let Some(second_name) = second_name {
             Ok(QualifiedName {
                 db_name: Some(first_name),
-                name: secone_name,
+                name: second_name,
                 alias: alias_name,
             })
         } else {

--- a/testing/all.test
+++ b/testing/all.test
@@ -35,6 +35,7 @@ source $testdir/boolean.test
 source $testdir/literal.test
 source $testdir/null.test
 source $testdir/create_table.test
+source $testdir/create_index.test
 source $testdir/collate.test
 source $testdir/values.test
 source $testdir/integrity_check.test

--- a/testing/create_index.test
+++ b/testing/create_index.test
@@ -1,0 +1,15 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test_on_specific_db {:memory:} create-index-quoted-identifiers {
+    CREATE TABLE "t t" ("a a");
+    CREATE INDEX "idx idx" ON "t t" ("a a");
+    CREATE UNIQUE INDEX "unique idx idx" ON "t t" ("a a");
+
+    SELECT sql FROM sqlite_schema WHERE type='index';
+} {
+    "CREATE INDEX \"idx idx\" ON \"t t\" (\"a a\")"
+    "CREATE UNIQUE INDEX \"unique idx idx\" ON \"t t\" (\"a a\")"
+}


### PR DESCRIPTION
Discovered this one while working on #3322

It was a bit more elusive because the original error was essentially a red herring:
```
turso> CREATE INDEX idx ON "t t" (`a a`);
  × unexpected token at SourceSpan { offset: SourceOffset(22), length: 1 }
   ╭────
 1 │ CREATE INDEX idx ON "t t" (`a a`);
   ·                       ┬
   ·                       ╰── here
   ╰────
  help: expected [TK_LP] but found TK_ID
```

