### PR TITLE
Fix rusqlite compatibility claim

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -4,7 +4,7 @@ The next evolution of SQLite: A high-performance, SQLite-compatible database lib
 
 ## Features
 
-- **SQLite Compatible**: Drop-in replacement for rusqlite with familiar API
+- **SQLite Compatible**: Similar interface to rusqlite with familiar API apart from being async (using Tokio)
 - **High Performance**: Built with Rust for maximum speed and efficiency  
 - **Async/Await Support**: Native async operations with tokio support
 - **In-Process**: No network overhead, runs directly in your application


### PR DESCRIPTION
Make it clear that the Turso rust binding is not a drop-in replacement for rusqlite. Turso is async and rusqlite isn't