### PR TITLE
fix/core: use CAS to protect against concurrent TX state changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4954,6 +4954,7 @@ dependencies = [
  "mimalloc",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
+ "rusqlite",
  "tempfile",
  "thiserror 2.0.16",
  "tokio",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = { workspace = true }
 tracing-subscriber.workspace = true
 tracing.workspace = true
 mimalloc = { workspace = true, optional = true }
+rusqlite.workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2623,6 +2623,16 @@ impl Connection {
         self.transaction_state.get()
     }
 
+    /// Atomically compare and exchange transaction state.
+    /// Returns Ok(current) on success, or Err(actual_value) if the state was modified concurrently.
+    fn atomic_swap_tx_state(
+        &self,
+        current: TransactionState,
+        new: TransactionState,
+    ) -> Result<TransactionState, TransactionState> {
+        self.transaction_state.compare_exchange(current, new)
+    }
+
     pub(crate) fn get_mv_tx_id(&self) -> Option<u64> {
         self.mv_tx.read().map(|(tx_id, _)| tx_id)
     }


### PR DESCRIPTION
## Background

Concurrent use a of a connection across multiple threads is not supported, but we should not crash even if a client attempts to do so.

## Problem

We do crash when this happens. See: https://github.com/tursodatabase/turso/issues/3911

## Fix

The proper behavior is to return Busy if the same connection is already doing transactional work on another thread.

To ensure the above, this PR implements Connection::atomic_swap_tx_state() which uses CAS instead of simply setting the state.

## Testing

This PR also adds a regression test modeled after the reproduction in #3911 that only accepts `"database is locked"` errors and panics on anything else.

Been running this in a loop for a while now.

## Description of AI Usage

Prompt:

```
> This is Turso, the Rust rewrite of SQLite. Sharing connection across threads is not 
supported, but we should still guard against trying to promote conn transaction state with 
atomics.

See test: concurrent_inserts_on_shared_connection

Then see op_transaction_inner in execute.rs:

                // 3. Transaction state should be updated before checking for Schema cookie
 so that the tx is ended properly on error
                if updated {
                    conn.set_tx_state(new_transaction_state);
                }


This should be an atomic modification where we expect the current state to still be what we
 think it is, and if not, we get Busy
```
