### PR TITLE
reset statement in query()

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -252,6 +252,8 @@ impl Statement {
     }
     /// Query the database with this prepared statement.
     pub async fn query(&mut self, params: impl IntoParams) -> Result<Rows> {
+        self.reset()?;
+
         let mut stmt = self.inner.lock().unwrap();
         let params = params.into_params()?;
         match params {


### PR DESCRIPTION
This makes it possible to use a prepared statement more than once.

## AI disclosure

This has a really fun story behind it.

I was using Turso and kept hitting `SQLITE_BUSY`, so took a chance, and asked Claude if it could come up with a fuzz test that would reproduce this. It then wrote a version of the fuzz test in this PR, and this showed a panic in Turso. So I asked it to fix the panic, and to write a unit test that would show the panic. It then wrote the unit test, and that showed a totally different failure that had the same solution!

Claude wrote the code, and then I cleaned it up manually.