### PR TITLE
core/vdbe: Eliminate integrity check state reassignment

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -414,7 +414,9 @@ impl ProgramState {
             deleted_record: None,
         };
         self.op_idx_delete_state = None;
-        self.op_integrity_check_state = OpIntegrityCheckState::Start;
+        if !matches!(self.op_integrity_check_state, OpIntegrityCheckState::Start) {
+            self.op_integrity_check_state = OpIntegrityCheckState::Start;
+        }
         self.metrics = StatementMetrics::new();
         self.op_open_ephemeral_state = OpOpenEphemeralState::Start;
         self.op_new_rowid_state = OpNewRowidState::Start;


### PR DESCRIPTION
The reassignment looks innocent, but requires dropping the old value. I am sure we could do this optimization elsewhere too, but this is the one that shows up in profiles.