### PR TITLE
also check for None `checkpointed_txid_max_old` when determining if `RowVersion` exists in the Db

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -205,7 +205,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 begin_ts = Some(b);
                 if self
                     .checkpointed_txid_max_old
-                    .is_some_and(|txid_max_old| b <= txid_max_old.into())
+                    .is_none_or(|txid_max_old| b <= txid_max_old.into())
                 {
                     exists_in_db_file = true;
                 }
@@ -229,11 +229,9 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             // We need the `self.checkpointed_txid_max_old.is_none()` check as we may have not checkpointed yet,
             // and without this check, recovered rows could skipped accidently
             let is_uncheckpointed_insert = end_ts.is_none()
-                && (self.checkpointed_txid_max_old.is_none()
-                    || begin_ts.is_some_and(|b| {
-                        self.checkpointed_txid_max_old
-                            .is_some_and(|txid_max_old| b > txid_max_old.into())
-                    }));
+                && self
+                    .checkpointed_txid_max_old
+                    .is_none_or(|txid_max_old| begin_ts.is_some_and(|b| b > txid_max_old.into()));
             // - It is a delete, AND some version of the row exists in the database file.
             let is_delete_and_exists_in_db_file = end_ts.is_some() && exists_in_db_file;
             let should_checkpoint = is_uncheckpointed_insert || is_delete_and_exists_in_db_file;


### PR DESCRIPTION

## Description
We should also check for if `checkpointed_txid_max_old` is None when setting `exists_in_db_file` to true
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
My fuzzer in #4074 was failing because we were not checkpointing a delete that exists in the Db file
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## AI Disclosure
Ai helped me discover the bug
<!-- 
Please disclose if any LLM's were used in the creation of this PR and to what extent, 
to help maintainers properly review.
-->
