### PR TITLE
antithesis-tests: Don't fail tests on ProgrammingError

### DIFF
--- a/antithesis-tests/stress-composer/parallel_driver_alter_table.py
+++ b/antithesis-tests/stress-composer/parallel_driver_alter_table.py
@@ -126,6 +126,10 @@ try:
     con.commit()
     con_init.commit()
 
+except turso.ProgrammingError as e:
+    print(f"Table/column might have been dropped in parallel: {e}")
+    con.rollback()
+    con_init.rollback()
 except turso.OperationalError as e:
     print(f"Failed to alter table: {e}")
     con.rollback()

--- a/antithesis-tests/stress-composer/parallel_driver_create_index.py
+++ b/antithesis-tests/stress-composer/parallel_driver_create_index.py
@@ -90,6 +90,9 @@ if create_composite:
             """)
             con_init.commit()
             print(f"Successfully created composite index: {index_name}")
+        except turso.ProgrammingError as e:
+            print(f"Table/column might have been dropped in parallel: {e}")
+            con.rollback()
         except turso.OperationalError as e:
             print(f"Failed to create composite index: {e}")
             con.rollback()
@@ -137,6 +140,9 @@ else:
             """)
             con_init.commit()
             print(f"Successfully created {idx_type} index: {index_name}")
+        except turso.ProgrammingError as e:
+            print(f"Table/column might have been dropped in parallel: {e}")
+            con.rollback()
         except turso.OperationalError as e:
             print(f"Failed to create index: {e}")
             con.rollback()

--- a/antithesis-tests/stress-composer/parallel_driver_delete.py
+++ b/antithesis-tests/stress-composer/parallel_driver_delete.py
@@ -48,6 +48,10 @@ for i in range(deletions):
         cur.execute(f"""
             DELETE FROM tbl_{selected_tbl} WHERE {where_clause}
         """)
+    except turso.ProgrammingError:
+        # Table/column might have been dropped in parallel - this is expected
+        con.rollback()
+        break
     except turso.OperationalError:
         con.rollback()
         # Re-raise other operational errors

--- a/antithesis-tests/stress-composer/parallel_driver_drop_index.py
+++ b/antithesis-tests/stress-composer/parallel_driver_drop_index.py
@@ -55,11 +55,13 @@ try:
     con_init.commit()
 
     print(f"Successfully dropped index: {index_name}")
+except turso.ProgrammingError as e:
+    print(f"Index {index_name} already dropped in parallel: {e}")
+    con.rollback()
 except turso.OperationalError as e:
     print(f"Failed to drop index: {e}")
     con.rollback()
 except Exception as e:
-    # Handle case where index might not exist in indexes table
     print(f"Warning: Could not remove index from metadata: {e}")
 
 con.commit()

--- a/antithesis-tests/stress-composer/parallel_driver_drop_table.py
+++ b/antithesis-tests/stress-composer/parallel_driver_drop_table.py
@@ -31,9 +31,14 @@ except Exception as e:
 
 cur = con.cursor()
 
-cur.execute(f"DROP TABLE tbl_{selected_tbl}")
-
-con.commit()
+try:
+    cur.execute(f"DROP TABLE tbl_{selected_tbl}")
+    con.commit()
+    print(f"Successfully dropped table tbl_{selected_tbl}")
+except turso.ProgrammingError as e:
+    # Table might have been dropped in parallel - this is expected
+    print(f"Table tbl_{selected_tbl} already dropped in parallel: {e}")
+    con.rollback()
 
 con.close()
 

--- a/antithesis-tests/stress-composer/parallel_driver_insert.py
+++ b/antithesis-tests/stress-composer/parallel_driver_insert.py
@@ -46,6 +46,10 @@ for i in range(insertions):
             INSERT INTO tbl_{selected_tbl} ({cols})
             VALUES ({", ".join(values)})
         """)
+    except turso.ProgrammingError:
+        # Table/column might have been dropped in parallel - this is expected
+        con.rollback()
+        break
     except turso.OperationalError as e:
         if "UNIQUE constraint failed" in str(e):
             # Ignore UNIQUE constraint violations

--- a/antithesis-tests/stress-composer/parallel_driver_rollback.py
+++ b/antithesis-tests/stress-composer/parallel_driver_rollback.py
@@ -46,6 +46,10 @@ for i in range(insertions):
             INSERT INTO tbl_{selected_tbl} ({cols})
             VALUES ({", ".join(values)})
         """)
+    except turso.ProgrammingError:
+        # Table/column might have been dropped in parallel - this is expected
+        con.rollback()
+        break
     except turso.OperationalError as e:
         if "UNIQUE constraint failed" in str(e):
             # Ignore UNIQUE constraint violations

--- a/antithesis-tests/stress-composer/parallel_driver_update.py
+++ b/antithesis-tests/stress-composer/parallel_driver_update.py
@@ -60,6 +60,10 @@ for i in range(updates):
         cur.execute(f"""
             UPDATE tbl_{selected_tbl} SET {set_clause} WHERE {where_clause}
         """)
+    except turso.ProgrammingError:
+        # Table/column might have been dropped in parallel - this is expected
+        con.rollback()
+        break
     except turso.OperationalError as e:
         if "UNIQUE constraint failed" in str(e):
             # Ignore UNIQUE constraint violations


### PR DESCRIPTION
The ProgrammingError exception is thrown when tables, indexes, or columns are dropped in parallel. Let's not fail the Antithesis test drivers when that happens.