### PR TITLE
clean up core tester to use `conn.execute` and `conn.exec_rows` for parsing correctly the expected values from select queries

### DIFF
--- a/tests/integration/functions/test_sum.rs
+++ b/tests/integration/functions/test_sum.rs
@@ -1,4 +1,4 @@
-use crate::common::{limbo_exec_rows, limbo_exec_rows_fallible, sqlite_exec_rows, TempDatabase};
+use crate::common::{limbo_exec_rows_fallible, sqlite_exec_rows, ExecRows, TempDatabase};
 use turso_core::LimboError;
 
 #[turso_macros::test(mvcc)]
@@ -8,17 +8,29 @@ fn sum_errors_on_integer_overflow(tmp_db: TempDatabase) {
     let conn = tmp_db.connect_limbo();
     let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
 
-    limbo_exec_rows(&conn, "CREATE TABLE t(a)");
+    conn.execute("CREATE TABLE t(a)").unwrap();
     sqlite_exec_rows(&sqlite_conn, "CREATE TABLE t(a)");
 
-    limbo_exec_rows(&conn, "INSERT INTO t VALUES (9223372036854775807)");
+    conn.execute("INSERT INTO t VALUES (9223372036854775807)")
+        .unwrap();
     sqlite_exec_rows(&sqlite_conn, "INSERT INTO t VALUES (9223372036854775807)");
 
-    let limbo_before_overflow = limbo_exec_rows(&conn, "SELECT sum(a) FROM t");
+    let limbo_before_overflow: Vec<(i64,)> = conn.exec_rows("SELECT sum(a) FROM t");
     let sqlite_before_overflow = sqlite_exec_rows(&sqlite_conn, "SELECT sum(a) FROM t");
-    assert_eq!(limbo_before_overflow, sqlite_before_overflow);
+    assert_eq!(
+        limbo_before_overflow,
+        vec![(9223372036854775807i64,)],
+        "limbo mismatch"
+    );
+    assert_eq!(
+        sqlite_before_overflow,
+        vec![vec![rusqlite::types::Value::Integer(
+            9223372036854775807i64
+        )]],
+        "sqlite mismatch"
+    );
 
-    limbo_exec_rows(&conn, "INSERT INTO t VALUES (1)");
+    conn.execute("INSERT INTO t VALUES (1)").unwrap();
     sqlite_exec_rows(&sqlite_conn, "INSERT INTO t VALUES (1)");
 
     let err = limbo_exec_rows_fallible(&tmp_db, &conn, "SELECT sum(a) FROM t")

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -2,14 +2,13 @@ use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use rusqlite::types::Value;
 use tempfile::TempDir;
 use turso_core::{
     types::{WalFrameInfo, WalState},
     CheckpointMode, LimboError, StepResult,
 };
 
-use crate::common::{limbo_exec_rows, rng_from_time, TempDatabase};
+use crate::common::{rng_from_time, ExecRows, TempDatabase};
 
 // TODO: mvcc
 #[turso_macros::test()]
@@ -60,14 +59,8 @@ fn test_wal_frame_transfer_no_schema_changes(db: TempDatabase) {
 
     conn2.wal_insert_end(false).unwrap();
     assert_eq!(conn2.wal_state().unwrap().max_frame, 15);
-    assert_eq!(
-        limbo_exec_rows(&conn2, "SELECT x, length(y) FROM t"),
-        vec![
-            vec![Value::Integer(5), Value::Integer(1)],
-            vec![Value::Integer(10), Value::Integer(2)],
-            vec![Value::Integer(1024), Value::Integer(40960)],
-        ]
-    );
+    let rows: Vec<(i64, i64)> = conn2.exec_rows("SELECT x, length(y) FROM t");
+    assert_eq!(rows, vec![(5, 1), (10, 2), (1024, 40960)]);
 }
 
 // TODO: mvcc
@@ -99,14 +92,10 @@ fn test_wal_frame_transfer_various_schema_changes(db: TempDatabase) {
     };
 
     sync();
-    assert_eq!(
-        limbo_exec_rows(&conn2, "SELECT * FROM t"),
-        vec![] as Vec<Vec<rusqlite::types::Value>>
-    );
-    assert_eq!(
-        limbo_exec_rows(&conn3, "SELECT * FROM t"),
-        vec![] as Vec<Vec<rusqlite::types::Value>>
-    );
+    let rows: Vec<(i64, i64)> = conn2.exec_rows("SELECT * FROM t");
+    assert!(rows.is_empty());
+    let rows: Vec<(i64, i64)> = conn3.exec_rows("SELECT * FROM t");
+    assert!(rows.is_empty());
 
     conn1.execute("DROP TABLE t").unwrap();
 
@@ -124,14 +113,10 @@ fn test_wal_frame_transfer_various_schema_changes(db: TempDatabase) {
     conn1.execute("CREATE TABLE b(x, y)").unwrap();
 
     sync();
-    assert_eq!(
-        limbo_exec_rows(&conn2, "SELECT 1 FROM a UNION ALL SELECT 1 FROM b"),
-        vec![] as Vec<Vec<rusqlite::types::Value>>
-    );
-    assert_eq!(
-        limbo_exec_rows(&conn3, "SELECT 1 FROM a UNION ALL SELECT 1 FROM b"),
-        vec![] as Vec<Vec<rusqlite::types::Value>>
-    );
+    let rows: Vec<(i64,)> = conn2.exec_rows("SELECT 1 FROM a UNION ALL SELECT 1 FROM b");
+    assert!(rows.is_empty());
+    let rows: Vec<(i64,)> = conn3.exec_rows("SELECT 1 FROM a UNION ALL SELECT 1 FROM b");
+    assert!(rows.is_empty());
 }
 
 // TODO: mvcc
@@ -168,14 +153,8 @@ fn test_wal_frame_transfer_schema_changes(db: TempDatabase) {
     conn2.wal_insert_end(false).unwrap();
     assert_eq!(commits, 3);
     assert_eq!(conn2.wal_state().unwrap().max_frame, 15);
-    assert_eq!(
-        limbo_exec_rows(&conn2, "SELECT x, length(y) FROM t"),
-        vec![
-            vec![Value::Integer(5), Value::Integer(1)],
-            vec![Value::Integer(10), Value::Integer(2)],
-            vec![Value::Integer(1024), Value::Integer(40960)],
-        ]
-    );
+    let rows: Vec<(i64, i64)> = conn2.exec_rows("SELECT x, length(y) FROM t");
+    assert_eq!(rows, vec![(5, 1), (10, 2), (1024, 40960)]);
 }
 
 // TODO: mvcc
@@ -208,18 +187,14 @@ fn test_wal_frame_transfer_no_schema_changes_rollback(db: TempDatabase) {
     }
     conn2.wal_insert_end(false).unwrap();
     assert_eq!(conn2.wal_state().unwrap().max_frame, 2);
-    assert_eq!(
-        limbo_exec_rows(&conn2, "SELECT x, length(y) FROM t"),
-        vec![] as Vec<Vec<rusqlite::types::Value>>
-    );
+    let rows: Vec<(i64, i64)> = conn2.exec_rows("SELECT x, length(y) FROM t");
+    assert!(rows.is_empty());
     conn2.execute("CREATE TABLE q(x)").unwrap();
     conn2
         .execute("INSERT INTO q VALUES (randomblob(4096 * 10))")
         .unwrap();
-    assert_eq!(
-        limbo_exec_rows(&conn2, "SELECT x, LENGTH(y) FROM t"),
-        vec![] as Vec<Vec<rusqlite::types::Value>>
-    );
+    let rows: Vec<(i64, i64)> = conn2.exec_rows("SELECT x, LENGTH(y) FROM t");
+    assert!(rows.is_empty());
 }
 
 // TODO: mvcc
