### PR TITLE
Clean up Connection::from_uri() by using DatabaseOpts

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use std::num::NonZeroUsize;
 use std::rc::Rc;
 use std::sync::Arc;
-use turso_core::Value;
+use turso_core::{DatabaseOpts, Value};
 
 mod errors;
 
@@ -317,7 +317,7 @@ impl Drop for Connection {
 #[allow(clippy::arc_with_non_send_sync)]
 #[pyfunction(signature = (path))]
 pub fn connect(path: &str) -> Result<Connection> {
-    match turso_core::Connection::from_uri(path, true, false, false, false, false, false, false) {
+    match turso_core::Connection::from_uri(path, DatabaseOpts::default()) {
         Ok((io, conn)) => Ok(Connection { conn, _io: io }),
         Err(e) => Err(PyErr::new::<ProgrammingError, _>(format!(
             "Failed to create connection: {e:?}"

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -32,7 +32,8 @@ use std::{
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use turso_core::{
-    Connection, Database, LimboError, OpenFlags, QueryMode, Statement, StepResult, Value,
+    Connection, Database, DatabaseOpts, LimboError, OpenFlags, QueryMode, Statement, StepResult,
+    Value,
 };
 
 #[derive(Parser, Debug)]
@@ -188,16 +189,17 @@ impl Limbo {
             .as_ref()
             .map_or(":memory:".to_string(), |p| p.to_string_lossy().to_string());
         let indexes_enabled = opts.experimental_indexes.unwrap_or(true);
+
         let (io, conn) = if db_file.contains([':', '?', '&', '#']) {
             Connection::from_uri(
                 &db_file,
-                indexes_enabled,
-                opts.experimental_mvcc,
-                opts.experimental_views,
-                opts.experimental_strict,
-                opts.experimental_encryption,
-                opts.experimental_index_method,
-                opts.experimental_autovacuum,
+                DatabaseOpts::new()
+                    .with_indexes(indexes_enabled)
+                    .with_mvcc(opts.experimental_mvcc)
+                    .with_views(opts.experimental_views)
+                    .with_strict(opts.experimental_strict)
+                    .with_encryption(opts.experimental_encryption)
+                    .with_index_method(opts.experimental_index_method),
             )?
         } else {
             let flags = if opts.readonly {

--- a/cli/mcp_server.rs
+++ b/cli/mcp_server.rs
@@ -408,7 +408,7 @@ impl TursoMcpServer {
 
         // Open the new database connection
         let conn = if path == ":memory:" || path.contains([':', '?', '&', '#']) {
-            match Connection::from_uri(&path, true, false, false, false, false, false, false) {
+            match Connection::from_uri(&path, DatabaseOpts::default()) {
                 Ok((_io, c)) => c,
                 Err(e) => return format!("Failed to open database '{path}': {e}"),
             }

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -1,7 +1,7 @@
 use crate::common::{do_flush, run_query, run_query_on_row, TempDatabase};
 use rand::{rng, RngCore};
 use std::panic;
-use turso_core::Row;
+use turso_core::{DatabaseOpts, Row};
 
 const ENABLE_ENCRYPTION: bool = true;
 
@@ -48,13 +48,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         );
         let (_io, conn) = turso_core::Connection::from_uri(
             &uri,
-            true,
-            false,
-            false,
-            false,
-            ENABLE_ENCRYPTION,
-            false,
-            false,
+            DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
         )?;
         let mut row_count = 0;
         run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |row: &Row| {
@@ -72,13 +66,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         );
         let (_io, conn) = turso_core::Connection::from_uri(
             &uri,
-            true,
-            false,
-            false,
-            false,
-            ENABLE_ENCRYPTION,
-            false,
-            false,
+            DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
         )?;
         run_query(
             &tmp_db,
@@ -95,13 +83,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         );
         let (_io, conn) = turso_core::Connection::from_uri(
             &uri,
-            true,
-            false,
-            false,
-            false,
-            ENABLE_ENCRYPTION,
-            false,
-            false,
+            DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
         )?;
         run_query(
             &tmp_db,
@@ -126,13 +108,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         );
         let (_io, conn) = turso_core::Connection::from_uri(
             &uri,
-            true,
-            false,
-            false,
-            false,
-            ENABLE_ENCRYPTION,
-            false,
-            false,
+            DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
         )?;
         let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |_row: &Row| {}).unwrap();
@@ -148,13 +124,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             turso_core::Connection::from_uri(
                 &uri,
-                true,
-                false,
-                false,
-                false,
-                ENABLE_ENCRYPTION,
-                false,
-                false,
+                DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
             )
             .unwrap();
         }));
@@ -171,13 +141,7 @@ fn test_per_page_encryption() -> anyhow::Result<()> {
         let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             turso_core::Connection::from_uri(
                 &uri,
-                true,
-                false,
-                false,
-                false,
-                ENABLE_ENCRYPTION,
-                false,
-                false,
+                DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
             )
             .unwrap();
         }));
@@ -247,13 +211,7 @@ fn test_non_4k_page_size_encryption() -> anyhow::Result<()> {
         );
         let (_io, conn) = turso_core::Connection::from_uri(
             &uri,
-            true,
-            false,
-            false,
-            false,
-            ENABLE_ENCRYPTION,
-            false,
-            false,
+            DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
         )?;
         run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |row: &Row| {
             assert_eq!(row.get::<i64>(0).unwrap(), 1);
@@ -314,13 +272,7 @@ fn test_corruption_turso_magic_bytes() -> anyhow::Result<()> {
         let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             let (_io, conn) = turso_core::Connection::from_uri(
                 &uri,
-                true,
-                false,
-                false,
-                false,
-                ENABLE_ENCRYPTION,
-                false,
-                false,
+                DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
             )
             .unwrap();
             run_query_on_row(&tmp_db, &conn, "SELECT * FROM test", |_row: &Row| {}).unwrap();
@@ -408,13 +360,7 @@ fn test_corruption_associated_data_bytes() -> anyhow::Result<()> {
             let should_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                 let (_io, conn) = turso_core::Connection::from_uri(
                     &uri,
-                    true,
-                    false,
-                    false,
-                    false,
-                    ENABLE_ENCRYPTION,
-                    false,
-                    false,
+                    DatabaseOpts::new().with_encryption(ENABLE_ENCRYPTION),
                 )
                 .unwrap();
                 run_query_on_row(&test_tmp_db, &conn, "SELECT * FROM test", |_row: &Row| {})


### PR DESCRIPTION
Fixes #3900 

Migrating the `from_uri` function to use `DatabaseOpts`