### PR TITLE
Add Nightly versions of benchmarks that run on Nyrkiö runners

### DIFF
--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   bench:
-    runs-on: nyrkio_perf_server_2cpu_ubuntu2404
+    runs-on: nyrkio_perf_server_4cpu_ubuntu2404
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
           nyrkio-settings-threshold: 0%
 
   clickbench:
-    runs-on: nyrkio_perf_server_2cpu_ubuntu2404
+    runs-on: nyrkio_perf_server_4cpu_ubuntu2404
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -109,7 +109,7 @@ jobs:
           nyrkio-public: true
 
   tpc-h-criterion:
-    runs-on: nyrkio_perf_server_2cpu_ubuntu2404
+    runs-on: nyrkio_perf_server_4cpu_ubuntu2404
     timeout-minutes: 60
     env:
       DB_FILE: "perf/tpc-h/TPC-H.db"


### PR DESCRIPTION
Nyrkiö is piloting a GitHub Runner service, and congratulations, you are the pilot customer! In order to reduce the risk somewhat, we'll introduce this as a parallel workflow, so the existing benchmarks will continue to run on the regular runners and they won't have any discontinuity in their results because of this. Also since these runners are actually a bit more expensive, we can manage the cost by only running them periodically. Similarly, this allows us to fine tune the Nyrkiö instance size, for example to have an EBS disk that is the optimal size and IOPS configuration, so you don't pay for empty space.


I will show up in discord to discuss.

And congratulations on the beta release by the way! I worked hard to get this done for your beta period, let's hope it works now.




