### PR TITLE
antithesis: Fix unique constraint exception handling in stress-composer tests

### DIFF
--- a/antithesis-tests/stress-composer/parallel_driver_insert.py
+++ b/antithesis-tests/stress-composer/parallel_driver_insert.py
@@ -50,13 +50,8 @@ for i in range(insertions):
         # Table/column might have been dropped in parallel - this is expected
         con.rollback()
         break
-    except turso.OperationalError as e:
-        if "UNIQUE constraint failed" in str(e):
-            # Ignore UNIQUE constraint violations
-            pass
-        else:
-            con.rollback()
-            # Re-raise other operational errors
-            raise
+    except turso.IntegrityError:
+        # Ignore constraint violations - can happen with random values
+        pass
 
 con.commit()

--- a/antithesis-tests/stress-composer/parallel_driver_rollback.py
+++ b/antithesis-tests/stress-composer/parallel_driver_rollback.py
@@ -50,13 +50,9 @@ for i in range(insertions):
         # Table/column might have been dropped in parallel - this is expected
         con.rollback()
         break
-    except turso.OperationalError as e:
-        if "UNIQUE constraint failed" in str(e):
-            # Ignore UNIQUE constraint violations
-            pass
-        else:
-            # Re-raise other operational errors
-            raise
+    except turso.IntegrityError:
+        # Ignore constraint violations - can happen with random values
+        pass
 
 print("Rolling back...")
 con.rollback()

--- a/antithesis-tests/stress-composer/parallel_driver_update.py
+++ b/antithesis-tests/stress-composer/parallel_driver_update.py
@@ -64,13 +64,8 @@ for i in range(updates):
         # Table/column might have been dropped in parallel - this is expected
         con.rollback()
         break
-    except turso.OperationalError as e:
-        if "UNIQUE constraint failed" in str(e):
-            # Ignore UNIQUE constraint violations
-            pass
-        else:
-            con.rollback()
-            # Re-raise other operational errors
-            raise
+    except turso.IntegrityError:
+        # Ignore constraint violations - can happen with random values
+        pass
 
 con.commit()


### PR DESCRIPTION
The SDK kit rewrite (49b207ce) changed the Python driver's exception types. The tests were only catching turso.OperationalError, but UNIQUE constraint violations now raise turso.IntegrityError.