### PR TITLE
Reject unsupported FROM clauses in UPDATE

### DIFF
--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -113,6 +113,9 @@ pub fn prepare_update_plan(
     if body.or_conflict.is_some() {
         bail_parse_error!("ON CONFLICT clause is not supported in UPDATE");
     }
+    if body.from.is_some() {
+        bail_parse_error!("FROM clause is not supported in UPDATE");
+    }
     if body
         .indexed
         .as_ref()


### PR DESCRIPTION
Before, FROM clauses were simply ignored:

```
turso> update t set a = b from (select random() as b);
  × Parse error: no such column: b
```

Now, they will be rejected with a clear message. It also makes it clearer that they need to be implemented:


```
turso> update t set a = b from (select random() as b);
  × Parse error: FROM clause is not supported in UPDATE
```