### PR TITLE
stress: use multithreaded runtime

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -532,9 +532,8 @@ fn sqlite_integrity_check(
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .unhandled_panic(tokio::runtime::UnhandledPanic::ShutdownRuntime)
         .build()?;
 
     rt.block_on(async_main())


### PR DESCRIPTION
an earlier PR changed this to single threaded which is not what we want because we're interested in interactions that occur when multiple parallel threads access the db

`ShutdownRuntime` is not supported for multithreaded runtime so remove it. We already made `stress` not panic on `Busy` errors in #4380 