### PR TITLE
fix bug in sync server implementation

### DIFF
--- a/cli/sync_server.mdx
+++ b/cli/sync_server.mdx
@@ -2,7 +2,7 @@
 name: local-sync-server
 ---
 
-<Code model="anthropic/claude-opus-4-5" language="rust" output="sync_server.rs" id="code">
+<Code model="anthropic/claude-opus-4-5" language="rust" output="sync_server.rs" version="0.0.1" id="code">
     <Output ref="prompt" />
 </Code>
 

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -518,7 +518,7 @@ impl TursoSyncServer {
         let db_size = if wal_state.max_frame > 0 {
             let mut last_frame = vec![0u8; frame_size];
             let last_info = conn.wal_get_frame(wal_state.max_frame, &mut last_frame)?;
-            last_info.db_size as u64 * PAGE_SIZE as u64
+            last_info.db_size as u64
         } else {
             0
         };

--- a/sync/engine/src/server_proto.rs
+++ b/sync/engine/src/server_proto.rs
@@ -63,6 +63,7 @@ pub struct PageSetZstdEncodingProto {
 pub struct PullUpdatesRespProtoBody {
     #[prost(string, tag = "1")]
     pub server_revision: String,
+    // db size in pages (e.g. for 4kb db file db_size equals to 1)
     #[prost(uint64, tag = "2")]
     pub db_size: u64,
     #[prost(optional, message, tag = "3")]


### PR DESCRIPTION
`db_size` returned by the server is the amount of pages - not the byte size