### PR TITLE
Prevent DROP TABLE when table is referenced by foreign keys

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -231,7 +231,7 @@ pub fn translate_inner(
         ast::Stmt::DropTable {
             if_exists,
             tbl_name,
-        } => translate_drop_table(tbl_name, resolver, if_exists, program)?,
+        } => translate_drop_table(tbl_name, resolver, if_exists, program, connection)?,
         ast::Stmt::DropTrigger { .. } => bail_parse_error!("DROP TRIGGER not supported yet"),
         ast::Stmt::DropView {
             if_exists,

--- a/testing/drop_table.test
+++ b/testing/drop_table.test
@@ -62,3 +62,24 @@ do_execsql_test_on_specific_db {:memory:} drop-table-after-ops-1 {
     DROP TABLE t6;
     SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='t6';
 } {0}
+
+# Test that DROP TABLE fails when table is referenced by foreign keys
+do_execsql_test_in_memory_any_error drop-table-fk-constraint-failed {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(a INTEGER PRIMARY KEY);
+    CREATE TABLE child(a INTEGER PRIMARY KEY, b INTEGER, FOREIGN KEY(b) REFERENCES parent(a));
+    INSERT INTO parent VALUES (1);
+    INSERT INTO child VALUES (123, 1);
+    DROP TABLE parent;
+}
+
+# Test that DROP TABLE succeeds when foreign keys are disabled
+do_execsql_test_on_specific_db {:memory:} drop-table-fk-disabled-ok {
+    PRAGMA foreign_keys=OFF;
+    CREATE TABLE parent(a INTEGER PRIMARY KEY);
+    CREATE TABLE child(a INTEGER PRIMARY KEY, b INTEGER, FOREIGN KEY(b) REFERENCES parent(a));
+    INSERT INTO parent VALUES (1);
+    INSERT INTO child VALUES (123, 1);
+    DROP TABLE parent;
+    SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='parent';
+} {0}


### PR DESCRIPTION
## Related issue 
- closes #3885

## Description
Add a check to reject dropping a table when PRAGMA foreign_keys=ON and the table is referenced by foreign keys
