### PR TITLE
fix for join with the USING keyword

### DIFF
--- a/core/incremental/expr_compiler.rs
+++ b/core/incremental/expr_compiler.rs
@@ -112,7 +112,15 @@ impl TrivialExpression {
     /// Automatically promotes integers to floats when mixing types in arithmetic
     pub fn evaluate(&self, values: &[Value]) -> Value {
         match self {
-            TrivialExpression::Column(idx) => values.get(*idx).cloned().unwrap_or(Value::Null),
+            TrivialExpression::Column(idx) => {
+                assert!(
+                    *idx < values.len(),
+                    "Column index {} is out of bounds for input with {} values",
+                    idx,
+                    values.len()
+                );
+                values[*idx].clone()
+            }
             TrivialExpression::Immediate(val) => val.clone(),
             TrivialExpression::Binary { left, op, right } => {
                 let left_val = left.evaluate(values);

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -2727,6 +2727,7 @@ mod tests {
                 AggregateFunction::Max(1), // name is at index 1
             ],
             vec!["id".to_string(), "name".to_string()],
+            vec![], // No USING columns
         );
 
         // Initial data with text values
@@ -2935,6 +2936,7 @@ mod tests {
             vec![0],
             vec!["customer_id".to_string(), "amount".to_string()],
             vec!["id".to_string(), "name".to_string()],
+            vec![], // No USING columns
         )
         .unwrap();
 
@@ -3033,6 +3035,7 @@ mod tests {
             vec![0],
             vec!["customer_id".to_string(), "amount".to_string()],
             vec!["id".to_string(), "name".to_string()],
+            vec![], // No USING columns
         )
         .unwrap();
 
@@ -3128,6 +3131,7 @@ mod tests {
                 "amount".to_string(),
             ],
             vec!["id".to_string(), "name".to_string()],
+            vec![], // No USING columns
         )
         .unwrap();
 
@@ -3265,6 +3269,7 @@ mod tests {
                 "price".to_string(),
             ],
             vec!["id".to_string(), "category_name".to_string()],
+            vec![], // No USING columns
         )
         .unwrap();
 
@@ -3382,6 +3387,7 @@ mod tests {
                 "amount".to_string(),
             ],
             vec!["id".to_string(), "name".to_string()],
+            vec![], // No USING columns
         )
         .unwrap();
 
@@ -3501,6 +3507,7 @@ mod tests {
             vec![0],
             vec!["key".to_string(), "val_left".to_string()],
             vec!["key".to_string(), "val_right".to_string()],
+            vec![], // No USING columns
         )
         .unwrap();
 
@@ -3568,10 +3575,12 @@ mod tests {
             vec![0], // Join on first column (id)
             vec![0], // Join on first column (user_id)
             vec!["id".to_string(), "name".to_string()],
+            vec![], // No USING columns
             vec![
                 "user_id".to_string(),
                 "product_id".to_string(),
                 "quantity".to_string(),
+                vec![], // No USING columns
             ],
         )
         .unwrap();

--- a/testing/materialized_views.test
+++ b/testing/materialized_views.test
@@ -896,6 +896,56 @@ Orwell|1984|1949
 Asimov|Foundation|1951
 Herbert|Dune|1965}
 
+# Test: JOIN USING column deduplication
+do_execsql_test_on_specific_db {:memory:} matview-join-using-deduplication {
+    CREATE TABLE t(a INTEGER);
+    CREATE TABLE u(a INTEGER);
+    CREATE TABLE v(a INTEGER);
+    INSERT INTO t VALUES (1), (2), (3), (4), (5);
+    INSERT INTO u VALUES (1), (2), (3), (4), (5);
+    INSERT INTO v VALUES (1), (2), (3), (4), (5);
+
+    -- Test JOIN USING with materialized view
+    -- Should only have one 'a' column, not three
+    CREATE MATERIALIZED VIEW tuv AS
+        SELECT * FROM t JOIN u USING (a) JOIN v USING (a);
+
+    -- Verify column count and data
+    SELECT * FROM tuv ORDER BY a;
+} {1
+2
+3
+4
+5}
+
+do_execsql_test_on_specific_db {:memory:} matview-join-using-column-info {
+    CREATE TABLE t1(a INTEGER, b INTEGER);
+    CREATE TABLE t2(a INTEGER, c INTEGER);
+    INSERT INTO t1 VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO t2 VALUES (1, 100), (2, 200), (3, 300);
+
+    CREATE MATERIALIZED VIEW t1t2 AS
+        SELECT * FROM t1 JOIN t2 USING (a);
+
+    SELECT * FROM t1t2 ORDER BY a;
+} {1|10|100
+2|20|200
+3|30|300}
+
+do_execsql_test_on_specific_db {:memory:} matview-three-table-join-using {
+    CREATE TABLE t(a INTEGER, b INTEGER);
+    CREATE TABLE u(a INTEGER, c INTEGER);
+    CREATE TABLE v(a INTEGER, d INTEGER);
+    INSERT INTO t VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO u VALUES (1, 100), (2, 200), (3, 300);
+    INSERT INTO v VALUES (1, 1000), (2, 2000), (3, 3000);
+
+    CREATE MATERIALIZED VIEW tuv AS SELECT * FROM t JOIN u USING (a) JOIN v USING (a);
+    SELECT * FROM tuv ORDER BY a;
+} {1|10|100|1000
+2|20|200|2000
+3|30|300|3000}
+
 # Test 6: Modifying only one table in transaction
 do_execsql_test_on_specific_db {:memory:} matview-join-single-table-modified {
     CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT, active INTEGER);


### PR DESCRIPTION
USING is a convenient way to express an equijoin. Instead of writing a.id = b.id, you can just JOIN USING (a), and the database will find a table with that name in both tables.

It is not hard to support this with our operator, since it is ultimately an equijoin, but we have to do the work to deduplicate the columns when producing the final schema.

Fixes #3362