### PR TITLE
Simulator: after freestanding DML statement, check the table's content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4988,7 +4988,7 @@ dependencies = [
  "miette",
  "mimalloc",
  "nu-ansi-term",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rustyline",
  "schemars 0.8.22",
  "serde",

--- a/simulator/model/interactions.rs
+++ b/simulator/model/interactions.rs
@@ -300,7 +300,8 @@ impl Interactions {
     pub fn check_tables(&self) -> bool {
         match &self.interactions {
             InteractionsType::Property(property) => property.check_tables(),
-            InteractionsType::Query(..) | InteractionsType::Fault(..) => false,
+            InteractionsType::Query(query) => query.is_dml(),
+            InteractionsType::Fault(..) => false,
         }
     }
 
@@ -312,6 +313,7 @@ impl Interactions {
             || matches!(
                 self.interactions,
                 InteractionsType::Property(Property::AllTableHaveExpectedContent { .. })
+                    | InteractionsType::Property(Property::TableHasExpectedContent { .. })
             )
     }
 }

--- a/simulator/model/mod.rs
+++ b/simulator/model/mod.rs
@@ -141,6 +141,11 @@ impl Query {
                 | Self::DropIndex(..)
         )
     }
+
+    #[inline]
+    pub fn is_dml(&self) -> bool {
+        matches!(self, Self::Insert(..) | Self::Update(..) | Self::Delete(..))
+    }
 }
 
 impl Display for Query {

--- a/simulator/profiles/query.rs
+++ b/simulator/profiles/query.rs
@@ -8,6 +8,9 @@ use sql_generation::generation::Opts;
 pub struct QueryProfile {
     #[garde(dive)]
     pub gen_opts: Opts,
+    /// Produces a new `TableHasExpectedContent` after each freestanding DML statement
+    #[garde(skip)]
+    pub check_after_dml: bool,
     #[garde(skip)]
     pub select_weight: u32,
     #[garde(skip)]
@@ -34,6 +37,7 @@ impl Default for QueryProfile {
     fn default() -> Self {
         Self {
             gen_opts: Opts::default(),
+            check_after_dml: true,
             select_weight: 60,
             create_table_weight: 15,
             create_index_weight: 5,


### PR DESCRIPTION
Right now this is a Profile Option that is enabled by default. For longer runs and when we have better shrinking, we can disable this