### PR TITLE
core: Disallow CREATE INDEX when MVCC is enabled

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -476,6 +476,14 @@ impl Database {
                     // a warning to the user to load the module
                     eprintln!("Warning: {e}");
                 }
+
+                if db.mvcc_enabled() && !schema.indexes.is_empty() {
+                    return Err(LimboError::ParseError(
+                        "Database contains indexes which are not supported when MVCC is enabled."
+                            .to_string(),
+                    ));
+                }
+
                 Ok(())
             })?;
         }
@@ -826,6 +834,10 @@ impl Database {
 
     pub fn experimental_strict_enabled(&self) -> bool {
         self.opts.enable_strict
+    }
+
+    pub fn mvcc_enabled(&self) -> bool {
+        self.opts.enable_mvcc
     }
 }
 
@@ -1901,6 +1913,10 @@ impl Connection {
 
     pub fn experimental_strict_enabled(&self) -> bool {
         self.db.experimental_strict_enabled()
+    }
+
+    pub fn mvcc_enabled(&self) -> bool {
+        self.db.mvcc_enabled()
     }
 
     /// Query the current value(s) of `pragma_name` associated to

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -39,6 +39,9 @@ pub fn translate_create_index(
     if tbl_name.eq_ignore_ascii_case("sqlite_sequence") {
         crate::bail_parse_error!("table sqlite_sequence may not be indexed");
     }
+    if connection.mvcc_enabled() {
+        crate::bail_parse_error!("CREATE INDEX is currently not supported when MVCC is enabled.");
+    }
     if !resolver.schema.indexes_enabled() {
         crate::bail_parse_error!(
             "CREATE INDEX is disabled by default. Run with `--experimental-indexes` to enable this feature."


### PR DESCRIPTION
MVCC does currently not support indexes. Therefore,

- Fail if a database with indexes is opened with MVCC
- Disallow `CREATE INDEX` when MVCC is enabled

Fixes: #3108