### PR TITLE
Add scripts/corruption-debug-tools

### DIFF
--- a/scripts/corruption-debug-tools/README.md
+++ b/scripts/corruption-debug-tools/README.md
@@ -1,0 +1,314 @@
+# Tursodb Corruption Debug Tools
+
+A collection of Python scripts for analyzing WAL files and debugging database corruption issues.
+
+## Prerequisites
+
+- Python 3.8+
+- SQLite CLI (`sqlite3`) for integrity checks
+
+## Scripts
+
+### WAL Analysis
+
+#### `wal_info.py`
+Show WAL file header and summary information.
+
+```bash
+./wal_info.py my_corrupted_database.db
+./wal_info.py my_corrupted_database.db-wal
+./wal_info.py my_corrupted_database.db -v  # Verbose: show pages by write count
+```
+
+Example output:
+```
+WAL Header
+==================================================
+  File:            my_corrupted_database.db-wal
+  Size:            22,598,232 bytes
+  Magic:           0x377f0682 (big-endian checksums)
+  Page size:       4096 bytes
+  Checkpoint seq:  0
+
+Summary
+==================================================
+  Total frames:    5485
+  Commit frames:   1459
+  Unique pages:    67
+```
+
+#### `wal_commits.py`
+List commit frames and transaction boundaries.
+
+```bash
+./wal_commits.py my_corrupted_database.db --last 20     # Last 20 commits
+./wal_commits.py my_corrupted_database.db --around 5133 # Focus on specific frame
+./wal_commits.py my_corrupted_database.db --all         # All commits
+```
+
+Example output (`--around 5137`):
+```
+=== Analysis around frame 5137 ===
+
+Previous commit: Frame 5131
+  Page: 64
+  DB size: 64 pages
+
+Target commit: Frame 5137
+  Page: 60
+  DB size: 64 pages
+
+Transaction frames (5132 to 5137):
+--------------------------------------------------
+  Frame  5132: page     7
+  Frame  5133: page    26
+  Frame  5134: page    27
+  Frame  5135: page    43
+  Frame  5136: page    56
+  Frame  5137: page    60  COMMIT <-- TARGET
+```
+
+### Corruption Detection
+
+#### `find_corrupt_frame.py`
+Binary search to find the earliest WAL frame that introduces corruption.
+
+```bash
+./find_corrupt_frame.py my_corrupted_database.db
+./find_corrupt_frame.py my_corrupted_database.db -v  # Show integrity check output
+```
+
+Example output:
+```
+WAL has 5846 frames
+Checking with 0 frames (DB file only)... OK
+Checking with all 5846 frames... CORRUPT
+
+[1] Testing 2923 frames (range 0-5846)... OK
+[2] Testing 4384 frames (range 2923-5846)... OK
+...
+[13] Testing 5133 frames (range 5132-5134)... CORRUPT
+
+Found: Frame 5133 (0-indexed: 5132) introduces corruption
+Last good state: 5132 frames
+```
+
+### Page Analysis
+
+#### `page_info.py`
+Show detailed information about a database page.
+
+```bash
+./page_info.py my_corrupted_database.db 26                  # Current state
+./page_info.py my_corrupted_database.db 26 --frame 5127     # State at frame 5127
+./page_info.py my_corrupted_database.db 26 --cells          # Show cell pointers
+./page_info.py my_corrupted_database.db 26 --keys           # Show index keys (for index pages)
+```
+
+Example output:
+```
+Page 26 (after frame 5127)
+============================================================
+  Type:            0x0a (leaf index)
+  Cell count:      185
+  Content start:   559
+  First freeblock: 0
+  Fragmented:      0 bytes
+
+  Index entries:   185 rowids
+  Rowids (first 10): [4, 17, 23, 45, 67, 89, 102, 115, 128, 141]
+  Rowids (last 10):  [601, 614, 627, 640, 653, 661, 666, 679, 692, 705]
+```
+
+#### `page_diff.py`
+Compare page states between two WAL frames.
+
+```bash
+./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133
+./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133 --rowids  # Compare rowids
+./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133 --keys    # Show key changes
+./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133 --hex     # Show hex diff
+```
+
+Example output (`--rowids`):
+```
+Page 26 Diff: Frame 5131 -> Frame 5133
+============================================================
+Changed bytes:     1609 / 4096
+Cell count:        185 -> 185
+Content start:     559 -> 558 (-1)
+
+Rowids:
+  Lost:            [661]
+  Gained:          [365]
+  Unchanged:       184 rowids
+```
+
+#### `page_history.py`
+Show all WAL writes to a specific page.
+
+```bash
+./page_history.py my_corrupted_database.db 26
+./page_history.py my_corrupted_database.db 26 --track-key "dark_wall_716"  # Track key presence
+./page_history.py my_corrupted_database.db 26 --track-rowid 661            # Track rowid
+./page_history.py my_corrupted_database.db 26 --limit 50                   # Limit output
+```
+
+Example output (`--track-rowid 661`):
+```
+Page 26 History
+======================================================================
+DB file state: leaf index, 192 cells, content_start=428
+  Rowid 661: absent
+
+WAL writes:
+----------------------------------------------------------------------
+  Frame  5098: 193 cells, content_start=409
+  Frame  5106: 185 cells, content_start=559  ROWID 661 APPEARS
+  Frame  5133: 185 cells, content_start=558  ROWID 661 DISAPPEARS
+  ...
+```
+
+### Rowid Tracking
+
+#### `track_rowid.py`
+Track when a rowid appears/disappears across pages.
+
+```bash
+./track_rowid.py my_corrupted_database.db 661 --pages 26,42     # Track in specific pages
+./track_rowid.py my_corrupted_database.db 661 --all-index       # Track in all index pages
+./track_rowid.py my_corrupted_database.db 661 --all-table       # Track in all table pages
+```
+
+Example output:
+```
+Tracking rowid 661
+======================================================================
+Tracking pages: [26, 42]
+
+WAL changes:
+----------------------------------------------------------------------
+  Frame  5106: Page  26 - rowid 661 APPEARS
+  Frame  5108: Page  42 - rowid 661 APPEARS
+  Frame  5133: Page  26 - rowid 661 DISAPPEARS
+  Frame  5145: Page  42 - rowid 661 DISAPPEARS
+
+Timeline:
+----------------------------------------------------------------------
+  Frame 5106: APPEARS in page 26
+  Frame 5108: APPEARS in page 42
+  Frame 5133: DISAPPEARS in page 26
+  Frame 5145: DISAPPEARS in page 42
+```
+
+### Stale Page Verification
+
+#### `verify_stale.py`
+Verify if corruption looks like it was caused by reading a stale page.
+
+```bash
+# Check if frame 5133 looks like frame 5098 + insertion of rowid 663
+./verify_stale.py my_corrupted_database.db 26 --stale-frame 5098 --corrupt-frame 5133 --gained-rowid 663
+
+# Compare against known good state
+./verify_stale.py my_corrupted_database.db 26 --stale-frame 5098 --corrupt-frame 5133 --good-frame 5106
+```
+
+Example output:
+```
+Stale Page Analysis for Page 26
+======================================================================
+
+Stale source (frame 5105):
+  Type:          leaf index
+  Cell count:    193
+
+Corrupt state (frame 5133):
+  Type:          leaf index
+  Cell count:    185
+
+Rowid Analysis:
+  Stale rowids:    193
+  Corrupt rowids:  185
+
+--- Stale Page Hypothesis ---
+  Common rowids:     185
+  Only in stale:     8 [324, 344, 448, 449, 588, 613, 640, 653]
+  Only in corrupt:   0 []
+
+  Note: Stale has rowids not in corrupt - suggests B-tree rebalance
+
+--- Byte Comparison ---
+  Stale vs Corrupt: 1911 bytes differ (53.3% similar)
+  Good vs Corrupt:  1609 bytes differ (60.7% similar)
+```
+
+## Library Modules
+
+The scripts use a shared library in `lib/`:
+
+- `lib/wal.py` - WAL parsing (headers, frames, commits)
+- `lib/page.py` - Page reading and header parsing
+- `lib/record.py` - SQLite record format (varints, serial types)
+- `lib/diff.py` - Comparison utilities
+
+### Using the Library
+
+```python
+import sys
+sys.path.insert(0, "/path/to/corruption-debug-tools")
+
+from lib.wal import iter_frames, get_frame_count
+from lib.page import get_page_at_frame, parse_page_header
+from lib.record import get_index_rowids, get_index_keys
+from lib.diff import compare_pages, compare_rowids
+
+# Get page state at a specific frame
+page = get_page_at_frame("db.db", "db.db-wal", page_num=26, up_to_frame=5127)
+
+# Parse the page header
+header = parse_page_header(page)
+print(f"Type: {header.type_name}, Cells: {header.cell_count}")
+
+# Get rowids from an index page
+rowids = get_index_rowids(page)
+print(f"Rowids: {rowids}")
+```
+
+## Typical Investigation Workflow
+
+1. **Find the corrupt frame**:
+   ```bash
+   ./find_corrupt_frame.py my_corrupted_database.db
+   # Output: Frame 5133 introduces corruption
+   ```
+
+2. **Analyze the corrupt transaction**:
+   ```bash
+   ./wal_commits.py my_corrupted_database.db --around 5133
+   # Shows frames 5128-5133 in the transaction
+   ```
+
+3. **Compare page states**:
+   ```bash
+   ./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133 --rowids --keys
+   # Shows: Lost rowid 661, Gained rowid 663
+   ```
+
+4. **Track the lost rowid**:
+   ```bash
+   ./track_rowid.py my_corrupted_database.db 661 --pages 26,42
+   # Shows when rowid 661 appeared and disappeared
+   ```
+
+5. **Find the stale source**:
+   ```bash
+   ./page_history.py my_corrupted_database.db 26 --track-rowid 661
+   # Find frames where 661 was present vs absent
+   ```
+
+6. **Verify stale page hypothesis**:
+   ```bash
+   ./verify_stale.py my_corrupted_database.db 26 --stale-frame 5098 --corrupt-frame 5133 --gained-rowid 663
+   # Confirms if corruption matches stale + insertion pattern
+   ```

