### PR TITLE
Simulator: persist files in sim memory IO for integrity check

### DIFF
--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -611,6 +611,8 @@ fn run_simulation_default(
 
     tracing::info!("Simulation completed");
 
+    env.io.persist_files().unwrap();
+
     if result.error.is_none() {
         let ic = integrity_check(&env.get_db_path());
         if let Err(err) = ic {
@@ -684,6 +686,7 @@ const BANNER: &str = r#"
 "#;
 
 fn integrity_check(db_path: &Path) -> anyhow::Result<()> {
+    assert!(db_path.exists());
     let conn = rusqlite::Connection::open(db_path)?;
     let mut stmt = conn.prepare("SELECT * FROM pragma_integrity_check;")?;
     let mut rows = stmt.query(())?;

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -79,6 +79,11 @@ impl SimIO for SimulatorIO {
     fn close_files(&self) {
         self.files.borrow_mut().clear()
     }
+
+    fn persist_files(&self) -> anyhow::Result<()> {
+        // Files are persisted automatically
+        Ok(())
+    }
 }
 
 impl Clock for SimulatorIO {

--- a/simulator/runner/memory/io.rs
+++ b/simulator/runner/memory/io.rs
@@ -190,6 +190,17 @@ impl SimIO for MemorySimIO {
             file.closed.set(true);
         }
     }
+
+    fn persist_files(&self) -> anyhow::Result<()> {
+        let files = self.files.borrow();
+        for (file_path, file) in files.iter() {
+            if file_path.ends_with(".db") || file_path.ends_with("wal") || file_path.ends_with("lg")
+            {
+                std::fs::write(file_path, &*file.buffer.borrow())?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Clock for MemorySimIO {

--- a/simulator/runner/mod.rs
+++ b/simulator/runner/mod.rs
@@ -20,4 +20,6 @@ pub trait SimIO: turso_core::IO {
     fn syncing(&self) -> bool;
 
     fn close_files(&self);
+
+    fn persist_files(&self) -> anyhow::Result<()>;
 }


### PR DESCRIPTION
If we don't persist the files, rusqlite will open an empty file and perform integrity check on it. 