### PR TITLE
Fix more instances of marking pages dirty after modification

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2602,6 +2602,7 @@ impl BTreeCursor {
             0,
             BtreePageAllocMode::Any
         ));
+        self.pager.add_dirty(&new_rightmost_leaf)?;
 
         let usable_space = self.usable_space();
         let old_rightmost_leaf = self.stack.top_ref();
@@ -2616,6 +2617,7 @@ impl BTreeCursor {
             .stack
             .get_page_at_level(self.stack.current() - 1)
             .expect("parent page should be on the stack");
+        self.pager.add_dirty(parent)?;
         let parent_contents = parent.get_contents();
         let rightmost_pointer = parent_contents
             .rightmost_pointer()
@@ -2658,8 +2660,6 @@ impl BTreeCursor {
             usable_space,
         )?;
         parent_contents.write_rightmost_ptr(new_rightmost_leaf.get().id as u32);
-        self.pager.add_dirty(parent)?;
-        self.pager.add_dirty(&new_rightmost_leaf)?;
 
         // Continue balance from the parent page (inserting the new divider cell may have overflowed the parent)
         self.stack.pop();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1130,6 +1130,7 @@ impl Pager {
                     offset_in_ptrmap_page,
                 } => {
                     turso_assert!(ptrmap_page.is_loaded(), "page should be loaded");
+                    self.add_dirty(&ptrmap_page)?;
                     let ptrmap_page_inner = ptrmap_page.get();
                     let ptrmap_pg_no = ptrmap_page_inner.id;
 
@@ -1167,7 +1168,6 @@ impl Pager {
                         ptrmap_page.get().id == ptrmap_pg_no,
                         "ptrmap page has unexpected number"
                     );
-                    self.add_dirty(&ptrmap_page)?;
                     self.vacuum_state.write().ptrmap_put_state = PtrMapPutState::Start;
                     break Ok(IOResult::Done(()));
                 }


### PR DESCRIPTION
Follow-up to #4231. Similar reasoning - very dangerous and nasty stuff.

I'm working on a branch that enforces that mutable access MUST be preceded by a call to add_dirty(), and found these instances during its development.