### PR TITLE
core/mvcc: set_null_flag(false) when seek is called

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1134,6 +1134,10 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                     let _ = self.index_iterator.take();
                     self.reset_dual_peek();
                     self.invalidate_record();
+                    // We need to clear the null flag for the table cursor before seeking,
+                    // because it might have been set to false by an unmatched left-join row during the previous iteration
+                    // on the outer loop.
+                    self.set_null_flag(false);
 
                     let direction = op.iteration_direction();
                     let inclusive = matches!(op, SeekOp::GE { .. } | SeekOp::LE { .. });

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1506,6 +1506,7 @@ pub fn op_column(
                             let cursor = cursor_ref.as_btree_mut();
 
                             if cursor.get_null_flag() {
+                                tracing::trace!("op_column(null_flag)");
                                 state.registers[*dest] = Register::Value(Value::Null);
                                 break 'outer;
                             }

--- a/testing/all-mvcc.test
+++ b/testing/all-mvcc.test
@@ -3,8 +3,6 @@
 set testdir [file dirname $argv0]
 
 # failing:
-source $testdir/insert.test
-# source $testdir/join.test
 # source $testdir/pragma.test
 # source $testdir/select.test
 # source $testdir/changes.test
@@ -27,6 +25,8 @@ source $testdir/insert.test
 # source $testdir/offset.test
 
 # works
+source $testdir/join.test
+source $testdir/insert.test
 source $testdir/glob.test
 source $testdir/autoincr.test
 source $testdir/cmdlineshell.test


### PR DESCRIPTION
## Description

BTreeCursor sets null flag to false once `seek` is called. This PR does the same for MVCC

## Motivation and context

join.test failed with some cases due to this bug


## Description of AI Usage

I asked AI to find the issue but I ended showing the agent why he did things wrong and that he should be ashamed
