### PR TITLE
Fix change counter incrementation

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5915,12 +5915,9 @@ pub fn op_insert(
                 };
                 if let Some(rowid) = maybe_rowid {
                     program.connection.update_last_rowid(rowid);
-
-                    if !flag.has(InsertFlags::UPDATE_ROWID_CHANGE) {
-                        program
-                            .n_change
-                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    }
+                    program
+                        .n_change
+                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 }
                 let schema = program.connection.schema.read();
                 let dependent_views = schema.get_dependent_materialized_views(table_name);

--- a/testing/changes.test
+++ b/testing/changes.test
@@ -42,3 +42,64 @@ do_execsql_test_on_specific_db {:memory:} changes-1.69 {
      select changes();
 } {1
 1}
+
+do_execsql_test_on_specific_db {:memory:} changes-on-delete {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1), (2), (3), (4), (5);
+    delete from temp where t1 > 2;
+    select changes();
+} {3}
+
+do_execsql_test_on_specific_db {:memory:} changes-on-update {
+    create table temp (t1 integer, t2 text, primary key (t1));
+    insert into temp values (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd');
+    update temp set t2 = 'updated' where t1 <= 3;
+    select changes();
+} {3}
+
+do_execsql_test_on_specific_db {:memory:} changes-on-update-rowid {
+    create table temp (t1 integer primary key, t2 text);
+    insert into temp values (1, 'a'), (2, 'b'), (3, 'c');
+    update temp set t1 = t1 + 10 where t1 = 2;
+    select changes();
+} {1}
+
+
+do_execsql_test_on_specific_db {:memory:} changes-resets-after-select {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1), (2), (3);
+    select * from temp;
+    select changes();
+} {1
+2
+3
+3}
+
+do_execsql_test_on_specific_db {:memory:} changes-on-delete-no-match {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1), (2), (3);
+    delete from temp where t1 > 100;
+    select changes();
+} {0}
+
+do_execsql_test_on_specific_db {:memory:} changes-on-update-no-match {
+    create table temp (t1 integer, t2 text, primary key (t1));
+    insert into temp values (1, 'a'), (2, 'b');
+    update temp set t2 = 'updated' where t1 > 100;
+    select changes();
+} {0}
+
+do_execsql_test_on_specific_db {:memory:} changes-on-delete-all {
+    create table temp (t1 integer, primary key (t1));
+    insert into temp values (1), (2), (3), (4), (5), (6);
+    delete from temp;
+    select changes();
+} {6}
+
+do_execsql_test_on_specific_db {:memory:} changes-mixed-operations {
+    create table temp (t1 integer, t2 text, primary key (t1));
+    insert into temp values (1, 'a'), (2, 'b'), (3, 'c');
+    update temp set t2 = 'updated' where t1 <= 2;
+    delete from temp where t1 = 1;
+    select changes();
+} {1}


### PR DESCRIPTION
We merged two concurrent fixes to `nchange` handling last night and AFAICT the fix in #3692 was incorrect because it doesn't count UPDATEs in cases where the original row was DELETEd as part of the UPDATE statement.

The correct fix was in 87434b8

EDIT: okay, it's not strictly _incorrect_ in #3692 I guess, I just think it's more intuitive to increment the change for UPDATE in the `insert` opcode because that's what performs the actual update.