### PR TITLE
bindings/rust: Bump version recommendation to 0.2

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-turso = "0.1"
+turso = "0.2"
 tokio = { version = "1.0", features = ["full"] }
 ```
 


### PR DESCRIPTION
Bump version number for crate docs starter setup