### PR TITLE
Fix zero limit

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -1,5 +1,5 @@
 use crate::schema::{Index, IndexColumn, Schema};
-use crate::translate::emitter::{emit_query, init_limit, LimitCtx, Resolver, TranslateCtx};
+use crate::translate::emitter::{emit_query, LimitCtx, Resolver, TranslateCtx};
 use crate::translate::expr::translate_expr;
 use crate::translate::plan::{Plan, QueryDestination, SelectPlan};
 use crate::translate::result_row::try_fold_expr_to_i64;

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -31,13 +31,6 @@ pub fn emit_program_for_compound_select(
     };
 
     let right_plan = right_most.clone();
-    // Trivial exit on LIMIT 0
-    if matches!(limit.as_ref().and_then(try_fold_expr_to_i64), Some(v) if v == 0) {
-        program.result_columns = right_plan.result_columns;
-        program.table_references.extend(right_plan.table_references);
-        return Ok(());
-    }
-
     let right_most_ctx = TranslateCtx::new(
         program,
         resolver.schema,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1726,7 +1726,7 @@ pub fn emit_cdc_insns(
 /// Initialize the limit/offset counters and registers.
 /// In case of compound SELECTs, the limit counter is initialized only once,
 /// hence [LimitCtx::initialize_counter] being false in those cases.
-fn init_limit(
+pub fn init_limit(
     program: &mut ProgramBuilder,
     t_ctx: &mut TranslateCtx,
     limit: &Option<Box<Expr>>,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -234,14 +234,6 @@ fn emit_program_for_select(
         plan.table_references.joined_tables().len(),
     );
 
-    // Trivial exit on LIMIT 0
-    if let Some(limit) = plan.limit.as_ref().and_then(try_fold_expr_to_i64) {
-        if limit == 0 {
-            program.result_columns = plan.result_columns;
-            program.table_references.extend(plan.table_references);
-            return Ok(());
-        }
-    }
     // Emit main parts of query
     emit_query(program, &mut plan, &mut t_ctx)?;
 
@@ -264,13 +256,14 @@ pub fn emit_query<'a>(
     // Emit subqueries first so the results can be read in the main query loop.
     emit_subqueries(program, t_ctx, &mut plan.table_references)?;
 
+    let after_main_loop_label = program.allocate_label();
+    t_ctx.label_main_loop_end = Some(after_main_loop_label);
+
     init_limit(program, t_ctx, &plan.limit, &plan.offset);
 
     // No rows will be read from source table loops if there is a constant false condition eg. WHERE 0
     // however an aggregation might still happen,
     // e.g. SELECT COUNT(*) WHERE 0 returns a row with 0, not an empty result set
-    let after_main_loop_label = program.allocate_label();
-    t_ctx.label_main_loop_end = Some(after_main_loop_label);
     if plan.contains_constant_false_condition {
         program.emit_insn(Insn::Goto {
             target_pc: after_main_loop_label,
@@ -424,20 +417,12 @@ fn emit_program_for_delete(
         plan.table_references.joined_tables().len(),
     );
 
-    // exit early if LIMIT 0
-    if let Some(limit) = plan.limit.as_ref().and_then(try_fold_expr_to_i64) {
-        if limit == 0 {
-            program.result_columns = plan.result_columns;
-            program.table_references.extend(plan.table_references);
-            return Ok(());
-        }
-    }
+    let after_main_loop_label = program.allocate_label();
+    t_ctx.label_main_loop_end = Some(after_main_loop_label);
 
     init_limit(program, &mut t_ctx, &plan.limit, &None);
 
     // No rows will be read from source table loops if there is a constant false condition eg. WHERE 0
-    let after_main_loop_label = program.allocate_label();
-    t_ctx.label_main_loop_end = Some(after_main_loop_label);
     if plan.contains_constant_false_condition {
         program.emit_insn(Insn::Goto {
             target_pc: after_main_loop_label,
@@ -720,18 +705,12 @@ fn emit_program_for_update(
         plan.table_references.joined_tables().len(),
     );
 
-    // Exit on LIMIT 0
-    if let Some(limit) = plan.limit.as_ref().and_then(try_fold_expr_to_i64) {
-        if limit == 0 {
-            program.result_columns = plan.returning.unwrap_or_default();
-            program.table_references.extend(plan.table_references);
-            return Ok(());
-        }
-    }
-
-    init_limit(program, &mut t_ctx, &plan.limit, &plan.offset);
     let after_main_loop_label = program.allocate_label();
     t_ctx.label_main_loop_end = Some(after_main_loop_label);
+
+    init_limit(program, &mut t_ctx, &plan.limit, &plan.offset);
+
+    // No rows will be read from source table loops if there is a constant false condition eg. WHERE 0
     if plan.contains_constant_false_condition {
         program.emit_insn(Insn::Goto {
             target_pc: after_main_loop_label,
@@ -1758,6 +1737,7 @@ fn init_limit(
     let Some(limit_ctx) = &t_ctx.limit_ctx else {
         return;
     };
+
     if limit_ctx.initialize_counter {
         if let Some(expr) = limit {
             if let Some(value) = try_fold_expr_to_i64(expr) {
@@ -1808,6 +1788,16 @@ fn init_limit(
             }
         }
     }
+
+    // exit early if LIMIT 0
+    let main_loop_end = t_ctx
+        .label_main_loop_end
+        .expect("label_main_loop_end must be set before init_limit");
+    program.emit_insn(Insn::IfNot {
+        reg: limit_ctx.reg_limit,
+        target_pc: main_loop_end,
+        jump_if_null: false,
+    });
 }
 
 /// We have `Expr`s which have *not* had column references bound to them,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1726,7 +1726,7 @@ pub fn emit_cdc_insns(
 /// Initialize the limit/offset counters and registers.
 /// In case of compound SELECTs, the limit counter is initialized only once,
 /// hence [LimitCtx::initialize_counter] being false in those cases.
-pub fn init_limit(
+fn init_limit(
     program: &mut ProgramBuilder,
     t_ctx: &mut TranslateCtx,
     limit: &Option<Box<Expr>>,


### PR DESCRIPTION
Before, we validated that condition during program emit - which works for fixed values of parameters but doesn't work with variables provided externally to the prepared statement