### PR TITLE
reset move_to_right_state cached state in case of quick balancing

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2589,6 +2589,9 @@ impl BTreeCursor {
     /// 4. Continue balance from the parent page (inserting the new divider cell may have overflowed the parent)
     #[instrument(skip(self), level = Level::DEBUG)]
     fn balance_quick(&mut self) -> Result<IOResult<()>> {
+        // Since we are going to change the btree structure, let's forget our cached knowledge of the rightmost page.
+        let _ = self.move_to_right_state.1.take();
+
         // Allocate a new leaf page and insert the overflow cell payload in it.
         let new_rightmost_leaf = return_if_io!(self.pager.do_allocate_page(
             PageType::TableLeaf,


### PR DESCRIPTION
Reset cached value for `move_to_right_state` in case of `balance_quick`.

I don't know if it's possible to hit this situation with current generation of VM programs - so don't know what test I can add here.