### PR TITLE
fix stack overflow in long unary expressions

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -4804,10 +4804,7 @@ mod tests {
                             distinctness: None,
                             columns: vec![ResultColumn::Expr(
                                 Box::new(Expr::Binary(
-                                    Box::new(Expr::Unary(
-                                        UnaryOperator::Positive,
-                                        Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
-                                    )),
+                                    Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
                                     Operator::Add,
                                     Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
                                 )),
@@ -11630,6 +11627,76 @@ mod tests {
                         options: TableOptions::NONE,
                     },
                 })],
+            ),
+            // issue 4197
+            (
+                b"SELECT +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++123;".as_slice(),
+                vec![Cmd::Stmt(Stmt::Select(Select {
+                    with: None,
+                    body: SelectBody {
+                        select: OneSelect::Select {
+                            distinctness: None,
+                            columns: vec![ResultColumn::Expr(
+                              Box::new(Expr::Literal(Literal::Numeric("123".to_owned()))),
+                              None,
+                            )],
+                            from: None,
+                            where_clause: None,
+                            group_by: None,
+                            window_clause: vec![],
+                        },
+                        compounds: vec![],
+                    },
+                    order_by: vec![],
+                    limit: None,
+                }))],
+            ),
+            (
+                b"SELECT - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -123;".as_slice(),
+                vec![Cmd::Stmt(Stmt::Select(Select {
+                    with: None,
+                    body: SelectBody {
+                        select: OneSelect::Select {
+                            distinctness: None,
+                            columns: vec![ResultColumn::Expr(
+                              Box::new(Expr::Literal(Literal::Numeric("123".to_owned()))),
+                              None,
+                            )],
+                            from: None,
+                            where_clause: None,
+                            group_by: None,
+                            window_clause: vec![],
+                        },
+                        compounds: vec![],
+                    },
+                    order_by: vec![],
+                    limit: None,
+                }))],
+            ),
+            (
+                b"SELECT +++++++++++++++++++++++++++++++++++++++++++++++++++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-123;".as_slice(),
+                vec![Cmd::Stmt(Stmt::Select(Select {
+                    with: None,
+                    body: SelectBody {
+                        select: OneSelect::Select {
+                            distinctness: None,
+                            columns: vec![ResultColumn::Expr(
+                              Box::new(Expr::Unary(
+                                  UnaryOperator::Negative,
+                                  Box::new(Expr::Literal(Literal::Numeric("123".to_owned()))),
+                              )),
+                              None,
+                            )],
+                            from: None,
+                            where_clause: None,
+                            group_by: None,
+                            window_clause: vec![],
+                        },
+                        compounds: vec![],
+                    },
+                    order_by: vec![],
+                    limit: None,
+                }))],
             ),
             (
                 b"CREATE INDEX t_idx ON t USING custom_index (x) WITH (a = 1, b = 'test', c = x'deadbeef', d = NULL)".as_slice(),

--- a/testing/select.test
+++ b/testing/select.test
@@ -43,6 +43,18 @@ do_execsql_test select-blob-emoji {
   SELECT x'F09FA680';
 } {🦀}
 
+do_execsql_test select-long-unary-expr-1 {
+    select +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++123;
+} {123}
+
+do_execsql_test select-long-unary-expr-2 {
+    select - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -123;
+} {123}
+
+do_execsql_test select-long-unary-expr-3 {
+    select +++++++++++++++++++++++++++++++++++++++++++++++++++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-123;
+} {-123}
+
 do_execsql_test select-limit-0 {
   SELECT id FROM users LIMIT 0;
 } {}


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->
This PR fixes https://github.com/tursodatabase/turso/issues/4197 by collapsing `+` and `-` operators in unary expressions.

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->
By collapsing `+` and `-` operators in unary expressions, we're able to prevent stack overflow in very long unary expressions. The following queries can be used to test this change:
```sql
select +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++123;

select - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -123;

select +++++++++++++++++++++++++++++++++++++++++++++++++++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+123;
```
All of the queries above crashes with a stack overflow error prior to this fix.

## Description of AI Usage

No AI was used in this PR.
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
