### PR TITLE
fix page cache clear to not iterate twice over all pages

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -432,11 +432,6 @@ impl PageCache {
                     pgno: entry.page.get().id,
                 });
             }
-        }
-
-        // Clean all pages
-        for &entry_ptr in self.map.values() {
-            let entry = unsafe { &*entry_ptr };
             entry.page.clear_loaded();
             let _ = entry.page.get().contents.take();
         }


### PR DESCRIPTION
## Description
This PR just removes an unnecessary O(N) iteration of every page in the page cache to check for dirty pages in cache.clear

## Motivation and context
performance


## AI Disclosure
No LLM's were used in this PR