--- a/scripts/corruption-debug-tools/find_corrupt_frame.py
+++ b/scripts/corruption-debug-tools/find_corrupt_frame.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Binary search to find the earliest WAL frame that introduces corruption.
+
+This script performs a binary search through WAL frames, running SQLite's
+integrity check at each step to find the exact frame where corruption begins.
+
+Usage:
+    ./find_corrupt_frame.py <db-file>
+    ./find_corrupt_frame.py <db-file> --verbose
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.wal import create_truncated_wal, get_frame_count, get_page_size_from_wal
+
+
+def check_integrity(db_path: str, wal_path: str, num_frames: int, page_size: int, verbose: bool = False) -> bool:
+    """Check integrity of DB with truncated WAL. Returns True if OK."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_db = os.path.join(tmpdir, "test.db")
+        tmp_wal = os.path.join(tmpdir, "test.db-wal")
+
+        # Copy the database file
+        shutil.copy2(db_path, tmp_db)
+
+        # Create truncated WAL
+        if num_frames > 0:
+            create_truncated_wal(wal_path, num_frames, tmp_wal, page_size)
+
+        # Run integrity check using sqlite3 CLI
+        try:
+            result = subprocess.run(
+                ["sqlite3", tmp_db, "PRAGMA integrity_check;"], capture_output=True, text=True, timeout=60
+            )
+            output = result.stdout.strip()
+
+            if verbose and output != "ok":
+                print(f"    Integrity check output: {output[:200]}")
+
+            return output == "ok"
+
+        except subprocess.TimeoutExpired:
+            print("  Warning: integrity check timed out", file=sys.stderr)
+            return False
+        except FileNotFoundError:
+            print("Error: sqlite3 CLI not found. Please install SQLite.", file=sys.stderr)
+            sys.exit(1)
+        except Exception as e:
+            print(f"  Error checking integrity: {e}", file=sys.stderr)
+            return False
+
+
+def binary_search_corrupt_frame(db_path: str, wal_path: str, verbose: bool = False) -> int:
+    """
+    Find the earliest frame that causes corruption.
+
+    Returns:
+        Frame number (1-indexed) that introduces corruption, or -1 if not found
+    """
+    page_size = get_page_size_from_wal(wal_path)
+    total_frames = get_frame_count(wal_path, page_size)
+
+    print(f"Database: {db_path}")
+    print(f"WAL file: {wal_path}")
+    print(f"WAL has {total_frames} frames")
+    print()
+
+    # First check: is 0 frames OK?
+    print("Checking with 0 frames (DB file only)...", end=" ", flush=True)
+    if not check_integrity(db_path, wal_path, 0, page_size, verbose):
+        print("CORRUPT")
+        print("\nDatabase file is already corrupt without any WAL frames!")
+        return -1
+    print("OK")
+
+    # Check if full WAL is actually corrupt
+    print(f"Checking with all {total_frames} frames...", end=" ", flush=True)
+    if check_integrity(db_path, wal_path, total_frames, page_size, verbose):
+        print("OK")
+        print("\nFull WAL passes integrity check - no corruption found!")
+        return -1
+    print("CORRUPT")
+    print()
+
+    # Binary search for first corrupting frame
+    low = 0  # Last known good
+    high = total_frames  # Known bad
+
+    iterations = 0
+    while high - low > 1:
+        mid = (low + high) // 2
+        iterations += 1
+        print(f"[{iterations}] Testing {mid} frames (range {low}-{high})...", end=" ", flush=True)
+
+        if check_integrity(db_path, wal_path, mid, page_size, verbose):
+            print("OK")
+            low = mid
+        else:
+            print("CORRUPT")
+            high = mid
+
+    print()
+    print("=" * 60)
+    print(f"Found: Frame {high} (0-indexed: {high - 1}) introduces corruption")
+    print(f"Last good state: {low} frames")
+    print(f"Binary search completed in {iterations} iterations")
+
+    # Calculate byte offset of the corrupting frame
+    from lib.wal import FRAME_HEADER_SIZE, WAL_HEADER_SIZE
+
+    frame_offset = WAL_HEADER_SIZE + (high - 1) * (FRAME_HEADER_SIZE + page_size)
+    print(f"Corrupting frame byte offset: {frame_offset} (0x{frame_offset:x})")
+
+    return high
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Binary search for the first WAL frame that introduces corruption")
+    parser.add_argument("db_path", help="Path to database file")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Show integrity check output on failures")
+    args = parser.parse_args()
+
+    db_path = args.db_path
+    wal_path = db_path + "-wal"
+
+    if not os.path.exists(db_path):
+        print(f"Error: Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.exists(wal_path):
+        print(f"Error: WAL file not found: {wal_path}", file=sys.stderr)
+        sys.exit(1)
+
+    corrupt_frame = binary_search_corrupt_frame(db_path, wal_path, args.verbose)
+    sys.exit(0 if corrupt_frame > 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corruption-debug-tools/lib/__init__.py
+++ b/scripts/corruption-debug-tools/lib/__init__.py
@@ -1,0 +1,69 @@
+"""
+SQLite/Limbo corruption debugging library.
+
+Provides utilities for parsing WAL files, database pages, and SQLite records.
+"""
+
+from .diff import (
+    compare_cell_pointers,
+    compare_pages,
+    compare_rowids,
+)
+from .page import (
+    PAGE_TYPES,
+    get_cell_pointers,
+    get_interior_children,
+    get_page_at_frame,
+    get_page_from_db,
+    parse_page_header,
+)
+from .record import (
+    decode_serial_type,
+    get_index_keys,
+    get_index_rowids,
+    get_table_rowids,
+    parse_record,
+    read_varint,
+)
+from .wal import (
+    FRAME_HEADER_SIZE,
+    WAL_HEADER_SIZE,
+    create_truncated_wal,
+    get_frame_count,
+    get_frame_page,
+    get_page_size_from_wal,
+    iter_frames,
+    parse_frame_header,
+    parse_wal_header,
+)
+
+__all__ = [
+    # WAL
+    "WAL_HEADER_SIZE",
+    "FRAME_HEADER_SIZE",
+    "parse_wal_header",
+    "parse_frame_header",
+    "get_frame_count",
+    "get_page_size_from_wal",
+    "iter_frames",
+    "get_frame_page",
+    "create_truncated_wal",
+    # Page
+    "PAGE_TYPES",
+    "get_page_from_db",
+    "get_page_at_frame",
+    "parse_page_header",
+    "get_cell_pointers",
+    "get_interior_children",
+    # Record
+    "read_varint",
+    "decode_serial_type",
+    "parse_record",
+    "get_index_rowids",
+    "get_index_keys",
+    "get_table_rowids",
+    # Diff
+    "compare_pages",
+    "compare_cell_pointers",
+    "compare_rowids",
+]

--- a/scripts/corruption-debug-tools/lib/diff.py
+++ b/scripts/corruption-debug-tools/lib/diff.py
@@ -1,0 +1,152 @@
+"""
+Comparison and diff utilities for pages and records.
+"""
+
+from typing import List, NamedTuple, Set, Tuple
+
+from .page import get_cell_pointers, parse_page_header
+from .record import get_index_rowids
+
+
+class PageDiff(NamedTuple):
+    """Result of comparing two page states."""
+
+    bytes_changed: int
+    total_bytes: int
+    cell_count_before: int
+    cell_count_after: int
+    content_start_before: int
+    content_start_after: int
+    identical: bool
+
+
+class CellPointerDiff(NamedTuple):
+    """Result of comparing cell pointer arrays."""
+
+    pointers_lost: Set[int]
+    pointers_gained: Set[int]
+    pointers_unchanged: Set[int]
+    first_diff_index: int  # -1 if identical
+
+
+class RowidDiff(NamedTuple):
+    """Result of comparing rowid sets."""
+
+    rowids_lost: Set[int]
+    rowids_gained: Set[int]
+    rowids_unchanged: Set[int]
+
+
+def compare_pages(before: bytes, after: bytes) -> PageDiff:
+    """
+    Compare two page states byte-by-byte.
+
+    Args:
+        before: Page data before
+        after: Page data after
+
+    Returns:
+        PageDiff with comparison results
+    """
+    # Count differing bytes
+    min_len = min(len(before), len(after))
+    bytes_changed = sum(1 for i in range(min_len) if before[i] != after[i])
+    bytes_changed += abs(len(before) - len(after))
+
+    before_header = parse_page_header(before)
+    after_header = parse_page_header(after)
+
+    return PageDiff(
+        bytes_changed=bytes_changed,
+        total_bytes=max(len(before), len(after)),
+        cell_count_before=before_header.cell_count,
+        cell_count_after=after_header.cell_count,
+        content_start_before=before_header.cell_content_start,
+        content_start_after=after_header.cell_content_start,
+        identical=(bytes_changed == 0),
+    )
+
+
+def compare_cell_pointers(before: bytes, after: bytes, page_offset: int = 0) -> CellPointerDiff:
+    """
+    Compare cell pointer arrays between two page states.
+
+    Args:
+        before: Page data before
+        after: Page data after
+        page_offset: Header offset (100 for page 1)
+
+    Returns:
+        CellPointerDiff with comparison results
+    """
+    before_ptrs = set(get_cell_pointers(before, page_offset))
+    after_ptrs = set(get_cell_pointers(after, page_offset))
+
+    lost = before_ptrs - after_ptrs
+    gained = after_ptrs - before_ptrs
+    unchanged = before_ptrs & after_ptrs
+
+    # Find first differing index
+    before_list = get_cell_pointers(before, page_offset)
+    after_list = get_cell_pointers(after, page_offset)
+
+    first_diff = -1
+    for i in range(min(len(before_list), len(after_list))):
+        if before_list[i] != after_list[i]:
+            first_diff = i
+            break
+
+    if first_diff == -1 and len(before_list) != len(after_list):
+        first_diff = min(len(before_list), len(after_list))
+
+    return CellPointerDiff(
+        pointers_lost=lost,
+        pointers_gained=gained,
+        pointers_unchanged=unchanged,
+        first_diff_index=first_diff,
+    )
+
+
+def compare_rowids(before: bytes, after: bytes, page_offset: int = 0) -> RowidDiff:
+    """
+    Compare rowids between two index page states.
+
+    Args:
+        before: Page data before
+        after: Page data after
+        page_offset: Header offset (100 for page 1)
+
+    Returns:
+        RowidDiff with comparison results
+    """
+    before_rowids = get_index_rowids(before, page_offset)
+    after_rowids = get_index_rowids(after, page_offset)
+
+    return RowidDiff(
+        rowids_lost=before_rowids - after_rowids,
+        rowids_gained=after_rowids - before_rowids,
+        rowids_unchanged=before_rowids & after_rowids,
+    )
+
+
+def find_matching_bytes(page: bytes, candidates: List[Tuple[str, bytes]]) -> List[Tuple[str, int, float]]:
+    """
+    Find how well a page matches each candidate source.
+
+    Args:
+        page: Page to check
+        candidates: List of (name, page_data) tuples
+
+    Returns:
+        List of (name, matching_bytes, percentage) sorted by match percentage
+    """
+    results = []
+
+    for name, candidate in candidates:
+        min_len = min(len(page), len(candidate))
+        matching = sum(1 for i in range(min_len) if page[i] == candidate[i])
+        percentage = (matching / len(page)) * 100 if len(page) > 0 else 0
+
+        results.append((name, matching, percentage))
+
+    return sorted(results, key=lambda x: x[2], reverse=True)

--- a/scripts/corruption-debug-tools/lib/page.py
+++ b/scripts/corruption-debug-tools/lib/page.py
@@ -1,0 +1,208 @@
+"""
+SQLite page parsing utilities.
+
+Page types:
+- 0x02: Interior index B-tree page
+- 0x05: Interior table B-tree page
+- 0x0a: Leaf index B-tree page
+- 0x0d: Leaf table B-tree page
+"""
+
+import struct
+from typing import List, NamedTuple, Optional
+
+from .wal import (
+    FRAME_HEADER_SIZE,
+    WAL_HEADER_SIZE,
+    get_page_size_from_wal,
+)
+
+PAGE_TYPES = {
+    0x02: "interior index",
+    0x05: "interior table",
+    0x0A: "leaf index",
+    0x0D: "leaf table",
+}
+
+
+class PageHeader(NamedTuple):
+    """Parsed B-tree page header."""
+
+    page_type: int
+    type_name: str
+    first_freeblock: int
+    cell_count: int
+    cell_content_start: int
+    fragmented_bytes: int
+    rightmost_ptr: Optional[int]  # Only for interior pages
+    header_size: int
+
+    @property
+    def is_leaf(self) -> bool:
+        return self.page_type in (0x0A, 0x0D)
+
+    @property
+    def is_interior(self) -> bool:
+        return self.page_type in (0x02, 0x05)
+
+    @property
+    def is_index(self) -> bool:
+        return self.page_type in (0x02, 0x0A)
+
+    @property
+    def is_table(self) -> bool:
+        return self.page_type in (0x05, 0x0D)
+
+
+def get_page_from_db(db_path: str, page_num: int, page_size: int = 4096) -> bytes:
+    """Read a page directly from the database file (1-indexed)."""
+    with open(db_path, "rb") as f:
+        f.seek((page_num - 1) * page_size)
+        return f.read(page_size)
+
+
+def get_page_at_frame(
+    db_path: str, wal_path: str, page_num: int, up_to_frame: int, page_size: Optional[int] = None
+) -> bytes:
+    """
+    Get page state after applying WAL frames up to (but not including) up_to_frame.
+
+    Args:
+        db_path: Path to database file
+        wal_path: Path to WAL file
+        page_num: Page number (1-indexed)
+        up_to_frame: Apply frames 0 to up_to_frame-1 (0 means DB file only)
+        page_size: Page size (auto-detected from WAL if not provided)
+
+    Returns:
+        Page data bytes
+    """
+    if page_size is None:
+        page_size = get_page_size_from_wal(wal_path)
+
+    # Start with page from DB file
+    page_data = get_page_from_db(db_path, page_num, page_size)
+
+    if up_to_frame == 0:
+        return page_data
+
+    # Apply WAL frames
+    frame_size = FRAME_HEADER_SIZE + page_size
+
+    with open(wal_path, "rb") as f:
+        wal_data = f.read()
+
+    for frame_idx in range(up_to_frame):
+        offset = WAL_HEADER_SIZE + frame_idx * frame_size
+        if offset + 4 > len(wal_data):
+            break
+
+        frame_page_num = struct.unpack(">I", wal_data[offset : offset + 4])[0]
+        if frame_page_num == page_num:
+            page_data = wal_data[offset + FRAME_HEADER_SIZE : offset + frame_size]
+
+    return page_data
+
+
+def parse_page_header(data: bytes, page_offset: int = 0) -> PageHeader:
+    """
+    Parse B-tree page header.
+
+    Args:
+        data: Page data
+        page_offset: Offset within page for header (100 for page 1 due to DB header)
+
+    Returns:
+        Parsed PageHeader
+    """
+    base = page_offset
+    page_type = data[base]
+    first_freeblock = struct.unpack(">H", data[base + 1 : base + 3])[0]
+    cell_count = struct.unpack(">H", data[base + 3 : base + 5])[0]
+    cell_content_start = struct.unpack(">H", data[base + 5 : base + 7])[0]
+
+    # 0 means 65536
+    if cell_content_start == 0:
+        cell_content_start = 65536
+
+    fragmented_bytes = data[base + 7]
+
+    # Interior pages have a 4-byte rightmost pointer
+    if page_type in (0x02, 0x05):
+        rightmost_ptr = struct.unpack(">I", data[base + 8 : base + 12])[0]
+        header_size = 12
+    else:
+        rightmost_ptr = None
+        header_size = 8
+
+    return PageHeader(
+        page_type=page_type,
+        type_name=PAGE_TYPES.get(page_type, f"unknown (0x{page_type:02x})"),
+        first_freeblock=first_freeblock,
+        cell_count=cell_count,
+        cell_content_start=cell_content_start,
+        fragmented_bytes=fragmented_bytes,
+        rightmost_ptr=rightmost_ptr,
+        header_size=header_size,
+    )
+
+
+def get_cell_pointers(data: bytes, page_offset: int = 0) -> List[int]:
+    """
+    Get list of cell pointers from a page.
+
+    Args:
+        data: Page data
+        page_offset: Offset for page header (100 for page 1)
+
+    Returns:
+        List of cell pointer offsets
+    """
+    header = parse_page_header(data, page_offset)
+    ptr_array_start = page_offset + header.header_size
+
+    pointers = []
+    for i in range(header.cell_count):
+        ptr_offset = ptr_array_start + i * 2
+        ptr = struct.unpack(">H", data[ptr_offset : ptr_offset + 2])[0]
+        pointers.append(ptr)
+
+    return pointers
+
+
+def get_interior_children(data: bytes, page_offset: int = 0) -> List[int]:
+    """
+    Get child page numbers from an interior B-tree page.
+
+    Returns list of child page numbers. For interior pages, each cell has a
+    left child pointer, plus there's a rightmost pointer in the header.
+
+    Args:
+        data: Page data
+        page_offset: Offset for page header (100 for page 1)
+
+    Returns:
+        List of child page numbers
+    """
+    header = parse_page_header(data, page_offset)
+
+    if not header.is_interior:
+        return []
+
+    children = []
+    ptr_array_start = page_offset + header.header_size
+
+    for i in range(header.cell_count):
+        # Get cell pointer
+        ptr_offset = ptr_array_start + i * 2
+        cell_ptr = struct.unpack(">H", data[ptr_offset : ptr_offset + 2])[0]
+
+        # Interior cell starts with 4-byte left child pointer
+        left_child = struct.unpack(">I", data[cell_ptr : cell_ptr + 4])[0]
+        children.append(left_child)
+
+    # Add rightmost pointer
+    if header.rightmost_ptr:
+        children.append(header.rightmost_ptr)
+
+    return children

--- a/scripts/corruption-debug-tools/lib/record.py
+++ b/scripts/corruption-debug-tools/lib/record.py
@@ -1,0 +1,289 @@
+"""
+SQLite record format parsing utilities.
+
+SQLite records consist of:
+- Header: varint header size, followed by serial types for each column
+- Body: column values in order
+
+Serial types:
+- 0: NULL
+- 1: 8-bit signed integer
+- 2: 16-bit big-endian signed integer
+- 3: 24-bit big-endian signed integer
+- 4: 32-bit big-endian signed integer
+- 5: 48-bit big-endian signed integer
+- 6: 64-bit big-endian signed integer
+- 7: IEEE 754 64-bit float
+- 8: integer 0
+- 9: integer 1
+- 10, 11: reserved
+- N >= 12 even: BLOB of (N-12)/2 bytes
+- N >= 13 odd: TEXT of (N-13)/2 bytes
+"""
+
+import struct
+from typing import Any, List, NamedTuple, Set, Tuple
+
+from .page import get_cell_pointers, parse_page_header
+
+
+class SerialType(NamedTuple):
+    """Decoded serial type information."""
+
+    type_code: int
+    type_name: str
+    byte_size: int
+
+
+class RecordValue(NamedTuple):
+    """A parsed record value."""
+
+    serial_type: SerialType
+    value: Any
+    raw_bytes: bytes
+
+
+class IndexKey(NamedTuple):
+    """An index key with its associated rowid."""
+
+    key_values: List[Any]
+    rowid: int
+    raw_payload: bytes
+
+
+def read_varint(data: bytes, offset: int) -> Tuple[int, int]:
+    """
+    Read a SQLite varint from data at offset.
+
+    Returns:
+        Tuple of (value, bytes_consumed)
+    """
+    result = 0
+    bytes_read = 0
+
+    for i in range(9):
+        if offset + i >= len(data):
+            break
+
+        byte = data[offset + i]
+        bytes_read += 1
+
+        if i < 8:
+            result = (result << 7) | (byte & 0x7F)
+            if byte < 0x80:
+                break
+        else:
+            # 9th byte uses all 8 bits
+            result = (result << 8) | byte
+
+    return result, bytes_read
+
+
+def decode_serial_type(type_code: int) -> SerialType:  # noqa: C901
+    """Decode a serial type code into type information."""
+    if type_code == 0:
+        return SerialType(type_code, "NULL", 0)
+    elif type_code == 1:
+        return SerialType(type_code, "INT8", 1)
+    elif type_code == 2:
+        return SerialType(type_code, "INT16", 2)
+    elif type_code == 3:
+        return SerialType(type_code, "INT24", 3)
+    elif type_code == 4:
+        return SerialType(type_code, "INT32", 4)
+    elif type_code == 5:
+        return SerialType(type_code, "INT48", 6)
+    elif type_code == 6:
+        return SerialType(type_code, "INT64", 8)
+    elif type_code == 7:
+        return SerialType(type_code, "FLOAT64", 8)
+    elif type_code == 8:
+        return SerialType(type_code, "ZERO", 0)
+    elif type_code == 9:
+        return SerialType(type_code, "ONE", 0)
+    elif type_code >= 12 and type_code % 2 == 0:
+        size = (type_code - 12) // 2
+        return SerialType(type_code, f"BLOB({size})", size)
+    elif type_code >= 13 and type_code % 2 == 1:
+        size = (type_code - 13) // 2
+        return SerialType(type_code, f"TEXT({size})", size)
+    else:
+        return SerialType(type_code, f"RESERVED({type_code})", 0)
+
+
+def parse_record(payload: bytes) -> List[RecordValue]:  # noqa: C901
+    """
+    Parse a SQLite record payload into values.
+
+    Args:
+        payload: Record payload bytes (after cell header)
+
+    Returns:
+        List of RecordValue for each column
+    """
+    # Read header size
+    header_size, n = read_varint(payload, 0)
+    pos = n
+
+    # Read serial types
+    serial_types = []
+    while pos < header_size:
+        st, n = read_varint(payload, pos)
+        serial_types.append(decode_serial_type(st))
+        pos += n
+
+    # Read values
+    values = []
+    data_pos = header_size
+
+    for st in serial_types:
+        raw = payload[data_pos : data_pos + st.byte_size]
+
+        if st.type_name == "NULL":
+            value = None
+        elif st.type_name == "ZERO":
+            value = 0
+        elif st.type_name == "ONE":
+            value = 1
+        elif st.type_name == "INT8":
+            value = struct.unpack(">b", raw)[0]
+        elif st.type_name == "INT16":
+            value = struct.unpack(">h", raw)[0]
+        elif st.type_name == "INT24":
+            # Sign-extend 24-bit value
+            if raw[0] & 0x80:
+                value = struct.unpack(">i", b"\xff" + raw)[0]
+            else:
+                value = struct.unpack(">i", b"\x00" + raw)[0]
+        elif st.type_name == "INT32":
+            value = struct.unpack(">i", raw)[0]
+        elif st.type_name == "INT48":
+            # Sign-extend 48-bit value
+            if raw[0] & 0x80:
+                value = struct.unpack(">q", b"\xff\xff" + raw)[0]
+            else:
+                value = struct.unpack(">q", b"\x00\x00" + raw)[0]
+        elif st.type_name == "INT64":
+            value = struct.unpack(">q", raw)[0]
+        elif st.type_name == "FLOAT64":
+            value = struct.unpack(">d", raw)[0]
+        elif st.type_name.startswith("BLOB"):
+            value = raw
+        elif st.type_name.startswith("TEXT"):
+            try:
+                value = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                value = raw  # Return as bytes if not valid UTF-8
+        else:
+            value = raw
+
+        values.append(RecordValue(st, value, raw))
+        data_pos += st.byte_size
+
+    return values
+
+
+def get_index_rowids(page_data: bytes, page_offset: int = 0) -> Set[int]:
+    """
+    Extract all rowids from an index leaf page.
+
+    In an index, the last column of each record is the rowid.
+
+    Args:
+        page_data: Page bytes
+        page_offset: Header offset (100 for page 1)
+
+    Returns:
+        Set of rowids found in the page
+    """
+    header = parse_page_header(page_data, page_offset)
+
+    if header.page_type != 0x0A:  # Not a leaf index
+        return set()
+
+    rowids = set()
+    pointers = get_cell_pointers(page_data, page_offset)
+
+    for ptr in pointers:
+        # Index leaf cell: varint payload_size, payload
+        payload_size, n = read_varint(page_data, ptr)
+        payload = page_data[ptr + n : ptr + n + payload_size]
+
+        try:
+            values = parse_record(payload)
+            if values:
+                # Last value is the rowid
+                rowid = values[-1].value
+                if isinstance(rowid, int):
+                    rowids.add(rowid)
+        except Exception:
+            pass  # Skip malformed records
+
+    return rowids
+
+
+def get_index_keys(page_data: bytes, page_offset: int = 0) -> List[IndexKey]:
+    """
+    Extract all keys with their rowids from an index leaf page.
+
+    Args:
+        page_data: Page bytes
+        page_offset: Header offset (100 for page 1)
+
+    Returns:
+        List of IndexKey objects
+    """
+    header = parse_page_header(page_data, page_offset)
+
+    if header.page_type != 0x0A:  # Not a leaf index
+        return []
+
+    keys = []
+    pointers = get_cell_pointers(page_data, page_offset)
+
+    for ptr in pointers:
+        # Index leaf cell: varint payload_size, payload
+        payload_size, n = read_varint(page_data, ptr)
+        payload = page_data[ptr + n : ptr + n + payload_size]
+
+        try:
+            values = parse_record(payload)
+            if values:
+                # Last value is rowid, rest are key columns
+                rowid = values[-1].value
+                key_values = [v.value for v in values[:-1]]
+
+                if isinstance(rowid, int):
+                    keys.append(IndexKey(key_values, rowid, payload))
+        except Exception:
+            pass  # Skip malformed records
+
+    return keys
+
+
+def get_table_rowids(page_data: bytes, page_offset: int = 0) -> Set[int]:
+    """
+    Extract all rowids from a table leaf page.
+
+    Args:
+        page_data: Page bytes
+        page_offset: Header offset (100 for page 1)
+
+    Returns:
+        Set of rowids found in the page
+    """
+    header = parse_page_header(page_data, page_offset)
+
+    if header.page_type != 0x0D:  # Not a leaf table
+        return set()
+
+    rowids = set()
+    pointers = get_cell_pointers(page_data, page_offset)
+
+    for ptr in pointers:
+        # Table leaf cell: varint payload_size, varint rowid, payload
+        payload_size, n1 = read_varint(page_data, ptr)
+        rowid, n2 = read_varint(page_data, ptr + n1)
+        rowids.add(rowid)
+
+    return rowids

--- a/scripts/corruption-debug-tools/lib/wal.py
+++ b/scripts/corruption-debug-tools/lib/wal.py
@@ -1,0 +1,174 @@
+"""
+WAL (Write-Ahead Log) parsing utilities.
+
+SQLite WAL format:
+- 32-byte header
+- Sequence of frames, each containing:
+  - 24-byte frame header
+  - Page data (page_size bytes)
+"""
+
+import os
+import struct
+from typing import Iterator, NamedTuple, Optional
+
+WAL_HEADER_SIZE = 32
+FRAME_HEADER_SIZE = 24
+
+
+class WalHeader(NamedTuple):
+    """Parsed WAL header."""
+
+    magic: int
+    version: int
+    page_size: int
+    checkpoint_seq: int
+    salt1: int
+    salt2: int
+    checksum1: int
+    checksum2: int
+
+    @property
+    def is_big_endian(self) -> bool:
+        return self.magic == 0x377F0682
+
+    @property
+    def is_little_endian(self) -> bool:
+        return self.magic == 0x377F0683
+
+
+class FrameHeader(NamedTuple):
+    """Parsed frame header."""
+
+    page_num: int
+    db_size: int  # Non-zero indicates commit frame
+    salt1: int
+    salt2: int
+    checksum1: int
+    checksum2: int
+
+    @property
+    def is_commit(self) -> bool:
+        return self.db_size > 0
+
+
+class Frame(NamedTuple):
+    """A WAL frame with header and page data."""
+
+    index: int  # 0-indexed frame number
+    header: FrameHeader
+    page_data: bytes
+    offset: int  # Byte offset in WAL file
+
+
+def parse_wal_header(data: bytes) -> WalHeader:
+    """Parse the 32-byte WAL header."""
+    if len(data) < WAL_HEADER_SIZE:
+        raise ValueError(f"WAL header too short: {len(data)} bytes")
+
+    magic, version, page_size, checkpoint_seq, salt1, salt2, checksum1, checksum2 = struct.unpack(
+        ">IIIIIIII", data[:32]
+    )
+    return WalHeader(
+        magic=magic,
+        version=version,
+        page_size=page_size,
+        checkpoint_seq=checkpoint_seq,
+        salt1=salt1,
+        salt2=salt2,
+        checksum1=checksum1,
+        checksum2=checksum2,
+    )
+
+
+def parse_frame_header(data: bytes) -> FrameHeader:
+    """Parse a 24-byte frame header."""
+    if len(data) < FRAME_HEADER_SIZE:
+        raise ValueError(f"Frame header too short: {len(data)} bytes")
+
+    page_num, db_size, salt1, salt2, checksum1, checksum2 = struct.unpack(">IIIIII", data[:24])
+    return FrameHeader(
+        page_num=page_num,
+        db_size=db_size,
+        salt1=salt1,
+        salt2=salt2,
+        checksum1=checksum1,
+        checksum2=checksum2,
+    )
+
+
+def get_page_size_from_wal(wal_path: str) -> int:
+    """Get page size from WAL header."""
+    with open(wal_path, "rb") as f:
+        header = parse_wal_header(f.read(WAL_HEADER_SIZE))
+    return header.page_size
+
+
+def get_frame_count(wal_path: str, page_size: Optional[int] = None) -> int:
+    """Calculate number of frames in WAL file."""
+    if page_size is None:
+        page_size = get_page_size_from_wal(wal_path)
+
+    frame_size = FRAME_HEADER_SIZE + page_size
+    wal_size = os.path.getsize(wal_path)
+    return (wal_size - WAL_HEADER_SIZE) // frame_size
+
+
+def iter_frames(wal_path: str, page_size: Optional[int] = None) -> Iterator[Frame]:
+    """Iterate through all frames in a WAL file."""
+    if page_size is None:
+        page_size = get_page_size_from_wal(wal_path)
+
+    frame_size = FRAME_HEADER_SIZE + page_size
+
+    with open(wal_path, "rb") as f:
+        # Skip WAL header
+        f.seek(WAL_HEADER_SIZE)
+
+        frame_idx = 0
+        while True:
+            offset = WAL_HEADER_SIZE + frame_idx * frame_size
+            frame_data = f.read(frame_size)
+
+            if len(frame_data) < frame_size:
+                break  # End of file or incomplete frame
+
+            header = parse_frame_header(frame_data[:FRAME_HEADER_SIZE])
+            page_data = frame_data[FRAME_HEADER_SIZE:]
+
+            yield Frame(
+                index=frame_idx,
+                header=header,
+                page_data=page_data,
+                offset=offset,
+            )
+
+            frame_idx += 1
+
+
+def get_frame_page(wal_path: str, frame_num: int, page_size: Optional[int] = None) -> bytes:
+    """Get page data from a specific WAL frame (1-indexed)."""
+    if page_size is None:
+        page_size = get_page_size_from_wal(wal_path)
+
+    frame_size = FRAME_HEADER_SIZE + page_size
+    offset = WAL_HEADER_SIZE + (frame_num - 1) * frame_size
+
+    with open(wal_path, "rb") as f:
+        f.seek(offset + FRAME_HEADER_SIZE)
+        return f.read(page_size)
+
+
+def create_truncated_wal(wal_path: str, num_frames: int, output_path: str, page_size: Optional[int] = None) -> None:
+    """Create a WAL file with only the first num_frames frames."""
+    if page_size is None:
+        page_size = get_page_size_from_wal(wal_path)
+
+    frame_size = FRAME_HEADER_SIZE + page_size
+    size = WAL_HEADER_SIZE + (num_frames * frame_size)
+
+    with open(wal_path, "rb") as src:
+        data = src.read(size)
+
+    with open(output_path, "wb") as dst:
+        dst.write(data)

--- a/scripts/corruption-debug-tools/page_diff.py
+++ b/scripts/corruption-debug-tools/page_diff.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Compare page states between two WAL frames.
+
+Usage:
+    ./page_diff.py <db-file> <page-num> --before 5127 --after 5133
+    ./page_diff.py <db-file> <page-num> --before 5127 --after 5133 --rowids
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.diff import compare_cell_pointers, compare_pages, compare_rowids
+from lib.page import get_page_at_frame, parse_page_header
+from lib.record import get_index_keys
+from lib.wal import get_page_size_from_wal
+
+
+def main():  # noqa: C901
+    parser = argparse.ArgumentParser(description="Compare page states between two WAL frames")
+    parser.add_argument("db_path", help="Path to database file")
+    parser.add_argument("page_num", type=int, help="Page number (1-indexed)")
+    parser.add_argument("--before", type=int, required=True, help="Frame number for 'before' state")
+    parser.add_argument("--after", type=int, required=True, help="Frame number for 'after' state")
+    parser.add_argument("--rowids", action="store_true", help="Compare index rowids")
+    parser.add_argument("--keys", action="store_true", help="Show lost/gained keys (for index pages)")
+    parser.add_argument("--hex", action="store_true", help="Show hex diff of changed regions")
+    args = parser.parse_args()
+
+    db_path = args.db_path
+    wal_path = db_path + "-wal"
+    page_num = args.page_num
+
+    if not os.path.exists(db_path):
+        print(f"Error: Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.exists(wal_path):
+        print(f"Error: WAL file not found: {wal_path}", file=sys.stderr)
+        sys.exit(1)
+
+    page_size = get_page_size_from_wal(wal_path)
+    page_offset = 100 if page_num == 1 else 0
+
+    # Get page states
+    before = get_page_at_frame(db_path, wal_path, page_num, args.before, page_size)
+    after = get_page_at_frame(db_path, wal_path, page_num, args.after, page_size)
+
+    # Parse headers
+    before_header = parse_page_header(before, page_offset)
+    parse_page_header(after, page_offset)
+
+    print(f"Page {page_num} Diff: Frame {args.before} -> Frame {args.after}")
+    print("=" * 60)
+
+    # Basic comparison
+    diff = compare_pages(before, after)
+
+    if diff.identical:
+        print("Pages are identical - no changes")
+        return
+
+    print(f"Changed bytes:     {diff.bytes_changed} / {diff.total_bytes}")
+    print(f"Cell count:        {diff.cell_count_before} -> {diff.cell_count_after}", end="")
+    if diff.cell_count_before != diff.cell_count_after:
+        change = diff.cell_count_after - diff.cell_count_before
+        print(f" ({'+' if change > 0 else ''}{change})")
+    else:
+        print()
+
+    print(f"Content start:     {diff.content_start_before} -> {diff.content_start_after}", end="")
+    if diff.content_start_before != diff.content_start_after:
+        change = diff.content_start_after - diff.content_start_before
+        print(f" ({'+' if change > 0 else ''}{change})")
+    else:
+        print()
+
+    # Cell pointer comparison
+    ptr_diff = compare_cell_pointers(before, after, page_offset)
+    if ptr_diff.pointers_lost or ptr_diff.pointers_gained:
+        print("\nCell Pointers:")
+        print(f"  Lost:            {sorted(ptr_diff.pointers_lost) or 'none'}")
+        print(f"  Gained:          {sorted(ptr_diff.pointers_gained) or 'none'}")
+        if ptr_diff.first_diff_index >= 0:
+            print(f"  First diff at:   index {ptr_diff.first_diff_index}")
+
+    # Rowid comparison for index pages
+    if args.rowids and before_header.is_index and before_header.is_leaf:
+        rowid_diff = compare_rowids(before, after, page_offset)
+        print("\nRowids:")
+        print(f"  Lost:            {sorted(rowid_diff.rowids_lost) or 'none'}")
+        print(f"  Gained:          {sorted(rowid_diff.rowids_gained) or 'none'}")
+        print(f"  Unchanged:       {len(rowid_diff.rowids_unchanged)} rowids")
+
+    # Key comparison for index pages
+    if args.keys and before_header.is_index and before_header.is_leaf:
+        before_keys = get_index_keys(before, page_offset)
+        after_keys = get_index_keys(after, page_offset)
+
+        before_by_rowid = {k.rowid: k for k in before_keys}
+        after_by_rowid = {k.rowid: k for k in after_keys}
+
+        lost_rowids = set(before_by_rowid.keys()) - set(after_by_rowid.keys())
+        gained_rowids = set(after_by_rowid.keys()) - set(before_by_rowid.keys())
+
+        if lost_rowids:
+            print("\nLost Keys:")
+            for rowid in sorted(lost_rowids)[:20]:
+                key = before_by_rowid[rowid]
+                key_str = ", ".join(repr(v) for v in key.key_values)
+                print(f"  rowid {rowid}: {key_str}")
+            if len(lost_rowids) > 20:
+                print(f"  ... and {len(lost_rowids) - 20} more")
+
+        if gained_rowids:
+            print("\nGained Keys:")
+            for rowid in sorted(gained_rowids)[:20]:
+                key = after_by_rowid[rowid]
+                key_str = ", ".join(repr(v) for v in key.key_values)
+                print(f"  rowid {rowid}: {key_str}")
+            if len(gained_rowids) > 20:
+                print(f"  ... and {len(gained_rowids) - 20} more")
+
+    # Hex diff
+    if args.hex:
+        print("\nHex Diff (first 10 changed regions):")
+        print("-" * 60)
+        regions = []
+        i = 0
+        while i < len(before) and i < len(after):
+            if before[i] != after[i]:
+                start = i
+                while i < len(before) and i < len(after) and before[i] != after[i]:
+                    i += 1
+                regions.append((start, i))
+            else:
+                i += 1
+
+        for start, end in regions[:10]:
+            length = end - start
+            print(f"  Offset {start}-{end} ({length} bytes):")
+            print(f"    Before: {before[start : min(end, start + 32)].hex()}")
+            print(f"    After:  {after[start : min(end, start + 32)].hex()}")
+
+        if len(regions) > 10:
+            print(f"  ... and {len(regions) - 10} more regions")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corruption-debug-tools/page_history.py
+++ b/scripts/corruption-debug-tools/page_history.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Show all WAL writes to a specific page.
+
+Usage:
+    ./page_history.py <db-file> <page-num>
+    ./page_history.py <db-file> <page-num> --track-key "some_key"
+    ./page_history.py <db-file> <page-num> --track-rowid 661
+"""
+
+import argparse
+import os
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.page import get_page_from_db, parse_page_header
+from lib.record import get_index_rowids
+from lib.wal import (
+    FRAME_HEADER_SIZE,
+    WAL_HEADER_SIZE,
+    get_page_size_from_wal,
+)
+
+
+def main():  # noqa: C901
+    parser = argparse.ArgumentParser(description="Show all WAL writes to a specific page")
+    parser.add_argument("db_path", help="Path to database file")
+    parser.add_argument("page_num", type=int, help="Page number (1-indexed)")
+    parser.add_argument("--track-key", type=str, metavar="KEY", help="Track presence of a key (searches as bytes)")
+    parser.add_argument("--track-rowid", type=int, metavar="ROWID", help="Track presence of a rowid (for index pages)")
+    parser.add_argument("--limit", type=int, default=None, help="Limit to first N writes")
+    args = parser.parse_args()
+
+    db_path = args.db_path
+    wal_path = db_path + "-wal"
+    page_num = args.page_num
+
+    if not os.path.exists(db_path):
+        print(f"Error: Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.exists(wal_path):
+        print(f"Error: WAL file not found: {wal_path}", file=sys.stderr)
+        sys.exit(1)
+
+    page_size = get_page_size_from_wal(wal_path)
+    frame_size = FRAME_HEADER_SIZE + page_size
+    page_offset = 100 if page_num == 1 else 0
+
+    # Track key as bytes
+    track_key = args.track_key.encode() if args.track_key else None
+
+    # Get initial state from DB file
+    db_page = get_page_from_db(db_path, page_num, page_size)
+    db_header = parse_page_header(db_page, page_offset)
+
+    print(f"Page {page_num} History")
+    print("=" * 70)
+    print(
+        f"DB file state: {db_header.type_name}, {db_header.cell_count} cells, "
+        f"content_start={db_header.cell_content_start}"
+    )
+
+    if track_key:
+        has_key = track_key in db_page
+        print(f"  Key '{args.track_key}': {'present' if has_key else 'absent'}")
+
+    if args.track_rowid is not None and db_header.is_index and db_header.is_leaf:
+        rowids = get_index_rowids(db_page, page_offset)
+        has_rowid = args.track_rowid in rowids
+        print(f"  Rowid {args.track_rowid}: {'present' if has_rowid else 'absent'}")
+
+    print()
+    print("WAL writes:")
+    print("-" * 70)
+
+    # Read WAL
+    with open(wal_path, "rb") as f:
+        wal_data = f.read()
+
+    num_frames = (len(wal_data) - WAL_HEADER_SIZE) // frame_size
+    writes_found = 0
+
+    # Track previous state for change detection
+    prev_key_present = track_key in db_page if track_key else None
+    prev_rowid_present = None
+    if args.track_rowid is not None and db_header.is_index:
+        prev_rowid_present = args.track_rowid in get_index_rowids(db_page, page_offset)
+
+    for frame_idx in range(num_frames):
+        offset = WAL_HEADER_SIZE + frame_idx * frame_size
+        frame_page_num = struct.unpack(">I", wal_data[offset : offset + 4])[0]
+        db_size = struct.unpack(">I", wal_data[offset + 4 : offset + 8])[0]
+
+        if frame_page_num != page_num:
+            continue
+
+        page_data = wal_data[offset + FRAME_HEADER_SIZE : offset + frame_size]
+        header = parse_page_header(page_data, page_offset)
+
+        frame_num = frame_idx + 1
+        is_commit = "COMMIT" if db_size > 0 else ""
+
+        line = (
+            f"  Frame {frame_num:5d}: {header.cell_count:3d} cells, "
+            f"content_start={header.cell_content_start:4d}  {is_commit}"
+        )
+
+        # Track key changes
+        if track_key:
+            has_key = track_key in page_data
+            if has_key != prev_key_present:
+                if has_key:
+                    line += f"  KEY '{args.track_key}' APPEARS"
+                else:
+                    line += f"  KEY '{args.track_key}' DISAPPEARS"
+            prev_key_present = has_key
+
+        # Track rowid changes
+        if args.track_rowid is not None and header.is_index and header.is_leaf:
+            rowids = get_index_rowids(page_data, page_offset)
+            has_rowid = args.track_rowid in rowids
+            if has_rowid != prev_rowid_present:
+                if has_rowid:
+                    line += f"  ROWID {args.track_rowid} APPEARS"
+                else:
+                    line += f"  ROWID {args.track_rowid} DISAPPEARS"
+            prev_rowid_present = has_rowid
+
+        print(line)
+        writes_found += 1
+
+        if args.limit and writes_found >= args.limit:
+            print(f"  ... (limited to {args.limit} writes)")
+            break
+
+    print()
+    print(f"Total writes to page {page_num}: {writes_found}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corruption-debug-tools/page_info.py
+++ b/scripts/corruption-debug-tools/page_info.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Show detailed information about a database page.
+
+Usage:
+    ./page_info.py <db-file> <page-num>
+    ./page_info.py <db-file> <page-num> --frame 5127  # Show state at frame N
+    ./page_info.py <db-file> <page-num> --cells       # Show cell details
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.page import (
+    get_cell_pointers,
+    get_interior_children,
+    get_page_at_frame,
+    get_page_from_db,
+    parse_page_header,
+)
+from lib.record import get_index_keys, get_index_rowids, get_table_rowids
+from lib.wal import get_page_size_from_wal
+
+
+def main():  # noqa: C901
+    parser = argparse.ArgumentParser(description="Show detailed information about a database page")
+    parser.add_argument("db_path", help="Path to database file")
+    parser.add_argument("page_num", type=int, help="Page number (1-indexed)")
+    parser.add_argument("--frame", type=int, default=None, help="Show page state at this WAL frame (0 = DB file only)")
+    parser.add_argument("--cells", action="store_true", help="Show cell pointer details")
+    parser.add_argument("--keys", action="store_true", help="Show index keys (for index pages)")
+    args = parser.parse_args()
+
+    db_path = args.db_path
+    wal_path = db_path + "-wal"
+    page_num = args.page_num
+
+    if not os.path.exists(db_path):
+        print(f"Error: Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Determine page size
+    if os.path.exists(wal_path):
+        page_size = get_page_size_from_wal(wal_path)
+    else:
+        page_size = 4096  # Default
+
+    # Get page data
+    if args.frame is not None:
+        if not os.path.exists(wal_path):
+            print(f"Error: WAL file not found: {wal_path}", file=sys.stderr)
+            sys.exit(1)
+        page_data = get_page_at_frame(db_path, wal_path, page_num, args.frame, page_size)
+        source = f"after frame {args.frame}"
+    else:
+        if os.path.exists(wal_path):
+            from lib.wal import get_frame_count
+
+            total_frames = get_frame_count(wal_path, page_size)
+            page_data = get_page_at_frame(db_path, wal_path, page_num, total_frames, page_size)
+            source = f"after all {total_frames} frames"
+        else:
+            page_data = get_page_from_db(db_path, page_num, page_size)
+            source = "from DB file"
+
+    # Page 1 has 100-byte database header
+    page_offset = 100 if page_num == 1 else 0
+
+    # Parse header
+    header = parse_page_header(page_data, page_offset)
+
+    print(f"Page {page_num} ({source})")
+    print("=" * 60)
+    print(f"  Type:            0x{header.page_type:02x} ({header.type_name})")
+    print(f"  Cell count:      {header.cell_count}")
+    print(f"  Content start:   {header.cell_content_start}")
+    print(f"  First freeblock: {header.first_freeblock}")
+    print(f"  Fragmented:      {header.fragmented_bytes} bytes")
+
+    if header.rightmost_ptr is not None:
+        print(f"  Rightmost ptr:   {header.rightmost_ptr}")
+
+    # For interior pages, show children
+    if header.is_interior:
+        children = get_interior_children(page_data, page_offset)
+        print(f"\n  Child pages:     {children}")
+
+    # Show rowids for leaf pages
+    if header.is_leaf:
+        if header.is_index:
+            rowids = get_index_rowids(page_data, page_offset)
+            print(f"\n  Index entries:   {len(rowids)} rowids")
+            if rowids:
+                sorted_rowids = sorted(rowids)
+                if len(sorted_rowids) <= 20:
+                    print(f"  Rowids:          {sorted_rowids}")
+                else:
+                    print(f"  Rowids (first 10): {sorted_rowids[:10]}")
+                    print(f"  Rowids (last 10):  {sorted_rowids[-10:]}")
+        else:  # Table
+            rowids = get_table_rowids(page_data, page_offset)
+            print(f"\n  Table rows:      {len(rowids)} rowids")
+            if rowids:
+                sorted_rowids = sorted(rowids)
+                if len(sorted_rowids) <= 20:
+                    print(f"  Rowids:          {sorted_rowids}")
+                else:
+                    print(f"  Rowids (first 10): {sorted_rowids[:10]}")
+                    print(f"  Rowids (last 10):  {sorted_rowids[-10:]}")
+
+    # Show cell pointers if requested
+    if args.cells:
+        pointers = get_cell_pointers(page_data, page_offset)
+        print(f"\nCell Pointers ({len(pointers)}):")
+        print("-" * 40)
+        for i, ptr in enumerate(pointers):
+            print(f"  [{i:3d}] offset {ptr}")
+
+    # Show index keys if requested
+    if args.keys and header.is_index and header.is_leaf:
+        keys = get_index_keys(page_data, page_offset)
+        print(f"\nIndex Keys ({len(keys)}):")
+        print("-" * 40)
+        for i, key in enumerate(keys[:50]):  # Limit to first 50
+            key_str = ", ".join(repr(v) for v in key.key_values)
+            print(f"  [{i:3d}] rowid={key.rowid}: {key_str}")
+        if len(keys) > 50:
+            print(f"  ... and {len(keys) - 50} more")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corruption-debug-tools/track_rowid.py
+++ b/scripts/corruption-debug-tools/track_rowid.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Track when a rowid appears/disappears in index or table pages.
+
+Usage:
+    ./track_rowid.py <db-file> <rowid> --pages 26,42  # Track in specific pages
+    ./track_rowid.py <db-file> <rowid> --all-index    # Track in all index pages
+"""
+
+import argparse
+import os
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.page import get_page_from_db, parse_page_header
+from lib.record import get_index_rowids, get_table_rowids
+from lib.wal import (
+    FRAME_HEADER_SIZE,
+    WAL_HEADER_SIZE,
+    get_page_size_from_wal,
+)
+
+
+def main():  # noqa: C901
+    parser = argparse.ArgumentParser(description="Track when a rowid appears/disappears in pages")
+    parser.add_argument("db_path", help="Path to database file")
+    parser.add_argument("rowid", type=int, help="Rowid to track")
+    parser.add_argument("--pages", type=str, help="Comma-separated list of page numbers to track")
+    parser.add_argument("--all-index", action="store_true", help="Track in all index leaf pages")
+    parser.add_argument("--all-table", action="store_true", help="Track in all table leaf pages")
+    args = parser.parse_args()
+
+    db_path = args.db_path
+    wal_path = db_path + "-wal"
+    target_rowid = args.rowid
+
+    if not os.path.exists(db_path):
+        print(f"Error: Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.exists(wal_path):
+        print(f"Error: WAL file not found: {wal_path}", file=sys.stderr)
+        sys.exit(1)
+
+    page_size = get_page_size_from_wal(wal_path)
+    frame_size = FRAME_HEADER_SIZE + page_size
+
+    # Determine which pages to track
+    if args.pages:
+        target_pages = set(int(p.strip()) for p in args.pages.split(","))
+    elif args.all_index or args.all_table:
+        target_pages = None  # Will be determined dynamically
+    else:
+        print("Error: Specify --pages, --all-index, or --all-table", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Tracking rowid {target_rowid}")
+    print("=" * 70)
+
+    # Read WAL
+    with open(wal_path, "rb") as f:
+        wal_data = f.read()
+
+    num_frames = (len(wal_data) - WAL_HEADER_SIZE) // frame_size
+
+    # Track state per page: page_num -> (has_rowid, last_frame)
+    page_states = {}
+
+    # Initialize from DB file
+    db_size = os.path.getsize(db_path)
+    db_pages = db_size // page_size
+
+    if target_pages is None:
+        # Scan DB file for index/table leaf pages
+        target_pages = set()
+        for page_num in range(1, db_pages + 1):
+            page_data = get_page_from_db(db_path, page_num, page_size)
+            page_offset = 100 if page_num == 1 else 0
+            header = parse_page_header(page_data, page_offset)
+
+            if args.all_index and header.page_type == 0x0A:
+                target_pages.add(page_num)
+            elif args.all_table and header.page_type == 0x0D:
+                target_pages.add(page_num)
+
+    print(f"Tracking pages: {sorted(target_pages)}")
+    print()
+
+    # Initialize state from DB file
+    for page_num in target_pages:
+        page_data = get_page_from_db(db_path, page_num, page_size)
+        page_offset = 100 if page_num == 1 else 0
+        header = parse_page_header(page_data, page_offset)
+
+        if header.page_type == 0x0A:  # Index leaf
+            rowids = get_index_rowids(page_data, page_offset)
+            has_rowid = target_rowid in rowids
+        elif header.page_type == 0x0D:  # Table leaf
+            rowids = get_table_rowids(page_data, page_offset)
+            has_rowid = target_rowid in rowids
+        else:
+            has_rowid = False
+
+        page_states[page_num] = (has_rowid, "DB")
+
+        if has_rowid:
+            print(f"  Page {page_num:3d} (DB file): rowid {target_rowid} PRESENT")
+
+    print()
+    print("WAL changes:")
+    print("-" * 70)
+
+    # Scan WAL for changes
+    events = []
+
+    for frame_idx in range(num_frames):
+        offset = WAL_HEADER_SIZE + frame_idx * frame_size
+        frame_page_num = struct.unpack(">I", wal_data[offset : offset + 4])[0]
+        db_size_field = struct.unpack(">I", wal_data[offset + 4 : offset + 8])[0]
+
+        if frame_page_num not in target_pages:
+            continue
+
+        page_data = wal_data[offset + FRAME_HEADER_SIZE : offset + frame_size]
+        page_offset = 100 if frame_page_num == 1 else 0
+        header = parse_page_header(page_data, page_offset)
+
+        if header.page_type == 0x0A:  # Index leaf
+            rowids = get_index_rowids(page_data, page_offset)
+            has_rowid = target_rowid in rowids
+        elif header.page_type == 0x0D:  # Table leaf
+            rowids = get_table_rowids(page_data, page_offset)
+            has_rowid = target_rowid in rowids
+        else:
+            continue
+
+        frame_num = frame_idx + 1
+        prev_has_rowid, _ = page_states.get(frame_page_num, (False, None))
+
+        if has_rowid != prev_has_rowid:
+            is_commit = "COMMIT" if db_size_field > 0 else ""
+            if has_rowid:
+                action = "APPEARS"
+            else:
+                action = "DISAPPEARS"
+
+            events.append((frame_num, frame_page_num, action, is_commit))
+            print(f"  Frame {frame_num:5d}: Page {frame_page_num:3d} - rowid {target_rowid} {action}  {is_commit}")
+
+        page_states[frame_page_num] = (has_rowid, frame_num)
+
+    print()
+    print("Summary:")
+    print("-" * 70)
+
+    for page_num in sorted(target_pages):
+        has_rowid, last_source = page_states.get(page_num, (False, "DB"))
+        status = "present" if has_rowid else "absent"
+        print(f"  Page {page_num:3d}: rowid {target_rowid} is {status} (last updated: {last_source})")
+
+    # Show timeline if there were changes
+    if events:
+        print()
+        print("Timeline:")
+        print("-" * 70)
+        for frame_num, page_num, action, is_commit in events:
+            print(f"  Frame {frame_num}: {action} in page {page_num}  {is_commit}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corruption-debug-tools/verify_stale.py
+++ b/scripts/corruption-debug-tools/verify_stale.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Verify if a page state looks like it was created from a stale page read.
+
+This script checks if a "corrupt" page state could be explained by reading
+a stale version of the page and then performing an insertion/update.
+
+Usage:
+    ./verify_stale.py <db-file> <page-num> --stale-frame 5098 --corrupt-frame 5133
+    ./verify_stale.py <db-file> <page-num> --stale-frame 5107 --corrupt-frame 5131 --gained-rowid 663
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.diff import compare_pages
+from lib.page import get_page_at_frame, parse_page_header
+from lib.record import get_index_rowids
+from lib.wal import get_page_size_from_wal
+
+
+def main():  # noqa: C901
+    parser = argparse.ArgumentParser(description="Verify if corruption looks like a stale page read")
+    parser.add_argument("db_path", help="Path to database file")
+    parser.add_argument("page_num", type=int, help="Page number (1-indexed)")
+    parser.add_argument("--stale-frame", type=int, required=True, help="Frame that might be the stale source")
+    parser.add_argument("--corrupt-frame", type=int, required=True, help="Frame containing the corrupt page")
+    parser.add_argument(
+        "--good-frame", type=int, default=None, help="Frame containing the expected good state (optional)"
+    )
+    parser.add_argument("--gained-rowid", type=int, default=None, help="Rowid that was gained in the corrupt state")
+    args = parser.parse_args()
+
+    db_path = args.db_path
+    wal_path = db_path + "-wal"
+    page_num = args.page_num
+
+    if not os.path.exists(db_path):
+        print(f"Error: Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.exists(wal_path):
+        print(f"Error: WAL file not found: {wal_path}", file=sys.stderr)
+        sys.exit(1)
+
+    page_size = get_page_size_from_wal(wal_path)
+    page_offset = 100 if page_num == 1 else 0
+
+    # Get page states
+    stale_page = get_page_at_frame(db_path, wal_path, page_num, args.stale_frame, page_size)
+    corrupt_page = get_page_at_frame(db_path, wal_path, page_num, args.corrupt_frame, page_size)
+
+    good_page = None
+    if args.good_frame:
+        good_page = get_page_at_frame(db_path, wal_path, page_num, args.good_frame, page_size)
+
+    # Parse headers
+    stale_header = parse_page_header(stale_page, page_offset)
+    corrupt_header = parse_page_header(corrupt_page, page_offset)
+
+    print(f"Stale Page Analysis for Page {page_num}")
+    print("=" * 70)
+
+    print(f"\nStale source (frame {args.stale_frame}):")
+    print(f"  Type:          {stale_header.type_name}")
+    print(f"  Cell count:    {stale_header.cell_count}")
+    print(f"  Content start: {stale_header.cell_content_start}")
+
+    print(f"\nCorrupt state (frame {args.corrupt_frame}):")
+    print(f"  Type:          {corrupt_header.type_name}")
+    print(f"  Cell count:    {corrupt_header.cell_count}")
+    print(f"  Content start: {corrupt_header.cell_content_start}")
+
+    if good_page:
+        good_header = parse_page_header(good_page, page_offset)
+        print(f"\nExpected good state (frame {args.good_frame}):")
+        print(f"  Type:          {good_header.type_name}")
+        print(f"  Cell count:    {good_header.cell_count}")
+        print(f"  Content start: {good_header.cell_content_start}")
+
+    # For index pages, compare rowids
+    if stale_header.is_index and stale_header.is_leaf:
+        stale_rowids = get_index_rowids(stale_page, page_offset)
+        corrupt_rowids = get_index_rowids(corrupt_page, page_offset)
+
+        print("\nRowid Analysis:")
+        print(f"  Stale rowids:    {len(stale_rowids)}")
+        print(f"  Corrupt rowids:  {len(corrupt_rowids)}")
+
+        if good_page:
+            good_rowids = get_index_rowids(good_page, page_offset)
+            print(f"  Good rowids:     {len(good_rowids)}")
+
+            lost_from_good = good_rowids - corrupt_rowids
+            gained_vs_good = corrupt_rowids - good_rowids
+
+            print(f"\n  Lost vs good:    {sorted(lost_from_good)}")
+            print(f"  Gained vs good:  {sorted(gained_vs_good)}")
+
+        # Check stale page hypothesis
+        print("\n--- Stale Page Hypothesis ---")
+
+        if args.gained_rowid:
+            # Expected: corrupt = stale + gained_rowid
+            expected_if_stale = stale_rowids | {args.gained_rowid}
+
+            print(f"  If corrupt = stale + rowid {args.gained_rowid}:")
+            print(f"    Expected rowids: {len(expected_if_stale)}")
+            print(f"    Actual rowids:   {len(corrupt_rowids)}")
+
+            if corrupt_rowids == expected_if_stale:
+                print("\n  >>> STALE PAGE HYPOTHESIS CONFIRMED <<<")
+                print(f"  Corrupt state exactly matches: stale + rowid {args.gained_rowid}")
+            else:
+                missing = expected_if_stale - corrupt_rowids
+                extra = corrupt_rowids - expected_if_stale
+                print(f"\n    Missing: {sorted(missing)}")
+                print(f"    Extra:   {sorted(extra)}")
+
+                # Check if it's close
+                overlap = len(corrupt_rowids & expected_if_stale)
+                total = len(corrupt_rowids | expected_if_stale)
+                similarity = (overlap / total * 100) if total > 0 else 0
+                print(f"    Similarity: {similarity:.1f}%")
+
+        else:
+            # General comparison
+            common = stale_rowids & corrupt_rowids
+            only_stale = stale_rowids - corrupt_rowids
+            only_corrupt = corrupt_rowids - stale_rowids
+
+            print(f"  Common rowids:     {len(common)}")
+            print(f"  Only in stale:     {len(only_stale)} {sorted(only_stale)[:10]}")
+            print(f"  Only in corrupt:   {len(only_corrupt)} {sorted(only_corrupt)[:10]}")
+
+            # Check if corrupt looks like stale + insertions
+            if only_stale:
+                print("\n  Note: Stale has rowids not in corrupt - suggests B-tree rebalance")
+            if len(only_corrupt) <= 5:
+                print(f"\n  Corrupt looks like stale + {only_corrupt} (possible insertions)")
+
+    # Byte-level comparison
+    print("\n--- Byte Comparison ---")
+
+    stale_diff = compare_pages(stale_page, corrupt_page)
+    stale_pct = 100 - stale_diff.bytes_changed / stale_diff.total_bytes * 100
+    print(f"  Stale vs Corrupt: {stale_diff.bytes_changed} bytes differ ({stale_pct:.1f}% similar)")
+
+    if good_page:
+        good_diff = compare_pages(good_page, corrupt_page)
+        good_pct = 100 - good_diff.bytes_changed / good_diff.total_bytes * 100
+        print(f"  Good vs Corrupt:  {good_diff.bytes_changed} bytes differ ({good_pct:.1f}% similar)")
+
+        stale_good_diff = compare_pages(stale_page, good_page)
+        sg_pct = 100 - stale_good_diff.bytes_changed / stale_good_diff.total_bytes * 100
+        print(f"  Stale vs Good:    {stale_good_diff.bytes_changed} bytes differ ({sg_pct:.1f}% similar)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corruption-debug-tools/wal_commits.py
+++ b/scripts/corruption-debug-tools/wal_commits.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+List commit frames and transaction boundaries in a WAL file.
+
+Usage:
+    ./wal_commits.py <wal-file>
+    ./wal_commits.py <wal-file> --around 5133  # Focus on specific frame
+    ./wal_commits.py <wal-file> --last 10      # Show last N commits
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.wal import WAL_HEADER_SIZE, iter_frames, parse_wal_header
+
+
+def main():  # noqa: C901
+    parser = argparse.ArgumentParser(description="List commit frames and transaction boundaries")
+    parser.add_argument("path", help="WAL file or database file")
+    parser.add_argument("--around", type=int, metavar="FRAME", help="Focus analysis around a specific frame")
+    parser.add_argument("--last", type=int, metavar="N", default=10, help="Show last N commits (default: 10)")
+    parser.add_argument("--all", action="store_true", help="Show all commits")
+    args = parser.parse_args()
+
+    # Determine WAL path
+    if args.path.endswith("-wal"):
+        wal_path = args.path
+    else:
+        wal_path = args.path + "-wal"
+
+    if not os.path.exists(wal_path):
+        print(f"Error: WAL file not found: {wal_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse header
+    with open(wal_path, "rb") as f:
+        header = parse_wal_header(f.read(WAL_HEADER_SIZE))
+
+    # Collect all frames and commits
+    all_frames = list(iter_frames(wal_path, header.page_size))
+    commits = [(f.index + 1, f) for f in all_frames if f.header.is_commit]
+
+    print(f"WAL: {wal_path}")
+    print(f"Total frames: {len(all_frames)}, Commits: {len(commits)}")
+    print()
+
+    if args.around:
+        # Focus on frames around a specific point
+        target_frame = args.around
+
+        # Find the commit at or after target
+        target_commit_idx = None
+        for idx, (frame_num, frame) in enumerate(commits):
+            if frame_num >= target_frame:
+                target_commit_idx = idx
+                break
+
+        if target_commit_idx is None:
+            print(f"No commit found at or after frame {target_frame}")
+            return
+
+        # Show the transaction containing target frame
+        print(f"=== Analysis around frame {target_frame} ===")
+        print()
+
+        # Previous commit (transaction start)
+        if target_commit_idx > 0:
+            prev_frame_num, prev_frame = commits[target_commit_idx - 1]
+            print(f"Previous commit: Frame {prev_frame_num}")
+            print(f"  Page: {prev_frame.header.page_num}")
+            print(f"  DB size: {prev_frame.header.db_size} pages")
+            print()
+            tx_start = prev_frame_num + 1
+        else:
+            tx_start = 1
+
+        # Current commit
+        curr_frame_num, curr_frame = commits[target_commit_idx]
+        print(f"Target commit: Frame {curr_frame_num}")
+        print(f"  Page: {curr_frame.header.page_num}")
+        print(f"  DB size: {curr_frame.header.db_size} pages")
+        print()
+
+        # Show transaction frames
+        print(f"Transaction frames ({tx_start} to {curr_frame_num}):")
+        print("-" * 50)
+        for frame in all_frames[tx_start - 1 : curr_frame_num]:
+            frame_num = frame.index + 1
+            is_commit = "COMMIT" if frame.header.is_commit else ""
+            marker = " <-- TARGET" if frame_num == target_frame else ""
+            print(f"  Frame {frame_num:5d}: page {frame.header.page_num:5d}  {is_commit}{marker}")
+
+    else:
+        # Show last N commits or all
+        if args.all:
+            show_commits = commits
+            print("All commits:")
+        else:
+            show_commits = commits[-args.last :]
+            print(f"Last {len(show_commits)} commits:")
+
+        print("-" * 60)
+        prev_commit_frame = 0
+        for frame_num, frame in show_commits:
+            tx_size = frame_num - prev_commit_frame
+            print(
+                f"  Frame {frame_num:5d}: page {frame.header.page_num:3d}, "
+                f"db_size={frame.header.db_size:3d}, tx_frames={tx_size}"
+            )
+            prev_commit_frame = frame_num
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corruption-debug-tools/wal_info.py
+++ b/scripts/corruption-debug-tools/wal_info.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Show WAL file header and summary information.
+
+Usage:
+    ./wal_info.py <wal-file>
+    ./wal_info.py <db-file>  # Will use <db-file>-wal
+"""
+
+import argparse
+import os
+import sys
+
+# Add lib to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.wal import (
+    WAL_HEADER_SIZE,
+    get_frame_count,
+    iter_frames,
+    parse_wal_header,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Show WAL file header and summary information")
+    parser.add_argument("path", help="WAL file or database file")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Show additional details")
+    args = parser.parse_args()
+
+    # Determine WAL path
+    if args.path.endswith("-wal"):
+        wal_path = args.path
+    else:
+        wal_path = args.path + "-wal"
+
+    if not os.path.exists(wal_path):
+        print(f"Error: WAL file not found: {wal_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Read and parse header
+    with open(wal_path, "rb") as f:
+        header_data = f.read(WAL_HEADER_SIZE)
+
+    header = parse_wal_header(header_data)
+    frame_count = get_frame_count(wal_path, header.page_size)
+
+    # Count commits
+    commit_count = 0
+    page_writes = {}  # page_num -> count
+
+    for frame in iter_frames(wal_path, header.page_size):
+        if frame.header.is_commit:
+            commit_count += 1
+        page_num = frame.header.page_num
+        page_writes[page_num] = page_writes.get(page_num, 0) + 1
+
+    # Print summary
+    print("WAL Header")
+    print("=" * 50)
+    print(f"  File:            {wal_path}")
+    print(f"  Size:            {os.path.getsize(wal_path):,} bytes")
+    print(f"  Magic:           0x{header.magic:08x}", end="")
+    if header.is_big_endian:
+        print(" (big-endian checksums)")
+    elif header.is_little_endian:
+        print(" (little-endian checksums)")
+    else:
+        print(" (unknown)")
+    print(f"  Version:         {header.version}")
+    print(f"  Page size:       {header.page_size} bytes")
+    print(f"  Checkpoint seq:  {header.checkpoint_seq}")
+    print(f"  Salt:            0x{header.salt1:08x} 0x{header.salt2:08x}")
+    print(f"  Checksum:        0x{header.checksum1:08x} 0x{header.checksum2:08x}")
+    print()
+    print("Summary")
+    print("=" * 50)
+    print(f"  Total frames:    {frame_count}")
+    print(f"  Commit frames:   {commit_count}")
+    print(f"  Unique pages:    {len(page_writes)}")
+
+    if args.verbose and page_writes:
+        print()
+        print("Pages by write count (top 20)")
+        print("-" * 30)
+        sorted_pages = sorted(page_writes.items(), key=lambda x: -x[1])
+        for page_num, count in sorted_pages[:20]:
+            print(f"  Page {page_num:5d}: {count:5d} writes")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
During the investigation that eventually produced #4418 , Claude produced tens of thousands of lines worth of ad-hoc scripts, and I asked another Claude to extract the essentials from those scripts into reusable corruption investigation scripts. So here they are.

---

# Tursodb Corruption Debug Tools

A collection of Python scripts for analyzing WAL files and debugging database corruption issues.

## Prerequisites

- Python 3.8+
- SQLite CLI (`sqlite3`) for integrity checks

## Scripts

### WAL Analysis

#### `wal_info.py`
Show WAL file header and summary information.

```bash
./wal_info.py my_corrupted_database.db
./wal_info.py my_corrupted_database.db-wal
./wal_info.py my_corrupted_database.db -v  # Verbose: show pages by write count
```

Example output:
```
WAL Header
==================================================
  File:            my_corrupted_database.db-wal
  Size:            22,598,232 bytes
  Magic:           0x377f0682 (big-endian checksums)
  Page size:       4096 bytes
  Checkpoint seq:  0

Summary
==================================================
  Total frames:    5485
  Commit frames:   1459
  Unique pages:    67
```

#### `wal_commits.py`
List commit frames and transaction boundaries.

```bash
./wal_commits.py my_corrupted_database.db --last 20     # Last 20 commits
./wal_commits.py my_corrupted_database.db --around 5133 # Focus on specific frame
./wal_commits.py my_corrupted_database.db --all         # All commits
```

Example output (`--around 5137`):
```
=== Analysis around frame 5137 ===

Previous commit: Frame 5131
  Page: 64
  DB size: 64 pages

Target commit: Frame 5137
  Page: 60
  DB size: 64 pages

Transaction frames (5132 to 5137):
--------------------------------------------------
  Frame  5132: page     7
  Frame  5133: page    26
  Frame  5134: page    27
  Frame  5135: page    43
  Frame  5136: page    56
  Frame  5137: page    60  COMMIT <-- TARGET
```

### Corruption Detection

#### `find_corrupt_frame.py`
Binary search to find the earliest WAL frame that introduces corruption.

```bash
./find_corrupt_frame.py my_corrupted_database.db
./find_corrupt_frame.py my_corrupted_database.db -v  # Show integrity check output
```

Example output:
```
WAL has 5846 frames
Checking with 0 frames (DB file only)... OK
Checking with all 5846 frames... CORRUPT

[1] Testing 2923 frames (range 0-5846)... OK
[2] Testing 4384 frames (range 2923-5846)... OK
...
[13] Testing 5133 frames (range 5132-5134)... CORRUPT

Found: Frame 5133 (0-indexed: 5132) introduces corruption
Last good state: 5132 frames
```

### Page Analysis

#### `page_info.py`
Show detailed information about a database page.

```bash
./page_info.py my_corrupted_database.db 26                  # Current state
./page_info.py my_corrupted_database.db 26 --frame 5127     # State at frame 5127
./page_info.py my_corrupted_database.db 26 --cells          # Show cell pointers
./page_info.py my_corrupted_database.db 26 --keys           # Show index keys (for index pages)
```

Example output:
```
Page 26 (after frame 5127)
============================================================
  Type:            0x0a (leaf index)
  Cell count:      185
  Content start:   559
  First freeblock: 0
  Fragmented:      0 bytes

  Index entries:   185 rowids
  Rowids (first 10): [4, 17, 23, 45, 67, 89, 102, 115, 128, 141]
  Rowids (last 10):  [601, 614, 627, 640, 653, 661, 666, 679, 692, 705]
```

#### `page_diff.py`
Compare page states between two WAL frames.

```bash
./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133
./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133 --rowids  # Compare rowids
./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133 --keys    # Show key changes
./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133 --hex     # Show hex diff
```

Example output (`--rowids`):
```
Page 26 Diff: Frame 5131 -> Frame 5133
============================================================
Changed bytes:     1609 / 4096
Cell count:        185 -> 185
Content start:     559 -> 558 (-1)

Rowids:
  Lost:            [661]
  Gained:          [365]
  Unchanged:       184 rowids
```

#### `page_history.py`
Show all WAL writes to a specific page.

```bash
./page_history.py my_corrupted_database.db 26
./page_history.py my_corrupted_database.db 26 --track-key "dark_wall_716"  # Track key presence
./page_history.py my_corrupted_database.db 26 --track-rowid 661            # Track rowid
./page_history.py my_corrupted_database.db 26 --limit 50                   # Limit output
```

Example output (`--track-rowid 661`):
```
Page 26 History
======================================================================
DB file state: leaf index, 192 cells, content_start=428
  Rowid 661: absent

WAL writes:
----------------------------------------------------------------------
  Frame  5098: 193 cells, content_start=409
  Frame  5106: 185 cells, content_start=559  ROWID 661 APPEARS
  Frame  5133: 185 cells, content_start=558  ROWID 661 DISAPPEARS
  ...
```

### Rowid Tracking

#### `track_rowid.py`
Track when a rowid appears/disappears across pages.

```bash
./track_rowid.py my_corrupted_database.db 661 --pages 26,42     # Track in specific pages
./track_rowid.py my_corrupted_database.db 661 --all-index       # Track in all index pages
./track_rowid.py my_corrupted_database.db 661 --all-table       # Track in all table pages
```

Example output:
```
Tracking rowid 661
======================================================================
Tracking pages: [26, 42]

WAL changes:
----------------------------------------------------------------------
  Frame  5106: Page  26 - rowid 661 APPEARS
  Frame  5108: Page  42 - rowid 661 APPEARS
  Frame  5133: Page  26 - rowid 661 DISAPPEARS
  Frame  5145: Page  42 - rowid 661 DISAPPEARS

Timeline:
----------------------------------------------------------------------
  Frame 5106: APPEARS in page 26
  Frame 5108: APPEARS in page 42
  Frame 5133: DISAPPEARS in page 26
  Frame 5145: DISAPPEARS in page 42
```

### Stale Page Verification

#### `verify_stale.py`
Verify if corruption looks like it was caused by reading a stale page.

```bash
# Check if frame 5133 looks like frame 5098 + insertion of rowid 663
./verify_stale.py my_corrupted_database.db 26 --stale-frame 5098 --corrupt-frame 5133 --gained-rowid 663

# Compare against known good state
./verify_stale.py my_corrupted_database.db 26 --stale-frame 5098 --corrupt-frame 5133 --good-frame 5106
```

Example output:
```
Stale Page Analysis for Page 26
======================================================================

Stale source (frame 5105):
  Type:          leaf index
  Cell count:    193

Corrupt state (frame 5133):
  Type:          leaf index
  Cell count:    185

Rowid Analysis:
  Stale rowids:    193
  Corrupt rowids:  185

--- Stale Page Hypothesis ---
  Common rowids:     185
  Only in stale:     8 [324, 344, 448, 449, 588, 613, 640, 653]
  Only in corrupt:   0 []

  Note: Stale has rowids not in corrupt - suggests B-tree rebalance

--- Byte Comparison ---
  Stale vs Corrupt: 1911 bytes differ (53.3% similar)
  Good vs Corrupt:  1609 bytes differ (60.7% similar)
```

## Library Modules

The scripts use a shared library in `lib/`:

- `lib/wal.py` - WAL parsing (headers, frames, commits)
- `lib/page.py` - Page reading and header parsing
- `lib/record.py` - SQLite record format (varints, serial types)
- `lib/diff.py` - Comparison utilities

### Using the Library

```python
import sys
sys.path.insert(0, "/path/to/corruption-debug-tools")

from lib.wal import iter_frames, get_frame_count
from lib.page import get_page_at_frame, parse_page_header
from lib.record import get_index_rowids, get_index_keys
from lib.diff import compare_pages, compare_rowids

# Get page state at a specific frame
page = get_page_at_frame("db.db", "db.db-wal", page_num=26, up_to_frame=5127)

# Parse the page header
header = parse_page_header(page)
print(f"Type: {header.type_name}, Cells: {header.cell_count}")

# Get rowids from an index page
rowids = get_index_rowids(page)
print(f"Rowids: {rowids}")
```

## Typical Investigation Workflow

1. **Find the corrupt frame**:
   ```bash
   ./find_corrupt_frame.py my_corrupted_database.db
   # Output: Frame 5133 introduces corruption
   ```

2. **Analyze the corrupt transaction**:
   ```bash
   ./wal_commits.py my_corrupted_database.db --around 5133
   # Shows frames 5128-5133 in the transaction
   ```

3. **Compare page states**:
   ```bash
   ./page_diff.py my_corrupted_database.db 26 --before 5127 --after 5133 --rowids --keys
   # Shows: Lost rowid 661, Gained rowid 663
   ```

4. **Track the lost rowid**:
   ```bash
   ./track_rowid.py my_corrupted_database.db 661 --pages 26,42
   # Shows when rowid 661 appeared and disappeared
   ```

5. **Find the stale source**:
   ```bash
   ./page_history.py my_corrupted_database.db 26 --track-rowid 661
   # Find frames where 661 was present vs absent
   ```

6. **Verify stale page hypothesis**:
   ```bash
   ./verify_stale.py my_corrupted_database.db 26 --stale-frame 5098 --corrupt-frame 5133 --gained-rowid 663
   # Confirms if corruption matches stale + insertion pattern
   ```