### PR TITLE
mvcc: do not store index data twice in Row

### DIFF
--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -95,14 +95,11 @@ fn bench(c: &mut Criterion) {
             db.mvcc_store
                 .update(
                     tx_id,
-                    Row {
-                        id: RowID {
-                            table_id: (-2).into(),
-                            row_id: RowKey::Int(1),
-                        },
-                        data: record_data.clone(),
-                        column_count: 1,
-                    },
+                    Row::new_table_row(
+                        RowID::new((-2).into(), RowKey::Int(1)),
+                        record_data.clone(),
+                        1,
+                    ),
                 )
                 .unwrap();
             let mv_store = &db.mvcc_store;
@@ -123,14 +120,11 @@ fn bench(c: &mut Criterion) {
     db.mvcc_store
         .insert(
             tx_id,
-            Row {
-                id: RowID {
-                    table_id: (-2).into(),
-                    row_id: RowKey::Int(1),
-                },
-                data: record_data.clone(),
-                column_count: 1,
-            },
+            Row::new_table_row(
+                RowID::new((-2).into(), RowKey::Int(1)),
+                record_data.clone(),
+                1,
+            ),
         )
         .unwrap();
     group.bench_function("read", |b| {
@@ -152,14 +146,11 @@ fn bench(c: &mut Criterion) {
     db.mvcc_store
         .insert(
             tx_id,
-            Row {
-                id: RowID {
-                    table_id: (-2).into(),
-                    row_id: RowKey::Int(1),
-                },
-                data: record_data.clone(),
-                column_count: 1,
-            },
+            Row::new_table_row(
+                RowID::new((-2).into(), RowKey::Int(1)),
+                record_data.clone(),
+                1,
+            ),
         )
         .unwrap();
     group.bench_function("update", |b| {
@@ -167,14 +158,11 @@ fn bench(c: &mut Criterion) {
             db.mvcc_store
                 .update(
                     tx_id,
-                    Row {
-                        id: RowID {
-                            table_id: (-2).into(),
-                            row_id: RowKey::Int(1),
-                        },
-                        data: record_data.clone(),
-                        column_count: 1,
-                    },
+                    Row::new_table_row(
+                        RowID::new((-2).into(), RowKey::Int(1)),
+                        record_data.clone(),
+                        1,
+                    ),
                 )
                 .unwrap();
         })

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -271,7 +271,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 let mut special_write = None;
 
                 if version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                    let row_data = ImmutableRecord::from_bin_record(version.row.data.clone());
+                    let row_data = ImmutableRecord::from_bin_record(version.row.payload().to_vec());
                     let mut record_cursor = RecordCursor::new();
                     record_cursor
                         .parse_full_header(&row_data)
@@ -714,7 +714,8 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             .ok_or(LimboError::InternalError(
                                 "row version not found in write set".to_string(),
                             ))?;
-                        let record = ImmutableRecord::from_bin_record(row_version.row.data.clone());
+                        let record =
+                            ImmutableRecord::from_bin_record(row_version.row.payload().to_vec());
                         let mut record_cursor = RecordCursor::new();
                         record_cursor
                             .parse_full_header(&record)
@@ -726,7 +727,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             .collect::<Result<Vec<_>>>()?;
                         values[3] = Value::Integer(root_page as i64);
                         let record = ImmutableRecord::from_values(&values, values.len());
-                        row_version.row.data = record.get_payload().to_owned();
+                        row_version.row.data = Some(record.get_payload().to_owned());
                         row_version.clone()
                     };
                     self.created_btrees
@@ -753,7 +754,8 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             .ok_or(LimboError::InternalError(
                                 "row version not found in write set".to_string(),
                             ))?;
-                        let record = ImmutableRecord::from_bin_record(row_version.row.data.clone());
+                        let record =
+                            ImmutableRecord::from_bin_record(row_version.row.payload().to_vec());
                         let mut record_cursor = RecordCursor::new();
                         record_cursor
                             .parse_full_header(&record)
@@ -765,7 +767,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             .collect::<Result<Vec<_>>>()?;
                         values[3] = Value::Integer(root_page as i64);
                         let record = ImmutableRecord::from_values(&values, values.len());
-                        row_version.row.data = record.get_payload().to_owned();
+                        row_version.row.data = Some(record.get_payload().to_owned());
                         row_version.clone()
                     };
 


### PR DESCRIPTION
RowKey::Record already stores the entire index payload (like in btrees) so we don't need to store a Row::data property at all for indexes.

Previously we were storing two copies of the data.