### PR TITLE
bindings/dotnet: implement IsDBNull check

### DIFF
--- a/bindings/dotnet/src/Turso/TursoDataReader.cs
+++ b/bindings/dotnet/src/Turso/TursoDataReader.cs
@@ -167,7 +167,8 @@ public class TursoDataReader : DbDataReader
 
     public override bool IsDBNull(int ordinal)
     {
-        throw new NotImplementedException();
+        var valueType = TursoBindings.GetValue(_statement, ordinal).ValueType;
+        return valueType == TursoValueType.Null;
     }
 
     public override int FieldCount => TursoBindings.GetFieldCount(_statement);


### PR DESCRIPTION
## Description
`IsDBNull` was not implemented, although all the requirements are there. `DBNull` is currently mapped to `TursoValueType.Null`, so we can use `TursoValueType.Null` to check if a value is `DBNull`.

Note that I'm not sure if the same should go for `TursoValueType.Empty` as well. It does return `null` in `GetValue` but it's not mapped to `DBNull` explicitly, so I left it out for now. Can add it if required, though

## Motivation and context
This is needed for EntityFramework Core to properly handle type mapping internally


## Description of AI Usage
No AI was used to implement the code or draft this PR.
