### PR TITLE
do not propagate the MvStore to opcodes

### DIFF
--- a/core/incremental/expr_compiler.rs
+++ b/core/incremental/expr_compiler.rs
@@ -444,7 +444,7 @@ impl CompiledExpression {
                     state.pc = pc as u32;
 
                     // Execute the instruction
-                    match insn_fn(program, &mut state, insn, &pager, None)? {
+                    match insn_fn(program, &mut state, insn, &pager)? {
                         crate::vdbe::execute::InsnFunctionStepResult::IO(_) => {
                             return Err(crate::LimboError::InternalError(
                                 "Expression evaluation encountered unexpected I/O".to_string(),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -134,13 +134,8 @@ macro_rules! return_if_io {
     };
 }
 
-pub type InsnFunction = fn(
-    &Program,
-    &mut ProgramState,
-    &Insn,
-    &Arc<Pager>,
-    Option<&Arc<MvStore>>,
-) -> Result<InsnFunctionStepResult>;
+pub type InsnFunction =
+    fn(&Program, &mut ProgramState, &Insn, &Arc<Pager>) -> Result<InsnFunctionStepResult>;
 
 /// Compare two values using the specified collation for text values.
 /// Non-text values are compared using their natural ordering.
@@ -182,7 +177,6 @@ pub fn op_init(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Init { target_pc }, insn);
     assert!(target_pc.is_offset());
@@ -195,7 +189,6 @@ pub fn op_add(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Add { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -212,7 +205,6 @@ pub fn op_subtract(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Subtract { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -229,7 +221,6 @@ pub fn op_multiply(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Multiply { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -246,7 +237,6 @@ pub fn op_divide(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Divide { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -263,7 +253,6 @@ pub fn op_drop_index(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(DropIndex { index, db: _ }, insn);
     program
@@ -278,7 +267,6 @@ pub fn op_remainder(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Remainder { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -295,7 +283,6 @@ pub fn op_bit_and(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(BitAnd { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -312,7 +299,6 @@ pub fn op_bit_or(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(BitOr { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -329,7 +315,6 @@ pub fn op_bit_not(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(BitNot { reg, dest }, insn);
     state.registers[*dest] = Register::Value(state.registers[*reg].get_value().exec_bit_not());
@@ -349,9 +334,8 @@ pub fn op_checkpoint(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
-    match op_checkpoint_inner(program, state, insn, pager, mv_store) {
+    match op_checkpoint_inner(program, state, insn, pager) {
         Ok(result) => Ok(result),
         Err(err) => {
             state.op_checkpoint_state = OpCheckpointState::StartCheckpoint;
@@ -365,7 +349,6 @@ pub fn op_checkpoint_inner(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Checkpoint {
@@ -382,7 +365,8 @@ pub fn op_checkpoint_inner(
         // however.
         return Err(LimboError::TableLocked);
     }
-    if let Some(mv_store) = mv_store {
+    let mv_store = program.connection.mv_store();
+    if let Some(mv_store) = mv_store.as_ref() {
         if !matches!(checkpoint_mode, CheckpointMode::Truncate { .. }) {
             return Err(LimboError::InvalidArgument(
                 "Only TRUNCATE checkpoint mode is supported for MVCC".to_string(),
@@ -486,7 +470,6 @@ pub fn op_null(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     match insn {
         Insn::Null { dest, dest_end } | Insn::BeginSubrtn { dest, dest_end } => {
@@ -509,7 +492,6 @@ pub fn op_null_row(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(NullRow { cursor_id }, insn);
     {
@@ -526,7 +508,6 @@ pub fn op_compare(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Compare {
@@ -565,7 +546,6 @@ pub fn op_jump(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Jump {
@@ -598,7 +578,6 @@ pub fn op_move(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Move {
@@ -626,7 +605,6 @@ pub fn op_if_pos(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IfPos {
@@ -661,7 +639,6 @@ pub fn op_not_null(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(NotNull { reg, target_pc }, insn);
     assert!(target_pc.is_offset());
@@ -683,7 +660,6 @@ pub fn op_comparison(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     let (lhs, rhs, target_pc, flags, collation, op) = match insn {
         Insn::Eq {
@@ -854,7 +830,6 @@ pub fn op_if(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         If {
@@ -881,7 +856,6 @@ pub fn op_if_not(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IfNot {
@@ -908,7 +882,6 @@ pub fn op_open_read(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         OpenRead {
@@ -920,6 +893,7 @@ pub fn op_open_read(
     );
 
     let pager = program.get_pager_from_database_index(db);
+    let mv_store = program.connection.mv_store();
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
         if state.cursors[*cursor_id].is_none() {
@@ -957,6 +931,7 @@ pub fn op_open_read(
      -> Result<Box<dyn CursorTrait>> {
         if let Some(tx_id) = program.connection.get_mv_tx_id() {
             let mv_store = mv_store
+                .as_ref()
                 .expect("mv_store should be Some when MVCC transaction is active")
                 .clone();
             Ok(Box::new(MvCursor::new(
@@ -978,7 +953,7 @@ pub fn op_open_read(
 
             let btree_cursor = Box::new(BTreeCursor::new_table(
                 pager.clone(),
-                maybe_transform_root_page_to_positive(mv_store, *root_page),
+                maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 num_columns,
             ));
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
@@ -1007,7 +982,7 @@ pub fn op_open_read(
             // Regular table
             let btree_cursor = Box::new(BTreeCursor::new_table(
                 pager.clone(),
-                maybe_transform_root_page_to_positive(mv_store, *root_page),
+                maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 num_columns,
             ));
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
@@ -1053,7 +1028,6 @@ pub fn op_vopen(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(VOpen { cursor_id }, insn);
     let (_, cursor_type) = program
@@ -1078,7 +1052,6 @@ pub fn op_vcreate(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         VCreate {
@@ -1116,7 +1089,6 @@ pub fn op_vfilter(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         VFilter {
@@ -1160,7 +1132,6 @@ pub fn op_vcolumn(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         VColumn {
@@ -1185,7 +1156,6 @@ pub fn op_vupdate(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         VUpdate {
@@ -1252,7 +1222,6 @@ pub fn op_vnext(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         VNext {
@@ -1281,7 +1250,6 @@ pub fn op_vdestroy(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(VDestroy { db, table_name }, insn);
     let conn = program.connection.clone();
@@ -1303,7 +1271,6 @@ pub fn op_vbegin(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(VBegin { cursor_id }, insn);
     let cursor = state.get_cursor(*cursor_id);
@@ -1330,7 +1297,6 @@ pub fn op_vrename(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         VRename {
@@ -1362,7 +1328,6 @@ pub fn op_open_pseudo(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         OpenPseudo {
@@ -1389,7 +1354,6 @@ pub fn op_rewind(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Rewind {
@@ -1428,7 +1392,6 @@ pub fn op_last(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Last {
@@ -1473,7 +1436,6 @@ pub fn op_column(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Column {
@@ -1864,7 +1826,6 @@ pub fn op_type_check(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         TypeCheck {
@@ -1925,7 +1886,6 @@ pub fn op_make_record(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         MakeRecord {
@@ -1964,7 +1924,6 @@ pub fn op_mem_max(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(MemMax { dest_reg, src_reg }, insn);
 
@@ -1987,7 +1946,6 @@ pub fn op_result_row(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(ResultRow { start_reg, count }, insn);
     let row = Row {
@@ -2004,7 +1962,6 @@ pub fn op_next(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Next {
@@ -2058,7 +2015,6 @@ pub fn op_prev(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Prev {
@@ -2099,10 +2055,10 @@ pub fn halt(
     program: &Program,
     state: &mut ProgramState,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
     err_code: usize,
     description: &str,
 ) -> Result<InsnFunctionStepResult> {
+    let mv_store = program.connection.mv_store();
     if err_code > 0 {
         vtab_rollback_all(&program.connection, state)?;
     }
@@ -2171,7 +2127,7 @@ pub fn halt(
         state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
         vtab_commit_all(&program.connection, state)?;
         program
-            .commit_txn(pager.clone(), state, mv_store, false)
+            .commit_txn(pager.clone(), state, mv_store.as_ref(), false)
             .map(Into::into)
     } else {
         // Even if deferred violations are present, the statement subtransaction completes successfully when
@@ -2220,7 +2176,6 @@ pub fn op_halt(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Halt {
@@ -2229,7 +2184,7 @@ pub fn op_halt(
         },
         insn
     );
-    halt(program, state, pager, mv_store, *err_code, description)
+    halt(program, state, pager, *err_code, description)
 }
 
 pub fn op_halt_if_null(
@@ -2237,7 +2192,6 @@ pub fn op_halt_if_null(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         HaltIfNull {
@@ -2248,7 +2202,7 @@ pub fn op_halt_if_null(
         insn
     );
     if state.registers[*target_reg].get_value() == &Value::Null {
-        halt(program, state, pager, mv_store, *err_code, description)
+        halt(program, state, pager, *err_code, description)
     } else {
         state.pc += 1;
         Ok(InsnFunctionStepResult::Step)
@@ -2267,9 +2221,8 @@ pub fn op_transaction(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
-    match op_transaction_inner(program, state, insn, pager, mv_store) {
+    match op_transaction_inner(program, state, insn, pager) {
         Ok(result) => Ok(result),
         Err(err) => {
             state.op_transaction_state = OpTransactionState::Start;
@@ -2283,7 +2236,6 @@ pub fn op_transaction_inner(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Transaction {
@@ -2299,6 +2251,7 @@ pub fn op_transaction_inner(
         );
     }
     let pager = program.get_pager_from_database_index(db);
+    let mv_store = program.connection.mv_store();
     loop {
         match state.op_transaction_state {
             OpTransactionState::Start => {
@@ -2352,7 +2305,7 @@ pub fn op_transaction_inner(
                 };
 
                 // 2. Start transaction if needed
-                if let Some(mv_store) = &mv_store {
+                if let Some(mv_store) = mv_store.as_ref() {
                     // In MVCC we don't have write exclusivity, therefore we just need to start a transaction if needed.
                     // Programs can run Transaction twice, first with read flag and then with write flag. So a single txid is enough
                     // for both.
@@ -2448,7 +2401,7 @@ pub fn op_transaction_inner(
             // Can only read header if page 1 has been allocated already
             // begin_write_tx that happens, but not begin_read_tx
             OpTransactionState::CheckSchemaCookie => {
-                let res = get_schema_cookie(&pager, mv_store, program);
+                let res = get_schema_cookie(&pager, mv_store.as_ref(), program);
                 match res {
                     Ok(IOResult::Done(header_schema_cookie)) => {
                         if header_schema_cookie != *schema_cookie {
@@ -2492,7 +2445,6 @@ pub fn op_auto_commit(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         AutoCommit {
@@ -2502,14 +2454,15 @@ pub fn op_auto_commit(
         insn
     );
 
+    let mv_store = program.connection.mv_store();
     let conn = program.connection.clone();
     let fk_on = conn.foreign_keys_enabled();
     let had_autocommit = conn.auto_commit.load(Ordering::SeqCst); // true, not in tx
 
-    // Drive any multi-step commit/rollback that’s already in progress.
+    // Drive any multi-step commit/rollback that's already in progress.
     if matches!(state.commit_state, CommitState::Committing) {
         let res = program
-            .commit_txn(pager.clone(), state, mv_store, *rollback)
+            .commit_txn(pager.clone(), state, mv_store.as_ref(), *rollback)
             .map(Into::into);
         // Only clear after a final, successful non-rollback COMMIT.
         if fk_on
@@ -2538,7 +2491,7 @@ pub fn op_auto_commit(
     if changed {
         if requested_rollback {
             // ROLLBACK transition
-            if let Some(mv_store) = mv_store {
+            if let Some(mv_store) = mv_store.as_ref() {
                 if let Some(tx_id) = conn.get_mv_tx_id() {
                     mv_store.rollback_tx(tx_id, pager.clone(), &conn);
                 }
@@ -2587,7 +2540,7 @@ pub fn op_auto_commit(
     }
 
     let res = program
-        .commit_txn(pager.clone(), state, mv_store, requested_rollback)
+        .commit_txn(pager.clone(), state, mv_store.as_ref(), requested_rollback)
         .map(Into::into);
 
     // Clear deferred FK counters only after FINAL success of COMMIT/ROLLBACK.
@@ -2621,7 +2574,6 @@ pub fn op_goto(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Goto { target_pc }, insn);
     assert!(target_pc.is_offset());
@@ -2634,7 +2586,6 @@ pub fn op_gosub(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Gosub {
@@ -2654,7 +2605,6 @@ pub fn op_return(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Return {
@@ -2684,7 +2634,6 @@ pub fn op_integer(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Integer { value, dest }, insn);
     state.registers[*dest] = Register::Value(Value::Integer(*value));
@@ -2703,7 +2652,6 @@ pub fn op_program(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Program {
@@ -2792,7 +2740,6 @@ pub fn op_real(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Real { value, dest }, insn);
     state.registers[*dest] = Register::Value(Value::Float(*value));
@@ -2805,7 +2752,6 @@ pub fn op_real_affinity(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(RealAffinity { register }, insn);
     if let Value::Integer(i) = &state.registers[*register].get_value() {
@@ -2820,7 +2766,6 @@ pub fn op_string8(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(String8 { value, dest }, insn);
     state.registers[*dest] = Register::Value(Value::build_text(value.clone()));
@@ -2833,7 +2778,6 @@ pub fn op_blob(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Blob { value, dest }, insn);
     state.registers[*dest] = Register::Value(Value::Blob(value.clone()));
@@ -2846,7 +2790,6 @@ pub fn op_row_data(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(RowData { cursor_id, dest }, insn);
 
@@ -2888,7 +2831,6 @@ pub fn op_row_id(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(RowId { cursor_id, dest }, insn);
     loop {
@@ -3011,7 +2953,6 @@ pub fn op_idx_row_id(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(IdxRowId { cursor_id, dest }, insn);
     let cursors = &mut state.cursors;
@@ -3039,7 +2980,6 @@ pub fn op_seek_rowid(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         SeekRowid {
@@ -3127,7 +3067,6 @@ pub fn op_deferred_seek(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         DeferredSeek {
@@ -3170,7 +3109,6 @@ pub fn op_seek(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     let (cursor_id, is_index, record_source, target_pc) = match insn {
         Insn::SeekGE {
@@ -3234,7 +3172,6 @@ pub fn op_seek(
         program,
         state,
         pager,
-        mv_store,
         record_source,
         *cursor_id,
         is_index,
@@ -3277,12 +3214,12 @@ pub fn seek_internal(
     program: &Program,
     state: &mut ProgramState,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
     record_source: RecordSource,
     cursor_id: usize,
     is_index: bool,
     op: SeekOp,
 ) -> Result<SeekInternalResult> {
+    let mv_store = program.connection.mv_store();
     /// wrapper so we can use the ? operator and handle errors correctly in this outer function
     fn inner(
         program: &Program,
@@ -3508,7 +3445,7 @@ pub fn seek_internal(
         program,
         state,
         pager,
-        mv_store,
+        mv_store.as_ref(),
         record_source,
         cursor_id,
         is_index,
@@ -3567,7 +3504,6 @@ pub fn op_idx_ge(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IdxGE {
@@ -3618,7 +3554,6 @@ pub fn op_seek_end(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(SeekEnd { cursor_id }, *insn);
     {
@@ -3636,7 +3571,6 @@ pub fn op_idx_le(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IdxLE {
@@ -3687,7 +3621,6 @@ pub fn op_idx_gt(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IdxGT {
@@ -3738,7 +3671,6 @@ pub fn op_idx_lt(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IdxLT {
@@ -3789,7 +3721,6 @@ pub fn op_decr_jump_zero(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(DecrJumpZero { reg, target_pc }, insn);
     assert!(target_pc.is_offset());
@@ -3840,7 +3771,6 @@ pub fn op_agg_step(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         AggStep {
@@ -4177,7 +4107,6 @@ pub fn op_agg_final(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     let (acc_reg, dest_reg, func) = match insn {
         Insn::AggFinal { register, func } => (*register, *register, func),
@@ -4324,7 +4253,6 @@ pub fn op_sorter_open(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         SorterOpen {
@@ -4375,7 +4303,6 @@ pub fn op_sorter_data(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         SorterData {
@@ -4411,7 +4338,6 @@ pub fn op_sorter_insert(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         SorterInsert {
@@ -4438,7 +4364,6 @@ pub fn op_sorter_sort(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         SorterSort {
@@ -4473,7 +4398,6 @@ pub fn op_sorter_next(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         SorterNext {
@@ -4502,7 +4426,6 @@ pub fn op_sorter_compare(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         SorterCompare {
@@ -4565,7 +4488,6 @@ pub fn op_rowset_add(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    _mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         RowSetAdd {
@@ -4603,7 +4525,6 @@ pub fn op_rowset_read(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    _mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         RowSetRead {
@@ -4655,7 +4576,6 @@ pub fn op_rowset_test(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    _mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         RowSetTest {
@@ -4709,7 +4629,6 @@ pub fn op_function(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Function {
@@ -6154,7 +6073,6 @@ pub fn op_sequence(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Sequence {
@@ -6179,7 +6097,6 @@ pub fn op_sequence_test(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         SequenceTest {
@@ -6208,7 +6125,6 @@ pub fn op_init_coroutine(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         InitCoroutine {
@@ -6236,7 +6152,6 @@ pub fn op_end_coroutine(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(EndCoroutine { yield_reg }, insn);
 
@@ -6257,7 +6172,6 @@ pub fn op_yield(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Yield {
@@ -6316,7 +6230,6 @@ pub fn op_insert(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Insert {
@@ -6415,7 +6328,6 @@ pub fn op_insert(
                     program,
                     state,
                     pager,
-                    mv_store,
                     RecordSource::Unpacked {
                         start_reg: *key_reg,
                         num_regs: 1,
@@ -6576,7 +6488,6 @@ pub fn op_int_64(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Int64 {
@@ -6611,7 +6522,6 @@ pub fn op_delete(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Delete {
@@ -6724,7 +6634,6 @@ pub fn op_idx_delete(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IdxDelete {
@@ -6758,7 +6667,6 @@ pub fn op_idx_delete(
                     program,
                     state,
                     pager,
-                    mv_store,
                     RecordSource::Unpacked {
                         start_reg: *start_reg,
                         num_regs: *num_regs,
@@ -6841,7 +6749,6 @@ pub fn op_idx_insert(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IdxInsert {
@@ -6901,7 +6808,6 @@ pub fn op_idx_insert(
                 program,
                 state,
                 pager,
-                mv_store,
                 RecordSource::Packed { record_reg },
                 cursor_id,
                 true,
@@ -7008,7 +6914,6 @@ pub fn op_new_rowid(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         NewRowid {
@@ -7018,8 +6923,9 @@ pub fn op_new_rowid(
         },
         insn
     );
+    let mv_store = program.connection.mv_store();
     'mvcc_newrowid: {
-        if let Some(mv_store) = mv_store {
+        if let Some(mv_store) = mv_store.as_ref() {
             // With MVCC we can't simply find last rowid and get rowid + 1 as a result. To not have two conflicting rowids concurrently we need to call `get_next_rowid`
             // which will make sure we don't collide.
             let rowid = {
@@ -7158,7 +7064,6 @@ pub fn op_must_be_int(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(MustBeInt { reg }, insn);
     match &state.registers[*reg].get_value() {
@@ -7188,7 +7093,6 @@ pub fn op_soft_null(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(SoftNull { reg }, insn);
     state.registers[*reg] = Register::Value(Value::Null);
@@ -7209,7 +7113,6 @@ pub fn op_no_conflict(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         NoConflict {
@@ -7275,7 +7178,6 @@ pub fn op_no_conflict(
                     program,
                     state,
                     pager,
-                    mv_store,
                     record_source,
                     *cursor_id,
                     true,
@@ -7303,7 +7205,6 @@ pub fn op_not_exists(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         NotExists {
@@ -7330,7 +7231,6 @@ pub fn op_offset_limit(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         OffsetLimit {
@@ -7375,7 +7275,6 @@ pub fn op_open_write(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         OpenWrite {
@@ -7389,6 +7288,7 @@ pub fn op_open_write(
         return Err(LimboError::ReadOnly);
     }
     let pager = program.get_pager_from_database_index(db);
+    let mv_store = program.connection.mv_store();
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
         if state.cursors[*cursor_id].is_none() {
@@ -7421,7 +7321,7 @@ pub fn op_open_write(
     const SQLITE_SCHEMA_ROOT_PAGE: i64 = 1;
 
     if root_page == SQLITE_SCHEMA_ROOT_PAGE {
-        if let Some(mv_store) = mv_store {
+        if let Some(mv_store) = mv_store.as_ref() {
             let Some(tx_id) = program.connection.get_mv_tx_id() else {
                 return Err(LimboError::InternalError(
                     "Schema changes in MVCC mode require an exclusive MVCC transaction".to_string(),
@@ -7459,6 +7359,7 @@ pub fn op_open_write(
          -> Result<Box<dyn CursorTrait>> {
             if let Some(tx_id) = program.connection.get_mv_tx_id() {
                 let mv_store = mv_store
+                    .as_ref()
                     .expect("mv_store should be Some when MVCC transaction is active")
                     .clone();
                 Ok(Box::new(MvCursor::new(
@@ -7482,7 +7383,7 @@ pub fn op_open_write(
             let num_columns = index.columns.len();
             let btree_cursor = Box::new(BTreeCursor::new_index(
                 pager.clone(),
-                maybe_transform_root_page_to_positive(mv_store, root_page),
+                maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                 index.as_ref(),
                 num_columns,
             ));
@@ -7504,7 +7405,7 @@ pub fn op_open_write(
 
             let btree_cursor = Box::new(BTreeCursor::new_table(
                 pager.clone(),
-                maybe_transform_root_page_to_positive(mv_store, root_page),
+                maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                 num_columns,
             ));
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
@@ -7523,7 +7424,6 @@ pub fn op_copy(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Copy {
@@ -7545,7 +7445,6 @@ pub fn op_create_btree(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(CreateBtree { db, root, flags }, insn);
 
@@ -7558,8 +7457,9 @@ pub fn op_create_btree(
         // TODO: implement temp databases
         todo!("temp databases not implemented yet");
     }
+    let mv_store = program.connection.mv_store();
 
-    if let Some(mv_store) = mv_store {
+    if let Some(mv_store) = mv_store.as_ref() {
         let root_page = mv_store.get_next_table_id();
         state.registers[*root] = Register::Value(Value::Integer(root_page));
         state.pc += 1;
@@ -7577,14 +7477,14 @@ pub fn op_index_method_create(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(IndexMethodCreate { db, cursor_id }, insn);
     assert_eq!(*db, 0);
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    if let Some(mv_store) = mv_store {
+    let mv_store = program.connection.mv_store();
+    if let Some(_mv_store) = mv_store.as_ref() {
         todo!("MVCC is not supported yet");
     }
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
@@ -7609,14 +7509,14 @@ pub fn op_index_method_destroy(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(IndexMethodDestroy { db, cursor_id }, insn);
     assert_eq!(*db, 0);
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    if let Some(mv_store) = mv_store {
+    let mv_store = program.connection.mv_store();
+    if let Some(_mv_store) = mv_store.as_ref() {
         todo!("MVCC is not supported yet");
     }
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
@@ -7641,7 +7541,6 @@ pub fn op_index_method_query(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IndexMethodQuery {
@@ -7657,7 +7556,8 @@ pub fn op_index_method_query(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    if let Some(mv_store) = mv_store {
+    let mv_store = program.connection.mv_store();
+    if let Some(_mv_store) = mv_store.as_ref() {
         todo!("MVCC is not supported yet");
     }
     let cursor = state.cursors[*cursor_id]
@@ -7684,7 +7584,6 @@ pub fn op_destroy(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Destroy {
@@ -7697,6 +7596,7 @@ pub fn op_destroy(
     if *is_temp == 1 {
         todo!("temp databases not implemented yet.");
     }
+    let mv_store = program.connection.mv_store();
     if mv_store.is_some() {
         // MVCC only does pager operations in checkpoint
         state.pc += 1;
@@ -7729,7 +7629,6 @@ pub fn op_reset_sorter(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(ResetSorter { cursor_id }, insn);
 
@@ -7759,7 +7658,6 @@ pub fn op_drop_table(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(DropTable { db, table_name, .. }, insn);
     if *db > 0 {
@@ -7782,7 +7680,6 @@ pub fn op_drop_view(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    _mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(DropView { db, view_name }, insn);
     if *db > 0 {
@@ -7802,7 +7699,6 @@ pub fn op_drop_trigger(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(DropTrigger { db, trigger_name }, insn);
 
@@ -7820,7 +7716,6 @@ pub fn op_close(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Close { cursor_id }, insn);
     let cursors = &mut state.cursors;
@@ -7840,7 +7735,6 @@ pub fn op_is_null(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(IsNull { reg, target_pc }, insn);
     if matches!(state.registers[*reg], Register::Value(Value::Null)) {
@@ -7856,7 +7750,6 @@ pub fn op_coll_seq(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    _mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     let Insn::CollSeq { reg, collation } = insn else {
         unreachable!("unexpected Insn {:?}", insn)
@@ -7879,14 +7772,14 @@ pub fn op_page_count(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(PageCount { db, dest }, insn);
     if *db > 0 {
         // TODO: implement temp databases
         todo!("temp databases not implemented yet");
     }
-    let count = match with_header(pager, mv_store, program, |header| {
+    let mv_store = program.connection.mv_store();
+    let count = match with_header(pager, mv_store.as_ref(), program, |header| {
         header.database_size.get()
     }) {
         Err(_) => 0.into(),
@@ -7903,7 +7796,6 @@ pub fn op_parse_schema(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         ParseSchema {
@@ -7964,7 +7856,6 @@ pub fn op_populate_materialized_views(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    _mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(PopulateMaterializedViews { cursors }, insn);
 
@@ -8041,15 +7932,15 @@ pub fn op_read_cookie(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(ReadCookie { db, dest, cookie }, insn);
     if *db > 0 {
         // TODO: implement temp databases
         todo!("temp databases not implemented yet");
     }
+    let mv_store = program.connection.mv_store();
 
-    let cookie_value = match with_header(pager, mv_store, program, |header| match cookie {
+    let cookie_value = match with_header(pager, mv_store.as_ref(), program, |header| match cookie {
         Cookie::ApplicationId => header.application_id.get().into(),
         Cookie::UserVersion => header.user_version.get().into(),
         Cookie::SchemaVersion => header.schema_cookie.get().into(),
@@ -8071,7 +7962,6 @@ pub fn op_set_cookie(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         SetCookie {
@@ -8085,18 +7975,25 @@ pub fn op_set_cookie(
     if *db > 0 {
         todo!("temp databases not implemented yet");
     }
+    let mv_store = program.connection.mv_store();
 
-    return_if_io!(with_header_mut(pager, mv_store, program, |header| {
-        match cookie {
-            Cookie::ApplicationId => header.application_id = (*value).into(),
-            Cookie::UserVersion => header.user_version = (*value).into(),
-            Cookie::LargestRootPageNumber => {
-                header.vacuum_mode_largest_root_page = (*value as u32).into();
-            }
-            Cookie::IncrementalVacuum => header.incremental_vacuum_enabled = (*value as u32).into(),
-            Cookie::SchemaVersion => {
-                // we update transaction state to indicate that the schema has changed
-                match program.connection.get_tx_state() {
+    return_if_io!(with_header_mut(
+        pager,
+        mv_store.as_ref(),
+        program,
+        |header| {
+            match cookie {
+                Cookie::ApplicationId => header.application_id = (*value).into(),
+                Cookie::UserVersion => header.user_version = (*value).into(),
+                Cookie::LargestRootPageNumber => {
+                    header.vacuum_mode_largest_root_page = (*value as u32).into();
+                }
+                Cookie::IncrementalVacuum => {
+                    header.incremental_vacuum_enabled = (*value as u32).into()
+                }
+                Cookie::SchemaVersion => {
+                    // we update transaction state to indicate that the schema has changed
+                    match program.connection.get_tx_state() {
                     TransactionState::Write { schema_did_change } => {
                         program.connection.set_tx_state(TransactionState::Write { schema_did_change: true });
                     },
@@ -8104,14 +8001,15 @@ pub fn op_set_cookie(
                     TransactionState::None => unreachable!("invalid transaction state for SetCookie: TransactionState::None, should be write"),
                     TransactionState::PendingUpgrade => unreachable!("invalid transaction state for SetCookie: TransactionState::PendingUpgrade, should be write"),
                 }
-                program
-                    .connection
-                    .with_schema_mut(|schema| schema.schema_version = *value as u32);
-                header.schema_cookie = (*value as u32).into();
-            }
-            cookie => todo!("{cookie:?} is not yet implement for SetCookie"),
-        };
-    }));
+                    program
+                        .connection
+                        .with_schema_mut(|schema| schema.schema_version = *value as u32);
+                    header.schema_cookie = (*value as u32).into();
+                }
+                cookie => todo!("{cookie:?} is not yet implement for SetCookie"),
+            };
+        }
+    ));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -8122,7 +8020,6 @@ pub fn op_shift_right(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(ShiftRight { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -8139,7 +8036,6 @@ pub fn op_shift_left(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(ShiftLeft { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -8156,7 +8052,6 @@ pub fn op_add_imm(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(AddImm { register, value }, insn);
 
@@ -8185,7 +8080,6 @@ pub fn op_variable(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Variable { index, dest }, insn);
     state.registers[*dest] = Register::Value(state.get_parameter(*index));
@@ -8198,7 +8092,6 @@ pub fn op_zero_or_null(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(ZeroOrNull { rg1, rg2, dest }, insn);
     if state.registers[*rg1].is_null() || state.registers[*rg2].is_null() {
@@ -8215,7 +8108,6 @@ pub fn op_not(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Not { reg, dest }, insn);
     state.registers[*dest] = Register::Value(state.registers[*reg].get_value().exec_boolean_not());
@@ -8228,7 +8120,6 @@ pub fn op_concat(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Concat { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -8245,7 +8136,6 @@ pub fn op_and(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(And { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -8262,7 +8152,6 @@ pub fn op_or(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Or { lhs, rhs, dest }, insn);
     state.registers[*dest] = Register::Value(
@@ -8279,7 +8168,6 @@ pub fn op_noop(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     // Do nothing
     // Advance the program counter for the next opcode
@@ -8308,7 +8196,6 @@ pub fn op_open_ephemeral(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     let (cursor_id, is_table) = match insn {
         Insn::OpenEphemeral {
@@ -8318,11 +8205,14 @@ pub fn op_open_ephemeral(
         Insn::OpenAutoindex { cursor_id } => (*cursor_id, false),
         _ => unreachable!("unexpected Insn {:?}", insn),
     };
+    let mv_store = program.connection.mv_store();
     match &mut state.op_open_ephemeral_state {
         OpOpenEphemeralState::Start => {
             tracing::trace!("Start");
             let page_size =
-                return_if_io!(with_header(pager, mv_store, program, |header| header.page_size));
+                return_if_io!(with_header(pager, mv_store.as_ref(), program, |header| {
+                    header.page_size
+                }));
             let conn = program.connection.clone();
             let io = conn.pager.load().io.clone();
             let rand_num = io.generate_random_number();
@@ -8472,7 +8362,6 @@ pub fn op_open_dup(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         OpenDup {
@@ -8481,6 +8370,7 @@ pub fn op_open_dup(
         },
         insn
     );
+    let mv_store = program.connection.mv_store();
 
     let original_cursor = state.get_cursor(*original_cursor_id);
     let original_cursor = original_cursor.as_btree_mut();
@@ -8499,12 +8389,13 @@ pub fn op_open_dup(
         CursorType::BTreeTable(table) => {
             let cursor = Box::new(BTreeCursor::new_table(
                 pager.clone(),
-                maybe_transform_root_page_to_positive(mv_store, root_page),
+                maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                 table.columns.len(),
             ));
             let cursor: Box<dyn CursorTrait> =
                 if let Some(tx_id) = program.connection.get_mv_tx_id() {
                     let mv_store = mv_store
+                        .as_ref()
                         .expect("mv_store should be Some when MVCC transaction is active")
                         .clone();
                     Box::new(MvCursor::new(
@@ -8545,7 +8436,6 @@ pub fn op_once(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Once {
@@ -8569,7 +8459,6 @@ pub fn op_found(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     let (cursor_id, target_pc, record_reg, num_regs) = match insn {
         Insn::NotFound {
@@ -8603,7 +8492,6 @@ pub fn op_found(
         program,
         state,
         pager,
-        mv_store,
         record_source,
         *cursor_id,
         true,
@@ -8631,7 +8519,6 @@ pub fn op_affinity(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Affinity {
@@ -8665,7 +8552,6 @@ pub fn op_count(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Count {
@@ -8708,7 +8594,6 @@ pub fn op_integrity_check(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         IntegrityCk {
@@ -8718,10 +8603,11 @@ pub fn op_integrity_check(
         },
         insn
     );
+    let mv_store = program.connection.mv_store();
     match &mut state.op_integrity_check_state {
         OpIntegrityCheckState::Start => {
             let (freelist_trunk_page, db_size) =
-                return_if_io!(with_header(pager, mv_store, program, |header| (
+                return_if_io!(with_header(pager, mv_store.as_ref(), program, |header| (
                     header.freelist_trunk_page.get(),
                     header.database_size.get()
                 )));
@@ -8731,9 +8617,9 @@ pub fn op_integrity_check(
             // check freelist pages first, if there are any for database
             if freelist_trunk_page > 0 {
                 let expected_freelist_count =
-                    return_if_io!(with_header(pager, mv_store, program, |header| header
-                        .freelist_pages
-                        .get()));
+                    return_if_io!(with_header(pager, mv_store.as_ref(), program, |header| {
+                        header.freelist_pages.get()
+                    }));
                 integrity_check_state.set_expected_freelist_count(expected_freelist_count as usize);
                 integrity_check_state.start(
                     freelist_trunk_page as i64,
@@ -8830,7 +8716,6 @@ pub fn op_cast(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    _mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Cast { reg, affinity }, insn);
 
@@ -8853,7 +8738,6 @@ pub fn op_rename_table(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(RenameTable { from, to }, insn);
 
@@ -8923,7 +8807,6 @@ pub fn op_drop_column(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         DropColumn {
@@ -9022,7 +8905,6 @@ pub fn op_add_column(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(AddColumn { table, column }, insn);
 
@@ -9053,7 +8935,6 @@ pub fn op_alter_column(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         AlterColumn {
@@ -9204,7 +9085,6 @@ pub fn op_if_neg(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(IfNeg { reg, target_pc }, insn);
 
@@ -9276,7 +9156,6 @@ pub fn op_fk_counter(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         FkCounter {
@@ -9306,7 +9185,6 @@ pub fn op_fk_if_zero(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    _mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         FkIfZero {
@@ -9346,7 +9224,6 @@ pub fn op_hash_build(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         HashBuild {
@@ -9477,7 +9354,6 @@ pub fn op_hash_build_finalize(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-    _mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(HashBuildFinalize { hash_table_id }, insn);
     if let Some(ht) = state.hash_tables.get_mut(hash_table_id) {
@@ -9515,7 +9391,6 @@ pub fn op_hash_probe(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         HashProbe {
@@ -9622,7 +9497,6 @@ pub fn op_hash_next(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         HashNext {
@@ -9662,7 +9536,6 @@ pub fn op_hash_close(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(HashClose { hash_table_id }, insn);
     if let Some(mut hash_table) = state.hash_tables.remove(hash_table_id) {
@@ -9835,7 +9708,6 @@ pub fn op_max_pgcnt(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(MaxPgcnt { db, dest, new_max }, insn);
 
@@ -9863,7 +9735,6 @@ pub fn op_journal_mode(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(JournalMode { db, dest, new_mode }, insn);
     if *db > 0 {
@@ -9902,7 +9773,6 @@ pub fn op_filter(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         Filter {
@@ -9953,7 +9823,6 @@ pub fn op_filter_add(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-    mv_store: Option<&Arc<MvStore>>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(
         FilterAdd {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -775,16 +775,15 @@ impl Program {
     pub fn step(
         &self,
         state: &mut ProgramState,
-        mv_store: Option<&Arc<MvStore>>,
         pager: Arc<Pager>,
         query_mode: QueryMode,
         waker: Option<&Waker>,
     ) -> Result<StepResult> {
         state.execution_state = ProgramExecutionState::Running;
         let result = match query_mode {
-            QueryMode::Normal => self.normal_step(state, mv_store, pager, waker),
-            QueryMode::Explain => self.explain_step(state, mv_store, pager),
-            QueryMode::ExplainQueryPlan => self.explain_query_plan_step(state, mv_store, pager),
+            QueryMode::Normal => self.normal_step(state, pager, waker),
+            QueryMode::Explain => self.explain_step(state, pager),
+            QueryMode::ExplainQueryPlan => self.explain_query_plan_step(state, pager),
         };
         match &result {
             Ok(StepResult::Done) => {
@@ -801,12 +800,7 @@ impl Program {
         result
     }
 
-    fn explain_step(
-        &self,
-        state: &mut ProgramState,
-        _mv_store: Option<&Arc<MvStore>>,
-        pager: Arc<Pager>,
-    ) -> Result<StepResult> {
+    fn explain_step(&self, state: &mut ProgramState, pager: Arc<Pager>) -> Result<StepResult> {
         debug_assert!(state.column_count() == EXPLAIN_COLUMNS.len());
         if self.connection.is_closed() {
             // Connection is closed for whatever reason, rollback the transaction.
@@ -851,7 +845,7 @@ impl Program {
                     explain_state.current_subprogram_index = Some(sub_idx + 1);
                     state.pc = 0;
                     drop(explain_state);
-                    return self.explain_step(state, _mv_store, pager);
+                    return self.explain_step(state, pager);
                 } else {
                     *explain_state = ExplainState::default();
                     return Ok(StepResult::Done);
@@ -868,7 +862,7 @@ impl Program {
             // Process the subprogram - it will handle its own explain_step internally
             // The subprogram's explain_step will process all its instructions (including any nested subprograms)
             // and return StepResult::Row for each instruction, then StepResult::Done when finished
-            let result = p.step(state, None, pager.clone(), QueryMode::Explain, None)?;
+            let result = p.step(state, pager.clone(), QueryMode::Explain, None)?;
 
             match result {
                 StepResult::Done => {
@@ -881,7 +875,7 @@ impl Program {
                         state.pc = 0;
                         // Recursively call to process the next subprogram
                         drop(explain_state);
-                        return self.explain_step(state, _mv_store, pager);
+                        return self.explain_step(state, pager);
                     } else {
                         // All subprograms done
                         *explain_state = ExplainState::default();
@@ -916,7 +910,7 @@ impl Program {
             explain_state.subprogram_start_pc = None; // Will be set when we actually start processing
             state.pc = 0; // Reset PC to 0 for the first subprogram
             drop(explain_state);
-            return self.explain_step(state, _mv_store, pager);
+            return self.explain_step(state, pager);
         }
 
         let (current_insn, _) = &self.insns[state.pc as usize];
@@ -953,7 +947,6 @@ impl Program {
     fn explain_query_plan_step(
         &self,
         state: &mut ProgramState,
-        _mv_store: Option<&Arc<MvStore>>,
         pager: Arc<Pager>,
     ) -> Result<StepResult> {
         debug_assert!(state.column_count() == EXPLAIN_QUERY_PLAN_COLUMNS.len());
@@ -1001,7 +994,6 @@ impl Program {
     fn normal_step(
         &self,
         state: &mut ProgramState,
-        mv_store: Option<&Arc<MvStore>>,
         pager: Arc<Pager>,
         waker: Option<&Waker>,
     ) -> Result<StepResult> {
@@ -1016,7 +1008,7 @@ impl Program {
                 return Err(LimboError::InternalError("Connection closed".to_string()));
             }
             if matches!(state.execution_state, ProgramExecutionState::Interrupting) {
-                self.abort(mv_store, &pager, None, state);
+                self.abort(&pager, None, state);
                 return Ok(StepResult::Interrupt);
             }
 
@@ -1027,7 +1019,7 @@ impl Program {
                 }
                 if let Some(err) = io.get_error() {
                     let err = err.into();
-                    self.abort(mv_store, &pager, Some(&err), state);
+                    self.abort(&pager, Some(&err), state);
                     return Err(err);
                 }
                 state.io_completions = None;
@@ -1042,7 +1034,7 @@ impl Program {
             // Always increment VM steps for every loop iteration
             state.metrics.vm_steps = state.metrics.vm_steps.saturating_add(1);
 
-            match insn_function(self, state, insn, &pager, mv_store) {
+            match insn_function(self, state, insn, &pager) {
                 Ok(InsnFunctionStepResult::Step) => {
                     // Instruction completed, moving to next
                     state.metrics.insn_executed = state.metrics.insn_executed.saturating_add(1);
@@ -1069,7 +1061,7 @@ impl Program {
                     return Ok(StepResult::Busy);
                 }
                 Err(err) => {
-                    self.abort(mv_store, &pager, Some(&err), state);
+                    self.abort(&pager, Some(&err), state);
                     return Err(err);
                 }
             }
@@ -1324,13 +1316,7 @@ impl Program {
 
     /// Aborts the program due to various conditions (explicit error, interrupt or reset of unfinished statement) by rolling back the transaction
     /// This method is no-op if program was already finished (either aborted or executed to completion)
-    pub fn abort(
-        &self,
-        mv_store: Option<&Arc<MvStore>>,
-        pager: &Arc<Pager>,
-        err: Option<&LimboError>,
-        state: &mut ProgramState,
-    ) {
+    pub fn abort(&self, pager: &Arc<Pager>, err: Option<&LimboError>, state: &mut ProgramState) {
         if self.is_trigger_subprogram() {
             self.connection.end_trigger_execution();
         }
@@ -1357,7 +1343,7 @@ impl Program {
                 Some(LimboError::Constraint(_)) => {}
                 _ => {
                     if state.auto_txn_cleanup != TxnCleanup::None || err.is_some() {
-                        if let Some(mv_store) = mv_store {
+                        if let Some(mv_store) = self.connection.mv_store().as_ref() {
                             if let Some(tx_id) = self.connection.get_mv_tx_id() {
                                 self.connection.auto_commit.store(true, Ordering::SeqCst);
                                 mv_store.rollback_tx(tx_id, pager.clone(), &self.connection);


### PR DESCRIPTION
In my adventure of doing #3536, I had a bug where an opcode was using a stale MvStore reference when transitioning from MvStore to Wal mode. I did not want to special case just 1 opcode to ignore the `mv_store` argument (in my particular case it was `Insn::Checkpoint`), so I just edited it and forced the opcodes to get `mv_store` from the `program.connection.mv_store()` which is always up to date. 

But, if we don't want to make this change I can always just do the special case and move on.

**AI Disclosure:**
Asked Claude to do most of refactoring, but all the changes were manually approved by me.