### PR TITLE
core: Fix integrity_check pragma code generation

### DIFF
--- a/bindings/python/tests/test_database.py
+++ b/bindings/python/tests/test_database.py
@@ -1478,3 +1478,20 @@ def test_insert_returning_single_and_multiple_commit_without_consuming(provider)
     finally:
         conn.close()
 
+
+@pytest.mark.parametrize("provider", ["sqlite3", "turso"])
+def test_pragma_integrity_check(provider):
+    conn = connect(provider, ":memory:")
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA integrity_check")
+
+    # Verify fetchone returns the expected result, not None
+    # Bug: missing add_pragma_result_column in translate_integrity_check
+    # caused column_count to be 0, making execute() finalize the statement
+    # and leaving fetchone() to return None
+    row = cursor.fetchone()
+    assert row is not None, "PRAGMA integrity_check should return a row"
+    assert row == ("ok",)
+
+    conn.close()
+

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -35,5 +35,6 @@ pub fn translate_integrity_check(
         start_reg: message_register,
         count: 1,
     });
+    program.add_pragma_result_column("integrity_check".into());
     Ok(())
 }


### PR DESCRIPTION
The translate_integrity_check function was missing a call to add_pragma_result_column, causing num_columns() to return 0. This made the Python bindings treat it as a non-row-returning statement, finalizing it during execute() and leaving fetchone() to return None instead of ("ok",).

Spotted by Antithesis.