### PR TITLE
stress: Add busy timeout support with 5 second default

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -493,6 +493,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let plan = plan.clone();
         let conn = db.lock().await.connect()?;
 
+        conn.busy_timeout(std::time::Duration::from_millis(opts.busy_timeout))?;
+
         conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
 
         // Apply each DDL statement individually
@@ -525,6 +527,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let handle = tokio::spawn(async move {
             let mut conn = db.lock().await.connect()?;
 
+            conn.busy_timeout(std::time::Duration::from_millis(opts.busy_timeout))?;
+
             conn.execute("PRAGMA data_sync_retry = 1", ()).await?;
 
             println!("\rExecuting queries...");
@@ -542,6 +546,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     }
                     *db_guard = builder.build().await?;
                     conn = db_guard.connect()?;
+                    conn.busy_timeout(std::time::Duration::from_millis(opts.busy_timeout))?;
                 } else if gen_bool(0.0) {
                     // disabled
                     // Reconnect to the database
@@ -550,6 +555,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     }
                     let db_guard = db.lock().await;
                     conn = db_guard.connect()?;
+                    conn.busy_timeout(std::time::Duration::from_millis(opts.busy_timeout))?;
                 }
                 let sql = &plan.queries_per_thread[thread][query_index];
                 if !opts.silent {

--- a/stress/opts.rs
+++ b/stress/opts.rs
@@ -66,4 +66,12 @@ pub struct Opts {
     /// Number of tables to use
     #[clap(long, help = "Select number of tables to create")]
     pub tables: Option<usize>,
+
+    /// Busy timeout in milliseconds
+    #[clap(
+        long,
+        help = "Set busy timeout in milliseconds",
+        default_value_t = 5000
+    )]
+    pub busy_timeout: u64,
 }


### PR DESCRIPTION
Add `--busy-timeout` command-line option to turso-stress with a default value of 5000 ms. This helps prevent spurious database busy errors during concurrent stress testing and ensure that integrity checks are not skipped because of concurrent writes.