### PR TITLE
Improve DBSP view serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,6 +3697,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4746,6 +4752,7 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.2",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -72,7 +72,7 @@ strum_macros = { workspace = true }
 bitflags = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 paste = "1.0.15"
-uuid = { version = "1.11.0", features = ["v4", "v7"], optional = true }
+uuid = { version = "1.11.0", features = ["v4", "v5", "v7"], optional = true }
 tempfile = { workspace = true }
 pack1 = { version = "1.0.0", features = ["bytemuck"] }
 bytemuck = "1.23.1"

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -368,6 +368,10 @@ impl DbspNode {
     }
 }
 
+/// Version number for the DBSP circuit format
+/// This should be incremented when the circuit structure changes
+pub const DBSP_CIRCUIT_VERSION: u32 = 1;
+
 /// Represents a complete DBSP circuit (DAG of operators)
 #[derive(Debug)]
 pub struct DbspCircuit {
@@ -403,7 +407,7 @@ impl DbspCircuit {
         let empty_schema = Arc::new(LogicalSchema::new(vec![]));
         Self {
             nodes: HashMap::new(),
-            next_id: 0,
+            next_id: 1, // Start from 1 to reserve 0 for metadata
             root: None,
             output_schema: empty_schema,
             commit_state: CommitState::Init,

--- a/core/incremental/join_operator.rs
+++ b/core/incremental/join_operator.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::incremental::dbsp::Hash128;
 use crate::incremental::dbsp::{Delta, DeltaPair, HashableRow};
 use crate::incremental::operator::{
     generate_storage_id, ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator,
@@ -22,23 +23,39 @@ pub enum JoinType {
 fn read_next_join_row(
     storage_id: i64,
     join_key: &HashableRow,
-    last_element_id: i64,
+    last_element_hash: Option<Hash128>,
     cursors: &mut DbspStateCursors,
-) -> Result<IOResult<Option<(i64, HashableRow, isize)>>> {
+) -> Result<IOResult<Option<(Hash128, HashableRow, isize)>>> {
     // Build the index key: (storage_id, zset_id, element_id)
     // zset_id is the hash of the join key
-    let zset_id = join_key.cached_hash() as i64;
+    let zset_hash = join_key.cached_hash();
 
-    let index_key_values = vec![
-        Value::Integer(storage_id),
-        Value::Integer(zset_id),
-        Value::Integer(last_element_id),
-    ];
+    // For iteration, use the last element hash if we have one, or NULL to start
+    let index_key_values = match last_element_hash {
+        Some(last_hash) => vec![
+            Value::Integer(storage_id),
+            zset_hash.to_value(),
+            last_hash.to_value(),
+        ],
+        None => vec![
+            Value::Integer(storage_id),
+            zset_hash.to_value(),
+            Value::Null, // Start iteration from beginning
+        ],
+    };
 
     let index_record = ImmutableRecord::from_values(&index_key_values, index_key_values.len());
+
+    // Use GE (>=) for initial seek with NULL, GT (>) for continuation
+    let seek_op = if last_element_hash.is_none() {
+        SeekOp::GE { eq_only: false }
+    } else {
+        SeekOp::GT
+    };
+
     let seek_result = return_if_io!(cursors
         .index_cursor
-        .seek(SeekKey::IndexKey(&index_record), SeekOp::GT));
+        .seek(SeekKey::IndexKey(&index_record), seek_op));
 
     if !matches!(seek_result, SeekResult::Found) {
         return Ok(IOResult::Done(None));
@@ -48,7 +65,7 @@ fn read_next_join_row(
     let current_record = return_if_io!(cursors.index_cursor.record());
 
     // Extract all needed values from the record before dropping it
-    let (found_storage_id, found_zset_id, element_id) = if let Some(rec) = current_record {
+    let (found_storage_id, found_zset_hash, element_hash) = if let Some(rec) = current_record {
         let values = rec.get_values();
 
         // Index has 4 values: storage_id, zset_id, element_id, rowid (appended by WriteRow)
@@ -57,17 +74,21 @@ fn read_next_join_row(
                 Value::Integer(id) => *id,
                 _ => return Ok(IOResult::Done(None)),
             };
-            let found_zset_id = match &values[1].to_owned() {
-                Value::Integer(id) => *id,
+            let found_zset_hash = match &values[1].to_owned() {
+                Value::Blob(blob) => Hash128::from_blob(blob).ok_or_else(|| {
+                    crate::LimboError::InternalError("Invalid zset_hash blob".to_string())
+                })?,
                 _ => return Ok(IOResult::Done(None)),
             };
-            let element_id = match &values[2].to_owned() {
-                Value::Integer(id) => *id,
+            let element_hash = match &values[2].to_owned() {
+                Value::Blob(blob) => Hash128::from_blob(blob).ok_or_else(|| {
+                    crate::LimboError::InternalError("Invalid element_hash blob".to_string())
+                })?,
                 _ => {
                     return Ok(IOResult::Done(None));
                 }
             };
-            (found_storage_id, found_zset_id, element_id)
+            (found_storage_id, found_zset_hash, element_hash)
         } else {
             return Ok(IOResult::Done(None));
         }
@@ -77,7 +98,7 @@ fn read_next_join_row(
 
     // Now we can safely check if we're in the right range
     // If we've moved to a different storage_id or zset_id, we're done
-    if found_storage_id != storage_id || found_zset_id != zset_id {
+    if found_storage_id != storage_id || found_zset_hash != zset_hash {
         return Ok(IOResult::Done(None));
     }
 
@@ -109,7 +130,7 @@ fn read_next_join_row(
                     _ => return Ok(IOResult::Done(None)),
                 };
 
-                return Ok(IOResult::Done(Some((element_id, row, weight))));
+                return Ok(IOResult::Done(Some((element_hash, row, weight))));
             }
         }
     }
@@ -127,13 +148,13 @@ pub enum JoinEvalState {
         deltas: DeltaPair,
         output: Delta,
         current_idx: usize,
-        last_row_scanned: i64,
+        last_row_scanned: Option<Hash128>,
     },
     ProcessRightJoin {
         deltas: DeltaPair,
         output: Delta,
         current_idx: usize,
-        last_row_scanned: i64,
+        last_row_scanned: Option<Hash128>,
     },
     Done {
         output: Delta,
@@ -151,9 +172,9 @@ impl JoinEvalState {
         // Combine the rows
         let mut combined_values = left_row.values.clone();
         combined_values.extend(right_row.values.clone());
-        // Use hash of the combined values as rowid to ensure uniqueness
+        // Use hash of combined values as synthetic rowid
         let temp_row = HashableRow::new(0, combined_values.clone());
-        let joined_rowid = temp_row.cached_hash() as i64;
+        let joined_rowid = temp_row.cached_hash().as_i64();
         let joined_row = HashableRow::new(joined_rowid, combined_values);
 
         // Add to output with combined weight
@@ -177,7 +198,7 @@ impl JoinEvalState {
                         deltas: std::mem::take(deltas),
                         output: std::mem::take(output),
                         current_idx: 0,
-                        last_row_scanned: i64::MIN,
+                        last_row_scanned: None,
                     };
                 }
                 JoinEvalState::ProcessLeftJoin {
@@ -191,7 +212,7 @@ impl JoinEvalState {
                             deltas: std::mem::take(deltas),
                             output: std::mem::take(output),
                             current_idx: 0,
-                            last_row_scanned: i64::MIN,
+                            last_row_scanned: None,
                         };
                     } else {
                         let (left_row, left_weight) = &deltas.left.changes[*current_idx];
@@ -209,7 +230,7 @@ impl JoinEvalState {
                             cursors
                         ));
                         match next_row {
-                            Some((element_id, right_row, right_weight)) => {
+                            Some((element_hash, right_row, right_weight)) => {
                                 Self::combine_rows(
                                     left_row,
                                     (*left_weight) as i64,
@@ -222,7 +243,7 @@ impl JoinEvalState {
                                     deltas: std::mem::take(deltas),
                                     output: std::mem::take(output),
                                     current_idx: *current_idx,
-                                    last_row_scanned: element_id,
+                                    last_row_scanned: Some(element_hash),
                                 };
                             }
                             None => {
@@ -231,7 +252,7 @@ impl JoinEvalState {
                                     deltas: std::mem::take(deltas),
                                     output: std::mem::take(output),
                                     current_idx: *current_idx + 1,
-                                    last_row_scanned: i64::MIN,
+                                    last_row_scanned: None,
                                 };
                             }
                         }
@@ -263,7 +284,7 @@ impl JoinEvalState {
                             cursors
                         ));
                         match next_row {
-                            Some((element_id, left_row, left_weight)) => {
+                            Some((element_hash, left_row, left_weight)) => {
                                 Self::combine_rows(
                                     &left_row,
                                     left_weight as i64,
@@ -276,7 +297,7 @@ impl JoinEvalState {
                                     deltas: std::mem::take(deltas),
                                     output: std::mem::take(output),
                                     current_idx: *current_idx,
-                                    last_row_scanned: element_id,
+                                    last_row_scanned: Some(element_hash),
                                 };
                             }
                             None => {
@@ -285,7 +306,7 @@ impl JoinEvalState {
                                     deltas: std::mem::take(deltas),
                                     output: std::mem::take(output),
                                     current_idx: *current_idx + 1,
-                                    last_row_scanned: i64::MIN,
+                                    last_row_scanned: None,
                                 };
                             }
                         }
@@ -376,7 +397,7 @@ impl JoinOperator {
             JoinType::Inner => {} // Inner join is supported
         }
 
-        Ok(Self {
+        let result = Self {
             operator_id,
             join_type,
             left_key_indices,
@@ -385,7 +406,8 @@ impl JoinOperator {
             right_columns,
             tracker: None,
             commit_state: JoinCommitState::Idle,
-        })
+        };
+        Ok(result)
     }
 
     /// Extract join key from row values using the specified indices
@@ -485,8 +507,9 @@ impl JoinOperator {
 
                                 // Create the joined row with a unique rowid
                                 // Use hash of the combined values to ensure uniqueness
+                                // Use hash of combined values as synthetic rowid
                                 let temp_row = HashableRow::new(0, combined_values.clone());
-                                let joined_rowid = temp_row.cached_hash() as i64;
+                                let joined_rowid = temp_row.cached_hash().as_i64();
                                 let joined_row =
                                     HashableRow::new(joined_rowid, combined_values.clone());
 
@@ -617,20 +640,20 @@ impl IncrementalOperator for JoinOperator {
                     // The index key: (storage_id, zset_id, element_id)
                     // zset_id is the hash of the join key, element_id is hash of the row
                     let storage_id = self.left_storage_id();
-                    let zset_id = join_key.cached_hash() as i64;
-                    let element_id = row.cached_hash() as i64;
+                    let zset_hash = join_key.cached_hash();
+                    let element_hash = row.cached_hash();
                     let index_key = vec![
                         Value::Integer(storage_id),
-                        Value::Integer(zset_id),
-                        Value::Integer(element_id),
+                        zset_hash.to_value(),
+                        element_hash.to_value(),
                     ];
 
                     // The record values: we'll store the serialized row as a blob
                     let row_blob = serialize_hashable_row(row);
                     let record_values = vec![
                         Value::Integer(self.left_storage_id()),
-                        Value::Integer(join_key.cached_hash() as i64),
-                        Value::Integer(row.cached_hash() as i64),
+                        zset_hash.to_value(),
+                        element_hash.to_value(),
                         Value::Blob(row_blob),
                     ];
 
@@ -665,18 +688,20 @@ impl IncrementalOperator for JoinOperator {
                     let join_key = self.extract_join_key(&row.values, &self.right_key_indices);
 
                     // The index key: (storage_id, zset_id, element_id)
+                    let zset_hash = join_key.cached_hash();
+                    let element_hash = row.cached_hash();
                     let index_key = vec![
                         Value::Integer(self.right_storage_id()),
-                        Value::Integer(join_key.cached_hash() as i64),
-                        Value::Integer(row.cached_hash() as i64),
+                        zset_hash.to_value(),
+                        element_hash.to_value(),
                     ];
 
                     // The record values: we'll store the serialized row as a blob
                     let row_blob = serialize_hashable_row(row);
                     let record_values = vec![
                         Value::Integer(self.right_storage_id()),
-                        Value::Integer(join_key.cached_hash() as i64),
-                        Value::Integer(row.cached_hash() as i64),
+                        zset_hash.to_value(),
+                        element_hash.to_value(),
                         Value::Blob(row_blob),
                     ];
 

--- a/core/incremental/merge_operator.rs
+++ b/core/incremental/merge_operator.rs
@@ -57,7 +57,7 @@ impl MergeOperator {
                 for (row, weight) in delta.changes {
                     // Hash only the values (not rowid) for deduplication
                     let temp_row = HashableRow::new(0, row.values.clone());
-                    let value_hash = temp_row.cached_hash();
+                    let value_hash = temp_row.cached_hash().as_i64() as u64;
 
                     // Check if we've seen this value before
                     let assigned_rowid =

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -342,7 +342,6 @@ mod tests {
 
                             let group_key_str = AggregateOperator::group_key_to_string(&group_key);
                             let rowid = agg.generate_group_rowid(&group_key_str);
-
                             let output_row = HashableRow::new(rowid, output_values);
                             result.changes.push((output_row, 1));
                         }
@@ -2929,7 +2928,6 @@ mod tests {
         let index_cursor =
             BTreeCursor::new_index(None, pager.clone(), index_page_id, &index_def, 10);
         let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
-
         let mut join = JoinOperator::new(
             1, // operator_id
             JoinType::Inner,
@@ -2945,7 +2943,6 @@ mod tests {
         left_delta.insert(1, vec![Value::Integer(1), Value::Float(100.0)]);
         left_delta.insert(2, vec![Value::Integer(2), Value::Float(200.0)]);
         left_delta.insert(3, vec![Value::Integer(3), Value::Float(300.0)]); // No match initially
-
         let mut right_delta = Delta::new();
         right_delta.insert(1, vec![Value::Integer(1), Value::Text("Alice".into())]);
         right_delta.insert(2, vec![Value::Integer(2), Value::Text("Bob".into())]);

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -1,4 +1,4 @@
-use crate::incremental::operator::{AggregateFunction, AggregateState, DbspStateCursors};
+use crate::incremental::operator::{AggregateState, DbspStateCursors};
 use crate::storage::btree::{BTreeCursor, BTreeKey};
 use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult};
 use crate::{return_if_io, LimboError, Result, Value};
@@ -20,7 +20,6 @@ impl ReadRecord {
     pub fn read_record(
         &mut self,
         key: SeekKey,
-        aggregates: &[AggregateFunction],
         cursor: &mut BTreeCursor,
     ) -> Result<IOResult<Option<AggregateState>>> {
         loop {
@@ -41,12 +40,7 @@ impl ReadRecord {
                         let blob = values[3].to_owned();
 
                         let (state, _group_key) = match blob {
-                            Value::Blob(blob) => AggregateState::from_blob(&blob, aggregates)
-                                .ok_or_else(|| {
-                                    LimboError::InternalError(format!(
-                                        "Cannot deserialize aggregate state {blob:?}",
-                                    ))
-                                }),
+                            Value::Blob(blob) => AggregateState::from_blob(&blob),
                             _ => Err(LimboError::ParseError(
                                 "Value in aggregator not blob".to_string(),
                             )),

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -43,7 +43,7 @@ use turso_parser::{
 
 const SCHEMA_TABLE_NAME: &str = "sqlite_schema";
 const SCHEMA_TABLE_NAME_ALT: &str = "sqlite_master";
-pub const DBSP_TABLE_PREFIX: &str = "__turso_internal_dbsp_state_";
+pub const DBSP_TABLE_PREFIX: &str = "__turso_internal_dbsp_state_v";
 
 /// Check if a table name refers to a system table that should be protected from direct writes
 pub fn is_system_table(table_name: &str) -> bool {
@@ -74,6 +74,9 @@ pub struct Schema {
 
     /// Mapping from table names to the materialized views that depend on them
     pub table_to_materialized_views: HashMap<String, Vec<String>>,
+
+    /// Track views that exist but have incompatible versions
+    pub incompatible_views: HashSet<String>,
 }
 
 impl Schema {
@@ -97,6 +100,7 @@ impl Schema {
         let incremental_views = HashMap::new();
         let views: ViewsMap = HashMap::new();
         let table_to_materialized_views: HashMap<String, Vec<String>> = HashMap::new();
+        let incompatible_views = HashSet::new();
         Self {
             tables,
             materialized_view_names,
@@ -108,6 +112,7 @@ impl Schema {
             indexes_enabled,
             schema_version: 0,
             table_to_materialized_views,
+            incompatible_views,
         }
     }
 
@@ -137,9 +142,37 @@ impl Schema {
         self.incremental_views.get(&name).cloned()
     }
 
+    /// Check if DBSP state table exists with the current version
+    pub fn has_compatible_dbsp_state_table(&self, view_name: &str) -> bool {
+        use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
+        let view_name = normalize_ident(view_name);
+        let expected_table_name = format!("{DBSP_TABLE_PREFIX}{DBSP_CIRCUIT_VERSION}_{view_name}");
+
+        // Check if a table with the expected versioned name exists
+        self.tables.contains_key(&expected_table_name)
+    }
+
     pub fn is_materialized_view(&self, name: &str) -> bool {
         let name = normalize_ident(name);
         self.materialized_view_names.contains(&name)
+    }
+
+    /// Check if a table has any incompatible dependent materialized views
+    pub fn has_incompatible_dependent_views(&self, table_name: &str) -> Vec<String> {
+        let table_name = normalize_ident(table_name);
+
+        // Get all materialized views that depend on this table
+        let dependent_views = self
+            .table_to_materialized_views
+            .get(&table_name)
+            .cloned()
+            .unwrap_or_default();
+
+        // Filter to only incompatible views
+        dependent_views
+            .into_iter()
+            .filter(|view_name| self.incompatible_views.contains(view_name))
+            .collect()
     }
 
     pub fn remove_view(&mut self, name: &str) -> Result<()> {
@@ -516,12 +549,21 @@ impl Schema {
         dbsp_state_index_roots: std::collections::HashMap<String, usize>,
     ) -> Result<()> {
         for (view_name, (sql, main_root)) in materialized_view_info {
-            // Look up the DBSP state root for this view - must exist for materialized views
-            let dbsp_state_root = dbsp_state_roots.get(&view_name).ok_or_else(|| {
-                LimboError::InternalError(format!(
-                    "Materialized view {view_name} is missing its DBSP state table"
-                ))
-            })?;
+            // Look up the DBSP state root for this view
+            // If missing, it means version mismatch - skip this view
+            // Check if we have a compatible DBSP state root
+            let dbsp_state_root = if let Some(&root) = dbsp_state_roots.get(&view_name) {
+                root
+            } else {
+                tracing::warn!(
+                    "Materialized view '{}' has incompatible version or missing DBSP state table",
+                    view_name
+                );
+                // Track this as an incompatible view
+                self.incompatible_views.insert(view_name.clone());
+                // Use a dummy root page - the view won't be usable anyway
+                0
+            };
 
             // Look up the DBSP state index root (may not exist for older schemas)
             let dbsp_state_index_root =
@@ -531,7 +573,7 @@ impl Schema {
                 &sql,
                 self,
                 main_root,
-                *dbsp_state_root,
+                dbsp_state_root,
                 dbsp_state_index_root,
             )?;
             let referenced_tables = incremental_view.get_referenced_table_names();
@@ -547,9 +589,12 @@ impl Schema {
                 unique_sets: vec![],
             })));
 
-            self.add_materialized_view(incremental_view, table, sql);
+            // Only add to schema if compatible
+            if !self.incompatible_views.contains(&view_name) {
+                self.add_materialized_view(incremental_view, table, sql);
+            }
 
-            // Register dependencies
+            // Register dependencies regardless of compatibility
             for table_name in referenced_tables {
                 self.add_materialized_view_dependency(&table_name, &view_name);
             }
@@ -601,13 +646,33 @@ impl Schema {
 
                     // Check if this is a DBSP state table
                     if table.name.starts_with(DBSP_TABLE_PREFIX) {
-                        // Extract the view name from __turso_internal_dbsp_state_<viewname>
-                        let view_name = table
-                            .name
-                            .strip_prefix(DBSP_TABLE_PREFIX)
-                            .unwrap()
-                            .to_string();
-                        dbsp_state_roots.insert(view_name, root_page as usize);
+                        // Extract version and view name from __turso_internal_dbsp_state_v<version>_<viewname>
+                        let suffix = table.name.strip_prefix(DBSP_TABLE_PREFIX).unwrap();
+
+                        // Parse version and view name (format: "<version>_<viewname>")
+                        if let Some(underscore_pos) = suffix.find('_') {
+                            let version_str = &suffix[..underscore_pos];
+                            let view_name = &suffix[underscore_pos + 1..];
+
+                            // Check version compatibility
+                            if let Ok(stored_version) = version_str.parse::<u32>() {
+                                use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
+                                if stored_version == DBSP_CIRCUIT_VERSION {
+                                    // Version matches, store the root page
+                                    dbsp_state_roots
+                                        .insert(view_name.to_string(), root_page as usize);
+                                } else {
+                                    // Version mismatch - DO NOT insert into dbsp_state_roots
+                                    // This will cause populate_materialized_views to skip this view
+                                    tracing::warn!(
+                                        "Skipping materialized view '{}' - has version {} but current version is {}. DROP and recreate the view to use it.",
+                                        view_name, stored_version, DBSP_CIRCUIT_VERSION
+                                    );
+                                    // We can't track incompatible views here since we're in handle_schema_row
+                                    // which doesn't have mutable access to self
+                                }
+                            }
+                        }
                     }
 
                     if let Some(mv_store) = mv_store {
@@ -635,12 +700,23 @@ impl Schema {
 
                         // Check if this is an index for a DBSP state table
                         if table_name.starts_with(DBSP_TABLE_PREFIX) {
-                            // Extract the view name from __turso_internal_dbsp_state_<viewname>
-                            let view_name = table_name
-                                .strip_prefix(DBSP_TABLE_PREFIX)
-                                .unwrap()
-                                .to_string();
-                            dbsp_state_index_roots.insert(view_name, root_page as usize);
+                            // Extract version and view name from __turso_internal_dbsp_state_v<version>_<viewname>
+                            let suffix = table_name.strip_prefix(DBSP_TABLE_PREFIX).unwrap();
+
+                            // Parse version and view name (format: "<version>_<viewname>")
+                            if let Some(underscore_pos) = suffix.find('_') {
+                                let version_str = &suffix[..underscore_pos];
+                                let view_name = &suffix[underscore_pos + 1..];
+
+                                // Only store index root if version matches
+                                if let Ok(stored_version) = version_str.parse::<u32>() {
+                                    use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
+                                    if stored_version == DBSP_CIRCUIT_VERSION {
+                                        dbsp_state_index_roots
+                                            .insert(view_name.to_string(), root_page as usize);
+                                    }
+                                }
+                            }
                         } else {
                             match automatic_indices.entry(table_name) {
                                 std::collections::hash_map::Entry::Vacant(e) => {
@@ -767,6 +843,7 @@ impl Clone for Schema {
             .map(|(name, view)| (name.clone(), view.clone()))
             .collect();
         let views = self.views.clone();
+        let incompatible_views = self.incompatible_views.clone();
         Self {
             tables,
             materialized_view_names,
@@ -778,6 +855,7 @@ impl Clone for Schema {
             indexes_enabled: self.indexes_enabled,
             schema_version: self.schema_version,
             table_to_materialized_views: self.table_to_materialized_views.clone(),
+            incompatible_views,
         }
     }
 }

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -149,8 +149,8 @@ pub fn translate_create_materialized_view(
     let dbsp_sql = format!(
         "CREATE TABLE {dbsp_table_name} (\
          operator_id INTEGER NOT NULL, \
-         zset_id INTEGER NOT NULL, \
-         element_id NOT NULL, \
+         zset_id BLOB NOT NULL, \
+         element_id BLOB NOT NULL, \
          value BLOB, \
          weight INTEGER NOT NULL, \
          PRIMARY KEY (operator_id, zset_id, element_id)\

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -141,7 +141,10 @@ pub fn translate_create_materialized_view(
     )?;
 
     // Add the DBSP state table to sqlite_master (required for materialized views)
-    let dbsp_table_name = format!("{DBSP_TABLE_PREFIX}{normalized_view_name}");
+    // Include the version number in the table name
+    use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
+    let dbsp_table_name =
+        format!("{DBSP_TABLE_PREFIX}{DBSP_CIRCUIT_VERSION}_{normalized_view_name}");
     // The element_id column uses SQLite's dynamic typing system to store different value types:
     // - For hash-based operators (joins, filters): stores INTEGER hash values or rowids
     // - For future MIN/MAX operators: stores the actual values being compared (INTEGER, REAL, TEXT, BLOB)


### PR DESCRIPTION
Improve serialization for DBSP views.

The serialization code was written organically, without much forward thinking about stability as we evolved the table and operator format. Now that this is done, we are at at point where we can actually make it suck less and take a considerable step towards making this production ready.

We also add a simple version check (in the table name, because that is much easier than reading contents in parse_schema_row) to prevent views to be used if we had to do anything to evolve the format of the circuit (including the operators)