### PR TITLE
core/translate: allow creating column called 'rowid'

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2055,7 +2055,7 @@ mod tests {
         let table = BTreeTable::from_sql(sql, 0)?;
         let column = table.get_column("a").unwrap().1;
         assert!(
-            !column,
+            !column.is_rowid_alias,
             "column 'a´ shouldn't be a rowid alias because table has no rowid"
         );
         Ok(())

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -976,15 +976,11 @@ impl BTreeTable {
     pub fn get_rowid_alias_column(&self) -> Option<(usize, &Column)> {
         if self.primary_key_columns.len() == 1 {
             let (idx, col) = self.get_column(&self.primary_key_columns[0].0)?;
-            if self.column_is_rowid_alias(col) {
+            if col.is_rowid_alias {
                 return Some((idx, col));
             }
         }
         None
-    }
-
-    pub fn column_is_rowid_alias(&self, col: &Column) -> bool {
-        col.is_rowid_alias
     }
 
     /// Returns the column position and column for a given column name.
@@ -2027,7 +2023,7 @@ mod tests {
         let table = BTreeTable::from_sql(sql, 0)?;
         let column = table.get_column("a").unwrap().1;
         assert!(
-            !table.column_is_rowid_alias(column),
+            !column.is_rowid_alias,
             "column 'a´ has type different than INTEGER so can't be a rowid alias"
         );
         Ok(())
@@ -2038,10 +2034,7 @@ mod tests {
         let sql = r#"CREATE TABLE t1 (a INTEGER PRIMARY KEY, b TEXT);"#;
         let table = BTreeTable::from_sql(sql, 0)?;
         let column = table.get_column("a").unwrap().1;
-        assert!(
-            table.column_is_rowid_alias(column),
-            "column 'a´ should be a rowid alias"
-        );
+        assert!(column.is_rowid_alias, "column 'a´ should be a rowid alias");
         Ok(())
     }
 
@@ -2051,10 +2044,7 @@ mod tests {
         let sql = r#"CREATE TABLE t1 (a INTEGER, b TEXT, PRIMARY KEY(a));"#;
         let table = BTreeTable::from_sql(sql, 0)?;
         let column = table.get_column("a").unwrap().1;
-        assert!(
-            table.column_is_rowid_alias(column),
-            "column 'a´ should be a rowid alias"
-        );
+        assert!(column.is_rowid_alias, "column 'a´ should be a rowid alias");
         Ok(())
     }
 
@@ -2065,7 +2055,7 @@ mod tests {
         let table = BTreeTable::from_sql(sql, 0)?;
         let column = table.get_column("a").unwrap().1;
         assert!(
-            !table.column_is_rowid_alias(column),
+            !column,
             "column 'a´ shouldn't be a rowid alias because table has no rowid"
         );
         Ok(())
@@ -2077,7 +2067,7 @@ mod tests {
         let table = BTreeTable::from_sql(sql, 0)?;
         let column = table.get_column("a").unwrap().1;
         assert!(
-            !table.column_is_rowid_alias(column),
+            !column.is_rowid_alias,
             "column 'a´ shouldn't be a rowid alias because table has no rowid"
         );
         Ok(())
@@ -2100,7 +2090,7 @@ mod tests {
         let table = BTreeTable::from_sql(sql, 0)?;
         let column = table.get_column("a").unwrap().1;
         assert!(
-            !table.column_is_rowid_alias(column),
+            !column.is_rowid_alias,
             "column 'a´ shouldn't be a rowid alias because table has composite primary key"
         );
         Ok(())

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -3446,10 +3446,6 @@ impl<'a> Parser<'a> {
 
     pub fn parse_column_definition(&mut self, in_alter: bool) -> Result<ColumnDefinition> {
         let col_name = self.parse_nm()?;
-        if !in_alter && col_name.as_str().eq_ignore_ascii_case("rowid") {
-            return Err(Error::Custom("cannot use reserved word: ROWID".to_owned()));
-        }
-
         let col_type = self.parse_type()?;
         let constraints = self.parse_named_column_constraints(in_alter)?;
         Ok(ColumnDefinition {
@@ -4039,7 +4035,6 @@ mod tests {
             "ALTER TABLE my_table ADD COLUMN my_column PRIMARY KEY",
             "ALTER TABLE my_table ADD COLUMN my_column UNIQUE",
             "CREATE TEMP TABLE baz.foo(bar)",
-            "CREATE TABLE foo(rowid)",
             "CREATE TABLE foo(d INT AS (a*abs(b)))",
             "CREATE TABLE foo(d INT AS (a*abs(b)))",
             "CREATE TABLE foo(bar UNKNOWN_INT) STRICT",

--- a/testing/create_table.test
+++ b/testing/create_table.test
@@ -45,3 +45,11 @@ do_execsql_test_in_memory_any_error create_table_column_and_table_primary_keys {
 do_execsql_test_in_memory_any_error create_table_multiple_table_primary_keys {
     CREATE TABLE t(a,b,c,d,primary key(a,b), primary key(c,d));
 }
+
+# https://github.com/tursodatabase/turso/issues/3282
+do_execsql_test_on_specific_db {:memory:} col-named-rowid {
+  create table t(rowid, a);
+  insert into t values (1,2), (2,3), (3,4);
+  update t set rowid = 1; -- should allow regular update and not throw unique constraint
+  select count(*) from t where rowid = 1;
+} {3}


### PR DESCRIPTION
closes #3282

includes minor refactor, removing `column_is_rowid_alias`, which is only checking the public field of the argument Column.