### PR TITLE
Integrity check enhancements

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5811,6 +5811,8 @@ pub enum IntegrityCheckError {
         actual_count: usize,
         expected_count: usize,
     },
+    #[error("Page {page_id}: never used")]
+    PageNeverUsed { page_id: i64 },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -5836,16 +5838,18 @@ struct IntegrityCheckPageEntry {
 }
 pub struct IntegrityCheckState {
     page_stack: Vec<IntegrityCheckPageEntry>,
+    pub db_size: usize,
     first_leaf_level: Option<usize>,
-    page_reference: HashMap<i64, i64>,
+    pub page_reference: HashMap<i64, i64>,
     page: Option<PageRef>,
     pub freelist_count: CheckFreelist,
 }
 
 impl IntegrityCheckState {
-    pub fn new() -> Self {
+    pub fn new(db_size: usize) -> Self {
         Self {
             page_stack: Vec::new(),
+            db_size,
             page_reference: HashMap::new(),
             first_leaf_level: None,
             page: None,

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -16,6 +16,11 @@ pub fn translate_integrity_check(
     for table in schema.tables.values() {
         if let crate::schema::Table::BTree(table) = table.as_ref() {
             root_pages.push(table.root_page);
+            if let Some(indexes) = schema.indexes.get(table.name.as_str()) {
+                for index in indexes.iter() {
+                    root_pages.push(index.root_page);
+                }
+            }
         };
     }
     let message_register = program.alloc_register();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7817,12 +7817,13 @@ pub fn op_integrity_check(
     );
     match &mut state.op_integrity_check_state {
         OpIntegrityCheckState::Start => {
-            let freelist_trunk_page =
-                return_if_io!(with_header(pager, mv_store, program, |header| header
-                    .freelist_trunk_page
-                    .get()));
+            let (freelist_trunk_page, db_size) =
+                return_if_io!(with_header(pager, mv_store, program, |header| (
+                    header.freelist_trunk_page.get(),
+                    header.database_size.get()
+                )));
             let mut errors = Vec::new();
-            let mut integrity_check_state = IntegrityCheckState::new();
+            let mut integrity_check_state = IntegrityCheckState::new(db_size as usize);
             let mut current_root_idx = 0;
             // check freelist pages first, if there are any for database
             if freelist_trunk_page > 0 {
@@ -7864,6 +7865,16 @@ pub fn op_integrity_check(
                         actual_count: integrity_check_state.freelist_count.actual_count,
                         expected_count: integrity_check_state.freelist_count.expected_count,
                     });
+                }
+                for page_number in 2..=integrity_check_state.db_size {
+                    if !integrity_check_state
+                        .page_reference
+                        .contains_key(&(page_number as i64))
+                    {
+                        errors.push(IntegrityCheckError::PageNeverUsed {
+                            page_id: page_number as i64,
+                        });
+                    }
                 }
                 let message = if errors.is_empty() {
                     "ok".to_string()


### PR DESCRIPTION
- add index root pages to list of root pages to check
- check for dangling (unused) pages

```sql
$ cargo run wut.db 
turso> .mode list
turso> pragma integrity_check;
Page 3: never used
Page 4: never used
Page 7: never used
Page 8: never used
```

```sql
$ sqlite3 wut.db 'pragma integrity_check;'
*** in database main ***
Page 3: never used
Page 4: never used
Page 7: never used
Page 8: never used
```