### PR TITLE
stress: don't panic on busy errors

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -677,19 +677,22 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 if let Err(e) = conn.execute(sql, ()).await {
                     match e {
                         turso::Error::Corrupt(e) => {
-                            panic!("Error executing query: {}", e);
+                            panic!("Error[FATAL] executing query: {}", e);
                         }
                         turso::Error::Constraint(e) => {
                             if opts.verbose {
-                                println!("Skipping UNIQUE constraint violation: {e}");
+                                println!("Error[WARNING] executing query: {e}");
                             }
+                        }
+                        turso::Error::Busy(e) => {
+                            println!("Error[WARNING] executing query: {e}");
                         }
                         turso::Error::Error(e) => {
                             if opts.verbose {
                                 println!("Error executing query: {e}");
                             }
                         }
-                        _ => panic!("Error executing query: {}", e),
+                        _ => panic!("Error[FATAL] executing query: {}", e),
                     }
                 }
                 const INTEGRITY_CHECK_INTERVAL: usize = 100;


### PR DESCRIPTION
As far as I can tell all of the antithesis failures from last night are `"database is locked"`, so let's remove those