### PR TITLE
Update AEGIS crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "aegis"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb210c8891f193d75feaec2704b8be91d352407dc1c1a083382e210b5a79f7be"
+checksum = "0ba3d914d59750379281289041a0411a5d6f7b606f05d9bd7382846ed1764e29"
 dependencies = [
  "cc",
  "softaes",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1588,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "findshlibs"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -78,7 +78,7 @@ bytemuck = "1.23.1"
 aes-gcm = { version = "0.10.3"}
 aes = { version = "0.8.4"}
 turso_parser = { workspace = true }
-aegis = "0.9.3"
+aegis = "0.9.5"
 twox-hash = "2.1.1"
 intrusive-collections = "0.9.7"
 roaring = "0.11.2"


### PR DESCRIPTION
Likely the fix for https://github.com/tursodatabase/turso/issues/3958 

Apparently there was a [bug in gcc](https://github.com/jedisct1/rust-aegis/issues/8) which caused issue in arm64. The latest patch in aegis crate seems to have fixed this issue.