### PR TITLE
core: update aegis

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -80,7 +80,7 @@ bytemuck = "1.23.1"
 aes-gcm = { version = "0.10.3"}
 aes = { version = "0.8.4"}
 turso_parser = { workspace = true }
-aegis = "0.9.0"
+aegis = "0.9.3"
 twox-hash = "2.1.1"
 intrusive-collections = "0.9.7"
 


### PR DESCRIPTION
It seems that the build on macos arm is failing with `aegis` v0.9.0.
So, here I update `aegis`.