### PR TITLE
Index search fixes

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -142,10 +142,6 @@ fn optimize_update_plan(plan: &mut UpdatePlan, schema: &Schema) -> Result<()> {
     if !plan.indexes_to_update.iter().any(|i| Arc::ptr_eq(index, i)) {
         return Ok(());
     }
-    // Fine to use index if we aren't going to be iterating over it, since it returns at most 1 row.
-    if table_ref.op.returns_max_1_row() {
-        return Ok(());
-    }
     // Otherwise, fall back to a table scan.
     table_ref.op = Operation::Scan(Scan::BTreeTable {
         iter_dir: IterationDirection::Forwards,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -795,19 +795,6 @@ impl Operation {
             Operation::Search(Search::Seek { index, .. }) => index.as_ref(),
         }
     }
-
-    pub fn returns_max_1_row(&self) -> bool {
-        match self {
-            Operation::Scan(_) => false,
-            Operation::Search(Search::RowidEq { .. }) => true,
-            Operation::Search(Search::Seek { index, seek_def }) => {
-                let Some(index) = index else {
-                    return false;
-                };
-                index.unique && seek_def.seek.as_ref().is_some_and(|seek| seek.op.eq_only())
-            }
-        }
-    }
 }
 
 impl JoinedTable {


### PR DESCRIPTION
This PR bundles 2 fixes:
1. Index search must skip NULL values
2. UPDATE must avoid using index which column is used in the SET clause