### PR TITLE
tests/integration: Reduce collation fuzz test iterations

### DIFF
--- a/tests/integration/fuzz/mod.rs
+++ b/tests/integration/fuzz/mod.rs
@@ -608,7 +608,7 @@ mod tests {
         let (mut rng, seed) = rng_from_time_or_env();
         println!("collation_fuzz seed: {seed}");
 
-        const ITERS: usize = 3000;
+        const ITERS: usize = 1000;
         for iter in 0..ITERS {
             if iter % (ITERS / 100).max(1) == 0 {
                 println!("collation_fuzz: iteration {}/{}", iter + 1, ITERS);


### PR DESCRIPTION
The collation fuzz test case takes up to 4 minutes to run, making it the slowest of all the test cases. Let's reduce iteration count a bit to make this more CI friendly.