### PR TITLE
btree: `get_prev_record` and `get_next_record` automatically invalidate_record

### DIFF
--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -869,7 +869,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     rowid,
                     idx,
                 } => {
-                    if !return_if_io!(cursor.next()) {
+                    return_if_io!(cursor.next());
+                    if !cursor.has_record() {
                         return Err(LimboError::Corrupt("inverted index corrupted".to_string()));
                     }
                     self.delete_state = VectorSparseInvertedIndexDeleteState::DeleteInverted {
@@ -1378,8 +1379,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     component,
                     current,
                 } => {
-                    let result = return_if_io!(inverted.next());
-                    if !result {
+                    return_if_io!(inverted.next());
+                    if !inverted.has_record() {
                         let Some(mut current) = current.take() else {
                             return Err(LimboError::InternalError(
                                 "current must be present in Next state".to_string(),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -835,7 +835,9 @@ fn test_lazy_scan_cursor_basic() {
     .unwrap();
 
     // Check first row
-    assert!(matches!(cursor.next().unwrap(), IOResult::Done(true)));
+    let res = cursor.next().unwrap();
+    assert!(matches!(res, IOResult::Done(())));
+    assert!(cursor.has_record());
     assert!(!cursor.is_empty());
     let row = cursor.read_mvcc_current_row().unwrap().unwrap();
     assert_eq!(row.id.row_id.to_int_or_panic(), 1);
@@ -844,10 +846,10 @@ fn test_lazy_scan_cursor_basic() {
     let mut count = 1;
     loop {
         let res = cursor.next().unwrap();
-        let IOResult::Done(res) = res else {
+        let IOResult::Done(()) = res else {
             panic!("unexpected next result {res:?}");
         };
-        if !res {
+        if !cursor.has_record() {
             break;
         }
         count += 1;
@@ -859,7 +861,9 @@ fn test_lazy_scan_cursor_basic() {
     assert_eq!(count, 5);
 
     // After the last row, is_empty should return true
-    assert!(!matches!(cursor.next().unwrap(), IOResult::Done(true)));
+    let res = cursor.next().unwrap();
+    assert!(matches!(res, IOResult::Done(())));
+    assert!(!cursor.has_record());
     assert!(cursor.is_empty());
 }
 
@@ -878,7 +882,9 @@ fn test_lazy_scan_cursor_with_gaps() {
     .unwrap();
 
     // Check first row
-    assert!(matches!(cursor.next().unwrap(), IOResult::Done(true)));
+    let res = cursor.next().unwrap();
+    assert!(matches!(res, IOResult::Done(())));
+    assert!(cursor.has_record());
     assert!(!cursor.is_empty());
     let row = cursor.read_mvcc_current_row().unwrap().unwrap();
     assert_eq!(row.id.row_id.to_int_or_panic(), 5);
@@ -895,10 +901,10 @@ fn test_lazy_scan_cursor_with_gaps() {
 
     loop {
         let res = cursor.next().unwrap();
-        let IOResult::Done(res) = res else {
+        let IOResult::Done(()) = res else {
             panic!("unexpected next result {res:?}");
         };
-        if !res {
+        if !cursor.has_record() {
             break;
         }
         index += 1;
@@ -940,10 +946,10 @@ fn test_cursor_basic() {
     let mut count = 1;
     loop {
         let res = cursor.next().unwrap();
-        let IOResult::Done(res) = res else {
+        let IOResult::Done(()) = res else {
             panic!("unexpected next result {res:?}");
         };
-        if !res {
+        if !cursor.has_record() {
             break;
         }
         count += 1;
@@ -955,7 +961,9 @@ fn test_cursor_basic() {
     assert_eq!(count, 5);
 
     // After the last row, is_empty should return true
-    assert!(!matches!(cursor.next().unwrap(), IOResult::Done(true)));
+    let res = cursor.next().unwrap();
+    assert!(matches!(res, IOResult::Done(())));
+    assert!(!cursor.has_record());
     assert!(cursor.is_empty());
 }
 
@@ -1004,7 +1012,9 @@ fn test_cursor_modification_during_scan() {
     .unwrap();
 
     // Read first row
-    assert!(matches!(cursor.next().unwrap(), IOResult::Done(true)));
+    let res = cursor.next().unwrap();
+    assert!(matches!(res, IOResult::Done(())));
+    assert!(cursor.has_record());
     let first_row = cursor.read_mvcc_current_row().unwrap().unwrap();
     assert_eq!(first_row.id.row_id.to_int_or_panic(), 1);
 
@@ -1022,10 +1032,10 @@ fn test_cursor_modification_during_scan() {
     let mut read_rowids = vec![];
     loop {
         let res = cursor.next().unwrap();
-        let IOResult::Done(res) = res else {
+        let IOResult::Done(()) = res else {
             panic!("unexpected next result {res:?}");
         };
-        if !res {
+        if !cursor.has_record() {
             break;
         }
         read_rowids.push(
@@ -1039,7 +1049,9 @@ fn test_cursor_modification_during_scan() {
         );
     }
     assert_eq!(read_rowids, vec![2, 3, 4, 5]);
-    assert!(!matches!(cursor.next().unwrap(), IOResult::Done(true)));
+    let res = cursor.next().unwrap();
+    assert!(matches!(res, IOResult::Done(())));
+    assert!(!cursor.has_record());
     assert!(cursor.is_empty());
 }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3408,11 +3408,7 @@ pub fn seek_internal(
                             SeekOp::LT | SeekOp::LE { .. } => cursor.prev()?,
                         };
                         match result {
-                            IOResult::Done(found) => {
-                                cursor.set_has_record(found);
-                                cursor.invalidate_record();
-                                found
-                            }
+                            IOResult::Done(()) => cursor.has_record(),
                             IOResult::IO(io) => return Ok(SeekInternalResult::IO(io)),
                         }
                     };


### PR DESCRIPTION
## Description
We were forgetting to `invalidate_records` after calling `get_next_record` or `get_prev_record`. 


## Description of AI Usage
It came to me in an AI dream. 
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
