### PR TITLE
sim: fix bug in apply_snapshot

### DIFF
--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -258,10 +258,12 @@ where
                     committed.indexes = current_table.indexes.clone();
                     committed.columns = current_table.columns.clone();
                 } else {
-                    // New table created in transaction
-                    let mut new_table = current_table.clone();
-                    new_table.rows = Vec::new();
-                    self.commited_tables.push(new_table);
+                    // New table created in transaction - copy with rows intact.
+                    // The rows are already correct in current_tables since all insert
+                    // operations were applied there during the transaction.
+                    // We don't need to replay operations for new tables since the
+                    // inserts were skipped above (table didn't exist in committed_tables).
+                    self.commited_tables.push(current_table.clone());
                 }
             }
         }


### PR DESCRIPTION
Closes #4169 
Closes #4173 
Closes #4174 

## Beef

When a new table was created within a transaction AND rows were inserted into that table within the same tx, we were incorrectly clearing the rows of the new table when committing in `apply_snapshot()`.

This resulted in false positives where the sim thought there shouldn't be any rows in the table.

## Fix

Don't do that.

## AI usage

Opus 4.5 found the bug in 5 seconds with this prompt:

```
This is an SQL fuzzer/simulator for TursoDB, the rust rewrite of sqlite. I think there is a bug in apply_snapshot in the simulator.

cargo run --bin limbo_sim -- --seed 3076430551640710097 --disable-bugbase --memory-io --minimum-tests 100 --maximum-tests 1000 loop -n 10 --short-circuit

you can run that to see the output 
```