### PR TITLE
Enable tokio-unstable in Antithesis image

### DIFF
--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -86,7 +86,7 @@ COPY --from=planner /app/sdk-kit-macros ./sdk-kit-macros/
 
 RUN if [ "$antithesis" = "true" ]; then \
         cp /opt/antithesis/libvoidstar.so /usr/lib/libvoidstar.so && \
-        export RUSTFLAGS="-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -L/usr/lib/ -lvoidstar" && \
+        export RUSTFLAGS="--cfg=tokio_unstable -Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -L/usr/lib/ -lvoidstar" && \
         cargo build --bin turso_stress --features antithesis --profile antithesis; \
     else \
         cargo build --bin turso_stress --release; \


### PR DESCRIPTION
## Description

I broke the Antithesis because I used unstable APIs. This PR enables `tokio-unstable` in the docker image. It was already enabled in the workspace via `.cargo/Cargo.toml`, which is why I didn't see the failure locally.

I started an Antithesis experiment using this branch, and it's currently running.

## Description of AI Usage

Claude identified the issue from the CI logs and implemented the fix.