### PR TITLE
fix bug in the sync engine wasm implementation

### DIFF
--- a/bindings/javascript/sync/packages/wasm/promise-default.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-default.ts
@@ -92,7 +92,7 @@ class Database extends DatabasePromise {
         const memory = db.memory;
         const io = memory ? memoryIO() : BrowserIO;
         const run = runner(runOpts, io, engine);
-        super(engine.db() as unknown as any, () => run.wait());
+        super(db, () => run.wait());
 
         this.#runner = run;
         this.#engine = engine;


### PR DESCRIPTION
- We do unnecessary clone of the underlying DB object which we will never be able to close explicitly
- For language with GC this means that user has no control over object lifetime