### PR TITLE
perf/throughput: force sqlite to use fullfsync

### DIFF
--- a/perf/throughput/rusqlite/src/main.rs
+++ b/perf/throughput/rusqlite/src/main.rs
@@ -94,6 +94,7 @@ fn setup_database(db_path: &str) -> Result<Connection> {
 
     conn.pragma_update(None, "journal_mode", "WAL")?;
     conn.pragma_update(None, "synchronous", "FULL")?;
+    conn.pragma_update(None, "fullfsync", "true")?;
 
     conn.execute(
         "CREATE TABLE IF NOT EXISTS test_table (
@@ -115,6 +116,9 @@ fn worker_thread(
     compute_usec: u64,
 ) -> Result<u64> {
     let conn = Connection::open(&db_path)?;
+
+    conn.pragma_update(None, "synchronous", "FULL")?;
+    conn.pragma_update(None, "fullfsync", "true")?;
 
     conn.busy_timeout(std::time::Duration::from_secs(30))?;
 


### PR DESCRIPTION
I was sampling our performance and noticed that In the throughput test, we were only setting the `PRAGMA synchronous = full` in `setup_database` and not in the connection. Also we were not setting `PRAGMA fullfsync = true`. 

Now SQLite numbers and Turso numbers are much closer:

`Turso,1,1000,0,215095.94`

vs

`SQLite,1,1000,0,219748.39`

Specs: M2 Air 8gb

related: #3027 