### PR TITLE
Improve MVCC DX by dropping `--experimental-mvcc` flag

### DIFF
--- a/bindings/dart/rust/src/api/connect.rs
+++ b/bindings/dart/rust/src/api/connect.rs
@@ -23,10 +23,10 @@ pub struct ConnectArgs {
 pub async fn connect(args: ConnectArgs) -> RustConnection {
     let database = if args.url == ":memory:" {
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::MemoryIO::new());
-        turso_core::Database::open_file(io, args.url.as_str(), false)
+        turso_core::Database::open_file(io, args.url.as_str())
     } else {
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        turso_core::Database::open_file(io, args.url.as_str(), false)
+        turso_core::Database::open_file(io, args.url.as_str())
     }
     .unwrap();
     let connection = database.connect().unwrap();

--- a/bindings/java/rs_src/turso_db.rs
+++ b/bindings/java/rs_src/turso_db.rs
@@ -68,7 +68,7 @@ pub extern "system" fn Java_tech_turso_core_TursoDB_openUtf8<'local>(
         }
     };
 
-    let db = match Database::open_file(io.clone(), &path, false) {
+    let db = match Database::open_file(io.clone(), &path) {
         Ok(db) => db,
         Err(e) => {
             set_err_msg_and_throw_exception(&mut env, obj, TURSO_ETC, e.to_string());

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -179,7 +179,7 @@ fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
         io.clone(),
         &db.path,
         flags,
-        turso_core::DatabaseOpts::new().with_mvcc(false),
+        turso_core::DatabaseOpts::new(),
         None,
     )
     .map_err(|e| to_generic_error(&format!("failed to open database {}", db.path), e))?;

--- a/bindings/rust/src/connection.rs
+++ b/bindings/rust/src/connection.rs
@@ -230,6 +230,22 @@ impl Connection {
         Ok(())
     }
 
+    /// Set a pragma value.
+    pub fn pragma_update<V: std::fmt::Display>(
+        &self,
+        pragma_name: &str,
+        pragma_value: V,
+    ) -> Result<Vec<Row>> {
+        let conn = self.get_inner_connection()?;
+        let rows: Vec<Row> = conn
+            .pragma_update(pragma_name, pragma_value)
+            .map_err(|e| Error::SqlExecutionFailure(e.to_string()))?
+            .iter()
+            .map(|row| row.iter().collect::<Row>())
+            .collect();
+        Ok(rows)
+    }
+
     /// Returns the rowid of the last row inserted.
     pub fn last_insert_rowid(&self) -> i64 {
         let conn = self.get_inner_connection().unwrap();

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -88,7 +88,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// A builder for `Database`.
 pub struct Builder {
     path: String,
-    enable_mvcc: bool,
     enable_encryption: bool,
     vfs: Option<String>,
     encryption_opts: Option<EncryptionOpts>,
@@ -99,16 +98,10 @@ impl Builder {
     pub fn new_local(path: &str) -> Self {
         Self {
             path: path.to_string(),
-            enable_mvcc: false,
             enable_encryption: false,
             vfs: None,
             encryption_opts: None,
         }
-    }
-
-    pub fn with_mvcc(mut self, mvcc_enabled: bool) -> Self {
-        self.enable_mvcc = mvcc_enabled;
-        self
     }
 
     pub fn experimental_encryption(mut self, encryption_enabled: bool) -> Self {
@@ -130,9 +123,7 @@ impl Builder {
     #[allow(unused_variables, clippy::arc_with_non_send_sync)]
     pub async fn build(self) -> Result<Database> {
         let io = self.get_io()?;
-        let opts = turso_core::DatabaseOpts::default()
-            .with_mvcc(self.enable_mvcc)
-            .with_encryption(self.enable_encryption);
+        let opts = turso_core::DatabaseOpts::default().with_encryption(self.enable_encryption);
         let db = turso_core::Database::open_file_with_flags(
             io,
             self.path.as_str(),

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -66,8 +66,6 @@ pub struct Opts {
     pub vfs: Option<String>,
     #[clap(long, help = "Open the database in read-only mode")]
     pub readonly: bool,
-    #[clap(long, help = "Enable experimental MVCC feature")]
-    pub experimental_mvcc: bool,
     #[clap(long, help = "Enable experimental views feature")]
     pub experimental_views: bool,
     #[clap(long, help = "Enable experimental strict schema mode")]
@@ -193,7 +191,6 @@ impl Limbo {
             Connection::from_uri(
                 &db_file,
                 DatabaseOpts::new()
-                    .with_mvcc(opts.experimental_mvcc)
                     .with_views(opts.experimental_views)
                     .with_strict(opts.experimental_strict)
                     .with_encryption(opts.experimental_encryption)
@@ -210,7 +207,6 @@ impl Limbo {
                 opts.vfs.as_ref(),
                 flags,
                 turso_core::DatabaseOpts::new()
-                    .with_mvcc(opts.experimental_mvcc)
                     .with_views(opts.experimental_views)
                     .with_strict(opts.experimental_strict)
                     .with_encryption(opts.experimental_encryption)
@@ -415,7 +411,7 @@ impl Limbo {
                     _path => get_io(DbLocation::Path, &self.opts.io.to_string())?,
                 }
             };
-            (io.clone(), Database::open_file(io.clone(), path, false)?)
+            (io.clone(), Database::open_file(io.clone(), path)?)
         };
         self.io = io;
         self.conn = db.connect()?;
@@ -1769,7 +1765,7 @@ impl Limbo {
             anyhow::bail!("Refusing to overwrite existing file: {output_file}");
         }
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new()?);
-        let db = Database::open_file(io.clone(), output_file, false)?;
+        let db = Database::open_file(io.clone(), output_file)?;
         let target = db.connect()?;
 
         let mut applier = ApplyWriter::new(&target);

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -55,7 +55,7 @@ fn bench_open(criterion: &mut Criterion) {
     if !std::fs::exists("../testing/schema_5k.db").unwrap() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false).unwrap();
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
 
         for i in 0..5000 {
@@ -71,7 +71,7 @@ fn bench_open(criterion: &mut Criterion) {
         b.iter(|| {
             #[allow(clippy::arc_with_non_send_sync)]
             let io = Arc::new(PlatformIO::new().unwrap());
-            let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false).unwrap();
+            let db = Database::open_file(io.clone(), "../testing/schema_5k.db").unwrap();
             let conn = db.connect().unwrap();
             conn.execute("SELECT * FROM table_0").unwrap();
         });
@@ -97,7 +97,7 @@ fn bench_alter(criterion: &mut Criterion) {
     if !std::fs::exists("../testing/schema_5k.db").unwrap() {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false).unwrap();
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
 
         for i in 0..5000 {
@@ -112,7 +112,7 @@ fn bench_alter(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo_rename_table", ""), |b| {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false).unwrap();
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
         b.iter_custom(|iters| {
             (0..iters)
@@ -157,7 +157,7 @@ fn bench_alter(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo_rename_column", ""), |b| {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false).unwrap();
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
         b.iter_custom(|iters| {
             (0..iters)
@@ -203,7 +203,7 @@ fn bench_alter(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo_add_column", ""), |b| {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false).unwrap();
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
         b.iter_custom(|iters| {
             (0..iters)
@@ -248,7 +248,7 @@ fn bench_alter(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo_drop_column", ""), |b| {
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), "../testing/schema_5k.db", false).unwrap();
+        let db = Database::open_file(io.clone(), "../testing/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
         b.iter_custom(|iters| {
             (0..iters)
@@ -296,7 +296,7 @@ fn bench_prepare_query(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let queries = [
@@ -375,7 +375,7 @@ fn bench_execute_select_rows(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT * FROM users LIMIT ?`");
@@ -443,7 +443,7 @@ fn bench_execute_select_1(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT 1`");
@@ -495,7 +495,7 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let mut group = criterion.benchmark_group("Execute `SELECT count() FROM users`");
@@ -553,7 +553,7 @@ fn bench_insert_rows(criterion: &mut Criterion) {
 
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), db_path.to_str().unwrap(), false).unwrap();
+        let db = Database::open_file(io.clone(), db_path.to_str().unwrap()).unwrap();
         let limbo_conn = db.connect().unwrap();
 
         let mut stmt = limbo_conn
@@ -677,10 +677,14 @@ fn bench_limbo(
     let io = Arc::new(PlatformIO::new().unwrap());
     let temp_dir = tempfile::tempdir().unwrap();
     let path = temp_dir.path().join("bench.db");
-    let db = Database::open_file(io.clone(), path.to_str().unwrap(), mvcc).unwrap();
+    let db = Database::open_file(io.clone(), path.to_str().unwrap()).unwrap();
     let mut connecitons = Vec::new();
     {
         let conn = db.connect().unwrap();
+        if mvcc {
+            conn.execute("PRAGMA journal_mode = 'experimental_mvcc'")
+                .unwrap();
+        }
         conn.execute("CREATE TABLE test (x)").unwrap();
         conn.close().unwrap();
     }
@@ -760,9 +764,14 @@ fn bench_limbo_mvcc(
     let io = Arc::new(PlatformIO::new().unwrap());
     let temp_dir = tempfile::tempdir().unwrap();
     let path = temp_dir.path().join("bench.db");
-    let db = Database::open_file(io.clone(), path.to_str().unwrap(), mvcc).unwrap();
+    let db = Database::open_file(io.clone(), path.to_str().unwrap()).unwrap();
     let mut connecitons = Vec::new();
     let conn0 = db.connect().unwrap();
+    if mvcc {
+        conn0
+            .execute("PRAGMA journal_mode = 'experimental_mvcc'")
+            .unwrap();
+    }
     conn0.execute("CREATE TABLE test (x)").unwrap();
 
     let inserts =
@@ -939,7 +948,7 @@ fn bench_insert_randomblob(criterion: &mut Criterion) {
 
         #[allow(clippy::arc_with_non_send_sync)]
         let io = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), db_path.to_str().unwrap(), false).unwrap();
+        let db = Database::open_file(io.clone(), db_path.to_str().unwrap()).unwrap();
         let limbo_conn = db.connect().unwrap();
 
         let mut stmt = limbo_conn.query("CREATE TABLE test(x)").unwrap().unwrap();

--- a/core/benches/json_benchmark.rs
+++ b/core/benches/json_benchmark.rs
@@ -22,7 +22,7 @@ fn bench(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
     let limbo_conn = db.connect().unwrap();
 
     // Benchmark JSONB with different payload sizes
@@ -490,7 +490,7 @@ fn bench_sequential_jsonb(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
     let limbo_conn = db.connect().unwrap();
 
     // Select a subset of JSON payloads to use in the sequential test
@@ -646,7 +646,7 @@ fn bench_json_patch(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), "../testing/testing.db", false).unwrap();
+    let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let json_patch_cases = [

--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -16,8 +16,11 @@ struct BenchDb {
 
 fn bench_db() -> BenchDb {
     let io = Arc::new(MemoryIO::new());
-    let db = Database::open_file(io.clone(), ":memory:", true).unwrap();
+    let db = Database::open_file(io.clone(), ":memory:").unwrap();
     let conn = db.connect().unwrap();
+    // Enable MVCC via PRAGMA
+    conn.execute("PRAGMA journal_mode = 'experimental_mvcc'")
+        .unwrap();
     let mvcc_store = db.get_mv_store().clone().unwrap();
     BenchDb {
         _db: db,

--- a/core/benches/tpc_h_benchmark.rs
+++ b/core/benches/tpc_h_benchmark.rs
@@ -30,7 +30,7 @@ fn bench_tpc_h_queries(criterion: &mut Criterion) {
 
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io.clone(), TPC_H_PATH, false).unwrap();
+    let db = Database::open_file(io.clone(), TPC_H_PATH).unwrap();
     let limbo_conn = db.connect().unwrap();
 
     let queries = [

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -159,7 +159,7 @@ impl Database {
                 }
             },
         };
-        let db = Self::open_file(io.clone(), path, false)?;
+        let db = Self::open_file(io.clone(), path)?;
         Ok((io, db))
     }
 

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -1633,7 +1633,7 @@ impl DbspCompiler {
 
         // Create an internal connection for expression compilation
         let io = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io, ":memory:", false)?;
+        let db = Database::open_file(io, ":memory:")?;
         let internal_conn = db.connect()?;
         internal_conn.set_query_only(true);
         internal_conn.auto_commit.store(false, Ordering::SeqCst);
@@ -2557,7 +2557,7 @@ mod tests {
 
     fn setup_btree_for_circuit() -> (Arc<Pager>, i64, i64, i64) {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io.clone(), ":memory:", false).unwrap();
+        let db = Database::open_file(io.clone(), ":memory:").unwrap();
         let conn = db.connect().unwrap();
         let pager = conn.pager.load().clone();
 

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -311,7 +311,6 @@ mod tests {
             ":memory:",
             OpenFlags::default(),
             crate::DatabaseOpts {
-                enable_mvcc: false,
                 enable_views: true,
                 enable_strict: false,
                 enable_load_extension: false,

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -273,7 +273,7 @@ mod tests {
     /// Create a test pager for operator tests with both table and index
     fn create_test_pager() -> (std::sync::Arc<crate::Pager>, i64, i64) {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io.clone(), ":memory:", false).unwrap();
+        let db = Database::open_file(io.clone(), ":memory:").unwrap();
         let conn = db.connect().unwrap();
 
         let pager = conn.pager.load().clone();

--- a/core/incremental/project_operator.rs
+++ b/core/incremental/project_operator.rs
@@ -57,7 +57,7 @@ impl ProjectOperator {
     ) -> crate::Result<Self> {
         // Set up internal connection for expression evaluation
         let io = Arc::new(crate::MemoryIO::new());
-        let db = Database::open_file(io, ":memory:", false)?;
+        let db = Database::open_file(io, ":memory:")?;
         let internal_conn = db.connect()?;
         // Set to read-only mode and disable auto-commit since we're only evaluating expressions
         internal_conn.set_query_only(true);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7851,7 +7851,7 @@ mod tests {
                 .unwrap();
         }
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), path.to_str().unwrap(), false).unwrap();
+        let db = Database::open_file(io.clone(), path.to_str().unwrap()).unwrap();
 
         db
     }
@@ -8153,7 +8153,7 @@ mod tests {
     fn empty_btree() -> (Arc<Pager>, i64, Arc<Database>, Arc<Connection>) {
         #[allow(clippy::arc_with_non_send_sync)]
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io.clone(), ":memory:", false).unwrap();
+        let db = Database::open_file(io.clone(), ":memory:").unwrap();
         let conn = db.connect().unwrap();
         let pager = conn.pager.load().clone();
 
@@ -8173,7 +8173,7 @@ mod tests {
     fn btree_with_virtual_page_1() -> Result<()> {
         #[allow(clippy::arc_with_non_send_sync)]
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
-        let db = Database::open_file(io.clone(), ":memory:", false).unwrap();
+        let db = Database::open_file(io.clone(), ":memory:").unwrap();
         let conn = db.connect().unwrap();
         let pager = conn.pager.load().clone();
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2579,7 +2579,7 @@ pub mod test {
                 .unwrap();
         }
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), path.to_str().unwrap(), false).unwrap();
+        let db = Database::open_file(io.clone(), path.to_str().unwrap()).unwrap();
         // db + tmp directory
         (db, dbpath)
     }

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -153,7 +153,6 @@ The SQL shell supports the following command line options:
 | `-V`, `--version` | Print version |
 | `--mcp` | Start a MCP server instead of the interactive shell |
 | `--experimental-encryption` | Enable experimental encryption at rest feature. **Note:** the feature is not production ready so do not use it for critical data right now. |
-| `--experimental-mvcc` | Enable experimental MVCC feature. **Note:** the feature is not production ready so do not use it for critical data right now. |
 | `--experimental-strict` | Enable experimental strict schema feature. **Note**: the feature is not production ready so do not use it for critical data right now. |
 | `--experimental-views` | Enable experimental views feature. **Note**: the feature is not production ready so do not use it for critical data right now. |
 
@@ -589,7 +588,7 @@ Turso supports switching between different journal modes at runtime using the `P
 | Mode | Description |
 |------|-------------|
 | `wal` | Write-Ahead Logging mode. The default mode for new databases. Provides good concurrency for readers and writers. |
-| `experimental_mvcc` | Multi-Version Concurrency Control mode. Enables concurrent transactions with snapshot isolation. Requires the `--experimental-mvcc` flag. |
+| `experimental_mvcc` | Multi-Version Concurrency Control mode. Enables concurrent transactions with snapshot isolation. **Note:** the feature is not production ready so do not use it for critical data right now. |
 
 > **Note:** Legacy SQLite journal modes (`delete`, `truncate`, `persist`, `memory`, `off`) are recognized but not currently supported. Attempting to switch to these modes will return an error.
 
@@ -633,7 +632,6 @@ turso> PRAGMA journal_mode = experimental_mvcc;
 ### Important Notes
 
 - Switching journal modes triggers a checkpoint to ensure all pending changes are persisted before the mode change.
-- To use `experimental_mvcc` mode, you must start the database with the `--experimental-mvcc` flag enabled.
 - When switching from MVCC to WAL mode, the MVCC log file is cleared after checkpointing.
 - Legacy SQLite databases are automatically converted to WAL mode when opened.
 

--- a/macros/src/test.rs
+++ b/macros/src/test.rs
@@ -14,12 +14,6 @@ use syn::{
 #[derive(Debug, Clone, Copy)]
 struct SpannedType<T>(T, Span);
 
-impl<T> SpannedType<T> {
-    fn map<U>(self, func: impl FnOnce(T) -> U) -> SpannedType<U> {
-        SpannedType(func(self.0), self.1)
-    }
-}
-
 impl<T> Deref for SpannedType<T> {
     type Target = T;
 
@@ -62,22 +56,11 @@ impl Args {
             |path| path.to_token_stream(),
         );
 
-        let mut db_opts = quote! {
+        let db_opts = quote! {
             turso_core::DatabaseOpts::new()
                 .with_index_method(true)
                 .with_encryption(true)
         };
-
-        if let Some(spanned) = self
-            .mvcc
-            .filter(|_| mvcc)
-            .map(|val| val.map(|_| quote! {.with_mvcc(true)}))
-        {
-            db_opts = quote! {
-                #db_opts
-                #spanned
-            }
-        }
 
         builder = quote! {
             #builder
@@ -85,10 +68,19 @@ impl Args {
             .with_opts(#db_opts)
         };
 
-        if let Some(expr) = &self.init_sql {
+        // Enable MVCC if requested
+        if mvcc && self.mvcc.is_some() {
             builder = quote! {
                 #builder
-                .with_init_sql(#expr)
+                .with_mvcc(true)
+            };
+        }
+
+        // Add init_sql if provided
+        if let Some(user_sql) = &self.init_sql {
+            builder = quote! {
+                #builder
+                .with_init_sql(#user_sql)
             };
         }
 

--- a/scripts/turso-mvcc-sqlite3
+++ b/scripts/turso-mvcc-sqlite3
@@ -7,7 +7,8 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 TURSODB="$PROJECT_ROOT/target/debug/tursodb"
 
 # Add experimental features for testing
-EXPERIMENTAL_FLAGS="--experimental-mvcc --experimental-views --experimental-strict"
+# Note: MVCC is enabled via PRAGMA journal_mode = 'experimental_mvcc'
+EXPERIMENTAL_FLAGS="--experimental-views --experimental-strict"
 
 # if RUST_LOG is non-empty, enable tracing output
 if [ -n "$RUST_LOG" ]; then

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -493,7 +493,6 @@ impl TursoDatabase {
             for features in experimental_features.split(",").map(|s| s.trim()) {
                 opts = match features {
                     "views" => opts.with_views(true),
-                    "mvcc" => opts.with_mvcc(true),
                     "index_method" => opts.with_index_method(true),
                     "strict" => opts.with_strict(true),
                     "autovacuum" => opts.with_autovacuum(true),

--- a/simulator/runner/env.rs
+++ b/simulator/runner/env.rs
@@ -538,9 +538,7 @@ impl SimulatorEnv {
             io.clone(),
             db_path.to_str().unwrap(),
             turso_core::OpenFlags::default(),
-            turso_core::DatabaseOpts::new()
-                .with_mvcc(self.profile.experimental_mvcc)
-                .with_autovacuum(true),
+            turso_core::DatabaseOpts::new().with_autovacuum(true),
             None,
         ) {
             Ok(db) => db,
@@ -686,9 +684,7 @@ impl SimulatorEnv {
             io.clone(),
             db_path.to_str().unwrap(),
             turso_core::OpenFlags::default(),
-            turso_core::DatabaseOpts::new()
-                .with_mvcc(profile.experimental_mvcc)
-                .with_autovacuum(true),
+            turso_core::DatabaseOpts::new().with_autovacuum(true),
             None,
         ) {
             Ok(db) => db,
@@ -696,6 +692,15 @@ impl SimulatorEnv {
                 panic!("error opening simulator test file {db_path:?}: {e:?}");
             }
         };
+
+        // Switch to MVCC mode if the profile says to use MVCC
+        if profile.experimental_mvcc {
+            let conn = db
+                .connect()
+                .expect("Failed to create connection for MVCC setup");
+            conn.execute("PRAGMA journal_mode = 'experimental_mvcc'")
+                .expect("Failed to enable MVCC mode");
+        }
 
         let connections = (0..profile.max_connections)
             .map(|_| SimConnection::Disconnected)

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn sqlite3_open(
             Err(_) => return SQLITE_CANTOPEN,
         },
     };
-    match turso_core::Database::open_file(io.clone(), filename_str, false) {
+    match turso_core::Database::open_file(io.clone(), filename_str) {
         Ok(db) => {
             let conn = db.connect().unwrap();
             let filename = match filename_str {

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -687,7 +687,7 @@ mod tests {
         let db_path1 = temp_file1.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
         let mut gen = genawaiter::sync::Gen::new({
             let db1 = db1.clone();
@@ -717,7 +717,7 @@ mod tests {
         let db_path1 = temp_file1.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -785,10 +785,10 @@ mod tests {
         let db_path2 = temp_file2.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2, false).unwrap();
+        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -864,10 +864,10 @@ mod tests {
         let db_path2 = temp_file2.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2, false).unwrap();
+        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -937,10 +937,10 @@ mod tests {
         let db_path2 = temp_file2.path().to_str().unwrap();
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2, false).unwrap();
+        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1002,13 +1002,13 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2, false).unwrap();
+        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
-        let db3 = turso_core::Database::open_file(io.clone(), db_path3, false).unwrap();
+        let db3 = turso_core::Database::open_file(io.clone(), db_path3).unwrap();
         let db3 = Arc::new(DatabaseTape::new(db3));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1144,10 +1144,10 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2, false).unwrap();
+        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1228,10 +1228,10 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2, false).unwrap();
+        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1304,13 +1304,13 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2, false).unwrap();
+        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
-        let db3 = turso_core::Database::open_file(io.clone(), db_path3, false).unwrap();
+        let db3 = turso_core::Database::open_file(io.clone(), db_path3).unwrap();
         let db3 = Arc::new(DatabaseTape::new(db3));
 
         let mut gen = genawaiter::sync::Gen::new({
@@ -1399,13 +1399,13 @@ mod tests {
 
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
 
-        let db1 = turso_core::Database::open_file(io.clone(), db_path1, false).unwrap();
+        let db1 = turso_core::Database::open_file(io.clone(), db_path1).unwrap();
         let db1 = Arc::new(DatabaseTape::new(db1));
 
-        let db2 = turso_core::Database::open_file(io.clone(), db_path2, false).unwrap();
+        let db2 = turso_core::Database::open_file(io.clone(), db_path2).unwrap();
         let db2 = Arc::new(DatabaseTape::new(db2));
 
-        let db3 = turso_core::Database::open_file(io.clone(), db_path3, false).unwrap();
+        let db3 = turso_core::Database::open_file(io.clone(), db_path3).unwrap();
         let db3 = Arc::new(DatabaseTape::new(db3));
 
         let mut gen = genawaiter::sync::Gen::new({

--- a/sync/engine/src/io_operations.rs
+++ b/sync/engine/src/io_operations.rs
@@ -23,7 +23,7 @@ pub trait IoOperations {
 impl IoOperations for Arc<dyn turso_core::IO> {
     fn open_tape(&self, path: &str, capture: bool) -> Result<DatabaseTape> {
         let io = self.clone();
-        let clean = turso_core::Database::open_file(io, path, false).unwrap();
+        let clean = turso_core::Database::open_file(io, path).unwrap();
         let opts = DatabaseTapeOpts {
             cdc_table: None,
             cdc_mode: Some(if capture { "full" } else { "off" }.to_string()),

--- a/testing/cli_tests/mvcc.py
+++ b/testing/cli_tests/mvcc.py
@@ -13,8 +13,8 @@ class MVCCTest(BaseModel):
 
 
 def test_create_table_with_mvcc():
-    """Test CREATE TABLE t(x) with --experimental-mvcc flag"""
-    shell = TestTursoShell(flags="--experimental-mvcc", init_commands="")
+    """Test CREATE TABLE t(x) with MVCC journal mode"""
+    shell = TestTursoShell(init_commands="PRAGMA journal_mode = 'experimental_mvcc';")
     shell.run_test("create-table-mvcc", "CREATE TABLE t(x);", "")
     shell.run_test("insert-mvcc", "INSERT INTO t(x) VALUES (1);", "")
     shell.quit()

--- a/tests/integration/fuzz_transaction/mod.rs
+++ b/tests/integration/fuzz_transaction/mod.rs
@@ -589,10 +589,16 @@ async fn multiple_connections_fuzz(opts: FuzzOptions) {
         // Create a fresh database for each iteration
         let tempfile = tempfile::NamedTempFile::new().unwrap();
         let db = Builder::new_local(tempfile.path().to_str().unwrap())
-            .with_mvcc(opts.mvcc_enabled)
             .build()
             .await
             .unwrap();
+
+        // Enable MVCC if requested
+        if opts.mvcc_enabled {
+            let conn = db.connect().unwrap();
+            conn.pragma_update("journal_mode", "'experimental_mvcc'")
+                .unwrap();
+        }
 
         // SHARED shadow database for all connections
         let mut schema = BTreeMap::new();

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -353,10 +353,7 @@ fn test_mvcc_update_basic(tmp_db: TempDatabase) {
 
 #[test]
 fn test_mvcc_concurrent_insert_basic() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_update_basic.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_update_basic.db");
     let conn1 = tmp_db.connect_limbo();
     let conn2 = tmp_db.connect_limbo();
 
@@ -431,10 +428,7 @@ fn test_mvcc_update_same_row_twice(tmp_db: TempDatabase) {
 
 #[test]
 fn test_mvcc_concurrent_conflicting_update() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_concurrent_conflicting_update.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_concurrent_conflicting_update.db");
     let conn1 = tmp_db.connect_limbo();
     let conn2 = tmp_db.connect_limbo();
 
@@ -460,10 +454,7 @@ fn test_mvcc_concurrent_conflicting_update() {
 
 #[test]
 fn test_mvcc_concurrent_conflicting_update_2() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_concurrent_conflicting_update.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_concurrent_conflicting_update.db");
     let conn1 = tmp_db.connect_limbo();
     let conn2 = tmp_db.connect_limbo();
 
@@ -489,10 +480,7 @@ fn test_mvcc_concurrent_conflicting_update_2() {
 
 #[test]
 fn test_mvcc_checkpoint_works() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_checkpoint_works.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_checkpoint_works.db");
 
     // Create table
     let conn = tmp_db.connect_limbo();
@@ -594,9 +582,8 @@ fn query_and_log(conn: &Arc<Connection>, query: &str) -> Result<Option<Statement
 
 #[test]
 fn test_mvcc_recovery_of_both_checkpointed_and_noncheckpointed_tables_works() {
-    let tmp_db = TempDatabase::new_with_opts(
+    let tmp_db = TempDatabase::new_with_mvcc(
         "test_mvcc_recovery_of_both_checkpointed_and_noncheckpointed_tables_works.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
     );
     let conn = tmp_db.connect_limbo();
 
@@ -654,10 +641,7 @@ fn test_mvcc_recovery_of_both_checkpointed_and_noncheckpointed_tables_works() {
     drop(tmp_db);
 
     // Close and reopen database
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     // Verify table1 rows
@@ -709,10 +693,7 @@ fn test_non_mvcc_to_mvcc() {
     drop(tmp_db);
 
     // Reopen in mvcc mode
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     // Query should work
@@ -776,10 +757,7 @@ fn verify_table_contents(conn: &Arc<Connection>, expected: Vec<i64>) {
 
 #[test]
 fn test_mvcc_recovery_with_index_and_deletes() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_recovery_with_index_and_deletes.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_recovery_with_index_and_deletes.db");
     let conn = tmp_db.connect_limbo();
 
     // Create table with unique constraint (creates an index)
@@ -799,10 +777,7 @@ fn test_mvcc_recovery_with_index_and_deletes() {
     drop(tmp_db);
 
     // Reopen database (triggers logical log recovery)
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     // Verify only rows 1, 3, 5 exist
@@ -823,9 +798,8 @@ fn test_mvcc_recovery_with_index_and_deletes() {
 
 #[test]
 fn test_mvcc_checkpoint_before_delete_then_verify_same_session() {
-    let tmp_db = TempDatabase::new_with_opts(
+    let tmp_db = TempDatabase::new_with_mvcc(
         "test_mvcc_checkpoint_before_delete_then_verify_same_session.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
     );
     let conn = tmp_db.connect_limbo();
 
@@ -844,10 +818,7 @@ fn test_mvcc_checkpoint_before_delete_then_verify_same_session() {
 
 #[test]
 fn test_mvcc_checkpoint_before_delete_then_reopen() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_checkpoint_before_delete_then_reopen.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_checkpoint_before_delete_then_reopen.db");
     let conn = tmp_db.connect_limbo();
 
     execute_and_log(&conn, "CREATE TABLE t (x)").unwrap();
@@ -864,10 +835,7 @@ fn test_mvcc_checkpoint_before_delete_then_reopen() {
     drop(conn);
     drop(tmp_db);
 
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     verify_table_contents(&conn, vec![1, 3]);
@@ -875,10 +843,8 @@ fn test_mvcc_checkpoint_before_delete_then_reopen() {
 
 #[test]
 fn test_mvcc_delete_then_checkpoint_then_verify_same_session() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_delete_then_checkpoint_then_verify_same_session.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db =
+        TempDatabase::new_with_mvcc("test_mvcc_delete_then_checkpoint_then_verify_same_session.db");
     let conn = tmp_db.connect_limbo();
 
     execute_and_log(&conn, "CREATE TABLE t (x)").unwrap();
@@ -896,10 +862,7 @@ fn test_mvcc_delete_then_checkpoint_then_verify_same_session() {
 
 #[test]
 fn test_mvcc_delete_then_checkpoint_then_reopen() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_delete_then_checkpoint_then_reopen.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_delete_then_checkpoint_then_reopen.db");
     let conn = tmp_db.connect_limbo();
 
     execute_and_log(&conn, "CREATE TABLE t (x)").unwrap();
@@ -916,10 +879,7 @@ fn test_mvcc_delete_then_checkpoint_then_reopen() {
     drop(conn);
     drop(tmp_db);
 
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     verify_table_contents(&conn, vec![1, 3]);
@@ -927,10 +887,7 @@ fn test_mvcc_delete_then_checkpoint_then_reopen() {
 
 #[test]
 fn test_mvcc_delete_then_reopen_no_checkpoint() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_delete_then_reopen_no_checkpoint.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_delete_then_reopen_no_checkpoint.db");
     let conn = tmp_db.connect_limbo();
 
     execute_and_log(&conn, "CREATE TABLE t (x)").unwrap();
@@ -946,10 +903,7 @@ fn test_mvcc_delete_then_reopen_no_checkpoint() {
     drop(conn);
     drop(tmp_db);
 
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     verify_table_contents(&conn, vec![1, 3]);
@@ -957,9 +911,8 @@ fn test_mvcc_delete_then_reopen_no_checkpoint() {
 
 #[test]
 fn test_mvcc_checkpoint_delete_checkpoint_then_verify_same_session() {
-    let tmp_db = TempDatabase::new_with_opts(
+    let tmp_db = TempDatabase::new_with_mvcc(
         "test_mvcc_checkpoint_delete_checkpoint_then_verify_same_session.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
     );
     let conn = tmp_db.connect_limbo();
 
@@ -979,10 +932,8 @@ fn test_mvcc_checkpoint_delete_checkpoint_then_verify_same_session() {
 
 #[test]
 fn test_mvcc_checkpoint_delete_checkpoint_then_reopen() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_checkpoint_delete_checkpoint_then_reopen.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db =
+        TempDatabase::new_with_mvcc("test_mvcc_checkpoint_delete_checkpoint_then_reopen.db");
     let conn = tmp_db.connect_limbo();
 
     execute_and_log(&conn, "CREATE TABLE t (x)").unwrap();
@@ -1000,10 +951,7 @@ fn test_mvcc_checkpoint_delete_checkpoint_then_reopen() {
     drop(conn);
     drop(tmp_db);
 
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     verify_table_contents(&conn, vec![1, 3]);
@@ -1011,10 +959,8 @@ fn test_mvcc_checkpoint_delete_checkpoint_then_reopen() {
 
 #[test]
 fn test_mvcc_index_before_checkpoint_delete_after_checkpoint() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_index_before_checkpoint_delete_after_checkpoint.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db =
+        TempDatabase::new_with_mvcc("test_mvcc_index_before_checkpoint_delete_after_checkpoint.db");
     let conn = tmp_db.connect_limbo();
 
     execute_and_log(&conn, "CREATE TABLE t (x)").unwrap();
@@ -1031,10 +977,7 @@ fn test_mvcc_index_before_checkpoint_delete_after_checkpoint() {
     drop(conn);
     drop(tmp_db);
 
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     verify_table_contents(&conn, vec![1, 3]);
@@ -1042,10 +985,8 @@ fn test_mvcc_index_before_checkpoint_delete_after_checkpoint() {
 
 #[test]
 fn test_mvcc_index_after_checkpoint_delete_after_index() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_index_after_checkpoint_delete_after_index.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db =
+        TempDatabase::new_with_mvcc("test_mvcc_index_after_checkpoint_delete_after_index.db");
     let conn = tmp_db.connect_limbo();
 
     execute_and_log(&conn, "CREATE TABLE t (x)").unwrap();
@@ -1062,10 +1003,7 @@ fn test_mvcc_index_after_checkpoint_delete_after_index() {
     drop(conn);
     drop(tmp_db);
 
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     verify_table_contents(&conn, vec![1, 3]);
@@ -1073,10 +1011,7 @@ fn test_mvcc_index_after_checkpoint_delete_after_index() {
 
 #[test]
 fn test_mvcc_multiple_deletes_with_checkpoints() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_multiple_deletes_with_checkpoints.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_multiple_deletes_with_checkpoints.db");
     let conn = tmp_db.connect_limbo();
 
     execute_and_log(&conn, "CREATE TABLE t (x)").unwrap();
@@ -1097,10 +1032,7 @@ fn test_mvcc_multiple_deletes_with_checkpoints() {
     drop(conn);
     drop(tmp_db);
 
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     verify_table_contents(&conn, vec![1, 3, 5]);
@@ -1108,10 +1040,7 @@ fn test_mvcc_multiple_deletes_with_checkpoints() {
 
 #[test]
 fn test_mvcc_no_index_checkpoint_delete_reopen() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_no_index_checkpoint_delete_reopen.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_no_index_checkpoint_delete_reopen.db");
     let conn = tmp_db.connect_limbo();
 
     execute_and_log(&conn, "CREATE TABLE t (x)").unwrap();
@@ -1127,10 +1056,7 @@ fn test_mvcc_no_index_checkpoint_delete_reopen() {
     drop(conn);
     drop(tmp_db);
 
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     verify_table_contents(&conn, vec![1, 3]);
@@ -1138,9 +1064,8 @@ fn test_mvcc_no_index_checkpoint_delete_reopen() {
 
 #[test]
 fn test_mvcc_checkpoint_before_insert_delete_after_checkpoint() {
-    let tmp_db = TempDatabase::new_with_opts(
+    let tmp_db = TempDatabase::new_with_mvcc(
         "test_mvcc_checkpoint_before_insert_delete_after_checkpoint.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
     );
     let conn = tmp_db.connect_limbo();
 
@@ -1166,10 +1091,7 @@ fn test_mvcc_checkpoint_before_insert_delete_after_checkpoint() {
     drop(conn);
     drop(tmp_db);
 
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     verify_table_contents(&conn, vec![1, 4]);
@@ -1183,10 +1105,7 @@ fn test_mvcc_checkpoint_before_insert_delete_after_checkpoint() {
 /// Seeking for various rowids should find them in the correct location.
 #[test]
 fn test_mvcc_dual_seek_table_rowid_basic() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_dual_seek_table_rowid_basic.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_dual_seek_table_rowid_basic.db");
     let conn = tmp_db.connect_limbo();
 
     // Create table and insert initial rows
@@ -1203,10 +1122,7 @@ fn test_mvcc_dual_seek_table_rowid_basic() {
     drop(tmp_db);
 
     // Reopen to ensure btree is populated and MV store is empty
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     // Insert more rows into MVCC
@@ -1254,10 +1170,7 @@ fn test_mvcc_dual_seek_table_rowid_basic() {
 /// Btree has odd numbers (1,3,5,7,9), MVCC has even numbers (2,4,6,8,10).
 #[test]
 fn test_mvcc_dual_seek_interleaved_rows() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_dual_seek_interleaved_rows.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_dual_seek_interleaved_rows.db");
     let conn = tmp_db.connect_limbo();
 
     // Create table and insert odd rows
@@ -1274,10 +1187,7 @@ fn test_mvcc_dual_seek_interleaved_rows() {
     drop(tmp_db);
 
     // Reopen
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     // Insert even rows into MVCC
@@ -1319,10 +1229,7 @@ fn test_mvcc_dual_seek_interleaved_rows() {
 /// Test index seek with rows in both btree and MVCC.
 #[test]
 fn test_mvcc_dual_seek_index_basic() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_dual_seek_index_basic.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_dual_seek_index_basic.db");
     let conn = tmp_db.connect_limbo();
 
     // Create table with index
@@ -1342,10 +1249,7 @@ fn test_mvcc_dual_seek_index_basic() {
     drop(tmp_db);
 
     // Reopen
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     // Insert more rows into MVCC
@@ -1387,10 +1291,7 @@ fn test_mvcc_dual_seek_index_basic() {
 /// The seek should find the MVCC version (which shadows btree).
 #[test]
 fn test_mvcc_dual_seek_with_update() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_dual_seek_with_update.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_dual_seek_with_update.db");
     let conn = tmp_db.connect_limbo();
 
     // Create table and insert rows
@@ -1411,10 +1312,7 @@ fn test_mvcc_dual_seek_with_update() {
     drop(tmp_db);
 
     // Reopen
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     // Update row 3 (creates MVCC version that shadows btree)
@@ -1455,10 +1353,7 @@ fn test_mvcc_dual_seek_with_update() {
 /// The seek should NOT find the deleted row.
 #[test]
 fn test_mvcc_dual_seek_with_delete() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_dual_seek_with_delete.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_dual_seek_with_delete.db");
     let conn = tmp_db.connect_limbo();
 
     // Create table and insert rows
@@ -1475,10 +1370,7 @@ fn test_mvcc_dual_seek_with_delete() {
     drop(tmp_db);
 
     // Reopen
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     // Delete row 3
@@ -1517,10 +1409,7 @@ fn test_mvcc_dual_seek_with_delete() {
 /// Test range seek (GT, LT operations) with dual iteration.
 #[test]
 fn test_mvcc_dual_seek_range_operations() {
-    let tmp_db = TempDatabase::new_with_opts(
-        "test_mvcc_dual_seek_range_operations.db",
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_mvcc("test_mvcc_dual_seek_range_operations.db");
     let conn = tmp_db.connect_limbo();
 
     // Create table and insert rows
@@ -1537,10 +1426,7 @@ fn test_mvcc_dual_seek_range_operations() {
     drop(tmp_db);
 
     // Reopen
-    let tmp_db = TempDatabase::new_with_existent_with_opts(
-        &path,
-        turso_core::DatabaseOpts::new().with_mvcc(true),
-    );
+    let tmp_db = TempDatabase::new_with_existent(&path);
     let conn = tmp_db.connect_limbo();
 
     // Insert more rows into MVCC

--- a/whopper/main.rs
+++ b/whopper/main.rs
@@ -141,9 +141,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let db = {
-        let opts = DatabaseOpts::new()
-            .with_mvcc(args.enable_mvcc)
-            .with_encryption(encryption_opts.is_some());
+        let opts = DatabaseOpts::new().with_encryption(encryption_opts.is_some());
 
         match Database::open_file_with_flags(
             io.clone(),
@@ -165,6 +163,11 @@ fn main() -> anyhow::Result<()> {
             return Err(anyhow::anyhow!("Connection failed: {}", e));
         }
     };
+
+    // Enable MVCC if requested
+    if args.enable_mvcc {
+        boostrap_conn.execute("PRAGMA journal_mode = 'experimental_mvcc'")?;
+    }
 
     let schema = create_initial_schema(&mut rng);
     let tables = schema.iter().map(|t| t.table.clone()).collect::<Vec<_>>();


### PR DESCRIPTION
The DX is right now pretty terrible:

```
penberg@vonneumann turso % cargo run -- hello.db
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/tursodb hello.db`
Turso v0.4.0-pre.18
Enter ".help" for usage hints.
Did you know that Turso supports live materialized views? Type .manual materialized-views to learn more.
This software is in BETA, use caution with production data and ensure you have backups.
turso> PRAGMA journal_mode = 'experimental_mvcc';
  × Invalid argument supplied: MVCC is not enabled. Enable it with `--experimental-mvcc` flag in the CLI or by setting the MVCC option in `DatabaseOpts`

turso>
```

To add insult to the injury, many SDKs don't even have a way to enable MVCC via database options. Therefore, let's remove the flag altogether.