### PR TITLE
core/vdbe: Avoid cloning Arc<MvStore> on every VDBE step

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2472,7 +2472,7 @@ impl Statement {
         let mut res = if !self.accesses_db {
             self.program.step(
                 &mut self.state,
-                self.mv_store.clone(),
+                self.mv_store.as_ref(),
                 self.pager.clone(),
                 self.query_mode,
             )
@@ -2480,7 +2480,7 @@ impl Statement {
             const MAX_SCHEMA_RETRY: usize = 50;
             let mut res = self.program.step(
                 &mut self.state,
-                self.mv_store.clone(),
+                self.mv_store.as_ref(),
                 self.pager.clone(),
                 self.query_mode,
             );
@@ -2493,7 +2493,7 @@ impl Statement {
                 self.reprepare()?;
                 res = self.program.step(
                     &mut self.state,
-                    self.mv_store.clone(),
+                    self.mv_store.as_ref(),
                     self.pager.clone(),
                     self.query_mode,
                 );


### PR DESCRIPTION
The VDBE step() function was taking Arc<MvStore> by value, causing it to be cloned on every single step of query execution. This resulted in thousands of atomic reference count increments/decrements per query, showing up as a major hotspot in profiling.

Changed step() and related functions to take Option<&Arc<MvStore>> instead, passing a reference rather than cloning the Arc. This eliminates the unnecessary atomic operations while maintaining the same semantics.