### PR TITLE
stress: prevent thread from holding write lock and then stopping

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -629,6 +629,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     }
                 }
             }
+            // In case this thread is running an exclusive transaction, commit it so that it doesn't block other threads.
+            let _ = conn.execute("COMMIT", ()).await;
             Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
         });
         handles.push(handle);


### PR DESCRIPTION
When a stress thread runs out of work, execute COMMIT and ignore the result.

This prevents the currently extremely common scenario where:

- Thread x does BEGIN
- Thread x does e.g. INSERT ...

Then runs out of iterations and stops. No other threads can write anything and they just wait for 5 seconds (busy timeout) and then try again, forever.

Closes #3697 