### PR TITLE
mvcc: Disable automatic checkpointing by default

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2341,7 +2341,7 @@ impl Connection {
         *self.mv_tx.read()
     }
 
-    pub(crate) fn set_mvcc_checkpoint_threshold(&self, threshold: u64) -> Result<()> {
+    pub(crate) fn set_mvcc_checkpoint_threshold(&self, threshold: i64) -> Result<()> {
         match self.db.mv_store.as_ref() {
             Some(mv_store) => {
                 mv_store.set_checkpoint_threshold(threshold);
@@ -2351,7 +2351,7 @@ impl Connection {
         }
     }
 
-    pub(crate) fn mvcc_checkpoint_threshold(&self) -> Result<u64> {
+    pub(crate) fn mvcc_checkpoint_threshold(&self) -> Result<i64> {
         match self.db.mv_store.as_ref() {
             Some(mv_store) => Ok(mv_store.checkpoint_threshold()),
             None => Err(LimboError::InternalError("MVCC not enabled".into())),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2025,11 +2025,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         Ok(true)
     }
 
-    pub fn set_checkpoint_threshold(&self, threshold: u64) {
+    pub fn set_checkpoint_threshold(&self, threshold: i64) {
         self.storage.set_checkpoint_threshold(threshold)
     }
 
-    pub fn checkpoint_threshold(&self) -> u64 {
+    pub fn checkpoint_threshold(&self) -> i64 {
         self.storage.checkpoint_threshold()
     }
 }

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -44,11 +44,11 @@ impl Storage {
         self.logical_log.read().should_checkpoint()
     }
 
-    pub fn set_checkpoint_threshold(&self, threshold: u64) {
+    pub fn set_checkpoint_threshold(&self, threshold: i64) {
         self.logical_log.write().set_checkpoint_threshold(threshold)
     }
 
-    pub fn checkpoint_threshold(&self) -> u64 {
+    pub fn checkpoint_threshold(&self) -> i64 {
         self.logical_log.read().checkpoint_threshold()
     }
 }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -380,8 +380,10 @@ fn update_pragma(
         }
         PragmaName::MvccCheckpointThreshold => {
             let threshold = match parse_signed_number(&value)? {
-                Value::Integer(size) if size > 0 => size as u64,
-                _ => bail_parse_error!("mvcc_checkpoint_threshold must be a positive integer"),
+                Value::Integer(size) if size >= -1 => size,
+                _ => bail_parse_error!(
+                    "mvcc_checkpoint_threshold must be -1, 0, or a positive integer"
+                ),
             };
 
             connection.set_mvcc_checkpoint_threshold(threshold)?;
@@ -699,7 +701,7 @@ fn query_pragma(
         PragmaName::MvccCheckpointThreshold => {
             let threshold = connection.mvcc_checkpoint_threshold()?;
             let register = program.alloc_register();
-            program.emit_int(threshold as i64, register);
+            program.emit_int(threshold, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
             Ok((program, TransactionMode::None))


### PR DESCRIPTION
MVCC checkpointing currently prevents concurrent writes so disable it by default while we work on it.