### PR TITLE
fix: escape backslashes in json_object string values

### DIFF
--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -2296,7 +2296,8 @@ impl Jsonb {
     pub fn from_str_with_mode(input: &str, mode: Conv) -> PResult<Self> {
         // Parse directly as JSON if it's already JSON subtype or strict mode is on
         if matches!(mode, Conv::ToString) {
-            let mut str = input.replace('"', "\\\"");
+            // Escape backslashes first, then double quotes
+            let mut str = input.replace('\\', "\\\\").replace('"', "\\\"");
             str.insert(0, '"');
             str.push('"');
             Jsonb::from_str(&str)


### PR DESCRIPTION
When json_object received a string containing an unescaped backslash (e.g., "Hello\World"), it would fail with "malformed JSON" because the backslash was not escaped before wrapping the string in quotes.

Fix by escaping backslashes before double quotes in both convert_ref_dbtype_to_jsonb (Conv::NotStrict) and
Jsonb::from_str_with_mode (Conv::ToString).