### PR TITLE
docs: update clippy command in CONTRIBUTING.md to match CI job

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ Fork the repository and open a pull request to submit your work.
 
 The CI checks for formatting, Clippy warnings, and test failures so remember to run the following before submitting your pull request:
 
-* `cargo fmt` and `cargo clippy` to keep the code formatting in check.
+* `cargo fmt` and `cargo clippy --workspace --all-features --all-targets -- --deny=warnings` to keep the code formatting in check.
 * `make` to run the test suite.
 
 **Keep your pull requests focused and as small as possible, but not smaller.** IOW, when preparing a pull request, ensure it focuses on a single thing and that your commits align with that. For example, a good pull request might fix a specific bug or a group of related bugs. Or a good pull request might add a new feature and test for it. Conversely, a bad pull request might fix a bug, add a new feature, and refactor some code.


### PR DESCRIPTION
## Description

Update clippy command in CONTRIBUTING.md to match the command used in the CI job.

## Motivation and context

The current contributing guidelines instruct developers to run `cargo clippy` before submitting a PR. However, the CI pipeline runs `cargo clippy --workspace --all-features --all-targets -- --deny=warnings`. This mismatch can cause CI failures even when contributors have followed the documented instructions prior to opening a PR.

> The CI checks for formatting, Clippy warnings, and test failures so remember to run the following before submitting your pull request:
> - `cargo fmt` and `cargo clippy` to keep the code formatting in check.
> - `make` to run the test suite.

## Description of AI Usage

None.
