### PR TITLE
core/mvcc/cursor: return previous max id

### DIFF
--- a/testing/all-mvcc.test
+++ b/testing/all-mvcc.test
@@ -3,7 +3,6 @@
 set testdir [file dirname $argv0]
 
 # failing:
-# source $testdir/autoincr.test
 # source $testdir/join.test
 # source $testdir/insert.test
 # source $testdir/pragma.test
@@ -29,6 +28,7 @@ set testdir [file dirname $argv0]
 
 # works
 source $testdir/glob.test
+source $testdir/autoincr.test
 source $testdir/cmdlineshell.test
 source $testdir/alter_table.test
 source $testdir/coalesce.test


### PR DESCRIPTION
## Description
 
We weren't updating `prev_largest_reg` on auto increment mode. I opened an issue with regards to auto increment on MVCC because even tho this fixed something, there are race conditions possible https://github.com/tursodatabase/turso/issues/4188.

## AI Disclosure

I think I autocompleted something, it was wrong.
