### PR TITLE
add basic barebones rehexkey support

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -308,6 +308,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             CheckpointMode::Truncate {
                 upper_bound_inclusive: None,
             },
+            None,
         )? {
             IOResult::Done(result) => Ok(IOResult::Done(result)),
             IOResult::IO(io) => Ok(IOResult::IO(io)),

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -131,6 +131,9 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["mvcc_checkpoint_threshold"],
         ),
+
+        PragmaName::Rekey => Pragma::new(PragmaFlags::NoColumns1, &[]),
+        PragmaName::ReHexKey => Pragma::new(PragmaFlags::NoColumns1, &[]),
     }
 }
 

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -18,11 +18,35 @@ pub struct IOContext {
 }
 
 impl IOContext {
+    pub fn new_from_encryption_context(ctx: EncryptionContext) -> Self {
+        Self {
+            encryption_or_checksum: EncryptionOrChecksum::Encryption(ctx),
+        }
+    }
+
+    pub fn cipher_mode(&self) -> Option<crate::CipherMode> {
+        match &self.encryption_or_checksum {
+            EncryptionOrChecksum::Encryption(ctx) => Some(ctx.cipher_mode()),
+            _ => None,
+        }
+    }
+
     pub fn encryption_context(&self) -> Option<&EncryptionContext> {
         match &self.encryption_or_checksum {
             EncryptionOrChecksum::Encryption(ctx) => Some(ctx),
             _ => None,
         }
+    }
+
+    pub(crate) fn is_checksum_enabled(&self) -> bool {
+        matches!(
+            &self.encryption_or_checksum,
+            EncryptionOrChecksum::Checksum(_)
+        )
+    }
+
+    pub fn set_checksum(&mut self) {
+        self.encryption_or_checksum = EncryptionOrChecksum::Checksum(ChecksumContext::default());
     }
 
     pub fn get_reserved_space_bytes(&self) -> u8 {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -407,7 +407,7 @@ pub fn op_checkpoint_inner(
                     .connection
                     .pager
                     .write()
-                    .wal_checkpoint_start(*checkpoint_mode);
+                    .wal_checkpoint_start(*checkpoint_mode, None);
                 match step_result {
                     Ok(IOResult::Done(result)) => {
                         state.op_checkpoint_state = OpCheckpointState::FinishCheckpoint {
@@ -1395,6 +1395,22 @@ pub fn op_open_pseudo(
             .unwrap()
             .replace(Cursor::new_pseudo(cursor));
     }
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
+#[cfg(feature = "encryption")]
+pub fn op_rekey(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+    _mv_store: Option<&Arc<MvStore>>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(Rekey { new_key }, insn);
+
+    program.connection.rekey(new_key)?;
+
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -28,6 +28,17 @@ pub fn insn_to_row(
         }
     };
     match insn {
+                #[cfg(feature = "encryption")]
+          Insn::Rekey { new_key: _ } => (
+            "Rekey",
+            0,
+            0,
+            0,
+            Value::build_text(""),
+            0,
+            "database".to_string(),
+        ),
+
             Insn::Init { target_pc } => (
                 "Init",
                 0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1169,6 +1169,10 @@ pub enum Insn {
         p2: Option<usize>, // P2: address of parent explain instruction
         detail: String,    // P4: detail text
     },
+    #[cfg(feature = "encryption")]
+    Rekey {
+        new_key: crate::EncryptionKey,
+    },
 }
 
 const fn get_insn_virtual_table() -> [InsnFunction; InsnVariants::COUNT] {
@@ -1335,6 +1339,8 @@ impl InsnVariants {
             InsnVariants::MemMax => execute::op_mem_max,
             InsnVariants::Sequence => execute::op_sequence,
             InsnVariants::SequenceTest => execute::op_sequence_test,
+            #[cfg(feature = "encryption")]
+            InsnVariants::Rekey => execute::op_rekey,
         }
     }
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1420,6 +1420,13 @@ pub enum PragmaName {
     IntegrityCheck,
     /// `journal_mode` pragma
     JournalMode,
+    #[strum(serialize = "rekey")]
+    #[cfg_attr(feature = "serde", serde(rename = "rekey"))]
+    Rekey,
+
+    #[strum(serialize = "rehexkey")]
+    #[cfg_attr(feature = "serde", serde(rename = "rehexkey"))]
+    ReHexKey,
     /// encryption key for encrypted databases, specified as hexadecimal string.
     #[strum(serialize = "hexkey")]
     #[cfg_attr(feature = "serde", serde(rename = "hexkey"))]


### PR DESCRIPTION
checksum test fails - it does passes when feature flagged - i think i unintentionally made it compile or something, will look at this later

```zsh
turso on  encriiiiiinopt [$] is 📦 v0.2.0 via 🐍 v3.12.3 via 🦀 v1.88.0 took 41s
❯ RUSTFLAGS="-A warnings" cargo run --features encryption -- --experimental-encryption "file:breh.db?cipher=aegis256&hexkey=9908658607c3091c5211933e468204b7ef40c39a3f293d05105a0349524799cf"
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/tursodb --experimental-encryption 'file:breh.db?cipher=aegis256&hexkey=9908658607c3091c5211933e468204b7ef40c39a3f293d05105a0349524799cf'`
Turso v0.2.0
Enter ".help" for usage hints.
Did you know that Turso supports Change Data Capture? Type .manual cdc to learn more.
This software is in BETA, use caution with production data and ensure you have backups.
turso> .tables
tt
turso> select * from tt;
┌───┐
│ n │
├───┤
│ 1 │
└───┘
turso> PRAGMA rehexkey = '9908658607c3091c5211933e468204b7ef40c39a3f293d05105a0349524799cc';
turso> .exit

turso on  encriiiiiinopt [$] is 📦 v0.2.0 via 🐍 v3.12.3 via 🦀 v1.88.0 took 13s
❯ RUSTFLAGS="-A warnings" cargo run --features encryption -- --experimental-encryption "file:breh.db?cipher=aegis256&hexkey=9908658607c3091c5211933e468204b7ef40c39a3f293d05105a0349524799cc"
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/tursodb --experimental-encryption 'file:breh.db?cipher=aegis256&hexkey=9908658607c3091c5211933e468204b7ef40c39a3f293d05105a0349524799cc'`
Turso v0.2.0
Enter ".help" for usage hints.
Did you know that Turso supports Change Data Capture? Type .manual cdc to learn more.
This software is in BETA, use caution with production data and ensure you have backups.
turso> .tables
tt
turso> insert into tt values (1);
turso> select * from tt;
┌───┐
│ n │
├───┤
│ 1 │
├───┤
│ 1 │
└───┘
turso> .exit

turso on  encriiiiiinopt [$] is 📦 v0.2.0 via 🐍 v3.12.3 via 🦀 v1.88.0 took 18s
❯ RUSTFLAGS="-A warnings" cargo run --features encryption -- --experimental-encryption "file:breh.db?cipher=aegis256&hexkey=9908658607c3091c5211933e468204b7ef40c39a3f293d05105a0349524799cf"
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/tursodb --experimental-encryption 'file:breh.db?cipher=aegis256&hexkey=9908658607c3091c5211933e468204b7ef40c39a3f293d05105a0349524799cf'`
2025-10-08T15:00:18.317170Z ERROR ThreadId(01) turso_core::storage::sqlite3_ondisk: 1976: Failed to decrypt WAL frame data for page_idx=1: Internal error: AEGIS-256 decryption failed: invalid tag

thread 'main' panicked at core/storage/pager.rs:71:21:
page should be loaded
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

turso on  encriiiiiinopt [$] is 📦 v0.2.0 via 🐍 v3.12.3 via 🦀 v1.88.0
❯
```