### PR TITLE
Fix self-insert with nested subquery

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -286,6 +286,7 @@ pub fn emit_query<'a>(
     // Allocate registers for result columns
     if t_ctx.reg_result_cols_start.is_none() {
         t_ctx.reg_result_cols_start = Some(program.alloc_registers(plan.result_columns.len()));
+        program.reg_result_cols_start = t_ctx.reg_result_cols_start
     }
 
     // Initialize cursors and other resources needed for query execution

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -332,7 +332,7 @@ pub fn translate_insert(
                     };
 
                     program.emit_insn(Insn::MakeRecord {
-                        start_reg: yield_reg + 1,
+                        start_reg: program.reg_result_cols_start.unwrap_or(yield_reg + 1),
                         count: result.num_result_cols,
                         dest_reg: record_reg,
                         index_name: None,
@@ -434,10 +434,13 @@ pub fn translate_insert(
     let conflict_rowid_reg = program.alloc_register();
 
     if inserting_multiple_rows {
+        let select_result_start_reg = program
+            .reg_result_cols_start
+            .unwrap_or(yield_reg_opt.unwrap() + 1);
         translate_rows_multiple(
             &mut program,
             &insertion,
-            yield_reg_opt.unwrap() + 1,
+            select_result_start_reg,
             resolver,
             &temp_table_ctx,
         )?;

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -123,6 +123,7 @@ pub struct ProgramBuilder {
     /// Current parent explain address, if any.
     current_parent_explain_idx: Option<usize>,
     pub param_ctx: ParamState,
+    pub(crate) reg_result_cols_start: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -209,6 +210,7 @@ impl ProgramBuilder {
             query_mode,
             current_parent_explain_idx: None,
             param_ctx: ParamState::default(),
+            reg_result_cols_start: None,
         }
     }
 

--- a/testing/insert.test
+++ b/testing/insert.test
@@ -650,3 +650,11 @@ do_execsql_test_on_specific_db {:memory:} set-explicit-null-default-value {
     SELECT * FROM t;
 } {1|2
 1|}
+
+do_execsql_test_on_specific_db {:memory:} insert-select-nested-subquery {
+    CREATE TABLE t (x);
+    INSERT INTO T VALUES (1);
+    INSERT INTO T SELECT * FROM (SELECT * FROM t);
+    SELECT * FROM t;
+} {1
+1}


### PR DESCRIPTION
There were 2 problems:
1. The SELECT wasn't propagating which register it used for its results, so sometimes the INSERT read bad data.
2. `TableReferences::contains_table` was only checking the top-level tables, not the nested tables in FROM queries. This condition is used to emit "template 4", the bytecode template for self-inserts.

Closes https://github.com/tursodatabase/turso/issues/3312