### PR TITLE
stress: Make random seed configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,15 +106,6 @@ dependencies = [
 
 [[package]]
 name = "anarchist-readable-name-generator-lib"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a1e15a87b13ae79e04e07b3714fc41d5f6993dff11662fdbe0b207c6ad0fe0"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
-name = "anarchist-readable-name-generator-lib"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a645c34bad5551ed4b2496536985efdc4373b097c0e57abf2eb14774538278"
@@ -4331,7 +4322,7 @@ checksum = "d372029cb5195f9ab4e4b9aef550787dce78b124fcaee8d82519925defcd6f0d"
 name = "sql_generation"
 version = "0.4.0-pre.16"
 dependencies = [
- "anarchist-readable-name-generator-lib 0.2.0",
+ "anarchist-readable-name-generator-lib",
  "anyhow",
  "garde",
  "hex",
@@ -5185,10 +5176,10 @@ dependencies = [
 name = "turso_stress"
 version = "0.4.0-pre.16"
 dependencies = [
- "anarchist-readable-name-generator-lib 0.1.2",
  "antithesis_sdk",
  "clap",
  "hex",
+ "rand 0.9.2",
  "rusqlite",
  "tempfile",
  "tokio",

--- a/scripts/run-until-fail.sh
+++ b/scripts/run-until-fail.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -u
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <command> [args...]" >&2
+  exit 1
+fi
+
+# Run the given command repeatedly until it exits with non‑zero status.
+while "$@"; do
+  :
+done
+
+echo "Command failed with exit code $?; stopping."

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -16,13 +16,13 @@ path = "main.rs"
 
 [features]
 default = []
-antithesis = ["turso/antithesis", "antithesis_sdk/full"]
+antithesis = ["turso/antithesis", "dep:antithesis_sdk", "antithesis_sdk?/full"]
 
 [dependencies]
-anarchist-readable-name-generator-lib = "0.1.0"
-antithesis_sdk = { workspace = true }
+antithesis_sdk = { workspace = true, optional = true }
 clap = { workspace = true, features = ["derive"] }
 hex = { workspace = true }
+rand = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/stress/opts.rs
+++ b/stress/opts.rs
@@ -74,6 +74,10 @@ pub struct Opts {
         default_value_t = 5000
     )]
     pub busy_timeout: u64,
+
+    /// Random seed for reproducibility
+    #[clap(long, help = "Random seed for reproducibility")]
+    pub seed: Option<u64>,
 }
 
 const fn normal_or_miri<T: Copy>(normal_val: T, miri_val: T) -> T {


### PR DESCRIPTION
When we're not running under Antithesis, allow the user to specify a seed for random number generation, which impacts the SQL operations we do. Although not deterministic, this makes reproducing some issues easier.

Also, add a "scripts/run-until-fail.sh", which you can use to discover interesting seeds. For example, you can run

```
./scripts/run-until-fail.sh cargo run -p turso_stress -- -t1
```

to find a bug and then just copy-paste the reported seed to attempt to reproduce it.