### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Description
+
+<!-- 
+Please include a summary of the changes and the related issue. 
+-->
+
+## Motivation and context
+
+<!-- 
+Please include relevant motivation and context.
+Link relevant issues here.
+-->
+
+
+## AI Disclosure
+
+<!-- 
+Please disclose if any LLM's were used in the creation of this PR and to what extent, 
+to help maintainers properly review.
+-->


### PR DESCRIPTION
Recently maintainers have been self-disclosing LLM use in PR's, so I don't see why we can't have a PR template to encourage everyone to do so.