### PR TITLE
lint/perf: deny eager fallback function calls (ok_or, map_or, unwrap_or)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,3 +130,6 @@ debug = true
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+[workspace.lints.clippy]
+or_fun_call = "deny"

--- a/bindings/dart/rust/Cargo.toml
+++ b/bindings/dart/rust/Cargo.toml
@@ -19,3 +19,6 @@ turso_core = { workspace = true, features = ["fs"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }
+
+[lints.clippy]
+or_fun_call = "deny"

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [lib]
 name = "turso_dotnet"
 crate-type = ["cdylib"]

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 publish = false
+
+[lints]
+workspace = true
+
 [features]
 tracing_release = ["turso_core/tracing_release"]
 [lib]

--- a/bindings/javascript/Cargo.toml
+++ b/bindings/javascript/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 description = "The Turso database library Node bindings"
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib", "lib"]
 

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -599,14 +599,9 @@ impl Statement {
                 raw_array.coerce_to_object()?.to_unknown()
             }
             PresentationMode::Pluck => {
-                let (_, value) =
-                    row_data
-                        .get_values()
-                        .enumerate()
-                        .next()
-                        .ok_or(create_generic_error(
-                            "pluck mode requires at least one column in the result",
-                        ))?;
+                let (_, value) = row_data.get_values().enumerate().next().ok_or_else(|| {
+                    create_generic_error("pluck mode requires at least one column in the result")
+                })?;
                 to_js_value(env, value, safe_integers)?
             }
             PresentationMode::Expanded => {

--- a/bindings/javascript/sync/Cargo.toml
+++ b/bindings/javascript/sync/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -238,7 +238,9 @@ impl SyncEngine {
         )?));
         let opts_filled = SyncEngineOptsFilled {
             path: opts.path,
-            client_name: opts.client_name.unwrap_or("turso-sync-js".to_string()),
+            client_name: opts
+                .client_name
+                .unwrap_or_else(|| "turso-sync-js".to_string()),
             wal_pull_batch_size: opts.wal_pull_batch_size.unwrap_or(100),
             long_poll_timeout: opts
                 .long_poll_timeout_ms

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [lib]
 name = "_turso"
 crate-type = ["cdylib"]

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -212,14 +212,14 @@ impl PyTursoSyncDatabaseStats {
             self.revert_wal_size,
             self.last_pull_unix_time
                 .map(|x| x.to_string())
-                .unwrap_or("None".to_string()),
+                .unwrap_or_else(|| "None".to_string()),
             self.last_push_unix_time
                 .map(|x| x.to_string())
-                .unwrap_or("None".to_string()),
+                .unwrap_or_else(|| "None".to_string()),
             self.revision
                 .as_ref()
                 .map(|x| format!("\"{x}\""))
-                .unwrap_or("None".to_string()),
+                .unwrap_or_else(|| "None".to_string()),
             self.network_sent_bytes,
             self.network_received_bytes,
         ))

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace = true
 repository.workspace = true
 description = "Turso Rust API"
 
