### PR TITLE
Use u64::from instead of .into()

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -237,9 +237,9 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             // We need the `self.checkpointed_txid_max_old.is_none()` check as we may have not checkpointed yet,
             // and without this check, recovered rows could skipped accidently
             let is_uncheckpointed_insert = end_ts.is_none()
-                && self
-                    .checkpointed_txid_max_old
-                    .is_none_or(|txid_max_old| begin_ts.is_some_and(|b| b > u64::from(txid_max_old)));
+                && self.checkpointed_txid_max_old.is_none_or(|txid_max_old| {
+                    begin_ts.is_some_and(|b| b > u64::from(txid_max_old))
+                });
             // - It is a delete, AND some version of the row exists in the database file.
             let is_delete_and_exists_in_db_file = end_ts.is_some() && exists_in_db_file;
             let should_checkpoint = is_uncheckpointed_insert || is_delete_and_exists_in_db_file;


### PR DESCRIPTION
## Description
In certain edge cases, Into::into type inference fails and causes library to fail to build in downstream crates

## Motivation and context

See https://github.com/ranile/turso-compile-fail

In this case, patching chrono to work with `ic-cdk` fails compilation of turso. `ic-cdk` adds a dependency on `candid`, which provides some trait implementations that make Into::into type inference break. 

<details><summary>Error message</summary>

```
error[E0283]: type annotations needed
   --> /Users/me/.cargo/git/checkouts/turso-455557cd4a2364c7/2d78b53/core/mvcc/database/checkpoint_state_machine.rs:216:71
    |
216 |                         .is_some_and(|txid_max_old| b <= txid_max_old.into())
    |                                                       --              ^^^^
    |                                                       |
    |                                                       type must be known at this point
    |
    = note: multiple `impl`s satisfying `u64: PartialOrd<_>` found in the following crates: `candid`, `core`:
            - impl PartialOrd for u64;
            - impl PartialOrd<candid::types::number::Int> for u64;
            - impl PartialOrd<candid::types::number::Nat> for u64;
help: try using a fully qualified path to specify the expected types
    |
216 -                         .is_some_and(|txid_max_old| b <= txid_max_old.into())
216 +                         .is_some_and(|txid_max_old| b <= <std::num::NonZero<u64> as Into<T>>::into(txid_max_old))
    |

error[E0283]: type annotations needed
   --> /Users/me/.cargo/git/checkouts/turso-455557cd4a2364c7/2d78b53/core/mvcc/database/checkpoint_state_machine.rs:226:67
    |
226 |                     .is_some_and(|txid_max_old| e <= txid_max_old.into())
    |                                                   --              ^^^^
    |                                                   |
    |                                                   type must be known at this point
    |
    = note: multiple `impl`s satisfying `u64: PartialOrd<_>` found in the following crates: `candid`, `core`:
            - impl PartialOrd for u64;
            - impl PartialOrd<candid::types::number::Int> for u64;
            - impl PartialOrd<candid::types::number::Nat> for u64;
help: try using a fully qualified path to specify the expected types
    |
226 -                     .is_some_and(|txid_max_old| e <= txid_max_old.into())
226 +                     .is_some_and(|txid_max_old| e <= <std::num::NonZero<u64> as Into<T>>::into(txid_max_old))
    |

error[E0283]: type annotations needed
   --> /Users/me/.cargo/git/checkouts/turso-455557cd4a2364c7/2d78b53/core/mvcc/database/checkpoint_state_machine.rs:242:90
    |
242 |                     .is_none_or(|txid_max_old| begin_ts.is_some_and(|b| b > txid_max_old.into()));
    |                                                                           -              ^^^^
    |                                                                           |
    |                                                                           type must be known at this point
    |
    = note: multiple `impl`s satisfying `u64: PartialOrd<_>` found in the following crates: `candid`, `core`:
            - impl PartialOrd for u64;
            - impl PartialOrd<candid::types::number::Int> for u64;
            - impl PartialOrd<candid::types::number::Nat> for u64;
help: try using a fully qualified path to specify the expected types
    |
242 -                     .is_none_or(|txid_max_old| begin_ts.is_some_and(|b| b > txid_max_old.into()));
242 +                     .is_none_or(|txid_max_old| begin_ts.is_some_and(|b| b > <std::num::NonZero<u64> as Into<T>>::into(txid_max_old)));
    |

For more information about this error, try `rustc --explain E0283`.
error: could not compile `turso_core` (lib) due to 3 previous errors
```
</details>  

## Description of AI Usage

All code is hand-written
