### PR TITLE
fix(storage): improve error message for truncated database files

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -992,12 +992,14 @@ pub fn begin_read_page(
         // (and it's not an intentional empty read), the database is corrupt.
         if bytes_read == 0 {
             if !allow_empty_read {
-                turso_assert!(false, "read returned 0 bytes but empty reads are not allowed");
+                turso_assert!(
+                    false,
+                    "read returned 0 bytes but empty reads are not allowed"
+                );
             }
         } else if bytes_read != buf_len as i32 {
             panic!(
-                "database disk image is malformed: read {} bytes but expected {}",
-                bytes_read, buf_len
+                "database disk image is malformed: read {bytes_read} bytes but expected {buf_len}",
             );
         }
         let page = page.clone();


### PR DESCRIPTION
## Description

When reading a database file that was truncated (e.g., smaller than the page size), Turso would panic with a cryptic internal error message (read(1024) != expected(4096)). This commit changes the assertion to produce a user-friendly error message matching SQLite's behavior: "database disk image is malformed: read X bytes but expected Y".

Before:
thread 'main' panicked at core/storage/sqlite3_ondisk.rs:920:9:
read(1024) != expected(4096)

After:
thread 'main' panicked at core/storage/sqlite3_ondisk.rs:998:9:
database disk image is malformed: read 1024 bytes but expected 4096

This matches SQLite's error output:
Parse error: database disk image is malformed (11)

## Motivation and context

This fix addresses issue #4229. Truncated database files should produce a clear error indicating the database is corrupt, rather than an internal assertion failure with cryptic byte counts.

## Description of AI 
