### PR TITLE
btree: reset `AdvanceState` after last state transition

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5025,6 +5025,7 @@ impl CursorTrait for BTreeCursor {
                     let cursor_has_record = return_if_io!(self.get_next_record());
                     self.set_has_record(cursor_has_record);
                     self.invalidate_record();
+                    self.advance_state = AdvanceState::Start;
                     return Ok(IOResult::Done(cursor_has_record));
                 }
             }
@@ -5052,6 +5053,7 @@ impl CursorTrait for BTreeCursor {
                     let cursor_has_record = return_if_io!(self.get_prev_record());
                     self.set_has_record(cursor_has_record);
                     self.invalidate_record();
+                    self.advance_state = AdvanceState::Start;
                     return Ok(IOResult::Done(cursor_has_record));
                 }
             }


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage
AI pointed this out to me.
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
