### PR TITLE
remove unnecessary SchemaLocked error

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -49,8 +49,6 @@ pub enum LimboError {
     ExtensionError(String),
     #[error("Runtime error: integer overflow")]
     IntegerOverflow,
-    #[error("Schema is locked for write")]
-    SchemaLocked,
     #[error("Runtime error: database table is locked")]
     TableLocked,
     #[error("Error: Resource is read-only")]

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -654,7 +654,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 let schema_did_change = self.did_commit_schema_change;
                 if schema_did_change {
                     let schema = connection.schema.read().clone();
-                    connection.db.update_schema_if_newer(schema)?;
+                    connection.db.update_schema_if_newer(schema);
                 }
                 let tx = mvcc_store.txs.get(&self.tx_id).unwrap();
                 let tx_unlocked = tx.value();
@@ -1606,7 +1606,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             > connection.db.schema.lock().unwrap().schema_version
         {
             // Connection made schema changes during tx and rolled back -> revert connection-local schema.
-            *connection.schema.write() = connection.db.clone_schema()?;
+            *connection.schema.write() = connection.db.clone_schema();
         }
 
         let tx = tx_unlocked.value();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1198,7 +1198,7 @@ impl Pager {
 
         if schema_did_change {
             let schema = connection.schema.read().clone();
-            connection.db.update_schema_if_newer(schema)?;
+            connection.db.update_schema_if_newer(schema);
         }
         Ok(IOResult::Done(commit_status))
     }
@@ -2411,7 +2411,7 @@ impl Pager {
         }
         self.reset_internal_states();
         if schema_did_change {
-            *connection.schema.write() = connection.db.clone_schema()?;
+            *connection.schema.write() = connection.db.clone_schema();
         }
         if is_write {
             if let Some(wal) = self.wal.as_ref() {


### PR DESCRIPTION
- lock() return error in case when another thread panicked while holding the same lock
- we better to just panic too in any such case