### PR TITLE
triggers: don't rewrite qualified table names

### DIFF
--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -178,32 +178,6 @@ fn rewrite_trigger_expr_for_subprogram(
                     }
                 }
 
-                // Handle unqualified column references - they refer to NEW if available, else OLD
-                if let Some((idx, _)) = table.get_column(&col) {
-                    if let Some(new_params) = &ctx.new_param_map {
-                        if idx < new_params.len() {
-                            *e = Expr::Variable(format!(
-                                "{}",
-                                ctx.get_new_param(idx)
-                                    .expect("NEW parameters must be provided")
-                                    .get()
-                            ));
-                            return Ok(WalkControl::Continue);
-                        }
-                    }
-                    if let Some(old_params) = &ctx.old_param_map {
-                        if idx < old_params.len() {
-                            *e = Expr::Variable(format!(
-                                "{}",
-                                ctx.get_old_param(idx)
-                                    .expect("OLD parameters must be provided")
-                                    .get()
-                            ));
-                            return Ok(WalkControl::Continue);
-                        }
-                    }
-                }
-
                 Ok(WalkControl::Continue)
             }
             _ => Ok(WalkControl::Continue),

--- a/testing/all.test
+++ b/testing/all.test
@@ -49,3 +49,4 @@ source $testdir/window.test
 source $testdir/partial_idx.test
 source $testdir/foreign_keys.test
 source $testdir/returning.test
+source $testdir/trigger.test

--- a/testing/trigger.test
+++ b/testing/trigger.test
@@ -761,7 +761,7 @@ do_execsql_test_on_specific_db {:memory:} trigger-multiple-before-insert-lifo {
 5|1|1|1|jussi}
 
 # dropping table should drop triggers
-do_execsql_test_on_specific_db {:memory:} trigger-drop-make-same-table{
+do_execsql_test_on_specific_db {:memory:} trigger-drop-make-same-table {
   create table a(id int primary key, x int);
   create table t(id int primary key, b int, d int, c int);
   create table t1(id int, y int); create trigger trg after insert on t begin update a set x = x - new.d + new.c where id = new.b; insert into t1(id, y) values (new.id, new.c - new.d); end; insert into a values (1, 5000);
@@ -798,6 +798,20 @@ do_execsql_test_on_specific_db {:memory:} trigger-col-name-trigger-subquery {
     INSERT INTO t1 VALUES (0, '');
     UPDATE t1 SET y = 'z' WHERE TRUE; 
     select * from t union all select * from t1;
-} {2|abc
+} {42|abc
 42|abc
 0|z}
+
+# https://github.com/tursodatabase/turso/issues/4142
+do_execsql_test_on_specific_db {:memory:} trigger-table-qualified-where-clause {
+  CREATE TABLE t1 (a REAL, b TEXT, c BLOB, d TEXT, e REAL);
+  INSERT INTO t1 VALUES (-999.0, 'should_stay', X'686f6e6573745f70757269', 'original', -5858539611.591027);
+  CREATE TRIGGER trg BEFORE INSERT ON t1
+  BEGIN
+    UPDATE t1 SET b = 'UPDATED', e = 9999.0
+    WHERE (t1.c != X'686f6e6573745f70757269' OR t1.e > -4109695698.77);
+  END;
+  INSERT INTO t1 VALUES (1.0, 'new_row', X'6E6577', 'new', 1.0);
+  SELECT b, e FROM t1 ORDER BY a;
+} {should_stay|-5858539611.59103
+new_row|1.0}


### PR DESCRIPTION
## Description
closes https://github.com/tursodatabase/turso/issues/4142
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
compatibility, we were  wrongly rewriting table qualified cols, also added trigger.test to all.test and expect correct values in a test
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## AI Disclosure
None
<!-- 
Please disclose if any LLM's were used in the creation of this PR and to what extent, 
to help maintainers properly review.
-->
