### PR TITLE
github: Add 30 minute timeout to all jobs

### DIFF
--- a/.github/workflows/build-sim.yml
+++ b/.github/workflows/build-sim.yml
@@ -25,6 +25,7 @@ env:
 jobs:
   deploy:
     runs-on: blacksmith
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/c-compat.yml
+++ b/.github/workflows/c-compat.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,6 +12,7 @@ env:
   working-directory: bindings/dart
 jobs:
   test:
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ env.working-directory }}
@@ -39,6 +40,7 @@ jobs:
         run: flutter test
   precompile:
     if: ${{ false && startsWith(github.ref, 'refs/tags/') }}
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ env.working-directory }}
@@ -84,6 +86,7 @@ jobs:
           PRIVATE_KEY: ${{ secrets.CARGOKIT_PRIVATE_KEY }}
   publish:
     if: ${{ false && startsWith(github.ref, 'refs/tags/') }}
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
 
     defaults:
       run:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   labeler:
+    timeout-minutes: 30
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/long_fuzz_tests_btree.yml
+++ b/.github/workflows/long_fuzz_tests_btree.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   run-long-tests:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 0 
+    timeout-minutes: 30 
     
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
 
   simple-stress-test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 0
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
     - uses: useblacksmith/rust-cache@v3

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -161,6 +161,7 @@ jobs:
           if-no-files-found: error
   test-db-linux-x64-gnu-binding:
     name: Test DB bindings on Linux-x64-gnu - node@${{ matrix.node }}
+    timeout-minutes: 30
     needs:
       - build
     strategy:
@@ -192,6 +193,7 @@ jobs:
         run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim yarn workspace @tursodatabase/database test
   test-db-browser-binding:
     name: Test DB bindings on browser@${{ matrix.node }}
+    timeout-minutes: 30
     needs:
       - build
     strategy:
@@ -228,6 +230,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   configure-strategy:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     outputs:
       python-versions: ${{ steps.gen-matrix.outputs.python-versions }}
     steps:
@@ -26,6 +27,7 @@ jobs:
 
   test:
     needs: configure-strategy
+    timeout-minutes: 30
     strategy:
       matrix:
         os:
@@ -64,6 +66,7 @@ jobs:
 
   lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -85,6 +88,7 @@ jobs:
 
   linux:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ env.working-directory }}
@@ -112,6 +116,7 @@ jobs:
 
   macos-arm64:
     runs-on: macos-14
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ env.working-directory }}
@@ -141,6 +146,7 @@ jobs:
 
   sdist:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ env.working-directory }}
@@ -161,6 +167,7 @@ jobs:
   release:
     name: Release
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, macos-arm64, sdist]
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   cargo-fmt-check:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -21,6 +22,7 @@ jobs:
         run: cd fuzz && cargo fmt --check
 
   build-native:
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [blacksmith-4vcpu-ubuntu-2404, macos-latest, windows-latest]
@@ -54,6 +56,7 @@ jobs:
 
   clippy:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Clippy
@@ -97,6 +100,7 @@ jobs:
         timeout-minutes: 20
   test-sqlite:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: "./.github/shared/install_sqlite"

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: useblacksmith/setup-node@v5
@@ -55,6 +56,7 @@ jobs:
 
   clickbench:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: useblacksmith/setup-node@v5
@@ -102,6 +104,7 @@ jobs:
 
   tpc-h-criterion:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       DB_FILE: "perf/tpc-h/TPC-H.db"
     steps:
@@ -156,6 +159,7 @@ jobs:
 
   tpc-h:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: TPC-H
@@ -163,6 +167,7 @@ jobs:
 
   vfs-bench-compile:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: useblacksmith/rust-cache@v3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   stale:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     steps:
       - name: Close stale pull requests
         uses: actions/stale@v6


### PR DESCRIPTION
We're getting hit by macOS runner concurrency limits whenever some jobs get stuck (for example, because of a deadlock).