### PR TITLE
core/storage: Zero remaining buffer bytes in begin_write_btree_page()

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -598,7 +598,9 @@ pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completio
         let contents = page.get_contents();
         let src = contents.as_ptr();
         let write_buf = pager.buffer_pool.get_page();
-        write_buf.as_mut_slice()[..src.len()].copy_from_slice(src);
+        let dst = write_buf.as_mut_slice();
+        dst[..src.len()].copy_from_slice(src);
+        dst[src.len()..].fill(0);
         Arc::new(write_buf)
     };
     let buf_len = buffer.len();


### PR DESCRIPTION
Ensure the portion of the write buffer beyond the copied page data is zeroed to avoid leaking stale data from the buffer pool.

Refs: #4429