### PR TITLE
core/vdbe: Fix incorrect `unreachable` condition in op_seek_rowid

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2967,7 +2967,7 @@ pub fn op_seek_rowid(
                             match temp_reg.get_value() {
                                 Value::Integer(i) => Some(*i),
                                 Value::Float(f) => Some(*f as i64),
-                                _ => unreachable!("apply_affinity_char with Numeric should produce an integer if it returns true"),
+                                _ => None,
                             }
                         } else {
                             None


### PR DESCRIPTION
closes https://github.com/tursodatabase/turso-go/issues/55

In `apply_affinity_char`: we have things like the following:
```rust
    if matches!(value, Value::Blob(_)) {
        return true;
    }
````

Then at the call site in `op_seek_rowid` in execute.rs, we were saying it was an unreachable condition that a blob was in the register..
```rust
                        let converted = apply_affinity_char(&mut temp_reg, Affinity::Numeric);
                        if converted {
                            match temp_reg.get_value() {
                                Value::Integer(i) => Some(*i),
                                Value::Float(f) => Some(*f as i64),
                                _ => unreachable!(),
                            }
```
