### PR TITLE
feat: add FunctionList PRAGMA for listing all registered functions

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2736,6 +2736,10 @@ impl SymbolTable {
             self.index_methods.insert(name.clone(), module.clone());
         }
     }
+    // Returns an iterator over all functions
+    pub fn iter_functions(&self) -> impl Iterator<Item = &Arc<function::ExternalFunc>> {
+        self.functions.values()
+    }
 }
 
 pub struct QueryRunner<'a> {

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -151,6 +151,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["cache_spill"],
         ),
+        FunctionList => Pragma::new(
+            PragmaFlags::Result0,
+            &["name", "builtin", "type", "enc", "narg"],
+        ),
     }
 }
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -796,7 +796,7 @@ fn query_pragma(
             let base_reg = register;
             program.alloc_registers(5);
             let syms_guard = connection.syms.read();
-            let syms_ref: &SymbolTable = &*syms_guard;
+            let syms_ref: &SymbolTable = &syms_guard;
             for func in syms_ref.functions.values() {
                 let f = func.as_ref();
                 let (kind_str, nargs) = match &f.func {

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -793,22 +793,22 @@ fn query_pragma(
         }
         PragmaName::FunctionList => {
             let pragma = pragma_for(&pragma);
-            let base_reg = register;
-            program.alloc_registers(5);
             let syms_guard = connection.syms.read();
             let syms_ref: &SymbolTable = &syms_guard;
             for func in syms_ref.functions.values() {
+                let base_reg = register;
+                program.alloc_registers(5);
                 let f = func.as_ref();
                 let (kind_str, nargs) = match &f.func {
                     ExtFunc::Scalar(_) => ("scalar".to_string(), -1),
                     ExtFunc::Aggregate { argc, .. } => ("aggregate".to_string(), *argc as i64),
                 };
-                program.emit_string8(f.name.clone(), base_reg); //name
-                program.emit_int(1, base_reg + 1); //built-in (assume true)
-                program.emit_string8(kind_str, base_reg + 2); //type/kind
-                program.emit_string8("utf8".to_string(), base_reg + 3); //encoding
-                program.emit_int(nargs, base_reg + 4); //number of args
-                program.emit_result_row(base_reg, 5); //emit the result row
+                program.emit_string8(f.name.clone(), base_reg);
+                program.emit_int(1, base_reg + 1);
+                program.emit_string8(kind_str, base_reg + 2);
+                program.emit_string8("utf8".to_string(), base_reg + 3);
+                program.emit_int(nargs, base_reg + 4);
+                program.emit_result_row(base_reg, 5);
             }
             for col in pragma.columns.iter() {
                 program.add_pragma_result_column(col.to_string());

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1516,6 +1516,8 @@ pub enum PragmaName {
     WalCheckpoint,
     /// Sets or queries the threshold (in bytes) at which MVCC triggers an automatic checkpoint.
     MvccCheckpointThreshold,
+    /// returns a list of all registered functions
+    FunctionList,
 }
 
 /// `CREATE TRIGGER` time


### PR DESCRIPTION
## Description

This PR adds support for `PRAGMA function_list`;

## Motivation and context

`PRAGMA function_list` is a standard SQLite pragma that exposes the list of registered SQL functions along with their metadata (name, type, encoding, and argument count). Adding this improves SQLite compatibility and makes it easier to inspect available built-in functions during development and debugging.

The implementation iterates over the symbol table functions and emits result rows consistent with SQLite’s behavior for scalar and aggregate functions.

Feedback on correctness, structure, or edge cases is very welcome.