### PR TITLE
add rust-analyzer component to toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.88.0"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
## Description
Use correct version for Rust Analyzer
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
I keep getting this error message on my editor. 

`limbo/Cargo.toml` is using an outdated toolchain version `1.88.0` but rust-analyzer only supports `1.90.0` and higher. Consider using the rust-analyzer rustup component for your toolchain or upgrade your toolchain to a supported version`
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage
None
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
