### PR TITLE
Fix external sorter losing rows when chunks need async IO

### DIFF
--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -288,7 +288,7 @@ impl Sorter {
     fn next_from_chunk_heap(&mut self) -> Result<IOResult<Option<SortableImmutableRecord>>> {
         // If there is a pending IO, we must wait for it before popping from the heap,
         // otherwise we might return records out of order.
-        if let Some((completion, chunk_idx)) = self.pending_completion.take() {
+        while let Some((completion, chunk_idx)) = self.pending_completion.take() {
             if !completion.succeeded() {
                 // IO not complete - put it back and yield
                 self.pending_completion = Some((completion.clone(), chunk_idx));
@@ -298,7 +298,6 @@ impl Sorter {
             if let Some(c) = self.push_to_chunk_heap(chunk_idx)? {
                 self.pending_completion = Some((c, chunk_idx));
             }
-            return self.next_from_chunk_heap();
         }
 
         // No pending IO - safe to pop from heap


### PR DESCRIPTION
## Closes

Closes #4033 
Closes #4125

## Bugfix number 1

When reading from sorted chunk files during external merge sort, if a chunk needed async IO to read more data, the `next_chunk_idx` (index of the chunk that caused the IO) was lost after yielding. This caused rows to be permanently dropped from the result set because `push_to_chunk_heap` didn't end up getting called again after the IO was complete.

Fix:

- track the chunk index of `pending_completion` to ensure `push_to_chunk_heap()` gets called after the IO completes.

## Bugfix number 2

When the sorter's internal read buffer was full and a prefetch read was issued, the read would request 0 bytes. This obviously returned 0 bytes read, and was incorrectly interpreted as EOF, causing the sorter to think the chunk
was exhausted when most data remained unread. This resulted in "Corrupt database: Incomplete record" errors.

Fix:

- Avoid issuing pointless 0 byte reads
- Distinguish between "no room in buffer" and "nothing left to read",
  and only the latter causes EOF
  
## Other stuff

- I added more documentation to the sorter module

## AI disclosure

I gave Opus 4.5 the failing seed from #4125 and told it that `sorter.rs` loses rows probably during spilling. It found the first bug fairly quickly and then I iterated the solution with it a bit to arrive at the final result.

I had actually given Opus 4.5 the seed of the first bug without the `--memory-io` flag, and after the first fix I noticed the seed was still failing with `--memory-io` enabled (which introduces artificial IO latency). I pointed this out to the AI and it also found the second bug very quickly, and I only participated in cleaning up the solution to make the fix minimal.