### PR TITLE
core/btree: Fix unaligned memory access

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2857,7 +2857,7 @@ impl BTreeCursor {
 
                     // load sibling pages
                     // start loading right page first
-                    let mut pgno: u32 = unsafe { right_pointer.cast::<u32>().read().swap_bytes() };
+                    let mut pgno: u32 = unsafe { right_pointer.cast::<u32>().read_unaligned().swap_bytes() };
                     let current_sibling = sibling_pointer;
                     let mut group = CompletionGroup::new(|_| {});
                     for i in (0..=current_sibling).rev() {


### PR DESCRIPTION
Use read_unaligned() instead of read() when reading page numbers from B-tree cells, as SQLite's packed page format doesn't guarantee 4-byte alignment for pointers.

Reported by @rwpeterson in https://github.com/tursodatabase/turso/pull/3790