### PR TITLE
perf/throughput: Use connection per transaction in rusqlite benchmark

### DIFF
--- a/perf/throughput/rusqlite/src/main.rs
+++ b/perf/throughput/rusqlite/src/main.rs
@@ -115,18 +115,18 @@ fn worker_thread(
     start_barrier: Arc<Barrier>,
     compute_usec: u64,
 ) -> Result<u64> {
-    let conn = Connection::open(&db_path)?;
-
-    conn.pragma_update(None, "synchronous", "FULL")?;
-    conn.pragma_update(None, "fullfsync", "true")?;
-
-    conn.busy_timeout(std::time::Duration::from_secs(30))?;
-
     start_barrier.wait();
 
     let mut total_inserts = 0;
 
     for iteration in 0..iterations {
+        let conn = Connection::open(&db_path)?;
+
+        conn.pragma_update(None, "synchronous", "FULL")?;
+        conn.pragma_update(None, "fullfsync", "true")?;
+
+        conn.busy_timeout(std::time::Duration::from_secs(30))?;
+
         let mut stmt = conn.prepare("INSERT INTO test_table (id, data) VALUES (?, ?)")?;
 
         conn.execute("BEGIN", [])?;


### PR DESCRIPTION
Open a connection per transaction in the rusqlite benchmark so that we're comparing the same workload with Turso.