### PR TITLE
antithesis: Upload config image in GitHub Actions workflow

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -24,8 +24,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Publish workload 
+    - name: Publish workload
       run: bash ./scripts/antithesis/publish-workload.sh
+
+    - name: Publish config
+      run: bash ./scripts/antithesis/publish-config.sh
 
     - name: Launch experiment
       run: bash ./scripts/antithesis/launch.sh

--- a/scripts/antithesis/publish-config.sh
+++ b/scripts/antithesis/publish-config.sh
@@ -14,6 +14,6 @@ export DOCKERFILE=stress/Dockerfile.antithesis-config
 
 export DOCKER_DIR=stress
 
-cat turso.key.json | docker login -u _json_key https://$ANTITHESIS_DOCKER_HOST --password-stdin
+docker login -u _json_key https://$ANTITHESIS_DOCKER_HOST --password "$ANTITHESIS_REGISTRY_KEY"
 
 ${BASH_SOURCE%/*}/publish-docker.sh


### PR DESCRIPTION
The Antithesis config image was not being uploaded during CI runs, only the workload image. This caused experiment failures when the config image expired from the registry after 6 months of inactivity.