### PR TITLE
use explicit null if it set instead of column default value

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1712,7 +1712,9 @@ pub fn op_column(
 
                             match serial_type {
                                 // NULL
-                                0 => break 'ifnull,
+                                0 => {
+                                    state.registers[*dest] = Register::Value(Value::Null);
+                                }
                                 // I8
                                 1 => {
                                     state.registers[*dest] =

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -641,3 +641,12 @@ do_execsql_test_on_specific_db {:memory:} default-values-population {
     SELECT * FROM t;
 } {1|666|
 2|666|}
+
+do_execsql_test_on_specific_db {:memory:} set-explicit-null-default-value {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, x DEFAULT 1);
+    INSERT INTO t(id, x) VALUES (1, 2);
+    SELECT * FROM t;
+    UPDATE t SET x = NULL WHERE id = 1;
+    SELECT * FROM t;
+} {1|2
+1|}


### PR DESCRIPTION
Before, tursodb always used default value even if NULL was explicitly set by the user