### PR TITLE
core/mvcc/cursor: add missing reset state in `next`

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1039,6 +1039,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                     }
                 }
                 CursorPosition::BeforeFirst => {
+                    self.state.replace(None);
                     return Ok(IOResult::Done(false));
                 }
             };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clears `state` in `MvccLazyCursor` when `next()` reaches `End` and when `prev()` reaches `BeforeFirst`, preventing stale iteration state.
> 
> - **MVCC Cursor (`core/mvcc/cursor.rs`)**:
>   - `next()`: when reaching `CursorPosition::End`, now resets `self.state` before returning.
>   - `prev()`: when reaching `CursorPosition::BeforeFirst`, now resets `self.state` before returning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc8ae2c2e462ce0daec53309392d1c2ce734cc5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->