@@ -248,18 +223,14 @@ fn test_wal_frame_transfer_schema_changes_rollback(db: TempDatabase) {
     }
     conn2.wal_insert_end(false).unwrap();
     assert_eq!(conn2.wal_state().unwrap().max_frame, 2);
-    assert_eq!(
-        limbo_exec_rows(&conn2, "SELECT x, length(y) FROM t"),
-        vec![] as Vec<Vec<rusqlite::types::Value>>
-    );
+    let rows: Vec<(i64, i64)> = conn2.exec_rows("SELECT x, length(y) FROM t");
+    assert!(rows.is_empty());
     conn2.execute("CREATE TABLE q(x)").unwrap();
     conn2
         .execute("INSERT INTO q VALUES (randomblob(4096 * 10))")
         .unwrap();
-    assert_eq!(
-        limbo_exec_rows(&conn2, "SELECT x, LENGTH(y) FROM t"),
-        vec![] as Vec<Vec<rusqlite::types::Value>>
-    );
+    let rows: Vec<(i64, i64)> = conn2.exec_rows("SELECT x, LENGTH(y) FROM t");
+    assert!(rows.is_empty());
 }
 
 // TODO: mvcc
@@ -371,10 +342,8 @@ fn test_wal_frame_api_no_schema_changes_fuzz(db: TempDatabase) {
                 if rng.next_u32() % 10 == 0 {
                     synced_frame = rng.next_u32() as u64 % synced_frame;
                 }
-                assert_eq!(
-                    limbo_exec_rows(&conn2, "SELECT COUNT(*) FROM t"),
-                    vec![vec![Value::Integer(size as i64)]]
-                );
+                let rows: Vec<(i64,)> = conn2.exec_rows("SELECT COUNT(*) FROM t");
+                assert_eq!(rows, vec![(size as i64,)]);
             }
         }
     }
