### PR TITLE
Enable debug_assertions for antithesis profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ lto = false
 [profile.antithesis]
 inherits = "release"
 debug = true
+debug-assertions = true
 codegen-units = 1
 panic = "abort"
 lto = true


### PR DESCRIPTION
This allows #[cfg(debug_assertions)] code to be compiled and run when building with the antithesis profile.