### PR TITLE
Simulator: ignore `Property::AllTableHaveExpectedContent` when counting stats

### DIFF
--- a/simulator/generation/plan.rs
+++ b/simulator/generation/plan.rs
@@ -201,6 +201,11 @@ impl InteractionPlan {
         for interactions in &self.plan {
             match &interactions.interactions {
                 InteractionsType::Property(property) => {
+                    if matches!(property, Property::AllTableHaveExpectedContent { .. }) {
+                        // Skip Property::AllTableHaveExpectedContent when counting stats
+                        // this allows us to generate more relevant interactions as we count less Select's to the Stats
+                        continue;
+                    }
                     for interaction in &property.interactions(interactions.connection_index) {
                         if let InteractionType::Query(query) = &interaction.interaction {
                             query_stat(query, &mut stats);


### PR DESCRIPTION
`Property::AllTableHaveExpectedContent` adds a lot of simple Select full table scans to check the DB state. These statements were being counted in `InteractionStats`. The stats are used to calculate the Remaining queries we need to make. By not counting these simple checks we allow the simulator to create more meaningful interactions.