### PR TITLE
Fix COLLATE

### DIFF
--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -1,6 +1,15 @@
 use std::{cmp::Ordering, str::FromStr as _};
 
 use tracing::Level;
+use turso_parser::ast::Expr;
+
+use crate::{
+    translate::{
+        expr::{walk_expr, WalkControl},
+        plan::TableReferences,
+    },
+    Result,
+};
 
 // TODO: in the future allow user to define collation sequences
 // Will have to meddle with ffi for this
@@ -49,5 +58,436 @@ impl CollationSeq {
 
     fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
         lhs.trim_end().cmp(rhs.trim_end())
+    }
+}
+
+/// Every column of every table has an associated collating function. If no collating function is explicitly defined,
+/// then the collating function defaults to BINARY.
+/// The COLLATE clause of the column definition is used to define alternative collating functions for a column.
+///
+/// The rules for determining which collating function to use for a binary comparison operator (=, <, >, <=, >=, !=, IS, and IS NOT) are as follows:
+///
+/// If either operand has an explicit collating function assignment using the postfix COLLATE operator,
+/// then the explicit collating function is used for comparison, with precedence to the collating function of the left operand.
+///
+/// If either operand is a column, then the collating function of that column is used with precedence to the left operand.
+/// For the purposes of the previous sentence, a column name preceded by one or more unary "+" operators and/or CAST operators is still considered a column name.
+///
+/// Otherwise, the BINARY collating function is used for comparison.
+///
+/// An operand of a comparison is considered to have an explicit collating function assignment
+/// if any subexpression of the operand uses the postfix COLLATE operator.
+/// Thus, if a COLLATE operator is used anywhere in a comparison expression,
+/// the collating function defined by that operator is used for string comparison
+/// regardless of what table columns might be a part of that expression.
+/// If two or more COLLATE operator subexpressions appear anywhere in a comparison,
+/// the left most explicit collating function is used regardless of how deeply
+/// the COLLATE operators are nested in the expression and regardless of how
+/// the expression is parenthesized.
+pub fn get_collseq_from_expr(
+    top_expr: &Expr,
+    referenced_tables: &TableReferences,
+) -> Result<Option<CollationSeq>> {
+    let mut maybe_column_collseq = None;
+    let mut maybe_explicit_collseq = None;
+
+    walk_expr(top_expr, &mut |expr: &Expr| -> Result<WalkControl> {
+        match expr {
+            Expr::Collate(_, seq) => {
+                // Only store the first (leftmost) COLLATE operator we find
+                if maybe_explicit_collseq.is_none() {
+                    maybe_explicit_collseq =
+                        Some(CollationSeq::new(seq.as_str()).unwrap_or_default());
+                }
+                // Skip children since we've found a COLLATE operator
+                return Ok(WalkControl::SkipChildren);
+            }
+            Expr::Column { table, column, .. } => {
+                let table_ref = referenced_tables
+                    .find_table_by_internal_id(*table)
+                    .ok_or_else(|| crate::LimboError::ParseError("table not found".to_string()))?;
+                let column = table_ref
+                    .get_column_at(*column)
+                    .ok_or_else(|| crate::LimboError::ParseError("column not found".to_string()))?;
+                if maybe_column_collseq.is_none() {
+                    maybe_column_collseq = column.collation;
+                }
+                return Ok(WalkControl::Continue);
+            }
+            Expr::RowId { table, .. } => {
+                let table_ref = referenced_tables
+                    .find_table_by_internal_id(*table)
+                    .ok_or_else(|| crate::LimboError::ParseError("table not found".to_string()))?;
+                if let Some(btree) = table_ref.btree() {
+                    if let Some((_, rowid_alias_col)) = btree.get_rowid_alias_column() {
+                        if maybe_column_collseq.is_none() {
+                            maybe_column_collseq = rowid_alias_col.collation;
+                        }
+                    }
+                }
+                return Ok(WalkControl::Continue);
+            }
+            _ => {}
+        }
+        Ok(WalkControl::Continue)
+    })?;
+
+    Ok(maybe_explicit_collseq.or(maybe_column_collseq))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use turso_parser::ast::{Literal, Name, Operator, TableInternalId, UnaryOperator};
+
+    use crate::{
+        schema::{BTreeTable, Column, Table, Type},
+        translate::plan::{ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan},
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_get_collseq_from_expr_single_table_single_column() {
+        // plain column
+        for collation in [
+            None,
+            Some(CollationSeq::Binary),
+            Some(CollationSeq::NoCase),
+            Some(CollationSeq::Rtrim),
+        ] {
+            let table_references =
+                get_table_references_single_table_single_column_with_collation(collation);
+            let expr = Expr::Column {
+                database: None,
+                table: TableInternalId::from(1),
+                column: 0,
+                is_rowid_alias: false,
+            };
+            let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
+            assert_eq!(collseq, collation);
+        }
+    }
+
+    #[test]
+    fn test_get_collseq_from_expr_single_table_single_column_with_collate() {
+        let table_references = get_table_references_single_table_single_column_with_collation(
+            Some(CollationSeq::Binary),
+        );
+        // col COLLATE RTRIM, col COLLATE NOCASE, col COLLATE BINARY
+        for collation in ["RTRIM", "NOCASE", "BINARY"] {
+            let expected_collation = CollationSeq::new(collation).unwrap();
+            let expr = Expr::Collate(
+                Box::new(Expr::Column {
+                    database: None,
+                    table: TableInternalId::from(1),
+                    column: 0,
+                    is_rowid_alias: false,
+                }),
+                Name::exact(collation.to_string()),
+            );
+            let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
+            assert_eq!(collseq, Some(expected_collation));
+        }
+    }
+
+    #[test]
+    fn test_get_collseq_from_expr_multiple_collate_leftmost_wins() {
+        let table_references = get_table_references_single_table_single_column_with_collation(
+            Some(CollationSeq::Binary),
+        );
+        // (col COLLATE NOCASE) COLLATE RTRIM -- RTRIM wins as it is the leftmost AST node with a COLLATE
+        let inner = Expr::Collate(
+            Box::new(Expr::Column {
+                database: None,
+                table: TableInternalId::from(1),
+                column: 0,
+                is_rowid_alias: false,
+            }),
+            Name::exact("NOCASE".to_string()),
+        );
+        let expr = Expr::Collate(
+            Box::new(Expr::Parenthesized(vec![Box::new(inner)])),
+            Name::exact("RTRIM".to_string()),
+        );
+        let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
+        assert_eq!(collseq, Some(CollationSeq::Rtrim));
+    }
+
+    #[test]
+    fn test_get_collseq_from_expr_unary_plus_and_cast_still_column() {
+        let table_references = get_table_references_single_table_single_column_with_collation(
+            Some(CollationSeq::NoCase),
+        );
+        // Unary plus on column
+        let expr_plus = Expr::unary(
+            UnaryOperator::Positive,
+            Expr::Column {
+                database: None,
+                table: TableInternalId::from(1),
+                column: 0,
+                is_rowid_alias: false,
+            },
+        );
+        let collseq_plus = get_collseq_from_expr(&expr_plus, &table_references).unwrap();
+        assert_eq!(collseq_plus, Some(CollationSeq::NoCase));
+
+        // CAST(column AS TEXT)
+        let cast_ty = Some(turso_parser::ast::Type {
+            name: "TEXT".to_string(),
+            size: None,
+        });
+        let expr_cast = Expr::cast(
+            Expr::Column {
+                database: None,
+                table: TableInternalId::from(1),
+                column: 0,
+                is_rowid_alias: false,
+            },
+            cast_ty,
+        );
+        let collseq_cast = get_collseq_from_expr(&expr_cast, &table_references).unwrap();
+        assert_eq!(collseq_cast, Some(CollationSeq::NoCase));
+    }
+
+    #[test]
+    fn test_get_collseq_from_expr_explicit_collate_anywhere_in_operand() {
+        let table_references = get_table_references_two_tables_single_column_with_collations(
+            Some(CollationSeq::NoCase),
+            None,
+        );
+        // RTRIM wins because it's an explicit COLLATE even though it appears on the right side of the expression
+        let lhs = Expr::Column {
+            database: None,
+            table: TableInternalId::from(1),
+            column: 0,
+            is_rowid_alias: false,
+        };
+        let rhs = Expr::Parenthesized(vec![Box::new(Expr::Collate(
+            Box::new(Expr::Literal(Literal::String("x".to_string()))),
+            Name::exact("RTRIM".to_string()),
+        ))]);
+        let expr = Expr::binary(lhs, Operator::Add, rhs);
+        let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
+        assert_eq!(collseq, Some(CollationSeq::Rtrim));
+    }
+
+    #[test]
+    fn test_get_collseq_from_expr_column_plus_column_leftside_column_wins() {
+        let table_references = get_table_references_two_tables_single_column_with_collations(
+            Some(CollationSeq::NoCase),
+            Some(CollationSeq::Rtrim),
+        );
+        // col1 + col2 -- col1's NOCASE collation wins since it's on the left side
+        let lhs = Expr::Column {
+            database: None,
+            table: TableInternalId::from(1),
+            column: 0,
+            is_rowid_alias: false,
+        };
+        let rhs = Expr::Column {
+            database: None,
+            table: TableInternalId::from(2),
+            column: 0,
+            is_rowid_alias: false,
+        };
+        let expr = Expr::binary(lhs, Operator::Add, rhs);
+        let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
+        assert_eq!(collseq, Some(CollationSeq::NoCase));
+    }
+
+    #[test]
+    fn test_get_collseq_from_expr_collate_vs_collate_leftside_expr_wins() {
+        let table_references = TableReferences::new_empty();
+        // (x COLLATE NOCASE) + (y COLLATE RTRIM) -- NOCASE wins since it's on the left side
+        let lhs = Expr::Collate(
+            Box::new(Expr::Literal(Literal::String("x".to_string()))),
+            Name::exact("NOCASE".to_string()),
+        );
+        let rhs = Expr::Collate(
+            Box::new(Expr::Literal(Literal::String("y".to_string()))),
+            Name::exact("RTRIM".to_string()),
+        );
+        let expr = Expr::binary(lhs, Operator::Add, rhs);
+        let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
+        assert_eq!(collseq, Some(CollationSeq::NoCase));
+    }
+
+    #[test]
+    fn test_get_collseq_from_expr_default_binary_when_no_collate_or_column() {
+        let table_references = TableReferences::new_empty();
+        let expr = Expr::Literal(Literal::String("abc".to_string()));
+        let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
+        assert_eq!(collseq, None);
+    }
+
+    #[test]
+    fn test_get_collseq_from_expr_rowid_uses_rowid_alias_collation() {
+        let table_references = get_table_references_single_table_rowid_alias_with_collation(Some(
+            CollationSeq::NoCase,
+        ));
+        let expr = Expr::RowId {
+            database: None,
+            table: TableInternalId::from(1),
+        };
+        let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
+        assert_eq!(collseq, Some(CollationSeq::NoCase));
+    }
+
+    // Helpers //
+
+    fn get_table_references_single_table_single_column_with_collation(
+        collation: Option<CollationSeq>,
+    ) -> TableReferences {
+        let mut table_references = TableReferences::new_empty();
+        table_references.add_joined_table(JoinedTable {
+            op: Operation::Scan(Scan::BTreeTable {
+                iter_dir: IterationDirection::Forwards,
+                index: None,
+            }),
+            col_used_mask: ColumnUsedMask::default(),
+            database_id: 0,
+            identifier: "foo".to_string(),
+            internal_id: TableInternalId::from(1),
+            join_info: None,
+            table: Table::BTree(Arc::new(BTreeTable {
+                root_page: 0,
+                has_autoincrement: false,
+                has_rowid: false,
+                is_strict: false,
+                name: "foo".to_string(),
+                primary_key_columns: vec![],
+                columns: vec![Column {
+                    name: Some("foo".to_string()),
+                    ty: Type::Text,
+                    ty_str: "text".to_string(),
+                    primary_key: false,
+                    is_rowid_alias: false,
+                    notnull: false,
+                    default: None,
+                    unique: false,
+                    collation,
+                    hidden: false,
+                }],
+                unique_sets: vec![],
+            })),
+        });
+
+        table_references
+    }
+
+    fn get_table_references_two_tables_single_column_with_collations(
+        left: Option<CollationSeq>,
+        right: Option<CollationSeq>,
+    ) -> TableReferences {
+        let mut table_references = TableReferences::new_empty();
+        // Left table t1(id=1)
+        table_references.add_joined_table(JoinedTable {
+            op: Operation::Scan(Scan::BTreeTable {
+                iter_dir: IterationDirection::Forwards,
+                index: None,
+            }),
+            col_used_mask: ColumnUsedMask::default(),
+            database_id: 0,
+            identifier: "t1".to_string(),
+            internal_id: TableInternalId::from(1),
+            join_info: None,
+            table: Table::BTree(Arc::new(BTreeTable {
+                root_page: 0,
+                has_autoincrement: false,
+                has_rowid: true,
+                is_strict: false,
+                name: "t1".to_string(),
+                primary_key_columns: vec![],
+                columns: vec![Column {
+                    name: Some("a".to_string()),
+                    ty: Type::Text,
+                    ty_str: "text".to_string(),
+                    primary_key: false,
+                    is_rowid_alias: false,
+                    notnull: false,
+                    default: None,
+                    unique: false,
+                    collation: left,
+                    hidden: false,
+                }],
+                unique_sets: vec![],
+            })),
+        });
+        // Right table t2(id=2)
+        table_references.add_joined_table(JoinedTable {
+            op: Operation::Scan(Scan::BTreeTable {
+                iter_dir: IterationDirection::Forwards,
+                index: None,
+            }),
+            col_used_mask: ColumnUsedMask::default(),
+            database_id: 0,
+            identifier: "t2".to_string(),
+            internal_id: TableInternalId::from(2),
+            join_info: None,
+            table: Table::BTree(Arc::new(BTreeTable {
+                root_page: 0,
+                has_autoincrement: false,
+                has_rowid: true,
+                is_strict: false,
+                name: "t2".to_string(),
+                primary_key_columns: vec![],
+                columns: vec![Column {
+                    name: Some("b".to_string()),
+                    ty: Type::Text,
+                    ty_str: "text".to_string(),
+                    primary_key: false,
+                    is_rowid_alias: false,
+                    notnull: false,
+                    default: None,
+                    unique: false,
+                    collation: right,
+                    hidden: false,
+                }],
+                unique_sets: vec![],
+            })),
+        });
+        table_references
+    }
+
+    fn get_table_references_single_table_rowid_alias_with_collation(
+        collation: Option<CollationSeq>,
+    ) -> TableReferences {
+        use turso_parser::ast::SortOrder;
+        let mut table_references = TableReferences::new_empty();
+        table_references.add_joined_table(JoinedTable {
+            op: Operation::Scan(Scan::BTreeTable {
+                iter_dir: IterationDirection::Forwards,
+                index: None,
+            }),
+            col_used_mask: ColumnUsedMask::default(),
+            database_id: 0,
+            identifier: "bar".to_string(),
+            internal_id: TableInternalId::from(1),
+            join_info: None,
+            table: Table::BTree(Arc::new(BTreeTable {
+                root_page: 0,
+                has_autoincrement: false,
+                has_rowid: true,
+                is_strict: false,
+                name: "bar".to_string(),
+                primary_key_columns: vec![("id".to_string(), SortOrder::Asc)],
+                columns: vec![Column {
+                    name: Some("id".to_string()),
+                    ty: Type::Integer,
+                    ty_str: "INTEGER".to_string(),
+                    primary_key: true,
+                    is_rowid_alias: true,
+                    notnull: false,
+                    default: None,
+                    unique: true,
+                    collation,
+                    hidden: false,
+                }],
+                unique_sets: vec![],
+            })),
+        });
+        table_references
     }
 }

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -327,7 +327,7 @@ pub fn emit_query<'a>(
     }
 
     let distinct_ctx = if let Distinctness::Distinct { .. } = &plan.distinctness {
-        Some(init_distinct(program, plan))
+        Some(init_distinct(program, plan)?)
     } else {
         None
     };

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -498,9 +498,13 @@ pub fn group_by_process_single_group(
             collation: CollationSeq::default(),
         })
         .collect::<Vec<_>>();
