### PR TITLE
core/vdbe: Fix BEGIN after BEGIN CONCURRENT check

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2474,9 +2474,11 @@ pub fn op_auto_commit(
             }
         } else {
             let is_begin = !*auto_commit && !*rollback;
-            return Err(LimboError::TxError(
-                "cannot use BEGIN after BEGIN CONCURRENT".to_string(),
-            ));
+            if is_begin {
+                return Err(LimboError::TxError(
+                    "cannot use BEGIN after BEGIN CONCURRENT".to_string(),
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
We're supposed to error out only when "is_begin" is true.