### PR TITLE
Fix typo in manual.md

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -396,7 +396,7 @@ ROLLBACK [ TRANSACTION ]
 SELECT expression
     [ FROM table-or-subquery ]
     [ WHERE condition ]
-    [ GROU BY expression ]
+    [ GROUP BY expression ]
 ```
 
 **Example:**


### PR DESCRIPTION
In `SELECT` section there is `GROU BY` instead of `GROUP BY`