### PR TITLE
Make sqlite_version() compatible with SQLite

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -310,6 +310,7 @@ pub enum ScalarFunc {
     Unicode,
     Quote,
     SqliteVersion,
+    TursoVersion,
     SqliteSourceId,
     UnixEpoch,
     JulianDay,
@@ -373,6 +374,7 @@ impl ScalarFunc {
             ScalarFunc::Unicode => true,
             ScalarFunc::Quote => true,
             ScalarFunc::SqliteVersion => true,
+            ScalarFunc::TursoVersion => true,
             ScalarFunc::SqliteSourceId => true,
             ScalarFunc::UnixEpoch => false,
             ScalarFunc::JulianDay => false,
@@ -437,6 +439,7 @@ impl Display for ScalarFunc {
             Self::Unicode => "unicode".to_string(),
             Self::Quote => "quote".to_string(),
             Self::SqliteVersion => "sqlite_version".to_string(),
+            Self::TursoVersion => "turso_version".to_string(),
             Self::SqliteSourceId => "sqlite_source_id".to_string(),
             Self::JulianDay => "julianday".to_string(),
             Self::UnixEpoch => "unixepoch".to_string(),
@@ -652,6 +655,7 @@ impl Func {
                         | ScalarFunc::Random
                         | ScalarFunc::TotalChanges
                         | ScalarFunc::SqliteVersion
+                        | ScalarFunc::TursoVersion
                         | ScalarFunc::SqliteSourceId
                         | ScalarFunc::LastInsertRowid
                 )
@@ -770,6 +774,7 @@ impl Func {
             "unicode" => Ok(Self::Scalar(ScalarFunc::Unicode)),
             "quote" => Ok(Self::Scalar(ScalarFunc::Quote)),
             "sqlite_version" => Ok(Self::Scalar(ScalarFunc::SqliteVersion)),
+            "turso_version" => Ok(Self::Scalar(ScalarFunc::TursoVersion)),
             "sqlite_source_id" => Ok(Self::Scalar(ScalarFunc::SqliteSourceId)),
             "replace" => Ok(Self::Scalar(ScalarFunc::Replace)),
             "likely" => Ok(Self::Scalar(ScalarFunc::Likely)),

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1499,31 +1499,11 @@ pub fn translate_expr(
 
                             Ok(target_register)
                         }
-                        ScalarFunc::SqliteVersion => {
+                        ScalarFunc::SqliteVersion
+                        | ScalarFunc::TursoVersion
+                        | ScalarFunc::SqliteSourceId => {
                             if !args.is_empty() {
                                 crate::bail_parse_error!("sqlite_version function with arguments");
-                            }
-
-                            let output_register = program.alloc_register();
-                            program.emit_insn(Insn::Function {
-                                constant_mask: 0,
-                                start_reg: output_register,
-                                dest: output_register,
-                                func: func_ctx,
-                            });
-
-                            program.emit_insn(Insn::Copy {
-                                src_reg: output_register,
-                                dst_reg: target_register,
-                                extra_amount: 0,
-                            });
-                            Ok(target_register)
-                        }
-                        ScalarFunc::SqliteSourceId => {
-                            if !args.is_empty() {
-                                crate::bail_parse_error!(
-                                    "sqlite_source_id function with arguments"
-                                );
                             }
 
                             let output_register = program.alloc_register();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4971,7 +4971,7 @@ pub fn op_function(
                     }
                 }
             }
-            ScalarFunc::SqliteVersion => {
+            ScalarFunc::TursoVersion => {
                 if !program.connection.is_db_initialized() {
                     state.registers[*dest] =
                         Register::Value(Value::build_text(info::build::PKG_VERSION));
@@ -4979,9 +4979,13 @@ pub fn op_function(
                     let version_integer =
                         return_if_io!(pager.with_header(|header| header.version_number)).get()
                             as i64;
-                    let version = execute_sqlite_version(version_integer);
+                    let version = execute_turso_version(version_integer);
                     state.registers[*dest] = Register::Value(Value::build_text(version));
                 }
+            }
+            ScalarFunc::SqliteVersion => {
+                let version = execute_sqlite_version();
+                state.registers[*dest] = Register::Value(Value::build_text(version));
             }
             ScalarFunc::SqliteSourceId => {
                 let src_id = format!(
@@ -9508,7 +9512,12 @@ fn try_float_to_integer_affinity(value: &mut Value, fl: f64) -> bool {
     false
 }
 
-fn execute_sqlite_version(version_integer: i64) -> String {
+// Compat for applications that test for SQLite.
+fn execute_sqlite_version() -> String {
+    "3.50.4".to_string()
+}
+
+fn execute_turso_version(version_integer: i64) -> String {
     let major = version_integer / 1_000_000;
     let minor = (version_integer % 1_000_000) / 1_000;
     let release = version_integer % 1_000;
@@ -10392,7 +10401,7 @@ mod tests {
 
     use crate::vdbe::{Bitfield, Register};
 
-    use super::{exec_char, execute_sqlite_version};
+    use super::{exec_char, execute_turso_version};
     use std::collections::HashMap;
 
     #[test]
@@ -11180,7 +11189,7 @@ mod tests {
     fn test_execute_sqlite_version() {
         let version_integer = 3046001;
         let expected = "3.46.1";
-        assert_eq!(execute_sqlite_version(version_integer), expected);
+        assert_eq!(execute_turso_version(version_integer), expected);
     }
 
     #[test]


### PR DESCRIPTION
I found an application in the open that expects sqlite_version() to return a specific string (higher than 3.8...).

We had tons of those issues at Scylla, and the lesson was that you tell your kids not to lie, but when life hits, well... you lie.

We'll add a new function, turso_version, that tells the truth.