### PR TITLE
Switch to SQLite's Julian date logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,15 +2411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "julian_day_converter"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2987f71b89b85c812c8484cbf0c5d7912589e77bfdc66fd3e52f760e7859f16"
-dependencies = [
- "chrono",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4916,7 +4907,6 @@ dependencies = [
  "hex",
  "intrusive-collections",
  "io-uring",
- "julian_day_converter",
  "libc",
  "libloading",
  "libm",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -57,7 +57,6 @@ regex-syntax = { workspace = true, default-features = false, features = [
     "unicode",
 ] }
 chrono = { workspace = true, default-features = false, features = ["clock"] }
-julian_day_converter = "0.4.5"
 rand = { workspace = true }
 libm = "0.2"
 turso_macros = { workspace = true }


### PR DESCRIPTION
The `julian_day_converter` crate is GPL, which is problematic for apps embedding Turso.