### PR TITLE
feat(core/translate): apply column affinity to equality and IN list comparisons

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -238,6 +238,8 @@ fn translate_in_list(
     let mut check_null_reg = 0;
     let label_ok = program.allocate_label();
 
+    let affinity = get_expr_affinity(lhs, referenced_tables);
+
     if condition_metadata.jump_target_when_false != condition_metadata.jump_target_when_null {
         check_null_reg = program.alloc_register();
         program.emit_insn(Insn::BitAnd {
@@ -268,8 +270,7 @@ fn translate_in_list(
                     lhs: lhs_reg,
                     rhs: rhs_reg,
                     target_pc: label_ok,
-                    // Use affinity instead
-                    flags: CmpInsFlags::default(),
+                    flags: CmpInsFlags::default().with_affinity(affinity),
                     collation: program.curr_collation(),
                 });
             } else {
@@ -284,7 +285,7 @@ fn translate_in_list(
                 lhs: lhs_reg,
                 rhs: rhs_reg,
                 target_pc: condition_metadata.jump_target_when_false,
-                flags: CmpInsFlags::default(),
+                flags: CmpInsFlags::default().with_affinity(affinity),
                 collation: program.curr_collation(),
             });
         } else {

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -188,7 +188,12 @@ impl Affinity {
                         .flatten()
                         .map(Either::Right)
                 } else {
-                    None
+                    match val {
+                        ValueRef::Integer(_) | ValueRef::Float(_) => {
+                            stringify_register(val).map(Either::Right)
+                        }
+                        _ => None,
+                    }
                 }
             }
 

--- a/testing/select.test
+++ b/testing/select.test
@@ -1340,17 +1340,21 @@ do_execsql_test_on_specific_db {:memory:} affinity-conversion-10 {
   SELECT * FROM t7 WHERE name = 20.5;
 } {20.5}
 
-# TODO: Program does not emit correct opcodes to handle this IN query yet
 # ============================================
 # TEST 8: TEXT column with IN clause
-# Should emit OP_Affinity for batch conversion
 # ============================================
-# do_execsql_test_on_specific_db {:memory:} affinity-conversion-11 {
-#  CREATE TABLE t8(name TEXT);
-#  INSERT INTO t8 VALUES ('1'), ('2'), ('3'), ('4'), ('abc');
-#  CREATE INDEX idx8 ON t8(name);
-#  SELECT * FROM t8 WHERE name IN (1, 2, 3);
-#} {1 2 3}
+do_execsql_test_on_specific_db {:memory:} affinity-conversion-11 {
+  CREATE TABLE t8(name TEXT);
+  INSERT INTO t8 VALUES ('1'), ('2'), ('3'), ('4'), ('abc');
+  CREATE INDEX idx8 ON t8(name);
+  SELECT * FROM t8 WHERE name IN (1, 2, 3);
+} {1 2 3}
+
+do_execsql_test_on_specific_db {:memory:} affinity-conversion-11-2 {
+  CREATE TABLE t(a TEXT);
+  INSERT INTO t VALUES ('1');
+  SELECT * FROM t WHERE a IN (1);
+} {1}
 
 # ============================================
 # TEST 9: Compound index with mixed types
@@ -1486,6 +1490,12 @@ do_execsql_test_on_specific_db {:memory:} affinity-conversion-22 {
 #   CREATE INDEX idx20 ON t20(lower(name));
 #   SELECT * FROM t20 WHERE lower(name) = 'abc';
 # } {ABC abc}
+
+do_execsql_test_on_specific_db {:memory:} affinity-conversion-equality-24 {
+  CREATE TABLE t(a TEXT);
+  INSERT INTO t VALUES ('1');
+  SELECT * FROM t WHERE a = 1;
+} {1}
 
 do_execsql_test_regex sqlite-version-should-return-valid-output {
   SELECT sqlite_version();


### PR DESCRIPTION
## Description

This PR fixes an issue where equality (`a = 1`) and IN list (`a IN (1)`) comparisons did not apply the correct column affinity, which could lead to incorrect results when comparing columns and values of different types (for example, a TEXT column compared to a numeric value). The fix ensures that the column's affinity is applied in both cases, matching SQLite's behavior.

```
turso> create table t(a text);
turso> insert into t values ('1');
turso> select * from t where a = 1;
┌───┐
│ a │
├───┤
│ 1 │
└───┘
turso> select * from t where a in (1);
┌───┐
│ a │
├───┤
│ 1 │
└───┘
```

## Motivation and context

Fixes #3477.

Currently, Turso does not handle column affinity as expected:
```
turso> create table t(a text);
turso> insert into t values ('1');
turso> select * from t where a = 1;
turso> select * from t where a in (1);
```

Expected behavior:
```
sqlite> create table t(a text);
sqlite> insert into t values ('1');
sqlite> select * from t where a = 1;
1
sqlite> select * from t where a in (1);
1
```

## Description of AI Usage

This PR was developed with assistance from Claude Sonnet 4.5. The AI helped identify the root cause and locate existing tests.