### PR TITLE
Avoid heavy macro

### DIFF
--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -633,6 +633,7 @@ fn parse_modifier(modifier: &str) -> Result<Modifier> {
 
     let modifier = modifier.trim();
 
+    // We intentionally avoid usage of match_ignore_ascii_case! macro here because it lead to enormous amount of LLVM code which signifnicantly increase compilation time (see https://github.com/tursodatabase/turso/pull/3929)
     // Fast path for exact matches
     if modifier.eq_ignore_ascii_case("ceiling") {
         return Ok(Modifier::Ceiling);


### PR DESCRIPTION
Rewrite `parse_modifier` function because its current version lead to enormous amount of generated LLVM code which significantly increase compilation time


```sh
$> cargo llvm-lines
  Lines                  Copies               Function name
  -----                  ------               -------------
  1322611                29544                (TOTAL)
   278720 (21.1%, 21.1%)     1 (0.0%,  0.0%)  turso_core::functions::datetime::parse_modifier
```

Before:
```sh
$> cargo check
warning: `turso_core` (lib) generated 2 warnings
    Finished `dev` profile [unoptimized] target(s) in 5.61s
```

After:
```sh
$> cargo check
warning: `turso_core` (lib) generated 2 warnings
    Finished `dev` profile [unoptimized] target(s) in 2.24s
```