### PR TITLE
core/vdbe: Don't clear parameters in Statement::reset()

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -404,7 +404,6 @@ impl ProgramState {
         self.ended_coroutine.0 = [0; 4];
         self.regex_cache.like.clear();
         self.interrupted = false;
-        self.parameters.clear();
         self.current_collation = None;
         #[cfg(feature = "json")]
         self.json_cache.clear();


### PR DESCRIPTION
As per SQLite API, sqlite3_reset() does *not* clear bind parameters. Instead they're persistent across statement reset and only cleared with sqlite3_clear_bindings().