### PR TITLE
bindings/dotnet: allow setting TursoParameter.Direction

### DIFF
--- a/bindings/dotnet/src/Turso/TursoParameter.cs
+++ b/bindings/dotnet/src/Turso/TursoParameter.cs
@@ -65,7 +65,13 @@ public class TursoParameter : DbParameter
     public override ParameterDirection Direction
     {
         get => ParameterDirection.Input; 
-        set => throw new NotImplementedException();
+        set
+        {
+            if (value != ParameterDirection.Input)
+            {
+                throw new ArgumentException("Only input parameters are supported");
+            }
+        }
     }
     public override bool IsNullable { get; set; }
     public override string? ParameterName { get; set; }


### PR DESCRIPTION
## Description

EntityFramework Core, .NET's ORM solution - when building SQL queries that require parameters - sets the `Direction` member of parameters by default (see the [EF Core implementation](https://github.com/dotnet/efcore/blob/release/10.0/src/EFCore.Relational/Storage/RelationalTypeMapping.cs#L558)).
As such, allow setting the `Direction` of `TursoParameter` if it's an incoming parameter

## Motivation and context

EF Core is the most widely used ORM solution for the .NET ecosystem. It relies on the ADO.NET provider that is currently implemented in this repository and acts as a higher-level abstraction of it.
.NET offers an extensive Test Suite that allows for both verifying the EF Core implementation of a future Turso provider, as well as the underlying ADO.NET provider.
In an effort to implement a Turso provider for EF Core, I noticed the EF Core Test Suite was failing because it was unable to add data to the Turso database because `set_Direction` threw an Exception while EF Core requires it to be accessible.
This PR addresses this limitation by allowing the Direction to be set with the constraint that it has to be of `ParameterDirection.Input`.


## Description of AI Usage

No AI was used to create this PR or identify/make the underlying change