### PR TITLE
translate: refactor arguments and centralize parameter context

### DIFF
--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -4,7 +4,7 @@ use turso_parser::ast;
 
 use crate::{
     bail_parse_error,
-    schema::{BTreeTable, Schema},
+    schema::BTreeTable,
     storage::pager::CreateBTreeFlags,
     translate::{
         emitter::Resolver,
@@ -15,20 +15,19 @@ use crate::{
         builder::{CursorType, ProgramBuilder},
         insn::{Insn, RegisterOrLiteral},
     },
-    Result, SymbolTable,
+    Result,
 };
 
 pub fn translate_analyze(
     target_opt: Option<ast::QualifiedName>,
-    schema: &Schema,
-    syms: &SymbolTable,
+    resolver: &Resolver,
     mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     let Some(target) = target_opt else {
         bail_parse_error!("ANALYZE with no target is not supported");
     };
     let normalized = normalize_ident(target.name.as_str());
-    let Some(target_schema) = schema.get_table(&normalized) else {
+    let Some(target_schema) = resolver.schema.get_table(&normalized) else {
         bail_parse_error!("ANALYZE <schema_name> is not supported");
     };
     let Some(target_btree) = target_schema.btree() else {
@@ -48,7 +47,7 @@ pub fn translate_analyze(
     let sqlite_stat1_btreetable: Arc<BTreeTable>;
     let sqlite_stat1_source: RegisterOrLiteral<_>;
 
-    if let Some(sqlite_stat1) = schema.get_btree_table("sqlite_stat1") {
+    if let Some(sqlite_stat1) = resolver.schema.get_btree_table("sqlite_stat1") {
         sqlite_stat1_btreetable = sqlite_stat1.clone();
         sqlite_stat1_source = RegisterOrLiteral::Literal(sqlite_stat1.root_page);
         // sqlite_stat1 already exists, so we need to remove the row
@@ -131,7 +130,7 @@ pub fn translate_analyze(
         sqlite_stat1_btreetable = Arc::new(BTreeTable::from_sql(sql, 0)?);
         sqlite_stat1_source = RegisterOrLiteral::Register(table_root_reg);
 
-        let table = schema.get_btree_table(SQLITE_TABLEID).unwrap();
+        let table = resolver.schema.get_btree_table(SQLITE_TABLEID).unwrap();
         let sqlite_schema_cursor_id =
             program.alloc_cursor_id(CursorType::BTreeTable(table.clone()));
         program.emit_insn(Insn::OpenWrite {
@@ -140,7 +139,6 @@ pub fn translate_analyze(
             db: 0,
         });
 
-        let resolver = Resolver::new(schema, syms);
         // Add the table entry to sqlite_schema
         emit_schema_entry(
             &mut program,

--- a/core/translate/attach.rs
+++ b/core/translate/attach.rs
@@ -1,21 +1,19 @@
 use crate::function::{Func, ScalarFunc};
-use crate::schema::Schema;
 use crate::translate::emitter::Resolver;
 use crate::translate::expr::{sanitize_string, translate_expr};
 use crate::translate::{ProgramBuilder, ProgramBuilderOpts};
 use crate::util::normalize_ident;
 use crate::vdbe::insn::Insn;
-use crate::{Result, SymbolTable};
+use crate::Result;
 use turso_parser::ast::{Expr, Literal};
 
 /// Translate ATTACH statement
 /// SQLite implements ATTACH as a function call to sqlite_attach()
 pub fn translate_attach(
     expr: &Expr,
+    resolver: &Resolver,
     db_name: &Expr,
     key: &Option<Box<Expr>>,
-    schema: &Schema,
-    syms: &SymbolTable,
     mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     // SQLite treats ATTACH as a function call to sqlite_attach(filename, dbname, key)
@@ -28,7 +26,6 @@ pub fn translate_attach(
     });
 
     let arg_reg = program.alloc_registers(4); // 3 for args + 1 for result
-    let resolver = Resolver::new(schema, syms);
 
     // Load filename argument
     // Handle different expression types as string literals for filenames
@@ -120,8 +117,7 @@ pub fn translate_attach(
 /// SQLite implements DETACH as a function call to sqlite_detach()
 pub fn translate_detach(
     expr: &Expr,
-    schema: &Schema,
-    syms: &SymbolTable,
+    resolver: &Resolver,
     mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     // SQLite treats DETACH as a function call to sqlite_detach(dbname)
@@ -133,7 +129,6 @@ pub fn translate_detach(
     });
 
     let arg_reg = program.alloc_registers(2); // 1 for arg + 1 for result
-    let resolver = Resolver::new(schema, syms);
 
     // Load database name argument
     // Handle different expression types as string literals for database names

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -1,5 +1,5 @@
 use crate::schema::{Index, IndexColumn, Schema};
-use crate::translate::emitter::{emit_query, LimitCtx, TranslateCtx};
+use crate::translate::emitter::{emit_query, LimitCtx, Resolver, TranslateCtx};
 use crate::translate::expr::translate_expr;
 use crate::translate::plan::{Plan, QueryDestination, SelectPlan};
 use crate::translate::result_row::try_fold_expr_to_i64;
@@ -16,9 +16,8 @@ use tracing::Level;
 #[instrument(skip_all, level = Level::DEBUG)]
 pub fn emit_program_for_compound_select(
     program: &mut ProgramBuilder,
+    resolver: &Resolver,
     plan: Plan,
-    schema: &Schema,
-    syms: &SymbolTable,
 ) -> crate::Result<()> {
     let Plan::CompoundSelect {
         left: _left,
@@ -41,8 +40,8 @@ pub fn emit_program_for_compound_select(
 
     let right_most_ctx = TranslateCtx::new(
         program,
-        schema,
-        syms,
+        resolver.schema,
+        resolver.symbol_table,
         right_most.table_references.joined_tables().len(),
     );
 
@@ -102,8 +101,8 @@ pub fn emit_program_for_compound_select(
     emit_compound_select(
         program,
         plan,
-        schema,
-        syms,
+        right_most_ctx.resolver.schema,
+        right_most_ctx.resolver.symbol_table,
         limit_ctx,
         offset_reg,
         yield_reg,

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -1,12 +1,11 @@
-use crate::schema::Table;
-use crate::translate::emitter::emit_program;
-use crate::translate::expr::ParamState;
+use crate::schema::{Schema, Table};
+use crate::translate::emitter::{emit_program, Resolver};
 use crate::translate::optimizer::optimize_plan;
 use crate::translate::plan::{DeletePlan, Operation, Plan};
 use crate::translate::planner::{parse_limit, parse_where};
 use crate::util::normalize_ident;
-use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts, TableRefIdCounter};
-use crate::{schema::Schema, Result, SymbolTable};
+use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
+use crate::Result;
 use std::sync::Arc;
 use turso_parser::ast::{Expr, Limit, QualifiedName, ResultColumn};
 
@@ -14,12 +13,11 @@ use super::plan::{ColumnUsedMask, JoinedTable, TableReferences};
 
 #[allow(clippy::too_many_arguments)]
 pub fn translate_delete(
-    schema: &Schema,
     tbl_name: &QualifiedName,
+    resolver: &Resolver,
     where_clause: Option<Box<Expr>>,
     limit: Option<Limit>,
     returning: Vec<ResultColumn>,
-    syms: &SymbolTable,
     mut program: ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> Result<ProgramBuilder> {
@@ -30,7 +28,7 @@ pub fn translate_delete(
         crate::bail_parse_error!("table {} may not be modified", tbl_name);
     }
 
-    if schema.table_has_indexes(&tbl_name) && !schema.indexes_enabled() {
+    if resolver.schema.table_has_indexes(&tbl_name) && !resolver.schema.indexes_enabled() {
         // Let's disable altering a table with indices altogether instead of checking column by
         // column to be extra safe.
         crate::bail_parse_error!(
@@ -48,15 +46,15 @@ pub fn translate_delete(
     let result_columns = vec![];
 
     let mut delete_plan = prepare_delete_plan(
-        schema,
+        &mut program,
+        resolver.schema,
         tbl_name,
         where_clause,
         limit,
         result_columns,
-        &mut program.table_reference_counter,
         connection,
     )?;
-    optimize_plan(&mut delete_plan, schema)?;
+    optimize_plan(&mut delete_plan, resolver.schema)?;
     let Plan::Delete(ref delete) = delete_plan else {
         panic!("delete_plan is not a DeletePlan");
     };
@@ -66,17 +64,17 @@ pub fn translate_delete(
         approx_num_labels: 0,
     };
     program.extend(&opts);
-    emit_program(connection, &mut program, delete_plan, schema, syms, |_| {})?;
+    emit_program(connection, resolver, &mut program, delete_plan, |_| {})?;
     Ok(program)
 }
 
 pub fn prepare_delete_plan(
+    program: &mut ProgramBuilder,
     schema: &Schema,
     tbl_name: String,
     where_clause: Option<Box<Expr>>,
     limit: Option<Limit>,
     result_columns: Vec<super::plan::ResultSetColumn>,
-    table_ref_counter: &mut TableRefIdCounter,
     connection: &Arc<crate::Connection>,
 ) -> Result<Plan> {
     let table = match schema.get_table(&tbl_name) {
@@ -115,7 +113,7 @@ pub fn prepare_delete_plan(
         op: Operation::default_scan_for(&table),
         table,
         identifier: tbl_name,
-        internal_id: table_ref_counter.next(),
+        internal_id: program.table_reference_counter.next(),
         join_info: None,
         col_used_mask: ColumnUsedMask::default(),
         database_id: 0,
@@ -123,7 +121,6 @@ pub fn prepare_delete_plan(
     let mut table_references = TableReferences::new(joined_tables, vec![]);
 
     let mut where_predicates = vec![];
-    let mut param_ctx = ParamState::default();
 
     // Parse the WHERE clause
     parse_where(
@@ -132,12 +129,12 @@ pub fn prepare_delete_plan(
         None,
         &mut where_predicates,
         connection,
-        &mut param_ctx,
+        &mut program.param_ctx,
     )?;
 
     // Parse the LIMIT/OFFSET clause
     let (resolved_limit, resolved_offset) = limit.map_or(Ok((None, None)), |mut l| {
-        parse_limit(&mut l, connection, &mut param_ctx)
+        parse_limit(&mut l, connection, &mut program.param_ctx)
     })?;
 
     let plan = DeletePlan {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -4063,7 +4063,6 @@ pub fn process_returning_clause(
     table_name: &str,
     program: &mut ProgramBuilder,
     connection: &std::sync::Arc<crate::Connection>,
-    param_ctx: &mut ParamState,
 ) -> Result<(
     Vec<super::plan::ResultSetColumn>,
     super::plan::TableReferences,
@@ -4100,7 +4099,7 @@ pub fn process_returning_clause(
                     Some(&mut table_references),
                     None,
                     connection,
-                    param_ctx,
+                    &mut program.param_ctx,
                     BindingBehavior::TryResultColumnsFirst,
                 )?;
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -43,6 +43,7 @@ mod window;
 use crate::schema::Schema;
 use crate::storage::pager::Pager;
 use crate::translate::delete::translate_delete;
+use crate::translate::emitter::Resolver;
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts, QueryMode};
 use crate::vdbe::Program;
 use crate::{bail_parse_error, Connection, Result, SymbolTable};
@@ -91,19 +92,14 @@ pub fn translate(
     );
 
     program.prologue();
+    let resolver = Resolver::new(schema, syms);
 
     program = match stmt {
         // There can be no nesting with pragma, so lift it up here
-        ast::Stmt::Pragma { name, body } => pragma::translate_pragma(
-            schema,
-            syms,
-            &name,
-            body,
-            pager,
-            connection.clone(),
-            program,
-        )?,
-        stmt => translate_inner(schema, stmt, syms, program, &connection, input)?,
+        ast::Stmt::Pragma { name, body } => {
+            pragma::translate_pragma(&resolver, &name, body, pager, connection.clone(), program)?
+        }
+        stmt => translate_inner(stmt, &resolver, program, &connection, input)?,
     };
 
     program.epilogue(schema);
@@ -115,9 +111,8 @@ pub fn translate(
 // statements, we would have to return a program builder instead
 /// Translate SQL statement into bytecode program.
 pub fn translate_inner(
-    schema: &Schema,
     stmt: ast::Stmt,
-    syms: &SymbolTable,
+    resolver: &Resolver,
     program: ProgramBuilder,
     connection: &Arc<Connection>,
     input: &str,
@@ -148,13 +143,13 @@ pub fn translate_inner(
 
     let mut program = match stmt {
         ast::Stmt::AlterTable(alter) => {
-            translate_alter_table(alter, syms, schema, program, connection, input)?
+            translate_alter_table(alter, resolver, program, connection, input)?
         }
-        ast::Stmt::Analyze { name } => translate_analyze(name, schema, syms, program)?,
+        ast::Stmt::Analyze { name } => translate_analyze(name, resolver, program)?,
         ast::Stmt::Attach { expr, db_name, key } => {
-            attach::translate_attach(&expr, &db_name, &key, schema, syms, program)?
+            attach::translate_attach(&expr, resolver, &db_name, &key, program)?
         }
-        ast::Stmt::Begin { typ, name } => translate_tx_begin(typ, name, schema, program)?,
+        ast::Stmt::Begin { typ, name } => translate_tx_begin(typ, name, resolver.schema, program)?,
         ast::Stmt::Commit { name } => translate_tx_commit(name, program)?,
         ast::Stmt::CreateIndex {
             unique,
@@ -165,11 +160,10 @@ pub fn translate_inner(
             where_clause,
         } => translate_create_index(
             (unique, if_not_exists),
+            resolver,
             idx_name.name.as_str(),
             tbl_name.as_str(),
             &columns,
-            schema,
-            syms,
             program,
             connection,
             where_clause,
@@ -181,11 +175,10 @@ pub fn translate_inner(
             body,
         } => translate_create_table(
             tbl_name,
+            resolver,
             temporary,
             if_not_exists,
             body,
-            schema,
-            syms,
             program,
             connection,
         )?,
@@ -196,26 +189,24 @@ pub fn translate_inner(
             columns,
             ..
         } => view::translate_create_view(
-            schema,
             view_name.name.as_str(),
+            resolver,
             &select,
             &columns,
             connection.clone(),
-            syms,
             program,
         )?,
         ast::Stmt::CreateMaterializedView {
             view_name, select, ..
         } => view::translate_create_materialized_view(
-            schema,
             view_name.name.as_str(),
+            resolver,
             &select,
             connection.clone(),
-            syms,
             program,
         )?,
         ast::Stmt::CreateVirtualTable(vtab) => {
-            translate_create_virtual_table(vtab, schema, syms, program)?
+            translate_create_virtual_table(vtab, resolver, program)?
         }
         ast::Stmt::Delete {
             tbl_name,
@@ -236,30 +227,31 @@ pub fn translate_inner(
                 bail_parse_error!("ORDER BY clause is not supported in DELETE");
             }
             translate_delete(
-                schema,
                 &tbl_name,
+                resolver,
                 where_clause,
                 limit,
                 returning,
-                syms,
                 program,
                 connection,
             )?
         }
-        ast::Stmt::Detach { name } => attach::translate_detach(&name, schema, syms, program)?,
+        ast::Stmt::Detach { name } => attach::translate_detach(&name, resolver, program)?,
         ast::Stmt::DropIndex {
             if_exists,
             idx_name,
-        } => translate_drop_index(idx_name.name.as_str(), if_exists, schema, syms, program)?,
+        } => translate_drop_index(idx_name.name.as_str(), resolver, if_exists, program)?,
         ast::Stmt::DropTable {
             if_exists,
             tbl_name,
-        } => translate_drop_table(tbl_name, if_exists, schema, syms, program)?,
+        } => translate_drop_table(tbl_name, resolver, if_exists, program)?,
         ast::Stmt::DropTrigger { .. } => bail_parse_error!("DROP TRIGGER not supported yet"),
         ast::Stmt::DropView {
             if_exists,
             view_name,
-        } => view::translate_drop_view(schema, view_name.name.as_str(), if_exists, program)?,
+        } => {
+            view::translate_drop_view(resolver.schema, view_name.name.as_str(), if_exists, program)?
+        }
         ast::Stmt::Pragma { .. } => {
             bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")
         }
@@ -268,13 +260,12 @@ pub fn translate_inner(
         ast::Stmt::Rollback {
             tx_name,
             savepoint_name,
-        } => translate_rollback(schema, syms, program, tx_name, savepoint_name)?,
+        } => translate_rollback(program, tx_name, savepoint_name)?,
         ast::Stmt::Savepoint { .. } => bail_parse_error!("SAVEPOINT not supported yet"),
         ast::Stmt::Select(select) => {
             translate_select(
-                schema,
                 select,
-                syms,
+                resolver,
                 program,
                 plan::QueryDestination::ResultRows,
                 connection,
@@ -282,7 +273,7 @@ pub fn translate_inner(
             .program
         }
         ast::Stmt::Update(mut update) => {
-            translate_update(schema, &mut update, syms, program, connection)?
+            translate_update(&mut update, resolver, program, connection)?
         }
         ast::Stmt::Vacuum { .. } => bail_parse_error!("VACUUM not supported yet"),
         ast::Stmt::Insert {
@@ -293,14 +284,13 @@ pub fn translate_inner(
             body,
             returning,
         } => translate_insert(
-            schema,
             with,
+            resolver,
             or_conflict,
             tbl_name,
             columns,
             body,
             returning,
-            syms,
             program,
             connection,
         )?,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -9,21 +9,25 @@ use super::{
         ResultSetColumn, Scan, TableReferences, WhereTerm,
     },
     select::prepare_select_plan,
-    SymbolTable,
 };
-use crate::translate::expr::{BindingBehavior, WalkControl};
-use crate::translate::plan::{Window, WindowFunction};
+use crate::translate::{
+    emitter::Resolver,
+    expr::{BindingBehavior, WalkControl},
+};
 use crate::{
     ast::Limit,
     function::Func,
-    schema::{Schema, Table},
+    schema::Table,
     util::{exprs_are_equivalent, normalize_ident},
-    vdbe::builder::TableRefIdCounter,
     Result,
 };
 use crate::{
     function::{AggFunc, ExtFunc},
     translate::expr::{bind_and_rewrite_expr, ParamState},
+};
+use crate::{
+    translate::plan::{Window, WindowFunction},
+    vdbe::builder::ProgramBuilder,
 };
 use turso_parser::ast::Literal::Null;
 use turso_parser::ast::{
@@ -51,9 +55,8 @@ pub const ROWID_STRS: [&str; 3] = ["rowid", "_rowid_", "oid"];
 /// - `Err(..)` if an invalid function usage is detected (e.g., window
 ///   function encountered while `windows` is `None`).
 pub fn resolve_window_and_aggregate_functions(
-    schema: &Schema,
-    syms: &SymbolTable,
     top_level_expr: &Expr,
+    resolver: &Resolver,
     aggs: &mut Vec<Aggregate>,
     mut windows: Option<&mut Vec<Window>>,
 ) -> Result<bool> {
@@ -80,7 +83,7 @@ pub fn resolve_window_and_aggregate_functions(
                 let args_count = args.len();
                 let distinctness = Distinctness::from_ast(distinctness.as_ref());
 
-                if !schema.indexes_enabled() && distinctness.is_distinct() {
+                if !resolver.schema.indexes_enabled() && distinctness.is_distinct() {
                     crate::bail_parse_error!(
                         "SELECT with DISTINCT is not allowed without indexes enabled"
                     );
@@ -102,7 +105,10 @@ pub fn resolve_window_and_aggregate_functions(
                         return Ok(WalkControl::SkipChildren);
                     }
                     Err(e) => {
-                        if let Some(f) = syms.resolve_function(name.as_str(), args_count) {
+                        if let Some(f) = resolver
+                            .symbol_table
+                            .resolve_function(name.as_str(), args_count)
+                        {
                             let func = AggFunc::External(f.func.clone().into());
                             if let ExtFunc::Aggregate { .. } = f.as_ref().func {
                                 if let Some(over_clause) = filter_over.over_clause.as_ref() {
@@ -263,24 +269,21 @@ fn add_aggregate_if_not_exists(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn parse_from_clause_table(
-    schema: &Schema,
     table: ast::SelectTable,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
     table_references: &mut TableReferences,
     vtab_predicates: &mut Vec<Expr>,
     ctes: &mut Vec<JoinedTable>,
-    syms: &SymbolTable,
-    table_ref_counter: &mut TableRefIdCounter,
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
     match table {
         ast::SelectTable::Table(qualified_name, maybe_alias, _) => parse_table(
-            schema,
-            syms,
             table_references,
+            resolver,
+            program,
             ctes,
-            table_ref_counter,
             vtab_predicates,
             &qualified_name,
             maybe_alias.as_ref(),
@@ -289,11 +292,10 @@ fn parse_from_clause_table(
         ),
         ast::SelectTable::Select(subselect, maybe_alias) => {
             let Plan::Select(subplan) = prepare_select_plan(
-                schema,
                 subselect,
-                syms,
+                resolver,
+                program,
                 table_references.outer_query_refs(),
-                table_ref_counter,
                 QueryDestination::placeholder_for_subquery(),
                 connection,
             )?
@@ -312,16 +314,15 @@ fn parse_from_clause_table(
                 identifier,
                 subplan,
                 None,
-                table_ref_counter.next(),
+                program.table_reference_counter.next(),
             ));
             Ok(())
         }
         ast::SelectTable::TableCall(qualified_name, args, maybe_alias) => parse_table(
-            schema,
-            syms,
             table_references,
+            resolver,
+            program,
             ctes,
-            table_ref_counter,
             vtab_predicates,
             &qualified_name,
             maybe_alias.as_ref(),
@@ -334,11 +335,10 @@ fn parse_from_clause_table(
 
 #[allow(clippy::too_many_arguments)]
 fn parse_table(
-    schema: &Schema,
-    syms: &SymbolTable,
     table_references: &mut TableReferences,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
     ctes: &mut Vec<JoinedTable>,
-    table_ref_counter: &mut TableRefIdCounter,
     vtab_predicates: &mut Vec<Expr>,
     qualified_name: &QualifiedName,
     maybe_alias: Option<&As>,
@@ -380,7 +380,7 @@ fn parse_table(
                 ast::As::Elided(id) => id,
             })
             .map(|a| normalize_ident(a.as_str()));
-        let internal_id = table_ref_counter.next();
+        let internal_id = program.table_reference_counter.next();
         let tbl_ref = if let Table::Virtual(tbl) = table.as_ref() {
             transform_args_into_where_terms(args, internal_id, vtab_predicates, table.as_ref())?;
             Table::Virtual(tbl.clone())
@@ -418,13 +418,12 @@ fn parse_table(
 
         // Recursively call parse_from_clause_table with the view as a SELECT
         return parse_from_clause_table(
-            schema,
             ast::SelectTable::Select(*subselect.clone(), view_alias),
+            resolver,
+            program,
             table_references,
             vtab_predicates,
             ctes,
-            syms,
-            table_ref_counter,
             connection,
         );
     }
@@ -487,7 +486,7 @@ fn parse_table(
             }),
             table: Table::BTree(btree_table),
             identifier: alias.unwrap_or(normalized_qualified_name),
-            internal_id: table_ref_counter.next(),
+            internal_id: program.table_reference_counter.next(),
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
             database_id,
@@ -510,7 +509,7 @@ fn parse_table(
                 op: Operation::default_scan_for(&outer_ref.table),
                 table: outer_ref.table.clone(),
                 identifier: outer_ref.identifier.clone(),
-                internal_id: table_ref_counter.next(),
+                internal_id: program.table_reference_counter.next(),
                 join_info: None,
                 col_used_mask: ColumnUsedMask::default(),
                 database_id,
@@ -587,16 +586,14 @@ fn transform_args_into_where_terms(
 
 #[allow(clippy::too_many_arguments)]
 pub fn parse_from(
-    schema: &Schema,
     mut from: Option<FromClause>,
-    syms: &SymbolTable,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
     with: Option<With>,
     out_where_clause: &mut Vec<WhereTerm>,
     vtab_predicates: &mut Vec<Expr>,
     table_references: &mut TableReferences,
-    table_ref_counter: &mut TableRefIdCounter,
     connection: &Arc<crate::Connection>,
-    param_ctx: &mut ParamState,
 ) -> Result<()> {
     if from.is_none() {
         return Ok(());
@@ -620,7 +617,7 @@ pub fn parse_from(
             // TODO: sqlite actually allows overriding a catalog table with a CTE.
             // We should carry over the 'Scope' struct to all of our identifier resolution.
             let cte_name_normalized = normalize_ident(cte.tbl_name.as_str());
-            if schema.get_table(&cte_name_normalized).is_some() {
+            if resolver.schema.get_table(&cte_name_normalized).is_some() {
                 crate::bail_parse_error!(
                     "CTE name {} conflicts with catalog table name",
                     cte.tbl_name.as_str()
@@ -650,11 +647,10 @@ pub fn parse_from(
 
             // CTE can refer to other CTEs that came before it, plus any schema tables or tables in the outer scope.
             let cte_plan = prepare_select_plan(
-                schema,
                 cte.select,
-                syms,
+                resolver,
+                program,
                 &outer_query_refs_for_cte,
-                table_ref_counter,
                 QueryDestination::placeholder_for_subquery(),
                 connection,
             )?;
@@ -665,7 +661,7 @@ pub fn parse_from(
                 cte_name_normalized,
                 cte_plan,
                 None,
-                table_ref_counter.next(),
+                program.table_reference_counter.next(),
             ));
         }
     }
@@ -674,28 +670,25 @@ pub fn parse_from(
     let select_owned = from_owned.select;
     let joins_owned = from_owned.joins;
     parse_from_clause_table(
-        schema,
         *select_owned,
+        resolver,
+        program,
         table_references,
         vtab_predicates,
         &mut ctes_as_subqueries,
-        syms,
-        table_ref_counter,
         connection,
     )?;
 
     for join in joins_owned.into_iter() {
         parse_join(
-            schema,
             join,
-            syms,
+            resolver,
+            program,
             &mut ctes_as_subqueries,
             out_where_clause,
             vtab_predicates,
             table_references,
-            table_ref_counter,
             connection,
-            param_ctx,
         )?;
     }
 
@@ -905,16 +898,14 @@ pub fn determine_where_to_eval_expr(
 
 #[allow(clippy::too_many_arguments)]
 fn parse_join(
-    schema: &Schema,
     join: ast::JoinedSelectTable,
-    syms: &SymbolTable,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
     ctes: &mut Vec<JoinedTable>,
     out_where_clause: &mut Vec<WhereTerm>,
     vtab_predicates: &mut Vec<Expr>,
     table_references: &mut TableReferences,
-    table_ref_counter: &mut TableRefIdCounter,
     connection: &Arc<crate::Connection>,
-    param_ctx: &mut ParamState,
 ) -> Result<()> {
     let ast::JoinedSelectTable {
         operator: join_operator,
@@ -923,13 +914,12 @@ fn parse_join(
     } = join;
 
     parse_from_clause_table(
-        schema,
         table.as_ref().clone(),
+        resolver,
+        program,
         table_references,
         vtab_predicates,
         ctes,
-        syms,
-        table_ref_counter,
         connection,
     )?;
 
@@ -1007,7 +997,7 @@ fn parse_join(
                         Some(table_references),
                         None,
                         connection,
-                        param_ctx,
+                        &mut program.param_ctx,
                         BindingBehavior::TryResultColumnsFirst,
                     )?;
                 }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -15,12 +15,12 @@ use crate::storage::pager::AutoVacuumMode;
 use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
-use crate::translate::emitter::TransactionMode;
+use crate::translate::emitter::{Resolver, TransactionMode};
 use crate::translate::schema::translate_create_table;
 use crate::util::{normalize_ident, parse_signed_number, parse_string, IOExt as _};
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
 use crate::vdbe::insn::{Cookie, Insn};
-use crate::{bail_parse_error, CaptureDataChangesMode, LimboError, SymbolTable, Value};
+use crate::{bail_parse_error, CaptureDataChangesMode, LimboError, Value};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
@@ -32,10 +32,8 @@ fn list_pragmas(program: &mut ProgramBuilder) {
     program.add_pragma_result_column("pragma_list".into());
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn translate_pragma(
-    schema: &Schema,
-    syms: &SymbolTable,
+    resolver: &Resolver,
     name: &ast::QualifiedName,
     body: Option<ast::PragmaBody>,
     pager: Arc<Pager>,
@@ -60,12 +58,17 @@ pub fn translate_pragma(
     };
 
     let (mut program, mode) = match body {
-        None => query_pragma(pragma, schema, None, pager, connection, program)?,
+        None => query_pragma(pragma, resolver.schema, None, pager, connection, program)?,
         Some(ast::PragmaBody::Equals(value) | ast::PragmaBody::Call(value)) => match pragma {
-            PragmaName::TableInfo => {
-                query_pragma(pragma, schema, Some(*value), pager, connection, program)?
-            }
-            _ => update_pragma(pragma, schema, syms, *value, pager, connection, program)?,
+            PragmaName::TableInfo => query_pragma(
+                pragma,
+                resolver.schema,
+                Some(*value),
+                pager,
+                connection,
+                program,
+            )?,
+            _ => update_pragma(pragma, resolver, *value, pager, connection, program)?,
         },
     };
     match mode {
@@ -86,8 +89,7 @@ pub fn translate_pragma(
 
 fn update_pragma(
     pragma: PragmaName,
-    schema: &Schema,
-    syms: &SymbolTable,
+    resolver: &Resolver,
     value: ast::Expr,
     pager: Arc<Pager>,
     connection: Arc<crate::Connection>,
@@ -154,7 +156,7 @@ fn update_pragma(
         PragmaName::LegacyFileFormat => Ok((program, TransactionMode::None)),
         PragmaName::WalCheckpoint => query_pragma(
             PragmaName::WalCheckpoint,
-            schema,
+            resolver.schema,
             Some(value),
             pager,
             connection,
@@ -163,7 +165,7 @@ fn update_pragma(
         PragmaName::ModuleList => Ok((program, TransactionMode::None)),
         PragmaName::PageCount => query_pragma(
             PragmaName::PageCount,
-            schema,
+            resolver.schema,
             None,
             pager,
             connection,
@@ -287,13 +289,14 @@ fn update_pragma(
             // but for now, let's keep it as is...
             let opts = CaptureDataChangesMode::parse(&value)?;
             if let Some(table) = &opts.table() {
-                if schema.get_table(table).is_none() {
+                if resolver.schema.get_table(table).is_none() {
                     program = translate_create_table(
                         QualifiedName {
                             db_name: None,
                             name: ast::Name::new(table),
                             alias: None,
                         },
+                        resolver,
                         false,
                         true, // if_not_exists
                         ast::CreateTableBody::ColumnsAndConstraints {
@@ -301,8 +304,6 @@ fn update_pragma(
                             constraints: vec![],
                             options: ast::TableOptions::NONE,
                         },
-                        schema,
-                        syms,
                         program,
                         &connection,
                     )?;
@@ -314,7 +315,7 @@ fn update_pragma(
         PragmaName::DatabaseList => unreachable!("database_list cannot be set"),
         PragmaName::QueryOnly => query_pragma(
             PragmaName::QueryOnly,
-            schema,
+            resolver.schema,
             Some(value),
             pager,
             connection,
@@ -322,7 +323,7 @@ fn update_pragma(
         ),
         PragmaName::FreelistCount => query_pragma(
             PragmaName::FreelistCount,
-            schema,
+            resolver.schema,
             Some(value),
             pager,
             connection,

--- a/core/translate/rollback.rs
+++ b/core/translate/rollback.rs
@@ -1,14 +1,11 @@
 use turso_parser::ast::Name;
 
 use crate::{
-    schema::Schema,
     vdbe::{builder::ProgramBuilder, insn::Insn},
-    Result, SymbolTable,
+    Result,
 };
 
 pub fn translate_rollback(
-    _schema: &Schema,
-    _syms: &SymbolTable,
     mut program: ProgramBuilder,
     txn_name: Option<Name>,
     savepoint_name: Option<Name>,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -15,10 +15,10 @@ use crate::translate::planner::{
 };
 use crate::translate::window::plan_windows;
 use crate::util::normalize_ident;
-use crate::vdbe::builder::{ProgramBuilderOpts, TableRefIdCounter};
+use crate::vdbe::builder::ProgramBuilderOpts;
 use crate::vdbe::insn::Insn;
-use crate::{schema::Schema, vdbe::builder::ProgramBuilder, Result};
-use crate::{Connection, SymbolTable};
+use crate::Connection;
+use crate::{vdbe::builder::ProgramBuilder, Result};
 use std::sync::Arc;
 use turso_parser::ast::ResultColumn;
 use turso_parser::ast::{self, CompoundSelect, Expr};
@@ -29,23 +29,21 @@ pub struct TranslateSelectResult {
 }
 
 pub fn translate_select(
-    schema: &Schema,
     select: ast::Select,
-    syms: &SymbolTable,
+    resolver: &Resolver,
     mut program: ProgramBuilder,
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<TranslateSelectResult> {
     let mut select_plan = prepare_select_plan(
-        schema,
         select,
-        syms,
+        resolver,
+        &mut program,
         &[],
-        &mut program.table_reference_counter,
         query_destination,
         connection,
     )?;
-    optimize_plan(&mut select_plan, schema)?;
+    optimize_plan(&mut select_plan, resolver.schema)?;
     let num_result_cols;
     let opts = match &select_plan {
         Plan::Select(select) => {
@@ -84,7 +82,7 @@ pub fn translate_select(
     };
 
     program.extend(&opts);
-    emit_program(connection, &mut program, select_plan, schema, syms, |_| {})?;
+    emit_program(connection, resolver, &mut program, select_plan, |_| {})?;
     Ok(TranslateSelectResult {
         program,
         num_result_cols,
@@ -92,60 +90,52 @@ pub fn translate_select(
 }
 
 pub fn prepare_select_plan(
-    schema: &Schema,
     select: ast::Select,
-    syms: &SymbolTable,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
     outer_query_refs: &[OuterQueryReference],
-    table_ref_counter: &mut TableRefIdCounter,
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<Plan> {
     let compounds = select.body.compounds;
-    let mut param_ctx = ParamState::default();
     match compounds.is_empty() {
         true => Ok(Plan::Select(prepare_one_select_plan(
-            schema,
             select.body.select,
+            resolver,
+            program,
             select.limit,
             select.order_by,
             select.with,
-            syms,
             outer_query_refs,
-            table_ref_counter,
             query_destination,
             connection,
-            &mut param_ctx,
         )?)),
         false => {
             let mut last = prepare_one_select_plan(
-                schema,
                 select.body.select,
+                resolver,
+                program,
                 None,
                 vec![],
                 None,
-                syms,
                 outer_query_refs,
-                table_ref_counter,
                 query_destination.clone(),
                 connection,
-                &mut param_ctx,
             )?;
 
             let mut left = Vec::with_capacity(compounds.len());
             for CompoundSelect { select, operator } in compounds {
                 left.push((last, operator));
                 last = prepare_one_select_plan(
-                    schema,
                     select,
+                    resolver,
+                    program,
                     None,
                     vec![],
                     None,
-                    syms,
                     outer_query_refs,
-                    table_ref_counter,
                     query_destination.clone(),
                     connection,
-                    &mut param_ctx,
                 )?;
             }
 
@@ -157,7 +147,7 @@ pub fn prepare_select_plan(
                 }
             }
             let (limit, offset) = select.limit.map_or(Ok((None, None)), |mut l| {
-                parse_limit(&mut l, connection, &mut param_ctx)
+                parse_limit(&mut l, connection, &mut program.param_ctx)
             })?;
 
             // FIXME: handle ORDER BY for compound selects
@@ -181,17 +171,15 @@ pub fn prepare_select_plan(
 
 #[allow(clippy::too_many_arguments)]
 fn prepare_one_select_plan(
-    schema: &Schema,
     select: ast::OneSelect,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
     limit: Option<ast::Limit>,
     order_by: Vec<ast::SortedColumn>,
     with: Option<ast::With>,
-    syms: &SymbolTable,
     outer_query_refs: &[OuterQueryReference],
-    table_ref_counter: &mut TableRefIdCounter,
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
-    param_ctx: &mut ParamState,
 ) -> Result<SelectPlan> {
     match select {
         ast::OneSelect::Select {
@@ -203,7 +191,7 @@ fn prepare_one_select_plan(
             window_clause,
             ..
         } => {
-            if !schema.indexes_enabled() && distinctness.is_some() {
+            if !resolver.schema.indexes_enabled() && distinctness.is_some() {
                 crate::bail_parse_error!(
                     "SELECT with DISTINCT is not allowed without indexes enabled"
                 );
@@ -229,16 +217,14 @@ fn prepare_one_select_plan(
 
             // Parse the FROM clause into a vec of TableReferences. Fold all the join conditions expressions into the WHERE clause.
             parse_from(
-                schema,
                 from,
-                syms,
+                resolver,
+                program,
                 with,
                 &mut where_predicates,
                 &mut vtab_predicates,
                 &mut table_references,
-                table_ref_counter,
                 connection,
-                param_ctx,
             )?;
 
             // Preallocate space for the result columns
@@ -301,7 +287,7 @@ fn prepare_one_select_plan(
                         Some(&mut plan.table_references),
                         None,
                         connection,
-                        param_ctx,
+                        &mut program.param_ctx,
                         BindingBehavior::ResultColumnsNotAllowed,
                     )?;
                 }
@@ -311,7 +297,7 @@ fn prepare_one_select_plan(
                         Some(&mut plan.table_references),
                         None,
                         connection,
-                        param_ctx,
+                        &mut program.param_ctx,
                         BindingBehavior::ResultColumnsNotAllowed,
                     )?;
                 }
@@ -374,13 +360,12 @@ fn prepare_one_select_plan(
                             Some(&mut plan.table_references),
                             None,
                             connection,
-                            param_ctx,
+                            &mut program.param_ctx,
                             BindingBehavior::ResultColumnsNotAllowed,
                         )?;
                         let contains_aggregates = resolve_window_and_aggregate_functions(
-                            schema,
-                            syms,
                             expr,
+                            resolver,
                             &mut aggregate_expressions,
                             Some(&mut windows),
                         )?;
@@ -403,7 +388,7 @@ fn prepare_one_select_plan(
                 &mut vtab_predicates,
                 &mut plan,
                 connection,
-                param_ctx,
+                &mut program.param_ctx,
             )?;
 
             // Parse the actual WHERE clause and add its conditions to the plan WHERE clause that already contains the join conditions.
@@ -413,7 +398,7 @@ fn prepare_one_select_plan(
                 Some(&plan.result_columns),
                 &mut plan.where_clause,
                 connection,
-                param_ctx,
+                &mut program.param_ctx,
             )?;
 
             if let Some(mut group_by) = group_by {
@@ -424,7 +409,7 @@ fn prepare_one_select_plan(
                         Some(&mut plan.table_references),
                         Some(&plan.result_columns),
                         connection,
-                        param_ctx,
+                        &mut program.param_ctx,
                         BindingBehavior::TryResultColumnsFirst,
                     )?;
                 }
@@ -441,13 +426,12 @@ fn prepare_one_select_plan(
                                 Some(&mut plan.table_references),
                                 Some(&plan.result_columns),
                                 connection,
-                                param_ctx,
+                                &mut program.param_ctx,
                                 BindingBehavior::TryResultColumnsFirst,
                             )?;
                             let contains_aggregates = resolve_window_and_aggregate_functions(
-                                schema,
-                                syms,
                                 expr,
+                                resolver,
                                 &mut aggregate_expressions,
                                 None,
                             )?;
@@ -481,13 +465,12 @@ fn prepare_one_select_plan(
                     Some(&mut plan.table_references),
                     Some(&plan.result_columns),
                     connection,
-                    param_ctx,
+                    &mut program.param_ctx,
                     BindingBehavior::TryResultColumnsFirst,
                 )?;
                 resolve_window_and_aggregate_functions(
-                    schema,
-                    syms,
                     &o.expr,
+                    resolver,
                     &mut plan.aggregates,
                     Some(&mut windows),
                 )?;
@@ -502,17 +485,22 @@ fn prepare_one_select_plan(
                     &group_by.exprs,
                     &plan.order_by,
                     &plan.aggregates,
-                    &Resolver::new(schema, syms),
+                    resolver,
                 ));
             }
 
             // Parse the LIMIT/OFFSET clause
             (plan.limit, plan.offset) = limit.map_or(Ok((None, None)), |mut l| {
-                parse_limit(&mut l, connection, param_ctx)
+                parse_limit(&mut l, connection, &mut program.param_ctx)
             })?;
 
             if !windows.is_empty() {
-                plan_windows(schema, syms, &mut plan, table_ref_counter, &mut windows)?;
+                plan_windows(
+                    &mut plan,
+                    resolver,
+                    &mut program.table_reference_counter,
+                    &mut windows,
+                )?;
             }
 
             // Return the unoptimized query plan

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::schema::{BTreeTable, Column, Type, ROWID_SENTINEL};
+use crate::translate::emitter::Resolver;
 use crate::translate::expr::{
     bind_and_rewrite_expr, walk_expr, BindingBehavior, ParamState, WalkControl,
 };
@@ -14,7 +15,6 @@ use crate::{
     schema::{Schema, Table},
     util::normalize_ident,
     vdbe::builder::{ProgramBuilder, ProgramBuilderOpts},
-    SymbolTable,
 };
 use turso_parser::ast::{self, Expr, Indexed, SortOrder};
 
@@ -56,34 +56,32 @@ addr  opcode         p1    p2    p3    p4             p5  comment
 18    Goto           0     1     0                    0
 */
 pub fn translate_update(
-    schema: &Schema,
     body: &mut ast::Update,
-    syms: &SymbolTable,
+    resolver: &Resolver,
     mut program: ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> crate::Result<ProgramBuilder> {
-    let mut plan = prepare_update_plan(&mut program, schema, body, connection, false)?;
-    optimize_plan(&mut plan, schema)?;
+    let mut plan = prepare_update_plan(&mut program, resolver.schema, body, connection, false)?;
+    optimize_plan(&mut plan, resolver.schema)?;
     let opts = ProgramBuilderOpts {
         num_cursors: 1,
         approx_num_insns: 20,
         approx_num_labels: 4,
     };
     program.extend(&opts);
-    emit_program(connection, &mut program, plan, schema, syms, |_| {})?;
+    emit_program(connection, resolver, &mut program, plan, |_| {})?;
     Ok(program)
 }
 
 pub fn translate_update_for_schema_change(
-    schema: &Schema,
     body: &mut ast::Update,
-    syms: &SymbolTable,
+    resolver: &Resolver,
     mut program: ProgramBuilder,
     connection: &Arc<crate::Connection>,
     ddl_query: &str,
     after: impl FnOnce(&mut ProgramBuilder),
 ) -> crate::Result<ProgramBuilder> {
-    let mut plan = prepare_update_plan(&mut program, schema, body, connection, true)?;
+    let mut plan = prepare_update_plan(&mut program, resolver.schema, body, connection, true)?;
 
     if let Plan::Update(plan) = &mut plan {
         if program.capture_data_changes_mode().has_updates() {
@@ -91,14 +89,14 @@ pub fn translate_update_for_schema_change(
         }
     }
 
-    optimize_plan(&mut plan, schema)?;
+    optimize_plan(&mut plan, resolver.schema)?;
     let opts = ProgramBuilderOpts {
         num_cursors: 1,
         approx_num_insns: 20,
         approx_num_labels: 4,
     };
     program.extend(&opts);
-    emit_program(connection, &mut program, plan, schema, syms, after)?;
+    emit_program(connection, resolver, &mut program, plan, after)?;
     Ok(program)
 }
 
@@ -201,7 +199,6 @@ pub fn prepare_update_plan(
         .collect();
 
     let mut set_clauses = Vec::with_capacity(body.sets.len());
-    let mut param_idx = ParamState::default();
 
     // Process each SET assignment and map column names to expressions
     // e.g the statement `SET x = 1, y = 2, z = 3` has 3 set assigments
@@ -211,7 +208,7 @@ pub fn prepare_update_plan(
             Some(&mut table_references),
             None,
             connection,
-            &mut param_idx,
+            &mut program.param_ctx,
             BindingBehavior::ResultColumnsNotAllowed,
         )?;
 
@@ -271,7 +268,6 @@ pub fn prepare_update_plan(
         body.tbl_name.name.as_str(),
         program,
         connection,
-        &mut param_idx,
     )?;
 
     let order_by = body
@@ -283,7 +279,7 @@ pub fn prepare_update_plan(
                 Some(&mut table_references),
                 Some(&result_columns),
                 connection,
-                &mut param_idx,
+                &mut program.param_ctx,
                 BindingBehavior::ResultColumnsNotAllowed,
             );
             (o.expr.clone(), o.order.unwrap_or(SortOrder::Asc))
@@ -327,7 +323,7 @@ pub fn prepare_update_plan(
             Some(&result_columns),
             &mut where_clause,
             connection,
-            &mut param_idx,
+            &mut program.param_ctx,
         )?;
 
         let table = Arc::new(BTreeTable {
@@ -405,13 +401,13 @@ pub fn prepare_update_plan(
             Some(&result_columns),
             &mut where_clause,
             connection,
-            &mut param_idx,
+            &mut program.param_ctx,
         )?;
     };
 
     // Parse the LIMIT/OFFSET clause
     let (limit, offset) = body.limit.as_mut().map_or(Ok((None, None)), |l| {
-        parse_limit(l, connection, &mut param_idx)
+        parse_limit(l, connection, &mut program.param_ctx)
     })?;
 
     // Check what indexes will need to be updated by checking set_clauses and see

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -5,16 +5,15 @@ use crate::translate::schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEI
 use crate::util::{normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX};
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
 use crate::vdbe::insn::{CmpInsFlags, Cookie, Insn, RegisterOrLiteral};
-use crate::{Connection, Result, SymbolTable};
+use crate::{Connection, Result};
 use std::sync::Arc;
 use turso_parser::ast;
 
 pub fn translate_create_materialized_view(
-    schema: &Schema,
     view_name: &str,
+    resolver: &Resolver,
     select_stmt: &ast::Select,
     connection: Arc<Connection>,
-    syms: &SymbolTable,
     mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     // Check if experimental views are enabled
@@ -28,7 +27,8 @@ pub fn translate_create_materialized_view(
     let normalized_view_name = normalize_ident(view_name);
 
     // Check if view already exists
-    if schema
+    if resolver
+        .schema
         .get_materialized_view(&normalized_view_name)
         .is_some()
     {
@@ -42,7 +42,8 @@ pub fn translate_create_materialized_view(
     // storing invalid view definitions
     use crate::incremental::view::IncrementalView;
     use crate::schema::BTreeTable;
-    let view_column_schema = IncrementalView::validate_and_extract_columns(select_stmt, schema)?;
+    let view_column_schema =
+        IncrementalView::validate_and_extract_columns(select_stmt, resolver.schema)?;
     let view_columns = view_column_schema.flat_columns();
 
     // Reconstruct the SQL string for storage
@@ -120,7 +121,7 @@ pub fn translate_create_materialized_view(
     program.preassign_label_to_next_insn(clear_done_label);
 
     // Open cursor to sqlite_schema table
-    let table = schema.get_btree_table(SQLITE_TABLEID).unwrap();
+    let table = resolver.schema.get_btree_table(SQLITE_TABLEID).unwrap();
     let sqlite_schema_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(table.clone()));
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
@@ -129,10 +130,9 @@ pub fn translate_create_materialized_view(
     });
 
     // Add the materialized view entry to sqlite_schema
-    let resolver = Resolver::new(schema, syms);
     emit_schema_entry(
         &mut program,
-        &resolver,
+        resolver,
         sqlite_schema_cursor_id,
         None, // cdc_table_cursor_id, no cdc for views
         SchemaEntryType::View,
@@ -164,7 +164,7 @@ pub fn translate_create_materialized_view(
 
     emit_schema_entry(
         &mut program,
-        &resolver,
+        resolver,
         sqlite_schema_cursor_id,
         None, // cdc_table_cursor_id
         SchemaEntryType::Table,
@@ -211,7 +211,7 @@ pub fn translate_create_materialized_view(
     program.emit_insn(Insn::SetCookie {
         db: 0,
         cookie: Cookie::SchemaVersion,
-        value: (schema.schema_version + 1) as i32,
+        value: (resolver.schema.schema_version + 1) as i32,
         p5: 0,
     });
 
@@ -221,7 +221,7 @@ pub fn translate_create_materialized_view(
         cursors: cursor_info,
     });
 
-    program.epilogue(schema);
+    program.epilogue(resolver.schema);
     Ok(program)
 }
 
@@ -230,19 +230,19 @@ fn create_materialized_view_to_str(view_name: &str, select_stmt: &ast::Select) -
 }
 
 pub fn translate_create_view(
-    schema: &Schema,
     view_name: &str,
+    resolver: &Resolver,
     select_stmt: &ast::Select,
     _columns: &[ast::IndexedColumn],
     _connection: Arc<Connection>,
-    syms: &SymbolTable,
     mut program: ProgramBuilder,
 ) -> Result<ProgramBuilder> {
     let normalized_view_name = normalize_ident(view_name);
 
     // Check if view already exists
-    if schema.get_view(&normalized_view_name).is_some()
-        || schema
+    if resolver.schema.get_view(&normalized_view_name).is_some()
+        || resolver
+            .schema
             .get_materialized_view(&normalized_view_name)
             .is_some()
     {
@@ -255,7 +255,7 @@ pub fn translate_create_view(
     let sql = create_view_to_str(view_name, select_stmt);
 
     // Open cursor to sqlite_schema table
-    let table = schema.get_btree_table(SQLITE_TABLEID).unwrap();
+    let table = resolver.schema.get_btree_table(SQLITE_TABLEID).unwrap();
     let sqlite_schema_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(table.clone()));
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
@@ -264,10 +264,9 @@ pub fn translate_create_view(
     });
 
     // Add the view entry to sqlite_schema
-    let resolver = Resolver::new(schema, syms);
     emit_schema_entry(
         &mut program,
-        &resolver,
+        resolver,
         sqlite_schema_cursor_id,
         None, // cdc_table_cursor_id, no cdc for views
         SchemaEntryType::View,
@@ -286,7 +285,7 @@ pub fn translate_create_view(
     program.emit_insn(Insn::SetCookie {
         db: 0,
         cookie: Cookie::SchemaVersion,
-        value: (schema.schema_version + 1) as i32,
+        value: (resolver.schema.schema_version + 1) as i32,
         p5: 0,
     });
 

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -1,4 +1,4 @@
-use crate::schema::{BTreeTable, Schema, Table};
+use crate::schema::{BTreeTable, Table};
 use crate::translate::aggregation::{translate_aggregation_step, AggArgumentSource};
 use crate::translate::emitter::{Resolver, TranslateCtx};
 use crate::translate::expr::{walk_expr, walk_expr_mut, WalkControl};
@@ -13,7 +13,6 @@ use crate::util::exprs_are_equivalent;
 use crate::vdbe::builder::{CursorType, ProgramBuilder, TableRefIdCounter};
 use crate::vdbe::insn::{InsertFlags, Insn};
 use crate::vdbe::{BranchOffset, CursorID};
-use crate::SymbolTable;
 use std::mem;
 use std::sync::Arc;
 use turso_parser::ast::Name::Ident;
@@ -22,8 +21,7 @@ use turso_parser::ast::{Expr, FunctionTail, Literal, Over, SortOrder, TableInter
 const SUBQUERY_DATABASE_ID: usize = 0;
 
 struct WindowSubqueryContext<'a> {
-    schema: &'a Schema,
-    syms: &'a SymbolTable,
+    resolver: &'a Resolver<'a>,
     subquery_order_by: &'a mut Vec<(Box<Expr>, SortOrder)>,
     subquery_result_columns: &'a mut Vec<ResultSetColumn>,
     subquery_id: &'a TableInternalId,
@@ -82,9 +80,8 @@ struct WindowSubqueryContext<'a> {
 /// );
 /// ```
 pub fn plan_windows(
-    schema: &Schema,
-    syms: &SymbolTable,
     plan: &mut SelectPlan,
+    resolver: &Resolver,
     table_ref_counter: &mut TableRefIdCounter,
     windows: &mut Vec<Window>,
 ) -> crate::Result<()> {
@@ -99,13 +96,12 @@ pub fn plan_windows(
         );
     }
 
-    prepare_window_subquery(schema, syms, plan, table_ref_counter, windows, 0)
+    prepare_window_subquery(plan, resolver, table_ref_counter, windows, 0)
 }
 
 fn prepare_window_subquery(
-    schema: &Schema,
-    syms: &SymbolTable,
     outer_plan: &mut SelectPlan,
+    resolver: &Resolver,
     table_ref_counter: &mut TableRefIdCounter,
     windows: &mut Vec<Window>,
     processed_window_count: usize,
@@ -139,8 +135,7 @@ fn prepare_window_subquery(
     }
 
     let mut ctx = WindowSubqueryContext {
-        schema,
-        syms,
+        resolver,
         subquery_order_by: &mut subquery_order_by,
         subquery_result_columns: &mut subquery_result_columns,
         subquery_id: &subquery_id,
@@ -213,9 +208,8 @@ fn prepare_window_subquery(
     };
 
     prepare_window_subquery(
-        schema,
-        syms,
         &mut inner_plan,
+        resolver,
         table_ref_counter,
         windows,
         processed_window_count + 1,
@@ -250,13 +244,8 @@ fn append_order_by(
     ctx.subquery_order_by
         .push((Box::new(expr.clone()), *sort_order));
 
-    let contains_aggregates = resolve_window_and_aggregate_functions(
-        ctx.schema,
-        ctx.syms,
-        expr,
-        &mut plan.aggregates,
-        None,
-    )?;
+    let contains_aggregates =
+        resolve_window_and_aggregate_functions(expr, ctx.resolver, &mut plan.aggregates, None)?;
     rewrite_expr_as_subquery_column(expr, ctx, contains_aggregates);
     Ok(())
 }
@@ -352,9 +341,8 @@ fn rewrite_expr_referencing_current_window(
             filter_over,
         } => {
             for arg in args.iter_mut() {
-                let contains_aggregates = resolve_window_and_aggregate_functions(
-                    ctx.schema, ctx.syms, arg, aggregates, None,
-                )?;
+                let contains_aggregates =
+                    resolve_window_and_aggregate_functions(arg, ctx.resolver, aggregates, None)?;
                 rewrite_expr_as_subquery_column(arg, ctx, contains_aggregates);
             }
             assert!(

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -10,6 +10,7 @@ use crate::{
     translate::{
         collate::CollationSeq,
         emitter::TransactionMode,
+        expr::ParamState,
         plan::{ResultSetColumn, TableReferences},
     },
     CaptureDataChangesMode, Connection, Value, VirtualTable,
@@ -118,6 +119,7 @@ pub struct ProgramBuilder {
     query_mode: QueryMode,
     /// Current parent explain address, if any.
     current_parent_explain_idx: Option<usize>,
+    pub param_ctx: ParamState,
 }
 
 #[derive(Debug, Clone)]
@@ -203,6 +205,7 @@ impl ProgramBuilder {
             rollback: false,
             query_mode,
             current_parent_explain_idx: None,
+            param_ctx: ParamState::default(),
         }
     }
 


### PR DESCRIPTION
This PR contains _no semantic changes_.

I made this cleanup on another branch when I was working on subqueries, as the inconsistency with passing around `Schema` and `SymbolTable` had been kinda bothering me. By adding `param_ctx` to the program, it prevents accidentally resetting it to zero.