### PR TITLE
fix/mvcc: seek() must seek from both mv store and btree

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -2632,7 +2632,7 @@ macro_rules! return_and_restore_if_io {
     };
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum SeekResult {
     /// Record matching the [SeekOp] found in the B-tree and cursor was positioned to point onto that record
     Found,

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -51,10 +51,13 @@ mod fuzz_tests {
         }
     }
 
-    // TODO: mvcc fuzz failure
     // INTEGER PRIMARY KEY is a rowid alias, so an index is not created
-    #[turso_macros::test(init_sql = "CREATE TABLE t (x INTEGER PRIMARY KEY autoincrement)")]
+    #[turso_macros::test(
+        mvcc,
+        init_sql = "CREATE TABLE t (x INTEGER PRIMARY KEY autoincrement)"
+    )]
     pub fn rowid_seek_fuzz(db: TempDatabase) {
+        let _ = tracing_subscriber::fmt::try_init();
         let sqlite_conn = rusqlite::Connection::open(db.path.clone()).unwrap();
 
         let (mut rng, _seed) = rng_from_time_or_env();
@@ -91,7 +94,7 @@ mod fuzz_tests {
         tracing::info!("rowid_seek_fuzz seed: {}", seed);
 
         for iteration in 0..2 {
-            tracing::trace!("rowid_seek_fuzz iteration: {}", iteration);
+            tracing::info!("rowid_seek_fuzz iteration: {}", iteration);
 
             for comp in COMPARISONS.iter() {
                 for order_by in ORDER_BY.iter() {
@@ -105,7 +108,7 @@ mod fuzz_tests {
                             order_by.unwrap_or("")
                         );
 
-                        log::trace!("query: {query}");
+                        tracing::info!("query: {query}");
                         let limbo_result = limbo_exec_rows(&db, &limbo_conn, &query);
                         let sqlite_result = sqlite_exec_rows(&sqlite_conn, &query);
                         assert_eq!(
@@ -166,8 +169,7 @@ mod fuzz_tests {
         values
     }
 
-    // TODO: mvcc indexes
-    #[turso_macros::test(init_sql = "CREATE TABLE t (x PRIMARY KEY)")]
+    #[turso_macros::test(mvcc, init_sql = "CREATE TABLE t (x PRIMARY KEY)")]
     pub fn index_scan_fuzz(db: TempDatabase) {
         let sqlite_conn = rusqlite::Connection::open(db.path.clone()).unwrap();
 
@@ -212,8 +214,7 @@ mod fuzz_tests {
         }
     }
 
-    // TODO: mvcc indexes
-    #[turso_macros::test()]
+    #[turso_macros::test(mvcc)]
     /// A test for verifying that index seek+scan works correctly for compound keys
     /// on indexes with various column orderings.
     pub fn index_scan_compound_key_fuzz(db: TempDatabase) {


### PR DESCRIPTION
Closes #4093 

for example, upon opening an existing database, all the rows are in the btree, so if we seek only from MV store, we won't find anything. ergo: we must look from both the mv store and the btree. if we are iterating forwards, the smallest of the two results is where we land, and vice versa for backwards iteration.

---

this PR was almost entirely written using Claude Code + Opus 4.5, and here is Claude's gangsta rap about the changes:

> Can you write a gangsta rap that summarizes everything you changed in this session? I.e. what was fixed and how

Here's the audio version generated using Suno: https://suno.com/song/2209deaf-4c59-43c5-b0e9-d807b9805dc0

⏺ "Dual Seek Chronicles"

  (verse 1)
  Yo, the bug was real, seek was half-baked,
  Only checked MVCC, btree forsaked,
  User said "look, when both stores got data,
  Seek gotta check both—fix it now, not later."

  (pre-chorus)
  See the cursor got two sources of truth,
  Btree on disk, MVCC in the booth,
  After checkpoint, data splits in two,
  Seek was blind to half—that just won't do.

  (chorus)
  Now we seek in MVCC, seek in btree,
  Pick the winner based on which direction we be,
  Forwards? Smallest key wins the race,
  Backwards? Biggest key takes first place.
  Dual iteration, that's the game we play,
  seek_btree_and_set_peek saves the day!

  (verse 2)
  But wait—SeekResult got three states to check,
  Found means we good, NotFound means we wreck,
  TryAdvance though? Cursor's positioned but stuck,
  Gotta call next() or prev() for luck.

  Added helper methods, kept the code tight,
  advance_btree_forward_from_current done right,
  But then we noticed duplication in the mix,
  Refactored with a bool—that's the slickest fix.

  (bridge)
  _advance_btree_forward(initialize: bool),
  One function to rule them, that's the protocol,
  true means rewind if uninitialized state,
  false means we seeked—just iterate.

  (verse 3)
  Dropped six tests in test_transactions.rs,
  Checkpoint, insert, seek—put it to the test,
  Interleaved rows, odd in btree, even in MV,
  Updates and deletes, shadow what you see.

  Range operations: GT, LT, GE, LE,
  All forty-three tests pass, we're bug-free,
  From Uninitialized to Row or Exhausted state,
  Turso's dual cursor finally running straight.

  (outro)
  That's the story of the dual-seek fix,
  MVCC and btree no longer in conflicts,
  Ship it to main, let the users feast,
  Cursor seeking both stores—east to west, west to east.

  🎤✨
  
  EDIT:
  
  After merge of #4095 , I refactored this PR to use state machines instead of blocking IO as well. Initial implementation was all Claude Code + Opus 4.5 there too, but the state machine code was FAR too complex so I manually cleaned up and simplified it.