### PR TITLE
tests/integration: Disable rowid alias differential fuzz test case

### DIFF
--- a/tests/integration/fuzz/rowid_alias.rs
+++ b/tests/integration/fuzz/rowid_alias.rs
@@ -66,6 +66,7 @@ fn convert_to_no_rowid_alias(create_sql: &str) -> String {
 }
 
 #[test]
+#[ignore]
 pub fn rowid_alias_differential_fuzz() {
     let (mut rng, seed) = rng_from_time_or_env();
     tracing::info!("rowid_alias_differential_fuzz seed: {}", seed);


### PR DESCRIPTION
The fuzz test seems to find something that causes the tests to hang. Let's disable it for now.