### PR TITLE
Fix descending index scan returning rows when seek key is NULL

### DIFF
--- a/testing/null.test
+++ b/testing/null.test
@@ -33,3 +33,79 @@ do_execsql_test_on_specific_db {:memory:} not-null-just-cuz-unique {
     insert into t(a) values(1);
     select * from t;
 } {1|}
+
+# Regression tests for NULL comparison with index scans
+# Any comparison with NULL should return 0 rows because NULL comparisons
+# always return NULL (unknown), which is falsy.
+
+# Ascending index: x > NULL should return 0 rows
+do_execsql_test_on_specific_db {:memory:} null-comparison-asc-gt {
+    CREATE TABLE t1(x);
+    CREATE INDEX t1_idx ON t1(x ASC);
+    INSERT INTO t1 VALUES (1), (2), (3);
+    SELECT * FROM t1 WHERE x > NULL;
+} {}
+
+# Descending index: x > NULL should return 0 rows
+do_execsql_test_on_specific_db {:memory:} null-comparison-desc-gt {
+    CREATE TABLE t2(x);
+    CREATE INDEX t2_idx ON t2(x DESC);
+    INSERT INTO t2 VALUES (1), (2), (3);
+    SELECT * FROM t2 WHERE x > NULL;
+} {}
+
+# Ascending index: x < NULL should return 0 rows
+do_execsql_test_on_specific_db {:memory:} null-comparison-asc-lt {
+    CREATE TABLE t3(x);
+    CREATE INDEX t3_idx ON t3(x ASC);
+    INSERT INTO t3 VALUES (1), (2), (3);
+    SELECT * FROM t3 WHERE x < NULL;
+} {}
+
+# Descending index: x < NULL should return 0 rows
+do_execsql_test_on_specific_db {:memory:} null-comparison-desc-lt {
+    CREATE TABLE t4(x);
+    CREATE INDEX t4_idx ON t4(x DESC);
+    INSERT INTO t4 VALUES (1), (2), (3);
+    SELECT * FROM t4 WHERE x < NULL;
+} {}
+
+# Ascending index: x >= NULL should return 0 rows
+do_execsql_test_on_specific_db {:memory:} null-comparison-asc-ge {
+    CREATE TABLE t5(x);
+    CREATE INDEX t5_idx ON t5(x ASC);
+    INSERT INTO t5 VALUES (1), (2), (3);
+    SELECT * FROM t5 WHERE x >= NULL;
+} {}
+
+# Descending index: x >= NULL should return 0 rows
+do_execsql_test_on_specific_db {:memory:} null-comparison-desc-ge {
+    CREATE TABLE t6(x);
+    CREATE INDEX t6_idx ON t6(x DESC);
+    INSERT INTO t6 VALUES (1), (2), (3);
+    SELECT * FROM t6 WHERE x >= NULL;
+} {}
+
+# Ascending index: x <= NULL should return 0 rows
+do_execsql_test_on_specific_db {:memory:} null-comparison-asc-le {
+    CREATE TABLE t7(x);
+    CREATE INDEX t7_idx ON t7(x ASC);
+    INSERT INTO t7 VALUES (1), (2), (3);
+    SELECT * FROM t7 WHERE x <= NULL;
+} {}
+
+# Descending index: x <= NULL should return 0 rows
+do_execsql_test_on_specific_db {:memory:} null-comparison-desc-le {
+    CREATE TABLE t8(x);
+    CREATE INDEX t8_idx ON t8(x DESC);
+    INSERT INTO t8 VALUES (1), (2), (3);
+    SELECT * FROM t8 WHERE x <= NULL;
+} {}
+
+# Descending index with ORDER BY: x > NULL should return 0 rows
+do_execsql_test_on_specific_db {:memory:} null-comparison-desc-order-by {
+    CREATE TABLE t9(x);
+    CREATE INDEX t9_idx ON t9(x DESC);
+    INSERT INTO t9 VALUES (1), (2), (3);
+    SELECT * FROM t9 WHERE x > NULL ORDER BY x DESC;
+} {}

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -378,12 +378,22 @@ mod fuzz_tests {
                 col_val: i32,
                 rng: &mut ChaCha8Rng,
             ) -> String {
-                if operator != "=" && rng.random_range(0..3) == 1 {
-                    let val2 = rng.random_range(0..=3000);
-                    let op2 = COMPARISONS[rng.random_range(0..COMPARISONS.len())];
-                    format!("{col_name} {operator} {col_val} AND {col_name} {op2} {val2}")
+                // 5% chance of using NULL as the comparison value
+                let val_str = if rng.random_range(0..20) == 0 {
+                    "NULL".to_string()
                 } else {
-                    format!("{col_name} {operator} {col_val}")
+                    col_val.to_string()
+                };
+                if operator != "=" && rng.random_range(0..3) == 1 {
+                    let val2 = if rng.random_range(0..20) == 0 {
+                        "NULL".to_string()
+                    } else {
+                        rng.random_range(0..=3000).to_string()
+                    };
+                    let op2 = COMPARISONS[rng.random_range(0..COMPARISONS.len())];
+                    format!("{col_name} {operator} {val_str} AND {col_name} {op2} {val2}")
+                } else {
+                    format!("{col_name} {operator} {val_str}")
                 }
             }
 


### PR DESCRIPTION
Closes #4066 
Closes #4129

## Problem
Take e.g.

CREATE TABLE t(x); CREATE INDEX txdesc ON t(x desc); INSERT INTO t values (1),(2),(3);

SELECT * FROM t WHERE x > NULL;

--

Our plan, like Sqlite, was to start iterating the descending index from the beginning (Rewind) and stop once we hit a row where x is <= than NULL using `IdxGe` instruction (GE in descending indexes means LE).

However, `IdxGe` and other similar instructions use a sort comparison where NULL is less than numbers/strings etc, so this would incorrectly not jump.

## Fix

Fix: we need to emit an explicit NULL check after rewinding.

## Tests

Added TCL tests + improved `index_scan_compound_key_fuzz` to have NULL seek keys sometimes.

## AI disclosure

I started debugging this with Claude Code thinking this is a much deeper corruption issue, but Opus 4.5 noticed immediately that we are returning rows from a `x > NULL` comparison which should never happen. Hence, the fix was then fairly simple.