### PR TITLE
feat: Integrate SQLite TCL tests with native TCL module

### DIFF
--- a/tclsqlite.c
+++ b/tclsqlite.c
@@ -1,0 +1,24 @@
+#include <tcl.h>
+
+static int Hello_Cmd(ClientData cdata, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
+    Tcl_SetObjResult(interp, Tcl_NewStringObj("Hello, World!", -1));
+    return TCL_OK;
+}
+
+static int Another_Cmd(ClientData cdata, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
+    Tcl_SetObjResult(interp, Tcl_NewStringObj("Hello, World!", -1));
+    return TCL_OK;
+}
+
+int DLLEXPORT Hello_Init(Tcl_Interp *interp) {
+    if (Tcl_InitStubs(interp, "9.0", 0) == NULL) {
+        return TCL_ERROR;
+    }
+    Tcl_CreateObjCommand(interp, "hello", Hello_Cmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "another", Another_Cmd, NULL, NULL);
+
+    Tcl_PkgProvide(interp, "Hello", "1.0");
+    Tcl_PkgProvide(interp, "Another", "1.0");
+
+    return TCL_OK;
+}


### PR DESCRIPTION
## Feature description

A WIP attempt to write a native TCL extension via #2408 

The aim of this PR is to build a TCL extension that wraps the SQLite API and expose the `sqlite3` as well as a few key commands. This will help with performance when running the tests and also enable easier addition of tests. 

As a first step, we will draft a TCL Extension over the next 2 days and then look into the commands.

## Alternative Approaches Considered.

To be filled.


## Implementation Timeline

- [ ] 10th Nov: Implement `db eval`, `db close`, `db exec` and `sqlite3` commands
- [ ] Implement metadata commands, error handling and config commands
- [ ] Implement testing and debugging commands

TODO: Fill with exact commands and implementation order.



