### PR TITLE
core/mvcc/cursor: rowid don't seek first rowid

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -385,23 +385,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                 in_btree: _,
                 btree_consumed: _,
             } => Some(row_id.row_id),
-            CursorPosition::BeforeFirst => {
-                // If we are before first, we need to try and find the first row.
-                let maybe_rowid =
-                    self.db
-                        .get_next_row_id_for_table(self.table_id, i64::MIN, self.tx_id);
-                if let Some(id) = maybe_rowid {
-                    self.current_pos.replace(CursorPosition::Loaded {
-                        row_id: id,
-                        in_btree: false,
-                        btree_consumed: true,
-                    });
-                    Some(id.row_id)
-                } else {
-                    self.current_pos.replace(CursorPosition::BeforeFirst);
-                    None
-                }
-            }
+            CursorPosition::BeforeFirst => None,
             CursorPosition::End => None,
         };
         Ok(IOResult::Done(rowid))


### PR DESCRIPTION
rowid should only try to use the current's position. So if we are not pointing to a `Loaded` row, then it should return None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change `rowid()` to return `None` unless cursor is on a `Loaded` row, removing the implicit seek from `BeforeFirst`.
> 
> - **Core MVCC Cursor (`core/mvcc/cursor.rs`)**:
>   - Adjust `rowid()` behavior: remove implicit first-row seek when `BeforeFirst`; return `None` unless position is `Loaded`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8848775a715a5f4bf207072f498d544407827483. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->