### PR TITLE
core/translate: implement basic foreign key constraint support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ simulator.log
 **/*.txt
 profile.json.gz
 simulator-output/
+tests/*.sql
 
 &1
 bisected.sql

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -448,8 +448,8 @@ Modifiers:
 | Eq             | Yes    |         |
 | Expire         | No     |         |
 | Explain        | No     |         |
-| FkCounter      | No     |         |
-| FkIfZero       | No     |         |
+| FkCounter      | Yes    |         |
+| FkIfZero       | Yes    |         |
 | Found          | Yes    |         |
 | Function       | Yes    |         |
 | Ge             | Yes    |         |

--- a/core/error.rs
+++ b/core/error.rs
@@ -163,6 +163,7 @@ impl From<turso_ext::ResultCode> for LimboError {
 
 pub const SQLITE_CONSTRAINT: usize = 19;
 pub const SQLITE_CONSTRAINT_PRIMARYKEY: usize = SQLITE_CONSTRAINT | (6 << 8);
+pub const SQLITE_CONSTRAINT_FOREIGNKEY: usize = SQLITE_CONSTRAINT | (7 << 8);
 pub const SQLITE_CONSTRAINT_NOTNULL: usize = SQLITE_CONSTRAINT | (5 << 8);
 pub const SQLITE_FULL: usize = 13; // we want this in autoincrement - incase if user inserts max allowed int
 pub const SQLITE_CONSTRAINT_UNIQUE: usize = 2067;

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -2245,6 +2245,7 @@ mod tests {
                 is_strict: false,
                 has_autoincrement: false,
                 unique_sets: vec![],
+                foreign_keys: vec![],
             };
             schema.add_btree_table(Arc::new(users_table));
 
@@ -2298,6 +2299,7 @@ mod tests {
                 is_strict: false,
                 has_autoincrement: false,
                 unique_sets: vec![],
+                foreign_keys: vec![],
             };
             schema.add_btree_table(Arc::new(products_table));
 
@@ -2363,6 +2365,7 @@ mod tests {
                 has_autoincrement: false,
                 is_strict: false,
                 unique_sets: vec![],
+                foreign_keys: vec![],
             };
             schema.add_btree_table(Arc::new(orders_table));
 
@@ -2401,6 +2404,7 @@ mod tests {
                 is_strict: false,
                 has_autoincrement: false,
                 unique_sets: vec![],
+                foreign_keys: vec![],
             };
             schema.add_btree_table(Arc::new(customers_table));
 
@@ -2463,6 +2467,7 @@ mod tests {
                 is_strict: false,
                 has_autoincrement: false,
                 unique_sets: vec![],
+                foreign_keys: vec![],
             };
             schema.add_btree_table(Arc::new(purchases_table));
 
@@ -2513,6 +2518,7 @@ mod tests {
                 is_strict: false,
                 has_autoincrement: false,
                 unique_sets: vec![],
+                foreign_keys: vec![],
             };
             schema.add_btree_table(Arc::new(vendors_table));
 
@@ -2550,6 +2556,7 @@ mod tests {
                 is_strict: false,
                 has_autoincrement: false,
                 unique_sets: vec![],
+                foreign_keys: vec![],
             };
             schema.add_btree_table(Arc::new(sales_table));
 

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -1411,6 +1411,7 @@ mod tests {
             has_rowid: true,
             is_strict: false,
             unique_sets: vec![],
+            foreign_keys: vec![],
             has_autoincrement: false,
         };
 
@@ -1460,6 +1461,7 @@ mod tests {
             has_rowid: true,
             is_strict: false,
             has_autoincrement: false,
+            foreign_keys: vec![],
             unique_sets: vec![],
         };
 
@@ -1509,6 +1511,7 @@ mod tests {
             has_rowid: true,
             is_strict: false,
             has_autoincrement: false,
+            foreign_keys: vec![],
             unique_sets: vec![],
         };
 
@@ -1558,6 +1561,7 @@ mod tests {
             has_rowid: true, // Has implicit rowid but no alias
             is_strict: false,
             has_autoincrement: false,
+            foreign_keys: vec![],
             unique_sets: vec![],
         };
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1539,6 +1539,7 @@ impl Connection {
     pub fn set_foreign_keys_enabled(&self, enable: bool) {
         self.fk_pragma.store(enable, Ordering::Release);
     }
+
     pub fn foreign_keys_enabled(&self) -> bool {
         self.fk_pragma.load(Ordering::Acquire)
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -583,6 +583,7 @@ impl Database {
             busy_timeout: RwLock::new(Duration::new(0, 0)),
             is_mvcc_bootstrap_connection: AtomicBool::new(is_mvcc_bootstrap_connection),
             fk_pragma: AtomicBool::new(false),
+            fk_deferred_violations: AtomicIsize::new(0),
         });
         self.n_connections
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -1102,6 +1103,7 @@ pub struct Connection {
     is_mvcc_bootstrap_connection: AtomicBool,
     /// Whether pragma foreign_keys=ON for this connection
     fk_pragma: AtomicBool,
+    fk_deferred_violations: AtomicIsize,
 }
 
 impl Drop for Connection {
@@ -1540,7 +1542,6 @@ impl Connection {
     pub fn foreign_keys_enabled(&self) -> bool {
         self.fk_pragma.load(Ordering::Acquire)
     }
-
     pub(crate) fn clear_deferred_foreign_key_violations(&self) -> isize {
         self.fk_deferred_violations.swap(0, Ordering::Release)
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1100,6 +1100,7 @@ pub struct Connection {
     busy_timeout: RwLock<std::time::Duration>,
     /// Whether this is an internal connection used for MVCC bootstrap
     is_mvcc_bootstrap_connection: AtomicBool,
+    /// Whether pragma foreign_keys=ON for this connection
     fk_pragma: AtomicBool,
 }
 

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -131,6 +131,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["mvcc_checkpoint_threshold"],
         ),
+        ForeignKeys => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["foreign_keys"],
+        ),
     }
 }
 

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -371,6 +371,7 @@ mod tests {
                     hidden: false,
                 }],
                 unique_sets: vec![],
+                foreign_keys: vec![],
             })),
         });
 
@@ -413,6 +414,7 @@ mod tests {
                     hidden: false,
                 }],
                 unique_sets: vec![],
+                foreign_keys: vec![],
             })),
         });
         // Right table t2(id=2)
@@ -446,6 +448,7 @@ mod tests {
                     hidden: false,
                 }],
                 unique_sets: vec![],
+                foreign_keys: vec![],
             })),
         });
         table_references
@@ -486,6 +489,7 @@ mod tests {
                     hidden: false,
                 }],
                 unique_sets: vec![],
+                foreign_keys: vec![],
             })),
         });
         table_references

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -24,11 +24,16 @@ use super::select::emit_simple_count;
 use super::subquery::emit_subqueries;
 use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
 use crate::function::Func;
-use crate::schema::{BTreeTable, Column, ResolvedFkRef, Schema, Table, ROWID_SENTINEL};
+use crate::schema::{BTreeTable, Column, Schema, Table, ROWID_SENTINEL};
 use crate::translate::compound_select::emit_program_for_compound_select;
 use crate::translate::expr::{
     emit_returning_results, translate_expr_no_constant_opt, walk_expr_mut, NoConstantOptReason,
     ReturningValueRegisters, WalkControl,
+};
+use crate::translate::fkeys::{
+    build_index_affinity_string, emit_fk_child_update_counters,
+    emit_fk_delete_parent_existence_checks, emit_fk_scope_if_needed, emit_parent_pk_change_checks,
+    stabilize_new_row_for_fk,
 };
 use crate::translate::plan::{DeletePlan, JoinedTable, Plan, QueryDestination, Search};
 use crate::translate::planner::ROWID_STRS;
@@ -432,25 +437,18 @@ fn emit_program_for_delete(
         });
     }
 
-    let has_parent_fks = connection.foreign_keys_enabled() && {
-        let table_name = plan
-            .table_references
-            .joined_tables()
-            .first()
-            .unwrap()
-            .table
-            .get_name();
-        resolver.schema.any_resolved_fks_referencing(table_name)
-    };
-    // Open FK scope for the whole statement
-    if has_parent_fks {
-        program.emit_insn(Insn::FkCounter {
-            increment_value: 1,
-            check_abort: false,
-            is_scope: true,
-        });
+    let fk_enabled = connection.foreign_keys_enabled();
+    let table_name = plan
+        .table_references
+        .joined_tables()
+        .first()
+        .unwrap()
+        .table
+        .get_name()
+        .to_string();
+    if fk_enabled {
+        emit_fk_scope_if_needed(program, resolver, &table_name, true)?;
     }
-
     // Initialize cursors and other resources needed for query execution
     init_loop(
         program,
@@ -489,16 +487,175 @@ fn emit_program_for_delete(
         None,
     )?;
     program.preassign_label_to_next_insn(after_main_loop_label);
-    if has_parent_fks {
-        program.emit_insn(Insn::FkCounter {
-            increment_value: -1,
-            check_abort: true,
-            is_scope: true,
-        });
+    if fk_enabled {
+        emit_fk_scope_if_needed(program, resolver, &table_name, false)?;
     }
     // Finalize program
     program.result_columns = plan.result_columns;
     program.table_references.extend(plan.table_references);
+    Ok(())
+}
+
+pub fn emit_fk_child_decrement_on_delete(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    child_tbl: &BTreeTable,
+    child_table_name: &str,
+    child_cursor_id: usize,
+    child_rowid_reg: usize,
+) -> crate::Result<()> {
+    for fk_ref in resolver.schema.resolved_fks_for_child(child_table_name)? {
+        if !fk_ref.fk.deferred {
+            continue;
+        }
+        // Fast path: if any FK column is NULL can't be a violation
+        let null_skip = program.allocate_label();
+        for cname in &fk_ref.child_cols {
+            let (pos, col) = child_tbl.get_column(cname).unwrap();
+            let src = if col.is_rowid_alias {
+                child_rowid_reg
+            } else {
+                let tmp = program.alloc_register();
+                program.emit_insn(Insn::Column {
+                    cursor_id: child_cursor_id,
+                    column: pos,
+                    dest: tmp,
+                    default: None,
+                });
+                tmp
+            };
+            program.emit_insn(Insn::IsNull {
+                reg: src,
+                target_pc: null_skip,
+            });
+        }
+
+        if fk_ref.parent_uses_rowid {
+            // Probe parent table by rowid
+            let parent_tbl = resolver
+                .schema
+                .get_btree_table(&fk_ref.fk.parent_table)
+                .expect("parent btree");
+            let pcur = program.alloc_cursor_id(CursorType::BTreeTable(parent_tbl.clone()));
+            program.emit_insn(Insn::OpenRead {
+                cursor_id: pcur,
+                root_page: parent_tbl.root_page,
+                db: 0,
+            });
+
+            let (pos, col) = child_tbl.get_column(&fk_ref.child_cols[0]).unwrap();
+            let val = if col.is_rowid_alias {
+                child_rowid_reg
+            } else {
+                let tmp = program.alloc_register();
+                program.emit_insn(Insn::Column {
+                    cursor_id: child_cursor_id,
+                    column: pos,
+                    dest: tmp,
+                    default: None,
+                });
+                tmp
+            };
+            let tmpi = program.alloc_register();
+            program.emit_insn(Insn::Copy {
+                src_reg: val,
+                dst_reg: tmpi,
+                extra_amount: 0,
+            });
+            program.emit_insn(Insn::MustBeInt { reg: tmpi });
+
+            // NotExists jumps when the parent key is missing, so we decrement there
+            let missing = program.allocate_label();
+            let done = program.allocate_label();
+
+            program.emit_insn(Insn::NotExists {
+                cursor: pcur,
+                rowid_reg: tmpi,
+                target_pc: missing,
+            });
+
+            // Parent FOUND, no decrement
+            program.emit_insn(Insn::Close { cursor_id: pcur });
+            program.emit_insn(Insn::Goto { target_pc: done });
+
+            // Parent MISSING, decrement is guarded by FkIfZero to avoid underflow
+            program.preassign_label_to_next_insn(missing);
+            program.emit_insn(Insn::Close { cursor_id: pcur });
+            program.emit_insn(Insn::FkIfZero {
+                is_scope: false,
+                target_pc: done,
+            });
+            program.emit_insn(Insn::FkCounter {
+                is_scope: false,
+                increment_value: -1,
+            });
+
+            program.preassign_label_to_next_insn(done);
+        } else {
+            // Probe parent unique index
+            let parent_tbl = resolver
+                .schema
+                .get_btree_table(&fk_ref.fk.parent_table)
+                .expect("parent btree");
+            let idx = fk_ref.parent_unique_index.as_ref().expect("unique index");
+            let icur = program.alloc_cursor_id(CursorType::BTreeIndex(idx.clone()));
+            program.emit_insn(Insn::OpenRead {
+                cursor_id: icur,
+                root_page: idx.root_page,
+                db: 0,
+            });
+
+            // Build probe from current child row
+            let n = fk_ref.child_cols.len();
+            let probe = program.alloc_registers(n);
+            for (i, cname) in fk_ref.child_cols.iter().enumerate() {
+                let (pos, col) = child_tbl.get_column(cname).unwrap();
+                let src = if col.is_rowid_alias {
+                    child_rowid_reg
+                } else {
+                    let r = program.alloc_register();
+                    program.emit_insn(Insn::Column {
+                        cursor_id: child_cursor_id,
+                        column: pos,
+                        dest: r,
+                        default: None,
+                    });
+                    r
+                };
+                program.emit_insn(Insn::Copy {
+                    src_reg: src,
+                    dst_reg: probe + i,
+                    extra_amount: 0,
+                });
+            }
+            program.emit_insn(Insn::Affinity {
+                start_reg: probe,
+                count: std::num::NonZeroUsize::new(n).unwrap(),
+                affinities: build_index_affinity_string(idx, &parent_tbl),
+            });
+
+            let ok = program.allocate_label();
+            program.emit_insn(Insn::Found {
+                cursor_id: icur,
+                target_pc: ok,
+                record_reg: probe,
+                num_regs: n,
+            });
+            program.emit_insn(Insn::Close { cursor_id: icur });
+            program.emit_insn(Insn::FkIfZero {
+                is_scope: false,
+                target_pc: ok,
+            });
+            program.emit_insn(Insn::FkCounter {
+                increment_value: -1,
+                is_scope: false,
+            });
+            program.preassign_label_to_next_insn(ok);
+            program.emit_insn(Insn::Close { cursor_id: icur });
+        }
+
+        program.preassign_label_to_next_insn(null_skip);
+    }
     Ok(())
 }
 
@@ -540,20 +697,32 @@ fn emit_delete_insns(
         dest: key_reg,
     });
 
-    if connection.foreign_keys_enabled()
-        && unsafe { &*table_reference }.btree().is_some()
-        && t_ctx
-            .resolver
-            .schema
-            .any_resolved_fks_referencing(table_name)
-    {
-        emit_fk_parent_existence_checks(
-            program,
-            &t_ctx.resolver,
-            table_name,
-            main_table_cursor_id,
-            key_reg,
-        )?;
+    if connection.foreign_keys_enabled() {
+        if let Some(table) = unsafe { &*table_reference }.btree() {
+            if t_ctx
+                .resolver
+                .schema
+                .any_resolved_fks_referencing(table_name)
+            {
+                emit_fk_delete_parent_existence_checks(
+                    program,
+                    &t_ctx.resolver,
+                    table_name,
+                    main_table_cursor_id,
+                    key_reg,
+                )?;
+            }
+            if t_ctx.resolver.schema.has_child_fks(table_name) {
+                emit_fk_child_decrement_on_delete(
+                    program,
+                    &t_ctx.resolver,
+                    &table,
+                    table_name,
+                    main_table_cursor_id,
+                    key_reg,
+                )?;
+            }
+        }
     }
 
     if unsafe { &*table_reference }.virtual_table().is_some() {
@@ -734,530 +903,6 @@ fn emit_delete_insns(
     Ok(())
 }
 
-/// Emit parent-side FK counter maintenance for UPDATE on a table with a composite PK.
-///
-/// For every child FK that targets `parent_table_name`:
-///  1. Pass 1: If any child row currently references the OLD parent key,
-///     increment the global FK counter (deferred violation potential).
-///     We try an index probe on child(child_cols...) if available, else do a table scan.
-///  2. Pass 2: If any child row references the NEW parent key, decrement the counter
-///     (because the reference would be “retargeted” by the update).
-pub fn emit_fk_parent_pk_change_counters(
-    program: &mut ProgramBuilder,
-    incoming: &[ResolvedFkRef],
-    resolver: &Resolver,
-    old_pk_start: usize,
-    new_pk_start: usize,
-    n_cols: usize,
-) -> crate::Result<()> {
-    if incoming.is_empty() {
-        return Ok(());
-    }
-    for fk_ref in incoming.iter() {
-        let child_tbl = &fk_ref.child_table;
-        let child_cols = &fk_ref.fk.child_columns;
-        // Prefer exact-prefix index on child
-        let idx = resolver.schema.get_indices(&child_tbl.name).find(|ix| {
-            ix.columns.len() == child_cols.len()
-                && ix
-                    .columns
-                    .iter()
-                    .zip(child_cols.iter())
-                    .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
-        });
-
-        if let Some(ix) = idx {
-            let icur = program.alloc_cursor_id(CursorType::BTreeIndex(ix.clone()));
-            program.emit_insn(Insn::OpenRead {
-                cursor_id: icur,
-                root_page: ix.root_page,
-                db: 0,
-            });
-
-            // Build child-probe key from OLD parent PK (1:1 map ensured by the column-name equality above)
-            // We just copy the OLD PK registers, apply index affinities before the probe.
-            let probe_start = old_pk_start;
-
-            // Apply affinities for composite comparison
-            let aff: String = ix
-                .columns
-                .iter()
-                .map(|ic| {
-                    let (_, col) = child_tbl
-                        .get_column(&ic.name)
-                        .expect("indexed child column not found");
-                    col.affinity().aff_mask()
-                })
-                .collect();
-            if let Some(count) = NonZeroUsize::new(n_cols) {
-                program.emit_insn(Insn::Affinity {
-                    start_reg: probe_start,
-                    count,
-                    affinities: aff,
-                });
-            }
-
-            let found = program.allocate_label();
-            program.emit_insn(Insn::Found {
-                cursor_id: icur,
-                target_pc: found,
-                record_reg: probe_start,
-                num_regs: n_cols,
-            });
-
-            // Not found => no increment
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            let skip = program.allocate_label();
-            program.emit_insn(Insn::Goto { target_pc: skip });
-
-            // Found => increment
-            program.preassign_label_to_next_insn(found);
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            program.emit_insn(Insn::FkCounter {
-                increment_value: 1,
-                check_abort: false,
-                is_scope: false,
-            });
-            program.preassign_label_to_next_insn(skip);
-        } else {
-            // Table-scan fallback with per-column checks (jump-if-NULL semantics)
-            let ccur = program.alloc_cursor_id(CursorType::BTreeTable(child_tbl.clone()));
-            program.emit_insn(Insn::OpenRead {
-                cursor_id: ccur,
-                root_page: child_tbl.root_page,
-                db: 0,
-            });
-
-            let done = program.allocate_label();
-            program.emit_insn(Insn::Rewind {
-                cursor_id: ccur,
-                pc_if_empty: done,
-            });
-
-            let loop_top = program.allocate_label();
-            let next_row = program.allocate_label();
-            program.preassign_label_to_next_insn(loop_top);
-
-            for (i, child_name) in child_cols.iter().enumerate() {
-                let (pos, _) = child_tbl.get_column(child_name).ok_or_else(|| {
-                    crate::LimboError::InternalError(format!("child col {child_name} missing"))
-                })?;
-                let tmp = program.alloc_register();
-                program.emit_insn(Insn::Column {
-                    cursor_id: ccur,
-                    column: pos,
-                    dest: tmp,
-                    default: None,
-                });
-
-                // Treat NULL as non-match: jump away immediately
-                program.emit_insn(Insn::IsNull {
-                    reg: tmp,
-                    target_pc: next_row,
-                });
-
-                // Eq(tmp, old_pk[i]) with Binary collation, jump-if-NULL enabled
-                let cont = program.allocate_label();
-                program.emit_insn(Insn::Eq {
-                    lhs: tmp,
-                    rhs: old_pk_start + i,
-                    target_pc: cont,
-                    flags: CmpInsFlags::default().jump_if_null(),
-                    collation: Some(super::collate::CollationSeq::Binary),
-                });
-                program.emit_insn(Insn::Goto {
-                    target_pc: next_row,
-                });
-                program.preassign_label_to_next_insn(cont);
-            }
-
-            // All columns matched OLD -> increment
-            program.emit_insn(Insn::FkCounter {
-                increment_value: 1,
-                check_abort: false,
-                is_scope: false,
-            });
-
-            program.preassign_label_to_next_insn(next_row);
-            program.emit_insn(Insn::Next {
-                cursor_id: ccur,
-                pc_if_next: loop_top,
-            });
-            program.preassign_label_to_next_insn(done);
-            program.emit_insn(Insn::Close { cursor_id: ccur });
-        }
-    }
-
-    // PASS 2: count children of NEW key
-    for fk_ref in incoming.iter() {
-        let child_tbl = &fk_ref.child_table;
-        let child_cols = &fk_ref.fk.child_columns;
-
-        let idx = resolver.schema.get_indices(&child_tbl.name).find(|ix| {
-            ix.columns.len() == child_cols.len()
-                && ix
-                    .columns
-                    .iter()
-                    .zip(child_cols.iter())
-                    .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
-        });
-
-        if let Some(ix) = idx {
-            let icur = program.alloc_cursor_id(CursorType::BTreeIndex(ix.clone()));
-            program.emit_insn(Insn::OpenRead {
-                cursor_id: icur,
-                root_page: ix.root_page,
-                db: 0,
-            });
-
-            // Build probe from NEW PK registers; apply affinities
-            let probe_start = new_pk_start;
-            let aff: String = ix
-                .columns
-                .iter()
-                .map(|ic| {
-                    let (_, col) = child_tbl
-                        .get_column(&ic.name)
-                        .expect("indexed child column not found");
-                    col.affinity().aff_mask()
-                })
-                .collect();
-            if let Some(count) = NonZeroUsize::new(n_cols) {
-                program.emit_insn(Insn::Affinity {
-                    start_reg: probe_start,
-                    count,
-                    affinities: aff,
-                });
-            }
-
-            let found = program.allocate_label();
-            program.emit_insn(Insn::Found {
-                cursor_id: icur,
-                target_pc: found,
-                record_reg: probe_start,
-                num_regs: n_cols,
-            });
-
-            // Not found => no decrement
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            let skip = program.allocate_label();
-            program.emit_insn(Insn::Goto { target_pc: skip });
-
-            // Found => decrement
-            program.preassign_label_to_next_insn(found);
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            program.emit_insn(Insn::FkCounter {
-                increment_value: -1,
-                check_abort: false,
-                is_scope: false,
-            });
-            program.preassign_label_to_next_insn(skip);
-        } else {
-            // Table-scan fallback on NEW key
-            let ccur = program.alloc_cursor_id(CursorType::BTreeTable(child_tbl.clone()));
-            program.emit_insn(Insn::OpenRead {
-                cursor_id: ccur,
-                root_page: child_tbl.root_page,
-                db: 0,
-            });
-
-            let done = program.allocate_label();
-            program.emit_insn(Insn::Rewind {
-                cursor_id: ccur,
-                pc_if_empty: done,
-            });
-
-            let loop_top = program.allocate_label();
-            let next_row = program.allocate_label();
-            program.preassign_label_to_next_insn(loop_top);
-
-            for (i, child_name) in child_cols.iter().enumerate() {
-                let (pos, _) = child_tbl.get_column(child_name).ok_or_else(|| {
-                    crate::LimboError::InternalError(format!("child col {child_name} missing"))
-                })?;
-                let tmp = program.alloc_register();
-                program.emit_insn(Insn::Column {
-                    cursor_id: ccur,
-                    column: pos,
-                    dest: tmp,
-                    default: None,
-                });
-
-                program.emit_insn(Insn::IsNull {
-                    reg: tmp,
-                    target_pc: next_row,
-                });
-
-                let cont = program.allocate_label();
-                program.emit_insn(Insn::Eq {
-                    lhs: tmp,
-                    rhs: new_pk_start + i,
-                    target_pc: cont,
-                    flags: CmpInsFlags::default().jump_if_null(),
-                    collation: Some(super::collate::CollationSeq::Binary),
-                });
-                program.emit_insn(Insn::Goto {
-                    target_pc: next_row,
-                });
-                program.preassign_label_to_next_insn(cont);
-            }
-
-            // All columns matched NEW: decrement
-            program.emit_insn(Insn::FkCounter {
-                increment_value: -1,
-                check_abort: false,
-                is_scope: false,
-            });
-
-            program.preassign_label_to_next_insn(next_row);
-            program.emit_insn(Insn::Next {
-                cursor_id: ccur,
-                pc_if_next: loop_top,
-            });
-            program.preassign_label_to_next_insn(done);
-            program.emit_insn(Insn::Close { cursor_id: ccur });
-        }
-    }
-    Ok(())
-}
-
-/// Emit checks that prevent updating/deleting a parent row that is still referenced by a child.
-///
-/// If the global deferred-FK counter is zero, we skip all checks (fast path for no outstanding refs).
-/// For each incoming FK:
-///   Build the parent key (in FK parent-column order) from the current row.
-///   Probe the child table for any row whose FK columns equal that key.
-///     - If an exact child index exists on the FK columns, use `NotFound` against that index.
-///     - Otherwise, scan the child table and compare each FK column (NULL short-circuits to “no match”).
-/// If a referencing child is found:
-///     - Deferred FK: increment counter (violation will be raised at COMMIT).
-///     - Immediate FK: raise `SQLITE_CONSTRAINT_FOREIGNKEY` now.
-pub fn emit_fk_parent_existence_checks(
-    program: &mut ProgramBuilder,
-    resolver: &Resolver,
-    parent_table_name: &str,
-    parent_cursor_id: usize,
-    parent_rowid_reg: usize,
-) -> Result<()> {
-    let parent_bt = resolver
-        .schema
-        .get_btree_table(parent_table_name)
-        .ok_or_else(|| crate::LimboError::InternalError("parent not btree".into()))?;
-
-    for fk_ref in resolver.schema.resolved_fks_referencing(parent_table_name) {
-        // Resolve parent key columns
-        let parent_cols: Vec<String> = if fk_ref.fk.parent_columns.is_empty() {
-            parent_bt
-                .primary_key_columns
-                .iter()
-                .map(|(n, _)| n.clone())
-                .collect()
-        } else {
-            fk_ref.fk.parent_columns.clone()
-        };
-
-        // Load parent key values for THIS row into regs, in parent_cols order
-        let parent_cols_len = parent_cols.len();
-        let parent_key_start = program.alloc_registers(parent_cols_len);
-        for (i, pcol) in parent_cols.iter().enumerate() {
-            let src = if pcol.eq_ignore_ascii_case("rowid") {
-                parent_rowid_reg
-            } else {
-                let (pos, col) = parent_bt
-                    .get_column(&normalize_ident(pcol))
-                    .ok_or_else(|| {
-                        crate::LimboError::InternalError(format!("col {pcol} missing"))
-                    })?;
-                if col.is_rowid_alias {
-                    parent_rowid_reg
-                } else {
-                    // read current cell's column value
-                    program.emit_insn(Insn::Column {
-                        cursor_id: parent_cursor_id,
-                        column: pos,
-                        dest: parent_key_start + i,
-                        default: None,
-                    });
-                    continue;
-                }
-            };
-            program.emit_insn(Insn::Copy {
-                src_reg: src,
-                dst_reg: parent_key_start + i,
-                extra_amount: 0,
-            });
-        }
-
-        // Build child-side probe key in child_columns order, from parent_key_start
-        //
-        // Map parent_col to child_col position 1:1
-        let child_cols = &fk_ref.fk.child_columns;
-        // Try to find an index on child(child_cols...) to do an existance check
-        let child_idx = resolver
-            .schema
-            .get_indices(&fk_ref.child_table.name)
-            .find(|idx| {
-                idx.columns.len() == child_cols.len()
-                    && idx
-                        .columns
-                        .iter()
-                        .zip(child_cols.iter())
-                        .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
-            });
-
-        if let Some(idx) = child_idx {
-            // Index existence probe: Found -> violation
-            let icur = program.alloc_cursor_id(CursorType::BTreeIndex(idx.clone()));
-            program.emit_insn(Insn::OpenRead {
-                cursor_id: icur,
-                root_page: idx.root_page,
-                db: 0,
-            });
-
-            // Pack the child key regs from the parent key regs in fk order.
-            // Same order because we matched columns 1:1 above
-            let probe_start = program.alloc_registers(parent_cols_len);
-            for i in 0..parent_cols_len {
-                program.emit_insn(Insn::Copy {
-                    src_reg: parent_key_start + i,
-                    dst_reg: probe_start + i,
-                    extra_amount: 0,
-                });
-            }
-            if let Some(count) = NonZeroUsize::new(parent_cols_len) {
-                // Apply index affinities for composite comparison
-                let aff: String = idx
-                    .columns
-                    .iter()
-                    .map(|ic| {
-                        let (_, col) = fk_ref
-                            .child_table
-                            .get_column(&ic.name)
-                            .expect("indexed child column not found");
-                        col.affinity().aff_mask()
-                    })
-                    .collect();
-                program.emit_insn(Insn::Affinity {
-                    start_reg: probe_start,
-                    count,
-                    affinities: aff,
-                });
-            }
-
-            let ok = program.allocate_label();
-            program.emit_insn(Insn::NotFound {
-                cursor_id: icur,
-                target_pc: ok,
-                record_reg: probe_start,
-                num_regs: parent_cols_len,
-            });
-
-            // found referencing child row = violation path
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            if fk_ref.fk.deferred {
-                program.emit_insn(Insn::FkCounter {
-                    increment_value: 1,
-                    check_abort: false,
-                    is_scope: false,
-                });
-            } else {
-                program.emit_insn(Insn::Halt {
-                    err_code: crate::error::SQLITE_CONSTRAINT_FOREIGNKEY,
-                    description: "FOREIGN KEY constraint failed".to_string(),
-                });
-            }
-            program.preassign_label_to_next_insn(ok);
-            program.emit_insn(Insn::Close { cursor_id: icur });
-        } else {
-            // Fallback: table-scan the child table
-            let ccur = program.alloc_cursor_id(CursorType::BTreeTable(fk_ref.child_table.clone()));
-            program.emit_insn(Insn::OpenRead {
-                cursor_id: ccur,
-                root_page: fk_ref.child_table.root_page,
-                db: 0,
-            });
-
-            let done = program.allocate_label();
-            program.emit_insn(Insn::Rewind {
-                cursor_id: ccur,
-                pc_if_empty: done,
-            });
-
-            // Loop labels local to this scan
-            let loop_top = program.allocate_label();
-            let next_row = program.allocate_label();
-
-            program.preassign_label_to_next_insn(loop_top);
-
-            // For each FK column: require a match, if NULL or mismatch -> next_row
-            for (i, child_col) in child_cols.iter().enumerate() {
-                let (pos, _) = fk_ref
-                    .child_table
-                    .get_column(&normalize_ident(child_col))
-                    .ok_or_else(|| {
-                        crate::LimboError::InternalError(format!("child col {child_col} missing"))
-                    })?;
-
-                let tmp = program.alloc_register();
-                program.emit_insn(Insn::Column {
-                    cursor_id: ccur,
-                    column: pos,
-                    dest: tmp,
-                    default: None,
-                });
-
-                // NULL FK value => this child row cannot reference the parent, skip row
-                program.emit_insn(Insn::IsNull {
-                    reg: tmp,
-                    target_pc: next_row,
-                });
-
-                // Equal? continue to check next column; else jump to next_row
-                let cont_i = program.allocate_label();
-                program.emit_insn(Insn::Eq {
-                    lhs: tmp,
-                    rhs: parent_key_start + i,
-                    target_pc: cont_i,
-                    flags: CmpInsFlags::default().jump_if_null(),
-                    collation: program.curr_collation(),
-                });
-                // Not equal -> skip this child row
-                program.emit_insn(Insn::Goto {
-                    target_pc: next_row,
-                });
-
-                // Equal path resumes here, then we check the next column
-                program.preassign_label_to_next_insn(cont_i);
-            }
-
-            // If we reached here, all FK columns matched, violation
-            if fk_ref.fk.deferred {
-                program.emit_insn(Insn::FkCounter {
-                    increment_value: 1,
-                    check_abort: false,
-                    is_scope: false,
-                });
-            } else {
-                program.emit_insn(Insn::Halt {
-                    err_code: crate::error::SQLITE_CONSTRAINT_FOREIGNKEY,
-                    description: "FOREIGN KEY constraint failed".to_string(),
-                });
-            }
-
-            // Advance to next child row and loop
-            program.preassign_label_to_next_insn(next_row);
-            program.emit_insn(Insn::Next {
-                cursor_id: ccur,
-                pc_if_next: loop_top,
-            });
-
-            program.preassign_label_to_next_insn(done);
-            program.emit_insn(Insn::Close { cursor_id: ccur });
-        }
-    }
-    Ok(())
-}
-
 #[instrument(skip_all, level = Level::DEBUG)]
 fn emit_program_for_update(
     connection: &Arc<Connection>,
@@ -1309,16 +954,13 @@ fn emit_program_for_update(
         .first()
         .unwrap()
         .table
-        .get_name();
-    let has_child_fks = fk_enabled && resolver.schema.has_child_fks(table_name);
-    let has_parent_fks = fk_enabled && resolver.schema.any_resolved_fks_referencing(table_name);
+        .get_name()
+        .to_string();
+
     // statement-level FK scope open
-    if has_child_fks || has_parent_fks {
-        program.emit_insn(Insn::FkCounter {
-            increment_value: 1,
-            check_abort: false,
-            is_scope: true,
-        });
+    if fk_enabled {
+        let open = true;
+        emit_fk_scope_if_needed(program, resolver, &table_name, open)?;
     }
 
     // Initialize the main loop
@@ -1387,13 +1029,9 @@ fn emit_program_for_update(
     )?;
 
     program.preassign_label_to_next_insn(after_main_loop_label);
-
-    if has_child_fks || has_parent_fks {
-        program.emit_insn(Insn::FkCounter {
-            increment_value: -1,
-            check_abort: true,
-            is_scope: true,
-        });
+    if fk_enabled {
+        let open = false;
+        emit_fk_scope_if_needed(program, resolver, &table_name, open)?;
     }
     after(program);
 
@@ -1662,41 +1300,23 @@ fn emit_update_insns(
     if connection.foreign_keys_enabled() {
         let rowid_new_reg = rowid_set_clause_reg.unwrap_or(beg);
         if let Some(table_btree) = unsafe { &*table_ref }.btree() {
-            //first, stablize the image of the NEW row in the registers
-            if !table_btree.primary_key_columns.is_empty() {
-                let set_cols: std::collections::HashSet<usize> = plan
-                    .set_clauses
-                    .iter()
-                    .filter_map(|(i, _)| if *i == ROWID_SENTINEL { None } else { Some(*i) })
-                    .collect();
-                for (pk_name, _) in &table_btree.primary_key_columns {
-                    let (pos, col) = table_btree.get_column(pk_name).unwrap();
-                    if !set_cols.contains(&pos) {
-                        if col.is_rowid_alias {
-                            program.emit_insn(Insn::Copy {
-                                src_reg: rowid_new_reg,
-                                dst_reg: start + pos,
-                                extra_amount: 0,
-                            });
-                        } else {
-                            program.emit_insn(Insn::Column {
-                                cursor_id,
-                                column: pos,
-                                dest: start + pos,
-                                default: None,
-                            });
-                        }
-                    }
-                }
-            }
+            stabilize_new_row_for_fk(
+                program,
+                &table_btree,
+                &plan.set_clauses,
+                cursor_id,
+                start,
+                rowid_new_reg,
+            )?;
             if t_ctx.resolver.schema.has_child_fks(table_name) {
                 // Child-side checks:
                 // this ensures updated row still satisfies child FKs that point OUT from this table
-                emit_fk_child_existence_checks(
+                emit_fk_child_update_counters(
                     program,
                     &t_ctx.resolver,
                     &table_btree,
                     table_name,
+                    cursor_id,
                     start,
                     rowid_new_reg,
                     &plan
@@ -1715,178 +1335,17 @@ fn emit_update_insns(
                 .schema
                 .any_resolved_fks_referencing(table_name)
             {
-                let updated_parent_positions: HashSet<usize> =
-                    plan.set_clauses.iter().map(|(i, _)| *i).collect();
-
-                // If no incoming FK’s parent key can be affected by these updates, skip the whole parent-FK block.
-                let incoming = t_ctx.resolver.schema.resolved_fks_referencing(table_name);
-                let parent_tbl = &table_btree;
-                let maybe_affects_parent_key = incoming
-                    .iter()
-                    .any(|r| r.parent_key_may_change(&updated_parent_positions, parent_tbl));
-                if maybe_affects_parent_key {
-                    let pk_len = table_btree.primary_key_columns.len();
-                    match pk_len {
-                        0 => {
-                            // Rowid table: the implicit PK is rowid.
-                            // If rowid is unchanged then we skip, else check that no child row still references the OLD key.
-                            let skip_parent_fk = program.allocate_label();
-                            let old_rowid_reg = beg;
-                            let new_rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
-
-                            program.emit_insn(Insn::Eq {
-                                lhs: new_rowid_reg,
-                                rhs: old_rowid_reg,
-                                target_pc: skip_parent_fk,
-                                flags: CmpInsFlags::default(),
-                                collation: program.curr_collation(),
-                            });
-                            // Rowid changed: check incoming FKs (children) that reference this parent row
-                            emit_fk_parent_existence_checks(
-                                program,
-                                &t_ctx.resolver,
-                                table_name,
-                                cursor_id,
-                                old_rowid_reg,
-                            )?;
-                            program.preassign_label_to_next_insn(skip_parent_fk);
-                        }
-                        1 => {
-                            // Single-column declared PK, may be a rowid alias or a real column.
-                            // If PK value unchanged then skip, else verify no child still references OLD key.
-                            let (pk_name, _) = &table_btree.primary_key_columns[0];
-                            let (pos, col) = table_btree.get_column(pk_name).unwrap();
-
-                            let old_reg = program.alloc_register();
-                            if col.is_rowid_alias {
-                                program.emit_insn(Insn::RowId {
-                                    cursor_id,
-                                    dest: old_reg,
-                                });
-                            } else {
-                                program.emit_insn(Insn::Column {
-                                    cursor_id,
-                                    column: pos,
-                                    dest: old_reg,
-                                    default: None,
-                                });
-                            }
-                            let new_reg = if col.is_rowid_alias {
-                                rowid_new_reg
-                            } else {
-                                start + pos
-                            };
-
-                            let skip_parent_fk = program.allocate_label();
-                            program.emit_insn(Insn::Eq {
-                                lhs: old_reg,
-                                rhs: new_reg,
-                                target_pc: skip_parent_fk,
-                                flags: CmpInsFlags::default(),
-                                collation: program.curr_collation(),
-                            });
-                            emit_fk_parent_existence_checks(
-                                program,
-                                &t_ctx.resolver,
-                                table_name,
-                                cursor_id,
-                                beg,
-                            )?;
-                            program.preassign_label_to_next_insn(skip_parent_fk);
-                        }
-                        _ => {
-                            // Composite PK:
-                            // 1. Materialize OLD PK vector from current row.
-                            // 2. Materialize NEW PK vector from updated registers.
-                            // 3. If any component differs, the PK changes -> run composite parent-FK update flow.
-                            let old_pk_start = program.alloc_registers(pk_len);
-                            for (i, (pk_name, _)) in
-                                table_btree.primary_key_columns.iter().enumerate()
-                            {
-                                let (pos, col) = table_btree.get_column(pk_name).unwrap();
-                                if col.is_rowid_alias {
-                                    program.emit_insn(Insn::Copy {
-                                        src_reg: beg,
-                                        dst_reg: old_pk_start + i,
-                                        extra_amount: 0,
-                                    });
-                                } else {
-                                    program.emit_insn(Insn::Column {
-                                        cursor_id,
-                                        column: pos,
-                                        dest: old_pk_start + i,
-                                        default: None,
-                                    });
-                                }
-                            }
-
-                            // Build NEW PK values from the updated registers
-                            let new_pk_start = program.alloc_registers(pk_len);
-                            for (i, (pk_name, _)) in
-                                table_btree.primary_key_columns.iter().enumerate()
-                            {
-                                let (pos, col) = table_btree.get_column(pk_name).unwrap();
-                                let src = if col.is_rowid_alias {
-                                    rowid_new_reg
-                                } else {
-                                    start + pos // Updated value from SET clause
-                                };
-                                program.emit_insn(Insn::Copy {
-                                    src_reg: src,
-                                    dst_reg: new_pk_start + i,
-                                    extra_amount: 0,
-                                });
-                            }
-
-                            // Compare OLD vs NEW to see if PK is changing
-                            let skip_parent_fk = program.allocate_label();
-                            let pk_changed = program.allocate_label();
-
-                            for i in 0..pk_len {
-                                if i == pk_len - 1 {
-                                    // Last comparison, if equal, all are equal
-                                    program.emit_insn(Insn::Eq {
-                                        lhs: old_pk_start + i,
-                                        rhs: new_pk_start + i,
-                                        target_pc: skip_parent_fk,
-                                        flags: CmpInsFlags::default(),
-                                        collation: program.curr_collation(),
-                                    });
-                                    // Not equal - PK is changing
-                                    program.emit_insn(Insn::Goto {
-                                        target_pc: pk_changed,
-                                    });
-                                } else {
-                                    // Not last comparison
-                                    let next_check = program.allocate_label();
-                                    program.emit_insn(Insn::Eq {
-                                        lhs: old_pk_start + i,
-                                        rhs: new_pk_start + i,
-                                        target_pc: next_check, // Equal, check next component
-                                        flags: CmpInsFlags::default(),
-                                        collation: program.curr_collation(),
-                                    });
-                                    // Not equal - PK is changing
-                                    program.emit_insn(Insn::Goto {
-                                        target_pc: pk_changed,
-                                    });
-                                    program.preassign_label_to_next_insn(next_check);
-                                }
-                            }
-                            program.preassign_label_to_next_insn(pk_changed);
-                            // PK changed: maintain the deferred FK counter in two passes
-                            emit_fk_parent_pk_change_counters(
-                                program,
-                                &incoming,
-                                &t_ctx.resolver,
-                                old_pk_start,
-                                new_pk_start,
-                                pk_len,
-                            )?;
-                            program.preassign_label_to_next_insn(skip_parent_fk);
-                        }
-                    }
-                }
+                emit_parent_pk_change_checks(
+                    program,
+                    &t_ctx.resolver,
+                    &table_btree,
+                    cursor_id,
+                    beg,
+                    start,
+                    rowid_new_reg,
+                    rowid_set_clause_reg,
+                    &plan.set_clauses,
+                )?;
             }
         }
     }
@@ -2339,160 +1798,6 @@ fn emit_update_insns(
         program.preassign_label_to_next_insn(label);
     }
 
-    Ok(())
-}
-
-pub fn emit_fk_child_existence_checks(
-    program: &mut ProgramBuilder,
-    resolver: &Resolver,
-    table: &BTreeTable,
-    table_name: &str,
-    start_reg: usize,
-    rowid_reg: usize,
-    updated_cols: &HashSet<usize>,
-) -> Result<()> {
-    for fk_ref in resolver.schema.resolved_fks_for_child(table_name) {
-        // Skip when the child key is untouched (including rowid-alias special case)
-        if !fk_ref.child_key_changed(updated_cols, table) {
-            continue;
-        }
-
-        let fk_ok = program.allocate_label();
-
-        // look for NULLs in any child FK column
-        for child_name in &fk_ref.child_cols {
-            let (i, col) = table.get_column(child_name).unwrap();
-            let src = if col.is_rowid_alias {
-                rowid_reg
-            } else {
-                start_reg + i
-            };
-            program.emit_insn(Insn::IsNull {
-                reg: src,
-                target_pc: fk_ok,
-            });
-        }
-
-        if fk_ref.parent_uses_rowid {
-            // Fast rowid probe on the parent table
-            let parent_tbl = resolver
-                .schema
-                .get_btree_table(&fk_ref.fk.parent_table)
-                .expect("Parent must be btree");
-
-            let pcur = program.alloc_cursor_id(CursorType::BTreeTable(parent_tbl.clone()));
-            program.emit_insn(Insn::OpenRead {
-                cursor_id: pcur,
-                root_page: parent_tbl.root_page,
-                db: 0,
-            });
-
-            let (i_child, col_child) = table.get_column(&fk_ref.child_cols[0]).unwrap();
-            let val_reg = if col_child.is_rowid_alias {
-                rowid_reg
-            } else {
-                start_reg + i_child
-            };
-            let tmp = program.alloc_register();
-            program.emit_insn(Insn::Copy {
-                src_reg: val_reg,
-                dst_reg: tmp,
-                extra_amount: 0,
-            });
-            program.emit_insn(Insn::MustBeInt { reg: tmp });
-            let violation = program.allocate_label();
-            program.emit_insn(Insn::NotExists {
-                cursor: pcur,
-                rowid_reg: tmp,
-                target_pc: violation,
-            });
-            program.emit_insn(Insn::Close { cursor_id: pcur });
-            program.emit_insn(Insn::Goto { target_pc: fk_ok });
-
-            program.preassign_label_to_next_insn(violation);
-            program.emit_insn(Insn::Close { cursor_id: pcur });
-            if fk_ref.fk.deferred {
-                program.emit_insn(Insn::FkCounter {
-                    increment_value: 1,
-                    check_abort: false,
-                    is_scope: false,
-                });
-            } else {
-                program.emit_insn(Insn::Halt {
-                    err_code: crate::error::SQLITE_CONSTRAINT_FOREIGNKEY,
-                    description: "FOREIGN KEY constraint failed".to_string(),
-                });
-            }
-        } else {
-            // Unique-index probe on the parent (already resolved)
-            let parent_idx = fk_ref
-                .parent_unique_index
-                .as_ref()
-                .expect("parent unique index required");
-            let icur = program.alloc_cursor_id(CursorType::BTreeIndex(parent_idx.clone()));
-            program.emit_insn(Insn::OpenRead {
-                cursor_id: icur,
-                root_page: parent_idx.root_page,
-                db: 0,
-            });
-
-            // Build probe key from NEW child values in fk order
-            let n = fk_ref.child_cols.len();
-            let probe_start = program.alloc_registers(n);
-            for (k, child_name) in fk_ref.child_cols.iter().enumerate() {
-                let (i, col) = table.get_column(child_name).unwrap();
-                program.emit_insn(Insn::Copy {
-                    src_reg: if col.is_rowid_alias {
-                        rowid_reg
-                    } else {
-                        start_reg + i
-                    },
-                    dst_reg: probe_start + k,
-                    extra_amount: 0,
-                });
-            }
-
-            let aff: String = parent_idx
-                .columns
-                .iter()
-                .map(|ic| table.columns[ic.pos_in_table].affinity().aff_mask())
-                .collect();
-            program.emit_insn(Insn::Affinity {
-                start_reg: probe_start,
-                count: NonZeroUsize::new(n).unwrap(),
-                affinities: aff,
-            });
-            let found = program.allocate_label();
-            program.emit_insn(Insn::Found {
-                cursor_id: icur,
-                target_pc: found,
-                record_reg: probe_start,
-                num_regs: n,
-            });
-
-            // Not found => violation
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            if fk_ref.fk.deferred {
-                program.emit_insn(Insn::FkCounter {
-                    increment_value: 1,
-                    check_abort: false,
-                    is_scope: false,
-                });
-            } else {
-                program.emit_insn(Insn::Halt {
-                    err_code: crate::error::SQLITE_CONSTRAINT_FOREIGNKEY,
-                    description: "FOREIGN KEY constraint failed".to_string(),
-                });
-            }
-            program.emit_insn(Insn::Goto { target_pc: fk_ok });
-
-            // Found => OK
-            program.preassign_label_to_next_insn(found);
-            program.emit_insn(Insn::Close { cursor_id: icur });
-        }
-
-        program.preassign_label_to_next_insn(fk_ok);
-    }
     Ok(())
 }
 

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -1,0 +1,1025 @@
+use turso_parser::ast::Expr;
+
+use super::ProgramBuilder;
+use crate::{
+    schema::{BTreeTable, ForeignKey, Index, ResolvedFkRef, ROWID_SENTINEL},
+    translate::{emitter::Resolver, planner::ROWID_STRS},
+    vdbe::{
+        builder::CursorType,
+        insn::{CmpInsFlags, Insn},
+    },
+    Result,
+};
+use std::{collections::HashSet, num::NonZeroUsize, sync::Arc};
+
+#[inline]
+/// Increment/decrement the FK scope counter if `table_name` has either outgoing or incoming FKs.
+///
+/// Returns `true` if a scope change was emitted. Scope open (+1) occurs before a statement
+/// touching the table; scope close (−1) occurs after. On scope close, remaining deferred
+/// violations are raised by the runtime.
+pub fn emit_fk_scope_if_needed(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    table_name: &str,
+    open: bool,
+) -> Result<bool> {
+    let has_fks = resolver.schema.has_child_fks(table_name)
+        || resolver.schema.any_resolved_fks_referencing(table_name);
+    if has_fks {
+        program.emit_insn(Insn::FkCounter {
+            increment_value: if open { 1 } else { -1 },
+            is_scope: true,
+        });
+    }
+    Ok(has_fks)
+}
+
+/// Open a read cursor on an index and return its cursor id.
+#[inline]
+pub fn open_read_index(program: &mut ProgramBuilder, idx: &Arc<Index>) -> usize {
+    let icur = program.alloc_cursor_id(CursorType::BTreeIndex(idx.clone()));
+    program.emit_insn(Insn::OpenRead {
+        cursor_id: icur,
+        root_page: idx.root_page,
+        db: 0,
+    });
+    icur
+}
+
+/// Open a read cursor on a table and return its cursor id.
+#[inline]
+pub fn open_read_table(program: &mut ProgramBuilder, tbl: &Arc<BTreeTable>) -> usize {
+    let tcur = program.alloc_cursor_id(CursorType::BTreeTable(tbl.clone()));
+    program.emit_insn(Insn::OpenRead {
+        cursor_id: tcur,
+        root_page: tbl.root_page,
+        db: 0,
+    });
+    tcur
+}
+
+/// Copy `len` registers starting at `src_start` to a fresh block and apply index affinities.
+/// Returns the destination start register.
+#[inline]
+fn copy_with_affinity(
+    program: &mut ProgramBuilder,
+    src_start: usize,
+    len: usize,
+    idx: &Index,
+    aff_from_tbl: &BTreeTable,
+) -> usize {
+    let dst = program.alloc_registers(len);
+    for i in 0..len {
+        program.emit_insn(Insn::Copy {
+            src_reg: src_start + i,
+            dst_reg: dst + i,
+            extra_amount: 0,
+        });
+    }
+    if let Some(count) = NonZeroUsize::new(len) {
+        program.emit_insn(Insn::Affinity {
+            start_reg: dst,
+            count,
+            affinities: build_index_affinity_string(idx, aff_from_tbl),
+        });
+    }
+    dst
+}
+
+/// Issue an index probe using `Found`/`NotFound` and route to `on_found`/`on_not_found`.
+pub fn index_probe<F, G>(
+    program: &mut ProgramBuilder,
+    icur: usize,
+    record_reg: usize,
+    num_regs: usize,
+    mut on_found: F,
+    mut on_not_found: G,
+) -> Result<()>
+where
+    F: FnMut(&mut ProgramBuilder) -> Result<()>,
+    G: FnMut(&mut ProgramBuilder) -> Result<()>,
+{
+    let lbl_found = program.allocate_label();
+    let lbl_join = program.allocate_label();
+
+    program.emit_insn(Insn::Found {
+        cursor_id: icur,
+        target_pc: lbl_found,
+        record_reg,
+        num_regs,
+    });
+
+    // NOT FOUND path
+    on_not_found(program)?;
+    program.emit_insn(Insn::Goto {
+        target_pc: lbl_join,
+    });
+
+    // FOUND path
+    program.preassign_label_to_next_insn(lbl_found);
+    on_found(program)?;
+
+    // Join & close once
+    program.preassign_label_to_next_insn(lbl_join);
+    program.emit_insn(Insn::Close { cursor_id: icur });
+    Ok(())
+}
+
+/// Iterate a table and call `on_match` when all child columns equal the key at `parent_key_start`.
+/// Skips rows where any FK column is NULL. If `self_exclude_rowid` is Some, the row with that rowid is skipped.
+fn table_scan_match_any<F>(
+    program: &mut ProgramBuilder,
+    child_tbl: &Arc<BTreeTable>,
+    child_cols: &[String],
+    parent_key_start: usize,
+    self_exclude_rowid: Option<usize>,
+    mut on_match: F,
+) -> Result<()>
+where
+    F: FnMut(&mut ProgramBuilder) -> Result<()>,
+{
+    let ccur = open_read_table(program, child_tbl);
+    let done = program.allocate_label();
+    program.emit_insn(Insn::Rewind {
+        cursor_id: ccur,
+        pc_if_empty: done,
+    });
+
+    let loop_top = program.allocate_label();
+    program.preassign_label_to_next_insn(loop_top);
+    let next_row = program.allocate_label();
+
+    // Compare each FK column to parent key component.
+    for (i, cname) in child_cols.iter().enumerate() {
+        let (pos, _) = child_tbl.get_column(cname).ok_or_else(|| {
+            crate::LimboError::InternalError(format!("child col {cname} missing"))
+        })?;
+        let tmp = program.alloc_register();
+        program.emit_insn(Insn::Column {
+            cursor_id: ccur,
+            column: pos,
+            dest: tmp,
+            default: None,
+        });
+        program.emit_insn(Insn::IsNull {
+            reg: tmp,
+            target_pc: next_row,
+        });
+
+        let cont = program.allocate_label();
+        program.emit_insn(Insn::Eq {
+            lhs: tmp,
+            rhs: parent_key_start + i,
+            target_pc: cont,
+            flags: CmpInsFlags::default().jump_if_null(),
+            collation: Some(super::collate::CollationSeq::Binary),
+        });
+        program.emit_insn(Insn::Goto {
+            target_pc: next_row,
+        });
+        program.preassign_label_to_next_insn(cont);
+    }
+
+    //self-reference exclusion on rowid
+    if let Some(parent_rowid) = self_exclude_rowid {
+        let child_rowid = program.alloc_register();
+        let skip = program.allocate_label();
+        program.emit_insn(Insn::RowId {
+            cursor_id: ccur,
+            dest: child_rowid,
+        });
+        program.emit_insn(Insn::Eq {
+            lhs: child_rowid,
+            rhs: parent_rowid,
+            target_pc: skip,
+            flags: CmpInsFlags::default(),
+            collation: None,
+        });
+        on_match(program)?;
+        program.preassign_label_to_next_insn(skip);
+    } else {
+        on_match(program)?;
+    }
+
+    program.preassign_label_to_next_insn(next_row);
+    program.emit_insn(Insn::Next {
+        cursor_id: ccur,
+        pc_if_next: loop_top,
+    });
+
+    program.preassign_label_to_next_insn(done);
+    program.emit_insn(Insn::Close { cursor_id: ccur });
+    Ok(())
+}
+
+/// Build the index affinity mask string (one char per indexed column).
+#[inline]
+pub fn build_index_affinity_string(idx: &Index, table: &BTreeTable) -> String {
+    idx.columns
+        .iter()
+        .map(|ic| table.columns[ic.pos_in_table].affinity().aff_mask())
+        .collect()
+}
+
+/// For deferred FKs: increment the global counter; for immediate FKs: halt with FK error.
+pub fn emit_fk_violation(program: &mut ProgramBuilder, fk: &ForeignKey) -> Result<()> {
+    if fk.deferred {
+        program.emit_insn(Insn::FkCounter {
+            increment_value: 1,
+            is_scope: false,
+        });
+    } else {
+        program.emit_insn(Insn::Halt {
+            err_code: crate::error::SQLITE_CONSTRAINT_FOREIGNKEY,
+            description: "FOREIGN KEY constraint failed".to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Stabilize the NEW row image for FK checks (UPDATE):
+/// fill in unmodified PK columns from the current row so the NEW PK vector is complete.
+pub fn stabilize_new_row_for_fk(
+    program: &mut ProgramBuilder,
+    table_btree: &BTreeTable,
+    set_clauses: &[(usize, Box<Expr>)],
+    cursor_id: usize,
+    start: usize,
+    rowid_new_reg: usize,
+) -> Result<()> {
+    if table_btree.primary_key_columns.is_empty() {
+        return Ok(());
+    }
+    let set_cols: HashSet<usize> = set_clauses
+        .iter()
+        .filter_map(|(i, _)| if *i == ROWID_SENTINEL { None } else { Some(*i) })
+        .collect();
+
+    for (pk_name, _) in &table_btree.primary_key_columns {
+        let (pos, col) = table_btree
+            .get_column(pk_name)
+            .ok_or_else(|| crate::LimboError::InternalError(format!("pk col {pk_name} missing")))?;
+        if !set_cols.contains(&pos) {
+            if col.is_rowid_alias {
+                program.emit_insn(Insn::Copy {
+                    src_reg: rowid_new_reg,
+                    dst_reg: start + pos,
+                    extra_amount: 0,
+                });
+            } else {
+                program.emit_insn(Insn::Column {
+                    cursor_id,
+                    column: pos,
+                    dest: start + pos,
+                    default: None,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parent-side checks when the parent PK might change (UPDATE on parent):
+/// Detect if any child references the OLD key (potential violation), and if any references the NEW key
+/// (which cancels one potential violation). For composite PKs this builds OLD/NEW vectors first.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_parent_pk_change_checks(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    table_btree: &BTreeTable,
+    cursor_id: usize,
+    old_rowid_reg: usize,
+    start: usize,
+    rowid_new_reg: usize,
+    rowid_set_clause_reg: Option<usize>,
+    set_clauses: &[(usize, Box<Expr>)],
+) -> Result<()> {
+    let updated_positions: HashSet<usize> = set_clauses.iter().map(|(i, _)| *i).collect();
+    let incoming = resolver
+        .schema
+        .resolved_fks_referencing(&table_btree.name)?;
+    let affects_pk = incoming
+        .iter()
+        .any(|r| r.parent_key_may_change(&updated_positions, table_btree));
+    if !affects_pk {
+        return Ok(());
+    }
+
+    match table_btree.primary_key_columns.len() {
+        0 => emit_rowid_pk_change_check(
+            program,
+            &incoming,
+            resolver,
+            old_rowid_reg,
+            rowid_set_clause_reg.unwrap_or(old_rowid_reg),
+        ),
+        1 => emit_single_pk_change_check(
+            program,
+            &incoming,
+            resolver,
+            table_btree,
+            cursor_id,
+            start,
+            rowid_new_reg,
+        ),
+        _ => emit_composite_pk_change_check(
+            program,
+            &incoming,
+            resolver,
+            table_btree,
+            cursor_id,
+            old_rowid_reg,
+            start,
+            rowid_new_reg,
+        ),
+    }
+}
+
+/// Rowid-table parent PK change: compare rowid OLD vs NEW; if changed, run two-pass counters.
+pub fn emit_rowid_pk_change_check(
+    program: &mut ProgramBuilder,
+    incoming: &[ResolvedFkRef],
+    resolver: &Resolver,
+    old_rowid_reg: usize,
+    new_rowid_reg: usize,
+) -> Result<()> {
+    let skip = program.allocate_label();
+    program.emit_insn(Insn::Eq {
+        lhs: new_rowid_reg,
+        rhs: old_rowid_reg,
+        target_pc: skip,
+        flags: CmpInsFlags::default(),
+        collation: None,
+    });
+
+    let old_pk = program.alloc_register();
+    let new_pk = program.alloc_register();
+    program.emit_insn(Insn::Copy {
+        src_reg: old_rowid_reg,
+        dst_reg: old_pk,
+        extra_amount: 0,
+    });
+    program.emit_insn(Insn::Copy {
+        src_reg: new_rowid_reg,
+        dst_reg: new_pk,
+        extra_amount: 0,
+    });
+
+    emit_fk_parent_pk_change_counters(program, incoming, resolver, old_pk, new_pk, 1)?;
+    program.preassign_label_to_next_insn(skip);
+    Ok(())
+}
+
+/// Single-column PK parent change: load OLD and NEW; if changed, run two-pass counters.
+pub fn emit_single_pk_change_check(
+    program: &mut ProgramBuilder,
+    incoming: &[ResolvedFkRef],
+    resolver: &Resolver,
+    table_btree: &BTreeTable,
+    cursor_id: usize,
+    start: usize,
+    rowid_new_reg: usize,
+) -> Result<()> {
+    let (pk_name, _) = &table_btree.primary_key_columns[0];
+    let (pos, col) = table_btree.get_column(pk_name).unwrap();
+
+    let old_reg = program.alloc_register();
+    if col.is_rowid_alias {
+        program.emit_insn(Insn::RowId {
+            cursor_id,
+            dest: old_reg,
+        });
+    } else {
+        program.emit_insn(Insn::Column {
+            cursor_id,
+            column: pos,
+            dest: old_reg,
+            default: None,
+        });
+    }
+    let new_reg = if col.is_rowid_alias {
+        rowid_new_reg
+    } else {
+        start + pos
+    };
+
+    let skip = program.allocate_label();
+    program.emit_insn(Insn::Eq {
+        lhs: old_reg,
+        rhs: new_reg,
+        target_pc: skip,
+        flags: CmpInsFlags::default(),
+        collation: None,
+    });
+
+    let old_pk = program.alloc_register();
+    let new_pk = program.alloc_register();
+    program.emit_insn(Insn::Copy {
+        src_reg: old_reg,
+        dst_reg: old_pk,
+        extra_amount: 0,
+    });
+    program.emit_insn(Insn::Copy {
+        src_reg: new_reg,
+        dst_reg: new_pk,
+        extra_amount: 0,
+    });
+
+    emit_fk_parent_pk_change_counters(program, incoming, resolver, old_pk, new_pk, 1)?;
+    program.preassign_label_to_next_insn(skip);
+    Ok(())
+}
+
+/// Composite-PK parent change: build OLD/NEW vectors; if any component differs, run two-pass counters.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_composite_pk_change_check(
+    program: &mut ProgramBuilder,
+    incoming: &[ResolvedFkRef],
+    resolver: &Resolver,
+    table_btree: &BTreeTable,
+    cursor_id: usize,
+    old_rowid_reg: usize,
+    start: usize,
+    rowid_new_reg: usize,
+) -> Result<()> {
+    let pk_len = table_btree.primary_key_columns.len();
+
+    let old_pk = program.alloc_registers(pk_len);
+    for (i, (pk_name, _)) in table_btree.primary_key_columns.iter().enumerate() {
+        let (pos, col) = table_btree.get_column(pk_name).unwrap();
+        if col.is_rowid_alias {
+            program.emit_insn(Insn::Copy {
+                src_reg: old_rowid_reg,
+                dst_reg: old_pk + i,
+                extra_amount: 0,
+            });
+        } else {
+            program.emit_insn(Insn::Column {
+                cursor_id,
+                column: pos,
+                dest: old_pk + i,
+                default: None,
+            });
+        }
+    }
+    let new_pk = program.alloc_registers(pk_len);
+    for (i, (pk_name, _)) in table_btree.primary_key_columns.iter().enumerate() {
+        let (pos, col) = table_btree.get_column(pk_name).unwrap();
+        let src = if col.is_rowid_alias {
+            rowid_new_reg
+        } else {
+            start + pos
+        };
+        program.emit_insn(Insn::Copy {
+            src_reg: src,
+            dst_reg: new_pk + i,
+            extra_amount: 0,
+        });
+    }
+
+    let skip = program.allocate_label();
+    let changed = program.allocate_label();
+    for i in 0..pk_len {
+        let next = if i + 1 == pk_len {
+            None
+        } else {
+            Some(program.allocate_label())
+        };
+        program.emit_insn(Insn::Eq {
+            lhs: old_pk + i,
+            rhs: new_pk + i,
+            target_pc: next.unwrap_or(skip),
+            flags: CmpInsFlags::default(),
+            collation: None,
+        });
+        program.emit_insn(Insn::Goto { target_pc: changed });
+        if let Some(n) = next {
+            program.preassign_label_to_next_insn(n);
+        }
+    }
+
+    program.preassign_label_to_next_insn(changed);
+    emit_fk_parent_pk_change_counters(program, incoming, resolver, old_pk, new_pk, pk_len)?;
+    program.preassign_label_to_next_insn(skip);
+    Ok(())
+}
+
+/// Two-pass parent-side maintenance for UPDATE of a parent key:
+/// 1. Probe child for OLD key, increment deferred counter if any references exist.
+/// 2. Probe child for NEW key, guarded decrement cancels exactly one increment if present
+pub fn emit_fk_parent_pk_change_counters(
+    program: &mut ProgramBuilder,
+    incoming: &[ResolvedFkRef],
+    resolver: &Resolver,
+    old_pk_start: usize,
+    new_pk_start: usize,
+    n_cols: usize,
+) -> Result<()> {
+    for fk_ref in incoming {
+        emit_fk_parent_key_probe(
+            program,
+            resolver,
+            fk_ref,
+            old_pk_start,
+            n_cols,
+            ParentProbePass::Old,
+        )?;
+        emit_fk_parent_key_probe(
+            program,
+            resolver,
+            fk_ref,
+            new_pk_start,
+            n_cols,
+            ParentProbePass::New,
+        )?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum ParentProbePass {
+    Old,
+    New,
+}
+
+/// Probe the child side for a given parent key. If `increment_value` is +1, increment counter on match.
+/// If −1, we guard with `FkIfZero` then decrement to avoid counter underflow in edge cases.
+fn emit_fk_parent_key_probe(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    fk_ref: &ResolvedFkRef,
+    parent_key_start: usize,
+    n_cols: usize,
+    pass: ParentProbePass,
+) -> Result<()> {
+    let child_tbl = &fk_ref.child_table;
+    let child_cols = &fk_ref.fk.child_columns;
+    let is_deferred = fk_ref.fk.deferred;
+
+    let on_match = |p: &mut ProgramBuilder| -> Result<()> {
+        match (is_deferred, pass) {
+            // OLD key referenced by a child
+            (false, ParentProbePass::Old) => {
+                // Immediate FK: fail now.
+                emit_fk_violation(p, &fk_ref.fk)?; // HALT for immediate
+            }
+            (true, ParentProbePass::Old) => {
+                // Deferred FK: increment counter.
+                p.emit_insn(Insn::FkCounter {
+                    increment_value: 1,
+                    is_scope: false,
+                });
+            }
+
+            // NEW key referenced by a child (cancel one deferred violation)
+            (true, ParentProbePass::New) => {
+                // Guard to avoid underflow if OLD pass didn't increment.
+                let skip = p.allocate_label();
+                p.emit_insn(Insn::FkIfZero {
+                    is_scope: false,
+                    target_pc: skip,
+                });
+                p.emit_insn(Insn::FkCounter {
+                    increment_value: -1,
+                    is_scope: false,
+                });
+                p.preassign_label_to_next_insn(skip);
+            }
+            // Immediate FK on NEW pass: nothing to cancel; do nothing.
+            (false, ParentProbePass::New) => {}
+        }
+        Ok(())
+    };
+
+    // Prefer exact child index on (child_cols...)
+    let idx = resolver.schema.get_indices(&child_tbl.name).find(|ix| {
+        ix.columns.len() == child_cols.len()
+            && ix
+                .columns
+                .iter()
+                .zip(child_cols.iter())
+                .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
+    });
+
+    if let Some(ix) = idx {
+        let icur = open_read_index(program, ix);
+        let probe = copy_with_affinity(program, parent_key_start, n_cols, ix, child_tbl);
+
+        // FOUND => on_match; NOT FOUND => no-op
+        index_probe(program, icur, probe, n_cols, on_match, |_p| Ok(()))?;
+    } else {
+        // Table scan fallback
+        table_scan_match_any(
+            program,
+            child_tbl,
+            child_cols,
+            parent_key_start,
+            None,
+            on_match,
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Build a parent key vector (in FK parent-column order) into `dest_start`.
+/// Handles rowid aliasing and explicit ROWID names; uses current row for non-rowid columns.
+fn build_parent_key(
+    program: &mut ProgramBuilder,
+    parent_bt: &BTreeTable,
+    parent_cols: &[String],
+    parent_cursor_id: usize,
+    parent_rowid_reg: usize,
+    dest_start: usize,
+) -> Result<()> {
+    for (i, pcol) in parent_cols.iter().enumerate() {
+        let src = if ROWID_STRS.iter().any(|s| pcol.eq_ignore_ascii_case(s)) {
+            parent_rowid_reg
+        } else {
+            let (pos, col) = parent_bt
+                .get_column(pcol)
+                .ok_or_else(|| crate::LimboError::InternalError(format!("col {pcol} missing")))?;
+            if col.is_rowid_alias {
+                parent_rowid_reg
+            } else {
+                program.emit_insn(Insn::Column {
+                    cursor_id: parent_cursor_id,
+                    column: pos,
+                    dest: dest_start + i,
+                    default: None,
+                });
+                continue;
+            }
+        };
+        program.emit_insn(Insn::Copy {
+            src_reg: src,
+            dst_reg: dest_start + i,
+            extra_amount: 0,
+        });
+    }
+    Ok(())
+}
+
+/// Child-side FK maintenance for UPDATE/UPSERT:
+/// If any FK columns of this child row changed:
+///  Pass 1 (OLD tuple): if OLD is non-NULL and parent is missing → decrement deferred counter (guarded).
+///  Pass 2 (NEW tuple): if NEW is non-NULL and parent is missing → immediate error or deferred(+1).
+#[allow(clippy::too_many_arguments)]
+pub fn emit_fk_child_update_counters(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    child_tbl: &BTreeTable,
+    child_table_name: &str,
+    child_cursor_id: usize,
+    new_start_reg: usize,
+    new_rowid_reg: usize,
+    updated_cols: &HashSet<usize>,
+) -> crate::Result<()> {
+    // Helper: materialize OLD tuple for this FK; returns (start_reg, ncols) or None if any component is NULL.
+    let load_old_tuple =
+        |program: &mut ProgramBuilder, fk_cols: &[String]| -> Option<(usize, usize)> {
+            let n = fk_cols.len();
+            let start = program.alloc_registers(n);
+            let null_jmp = program.allocate_label();
+
+            for (k, cname) in fk_cols.iter().enumerate() {
+                let (pos, _col) = match child_tbl.get_column(cname) {
+                    Some(v) => v,
+                    None => {
+                        // schema inconsistency; treat as no-old tuple
+                        return None;
+                    }
+                };
+                program.emit_column_or_rowid(child_cursor_id, pos, start + k);
+                program.emit_insn(Insn::IsNull {
+                    reg: start + k,
+                    target_pc: null_jmp,
+                });
+            }
+
+            // No NULLs, proceed
+            let cont = program.allocate_label();
+            program.emit_insn(Insn::Goto { target_pc: cont });
+            // NULL encountered -> invalidate tuple by jumping here
+            program.preassign_label_to_next_insn(null_jmp);
+
+            program.preassign_label_to_next_insn(cont);
+            Some((start, n))
+        };
+
+    for fk_ref in resolver.schema.resolved_fks_for_child(child_table_name)? {
+        // If the child-side FK columns did not change, there is nothing to do.
+        if !fk_ref.child_key_changed(updated_cols, child_tbl) {
+            continue;
+        }
+
+        let ncols = fk_ref.child_cols.len();
+
+        // Pass 1: OLD tuple handling only for deferred FKs
+        if fk_ref.fk.deferred {
+            if let Some((old_start, _)) = load_old_tuple(program, &fk_ref.child_cols) {
+                if fk_ref.parent_uses_rowid {
+                    // Parent key is rowid: probe parent table by rowid
+                    let parent_tbl = resolver
+                        .schema
+                        .get_btree_table(&fk_ref.fk.parent_table)
+                        .expect("parent btree");
+                    let pcur = open_read_table(program, &parent_tbl);
+
+                    // first FK col is the rowid value
+                    let rid = program.alloc_register();
+                    program.emit_insn(Insn::Copy {
+                        src_reg: old_start,
+                        dst_reg: rid,
+                        extra_amount: 0,
+                    });
+                    program.emit_insn(Insn::MustBeInt { reg: rid });
+
+                    // If NOT exists => decrement (guarded)
+                    let miss = program.allocate_label();
+                    program.emit_insn(Insn::NotExists {
+                        cursor: pcur,
+                        rowid_reg: rid,
+                        target_pc: miss,
+                    });
+                    // found → close & continue
+                    let join = program.allocate_label();
+                    program.emit_insn(Insn::Close { cursor_id: pcur });
+                    program.emit_insn(Insn::Goto { target_pc: join });
+
+                    // missing → guarded decrement
+                    program.preassign_label_to_next_insn(miss);
+                    program.emit_insn(Insn::Close { cursor_id: pcur });
+                    let skip = program.allocate_label();
+                    program.emit_insn(Insn::FkIfZero {
+                        is_scope: false,
+                        target_pc: skip,
+                    });
+                    program.emit_insn(Insn::FkCounter {
+                        is_scope: false,
+                        increment_value: -1,
+                    });
+                    program.preassign_label_to_next_insn(skip);
+
+                    program.preassign_label_to_next_insn(join);
+                } else {
+                    // Parent key is a unique index: use index probe and guarded decrement on NOT FOUND
+                    let parent_tbl = resolver
+                        .schema
+                        .get_btree_table(&fk_ref.fk.parent_table)
+                        .expect("parent btree");
+                    let idx = fk_ref
+                        .parent_unique_index
+                        .as_ref()
+                        .expect("parent unique index required");
+                    let icur = open_read_index(program, idx);
+
+                    // Copy OLD tuple and apply parent index affinities
+                    let probe = copy_with_affinity(program, old_start, ncols, idx, &parent_tbl);
+                    // Found: nothing; Not found: guarded decrement
+                    index_probe(
+                        program,
+                        icur,
+                        probe,
+                        ncols,
+                        |_p| Ok(()),
+                        |p| {
+                            let skip = p.allocate_label();
+                            p.emit_insn(Insn::FkIfZero {
+                                is_scope: false,
+                                target_pc: skip,
+                            });
+                            p.emit_insn(Insn::FkCounter {
+                                is_scope: false,
+                                increment_value: -1,
+                            });
+                            p.preassign_label_to_next_insn(skip);
+                            Ok(())
+                        },
+                    )?;
+                }
+            }
+        }
+
+        // Pass 2: NEW tuple handling
+        // If any NEW component is NULL → FK is satisfied vacuously.
+        let fk_ok = program.allocate_label();
+        for cname in &fk_ref.fk.child_columns {
+            let (i, col) = child_tbl.get_column(cname).unwrap();
+            let src = if col.is_rowid_alias {
+                new_rowid_reg
+            } else {
+                new_start_reg + i
+            };
+            program.emit_insn(Insn::IsNull {
+                reg: src,
+                target_pc: fk_ok,
+            });
+        }
+
+        if fk_ref.parent_uses_rowid {
+            let parent_tbl = resolver
+                .schema
+                .get_btree_table(&fk_ref.fk.parent_table)
+                .expect("parent btree");
+            let pcur = open_read_table(program, &parent_tbl);
+
+            // Take the first child column value (rowid) from NEW image
+            let (i_child, col_child) = child_tbl.get_column(&fk_ref.child_cols[0]).unwrap();
+            let val_reg = if col_child.is_rowid_alias {
+                new_rowid_reg
+            } else {
+                new_start_reg + i_child
+            };
+
+            let tmp = program.alloc_register();
+            program.emit_insn(Insn::Copy {
+                src_reg: val_reg,
+                dst_reg: tmp,
+                extra_amount: 0,
+            });
+            program.emit_insn(Insn::MustBeInt { reg: tmp });
+
+            let violation = program.allocate_label();
+            program.emit_insn(Insn::NotExists {
+                cursor: pcur,
+                rowid_reg: tmp,
+                target_pc: violation,
+            });
+            // found → close and continue
+            program.emit_insn(Insn::Close { cursor_id: pcur });
+            program.emit_insn(Insn::Goto { target_pc: fk_ok });
+
+            // missing → violation (immediate HALT or deferred +1)
+            program.preassign_label_to_next_insn(violation);
+            program.emit_insn(Insn::Close { cursor_id: pcur });
+            emit_fk_violation(program, &fk_ref.fk)?;
+        } else {
+            let parent_tbl = resolver
+                .schema
+                .get_btree_table(&fk_ref.fk.parent_table)
+                .expect("parent btree");
+            let idx = fk_ref
+                .parent_unique_index
+                .as_ref()
+                .expect("parent unique index required");
+            let icur = open_read_index(program, idx);
+
+            // Build NEW probe (in FK child column order → aligns with parent index columns)
+            let probe = {
+                let start = program.alloc_registers(ncols);
+                for (k, cname) in fk_ref.child_cols.iter().enumerate() {
+                    let (i, col) = child_tbl.get_column(cname).unwrap();
+                    program.emit_insn(Insn::Copy {
+                        src_reg: if col.is_rowid_alias {
+                            new_rowid_reg
+                        } else {
+                            new_start_reg + i
+                        },
+                        dst_reg: start + k,
+                        extra_amount: 0,
+                    });
+                }
+                // Apply affinities of the parent index/table
+                if let Some(cnt) = NonZeroUsize::new(ncols) {
+                    program.emit_insn(Insn::Affinity {
+                        start_reg: start,
+                        count: cnt,
+                        affinities: build_index_affinity_string(idx, &parent_tbl),
+                    });
+                }
+                start
+            };
+
+            // FOUND: ok; NOT FOUND: violation path
+            index_probe(
+                program,
+                icur,
+                probe,
+                ncols,
+                |_p| Ok(()),
+                |p| {
+                    emit_fk_violation(p, &fk_ref.fk)?;
+                    Ok(())
+                },
+            )?;
+            program.emit_insn(Insn::Goto { target_pc: fk_ok });
+        }
+
+        // Skip label for NEW tuple NULL short-circuit
+        program.preassign_label_to_next_insn(fk_ok);
+    }
+
+    Ok(())
+}
+
+/// Prevent deleting a parent row that is still referenced by any child.
+/// For each incoming FK referencing `parent_table_name`:
+///   1. Build the parent key vector from the current parent row (FK parent-column order,
+///      or the table's PK columns when the FK omits parent columns).
+///   2. Look for referencing child rows:
+///        - Prefer an exact child index on (child_columns...). If found, probe the index.
+///        - Otherwise scan the child table. For self-referential FKs, exclude the current rowid.
+///   3. If a referencing child exists:
+///        - Immediate FK: HALT with SQLITE_CONSTRAINT_FOREIGNKEY
+///        - Deferred FK: FkCounter +1
+pub fn emit_fk_delete_parent_existence_checks(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    parent_table_name: &str,
+    parent_cursor_id: usize,
+    parent_rowid_reg: usize,
+) -> Result<()> {
+    let parent_bt = resolver
+        .schema
+        .get_btree_table(parent_table_name)
+        .ok_or_else(|| crate::LimboError::InternalError("parent not btree".into()))?;
+
+    for fk_ref in resolver
+        .schema
+        .resolved_fks_referencing(parent_table_name)?
+    {
+        let is_self_ref = fk_ref
+            .child_table
+            .name
+            .eq_ignore_ascii_case(parent_table_name);
+
+        // Build parent key in FK's parent-column order (or table PK columns if unspecified).
+        let parent_cols: Vec<String> = if fk_ref.fk.parent_columns.is_empty() {
+            parent_bt
+                .primary_key_columns
+                .iter()
+                .map(|(n, _)| n.clone())
+                .collect()
+        } else {
+            fk_ref.fk.parent_columns.clone()
+        };
+        let ncols = parent_cols.len();
+
+        let parent_key_start = program.alloc_registers(ncols);
+        build_parent_key(
+            program,
+            &parent_bt,
+            &parent_cols,
+            parent_cursor_id,
+            parent_rowid_reg,
+            parent_key_start,
+        )?;
+
+        // Try an exact child index on (child_columns...) if available and not self-ref
+        let child_cols = &fk_ref.fk.child_columns;
+        let child_idx = if !is_self_ref {
+            resolver
+                .schema
+                .get_indices(&fk_ref.child_table.name)
+                .find(|idx| {
+                    idx.columns.len() == child_cols.len()
+                        && idx
+                            .columns
+                            .iter()
+                            .zip(child_cols.iter())
+                            .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
+                })
+        } else {
+            None
+        };
+
+        if let Some(idx) = child_idx {
+            // Index probe: FOUND => violation; NOT FOUND => ok.
+            let icur = open_read_index(program, idx);
+            let probe =
+                copy_with_affinity(program, parent_key_start, ncols, idx, &fk_ref.child_table);
+
+            index_probe(
+                program,
+                icur,
+                probe,
+                ncols,
+                |p| {
+                    emit_fk_violation(p, &fk_ref.fk)?;
+                    Ok(())
+                },
+                |_p| Ok(()),
+            )?;
+        } else {
+            // Table scan fallback; for self-ref, exclude the same parent row by rowid.
+            table_scan_match_any(
+                program,
+                &fk_ref.child_table,
+                child_cols,
+                parent_key_start,
+                if is_self_ref {
+                    Some(parent_rowid_reg)
+                } else {
+                    None
+                },
+                |p| {
+                    emit_fk_violation(p, &fk_ref.fk)?;
+                    Ok(())
+                },
+            )?;
+        }
+    }
+    Ok(())
+}

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -87,7 +87,7 @@ pub fn translate_insert(
     let has_child_fks = fk_enabled
         && !resolver
             .schema
-            .get_foreign_keys_for_table(table_name.as_str())
+            .get_fks_for_table(table_name.as_str())
             .is_empty();
     let has_parent_fks = fk_enabled && resolver.schema.any_incoming_fk_to(table_name.as_str());
 
@@ -1146,7 +1146,6 @@ pub fn translate_insert(
                 &mut result_columns,
                 cdc_table.as_ref().map(|c| c.0),
                 row_done_label,
-                connection,
             )?;
         } else {
             // UpsertDo::Nothing case
@@ -1910,7 +1909,7 @@ fn emit_fk_checks_for_insert(
     });
 
     // Iterate child FKs declared on this table
-    for fk in resolver.schema.get_foreign_keys_for_table(table_name) {
+    for fk in resolver.schema.get_fks_for_table(table_name) {
         let fk_ok = program.allocate_label();
 
         // If any child column is NULL, skip this FK

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -2389,6 +2389,7 @@ mod tests {
             name: "users".to_string(),
             root_page: 2,
             primary_key_columns: vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
+            foreign_keys: vec![],
             columns: vec![
                 SchemaColumn {
                     name: Some("id".to_string()),
@@ -2505,6 +2506,7 @@ mod tests {
             is_strict: false,
             has_autoincrement: false,
             unique_sets: vec![],
+            foreign_keys: vec![],
         };
         schema.add_btree_table(Arc::new(orders_table));
 
@@ -2567,6 +2569,7 @@ mod tests {
             is_strict: false,
             has_autoincrement: false,
             unique_sets: vec![],
+            foreign_keys: vec![],
         };
         schema.add_btree_table(Arc::new(products_table));
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod delete;
 pub(crate) mod display;
 pub(crate) mod emitter;
 pub(crate) mod expr;
+pub(crate) mod fkeys;
 pub(crate) mod group_by;
 pub(crate) mod index;
 pub(crate) mod insert;

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1664,6 +1664,7 @@ mod tests {
             has_rowid: true,
             is_strict: false,
             unique_sets: vec![],
+            foreign_keys: vec![],
         })
     }
 

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -478,6 +478,7 @@ fn parse_table(
             has_autoincrement: false,
 
             unique_sets: vec![],
+            foreign_keys: vec![],
         });
         drop(view_guard);
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -95,6 +95,20 @@ fn update_pragma(
     connection: Arc<crate::Connection>,
     mut program: ProgramBuilder,
 ) -> crate::Result<(ProgramBuilder, TransactionMode)> {
+    let parse_pragma_enabled = |expr: &ast::Expr| -> bool {
+        if let Expr::Literal(Literal::Numeric(n)) = expr {
+            return !matches!(n.as_str(), "0");
+        };
+        let name_bytes = match expr {
+            Expr::Literal(Literal::Keyword(name)) => name.as_bytes(),
+            Expr::Name(name) | Expr::Id(name) => name.as_str().as_bytes(),
+            _ => "".as_bytes(),
+        };
+        match_ignore_ascii_case!(match name_bytes {
+            b"ON" | b"TRUE" | b"YES" | b"1" => true,
+            _ => false,
+        })
+    };
     match pragma {
         PragmaName::ApplicationId => {
             let data = parse_signed_number(&value)?;
@@ -343,38 +357,15 @@ fn update_pragma(
         }
         PragmaName::Synchronous => {
             use crate::SyncMode;
-
-            let mode = match value {
-                Expr::Name(name) => {
-                    let name_bytes = name.as_str().as_bytes();
-                    match_ignore_ascii_case!(match name_bytes {
-                        b"OFF" | b"FALSE" | b"NO" | b"0" => SyncMode::Off,
-                        _ => SyncMode::Full,
-                    })
-                }
-                Expr::Literal(Literal::Numeric(n)) => match n.as_str() {
-                    "0" => SyncMode::Off,
-                    _ => SyncMode::Full,
-                },
-                _ => SyncMode::Full,
+            let mode = match parse_pragma_enabled(&value) {
+                true => SyncMode::Full,
+                false => SyncMode::Off,
             };
-
             connection.set_sync_mode(mode);
             Ok((program, TransactionMode::None))
         }
         PragmaName::DataSyncRetry => {
-            let retry_enabled = match value {
-                Expr::Name(name) => {
-                    let name_bytes = name.as_str().as_bytes();
-                    match_ignore_ascii_case!(match name_bytes {
-                        b"ON" | b"TRUE" | b"YES" | b"1" => true,
-                        _ => false,
-                    })
-                }
-                Expr::Literal(Literal::Numeric(n)) => !matches!(n.as_str(), "0"),
-                _ => false,
-            };
-
+            let retry_enabled = parse_pragma_enabled(&value);
             connection.set_data_sync_retry(retry_enabled);
             Ok((program, TransactionMode::None))
         }
@@ -388,24 +379,7 @@ fn update_pragma(
             Ok((program, TransactionMode::None))
         }
         PragmaName::ForeignKeys => {
-            let enabled = match value {
-                Expr::Name(name) | Expr::Id(name) => {
-                    let name_bytes = name.as_str().as_bytes();
-                    match_ignore_ascii_case!(match name_bytes {
-                        b"ON" | b"TRUE" | b"YES" | b"1" => true,
-                        _ => false,
-                    })
-                }
-                Expr::Literal(Literal::Keyword(name) | Literal::String(name)) => {
-                    let name_bytes = name.as_bytes();
-                    match_ignore_ascii_case!(match name_bytes {
-                        b"ON" | b"TRUE" | b"YES" | b"1" => true,
-                        _ => false,
-                    })
-                }
-                Expr::Literal(Literal::Numeric(n)) => !matches!(n.as_str(), "0"),
-                _ => false,
-            };
+            let enabled = parse_pragma_enabled(&value);
             connection.set_foreign_keys_enabled(enabled);
             Ok((program, TransactionMode::None))
         }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -4,7 +4,7 @@
 use chrono::Datelike;
 use std::sync::Arc;
 use turso_macros::match_ignore_ascii_case;
-use turso_parser::ast::{self, ColumnDefinition, Expr, Literal, Name};
+use turso_parser::ast::{self, ColumnDefinition, Expr, Literal};
 use turso_parser::ast::{PragmaName, QualifiedName};
 
 use super::integrity_check::translate_integrity_check;
@@ -388,10 +388,10 @@ fn update_pragma(
             Ok((program, TransactionMode::None))
         }
         PragmaName::ForeignKeys => {
-            let enabled = match &value {
-                Expr::Id(name) | Expr::Name(name) => {
-                    let name_str = name.as_str().as_bytes();
-                    match_ignore_ascii_case!(match name_str {
+            let enabled = match value {
+                Expr::Name(name) | Expr::Id(name) => {
+                    let name_bytes = name.as_str().as_bytes();
+                    match_ignore_ascii_case!(match name_bytes {
                         b"ON" | b"TRUE" | b"YES" | b"1" => true,
                         _ => false,
                     })

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -812,6 +812,7 @@ pub fn translate_drop_table(
             }],
             is_strict: false,
             unique_sets: vec![],
+            foreign_keys: vec![],
         });
         // cursor id 2
         let ephemeral_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(simple_table_rc));

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -353,6 +353,7 @@ pub fn prepare_update_plan(
             }],
             is_strict: false,
             unique_sets: vec![],
+            foreign_keys: vec![],
         });
 
         let temp_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(table.clone()));

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -5,10 +5,15 @@ use std::{collections::HashMap, sync::Arc};
 use turso_parser::ast::{self, Upsert};
 
 use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
+use crate::translate::emitter::{
+    emit_fk_child_existence_checks, emit_fk_parent_existence_checks,
+    emit_fk_parent_pk_change_counters,
+};
 use crate::translate::expr::{walk_expr, WalkControl};
 use crate::translate::insert::format_unique_violation_desc;
 use crate::translate::planner::ROWID_STRS;
 use crate::vdbe::insn::CmpInsFlags;
+use crate::Connection;
 use crate::{
     bail_parse_error,
     error::SQLITE_CONSTRAINT_NOTNULL,
@@ -346,6 +351,7 @@ pub fn emit_upsert(
     returning: &mut [ResultSetColumn],
     cdc_cursor_id: Option<usize>,
     row_done_label: BranchOffset,
+    connection: &Arc<Connection>,
 ) -> crate::Result<()> {
     // Seek & snapshot CURRENT
     program.emit_insn(Insn::SeekRowid {
@@ -464,10 +470,179 @@ pub fn emit_upsert(
         }
     }
 
+    let (changed_cols, rowid_changed) = collect_changed_cols(table, set_pairs);
+
+    if let Some(bt) = table.btree() {
+        if connection.foreign_keys_enabled() {
+            let rowid_new_reg = new_rowid_reg.unwrap_or(conflict_rowid_reg);
+
+            // Child-side checks
+            if resolver.schema.has_child_fks(bt.name.as_str()) {
+                emit_fk_child_existence_checks(
+                    program,
+                    resolver,
+                    &bt,
+                    table.get_name(),
+                    new_start,
+                    rowid_new_reg,
+                    &changed_cols,
+                )?;
+            }
+
+            // Parent-side checks only if any incoming FK could care
+            if resolver.schema.any_incoming_fk_to(table.get_name()) {
+                // if parent key can't change, skip
+                let updated_parent_positions: HashSet<usize> =
+                    set_pairs.iter().map(|(i, _)| *i).collect();
+                let incoming = resolver.schema.incoming_fks_to(table.get_name());
+                let parent_key_may_change = incoming
+                    .iter()
+                    .any(|r| r.parent_key_may_change(&updated_parent_positions, &bt));
+
+                if parent_key_may_change {
+                    let skip_parent_fk = program.allocate_label();
+                    let pk_len = bt.primary_key_columns.len();
+
+                    match pk_len {
+                        0 => {
+                            // implicit rowid
+                            program.emit_insn(Insn::Eq {
+                                lhs: rowid_new_reg,
+                                rhs: conflict_rowid_reg,
+                                target_pc: skip_parent_fk,
+                                flags: CmpInsFlags::default(),
+                                collation: program.curr_collation(),
+                            });
+                            emit_fk_parent_existence_checks(
+                                program,
+                                resolver,
+                                table.get_name(),
+                                tbl_cursor_id,
+                                conflict_rowid_reg,
+                            )?;
+                            program.preassign_label_to_next_insn(skip_parent_fk);
+                        }
+                        1 => {
+                            // single-col declared PK
+                            let (pk_name, _) = &bt.primary_key_columns[0];
+                            let (pos, col) = bt.get_column(pk_name).unwrap();
+
+                            let old_reg = program.alloc_register();
+                            if col.is_rowid_alias {
+                                program.emit_insn(Insn::RowId {
+                                    cursor_id: tbl_cursor_id,
+                                    dest: old_reg,
+                                });
+                            } else {
+                                program.emit_insn(Insn::Column {
+                                    cursor_id: tbl_cursor_id,
+                                    column: pos,
+                                    dest: old_reg,
+                                    default: None,
+                                });
+                            }
+                            let new_reg = new_start + pos;
+
+                            let skip = program.allocate_label();
+                            program.emit_insn(Insn::Eq {
+                                lhs: old_reg,
+                                rhs: new_reg,
+                                target_pc: skip,
+                                flags: CmpInsFlags::default(),
+                                collation: program.curr_collation(),
+                            });
+                            emit_fk_parent_existence_checks(
+                                program,
+                                resolver,
+                                table.get_name(),
+                                tbl_cursor_id,
+                                conflict_rowid_reg,
+                            )?;
+                            program.preassign_label_to_next_insn(skip);
+                        }
+                        _ => {
+                            // composite PK: build OLD/NEW vectors and do the 2-pass counter logic
+                            let old_pk_start = program.alloc_registers(pk_len);
+                            for (i, (pk_name, _)) in bt.primary_key_columns.iter().enumerate() {
+                                let (pos, col) = bt.get_column(pk_name).unwrap();
+                                if col.is_rowid_alias {
+                                    // old rowid (UPSERT target) == conflict_rowid_reg
+                                    program.emit_insn(Insn::Copy {
+                                        src_reg: conflict_rowid_reg,
+                                        dst_reg: old_pk_start + i,
+                                        extra_amount: 0,
+                                    });
+                                } else {
+                                    program.emit_insn(Insn::Column {
+                                        cursor_id: tbl_cursor_id,
+                                        column: pos,
+                                        dest: old_pk_start + i,
+                                        default: None,
+                                    });
+                                }
+                            }
+
+                            let new_pk_start = program.alloc_registers(pk_len);
+                            for (i, (pk_name, _)) in bt.primary_key_columns.iter().enumerate() {
+                                let (pos, col) = bt.get_column(pk_name).unwrap();
+                                let src = if col.is_rowid_alias {
+                                    rowid_new_reg
+                                } else {
+                                    new_start + pos
+                                };
+                                program.emit_insn(Insn::Copy {
+                                    src_reg: src,
+                                    dst_reg: new_pk_start + i,
+                                    extra_amount: 0,
+                                });
+                            }
+
+                            // Compare OLD vs NEW, if all equal then skip
+                            let skip = program.allocate_label();
+                            let changed = program.allocate_label();
+                            for i in 0..pk_len {
+                                if i == pk_len - 1 {
+                                    program.emit_insn(Insn::Eq {
+                                        lhs: old_pk_start + i,
+                                        rhs: new_pk_start + i,
+                                        target_pc: skip,
+                                        flags: CmpInsFlags::default(),
+                                        collation: program.curr_collation(),
+                                    });
+                                    program.emit_insn(Insn::Goto { target_pc: changed });
+                                } else {
+                                    let next = program.allocate_label();
+                                    program.emit_insn(Insn::Eq {
+                                        lhs: old_pk_start + i,
+                                        rhs: new_pk_start + i,
+                                        target_pc: next,
+                                        flags: CmpInsFlags::default(),
+                                        collation: program.curr_collation(),
+                                    });
+                                    program.emit_insn(Insn::Goto { target_pc: changed });
+                                    program.preassign_label_to_next_insn(next);
+                                }
+                            }
+
+                            program.preassign_label_to_next_insn(changed);
+                            emit_fk_parent_pk_change_counters(
+                                program,
+                                &incoming,
+                                resolver,
+                                old_pk_start,
+                                new_pk_start,
+                                pk_len,
+                            )?;
+                            program.preassign_label_to_next_insn(skip);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Index rebuild (DELETE old, INSERT new), honoring partial-index WHEREs
     if let Some(before) = before_start {
-        let (changed_cols, rowid_changed) = collect_changed_cols(table, set_pairs);
-
         for (idx_name, _root, idx_cid) in idx_cursors {
             let idx_meta = resolver
                 .schema

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -490,11 +490,14 @@ pub fn emit_upsert(
             }
 
             // Parent-side checks only if any incoming FK could care
-            if resolver.schema.any_incoming_fk_to(table.get_name()) {
+            if resolver
+                .schema
+                .any_resolved_fks_referencing(table.get_name())
+            {
                 // if parent key can't change, skip
                 let updated_parent_positions: HashSet<usize> =
                     set_pairs.iter().map(|(i, _)| *i).collect();
-                let incoming = resolver.schema.incoming_fks_to(table.get_name());
+                let incoming = resolver.schema.resolved_fks_referencing(table.get_name());
                 let parent_key_may_change = incoming
                     .iter()
                     .any(|r| r.parent_key_may_change(&updated_parent_positions, &bt));

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -80,6 +80,7 @@ pub fn translate_create_materialized_view(
         has_autoincrement: false,
 
         unique_sets: vec![],
+        foreign_keys: vec![],
     });
 
     // Allocate a cursor for writing to the view's btree during population

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -505,6 +505,7 @@ pub fn init_window<'a>(
         is_strict: false,
         unique_sets: vec![],
         has_autoincrement: false,
+        foreign_keys: vec![],
     });
     let cursor_buffer_read = program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));
     let cursor_buffer_write = program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -792,6 +792,9 @@ impl ProgramBuilder {
                 Insn::NotFound { target_pc, .. } => {
                     resolve(target_pc, "NotFound");
                 }
+                Insn::FkIfZero { target_pc, .. } => {
+                    resolve(target_pc, "FkIfZero");
+                }
                 _ => {}
             }
         }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1804,19 +1804,19 @@ pub fn insn_to_row(
             0,
             String::new(),
         ),
-        Insn::FkCounter{check_abort, increment_value, is_scope } => (
+        Insn::FkCounter{increment_value, is_scope } => (
         "FkCounter",
-            *check_abort as i32,
             *increment_value as i32,
             *is_scope as i32,
+            0,
             Value::build_text(""),
             0,
             String::new(),
         ),
-        Insn::FkIfZero{target_pc, if_zero } => (
+        Insn::FkIfZero{target_pc, is_scope } => (
         "FkIfZero",
             target_pc.as_debug_int(),
-            *if_zero as i32,
+            *is_scope as i32,
             0,
             Value::build_text(""),
             0,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1804,7 +1804,25 @@ pub fn insn_to_row(
             0,
             String::new(),
         ),
-        }
+        Insn::FkCounter{check_abort, increment_value} => (
+        "FkCounter",
+            *check_abort as i32,
+            *increment_value as i32,
+            0,
+            Value::build_text(""),
+            0,
+            String::new(),
+        ),
+        Insn::FkIfZero{target_pc, if_zero } => (
+        "FkIfZero",
+            target_pc.as_debug_int(),
+            *if_zero as i32,
+            0,
+            Value::build_text(""),
+            0,
+            String::new(),
+        ),
+    }
 }
 
 pub fn insn_to_row_with_comment(

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1804,11 +1804,11 @@ pub fn insn_to_row(
             0,
             String::new(),
         ),
-        Insn::FkCounter{check_abort, increment_value} => (
+        Insn::FkCounter{check_abort, increment_value, is_scope } => (
         "FkCounter",
             *check_abort as i32,
             *increment_value as i32,
-            0,
+            *is_scope as i32,
             Value::build_text(""),
             0,
             String::new(),

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1173,7 +1173,6 @@ pub enum Insn {
     // If P1 is non-zero, the database constraint counter is incremented (deferred foreign key constraints).
     // Otherwise, if P1 is zero, the statement counter is incremented (immediate foreign key constraints).
     FkCounter {
-        check_abort: bool,
         increment_value: isize,
         is_scope: bool,
     },
@@ -1181,7 +1180,7 @@ pub enum Insn {
     // If P1 is non-zero, then the jump is taken if the database constraint-counter is zero (the one that counts deferred constraint violations).
     // If P1 is zero, the jump is taken if the statement constraint-counter is zero (immediate foreign key constraint violations).
     FkIfZero {
-        if_zero: bool,
+        is_scope: bool,
         target_pc: BranchOffset,
     },
 }

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1175,6 +1175,7 @@ pub enum Insn {
     FkCounter {
         check_abort: bool,
         increment_value: isize,
+        is_scope: bool,
     },
     // This opcode tests if a foreign key constraint-counter is currently zero. If so, jump to instruction P2. Otherwise, fall through to the next instruction.
     // If P1 is non-zero, then the jump is taken if the database constraint-counter is zero (the one that counts deferred constraint violations).

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -832,7 +832,6 @@ impl Program {
 
         // Reset state for next use
         program_state.view_delta_state = ViewDeltaCommitState::NotStarted;
-
         if self.connection.get_tx_state() == TransactionState::None {
             // No need to do any work here if not in tx. Current MVCC logic doesn't work with this assumption,
             // hence the mv_store.is_none() check.
@@ -914,6 +913,9 @@ impl Program {
                 if self.change_cnt_on {
                     self.connection
                         .set_changes(self.n_change.load(Ordering::SeqCst));
+                }
+                if connection.foreign_keys_enabled() {
+                    connection.clear_deferred_foreign_key_violations();
                 }
                 Ok(IOResult::Done(()))
             }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -313,6 +313,7 @@ pub struct ProgramState {
     /// This is used when statement in auto-commit mode reseted after previous uncomplete execution - in which case we may need to rollback transaction started on previous attempt
     /// Note, that MVCC transactions are always explicit - so they do not update auto_txn_cleanup marker
     pub(crate) auto_txn_cleanup: TxnCleanup,
+    fk_constraint_counter: isize,
 }
 
 impl ProgramState {
@@ -359,6 +360,7 @@ impl ProgramState {
             op_checkpoint_state: OpCheckpointState::StartCheckpoint,
             view_delta_state: ViewDeltaCommitState::NotStarted,
             auto_txn_cleanup: TxnCleanup::None,
+            fk_constraint_counter: 0,
         }
     }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -914,9 +914,6 @@ impl Program {
                     self.connection
                         .set_changes(self.n_change.load(Ordering::SeqCst));
                 }
-                if connection.foreign_keys_enabled() {
-                    connection.clear_deferred_foreign_key_violations();
-                }
                 Ok(IOResult::Done(()))
             }
         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -313,7 +313,7 @@ pub struct ProgramState {
     /// This is used when statement in auto-commit mode reseted after previous uncomplete execution - in which case we may need to rollback transaction started on previous attempt
     /// Note, that MVCC transactions are always explicit - so they do not update auto_txn_cleanup marker
     pub(crate) auto_txn_cleanup: TxnCleanup,
-    fk_constraint_counter: isize,
+    fk_scope_counter: isize,
 }
 
 impl ProgramState {
@@ -360,7 +360,7 @@ impl ProgramState {
             op_checkpoint_state: OpCheckpointState::StartCheckpoint,
             view_delta_state: ViewDeltaCommitState::NotStarted,
             auto_txn_cleanup: TxnCleanup::None,
-            fk_constraint_counter: 0,
+            fk_scope_counter: 0,
         }
     }
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1416,6 +1416,8 @@ pub enum PragmaName {
     Encoding,
     /// Current free page count.
     FreelistCount,
+    /// Enable or disable foreign key constraint enforcement
+    ForeignKeys,
     /// Run integrity check on the database file
     IntegrityCheck,
     /// `journal_mode` pragma

--- a/testing/all.test
+++ b/testing/all.test
@@ -47,3 +47,4 @@ source $testdir/vtab.test
 source $testdir/upsert.test
 source $testdir/window.test
 source $testdir/partial_idx.test
+source $testdir/foreign_keys.test

--- a/testing/foreign_keys.test
+++ b/testing/foreign_keys.test
@@ -299,7 +299,7 @@ do_execsql_test_in_memory_any_error fk-rowid-mustbeint-coercion-fail {
     CREATE TABLE p(id INTEGER PRIMARY KEY);
     CREATE TABLE c(cid INTEGER PRIMARY KEY, pid REFERENCES p(id));
     INSERT INTO p(id) VALUES(10);
-    INSERT INTO c VALUES(2, 'abc');          -- MustBeInt fails to match any parent row
+    INSERT INTO c VALUES(2, 'abc'); -- MustBeInt fails to match any parent row
 }
 
 # Parent match via UNIQUE index (non-rowid), success path
@@ -331,3 +331,71 @@ do_execsql_test_on_specific_db {:memory:} fk-child-null-shortcircuit {
     INSERT INTO c VALUES (1, NULL);          -- NULL child is allowed
     SELECT id, pid FROM c;
 } {1|}
+
+do_execsql_test_on_specific_db {:memory:} fk-self-unique-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+      u TEXT,
+      v TEXT,
+      cu TEXT,
+      cv TEXT,
+      UNIQUE(u,v),
+      FOREIGN KEY(cu,cv) REFERENCES t(u,v)
+    );
+    -- Single row insert where child points to its own (u,v): allowed
+    INSERT INTO t(u,v,cu,cv) VALUES('A','B','A','B');
+    SELECT u, v, cu, cv FROM t;
+} {A|B|A|B}
+
+do_execsql_test_in_memory_any_error fk-self-unique-mismatch {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+      u TEXT,
+      v TEXT,
+      cu TEXT,
+      cv TEXT,
+      UNIQUE(u,v),
+      FOREIGN KEY(cu,cv) REFERENCES t(u,v)
+    );
+    -- Child points to a different (u,v) that doesn't exist: must fail
+    INSERT INTO t(u,v,cu,cv) VALUES('A','B','A','X');
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-self-unique-reference-existing-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+      u TEXT,
+      v TEXT,
+      cu TEXT,
+      cv TEXT,
+      UNIQUE(u,v),
+      FOREIGN KEY(cu,cv) REFERENCES t(u,v)
+    );
+    -- Insert a parent row first
+    INSERT INTO t(u,v,cu,cv) VALUES('P','Q',NULL,NULL);
+    -- Now insert a row whose FK references the existing ('P','Q'): OK
+    INSERT INTO t(u,v,cu,cv) VALUES('X','Y','P','Q');
+    SELECT u, v, cu, cv FROM t ORDER BY u, v, cu, cv;
+} {P|Q|| X|Y|P|Q}
+
+do_execsql_test_on_specific_db {:memory:} fk-self-unique-multirow-no-fastpath {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+      u TEXT,
+      v TEXT,
+      cu TEXT,
+      cv TEXT,
+      UNIQUE(u,v),
+      FOREIGN KEY(cu,cv) REFERENCES t(u,v)
+    );
+    INSERT INTO t(u,v,cu,cv) VALUES
+        ('C','D','C','D'),
+        ('E','F','E','F');
+} {}
+
+do_execsql_test_in_memory_any_error fk-self-multirow-one-bad {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, rid INTEGER,
+                   FOREIGN KEY(rid) REFERENCES t(id));
+    INSERT INTO t(id,rid) VALUES (1,1),(3,99); -- 99 has no parent -> error
+}

--- a/testing/foreign_keys.test
+++ b/testing/foreign_keys.test
@@ -124,16 +124,12 @@ do_execsql_test_in_memory_any_error fk-composite-unique-missing {
     INSERT INTO child  VALUES (2,'A','X');     -- no ('A','X') in parent
 }
 
-# SQLite doesnt let you name a foreign key constraint 'rowid' explicitly...
-# well it does.. but it throws a parse error only when you try to insert into the table -_-
-# We will throw a parse error when you create the table instead, because that is 
-# obviously the only sane thing to do
 do_execsql_test_in_memory_any_error fk-rowid-alias-parent {
     PRAGMA foreign_keys=ON;
     CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT);
-    CREATE TABLE c(cid INTEGER PRIMARY KEY, rid REFERENCES t(rowid)); -- we error here
+    CREATE TABLE c(cid INTEGER PRIMARY KEY, rid REFERENCES t(rowid));
     INSERT INTO t VALUES (100,'x');
-    INSERT INTO c VALUES (1, 100); - sqlite errors here
+    INSERT INTO c VALUES (1, 100);
 }
 
 do_execsql_test_in_memory_any_error fk-rowid-alias-parent-missing {
@@ -399,3 +395,712 @@ do_execsql_test_in_memory_any_error fk-self-multirow-one-bad {
                    FOREIGN KEY(rid) REFERENCES t(id));
     INSERT INTO t(id,rid) VALUES (1,1),(3,99); -- 99 has no parent -> error
 }
+
+# doesnt fail because tx is un-committed
+do_execsql_test_on_specific_db {:memory:} fk-deferred-commit-doesnt-fail-early {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1, 99); -- shouldnt fail because we are mid-tx
+} {}
+
+# it should fail here because we actuall COMMIT
+do_execsql_test_in_memory_any_error fk-deferred-commit-fails {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1, 99);
+  COMMIT;
+}
+
+
+# If we fix it before COMMIT, COMMIT succeeds
+do_execsql_test_on_specific_db {:memory:} fk-deferred-fix-before-commit-succeeds {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO c VALUES(1, 99);   -- temporary violation
+    INSERT INTO p VALUES(99);      -- fix parent
+  COMMIT;
+  SELECT * FROM p ORDER BY 1;
+} {99}
+
+#  ROLLBACK clears deferred state; a new tx can still fail if violation persists
+do_execsql_test_on_specific_db {:memory:} fk-deferred-rollback-clears {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO c VALUES(1, 123);
+  ROLLBACK;
+
+  -- Now start over and *fix* it, COMMIT should pass.
+  BEGIN;
+    INSERT INTO p VALUES(123);
+    INSERT INTO c VALUES(1, 123);
+  COMMIT;
+  SELECT * FROM c ORDER BY 1;
+} {1|123}
+
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-insert-parent-fixes-before-commit {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO c VALUES(1, 50); -- violation
+    INSERT INTO p VALUES(50);    -- resolve
+  COMMIT;
+  SELECT * FROM c ORDER BY 1;
+} {1|50}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-update-fixes-child-before-commit {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO c VALUES(1, 50); -- violation
+    INSERT INTO p VALUES(32);
+	UPDATE c SET pid=32 WHERE id=1; -- resolve child
+  COMMIT;
+  SELECT * FROM c ORDER BY 1;
+} {1|32}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-delete-fixes-child-before-commit {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO c VALUES(1, 50); -- violation
+    INSERT INTO p VALUES(32);
+	DELETE FROM c WHERE id=1; -- resolve by deleting child
+  COMMIT;
+  SELECT * FROM c ORDER BY 1;
+} {}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-update-fixes-parent-before-commit {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO c VALUES(1, 50); -- violation
+    INSERT INTO p VALUES(32);
+	UPDATE p SET id=50 WHERE id=32; -- resolve via parent
+  COMMIT;
+  SELECT * FROM c ORDER BY 1;
+} {1|50}
+
+# Self-referential: row referencing itself should succeed
+do_execsql_test_on_specific_db {:memory:} fk-deferred-self-ref-succeeds {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE t(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO t VALUES(1, 1);    -- self-match
+  COMMIT;
+  SELECT * FROM t ORDER BY 1;
+} {1|1}
+
+# Two-step self-ref: insert invalid, then create parent before COMMIT
+do_execsql_test_on_specific_db {:memory:} fk-deferred-self-ref-late-parent {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE t(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO t VALUES(2, 3);  -- currently invalid
+    INSERT INTO t VALUES(3, 3);  -- now parent exists
+  COMMIT;
+  SELECT * FROM t ORDER BY 1;
+} {2|3
+3|3}
+
+
+# counter must not be neutralized by later good statements
+do_execsql_test_in_memory_any_error fk-deferred-neutralize.1 {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE parent(id INTEGER PRIMARY KEY);
+  CREATE TABLE parent_comp(a INT NOT NULL, b INT NOT NULL, PRIMARY KEY(a,b));
+  CREATE TABLE child_deferred(id INTEGER PRIMARY KEY, pid INT,
+    FOREIGN KEY(pid) REFERENCES parent(id));
+
+  CREATE TABLE child_comp_deferred(id INTEGER PRIMARY KEY, ca INT, cb INT,
+    FOREIGN KEY(ca,cb) REFERENCES parent_comp(a,b));
+  INSERT INTO parent_comp VALUES (4,-1);
+  BEGIN;
+    INSERT INTO child_deferred VALUES (1, 999);
+    INSERT INTO child_comp_deferred VALUES (2, 4, -1);
+  COMMIT;
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-upsert-late-parent {
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE p(id INTEGER PRIMARY KEY);
+CREATE TABLE c(
+  id  INTEGER PRIMARY KEY,
+  pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+);
+
+BEGIN;
+  INSERT INTO c VALUES(1, 50);                 -- deferred violation
+  INSERT INTO p VALUES(32);                    -- parent exists, but pid still 50
+  INSERT INTO c(id,pid) VALUES(1,32)
+    ON CONFLICT(id) DO UPDATE SET pid=excluded.pid;  -- resolve child via UPSERT
+COMMIT;
+-- Expect: row is (1,32) and no violations remain
+SELECT * FROM c ORDER BY id;
+} {1|32}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-upsert-late-child {
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE p(
+  id INTEGER PRIMARY KEY,
+  u  INT UNIQUE
+);
+CREATE TABLE c(
+  id  INTEGER PRIMARY KEY,
+  pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+);
+BEGIN;
+  INSERT INTO c VALUES(1, 50);                 -- deferred violation (no parent 50)
+  INSERT INTO p VALUES(32, 7);                 -- parent row with u=7
+  -- Trigger DO UPDATE via conflict on p.u, then change the PK id to 50,
+  -- which satisfies the child reference.
+  INSERT INTO p(id,u) VALUES(999,7)
+    ON CONFLICT(u) DO UPDATE SET id=50;
+COMMIT;
+-- Expect: parent is now (50,7), child (1,50), no violations remain
+SELECT p.id, c.id FROM p  join c on c.pid = p.id;
+} {50|1}
+
+do_execsql_test_in_memory_any_error fk-deferred-insert-commit-fails {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(
+    id  INTEGER PRIMARY KEY,
+    pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO c VALUES(1, 99);  -- no parent -> deferred violation
+  COMMIT;                          -- must fail
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-insert-parent-fix-before-commit {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(
+    id  INTEGER PRIMARY KEY,
+    pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO c VALUES(1, 99);   -- violation
+    INSERT INTO p VALUES(99);      -- fix by inserting parent
+  COMMIT;
+  SELECT id, pid FROM c ORDER BY id;
+} {1|99}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-insert-multi-children-one-parent-fix {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1, 50);
+    INSERT INTO c VALUES(2, 50);   -- two violations pointing to same parent
+    INSERT INTO p VALUES(50);      -- one parent fixes both
+  COMMIT;
+  SELECT id, pid FROM c ORDER BY id;
+} {1|50 2|50}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-insert-then-delete-child-fix {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1, 77);   -- violation
+    DELETE FROM c WHERE id=1;      -- resolve by removing the child
+  COMMIT;
+  SELECT count(*) FROM c;
+} {0}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-insert-self-ref-succeeds {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE t(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  BEGIN;
+    INSERT INTO t VALUES(1, 1);    -- self-reference, legal at COMMIT
+  COMMIT;
+  SELECT id, pid FROM t;
+} {1|1}
+
+do_execsql_test_in_memory_any_error fk-deferred-update-child-breaks-commit-fails {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(10);
+  INSERT INTO c VALUES(1, 10);     -- valid
+  BEGIN;
+    UPDATE c SET pid=99 WHERE id=1;  -- create violation
+  COMMIT;                             -- must fail
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-update-child-fix-before-commit {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(10);
+  INSERT INTO c VALUES(1, 10);
+  BEGIN;
+    UPDATE c SET pid=99 WHERE id=1;  -- violation
+    UPDATE c SET pid=10 WHERE id=1;  -- fix child back
+  COMMIT;
+  SELECT id, pid FROM c;
+} {1|10}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-update-child-fix-by-inserting-parent {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(10);
+  INSERT INTO c VALUES(1, 10);
+  BEGIN;
+    UPDATE c SET pid=50 WHERE id=1;  -- violation
+    INSERT INTO p VALUES(50);        -- fix by adding parent
+  COMMIT;
+  SELECT id, pid FROM c;
+} {1|50}
+
+do_execsql_test_in_memory_any_error fk-deferred-update-parent-breaks-commit-fails {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(32);
+  INSERT INTO c VALUES(1, 32);      -- valid
+  BEGIN;
+    UPDATE p SET id=50 WHERE id=32;  -- break child reference
+  COMMIT;                            -- must fail (no fix)
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-update-parent-fix-by-updating-child {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(32);
+  INSERT INTO c VALUES(1, 32); 
+  BEGIN;
+    UPDATE p SET id=50 WHERE id=32;  -- break
+    UPDATE c SET pid=50 WHERE id=1;  -- fix child to new parent key
+  COMMIT;
+  SELECT id, pid FROM c;
+} {1|50}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-update-parent-fix-by-reverting-parent {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(32);
+  INSERT INTO c VALUES(1, 32);
+  BEGIN;
+    UPDATE p SET id=50 WHERE id=32;  -- break
+    UPDATE p SET id=32 WHERE id=50;  -- revert (fix)
+  COMMIT;
+  SELECT id, pid FROM c;
+} {1|32}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-update-self-ref-id-change-and-fix {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE t(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  INSERT INTO t VALUES(1,1);
+  BEGIN;
+    UPDATE t SET id=2 WHERE id=1;   -- break self-ref
+    UPDATE t SET pid=2 WHERE id=2;  -- fix to new self
+  COMMIT;
+  SELECT id, pid FROM t;
+} {2|2}
+
+do_execsql_test_in_memory_any_error fk-deferred-delete-parent-commit-fails {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(10);
+  INSERT INTO c VALUES(1, 10);      -- valid
+  BEGIN;
+    DELETE FROM p WHERE id=10;      -- break reference
+  COMMIT;                            -- must fail
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-delete-parent-then-delete-child-fix {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(10);
+  INSERT INTO c VALUES(1, 10);
+  BEGIN;
+    DELETE FROM p WHERE id=10;      -- break
+    DELETE FROM c WHERE id=1;       -- fix by removing child
+  COMMIT;
+  SELECT count(*) FROM p, c;        -- both empty
+} {0}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-delete-parent-then-reinsert-parent-fix {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(10);
+  INSERT INTO c VALUES(1, 10);
+  BEGIN;
+    DELETE FROM p WHERE id=10;      -- break
+    INSERT INTO p VALUES(10);       -- fix by re-creating parent
+  COMMIT;
+  SELECT id, pid FROM c;
+} {1|10}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-delete-self-ref-row-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE t(
+    id  INTEGER PRIMARY KEY,
+    pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  INSERT INTO t VALUES(1,1);        -- valid
+  BEGIN;
+    DELETE FROM t WHERE id=1;       -- removes both child+parent (same row)
+  COMMIT;                           -- should succeed
+  SELECT count(*) FROM t;
+} {0}
+
+do_execsql_test_on_specific_db {:memory:} fk-deferred-delete-parent-then-update-child-to-null-fix {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(
+    id INTEGER PRIMARY KEY,
+    pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  INSERT INTO p VALUES(5);
+  INSERT INTO c VALUES(1,5);
+  BEGIN;
+    DELETE FROM p WHERE id=5;       -- break
+    UPDATE c SET pid=NULL WHERE id=1;  -- fix (NULL never violates)
+  COMMIT;
+  SELECT id, pid FROM c;
+} {1|}
+
+# AUTOCOMMIT: deferred FK still fails at end-of-statement
+do_execsql_test_in_memory_any_error fk-deferred-autocommit-insert-missing-parent {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE parent(id INTEGER PRIMARY KEY);
+  CREATE TABLE child(id INTEGER PRIMARY KEY, pid INT REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO child VALUES(1, 3);   -- no BEGIN; should fail at statement end
+}
+
+# AUTOCOMMIT: self-referential insert is OK (parent is same row)
+do_execsql_test_on_specific_db {:memory:} fk-deferred-autocommit-selfref-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE t(id INTEGER PRIMARY KEY, pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO t VALUES(1,1);
+  SELECT * FROM t;
+} {1|1}
+
+# AUTOCOMMIT: deleting a parent that has a child → fails at statement end
+do_execsql_test_in_memory_any_error fk-deferred-autocommit-delete-parent-fails {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(1);
+  INSERT INTO c VALUES(10,1);
+  DELETE FROM p WHERE id=1;   -- no BEGIN; should fail at statement end
+}
+
+# TX: delete a referenced parent then reinsert before COMMIT -> OK
+do_execsql_test_on_specific_db {:memory:} fk-deferred-tx-delete-parent-then-reinsert-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(5);
+  INSERT INTO c VALUES(1,5);
+  BEGIN;
+    DELETE FROM p WHERE id=5;  -- violation (deferred)
+    INSERT INTO p VALUES(5);   -- fix in same tx
+  COMMIT;
+  SELECT count(*) FROM p WHERE id=5;
+} {1}
+
+# TX: multiple violating children, later insert parent, COMMIT -> OK
+do_execsql_test_on_specific_db {:memory:} fk-deferred-tx-multi-children-fixed-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1,99);
+    INSERT INTO c VALUES(2,99);
+    INSERT INTO p VALUES(99);
+  COMMIT;
+  SELECT id,pid FROM c ORDER BY id;
+} {1|99 2|99}
+
+#  one of several children left unfixed -> COMMIT fails
+do_execsql_test_in_memory_any_error fk-deferred-tx-multi-children-one-left-fails {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1,42);
+    INSERT INTO c VALUES(2,42);
+    INSERT INTO p VALUES(42);
+    UPDATE c SET pid=777 WHERE id=2;  -- reintroduce a bad reference
+  COMMIT;  -- should fail
+}
+
+# composite PK parent, fix via parent UPDATE before COMMIT -> OK
+do_execsql_test_on_specific_db {:memory:} fk-deferred-composite-parent-update-fix {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE parent(a INT NOT NULL, b INT NOT NULL, PRIMARY KEY(a,b));
+  CREATE TABLE child(id INT PRIMARY KEY, ca INT, cb INT,
+    FOREIGN KEY(ca,cb) REFERENCES parent(a,b) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO parent VALUES(1,1);
+  BEGIN;
+    INSERT INTO child VALUES(10, 7, 7);        -- violation
+    UPDATE parent SET a=7, b=7 WHERE a=1 AND b=1;  -- fix composite PK
+  COMMIT;
+  SELECT id, ca, cb FROM child;
+} {10|7|7}
+
+# TX: NULL in child FK -> never a violation
+do_execsql_test_on_specific_db {:memory:} fk-deferred-null-fk-never-violates {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1, NULL);  -- always OK
+  COMMIT;
+  SELECT id, pid FROM c;
+} {1|}
+
+# TX: child UPDATE to NULL resolves before COMMIT
+do_execsql_test_on_specific_db {:memory:} fk-deferred-update-child-null-resolves {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1, 500);  -- violation
+    UPDATE c SET pid=NULL WHERE id=1; -- resolves
+  COMMIT;
+  SELECT * FROM c;
+} {1|}
+
+# TX: delete violating child resolves before COMMIT
+do_execsql_test_on_specific_db {:memory:} fk-deferred-delete-child-resolves {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1, 777);  -- violation
+    DELETE FROM c WHERE id=1;      -- resolves
+  COMMIT;
+  SELECT count(*) FROM c;
+} {0}
+
+# TX: update parent PK to match child before COMMIT -> OK
+do_execsql_test_on_specific_db {:memory:} fk-deferred-update-parent-pk-resolves {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES(10);
+  BEGIN;
+    INSERT INTO c VALUES(1, 20);   -- violation
+    UPDATE p SET id=20 WHERE id=10; -- resolve via parent
+  COMMIT;
+  SELECT * FROM c;
+} {1|20}
+
+# Two-table cycle; both inserted before COMMIT -> OK
+do_execsql_test_on_specific_db {:memory:} fk-deferred-cycle-two-tables-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE a(id INT PRIMARY KEY, b_id INT, FOREIGN KEY(b_id) REFERENCES b(id) DEFERRABLE INITIALLY DEFERRED);
+  CREATE TABLE b(id INT PRIMARY KEY, a_id INT, FOREIGN KEY(a_id) REFERENCES a(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO a VALUES(1, 1);  -- refers to b(1) (not yet present)
+    INSERT INTO b VALUES(1, 1);  -- refers to a(1)
+  COMMIT;
+  SELECT count(b.id), count(a.id) FROM a, b;
+} {1|1}
+
+# Delete a row that self-references (child==parent) within a tx -> OK
+do_execsql_test_on_specific_db {:memory:} fk-deferred-selfref-delete-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE t(id INTEGER PRIMARY KEY, pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO t VALUES(1,1);
+  BEGIN;
+    DELETE FROM t WHERE id=1;
+  COMMIT;
+  SELECT count(*) FROM t;
+} {0}
+
+
+do_execsql_test_on_specific_db {:memory:} fk-parentcomp-donothing-noconflict-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE parent (id INTEGER PRIMARY KEY, a INT, b INT);
+  CREATE TABLE child_deferred (
+    id INTEGER PRIMARY KEY, pid INT, x INT,
+    FOREIGN KEY(pid) REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+  );
+  CREATE TABLE parent_comp (a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY(a,b));
+  CREATE TABLE child_comp_deferred (
+    id INTEGER PRIMARY KEY, ca INT, cb INT, z INT,
+    FOREIGN KEY (ca,cb) REFERENCES parent_comp(a,b) DEFERRABLE INITIALLY DEFERRED
+  );
+
+  -- No conflict on (a,b); should insert 1 row, no FK noise
+  INSERT INTO parent_comp VALUES (-1,-1,9) ON CONFLICT DO NOTHING;
+  SELECT a,b,c FROM parent_comp ORDER BY a,b;
+} {-1|-1|9}
+
+do_execsql_test_on_specific_db {:memory:} fk-parentcomp-donothing-conflict-noop {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE parent_comp (a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY(a,b));
+  CREATE TABLE child_comp_deferred (
+    id INTEGER PRIMARY KEY, ca INT, cb INT, z INT,
+    FOREIGN KEY (ca,cb) REFERENCES parent_comp(a,b) DEFERRABLE INITIALLY DEFERRED
+  );
+
+  INSERT INTO parent_comp VALUES (10,20,1);
+  -- Conflicts with existing (10,20); must do nothing (no triggers, no FK scans that mutate counters)
+  INSERT INTO parent_comp VALUES (10,20,999) ON CONFLICT DO NOTHING;
+  SELECT a,b,c FROM parent_comp;
+} {10|20|1}
+
+do_execsql_test_on_specific_db {:memory:} fk-parentcomp-donothing-unrelated-immediate-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE parent (id INTEGER PRIMARY KEY);
+  CREATE TABLE child_immediate (
+    id INTEGER PRIMARY KEY, pid INT,
+    FOREIGN KEY(pid) REFERENCES parent(id)          -- IMMEDIATE
+  );
+  CREATE TABLE parent_comp (a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY(a,b));
+  CREATE TABLE child_comp_deferred (
+    id INTEGER PRIMARY KEY, ca INT, cb INT, z INT,
+    FOREIGN KEY(ca,cb) REFERENCES parent_comp(a,b) DEFERRABLE INITIALLY DEFERRED
+  );
+
+  INSERT INTO parent_comp VALUES (-1,-1,9) ON CONFLICT DO NOTHING;
+  SELECT a,b,c FROM parent_comp;
+} {-1|-1|9}
+
+do_execsql_test_on_specific_db {:memory:} fk-parentcomp-deferred-fix-inside-tx-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE parent_comp (a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY(a,b));
+  CREATE TABLE child_comp_deferred (
+    id INTEGER PRIMARY KEY, ca INT, cb INT,
+    FOREIGN KEY(ca,cb) REFERENCES parent_comp(a,b) DEFERRABLE INITIALLY DEFERRED
+  );
+
+  BEGIN;
+    INSERT INTO child_comp_deferred VALUES (1, -5, -6);  -- violation
+    INSERT INTO parent_comp VALUES (-5, -6, 9);          -- fix via parent insert
+  COMMIT;
+  SELECT id,ca,cb FROM child_comp_deferred;
+} {1|-5|-6}
+
+do_execsql_test_on_specific_db {:memory:} fk-parentcomp-autocommit-unrelated-children-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE parent_comp (a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY(a,b));
+  CREATE TABLE child_comp_deferred (
+    id INTEGER PRIMARY KEY, ca INT, cb INT,
+    FOREIGN KEY(ca,cb) REFERENCES parent_comp(a,b) DEFERRABLE INITIALLY DEFERRED
+  );
+
+  INSERT INTO parent_comp VALUES (1,1,0);
+  INSERT INTO child_comp_deferred VALUES (10,1,1);    -- valid
+  INSERT INTO parent_comp VALUES (2,2,0) ON CONFLICT DO NOTHING;  -- unrelated insert; must not raise
+  SELECT a,b,c FROM parent_comp ORDER BY a,b;
+} {1|1|0
+2|2|0}
+
+# ROLLBACK must clear any deferred state; next statement must not trip.
+do_execsql_test_on_specific_db {:memory:} fk-rollback-clears-then-donothing-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  CREATE TABLE parent_comp(a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY(a,b));
+
+  BEGIN;
+    INSERT INTO c VALUES(1, 456);   -- create deferred violation
+  ROLLBACK;                          -- must clear counters
+
+  INSERT INTO parent_comp VALUES(-2,-2,0) ON CONFLICT DO NOTHING;
+  SELECT a,b,c FROM parent_comp;
+} {-2|-2|0}
+
+# DO NOTHING conflict path must touch no FK maintenance at all.
+do_execsql_test_on_specific_db {:memory:} fk-parentcomp-donothing-conflict-stays-quiet {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE parent_comp(a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY(a,b));
+  CREATE TABLE child_comp_deferred(
+    id INTEGER PRIMARY KEY, ca INT, cb INT,
+    FOREIGN KEY(ca,cb) REFERENCES parent_comp(a,b) DEFERRABLE INITIALLY DEFERRED
+  );
+
+  INSERT INTO parent_comp VALUES(10,20,1);
+  -- This conflicts with (10,20) and must be a no-op; if counters move here, it’s a bug.
+  INSERT INTO parent_comp VALUES(10,20,999) ON CONFLICT DO NOTHING;
+
+  -- Prove DB is sane afterwards (no stray FK error)
+  INSERT INTO parent_comp VALUES(11,22,3) ON CONFLICT DO NOTHING;
+  SELECT a,b FROM parent_comp ORDER BY a,b;
+} {10|20
+11|22}
+
+# Two-statement fix inside an explicit transaction (separate statements).
+#Insert child (violation), then insert parent in a new statement; commit must pass.
+do_execsql_test_on_specific_db {:memory:} fk-deferred-two-stmt-fix-inside-tx-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(id INTEGER PRIMARY KEY);
+  CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+  BEGIN;
+    INSERT INTO c VALUES(1, 777);   -- violation recorded in tx
+    INSERT INTO p VALUES(777);      -- next statement fixes it
+  COMMIT;
+  SELECT * FROM c;
+} {1|777}
+
+do_execsql_test_on_specific_db {:memory:} fk-delete-composite-bounds {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(a INT NOT NULL, b INT NOT NULL, v INT, PRIMARY KEY(a,b));
+  CREATE TABLE c(id INTEGER PRIMARY KEY, x INT, y INT, w INT,
+                 FOREIGN KEY(x,y) REFERENCES p(a,b));
+
+  INSERT INTO p VALUES (5,1,0),(5,2,0),(5,4,0);
+  INSERT INTO c VALUES (1,5,4,0);  -- child references (5,4)
+
+  -- This should be a no-op (no row (5,3)), and MUST NOT error.
+  DELETE FROM p WHERE a=5 AND b=3;
+} {}

--- a/testing/foreign_keys.test
+++ b/testing/foreign_keys.test
@@ -124,14 +124,17 @@ do_execsql_test_in_memory_any_error fk-composite-unique-missing {
     INSERT INTO child  VALUES (2,'A','X');     -- no ('A','X') in parent
 }
 
-do_execsql_test_on_specific_db {:memory:} fk-rowid-alias-parent-ok {
+# SQLite doesnt let you name a foreign key constraint 'rowid' explicitly...
+# well it does.. but it throws a parse error only when you try to insert into the table -_-
+# We will throw a parse error when you create the table instead, because that is 
+# obviously the only sane thing to do
+do_execsql_test_in_memory_any_error fk-rowid-alias-parent {
     PRAGMA foreign_keys=ON;
     CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT);
-    CREATE TABLE c(cid INTEGER PRIMARY KEY, rid REFERENCES t(rowid));
+    CREATE TABLE c(cid INTEGER PRIMARY KEY, rid REFERENCES t(rowid)); -- we error here
     INSERT INTO t VALUES (100,'x');
-    INSERT INTO c VALUES (1, 100);
-    SELECT cid, rid FROM c;
-} {1|100}
+    INSERT INTO c VALUES (1, 100); - sqlite errors here
+}
 
 do_execsql_test_in_memory_any_error fk-rowid-alias-parent-missing {
     PRAGMA foreign_keys=ON;
@@ -192,3 +195,139 @@ do_execsql_test_in_memory_any_error fk-composite-pk-delete-violate {
   -- Deleting the referenced tuple should fail
   DELETE FROM p WHERE a=2 AND b=3;
 }
+
+# Parent columns omitted: should default to parent's declared PRIMARY KEY (composite)
+do_execsql_test_on_specific_db {:memory:} fk-default-parent-pk-composite-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(
+      a INT NOT NULL,
+      b INT NOT NULL,
+      PRIMARY KEY(a,b)
+    );
+    -- Parent columns omitted in REFERENCES p
+    CREATE TABLE c(
+      id INT PRIMARY KEY,
+      x INT, y INT,
+      FOREIGN KEY(x,y) REFERENCES p
+    );
+    INSERT INTO p VALUES (1,1), (1,2);
+    INSERT INTO c VALUES (10,1,1), (11,1,2), (12,NULL,2);  -- NULL in child allowed
+    SELECT id,x,y FROM c ORDER BY id;
+} {10|1|1
+11|1|2
+12||2}
+
+do_execsql_test_in_memory_any_error fk-default-parent-pk-composite-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INT NOT NULL, b INT NOT NULL, PRIMARY KEY(a,b));
+    CREATE TABLE c(id INT PRIMARY KEY, x INT, y INT,
+                   FOREIGN KEY(x,y) REFERENCES p);        -- omit parent cols
+    INSERT INTO p VALUES (1,1);
+    INSERT INTO c VALUES (20,1,2);                         -- (1,2) missing in parent
+}
+
+# Parent has no explicitly declared PK, so we throw parse error when referencing bare table
+do_execsql_test_in_memory_any_error fk-default-parent-rowid-no-parent-pk {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p_no_pk(v TEXT);
+    CREATE TABLE c_rowid(id INT PRIMARY KEY,
+                         r REFERENCES p_no_pk);
+    INSERT INTO p_no_pk(v) VALUES ('a'), ('b');
+    INSERT INTO c_rowid VALUES (1, 1);
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-parent-omit-cols-parent-has-pk {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p_pk(id INTEGER PRIMARY KEY, v TEXT);
+  CREATE TABLE c_ok(id INT PRIMARY KEY, r REFERENCES p_pk);  -- binds to p_pk(id)
+  INSERT INTO p_pk VALUES (1,'a'),(2,'b');
+  INSERT INTO c_ok VALUES (10,1);
+  INSERT INTO c_ok VALUES (11,2);
+  SELECT id, r FROM c_ok ORDER BY id;
+} {10|1 11|2}
+
+
+# Self-reference (same table) with INTEGER PRIMARY KEY: single-row insert should pass
+do_execsql_test_on_specific_db {:memory:} fk-self-ipk-single-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+      id  INTEGER PRIMARY KEY,
+      rid REFERENCES t(id)          -- child->parent in same table
+    );
+    INSERT INTO t(id,rid) VALUES(5,5);       -- self-reference, single-row
+    SELECT id, rid FROM t;
+} {5|5}
+
+# Self-reference with mismatched value: should fail immediately (no counter semantics used)
+do_execsql_test_in_memory_any_error fk-self-ipk-single-mismatch {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+      id  INTEGER PRIMARY KEY,
+      rid REFERENCES t(id)
+    );
+    INSERT INTO t(id,rid) VALUES(5,4);       -- rid!=id -> FK violation
+}
+
+# Self-reference on composite PRIMARY KEY: single-row insert should pass
+do_execsql_test_on_specific_db {:memory:} fk-self-composite-single-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+      a INT NOT NULL,
+      b INT NOT NULL,
+      x INT, 
+      y INT,
+      PRIMARY KEY(a,b),
+      FOREIGN KEY(x,y) REFERENCES t(a,b)
+    );
+    INSERT INTO t(a,b,x,y) VALUES(1,2,1,2);  -- self-reference matches PK
+    SELECT a,b,x,y FROM t;
+} {1|2|1|2}
+
+# Rowid parent path: text '10' must be coerced to integer (MustBeInt) and succeed
+do_execsql_test_on_specific_db {:memory:} fk-rowid-mustbeint-coercion-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(cid INTEGER PRIMARY KEY, pid REFERENCES p(id));
+    INSERT INTO p(id) VALUES(10);
+    INSERT INTO c VALUES(1, '10');           -- text -> int via MustBeInt; should match
+    SELECT pid FROM c;
+} {10}
+
+# Rowid parent path: non-numeric text cannot be coerced -> violation
+do_execsql_test_in_memory_any_error fk-rowid-mustbeint-coercion-fail {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(cid INTEGER PRIMARY KEY, pid REFERENCES p(id));
+    INSERT INTO p(id) VALUES(10);
+    INSERT INTO c VALUES(2, 'abc');          -- MustBeInt fails to match any parent row
+}
+
+# Parent match via UNIQUE index (non-rowid), success path
+do_execsql_test_on_specific_db {:memory:} fk-parent-unique-index-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(u TEXT, v TEXT, pad INT, UNIQUE(u,v));
+    CREATE TABLE child(id INT PRIMARY KEY, cu TEXT, cv TEXT,
+                       FOREIGN KEY(cu,cv) REFERENCES parent(u,v));
+    INSERT INTO parent VALUES ('A','B',0),('A','C',0);
+    INSERT INTO child  VALUES (1,'A','B');
+    SELECT id, cu, cv FROM child ORDER BY id;
+} {1|A|B}
+
+# Parent UNIQUE index path: missing key -> immediate violation
+do_execsql_test_in_memory_any_error fk-parent-unique-index-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(u TEXT, v TEXT, pad INT, UNIQUE(u,v));
+    CREATE TABLE child(id INT PRIMARY KEY, cu TEXT, cv TEXT,
+                       FOREIGN KEY(cu,cv) REFERENCES parent(u,v));
+    INSERT INTO parent VALUES ('A','B',0);
+    INSERT INTO child  VALUES (2,'A','X');   -- no ('A','X') in parent
+}
+
+# NULL in child short-circuits FK check
+do_execsql_test_on_specific_db {:memory:} fk-child-null-shortcircuit {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid REFERENCES p(id));
+    INSERT INTO c VALUES (1, NULL);          -- NULL child is allowed
+    SELECT id, pid FROM c;
+} {1|}

--- a/testing/foreign_keys.test
+++ b/testing/foreign_keys.test
@@ -1,0 +1,194 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/sqlite3/tester.tcl
+
+do_execsql_test_on_specific_db {:memory:} fk-basic-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT);
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, tid REFERENCES t(id));
+    INSERT INTO t VALUES (1,'x'),(2,'y');
+    INSERT INTO t2 VALUES (10,1),(11,NULL);    -- NULL child ok
+    SELECT id,tid FROM t2 ORDER BY id;
+} {10|1
+11|}
+
+do_execsql_test_in_memory_any_error fk-insert-child-missing-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT);
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, tid REFERENCES t(id));
+    INSERT INTO t2 VALUES (20,99);
+}
+
+do_execsql_test_in_memory_any_error fk-update-child-to-missing-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT);
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, tid REFERENCES t(id));
+    INSERT INTO t VALUES (1,'x');
+    INSERT INTO t2 VALUES (10,1);
+    UPDATE t2 SET tid = 42 WHERE id = 10;      -- now missing
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-update-child-to-null-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t (id INTEGER PRIMARY KEY);
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, tid REFERENCES t(id));
+    INSERT INTO t VALUES (1);
+    INSERT INTO t2 VALUES (7,1);
+    UPDATE t2 SET tid = NULL WHERE id = 7;
+    SELECT id, tid FROM t2;
+} {7|}
+
+do_execsql_test_in_memory_any_error fk-delete-parent-blocked {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT);
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, tid REFERENCES t(id));
+    INSERT INTO t VALUES (1,'x'),(2,'y');
+    INSERT INTO t2 VALUES (10,2);
+    DELETE FROM t WHERE id=2;
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-delete-parent-ok-when-no-child {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT);
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, tid REFERENCES t(id));
+    INSERT INTO t VALUES (1,'x'),(2,'y');
+    INSERT INTO t2 VALUES (10,1);
+    DELETE FROM t WHERE id=2;
+    SELECT id FROM t ORDER BY id;
+} {1}
+
+
+do_execsql_test_on_specific_db {:memory:} fk-composite-pk-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(
+      a INT NOT NULL,
+      b INT NOT NULL,
+      PRIMARY KEY(a,b)
+    );
+    CREATE TABLE c(
+      id INT PRIMARY KEY,
+      x INT, y INT,
+      FOREIGN KEY(x,y) REFERENCES p(a,b)
+    );
+    INSERT INTO p VALUES (1,1),(1,2);
+    INSERT INTO c VALUES (10,1,1),(11,1,2),(12,NULL,2);  -- NULL in child allowed
+    SELECT id,x,y FROM c ORDER BY id;
+} {10|1|1
+11|1|2
+12||2}
+
+do_execsql_test_in_memory_any_error fk-composite-pk-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(
+      a INT NOT NULL,
+      b INT NOT NULL,
+      PRIMARY KEY(a,b)
+    );
+    CREATE TABLE c(
+      id INT PRIMARY KEY,
+      x INT, y INT,
+      FOREIGN KEY(x,y) REFERENCES p(a,b)
+    );
+    INSERT INTO p VALUES (1,1);
+    INSERT INTO c VALUES (20,1,2);             -- (1,2) missing
+}
+
+do_execsql_test_in_memory_any_error fk-composite-update-child-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INT NOT NULL, b INT NOT NULL, PRIMARY KEY(a,b));
+    CREATE TABLE c(id INT PRIMARY KEY, x INT, y INT,
+                   FOREIGN KEY(x,y) REFERENCES p(a,b));
+    INSERT INTO p VALUES (1,1),(2,2);
+    INSERT INTO c VALUES (5,1,1);
+    UPDATE c SET x=2,y=3 WHERE id=5;
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-composite-unique-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(u TEXT, v TEXT, pad INT, UNIQUE(u,v));
+    CREATE TABLE child(id INT PRIMARY KEY, cu TEXT, cv TEXT,
+                       FOREIGN KEY(cu,cv) REFERENCES parent(u,v));
+    INSERT INTO parent VALUES ('A','B',0),('A','C',0);
+    INSERT INTO child  VALUES (1,'A','B');
+    SELECT id, cu, cv FROM child ORDER BY id;
+} {1|A|B}
+
+do_execsql_test_in_memory_any_error fk-composite-unique-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(u TEXT, v TEXT, pad INT, UNIQUE(u,v));
+    CREATE TABLE child(id INT PRIMARY KEY, cu TEXT, cv TEXT,
+                       FOREIGN KEY(cu,cv) REFERENCES parent(u,v));
+    INSERT INTO parent VALUES ('A','B',0);
+    INSERT INTO child  VALUES (2,'A','X');     -- no ('A','X') in parent
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-rowid-alias-parent-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE TABLE c(cid INTEGER PRIMARY KEY, rid REFERENCES t(rowid));
+    INSERT INTO t VALUES (100,'x');
+    INSERT INTO c VALUES (1, 100);
+    SELECT cid, rid FROM c;
+} {1|100}
+
+do_execsql_test_in_memory_any_error fk-rowid-alias-parent-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE TABLE c(cid INTEGER PRIMARY KEY, rid REFERENCES t(rowid));
+    INSERT INTO c VALUES (1, 9999);
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-update-child-noop-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid REFERENCES p(id));
+    INSERT INTO p VALUES (1);
+    INSERT INTO c VALUES (10,1);
+    UPDATE c SET id = id WHERE id = 10;        -- no FK column touched
+    SELECT id, pid FROM c;
+} {10|1}
+
+do_execsql_test_in_memory_any_error fk-delete-parent-composite-scan {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INT NOT NULL, b INT NOT NULL, PRIMARY KEY(a,b));
+    CREATE TABLE c(id INT PRIMARY KEY, x INT, y INT,
+                   FOREIGN KEY(x,y) REFERENCES p(a,b));
+    INSERT INTO p VALUES (1,2),(2,3);
+    INSERT INTO c VALUES (7,2,3);
+    DELETE FROM p WHERE a=2 AND b=3;
+}
+
+do_execsql_test_on_specific_db {:memory:} fk-update-child-to-existing-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, tid REFERENCES t(id));
+    INSERT INTO t VALUES (1),(2);
+    INSERT INTO t2 VALUES (9,1);
+    UPDATE t2 SET tid = 2 WHERE id = 9;
+    SELECT id, tid FROM t2;
+} {9|2}
+
+do_execsql_test_on_specific_db {:memory:} fk-composite-pk-delete-ok {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(a INT NOT NULL, b INT NOT NULL, PRIMARY KEY(a,b));
+  CREATE TABLE c(id INT PRIMARY KEY, x INT, y INT,
+                 FOREIGN KEY(x,y) REFERENCES p(a,b));
+  INSERT INTO p VALUES (1,2),(2,3);
+  INSERT INTO c VALUES (7,2,3);
+  -- Deleting a non-referenced parent tuple is OK
+  DELETE FROM p WHERE a=1 AND b=2;
+  SELECT a,b FROM p ORDER BY a,b;
+} {2|3}
+
+do_execsql_test_in_memory_any_error fk-composite-pk-delete-violate {
+  PRAGMA foreign_keys=ON;
+  CREATE TABLE p(a INT NOT NULL, b INT NOT NULL, PRIMARY KEY(a,b));
+  CREATE TABLE c(id INT PRIMARY KEY, x INT, y INT,
+                 FOREIGN KEY(x,y) REFERENCES p(a,b));
+  INSERT INTO p VALUES (2,3);
+  INSERT INTO c VALUES (7,2,3);
+  -- Deleting the referenced tuple should fail
+  DELETE FROM p WHERE a=2 AND b=3;
+}

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -650,6 +650,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(unused_assignments)]
+    #[ignore] // ignoring because every error I can find is due to sqlite sub-transaction behavior
     pub fn fk_deferred_constraints_fuzz() {
         let _ = env_logger::try_init();
         let (mut rng, seed) = rng_from_time();
@@ -893,7 +895,7 @@ mod tests {
                         (s, l) => {
                             eprintln!("Non-tx mismatch: sqlite={s:?}, limbo={l:?}");
                             eprintln!("Statement: {stmt}");
-                            eprintln!("Seed: {seed}, outer: {outer}, tx: {tx_num}");
+                            eprintln!("Seed: {seed}, outer: {outer}, tx: {tx_num}, in_tx={in_tx}");
                             let mut file = std::fs::File::create("fk_deferred.sql").unwrap();
                             for stmt in stmts.iter() {
                                 writeln!(file, "{stmt};").expect("write to file");
@@ -947,7 +949,7 @@ mod tests {
                             eprintln!("\n=== COMMIT/ROLLBACK mismatch ===");
                             eprintln!("Operation: {s:?}");
                             eprintln!("sqlite={s:?}, limbo={l:?}");
-                            eprintln!("Seed: {seed}, outer: {outer}, tx: {tx_num}");
+                            eprintln!("Seed: {seed}, outer: {outer}, tx: {tx_num}, in_tx={in_tx}");
                             eprintln!("--- Replay statements ({}) ---", stmts.len());
                             let mut file = std::fs::File::create("fk_deferred.sql").unwrap();
                             for stmt in stmts.iter() {


### PR DESCRIPTION
This PR introduces support for foreign key constraints, and the `PRAGMA foreign_keys;`, and relevant opcodes: `FkCounter` and `FkIfZero`. Extensive fuzz tests were added both for regular and composite PK/rowid/unique index constraints, as well as some really weird edgecases to make sure we our affinity handling is correct as well when we trigger the constraints.


Foreign-key checking is driven by two VDBE ops: `FkCounter` and `FkIfZero`, and  

 `FkCounter` is a running meter on the `Connection` for deferred FK violations. When an `insert/delete/update` operation creates a potential orphan (we insert a child row that doesn’t have a matching parent, or we delete/update a parent that children still point at), this counter is incremented. When a later operation fixes that (e.g. we insert the missing parent or re-target the child), we decrement the counter. If any is remaining at commit time, the commit fails. For immediate constraints, on the violation path we emit Halt right away.

`FkIfZero` can either be used to guard a decrement of FkCounter to prevent underflow, or can potentially (in the future) be used to avoid work checking if any constraints need resolving.

NOTE: this PR does not implement `pragma defer_foreign_keys` for global `deferred` constraint semantics. only explicit `col INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED` is supported in this PR.

This PR does not add support for `ON UPDATE|DELETE CASCADE`, only for basic implicit `DO NOTHING` behavior.



~~NOTE: I did notice that, as referenced here: #3463~~

~~our current handling of unique constraints does not pass fuzz tests, I believe only in the case of composite primary keys,~~ ~~because the fuzz test for FK referencing composite PK is failing but only for UNIQUE constraints, never (or as many times as i tried) for foreign key constraints.~~

EDIT: all fuzzers are passing, because @sivukhin fixed the unique constraint issue.

The reason that the `deferred` fuzzer is `#[ignore]`'d is because sqlite uses sub-transactions, and even though the fuzzing only does 1 entry per transaction... the fuzzer can lose track of _when_ it's in a transaction and when it hits a FK constraint, and there is an error in both DB's, it can just continue to do run regular statements, and then the eventual ROLLBACK will revert different things in sqlite vs turso.. so for now, we leave it `ignore`d  