### PR TITLE
Implement json_object(*) to create JSON object from all columns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ uv-sync-test:
 	uv sync --all-extras --dev --package turso_test
 .PHONE: uv-sync
 
-test: build uv-sync-test test-compat test-alter-column test-vector test-sqlite3 test-shell test-memory test-write test-update test-constraint test-collate test-extensions test-mvcc test-matviews
+test: build uv-sync-test test-compat test-alter-column test-vector test-sqlite3 test-shell test-memory test-write test-update test-constraint test-collate test-extensions test-mvcc test-matviews test-json
 .PHONY: test
 
 test-extensions: build uv-sync-test
@@ -114,6 +114,7 @@ test-sqlite3: reset-db
 
 test-json:
 	RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) ./testing/json.test
+	RUST_LOG=$(RUST_LOG) SQLITE_EXEC=$(SQLITE_EXEC) ./testing/json_object_star.test
 .PHONY: test-json
 
 test-memory: build uv-sync-test

--- a/testing/json_object_star.test
+++ b/testing/json_object_star.test
@@ -1,0 +1,136 @@
+#!/usr/bin/env tclsh
+
+# Tests for json_object(*) - Turso-specific extension to create JSON object from all columns
+# This is NOT part of standard SQLite and should not be run in test-compat
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# Test error handling: json_object(*) without FROM clause should fail
+do_execsql_test_in_memory_any_error json_object_star_no_from_clause {
+    SELECT json_object(*);
+}
+
+do_execsql_test_on_specific_db :memory: json_object_star_basic {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99);
+    INSERT INTO js_products VALUES (2, 'Gadget', 19.99);
+    SELECT json_object(*) FROM js_products WHERE id = 1;
+} {{{"id":1,"name":"Widget","price":9.99}}}
+
+do_execsql_test_on_specific_db :memory: json_object_star_multiple_rows {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99);
+    INSERT INTO js_products VALUES (2, 'Gadget', 19.99);
+    SELECT json_object(*) FROM js_products ORDER BY id;
+} {{{"id":1,"name":"Widget","price":9.99}} {{"id":2,"name":"Gadget","price":19.99}}}
+
+do_execsql_test_on_specific_db :memory: json_object_star_with_alias {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99);
+    SELECT json_object(*) AS data FROM js_products WHERE id = 1;
+} {{{"id":1,"name":"Widget","price":9.99}}}
+
+do_execsql_test_on_specific_db :memory: json_object_star_null_values {
+    CREATE TABLE js_items (a INTEGER, b TEXT, c REAL);
+    INSERT INTO js_items VALUES (1, NULL, 3.14);
+    SELECT json_object(*) FROM js_items;
+} {{{"a":1,"b":null,"c":3.14}}}
+
+do_execsql_test_on_specific_db :memory: json_object_star_with_where {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99), (2, 'Gadget', 19.99);
+    SELECT json_object(*) FROM js_products WHERE price > 10;
+} {{{"id":2,"name":"Gadget","price":19.99}}}
+
+# Test json_object(*) used IN a WHERE clause (tests optimizer expansion)
+do_execsql_test_on_specific_db :memory: json_object_star_in_where_clause {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99), (2, 'Gadget', 19.99);
+    SELECT id FROM js_products WHERE json_object(*) = json('{"id":1,"name":"Widget","price":9.99}');
+} {1}
+
+# Test json_object(*) in WHERE clause with direct string comparison
+do_execsql_test_on_specific_db :memory: json_object_star_where_string_compare {
+    CREATE TABLE js_simple(a);
+    INSERT INTO js_simple VALUES(1);
+    SELECT * FROM js_simple WHERE json_object(*) = '{"a":1}';
+} {1}
+
+# Test json_object(*) in UNION ALL scenario (key use case from issue)
+do_execsql_test_on_specific_db :memory: json_object_star_union_all {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99);
+    CREATE TABLE js_services (id INTEGER PRIMARY KEY, service_name TEXT, hourly_rate REAL);
+    INSERT INTO js_services VALUES (100, 'Consulting', 150.00);
+    SELECT json_object(*) AS data FROM js_products WHERE id = 1
+    UNION ALL
+    SELECT json_object(*) AS data FROM js_services WHERE id = 100;
+} {{{"id":1,"name":"Widget","price":9.99}} {{"id":100,"service_name":"Consulting","hourly_rate":150.0}}}
+
+# Test jsonb_object(*)
+do_execsql_test_on_specific_db :memory: jsonb_object_star_basic {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99);
+    SELECT json(jsonb_object(*)) FROM js_products WHERE id = 1;
+} {{{"id":1,"name":"Widget","price":9.99}}}
+
+# Test json_object(*) with table alias
+do_execsql_test_on_specific_db :memory: json_object_star_table_alias {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (2, 'Gadget', 19.99);
+    SELECT json_object(*) FROM js_products p WHERE p.id = 2;
+} {{{"id":2,"name":"Gadget","price":19.99}}}
+
+# Test json_object(*) with join
+# json_object(*) should include all columns from all tables in a join
+do_execsql_test_on_specific_db :memory: json_object_star_join {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99);
+    CREATE TABLE js_product_cats (prod_id INTEGER, cat_id INTEGER);
+    INSERT INTO js_product_cats VALUES (1, 1);
+    SELECT json_object(*) FROM js_products JOIN js_product_cats ON js_products.id = js_product_cats.prod_id WHERE js_products.id = 1;
+} {{{"id":1,"name":"Widget","price":9.99,"prod_id":1,"cat_id":1}}}
+
+# Test empty table
+do_execsql_test_on_specific_db :memory: json_object_star_empty_table {
+    CREATE TABLE js_empty_table (x INTEGER, y TEXT);
+    SELECT json_object(*) FROM js_empty_table;
+} {}
+
+# Test json_object(*) with derived/computed columns via subquery
+do_execsql_test_on_specific_db :memory: json_object_star_derived_columns {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99);
+    SELECT json_object(*) FROM (
+        SELECT id, name, price * 2 AS double_price FROM js_products WHERE id = 1
+    );
+} {{{"id":1,"name":"Widget","double_price":19.98}}}
+
+# Test json_object(*) with default column naming (column1, column2, etc.)
+do_execsql_test_on_specific_db :memory: json_object_star_default_column_names {
+    SELECT json_object(*) FROM (SELECT 1+1, 2+2 as a, 3+3);
+} {{{"column1":2,"a":4,"column3":6}}}
+
+# Test json_object(*) in materialized view
+do_execsql_test_on_specific_db :memory: json_object_star_matview {
+    CREATE TABLE js_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO js_products VALUES (1, 'Widget', 9.99);
+    INSERT INTO js_products VALUES (2, 'Gadget', 19.99);
+    CREATE MATERIALIZED VIEW js_products_json AS SELECT json_object(*) AS data FROM js_products;
+    SELECT * FROM js_products_json ORDER BY data;
+} {{{"id":1,"name":"Widget","price":9.99}} {{"id":2,"name":"Gadget","price":19.99}}}
+
+# Test that hidden columns are NOT expanded by json_object(*)
+# The generate_series virtual table has hidden columns: start, stop, step
+# Only 'value' should appear in the JSON output
+do_execsql_test_on_specific_db :memory: json_object_star_hidden_columns_generate_series {
+    SELECT json_object(*) FROM generate_series(1, 3);
+} {{{"value":1}} {{"value":2}} {{"value":3}}}
+
+# Test that a shadowed rowid column is expanded by json_object(*)
+do_execsql_test_on_specific_db :memory: json_object_star_shadowed_rowid {
+    CREATE TABLE js_shadowed_rowid(rowid TEXT, data INT);
+    INSERT INTO js_shadowed_rowid VALUES('my-rowid', 999);
+    SELECT json_object(*) FROM js_shadowed_rowid;
+} {{{"rowid":"my-rowid","data":999}}}


### PR DESCRIPTION
This adds support for json_object(*) and jsonb_object(*) syntax which creates a JSON object with column names as keys and column values as values from all columns in the referenced tables.

Key use cases:
- Query generators and ORMs that lack schema information at compile time
- Reducing maintenance burden when schema changes
- Combining heterogeneous tables via UNION ALL

Implementation:
- Added needs_star_expansion() method to Func to identify functions that need * expanded to columns (json_object, jsonb_object)
- Modified supports_star_syntax() to return true for these functions
- Updated expr.rs translate_expr to expand FunctionCallStar for these functions into key-value pairs from all joined tables' columns

Fixes #4090