### PR TITLE
implement state machine for `op_journal_mode`

### DIFF
--- a/core/storage/journal_mode.rs
+++ b/core/storage/journal_mode.rs
@@ -1,14 +1,7 @@
 use std::sync::Arc;
 
-use crate::storage::sqlite3_ondisk::DatabaseHeader;
-use crate::storage::wal::CheckpointMode;
-use crate::util::IOExt;
-use crate::vdbe::Program;
-use crate::{mvcc, LimboError, MvStore, OpenFlags, Result, IO};
-use crate::{
-    storage::sqlite3_ondisk::{begin_write_btree_page, RawVersion, Version},
-    Pager,
-};
+use crate::storage::sqlite3_ondisk::Version;
+use crate::{mvcc, MvStore, OpenFlags, Result, IO};
 
 #[derive(
     Debug,
@@ -60,76 +53,6 @@ impl From<Version> for JournalMode {
             Version::Mvcc => Self::ExperimentalMvcc,
         }
     }
-}
-
-// As this is not a performance critical function, I made it synchronous simplify to the code
-// and not have to add an additional state machine
-pub fn change_mode(
-    db_path: impl AsRef<std::path::Path>,
-    program: &Program,
-    pager: &Pager,
-    prev_mode: JournalMode,
-    new_mode: JournalMode,
-) -> Result<JournalMode> {
-    if !new_mode.supported() {
-        return Err(crate::LimboError::ParseError(format!(
-            "Journal Mode `{new_mode}` is not supported"
-        )));
-    }
-
-    if prev_mode == new_mode {
-        return Ok(new_mode);
-    }
-
-    let db_path = db_path.as_ref();
-
-    if matches!(new_mode, JournalMode::ExperimentalMvcc) && !program.connection.db.mvcc_enabled() {
-        return Err(LimboError::InvalidArgument(
-                "MVCC is not enabled. Enable it with `--experimental-mvcc` flag in the CLI or by setting the MVCC option in `DatabaseOpts`".to_string(),
-            ));
-    }
-
-    // Checkpoint the WAL or MVCC
-    program.connection.checkpoint(CheckpointMode::Truncate {
-        upper_bound_inclusive: None,
-    })?;
-
-    let new_version = new_mode
-        .as_version()
-        .expect("Should be a supported Journal Mode");
-    let raw_version = RawVersion::from(new_version);
-
-    // After checkpoint, pager holds the most up-to-date version of the Header for both MVCC and WAL
-    pager.io.block(|| {
-        pager.with_header_mut(|header| {
-            header.read_version = raw_version;
-            header.write_version = raw_version;
-        })
-    })?;
-
-    let (page, c) = pager.read_page(DatabaseHeader::PAGE_ID as i64)?;
-    if let Some(c) = c {
-        pager.io.wait_for_completion(c)?;
-    }
-
-    // Flush it to Disk
-    let completion = begin_write_btree_page(pager, &page)?;
-    pager.io.wait_for_completion(completion)?;
-
-    pager.clear_page_cache(true);
-
-    if matches!(new_mode, JournalMode::ExperimentalMvcc) {
-        let mv_store = open_mv_store(pager.io.as_ref(), db_path)?;
-        program.connection.db.mv_store.store(Some(mv_store.clone()));
-        program.connection.demote_to_mvcc_connection();
-        mv_store.bootstrap(program.connection.clone())?;
-    }
-
-    if matches!(new_mode, JournalMode::Wal) {
-        program.connection.db.mv_store.store(None);
-    }
-
-    Ok(new_mode)
 }
 
 pub fn wal_exists(wal_path: impl AsRef<std::path::Path>) -> bool {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -44,8 +44,8 @@ use crate::{
     vdbe::{
         execute::{
             OpColumnState, OpDeleteState, OpDeleteSubState, OpDestroyState, OpIdxInsertState,
-            OpInsertState, OpInsertSubState, OpNewRowidState, OpNoConflictState, OpProgramState,
-            OpRowIdState, OpSeekState, OpTransactionState,
+            OpInsertState, OpInsertSubState, OpJournalModeState, OpNewRowidState,
+            OpNoConflictState, OpProgramState, OpRowIdState, OpSeekState, OpTransactionState,
         },
         hash_table::HashTable,
         metrics::StatementMetrics,
@@ -375,6 +375,7 @@ pub struct ProgramState {
     op_column_state: OpColumnState,
     op_row_id_state: OpRowIdState,
     op_transaction_state: OpTransactionState,
+    op_journal_mode_state: OpJournalModeState,
     /// State machine for committing view deltas with I/O handling
     view_delta_state: ViewDeltaCommitState,
     /// Marker which tells about auto transaction cleanup necessary for that connection in case of reset
@@ -456,6 +457,7 @@ impl ProgramState {
             op_column_state: OpColumnState::Start,
             op_row_id_state: OpRowIdState::Start,
             op_transaction_state: OpTransactionState::Start,
+            op_journal_mode_state: OpJournalModeState::default(),
             view_delta_state: ViewDeltaCommitState::NotStarted,
             auto_txn_cleanup: TxnCleanup::None,
             fk_deferred_violations_when_stmt_started: AtomicIsize::new(0),


### PR DESCRIPTION
## Description
Remove sync IO hacks for `op_journal_mode`
Close #4268 
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
Remove sync io hacks so it is friendlier for WASM
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage
Ai basically made the bulk refactoring and I made some adjustments and trimmed down the implementation

**Prompt**:

```
if look at @core/storage/journal_mode.rs and `op_journal_mode` in `execute.rs` you will see that we have some blocking io operations with
`pager.io.block` and `program.connection.checkpoint` that also blocks. I want you refactor the code to use state machines similar in nature to how we do it
 in many functions in `execute.rs`
```
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