@@ -479,28 +448,18 @@ fn test_wal_api_revert_pages(db1: TempDatabase) {
         .execute("INSERT INTO t VALUES (1024, randomblob(4096 * 2))")
         .unwrap();
 
-    assert_eq!(
-        limbo_exec_rows(&conn1, "SELECT x, length(y) FROM t"),
-        vec![
-            vec![Value::Integer(1), Value::Integer(10)],
-            vec![Value::Integer(3), Value::Integer(20)],
-            vec![Value::Integer(1024), Value::Integer(4096 * 2)],
-        ]
-    );
+    let rows: Vec<(i64, i64)> = conn1.exec_rows("SELECT x, length(y) FROM t");
+    assert_eq!(rows, vec![(1, 10), (3, 20), (1024, 4096 * 2)]);
 
     revert_to(&conn1, watermark2).unwrap();
 
-    assert_eq!(
-        limbo_exec_rows(&conn1, "SELECT x, length(y) FROM t"),
-        vec![vec![Value::Integer(1), Value::Integer(10)],]
-    );
+    let rows: Vec<(i64, i64)> = conn1.exec_rows("SELECT x, length(y) FROM t");
+    assert_eq!(rows, vec![(1, 10)]);
 
     revert_to(&conn1, watermark1).unwrap();
 
-    assert_eq!(
-        limbo_exec_rows(&conn1, "SELECT x, length(y) FROM t"),
-        vec![] as Vec<Vec<Value>>,
-    );
+    let rows: Vec<(i64, i64)> = conn1.exec_rows("SELECT x, length(y) FROM t");
+    assert!(rows.is_empty());
 }
 
 // TODO: mvcc
@@ -710,10 +669,8 @@ fn test_wal_revert_change_db_size(db: TempDatabase) {
     writer
         .execute("insert into t values (3, randomblob(30 * 4096))")
         .unwrap();
-    assert_eq!(
-        limbo_exec_rows(&writer, "SELECT x, length(y) FROM t"),
-        vec![vec![Value::Integer(3), Value::Integer(30 * 4096)]]
-    );
+    let rows: Vec<(i64, i64)> = writer.exec_rows("SELECT x, length(y) FROM t");
+    assert_eq!(rows, vec![(3, 30 * 4096)]);
 }
 
 // TODO: mvcc

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -137,10 +137,10 @@ fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
             Register::Value(Value::Integer((i + 1) as i64)),
         ];
         run(&tmp_db, || cursor.insert(&values)).unwrap();
