### PR TITLE
Add support for sqlite_version() star syntax

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -642,6 +642,28 @@ impl Func {
             Self::AlterTable(_) => true,
         }
     }
+
+    pub fn supports_star_syntax(&self) -> bool {
+        match self {
+            Self::Scalar(scalar_func) => {
+                matches!(
+                    scalar_func,
+                    ScalarFunc::Changes
+                        | ScalarFunc::Random
+                        | ScalarFunc::TotalChanges
+                        | ScalarFunc::SqliteVersion
+                        | ScalarFunc::SqliteSourceId
+                        | ScalarFunc::LastInsertRowid
+                )
+            }
+            Self::Math(math_func) => {
+                matches!(math_func.arity(), MathFuncArity::Nullary)
+            }
+            // Aggregate functions with (*) syntax are handled separately in the planner
+            Self::Agg(_) => false,
+            _ => false,
+        }
+    }
     pub fn resolve_function(name: &str, arg_count: usize) -> Result<Self, LimboError> {
         let normalized_name = crate::util::normalize_ident(name);
         match normalized_name.as_str() {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -180,7 +180,26 @@ pub fn resolve_window_and_aggregate_functions(
                                 name.as_str()
                             );
                         }
-                        crate::bail_parse_error!("Invalid aggregate function: {}", name.as_str());
+
+                        // Check if the function supports (*) syntax using centralized logic
+                        match crate::function::Func::resolve_function(name.as_str(), 0) {
+                            Ok(func) => {
+                                if func.supports_star_syntax() {
+                                    return Ok(WalkControl::Continue);
+                                } else {
+                                    crate::bail_parse_error!(
+                                        "wrong number of arguments to function {}()",
+                                        name.as_str()
+                                    );
+                                }
+                            }
+                            Err(_) => {
+                                crate::bail_parse_error!(
+                                    "wrong number of arguments to function {}()",
+                                    name.as_str()
+                                );
+                            }
+                        }
                     }
                     Err(e) => match e {
                         crate::LimboError::ParseError(e) => {


### PR DESCRIPTION
SQLite surprisingly supports this:

select sqlite_version(*);

this gets translated at the parser level to sqlite_version(), and it works for all functions that take 0 arguments.

Let's be compatible with SQLite and support the same thing.