### PR TITLE
Implement wasNull tracking in ResultSet getter methods

### DIFF
--- a/bindings/java/src/main/java/tech/turso/jdbc4/JDBC4ResultSet.java
+++ b/bindings/java/src/main/java/tech/turso/jdbc4/JDBC4ResultSet.java
@@ -236,14 +236,15 @@ public final class JDBC4ResultSet implements ResultSet, ResultSetMetaData {
     if (result == null) {
       return null;
     }
-    return wrapTypeConversion(() -> {
-      if (result instanceof String) {
-        return new ByteArrayInputStream(((String) result).getBytes("US-ASCII"));
-      } else if (result instanceof byte[]) {
-        return new ByteArrayInputStream((byte[]) result);
-      }
-      throw new SQLException("Cannot convert to ASCII stream: " + result.getClass());
-    });
+    return wrapTypeConversion(
+        () -> {
+          if (result instanceof String) {
+            return new ByteArrayInputStream(((String) result).getBytes("US-ASCII"));
+          } else if (result instanceof byte[]) {
+            return new ByteArrayInputStream((byte[]) result);
+          }
+          throw new SQLException("Cannot convert to ASCII stream: " + result.getClass());
+        });
   }
 
   @Override
@@ -254,14 +255,15 @@ public final class JDBC4ResultSet implements ResultSet, ResultSetMetaData {
     if (result == null) {
       return null;
     }
-    return wrapTypeConversion(() -> {
-      if (result instanceof String) {
-        return new ByteArrayInputStream(((String) result).getBytes("UTF-8"));
-      } else if (result instanceof byte[]) {
-        return new ByteArrayInputStream((byte[]) result);
-      }
-      throw new SQLException("Cannot convert to Unicode stream: " + result.getClass());
-    });
+    return wrapTypeConversion(
+        () -> {
+          if (result instanceof String) {
+            return new ByteArrayInputStream(((String) result).getBytes("UTF-8"));
+          } else if (result instanceof byte[]) {
+            return new ByteArrayInputStream((byte[]) result);
+          }
+          throw new SQLException("Cannot convert to Unicode stream: " + result.getClass());
+        });
   }
 
   @Override
@@ -272,12 +274,13 @@ public final class JDBC4ResultSet implements ResultSet, ResultSetMetaData {
     if (result == null) {
       return null;
     }
-    return wrapTypeConversion(() -> {
-      if (result instanceof byte[]) {
-        return new ByteArrayInputStream((byte[]) result);
-      }
-      throw new SQLException("Cannot convert to binary stream: " + result.getClass());
-    });
+    return wrapTypeConversion(
+        () -> {
+          if (result instanceof byte[]) {
+            return new ByteArrayInputStream((byte[]) result);
+          }
+          throw new SQLException("Cannot convert to binary stream: " + result.getClass());
+        });
   }
 
   @Override

--- a/bindings/java/src/test/java/tech/turso/jdbc4/JDBC4ResultSetTest.java
+++ b/bindings/java/src/test/java/tech/turso/jdbc4/JDBC4ResultSetTest.java
@@ -899,19 +899,19 @@ class JDBC4ResultSetTest {
   @Test
   void test_columnLabel_getters() throws Exception {
     stmt.executeUpdate(
-        "CREATE TABLE test_column_label (" +
-            "bool_col INTEGER, " +
-            "byte_col INTEGER, " +
-            "short_col INTEGER, " +
-            "int_col INTEGER, " +
-            "long_col BIGINT, " +
-            "float_col REAL, " +
-            "double_col REAL, " +
-            "bytes_col BLOB);");
+        "CREATE TABLE test_column_label ("
+            + "bool_col INTEGER, "
+            + "byte_col INTEGER, "
+            + "short_col INTEGER, "
+            + "int_col INTEGER, "
+            + "long_col BIGINT, "
+            + "float_col REAL, "
+            + "double_col REAL, "
+            + "bytes_col BLOB);");
 
     stmt.executeUpdate(
-        "INSERT INTO test_column_label VALUES (" +
-            "1, 127, 32767, 2147483647, 9223372036854775807, 3.14, 2.718281828, X'48656C6C6F');");
+        "INSERT INTO test_column_label VALUES ("
+            + "1, 127, 32767, 2147483647, 9223372036854775807, 3.14, 2.718281828, X'48656C6C6F');");
 
     ResultSet resultSet = stmt.executeQuery("SELECT * FROM test_column_label");
     assertTrue(resultSet.next());
@@ -1122,11 +1122,11 @@ class JDBC4ResultSetTest {
   @Test
   void test_wasNull_consistency_across_types() throws Exception {
     stmt.executeUpdate(
-        "CREATE TABLE test_null_types (" +
-            "int_col INTEGER, " +
-            "text_col TEXT, " +
-            "real_col REAL, " +
-            "blob_col BLOB);");
+        "CREATE TABLE test_null_types ("
+            + "int_col INTEGER, "
+            + "text_col TEXT, "
+            + "real_col REAL, "
+            + "blob_col BLOB);");
     stmt.executeUpdate("INSERT INTO test_null_types VALUES (NULL, NULL, NULL, NULL);");
 
     ResultSet resultSet = stmt.executeQuery("SELECT * FROM test_null_types");


### PR DESCRIPTION
## Summary
Implemented comprehensive wasNull tracking and refactored getter methods in JDBC4ResultSet to ensure JDBC specification compliance and improve code maintainability.

### Changes
Added wasNull tracking to all getter methods: Covers primitive types, objects, dates/times, streams, and BigDecimal
Refactored columnLabel getters to use delegation pattern: Eliminates code duplication and ensures consistent wasNull behavior

### Bug Fixes & Code Quality
- Fixed getString(String) to return null instead of empty string for null values
- Added @Nullable annotation to getBytes(String) to fix NullAway error
- Preserved String parsing in getDate(String) for TEXT-formatted dates
- Extracted timezone offset calculation to helper method

### Testing
Added comprehensive tests for wasNull tracking, columnLabel getters, stream methods, and null handling