### PR TITLE
Add DISTINCT support to aggregate operator

### DIFF
--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -14,9 +14,71 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{self, Display};
 use std::sync::{Arc, Mutex};
 
+// Architecture of the Aggregate Operator
+// ========================================
+//
+// This operator implements SQL aggregations (GROUP BY, DISTINCT, COUNT, SUM, AVG, MIN, MAX)
+// using DBSP-style incremental computation. The key insight is that all these operations
+// can be expressed as operations on weighted sets (Z-sets) stored in persistent BTrees.
+//
+// ## Storage Strategy
+//
+// We use three different storage encodings (identified by 2-bit type codes in storage IDs):
+// - **Regular aggregates** (COUNT/SUM/AVG): Store accumulated state as a blob
+// - **MIN/MAX aggregates**: Store individual values; BTree ordering gives us min/max efficiently
+// - **DISTINCT tracking**: Store distinct values with weights (positive = present, zero = deleted)
+//
+// ## MIN/MAX Handling
+//
+// MIN/MAX are special because they're not fully incrementalizable:
+// - **Inserts**: Can be computed incrementally (new_min = min(old_min, new_value))
+// - **Deletes**: Must recompute from the BTree when the current min/max is deleted
+//
+// Our approach:
+// 1. Store each value with its weight in a BTree (leveraging natural ordering)
+// 2. On insert: Simply compare with current min/max (incremental)
+// 3. On delete of current min/max: Scan the BTree to find the next min/max
+//    - For MIN: scan forward from the beginning to find first value with positive weight
+//    - For MAX: scan backward from the end to find last value with positive weight
+//
+// ## DISTINCT Handling
+//
+// DISTINCT operations (COUNT(DISTINCT), SUM(DISTINCT), etc.) are implemented using the
+// weighted set pattern:
+// - Each distinct value is stored with a weight (occurrence count)
+// - Weight > 0 means the value exists in the current dataset
+// - Weight = 0 means the value has been deleted (we may clean these up)
+// - We track transitions: when a value's weight crosses zero (appears/disappears)
+//
+// ## Plain DISTINCT (SELECT DISTINCT)
+//
+// A clever reuse of infrastructure: SELECT DISTINCT x, y, z is compiled to:
+// - GROUP BY x, y, z (making each unique row combination a group)
+// - Empty aggregates vector (no actual aggregations to compute)
+// - The groups themselves become the distinct rows
+//
+// This allows us to reuse all the incremental machinery for DISTINCT without special casing.
+// The `is_distinct_only` flag indicates this pattern, where the groups ARE the output rows.
+//
+// ## State Machines
+//
+// The operator uses async-ready state machines to handle I/O operations:
+// - **Eval state machine**: Fetches existing state, applies deltas, recomputes MIN/MAX
+// - **Commit state machine**: Persists updated state back to storage
+// - Each state represents a resumption point for when I/O operations yield
+
 /// Constants for aggregate type encoding in storage IDs (2 bits)
 pub const AGG_TYPE_REGULAR: u8 = 0b00; // COUNT/SUM/AVG
 pub const AGG_TYPE_MINMAX: u8 = 0b01; // MIN/MAX (BTree ordering gives both)
+pub const AGG_TYPE_DISTINCT: u8 = 0b10; // DISTINCT values tracking
+
+/// Hash a Value to generate an element_id for DISTINCT storage
+/// Uses HashableRow with column_idx as rowid for consistent hashing
+fn hash_value(value: &Value, column_idx: usize) -> Hash128 {
+    // Use column_idx as rowid to ensure different columns with same value get different hashes
+    let row = HashableRow::new(column_idx as i64, vec![value.clone()]);
+    row.cached_hash()
+}
 
 // Serialization type codes for aggregate functions
 const AGG_FUNC_COUNT: i64 = 0;
@@ -24,22 +86,31 @@ const AGG_FUNC_SUM: i64 = 1;
 const AGG_FUNC_AVG: i64 = 2;
 const AGG_FUNC_MIN: i64 = 3;
 const AGG_FUNC_MAX: i64 = 4;
+const AGG_FUNC_COUNT_DISTINCT: i64 = 5;
+const AGG_FUNC_SUM_DISTINCT: i64 = 6;
+const AGG_FUNC_AVG_DISTINCT: i64 = 7;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AggregateFunction {
     Count,
-    Sum(usize), // Column index
-    Avg(usize), // Column index
-    Min(usize), // Column index
-    Max(usize), // Column index
+    CountDistinct(usize), // COUNT(DISTINCT column_index)
+    Sum(usize),           // Column index
+    SumDistinct(usize),   // SUM(DISTINCT column_index)
+    Avg(usize),           // Column index
+    AvgDistinct(usize),   // AVG(DISTINCT column_index)
+    Min(usize),           // Column index
+    Max(usize),           // Column index
 }
 
 impl Display for AggregateFunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AggregateFunction::Count => write!(f, "COUNT(*)"),
+            AggregateFunction::CountDistinct(idx) => write!(f, "COUNT(DISTINCT col{idx})"),
             AggregateFunction::Sum(idx) => write!(f, "SUM(col{idx})"),
+            AggregateFunction::SumDistinct(idx) => write!(f, "SUM(DISTINCT col{idx})"),
             AggregateFunction::Avg(idx) => write!(f, "AVG(col{idx})"),
+            AggregateFunction::AvgDistinct(idx) => write!(f, "AVG(DISTINCT col{idx})"),
             AggregateFunction::Min(idx) => write!(f, "MIN(col{idx})"),
             AggregateFunction::Max(idx) => write!(f, "MAX(col{idx})"),
         }
