### PR TITLE
Fix CTE scope propagation for compound SELECTs

### DIFF
--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -741,6 +741,75 @@ fn test_cte_alias(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[turso_macros::test(
+    mvcc,
+    init_sql = "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);"
+)]
+fn test_cte_with_union(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO test (id, name) VALUES (1, 'Alice');")?;
+    conn.execute("INSERT INTO test (id, name) VALUES (2, 'Bob');")?;
+
+    // Test 1: CTE with UNION ALL - CTE used in first SELECT
+    let mut stmt = conn.prepare(
+        "WITH t AS (SELECT id, name FROM test WHERE id = 1) SELECT * FROM t UNION ALL SELECT 99, 'Extra'",
+    )?;
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                rows.push(row.get_values().cloned().collect::<Vec<_>>());
+            }
+            StepResult::Done => break,
+            StepResult::IO => stmt.run_once()?,
+            _ => panic!("Unexpected step result"),
+        }
+    }
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0], Value::Integer(1));
+    assert_eq!(rows[1][0], Value::Integer(99));
+
+    // Test 2: CTE with UNION (not UNION ALL)
+    let mut stmt = conn.prepare("WITH t AS (SELECT 1 as x) SELECT * FROM t UNION SELECT 2 as x")?;
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                rows.push(row.get_values().cloned().collect::<Vec<_>>());
+            }
+            StepResult::Done => break,
+            StepResult::IO => stmt.run_once()?,
+            _ => panic!("Unexpected step result"),
+        }
+    }
+    assert_eq!(rows.len(), 2);
+
+    // Test 3: Multiple CTEs with UNION ALL - both CTEs used in different branches
+    let mut stmt = conn.prepare(
+        "WITH t1 AS (SELECT id FROM test WHERE id = 1), t2 AS (SELECT id FROM test WHERE id = 2) \
+         SELECT * FROM t1 UNION ALL SELECT * FROM t2",
+    )?;
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                rows.push(row.get_values().cloned().collect::<Vec<_>>());
+            }
+            StepResult::Done => break,
+            StepResult::IO => stmt.run_once()?,
+            _ => panic!("Unexpected step result"),
+        }
+    }
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0], Value::Integer(1));
+    assert_eq!(rows[1][0], Value::Integer(2));
+
+    Ok(())
+}
+
 #[turso_macros::test(mvcc, init_sql = "create table t (x, y);")]
 fn test_avg_agg(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();


### PR DESCRIPTION
CTEs now work correctly when combined with UNION, UNION ALL, INTERSECT, and EXCEPT.

**Before:**
```sql
WITH t AS (SELECT 1 as x) SELECT * FROM t UNION ALL SELECT 2 as x
-- Error: Parse error: no such table: t
```

**After:**
```sql
WITH t AS (SELECT 1 as x) SELECT * FROM t UNION ALL SELECT 2 as x
-- Works correctly, returns rows (1) and (2)
```