### PR TITLE
add readonly checks to ensure we do not change the header

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -9918,6 +9918,11 @@ fn op_journal_mode_inner(
                     return Ok(InsnFunctionStepResult::Step);
                 }
 
+                // Check if database is readonly - cannot change journal mode on readonly databases
+                if program.connection.is_readonly(*db) {
+                    return Err(LimboError::ReadOnly);
+                }
+
                 // Check MVCC enabled if switching to MVCC
                 if matches!(new_mode, journal_mode::JournalMode::ExperimentalMvcc)
                     && !program.connection.db.mvcc_enabled()


### PR DESCRIPTION
## Description
Add some readonly checks in header validation and `pragma journal_mode` . Depends on #4279 being merged first, to avoid conflicts here. 
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
Close #4270
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage
AI again did most of the work here, as it is pretty basic stuff and mostly boilerplate. The main usefullness for AI here was to write the tests to check for these edge cases. 

**Prompt:**

```
I want to Make sure readonly databases cannot modify header page on Database open nor call `pragma journal mode` to update the journal mode. I need you
to implement the necessary checks to ensure we can still continue working normally and emit warnings to show that we cannot change to mvcc. Lastly add
tests in `header_version.rs` to prove your modifications works.
```
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
