### PR TITLE
core/mvcc/logical_log: off by one error reading logical log encrypted

### DIFF
--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -322,7 +322,7 @@ impl StreamingLogicalLogReader {
             header.salt = u64::from_be_bytes([
                 buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8],
             ]);
-            header.encrypted = buf[10];
+            header.encrypted = buf[9];
             tracing::trace!("LogicalLog header={:?}", header);
         });
         let c = Completion::new_read(header_buf, completion);
@@ -358,7 +358,7 @@ impl StreamingLogicalLogReader {
                     transaction_read_bytes,
                 } => {
                     if transaction_read_bytes > transaction_size as usize {
-                        return Err(LimboError::Corrupt(format!("streaming log read more bytes than expected from a transaction expected={transaction_size} read={transaction_size}")));
+                        return Err(LimboError::Corrupt(format!("streaming log read more bytes than expected from a transaction expected={transaction_size} read={transaction_read_bytes}")));
                     } else if transaction_size as usize == transaction_read_bytes {
                         // TODO: offset verification
                         let _offset_after = self.consume_u64(io)?;


### PR DESCRIPTION
## Description
buf[10] was off by one as the correct one is buf[9]

## Motivation and context




## Description of AI Usage

claude found this issue so I just patched it