-    for i in 0..group_by.exprs.len() {
+    for (i, c) in compare_key_info
+        .iter_mut()
+        .enumerate()
+        .take(group_by.exprs.len())
+    {
         let maybe_collation = get_collseq_from_expr(&group_by.exprs[i], &plan.table_references)?;
-        compare_key_info[i].collation = maybe_collation.unwrap_or_default();
+        c.collation = maybe_collation.unwrap_or_default();
     }
 
     // Compare the group by columns to the previous group by columns to see if we are at a new group or not

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -88,9 +88,9 @@ impl Constraint {
             panic!("Expected a valid binary expression");
         };
         if side == BinaryExprSide::Lhs {
-            &lhs
+            lhs
         } else {
-            &rhs
+            rhs
         }
     }
 }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -340,8 +340,8 @@ fn optimize_table_access(
                     let usable_constraints = table_constraints
                         .constraints
                         .iter()
-                        .cloned()
                         .filter(|c| c.usable)
+                        .cloned()
                         .collect::<Vec<_>>();
                     let temp_constraint_refs = (0..usable_constraints.len())
                         .map(|i| ConstraintRef {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -337,15 +337,21 @@ fn optimize_table_access(
                         });
                         continue;
                     };
-                    let temp_constraint_refs = (0..table_constraints.constraints.len())
+                    let usable_constraints = table_constraints
+                        .constraints
+                        .iter()
+                        .cloned()
+                        .filter(|c| c.usable)
+                        .collect::<Vec<_>>();
+                    let temp_constraint_refs = (0..usable_constraints.len())
                         .map(|i| ConstraintRef {
                             constraint_vec_pos: i,
-                            index_col_pos: table_constraints.constraints[i].table_col_pos,
+                            index_col_pos: usable_constraints[i].table_col_pos,
                             sort_order: SortOrder::Asc,
                         })
                         .collect::<Vec<_>>();
                     let usable_constraint_refs = usable_constraints_for_join_order(
-                        &table_constraints.constraints,
+                        &usable_constraints,
                         &temp_constraint_refs,
                         &best_join_order[..=i],
                     );
@@ -358,14 +364,14 @@ fn optimize_table_access(
                     }
                     let ephemeral_index = ephemeral_index_build(
                         &joined_tables[table_idx],
-                        &table_constraints.constraints,
+                        &usable_constraints,
                         usable_constraint_refs,
                     );
                     let ephemeral_index = Arc::new(ephemeral_index);
                     joined_tables[table_idx].op = Operation::Search(Search::Seek {
                         index: Some(ephemeral_index),
                         seek_def: build_seek_def_from_constraints(
-                            &table_constraints.constraints,
+                            &usable_constraints,
                             usable_constraint_refs,
                             *iter_dir,
                             where_clause,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -315,7 +315,7 @@ fn parse_from_clause_table(
                 subplan,
                 None,
                 program.table_reference_counter.next(),
-            ));
+            )?);
             Ok(())
         }
         ast::SelectTable::TableCall(qualified_name, args, maybe_alias) => parse_table(
@@ -662,7 +662,7 @@ pub fn parse_from(
                 cte_plan,
                 None,
                 program.table_reference_counter.next(),
-            ));
+            )?);
         }
     }
 

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -702,10 +702,14 @@ fn emit_flush_buffer_if_new_partition(
                 collation: CollationSeq::default(),
             })
             .collect::<Vec<_>>();
