### PR TITLE
aws/sim: disable io-uring

### DIFF
--- a/simulator-docker-runner/docker-entrypoint.simulator.ts
+++ b/simulator-docker-runner/docker-entrypoint.simulator.ts
@@ -157,7 +157,7 @@ const run = async (seed: string, bin: string, args: string[]): Promise<boolean> 
   return issuePosted;
 }
 
-const IO_BACKENDS = ["memory", "io-uring", "default"] as const;
+const IO_BACKENDS = ["memory", "default"] as const; // ECS fargate blocks io-uring with seccomp so we can't currently use it
 type IoBackend = (typeof IO_BACKENDS)[number];
 
 const getRandomIoBackend = (): IoBackend => {


### PR DESCRIPTION
ECS fargate uses seccomp to block io_uring so we can't use it with our current simulation infra, which means whenever the sim tries to start an io_uring backed test run it fails with PermissionDenied.

We can move to EC2-backed ECS later to resolve this.
