### PR TITLE
fix(core): prevent ALTER COLUMN from resulting in tables with only generated columns

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -2284,6 +2284,7 @@ mod tests {
                         Some("id".to_string()),
                         "INTEGER".to_string(),
                         None,
+                        None,
                         Type::Integer,
                         None,
                         ColDef {
@@ -2327,6 +2328,7 @@ mod tests {
                         Some("product_id".to_string()),
                         "INTEGER".to_string(),
                         None,
+                        None,
                         Type::Integer,
                         None,
                         ColDef {
@@ -2369,6 +2371,7 @@ mod tests {
                     SchemaColumn::new(
                         Some("order_id".to_string()),
                         "INTEGER".to_string(),
+                        None,
                         None,
                         Type::Integer,
                         None,
@@ -2415,6 +2418,7 @@ mod tests {
                         Some("id".to_string()),
                         "INTEGER".to_string(),
                         None,
+                        None,
                         Type::Integer,
                         None,
                         ColDef {
@@ -2449,6 +2453,7 @@ mod tests {
                     SchemaColumn::new(
                         Some("id".to_string()),
                         "INTEGER".to_string(),
+                        None,
                         None,
                         Type::Integer,
                         None,
@@ -2494,6 +2499,7 @@ mod tests {
                     SchemaColumn::new(
                         Some("id".to_string()),
                         "INTEGER".to_string(),
+                        None,
                         None,
                         Type::Integer,
                         None,

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -1415,6 +1415,7 @@ mod tests {
                     Some("id".to_string()),
                     "INTEGER".to_string(),
                     None,
+                    None,
                     Type::Integer,
                     None,
                     ColDef {
@@ -1444,6 +1445,7 @@ mod tests {
                     Some("id".to_string()),
                     "INTEGER".to_string(),
                     None,
+                    None,
                     Type::Integer,
                     None,
                     ColDef {
@@ -1457,6 +1459,7 @@ mod tests {
                 SchemaColumn::new(
                     Some("customer_id".to_string()),
                     "INTEGER".to_string(),
+                    None,
                     None,
                     Type::Integer,
                     None,
@@ -1485,6 +1488,7 @@ mod tests {
                     Some("id".to_string()),
                     "INTEGER".to_string(),
                     None,
+                    None,
                     Type::Integer,
                     None,
                     ColDef {
@@ -1499,6 +1503,7 @@ mod tests {
                 SchemaColumn::new(
                     Some("price".to_string()),
                     "REAL".to_string(),
+                    None,
                     None,
                     Type::Real,
                     None,
@@ -1521,6 +1526,7 @@ mod tests {
                 SchemaColumn::new(
                     Some("message".to_string()),
                     "TEXT".to_string(),
+                    None,
                     None,
                     Type::Text,
                     None,

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -362,6 +362,7 @@ mod tests {
                 Some("foo".to_string()),
                 "text".to_string(),
                 None,
+                None,
                 Type::Text,
                 collation,
                 ColDef::default(),
@@ -416,6 +417,7 @@ mod tests {
                     Some("a".to_string()),
                     "text".to_string(),
                     None,
+                    None,
                     Type::Text,
                     left,
                     ColDef::default(),
@@ -447,6 +449,7 @@ mod tests {
                 columns: vec![Column::new(
                     Some("b".to_string()),
                     "text".to_string(),
+                    None,
                     None,
                     Type::Text,
                     right,
@@ -486,6 +489,7 @@ mod tests {
                 columns: vec![Column::new(
                     Some("id".to_string()),
                     "INTEGER".to_string(),
+                    None,
                     None,
                     Type::Integer,
                     collation,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1445,6 +1445,7 @@ pub const ROWID_COLUMN: Column = Column::new(
     None,          // name
     String::new(), // type string
     None,          // default
+    None,          // generated
     schema::Type::Integer,
     None,
     ColDef {

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -2395,6 +2395,7 @@ mod tests {
                     Some("id".to_string()),
                     "INTEGER".to_string(),
                     None,
+                    None,
                     Type::Integer,
                     None,
                     ColDef {
@@ -2431,6 +2432,7 @@ mod tests {
                     Some("id".to_string()),
                     "INTEGER".to_string(),
                     None,
+                    None,
                     Type::Integer,
                     None,
                     ColDef {
@@ -2453,6 +2455,7 @@ mod tests {
                 SchemaColumn::new(
                     Some("amount".to_string()),
                     "REAL".to_string(),
+                    None,
                     None,
                     Type::Real,
                     None,
@@ -2479,6 +2482,7 @@ mod tests {
                     Some("id".to_string()),
                     "INTEGER".to_string(),
                     None,
+                    None,
                     Type::Integer,
                     None,
                     ColDef {
@@ -2492,6 +2496,7 @@ mod tests {
                 SchemaColumn::new(
                     Some("price".to_string()),
                     "REAL".to_string(),
+                    None,
                     None,
                     Type::Real,
                     None,

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -2248,6 +2248,7 @@ mod tests {
             Some(c.name.clone()),
             c.ty.to_string(),
             None,
+            None,
             c.ty,
             None,
             ColDef {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1068,6 +1068,7 @@ impl JoinedTable {
                     rc.name(&plan.table_references).map(String::from),
                     "BLOB".to_string(),
                     None,
+                    None,
                     Type::Blob, // FIXME: infer proper type
                     None,
                     ColDef::default(),

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -837,6 +837,7 @@ pub fn translate_drop_table(
                 Some("rowid".to_string()),
                 "INTEGER".to_string(),
                 None,
+                None,
                 Type::Integer,
                 None,
                 ColDef::default(),

--- a/core/util.rs
+++ b/core/util.rs
@@ -1399,6 +1399,7 @@ pub fn extract_view_columns(
                                         Some(final_name),
                                         table_column.ty_str.clone(),
                                         None,
+                                        None,
                                         table_column.ty(),
                                         table_column.collation_opt(),
                                         ColDef::default(),
@@ -1444,6 +1445,7 @@ pub fn extract_view_columns(
                                     column: Column::new(
                                         Some(final_name),
                                         table_column.ty_str.clone(),
+                                        None,
                                         None,
                                         table_column.ty(),
                                         table_column.collation_opt(),

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -105,4 +105,6 @@ pub enum Error {
     // Custom error message
     #[error("{0}")]
     Custom(String),
+    #[error("Parse error: {0}")]
+    ParseError(String),
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -2905,7 +2905,7 @@ impl<'a> Parser<'a> {
 
                 // larger than or equal columns len means we have only generated columns
                 if generated_count >= columns.len() {
-                    return Err(Error::Custom(
+                    return Err(Error::ParseError(
                         "must have at least one non-generated column".to_owned(),
                     ));
                 }

--- a/testing/alter_column.test
+++ b/testing/alter_column.test
@@ -307,6 +307,29 @@ do_execsql_test_in_memory_error_content alter-table-add-generated-column-error {
     "Parse error: Alter table does not support adding generated columns"
 }
 
+do_execsql_test_in_memory_error_content alter-column-only-to-generated-error {
+    CREATE TABLE t(a);
+    ALTER TABLE t ALTER COLUMN a TO b AS (123);
+} {
+    "Parse error: must have at least one non-generated column"
+}
+
+do_execsql_test_in_memory_error_content alter-column-all-to-generated-error {
+    CREATE TABLE t(a, b);
+    ALTER TABLE t ALTER COLUMN a TO c AS (123);
+    ALTER TABLE t ALTER COLUMN b TO d AS (123);
+} {
+    "Parse error: must have at least one non-generated column"
+}
+
+do_execsql_test_on_specific_db {:memory:} alter-column-to-generated-with-other-columns {
+    CREATE TABLE t(a, b);
+    ALTER TABLE t ALTER COLUMN a TO c AS (123);
+    SELECT sql FROM sqlite_schema WHERE name = 't';
+} {
+    "CREATE TABLE t (c AS (123), b)"
+}
+
 # Add column with a foreign key reference and verify schema SQL
 do_execsql_test_on_specific_db {:memory:} alter-table-add-column-with-fk-updates-schema {
     CREATE TABLE t(a);

--- a/testing/create_table.test
+++ b/testing/create_table.test
@@ -115,3 +115,7 @@ do_execsql_test_on_specific_db {:memory:} col-default-false {
   insert into t (id) values (1);
   SELECT a from t;
 } {0}
+
+do_execsql_test_in_memory_any_error create-table-only-generated-column-error {
+    CREATE TABLE t(a AS (123));
+}


### PR DESCRIPTION
## Description

This PR prevents `ALTER COLUMN` from resulting in tables with only generated columns. Currently, Turso only applies this rule in `CREATE TABLE` but not in `ALTER COLUMN`.

Expected behavior:
```
turso> CREATE TABLE t1(a as (123));
  × Parse error: must have at least one non-generated column

turso> CREATE TABLE t2(a);
turso> ALTER TABLE t2 ALTER COLUMN a TO b AS (123);
  × Parse error: must have at least one non-generated column

turso> CREATE TABLE t3(a, b);
turso> ALTER TABLE t3 ALTER COLUMN a TO c AS (123);
turso> ALTER TABLE t3 ALTER COLUMN b TO d AS (123);
  × Parse error: must have at least one non-generated column
```

## Motivation and context

Fixes #3653.

Currently, Turso does not restrict tables from having only generated columns when using `ALTER COLUMN`:
```
turso> create table t(a);
turso> alter table t alter column a to b as (123);
turso> select * from sqlite_schema;
┌───────┬──────┬──────────┬──────────┬─────────────────────────────┐
│ type  │ name │ tbl_name │ rootpage │ sql                         │
├───────┼──────┼──────────┼──────────┼─────────────────────────────┤
│ table │ t    │ t        │        2 │ CREATE TABLE t (b AS (123)) │
└───────┴──────┴──────────┴──────────┴─────────────────────────────┘
```

## Description of AI Usage

This PR was developed with assistance from Claude Sonnet 4.5. The AI helped identify the root cause and assisted in debugging issues in my initial implementation.