+[lints]
+workspace = true
+
 [features]
 default = ["mimalloc"]
 antithesis = ["turso_sdk_kit/antithesis"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace = true
 repository.workspace = true
 description = "The Turso database library"
 
+[lints]
+workspace = true
+
 [lib]
 name = "turso_core"
 path = "lib.rs"

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -345,9 +345,7 @@ mod tests {
             .schema
             .read()
             .get_materialized_view("test_view")
-            .ok_or(crate::LimboError::InternalError(
-                "View not found".to_string(),
-            ))?;
+            .ok_or_else(|| crate::LimboError::InternalError("View not found".to_string()))?;
 
         // Get the view's root page
         let view = view_mutex.lock();

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -605,9 +605,9 @@ impl IO for UringIO {
             "fixed buffer length must be logical block aligned"
         );
         let mut inner = self.inner.lock();
-        let slot = inner.free_arenas.iter().position(|e| e.is_none()).ok_or(
-            crate::error::CompletionError::UringIOError("no free fixed buffer slots"),
-        )?;
+        let slot = inner.free_arenas.iter().position(|e| e.is_none()).ok_or({
+            crate::error::CompletionError::UringIOError("no free fixed buffer slots")
+        })?;
         unsafe {
             inner.ring.ring.submitter().register_buffers_update(
                 slot as u32,

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -61,9 +61,9 @@ impl IO for MemoryIO {
         }
         Ok(files
             .get(path)
-            .ok_or(crate::LimboError::InternalError(
-                "file should exist after insert".to_string(),
-            ))?
+            .ok_or_else(|| {
+                crate::LimboError::InternalError("file should exist after insert".to_string())
+            })?
             .clone())
     }
     fn remove_file(&self, path: &str) -> Result<()> {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2697,12 +2697,9 @@ pub fn resolve_ext_path(extpath: &str) -> Result<std::path::PathBuf> {
             )));
         };
         let maybe = path.with_extension(std::env::consts::DLL_EXTENSION);
-        maybe
-            .exists()
-            .then_some(maybe)
-            .ok_or(LimboError::ExtensionError(format!(
-                "Extension file not found: {extpath}"
-            )))
+        maybe.exists().then_some(maybe).ok_or_else(|| {
+            LimboError::ExtensionError(format!("Extension file not found: {extpath}"))
+        })
     } else {
         Ok(path.to_path_buf())
     }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1968,7 +1968,8 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                         }
                         ast::ColumnConstraint::Default(ref expr) => {
                             default = Some(
-                                translate_ident_to_string_literal(expr).unwrap_or(expr.clone()),
+                                translate_ident_to_string_literal(expr)
+                                    .unwrap_or_else(|| expr.clone()),
                             );
                         }
                         // TODO: for now we don't check Resolve type of unique
