### PR TITLE
Modify bench-profile to allow generating better flamegraphs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,14 +140,14 @@ cargo tarpaulin -o html
 Run benchmarks:
 
 ```console
-cargo bench
+cargo bench --profile bench-profile --bench benchmark
 ```
 
 Run benchmarks and generate flamegraphs:
 
 ```console
 echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
-cargo bench --bench benchmark -- --profile-time=5
+cargo bench --profile bench-profile --bench benchmark -- --profile-time=5
 ```
 
 ## Debugging bugs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,8 @@ lto = true
 [profile.bench-profile]
 inherits = "release"
 debug = true
+lto = false               # LTO hides function boundaries
+codegen-units = 16        # Less cross-unit inlining
 
 [profile.dist]
 inherits = "release"


### PR DESCRIPTION
With these settings I can see much more clearly which functions are major contributors in flamegraphs -- using default profile has heavy inlining which obfuscates things.