### PR TITLE
fix/mvcc: set log offset to end of file after recovery finishes

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1973,6 +1973,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     self.delete(tx_id, rowid)?;
                 }
                 StreamingResult::Eof => {
+                    // Set offset to the end so that next writes go to the end of the file
+                    self.storage.logical_log.write().unwrap().offset = reader.offset as u64;
                     break;
                 }
             }

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -14,7 +14,7 @@ use crate::{types::IOResult, File};
 
 pub struct LogicalLog {
     pub file: Arc<dyn File>,
-    offset: u64,
+    pub offset: u64,
 }
 
 /// Log's Header, this will be the 64 bytes in any logical log file.
@@ -231,7 +231,7 @@ enum StreamingState {
 pub struct StreamingLogicalLogReader {
     file: Arc<dyn File>,
     /// Offset to read from file
-    offset: usize,
+    pub offset: usize,
     /// Log Header
     header: Option<Arc<LogHeader>>,
     /// Cached buffer after io read


### PR DESCRIPTION
otherwise we start overwriting existing log entries

Closes #3495 