### PR TITLE
fix/vdbe: reset op_transaction state properly

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2414,6 +2414,7 @@ pub fn op_transaction_inner(
                 }
 
                 state.pc += 1;
+                state.op_transaction_state = OpTransactionState::Start;
                 return Ok(InsnFunctionStepResult::Step);
             }
         }


### PR DESCRIPTION
essentially after the first runthrough of `op_transaction` per a given `ProgramState`, we weren't resetting the instruction state to `Start´ at all, which means we didn't do any transaction state checking/updating after that.

PR includes a rust bindings regression test that used to panic before this change, and I bet it also fixes this issue in turso-go:

https://github.com/tursodatabase/turso-go/issues/28