### PR TITLE
remove the warning directive to allow environment filter to work

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1083,6 +1083,10 @@ impl Limbo {
                 IsTerminal::is_terminal(&std::io::stderr()),
             )
         };
+        let default_env_filter = EnvFilter::builder()
+            .with_default_directive(tracing::level_filters::LevelFilter::WARN.into())
+            .from_env_lossy();
+
         // Disable rustyline traces
         if let Err(e) = tracing_subscriber::registry()
             .with(
@@ -1092,11 +1096,7 @@ impl Limbo {
                     .with_thread_ids(true)
                     .with_ansi(should_emit_ansi),
             )
-            .with(
-                EnvFilter::from_default_env()
-                    .add_directive(tracing::level_filters::LevelFilter::WARN.into())
-                    .add_directive("rustyline=off".parse().unwrap()),
-            )
+            .with(default_env_filter.add_directive("rustyline=off".parse().unwrap()))
             .try_init()
         {
             println!("Unable to setup tracing appender: {e:?}");


### PR DESCRIPTION
## Description
I screwed up in a previous commit and accidentally removed the ability to enable `RUST_LOG` in the cli.
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
