### PR TITLE
core/io/unix: Fix short writes in try_pwritev_raw()

### DIFF
--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -50,8 +50,9 @@ fn try_pwritev_raw(
     let mut iov_count = 0;
     for (i, b) in bufs.iter().enumerate().skip(start_idx).take(iov_len) {
         let s = b.as_slice();
-        let ptr = if i == start_idx { &s[start_off..] } else { s }.as_ptr();
-        let len = b.len();
+        let slice = if i == start_idx { &s[start_off..] } else { s };
+        let ptr = slice.as_ptr();
+        let len = slice.len();
 
         if let Some((last_ptr, last_len)) = last_end {
             // Check if this buffer is adjacent to the last


### PR DESCRIPTION
Fixes incorrect buffer length calculation in try_pwritev_raw when handling the first slice of the I/O vector.
Why:
With the faulty libc tests, a short write was simulated and the code incorrectly computed the length for the first buffer, leading to more bytes being written than expected, leading to a panic inside the completion.
How:
Adjusted the slice calculation to ensure only the intended range of bytes is written.

Backport: 0.2