### PR TITLE
update go mod name as we will serve module through custom proxy

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/tursodatabase/turso/bindings/go
+module turso.tech/database/tursogo
 
 go 1.24.0
 


### PR DESCRIPTION
`go get turso.tech/database/tursogo`

Depends on internal PR: https://github.com/tursodatabase/frontend/pull/2275