### PR TITLE
Format imports

### DIFF
--- a/bindings/dart/rust/src/api/statement.rs
+++ b/bindings/dart/rust/src/api/statement.rs
@@ -1,16 +1,15 @@
-use std::collections::HashMap;
-use std::num::NonZero;
-use std::sync::Arc;
+use std::{collections::HashMap, num::NonZero, sync::Arc};
 
 use flutter_rust_bridge::frb;
-pub use turso_core::Connection;
-pub use turso_core::Statement;
 use turso_core::Value;
+pub use turso_core::{Connection, Statement};
 
-use crate::helpers::result::ExecuteResult;
-use crate::helpers::return_value::ReturnValue;
-use crate::helpers::wrapper::Wrapper;
-use crate::helpers::{params::Params, result::QueryResult};
+use crate::helpers::{
+    params::Params,
+    result::{ExecuteResult, QueryResult},
+    return_value::ReturnValue,
+    wrapper::Wrapper,
+};
 
 #[frb(opaque)]
 pub struct RustStatement {

--- a/bindings/dart/rust/src/frb_generated.rs
+++ b/bindings/dart/rust/src/frb_generated.rs
@@ -25,12 +25,17 @@
 
 // Section: imports
 
-use crate::api::connection::*;
-use crate::api::statement::*;
-use crate::helpers::wrapper::*;
-use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
-use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
-use flutter_rust_bridge::{Handler, IntoIntoDart};
+use crate::{
+    api::{connection::*, statement::*},
+    helpers::wrapper::*,
+};
+use flutter_rust_bridge::{
+    for_generated::{
+        byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt},
+        transform_result_dco, Lifetimeable, Lockable,
+    },
+    Handler, IntoIntoDart,
+};
 
 // Section: boilerplate
 