@@ -2495,8 +2496,9 @@ impl From<&ColumnDefinition> for Column {
                 ast::ColumnConstraint::NotNull { .. } => notnull = true,
                 ast::ColumnConstraint::Unique(..) => unique = true,
                 ast::ColumnConstraint::Default(expr) => {
-                    default
-                        .replace(translate_ident_to_string_literal(expr).unwrap_or(expr.clone()));
+                    default.replace(
+                        translate_ident_to_string_literal(expr).unwrap_or_else(|| expr.clone()),
+                    );
                 }
                 ast::ColumnConstraint::Collate { collation_name } => {
                     collation.replace(

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2614,7 +2614,7 @@ impl BTreeCursor {
                     );
                     let current_page = self.stack.top_ref();
                     let next_balance_depth =
-                        balance_ancestor_at_depth.unwrap_or(self.stack.current());
+                        balance_ancestor_at_depth.unwrap_or_else(|| self.stack.current());
                     {
                         // check if we don't need to balance
                         // don't continue if:

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1175,9 +1175,9 @@ impl Wal for WalFile {
         }
         self.with_shared(|shared| {
             let frames = shared.frame_cache.lock();
-            let range = frame_watermark.map(|x| 0..=x).unwrap_or(
-                self.min_frame.load(Ordering::Acquire)..=self.max_frame.load(Ordering::Acquire),
-            );
+            let range = frame_watermark.map(|x| 0..=x).unwrap_or_else(|| {
+                self.min_frame.load(Ordering::Acquire)..=self.max_frame.load(Ordering::Acquire)
+            });
             tracing::debug!(
                 "find_frame(page_id={}, frame_watermark={:?}): min_frame={}, max_frame={}",
                 page_id,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -788,7 +788,7 @@ fn translate_rows_and_open_tables(
     if inserting_multiple_rows {
         let select_result_start_reg = program
             .reg_result_cols_start
-            .unwrap_or(ctx.yield_reg_opt.unwrap() + 1);
+            .unwrap_or_else(|| ctx.yield_reg_opt.unwrap() + 1);
         translate_rows_multiple(
             program,
             insertion,
@@ -1145,7 +1145,7 @@ fn bind_insert(
                 .map(|c| {
                     c.default
                         .clone()
-                        .unwrap_or(Box::new(ast::Expr::Literal(ast::Literal::Null)))
+                        .unwrap_or_else(|| Box::new(ast::Expr::Literal(ast::Literal::Null)))
                 })
                 .collect();
         }
@@ -1470,7 +1470,7 @@ fn init_source_emission<'a>(
             values.extend(table.columns().iter().map(|c| {
                 c.default
                     .clone()
-                    .unwrap_or(Box::new(ast::Expr::Literal(ast::Literal::Null)))
+                    .unwrap_or_else(|| Box::new(ast::Expr::Literal(ast::Literal::Null)))
             }));
             (
                 num_values,

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -93,7 +93,7 @@ pub fn join_lhs_and_rhs<'a>(
     {
         if constraint_refs.is_empty() {
             // Check if there are usable constraints that will create an ephemeral index
-            let lhs_mask_for_ephemeral = lhs.map_or(TableMask::new(), |l| {
+            let lhs_mask_for_ephemeral = lhs.map_or_else(TableMask::new, |l| {
                 TableMask::from_table_number_iter(l.table_numbers())
             });
             let has_usable_constraints = rhs_constraints.constraints.iter().any(|c| {
@@ -116,7 +116,7 @@ pub fn join_lhs_and_rhs<'a>(
     let mut best_access_method = method;
 
     // Reuse for both hash cost and output cardinality computation
-    let lhs_mask = lhs.map_or(TableMask::new(), |l| {
+    let lhs_mask = lhs.map_or_else(TableMask::new, |l| {
         TableMask::from_table_number_iter(l.table_numbers())
     });
     let output_cardinality_multiplier = rhs_constraints

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -861,7 +861,7 @@ fn optimize_table_access(
                     let join_order_pos = best_join_order
                         .iter()
                         .position(|m| m.original_idx == table_idx)
-                        .unwrap_or(best_join_order.len().saturating_sub(1));
+                        .unwrap_or_else(|| best_join_order.len().saturating_sub(1));
 
                     // Build a mapping from table_col_pos to index_col_pos.
                     // Multiple constraints on the same column should share the same index_col_pos.

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -346,7 +346,7 @@ fn parse_from_clause_table(
                     ast::As::Elided(id) => id,
                 })
                 .map(|id| normalize_ident(id.as_str()))
-                .unwrap_or(format!("subquery_{cur_table_index}"));
+                .unwrap_or_else(|| format!("subquery_{cur_table_index}"));
             table_references.add_joined_table(JoinedTable::new_subquery(
                 identifier,
                 subplan,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -648,7 +648,7 @@ fn query_pragma(
                 pager
                     .io
                     .block(|| pager.with_header(|header| header.page_size.get()))
-                    .unwrap_or(connection.get_page_size().get()) as i64,
+                    .unwrap_or_else(|_| connection.get_page_size().get()) as i64,
                 register,
             );
             program.emit_result_row(register, 1);

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -888,8 +888,8 @@ pub fn emit_upsert(
                     .columns()
                     .iter()
                     .find(|c| c.is_rowid_alias())
-                    .and_then(|c| c.name.as_ref())
-                    .unwrap_or(&"rowid".to_string())
+                    .and_then(|c| c.name.as_deref())
+                    .unwrap_or("rowid")
             ),
         });
         program.preassign_label_to_next_insn(ok);

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -585,7 +585,7 @@ pub fn insn_to_row(
                         "r[{}]={}.{}",
                         dest,
                         get_table_or_index_name(*cursor_id),
-                        column_name.unwrap_or(&format!("column {}", *column))
+                        &column_name.map_or_else(|| format!("column {}", *column), |name| name.to_string())
                     ),
                 )
             }
@@ -623,7 +623,7 @@ pub fn insn_to_row(
                         dest_reg,
                         start_reg,
                         start_reg + count - 1,
-                        for_index.unwrap_or("".to_string())
+                        for_index.unwrap_or_else(|| "".to_string())
                     ),
                 )
             }
@@ -814,7 +814,7 @@ pub fn insn_to_row(
                             if k.index.is_some() { "index" } else { "table" },
                             get_table_or_index_name(*cursor_id),
                         ))
-                        .unwrap_or(format!("cursor {cursor_id}"))
+                        .unwrap_or_else(|| format!("cursor {cursor_id}"))
                 ),
             ),
             Insn::SeekRowid {
@@ -840,7 +840,7 @@ pub fn insn_to_row(
                             if k.index.is_some() { "index" } else { "table" },
                             get_table_or_index_name(*cursor_id),
                         ))
-                        .unwrap_or(format!("cursor {cursor_id}")),
+                        .unwrap_or_else(|| format!("cursor {cursor_id}")),
                     target_pc.as_debug_int()
                 ),
             ),
@@ -1484,9 +1484,9 @@ pub fn insn_to_row(
                 *db as i64,
                 0,
                 0,
-                Value::build_text(where_clause.clone().unwrap_or("NULL".to_string())),
+                Value::build_text(where_clause.clone().unwrap_or_else(|| "NULL".to_string())),
                 0,
-                where_clause.clone().unwrap_or("NULL".to_string()),
+                where_clause.clone().unwrap_or_else(|| "NULL".to_string()),
             ),
             Insn::PopulateMaterializedViews { cursors } => (
                 "PopulateMaterializedViews",

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -135,9 +135,13 @@ impl VirtualTable {
 
     fn resolve_columns(schema: String) -> crate::Result<Vec<Column>> {
         let mut parser = Parser::new(schema.as_bytes());
-        if let ast::Cmd::Stmt(ast::Stmt::CreateTable { body, .. }) = parser.next_cmd()?.ok_or(
-            LimboError::ParseError("Failed to parse schema from virtual table module".to_string()),
-        )? {
+        if let ast::Cmd::Stmt(ast::Stmt::CreateTable { body, .. }) =
+            parser.next_cmd()?.ok_or_else(|| {
+                LimboError::ParseError(
+                    "Failed to parse schema from virtual table module".to_string(),
+                )
+            })?
+        {
             columns_from_create_table_body(&body)
         } else {
             Err(LimboError::ParseError(
@@ -335,9 +339,9 @@ impl ExtVirtualTable {
         args: Vec<turso_ext::Value>,
         kind: VTabKind,
     ) -> crate::Result<(Self, String)> {
-        let module = module.ok_or(LimboError::ExtensionError(format!(
-            "Virtual table module not found: {module_name}"
-        )))?;
+        let module = module.ok_or_else(|| {
+            LimboError::ExtensionError(format!("Virtual table module not found: {module_name}"))
+        })?;
         if kind != module.module_kind {
             let expected = match kind {
                 VTabKind::VirtualTable => "virtual table",

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -550,7 +550,7 @@ impl VTabCursor for StatsCursor {
     fn column(&self, idx: u32) -> Result<Value, Self::Error> {
         self.rows
             .get(self.pos)
-            .ok_or("row out of range".to_string())
+            .ok_or_else(|| "row out of range".to_string())
             .and_then(|(name, cnt)| match idx {
                 0 => Ok(Value::from_text(name.clone())),
                 1 => Ok(Value::from_integer(*cnt)),


### PR DESCRIPTION
in the past we've already have horrible performance regressions due to e.g. `.unwrap_or(SomeError::AllocateString("foo".to_string()))` in the hot path, so let's just ban it with the `or_fun_call` clippy rule,

Also fixing all the existing usages of such patterns here.
