### PR TITLE
stress: Don't panic in I/O error

### DIFF
--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -26,6 +26,7 @@ create_exception!(turso, Readonly, PyException, "database is readonly");
 create_exception!(turso, DatabaseFull, PyException, "database is full");
 create_exception!(turso, NotAdb, PyException, "not a database`");
 create_exception!(turso, Corrupt, PyException, "database corrupted");
+create_exception!(turso, IoError, PyException, "I/O error");
 
 pub(crate) fn turso_error_to_py_err(err: TursoError) -> PyErr {
     match err {
@@ -38,6 +39,7 @@ pub(crate) fn turso_error_to_py_err(err: TursoError) -> PyErr {
         rsapi::TursoError::DatabaseFull(message) => DatabaseFull::new_err(message),
         rsapi::TursoError::NotAdb(message) => NotAdb::new_err(message),
         rsapi::TursoError::Corrupt(message) => Corrupt::new_err(message),
+        rsapi::TursoError::IoError(kind) => IoError::new_err(format!("{kind:?}")),
     }
 }
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -103,6 +103,8 @@ pub enum Error {
     NotAdb(String),
     #[error("{0}")]
     Corrupt(String),
+    #[error("I/O error: {0}")]
+    IoError(std::io::ErrorKind),
 }
 
 impl From<turso_sdk_kit::rsapi::TursoError> for Error {
@@ -117,6 +119,7 @@ impl From<turso_sdk_kit::rsapi::TursoError> for Error {
             turso_sdk_kit::rsapi::TursoError::DatabaseFull(err) => Error::DatabaseFull(err),
             turso_sdk_kit::rsapi::TursoError::NotAdb(err) => Error::NotAdb(err),
             turso_sdk_kit::rsapi::TursoError::Corrupt(err) => Error::Corrupt(err),
+            turso_sdk_kit::rsapi::TursoError::IoError(kind) => Error::IoError(kind),
         }
     }
 }

--- a/sdk-kit/src/bindings.rs
+++ b/sdk-kit/src/bindings.rs
@@ -41,6 +41,7 @@ pub enum turso_status_code_t {
     TURSO_DATABASE_FULL = 131,
     TURSO_NOTADB = 132,
     TURSO_CORRUPT = 133,
+    TURSO_IOERR = 134,
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/sdk-kit/src/capi.rs
+++ b/sdk-kit/src/capi.rs
@@ -687,7 +687,7 @@ mod tests {
             let mut error = std::ptr::null();
             let status = turso_database_open(db, &mut error);
 
-            assert_eq!(status, turso_status_code_t::TURSO_ERROR);
+            assert_eq!(status, turso_status_code_t::TURSO_IOERR);
             assert_eq!(
                 std::ffi::CStr::from_ptr(error).to_str().unwrap(),
                 "I/O error: entity not found"

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -304,6 +304,7 @@ pub enum TursoError {
     DatabaseFull(String),
     NotAdb(String),
     Corrupt(String),
+    IoError(std::io::ErrorKind),
 }
 
 impl TursoStatusCode {
@@ -340,6 +341,7 @@ impl TursoError {
             TursoError::DatabaseFull(_) => capi::c::turso_status_code_t::TURSO_DATABASE_FULL,
             TursoError::NotAdb(_) => capi::c::turso_status_code_t::TURSO_NOTADB,
             TursoError::Corrupt(_) => capi::c::turso_status_code_t::TURSO_CORRUPT,
+            TursoError::IoError(_) => capi::c::turso_status_code_t::TURSO_IOERR,
         }
     }
 }
@@ -356,6 +358,7 @@ impl Display for TursoError {
             | TursoError::DatabaseFull(s)
             | TursoError::NotAdb(s)
             | TursoError::Corrupt(s) => f.write_str(s),
+            TursoError::IoError(kind) => write!(f, "I/O error: {kind}"),
         }
     }
 }
@@ -380,6 +383,9 @@ impl From<LimboError> for TursoError {
             LimboError::DatabaseFull(e) => TursoError::DatabaseFull(e),
             LimboError::ReadOnly => TursoError::Readonly("database is readonly".to_string()),
             LimboError::Busy => TursoError::Busy("database is locked".to_string()),
+            LimboError::CompletionError(turso_core::CompletionError::IOError(kind)) => {
+                TursoError::IoError(kind)
+            }
             _ => TursoError::Error(value.to_string()),
         }
     }

--- a/sdk-kit/turso.h
+++ b/sdk-kit/turso.h
@@ -31,6 +31,7 @@ typedef enum
     TURSO_DATABASE_FULL = 131,
     TURSO_NOTADB = 132,
     TURSO_CORRUPT = 133,
+    TURSO_IOERR = 134,
 } turso_status_code_t;
 
 // enumeration of value types supported by the database


### PR DESCRIPTION
For example, if we run out of disk space (via fault injection or otherwise), don't panic the stress program. Instead exit cleanly to avoid Antithesis getting spooked.