### PR TITLE
perf/throughput: Delete database before benchmark run

### DIFF
--- a/perf/throughput/rusqlite/scripts/bench.sh
+++ b/perf/throughput/rusqlite/scripts/bench.sh
@@ -6,6 +6,7 @@ echo "system,threads,batch_size,compute,throughput"
 
 for threads in 1 2 4 8; do
   for compute in 0 100 500 1000; do
+      rm -f write_throughput_test.db*
       ../../../target/release/write-throughput-sqlite --threads ${threads} --batch-size 100 --compute ${compute} -i 1000
   done
 done

--- a/perf/throughput/turso/scripts/bench.sh
+++ b/perf/throughput/turso/scripts/bench.sh
@@ -6,6 +6,7 @@ echo "system,threads,batch_size,compute,throughput"
 
 for threads in 1 2 4 8; do
   for compute in 0 100 500 1000; do
+      rm -f write_throughput_test.db*
       ../../../target/release/write-throughput --threads ${threads} --batch-size 100 --compute ${compute} -i 1000 --mode concurrent
   done
 done


### PR DESCRIPTION
Let's reduce variance between benchmark runs by starting with an empty database.