### PR TITLE
bindings/rust: Enable mimalloc as global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,6 +4838,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "turso"
 version = "0.3.0-pre.4"
 dependencies = [
+ "mimalloc",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "tempfile",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -21,6 +21,7 @@ turso_core = { workspace = true, features = ["io_uring"] }
 thiserror = { workspace = true }
 tracing-subscriber.workspace = true
 tracing.workspace = true
+mimalloc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -32,6 +32,10 @@
 //! # }
 //! ```
 
+#[cfg(all(not(target_family = "wasm"), not(miri)))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 pub mod params;
 mod rows;
 pub mod transaction;


### PR DESCRIPTION
This improves performance by using mimalloc for memory allocation in the Rust bindings.