### PR TITLE
Prevent creating index on rowid pseudo-column

### DIFF
--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -19,7 +19,6 @@ use crate::translate::insert::format_unique_violation_desc;
 use crate::translate::plan::{
     ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReferences,
 };
-use crate::translate::planner::ROWID_STRS;
 use crate::vdbe::builder::CursorKey;
 use crate::vdbe::insn::{CmpInsFlags, Cookie};
 use crate::vdbe::BranchOffset;
@@ -617,10 +616,9 @@ fn validate_index_expression(expr: &Expr, table: &BTreeTable) -> bool {
         }
         match e {
             Expr::Literal(_) | Expr::RowId { .. } => {}
-            // must be a column of the target table or ROWID
+            // must be a column of the target table
             Expr::Id(n) | Expr::Name(n) => {
-                let n = n.as_str();
-                if !ROWID_STRS.iter().any(|s| s.eq_ignore_ascii_case(n)) && !has_col(n) {
+                if !has_col(n.as_str()) {
                     ok = false;
                 }
             }

--- a/testing/create_index.test
+++ b/testing/create_index.test
@@ -59,3 +59,45 @@ do_execsql_test_on_specific_db {:memory:} create-unique-index-with-duplicates-5 
     SELECT count(*) FROM t5;
 } {2}
 
+# creating index on rowid (pseudo-column) should fail
+# SQLite: "no such column: rowid", Limbo: "invalid expression in CREATE INDEX: rowid"
+do_execsql_test_in_memory_error create-index-on-rowid {
+    CREATE TABLE t6(x);
+    CREATE INDEX idx6 ON t6(rowid);
+} {rowid}
+
+# creating index on _rowid_ (pseudo-column alias) should fail
+# SQLite: "no such column: _rowid_", Limbo: "invalid expression in CREATE INDEX: _rowid_"
+do_execsql_test_in_memory_error create-index-on-rowid-alias-1 {
+    CREATE TABLE t7(x);
+    CREATE INDEX idx7 ON t7(_rowid_);
+} {_rowid_}
+
+# creating index on oid (pseudo-column alias) should fail
+# SQLite: "no such column: oid", Limbo: "invalid expression in CREATE INDEX: oid"
+do_execsql_test_in_memory_error create-index-on-rowid-alias-2 {
+    CREATE TABLE t8(x);
+    CREATE INDEX idx8 ON t8(oid);
+} {oid}
+
+# creating index on shadowed rowid column should succeed
+do_execsql_test_on_specific_db {:memory:} create-index-on-shadowed-rowid {
+    CREATE TABLE t9(rowid int, x);
+    CREATE INDEX idx9 ON t9(rowid);
+    SELECT name FROM sqlite_schema WHERE type='index';
+} {idx9}
+
+# creating index on shadowed _rowid_ column should succeed
+do_execsql_test_on_specific_db {:memory:} create-index-on-shadowed-rowid-alias-1 {
+    CREATE TABLE t10(_rowid_ int, x);
+    CREATE INDEX idx10 ON t10(_rowid_);
+    SELECT name FROM sqlite_schema WHERE type='index';
+} {idx10}
+
+# creating index on shadowed oid column should succeed
+do_execsql_test_on_specific_db {:memory:} create-index-on-shadowed-rowid-alias-2 {
+    CREATE TABLE t11(oid int, x);
+    CREATE INDEX idx11 ON t11(oid);
+    SELECT name FROM sqlite_schema WHERE type='index';
+} {idx11}
+


### PR DESCRIPTION
SQLite rejects `CREATE INDEX idx ON t(rowid)` with "no such column: rowid" because rowid is a pseudo-column, not an actual column. Limbo was incorrectly allowing this.

The fix removes the special exception for ROWID_STRS (rowid, _rowid_, oid) in validate_index_expression(). Now these identifiers are only allowed if they match an actual column name in the table (i.e., when shadowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes https://github.com/tursodatabase/turso/issues/4011