### PR TITLE
core/storage: Eliminate buffer copy in begin_write_btree_page()

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -587,16 +587,7 @@ pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completio
     let page_id = page.get().id;
     tracing::trace!("begin_write_btree_page(page_id={})", page_id);
 
-    // Copy the page data to a new buffer for the async write
-    let buffer = {
-        let contents = page.get_contents();
-        let src = contents.as_ptr();
-        let write_buf = pager.buffer_pool.get_page();
-        let dst = write_buf.as_mut_slice();
-        dst[..src.len()].copy_from_slice(src);
-        dst[src.len()..].fill(0);
-        Arc::new(write_buf)
-    };
+    let buffer = page.get().buffer.clone().expect("buffer not loaded");
     let buf_len = buffer.len();
 
     let write_complete = {


### PR DESCRIPTION
Now that PageInner stores Arc<Buffer>, we can simply clone the Arc instead of allocating a new buffer and copying the page data.

Note: This re-introduces a potential TOCTOU race where the page buffer could be modified while the async write is in flight. We've not seen this problem in practice, though, so let's just bring back the old behavior.