-        for i in 0..window.partition_by.len() {
+        for (i, c) in compare_key_info
+            .iter_mut()
+            .enumerate()
+            .take(window.partition_by.len())
+        {
             let maybe_collation =
                 get_collseq_from_expr(&window.partition_by[i], &plan.table_references)?;
-            compare_key_info[i].collation = maybe_collation.unwrap_or_default();
+            c.collation = maybe_collation.unwrap_or_default();
         }
         program.emit_insn(Insn::Compare {
             start_reg_a: registers.src_columns_start,
@@ -802,10 +806,14 @@ fn emit_flush_buffer_if_not_peer(
                 collation: CollationSeq::default(),
             })
             .collect::<Vec<_>>();
-        for i in 0..window.order_by.len() {
+        for (i, c) in compare_key_info
+            .iter_mut()
+            .enumerate()
+            .take(window.order_by.len())
+        {
             let maybe_collation =
                 get_collseq_from_expr(&window.order_by[i].0, &plan.table_references)?;
-            compare_key_info[i].collation = maybe_collation.unwrap_or_default();
+            c.collation = maybe_collation.unwrap_or_default();
         }
         program.emit_insn(Insn::Compare {
             start_reg_a: reg_prev_order_by_columns_start,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -73,7 +73,7 @@ use super::{
 };
 use parking_lot::RwLock;
 use rand::{thread_rng, Rng};
-use turso_parser::ast::{self, Name};
+use turso_parser::ast::{self, Name, SortOrder};
 use turso_parser::parser::Parser;
 
 use super::{
@@ -523,14 +523,13 @@ pub fn op_compare(
             start_reg_a,
             start_reg_b,
             count,
-            collation,
+            key_info,
         },
         insn
     );
     let start_reg_a = *start_reg_a;
     let start_reg_b = *start_reg_b;
     let count = *count;
-    let collation = collation.unwrap_or_default();
 
     if start_reg_a + count > start_reg_b {
         return Err(LimboError::InternalError(
@@ -538,21 +537,30 @@ pub fn op_compare(
         ));
     }
 
-    let mut cmp = None;
+    let mut cmp = std::cmp::Ordering::Equal;
     for i in 0..count {
+        // TODO (https://github.com/tursodatabase/turso/issues/2304): this logic is almost the same as compare_immutable()
+        // but that one works on RefValue and this works on Value. There are tons of cases like this where we could reuse
+        // functionality if we had a trait that both RefValue and Value implement.
         let a = state.registers[start_reg_a + i].get_value();
         let b = state.registers[start_reg_b + i].get_value();
+        let column_order = key_info[i].sort_order;
+        let collation = key_info[i].collation;
         cmp = match (a, b) {
             (Value::Text(left), Value::Text(right)) => {
-                Some(collation.compare_strings(left.as_str(), right.as_str()))
+                collation.compare_strings(left.as_str(), right.as_str())
             }
-            _ => Some(a.cmp(b)),
+            _ => a.partial_cmp(b).unwrap(),
         };
-        if cmp != Some(std::cmp::Ordering::Equal) {
+        if !cmp.is_eq() {
+            cmp = match column_order {
+                SortOrder::Asc => cmp,
+                SortOrder::Desc => cmp.reverse(),
+            };
             break;
         }
     }
-    state.last_compare = cmp;
+    state.last_compare = Some(cmp);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -538,14 +538,14 @@ pub fn op_compare(
     }
 
     let mut cmp = std::cmp::Ordering::Equal;
-    for i in 0..count {
+    for (i, key_col) in key_info.iter().enumerate().take(count) {
         // TODO (https://github.com/tursodatabase/turso/issues/2304): this logic is almost the same as compare_immutable()
         // but that one works on RefValue and this works on Value. There are tons of cases like this where we could reuse
         // functionality if we had a trait that both RefValue and Value implement.
         let a = state.registers[start_reg_a + i].get_value();
         let b = state.registers[start_reg_b + i].get_value();
-        let column_order = key_info[i].sort_order;
-        let collation = key_info[i].collation;
+        let column_order = key_col.sort_order;
+        let collation = key_col.collation;
         cmp = match (a, b) {
             (Value::Text(left), Value::Text(right)) => {
                 collation.compare_strings(left.as_str(), right.as_str())

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -151,13 +151,13 @@ pub fn insn_to_row(
                 start_reg_a,
                 start_reg_b,
                 count,
-                collation,
+                key_info,
             } => (
                 "Compare",
                 *start_reg_a as i32,
                 *start_reg_b as i32,
                 *count as i32,
-                Value::build_text(format!("k({count}, {})", collation.unwrap_or_default())),
+                Value::build_text(format!("k({count}, {})", key_info.iter().map(|k| k.collation.to_string()).collect::<Vec<_>>().join(", "))),
                 0,
                 format!(
                     "r[{}..{}]==r[{}..{}]",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -8,6 +8,7 @@ use crate::{
     schema::{Affinity, BTreeTable, Column, Index},
     storage::{pager::CreateBTreeFlags, wal::CheckpointMode},
     translate::{collate::CollationSeq, emitter::TransactionMode},
+    types::KeyInfo,
     Value,
 };
 use strum::EnumCount;
@@ -217,7 +218,7 @@ pub enum Insn {
         start_reg_a: usize,
         start_reg_b: usize,
         count: usize,
-        collation: Option<CollationSeq>,
+        key_info: Vec<KeyInfo>,
     },
     /// Place the result of rhs bitwise AND lhs in third register.
     BitAnd {

--- a/testing/collate.test
+++ b/testing/collate.test
@@ -102,3 +102,211 @@ do_execsql_test_on_specific_db {:memory:} collate_groupped_aggregation_explicit_
     select max(name collate nocase) from fruits group by category;
 } {banana
 CHERRY}
+
+do_execsql_test_on_specific_db {:memory:} collate_join_nocase {
+    CREATE TABLE a(s TEXT);
+    CREATE TABLE b(s TEXT);
+    INSERT INTO a VALUES ('A');
+    INSERT INTO b VALUES ('a');
+
+    SELECT a.s, b.s FROM a JOIN b ON a.s COLLATE NOCASE = b.s;
+} {A|a}
+
+do_execsql_test_on_specific_db {:memory:} collate_columns_where_implicit {
+    CREATE TABLE t(
+        a TEXT COLLATE NOCASE,
+        b TEXT COLLATE BINARY,
+        c TEXT COLLATE RTRIM
+    );
+    INSERT INTO t(a,b,c) VALUES
+        ('hat','hat','hat '),
+        ('hAt','hAt','hat'),
+        ('HAT','HAT','hat    '),
+        ('other','other','other');
+
+    SELECT count(*) FROM t WHERE a = 'hAt';
+    SELECT count(*) FROM t WHERE b = 'hAt';
+    SELECT count(*) FROM t WHERE c = 'hat';
+} {3
+1
+3}
+
+do_execsql_test_on_specific_db {:memory:} collate_columns_where_explicit_override {
+    CREATE TABLE t(
+        a TEXT COLLATE NOCASE,
+        b TEXT COLLATE BINARY,
+        c TEXT COLLATE RTRIM
+    );
+    INSERT INTO t(a,b,c) VALUES
+        ('hat','hat','hat '),
+        ('hAt','hAt','hat'),
+        ('HAT','HAT','hat    '),
+        ('other','other','other');
+
+    SELECT count(*) FROM t WHERE a COLLATE BINARY = 'hAt';   -- override to binary
+    SELECT count(*) FROM t WHERE b COLLATE NOCASE = 'hAt';   -- override to nocase
+    SELECT count(*) FROM t WHERE c COLLATE BINARY = 'hat';   -- override to binary
+} {1
+3
+1}
+
+do_execsql_test_on_specific_db {:memory:} collate_order_by_binary {
+    CREATE TABLE words(w TEXT COLLATE BINARY);
+    INSERT INTO words(w) VALUES ('Apple'), ('banana'), ('CHERRY');
+    SELECT w FROM words ORDER BY w;
+} {Apple
+CHERRY
+banana}
+
+do_execsql_test_on_specific_db {:memory:} collate_order_by_nocase {
+    CREATE TABLE words(w TEXT COLLATE NOCASE);
+    INSERT INTO words(w) VALUES ('Apple'), ('banana'), ('CHERRY');
+    SELECT w FROM words ORDER BY w;
+} {Apple
+banana
+CHERRY}
+
+do_execsql_test_on_specific_db {:memory:} collate_order_by_explicit_override {
+    CREATE TABLE words(w TEXT COLLATE NOCASE);
+    INSERT INTO words(w) VALUES ('Apple'), ('banana'), ('CHERRY');
+    SELECT w FROM words ORDER BY w COLLATE BINARY;
+} {Apple
+CHERRY
+banana}
+
+do_execsql_test_on_specific_db {:memory:} collate_distinct_rtrim {
+    CREATE TABLE t(c TEXT COLLATE RTRIM);
+    INSERT INTO t(c) VALUES ('x'), ('x '), ('x  '), ('y'), ('y  ');
+    SELECT count(DISTINCT c) FROM t;
+} {2}
+
+do_execsql_test_in_memory_any_error collate_unique_nocase_conflict {
+    CREATE TABLE u(a TEXT COLLATE NOCASE UNIQUE);
+    INSERT INTO u VALUES ('aa');
+    INSERT INTO u VALUES ('AA');
+}
+
+do_execsql_test_in_memory_any_error collate_unique_rtrim_conflict {
+    CREATE TABLE r(a TEXT COLLATE RTRIM UNIQUE);
+    INSERT INTO r VALUES ('bb');
+    INSERT INTO r VALUES ('bb ');
+}
+
+do_execsql_test_on_specific_db {:memory:} collate_unique_binary_allows_case {
+    CREATE TABLE ub(a TEXT COLLATE BINARY UNIQUE);
+    INSERT INTO ub VALUES ('aa');
+    INSERT INTO ub VALUES ('AA');
+    SELECT count(*) FROM ub;
+} {2}
+
+do_execsql_test_in_memory_any_error collate_pk_rtrim_conflict {
+    CREATE TABLE p(a TEXT COLLATE RTRIM PRIMARY KEY);
+    INSERT INTO p VALUES ('key');
+    INSERT INTO p VALUES ('key   ');
+}
+
+do_execsql_test_on_specific_db {:memory:} collate_join_implicit_nocase_columns {
+    CREATE TABLE a(s TEXT COLLATE NOCASE);
+    CREATE TABLE b(s TEXT COLLATE NOCASE);
+    INSERT INTO a VALUES ('A');
+    INSERT INTO b VALUES ('a');
+    SELECT a.s, b.s FROM a JOIN b ON a.s = b.s;
+} {A|a}
+
+do_execsql_test_on_specific_db {:memory:} collate_join_mixed_implicit_binary_left {
+    CREATE TABLE a(s TEXT COLLATE BINARY);
+    CREATE TABLE b(s TEXT COLLATE NOCASE);
+    INSERT INTO a VALUES ('A');
+    INSERT INTO b VALUES ('a');
+    SELECT a.s, b.s FROM a JOIN b ON a.s = b.s;
+} {}
+
+do_execsql_test_on_specific_db {:memory:} collate_join_mixed_explicit_nocase_left {
+    CREATE TABLE a(s TEXT COLLATE BINARY);
+    CREATE TABLE b(s TEXT COLLATE NOCASE);
+    INSERT INTO a VALUES ('A');
+    INSERT INTO b VALUES ('a');
+    SELECT a.s, b.s FROM a JOIN b ON a.s COLLATE NOCASE = b.s;
+} {A|a}
+
+do_execsql_test_on_specific_db {:memory:} collate_where_with_and_without_explicit {
+    CREATE TABLE t(a TEXT COLLATE NOCASE, b TEXT COLLATE BINARY, c TEXT COLLATE RTRIM);
+    INSERT INTO t VALUES ('Foo','Foo','Foo '), ('fOo','fOo','Foo'), ('other','other','other');
+    -- implicit uses column collation
+    SELECT count(*) FROM t WHERE a = 'foo';
+    -- explicit override on binary column
+    SELECT count(*) FROM t WHERE b COLLATE NOCASE = 'foo';
+    -- implicit RTRIM on c
+    SELECT count(*) FROM t WHERE c = 'Foo';
+    -- explicit override to BINARY on RTRIM column
+    SELECT count(*) FROM t WHERE c COLLATE BINARY = 'Foo';
+} {2
+2
+2
+1}
+
+do_execsql_test_on_specific_db {:memory:} collate_group_by_implicit_nocase {
+    CREATE TABLE t(s TEXT COLLATE NOCASE);
+    INSERT INTO t VALUES ('A'), ('a'), ('B'), ('b');
+    SELECT s, count(*) FROM t GROUP BY s ORDER BY s;
+} {A|2
+B|2}
+
+do_execsql_test_on_specific_db {:memory:} collate_group_by_implicit_rtrim {
+    CREATE TABLE t(s TEXT COLLATE RTRIM);
+    INSERT INTO t VALUES ('A'), ('A '), ('B'), ('B  ');
+    SELECT s, count(*) FROM t GROUP BY s ORDER BY s;
+} {A|2
+B|2}
+
+do_execsql_test_on_specific_db {:memory:} collate_group_by_explicit_override {
+    CREATE TABLE t(s TEXT COLLATE BINARY);
+    INSERT INTO t VALUES ('A'), ('a'), ('B'), ('b');
+    SELECT s, count(*) FROM t GROUP BY s COLLATE NOCASE ORDER BY s;
+} {A|2
+B|2}
+
+do_execsql_test_on_specific_db {:memory:} collate_group_by_mixed_columns {
+    CREATE TABLE t(a TEXT COLLATE NOCASE, b TEXT COLLATE RTRIM);
+    INSERT INTO t VALUES ('A', 'x'), ('a', 'x '), ('B', 'y'), ('b', 'y  ');
+    SELECT a, b, count(*) FROM t GROUP BY a, b ORDER BY a, b;
+} {A|x|2
+B|y|2}
+
+
+do_execsql_test_on_specific_db {:memory:} collate_subquery_preserves_column_collation {
+    CREATE TABLE t(a TEXT COLLATE NOCASE, b TEXT COLLATE BINARY);
+    INSERT INTO t VALUES ('A', 'A'), ('a', 'a'), ('B', 'B'), ('b', 'b');
+    
+    -- Subquery preserves NOCASE collation
+    SELECT count(*) FROM (SELECT a FROM t) WHERE a = 'a';
+    -- Subquery preserves BINARY collation 
+    SELECT count(*) FROM (SELECT b FROM t) WHERE b = 'a';
+} {2
+1}
+
+do_execsql_test_on_specific_db {:memory:} collate_subquery_preserves_explicit_collation {
+    CREATE TABLE t(a TEXT COLLATE BINARY, b TEXT COLLATE BINARY);
+    INSERT INTO t VALUES ('A', 'A'), ('a', 'a'), ('B', 'B'), ('b', 'b');
+    
+    -- Explicit NOCASE in subquery is preserved
+    SELECT count(*) FROM (SELECT a COLLATE NOCASE as a FROM t) WHERE a = 'a';
+    -- Explicit BINARY in subquery is preserved
+    SELECT count(*) FROM (SELECT b COLLATE BINARY as b FROM t) WHERE b = 'a';
+} {2
+1}
+
+do_execsql_test_on_specific_db {:memory:} collate_subquery_preserves_collation_in_order_by {
+    CREATE TABLE t(a TEXT COLLATE NOCASE, b TEXT COLLATE BINARY);
+    INSERT INTO t VALUES ('A', 'A'), ('b', 'b'), ('C', 'C');
+    
+    -- ORDER BY in subquery preserves NOCASE collation
+    SELECT a FROM (SELECT a FROM t ORDER BY a);
+    -- ORDER BY in subquery preserves BINARY collation
+    SELECT b FROM (SELECT b FROM t ORDER BY b);
+} {A
+b
+C
+A
+C
+b}

--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -496,6 +496,159 @@ mod tests {
     }
 
     #[test]
+    pub fn collation_fuzz() {
+        let _ = env_logger::try_init();
+        let (mut rng, seed) = if std::env::var("SEED").is_ok() {
+            let seed = std::env::var("SEED").unwrap().parse::<u64>().unwrap();
+            (ChaCha8Rng::seed_from_u64(seed), seed)
+        } else {
+            rng_from_time()
+        };
+        println!("collation_fuzz seed: {seed}");
+
+        // Build six table variants that assign BINARY/NOCASE/RTRIM across (a,b,c)
+        // and include UNIQUE constraints so that auto-created indexes must honor column collations.
+        let variants: [(&str, &str, &str); 6] = [
+            ("BINARY", "NOCASE", "RTRIM"),
+            ("BINARY", "RTRIM", "NOCASE"),
+            ("NOCASE", "BINARY", "RTRIM"),
+            ("NOCASE", "RTRIM", "BINARY"),
+            ("RTRIM", "BINARY", "NOCASE"),
+            ("RTRIM", "NOCASE", "BINARY"),
+        ];
+
+        let table_defs: Vec<String> = variants
+            .iter()
+            .flat_map(|(ca, cb, cc)| {
+                // Create unique indexes so that index seek/scan behavior with unique constraints is exercised too.
+                vec![
+                    // No unique constraints
+                    format!(
+                        "CREATE TABLE t (a TEXT COLLATE {ca}, b TEXT COLLATE {cb}, c TEXT COLLATE {cc})"
+                    ),
+                    // Single column unique constraints
+                    format!(
+                        "CREATE TABLE t (a TEXT COLLATE {ca}, b TEXT COLLATE {cb}, c TEXT COLLATE {cc}, UNIQUE(a))"
+                    ),
+                    format!(
+                        "CREATE TABLE t (a TEXT COLLATE {ca}, b TEXT COLLATE {cb}, c TEXT COLLATE {cc}, UNIQUE(b))"
+                    ),
+                    format!(
+                        "CREATE TABLE t (a TEXT COLLATE {ca}, b TEXT COLLATE {cb}, c TEXT COLLATE {cc}, UNIQUE(c))"
+                    ),
+                    // Two column unique constraints
+                    format!(
+                        "CREATE TABLE t (a TEXT COLLATE {ca}, b TEXT COLLATE {cb}, c TEXT COLLATE {cc}, UNIQUE(a,b))"
+                    ),
+                    format!(
+                        "CREATE TABLE t (a TEXT COLLATE {ca}, b TEXT COLLATE {cb}, c TEXT COLLATE {cc}, UNIQUE(a,c))"
+                    ),
+                    format!(
+                        "CREATE TABLE t (a TEXT COLLATE {ca}, b TEXT COLLATE {cb}, c TEXT COLLATE {cc}, UNIQUE(b,c))"
+                    ),
+                    // Three column unique constraint
+                    format!(
+                        "CREATE TABLE t (a TEXT COLLATE {ca}, b TEXT COLLATE {cb}, c TEXT COLLATE {cc}, UNIQUE(a,b,c))"
+                    ),
+                ]
+            })
+            .collect();
+
+        // Create databases for each variant using rusqlite, then open limbo on the same file.
+        let dbs: Vec<TempDatabase> = table_defs
+            .iter()
+            .map(|ddl| TempDatabase::new_with_rusqlite(ddl, true))
+            .collect();
+
+        // Seed data focuses on case and trailing spaces to exercise NOCASE and RTRIM semantics.
+        const STR_POOL: [&str; 36] = [
+            "", " ", "  ", "a", "A", "a ", "A  ", "aa", "Aa", "AA", "aa ", "AA   ", "abc", "ABC",
+            "abc ", "ABC   ", "b", "B", "b ", "B  ", "ba", "BA", "ba ", "BA  ", "c", "C", "c  ",
+            " C", "c C", "C c", "foo", "Foo", "FOO", "bar", "Bar", "BAR",
+        ];
+
+        // Insert rows into the SQLite side (shared file) and ignore uniqueness errors to keep seeding going.
+        let row_target = 800usize;
+        for db in dbs.iter() {
+            let sqlite_conn = rusqlite::Connection::open(db.path.clone()).unwrap();
+            for _ in 0..row_target {
+                let a = STR_POOL[rng.random_range(0..STR_POOL.len())];
+                let b = STR_POOL[rng.random_range(0..STR_POOL.len())];
+                let c = STR_POOL[rng.random_range(0..STR_POOL.len())];
+                let insert = format!(
+                    "INSERT INTO t(a,b,c) VALUES ('{}','{}','{}')",
+                    a.replace("'", "''"),
+                    b.replace("'", "''"),
+                    c.replace("'", "''"),
+                );
+                let _ = sqlite_conn.execute(&insert, params![]);
+            }
+            sqlite_conn.close().unwrap();
+        }
+
+        // Open connections for query phase
+        let sqlite_conns: Vec<rusqlite::Connection> = dbs
+            .iter()
+            .map(|db| rusqlite::Connection::open(db.path.clone()).unwrap())
+            .collect();
+        let limbo_conns: Vec<_> = dbs.iter().map(|db| db.connect_limbo()).collect();
+
+        // Fuzz WHERE clauses with and without explicit COLLATE on a/b/c
+        let columns = ["a", "b", "c"];
+        let collates = [None, Some("BINARY"), Some("NOCASE"), Some("RTRIM")];
+        let (mut rng, seed) = if std::env::var("SEED").is_ok() {
+            let seed = std::env::var("SEED").unwrap().parse::<u64>().unwrap();
+            (ChaCha8Rng::seed_from_u64(seed), seed)
+        } else {
+            rng_from_time()
+        };
+        println!("collation_fuzz seed: {seed}");
+
+        const ITERS: usize = 3000;
+        for iter in 0..ITERS {
+            if iter % (ITERS / 100).max(1) == 0 {
+                println!("collation_fuzz: iteration {}/{}", iter + 1, ITERS);
+            }
+
+            // Choose predicate spec
+            let col = columns[rng.random_range(0..columns.len())];
+            let coll = collates[rng.random_range(0..collates.len())];
+            let val = STR_POOL[rng.random_range(0..STR_POOL.len())];
+            let collate_clause = coll.map(|c| format!(" COLLATE {c}")).unwrap_or_default();
+            let where_clause =
+                format!("WHERE {col}{collate_clause} = '{}'", val.replace("'", "''"));
+
+            let mut cols_clone = columns.to_vec();
+            cols_clone.shuffle(&mut rng);
+            let order_by = {
+                let mut order_by = String::new();
+                for col in cols_clone.iter() {
+                    let collate = collates
+                        .choose(&mut rng)
+                        .unwrap()
+                        .map(|c| format!(" COLLATE {c}"))
+                        .unwrap_or_default();
+                    let sort_order = if rng.random_bool(0.5) { "ASC" } else { "DESC" };
+                    order_by.push_str(&format!("{col}{collate} {sort_order}, "));
+                }
+                order_by.push_str("rowid ASC"); // sqlite and turso might return within-group rows in different orders which is semantically ok, so let's add rowid as a tiebreaker
+                order_by
+            };
+
+            let query = format!("SELECT a, b, c FROM t {where_clause} ORDER BY {order_by}");
+            for i in 0..sqlite_conns.len() {
+                let sqlite_rows = sqlite_exec_rows(&sqlite_conns[i], &query);
+                let limbo_rows = limbo_exec_rows(&dbs[i], &limbo_conns[i], &query);
+                assert_eq!(
+                    sqlite_rows, limbo_rows,
+                    "Different results! limbo: {:?}, sqlite: {:?}, seed: {}, query: {}, table def: {}",
+                    limbo_rows, sqlite_rows, seed, query, table_defs[i]
+                );
+            }
+        }
+    }
+
+    #[test]
     /// Create a table with a random number of columns and indexes, and then randomly update or delete rows from the table.
     /// Verify that the results are the same for SQLite and Turso.
     pub fn table_index_mutation_fuzz() {


### PR DESCRIPTION
Fixes the following problems with COLLATE:

- Fix: incorrectly used e.g. `x COLLATE NOCASE = 'fOo'` as index constraint on an index whose column was not case-insensitively collated
- Fix: various ephemeral indexes (in GROUP BY, ORDER BY, DISTINCT) and subqueries did not retain proper collation information of columns
- Fix: collation of a given expression was not determined properly according to SQLite's rules

Adds TCL tests and fuzz test

Closes #3476
Closes #1524 
Closes #3305