@@ -58,11 +129,29 @@ impl AggregateFunction {
     pub fn to_values(&self) -> Vec<Value> {
         match self {
             AggregateFunction::Count => vec![Value::Integer(AGG_FUNC_COUNT)],
+            AggregateFunction::CountDistinct(idx) => {
+                vec![
+                    Value::Integer(AGG_FUNC_COUNT_DISTINCT),
+                    Value::Integer(*idx as i64),
+                ]
+            }
             AggregateFunction::Sum(idx) => {
                 vec![Value::Integer(AGG_FUNC_SUM), Value::Integer(*idx as i64)]
             }
+            AggregateFunction::SumDistinct(idx) => {
+                vec![
+                    Value::Integer(AGG_FUNC_SUM_DISTINCT),
+                    Value::Integer(*idx as i64),
+                ]
+            }
             AggregateFunction::Avg(idx) => {
                 vec![Value::Integer(AGG_FUNC_AVG), Value::Integer(*idx as i64)]
+            }
+            AggregateFunction::AvgDistinct(idx) => {
+                vec![
+                    Value::Integer(AGG_FUNC_AVG_DISTINCT),
+                    Value::Integer(*idx as i64),
+                ]
             }
             AggregateFunction::Min(idx) => {
                 vec![Value::Integer(AGG_FUNC_MIN), Value::Integer(*idx as i64)]
@@ -85,6 +174,20 @@ impl AggregateFunction {
                 *cursor += 1;
                 AggregateFunction::Count
             }
+            Value::Integer(AGG_FUNC_COUNT_DISTINCT) => {
+                *cursor += 1;
+                let idx = values.get(*cursor).ok_or_else(|| {
+                    LimboError::InternalError("Missing COUNT(DISTINCT) column index".into())
+                })?;
+                if let Value::Integer(idx) = idx {
+                    *cursor += 1;
+                    AggregateFunction::CountDistinct(*idx as usize)
+                } else {
+                    return Err(LimboError::InternalError(format!(
+                        "Expected Integer for COUNT(DISTINCT) column index, got {idx:?}"
+                    )));
+                }
+            }
             Value::Integer(AGG_FUNC_SUM) => {
                 *cursor += 1;
                 let idx = values
@@ -99,6 +202,20 @@ impl AggregateFunction {
                     )));
                 }
             }
+            Value::Integer(AGG_FUNC_SUM_DISTINCT) => {
+                *cursor += 1;
+                let idx = values.get(*cursor).ok_or_else(|| {
+                    LimboError::InternalError("Missing SUM(DISTINCT) column index".into())
+                })?;
+                if let Value::Integer(idx) = idx {
+                    *cursor += 1;
+                    AggregateFunction::SumDistinct(*idx as usize)
+                } else {
+                    return Err(LimboError::InternalError(format!(
+                        "Expected Integer for SUM(DISTINCT) column index, got {idx:?}"
+                    )));
+                }
+            }
             Value::Integer(AGG_FUNC_AVG) => {
                 *cursor += 1;
                 let idx = values
@@ -110,6 +227,20 @@ impl AggregateFunction {
                 } else {
                     return Err(LimboError::InternalError(format!(
                         "Expected Integer for AVG column index, got {idx:?}"
+                    )));
+                }
+            }
+            Value::Integer(AGG_FUNC_AVG_DISTINCT) => {
+                *cursor += 1;
+                let idx = values.get(*cursor).ok_or_else(|| {
+                    LimboError::InternalError("Missing AVG(DISTINCT) column index".into())
+                })?;
+                if let Value::Integer(idx) = idx {
+                    *cursor += 1;
+                    AggregateFunction::AvgDistinct(*idx as usize)
+                } else {
+                    return Err(LimboError::InternalError(format!(
+                        "Expected Integer for AVG(DISTINCT) column index, got {idx:?}"
                     )));
                 }
             }
@@ -189,6 +320,27 @@ type ComputedStates = HashMap<String, (Vec<Value>, AggregateState)>;
 // group_key_str -> (column_index, value_as_hashable_row) -> accumulated_weight
 pub type MinMaxDeltas = HashMap<String, HashMap<(usize, HashableRow), isize>>;
 
+/// Type for tracking distinct values within a batch
+/// Maps: group_key_str -> (column_idx, HashableRow) -> accumulated_weight
+/// HashableRow contains the value with column_idx as rowid for proper hashing
+type DistinctDeltas = HashMap<String, HashMap<(usize, HashableRow), isize>>;
+
+/// Return type for merge_delta_with_existing function
+type MergeResult = (Delta, HashMap<String, (Vec<Value>, AggregateState)>);
+
+/// Information about distinct value transitions for a single column
+#[derive(Debug, Clone)]
+pub struct DistinctTransition {
+    pub transition_type: TransitionType,
+    pub transitioned_value: Value, // The value that was added/removed
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TransitionType {
+    Added,   // Value added to distinct set
+    Removed, // Value removed from distinct set
+}
+
 #[derive(Debug)]
 enum AggregateCommitState {
     Idle,
@@ -198,13 +350,21 @@ enum AggregateCommitState {
     PersistDelta {
         delta: Delta,
         computed_states: ComputedStates,
+        old_states: HashMap<String, i64>, // Track old counts for plain DISTINCT
         current_idx: usize,
         write_row: WriteRow,
         min_max_deltas: MinMaxDeltas,
+        distinct_deltas: DistinctDeltas,
+        input_delta: Delta, // Keep original input delta for distinct processing
     },
     PersistMinMax {
         delta: Delta,
         min_max_persist_state: MinMaxPersistState,
+        distinct_deltas: DistinctDeltas,
+    },
+    PersistDistinctValues {
+        delta: Delta,
+        distinct_persist_state: DistinctPersistState,
     },
     Done {
         delta: Delta,
@@ -221,8 +381,9 @@ pub enum AggregateEvalState {
         groups_to_read: Vec<(String, Vec<Value>)>, // Changed to Vec for index-based access
         existing_groups: HashMap<String, AggregateState>,
         old_values: HashMap<String, Vec<Value>>,
+        pre_existing_groups: HashSet<String>, // Track groups that existed before this delta
     },
-    FetchData {
+    FetchAggregateState {
         delta: Delta, // Keep original delta for merge operation
         current_idx: usize,
         groups_to_read: Vec<(String, Vec<Value>)>, // Changed to Vec for index-based access
@@ -230,12 +391,23 @@ pub enum AggregateEvalState {
         old_values: HashMap<String, Vec<Value>>,
         rowid: Option<i64>, // Rowid found by FetchKey (None if not found)
         read_record_state: Box<ReadRecord>,
+        pre_existing_groups: HashSet<String>, // Track groups that existed before this delta
+    },
+    FetchDistinctValues {
+        delta: Delta, // Keep original delta for merge operation
+        current_idx: usize,
+        groups_to_read: Vec<(String, Vec<Value>)>, // Changed to Vec for index-based access
+        existing_groups: HashMap<String, AggregateState>,
+        old_values: HashMap<String, Vec<Value>>,
+        fetch_distinct_state: Box<FetchDistinctState>,
+        pre_existing_groups: HashSet<String>, // Track groups that existed before this delta
     },
     RecomputeMinMax {
         delta: Delta,
         existing_groups: HashMap<String, AggregateState>,
         old_values: HashMap<String, Vec<Value>>,
         recompute_state: Box<RecomputeMinMax>,
+        pre_existing_groups: HashSet<String>, // Track groups that existed before this delta
     },
     Done {
         output: (Delta, ComputedStates),
@@ -257,10 +429,15 @@ pub struct AggregateOperator {
     pub input_column_names: Vec<String>,
     // Map from column index to aggregate info for quick lookup
     pub column_min_max: HashMap<usize, AggColumnInfo>,
+    // Set of column indices that have distinct aggregates
+    pub distinct_columns: HashSet<usize>,
     tracker: Option<Arc<Mutex<ComputationTracker>>>,
 
     // State machine for commit operation
     commit_state: AggregateCommitState,
+
+    // SELECT DISTINCT x,y,z.... with no aggregations.
+    is_distinct_only: bool,
 }
 
 /// State for a single group's aggregates
@@ -276,9 +453,34 @@ pub struct AggregateState {
     pub mins: HashMap<usize, Value>,
     // For MAX: column_index -> maximum value
     pub maxs: HashMap<usize, Value>,
+    // For DISTINCT aggregates: column_index -> computed value
+    // These are populated during eval when we scan the BTree (or in-memory map)
+    pub distinct_counts: HashMap<usize, i64>,
+    pub distinct_sums: HashMap<usize, f64>,
+
+    // Weights of specific distinct values needed for current delta processing
+    // (column_index, value) -> weight
+    // Populated during FetchKey for values mentioned in the delta
+    pub(crate) distinct_value_weights: HashMap<(usize, HashableRow), i64>,
 }
 
 impl AggregateEvalState {
+    /// Process a delta through the aggregate state machine.
+    ///
+    /// Control flow is strictly linear for maintainability:
+    /// 1. FetchKey → FetchAggregateState (always)
+    /// 2. FetchAggregateState → FetchKey (always, loops until all groups processed)
+    /// 3. FetchKey (when done) → FetchDistinctValues (always)
+    /// 4. FetchDistinctValues → RecomputeMinMax (always)
+    /// 5. RecomputeMinMax → Done (always)
+    ///
+    /// Some states may be no-ops depending on the operator configuration:
+    /// - FetchAggregateState: For plain DISTINCT, skips reading aggregate blob (no aggregates to fetch)
+    /// - FetchDistinctValues: No-op if no distinct columns exist (distinct_columns is empty)
+    /// - RecomputeMinMax: No-op if no MIN/MAX aggregates exist (has_min_max() returns false)
+    ///
+    /// This deterministic flow ensures each state always transitions to the same next state,
+    /// making the state machine easier to understand and debug.
     fn process_delta(
         &mut self,
         operator: &mut AggregateOperator,
@@ -292,40 +494,47 @@ impl AggregateEvalState {
                     groups_to_read,
                     existing_groups,
                     old_values,
+                    pre_existing_groups,
                 } => {
                     if *current_idx >= groups_to_read.len() {
-                        // All groups have been fetched, move to RecomputeMinMax
-                        // Extract MIN/MAX deltas from the input delta
-                        let min_max_deltas = operator.extract_min_max_deltas(delta);
-
-                        let recompute_state = Box::new(RecomputeMinMax::new(
-                            min_max_deltas,
+                        // All groups have been fetched, move to FetchDistinctValues
+                        // Create FetchDistinctState based on the delta and existing groups
+                        let fetch_distinct_state = FetchDistinctState::new(
+                            delta,
+                            &operator.distinct_columns,
+                            |values| operator.extract_group_key(values),
+                            AggregateOperator::group_key_to_string,
                             existing_groups,
-                            operator,
-                        ));
+                            operator.is_distinct_only,
+                        );
 
-                        *self = AggregateEvalState::RecomputeMinMax {
+                        *self = AggregateEvalState::FetchDistinctValues {
                             delta: std::mem::take(delta),
+                            current_idx: 0,
+                            groups_to_read: std::mem::take(groups_to_read),
                             existing_groups: std::mem::take(existing_groups),
                             old_values: std::mem::take(old_values),
-                            recompute_state,
+                            fetch_distinct_state: Box::new(fetch_distinct_state),
+                            pre_existing_groups: std::mem::take(pre_existing_groups),
                         };
                     } else {
                         // Get the current group to read
                         let (group_key_str, _group_key) = &groups_to_read[*current_idx];
 
-                        // Build the key for the index: (operator_id, zset_hash, element_id)
-                        // For regular aggregates, use column_index=0 and AGG_TYPE_REGULAR
+                        // For plain DISTINCT, we still need to transition to FetchAggregateState
+                        // to add the group to existing_groups, but we won't read any aggregate blob
+
+                        // Build the key for regular aggregate state: (operator_id, zset_hash, element_id=0)
                         let operator_storage_id =
                             generate_storage_id(operator.operator_id, 0, AGG_TYPE_REGULAR);
                         let zset_hash = operator.generate_group_hash(group_key_str);
-                        let element_id = 0i64; // Always 0 for aggregators
+                        let element_id = Hash128::new(0, 0); // Always zeros for aggregate state
 
                         // Create index key values
                         let index_key_values = vec![
                             Value::Integer(operator_storage_id),
                             zset_hash.to_value(),
-                            Value::Integer(element_id),
+                            element_id.to_value(),
                         ];
 
                         // Create an immutable record for the index key
@@ -347,10 +556,10 @@ impl AggregateEvalState {
                             None
                         };
 
-                        // Always transition to FetchData
+                        // Always transition to FetchAggregateState
                         let taken_existing = std::mem::take(existing_groups);
                         let taken_old_values = std::mem::take(old_values);
-                        let next_state = AggregateEvalState::FetchData {
+                        let next_state = AggregateEvalState::FetchAggregateState {
                             delta: std::mem::take(delta),
                             current_idx: *current_idx,
                             groups_to_read: std::mem::take(groups_to_read),
@@ -358,11 +567,12 @@ impl AggregateEvalState {
                             old_values: taken_old_values,
                             rowid,
                             read_record_state: Box::new(ReadRecord::new()),
+                            pre_existing_groups: std::mem::take(pre_existing_groups), // Pass through existing
                         };
                         *self = next_state;
                     }
                 }
-                AggregateEvalState::FetchData {
+                AggregateEvalState::FetchAggregateState {
                     delta,
                     current_idx,
                     groups_to_read,
@@ -370,13 +580,20 @@ impl AggregateEvalState {
                     old_values,
                     rowid,
                     read_record_state,
+                    pre_existing_groups,
                 } => {
                     // Get the current group to read
                     let (group_key_str, group_key) = &groups_to_read[*current_idx];
 
-                    // Only try to read if we have a rowid
-                    if let Some(rowid) = rowid {
+                    // For plain DISTINCT, skip aggregate state fetch entirely
+                    // The distinct values are handled separately in FetchDistinctValues
+                    if operator.is_distinct_only {
+                        // Always insert the group key so FetchDistinctState will process it
+                        // The count will be set properly when we fetch distinct values
+                        existing_groups.insert(group_key_str.clone(), AggregateState::default());
+                    } else if let Some(rowid) = rowid {
                         let key = SeekKey::TableRowId(*rowid);
+                        // Regular aggregates - read the blob
                         let state = return_if_io!(
                             read_record_state.read_record(key, &mut cursors.table_cursor)
                         );
@@ -385,23 +602,75 @@ impl AggregateEvalState {
                             let mut old_row = group_key.clone();
                             old_row.extend(state.to_values(&operator.aggregates));
                             old_values.insert(group_key_str.clone(), old_row);
-                            existing_groups.insert(group_key_str.clone(), state.clone());
+                            existing_groups.insert(group_key_str.clone(), state);
+                            // Track that this group exists in storage
+                            pre_existing_groups.insert(group_key_str.clone());
                         }
-                    } else {
-                        // No rowid for this group, skipping read
                     }
                     // If no rowid, there's no existing state for this group
 
-                    // Move to next group
+                    // Always move to next group via FetchKey
                     let next_idx = *current_idx + 1;
+
                     let taken_existing = std::mem::take(existing_groups);
                     let taken_old_values = std::mem::take(old_values);
+                    let taken_pre_existing_groups = std::mem::take(pre_existing_groups);
                     let next_state = AggregateEvalState::FetchKey {
                         delta: std::mem::take(delta),
                         current_idx: next_idx,
                         groups_to_read: std::mem::take(groups_to_read),
                         existing_groups: taken_existing,
                         old_values: taken_old_values,
+                        pre_existing_groups: taken_pre_existing_groups,
+                    };
+                    *self = next_state;
+                }
+                AggregateEvalState::FetchDistinctValues {
+                    delta,
+                    current_idx: _,
+                    groups_to_read: _,
+                    existing_groups,
+                    old_values,
+                    fetch_distinct_state,
+                    pre_existing_groups,
+                } => {
+                    // Use FetchDistinctState to read distinct values from BTree storage
+                    return_if_io!(fetch_distinct_state.fetch_distinct_values(
+                        operator.operator_id,
+                        existing_groups,
+                        cursors,
+                        |group_key| operator.generate_group_hash(group_key),
+                        operator.is_distinct_only
+                    ));
+
+                    // For plain DISTINCT, mark groups as "from storage" if they have distinct values
+                    if operator.is_distinct_only {
+                        for (group_key_str, state) in existing_groups.iter() {
+                            // Check if this group has any distinct values with positive weight
+                            let has_values = state.distinct_value_weights.values().any(|&w| w > 0);
+                            if has_values {
+                                pre_existing_groups.insert(group_key_str.clone());
+                            }
+                        }
+                    }
+
+                    // Extract MIN/MAX deltas for recomputation
+                    let min_max_deltas = operator.extract_min_max_deltas(delta);
+
+                    // Create RecomputeMinMax before moving existing_groups
+                    let recompute_state = Box::new(RecomputeMinMax::new(
+                        min_max_deltas,
+                        existing_groups,
+                        operator,
+                    ));
+
+                    // Transition to RecomputeMinMax
+                    let next_state = AggregateEvalState::RecomputeMinMax {
+                        delta: std::mem::take(delta),
+                        existing_groups: std::mem::take(existing_groups),
+                        old_values: std::mem::take(old_values),
+                        recompute_state,
+                        pre_existing_groups: std::mem::take(pre_existing_groups),
                     };
                     *self = next_state;
                 }
@@ -410,6 +679,7 @@ impl AggregateEvalState {
                     existing_groups,
                     old_values,
                     recompute_state,
+                    pre_existing_groups,
                 } => {
                     if operator.has_min_max() {
                         // Process MIN/MAX recomputation - this will update existing_groups with correct MIN/MAX
@@ -417,15 +687,20 @@ impl AggregateEvalState {
                     }
 
                     // Now compute final output with updated MIN/MAX values
-                    let (output_delta, computed_states) =
-                        operator.merge_delta_with_existing(delta, existing_groups, old_values);
+                    let (output_delta, computed_states) = operator.merge_delta_with_existing(
+                        delta,
+                        existing_groups,
+                        old_values,
+                        pre_existing_groups,
+                    );
 
                     *self = AggregateEvalState::Done {
                         output: (output_delta, computed_states),
                     };
                 }
                 AggregateEvalState::Done { output } => {
-                    return Ok(IOResult::Done(output.clone()));
+                    let (delta, computed_states) = output.clone();
+                    return Ok(IOResult::Done((delta, computed_states)));
                 }
             }
         }
@@ -459,14 +734,33 @@ impl AggregateState {
                 AggregateFunction::Count => {
                     // Count state is already stored at the beginning
                 }
+                AggregateFunction::CountDistinct(col_idx) => {
+                    // Store the distinct count for this column
+                    let count = self.distinct_counts.get(col_idx).copied().unwrap_or(0);
+                    values.push(Value::Integer(count));
+                }
                 AggregateFunction::Sum(col_idx) => {
                     let sum = self.sums.get(col_idx).copied().unwrap_or(0.0);
+                    values.push(Value::Float(sum));
+                }
+                AggregateFunction::SumDistinct(col_idx) => {
+                    // Store both the distinct count and sum for this column
+                    let count = self.distinct_counts.get(col_idx).copied().unwrap_or(0);
+                    let sum = self.distinct_sums.get(col_idx).copied().unwrap_or(0.0);
+                    values.push(Value::Integer(count));
                     values.push(Value::Float(sum));
                 }
                 AggregateFunction::Avg(col_idx) => {
                     let (sum, count) = self.avgs.get(col_idx).copied().unwrap_or((0.0, 0));
                     values.push(Value::Float(sum));
                     values.push(Value::Integer(count));
+                }
+                AggregateFunction::AvgDistinct(col_idx) => {
+                    // Store both the distinct count and sum for this column
+                    let count = self.distinct_counts.get(col_idx).copied().unwrap_or(0);
+                    let sum = self.distinct_sums.get(col_idx).copied().unwrap_or(0.0);
+                    values.push(Value::Integer(count));
+                    values.push(Value::Float(sum));
                 }
                 AggregateFunction::Min(col_idx) => {
                     if let Some(min_val) = self.mins.get(col_idx) {
@@ -531,6 +825,69 @@ impl AggregateState {
             match agg_fn {
                 AggregateFunction::Count => {
                     // Count state is already stored at the beginning
+                }
+                AggregateFunction::CountDistinct(col_idx) => {
+                    let count = values.get(cursor).ok_or_else(|| {
+                        LimboError::InternalError("Missing COUNT(DISTINCT) value".into())
+                    })?;
+                    if let Value::Integer(count) = count {
+                        state.distinct_counts.insert(col_idx, *count);
+                        cursor += 1;
+                    } else {
+                        return Err(LimboError::InternalError(format!(
+                            "Expected Integer for COUNT(DISTINCT) value, got {count:?}"
+                        )));
+                    }
+                }
+                AggregateFunction::SumDistinct(col_idx) => {
+                    let count = values.get(cursor).ok_or_else(|| {
+                        LimboError::InternalError("Missing SUM(DISTINCT) count".into())
+                    })?;
+                    if let Value::Integer(count) = count {
+                        state.distinct_counts.insert(col_idx, *count);
+                        cursor += 1;
+                    } else {
+                        return Err(LimboError::InternalError(format!(
+                            "Expected Integer for SUM(DISTINCT) count, got {count:?}"
+                        )));
+                    }
+
+                    let sum = values.get(cursor).ok_or_else(|| {
+                        LimboError::InternalError("Missing SUM(DISTINCT) sum".into())
+                    })?;
+                    if let Value::Float(sum) = sum {
+                        state.distinct_sums.insert(col_idx, *sum);
+                        cursor += 1;
+                    } else {
+                        return Err(LimboError::InternalError(format!(
+                            "Expected Float for SUM(DISTINCT) sum, got {sum:?}"
+                        )));
+                    }
+                }
+                AggregateFunction::AvgDistinct(col_idx) => {
+                    let count = values.get(cursor).ok_or_else(|| {
+                        LimboError::InternalError("Missing AVG(DISTINCT) count".into())
+                    })?;
+                    if let Value::Integer(count) = count {
+                        state.distinct_counts.insert(col_idx, *count);
+                        cursor += 1;
+                    } else {
+                        return Err(LimboError::InternalError(format!(
+                            "Expected Integer for AVG(DISTINCT) count, got {count:?}"
+                        )));
+                    }
+
+                    let sum = values.get(cursor).ok_or_else(|| {
+                        LimboError::InternalError("Missing AVG(DISTINCT) sum".into())
+                    })?;
+                    if let Value::Float(sum) = sum {
+                        state.distinct_sums.insert(col_idx, *sum);
+                        cursor += 1;
+                    } else {
+                        return Err(LimboError::InternalError(format!(
+                            "Expected Float for AVG(DISTINCT) sum, got {sum:?}"
+                        )));
+                    }
                 }
                 AggregateFunction::Sum(col_idx) => {
                     let sum = values
@@ -689,15 +1046,71 @@ impl AggregateState {
         weight: isize,
         aggregates: &[AggregateFunction],
         _column_names: &[String], // No longer needed
+        distinct_transitions: &HashMap<usize, DistinctTransition>,
     ) {
         // Update COUNT
         self.count += weight as i64;
 
-        // Update other aggregates
+        // Track which columns have had their distinct counts/sums updated
+        // This prevents double-counting when multiple distinct aggregates
+        // operate on the same column (e.g., COUNT(DISTINCT col), SUM(DISTINCT col), AVG(DISTINCT col))
+        let mut processed_counts: HashSet<usize> = HashSet::new();
+        let mut processed_sums: HashSet<usize> = HashSet::new();
+
+        // Update distinct aggregate state
         for agg in aggregates {
             match agg {
                 AggregateFunction::Count => {
                     // Already handled above
+                }
+                AggregateFunction::CountDistinct(col_idx) => {
+                    // Only update count if we haven't processed this column yet
+                    if !processed_counts.contains(col_idx) {
+                        if let Some(transition) = distinct_transitions.get(col_idx) {
+                            let current_count =
+                                self.distinct_counts.get(col_idx).copied().unwrap_or(0);
+                            let new_count = match transition.transition_type {
+                                TransitionType::Added => current_count + 1,
+                                TransitionType::Removed => current_count - 1,
+                            };
+                            self.distinct_counts.insert(*col_idx, new_count);
+                            processed_counts.insert(*col_idx);
+                        }
+                    }
+                }
+                AggregateFunction::SumDistinct(col_idx)
+                | AggregateFunction::AvgDistinct(col_idx) => {
+                    if let Some(transition) = distinct_transitions.get(col_idx) {
+                        // Update count if not already processed (needed for AVG)
+                        if !processed_counts.contains(col_idx) {
+                            let current_count =
+                                self.distinct_counts.get(col_idx).copied().unwrap_or(0);
+                            let new_count = match transition.transition_type {
+                                TransitionType::Added => current_count + 1,
+                                TransitionType::Removed => current_count - 1,
+                            };
+                            self.distinct_counts.insert(*col_idx, new_count);
+                            processed_counts.insert(*col_idx);
+                        }
+
+                        // Update sum if not already processed
+                        if !processed_sums.contains(col_idx) {
+                            let current_sum =
+                                self.distinct_sums.get(col_idx).copied().unwrap_or(0.0);
+                            let value_as_float = match &transition.transitioned_value {
+                                Value::Integer(i) => *i as f64,
+                                Value::Float(f) => *f,
+                                _ => 0.0,
+                            };
+
+                            let new_sum = match transition.transition_type {
+                                TransitionType::Added => current_sum + value_as_float,
+                                TransitionType::Removed => current_sum - value_as_float,
+                            };
+                            self.distinct_sums.insert(*col_idx, new_sum);
+                            processed_sums.insert(*col_idx);
+                        }
+                    }
                 }
                 AggregateFunction::Sum(col_idx) => {
                     if let Some(val) = values.get(*col_idx) {
@@ -760,9 +1173,23 @@ impl AggregateState {
                 AggregateFunction::Count => {
                     result.push(Value::Integer(self.count));
                 }
+                AggregateFunction::CountDistinct(col_idx) => {
+                    // Return the computed DISTINCT count
+                    let count = self.distinct_counts.get(col_idx).copied().unwrap_or(0);
+                    result.push(Value::Integer(count));
+                }
                 AggregateFunction::Sum(col_idx) => {
                     let sum = self.sums.get(col_idx).copied().unwrap_or(0.0);
                     // Return as integer if it's a whole number, otherwise as float
+                    if sum.fract() == 0.0 {
+                        result.push(Value::Integer(sum as i64));
+                    } else {
+                        result.push(Value::Float(sum));
+                    }
+                }
+                AggregateFunction::SumDistinct(col_idx) => {
+                    // Return the computed SUM(DISTINCT)
+                    let sum = self.distinct_sums.get(col_idx).copied().unwrap_or(0.0);
                     if sum.fract() == 0.0 {
                         result.push(Value::Integer(sum as i64));
                     } else {
@@ -776,6 +1203,18 @@ impl AggregateState {
                         } else {
                             result.push(Value::Null);
                         }
+                    } else {
+                        result.push(Value::Null);
+                    }
+                }
+                AggregateFunction::AvgDistinct(col_idx) => {
+                    // Compute AVG from SUM(DISTINCT) / COUNT(DISTINCT)
+                    let count = self.distinct_counts.get(col_idx).copied().unwrap_or(0);
+                    if count > 0 {
+                        let sum = self.distinct_sums.get(col_idx).copied().unwrap_or(0.0);
+                        let avg = sum / count as f64;
+                        // AVG always returns a float value for consistency with SQLite
+                        result.push(Value::Float(avg));
                     } else {
                         result.push(Value::Null);
                     }
@@ -796,12 +1235,109 @@ impl AggregateState {
 }
 
 impl AggregateOperator {
+    /// Detect if a distinct value crosses the zero boundary (using pre-fetched weights and batch-accumulated weights)
+    fn detect_distinct_value_transition(
+        col_idx: usize,
+        val: &Value,
+        weight: isize,
+        existing_state: &AggregateState,
+        group_distinct_deltas: Option<&HashMap<(usize, HashableRow), isize>>,
+    ) -> Option<DistinctTransition> {
+        let hashable_row = HashableRow::new(col_idx as i64, vec![val.clone()]);
+
+        // Get the weight from storage (pre-fetched in AggregateState)
+        let storage_count = existing_state
+            .distinct_value_weights
+            .get(&(col_idx, hashable_row.clone()))
+            .copied()
+            .unwrap_or(0);
+
+        // Get the accumulated weight from the current batch (before this row)
+        let batch_accumulated = if let Some(deltas) = group_distinct_deltas {
+            deltas
+                .get(&(col_idx, hashable_row.clone()))
+                .copied()
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        // The old count is storage + batch accumulated so far (before this row)
+        let old_count = storage_count + batch_accumulated as i64;
+        // The new count includes the current weight
+        let new_count = old_count + weight as i64;
+
+        // Detect transitions
+        if old_count <= 0 && new_count > 0 {
+            // Value added to distinct set
+            Some(DistinctTransition {
+                transition_type: TransitionType::Added,
+                transitioned_value: val.clone(),
+            })
+        } else if old_count > 0 && new_count <= 0 {
+            // Value removed from distinct set
+            Some(DistinctTransition {
+                transition_type: TransitionType::Removed,
+                transitioned_value: val.clone(),
+            })
+        } else {
+            // No transition
+            None
+        }
+    }
+
+    /// Detect distinct value transitions for a single row
+    fn detect_distinct_transitions(
+        &self,
+        row_values: &[Value],
+        weight: isize,
+        existing_state: &AggregateState,
+        group_distinct_deltas: Option<&HashMap<(usize, HashableRow), isize>>,
+    ) -> HashMap<usize, DistinctTransition> {
+        let mut transitions = HashMap::new();
+
+        // Plain Distinct doesn't track individual values, so no transitions needed
+        if self.is_distinct_only {
+            // Distinct is handled by the count alone in apply_delta
+            return transitions;
+        }
+
+        // Process each distinct column
+        for &col_idx in &self.distinct_columns {
+            let val = match row_values.get(col_idx) {
+                Some(v) => v,
+                None => continue,
+            };
+
+            // Skip null values
+            if val == &Value::Null {
+                continue;
+            }
+
+            if let Some(transition) = Self::detect_distinct_value_transition(
+                col_idx,
+                val,
+                weight,
+                existing_state,
+                group_distinct_deltas,
+            ) {
+                transitions.insert(col_idx, transition);
+            }
+        }
+
+        transitions
+    }
+
     pub fn new(
         operator_id: i64,
         group_by: Vec<usize>,
         aggregates: Vec<AggregateFunction>,
         input_column_names: Vec<String>,
     ) -> Self {
+        // Precompute flags for runtime efficiency
+        // Plain DISTINCT is indicated by empty aggregates vector
+        let is_distinct_only = aggregates.is_empty();
+
         // Build map of column indices to their MIN/MAX info
         let mut column_min_max = HashMap::new();
         let mut storage_indices = HashMap::new();
@@ -821,7 +1357,7 @@ impl AggregateOperator {
             }
         }
 
-        // Second pass: build the column info map
+        // Second pass: build the column info map for MIN/MAX
         for agg in &aggregates {
             match agg {
                 AggregateFunction::Min(col_idx) => {
@@ -846,19 +1382,39 @@ impl AggregateOperator {
             }
         }
 
+        // Build the distinct columns set
+        let mut distinct_columns = HashSet::new();
+        for agg in &aggregates {
+            match agg {
+                AggregateFunction::CountDistinct(col_idx)
+                | AggregateFunction::SumDistinct(col_idx)
+                | AggregateFunction::AvgDistinct(col_idx) => {
+                    distinct_columns.insert(*col_idx);
+                }
+                _ => {}
+            }
+        }
+
         Self {
             operator_id,
             group_by,
             aggregates,
             input_column_names,
             column_min_max,
+            distinct_columns,
             tracker: None,
             commit_state: AggregateCommitState::Idle,
+            is_distinct_only,
         }
     }
 
     pub fn has_min_max(&self) -> bool {
         !self.column_min_max.is_empty()
+    }
+
+    /// Check if this operator has any DISTINCT aggregates or plain DISTINCT
+    pub fn has_distinct(&self) -> bool {
+        !self.distinct_columns.is_empty() || self.is_distinct_only
     }
 
     fn eval_internal(
@@ -896,6 +1452,7 @@ impl AggregateOperator {
                     groups_to_read: groups_to_read.into_iter().collect(),
                     existing_groups: HashMap::new(),
                     old_values: HashMap::new(),
+                    pre_existing_groups: HashSet::new(), // Initialize empty
                 }));
             }
             EvalState::Aggregate(_agg_state) => {
@@ -924,12 +1481,17 @@ impl AggregateOperator {
         delta: &Delta,
         existing_groups: &mut HashMap<String, AggregateState>,
         old_values: &mut HashMap<String, Vec<Value>>,
-    ) -> (Delta, HashMap<String, (Vec<Value>, AggregateState)>) {
+        pre_existing_groups: &HashSet<String>,
+    ) -> MergeResult {
         let mut output_delta = Delta::new();
         let mut temp_keys: HashMap<String, Vec<Value>> = HashMap::new();
 
+        // Track distinct value weights as we process the batch
+        let mut batch_distinct_weights: HashMap<String, HashMap<(usize, HashableRow), isize>> =
+            HashMap::new();
+
         // Process each change in the delta
-        for (row, weight) in &delta.changes {
+        for (row, weight) in delta.changes.iter() {
             if let Some(tracker) = &self.tracker {
                 tracker.lock().unwrap().record_aggregation();
             }
@@ -938,48 +1500,157 @@ impl AggregateOperator {
             let group_key = self.extract_group_key(&row.values);
             let group_key_str = Self::group_key_to_string(&group_key);
 
+            // Get or create the state for this group
             let state = existing_groups.entry(group_key_str.clone()).or_default();
+
+            // Get batch weights for this group
+            let group_batch_weights = batch_distinct_weights.get(&group_key_str);
+
+            // Detect distinct transitions using the existing state and batch-accumulated weights
+            let distinct_transitions = if self.has_distinct() {
+                self.detect_distinct_transitions(&row.values, *weight, state, group_batch_weights)
+            } else {
+                HashMap::new()
+            };
+
+            // Update batch weights after detecting transitions
+            if self.has_distinct() {
+                for &col_idx in &self.distinct_columns {
+                    if let Some(val) = row.values.get(col_idx) {
+                        if val != &Value::Null {
+                            let hashable_row = HashableRow::new(col_idx as i64, vec![val.clone()]);
+                            let group_entry = batch_distinct_weights
+                                .entry(group_key_str.clone())
+                                .or_default();
+                            let weight_entry =
+                                group_entry.entry((col_idx, hashable_row)).or_insert(0);
+                            *weight_entry += weight;
+                        }
+                    }
+                }
+            }
 
             temp_keys.insert(group_key_str.clone(), group_key.clone());
 
-            // Apply the delta to the temporary state
+            // Apply the delta to the state with pre-computed transitions
             state.apply_delta(
                 &row.values,
                 *weight,
                 &self.aggregates,
                 &self.input_column_names,
+                &distinct_transitions,
             );
         }
 
         // Generate output delta from temporary states and collect final states
         let mut final_states = HashMap::new();
 
-        for (group_key_str, state) in existing_groups {
-            let group_key = temp_keys.get(group_key_str).cloned().unwrap_or_default();
+        for (group_key_str, state) in existing_groups.iter() {
+            let group_key = if let Some(key) = temp_keys.get(group_key_str) {
+                key.clone()
+            } else if let Some(old_row) = old_values.get(group_key_str) {
+                // Extract group key from old row (first N columns where N = group_by.len())
+                old_row[0..self.group_by.len()].to_vec()
+            } else {
+                vec![]
+            };
 
             // Generate synthetic rowid for this group
             let result_key = self.generate_group_rowid(group_key_str);
 
-            if let Some(old_row_values) = old_values.get(group_key_str) {
-                let old_row = HashableRow::new(result_key, old_row_values.clone());
-                output_delta.changes.push((old_row, -1));
-            }
-
             // Always store the state for persistence (even if count=0, we need to delete it)
             final_states.insert(group_key_str.clone(), (group_key.clone(), state.clone()));
 
-            // Only include groups with count > 0 in the output delta
-            if state.count > 0 {
-                // Build output row: group_by columns + aggregate values
-                let mut output_values = group_key.clone();
-                let aggregate_values = state.to_values(&self.aggregates);
-                output_values.extend(aggregate_values);
+            // Check if we only have DISTINCT (no other aggregates)
+            if self.is_distinct_only {
+                // For plain DISTINCT, we output each distinct VALUE (not group)
+                // state.count tells us how many distinct values have positive weight
 
-                let output_row = HashableRow::new(result_key, output_values.clone());
-                output_delta.changes.push((output_row, 1));
+                // Check if this group had any values before
+                let old_existed = pre_existing_groups.contains(group_key_str);
+                let new_exists = state.count > 0;
+
+                if old_existed && !new_exists {
+                    // All distinct values removed: output deletion
+                    if let Some(old_row_values) = old_values.get(group_key_str) {
+                        let old_row = HashableRow::new(result_key, old_row_values.clone());
+                        output_delta.changes.push((old_row, -1));
+                    } else {
+                        // For plain DISTINCT, the old row is just the group key itself
+                        let old_row = HashableRow::new(result_key, group_key.clone());
+                        output_delta.changes.push((old_row, -1));
+                    }
+                } else if !old_existed && new_exists {
+                    // First distinct value added: output insertion
+                    let output_values = group_key.clone();
+                    // DISTINCT doesn't add aggregate values - just the group key
+                    let output_row = HashableRow::new(result_key, output_values.clone());
+                    output_delta.changes.push((output_row, 1));
+                }
+                // No output if staying positive or staying at zero
+            } else {
+                // Normal aggregates: output deletions and insertions as before
+                if let Some(old_row_values) = old_values.get(group_key_str) {
+                    let old_row = HashableRow::new(result_key, old_row_values.clone());
+                    output_delta.changes.push((old_row, -1));
+                }
+
+                // Only include groups with count > 0 in the output delta
+                if state.count > 0 {
+                    // Build output row: group_by columns + aggregate values
+                    let mut output_values = group_key.clone();
+                    let aggregate_values = state.to_values(&self.aggregates);
+                    output_values.extend(aggregate_values);
+
+                    let output_row = HashableRow::new(result_key, output_values.clone());
+                    output_delta.changes.push((output_row, 1));
+                }
             }
         }
+
         (output_delta, final_states)
+    }
+
+    /// Extract distinct values from delta changes for batch tracking
+    fn extract_distinct_deltas(&self, delta: &Delta) -> DistinctDeltas {
+        let mut distinct_deltas: DistinctDeltas = HashMap::new();
+
+        for (row, weight) in &delta.changes {
+            let group_key = self.extract_group_key(&row.values);
+            let group_key_str = Self::group_key_to_string(&group_key);
+
+            // Get or create entry for this group
+            let group_entry = distinct_deltas.entry(group_key_str.clone()).or_default();
+
+            if self.is_distinct_only {
+                // For plain DISTINCT, the group itself is what we're tracking
+                // We store a single entry that represents "this group exists N times"
+                // Use column index 0 with the group_key_str as the value
+                // For group key, use 0 as column index
+                let key = (
+                    0,
+                    HashableRow::new(0, vec![Value::Text(group_key_str.clone().into())]),
+                );
+                let value_entry = group_entry.entry(key).or_insert(0);
+                *value_entry += weight;
+            } else {
+                // For DISTINCT aggregates, track individual column values
+                for &col_idx in &self.distinct_columns {
+                    if let Some(val) = row.values.get(col_idx) {
+                        // Skip NULL values
+                        if val == &Value::Null {
+                            continue;
+                        }
+
+                        let key = (col_idx, HashableRow::new(col_idx as i64, vec![val.clone()]));
+                        let value_entry = group_entry.entry(key).or_insert(0);
+                        *value_entry += weight;
+                    }
+                }
+            }
+        }
+
+        distinct_deltas
     }
 
     /// Extract MIN/MAX values from delta changes for persistence to index
@@ -1104,14 +1775,25 @@ impl IncrementalOperator for AggregateOperator {
                     self.commit_state = AggregateCommitState::Eval { eval_state };
                 }
                 AggregateCommitState::Eval { ref mut eval_state } => {
-                    // Extract input delta before eval for MIN/MAX processing
-                    let input_delta = eval_state.extract_delta();
+                    // Clone the delta for MIN/MAX processing before eval consumes it
+                    // We need to get the delta from the eval_state if it's still in Init
+                    let input_delta = match eval_state {
+                        EvalState::Init { deltas } => deltas.left.clone(),
+                        _ => Delta::new(), // Empty delta if already processed
+                    };
 
-                    // Extract MIN/MAX deltas before any I/O operations
+                    // Extract MIN/MAX and DISTINCT deltas before any I/O operations
                     let min_max_deltas = self.extract_min_max_deltas(&input_delta);
+                    // For plain DISTINCT, we need to extract deltas too
+                    let distinct_deltas = if self.has_distinct() || self.is_distinct_only {
+                        self.extract_distinct_deltas(&input_delta)
+                    } else {
+                        HashMap::new()
+                    };
 
-                    // Create a new eval state with the same delta
-                    *eval_state = EvalState::from_delta(input_delta.clone());
+                    // Get old counts before eval modifies the states
+                    // We need to extract this from the eval_state before it's consumed
+                    let old_states = HashMap::new(); // TODO: Extract from eval_state
 
                     let (output_delta, computed_states) = return_and_restore_if_io!(
                         &mut self.commit_state,
@@ -1122,17 +1804,23 @@ impl IncrementalOperator for AggregateOperator {
                     self.commit_state = AggregateCommitState::PersistDelta {
                         delta: output_delta,
                         computed_states,
+                        old_states,
                         current_idx: 0,
                         write_row: WriteRow::new(),
-                        min_max_deltas, // Store for later use
+                        min_max_deltas,  // Store for later use
+                        distinct_deltas, // Store for distinct processing
+                        input_delta,     // Store original input
                     };
                 }
                 AggregateCommitState::PersistDelta {
                     delta,
                     computed_states,
+                    old_states,
                     current_idx,
                     write_row,
                     min_max_deltas,
+                    distinct_deltas,
+                    input_delta,
                 } => {
                     let states_vec: Vec<_> = computed_states.iter().collect();
 
@@ -1141,28 +1829,59 @@ impl IncrementalOperator for AggregateOperator {
                         self.commit_state = AggregateCommitState::PersistMinMax {
                             delta: delta.clone(),
                             min_max_persist_state: MinMaxPersistState::new(min_max_deltas.clone()),
+                            distinct_deltas: distinct_deltas.clone(),
                         };
                     } else {
                         let (group_key_str, (group_key, agg_state)) = states_vec[*current_idx];
 
-                        // Build the key components for the new table structure
-                        // For regular aggregates, use column_index=0 and AGG_TYPE_REGULAR
+                        // Skip aggregate state persistence for plain DISTINCT
+                        // Plain DISTINCT only uses the distinct value weights, not aggregate state
+                        if self.is_distinct_only {
+                            // Skip to next - distinct values are handled in PersistDistinctValues
+                            // We still need to transition states properly
+                            let next_idx = *current_idx + 1;
+                            if next_idx >= states_vec.len() {
+                                // Done with all groups, move to PersistMinMax
+                                self.commit_state = AggregateCommitState::PersistMinMax {
+                                    delta: std::mem::take(delta),
+                                    min_max_persist_state: MinMaxPersistState::new(std::mem::take(
+                                        min_max_deltas,
+                                    )),
+                                    distinct_deltas: std::mem::take(distinct_deltas),
+                                };
+                            } else {
+                                // Move to next group
+                                self.commit_state = AggregateCommitState::PersistDelta {
+                                    delta: std::mem::take(delta),
+                                    computed_states: std::mem::take(computed_states),
+                                    old_states: std::mem::take(old_states),
+                                    current_idx: next_idx,
+                                    write_row: WriteRow::new(),
+                                    min_max_deltas: std::mem::take(min_max_deltas),
+                                    distinct_deltas: std::mem::take(distinct_deltas),
+                                    input_delta: std::mem::take(input_delta),
+                                };
+                            }
+                            continue;
+                        }
+
+                        // Build the key components for regular aggregates
                         let operator_storage_id =
                             generate_storage_id(self.operator_id, 0, AGG_TYPE_REGULAR);
                         let zset_hash = self.generate_group_hash(group_key_str);
-                        let element_id = 0i64;
+                        let element_id = Hash128::new(0, 0); // Always zeros for regular aggregates
 
-                        // Determine weight: -1 to delete (cancels existing weight=1), 1 to insert/update
+                        // Determine weight: 1 if exists, -1 if deleted
                         let weight = if agg_state.count == 0 { -1 } else { 1 };
 
-                        // Serialize the aggregate state with group key (even for deletion, we need a row)
+                        // Serialize the aggregate state (only for regular aggregates, not plain DISTINCT)
                         let state_blob = agg_state.to_blob(&self.aggregates, group_key);
                         let blob_value = Value::Blob(state_blob);
 
                         // Build the aggregate storage format: [operator_id, zset_hash, element_id, value, weight]
                         let operator_id_val = Value::Integer(operator_storage_id);
                         let zset_hash_val = zset_hash.to_value();
-                        let element_id_val = Value::Integer(element_id);
+                        let element_id_val = element_id.to_value();
                         let blob_val = blob_value.clone();
 
                         // Create index key - the first 3 columns of our primary key
@@ -1185,24 +1904,27 @@ impl IncrementalOperator for AggregateOperator {
                         let delta = std::mem::take(delta);
                         let computed_states = std::mem::take(computed_states);
                         let min_max_deltas = std::mem::take(min_max_deltas);
+                        let distinct_deltas = std::mem::take(distinct_deltas);
+                        let input_delta = std::mem::take(input_delta);
 
                         self.commit_state = AggregateCommitState::PersistDelta {
                             delta,
                             computed_states,
+                            old_states: std::mem::take(old_states),
                             current_idx: *current_idx + 1,
                             write_row: WriteRow::new(), // Reset for next write
                             min_max_deltas,
+                            distinct_deltas,
+                            input_delta,
                         };
                     }
                 }
                 AggregateCommitState::PersistMinMax {
                     delta,
                     min_max_persist_state,
+                    distinct_deltas,
                 } => {
-                    if !self.has_min_max() {
-                        let delta = std::mem::take(delta);
-                        self.commit_state = AggregateCommitState::Done { delta };
-                    } else {
+                    if self.has_min_max() {
                         return_and_restore_if_io!(
                             &mut self.commit_state,
                             state,
@@ -1213,10 +1935,37 @@ impl IncrementalOperator for AggregateOperator {
                                 |group_key_str| self.generate_group_hash(group_key_str)
                             )
                         );
-
-                        let delta = std::mem::take(delta);
-                        self.commit_state = AggregateCommitState::Done { delta };
                     }
+
+                    // Transition to PersistDistinctValues
+                    let delta = std::mem::take(delta);
+                    let distinct_deltas = std::mem::take(distinct_deltas);
+                    let distinct_persist_state = DistinctPersistState::new(distinct_deltas);
+                    self.commit_state = AggregateCommitState::PersistDistinctValues {
+                        delta,
+                        distinct_persist_state,
+                    };
+                }
+                AggregateCommitState::PersistDistinctValues {
+                    delta,
+                    distinct_persist_state,
+                } => {
+                    if self.has_distinct() {
+                        // Use the state machine to persist distinct values to BTree
+                        return_and_restore_if_io!(
+                            &mut self.commit_state,
+                            state,
+                            distinct_persist_state.persist_distinct_values(
+                                self.operator_id,
+                                cursors,
+                                |group_key_str| self.generate_group_hash(group_key_str)
+                            )
+                        );
+                    }
+
+                    // Transition to Done
+                    let delta = std::mem::take(delta);
+                    self.commit_state = AggregateCommitState::Done { delta };
                 }
                 AggregateCommitState::Done { delta } => {
                     self.commit_state = AggregateCommitState::Idle;
@@ -1753,6 +2502,484 @@ pub enum MinMaxPersistState {
         write_row: WriteRow,
     },
     Done,
+}
+
+/// State machine for fetching distinct values from BTree storage
+#[derive(Debug)]
+pub enum FetchDistinctState {
+    Init {
+        groups_to_fetch: Vec<(String, HashMap<usize, HashSet<HashableRow>>)>,
+    },
+    FetchGroup {
+        groups_to_fetch: Vec<(String, HashMap<usize, HashSet<HashableRow>>)>,
+        group_idx: usize,
+        value_idx: usize,
+        values_to_fetch: Vec<(usize, Value)>,
+    },
+    ReadValue {
+        groups_to_fetch: Vec<(String, HashMap<usize, HashSet<HashableRow>>)>,
+        group_idx: usize,
+        value_idx: usize,
+        values_to_fetch: Vec<(usize, Value)>,
+        group_key: String,
+        column_idx: usize,
+        value: Value,
+    },
+    Done,
+}
+
+impl FetchDistinctState {
+    /// Add fetch entry for plain DISTINCT - the group itself is the distinct value
+    fn add_plain_distinct_fetch(
+        group_entry: &mut HashMap<usize, HashSet<HashableRow>>,
+        group_key_str: &str,
+    ) {
+        let group_value = Value::Text(group_key_str.to_string().into());
+        group_entry
+            .entry(0)
+            .or_default()
+            .insert(HashableRow::new(0, vec![group_value]));
+    }
+
+    /// Add fetch entries for DISTINCT aggregates - individual column values
+    fn add_aggregate_distinct_fetch(
+        group_entry: &mut HashMap<usize, HashSet<HashableRow>>,
+        row_values: &[Value],
+        distinct_columns: &HashSet<usize>,
+    ) {
+        for &col_idx in distinct_columns {
+            if let Some(val) = row_values.get(col_idx) {
+                if val != &Value::Null {
+                    group_entry
+                        .entry(col_idx)
+                        .or_default()
+                        .insert(HashableRow::new(col_idx as i64, vec![val.clone()]));
+                }
+            }
+        }
+    }
+
+    pub fn new(
+        delta: &Delta,
+        distinct_columns: &HashSet<usize>,
+        extract_group_key: impl Fn(&[Value]) -> Vec<Value>,
+        group_key_to_string: impl Fn(&[Value]) -> String,
+        existing_groups: &HashMap<String, AggregateState>,
+        is_plain_distinct: bool,
+    ) -> Self {
+        let mut groups_to_fetch: HashMap<String, HashMap<usize, HashSet<HashableRow>>> =
+            HashMap::new();
+
+        for (row, _weight) in &delta.changes {
+            let group_key = extract_group_key(&row.values);
+            let group_key_str = group_key_to_string(&group_key);
+
+            // Skip groups we don't need to fetch
+            // For DISTINCT aggregates, only fetch for existing groups
+            if !is_plain_distinct && !existing_groups.contains_key(&group_key_str) {
+                continue;
+            }
+
+            let group_entry = groups_to_fetch.entry(group_key_str.clone()).or_default();
+
+            if is_plain_distinct {
+                Self::add_plain_distinct_fetch(group_entry, &group_key_str);
+            } else {
+                Self::add_aggregate_distinct_fetch(group_entry, &row.values, distinct_columns);
+            }
+        }
+
+        let groups_to_fetch: Vec<_> = groups_to_fetch.into_iter().collect();
+
+        if groups_to_fetch.is_empty() {
+            Self::Done
+        } else {
+            Self::Init { groups_to_fetch }
+        }
+    }
+
+    pub fn fetch_distinct_values(
+        &mut self,
+        operator_id: i64,
+        existing_groups: &mut HashMap<String, AggregateState>,
+        cursors: &mut DbspStateCursors,
+        generate_group_hash: impl Fn(&str) -> Hash128,
+        is_plain_distinct: bool,
+    ) -> Result<IOResult<()>> {
+        loop {
+            match self {
+                FetchDistinctState::Init { groups_to_fetch } => {
+                    if groups_to_fetch.is_empty() {
+                        *self = FetchDistinctState::Done;
+                        continue;
+                    }
+
+                    let groups = std::mem::take(groups_to_fetch);
+                    *self = FetchDistinctState::FetchGroup {
+                        groups_to_fetch: groups,
+                        group_idx: 0,
+                        value_idx: 0,
+                        values_to_fetch: Vec::new(),
+                    };
+                }
+                FetchDistinctState::FetchGroup {
+                    groups_to_fetch,
+                    group_idx,
+                    value_idx,
+                    values_to_fetch,
+                } => {
+                    if *group_idx >= groups_to_fetch.len() {
+                        *self = FetchDistinctState::Done;
+                        continue;
+                    }
+
+                    // Build list of values to fetch for current group if not done
+                    if values_to_fetch.is_empty() && *group_idx < groups_to_fetch.len() {
+                        let (_group_key, cols_values) = &groups_to_fetch[*group_idx];
+                        for (col_idx, values) in cols_values {
+                            for hashable_row in values {
+                                // Extract the value from HashableRow
+                                values_to_fetch
+                                    .push((*col_idx, hashable_row.values.first().unwrap().clone()));
+                            }
+                        }
+                    }
+
+                    if *value_idx >= values_to_fetch.len() {
+                        // Move to next group
+                        *group_idx += 1;
+                        *value_idx = 0;
+                        values_to_fetch.clear();
+                        continue;
+                    }
+
+                    // Fetch current value
+                    let (group_key, _) = groups_to_fetch[*group_idx].clone();
+                    let (column_idx, value) = values_to_fetch[*value_idx].clone();
+
+                    let groups = std::mem::take(groups_to_fetch);
+                    let values = std::mem::take(values_to_fetch);
+                    *self = FetchDistinctState::ReadValue {
+                        groups_to_fetch: groups,
+                        group_idx: *group_idx,
+                        value_idx: *value_idx,
+                        values_to_fetch: values,
+                        group_key,
+                        column_idx,
+                        value,
+                    };
+                }
+                FetchDistinctState::ReadValue {
+                    groups_to_fetch,
+                    group_idx,
+                    value_idx,
+                    values_to_fetch,
+                    group_key,
+                    column_idx,
+                    value,
+                } => {
+                    // Read the record from BTree using the same pattern as WriteRow:
+                    // 1. Seek in index to find the entry
+                    // 2. Get rowid from index cursor
+                    // 3. Use rowid to read from table cursor
+                    let storage_id =
+                        generate_storage_id(operator_id, *column_idx, AGG_TYPE_DISTINCT);
+                    let zset_hash = generate_group_hash(group_key);
+                    let element_id = hash_value(value, *column_idx);
+
+                    // First, seek in the index cursor
+                    let index_key = vec![
+                        Value::Integer(storage_id),
+                        zset_hash.to_value(),
+                        element_id.to_value(),
+                    ];
+                    let index_record = ImmutableRecord::from_values(&index_key, index_key.len());
+
+                    let seek_result = return_if_io!(cursors.index_cursor.seek(
+                        SeekKey::IndexKey(&index_record),
+                        SeekOp::GE { eq_only: true }
+                    ));
+
+                    // Early exit if not found in index
+                    if !matches!(seek_result, SeekResult::Found) {
+                        let groups = std::mem::take(groups_to_fetch);
+                        let values = std::mem::take(values_to_fetch);
+                        *self = FetchDistinctState::FetchGroup {
+                            groups_to_fetch: groups,
+                            group_idx: *group_idx,
+                            value_idx: *value_idx + 1,
+                            values_to_fetch: values,
+                        };
+                        continue;
+                    }
+
+                    // Get the rowid from the index cursor
+                    let rowid = return_if_io!(cursors.index_cursor.rowid());
+
+                    // Early exit if no rowid
+                    let rowid = match rowid {
+                        Some(id) => id,
+                        None => {
+                            let groups = std::mem::take(groups_to_fetch);
+                            let values = std::mem::take(values_to_fetch);
+                            *self = FetchDistinctState::FetchGroup {
+                                groups_to_fetch: groups,
+                                group_idx: *group_idx,
+                                value_idx: *value_idx + 1,
+                                values_to_fetch: values,
+                            };
+                            continue;
+                        }
+                    };
+
+                    // Now seek in the table cursor using the rowid
+                    let table_result = return_if_io!(cursors
+                        .table_cursor
+                        .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true }));
+
+                    // Early exit if not found in table
+                    if !matches!(table_result, SeekResult::Found) {
+                        let groups = std::mem::take(groups_to_fetch);
+                        let values = std::mem::take(values_to_fetch);
+                        *self = FetchDistinctState::FetchGroup {
+                            groups_to_fetch: groups,
+                            group_idx: *group_idx,
+                            value_idx: *value_idx + 1,
+                            values_to_fetch: values,
+                        };
+                        continue;
+                    }
+
+                    // Read the actual record from the table cursor
+                    let record = return_if_io!(cursors.table_cursor.record());
+
+                    if let Some(r) = record {
+                        let values = r.get_values();
+
+                        // The table has 5 columns: storage_id, zset_hash, element_id, blob, weight
+                        // The weight is at index 4
+                        if values.len() >= 5 {
+                            // Get the weight directly from column 4
+                            let weight = match values[4].to_owned() {
+                                Value::Integer(w) => w,
+                                _ => 0,
+                            };
+
+                            // Store the weight in the existing group's state
+                            let state = existing_groups.entry(group_key.clone()).or_default();
+                            state.distinct_value_weights.insert(
+                                (
+                                    *column_idx,
+                                    HashableRow::new(*column_idx as i64, vec![value.clone()]),
+                                ),
+                                weight,
+                            );
+                        }
+                    }
+
+                    // Move to next value
+                    let groups = std::mem::take(groups_to_fetch);
+                    let values = std::mem::take(values_to_fetch);
+                    *self = FetchDistinctState::FetchGroup {
+                        groups_to_fetch: groups,
+                        group_idx: *group_idx,
+                        value_idx: *value_idx + 1,
+                        values_to_fetch: values,
+                    };
+                }
+                FetchDistinctState::Done => {
+                    // For plain DISTINCT, construct AggregateState from the weights we fetched
+                    if is_plain_distinct {
+                        for (_group_key_str, state) in existing_groups.iter_mut() {
+                            // For plain DISTINCT, sum all the weights to get total count
+                            // Each weight represents how many times the distinct value appears
+                            let total_weight: i64 = state.distinct_value_weights.values().sum();
+
+                            // Set the count based on total weight
+                            state.count = total_weight;
+                        }
+                    }
+                    return Ok(IOResult::Done(()));
+                }
+            }
+        }
+    }
+}
+
+/// State machine for persisting distinct values to BTree storage
+#[derive(Debug)]
+pub enum DistinctPersistState {
+    Init {
+        distinct_deltas: DistinctDeltas,
+        group_keys: Vec<String>,
+    },
+    ProcessGroup {
+        distinct_deltas: DistinctDeltas,
+        group_keys: Vec<String>,
+        group_idx: usize,
+        value_keys: Vec<(usize, HashableRow)>, // (col_idx, value) pairs for current group
+        value_idx: usize,
+    },
+    WriteValue {
+        distinct_deltas: DistinctDeltas,
+        group_keys: Vec<String>,
+        group_idx: usize,
+        value_keys: Vec<(usize, HashableRow)>,
+        value_idx: usize,
+        group_key: String,
+        col_idx: usize,
+        value: Value,
+        weight: isize,
+        write_row: WriteRow,
+    },
+    Done,
+}
+
+impl DistinctPersistState {
+    pub fn new(distinct_deltas: DistinctDeltas) -> Self {
+        let group_keys: Vec<String> = distinct_deltas.keys().cloned().collect();
+        Self::Init {
+            distinct_deltas,
+            group_keys,
+        }
+    }
+
+    pub fn persist_distinct_values(
+        &mut self,
+        operator_id: i64,
+        cursors: &mut DbspStateCursors,
+        generate_group_hash: impl Fn(&str) -> Hash128,
+    ) -> Result<IOResult<()>> {
+        loop {
+            match self {
+                DistinctPersistState::Init {
+                    distinct_deltas,
+                    group_keys,
+                } => {
+                    let distinct_deltas = std::mem::take(distinct_deltas);
+                    let group_keys = std::mem::take(group_keys);
+                    *self = DistinctPersistState::ProcessGroup {
+                        distinct_deltas,
+                        group_keys,
+                        group_idx: 0,
+                        value_keys: Vec::new(),
+                        value_idx: 0,
+                    };
+                }
+                DistinctPersistState::ProcessGroup {
+                    distinct_deltas,
+                    group_keys,
+                    group_idx,
+                    value_keys,
+                    value_idx,
+                } => {
+                    // Check if we're past all groups
+                    if *group_idx >= group_keys.len() {
+                        *self = DistinctPersistState::Done;
+                        continue;
+                    }
+
+                    // Check if we need to get value_keys for current group
+                    if value_keys.is_empty() && *group_idx < group_keys.len() {
+                        let group_key_str = &group_keys[*group_idx];
+                        if let Some(group_values) = distinct_deltas.get(group_key_str) {
+                            *value_keys = group_values.keys().cloned().collect();
+                        }
+                    }
+
+                    // Check if we have more values in current group
+                    if *value_idx >= value_keys.len() {
+                        *group_idx += 1;
+                        *value_idx = 0;
+                        value_keys.clear();
+                        continue;
+                    }
+
+                    // Process current value
+                    let group_key = group_keys[*group_idx].clone();
+                    let (col_idx, hashable_row) = value_keys[*value_idx].clone();
+                    let weight = distinct_deltas[&group_key][&(col_idx, hashable_row.clone())];
+                    // Extract the value from HashableRow (it's the first element in values vector)
+                    let value = hashable_row.values.first().unwrap().clone();
+
+                    let distinct_deltas = std::mem::take(distinct_deltas);
+                    let group_keys = std::mem::take(group_keys);
+                    let value_keys = std::mem::take(value_keys);
+                    *self = DistinctPersistState::WriteValue {
+                        distinct_deltas,
+                        group_keys,
+                        group_idx: *group_idx,
+                        value_keys,
+                        value_idx: *value_idx,
+                        group_key,
+                        col_idx,
+                        value,
+                        weight,
+                        write_row: WriteRow::new(),
+                    };
+                }
+                DistinctPersistState::WriteValue {
+                    distinct_deltas,
+                    group_keys,
+                    group_idx,
+                    value_keys,
+                    value_idx,
+                    group_key,
+                    col_idx,
+                    value,
+                    weight,
+                    write_row,
+                } => {
+                    // Build the key components for DISTINCT storage
+                    let storage_id = generate_storage_id(operator_id, *col_idx, AGG_TYPE_DISTINCT);
+                    let zset_hash = generate_group_hash(group_key);
+
+                    // For DISTINCT, element_id is a hash of the value
+                    let element_id = hash_value(value, *col_idx);
+
+                    // Create index key
+                    let index_key = vec![
+                        Value::Integer(storage_id),
+                        zset_hash.to_value(),
+                        element_id.to_value(),
+                    ];
+
+                    // Record values (operator_id, zset_hash, element_id, weight_blob)
+                    // Store weight as a minimal AggregateState blob so ReadRecord can parse it
+                    let weight_state = AggregateState {
+                        count: *weight as i64,
+                        ..Default::default()
+                    };
+                    let weight_blob = weight_state.to_blob(&[], &[]);
+
+                    let record_values = vec![
+                        Value::Integer(storage_id),
+                        zset_hash.to_value(),
+                        element_id.to_value(),
+                        Value::Blob(weight_blob),
+                    ];
+
+                    // Write to BTree
+                    return_if_io!(write_row.write_row(cursors, index_key, record_values, *weight));
+
+                    // Move to next value
+                    let distinct_deltas = std::mem::take(distinct_deltas);
+                    let group_keys = std::mem::take(group_keys);
+                    let value_keys = std::mem::take(value_keys);
+                    *self = DistinctPersistState::ProcessGroup {
+                        distinct_deltas,
+                        group_keys,
+                        group_idx: *group_idx,
+                        value_keys,
+                        value_idx: *value_idx + 1,
+                    };
+                }
+                DistinctPersistState::Done => {
+                    return Ok(IOResult::Done(()));
+                }
+            }
+        }
+    }
 }
 
 impl MinMaxPersistState {

--- a/testing/materialized_views.test
+++ b/testing/materialized_views.test
@@ -1720,3 +1720,777 @@ do_execsql_test_on_specific_db {:memory:} matview-groupby-join-position {
     SELECT * FROM tujoingroup ORDER BY a;
 } {1|2
 2|1}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-basic {
+    CREATE TABLE items(id INTEGER, category TEXT, value INTEGER);
+    INSERT INTO items VALUES
+        (1, 'A', 100),
+        (2, 'B', 200),
+        (3, 'A', 100),  -- duplicate of row 1
+        (4, 'C', 300),
+        (5, 'B', 200),  -- duplicate of row 2
+        (6, 'A', 100);  -- another duplicate of row 1
+
+    CREATE MATERIALIZED VIEW distinct_items AS
+        SELECT DISTINCT category, value FROM items;
+
+    SELECT category, value FROM distinct_items ORDER BY category, value;
+} {A|100
+B|200
+C|300}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-single-column {
+    CREATE TABLE numbers(n INTEGER);
+    INSERT INTO numbers VALUES (1), (2), (1), (3), (2), (1), (4), (3);
+
+    CREATE MATERIALIZED VIEW distinct_numbers AS
+        SELECT DISTINCT n FROM numbers;
+
+    SELECT n FROM distinct_numbers ORDER BY n;
+} {1
+2
+3
+4}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-incremental-insert {
+    CREATE TABLE data(x INTEGER, y TEXT);
+    CREATE MATERIALIZED VIEW distinct_data AS
+        SELECT DISTINCT x, y FROM data;
+
+    -- Initial data
+    INSERT INTO data VALUES (1, 'alpha'), (2, 'beta'), (1, 'alpha');
+    SELECT x, y FROM distinct_data ORDER BY x, y;
+} {1|alpha
+2|beta}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-incremental-insert-new {
+    CREATE TABLE data(x INTEGER, y TEXT);
+    CREATE MATERIALIZED VIEW distinct_data AS
+        SELECT DISTINCT x, y FROM data;
+
+    -- Initial data
+    INSERT INTO data VALUES (1, 'alpha'), (2, 'beta'), (1, 'alpha');
+
+    -- Add new distinct values
+    INSERT INTO data VALUES (3, 'gamma'), (4, 'delta');
+    SELECT x, y FROM distinct_data ORDER BY x, y;
+} {1|alpha
+2|beta
+3|gamma
+4|delta}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-incremental-insert-dups {
+    CREATE TABLE data(x INTEGER, y TEXT);
+    CREATE MATERIALIZED VIEW distinct_data AS
+        SELECT DISTINCT x, y FROM data;
+
+    -- Initial data with some new values
+    INSERT INTO data VALUES
+        (1, 'alpha'), (2, 'beta'), (1, 'alpha'),
+        (3, 'gamma'), (4, 'delta');
+
+    -- Add duplicates of existing values
+    INSERT INTO data VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma');
+    -- Should be same as before the duplicate insert
+    SELECT x, y FROM distinct_data ORDER BY x, y;
+} {1|alpha
+2|beta
+3|gamma
+4|delta}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-incremental-delete {
+    CREATE TABLE records(id INTEGER PRIMARY KEY, category TEXT, status INTEGER);
+    INSERT INTO records VALUES
+        (1, 'X', 1),
+        (2, 'Y', 2),
+        (3, 'X', 1),  -- duplicate values
+        (4, 'Z', 3),
+        (5, 'Y', 2);  -- duplicate values
+
+    CREATE MATERIALIZED VIEW distinct_records AS
+        SELECT DISTINCT category, status FROM records;
+
+    SELECT category, status FROM distinct_records ORDER BY category, status;
+} {X|1
+Y|2
+Z|3}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-incremental-delete-partial {
+    CREATE TABLE records(id INTEGER PRIMARY KEY, category TEXT, status INTEGER);
+    INSERT INTO records VALUES
+        (1, 'X', 1),
+        (2, 'Y', 2),
+        (3, 'X', 1),  -- duplicate values
+        (4, 'Z', 3),
+        (5, 'Y', 2);  -- duplicate values
+
+    CREATE MATERIALIZED VIEW distinct_records AS
+        SELECT DISTINCT category, status FROM records;
+
+    -- Delete one instance of duplicate
+    DELETE FROM records WHERE id = 3;
+    -- X|1 should still exist (one instance remains)
+    SELECT category, status FROM distinct_records ORDER BY category, status;
+} {X|1
+Y|2
+Z|3}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-incremental-delete-all {
+    CREATE TABLE records(id INTEGER PRIMARY KEY, category TEXT, status INTEGER);
+    INSERT INTO records VALUES
+        (1, 'X', 1),
+        (2, 'Y', 2),
+        (4, 'Z', 3),
+        (5, 'Y', 2);  -- duplicate values
+
+    CREATE MATERIALIZED VIEW distinct_records AS
+        SELECT DISTINCT category, status FROM records;
+
+    -- Delete all instances of X|1
+    DELETE FROM records WHERE category = 'X' AND status = 1;
+    -- Now X|1 should be gone
+    SELECT category, status FROM distinct_records ORDER BY category, status;
+} {Y|2
+Z|3}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-incremental-reappear {
+    CREATE TABLE records(id INTEGER PRIMARY KEY, category TEXT, status INTEGER);
+    INSERT INTO records VALUES
+        (2, 'Y', 2),
+        (4, 'Z', 3),
+        (5, 'Y', 2);  -- duplicate values
+
+    CREATE MATERIALIZED VIEW distinct_records AS
+        SELECT DISTINCT category, status FROM records;
+
+    -- Re-add a previously deleted value
+    INSERT INTO records VALUES (6, 'X', 1);
+    -- X|1 should appear
+    SELECT category, status FROM distinct_records ORDER BY category, status;
+} {X|1
+Y|2
+Z|3}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-null-handling {
+    CREATE TABLE nullable(a INTEGER, b TEXT);
+    INSERT INTO nullable VALUES
+        (1, 'one'),
+        (2, NULL),
+        (NULL, 'three'),
+        (1, 'one'),     -- duplicate
+        (2, NULL),      -- duplicate with NULL
+        (NULL, 'three'), -- duplicate with NULL
+        (NULL, NULL);
+
+    CREATE MATERIALIZED VIEW distinct_nullable AS
+        SELECT DISTINCT a, b FROM nullable;
+
+    -- NULLs should be handled as distinct values
+    SELECT a, b FROM distinct_nullable ORDER BY a, b;
+} {|
+|three
+1|one
+2|}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-empty-table {
+    CREATE TABLE empty_source(x INTEGER, y TEXT);
+    CREATE MATERIALIZED VIEW distinct_empty AS
+        SELECT DISTINCT x, y FROM empty_source;
+
+    -- Should be empty
+    SELECT COUNT(*) FROM distinct_empty;
+} {0}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-empty-then-insert {
+    CREATE TABLE empty_source(x INTEGER, y TEXT);
+    CREATE MATERIALIZED VIEW distinct_empty AS
+        SELECT DISTINCT x, y FROM empty_source;
+
+    -- Insert into previously empty table
+    INSERT INTO empty_source VALUES (1, 'first'), (1, 'first'), (2, 'second');
+    SELECT x, y FROM distinct_empty ORDER BY x, y;
+} {1|first
+2|second}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-multi-column-types {
+    CREATE TABLE mixed_types(i INTEGER, t TEXT, r REAL, b BLOB);
+    INSERT INTO mixed_types VALUES
+        (1, 'text1', 1.5, x'0102'),
+        (2, 'text2', 2.5, x'0304'),
+        (1, 'text1', 1.5, x'0102'),  -- exact duplicate
+        (3, 'text3', 3.5, x'0506'),
+        (2, 'text2', 2.5, x'0304');  -- another duplicate
+
+    CREATE MATERIALIZED VIEW distinct_mixed AS
+        SELECT DISTINCT i, t FROM mixed_types;
+
+    SELECT i, t FROM distinct_mixed ORDER BY i, t;
+} {1|text1
+2|text2
+3|text3}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-update-simulation {
+    CREATE TABLE updatable(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO updatable VALUES (1, 'old'), (2, 'old'), (3, 'new');
+
+    CREATE MATERIALIZED VIEW distinct_vals AS
+        SELECT DISTINCT val FROM updatable;
+
+    SELECT val FROM distinct_vals ORDER BY val;
+} {new
+old}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-update-simulation-change {
+    CREATE TABLE updatable(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO updatable VALUES (1, 'old'), (2, 'old'), (3, 'new');
+
+    CREATE MATERIALIZED VIEW distinct_vals AS
+        SELECT DISTINCT val FROM updatable;
+
+    -- Simulate update by delete + insert
+    DELETE FROM updatable WHERE id = 1;
+    INSERT INTO updatable VALUES (1, 'new');
+
+    -- Now we have two 'new' and one 'old', but distinct shows each once
+    SELECT val FROM distinct_vals ORDER BY val;
+} {new
+old}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-update-simulation-all-same {
+    CREATE TABLE updatable(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO updatable VALUES (1, 'new'), (2, 'old'), (3, 'new');
+
+    CREATE MATERIALIZED VIEW distinct_vals AS
+        SELECT DISTINCT val FROM updatable;
+
+    -- Change the 'old' to 'new'
+    DELETE FROM updatable WHERE id = 2;
+    INSERT INTO updatable VALUES (2, 'new');
+
+    -- Now all three rows have 'new', old should disappear
+    SELECT val FROM distinct_vals ORDER BY val;
+} {new}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-large-duplicates {
+    CREATE TABLE many_dups(x INTEGER);
+
+    -- Insert many duplicates
+    INSERT INTO many_dups VALUES (1), (1), (1), (1), (1);
+    INSERT INTO many_dups VALUES (2), (2), (2), (2), (2);
+    INSERT INTO many_dups VALUES (3), (3), (3), (3), (3);
+
+    CREATE MATERIALIZED VIEW distinct_many AS
+        SELECT DISTINCT x FROM many_dups;
+
+    SELECT x FROM distinct_many ORDER BY x;
+} {1
+2
+3}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-large-duplicates-remove {
+    CREATE TABLE many_dups(x INTEGER);
+
+    -- Insert many duplicates
+    INSERT INTO many_dups VALUES (1), (1), (1), (1), (1);
+    INSERT INTO many_dups VALUES (2), (2), (2), (2), (2);
+    INSERT INTO many_dups VALUES (3), (3), (3), (3), (3);
+
+    CREATE MATERIALIZED VIEW distinct_many AS
+        SELECT DISTINCT x FROM many_dups;
+
+    -- Remove some instances of value 2 (rowids 7,8,9,10 keeping rowid 6)
+    DELETE FROM many_dups WHERE rowid IN (7, 8, 9, 10);
+
+    -- Should still have all three values
+    SELECT x FROM distinct_many ORDER BY x;
+} {1
+2
+3}
+
+do_execsql_test_on_specific_db {:memory:} matview-distinct-large-duplicates-remove-all {
+    CREATE TABLE many_dups(x INTEGER);
+
+    -- Insert many duplicates but only one instance of 2
+    INSERT INTO many_dups VALUES (1), (1), (1), (1), (1);
+    INSERT INTO many_dups VALUES (2);
+    INSERT INTO many_dups VALUES (3), (3), (3), (3), (3);
+
+    CREATE MATERIALIZED VIEW distinct_many AS
+        SELECT DISTINCT x FROM many_dups;
+
+    -- Remove ALL instances of value 2
+    DELETE FROM many_dups WHERE x = 2;
+
+    -- Now 2 should be gone
+    SELECT x FROM distinct_many ORDER BY x;
+} {1
+3}
+
+# COUNT(DISTINCT) tests for materialized views
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-basic {
+    CREATE TABLE sales(region TEXT, product TEXT, amount INTEGER);
+    INSERT INTO sales VALUES
+        ('North', 'A', 100),
+        ('North', 'A', 100),  -- Duplicate
+        ('North', 'B', 200),
+        ('South', 'A', 150),
+        ('South', 'A', 150);  -- Duplicate
+
+    CREATE MATERIALIZED VIEW sales_summary AS
+        SELECT region, COUNT(DISTINCT product) as unique_products
+        FROM sales GROUP BY region;
+
+    SELECT * FROM sales_summary ORDER BY region;
+} {North|2
+South|1}
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-nulls {
+    -- COUNT(DISTINCT) should ignore NULL values per SQL standard
+    CREATE TABLE data(grp INTEGER, val INTEGER);
+    INSERT INTO data VALUES
+        (1, 10),
+        (1, 20),
+        (1, NULL),
+        (1, NULL),  -- Multiple NULLs
+        (2, 30),
+        (2, NULL);
+
+    CREATE MATERIALIZED VIEW v AS
+        SELECT grp, COUNT(DISTINCT val) as cnt FROM data GROUP BY grp;
+
+    SELECT * FROM v ORDER BY grp;
+
+    -- Add more NULLs (should not affect count)
+    INSERT INTO data VALUES (1, NULL), (2, NULL);
+    SELECT * FROM v ORDER BY grp;
+
+    -- Add a non-NULL value
+    INSERT INTO data VALUES (2, 40);
+    SELECT * FROM v ORDER BY grp;
+} {1|2
+2|1
+1|2
+2|1
+1|2
+2|2}
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-empty-groups {
+    CREATE TABLE items(category TEXT, item TEXT);
+    INSERT INTO items VALUES
+        ('A', 'x'),
+        ('A', 'y'),
+        ('B', 'z');
+
+    CREATE MATERIALIZED VIEW category_counts AS
+        SELECT category, COUNT(DISTINCT item) as unique_items
+        FROM items GROUP BY category;
+
+    SELECT * FROM category_counts ORDER BY category;
+
+    -- Delete all items from category B
+    DELETE FROM items WHERE category = 'B';
+    SELECT * FROM category_counts ORDER BY category;
+
+    -- Re-add items to B
+    INSERT INTO items VALUES ('B', 'w'), ('B', 'w');  -- Same value twice
+    SELECT * FROM category_counts ORDER BY category;
+} {A|2
+B|1
+A|2
+A|2
+B|1}
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-updates {
+    CREATE TABLE records(id INTEGER PRIMARY KEY, grp TEXT, val INTEGER);
+    INSERT INTO records VALUES
+        (1, 'X', 100),
+        (2, 'X', 200),
+        (3, 'Y', 100),
+        (4, 'Y', 100);  -- Duplicate
+
+    CREATE MATERIALIZED VIEW grp_summary AS
+        SELECT grp, COUNT(DISTINCT val) as distinct_vals
+        FROM records GROUP BY grp;
+
+    SELECT * FROM grp_summary ORDER BY grp;
+
+    -- Update that changes group membership
+    UPDATE records SET grp = 'Y' WHERE id = 1;
+    SELECT * FROM grp_summary ORDER BY grp;
+
+    -- Update that changes value within group
+    UPDATE records SET val = 300 WHERE id = 3;
+    SELECT * FROM grp_summary ORDER BY grp;
+} {X|2
+Y|1
+X|1
+Y|1
+X|1
+Y|2}
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-large-scale {
+    CREATE TABLE events(user_id INTEGER, event_type INTEGER);
+
+    -- Insert many events with varying duplication
+    INSERT INTO events VALUES
+        (1, 1), (1, 1), (1, 1), (1, 2), (1, 3),  -- User 1: 3 distinct
+        (2, 1), (2, 2), (2, 2), (2, 2),           -- User 2: 2 distinct
+        (3, 4), (3, 4), (3, 4), (3, 4), (3, 4);   -- User 3: 1 distinct
+
+    CREATE MATERIALIZED VIEW user_stats AS
+        SELECT user_id, COUNT(DISTINCT event_type) as unique_events
+        FROM events GROUP BY user_id;
+
+    SELECT * FROM user_stats ORDER BY user_id;
+
+    -- Mass deletion
+    DELETE FROM events WHERE event_type = 2;
+    SELECT * FROM user_stats ORDER BY user_id;
+
+    -- Mass insertion with duplicates
+    INSERT INTO events VALUES
+        (1, 5), (1, 5), (1, 6),
+        (2, 5), (2, 6), (2, 7);
+    SELECT * FROM user_stats ORDER BY user_id;
+} {1|3
+2|2
+3|1
+1|2
+2|1
+3|1
+1|4
+2|4
+3|1}
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-group-by-empty-start {
+    CREATE TABLE measurements(device TEXT, reading INTEGER);
+
+    CREATE MATERIALIZED VIEW device_summary AS
+        SELECT device, COUNT(DISTINCT reading) as unique_readings
+        FROM measurements GROUP BY device;
+
+    -- Start with empty table (no groups yet)
+    SELECT COUNT(*) FROM device_summary;
+
+    -- Add first group
+    INSERT INTO measurements VALUES ('D1', 100), ('D1', 100);
+    SELECT * FROM device_summary;
+
+    -- Add second group with distinct values
+    INSERT INTO measurements VALUES ('D2', 200), ('D2', 300);
+    SELECT * FROM device_summary ORDER BY device;
+
+    -- Remove all data
+    DELETE FROM measurements;
+    SELECT COUNT(*) FROM device_summary;
+} {0
+D1|1
+D1|1
+D2|2
+0}
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-single-row-groups {
+    CREATE TABLE singles(k TEXT PRIMARY KEY, v INTEGER);
+    INSERT INTO singles VALUES
+        ('a', 1),
+        ('b', 2),
+        ('c', 3);
+
+    CREATE MATERIALIZED VIEW v AS
+        SELECT k, COUNT(DISTINCT v) as cnt FROM singles GROUP BY k;
+
+    SELECT * FROM v ORDER BY k;
+
+    -- Each group has exactly one row, so COUNT(DISTINCT v) = 1
+    UPDATE singles SET v = 999 WHERE k = 'b';
+    SELECT * FROM v ORDER BY k;
+
+    DELETE FROM singles WHERE k = 'c';
+    SELECT * FROM v ORDER BY k;
+} {a|1
+b|1
+c|1
+a|1
+b|1
+c|1
+a|1
+b|1}
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-transactions {
+    CREATE TABLE txn_data(grp TEXT, val INTEGER);
+    INSERT INTO txn_data VALUES ('A', 1), ('A', 2);
+
+    CREATE MATERIALIZED VIEW txn_view AS
+        SELECT grp, COUNT(DISTINCT val) as cnt FROM txn_data GROUP BY grp;
+
+    SELECT * FROM txn_view;
+
+    -- Transaction that adds duplicates (should not change count)
+    BEGIN;
+    INSERT INTO txn_data VALUES ('A', 1), ('A', 2);
+    SELECT * FROM txn_view;
+    COMMIT;
+
+    SELECT * FROM txn_view;
+
+    -- Transaction that adds new distinct value then rolls back
+    BEGIN;
+    INSERT INTO txn_data VALUES ('A', 3);
+    SELECT * FROM txn_view;
+    ROLLBACK;
+
+    SELECT * FROM txn_view;
+} {A|2
+A|2
+A|2
+A|3
+A|2}
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-text-values {
+    CREATE TABLE strings(category INTEGER, str TEXT);
+    INSERT INTO strings VALUES
+        (1, 'hello'),
+        (1, 'world'),
+        (1, 'hello'),  -- Duplicate
+        (2, 'foo'),
+        (2, 'bar'),
+        (2, 'bar');    -- Duplicate
+
+    CREATE MATERIALIZED VIEW str_counts AS
+        SELECT category, COUNT(DISTINCT str) as unique_strings
+        FROM strings GROUP BY category;
+
+    SELECT * FROM str_counts ORDER BY category;
+
+    -- Case sensitivity test
+    INSERT INTO strings VALUES (1, 'HELLO'), (2, 'FOO');
+    SELECT * FROM str_counts ORDER BY category;
+
+    -- Empty strings
+    INSERT INTO strings VALUES (1, ''), (1, ''), (2, '');
+    SELECT * FROM str_counts ORDER BY category;
+} {1|2
+2|2
+1|3
+2|3
+1|4
+2|4}
+
+do_execsql_test_on_specific_db {:memory:} matview-sum-distinct {
+    CREATE TABLE sales(region TEXT, amount INTEGER);
+    INSERT INTO sales VALUES
+        ('North', 100),
+        ('North', 200),
+        ('North', 100),  -- Duplicate
+        ('North', NULL),
+        ('South', 300),
+        ('South', 300),  -- Duplicate
+        ('South', 400);
+
+    CREATE MATERIALIZED VIEW sales_summary AS
+        SELECT region, SUM(DISTINCT amount) as total_distinct
+        FROM sales GROUP BY region;
+
+    SELECT * FROM sales_summary ORDER BY region;
+
+    -- Add a duplicate value
+    INSERT INTO sales VALUES ('North', 200);
+    SELECT * FROM sales_summary ORDER BY region;
+
+    -- Add a new distinct value
+    INSERT INTO sales VALUES ('South', 500);
+    SELECT * FROM sales_summary ORDER BY region;
+} {North|300
+South|700
+North|300
+South|700
+North|300
+South|1200}
+
+do_execsql_test_on_specific_db {:memory:} matview-avg-distinct {
+    CREATE TABLE grades(student TEXT, score INTEGER);
+    INSERT INTO grades VALUES
+        ('Alice', 90),
+        ('Alice', 85),
+        ('Alice', 90),  -- Duplicate
+        ('Alice', NULL),
+        ('Bob', 75),
+        ('Bob', 80),
+        ('Bob', 75);  -- Duplicate
+
+    CREATE MATERIALIZED VIEW avg_grades AS
+        SELECT student, AVG(DISTINCT score) as avg_score
+        FROM grades GROUP BY student;
+
+    SELECT * FROM avg_grades ORDER BY student;
+
+    -- Add duplicate scores
+    INSERT INTO grades VALUES ('Alice', 85), ('Bob', 80);
+    SELECT * FROM avg_grades ORDER BY student;
+
+    -- Add new distinct score
+    INSERT INTO grades VALUES ('Alice', 95);
+    SELECT * FROM avg_grades ORDER BY student;
+} {Alice|87.5
+Bob|77.5
+Alice|87.5
+Bob|77.5
+Alice|90.0
+Bob|77.5}
+
+do_execsql_test_on_specific_db {:memory:} matview-min-distinct {
+    CREATE TABLE metrics(category TEXT, value INTEGER);
+    INSERT INTO metrics VALUES
+        ('A', 10),
+        ('A', 20),
+        ('A', 10),  -- Duplicate
+        ('A', 30),
+        ('A', NULL),
+        ('B', 5),
+        ('B', 15),
+        ('B', 5);  -- Duplicate
+
+    CREATE MATERIALIZED VIEW metric_min AS
+        SELECT category,
+               MIN(DISTINCT value) as min_val
+        FROM metrics GROUP BY category;
+
+    SELECT * FROM metric_min ORDER BY category;
+
+    -- Add values that don't change min
+    INSERT INTO metrics VALUES ('A', 15), ('B', 10);
+    SELECT * FROM metric_min ORDER BY category;
+
+    -- Add values that change min
+    INSERT INTO metrics VALUES ('A', 5), ('B', 3);
+    SELECT * FROM metric_min ORDER BY category;
+} {A|10
+B|5
+A|10
+B|5
+A|5
+B|3}
+
+do_execsql_test_on_specific_db {:memory:} matview-max-distinct {
+    CREATE TABLE metrics2(category TEXT, value INTEGER);
+    INSERT INTO metrics2 VALUES
+        ('A', 10),
+        ('A', 20),
+        ('A', 10),  -- Duplicate
+        ('A', 30),
+        ('A', NULL),
+        ('B', 5),
+        ('B', 15),
+        ('B', 5);  -- Duplicate
+
+    CREATE MATERIALIZED VIEW metric_max AS
+        SELECT category,
+               MAX(DISTINCT value) as max_val
+        FROM metrics2 GROUP BY category;
+
+    SELECT * FROM metric_max ORDER BY category;
+
+    -- Add values that don't change max
+    INSERT INTO metrics2 VALUES ('A', 15), ('B', 10);
+    SELECT * FROM metric_max ORDER BY category;
+
+    -- Add values that change max
+    INSERT INTO metrics2 VALUES ('A', 40), ('B', 20);
+    SELECT * FROM metric_max ORDER BY category;
+} {A|30
+B|15
+A|30
+B|15
+A|40
+B|20}
+
+do_execsql_test_on_specific_db {:memory:} matview-multiple-distinct-aggregates-with-groupby {
+    CREATE TABLE data(grp TEXT, x INTEGER, y INTEGER, z INTEGER);
+    INSERT INTO data VALUES
+        ('A', 1, 10, 100),
+        ('A', 2, 20, 200),
+        ('A', 1, 10, 300),  -- x,y duplicates
+        ('A', 3, 30, 100),  -- z duplicate
+        ('A', NULL, 40, 400),
+        ('B', 4, 50, 500),
+        ('B', 5, 50, 600),  -- y duplicate
+        ('B', 4, 60, 700),  -- x duplicate
+        ('B', 6, NULL, 500), -- z duplicate
+        ('B', NULL, 70, NULL);
+
+    CREATE MATERIALIZED VIEW multi_distinct AS
+        SELECT grp,
+               COUNT(DISTINCT x) as cnt_x,
+               SUM(DISTINCT y) as sum_y,
+               AVG(DISTINCT z) as avg_z
+        FROM data GROUP BY grp;
+
+    SELECT * FROM multi_distinct ORDER BY grp;
+
+    -- Add more data with duplicates
+    INSERT INTO data VALUES
+        ('A', 1, 20, 200),  -- Existing values
+        ('B', 7, 80, 800);  -- New values
+
+    SELECT * FROM multi_distinct ORDER BY grp;
+} {A|3|100|250.0
+B|3|180|600.0
+A|3|100|250.0
+B|4|260|650.0}
+
+do_execsql_test_on_specific_db {:memory:} matview-multiple-distinct-aggregates-no-groupby {
+    CREATE TABLE data2(x INTEGER, y INTEGER, z INTEGER);
+    INSERT INTO data2 VALUES
+        (1, 10, 100),
+        (2, 20, 200),
+        (1, 10, 300),  -- x,y duplicates
+        (3, 30, 100),  -- z duplicate
+        (NULL, 40, 400),
+        (4, 50, 500),
+        (5, 50, 600),  -- y duplicate
+        (4, 60, 700),  -- x duplicate
+        (6, NULL, 500), -- z duplicate
+        (NULL, 70, NULL);
+
+    CREATE MATERIALIZED VIEW multi_distinct_global AS
+        SELECT COUNT(DISTINCT x) as cnt_x,
+               SUM(DISTINCT y) as sum_y,
+               AVG(DISTINCT z) as avg_z
+        FROM data2;
+
+    SELECT * FROM multi_distinct_global;
+
+    -- Add more data
+    INSERT INTO data2 VALUES
+        (1, 20, 200),  -- Existing values
+        (7, 80, 800);  -- New values
+
+    SELECT * FROM multi_distinct_global;
+} {6|280|400.0
+7|360|450.0}
+
+do_execsql_test_on_specific_db {:memory:} matview-count-distinct-global-aggregate {
+    CREATE TABLE all_data(val INTEGER);
+    INSERT INTO all_data VALUES (1), (2), (1), (3), (2);
+
+    CREATE MATERIALIZED VIEW summary AS
+        SELECT COUNT(DISTINCT val) as total_distinct FROM all_data;
+
+    SELECT * FROM summary;
+
+    -- Add duplicates
+    INSERT INTO all_data VALUES (1), (2), (3);
+    SELECT * FROM summary;
+
+    -- Add new distinct values
+    INSERT INTO all_data VALUES (4), (5);
+    SELECT * FROM summary;
+
+    -- Delete all of one value
+    DELETE FROM all_data WHERE val = 3;
+    SELECT * FROM summary;
+} {3
+3
+5
+4}


### PR DESCRIPTION
Implements COUNT/SUM/AVG(DISTINCT) and SELECT DISTINCT for materialized views. To do this we have to keep a list of the actual distinct values (similarly to how we do for min/max). We then update the operator (and issue deltas) only when there is a state transition (for example, if we already count the value x = 1, and we see an insert for x = 1, we do nothing).

SELECT DISTINCT (with no aggregator) is similar. We already have to keep a list of the values anyway to power the aggregates. So we just issue new deltas based on the transition, without updating the aggregator.