### PR TITLE
Raise log level polling frequency

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -596,7 +596,7 @@ pub fn init_tracing() -> Result<(WorkerGuard, LogLevelReloadHandle), std::io::Er
     Ok((guard, reload_handle))
 }
 
-const LOG_LEVEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+const LOG_LEVEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
 const LOG_LEVEL_FILE: &str = "RUST_LOG";
 


### PR DESCRIPTION
## Description

This PR lowers the log level polling delay to 100ms. The reason is that the current value (2 seconds) is too high, in an Antithesis run I'm investigating, I would need something less than 700ms. Hopefully with this change we can catch the logs next time a failure occurs.