### PR TITLE
stress: Keep going on I/O errors instead of panicking

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -848,12 +848,10 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                             }
                         }
                         turso::Error::DatabaseFull(e) => {
-                            eprintln!("Database full, stopping thread: {e}");
-                            break;
+                            eprintln!("Database full: {e}");
                         }
-                        turso::Error::IoError(std::io::ErrorKind::StorageFull) => {
-                            eprintln!("No storage space, stopping thread");
-                            break;
+                        turso::Error::IoError(kind) => {
+                            eprintln!("I/O error ({kind:?}), continuing...");
                         }
                         _ => panic!("Error[FATAL] executing query: {}", e),
                     }


### PR DESCRIPTION
Log I/O errors (including storage full and database full) and continue the stress run instead of stopping or panicking. This is needed with unreliable-libc in particular under Antithesis to avoid spurious panics.