@@ -1749,14 +1754,17 @@ mod io {
     // Section: imports
 
     use super::*;
-    use crate::api::connection::*;
-    use crate::api::statement::*;
-    use crate::helpers::wrapper::*;
-    use flutter_rust_bridge::for_generated::byteorder::{
-        NativeEndian, ReadBytesExt, WriteBytesExt,
+    use crate::{
+        api::{connection::*, statement::*},
+        helpers::wrapper::*,
     };
-    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
-    use flutter_rust_bridge::{Handler, IntoIntoDart};
+    use flutter_rust_bridge::{
+        for_generated::{
+            byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt},
+            transform_result_dco, Lifetimeable, Lockable,
+        },
+        Handler, IntoIntoDart,
+    };
 
     // Section: boilerplate
 
@@ -1830,16 +1838,19 @@ mod web {
     // Section: imports
 
     use super::*;
-    use crate::api::connection::*;
-    use crate::api::statement::*;
-    use crate::helpers::wrapper::*;
-    use flutter_rust_bridge::for_generated::byteorder::{
-        NativeEndian, ReadBytesExt, WriteBytesExt,
+    use crate::{
+        api::{connection::*, statement::*},
+        helpers::wrapper::*,
     };
-    use flutter_rust_bridge::for_generated::wasm_bindgen;
-    use flutter_rust_bridge::for_generated::wasm_bindgen::prelude::*;
-    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
-    use flutter_rust_bridge::{Handler, IntoIntoDart};
+    use flutter_rust_bridge::{
+        for_generated::{
+            byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt},
+            transform_result_dco, wasm_bindgen,
+            wasm_bindgen::prelude::*,
+            Lifetimeable, Lockable,
+        },
+        Handler, IntoIntoDart,
+    };
 
     // Section: boilerplate
 

--- a/bindings/java/rs_src/turso_connection.rs
+++ b/bindings/java/rs_src/turso_connection.rs
@@ -1,12 +1,16 @@
-use crate::errors::{
-    Result, TursoError, TURSO_ETC, TURSO_FAILED_TO_PARSE_BYTE_ARRAY,
-    TURSO_FAILED_TO_PREPARE_STATEMENT,
+use crate::{
+    errors::{
+        Result, TursoError, TURSO_ETC, TURSO_FAILED_TO_PARSE_BYTE_ARRAY,
+        TURSO_FAILED_TO_PREPARE_STATEMENT,
+    },
+    turso_statement::TursoStatement,
+    utils::{set_err_msg_and_throw_exception, utf8_byte_arr_to_str},
 };
-use crate::turso_statement::TursoStatement;
-use crate::utils::{set_err_msg_and_throw_exception, utf8_byte_arr_to_str};
-use jni::objects::{JByteArray, JObject};
-use jni::sys::jlong;
-use jni::JNIEnv;
+use jni::{
+    objects::{JByteArray, JObject},
+    sys::jlong,
+    JNIEnv,
+};
 use std::sync::Arc;
 use turso_core::Connection;
 

--- a/bindings/java/rs_src/turso_db.rs
+++ b/bindings/java/rs_src/turso_db.rs
@@ -1,9 +1,13 @@
-use crate::errors::{Result, TursoError, TURSO_ETC};
-use crate::turso_connection::TursoConnection;
-use crate::utils::set_err_msg_and_throw_exception;
-use jni::objects::{JByteArray, JObject};
-use jni::sys::{jint, jlong};
-use jni::JNIEnv;
+use crate::{
+    errors::{Result, TursoError, TURSO_ETC},
+    turso_connection::TursoConnection,
+    utils::set_err_msg_and_throw_exception,
+};
+use jni::{
+    objects::{JByteArray, JObject},
+    sys::{jint, jlong},
+    JNIEnv,
+};
 use std::sync::Arc;
 use turso_core::Database;
 

--- a/bindings/java/rs_src/turso_statement.rs
+++ b/bindings/java/rs_src/turso_statement.rs
@@ -1,10 +1,13 @@
-use crate::errors::{Result, SQLITE_ERROR, SQLITE_OK};
-use crate::errors::{TursoError, TURSO_ETC};
-use crate::turso_connection::TursoConnection;
-use crate::utils::set_err_msg_and_throw_exception;
-use jni::objects::{JByteArray, JObject, JObjectArray, JString, JValue};
-use jni::sys::{jdouble, jint, jlong};
-use jni::JNIEnv;
+use crate::{
+    errors::{Result, TursoError, SQLITE_ERROR, SQLITE_OK, TURSO_ETC},
+    turso_connection::TursoConnection,
+    utils::set_err_msg_and_throw_exception,
+};
+use jni::{
+    objects::{JByteArray, JObject, JObjectArray, JString, JValue},
+    sys::{jdouble, jint, jlong},
+    JNIEnv,
+};
 use std::num::NonZero;
 use turso_core::{Statement, StepResult, Value};
 

--- a/bindings/java/rs_src/utils.rs
+++ b/bindings/java/rs_src/utils.rs
@@ -1,6 +1,8 @@
 use crate::errors::TursoError;
-use jni::objects::{JByteArray, JObject};
-use jni::JNIEnv;
+use jni::{
+    objects::{JByteArray, JObject},
+    JNIEnv,
+};
 
 pub(crate) fn utf8_byte_arr_to_str(
     env: &JNIEnv,

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -13,17 +13,14 @@
 #[cfg(feature = "browser")]
 pub mod browser;
 
-use napi::bindgen_prelude::*;
-use napi::{Env, Task};
+use napi::{bindgen_prelude::*, Env, Task};
 use napi_derive::napi;
-use std::sync::{Mutex, OnceLock};
 use std::{
     cell::{Cell, RefCell},
     num::NonZeroUsize,
-    sync::Arc,
+    sync::{Arc, Mutex, OnceLock},
 };
-use tracing_subscriber::filter::LevelFilter;
-use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::{filter::LevelFilter, fmt::format::FmtSpan};
 
 /// Step result constants
 const STEP_ROW: u32 = 1;

--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -1,5 +1,4 @@
-use pyo3::create_exception;
-use pyo3::exceptions::PyException;
+use pyo3::{create_exception, exceptions::PyException};
 
 create_exception!(
     limbo,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
 use errors::*;
-use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyList, PyTuple};
-use std::cell::RefCell;
-use std::num::NonZeroUsize;
-use std::rc::Rc;
-use std::sync::Arc;
+use pyo3::{
+    prelude::*,
+    types::{PyBytes, PyList, PyTuple},
+};
+use std::{cell::RefCell, num::NonZeroUsize, rc::Rc, sync::Arc};
 use turso_core::{DatabaseOpts, Value};
 
 mod errors;

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -46,16 +46,18 @@ use transaction::TransactionBehavior;
 use turso_core::types::WalFrameInfo;
 pub use value::Value;
 
-pub use params::params_from_iter;
-pub use params::IntoParams;
+pub use params::{params_from_iter, IntoParams};
 
-use std::fmt::Debug;
-use std::future::Future;
-use std::num::NonZero;
-use std::sync::atomic::AtomicU8;
-use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
-use std::task::Poll;
+use std::{
+    fmt::Debug,
+    future::Future,
+    num::NonZero,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc, Mutex,
+    },
+    task::Poll,
+};
 pub use turso_core::EncryptionOpts;
 use turso_core::OpenFlags;
 

--- a/bindings/rust/src/rows.rs
+++ b/bindings/rust/src/rows.rs
@@ -1,10 +1,12 @@
 use turso_core::types::FromValue;
 
 use crate::{Error, Result, Value};
-use std::fmt::Debug;
-use std::future::Future;
-use std::sync::{Arc, Mutex};
-use std::task::Poll;
+use std::{
+    fmt::Debug,
+    future::Future,
+    sync::{Arc, Mutex},
+    task::Poll,
+};
 
 /// Results of a prepared statement query.
 pub struct Rows {

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,12 +1,12 @@
 //! Build.rs script to generate a binary syntax set for syntect
 //! based on the SQL.sublime-syntax file.
 
-use std::env;
-use std::path::Path;
+use std::{env, path::Path};
 
-use syntect::dumps::dump_to_uncompressed_file;
-use syntect::parsing::SyntaxDefinition;
-use syntect::parsing::SyntaxSet;
+use syntect::{
+    dumps::dump_to_uncompressed_file,
+    parsing::{SyntaxDefinition, SyntaxSet},
+};
 
 fn main() {
     println!("cargo::rerun-if-changed=SQL.sublime-syntax");

--- a/cli/config/mod.rs
+++ b/cli/config/mod.rs
@@ -1,16 +1,12 @@
 mod palette;
 mod terminal;
 
-use crate::input::OutputMode;
-use crate::HOME_DIR;
+use crate::{input::OutputMode, HOME_DIR};
 use nu_ansi_term::Color;
 use palette::LimboColor;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer};
-use std::fmt::Debug;
-use std::fs::read_to_string;
-use std::path::PathBuf;
-use std::sync::LazyLock;
+use std::{fmt::Debug, fs::read_to_string, path::PathBuf, sync::LazyLock};
 use terminal::{TerminalDetector, TerminalTheme};
 use validator::Validate;
 

--- a/cli/helper.rs
+++ b/cli/helper.rs
@@ -1,23 +1,28 @@
 use clap::Parser;
 use nu_ansi_term::{Color, Style};
-use rustyline::completion::{extract_word, Completer, Pair};
-use rustyline::highlight::Highlighter;
-use rustyline::hint::HistoryHinter;
-use rustyline::{Completer, Helper, Hinter, Validator};
+use rustyline::{
+    completion::{extract_word, Completer, Pair},
+    highlight::Highlighter,
+    hint::HistoryHinter,
+    Completer, Helper, Hinter, Validator,
+};
 use shlex::Shlex;
-use std::cell::RefCell;
-use std::marker::PhantomData;
-use std::sync::Arc;
-use std::{ffi::OsString, path::PathBuf, str::FromStr as _};
-use syntect::dumps::from_uncompressed_data;
-use syntect::easy::HighlightLines;
-use syntect::highlighting::ThemeSet;
-use syntect::parsing::{Scope, SyntaxSet};
-use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
+use std::{
+    cell::RefCell, ffi::OsString, marker::PhantomData, path::PathBuf, str::FromStr as _, sync::Arc,
+};
+use syntect::{
+    dumps::from_uncompressed_data,
+    easy::HighlightLines,
+    highlighting::ThemeSet,
+    parsing::{Scope, SyntaxSet},
+    util::{as_24_bit_terminal_escaped, LinesWithEndings},
+};
 use turso_core::{Connection, StepResult};
 
-use crate::commands::CommandParser;
-use crate::config::{HighlightConfig, CONFIG_DIR};
+use crate::{
+    commands::CommandParser,
+    config::{HighlightConfig, CONFIG_DIR},
+};
 
 macro_rules! try_result {
     ($expr:expr, $err:expr) => {

--- a/cli/mcp_server.rs
+++ b/cli/mcp_server.rs
@@ -1,13 +1,16 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::io::{self, BufRead, BufReader, Write};
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Duration;
+use std::{
+    io::{self, BufRead, BufReader, Write},
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc, Arc, Mutex,
+    },
+    thread,
+    time::Duration,
+};
 use turso_core::{Connection, Database, DatabaseOpts, OpenFlags, StepResult, Value as DbValue};
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -1,12 +1,17 @@
 use std::sync::Arc;
 
-use criterion::async_executor::FuturesExecutor;
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{
+    async_executor::FuturesExecutor, criterion_group, criterion_main, Criterion, Throughput,
+};
 use pprof::criterion::{Output, PProfProfiler};
-use turso_core::mvcc::clock::LocalClock;
-use turso_core::mvcc::database::{MvStore, Row, RowID};
-use turso_core::types::{IOResult, ImmutableRecord, Text};
-use turso_core::{Connection, Database, MemoryIO, Value};
+use turso_core::{
+    mvcc::{
+        clock::LocalClock,
+        database::{MvStore, Row, RowID},
+    },
+    types::{IOResult, ImmutableRecord, Text},
+    Connection, Database, MemoryIO, Value,
+};
 
 struct BenchDb {
     _db: Arc<Database>,

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-use std::{env, fs};
+use std::{env, fs, path::PathBuf};
 
 fn main() {
     let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -1,16 +1,19 @@
 #[cfg(feature = "fs")]
 mod dynamic;
 mod vtab_xconnect;
-use crate::index_method::backing_btree::BackingBtreeIndexMethod;
-use crate::index_method::toy_vector_sparse_ivf::VectorSparseInvertedIndexMethod;
-use crate::index_method::{
-    BACKING_BTREE_INDEX_METHOD_NAME, TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
-};
-use crate::schema::{Schema, Table};
 #[cfg(all(target_os = "linux", feature = "io_uring", not(miri)))]
 use crate::UringIO;
-use crate::{function::ExternalFunc, Connection, Database};
-use crate::{vtab::VirtualTable, SymbolTable};
+use crate::{
+    function::ExternalFunc,
+    index_method::{
+        backing_btree::BackingBtreeIndexMethod,
+        toy_vector_sparse_ivf::VectorSparseInvertedIndexMethod, BACKING_BTREE_INDEX_METHOD_NAME,
+        TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
+    },
+    schema::{Schema, Table},
+    vtab::VirtualTable,
+    Connection, Database, SymbolTable,
+};
 #[cfg(feature = "fs")]
 use crate::{LimboError, IO};
 #[cfg(feature = "fs")]

--- a/core/function.rs
+++ b/core/function.rs
@@ -1,6 +1,8 @@
-use std::fmt;
-use std::fmt::{Debug, Display};
-use std::sync::Arc;
+use std::{
+    fmt,
+    fmt::{Debug, Display},
+    sync::Arc,
+};
 use turso_ext::{FinalizeFunction, InitAggFunction, ScalarFunction, StepFunction};
 
 use crate::LimboError;

--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -1,7 +1,8 @@
-use crate::types::AsValueRef;
-use crate::types::Value;
-use crate::LimboError::InvalidModifier;
-use crate::{Result, ValueRef};
+use crate::{
+    types::{AsValueRef, Value},
+    LimboError::InvalidModifier,
+    Result, ValueRef,
+};
 use chrono::{
     DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, TimeDelta, TimeZone, Timelike, Utc,
 };

--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -1,8 +1,6 @@
 use core::f64;
 
-use crate::types::Value;
-use crate::vdbe::Register;
-use crate::LimboError;
+use crate::{types::Value, vdbe::Register, LimboError};
 
 fn get_exponential_formatted_str(number: &f64, uppercase: bool) -> crate::Result<String> {
     let pre_formatted = format!("{number:.6e}");

--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -1,19 +1,26 @@
 // Aggregate operator for DBSP-style incremental computation
 
-use crate::function::{AggFunc, Func};
-use crate::incremental::dbsp::Hash128;
-use crate::incremental::dbsp::{Delta, DeltaPair, HashableRow};
-use crate::incremental::operator::{
-    generate_storage_id, ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator,
+use crate::{
+    function::{AggFunc, Func},
+    incremental::{
+        dbsp::{Delta, DeltaPair, Hash128, HashableRow},
+        operator::{
+            generate_storage_id, ComputationTracker, DbspStateCursors, EvalState,
+            IncrementalOperator,
+        },
+        persistence::{ReadRecord, WriteRow},
+    },
+    return_and_restore_if_io, return_if_io,
+    storage::btree::CursorTrait,
+    types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult, ValueRef},
+    LimboError, Result, Value,
 };
-use crate::incremental::persistence::{ReadRecord, WriteRow};
-use crate::storage::btree::CursorTrait;
-use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult, ValueRef};
-use crate::{return_and_restore_if_io, return_if_io, LimboError, Result, Value};
 use parking_lot::Mutex;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fmt::{self, Display};
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt::{self, Display},
+    sync::Arc,
+};
 
 // Architecture of the Aggregate Operator
 // ========================================

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -297,9 +297,7 @@ impl MaterializedViewCursor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::btree::BTreeCursor;
-    use crate::util::IOExt;
-    use crate::{Connection, Database, OpenFlags};
+    use crate::{storage::btree::BTreeCursor, util::IOExt, Connection, Database, OpenFlags};
     use std::sync::Arc;
 
     /// Helper to create a test connection with a table and materialized view

--- a/core/incremental/dbsp.rs
+++ b/core/incremental/dbsp.rs
@@ -2,8 +2,10 @@
 // For now, we'll use a basic approach and can expand to full DBSP later
 
 use crate::Value;
-use std::collections::{BTreeMap, HashMap};
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::{BTreeMap, HashMap},
+    hash::{Hash, Hasher},
+};
 
 /// A 128-bit hash value implemented as a UUID
 /// We use UUID because it's a standard 128-bit type we already depend on

--- a/core/incremental/expr_compiler.rs
+++ b/core/incremental/expr_compiler.rs
@@ -2,16 +2,18 @@
 // This module provides utilities to compile SQL expressions into VDBE subprograms
 // that can be executed efficiently in the incremental computation context.
 
-use crate::schema::Schema;
-use crate::storage::pager::Pager;
-use crate::translate::emitter::Resolver;
-use crate::translate::expr::translate_expr;
-use crate::types::Text;
-use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
-use crate::vdbe::insn::Insn;
-use crate::vdbe::{Program, ProgramState, Register};
-use crate::SymbolTable;
-use crate::{CaptureDataChangesMode, Connection, QueryMode, Result, Value};
+use crate::{
+    schema::Schema,
+    storage::pager::Pager,
+    translate::{emitter::Resolver, expr::translate_expr},
+    types::Text,
+    vdbe::{
+        builder::{ProgramBuilder, ProgramBuilderOpts},
+        insn::Insn,
+        Program, ProgramState, Register,
+    },
+    CaptureDataChangesMode, Connection, QueryMode, Result, SymbolTable, Value,
+};
 use std::sync::Arc;
 use turso_parser::ast::{Expr, Literal, Operator};
 

--- a/core/incremental/filter_operator.rs
+++ b/core/incremental/filter_operator.rs
@@ -2,12 +2,14 @@
 // Filter operator for DBSP-style incremental computation
 // This operator filters rows based on predicates
 
-use crate::incremental::dbsp::{Delta, DeltaPair};
-use crate::incremental::operator::{
-    ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator,
+use crate::{
+    incremental::{
+        dbsp::{Delta, DeltaPair},
+        operator::{ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator},
+    },
+    types::IOResult,
+    Result, Value,
 };
-use crate::types::IOResult;
-use crate::{Result, Value};
 use parking_lot::Mutex;
 use std::sync::Arc;
 

--- a/core/incremental/input_operator.rs
+++ b/core/incremental/input_operator.rs
@@ -1,12 +1,14 @@
 // Input operator for DBSP-style incremental computation
 // This operator serves as the entry point for data into the incremental computation pipeline
 
-use crate::incremental::dbsp::{Delta, DeltaPair};
-use crate::incremental::operator::{
-    ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator,
+use crate::{
+    incremental::{
+        dbsp::{Delta, DeltaPair},
+        operator::{ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator},
+    },
+    types::IOResult,
+    Result,
 };
-use crate::types::IOResult;
-use crate::Result;
 use parking_lot::Mutex;
 use std::sync::Arc;
 

--- a/core/incremental/join_operator.rs
+++ b/core/incremental/join_operator.rs
@@ -1,14 +1,19 @@
 #![allow(dead_code)]
 
-use crate::incremental::dbsp::Hash128;
-use crate::incremental::dbsp::{Delta, DeltaPair, HashableRow};
-use crate::incremental::operator::{
-    generate_storage_id, ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator,
+use crate::{
+    incremental::{
+        dbsp::{Delta, DeltaPair, Hash128, HashableRow},
+        operator::{
+            generate_storage_id, ComputationTracker, DbspStateCursors, EvalState,
+            IncrementalOperator,
+        },
+        persistence::WriteRow,
+    },
+    return_and_restore_if_io, return_if_io,
+    storage::btree::CursorTrait,
+    types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult},
+    Result, Value,
 };
-use crate::incremental::persistence::WriteRow;
-use crate::storage::btree::CursorTrait;
-use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult};
-use crate::{return_and_restore_if_io, return_if_io, Result, Value};
 use parking_lot::Mutex;
 use std::sync::Arc;
 

--- a/core/incremental/merge_operator.rs
+++ b/core/incremental/merge_operator.rs
@@ -1,17 +1,21 @@
 // Merge operator for DBSP - combines two delta streams
 // Used in recursive CTEs and UNION operations
 
-use crate::incremental::dbsp::{Delta, DeltaPair, HashableRow};
-use crate::incremental::operator::{
-    ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator,
+use crate::{
+    incremental::{
+        dbsp::{Delta, DeltaPair, HashableRow},
+        operator::{ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator},
+    },
+    types::IOResult,
+    Result,
 };
-use crate::types::IOResult;
-use crate::Result;
 use parking_lot::Mutex;
-use std::collections::{hash_map::DefaultHasher, HashMap};
-use std::fmt::{self, Display};
-use std::hash::{Hash, Hasher};
-use std::sync::Arc;
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    fmt::{self, Display},
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 /// How the merge operator should handle rowids when combining deltas
 #[derive(Debug, Clone)]

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -2,22 +2,23 @@
 // Operator DAG for DBSP-style incremental computation
 // Based on Feldera DBSP design but adapted for Turso's architecture
 
-pub use crate::incremental::aggregate_operator::{
-    AggregateEvalState, AggregateFunction, AggregateState,
+pub use crate::incremental::{
+    aggregate_operator::{AggregateEvalState, AggregateFunction, AggregateState},
+    filter_operator::{FilterOperator, FilterPredicate},
+    input_operator::InputOperator,
+    join_operator::{JoinEvalState, JoinOperator, JoinType},
+    project_operator::{ProjectColumn, ProjectOperator},
 };
-pub use crate::incremental::filter_operator::{FilterOperator, FilterPredicate};
-pub use crate::incremental::input_operator::InputOperator;
-pub use crate::incremental::join_operator::{JoinEvalState, JoinOperator, JoinType};
-pub use crate::incremental::project_operator::{ProjectColumn, ProjectOperator};
 
-use crate::incremental::dbsp::{Delta, DeltaPair};
-use crate::schema::{Index, IndexColumn};
-use crate::storage::btree::BTreeCursor;
-use crate::types::IOResult;
-use crate::Result;
+use crate::{
+    incremental::dbsp::{Delta, DeltaPair},
+    schema::{Index, IndexColumn},
+    storage::btree::BTreeCursor,
+    types::IOResult,
+    Result,
+};
 use parking_lot::Mutex;
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
 /// Struct to hold both table and index cursors for DBSP state operations
 pub struct DbspStateCursors {
@@ -256,14 +257,16 @@ pub trait IncrementalOperator: Debug + Send {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::incremental::aggregate_operator::{AggregateOperator, AGG_TYPE_REGULAR};
-    use crate::incremental::dbsp::HashableRow;
-    use crate::storage::btree::CursorTrait;
-    use crate::storage::pager::CreateBTreeFlags;
-    use crate::types::Text;
-    use crate::util::IOExt;
-    use crate::Value;
-    use crate::{Database, MemoryIO, IO};
+    use crate::{
+        incremental::{
+            aggregate_operator::{AggregateOperator, AGG_TYPE_REGULAR},
+            dbsp::HashableRow,
+        },
+        storage::{btree::CursorTrait, pager::CreateBTreeFlags},
+        types::Text,
+        util::IOExt,
+        Database, MemoryIO, Value, IO,
+    };
     use parking_lot::Mutex;
     use std::sync::Arc;
 

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -1,7 +1,10 @@
-use crate::incremental::operator::{AggregateState, DbspStateCursors};
-use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
-use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult};
-use crate::{return_if_io, LimboError, Result, Value};
+use crate::{
+    incremental::operator::{AggregateState, DbspStateCursors},
+    return_if_io,
+    storage::btree::{BTreeCursor, BTreeKey, CursorTrait},
+    types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult},
+    LimboError, Result, Value,
+};
 
 #[derive(Debug, Default)]
 pub enum ReadRecord {

--- a/core/incremental/project_operator.rs
+++ b/core/incremental/project_operator.rs
@@ -1,13 +1,15 @@
 // Project operator for DBSP-style incremental computation
 // This operator projects/transforms columns in a relational stream
 
-use crate::incremental::dbsp::{Delta, DeltaPair, HashableRow};
-use crate::incremental::expr_compiler::CompiledExpression;
-use crate::incremental::operator::{
-    ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator,
+use crate::{
+    incremental::{
+        dbsp::{Delta, DeltaPair, HashableRow},
+        expr_compiler::CompiledExpression,
+        operator::{ComputationTracker, DbspStateCursors, EvalState, IncrementalOperator},
+    },
+    types::IOResult,
+    Connection, Database, Result, Value,
 };
-use crate::types::IOResult;
-use crate::{Connection, Database, Result, Value};
 use parking_lot::Mutex;
 use std::sync::{atomic::Ordering, Arc};
 

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -1,20 +1,27 @@
-use super::compiler::{DbspCircuit, DbspCompiler, DeltaSet};
-use super::dbsp::Delta;
-use super::operator::ComputationTracker;
-use crate::schema::{BTreeTable, Schema};
-use crate::storage::btree::CursorTrait;
-use crate::translate::logical::LogicalPlanBuilder;
-use crate::types::{IOResult, Value};
-use crate::util::{extract_view_columns, ViewColumnSchema};
-use crate::{return_if_io, LimboError, Pager, Result, Statement};
+use super::{
+    compiler::{DbspCircuit, DbspCompiler, DeltaSet},
+    dbsp::Delta,
+    operator::ComputationTracker,
+};
+use crate::{
+    return_if_io,
+    schema::{BTreeTable, Schema},
+    storage::btree::CursorTrait,
+    translate::logical::LogicalPlanBuilder,
+    types::{IOResult, Value},
+    util::{extract_view_columns, ViewColumnSchema},
+    LimboError, Pager, Result, Statement,
+};
 use parking_lot::Mutex;
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
-use std::fmt;
-use std::rc::Rc;
-use std::sync::Arc;
-use turso_parser::ast;
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    fmt,
+    rc::Rc,
+    sync::Arc,
+};
 use turso_parser::{
+    ast,
     ast::{Cmd, Stmt},
     parser::Parser,
 };
@@ -1386,8 +1393,7 @@ mod tests {
     use super::*;
     use crate::schema::{BTreeTable, ColDef, Column as SchemaColumn, Schema, Type};
     use std::sync::Arc;
-    use turso_parser::ast;
-    use turso_parser::parser::Parser;
+    use turso_parser::{ast, parser::Parser};
 
     // Helper function to create a test schema with multiple tables
     fn create_test_schema() -> Schema {

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -1,6 +1,5 @@
 use super::{Buffer, Clock, Completion, File, OpenFlags, IO};
-use crate::turso_assert;
-use crate::{io::clock::DefaultClock, Result};
+use crate::{io::clock::DefaultClock, turso_assert, Result};
 
 use crate::io::clock::Instant;
 use parking_lot::Mutex;

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -1,14 +1,11 @@
-use crate::storage::buffer_pool::ArenaBuffer;
-use crate::storage::sqlite3_ondisk::WAL_FRAME_HEADER_SIZE;
-use crate::{BufferPool, Result};
+use crate::{
+    storage::{buffer_pool::ArenaBuffer, sqlite3_ondisk::WAL_FRAME_HEADER_SIZE},
+    BufferPool, Result,
+};
 use bitflags::bitflags;
 use cfg_block::cfg_block;
 use rand::{Rng, RngCore};
-use std::cell::RefCell;
-use std::fmt;
-use std::ptr::NonNull;
-use std::sync::Arc;
-use std::{fmt::Debug, pin::Pin};
+use std::{cell::RefCell, fmt, fmt::Debug, pin::Pin, ptr::NonNull, sync::Arc};
 
 cfg_block! {
     #[cfg(all(target_os = "linux", feature = "io_uring", not(miri)))] {

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -1,11 +1,17 @@
 use super::{Buffer, Completion, File, OpenFlags, IO};
-use crate::ext::VfsMod;
-use crate::io::clock::{Clock, DefaultClock, Instant};
-use crate::io::CompletionInner;
-use crate::{LimboError, Result};
-use std::ffi::{c_void, CString};
-use std::ptr::NonNull;
-use std::sync::Arc;
+use crate::{
+    ext::VfsMod,
+    io::{
+        clock::{Clock, DefaultClock, Instant},
+        CompletionInner,
+    },
+    LimboError, Result,
+};
+use std::{
+    ffi::{c_void, CString},
+    ptr::NonNull,
+    sync::Arc,
+};
 use turso_ext::{BufferRef, IOCallback, SendPtr, VfsFileImpl, VfsImpl};
 
 impl Clock for VfsMod {

--- a/core/json/cache.rs
+++ b/core/json/cache.rs
@@ -1,7 +1,6 @@
 use std::cell::{Cell, UnsafeCell};
 
-use crate::types::AsValueRef;
-use crate::{Value, ValueRef};
+use crate::{types::AsValueRef, Value, ValueRef};
 
 use super::jsonb::Jsonb;
 

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -1,6 +1,11 @@
-use crate::json::error::{Error as PError, Result as PResult};
-use crate::json::Conv;
-use crate::{bail_parse_error, LimboError, Result};
+use crate::{
+    bail_parse_error,
+    json::{
+        error::{Error as PError, Result as PResult},
+        Conv,
+    },
+    LimboError, Result,
+};
 use std::{
     borrow::Cow,
     collections::{HashMap, VecDeque},

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -5,18 +5,22 @@ mod ops;
 pub(crate) mod path;
 pub(crate) mod vtab;
 
-use crate::json::error::Error as JsonError;
 pub use crate::json::ops::{
     json_insert, json_patch, json_remove, json_replace, jsonb_insert, jsonb_patch, jsonb_remove,
     jsonb_replace,
 };
-use crate::json::path::{json_path, JsonPath, PathElement};
-use crate::types::{AsValueRef, Text, TextSubtype, Value, ValueType};
-use crate::{bail_constraint_error, bail_parse_error, LimboError, ValueRef};
+use crate::{
+    bail_constraint_error, bail_parse_error,
+    json::{
+        error::Error as JsonError,
+        path::{json_path, JsonPath, PathElement},
+    },
+    types::{AsValueRef, Text, TextSubtype, Value, ValueType},
+    LimboError, ValueRef,
+};
 pub use cache::JsonCacheCell;
 use jsonb::{ElementType, Jsonb, JsonbHeader, PathOperationMode, SearchOperation, SetOperation};
-use std::borrow::Cow;
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 #[derive(Debug, Clone, Copy)]
 pub enum Conv {

--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -1,6 +1,5 @@
 use parking_lot::RwLock;
-use std::iter::successors;
-use std::{result::Result, sync::Arc};
+use std::{iter::successors, result::Result, sync::Arc};
 
 use turso_ext::{ConstraintOp, ConstraintUsage, ResultCode};
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -40,42 +40,47 @@ pub mod numeric;
 #[cfg(not(feature = "fuzz"))]
 mod numeric;
 
-use crate::index_method::IndexMethod;
-use crate::schema::Trigger;
-use crate::storage::checksum::CHECKSUM_REQUIRED_RESERVED_BYTES;
-use crate::storage::encryption::AtomicCipherMode;
-use crate::storage::pager::{AutoVacuumMode, HeaderRef};
-use crate::translate::display::PlanContext;
-use crate::translate::pragma::TURSO_CDC_DEFAULT_TABLE_NAME;
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
 #[cfg(feature = "fs")]
 use crate::util::{OpenMode, OpenOptions};
-use crate::vdbe::explain::{EXPLAIN_COLUMNS_TYPE, EXPLAIN_QUERY_PLAN_COLUMNS_TYPE};
-use crate::vdbe::metrics::ConnectionMetrics;
-use crate::vtab::VirtualTable;
-use crate::{incremental::view::AllViewsTxState, translate::emitter::TransactionMode};
+use crate::{
+    incremental::view::AllViewsTxState,
+    index_method::IndexMethod,
+    schema::Trigger,
+    storage::{
+        checksum::CHECKSUM_REQUIRED_RESERVED_BYTES,
+        encryption::AtomicCipherMode,
+        pager::{AutoVacuumMode, HeaderRef},
+    },
+    translate::{
+        display::PlanContext, emitter::TransactionMode, pragma::TURSO_CDC_DEFAULT_TABLE_NAME,
+    },
+    vdbe::{
+        explain::{EXPLAIN_COLUMNS_TYPE, EXPLAIN_QUERY_PLAN_COLUMNS_TYPE},
+        metrics::ConnectionMetrics,
+    },
+    vtab::VirtualTable,
+};
 use arc_swap::ArcSwap;
 use core::str;
 pub use error::{CompletionError, LimboError};
-pub use io::clock::{Clock, Instant};
 #[cfg(all(feature = "fs", target_family = "unix", not(miri)))]
 pub use io::UnixIO;
 #[cfg(all(feature = "fs", target_os = "linux", feature = "io_uring", not(miri)))]
 pub use io::UringIO;
 pub use io::{
+    clock::{Clock, Instant},
     Buffer, Completion, CompletionType, File, GroupCompletion, MemoryIO, OpenFlags, PlatformIO,
     SyscallIO, WriteCompletion, IO,
 };
 use parking_lot::{Mutex, RwLock};
 use rustc_hash::FxHashMap;
 use schema::Schema;
-use std::collections::HashSet;
-use std::task::Waker;
 use std::{
     borrow::Cow,
     cell::{Cell, RefCell},
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt::{self, Display},
     num::NonZero,
     ops::Deref,
@@ -84,33 +89,38 @@ use std::{
         atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicUsize, Ordering},
         Arc, LazyLock, Weak,
     },
+    task::Waker,
     time::Duration,
 };
 #[cfg(feature = "fs")]
 use storage::database::DatabaseFile;
-pub use storage::database::IOContext;
-pub use storage::encryption::{CipherMode, EncryptionContext, EncryptionKey};
-use storage::page_cache::PageCache;
-use storage::pager::{AtomicDbState, DbState};
-use storage::sqlite3_ondisk::PageSize;
 pub use storage::{
     buffer_pool::BufferPool,
-    database::DatabaseStorage,
-    pager::PageRef,
-    pager::{Page, Pager},
+    database::{DatabaseStorage, IOContext},
+    encryption::{CipherMode, EncryptionContext, EncryptionKey},
+    pager::{Page, PageRef, Pager},
     wal::{CheckpointMode, CheckpointResult, Wal, WalFile, WalFileShared},
+};
+use storage::{
+    page_cache::PageCache,
+    pager::{AtomicDbState, DbState},
+    sqlite3_ondisk::PageSize,
 };
 use tracing::{instrument, Level};
 use turso_macros::{match_ignore_ascii_case, AtomicEnum};
-use turso_parser::ast::fmt::ToTokens;
-use turso_parser::{ast, ast::Cmd, parser::Parser};
+use turso_parser::{
+    ast,
+    ast::{fmt::ToTokens, Cmd},
+    parser::Parser,
+};
 use types::IOResult;
-pub use types::Value;
-pub use types::ValueRef;
+pub use types::{Value, ValueRef};
 use util::parse_schema_rows;
 pub use util::IOExt;
 pub use vdbe::{
-    builder::QueryMode, explain::EXPLAIN_COLUMNS, explain::EXPLAIN_QUERY_PLAN_COLUMNS, Register,
+    builder::QueryMode,
+    explain::{EXPLAIN_COLUMNS, EXPLAIN_QUERY_PLAN_COLUMNS},
+    Register,
 };
 
 /// Configuration for database features

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,17 +1,23 @@
 use parking_lot::RwLock;
 
-use crate::mvcc::clock::LogicalClock;
-use crate::mvcc::database::{MVTableId, MvStore, Row, RowID, RowVersionState};
-use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
-use crate::translate::plan::IterationDirection;
-use crate::types::{IOResult, ImmutableRecord, RecordCursor, SeekKey, SeekOp, SeekResult};
-use crate::{return_if_io, Result};
-use crate::{Pager, Value};
-use std::any::Any;
-use std::cell::{Ref, RefCell};
-use std::fmt::Debug;
-use std::ops::Bound;
-use std::sync::Arc;
+use crate::{
+    mvcc::{
+        clock::LogicalClock,
+        database::{MVTableId, MvStore, Row, RowID, RowVersionState},
+    },
+    return_if_io,
+    storage::btree::{BTreeCursor, BTreeKey, CursorTrait},
+    translate::plan::IterationDirection,
+    types::{IOResult, ImmutableRecord, RecordCursor, SeekKey, SeekOp, SeekResult},
+    Pager, Result, Value,
+};
+use std::{
+    any::Any,
+    cell::{Ref, RefCell},
+    fmt::Debug,
+    ops::Bound,
+    sync::Arc,
+};
 
 #[derive(Debug, Copy, Clone)]
 enum CursorPosition {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1,21 +1,26 @@
-use crate::mvcc::clock::LogicalClock;
-use crate::mvcc::database::{
-    DeleteRowStateMachine, MVTableId, MvStore, RowVersion, TxTimestampOrID, WriteRowStateMachine,
-    SQLITE_SCHEMA_MVCC_TABLE_ID,
-};
-use crate::state_machine::{StateMachine, StateTransition, TransitionResult};
-use crate::storage::btree::{BTreeCursor, CursorTrait};
-use crate::storage::pager::CreateBTreeFlags;
-use crate::storage::wal::{CheckpointMode, TursoRwLock};
-use crate::types::{IOCompletions, IOResult, ImmutableRecord, RecordCursor};
 use crate::{
+    mvcc::{
+        clock::LogicalClock,
+        database::{
+            DeleteRowStateMachine, MVTableId, MvStore, RowVersion, TxTimestampOrID,
+            WriteRowStateMachine, SQLITE_SCHEMA_MVCC_TABLE_ID,
+        },
+    },
+    state_machine::{StateMachine, StateTransition, TransitionResult},
+    storage::{
+        btree::{BTreeCursor, CursorTrait},
+        pager::CreateBTreeFlags,
+        wal::{CheckpointMode, TursoRwLock},
+    },
+    types::{IOCompletions, IOResult, ImmutableRecord, RecordCursor},
     CheckpointResult, Completion, Connection, IOExt, Pager, Result, TransactionState, Value,
     ValueRef,
 };
 use parking_lot::RwLock;
-use std::collections::{HashMap, HashSet};
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{atomic::Ordering, Arc},
+};
 
 #[derive(Debug)]
 pub enum CheckpointState {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1,48 +1,35 @@
-use crate::mvcc::clock::LogicalClock;
-use crate::mvcc::persistent_storage::Storage;
-use crate::state_machine::StateMachine;
-use crate::state_machine::StateTransition;
-use crate::state_machine::TransitionResult;
-use crate::storage::btree::BTreeCursor;
-use crate::storage::btree::BTreeKey;
-use crate::storage::btree::CursorTrait;
-use crate::storage::btree::CursorValidState;
-use crate::storage::sqlite3_ondisk::DatabaseHeader;
-use crate::storage::wal::TursoRwLock;
-use crate::translate::plan::IterationDirection;
-use crate::turso_assert;
-use crate::types::IOCompletions;
-use crate::types::IOResult;
-use crate::types::ImmutableRecord;
-use crate::types::RecordCursor;
-use crate::types::SeekResult;
-use crate::Completion;
-use crate::File;
-use crate::IOExt;
-use crate::LimboError;
-use crate::Result;
-use crate::Statement;
-use crate::StepResult;
-use crate::Value;
-use crate::ValueRef;
-use crate::{Connection, Pager};
+use crate::{
+    mvcc::{clock::LogicalClock, persistent_storage::Storage},
+    state_machine::{StateMachine, StateTransition, TransitionResult},
+    storage::{
+        btree::{BTreeCursor, BTreeKey, CursorTrait, CursorValidState},
+        sqlite3_ondisk::DatabaseHeader,
+        wal::TursoRwLock,
+    },
+    translate::plan::IterationDirection,
+    turso_assert,
+    types::{IOCompletions, IOResult, ImmutableRecord, RecordCursor, SeekResult},
+    Completion, Connection, File, IOExt, LimboError, Pager, Result, Statement, StepResult, Value,
+    ValueRef,
+};
 use crossbeam_skiplist::{SkipMap, SkipSet};
 use parking_lot::RwLock;
-use std::cell::RefCell;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::ops::Bound;
-use std::sync::atomic::AtomicI64;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use tracing::instrument;
-use tracing::Level;
+use std::{
+    cell::RefCell,
+    fmt::Debug,
+    marker::PhantomData,
+    ops::Bound,
+    sync::{
+        atomic::{AtomicI64, AtomicU64, Ordering},
+        Arc,
+    },
+};
+use tracing::{instrument, Level};
 
 pub mod checkpoint_state_machine;
 pub use checkpoint_state_machine::{CheckpointState, CheckpointStateMachine};
 
-use super::persistent_storage::logical_log::StreamingLogicalLogReader;
-use super::persistent_storage::logical_log::StreamingResult;
+use super::persistent_storage::logical_log::{StreamingLogicalLogReader, StreamingResult};
 
 #[cfg(test)]
 pub mod tests;

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1,7 +1,5 @@
 use super::*;
-use crate::io::PlatformIO;
-use crate::mvcc::clock::LocalClock;
-use crate::storage::sqlite3_ondisk::DatabaseHeader;
+use crate::{io::PlatformIO, mvcc::clock::LocalClock, storage::sqlite3_ondisk::DatabaseHeader};
 use parking_lot::RwLock;
 
 pub(crate) struct MvccTestDbNoConn {
@@ -712,13 +710,14 @@ fn test_future_row() {
     assert_eq!(row, None);
 }
 
-use crate::mvcc::cursor::MvccLazyCursor;
-use crate::mvcc::database::{MvStore, Row, RowID};
-use crate::types::Text;
-use crate::Value;
-use crate::{Database, StepResult};
-use crate::{MemoryIO, Statement};
-use crate::{ValueRef, DATABASE_MANAGER};
+use crate::{
+    mvcc::{
+        cursor::MvccLazyCursor,
+        database::{MvStore, Row, RowID},
+    },
+    types::Text,
+    Database, MemoryIO, Statement, StepResult, Value, ValueRef, DATABASE_MANAGER,
+};
 
 // Simple atomic clock implementation for testing
 

--- a/core/mvcc/mod.rs
+++ b/core/mvcc/mod.rs
@@ -41,13 +41,14 @@ pub use database::MvStore;
 
 #[cfg(test)]
 mod tests {
-    use crate::mvcc::database::tests::{
-        commit_tx_no_conn, generate_simple_string_row, MvccTestDbNoConn,
+    use crate::mvcc::database::{
+        tests::{commit_tx_no_conn, generate_simple_string_row, MvccTestDbNoConn},
+        RowID,
     };
-    use crate::mvcc::database::RowID;
-    use std::sync::atomic::AtomicI64;
-    use std::sync::atomic::Ordering;
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicI64, Ordering},
+        Arc,
+    };
 
     static IDS: AtomicI64 = AtomicI64::new(1);
 

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -1,11 +1,11 @@
 use parking_lot::RwLock;
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
 pub mod logical_log;
-use crate::mvcc::database::LogRecord;
-use crate::mvcc::persistent_storage::logical_log::LogicalLog;
-use crate::{Completion, File, Result};
+use crate::{
+    mvcc::{database::LogRecord, persistent_storage::logical_log::LogicalLog},
+    Completion, File, Result,
+};
 
 pub struct Storage {
     pub logical_log: RwLock<LogicalLog>,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,10 +1,14 @@
-use crate::function::Func;
-use crate::incremental::view::IncrementalView;
-use crate::index_method::{IndexMethodAttachment, IndexMethodConfiguration};
-use crate::translate::expr::{bind_and_rewrite_expr, walk_expr, BindingBehavior, WalkControl};
-use crate::translate::index::{resolve_index_method_parameters, resolve_sorted_columns};
-use crate::translate::planner::ROWID_STRS;
-use crate::vdbe::affinity::Affinity;
+use crate::{
+    function::Func,
+    incremental::view::IncrementalView,
+    index_method::{IndexMethodAttachment, IndexMethodConfiguration},
+    translate::{
+        expr::{bind_and_rewrite_expr, walk_expr, BindingBehavior, WalkControl},
+        index::{resolve_index_method_parameters, resolve_sorted_columns},
+        planner::ROWID_STRS,
+    },
+    vdbe::affinity::Affinity,
+};
 use parking_lot::RwLock;
 use turso_macros::AtomicEnum;
 
@@ -115,28 +119,32 @@ impl Trigger {
     }
 }
 
-use crate::storage::btree::{BTreeCursor, CursorTrait};
-use crate::translate::collate::CollationSeq;
-use crate::translate::plan::{SelectPlan, TableReferences};
-use crate::util::{
-    module_args_from_sql, module_name_from_sql, type_from_name, IOExt, UnparsedFromSqlIndex,
-};
 use crate::{
     bail_parse_error, contains_ignore_ascii_case, eq_ignore_ascii_case, match_ignore_ascii_case,
-    Connection, LimboError, MvCursor, MvStore, Pager, SymbolTable, ValueRef, VirtualTable,
+    storage::btree::{BTreeCursor, CursorTrait},
+    translate::{
+        collate::CollationSeq,
+        plan::{SelectPlan, TableReferences},
+    },
+    util::{
+        module_args_from_sql, module_name_from_sql, normalize_ident, type_from_name, IOExt,
+        UnparsedFromSqlIndex,
+    },
+    Connection, LimboError, MvCursor, MvStore, Pager, Result, SymbolTable, ValueRef, VirtualTable,
 };
-use crate::{util::normalize_ident, Result};
 use core::fmt;
 use parking_lot::Mutex;
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::ops::Deref;
-use std::sync::Arc;
-use tracing::trace;
-use turso_parser::ast::{
-    self, ColumnDefinition, Expr, InitDeferredPred, Literal, RefAct, SortOrder, TableOptions,
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    ops::Deref,
+    sync::Arc,
 };
+use tracing::trace;
 use turso_parser::{
-    ast::{Cmd, CreateTableBody, ResultColumn, Stmt},
+    ast::{
+        self, Cmd, ColumnDefinition, CreateTableBody, Expr, InitDeferredPred, Literal, RefAct,
+        ResultColumn, SortOrder, Stmt, TableOptions,
+    },
     parser::Parser,
 };
 
@@ -917,8 +925,10 @@ impl Schema {
             }
             "view" => {
                 use crate::schema::View;
-                use turso_parser::ast::{Cmd, Stmt};
-                use turso_parser::parser::Parser;
+                use turso_parser::{
+                    ast::{Cmd, Stmt},
+                    parser::Parser,
+                };
 
                 let sql = maybe_sql.expect("sql should be present for view");
                 let view_name = name.to_string();
@@ -969,8 +979,10 @@ impl Schema {
                 }
             }
             "trigger" => {
-                use turso_parser::ast::{Cmd, Stmt};
-                use turso_parser::parser::Parser;
+                use turso_parser::{
+                    ast::{Cmd, Stmt},
+                    parser::Parser,
+                };
 
                 let sql = maybe_sql.expect("sql should be present for trigger");
                 let trigger_name = name.to_string();

--- a/core/storage/buffer_pool.rs
+++ b/core/storage/buffer_pool.rs
@@ -1,12 +1,14 @@
 use super::{slot_bitmap::SlotBitmap, sqlite3_ondisk::WAL_FRAME_HEADER_SIZE};
-use crate::fast_lock::SpinLock;
-use crate::io::TEMP_BUFFER_CACHE;
-use crate::{turso_assert, Buffer, LimboError, IO};
+use crate::{fast_lock::SpinLock, io::TEMP_BUFFER_CACHE, turso_assert, Buffer, LimboError, IO};
 use parking_lot::Mutex;
-use std::cell::UnsafeCell;
-use std::ptr::NonNull;
-use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
-use std::sync::{Arc, Weak};
+use std::{
+    cell::UnsafeCell,
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicU32, AtomicUsize, Ordering},
+        Arc, Weak,
+    },
+};
 
 #[derive(Debug)]
 /// A buffer allocated from an arena from `[BufferPool]`
@@ -433,8 +435,7 @@ impl Arena {
 
 #[cfg(all(unix, not(miri)))]
 mod arena {
-    use libc::MAP_ANONYMOUS;
-    use libc::{mmap, munmap, MAP_PRIVATE, PROT_READ, PROT_WRITE};
+    use libc::{mmap, munmap, MAP_ANONYMOUS, MAP_PRIVATE, PROT_READ, PROT_WRITE};
     use std::ffi::c_void;
 
     pub unsafe fn alloc(len: usize) -> *mut u8 {

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -1,7 +1,9 @@
-use crate::error::LimboError;
-use crate::storage::checksum::ChecksumContext;
-use crate::storage::encryption::EncryptionContext;
-use crate::{io::Completion, Buffer, CompletionError, Result};
+use crate::{
+    error::LimboError,
+    io::Completion,
+    storage::{checksum::ChecksumContext, encryption::EncryptionContext},
+    Buffer, CompletionError, Result,
+};
 use std::sync::Arc;
 use tracing::{instrument, Level};
 

--- a/core/storage/encryption.rs
+++ b/core/storage/encryption.rs
@@ -1,11 +1,9 @@
 #![allow(unused_variables, dead_code)]
 use crate::{LimboError, Result};
-use aegis::aegis128l::Aegis128L;
-use aegis::aegis128x2::Aegis128X2;
-use aegis::aegis128x4::Aegis128X4;
-use aegis::aegis256::Aegis256;
-use aegis::aegis256x2::Aegis256X2;
-use aegis::aegis256x4::Aegis256X4;
+use aegis::{
+    aegis128l::Aegis128L, aegis128x2::Aegis128X2, aegis128x4::Aegis128X4, aegis256::Aegis256,
+    aegis256x2::Aegis256X2, aegis256x4::Aegis256X4,
+};
 use aes_gcm::{
     aead::{Aead, AeadCore, KeyInit, OsRng},
     Aes128Gcm, Aes256Gcm, Key, Nonce,

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -547,9 +547,11 @@ impl Default for PageCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::page_cache::CacheError;
-    use crate::storage::pager::{Page, PageRef};
-    use crate::storage::sqlite3_ondisk::PageContent;
+    use crate::storage::{
+        page_cache::CacheError,
+        pager::{Page, PageRef},
+        sqlite3_ondisk::PageContent,
+    };
     use rand_chacha::{
         rand_core::{RngCore, SeedableRng},
         ChaCha8Rng,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -47,31 +47,40 @@ use bytemuck::{Pod, Zeroable};
 use pack1::{I32BE, U16BE, U32BE};
 use tracing::{instrument, Level};
 
-use super::pager::PageRef;
-use super::wal::TursoRwLock;
-use crate::error::LimboError;
-use crate::fast_lock::SpinLock;
-use crate::io::{Buffer, Completion, ReadComplete};
-use crate::storage::btree::offset::{
-    BTREE_CELL_CONTENT_AREA, BTREE_CELL_COUNT, BTREE_FIRST_FREEBLOCK, BTREE_FRAGMENTED_BYTES_COUNT,
-    BTREE_PAGE_TYPE, BTREE_RIGHTMOST_PTR,
-};
-use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_threshold_min};
-use crate::storage::buffer_pool::BufferPool;
-use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum};
-use crate::storage::pager::Pager;
-use crate::storage::wal::READMARK_NOT_USED;
-use crate::types::{SerialType, SerialTypeKind, TextRef, TextSubtype, ValueRef};
+use super::{pager::PageRef, wal::TursoRwLock};
 use crate::{
-    bail_corrupt_error, turso_assert, CompletionError, File, IOContext, Result, WalFileShared,
+    bail_corrupt_error,
+    error::LimboError,
+    fast_lock::SpinLock,
+    io::{Buffer, Completion, ReadComplete},
+    storage::{
+        btree::{
+            offset::{
+                BTREE_CELL_CONTENT_AREA, BTREE_CELL_COUNT, BTREE_FIRST_FREEBLOCK,
+                BTREE_FRAGMENTED_BYTES_COUNT, BTREE_PAGE_TYPE, BTREE_RIGHTMOST_PTR,
+            },
+            payload_overflow_threshold_max, payload_overflow_threshold_min,
+        },
+        buffer_pool::BufferPool,
+        database::{DatabaseStorage, EncryptionOrChecksum},
+        pager::Pager,
+        wal::READMARK_NOT_USED,
+    },
+    turso_assert,
+    types::{SerialType, SerialTypeKind, TextRef, TextSubtype, ValueRef},
+    CompletionError, File, IOContext, Result, WalFileShared,
 };
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
-use std::collections::BTreeMap;
-use std::mem::MaybeUninit;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::{
+    collections::BTreeMap,
+    mem::MaybeUninit,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 /// The minimum size of a cell in bytes.
 pub const MINIMUM_CELL_SIZE: usize = 4;

--- a/core/time/internal.rs
+++ b/core/time/internal.rs
@@ -1,7 +1,6 @@
 use std::ops::{Deref, Sub};
 
-use chrono::{self, DateTime, Timelike, Utc};
-use chrono::{prelude::*, DurationRound};
+use chrono::{self, prelude::*, DateTime, DurationRound, Timelike, Utc};
 
 use turso_ext::Value;
 

--- a/core/translate/attach.rs
+++ b/core/translate/attach.rs
@@ -1,10 +1,14 @@
-use crate::function::{Func, ScalarFunc};
-use crate::translate::emitter::Resolver;
-use crate::translate::expr::{sanitize_string, translate_expr};
-use crate::translate::{ProgramBuilder, ProgramBuilderOpts};
-use crate::util::normalize_ident;
-use crate::vdbe::insn::Insn;
-use crate::Result;
+use crate::{
+    function::{Func, ScalarFunc},
+    translate::{
+        emitter::Resolver,
+        expr::{sanitize_string, translate_expr},
+        ProgramBuilder, ProgramBuilderOpts,
+    },
+    util::normalize_ident,
+    vdbe::insn::Insn,
+    Result,
+};
 use turso_parser::ast::{Expr, Literal};
 
 /// Translate ATTACH statement

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -1,12 +1,19 @@
-use crate::schema::{Index, IndexColumn, Schema};
-use crate::translate::collate::get_collseq_from_expr;
-use crate::translate::emitter::{emit_query, LimitCtx, Resolver, TranslateCtx};
-use crate::translate::expr::translate_expr;
-use crate::translate::plan::{Plan, QueryDestination, SelectPlan};
-use crate::vdbe::builder::{CursorType, ProgramBuilder};
-use crate::vdbe::insn::Insn;
-use crate::vdbe::BranchOffset;
-use crate::{emit_explain, LimboError, QueryMode, SymbolTable};
+use crate::{
+    emit_explain,
+    schema::{Index, IndexColumn, Schema},
+    translate::{
+        collate::get_collseq_from_expr,
+        emitter::{emit_query, LimitCtx, Resolver, TranslateCtx},
+        expr::translate_expr,
+        plan::{Plan, QueryDestination, SelectPlan},
+    },
+    vdbe::{
+        builder::{CursorType, ProgramBuilder},
+        insn::Insn,
+        BranchOffset,
+    },
+    LimboError, QueryMode, SymbolTable,
+};
 use std::sync::Arc;
 use tracing::instrument;
 use turso_parser::ast::{CompoundOperator, Expr, Literal, SortOrder};

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -1,15 +1,20 @@
-use crate::schema::{Schema, Table};
-use crate::translate::emitter::{emit_program, Resolver};
-use crate::translate::expr::process_returning_clause;
-use crate::translate::optimizer::optimize_plan;
-use crate::translate::plan::{
-    DeletePlan, JoinOrderMember, Operation, Plan, QueryDestination, ResultSetColumn, SelectPlan,
+use crate::{
+    schema::{Schema, Table},
+    translate::{
+        emitter::{emit_program, Resolver},
+        expr::process_returning_clause,
+        optimizer::optimize_plan,
+        plan::{
+            DeletePlan, JoinOrderMember, Operation, Plan, QueryDestination, ResultSetColumn,
+            SelectPlan,
+        },
+        planner::{parse_limit, parse_where},
+        trigger_exec::has_relevant_triggers_type_only,
+    },
+    util::normalize_ident,
+    vdbe::builder::{ProgramBuilder, ProgramBuilderOpts},
+    Result,
 };
-use crate::translate::planner::{parse_limit, parse_where};
-use crate::translate::trigger_exec::has_relevant_triggers_type_only;
-use crate::util::normalize_ident;
-use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
-use crate::Result;
 use std::sync::Arc;
 use turso_parser::ast::{Expr, Limit, QualifiedName, ResultColumn, TriggerEvent};
 

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -3,26 +3,28 @@ use std::sync::Arc;
 use tracing::{instrument, Level};
 use turso_parser::ast::{self, Expr, SubqueryType, UnaryOperator};
 
-use super::emitter::Resolver;
-use super::optimizer::Optimizable;
-use super::plan::TableReferences;
+use super::{emitter::Resolver, optimizer::Optimizable, plan::TableReferences};
 #[cfg(feature = "json")]
 use crate::function::JsonFunc;
-use crate::function::{Func, FuncCtx, MathFuncArity, ScalarFunc, VectorFunc};
-use crate::functions::datetime;
-use crate::schema::{Table, Type};
-use crate::translate::optimizer::TakeOwnership;
-use crate::translate::plan::{Operation, ResultSetColumn};
-use crate::translate::planner::parse_row_id;
-use crate::util::{exprs_are_equivalent, normalize_ident, parse_numeric_literal};
-use crate::vdbe::affinity::Affinity;
-use crate::vdbe::builder::CursorKey;
-use crate::vdbe::{
-    builder::ProgramBuilder,
-    insn::{CmpInsFlags, Insn},
-    BranchOffset,
+use crate::{
+    function::{Func, FuncCtx, MathFuncArity, ScalarFunc, VectorFunc},
+    functions::datetime,
+    schema::{Table, Type},
+    translate::{
+        optimizer::TakeOwnership,
+        plan::{Operation, ResultSetColumn},
+        planner::parse_row_id,
+    },
+    turso_assert,
+    util::{exprs_are_equivalent, normalize_ident, parse_numeric_literal},
+    vdbe::{
+        affinity::Affinity,
+        builder::{CursorKey, ProgramBuilder},
+        insn::{CmpInsFlags, Insn},
+        BranchOffset,
+    },
+    Result, Value,
 };
-use crate::{turso_assert, Result, Value};
 
 use super::collate::CollationSeq;
 

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -7,18 +7,17 @@ use super::{
     plan::{Distinctness, GroupBy, SelectPlan},
     result_row::emit_select_result,
 };
-use crate::translate::{
-    aggregation::{translate_aggregation_step, AggArgumentSource},
-    plan::Aggregate,
-};
-use crate::translate::{
-    emitter::Resolver,
-    expr::{walk_expr, WalkControl},
-    optimizer::Optimizable,
-};
 use crate::{
     schema::PseudoCursorType,
-    translate::collate::{get_collseq_from_expr, CollationSeq},
+    translate::{
+        aggregation::{translate_aggregation_step, AggArgumentSource},
+        collate::{get_collseq_from_expr, CollationSeq},
+        emitter::Resolver,
+        expr::{walk_expr, WalkControl},
+        optimizer::Optimizable,
+        plan::{Aggregate, ResultSetColumn},
+    },
+    types::KeyInfo,
     util::exprs_are_equivalent,
     vdbe::{
         builder::{CursorType, ProgramBuilder},
@@ -27,7 +26,6 @@ use crate::{
     },
     Result,
 };
-use crate::{translate::plan::ResultSetColumn, types::KeyInfo};
 
 /// Labels needed for various jumps in GROUP BY handling.
 #[derive(Debug)]

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,29 +1,25 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use crate::bail_parse_error;
-use crate::error::SQLITE_CONSTRAINT_UNIQUE;
-use crate::index_method::IndexMethodConfiguration;
-use crate::numeric::Numeric;
-use crate::schema::{Table, RESERVED_TABLE_PREFIXES};
-use crate::translate::emitter::{
-    emit_cdc_full_record, emit_cdc_insns, prepare_cdc_if_necessary, OperationMode, Resolver,
-};
-use crate::translate::expr::{translate_condition_expr, ConditionMetadata};
-use crate::translate::insert::format_unique_violation_desc;
-use crate::translate::plan::{
-    ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReferences,
-};
-use crate::vdbe::builder::CursorKey;
-use crate::vdbe::insn::{CmpInsFlags, Cookie};
-use crate::vdbe::BranchOffset;
 use crate::{
-    schema::{BTreeTable, Index, IndexColumn, PseudoCursorType},
+    bail_parse_error,
+    error::SQLITE_CONSTRAINT_UNIQUE,
+    index_method::IndexMethodConfiguration,
+    numeric::Numeric,
+    schema::{BTreeTable, Index, IndexColumn, PseudoCursorType, Table, RESERVED_TABLE_PREFIXES},
     storage::pager::CreateBTreeFlags,
+    translate::{
+        emitter::{
+            emit_cdc_full_record, emit_cdc_insns, prepare_cdc_if_necessary, OperationMode, Resolver,
+        },
+        expr::{translate_condition_expr, ConditionMetadata},
+        insert::format_unique_violation_desc,
+        plan::{ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReferences},
+    },
     util::normalize_ident,
     vdbe::{
-        builder::{CursorType, ProgramBuilder},
-        insn::{IdxInsertFlags, Insn, RegisterOrLiteral},
+        builder::{CursorKey, CursorType, ProgramBuilder},
+        insn::{CmpInsFlags, Cookie, IdxInsertFlags, Insn, RegisterOrLiteral},
+        BranchOffset,
     },
 };
 use turso_parser::ast::{self, Expr, SortOrder, SortedColumn};

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -7,13 +7,17 @@
 //!
 //! The main entry point is `LogicalPlanBuilder` which constructs logical plans
 //! from SQL AST nodes.
-use crate::function::AggFunc;
-use crate::schema::{Schema, Type};
-use crate::types::Value;
-use crate::{LimboError, Result};
-use std::collections::HashMap;
-use std::fmt::{self, Display, Formatter};
-use std::sync::Arc;
+use crate::{
+    function::AggFunc,
+    schema::{Schema, Type},
+    types::Value,
+    LimboError, Result,
+};
+use std::{
+    collections::HashMap,
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 use turso_macros::match_ignore_ascii_case;
 use turso_parser::ast;
 

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -21,28 +21,22 @@ use super::{
 use crate::{
     schema::{Index, IndexColumn, Table},
     translate::{
-        emitter::prepare_cdc_if_necessary,
-        plan::{DistinctCtx, Distinctness, Scan, SeekKeyComponent},
+        collate::get_collseq_from_expr,
+        emitter::{prepare_cdc_if_necessary, UpdateRowSource},
+        plan::{DistinctCtx, Distinctness, EvalAt, NonFromClauseSubquery, Scan, SeekKeyComponent},
         result_row::emit_select_result,
+        subquery::emit_non_from_clause_subquery,
+        window::emit_window_loop_source,
     },
     types::SeekOp,
     vdbe::{
         affinity,
+        affinity::Affinity,
         builder::{CursorKey, CursorType, ProgramBuilder},
         insn::{CmpInsFlags, IdxInsertFlags, Insn},
         BranchOffset, CursorID,
     },
     Result,
-};
-use crate::{
-    translate::{
-        collate::get_collseq_from_expr,
-        emitter::UpdateRowSource,
-        plan::{EvalAt, NonFromClauseSubquery},
-        subquery::emit_non_from_clause_subquery,
-        window::emit_window_loop_source,
-    },
-    vdbe::affinity::Affinity,
 };
 
 // Metadata for handling LEFT JOIN operations

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -43,13 +43,17 @@ mod values;
 pub(crate) mod view;
 mod window;
 
-use crate::schema::Schema;
-use crate::storage::pager::Pager;
-use crate::translate::delete::translate_delete;
-use crate::translate::emitter::Resolver;
-use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts, QueryMode};
-use crate::vdbe::Program;
-use crate::{bail_parse_error, Connection, Result, SymbolTable};
+use crate::{
+    bail_parse_error,
+    schema::Schema,
+    storage::pager::Pager,
+    translate::{delete::translate_delete, emitter::Resolver},
+    vdbe::{
+        builder::{ProgramBuilder, ProgramBuilderOpts, QueryMode},
+        Program,
+    },
+    Connection, Result, SymbolTable,
+};
 use alter::translate_alter_table;
 use analyze::translate_analyze;
 use index::{translate_create_index, translate_drop_index};

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use turso_ext::{ConstraintInfo, ConstraintUsage, ResultCode};
 use turso_parser::ast::SortOrder;
 
-use crate::translate::optimizer::constraints::{
-    convert_to_vtab_constraint, Constraint, RangeConstraintRef,
-};
 use crate::{
     schema::{Index, Table},
-    translate::plan::{IterationDirection, JoinOrderMember, JoinedTable},
+    translate::{
+        optimizer::constraints::{convert_to_vtab_constraint, Constraint, RangeConstraintRef},
+        plan::{IterationDirection, JoinOrderMember, JoinedTable},
+    },
     vtab::VirtualTable,
     LimboError, Result,
 };

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -3,8 +3,10 @@ use std::cell::RefCell;
 use turso_parser::ast::{self, SortOrder, TableInternalId};
 
 use crate::{
-    translate::optimizer::access_method::AccessMethodParams,
-    translate::plan::{GroupBy, IterationDirection, JoinedTable},
+    translate::{
+        optimizer::access_method::AccessMethodParams,
+        plan::{GroupBy, IterationDirection, JoinedTable},
+    },
     util::exprs_are_equivalent,
 };
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -5,11 +5,12 @@ use turso_parser::ast::{
 
 use crate::{
     function::AggFunc,
-    schema::{BTreeTable, ColDef, Column, FromClauseSubquery, Index, Schema, Table},
+    schema::{BTreeTable, ColDef, Column, FromClauseSubquery, Index, Schema, Table, Type},
     translate::{
         collate::get_collseq_from_expr, emitter::UpdateRowSource,
         optimizer::constraints::SeekRangeConstraint,
     },
+    types::SeekOp,
     vdbe::{
         affinity::Affinity,
         builder::{CursorKey, CursorType, ProgramBuilder},
@@ -18,7 +19,6 @@ use crate::{
     },
     Result, VirtualTable,
 };
-use crate::{schema::Type, types::SeekOp};
 
 use turso_parser::ast::TableInternalId;
 
@@ -163,8 +163,7 @@ impl From<Expr> for WhereTerm {
     }
 }
 
-use crate::ast::Expr;
-use crate::util::exprs_are_equivalent;
+use crate::{ast::Expr, util::exprs_are_equivalent};
 
 /// The loop index where to evaluate the condition.
 /// For example, in `SELECT * FROM u JOIN p WHERE u.id = 5`, the condition can already be evaluated at the first loop (idx 0),

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1,5 +1,4 @@
-use std::cmp::PartialEq;
-use std::sync::Arc;
+use std::{cmp::PartialEq, sync::Arc};
 
 use super::{
     expr::walk_expr,
@@ -10,29 +9,22 @@ use super::{
     },
     select::prepare_select_plan,
 };
-use crate::translate::{
-    emitter::Resolver,
-    expr::{BindingBehavior, WalkControl},
-    plan::{NonFromClauseSubquery, SubqueryState},
-};
 use crate::{
     ast::Limit,
-    function::Func,
+    function::{AggFunc, ExtFunc, Func},
     schema::Table,
+    translate::{
+        emitter::Resolver,
+        expr::{bind_and_rewrite_expr, BindingBehavior, WalkControl},
+        plan::{NonFromClauseSubquery, SubqueryState, Window, WindowFunction},
+    },
     util::{exprs_are_equivalent, normalize_ident},
+    vdbe::builder::ProgramBuilder,
     Result,
 };
-use crate::{
-    function::{AggFunc, ExtFunc},
-    translate::expr::bind_and_rewrite_expr,
-};
-use crate::{
-    translate::plan::{Window, WindowFunction},
-    vdbe::builder::ProgramBuilder,
-};
-use turso_parser::ast::Literal::Null;
 use turso_parser::ast::{
-    self, As, Expr, FromClause, JoinType, Materialized, Over, QualifiedName, TableInternalId, With,
+    self, As, Expr, FromClause, JoinType, Literal::Null, Materialized, Over, QualifiedName,
+    TableInternalId, With,
 };
 
 /// Valid ways to refer to the rowid of a btree table.

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -4,23 +4,30 @@
 use chrono::Datelike;
 use std::sync::Arc;
 use turso_macros::match_ignore_ascii_case;
-use turso_parser::ast::{self, ColumnDefinition, Expr, Literal};
-use turso_parser::ast::{PragmaName, QualifiedName};
+use turso_parser::ast::{self, ColumnDefinition, Expr, Literal, PragmaName, QualifiedName};
 
 use super::integrity_check::translate_integrity_check;
-use crate::pragma::pragma_for;
-use crate::schema::Schema;
-use crate::storage::encryption::{CipherMode, EncryptionKey};
-use crate::storage::pager::AutoVacuumMode;
-use crate::storage::pager::Pager;
-use crate::storage::sqlite3_ondisk::CacheSize;
-use crate::storage::wal::CheckpointMode;
-use crate::translate::emitter::{Resolver, TransactionMode};
-use crate::translate::schema::translate_create_table;
-use crate::util::{normalize_ident, parse_signed_number, parse_string, IOExt as _};
-use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
-use crate::vdbe::insn::{Cookie, Insn};
-use crate::{bail_parse_error, CaptureDataChangesMode, LimboError, Value};
+use crate::{
+    bail_parse_error,
+    pragma::pragma_for,
+    schema::Schema,
+    storage::{
+        encryption::{CipherMode, EncryptionKey},
+        pager::{AutoVacuumMode, Pager},
+        sqlite3_ondisk::CacheSize,
+        wal::CheckpointMode,
+    },
+    translate::{
+        emitter::{Resolver, TransactionMode},
+        schema::translate_create_table,
+    },
+    util::{normalize_ident, parse_signed_number, parse_string, IOExt as _},
+    vdbe::{
+        builder::{ProgramBuilder, ProgramBuilderOpts},
+        insn::{Cookie, Insn},
+    },
+    CaptureDataChangesMode, LimboError, Value,
+};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1,21 +1,23 @@
 use std::sync::Arc;
 
-use crate::ast;
-use crate::ext::VTabImpl;
-use crate::schema::{
-    create_table, BTreeTable, ColDef, Column, Table, Type, RESERVED_TABLE_PREFIXES,
+use crate::{
+    ast, bail_constraint_error, bail_parse_error,
+    ext::VTabImpl,
+    schema::{create_table, BTreeTable, ColDef, Column, Table, Type, RESERVED_TABLE_PREFIXES},
+    storage::pager::CreateBTreeFlags,
+    translate::{
+        emitter::{
+            emit_cdc_full_record, emit_cdc_insns, prepare_cdc_if_necessary, OperationMode, Resolver,
+        },
+        ProgramBuilder, ProgramBuilderOpts,
+    },
+    util::{normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX},
+    vdbe::{
+        builder::CursorType,
+        insn::{CmpInsFlags, Cookie, InsertFlags, Insn},
+    },
+    Connection, Result,
 };
-use crate::storage::pager::CreateBTreeFlags;
-use crate::translate::emitter::{
-    emit_cdc_full_record, emit_cdc_insns, prepare_cdc_if_necessary, OperationMode, Resolver,
-};
-use crate::translate::{ProgramBuilder, ProgramBuilderOpts};
-use crate::util::normalize_ident;
-use crate::util::PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX;
-use crate::vdbe::builder::CursorType;
-use crate::vdbe::insn::{CmpInsFlags, Cookie, InsertFlags, Insn};
-use crate::Connection;
-use crate::{bail_constraint_error, bail_parse_error, Result};
 
 use turso_ext::VTabKind;
 

--- a/core/translate/transaction.rs
+++ b/core/translate/transaction.rs
@@ -1,7 +1,9 @@
-use crate::schema::Schema;
-use crate::translate::{emitter::TransactionMode, ProgramBuilder, ProgramBuilderOpts};
-use crate::vdbe::insn::Insn;
-use crate::Result;
+use crate::{
+    schema::Schema,
+    translate::{emitter::TransactionMode, ProgramBuilder, ProgramBuilderOpts},
+    vdbe::insn::Insn,
+    Result,
+};
 use turso_parser::ast::{Name, TransactionType};
 
 pub fn translate_tx_begin(

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -1,11 +1,17 @@
-use crate::translate::emitter::Resolver;
-use crate::translate::schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID};
-use crate::translate::ProgramBuilder;
-use crate::translate::ProgramBuilderOpts;
-use crate::util::normalize_ident;
-use crate::vdbe::builder::CursorType;
-use crate::vdbe::insn::{Cookie, Insn};
-use crate::{bail_parse_error, Result};
+use crate::{
+    bail_parse_error,
+    translate::{
+        emitter::Resolver,
+        schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID},
+        ProgramBuilder, ProgramBuilderOpts,
+    },
+    util::normalize_ident,
+    vdbe::{
+        builder::CursorType,
+        insn::{Cookie, Insn},
+    },
+    Result,
+};
 use turso_parser::ast::{self, QualifiedName};
 
 /// Reconstruct SQL string from CREATE TRIGGER AST

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -1,14 +1,16 @@
-use crate::schema::{BTreeTable, Trigger};
-use crate::translate::emitter::Resolver;
-use crate::translate::expr::translate_expr;
-use crate::translate::{translate_inner, ProgramBuilder, ProgramBuilderOpts};
-use crate::util::normalize_ident;
-use crate::vdbe::insn::Insn;
-use crate::{bail_parse_error, QueryMode, Result, Statement};
+use crate::{
+    bail_parse_error,
+    schema::{BTreeTable, Trigger},
+    translate::{
+        emitter::Resolver, expr::translate_expr, translate_inner, ProgramBuilder,
+        ProgramBuilderOpts,
+    },
+    util::normalize_ident,
+    vdbe::insn::Insn,
+    QueryMode, Result, Statement,
+};
 use parking_lot::RwLock;
-use std::collections::HashSet;
-use std::num::NonZero;
-use std::sync::Arc;
+use std::{collections::HashSet, num::NonZero, sync::Arc};
 use turso_parser::ast::{self, Expr, TriggerEvent, TriggerTime};
 
 /// Context for trigger execution
@@ -87,8 +89,7 @@ fn rewrite_trigger_expr_for_subprogram(
     table: &BTreeTable,
     ctx: &TriggerSubprogramContext,
 ) -> Result<()> {
-    use crate::translate::expr::walk_expr_mut;
-    use crate::translate::expr::WalkControl;
+    use crate::translate::expr::{walk_expr_mut, WalkControl};
 
     walk_expr_mut(expr, &mut |e: &mut ast::Expr| -> Result<WalkControl> {
         match e {
@@ -732,8 +733,7 @@ fn rewrite_trigger_expr_for_when_clause(
     table: &BTreeTable,
     ctx: &TriggerContext,
 ) -> Result<()> {
-    use crate::translate::expr::walk_expr_mut;
-    use crate::translate::expr::WalkControl;
+    use crate::translate::expr::{walk_expr_mut, WalkControl};
 
     walk_expr_mut(expr, &mut |e: &mut ast::Expr| -> Result<WalkControl> {
         match e {

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -1,26 +1,29 @@
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
-use crate::schema::ROWID_SENTINEL;
-use crate::translate::emitter::Resolver;
-use crate::translate::expr::{bind_and_rewrite_expr, walk_expr, BindingBehavior, WalkControl};
-use crate::translate::plan::{Operation, Scan};
-use crate::translate::planner::{parse_limit, ROWID_STRS};
 use crate::{
     bail_parse_error,
-    schema::{Schema, Table},
+    schema::{Schema, Table, ROWID_SENTINEL},
+    translate::{
+        emitter::Resolver,
+        expr::{bind_and_rewrite_expr, walk_expr, BindingBehavior, WalkControl},
+        plan::{Operation, Scan},
+        planner::{parse_limit, ROWID_STRS},
+    },
     util::normalize_ident,
     vdbe::builder::{ProgramBuilder, ProgramBuilderOpts},
 };
 use turso_parser::ast::{self, Expr, Indexed, SortOrder};
 
-use super::emitter::emit_program;
-use super::expr::process_returning_clause;
-use super::optimizer::optimize_plan;
-use super::plan::{
-    ColumnUsedMask, IterationDirection, JoinedTable, Plan, TableReferences, UpdatePlan,
+use super::{
+    emitter::emit_program,
+    expr::process_returning_clause,
+    optimizer::optimize_plan,
+    plan::{ColumnUsedMask, IterationDirection, JoinedTable, Plan, TableReferences, UpdatePlan},
+    planner::parse_where,
 };
-use super::planner::parse_where;
 /*
 * Update is simple. By default we scan the table, and for each row, we check the WHERE
 * clause. If it evaluates to true, we build the new record with the updated value and insert.

--- a/core/translate/values.rs
+++ b/core/translate/values.rs
@@ -1,11 +1,17 @@
-use crate::translate::emitter::TranslateCtx;
-use crate::translate::expr::{translate_expr_no_constant_opt, NoConstantOptReason};
-use crate::translate::plan::{QueryDestination, SelectPlan};
-use crate::translate::result_row::emit_offset;
-use crate::vdbe::builder::ProgramBuilder;
-use crate::vdbe::insn::{IdxInsertFlags, Insn};
-use crate::vdbe::BranchOffset;
-use crate::Result;
+use crate::{
+    translate::{
+        emitter::TranslateCtx,
+        expr::{translate_expr_no_constant_opt, NoConstantOptReason},
+        plan::{QueryDestination, SelectPlan},
+        result_row::emit_offset,
+    },
+    vdbe::{
+        builder::ProgramBuilder,
+        insn::{IdxInsertFlags, Insn},
+        BranchOffset,
+    },
+    Result,
+};
 
 pub fn emit_values(
     program: &mut ProgramBuilder,

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -1,11 +1,17 @@
-use crate::schema::{Schema, DBSP_TABLE_PREFIX};
-use crate::storage::pager::CreateBTreeFlags;
-use crate::translate::emitter::Resolver;
-use crate::translate::schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID};
-use crate::util::{normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX};
-use crate::vdbe::builder::{CursorType, ProgramBuilder};
-use crate::vdbe::insn::{CmpInsFlags, Cookie, Insn, RegisterOrLiteral};
-use crate::{Connection, Result};
+use crate::{
+    schema::{Schema, DBSP_TABLE_PREFIX},
+    storage::pager::CreateBTreeFlags,
+    translate::{
+        emitter::Resolver,
+        schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID},
+    },
+    util::{normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX},
+    vdbe::{
+        builder::{CursorType, ProgramBuilder},
+        insn::{CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
+    },
+    Connection, Result,
+};
 use std::sync::Arc;
 use turso_parser::ast;
 
@@ -40,8 +46,7 @@ pub fn translate_create_materialized_view(
     // Validate the view can be created and extract its columns
     // This validation happens before updating sqlite_master to prevent
     // storing invalid view definitions
-    use crate::incremental::view::IncrementalView;
-    use crate::schema::BTreeTable;
+    use crate::{incremental::view::IncrementalView, schema::BTreeTable};
     let view_column_schema =
         IncrementalView::validate_and_extract_columns(select_stmt, resolver.schema)?;
     let view_columns = view_column_schema.flat_columns();

--- a/core/types.rs
+++ b/core/types.rs
@@ -4,25 +4,29 @@ use serde::Deserialize;
 use turso_ext::{AggCtx, FinalizeFunction, StepFunction};
 use turso_parser::ast::SortOrder;
 
-use crate::error::LimboError;
-use crate::ext::{ExtValue, ExtValueType};
-use crate::index_method::IndexMethodCursor;
-use crate::numeric::format_float;
-use crate::pseudo::PseudoCursor;
-use crate::schema::Index;
-use crate::storage::btree::CursorTrait;
-use crate::storage::sqlite3_ondisk::{read_integer, read_value, read_varint, write_varint};
-use crate::translate::collate::CollationSeq;
-use crate::translate::plan::IterationDirection;
-use crate::vdbe::sorter::Sorter;
-use crate::vdbe::Register;
-use crate::vtab::VirtualTableCursor;
-use crate::{Completion, CompletionError, Result, IO};
-use std::borrow::{Borrow, Cow};
-use std::fmt::{Debug, Display};
-use std::iter::Peekable;
-use std::ops::Deref;
-use std::task::Waker;
+use crate::{
+    error::LimboError,
+    ext::{ExtValue, ExtValueType},
+    index_method::IndexMethodCursor,
+    numeric::format_float,
+    pseudo::PseudoCursor,
+    schema::Index,
+    storage::{
+        btree::CursorTrait,
+        sqlite3_ondisk::{read_integer, read_value, read_varint, write_varint},
+    },
+    translate::{collate::CollationSeq, plan::IterationDirection},
+    vdbe::{sorter::Sorter, Register},
+    vtab::VirtualTableCursor,
+    Completion, CompletionError, Result, IO,
+};
+use std::{
+    borrow::{Borrow, Cow},
+    fmt::{Debug, Display},
+    iter::Peekable,
+    ops::Deref,
+    task::Waker,
+};
 
 /// SQLite by default uses 2000 as maximum numbers in a row.
 /// It controlld by the constant called SQLITE_MAX_COLUMN

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1045,8 +1045,10 @@ pub fn construct_like_regex(pattern: &str) -> Regex {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::Value;
-    use crate::vdbe::{Bitfield, Register};
+    use crate::{
+        types::Value,
+        vdbe::{Bitfield, Register},
+    };
 
     use rand::{Rng, RngCore};
     use std::collections::HashMap;

--- a/core/vector/mod.rs
+++ b/core/vector/mod.rs
@@ -1,9 +1,7 @@
-use crate::types::AsValueRef;
-use crate::types::Value;
-use crate::types::ValueType;
-use crate::LimboError;
-use crate::Result;
-use crate::ValueRef;
+use crate::{
+    types::{AsValueRef, Value, ValueType},
+    LimboError, Result, ValueRef,
+};
 
 pub mod operations;
 pub mod vector_types;

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -1,12 +1,18 @@
-use crate::pragma::{PragmaVirtualTable, PragmaVirtualTableCursor};
-use crate::schema::Column;
-use crate::util::columns_from_create_table_body;
-use crate::{Connection, LimboError, SymbolTable, Value};
+use crate::{
+    pragma::{PragmaVirtualTable, PragmaVirtualTableCursor},
+    schema::Column,
+    util::columns_from_create_table_body,
+    Connection, LimboError, SymbolTable, Value,
+};
 use parking_lot::RwLock;
-use std::ffi::c_void;
-use std::ptr::NonNull;
-use std::sync::atomic::{AtomicPtr, Ordering};
-use std::sync::Arc;
+use std::{
+    ffi::c_void,
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicPtr, Ordering},
+        Arc,
+    },
+};
 use turso_ext::{ConstraintInfo, IndexInfo, OrderByInfo, ResultCode, VTabKind, VTabModuleImpl};
 use turso_parser::{ast, parser::Parser};
 

--- a/extensions/csv/src/lib.rs
+++ b/extensions/csv/src/lib.rs
@@ -20,9 +20,11 @@
 //!   accepts `yes`/`no`, `on`/`off`, `true`/`false`, or `1`/`0`
 //! - `columns` — number of columns
 //! - `schema` — optional custom SQL `CREATE TABLE` schema
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
-use std::sync::Arc;
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    sync::Arc,
+};
 use turso_ext::{
     register_extension, Connection, ResultCode, VTabCursor, VTabKind, VTabModule, VTabModuleDerive,
     VTable, Value,

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -1,10 +1,12 @@
-use std::cell::RefCell;
-use std::collections::{BTreeMap, VecDeque};
-use std::fs::{File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
-use std::num::NonZeroUsize;
-use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, VecDeque},
+    fs::{File, OpenOptions},
+    io::{Read, Seek, SeekFrom, Write},
+    num::NonZeroUsize,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 use turso_ext::{
     register_extension, scalar, Connection, ConstraintInfo, ConstraintOp, ConstraintUsage,
     ExtResult, IndexInfo, OrderByInfo, ResultCode, StepResult, VTabCursor, VTabKind, VTabModule,

--- a/macros/src/ext/agg_derive.rs
+++ b/macros/src/ext/agg_derive.rs
@@ -1,7 +1,6 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::parse_macro_input;
-use syn::DeriveInput;
+use syn::{parse_macro_input, DeriveInput};
 
 pub fn derive_agg_func(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/macros/src/ext/mod.rs
+++ b/macros/src/ext/mod.rs
@@ -1,9 +1,8 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::parse::ParseStream;
-use syn::punctuated::Punctuated;
-use syn::token::Eq;
-use syn::{parse_macro_input, Ident, LitStr, Token};
+use syn::{
+    parse::ParseStream, parse_macro_input, punctuated::Punctuated, token::Eq, Ident, LitStr, Token,
+};
 mod agg_derive;
 mod match_ignore_ascii_case;
 mod scalars;

--- a/parser/src/ast/fmt.rs
+++ b/parser/src/ast/fmt.rs
@@ -1,10 +1,11 @@
 //! AST node format
 use std::fmt::{self, Display, Formatter, Write};
 
-use crate::ast::*;
-use crate::token::TokenType;
-use crate::token::TokenType::*;
-use crate::Result;
+use crate::{
+    ast::*,
+    token::{TokenType, TokenType::*},
+    Result,
+};
 
 use crate::ast::TableInternalId;
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,19 +1,22 @@
-use crate::ast::{
-    check::ColumnCount, AlterTable, AlterTableBody, As, Cmd, ColumnConstraint, ColumnDefinition,
-    CommonTableExpr, CompoundOperator, CompoundSelect, CreateTableBody, CreateVirtualTable,
-    DeferSubclause, Distinctness, Expr, ForeignKeyClause, FrameBound, FrameClause, FrameExclude,
-    FrameMode, FromClause, FunctionTail, GroupBy, Indexed, IndexedColumn, InitDeferredPred,
-    InsertBody, JoinConstraint, JoinOperator, JoinType, JoinedSelectTable, LikeOperator, Limit,
-    Literal, Materialized, Name, NamedColumnConstraint, NamedTableConstraint, NullsOrder,
-    OneSelect, Operator, Over, PragmaBody, PragmaValue, QualifiedName, RefAct, RefArg, ResolveType,
-    ResultColumn, Select, SelectBody, SelectTable, Set, SortOrder, SortedColumn, Stmt,
-    TableConstraint, TableOptions, TransactionType, TriggerCmd, TriggerEvent, TriggerTime, Type,
-    TypeSize, UnaryOperator, Update, Upsert, UpsertDo, UpsertIndex, Window, WindowDef, With,
+use crate::{
+    ast::{
+        check::ColumnCount, AlterTable, AlterTableBody, As, Cmd, ColumnConstraint,
+        ColumnDefinition, CommonTableExpr, CompoundOperator, CompoundSelect, CreateTableBody,
+        CreateVirtualTable, DeferSubclause, Distinctness, Expr, ForeignKeyClause, FrameBound,
+        FrameClause, FrameExclude, FrameMode, FromClause, FunctionTail, GroupBy, Indexed,
+        IndexedColumn, InitDeferredPred, InsertBody, JoinConstraint, JoinOperator, JoinType,
+        JoinedSelectTable, LikeOperator, Limit, Literal, Materialized, Name, NamedColumnConstraint,
+        NamedTableConstraint, NullsOrder, OneSelect, Operator, Over, PragmaBody, PragmaValue,
+        QualifiedName, RefAct, RefArg, ResolveType, ResultColumn, Select, SelectBody, SelectTable,
+        Set, SortOrder, SortedColumn, Stmt, TableConstraint, TableOptions, TransactionType,
+        TriggerCmd, TriggerEvent, TriggerTime, Type, TypeSize, UnaryOperator, Update, Upsert,
+        UpsertDo, UpsertIndex, Window, WindowDef, With,
+    },
+    error::Error,
+    lexer::{Lexer, Token},
+    token::TokenType::{self, *},
+    Result,
 };
-use crate::error::Error;
-use crate::lexer::{Lexer, Token};
-use crate::token::TokenType::{self, *};
-use crate::Result;
 use turso_macros::match_ignore_ascii_case;
 
 macro_rules! peek_expect {

--- a/perf/encryption/src/main.rs
+++ b/perf/encryption/src/main.rs
@@ -1,9 +1,12 @@
 use clap::Parser;
-use rand::rngs::SmallRng;
-use rand::{Rng, RngCore, SeedableRng};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Barrier};
-use std::time::{Duration, Instant};
+use rand::{rngs::SmallRng, Rng, RngCore, SeedableRng};
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Barrier,
+    },
+    time::{Duration, Instant},
+};
 use turso::{Builder, Database, EncryptionOpts, Result};
 
 #[derive(Parser)]

--- a/perf/throughput/rusqlite/src/main.rs
+++ b/perf/throughput/rusqlite/src/main.rs
@@ -1,8 +1,10 @@
 use clap::Parser;
 use rusqlite::{Connection, Result};
-use std::sync::{Arc, Barrier};
-use std::thread;
-use std::time::Instant;
+use std::{
+    sync::{Arc, Barrier},
+    thread,
+    time::Instant,
+};
 
 #[derive(Parser)]
 #[command(name = "write-throughput")]

--- a/perf/throughput/turso/src/main.rs
+++ b/perf/throughput/turso/src/main.rs
@@ -1,10 +1,12 @@
 use clap::{Parser, ValueEnum};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Barrier};
-use std::time::{Duration, Instant};
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Layer};
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Barrier,
+    },
+    time::{Duration, Instant},
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 use turso::{Builder, Database, Result};
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -2,29 +2,36 @@
 use anyhow::anyhow;
 use clap::Parser;
 use rand::prelude::*;
-use runner::bugbase::BugBase;
-use runner::cli::{SimulatorCLI, SimulatorCommand};
-use runner::differential;
-use runner::env::SimulatorEnv;
-use runner::execution::{Execution, ExecutionHistory, ExecutionResult, execute_interactions};
-use std::any::Any;
-use std::backtrace::Backtrace;
-use std::fs::OpenOptions;
-use std::io::{IsTerminal, Write};
-use std::path::Path;
-use std::rc::Rc;
-use std::sync::{Arc, Mutex};
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::field::MakeExt;
-use tracing_subscriber::fmt::format;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-use crate::model::interactions::{
-    ConnectionState, InteractionPlan, InteractionPlanIterator, InteractionPlanState,
+use runner::{
+    bugbase::BugBase,
+    cli::{SimulatorCLI, SimulatorCommand},
+    differential,
+    env::SimulatorEnv,
+    execution::{Execution, ExecutionHistory, ExecutionResult, execute_interactions},
 };
-use crate::profiles::Profile;
-use crate::runner::doublecheck;
-use crate::runner::env::{Paths, SimulationPhase, SimulationType};
+use std::{
+    any::Any,
+    backtrace::Backtrace,
+    fs::OpenOptions,
+    io::{IsTerminal, Write},
+    path::Path,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
+use tracing_subscriber::{
+    EnvFilter, field::MakeExt, fmt::format, layer::SubscriberExt, util::SubscriberInitExt,
+};
+
+use crate::{
+    model::interactions::{
+        ConnectionState, InteractionPlan, InteractionPlanIterator, InteractionPlanState,
+    },
+    profiles::Profile,
+    runner::{
+        doublecheck,
+        env::{Paths, SimulationPhase, SimulationType},
+    },
+};
 
 mod common;
 mod generation;

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -4,13 +4,12 @@ use anyhow::Context;
 use bitflags::bitflags;
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
-use sql_generation::model::query::select::SelectTable;
 use sql_generation::model::{
     query::{
         Create, CreateIndex, Delete, Drop, DropIndex, Insert, Select,
         alter_table::{AlterTable, AlterTableType},
         pragma::Pragma,
-        select::{CompoundOperator, FromClause, ResultColumn, SelectInner},
+        select::{CompoundOperator, FromClause, ResultColumn, SelectInner, SelectTable},
         transaction::{Begin, Commit, Rollback},
         update::Update,
     },

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -1,26 +1,29 @@
-use std::fmt::Display;
-use std::mem;
-use std::ops::{Deref, DerefMut};
-use std::panic::UnwindSafe;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{
+    fmt::Display,
+    mem,
+    ops::{Deref, DerefMut},
+    panic::UnwindSafe,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use bitmaps::Bitmap;
 use garde::Validate;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use sql_generation::generation::GenerationContext;
-use sql_generation::model::query::transaction::Rollback;
-use sql_generation::model::table::Table;
+use sql_generation::{
+    generation::GenerationContext,
+    model::{query::transaction::Rollback, table::Table},
+};
 use tracing::trace;
 use turso_core::Database;
 
-use crate::generation::Shadow;
-use crate::model::Query;
-use crate::profiles::Profile;
-use crate::runner::SimIO;
-use crate::runner::io::SimulatorIO;
-use crate::runner::memory::io::MemorySimIO;
+use crate::{
+    generation::Shadow,
+    model::Query,
+    profiles::Profile,
+    runner::{SimIO, io::SimulatorIO, memory::io::MemorySimIO},
+};
 
 use super::cli::SimulatorCLI;
 

--- a/simulator/runner/memory/io.rs
+++ b/simulator/runner/memory/io.rs
@@ -1,5 +1,4 @@
-use std::cell::RefCell;
-use std::sync::Arc;
+use std::{cell::RefCell, sync::Arc};
 
 use indexmap::IndexMap;
 use parking_lot::Mutex;
@@ -7,9 +6,7 @@ use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use turso_core::{Clock, Completion, IO, Instant, OpenFlags, Result};
 
-use crate::runner::SimIO;
-use crate::runner::clock::SimulatorClock;
-use crate::runner::memory::file::MemorySimFile;
+use crate::runner::{SimIO, clock::SimulatorClock, memory::file::MemorySimFile};
 
 /// File descriptor
 pub type Fd = String;

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -1,22 +1,27 @@
-use crate::generation::{
-    gen_random_text, pick_index, pick_n_unique, pick_unique, Arbitrary, ArbitraryFrom,
-    ArbitrarySized, GenerationContext,
-};
-use crate::model::query::alter_table::{AlterTable, AlterTableType, AlterTableTypeDiscriminants};
-use crate::model::query::predicate::Predicate;
-use crate::model::query::select::{
-    CompoundOperator, CompoundSelect, Distinctness, FromClause, OrderBy, ResultColumn, SelectBody,
-    SelectInner, SelectTable,
-};
-use crate::model::query::update::Update;
-use crate::model::query::{Create, CreateIndex, Delete, Drop, DropIndex, Insert, Select};
-use crate::model::table::{
-    Column, Index, JoinTable, JoinType, JoinedTable, Name, SimValue, Table, TableContext,
+use crate::{
+    generation::{
+        gen_random_text, pick_index, pick_n_unique, pick_unique, Arbitrary, ArbitraryFrom,
+        ArbitrarySized, GenerationContext,
+    },
+    model::{
+        query::{
+            alter_table::{AlterTable, AlterTableType, AlterTableTypeDiscriminants},
+            predicate::Predicate,
+            select::{
+                CompoundOperator, CompoundSelect, Distinctness, FromClause, OrderBy, ResultColumn,
+                SelectBody, SelectInner, SelectTable,
+            },
+            update::Update,
+            Create, CreateIndex, Delete, Drop, DropIndex, Insert, Select,
+        },
+        table::{
+            Column, Index, JoinTable, JoinType, JoinedTable, Name, SimValue, Table, TableContext,
+        },
+    },
 };
 use indexmap::IndexSet;
 use itertools::Itertools;
-use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::{seq::IndexedRandom, Rng};
 use turso_parser::ast::{Expr, SortOrder};
 
 use super::{backtrack, pick};

--- a/sql_generation/generation/table.rs
+++ b/sql_generation/generation/table.rs
@@ -3,8 +3,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use indexmap::IndexSet;
 use rand::Rng;
 
-use crate::generation::{pick, readable_name_custom, Arbitrary, GenerationContext};
-use crate::model::table::{Column, ColumnType, Name, Table};
+use crate::{
+    generation::{pick, readable_name_custom, Arbitrary, GenerationContext},
+    model::table::{Column, ColumnType, Name, Table},
+};
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 

--- a/sql_generation/model/query/predicate.rs
+++ b/sql_generation/model/query/predicate.rs
@@ -2,8 +2,8 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 use turso_parser::ast::{
-    self,
     fmt::{BlankContext, ToTokens},
+    {self},
 };
 
 use crate::model::table::{SimValue, Table, TableContext};

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -1,8 +1,10 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(non_camel_case_types)]
 
-use std::ffi::{self, CStr, CString};
-use std::num::{NonZero, NonZeroUsize};
+use std::{
+    ffi::{self, CStr, CString},
+    num::{NonZero, NonZeroUsize},
+};
 use tracing::trace;
 use turso_core::{CheckpointMode, LimboError, Value};
 

--- a/stress/main.rs
+++ b/stress/main.rs
@@ -1,20 +1,22 @@
 mod opts;
 
 use anarchist_readable_name_generator_lib::readable_name_custom;
-use antithesis_sdk::random::{get_random, AntithesisRng};
-use antithesis_sdk::*;
+use antithesis_sdk::{
+    random::{get_random, AntithesisRng},
+    *,
+};
 use clap::Parser;
 use core::panic;
 use opts::Opts;
-use std::collections::HashSet;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::sync::Arc;
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::{Read, Write},
+    sync::Arc,
+};
 use tokio::sync::Mutex;
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use turso::Builder;
 
 pub struct Plan {

--- a/sync/engine/src/server_proto.rs
+++ b/sync/engine/src/server_proto.rs
@@ -266,8 +266,10 @@ pub enum Value {
 }
 
 pub mod option_u64_as_str {
-    use serde::de::Error;
-    use serde::{de::Visitor, ser, Deserializer, Serialize as _};
+    use serde::{
+        de::{Error, Visitor},
+        ser, Deserializer, Serialize as _,
+    };
 
     pub fn serialize<S: ser::Serializer>(value: &Option<u64>, ser: S) -> Result<S::Ok, S::Error> {
         value.map(|v| v.to_string()).serialize(ser)
@@ -350,8 +352,7 @@ pub mod option_u64_as_str {
 }
 
 mod i64_as_str {
-    use serde::{de, ser};
-    use serde::{de::Error as _, Serialize as _};
+    use serde::{de, de::Error as _, ser, Serialize as _};
 
     pub fn serialize<S: ser::Serializer>(value: &i64, ser: S) -> Result<S::Ok, S::Error> {
         value.to_string().serialize(ser)
@@ -371,8 +372,7 @@ mod i64_as_str {
 pub(crate) mod bytes_as_base64 {
     use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
     use bytes::Bytes;
-    use serde::{de, ser};
-    use serde::{de::Error as _, Serialize as _};
+    use serde::{de, de::Error as _, ser, Serialize as _};
 
     pub fn serialize<S: ser::Serializer>(value: &Bytes, ser: S) -> Result<S::Ok, S::Error> {
         STANDARD_NO_PAD.encode(value).serialize(ser)
@@ -389,8 +389,10 @@ pub(crate) mod bytes_as_base64 {
 }
 
 mod option_i64_as_str {
-    use serde::de::{Error, Visitor};
-    use serde::{ser, Deserializer, Serialize as _};
+    use serde::{
+        de::{Error, Visitor},
+        ser, Deserializer, Serialize as _,
+    };
 
     pub fn serialize<S: ser::Serializer>(value: &Option<i64>, ser: S) -> Result<S::Ok, S::Error> {
         value.map(|v| v.to_string()).serialize(ser)
@@ -449,8 +451,7 @@ mod option_i64_as_str {
 pub(crate) mod bytes_as_base64_pad {
     use base64::{engine::general_purpose::STANDARD, Engine as _};
     use bytes::Bytes;
-    use serde::{de, ser};
-    use serde::{de::Error as _, Serialize as _};
+    use serde::{de, de::Error as _, ser, Serialize as _};
 
     pub fn serialize<S: ser::Serializer>(value: &Bytes, ser: S) -> Result<S::Ok, S::Error> {
         STANDARD.encode(value).serialize(ser)

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -3,8 +3,10 @@ pub mod rowid_alias;
 
 #[cfg(test)]
 mod fuzz_tests {
-    use rand::seq::{IndexedRandom, IteratorRandom, SliceRandom};
-    use rand::Rng;
+    use rand::{
+        seq::{IndexedRandom, IteratorRandom, SliceRandom},
+        Rng,
+    };
     use rand_chacha::ChaCha8Rng;
     use rusqlite::{params, types::Value};
     use std::{collections::HashSet, io::Write};

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -1,8 +1,10 @@
 use rand::{rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use rusqlite::params;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tempfile::TempDir;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use turso_core::{Connection, Database, Row, StepResult, IO};

--- a/tests/integration/functions/test_sum.rs
+++ b/tests/integration/functions/test_sum.rs
@@ -26,9 +26,7 @@ fn sum_errors_on_integer_overflow() {
         .expect_err("SUM should report integer overflow");
     assert!(matches!(err, LimboError::IntegerOverflow));
 
-    use rusqlite::ffi::Error as FfiError;
-    use rusqlite::Error::SqliteFailure;
-    use rusqlite::ErrorCode;
+    use rusqlite::{ffi::Error as FfiError, Error::SqliteFailure, ErrorCode};
 
     let mut stmt = sqlite_conn
         .prepare("SELECT sum(a) FROM t")

--- a/tests/integration/fuzz_transaction/mod.rs
+++ b/tests/integration/fuzz_transaction/mod.rs
@@ -1,5 +1,4 @@
-use rand::seq::IndexedRandom;
-use rand::Rng;
+use rand::{seq::IndexedRandom, Rng};
 use rand_chacha::ChaCha8Rng;
 use std::collections::BTreeMap;
 use turso::{Builder, Value};

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -10,7 +10,10 @@ use turso_core::{
     },
     schema::IndexColumn,
     types::IOResult,
-    vector::{self, vector_types::VectorType},
+    vector::{
+        vector_types::VectorType,
+        {self},
+    },
     Register, Result, Value,
 };
 use turso_parser::ast::SortOrder;

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -253,8 +253,10 @@ fn test_corruption_turso_magic_bytes() -> anyhow::Result<()> {
 
     // corrupt the Turso magic bytes by changing "Turso" to "Vurso" (the db name as it was intended)
     {
-        use std::fs::OpenOptions;
-        use std::io::{Seek, SeekFrom, Write};
+        use std::{
+            fs::OpenOptions,
+            io::{Seek, SeekFrom, Write},
+        };
 
         let mut file = OpenOptions::new().write(true).open(&db_path)?;
 
@@ -331,8 +333,10 @@ fn test_corruption_associated_data_bytes() -> anyhow::Result<()> {
 
         // corrupt one byte
         {
-            use std::fs::OpenOptions;
-            use std::io::{Read, Seek, SeekFrom, Write};
+            use std::{
+                fs::OpenOptions,
+                io::{Read, Seek, SeekFrom, Write},
+            };
 
             let mut file = OpenOptions::new()
                 .read(true)
@@ -383,8 +387,10 @@ fn test_turso_header_structure() -> anyhow::Result<()> {
 
     let verify_header =
         |db_path: &str, expected_cipher_id: u8, description: &str| -> anyhow::Result<()> {
-            use std::fs::File;
-            use std::io::{Read, Seek, SeekFrom};
+            use std::{
+                fs::File,
+                io::{Read, Seek, SeekFrom},
+            };
 
             let mut file = File::open(db_path)?;
             let mut header = [0u8; 16];

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1,8 +1,12 @@
-use crate::common::{self, limbo_exec_rows, maybe_setup_tracing, rusqlite_integrity_check};
-use crate::common::{compare_string, do_flush, TempDatabase};
+use crate::common::{
+    self, compare_string, do_flush, limbo_exec_rows, maybe_setup_tracing, rusqlite_integrity_check,
+    TempDatabase,
+};
 use log::debug;
-use std::io::{Read, Seek, Write};
-use std::sync::Arc;
+use std::{
+    io::{Read, Seek, Write},
+    sync::Arc,
+};
 use turso_core::{
     CheckpointMode, Connection, Database, DatabaseOpts, LimboError, Row, Statement, StepResult,
     Value,

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -1,8 +1,10 @@
 use crate::common::{do_flush, maybe_setup_tracing, TempDatabase};
-use std::cell::RefCell;
-use std::ops::Deref;
-use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::{
+    cell::RefCell,
+    ops::Deref,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 use turso_core::{Connection, LimboError, Result, StepResult};
 
 #[allow(clippy::arc_with_non_send_sync)]

--- a/whopper/io.rs
+++ b/whopper/io.rs
@@ -1,9 +1,11 @@
 use memmap2::{MmapMut, MmapOptions};
 use rand::{Rng, RngCore};
 use rand_chacha::ChaCha8Rng;
-use std::collections::{HashMap, HashSet};
-use std::fs::{File as StdFile, OpenOptions};
-use std::sync::{Arc, Mutex, Weak};
+use std::{
+    collections::{HashMap, HashSet},
+    fs::{File as StdFile, OpenOptions},
+    sync::{Arc, Mutex, Weak},
+};
 use tracing::debug;
 use turso_core::{Clock, Completion, File, IO, Instant, OpenFlags, Result};
 

--- a/whopper/main.rs
+++ b/whopper/main.rs
@@ -12,9 +12,7 @@ use sql_generation::{
         table::{Column, ColumnType, Index, Table},
     },
 };
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{cell::RefCell, collections::HashMap, sync::Arc};
 use tracing::trace;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 use turso_core::{


### PR DESCRIPTION
Our imports are a mess. This adds a "scripts/fmt-import" script, which executes "cargo fmt" with the crate-level import sorting flag. Fun fact: we cannot add that to rustfmt.toml because that would require us to use nightly...