### PR TITLE
btree/pager: performance tuning

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -279,14 +279,6 @@ impl<'a> WriteBatch<'a> {
     #[inline]
     pub fn submit(self) -> Result<Vec<Completion>> {
         let mut completions = Vec::with_capacity(self.ops.len());
-        self.submit_into(&mut completions)?;
-        Ok(completions)
-    }
-
-    /// Submit all writes into an existing Vec, avoiding allocation if Vec has capacity.
-    #[inline]
-    pub fn submit_into(self, completions: &mut Vec<Completion>) -> Result<()> {
-        completions.reserve(self.ops.len());
         for WriteOp { pos, bufs } in self.ops {
             let total_len = bufs.iter().map(|b| b.len()).sum::<usize>() as i32;
             let c = Completion::new_write(move |res| {
@@ -300,7 +292,7 @@ impl<'a> WriteBatch<'a> {
             });
             completions.push(self.file.pwritev(pos, bufs.to_vec(), c)?);
         }
-        Ok(())
+        Ok(completions)
     }
 
     /// Returns the file for fsync after writes complete.

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -957,8 +957,7 @@ impl BTreeCursor {
                 *remaining_to_read == 0 && next == 0,
                 "we can't have more pages to read while also have read everything"
             );
-            let mut payload_swap = Vec::new();
-            std::mem::swap(payload, &mut payload_swap);
+            let payload_swap = std::mem::take(payload);
 
             let mut reuse_immutable = self.get_immutable_record_or_create();
             reuse_immutable.as_mut().unwrap().invalidate();

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -766,6 +766,7 @@ impl PageContent {
         self.read_u8(BTREE_FRAGMENTED_BYTES_COUNT)
     }
 
+    #[inline]
     pub fn rightmost_pointer(&self) -> Option<u32> {
         match self.page_type() {
             PageType::IndexInterior => Some(self.read_u32(BTREE_RIGHTMOST_PTR)),
@@ -775,6 +776,7 @@ impl PageContent {
         }
     }
 
+    #[inline]
     pub fn rightmost_pointer_raw(&self) -> Option<*mut u8> {
         match self.page_type() {
             PageType::IndexInterior | PageType::TableInterior => Some(unsafe {
@@ -787,6 +789,7 @@ impl PageContent {
         }
     }
 
+    #[inline]
     pub fn cell_get(&self, idx: usize, usable_size: usize) -> Result<BTreeCell> {
         tracing::trace!("cell_get(idx={})", idx);
         let buf = self.as_ptr();
@@ -884,6 +887,7 @@ impl PageContent {
     /// FIXME: make all usages of [cell_get_raw_region] to use the _faster version in cases where the method is called
     /// repeatedly, since page_type, max_local, min_local are the same for all cells on the page. Also consider whether
     /// max_local and min_local should be static properties of the page.
+    #[inline]
     pub fn cell_get_raw_region(&self, idx: usize, usable_size: usize) -> (usize, usize) {
         let page_type = self.page_type();
         let max_local = payload_overflow_threshold_max(page_type, usable_size);


### PR DESCRIPTION
## Description
Minor perf wins in the pager and btree code, re-using allocations, replacing the `pager.dirty_pages` BTreeMap with a RoaringBitmap, and lots of `#[inline]` annotations.

## Motivation and context
Benchmarks are showing a fair improvement, 2-6% on TPC-H and even more on `make bench-exclude-tpc-h`

## Description of AI Usage
Some of this was assisted by CC