### PR TITLE
apply create DDL operation with IF NOT EXISTS clause in order to make them idempotent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4589,6 +4589,7 @@ dependencies = [
  "tracing-subscriber",
  "turso",
  "turso_core",
+ "turso_parser",
  "uuid",
 ]
 

--- a/sync/engine/Cargo.toml
+++ b/sync/engine/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 turso_core = { workspace = true, features = ["conn_raw_api"] }
+turso_parser = { workspace = true }
 thiserror = "2.0.12"
 tracing = "0.1.41"
 serde_json.workspace = true

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -1200,7 +1200,7 @@ mod tests {
                             turso_core::Value::Text(turso_core::types::Text::new("t")),
                             turso_core::Value::Integer(6),
                             turso_core::Value::Text(turso_core::types::Text::new(
-                                "CREATE INDEX t_idx ON t (y)"
+                                "CREATE INDEX IF NOT EXISTS t_idx ON t (y)"
                             )),
                         ]
                     ]


### PR DESCRIPTION
In order to follow "last-push-wins" default conflict resolution strategy for DDL operations we must use `... IF NOT EXISTS ...` variant for them.

This PR enabled `if_not_exists` flag in the AST before emitting DDL operation for the remote in order to use `last-push-win` strategy for these operations instead of erroring out.