### PR TITLE
User rust-gdb instead of gdb

### DIFF
--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -103,7 +103,7 @@ RUN make
 #
 
 FROM debian:bullseye-slim AS runtime
-RUN apt-get update && apt-get install -y bash curl xz-utils python3 procps sqlite3 bc binutils pip gdb && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bash curl xz-utils python3 procps sqlite3 bc binutils pip rust-gdb && rm -rf /var/lib/apt/lists/*
 RUN pip install antithesis
 
 WORKDIR /app


### PR DESCRIPTION
## Description

In my last PR (https://github.com/tursodatabase/turso/pull/4360), I added `gdb` to the Antithesis docker image, but I forgot that gdb doesn't come with visualizers for rust-gdb, so that things like Strings will be nicely formatted in the output of `frame variables`, for example.

This PR replaces gdb with rust-gdb. Below is the package information from the `debian:bullseye-slim` base image. As you can see, it depends on gdb, in fact it's just a small wrapper that adds Rust visualizers.

```
root@5f6684914cdf:/# apt-cache depends rust-gdb
rust-gdb
  Depends: gdb
    gdb-minimal
  Suggests: <gdb-doc>
  Replaces: rustc
```
