### PR TITLE
increase lantency check for flaky test in test_read_path.rs

### DIFF
--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -1129,5 +1129,5 @@ fn test_eval_param_only_once(tmp_db: TempDatabase) {
     let end_time = std::time::Instant::now();
     let elapsed = end_time.duration_since(start_time);
     // the test will allocate 10^8 * 10^4 bytes in case if parameter will be evaluated for every row
-    assert!(elapsed < std::time::Duration::from_millis(100));
+    assert!(elapsed < std::time::Duration::from_millis(120));
 }


### PR DESCRIPTION
## Description
increase check by 20% to account for slow runners.


## Motivation and context
test is flaky, see failing run in #4193 


## AI Disclosure
none