-        limbo_exec_rows(
-            &conn,
-            &format!("INSERT INTO t VALUES ('{i}', vector32_sparse('{vector_str}'))"),
-        );
+        conn.execute(format!(
+            "INSERT INTO t VALUES ('{i}', vector32_sparse('{vector_str}'))"
+        ))
+        .unwrap();
     }
     for (vector, results) in [
         ("[0, 0, 0, 1]", &[(1, 0.0)][..]),
@@ -232,19 +232,19 @@ fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
         Register::Value(Value::Integer(1)),
     ];
     run(&tmp_db, || writer.insert(&insert0_values)).unwrap();
-    limbo_exec_rows(
-        &conn,
-        &format!("INSERT INTO t VALUES ('test', vector32_sparse('{v0_str}'))"),
-    );
+    conn.execute(format!(
+        "INSERT INTO t VALUES ('test', vector32_sparse('{v0_str}'))"
+    ))
+    .unwrap();
 
     let mut reader = attached.init().unwrap();
     run(&tmp_db, || reader.open_read(&conn)).unwrap();
     assert!(!run(&tmp_db, || reader.query_start(&query_values)).unwrap());
 
-    limbo_exec_rows(
-        &conn,
-        &format!("UPDATE t SET embedding = vector32_sparse('{v1_str}') WHERE rowid = 1"),
-    );
+    conn.execute(format!(
+        "UPDATE t SET embedding = vector32_sparse('{v1_str}') WHERE rowid = 1"
+    ))
+    .unwrap();
     run(&tmp_db, || writer.delete(&insert0_values)).unwrap();
     run(&tmp_db, || writer.insert(&insert1_values)).unwrap();
 

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -1,4 +1,4 @@
-use crate::common::{limbo_exec_rows, TempDatabase};
+use crate::common::{ExecRows, TempDatabase};
 use turso_core::{LimboError, StepResult, Value};
 
 #[turso_macros::test(mvcc, init_sql = "create table test (i integer);")]
@@ -950,8 +950,8 @@ fn test_multiple_connections_visibility(tmp_db: TempDatabase) -> anyhow::Result<
     drop(stmt);
     conn1.execute("COMMIT")?;
 
-    let rows = limbo_exec_rows(&conn2, "SELECT COUNT(*) FROM test");
-    assert_eq!(rows, vec![vec![rusqlite::types::Value::Integer(2)]]);
+    let rows: Vec<(i64,)> = conn2.exec_rows("SELECT COUNT(*) FROM test");
+    assert_eq!(rows, vec![(2,)]);
     Ok(())
 }
 
@@ -983,17 +983,8 @@ fn test_stmt_reset(tmp_db: TempDatabase) -> anyhow::Result<()> {
             _ => tmp_db.io.step().unwrap(),
         }
     }
-    let rows = limbo_exec_rows(&conn1, "SELECT rowid FROM test");
-    assert_eq!(
-        rows,
-        vec![
-            vec![rusqlite::types::Value::Integer(1)],
-            vec![rusqlite::types::Value::Integer(2)],
-            vec![rusqlite::types::Value::Integer(3)],
-            vec![rusqlite::types::Value::Integer(4)],
-            vec![rusqlite::types::Value::Integer(5)],
-        ]
-    );
+    let rows: Vec<(i64,)> = conn1.exec_rows("SELECT rowid FROM test");
+    assert_eq!(rows, vec![(1,), (2,), (3,), (4,), (5,)]);
     Ok(())
 }
 


### PR DESCRIPTION
## Description
The PR title. `exec_rows` also does validation of outputs automatically which is good practice for testing
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
Better typing and don't have to constantly match on `turso_core::Value`
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## AI Disclosure
Ai did most of the migration 
<!-- 
Please disclose if any LLM's were used in the creation of this PR and to what extent, 
to help maintainers properly review.
-->
