### PR TITLE
tests: Separate integration and fuzz tests

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,6 +14,10 @@ path = "lib.rs"
 name = "integration_tests"
 path = "integration/mod.rs"
 
+[[test]]
+name = "fuzz_tests"
+path = "fuzz/mod.rs"
+
 [dependencies]
 anyhow.workspace = true
 env_logger = { workspace = true }
@@ -31,11 +35,11 @@ ctor = "0.5.0"
 twox-hash = "2.1.1"
 sql_generation = { path = "../sql_generation" }
 turso_parser = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 test-log = { version = "0.2.17", features = ["trace"] }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tracing = { workspace = true }
 
 [features]
 default = ["test_helper"]

--- a/tests/fuzz/grammar_generator.rs
+++ b/tests/fuzz/grammar_generator.rs
@@ -89,6 +89,12 @@ struct GrammarGeneratorInner {
     symbols: HashMap<SymbolHandle, SymbolType>,
 }
 
+impl Default for GrammarGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GrammarGenerator {
     pub fn new() -> Self {
         GrammarGenerator(Rc::new(RefCell::new(GrammarGeneratorInner {

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -2,7 +2,7 @@ pub mod grammar_generator;
 pub mod rowid_alias;
 
 #[cfg(test)]
-mod tests {
+mod fuzz_tests {
     use rand::seq::{IndexedRandom, IteratorRandom, SliceRandom};
     use rand::Rng;
     use rand_chacha::ChaCha8Rng;
@@ -10,14 +10,13 @@ mod tests {
     use std::{collections::HashSet, io::Write};
     use turso_core::DatabaseOpts;
 
-    use crate::{
-        common::{
-            do_flush, limbo_exec_rows, limbo_exec_rows_fallible, limbo_stmt_get_column_names,
-            maybe_setup_tracing, rng_from_time_or_env, rusqlite_integrity_check, sqlite_exec_rows,
-            TempDatabase,
-        },
-        fuzz::grammar_generator::{const_str, rand_int, rand_str, GrammarGenerator},
+    use core_tester::common::{
+        do_flush, limbo_exec_rows, limbo_exec_rows_fallible, limbo_stmt_get_column_names,
+        maybe_setup_tracing, rng_from_time_or_env, rusqlite_integrity_check, sqlite_exec_rows,
+        TempDatabase,
     };
+
+    use super::grammar_generator::{const_str, rand_int, rand_str, GrammarGenerator};
 
     use super::grammar_generator::SymbolHandle;
 
@@ -4112,7 +4111,7 @@ mod tests {
     #[test]
     #[cfg(feature = "test_helper")]
     pub fn fuzz_pending_byte_database() -> anyhow::Result<()> {
-        use crate::common::rusqlite_integrity_check;
+        use core_tester::common::rusqlite_integrity_check;
 
         maybe_setup_tracing();
         let (mut rng, seed) = rng_from_time_or_env();

--- a/tests/fuzz/rowid_alias.rs
+++ b/tests/fuzz/rowid_alias.rs
@@ -1,4 +1,4 @@
-use crate::common::{limbo_exec_rows, TempDatabase};
+use core_tester::common::{limbo_exec_rows, TempDatabase};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use sql_generation::{

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -163,7 +163,7 @@ impl TempDatabase {
     }
 }
 
-pub(crate) fn do_flush(conn: &Arc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
+pub fn do_flush(conn: &Arc<Connection>, tmp_db: &TempDatabase) -> anyhow::Result<()> {
     let completions = conn.cacheflush()?;
     for c in completions {
         tmp_db.io.wait_for_completion(c)?;
@@ -171,7 +171,7 @@ pub(crate) fn do_flush(conn: &Arc<Connection>, tmp_db: &TempDatabase) -> anyhow:
     Ok(())
 }
 
-pub(crate) fn compare_string(a: impl AsRef<str>, b: impl AsRef<str>) {
+pub fn compare_string(a: impl AsRef<str>, b: impl AsRef<str>) {
     let a = a.as_ref();
     let b = b.as_ref();
 
@@ -204,7 +204,7 @@ pub fn maybe_setup_tracing() {
         .try_init();
 }
 
-pub(crate) fn sqlite_exec_rows(
+pub fn sqlite_exec_rows(
     conn: &rusqlite::Connection,
     query: &str,
 ) -> Vec<Vec<rusqlite::types::Value>> {
@@ -227,7 +227,7 @@ pub(crate) fn sqlite_exec_rows(
     results
 }
 
-pub(crate) fn limbo_exec_rows(
+pub fn limbo_exec_rows(
     _db: &TempDatabase,
     conn: &Arc<turso_core::Connection>,
     query: &str,
@@ -266,7 +266,8 @@ pub(crate) fn limbo_exec_rows(
     rows
 }
 
-pub(crate) fn limbo_stmt_get_column_names(
+#[allow(dead_code)]
+pub fn limbo_stmt_get_column_names(
     _db: &TempDatabase,
     conn: &Arc<turso_core::Connection>,
     query: &str,
@@ -280,7 +281,7 @@ pub(crate) fn limbo_stmt_get_column_names(
     names
 }
 
-pub(crate) fn limbo_exec_rows_fallible(
+pub fn limbo_exec_rows_fallible(
     _db: &TempDatabase,
     conn: &Arc<turso_core::Connection>,
     query: &str,
@@ -319,7 +320,7 @@ pub(crate) fn limbo_exec_rows_fallible(
     Ok(rows)
 }
 
-pub(crate) fn limbo_exec_rows_error(
+pub fn limbo_exec_rows_error(
     _db: &TempDatabase,
     conn: &Arc<turso_core::Connection>,
     query: &str,
@@ -338,7 +339,7 @@ pub(crate) fn limbo_exec_rows_error(
     }
 }
 
-pub(crate) fn rng_from_time() -> (ChaCha8Rng, u64) {
+pub fn rng_from_time() -> (ChaCha8Rng, u64) {
     let seed = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -401,6 +402,7 @@ pub fn run_query_core(
     Ok(())
 }
 
+#[allow(dead_code)]
 pub fn rusqlite_integrity_check(db_path: &Path) -> anyhow::Result<()> {
     let conn = rusqlite::Connection::open(db_path)?;
     let mut stmt = conn.prepare("SELECT * FROM pragma_integrity_check;")?;

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,6 +1,5 @@
 mod common;
 mod functions;
-mod fuzz;
 mod fuzz_transaction;
 mod pragma;
 mod query_processing;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,1 +1,3 @@
-
+// Shared test utilities
+#[path = "integration/common.rs"]
+pub mod common;


### PR DESCRIPTION
This separates fuzz tests from integration tests so that you can run the fast test cases with:

```
cargo test --test integration_tests
```

and the longer fuzz cases with:

```
cargo test --test fuzz_tests
```