### PR TITLE
MVCC: Handle table ID / rootpages properly for both checkpointed and non-checkpointed tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ simulator-output/
 bisected.sql
 *.log
 
+*.db-lg

--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -68,7 +68,7 @@ fn bench(c: &mut Criterion) {
                 .read(
                     tx_id,
                     RowID {
-                        table_id: 1,
+                        table_id: (-2).into(),
                         row_id: 1,
                     },
                 )
@@ -98,7 +98,7 @@ fn bench(c: &mut Criterion) {
                     tx_id,
                     Row {
                         id: RowID {
-                            table_id: 1,
+                            table_id: (-2).into(),
                             row_id: 1,
                         },
                         data: record_data.clone(),
@@ -126,7 +126,7 @@ fn bench(c: &mut Criterion) {
             tx_id,
             Row {
                 id: RowID {
-                    table_id: 1,
+                    table_id: (-2).into(),
                     row_id: 1,
                 },
                 data: record_data.clone(),
@@ -140,7 +140,7 @@ fn bench(c: &mut Criterion) {
                 .read(
                     tx_id,
                     RowID {
-                        table_id: 1,
+                        table_id: (-2).into(),
                         row_id: 1,
                     },
                 )
@@ -155,7 +155,7 @@ fn bench(c: &mut Criterion) {
             tx_id,
             Row {
                 id: RowID {
-                    table_id: 1,
+                    table_id: (-2).into(),
                     row_id: 1,
                 },
                 data: record_data.clone(),
@@ -170,7 +170,7 @@ fn bench(c: &mut Criterion) {
                     tx_id,
                     Row {
                         id: RowID {
-                            table_id: 1,
+                            table_id: (-2).into(),
                             row_id: 1,
                         },
                         data: record_data.clone(),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -443,6 +443,13 @@ impl Database {
             buffer_pool: BufferPool::begin_init(&io, arena_size),
             n_connections: AtomicUsize::new(0),
         });
+
+        if opts.enable_mvcc {
+            let mv_store = db.mv_store.as_ref().unwrap();
+            let mvcc_bootstrap_conn = db.connect_mvcc_bootstrap()?;
+            mv_store.bootstrap(mvcc_bootstrap_conn)?;
+        }
+
         db.register_global_builtin_extensions()
             .expect("unable to register global extensions");
 
@@ -487,17 +494,26 @@ impl Database {
                 Ok(())
             })?;
         }
+
         Ok(db)
     }
 
     #[instrument(skip_all, level = Level::INFO)]
     pub fn connect(self: &Arc<Database>) -> Result<Arc<Connection>> {
+        self._connect(false)
+    }
+
+    pub(crate) fn connect_mvcc_bootstrap(self: &Arc<Database>) -> Result<Arc<Connection>> {
+        self._connect(true)
+    }
+
+    #[instrument(skip_all, level = Level::INFO)]
+    fn _connect(
+        self: &Arc<Database>,
+        is_mvcc_bootstrap_connection: bool,
+    ) -> Result<Arc<Connection>> {
         let pager = self.init_pager(None)?;
         let pager = Arc::new(pager);
-
-        if self.mv_store.is_some() {
-            self.maybe_recover_logical_log(pager.clone())?;
-        }
 
         let page_size = pager.get_page_size_unchecked();
 
@@ -539,6 +555,7 @@ impl Database {
             sync_mode: RwLock::new(SyncMode::Full),
             data_sync_retry: AtomicBool::new(false),
             busy_timeout: RwLock::new(Duration::new(0, 0)),
+            is_mvcc_bootstrap_connection: AtomicBool::new(is_mvcc_bootstrap_connection),
         });
         self.n_connections
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -546,17 +563,6 @@ impl Database {
         // add built-in extensions symbols to the connection to prevent having to load each time
         conn.syms.write().extend(&builtin_syms);
         Ok(conn)
-    }
-
-    pub fn maybe_recover_logical_log(self: &Arc<Database>, pager: Arc<Pager>) -> Result<()> {
-        let Some(mv_store) = self.mv_store.clone() else {
-            panic!("tryign to recover logical log without mvcc");
-        };
-        if !mv_store.needs_recover() {
-            return Ok(());
-        }
-
-        mv_store.recover_logical_log(&self.io, &pager)
     }
 
     pub fn is_readonly(&self) -> bool {
@@ -1052,6 +1058,8 @@ pub struct Connection {
     /// User defined max accumulated Busy timeout duration
     /// Default is 0 (no timeout)
     busy_timeout: RwLock<std::time::Duration>,
+    /// Whether this is an internal connection used for MVCC bootstrap
+    is_mvcc_bootstrap_connection: AtomicBool,
 }
 
 impl Drop for Connection {
@@ -1066,8 +1074,20 @@ impl Drop for Connection {
 }
 
 impl Connection {
-    #[instrument(skip_all, level = Level::INFO)]
     pub fn prepare(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
+        if self.is_mvcc_bootstrap_connection() {
+            // Never use MV store for bootstrapping - we read state directly from sqlite_schema in the DB file.
+            return self._prepare(sql, None);
+        }
+        self._prepare(sql, self.db.mv_store.clone())
+    }
+
+    #[instrument(skip_all, level = Level::INFO)]
+    pub fn _prepare(
+        self: &Arc<Connection>,
+        sql: impl AsRef<str>,
+        mv_store: Option<Arc<MvStore>>,
+    ) -> Result<Statement> {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
@@ -1100,12 +1120,19 @@ impl Connection {
             mode,
             input,
         )?;
-        Ok(Statement::new(
-            program,
-            self.db.mv_store.clone(),
-            pager,
-            mode,
-        ))
+        Ok(Statement::new(program, mv_store, pager, mode))
+    }
+
+    /// Whether this is an internal connection used for MVCC bootstrap
+    pub fn is_mvcc_bootstrap_connection(&self) -> bool {
+        self.is_mvcc_bootstrap_connection.load(Ordering::SeqCst)
+    }
+
+    /// Promote MVCC bootstrap connection to a regular connection so it reads from the MV store again.
+    pub fn promote_to_regular_connection(&self) {
+        assert!(self.is_mvcc_bootstrap_connection.load(Ordering::SeqCst));
+        self.is_mvcc_bootstrap_connection
+            .store(false, Ordering::SeqCst);
     }
 
     /// Parse schema from scratch if version of schema for the connection differs from the schema cookie in the root page
@@ -1206,14 +1233,7 @@ impl Connection {
         let stmt = self.prepare("SELECT * FROM sqlite_schema")?;
 
         // TODO: This function below is synchronous, make it async
-        parse_schema_rows(
-            stmt,
-            &mut fresh,
-            &self.syms.read(),
-            None,
-            existing_views,
-            self.db.mv_store.as_ref(),
-        )?;
+        parse_schema_rows(stmt, &mut fresh, &self.syms.read(), None, existing_views)?;
 
         tracing::debug!(
             "reparse_schema: schema_version={}, tables={:?}",
@@ -1720,7 +1740,7 @@ impl Connection {
     }
 
     pub fn is_wal_auto_checkpoint_disabled(&self) -> bool {
-        self.wal_auto_checkpoint_disabled.load(Ordering::SeqCst)
+        self.wal_auto_checkpoint_disabled.load(Ordering::SeqCst) || self.db.mv_store.is_some()
     }
 
     pub fn last_insert_rowid(&self) -> i64 {
@@ -1862,14 +1882,9 @@ impl Connection {
         let syms = self.syms.read();
         self.with_schema_mut(|schema| {
             let existing_views = schema.incremental_views.clone();
-            if let Err(LimboError::ExtensionError(e)) = parse_schema_rows(
-                rows,
-                schema,
-                &syms,
-                None,
-                existing_views,
-                self.db.mv_store.as_ref(),
-            ) {
+            if let Err(LimboError::ExtensionError(e)) =
+                parse_schema_rows(rows, schema, &syms, None, existing_views)
+            {
                 // this means that a vtab exists and we no longer have the module loaded. we print
                 // a warning to the user to load the module
                 eprintln!("Warning: {e}");

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -20,7 +20,7 @@ enum CursorPosition {
 pub struct MvccLazyCursor<Clock: LogicalClock> {
     pub db: Arc<MvStore<Clock>>,
     current_pos: CursorPosition,
-    table_id: i64,
+    pub table_id: i64,
     tx_id: u64,
 }
 

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,5 +1,5 @@
 use crate::mvcc::clock::LogicalClock;
-use crate::mvcc::database::{MvStore, Row, RowID};
+use crate::mvcc::database::{MVTableId, MvStore, Row, RowID};
 use crate::types::{IOResult, SeekKey, SeekOp, SeekResult};
 use crate::Result;
 use crate::{Pager, Value};
@@ -20,7 +20,7 @@ enum CursorPosition {
 pub struct MvccLazyCursor<Clock: LogicalClock> {
     pub db: Arc<MvStore<Clock>>,
     current_pos: CursorPosition,
-    pub table_id: i64,
+    pub table_id: MVTableId,
     tx_id: u64,
 }
 
@@ -28,7 +28,7 @@ impl<Clock: LogicalClock> MvccLazyCursor<Clock> {
     pub fn new(
         db: Arc<MvStore<Clock>>,
         tx_id: u64,
-        table_id: i64,
+        table_id: MVTableId,
         pager: Arc<Pager>,
     ) -> Result<MvccLazyCursor<Clock>> {
         db.maybe_initialize_table(table_id, pager)?;

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -28,9 +28,10 @@ impl<Clock: LogicalClock> MvccLazyCursor<Clock> {
     pub fn new(
         db: Arc<MvStore<Clock>>,
         tx_id: u64,
-        table_id: MVTableId,
+        root_page_or_table_id: i64,
         pager: Arc<Pager>,
     ) -> Result<MvccLazyCursor<Clock>> {
+        let table_id = db.get_table_id_from_root_page(root_page_or_table_id);
         db.maybe_initialize_table(table_id, pager)?;
         let cursor = Self {
             db,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1930,13 +1930,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         loop {
             match reader.next_record(&pager.io).unwrap() {
                 StreamingResult::InsertRow { row, rowid } => {
-                    tracing::trace!("read {row:?} with rowid {rowid:?}");
                     if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
                         // Sqlite schema row version inserts
                         let row_data = row.data.clone();
                         let record = ImmutableRecord::from_bin_record(row_data);
                         let mut record_cursor = RecordCursor::new();
                         let record_values = record_cursor.get_values(&record).unwrap();
+                        println!("record_values: {:?}", record_values);
                         let RefValue::Integer(root_page) = record_values[3] else {
                             panic!(
                                 "Expected integer value for root page, got {:?}",

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1936,7 +1936,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let record = ImmutableRecord::from_bin_record(row_data);
                         let mut record_cursor = RecordCursor::new();
                         let record_values = record_cursor.get_values(&record).unwrap();
-                        println!("record_values: {:?}", record_values);
                         let RefValue::Integer(root_page) = record_values[3] else {
                             panic!(
                                 "Expected integer value for root page, got {:?}",

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -18,6 +18,9 @@ use crate::File;
 use crate::IOExt;
 use crate::LimboError;
 use crate::Result;
+use crate::Statement;
+use crate::StepResult;
+use crate::Value;
 use crate::{Connection, Pager};
 use crossbeam_skiplist::{SkipMap, SkipSet};
 use parking_lot::RwLock;
@@ -25,6 +28,7 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Bound;
+use std::sync::atomic::AtomicI64;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tracing::instrument;
@@ -522,7 +526,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                                         row_version.clone(),
                                     ); // FIXME: optimize cloning out
 
-                                    if row_version.row.id.table_id == 1 {
+                                    if row_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
                                         self.did_commit_schema_change = true;
                                     }
                                 }
@@ -537,7 +541,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                                         row_version.clone(),
                                     ); // FIXME: optimize cloning out
 
-                                    if row_version.row.id.table_id == 1 {
+                                    if row_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
                                         self.did_commit_schema_change = true;
                                     }
                                 }
@@ -824,14 +828,28 @@ impl DeleteRowStateMachine {
     }
 }
 
+pub const SQLITE_SCHEMA_MVCC_TABLE_ID: i64 = -1;
+
 /// A multi-version concurrency control database.
 #[derive(Debug)]
 pub struct MvStore<Clock: LogicalClock> {
     rows: SkipMap<RowID, RwLock<Vec<RowVersion>>>,
+    /// Table ID is an opaque identifier that is only meaningful to the MV store.
+    /// Each checkpointed MVCC table corresponds to a single B-tree on the pager,
+    /// which naturally has a root page.
+    /// We cannot use root page as the MVCC table ID directly because:
+    /// - We assign table IDs during MVCC commit, but
+    /// - we commit pages to the pager only during checkpoint
+    ///
+    /// which means the root page is not easily knowable ahead of time.
+    /// Hence, we store the mapping here.
+    /// The value is Option because tables created in an MVCC commit that have not
+    /// been checkpointed yet have no real root page assigned yet.
+    pub table_id_to_rootpage: SkipMap<i64, Option<u64>>,
     txs: SkipMap<TxID, Transaction>,
     tx_ids: AtomicU64,
     next_rowid: AtomicU64,
-    next_table_id: AtomicU64,
+    next_table_id: AtomicI64,
     clock: Clock,
     storage: Storage,
     loaded_tables: RwLock<HashSet<i64>>,
@@ -864,10 +882,6 @@ pub struct MvStore<Clock: LogicalClock> {
     /// If there are two concurrent BEGIN (non-CONCURRENT) transactions, and one tries to promote
     /// to exclusive, it will abort if another transaction committed after its begin timestamp.
     last_committed_tx_ts: AtomicU64,
-
-    /// Lock used while recovering a logical log file. We don't want multiple connections trying to
-    /// load the file.
-    recover_lock: RwLock<()>,
 }
 
 impl<Clock: LogicalClock> MvStore<Clock> {
@@ -875,10 +889,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     pub fn new(clock: Clock, storage: Storage) -> Self {
         Self {
             rows: SkipMap::new(),
+            table_id_to_rootpage: SkipMap::from_iter(vec![(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1))]), // table id 1 / root page 1 is always sqlite_schema.
             txs: SkipMap::new(),
             tx_ids: AtomicU64::new(1), // let's reserve transaction 0 for special purposes
             next_rowid: AtomicU64::new(0), // TODO: determine this from B-Tree
-            next_table_id: AtomicU64::new(2), // table id 1 / root page 1 is always sqlite_schema.
+            next_table_id: AtomicI64::new(-2), // table id -1 / root page 1 is always sqlite_schema.
             clock,
             storage,
             loaded_tables: RwLock::new(HashSet::new()),
@@ -891,16 +906,88 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             checkpointed_txid_max: AtomicU64::new(0),
             last_committed_schema_change_ts: AtomicU64::new(0),
             last_committed_tx_ts: AtomicU64::new(0),
-            recover_lock: RwLock::new(()),
         }
+    }
+
+    /// Get the table ID from the root page.
+    /// If the root page is negative, it is a non-checkpointed table and the table ID and root page are both the same negative value.
+    /// If the root page is positive, it is a checkpointed table and there should be a corresponding table ID.
+    pub fn get_table_id_from_root_page(&self, root_page: i64) -> i64 {
+        if root_page < 0 {
+            // Not checkpointed table - table ID and root_page are both the same negative value
+            root_page
+        } else {
+            // Root page is positive: it is a checkpointed table and there should be a corresponding table ID
+            let root_page = root_page as u64;
+            let table_id = self
+                .table_id_to_rootpage
+                .iter()
+                .find(|entry| entry.value().is_some_and(|value| value == root_page))
+                .map(|entry| *entry.key())
+                .expect("Positive root page is not mapped to a table id");
+            table_id
+        }
+    }
+
+    /// Insert a table ID and root page mapping.
+    /// Root page must be positive here, because we only invoke this method with Some() for checkpointed tables.
+    pub fn insert_table_id_to_rootpage(&self, table_id: i64, root_page: Option<u64>) {
+        self.table_id_to_rootpage.insert(table_id, root_page);
+        let minimum = if let Some(root_page) = root_page {
+            // On recovery, we assign table_id = -root_page. Let's make sure we don't get any clashes between checkpointed and non-checkpointed tables
+            // E.g. if we checkpoint a table that has physical root page 7, let's require the next table_id to be less than -7 (or if table_id is already smaller, then smaller than that.)
+            table_id.min(-(root_page as i64))
+        } else {
+            table_id
+        };
+        if minimum < self.next_table_id.load(Ordering::SeqCst) {
+            self.next_table_id.store(minimum - 1, Ordering::SeqCst);
+        }
+    }
+
+    /// Bootstrap the MV store from the SQLite schema table and logical log.
+    /// 1. Get all root pages from the SQLite schema table (using bootstrap connection, which does not attempt to read from MV store)
+    /// 2. Assign table IDs to the root pages (table_id = -1 * root_page)
+    /// 3. Recover the logical log
+    /// 4. Promote the bootstrap connection to a regular connection so that it reads from the MV store again
+    /// 5. Make sure schema changes reflected from deserialized logical log are captured in the schema
+    pub fn bootstrap(&self, bootstrap_conn: Arc<Connection>) -> Result<()> {
+        // Get all rows from the SQLite schema table
+        let mut get_all_sqlite_schema_rows =
+            bootstrap_conn.prepare("SELECT rootpage FROM sqlite_schema WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '__turso_internal_%'")?;
+        let sqlite_schema_root_pages = stmt_get_all_rows(&mut get_all_sqlite_schema_rows)?
+            .into_iter()
+            .map(|row| {
+                let root_page = row[0].as_int().expect("rootpage is integer");
+                assert!(root_page > 0, "rootpage is positive integer");
+                root_page as u64
+            })
+            .collect::<Vec<u64>>();
+        // Map all existing checkpointed root pages to table ids so that if root_page=R, table_id=-R
+        for root_page in sqlite_schema_root_pages.iter() {
+            self.insert_table_id_to_rootpage(-(*root_page as i64), Some(*root_page));
+        }
+
+        if !self.maybe_recover_logical_log(bootstrap_conn.pager.read().clone())? {
+            // There was no logical log to recover, so we're done.
+            return Ok(());
+        }
+
+        // Make sure we capture all the schema changes that were deserialized from the logical log.
+        bootstrap_conn.promote_to_regular_connection();
+        bootstrap_conn.reparse_schema()?;
+        *bootstrap_conn.db.schema.lock().unwrap() = bootstrap_conn.schema.read().clone();
+
+        Ok(())
     }
 
     /// MVCC does not use the pager/btree cursors to create pages until checkpoint.
     /// This method is used to assign root page numbers when Insn::CreateBtree is used.
-    /// NOTE: during MVCC recovery (not implemented yet), [MvStore::next_table_id] must be
-    /// initialized to the current highest table id / root page number.
-    pub fn get_next_table_id(&self) -> u64 {
-        self.next_table_id.fetch_add(1, Ordering::SeqCst)
+    /// MVCC table ids are always negative. Their corresponding rootpage entry in sqlite_schema
+    /// is the same negative value if the table has not been checkpointed yet. Otherwise, the root page
+    /// will be positive and corresponds to the actual physical page.
+    pub fn get_next_table_id(&self) -> i64 {
+        self.next_table_id.fetch_sub(1, Ordering::SeqCst)
     }
 
     pub fn get_next_rowid(&self) -> i64 {
@@ -1682,11 +1769,15 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     ///
     /// This is initialization step for a table, where we still don't have any rows so we need to insert them if there are.
     fn scan_load_table(&self, table_id: i64, pager: Arc<Pager>) -> Result<()> {
-        let root_page = table_id;
+        let entry = self
+            .table_id_to_rootpage
+            .get(&table_id)
+            .expect("Table ID does not have a root page");
+        let root_page = entry.value().expect("Table ID does not have a root page");
         let mut cursor = BTreeCursor::new_table(
             None, // No MVCC cursor for scanning
             pager.clone(),
-            root_page,
+            root_page as i64,
             1, // We'll adjust this as needed
         );
         loop {
@@ -1766,40 +1857,37 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         last_rowid
     }
 
-    pub fn needs_recover(&self) -> bool {
-        self.storage.needs_recover()
-    }
-
-    pub fn mark_recovered(&self) {
-        self.storage.mark_recovered();
-    }
-
     pub fn get_logical_log_file(&self) -> Arc<dyn File> {
         self.storage.get_logical_log_file()
     }
 
-    pub fn recover_logical_log(&self, io: &Arc<dyn crate::IO>, pager: &Arc<Pager>) -> Result<()> {
-        // Get lock, if we don't get it we will wait until recover finishes in another connection
-        // and then return.
-        let _recover_guard = self.recover_lock.write();
-        if !self.storage.needs_recover() {
-            // another connection completed recover
-            return Ok(());
-        }
+    // Recovers the logical log if there is any content.
+    // Returns true if the logical log was recovered, false otherwise.
+    pub fn maybe_recover_logical_log(&self, pager: Arc<Pager>) -> Result<bool> {
         let file = self.get_logical_log_file();
         let mut reader = StreamingLogicalLogReader::new(file.clone());
 
+        if file.size()? == 0 {
+            return Ok(false);
+        }
+
         let c = reader.read_header()?;
-        io.wait_for_completion(c)?;
+        pager.io.wait_for_completion(c)?;
         let tx_id = 0;
         self.begin_load_tx(pager.clone())?;
         loop {
-            match reader.next_record(io).unwrap() {
+            match reader.next_record(&pager.io).unwrap() {
                 StreamingResult::InsertRow { row, rowid } => {
-                    tracing::trace!("read {rowid:?}");
+                    tracing::trace!("read {row:?} with rowid {rowid:?}");
+                    if self.table_id_to_rootpage.get(&row.id.table_id).is_none() {
+                        self.insert_table_id_to_rootpage(row.id.table_id, None);
+                    }
                     self.insert(tx_id, row)?;
                 }
                 StreamingResult::DeleteRow { rowid } => {
+                    if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
+                        self.insert_table_id_to_rootpage(rowid.table_id, None);
+                    }
                     self.delete(tx_id, rowid)?;
                 }
                 StreamingResult::Eof => {
@@ -1808,8 +1896,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             }
         }
         self.commit_load_tx(tx_id);
-        self.mark_recovered();
-        Ok(())
+        Ok(true)
     }
 }
 
@@ -1914,4 +2001,29 @@ fn is_end_visible(
         }
         None => true,
     }
+}
+
+fn stmt_get_all_rows(stmt: &mut Statement) -> Result<Vec<Vec<Value>>> {
+    let mut rows = Vec::new();
+    loop {
+        let step = stmt.step()?;
+        match step {
+            StepResult::Row => {
+                rows.push(stmt.row().unwrap().get_values().cloned().collect());
+            }
+            StepResult::Done => {
+                break;
+            }
+            StepResult::IO => {
+                stmt.run_once()?;
+            }
+            StepResult::Interrupt => {
+                return Err(LimboError::InternalError("interrupted".to_string()))
+            }
+            StepResult::Busy => {
+                return Err(LimboError::Busy);
+            }
+        }
+    }
+    Ok(rows)
 }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -759,7 +759,7 @@ fn setup_lazy_db(initial_keys: &[i64]) -> (MvccTestDb, u64) {
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
 
-    let table_id = MvTableId::new(-1);
+    let table_id = -1;
     for i in initial_keys {
         let id = RowID::new(table_id, *i);
         let data = format!("row{i}");
@@ -821,7 +821,7 @@ pub(crate) fn commit_tx_no_conn(
 #[test]
 fn test_lazy_scan_cursor_basic() {
     let (db, tx_id) = setup_lazy_db(&[1, 2, 3, 4, 5]);
-    let table_id = MvTableId::new(-1);
+    let table_id = -1;
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),
@@ -856,7 +856,7 @@ fn test_lazy_scan_cursor_basic() {
 #[test]
 fn test_lazy_scan_cursor_with_gaps() {
     let (db, tx_id) = setup_test_db();
-    let table_id = MvTableId::new(-1);
+    let table_id = -1;
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),
@@ -892,7 +892,7 @@ fn test_lazy_scan_cursor_with_gaps() {
 #[test]
 fn test_cursor_basic() {
     let (db, tx_id) = setup_lazy_db(&[1, 2, 3, 4, 5]);
-    let table_id = MvTableId::new(-1);
+    let table_id = -1;
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),
@@ -938,7 +938,7 @@ fn test_cursor_with_empty_table() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let table_id = MvTableId::new(-1); // Empty table
+    let table_id = -1; // Empty table
 
     // Test LazyScanCursor with empty table
     let mut cursor = MvccLazyCursor::new(
@@ -955,7 +955,7 @@ fn test_cursor_with_empty_table() {
 #[test]
 fn test_cursor_modification_during_scan() {
     let (db, tx_id) = setup_lazy_db(&[1, 2, 4, 5]);
-    let table_id = MvTableId::new(-1);
+    let table_id = -1;
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -727,7 +727,7 @@ fn setup_test_db() -> (MvccTestDb, u64) {
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
 
-    let table_id = -1;
+    let table_id = MVTableId::new(1);
     let test_rows = [
         (5, "row5"),
         (10, "row10"),
@@ -759,7 +759,7 @@ fn setup_lazy_db(initial_keys: &[i64]) -> (MvccTestDb, u64) {
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
 
-    let table_id = -1;
+    let table_id = MvTableId::new(-1);
     for i in initial_keys {
         let id = RowID::new(table_id, *i);
         let data = format!("row{i}");
@@ -821,7 +821,7 @@ pub(crate) fn commit_tx_no_conn(
 #[test]
 fn test_lazy_scan_cursor_basic() {
     let (db, tx_id) = setup_lazy_db(&[1, 2, 3, 4, 5]);
-    let table_id = -1;
+    let table_id = MvTableId::new(-1);
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),
@@ -856,7 +856,7 @@ fn test_lazy_scan_cursor_basic() {
 #[test]
 fn test_lazy_scan_cursor_with_gaps() {
     let (db, tx_id) = setup_test_db();
-    let table_id = -1;
+    let table_id = MvTableId::new(-1);
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),
@@ -892,7 +892,7 @@ fn test_lazy_scan_cursor_with_gaps() {
 #[test]
 fn test_cursor_basic() {
     let (db, tx_id) = setup_lazy_db(&[1, 2, 3, 4, 5]);
-    let table_id = -1;
+    let table_id = MvTableId::new(-1);
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),
@@ -938,7 +938,7 @@ fn test_cursor_with_empty_table() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let table_id = -1; // Empty table
+    let table_id = MvTableId::new(-1); // Empty table
 
     // Test LazyScanCursor with empty table
     let mut cursor = MvccLazyCursor::new(
@@ -955,7 +955,7 @@ fn test_cursor_with_empty_table() {
 #[test]
 fn test_cursor_modification_during_scan() {
     let (db, tx_id) = setup_lazy_db(&[1, 2, 4, 5]);
-    let table_id = -1;
+    let table_id = MvTableId::new(-1);
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -727,7 +727,7 @@ fn setup_test_db() -> (MvccTestDb, u64) {
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
 
-    let table_id = 1;
+    let table_id = -1;
     let test_rows = [
         (5, "row5"),
         (10, "row10"),
@@ -759,7 +759,7 @@ fn setup_lazy_db(initial_keys: &[i64]) -> (MvccTestDb, u64) {
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
 
-    let table_id = 1;
+    let table_id = -1;
     for i in initial_keys {
         let id = RowID::new(table_id, *i);
         let data = format!("row{i}");
@@ -821,7 +821,7 @@ pub(crate) fn commit_tx_no_conn(
 #[test]
 fn test_lazy_scan_cursor_basic() {
     let (db, tx_id) = setup_lazy_db(&[1, 2, 3, 4, 5]);
-    let table_id = 1;
+    let table_id = -1;
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),
@@ -856,7 +856,7 @@ fn test_lazy_scan_cursor_basic() {
 #[test]
 fn test_lazy_scan_cursor_with_gaps() {
     let (db, tx_id) = setup_test_db();
-    let table_id = 1;
+    let table_id = -1;
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),
@@ -892,7 +892,7 @@ fn test_lazy_scan_cursor_with_gaps() {
 #[test]
 fn test_cursor_basic() {
     let (db, tx_id) = setup_lazy_db(&[1, 2, 3, 4, 5]);
-    let table_id = 1;
+    let table_id = -1;
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),
@@ -938,7 +938,7 @@ fn test_cursor_with_empty_table() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let table_id = 1; // Empty table
+    let table_id = -1; // Empty table
 
     // Test LazyScanCursor with empty table
     let mut cursor = MvccLazyCursor::new(
@@ -955,7 +955,7 @@ fn test_cursor_with_empty_table() {
 #[test]
 fn test_cursor_modification_during_scan() {
     let (db, tx_id) = setup_lazy_db(&[1, 2, 4, 5]);
-    let table_id = 1;
+    let table_id = -1;
 
     let mut cursor = MvccLazyCursor::new(
         db.mvcc_store.clone(),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1503,7 +1503,7 @@ fn transaction_display() {
         header: RwLock::new(DatabaseHeader::default()),
     };
 
-    let expected = "{ state: Preparing, id: 42, begin_ts: 20250914, write_set: [RowID { table_id: MVTableId(-1), row_id: 11 }, RowID { table_id: MVTableId(-1), row_id: 13 }], read_set: [RowID { table_id: MVTableId(-2), row_id: 17 }, RowID { table_id: MVTableId(-2), row_id: 19 }] }";
+    let expected = "{ state: Preparing, id: 42, begin_ts: 20250914, write_set: [RowID { table_id: MVTableId(-2), row_id: 11 }, RowID { table_id: MVTableId(-2), row_id: 13 }], read_set: [RowID { table_id: MVTableId(-2), row_id: 17 }, RowID { table_id: MVTableId(-2), row_id: 19 }] }";
     let output = format!("{tx}");
     assert_eq!(output, expected);
 }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -123,14 +123,14 @@ fn test_insert_read() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
+    let tx1_row = generate_simple_string_row((-2).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -148,7 +148,7 @@ fn test_insert_read() {
         .read(
             tx2,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -167,7 +167,7 @@ fn test_read_nonexistent() {
     let row = db.mvcc_store.read(
         tx,
         RowID {
-            table_id: (-1).into(),
+            table_id: (-2).into(),
             row_id: 1,
         },
     );
@@ -182,14 +182,14 @@ fn test_delete() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
+    let tx1_row = generate_simple_string_row((-2).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -200,7 +200,7 @@ fn test_delete() {
         .delete(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -210,7 +210,7 @@ fn test_delete() {
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -227,7 +227,7 @@ fn test_delete() {
         .read(
             tx2,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -247,7 +247,7 @@ fn test_delete_nonexistent() {
         .delete(
             tx,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1
             },
         )
@@ -261,28 +261,28 @@ fn test_commit() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
+    let tx1_row = generate_simple_string_row((-2).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
         .unwrap()
         .unwrap();
     assert_eq!(tx1_row, row);
-    let tx1_updated_row = generate_simple_string_row((-1).into(), 1, "World");
+    let tx1_updated_row = generate_simple_string_row((-2).into(), 1, "World");
     db.mvcc_store.update(tx1, tx1_updated_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -300,7 +300,7 @@ fn test_commit() {
         .read(
             tx2,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -318,28 +318,28 @@ fn test_rollback() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let row1 = generate_simple_string_row((-1).into(), 1, "Hello");
+    let row1 = generate_simple_string_row((-2).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, row1.clone()).unwrap();
     let row2 = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
         .unwrap()
         .unwrap();
     assert_eq!(row1, row2);
-    let row3 = generate_simple_string_row((-1).into(), 1, "World");
+    let row3 = generate_simple_string_row((-2).into(), 1, "World");
     db.mvcc_store.update(tx1, row3.clone()).unwrap();
     let row4 = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -358,7 +358,7 @@ fn test_rollback() {
         .read(
             tx2,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -375,14 +375,14 @@ fn test_dirty_write() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
+    let tx1_row = generate_simple_string_row((-2).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -393,7 +393,7 @@ fn test_dirty_write() {
     let conn2 = db.db.connect().unwrap();
     // T2 attempts to delete row with ID 1, but fails because T1 has not committed.
     let tx2 = db.mvcc_store.begin_tx(conn2.pager.read().clone()).unwrap();
-    let tx2_row = generate_simple_string_row((-1).into(), 1, "World");
+    let tx2_row = generate_simple_string_row((-2).into(), 1, "World");
     assert!(!db.mvcc_store.update(tx2, tx2_row).unwrap());
 
     let row = db
@@ -401,7 +401,7 @@ fn test_dirty_write() {
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -419,7 +419,7 @@ fn test_dirty_read() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let row1 = generate_simple_string_row((-1).into(), 1, "Hello");
+    let row1 = generate_simple_string_row((-2).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, row1).unwrap();
 
     // T2 attempts to read row with ID 1, but doesn't see one because T1 has not committed.
@@ -430,7 +430,7 @@ fn test_dirty_read() {
         .read(
             tx2,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -447,7 +447,7 @@ fn test_dirty_read_deleted() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
+    let tx1_row = generate_simple_string_row((-2).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     commit_tx(db.mvcc_store.clone(), &db.conn, tx1).unwrap();
 
@@ -459,7 +459,7 @@ fn test_dirty_read_deleted() {
         .delete(
             tx2,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1
             },
         )
@@ -473,7 +473,7 @@ fn test_dirty_read_deleted() {
         .read(
             tx3,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -491,14 +491,14 @@ fn test_fuzzy_read() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row((-1).into(), 1, "First");
+    let tx1_row = generate_simple_string_row((-2).into(), 1, "First");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -515,7 +515,7 @@ fn test_fuzzy_read() {
         .read(
             tx2,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -526,7 +526,7 @@ fn test_fuzzy_read() {
     // T3 updates the row and commits.
     let conn3 = db.db.connect().unwrap();
     let tx3 = db.mvcc_store.begin_tx(conn3.pager.read().clone()).unwrap();
-    let tx3_row = generate_simple_string_row((-1).into(), 1, "Second");
+    let tx3_row = generate_simple_string_row((-2).into(), 1, "Second");
     db.mvcc_store.update(tx3, tx3_row).unwrap();
     commit_tx(db.mvcc_store.clone(), &conn3, tx3).unwrap();
 
@@ -536,7 +536,7 @@ fn test_fuzzy_read() {
         .read(
             tx2,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -546,7 +546,7 @@ fn test_fuzzy_read() {
 
     // T2 tries to update the row, but fails because T3 has already committed an update to the row,
     // so T2 trying to write would violate snapshot isolation if it succeeded.
-    let tx2_newrow = generate_simple_string_row((-1).into(), 1, "Third");
+    let tx2_newrow = generate_simple_string_row((-2).into(), 1, "Third");
     let update_result = db.mvcc_store.update(tx2, tx2_newrow);
     assert!(matches!(update_result, Err(LimboError::WriteWriteConflict)));
 }
@@ -560,14 +560,14 @@ fn test_lost_update() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
+    let tx1_row = generate_simple_string_row((-2).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -579,13 +579,13 @@ fn test_lost_update() {
     // T2 attempts to update row ID 1 within an active transaction.
     let conn2 = db.db.connect().unwrap();
     let tx2 = db.mvcc_store.begin_tx(conn2.pager.read().clone()).unwrap();
-    let tx2_row = generate_simple_string_row((-1).into(), 1, "World");
+    let tx2_row = generate_simple_string_row((-2).into(), 1, "World");
     assert!(db.mvcc_store.update(tx2, tx2_row.clone()).unwrap());
 
     // T3 also attempts to update row ID 1 within an active transaction.
     let conn3 = db.db.connect().unwrap();
     let tx3 = db.mvcc_store.begin_tx(conn3.pager.read().clone()).unwrap();
-    let tx3_row = generate_simple_string_row((-1).into(), 1, "Hello, world!");
+    let tx3_row = generate_simple_string_row((-2).into(), 1, "Hello, world!");
     assert!(matches!(
         db.mvcc_store.update(tx3, tx3_row),
         Err(LimboError::WriteWriteConflict)
@@ -608,7 +608,7 @@ fn test_lost_update() {
         .read(
             tx4,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -628,21 +628,21 @@ fn test_committed_visibility() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row((-1).into(), 1, "10");
+    let tx1_row = generate_simple_string_row((-2).into(), 1, "10");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     commit_tx(db.mvcc_store.clone(), &db.conn, tx1).unwrap();
 
     // but I like more money, so let me try adding $10 more
     let conn2 = db.db.connect().unwrap();
     let tx2 = db.mvcc_store.begin_tx(conn2.pager.read().clone()).unwrap();
-    let tx2_row = generate_simple_string_row((-1).into(), 1, "20");
+    let tx2_row = generate_simple_string_row((-2).into(), 1, "20");
     assert!(db.mvcc_store.update(tx2, tx2_row.clone()).unwrap());
     let row = db
         .mvcc_store
         .read(
             tx2,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -658,7 +658,7 @@ fn test_committed_visibility() {
         .read(
             tx3,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -679,7 +679,7 @@ fn test_future_row() {
 
     let conn2 = db.db.connect().unwrap();
     let tx2 = db.mvcc_store.begin_tx(conn2.pager.read().clone()).unwrap();
-    let tx2_row = generate_simple_string_row((-1).into(), 1, "Hello");
+    let tx2_row = generate_simple_string_row((-2).into(), 1, "Hello");
     db.mvcc_store.insert(tx2, tx2_row).unwrap();
 
     // transaction in progress, so tx1 shouldn't be able to see the value
@@ -688,7 +688,7 @@ fn test_future_row() {
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -702,7 +702,7 @@ fn test_future_row() {
         .read(
             tx1,
             RowID {
-                table_id: (-1).into(),
+                table_id: (-2).into(),
                 row_id: 1,
             },
         )
@@ -1080,7 +1080,7 @@ fn test_snapshot_isolation_tx_visible1() {
         let row_version = RowVersion {
             begin,
             end,
-            row: generate_simple_string_row((-1).into(), 1, "testme"),
+            row: generate_simple_string_row((-2).into(), 1, "testme"),
         };
         tracing::debug!("Testing visibility of {row_version:?}");
         row_version.is_visible_to(&current_tx, &txs)
@@ -1162,8 +1162,34 @@ fn test_restart() {
         let conn = db.connect();
         let mvcc_store = db.get_mvcc_store();
         let tx_id = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
-        let row = generate_simple_string_row((-1).into(), 1, "foo");
-
+        // insert table id -2 into sqlite_schema table (table_id -1)
+        let data = ImmutableRecord::from_values(
+            &[
+                Value::Text(Text::new("table")), // type
+                Value::Text(Text::new("test")),  // name
+                Value::Text(Text::new("test")),  // tbl_name
+                Value::Integer(-2),              // rootpage
+                Value::Text(Text::new(
+                    "CREATE TABLE test(id INTEGER PRIMARY KEY, data TEXT)",
+                )), // sql
+            ],
+            5,
+        );
+        mvcc_store
+            .insert(
+                tx_id,
+                Row {
+                    id: RowID {
+                        table_id: (-1).into(),
+                        row_id: 1,
+                    },
+                    data: data.as_blob().to_vec(),
+                    column_count: 5,
+                },
+            )
+            .unwrap();
+        // now insert a row into table -2
+        let row = generate_simple_string_row((-2).into(), 1, "foo");
         mvcc_store.insert(tx_id, row).unwrap();
         commit_tx(mvcc_store.clone(), &conn, tx_id).unwrap();
         conn.close().unwrap();
@@ -1174,14 +1200,14 @@ fn test_restart() {
         let conn = db.connect();
         let mvcc_store = db.get_mvcc_store();
         let tx_id = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
-        let row = generate_simple_string_row((-1).into(), 2, "bar");
+        let row = generate_simple_string_row((-2).into(), 2, "bar");
 
         mvcc_store.insert(tx_id, row).unwrap();
         commit_tx(mvcc_store.clone(), &conn, tx_id).unwrap();
 
         let tx_id = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
         let row = mvcc_store
-            .read(tx_id, RowID::new((-1).into(), 2))
+            .read(tx_id, RowID::new((-2).into(), 2))
             .unwrap()
             .unwrap();
         let record = get_record_value(&row);
@@ -1461,8 +1487,8 @@ fn transaction_display() {
     let begin_ts = 20250914;
 
     let write_set = SkipSet::new();
-    write_set.insert(RowID::new((-1).into(), 11));
-    write_set.insert(RowID::new((-1).into(), 13));
+    write_set.insert(RowID::new((-2).into(), 11));
+    write_set.insert(RowID::new((-2).into(), 13));
 
     let read_set = SkipSet::new();
     read_set.insert(RowID::new((-2).into(), 17));

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -103,7 +103,7 @@ impl MvccTestDbNoConn {
     }
 }
 
-pub(crate) fn generate_simple_string_row(table_id: i64, id: i64, data: &str) -> Row {
+pub(crate) fn generate_simple_string_row(table_id: MVTableId, id: i64, data: &str) -> Row {
     let record = ImmutableRecord::from_values(&[Value::Text(Text::new(data))], 1);
     Row {
         id: RowID {
@@ -123,14 +123,14 @@ fn test_insert_read() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row(1, 1, "Hello");
+    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -148,7 +148,7 @@ fn test_insert_read() {
         .read(
             tx2,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -167,7 +167,7 @@ fn test_read_nonexistent() {
     let row = db.mvcc_store.read(
         tx,
         RowID {
-            table_id: 1,
+            table_id: (-1).into(),
             row_id: 1,
         },
     );
@@ -182,14 +182,14 @@ fn test_delete() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row(1, 1, "Hello");
+    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -200,7 +200,7 @@ fn test_delete() {
         .delete(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -210,7 +210,7 @@ fn test_delete() {
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -227,7 +227,7 @@ fn test_delete() {
         .read(
             tx2,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -247,7 +247,7 @@ fn test_delete_nonexistent() {
         .delete(
             tx,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1
             },
         )
@@ -261,28 +261,28 @@ fn test_commit() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row(1, 1, "Hello");
+    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
         .unwrap()
         .unwrap();
     assert_eq!(tx1_row, row);
-    let tx1_updated_row = generate_simple_string_row(1, 1, "World");
+    let tx1_updated_row = generate_simple_string_row((-1).into(), 1, "World");
     db.mvcc_store.update(tx1, tx1_updated_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -300,7 +300,7 @@ fn test_commit() {
         .read(
             tx2,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -318,28 +318,28 @@ fn test_rollback() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let row1 = generate_simple_string_row(1, 1, "Hello");
+    let row1 = generate_simple_string_row((-1).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, row1.clone()).unwrap();
     let row2 = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
         .unwrap()
         .unwrap();
     assert_eq!(row1, row2);
-    let row3 = generate_simple_string_row(1, 1, "World");
+    let row3 = generate_simple_string_row((-1).into(), 1, "World");
     db.mvcc_store.update(tx1, row3.clone()).unwrap();
     let row4 = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -358,7 +358,7 @@ fn test_rollback() {
         .read(
             tx2,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -375,14 +375,14 @@ fn test_dirty_write() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row(1, 1, "Hello");
+    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -393,7 +393,7 @@ fn test_dirty_write() {
     let conn2 = db.db.connect().unwrap();
     // T2 attempts to delete row with ID 1, but fails because T1 has not committed.
     let tx2 = db.mvcc_store.begin_tx(conn2.pager.read().clone()).unwrap();
-    let tx2_row = generate_simple_string_row(1, 1, "World");
+    let tx2_row = generate_simple_string_row((-1).into(), 1, "World");
     assert!(!db.mvcc_store.update(tx2, tx2_row).unwrap());
 
     let row = db
@@ -401,7 +401,7 @@ fn test_dirty_write() {
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -419,7 +419,7 @@ fn test_dirty_read() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let row1 = generate_simple_string_row(1, 1, "Hello");
+    let row1 = generate_simple_string_row((-1).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, row1).unwrap();
 
     // T2 attempts to read row with ID 1, but doesn't see one because T1 has not committed.
@@ -430,7 +430,7 @@ fn test_dirty_read() {
         .read(
             tx2,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -447,7 +447,7 @@ fn test_dirty_read_deleted() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row(1, 1, "Hello");
+    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     commit_tx(db.mvcc_store.clone(), &db.conn, tx1).unwrap();
 
@@ -459,7 +459,7 @@ fn test_dirty_read_deleted() {
         .delete(
             tx2,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1
             },
         )
@@ -473,7 +473,7 @@ fn test_dirty_read_deleted() {
         .read(
             tx3,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -491,14 +491,14 @@ fn test_fuzzy_read() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row(1, 1, "First");
+    let tx1_row = generate_simple_string_row((-1).into(), 1, "First");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -515,7 +515,7 @@ fn test_fuzzy_read() {
         .read(
             tx2,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -526,7 +526,7 @@ fn test_fuzzy_read() {
     // T3 updates the row and commits.
     let conn3 = db.db.connect().unwrap();
     let tx3 = db.mvcc_store.begin_tx(conn3.pager.read().clone()).unwrap();
-    let tx3_row = generate_simple_string_row(1, 1, "Second");
+    let tx3_row = generate_simple_string_row((-1).into(), 1, "Second");
     db.mvcc_store.update(tx3, tx3_row).unwrap();
     commit_tx(db.mvcc_store.clone(), &conn3, tx3).unwrap();
 
@@ -536,7 +536,7 @@ fn test_fuzzy_read() {
         .read(
             tx2,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -546,7 +546,7 @@ fn test_fuzzy_read() {
 
     // T2 tries to update the row, but fails because T3 has already committed an update to the row,
     // so T2 trying to write would violate snapshot isolation if it succeeded.
-    let tx2_newrow = generate_simple_string_row(1, 1, "Third");
+    let tx2_newrow = generate_simple_string_row((-1).into(), 1, "Third");
     let update_result = db.mvcc_store.update(tx2, tx2_newrow);
     assert!(matches!(update_result, Err(LimboError::WriteWriteConflict)));
 }
@@ -560,14 +560,14 @@ fn test_lost_update() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row(1, 1, "Hello");
+    let tx1_row = generate_simple_string_row((-1).into(), 1, "Hello");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     let row = db
         .mvcc_store
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -579,13 +579,13 @@ fn test_lost_update() {
     // T2 attempts to update row ID 1 within an active transaction.
     let conn2 = db.db.connect().unwrap();
     let tx2 = db.mvcc_store.begin_tx(conn2.pager.read().clone()).unwrap();
-    let tx2_row = generate_simple_string_row(1, 1, "World");
+    let tx2_row = generate_simple_string_row((-1).into(), 1, "World");
     assert!(db.mvcc_store.update(tx2, tx2_row.clone()).unwrap());
 
     // T3 also attempts to update row ID 1 within an active transaction.
     let conn3 = db.db.connect().unwrap();
     let tx3 = db.mvcc_store.begin_tx(conn3.pager.read().clone()).unwrap();
-    let tx3_row = generate_simple_string_row(1, 1, "Hello, world!");
+    let tx3_row = generate_simple_string_row((-1).into(), 1, "Hello, world!");
     assert!(matches!(
         db.mvcc_store.update(tx3, tx3_row),
         Err(LimboError::WriteWriteConflict)
@@ -608,7 +608,7 @@ fn test_lost_update() {
         .read(
             tx4,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -628,21 +628,21 @@ fn test_committed_visibility() {
         .mvcc_store
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
-    let tx1_row = generate_simple_string_row(1, 1, "10");
+    let tx1_row = generate_simple_string_row((-1).into(), 1, "10");
     db.mvcc_store.insert(tx1, tx1_row.clone()).unwrap();
     commit_tx(db.mvcc_store.clone(), &db.conn, tx1).unwrap();
 
     // but I like more money, so let me try adding $10 more
     let conn2 = db.db.connect().unwrap();
     let tx2 = db.mvcc_store.begin_tx(conn2.pager.read().clone()).unwrap();
-    let tx2_row = generate_simple_string_row(1, 1, "20");
+    let tx2_row = generate_simple_string_row((-1).into(), 1, "20");
     assert!(db.mvcc_store.update(tx2, tx2_row.clone()).unwrap());
     let row = db
         .mvcc_store
         .read(
             tx2,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -658,7 +658,7 @@ fn test_committed_visibility() {
         .read(
             tx3,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -679,7 +679,7 @@ fn test_future_row() {
 
     let conn2 = db.db.connect().unwrap();
     let tx2 = db.mvcc_store.begin_tx(conn2.pager.read().clone()).unwrap();
-    let tx2_row = generate_simple_string_row(1, 1, "Hello");
+    let tx2_row = generate_simple_string_row((-1).into(), 1, "Hello");
     db.mvcc_store.insert(tx2, tx2_row).unwrap();
 
     // transaction in progress, so tx1 shouldn't be able to see the value
@@ -688,7 +688,7 @@ fn test_future_row() {
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -702,7 +702,7 @@ fn test_future_row() {
         .read(
             tx1,
             RowID {
-                table_id: 1,
+                table_id: (-1).into(),
                 row_id: 1,
             },
         )
@@ -727,7 +727,7 @@ fn setup_test_db() -> (MvccTestDb, u64) {
         .begin_tx(db.conn.pager.read().clone())
         .unwrap();
 
-    let table_id = MVTableId::new(1);
+    let table_id = MVTableId::new(-1);
     let test_rows = [
         (5, "row5"),
         (10, "row10"),
@@ -761,7 +761,7 @@ fn setup_lazy_db(initial_keys: &[i64]) -> (MvccTestDb, u64) {
 
     let table_id = -1;
     for i in initial_keys {
-        let id = RowID::new(table_id, *i);
+        let id = RowID::new(table_id.into(), *i);
         let data = format!("row{i}");
         let record = ImmutableRecord::from_values(&[Value::Text(Text::new(&data))], 1);
         let row = Row::new(id, record.as_blob().to_vec(), 1);
@@ -971,8 +971,8 @@ fn test_cursor_modification_during_scan() {
     assert_eq!(first_row.id.row_id, 1);
 
     // Insert a new row with ID between existing rows
-    let new_row_id = RowID::new(table_id, 3);
-    let new_row = generate_simple_string_row(table_id, new_row_id.row_id, "new_row");
+    let new_row_id = RowID::new(table_id.into(), 3);
+    let new_row = generate_simple_string_row(table_id.into(), new_row_id.row_id, "new_row");
 
     cursor.insert(new_row).unwrap();
     let row = db.mvcc_store.read(tx_id, new_row_id).unwrap().unwrap();
@@ -991,7 +991,7 @@ fn test_cursor_modification_during_scan() {
     cursor.forward(); // Move to 4
     let row = db
         .mvcc_store
-        .read(tx_id, RowID::new(table_id, 4))
+        .read(tx_id, RowID::new(table_id.into(), 4))
         .unwrap()
         .unwrap();
     assert_eq!(row.id.row_id, 4);
@@ -999,7 +999,7 @@ fn test_cursor_modification_during_scan() {
     cursor.forward(); // Move to 5 (our new row)
     let row = db
         .mvcc_store
-        .read(tx_id, RowID::new(table_id, 5))
+        .read(tx_id, RowID::new(table_id.into(), 5))
         .unwrap()
         .unwrap();
     assert_eq!(row.id.row_id, 5);
@@ -1080,7 +1080,7 @@ fn test_snapshot_isolation_tx_visible1() {
         let row_version = RowVersion {
             begin,
             end,
-            row: generate_simple_string_row(1, 1, "testme"),
+            row: generate_simple_string_row((-1).into(), 1, "testme"),
         };
         tracing::debug!("Testing visibility of {row_version:?}");
         row_version.is_visible_to(&current_tx, &txs)
@@ -1162,7 +1162,7 @@ fn test_restart() {
         let conn = db.connect();
         let mvcc_store = db.get_mvcc_store();
         let tx_id = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
-        let row = generate_simple_string_row(1, 1, "foo");
+        let row = generate_simple_string_row((-1).into(), 1, "foo");
 
         mvcc_store.insert(tx_id, row).unwrap();
         commit_tx(mvcc_store.clone(), &conn, tx_id).unwrap();
@@ -1174,13 +1174,16 @@ fn test_restart() {
         let conn = db.connect();
         let mvcc_store = db.get_mvcc_store();
         let tx_id = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
-        let row = generate_simple_string_row(1, 2, "bar");
+        let row = generate_simple_string_row((-1).into(), 2, "bar");
 
         mvcc_store.insert(tx_id, row).unwrap();
         commit_tx(mvcc_store.clone(), &conn, tx_id).unwrap();
 
         let tx_id = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
-        let row = mvcc_store.read(tx_id, RowID::new(1, 2)).unwrap().unwrap();
+        let row = mvcc_store
+            .read(tx_id, RowID::new((-1).into(), 2))
+            .unwrap()
+            .unwrap();
         let record = get_record_value(&row);
         match record.get_value(0).unwrap() {
             RefValue::Text(text) => {
@@ -1458,12 +1461,12 @@ fn transaction_display() {
     let begin_ts = 20250914;
 
     let write_set = SkipSet::new();
-    write_set.insert(RowID::new(1, 11));
-    write_set.insert(RowID::new(1, 13));
+    write_set.insert(RowID::new((-1).into(), 11));
+    write_set.insert(RowID::new((-1).into(), 13));
 
     let read_set = SkipSet::new();
-    read_set.insert(RowID::new(2, 17));
-    read_set.insert(RowID::new(2, 19));
+    read_set.insert(RowID::new((-2).into(), 17));
+    read_set.insert(RowID::new((-2).into(), 19));
 
     let tx = Transaction {
         state,
@@ -1474,7 +1477,7 @@ fn transaction_display() {
         header: RwLock::new(DatabaseHeader::default()),
     };
 
-    let expected = "{ state: Preparing, id: 42, begin_ts: 20250914, write_set: [RowID { table_id: 1, row_id: 11 }, RowID { table_id: 1, row_id: 13 }], read_set: [RowID { table_id: 2, row_id: 17 }, RowID { table_id: 2, row_id: 19 }] }";
+    let expected = "{ state: Preparing, id: 42, begin_ts: 20250914, write_set: [RowID { table_id: MVTableId(-1), row_id: 11 }, RowID { table_id: MVTableId(-1), row_id: 13 }], read_set: [RowID { table_id: MVTableId(-2), row_id: 17 }, RowID { table_id: MVTableId(-2), row_id: 19 }] }";
     let output = format!("{tx}");
     assert_eq!(output, expected);
 }

--- a/core/mvcc/mod.rs
+++ b/core/mvcc/mod.rs
@@ -68,10 +68,10 @@ mod tests {
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
                     let id = IDS.fetch_add(1, Ordering::SeqCst);
                     let id = RowID {
-                        table_id: (-1).into(),
+                        table_id: (-2).into(),
                         row_id: id,
                     };
-                    let row = generate_simple_string_row((-1).into(), id.row_id, "Hello");
+                    let row = generate_simple_string_row((-2).into(), id.row_id, "Hello");
                     mvcc_store.insert(tx, row.clone()).unwrap();
                     commit_tx_no_conn(&db, tx, &conn).unwrap();
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
@@ -89,10 +89,10 @@ mod tests {
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
                     let id = IDS.fetch_add(1, Ordering::SeqCst);
                     let id = RowID {
-                        table_id: (-1).into(),
+                        table_id: (-2).into(),
                         row_id: id,
                     };
-                    let row = generate_simple_string_row((-1).into(), id.row_id, "World");
+                    let row = generate_simple_string_row((-2).into(), id.row_id, "World");
                     mvcc_store.insert(tx, row.clone()).unwrap();
                     commit_tx_no_conn(&db, tx, &conn).unwrap();
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
@@ -130,11 +130,11 @@ mod tests {
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
                     let id = i % 16;
                     let id = RowID {
-                        table_id: (-1).into(),
+                        table_id: (-2).into(),
                         row_id: id,
                     };
                     let row = generate_simple_string_row(
-                        (-1).into(),
+                        (-2).into(),
                         id.row_id,
                         &format!("{prefix} @{tx}"),
                     );

--- a/core/mvcc/mod.rs
+++ b/core/mvcc/mod.rs
@@ -68,10 +68,10 @@ mod tests {
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
                     let id = IDS.fetch_add(1, Ordering::SeqCst);
                     let id = RowID {
-                        table_id: 1,
+                        table_id: (-1).into(),
                         row_id: id,
                     };
-                    let row = generate_simple_string_row(1, id.row_id, "Hello");
+                    let row = generate_simple_string_row((-1).into(), id.row_id, "Hello");
                     mvcc_store.insert(tx, row.clone()).unwrap();
                     commit_tx_no_conn(&db, tx, &conn).unwrap();
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
@@ -89,10 +89,10 @@ mod tests {
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
                     let id = IDS.fetch_add(1, Ordering::SeqCst);
                     let id = RowID {
-                        table_id: 1,
+                        table_id: (-1).into(),
                         row_id: id,
                     };
-                    let row = generate_simple_string_row(1, id.row_id, "World");
+                    let row = generate_simple_string_row((-1).into(), id.row_id, "World");
                     mvcc_store.insert(tx, row.clone()).unwrap();
                     commit_tx_no_conn(&db, tx, &conn).unwrap();
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
@@ -130,10 +130,14 @@ mod tests {
                     let tx = mvcc_store.begin_tx(conn.pager.read().clone()).unwrap();
                     let id = i % 16;
                     let id = RowID {
-                        table_id: 1,
+                        table_id: (-1).into(),
                         row_id: id,
                     };
-                    let row = generate_simple_string_row(1, id.row_id, &format!("{prefix} @{tx}"));
+                    let row = generate_simple_string_row(
+                        (-1).into(),
+                        id.row_id,
+                        &format!("{prefix} @{tx}"),
+                    );
                     if let Err(e) = mvcc_store.upsert(tx, row.clone()) {
                         tracing::trace!("upsert failed: {e}");
                         failed_upserts += 1;

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -474,7 +474,7 @@ mod tests {
             let mvcc_store = db.get_mvcc_store();
             let tx_id = mvcc_store.begin_tx(pager.clone()).unwrap();
 
-            let row = generate_simple_string_row(1, 1, "foo");
+            let row = generate_simple_string_row((-1).into(), 1, "foo");
             mvcc_store.insert(tx_id, row).unwrap();
             commit_tx(mvcc_store.clone(), &conn, tx_id).unwrap();
             conn.close().unwrap();
@@ -489,7 +489,10 @@ mod tests {
         let mvcc_store = Arc::new(MvStore::new(LocalClock::new(), Storage::new(file.clone())));
         mvcc_store.maybe_recover_logical_log(pager.clone()).unwrap();
         let tx = mvcc_store.begin_tx(pager.clone()).unwrap();
-        let row = mvcc_store.read(tx, RowID::new(1, 1)).unwrap().unwrap();
+        let row = mvcc_store
+            .read(tx, RowID::new((-1).into(), 1))
+            .unwrap()
+            .unwrap();
         let record = ImmutableRecord::from_bin_record(row.data.clone());
         let values = record.get_values();
         let foo = values.first().unwrap();
@@ -502,7 +505,7 @@ mod tests {
     #[test]
     fn test_logical_log_read_multiple_transactions() {
         let values = (0..100)
-            .map(|i| (RowID::new(1, i), format!("foo_{i}")))
+            .map(|i| (RowID::new((-1).into(), i), format!("foo_{i}")))
             .collect::<Vec<(RowID, String)>>();
         // let's not drop db as we don't want files to be removed
         let db = MvccTestDbNoConn::new_with_random_db();
@@ -559,7 +562,7 @@ mod tests {
                 match op_type {
                     0 => {
                         let row_id = rng.next_u64();
-                        let rowid = RowID::new(1, row_id as i64);
+                        let rowid = RowID::new((-1).into(), row_id as i64);
                         let row = generate_simple_string_row(
                             rowid.table_id,
                             rowid.row_id,

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -36,14 +36,6 @@ impl Storage {
         self.logical_log.write().unwrap().truncate()
     }
 
-    pub fn needs_recover(&self) -> bool {
-        self.logical_log.read().unwrap().needs_recover()
-    }
-
-    pub fn mark_recovered(&self) {
-        self.logical_log.write().unwrap().mark_recovered();
-    }
-
     pub fn get_logical_log_file(&self) -> Arc<dyn File> {
         self.logical_log.write().unwrap().file.clone()
     }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -645,9 +645,6 @@ impl Schema {
                         )?
                     };
                     self.add_virtual_table(vtab);
-                    if let Some(mv_store) = mv_store {
-                        mv_store.mark_table_as_loaded(root_page);
-                    }
                 } else {
                     let table = BTreeTable::from_sql(sql, root_page)?;
 
@@ -681,9 +678,6 @@ impl Schema {
                         }
                     }
 
-                    if let Some(mv_store) = mv_store {
-                        mv_store.mark_table_as_loaded(root_page);
-                    }
                     self.add_btree_table(Arc::new(table));
                 }
             }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -4718,7 +4718,8 @@ impl BTreeCursor {
         match &self.mv_cursor {
             Some(mv_cursor) => match key.maybe_rowid() {
                 Some(rowid) => {
-                    let row_id = crate::mvcc::database::RowID::new(self.table_id(), rowid);
+                    let row_id =
+                        crate::mvcc::database::RowID::new(mv_cursor.read().table_id, rowid);
                     let record_buf = key.get_record().unwrap().get_payload().to_vec();
                     let num_columns = match key {
                         BTreeKey::IndexKey(record) => record.column_count(),
@@ -5462,10 +5463,6 @@ impl BTreeCursor {
 
         self.pager.add_dirty(root_page);
         btree_init_page(root_page, page_type, 0, self.pager.usable_space());
-    }
-
-    pub fn table_id(&self) -> i64 {
-        self.root_page
     }
 
     pub fn overwrite_cell(

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -56,9 +56,10 @@ pub fn translate_create_table(
     };
     program.extend(&opts);
 
-    if RESERVED_TABLE_PREFIXES
-        .iter()
-        .any(|prefix| normalized_tbl_name.starts_with(prefix))
+    if !connection.is_mvcc_bootstrap_connection()
+        && RESERVED_TABLE_PREFIXES
+            .iter()
+            .any(|prefix| normalized_tbl_name.starts_with(prefix))
     {
         bail_parse_error!(
             "Object name reserved for internal use: {}",

--- a/core/util.rs
+++ b/core/util.rs
@@ -135,9 +135,9 @@ pub fn parse_schema_rows(
     syms: &SymbolTable,
     mv_tx: Option<(u64, TransactionMode)>,
     mut existing_views: HashMap<String, Arc<Mutex<IncrementalView>>>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<()> {
     rows.set_mv_tx(mv_tx);
+    let mv_store = rows.mv_store.clone();
     // TODO: if we IO, this unparsed indexes is lost. Will probably need some state between
     // IO runs
     let mut from_sql_indexes = Vec::with_capacity(10);
@@ -173,7 +173,7 @@ pub fn parse_schema_rows(
                     &mut dbsp_state_roots,
                     &mut dbsp_state_index_roots,
                     &mut materialized_view_info,
-                    mv_store,
+                    mv_store.as_ref(),
                 )?
             }
             StepResult::IO => {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1038,9 +1038,8 @@ pub fn op_open_read(
     let (_, cursor_type) = program.cursor_ref.get(*cursor_id).unwrap();
     let mv_cursor = if let Some(tx_id) = program.connection.get_mv_tx_id() {
         let mv_store = mv_store.unwrap().clone();
-        let table_id = mv_store.get_table_id_from_root_page(*root_page);
         let mv_cursor = Arc::new(RwLock::new(
-            MvCursor::new(mv_store, tx_id, table_id, pager.clone()).unwrap(),
+            MvCursor::new(mv_store, tx_id, *root_page, pager.clone()).unwrap(),
         ));
         Some(mv_cursor)
     } else {
@@ -6649,9 +6648,8 @@ pub fn op_open_write(
     };
     let mv_cursor = if let Some(tx_id) = program.connection.get_mv_tx_id() {
         let mv_store = mv_store.unwrap().clone();
-        let table_id = mv_store.get_table_id_from_root_page(root_page);
         let mv_cursor = Arc::new(RwLock::new(
-            MvCursor::new(mv_store.clone(), tx_id, table_id, pager.clone()).unwrap(),
+            MvCursor::new(mv_store.clone(), tx_id, root_page, pager.clone()).unwrap(),
         ));
         Some(mv_cursor)
     } else {
@@ -7421,9 +7419,8 @@ pub fn op_open_ephemeral(
             let (_, cursor_type) = program.cursor_ref.get(cursor_id).unwrap();
             let mv_cursor = if let Some(tx_id) = program.connection.get_mv_tx_id() {
                 let mv_store = mv_store.unwrap().clone();
-                let table_id = mv_store.get_table_id_from_root_page(root_page);
                 let mv_cursor = Arc::new(RwLock::new(
-                    MvCursor::new(mv_store.clone(), tx_id, table_id, pager.clone()).unwrap(),
+                    MvCursor::new(mv_store.clone(), tx_id, root_page, pager.clone()).unwrap(),
                 ));
                 Some(mv_cursor)
             } else {
@@ -7520,11 +7517,10 @@ pub fn op_open_dup(
 
     let mv_cursor = if let Some(tx_id) = program.connection.get_mv_tx_id() {
         let mv_store = mv_store.unwrap().clone();
-        let table_id = mv_store.get_table_id_from_root_page(root_page);
         let mv_cursor = Arc::new(RwLock::new(MvCursor::new(
             mv_store,
             tx_id,
-            table_id,
+            root_page,
             pager.clone(),
         )?));
         Some(mv_cursor)

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -63,6 +63,23 @@ impl TempDatabase {
         )
     }
 
+    pub fn new_with_existent_with_opts(db_path: &Path, opts: turso_core::DatabaseOpts) -> Self {
+        let io: Arc<dyn IO + Send> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            db_path.to_str().unwrap(),
+            turso_core::OpenFlags::default(),
+            opts,
+            None,
+        )
+        .unwrap();
+        Self {
+            path: db_path.to_path_buf(),
+            io,
+            db,
+        }
+    }
+
     pub fn new_with_existent_with_flags(
         db_path: &Path,
         flags: turso_core::OpenFlags,

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -571,7 +571,7 @@ fn test_mvcc_recovery_of_both_checkpointed_and_noncheckpointed_tables_works() {
         let value = i * 10;
         execute_and_log(
             &conn,
-            &format!("INSERT INTO test1 (id, value) VALUES ({}, {})", i, value),
+            &format!("INSERT INTO test1 (id, value) VALUES ({i}, {value})"),
         )
         .unwrap();
         expected_rows1.push((i, value));
@@ -592,7 +592,7 @@ fn test_mvcc_recovery_of_both_checkpointed_and_noncheckpointed_tables_works() {
         let value = i * 20;
         execute_and_log(
             &conn,
-            &format!("INSERT INTO test2 (id, value) VALUES ({}, {})", i, value),
+            &format!("INSERT INTO test2 (id, value) VALUES ({i}, {value})"),
         )
         .unwrap();
         expected_rows2.push((i, value));

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -1,4 +1,6 @@
-use turso_core::{LimboError, Result, StepResult, Value};
+use std::sync::Arc;
+
+use turso_core::{Connection, LimboError, Result, Statement, StepResult, Value};
 
 use crate::common::TempDatabase;
 
@@ -537,6 +539,111 @@ fn test_mvcc_checkpoint_works() {
         log_size == 0,
         "log size should be 0 bytes, but is {log_size} bytes"
     );
+}
+
+fn execute_and_log(conn: &Arc<Connection>, query: &str) -> Result<()> {
+    tracing::info!("Executing query: {}", query);
+    conn.execute(query)
+}
+
+fn query_and_log(conn: &Arc<Connection>, query: &str) -> Result<Option<Statement>> {
+    tracing::info!("Executing query: {}", query);
+    conn.query(query)
+}
+
+#[test]
+fn test_mvcc_recovery_of_both_checkpointed_and_noncheckpointed_tables_works() {
+    let tmp_db = TempDatabase::new_with_opts(
+        "test_mvcc_recovery_of_both_checkpointed_and_noncheckpointed_tables_works.db",
+        turso_core::DatabaseOpts::new().with_mvcc(true),
+    );
+    let conn = tmp_db.connect_limbo();
+
+    // Create first table and insert rows
+    execute_and_log(
+        &conn,
+        "CREATE TABLE test1 (id INTEGER PRIMARY KEY, value INTEGER)",
+    )
+    .unwrap();
+
+    let mut expected_rows1 = Vec::new();
+    for i in 0..10 {
+        let value = i * 10;
+        execute_and_log(
+            &conn,
+            &format!("INSERT INTO test1 (id, value) VALUES ({}, {})", i, value),
+        )
+        .unwrap();
+        expected_rows1.push((i, value));
+    }
+
+    // Checkpoint
+    execute_and_log(&conn, "PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    // Create second table and insert rows
+    execute_and_log(
+        &conn,
+        "CREATE TABLE test2 (id INTEGER PRIMARY KEY, value INTEGER)",
+    )
+    .unwrap();
+
+    let mut expected_rows2 = Vec::new();
+    for i in 0..5 {
+        let value = i * 20;
+        execute_and_log(
+            &conn,
+            &format!("INSERT INTO test2 (id, value) VALUES ({}, {})", i, value),
+        )
+        .unwrap();
+        expected_rows2.push((i, value));
+    }
+
+    // Sort expected rows
+    expected_rows1.sort_by(|a, b| match a.0.cmp(&b.0) {
+        std::cmp::Ordering::Equal => a.1.cmp(&b.1),
+        other => other,
+    });
+    expected_rows2.sort_by(|a, b| match a.0.cmp(&b.0) {
+        std::cmp::Ordering::Equal => a.1.cmp(&b.1),
+        other => other,
+    });
+
+    let path = tmp_db.path.clone();
+    drop(conn);
+    drop(tmp_db);
+
+    // Close and reopen database
+    let tmp_db = TempDatabase::new_with_existent_with_opts(
+        &path,
+        turso_core::DatabaseOpts::new().with_mvcc(true),
+    );
+    let conn = tmp_db.connect_limbo();
+
+    // Verify table1 rows
+    let stmt = query_and_log(&conn, "SELECT * FROM test1 ORDER BY id, value")
+        .unwrap()
+        .unwrap();
+    let rows = helper_read_all_rows(stmt);
+
+    let expected1: Vec<Vec<Value>> = expected_rows1
+        .into_iter()
+        .map(|(id, value)| vec![Value::Integer(id as i64), Value::Integer(value as i64)])
+        .collect();
+
+    assert_eq!(rows, expected1);
+
+    // Verify table2 rows
+    let stmt = query_and_log(&conn, "SELECT * FROM test2 ORDER BY id, value")
+        .unwrap()
+        .unwrap();
+    let rows = helper_read_all_rows(stmt);
+
+    let expected2: Vec<Vec<Value>> = expected_rows2
+        .into_iter()
+        .map(|(id, value)| vec![Value::Integer(id as i64), Value::Integer(value as i64)])
+        .collect();
+
+    assert_eq!(rows, expected2);
 }
 
 fn helper_read_all_rows(mut stmt: turso_core::Statement) -> Vec<Vec<Value>> {


### PR DESCRIPTION
**Handle table ID / rootpages properly for both checkpointed and non-checkpointed tables**

Table ID is an opaque identifier that is only meaningful to the MV store.
Each checkpointed MVCC table corresponds to a single B-tree on the pager,
which naturally has a root page.

**We cannot use root page as the MVCC table ID directly because:**
- We assign table IDs during MVCC commit, but
- we commit pages to the pager only during checkpoint
which means the root page is not easily knowable ahead of time.

**Hence:**

- MVCC table ids are always negative
- sqlite_schema rows will have a negative rootpage column if the
  table has not been checkpointed yet.
- on checkpoint when the table is allocated a real root page, we update the row in sqlite_schema and in MV store's internal mapping

**On recovery:**

- All sqlite_schema tables are read directly from disk and assigned `table_id = -1 * root_page` -- root_page on disk must be positive
- Logical log is deserialized and inserted into MV store
- Schema changes from logical_log are captured into the DB's global schema

**Note about recovery:**

I changed MVCC recovery to happen on DB initialization which should prevent any races, so no need for `recover_lock`, right @pereman2 ?