### PR TITLE
core/vdbe: Don't clear cursors in ProgramState::reset()

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -395,7 +395,6 @@ impl ProgramState {
             self.registers
                 .resize_with(max_resgisters, || Register::Value(Value::Null));
         }
-        self.cursors.iter_mut().for_each(|c| *c = None);
         self.registers
             .iter_mut()
             .for_each(|r| *r = Register::Value(Value::Null));


### PR DESCRIPTION
We don't need to clear the cursors explicitly because OpenRead and OpenWrite will anyway replace them.