### PR TITLE
core/mvcc: Return completions from logical log methods

### DIFF
--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -4,8 +4,7 @@ use std::sync::{Arc, RwLock};
 pub mod logical_log;
 use crate::mvcc::database::LogRecord;
 use crate::mvcc::persistent_storage::logical_log::LogicalLog;
-use crate::types::IOResult;
-use crate::{File, Result};
+use crate::{Completion, File, Result};
 
 pub struct Storage {
     pub logical_log: RwLock<LogicalLog>,
@@ -20,7 +19,7 @@ impl Storage {
 }
 
 impl Storage {
-    pub fn log_tx(&self, m: &LogRecord) -> Result<IOResult<()>> {
+    pub fn log_tx(&self, m: &LogRecord) -> Result<Completion> {
         self.logical_log.write().unwrap().log_tx(m)
     }
 
@@ -28,11 +27,11 @@ impl Storage {
         todo!()
     }
 
-    pub fn sync(&self) -> Result<IOResult<()>> {
+    pub fn sync(&self) -> Result<Completion> {
         self.logical_log.write().unwrap().sync()
     }
 
-    pub fn truncate(&self) -> Result<IOResult<()>> {
+    pub fn truncate(&self) -> Result<Completion> {
         self.logical_log.write().unwrap().truncate()
     }
 


### PR DESCRIPTION
`IOResult` implies we have a state machine that needs to be polled to `Completion`, which is not the case here. We are just emitting the IO operation in this case. This led us to never reaching the `IOResult::Done` branch that actually fsynced the logical log in `Checkpoint`.

I also sprinkled some
```rust
if c.is_completed() {
   Ok(TransitionResult::Continue)
} else {
   Ok(TransitionResult::Io(IOCompletions::Single(c)))
}
```
just to be more efficient with sync IO, but it is not strictly necessary here. 