### PR TITLE
core: Don't rollback transaction when schema updated

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1877,6 +1877,11 @@ impl Connection {
 
             if !force_commit {
                 // remove all non-commited changes in case if WAL session left some suffix without commit frame
+                if let Some(mv_store) = self.mv_store().as_ref() {
+                    if let Some(tx_id) = self.get_mv_tx_id() {
+                        mv_store.rollback_tx(tx_id, pager.clone(), self);
+                    }
+                }
                 pager.rollback(false, self, true);
             }
             if let Some(err) = commit_err {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1344,6 +1344,9 @@ impl Program {
                 // Instead individual statement subtransactions will roll back and these are handled in op_auto_commit
                 // and op_halt.
                 Some(LimboError::Constraint(_)) => {}
+                // Schema updated errors do not cause a rollback; the statement will be reprepared and retried,
+                // and the caller is expected to handle transaction cleanup explicitly if needed.
+                Some(LimboError::SchemaUpdated) => {}
                 _ => {
                     if state.auto_txn_cleanup != TxnCleanup::None || err.is_some() {
                         if let Some(mv_store) = self.connection.mv_store().as_ref() {

--- a/tests/integration/fuzz_transaction/mod.rs
+++ b/tests/integration/fuzz_transaction/mod.rs
@@ -639,10 +639,13 @@ async fn multiple_connections_fuzz(opts: FuzzOptions) {
                 || e_string.contains("busy")
                 || e_string.contains("Write-write conflict")
                 || e_string.contains("schema changed")
+                || e_string.contains("has no column named")
+                || e_string.contains("no such column:")
+                || e_string.contains("cannot drop column")
         };
         let requires_rollback = |e: &turso::Error| -> bool {
             let e_string = e.to_string();
-            e_string.contains("Write-write conflict") || e_string.contains("schema changed")
+            e_string.contains("Write-write conflict")
         };
 
         let handle_error = |e: &turso::Error,

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -7,4 +7,5 @@ mod encryption;
 mod test_expr_index;
 mod test_multi_thread;
 mod test_page1;
+mod test_schema_updated;
 mod test_transactions;

--- a/tests/integration/query_processing/test_schema_updated.rs
+++ b/tests/integration/query_processing/test_schema_updated.rs
@@ -1,0 +1,94 @@
+use turso_core::{Result, StepResult, Value};
+
+use crate::common::TempDatabase;
+
+/// Test that SchemaUpdated error reprepares the statement.
+///
+/// Scenario:
+/// 1. Connection 1 starts a transaction and prepares a SELECT statement
+/// 2. Connection 2 changes the schema (ALTER TABLE)
+/// 3. Connection 1 tries to execute the prepared statement - gets SchemaUpdated
+/// 4. Verify the transaction is still active (can execute other statements)
+/// 5. Verify the statement can be retried and will succeed after reprepare
+#[turso_macros::test]
+fn test_schema_update_reprepares_statement(tmp_db: TempDatabase) -> Result<()> {
+    let conn1 = tmp_db.connect_limbo();
+    let conn2 = tmp_db.connect_limbo();
+
+    // Create initial table
+    conn1.execute("CREATE TABLE t (a INTEGER, b TEXT)")?;
+    conn1.execute("INSERT INTO t VALUES (1, 'first'), (2, 'second')")?;
+
+    // Connection 1 starts a transaction
+    conn1.execute("BEGIN")?;
+
+    // Prepare a SELECT statement (this captures the schema cookie at prepare time)
+    let mut stmt = conn1.prepare("SELECT a, b FROM t WHERE a = 1")?;
+
+    // Connection 2 changes the schema (this increments the schema cookie)
+    conn2.execute("ALTER TABLE t ADD COLUMN c INTEGER")?;
+
+    // Connection 1 tries to execute the prepared statement
+    // Note: Statement::step() will automatically reprepare and retry on SchemaUpdated
+    // for statements that access the database. However, we can still verify that
+    // the transaction is not rolled back even if SchemaUpdated occurs.
+    // For this test, we'll use a statement that should trigger SchemaUpdated
+    // but the automatic reprepare should handle it.
+
+    // First, let's verify the statement can execute (it will be automatically reprepared)
+    let mut found_row = false;
+    loop {
+        match stmt.step()? {
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                let a = row.get::<&Value>(0).unwrap();
+                let b = row.get::<&Value>(1).unwrap();
+                assert_eq!(*a, Value::Integer(1));
+                assert_eq!(*b, Value::build_text("first"));
+                found_row = true;
+            }
+            StepResult::IO => stmt.run_once()?,
+            StepResult::Done => break,
+            r => panic!("Unexpected step result: {r:?}"),
+        }
+    }
+    assert!(found_row, "Expected to find a row");
+
+    // Verify the transaction is still active by executing another statement
+    conn1.execute("INSERT INTO t (a, b) VALUES (3, 'third')")?;
+
+    // Verify we can still query within the transaction
+    let mut stmt2 = conn1.prepare("SELECT COUNT(*) FROM t")?;
+    loop {
+        match stmt2.step()? {
+            StepResult::Row => {
+                let row = stmt2.row().unwrap();
+                let count = row.get::<&Value>(0).unwrap();
+                assert_eq!(*count, Value::Integer(3));
+            }
+            StepResult::IO => stmt2.run_once()?,
+            StepResult::Done => break,
+            r => panic!("Unexpected step result: {r:?}"),
+        }
+    }
+
+    // Commit the transaction
+    conn1.execute("COMMIT")?;
+
+    // Verify all changes are committed
+    let mut stmt3 = conn1.prepare("SELECT COUNT(*) FROM t")?;
+    loop {
+        match stmt3.step()? {
+            StepResult::Row => {
+                let row = stmt3.row().unwrap();
+                let count = row.get::<&Value>(0).unwrap();
+                assert_eq!(*count, Value::Integer(3));
+            }
+            StepResult::IO => stmt3.run_once()?,
+            StepResult::Done => break,
+            r => panic!("Unexpected step result: {r:?}"),
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
When the SchemaUpdated error occurs during statement execution, don't roll back the transaction, but instead re-prepare the statement.

Spotted by Whopper.