### PR TITLE
Get mutable reference to table in Schema so we can modify it with `Arc::make_mut`

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1110,10 +1110,10 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 self.connection.db.with_schema_mut(|schema| {
                     for table in schema.tables.values_mut() {
                         let table = Arc::get_mut(table).expect("this should be the only reference");
-                        let Some(mut btree_table) = table.btree() else {
+                        let Some(btree_table) = table.btree_mut() else {
                             continue;
                         };
-                        let btree_table = Arc::make_mut(&mut btree_table);
+                        let btree_table = Arc::make_mut(btree_table);
                         if btree_table.root_page < 0 {
                             btree_table.root_page = btree_table.root_page.abs();
                         }
@@ -1134,7 +1134,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             self.mvstore.global_header.write().replace(*header);
                             IOResult::Done(())
                         })
-                    });
+                    })?;
                     Ok(())
                 })?;
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1448,6 +1448,14 @@ impl Table {
         }
     }
 
+    pub fn btree_mut(&mut self) -> Option<&mut Arc<BTreeTable>> {
+        match self {
+            Self::BTree(table) => Some(table),
+            Self::Virtual(_) => None,
+            Self::FromClauseSubquery(_) => None,
+        }
+    }
+
     pub fn virtual_table(&self) -> Option<Arc<VirtualTable>> {
         match self {
             Self::Virtual(table) => Some(table.clone()),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -917,7 +917,10 @@ pub fn op_open_read(
         .get(*cursor_id)
         .expect("cursor_id should exist in cursor_ref");
     if program.connection.get_mv_tx_id().is_none() {
-        assert!(*root_page >= 0, "");
+        assert!(
+            *root_page >= 0,
+            "root page should be non negative when we are not in a MVCC transaction"
+        );
     }
     let cursors = &mut state.cursors;
     let num_columns = match cursor_type {


### PR DESCRIPTION

## Description
If we use `btree()`, it creates a clone of the value inside the `Table`, which means the number of ref counts > 1. This means that if we you try to use `Arc::make_mut`, it will just clone the Btree table, and never change the actual schema
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
My fuzzer was failing in #4074 with negative rootpages
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## AI Disclosure
None
<!-- 
Please disclose if any LLM's were used in the creation of this PR and to what extent, 
to help maintainers properly review.
-->
