### PR TITLE
fix/pager: mark freelist trunk page dirty BEFORE modifying it

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2654,6 +2654,9 @@ impl Pager {
                         );
                     }
 
+                    // Mark trunk page dirty BEFORE modifying it so subjournal captures original content
+                    self.add_dirty(trunk_page)?;
+
                     // Shift left all the other leaf pages in the trunk page and subtract 1 from the leaf count
                     let remaining_leaves_count = (*number_of_freelist_leaves - 1) as usize;
                     {
@@ -2674,7 +2677,6 @@ impl Pager {
                         FREELIST_TRUNK_OFFSET_LEAF_COUNT,
                         remaining_leaves_count as u32,
                     );
-                    self.add_dirty(trunk_page)?;
 
                     header.freelist_pages = (header.freelist_pages.get() - 1).into();
                     let leaf_page = leaf_page.clone();


### PR DESCRIPTION
## Background

Marking a page as dirty snapshots the page into the subjournal, so that if the statement rolls back, the page can be restored to the form that it was before modifications.

## Problem

In AllocatePageState::ReuseFreelistLeaf, we were marking a freelist trunk page as dirty AFTER modifying it, which meant that restoring the page would still contain the modified contents.

This manifested in antithesis runs / stress tests as an orphaned page, as the "reused" page was removed from the freelist trunk page bookkeeping, but never actually taken into use (because the statement failed).

## Fix

Mark dirty before modification.

## Description of AI Usage

According to @penberg, Claude found the issue. I was then consulted to see whether the fix makes sense, and it makes complete sense, so ship it.

## Notes

I want to investigate a solution where we can enforce at compile time that non-dirty pages cannot be mutated.