### PR TITLE
core/wal: check index header on begin_write_tx

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -993,9 +993,6 @@ impl Wal for WalFile {
             let checkpoint_seq = shared.wal_header.lock().checkpoint_seq;
             (mx, nb, ck, checkpoint_seq)
         };
-        // dbg!(shared_max != self.max_frame.load(Ordering::Acquire));
-        // dbg!(last_checksum != self.last_checksum);
-        // dbg!(checkpoint_seq != self.checkpoint_seq.load(Ordering::Acquire));
         let db_changed = shared_max != self.max_frame.load(Ordering::Acquire)
             || last_checksum != self.last_checksum
             || checkpoint_seq != self.checkpoint_seq.load(Ordering::Acquire);

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -983,12 +983,17 @@ impl Wal for WalFile {
         if !shared.write_lock.write() {
             return Err(LimboError::Busy);
         }
-        let (shared_max, nbackfills, last_checksum) = (
-            shared.max_frame.load(Ordering::Acquire),
-            shared.nbackfills.load(Ordering::Acquire),
-            shared.last_checksum,
-        );
-        if self.max_frame.load(Ordering::Acquire) == shared_max {
+        let (shared_max, nbackfills, last_checksum, checkpoint_seq) = {
+            let mx = shared.max_frame.load(Ordering::Acquire);
+            let nb = shared.nbackfills.load(Ordering::Acquire);
+            let ck = shared.last_checksum;
+            let checkpoint_seq = shared.wal_header.lock().checkpoint_seq;
+            (mx, nb, ck, checkpoint_seq)
+        };
+        let db_changed = shared_max != self.max_frame.load(Ordering::Acquire)
+            || last_checksum != self.last_checksum
+            || checkpoint_seq != self.checkpoint_seq.load(Ordering::Acquire);
+        if !db_changed {
             // Snapshot still valid; adopt counters
             drop(shared);
             self.last_checksum = last_checksum;


### PR DESCRIPTION
Fixes a page cache staleness issue where connections could incorrectly believe the database hasn't changed after checkpointing. This can happen when writes following a checkpoint resulted in the same `max_frame value`, causing connections to miss updates since they only checked `max_frame` to detect changes.