### PR TITLE
feat(hash-join): add hash matching for equivalent integer and real values

### DIFF
--- a/core/vdbe/bloom_filter.rs
+++ b/core/vdbe/bloom_filter.rs
@@ -72,35 +72,24 @@ impl BloomFilter {
     /// Inserts a Value into the bloom filter.
     /// Safety NOTE: does not accept NULL values.
     pub fn insert_value(&mut self, value: &Value) {
-        match value {
-            Value::Integer(i) => {
-                self.inner.insert(i);
-            }
-            Value::Float(f) => {
-                self.inner.insert(&f.to_bits());
-            }
-            Value::Text(s) => {
-                self.inner.insert(&s.as_str().as_bytes());
-            }
-            Value::Blob(b) => {
-                self.inner.insert(&b.as_slice());
-            }
-            Value::Null => {
-                // we do not insert NULLs into
-            }
+        if !matches!(value, Value::Null) {
+            let mut hasher = rapidhash::fast::RapidHasher::default();
+            hash_value(&mut hasher, &value.as_ref());
+            let hash = hasher.finish();
+            self.inner.insert(&hash);
         }
         self.count += 1;
     }
 
     /// Checks if a Value might be in the bloom filter.
     pub fn contains_value(&self, value: &Value) -> bool {
-        match value {
-            Value::Integer(i) => self.inner.contains(i),
-            Value::Float(f) => self.inner.contains(&f.to_bits()),
-            Value::Text(s) => self.inner.contains(&s.as_str().as_bytes()),
-            Value::Blob(b) => self.inner.contains(&b.as_slice()),
-            Value::Null => false,
+        if matches!(value, Value::Null) {
+            return false;
         }
+        let mut hasher = rapidhash::fast::RapidHasher::default();
+        hash_value(&mut hasher, &value.as_ref());
+        let hash = hasher.finish();
+        self.inner.contains(&hash)
     }
 
     /// Inserts multiple owned Values as a composite key into the bloom filter.
@@ -154,12 +143,19 @@ fn hash_value<H: Hasher>(hasher: &mut H, value: &ValueRef) {
         // do nothing for NULLs as we will always return false for set membership
         ValueRef::Null => {}
         ValueRef::Integer(i) => {
-            1u8.hash(hasher);
-            i.hash(hasher);
+            // Hash integers in the same bucket as numerically equivalent REALs so
+            // bloom-filter membership can never return a false-negative for e.g. 10 vs 10.0.
+            let f = *i as f64;
+            if (f as i64) == *i && f.is_finite() {
+                hash_numeric(hasher, f);
+            } else {
+                // Fallback to the integer domain when the float representation would lose precision.
+                1u8.hash(hasher);
+                i.hash(hasher);
+            }
         }
         ValueRef::Float(f) => {
-            2u8.hash(hasher);
-            f.to_bits().hash(hasher);
+            hash_numeric(hasher, *f);
         }
         ValueRef::Text(s) => {
             3u8.hash(hasher);
@@ -169,6 +165,25 @@ fn hash_value<H: Hasher>(hasher: &mut H, value: &ValueRef) {
             4u8.hash(hasher);
             b.hash(hasher);
         }
+    }
+}
+
+/// Hashes numeric values (both INTEGER and REAL) into the same domain to mirror SQLite's
+/// numeric comparison semantics (e.g. 10 == 10.0, -0.0 == 0.0).
+fn hash_numeric<H: Hasher>(hasher: &mut H, f: f64) {
+    const NUMERIC_TAG: u8 = 2;
+    let bits = normalized_f64_bits(f);
+    NUMERIC_TAG.hash(hasher);
+    bits.hash(hasher);
+}
+
+/// Normalize signed zero so 0.0 and -0.0 hash the same.
+#[inline]
+fn normalized_f64_bits(f: f64) -> u64 {
+    if f == 0.0 {
+        0.0f64.to_bits()
+    } else {
+        f.to_bits()
     }
 }
 
@@ -204,7 +219,8 @@ mod bloomtests {
 
         assert!(bf.contains_value(&int_val));
         assert!(bf.contains_value(&text_val));
-        assert!(bf.contains_value(&null_val));
+        // NULLs are not hashed into the filter, so membership should be false.
+        assert!(!bf.contains_value(&null_val));
     }
 
     #[test]
@@ -229,5 +245,32 @@ mod bloomtests {
         // False positive rate should be around 1% (allow some variance)
         let rate = false_positives as f64 / test_count as f64;
         assert!(rate < 0.05, "False positive rate {rate} is too high");
+    }
+
+    #[test]
+    fn test_bloom_filter_numeric_equivalence() {
+        let mut bf = BloomFilter::new();
+
+        // Zero variants should all be found regardless of sign or int/float representation
+        let zero_float = Value::Float(0.0);
+        let zero_neg_float = Value::Float(-0.0);
+        let zero_int = Value::Integer(0);
+        bf.insert_value(&zero_float);
+        assert!(bf.contains_value(&zero_float));
+        assert!(bf.contains_value(&zero_neg_float));
+        assert!(bf.contains_value(&zero_int));
+
+        // Integer/float representations of the same numeric value should match
+        let ten_int = Value::Integer(10);
+        let ten_float = Value::Float(10.0);
+        bf.insert_value(&ten_int);
+        assert!(bf.contains_value(&ten_int));
+        assert!(bf.contains_value(&ten_float));
+
+        let neg_ten_float = Value::Float(-10.0);
+        let neg_ten_int = Value::Integer(-10);
+        bf.insert_value(&neg_ten_float);
+        assert!(bf.contains_value(&neg_ten_float));
+        assert!(bf.contains_value(&neg_ten_int));
     }
 }

--- a/testing/join.test
+++ b/testing/join.test
@@ -517,3 +517,62 @@ do_execsql_test_on_specific_db {:memory:} four-way-left-joins-null-keys {
    order by t.a;
 } {1|t1|t1||w1
 2||||}
+
+do_execsql_test_on_specific_db {:memory:} left-join-integer-real {
+  CREATE TABLE IF NOT EXISTS t1 (a INTEGER, b INTEGER);
+  CREATE TABLE IF NOT EXISTS t2 (a INTEGER, c REAL);
+  INSERT INTO t1 (a, b) VALUES (1, NULL), (2, 10);
+  INSERT INTO t2 (a, c) VALUES (1, 10.0), (3, NULL);
+  SELECT * FROM t1 LEFT JOIN t2 ON t1.b = t2.c;
+} {1|||
+2|10|1|10.0}
+
+do_execsql_test_on_specific_db {:memory:} left-join-real-integer {
+  CREATE TABLE IF NOT EXISTS t3 (a INTEGER, b REAL);
+  CREATE TABLE IF NOT EXISTS t4 (a INTEGER, c INTEGER);
+  INSERT INTO t3 (a, b) VALUES (1, NULL), (2, 10.0);
+  INSERT INTO t4 (a, c) VALUES (1, 10), (3, NULL);
+  SELECT * FROM t3 LEFT JOIN t4 ON t3.b = t4.c;
+} {1|||
+2|10.0|1|10}
+
+do_execsql_test_on_specific_db {:memory:} inner-join-integer-real {
+  CREATE TABLE IF NOT EXISTS t5 (a INTEGER, b INTEGER);
+  CREATE TABLE IF NOT EXISTS t6 (a INTEGER, c REAL);
+  INSERT INTO t5 (a, b) VALUES (1, 5), (2, 10), (3, 15);
+  INSERT INTO t6 (a, c) VALUES (1, 10.0), (2, 20.0), (3, 5.0);
+  SELECT t5.a, t5.b, t6.a, t6.c FROM t5 INNER JOIN t6 ON t5.b = t6.c ORDER BY t5.a;
+} {1|5|3|5.0
+2|10|1|10.0}
+
+do_execsql_test_on_specific_db {:memory:} left-join-integer-real-zero {
+  CREATE TABLE IF NOT EXISTS t7 (a INTEGER, b INTEGER);
+  CREATE TABLE IF NOT EXISTS t8 (a INTEGER, c REAL);
+  INSERT INTO t7 (a, b) VALUES (1, 0);
+  INSERT INTO t8 (a, c) VALUES (1, 0.0);
+  SELECT * FROM t7 LEFT JOIN t8 ON t7.b = t8.c;
+} {1|0|1|0.0}
+
+do_execsql_test_on_specific_db {:memory:} left-join-integer-real-negative {
+  CREATE TABLE IF NOT EXISTS t9 (a INTEGER, b INTEGER);
+  CREATE TABLE IF NOT EXISTS t10 (a INTEGER, c REAL);
+  INSERT INTO t9 (a, b) VALUES (1, -10);
+  INSERT INTO t10 (a, c) VALUES (1, -10.0);
+  SELECT * FROM t9 LEFT JOIN t10 ON t9.b = t10.c;
+} {1|-10|1|-10.0}
+
+do_execsql_test_on_specific_db {:memory:} left-join-integer-real-no-match {
+  CREATE TABLE IF NOT EXISTS t11 (a INTEGER, b INTEGER);
+  CREATE TABLE IF NOT EXISTS t12 (a INTEGER, c REAL);
+  INSERT INTO t11 (a, b) VALUES (1, 10);
+  INSERT INTO t12 (a, c) VALUES (1, 10.5);
+  SELECT * FROM t11 LEFT JOIN t12 ON t11.b = t12.c;
+} {1|10||}
+
+do_execsql_test_on_specific_db {:memory:} left-join-integer-real-multi-key {
+  CREATE TABLE IF NOT EXISTS t13 (a INTEGER, b INTEGER, c INTEGER);
+  CREATE TABLE IF NOT EXISTS t14 (a INTEGER, b REAL, c REAL);
+  INSERT INTO t13 (a, b, c) VALUES (1, 10, 20);
+  INSERT INTO t14 (a, b, c) VALUES (1, 10.0, 20.0);
+  SELECT * FROM t13 LEFT JOIN t14 ON t13.b = t14.b AND t13.c = t14.c;
+} {1|10|20|1|10.0|20.0}


### PR DESCRIPTION
## Description

This PR adds hash matching for equivalent integer and real values in hash joins. This is achieved by ensuring that integer/real equivalents (including signed zeros) share the same hash in internal bloom filters and hash tables.

```
turso> CREATE TABLE IF NOT EXISTS t1 (a INTEGER, b INTEGER);
CREATE TABLE IF NOT EXISTS t2 (a INTEGER, c REAL);
INSERT INTO t1 (a, b) VALUES (1, NULL), (2, 10);
INSERT INTO t2 (a, c) VALUES (1, 10.0), (3, NULL);
SELECT * FROM t1 LEFT JOIN t2 ON t1.b = t2.c;
┌───┬────┬───┬──────┐
│ a │ b  │ a │ c    │
├───┼────┼───┼──────┤
│ 1 │    │   │      │
├───┼────┼───┼──────┤
│ 2 │ 10 │ 1 │ 10.0 │
└───┴────┴───┴──────┘
```

## Motivation and context

This change fixes the `LEFT JOIN` mismatch reported in #4147, where joins on numerically equal `INTEGER` and `REAL` values failed in Turso but succeeded in SQLite:

```
turso> CREATE TABLE IF NOT EXISTS t1 (a INTEGER, b INTEGER);
CREATE TABLE IF NOT EXISTS t2 (a INTEGER, c REAL);
INSERT INTO t1 (a, b) VALUES (1, NULL), (2, 10);
INSERT INTO t2 (a, c) VALUES (1, 10.0), (3, NULL);
SELECT * FROM t1 LEFT JOIN t2 ON t1.b = t2.c;
┌───┬────┬───┬───┐
│ a │ b  │ a │ c │
├───┼────┼───┼───┤
│ 1 │    │   │   │
├───┼────┼───┼───┤
│ 2 │ 10 │   │   │
└───┴────┴───┴───┘
```

```
sqlite> CREATE TABLE IF NOT EXISTS t1 (a INTEGER, b INTEGER);
sqlite> CREATE TABLE IF NOT EXISTS t2 (a INTEGER, c REAL);
sqlite> INSERT INTO t1 (a, b) VALUES (1, NULL), (2, 10);
sqlite> INSERT INTO t2 (a, c) VALUES (1, 10.0), (3, NULL);
sqlite> SELECT * FROM t1 LEFT JOIN t2 ON t1.b = t2.c;
1|||
2|10|1|10.0
```

Fixes #4147.

## Description of AI Usage

This PR was developed with assistance from GPT-5.1 Codex Max. The AI helped analyze the hash join–related codebase (including bloom filters and hash table implementations), identify the root cause of the issue, and assist in writing the tests.