### PR TITLE
workflows: Add GITHUB_TOKEN to all Nyrkiö steps

### DIFF
--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -36,6 +36,7 @@ jobs:
           name: nightly/turso
           tool: criterion
           output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
           # What to do if a change is immediately detected by Nyrkiö.
           # Note that smaller changes are only detected with delay, usually after a change
@@ -78,6 +79,7 @@ jobs:
           name: nightly/clickbench/turso
           tool: time
           output-file-path: clickbench-tursodb.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           # What to do if a change is immediately detected by Nyrkiö.
           # Note that smaller changes are only detected with delay, usually after a change
           # persisted over 2-7 commits. Go to nyrkiö.com to view those or configure alerts.
@@ -104,6 +106,7 @@ jobs:
           tool: time
           output-file-path: clickbench-sqlite3.txt
           fail-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
           comment-always: false
           nyrkio-token: ${{ secrets.NYRKIO_JWT_TOKEN }}
@@ -143,6 +146,7 @@ jobs:
           name: nightly/tpc-h
           tool: criterion
           output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
           # What to do if a change is immediately detected by Nyrkiö.
           # Note that smaller changes are only detected with delay, usually after a change

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -31,6 +31,7 @@ jobs:
           name: turso
           tool: criterion
           output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
           # What to do if a change is immediately detected by Nyrkiö.
           # Note that smaller changes are only detected with delay, usually after a change
@@ -72,6 +73,7 @@ jobs:
           name: clickbench/turso
           tool: time
           output-file-path: clickbench-tursodb.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           # What to do if a change is immediately detected by Nyrkiö.
           # Note that smaller changes are only detected with delay, usually after a change
           # persisted over 2-7 commits. Go to nyrkiö.com to view those or configure alerts.
@@ -97,6 +99,7 @@ jobs:
           name: clickbench/sqlite3
           tool: time
           output-file-path: clickbench-sqlite3.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-alert: false
           comment-on-alert: true
           comment-always: false
@@ -137,6 +140,7 @@ jobs:
           name: tpc-h
           tool: criterion
           output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
           # What to do if a change is immediately detected by Nyrkiö.
           # Note that smaller changes are only detected with delay, usually after a change


### PR DESCRIPTION
Previously we didn't use GITHUB_TOKEN for anything. But now that PR meta-data must be fetched with a extra GitHub API call, then PRs at least will always nedd GITHUB_TOKEN.
