### PR TITLE
Fix incorrect conversion from TEXT to INTEGER when text is a number followed by a trailing non-breaking space

### DIFF
--- a/core/util.rs
+++ b/core/util.rs
@@ -2622,6 +2622,25 @@ pub mod tests {
     }
 
     #[test]
+    fn test_trim_ascii_whitespace_helper() {
+        assert_eq!(trim_ascii_whitespace("  hello  "), "hello");
+        assert_eq!(trim_ascii_whitespace("\t\nhello\r\n"), "hello");
+        assert_eq!(trim_ascii_whitespace("hello"), "hello");
+        assert_eq!(trim_ascii_whitespace("   "), "");
+        assert_eq!(trim_ascii_whitespace(""), "");
+
+        // non-breaking space should NOT be trimmed
+        assert_eq!(
+            trim_ascii_whitespace("\u{00A0}hello\u{00A0}"),
+            "\u{00A0}hello\u{00A0}"
+        );
+        assert_eq!(
+            trim_ascii_whitespace("  \u{00A0}hello\u{00A0}  "),
+            "\u{00A0}hello\u{00A0}"
+        );
+    }
+
+    #[test]
     fn test_cast_real_to_integer_limits() {
         let max_exact = ((1i64 << 51) - 1) as f64;
         assert_eq!(cast_real_to_integer(max_exact), Ok((1i64 << 51) - 1));

--- a/testing/affinity.test
+++ b/testing/affinity.test
@@ -20,3 +20,9 @@ do_execsql_test_on_specific_db {:memory:} affinity-rowid {
 	select * from t where a = '1';
 } {1
 1}
+
+do_execsql_test_on_specific_db {:memory:} affinity-ascii-whitespace-1.1 {
+  CREATE TABLE nb1(i INTEGER);
+  INSERT INTO nb1 VALUES ('12' || CHAR(160));
+  SELECT TYPEOF(i), LENGTH(i) FROM nb1;
+} {text|3}


### PR DESCRIPTION
This PR fixes incorrect conversion from TEXT to INTEGER when text is a number followed by a trailing non-breaking space.

This happens because `str::trim()` trims non-breaking space and unicode whitespace while SQLite only trims ASCII whitespace. 

Closes: https://github.com/tursodatabase/turso/issues/3679