### PR TITLE
Minor cleanups in function.rs and refactoring allocations

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -5,14 +5,19 @@ use turso_ext::{FinalizeFunction, InitAggFunction, ScalarFunction, StepFunction}
 
 use crate::LimboError;
 
+pub trait Deterministic: std::fmt::Display {
+    fn is_deterministic(&self) -> bool;
+}
+
 pub struct ExternalFunc {
     pub name: String,
     pub func: ExtFunc,
 }
 
-impl ExternalFunc {
-    pub fn is_deterministic(&self) -> bool {
-        false // external functions can be whatever so let's just default to false
+impl Deterministic for ExternalFunc {
+    fn is_deterministic(&self) -> bool {
+        // external functions can be whatever so let's just default to false
+        false
     }
 }
 
@@ -105,8 +110,8 @@ pub enum JsonFunc {
 }
 
 #[cfg(feature = "json")]
-impl JsonFunc {
-    pub fn is_deterministic(&self) -> bool {
+impl Deterministic for JsonFunc {
+    fn is_deterministic(&self) -> bool {
         true
     }
 }
@@ -118,32 +123,32 @@ impl Display for JsonFunc {
             f,
             "{}",
             match self {
-                Self::Json => "json".to_string(),
-                Self::Jsonb => "jsonb".to_string(),
-                Self::JsonArray => "json_array".to_string(),
-                Self::JsonbArray => "jsonb_array".to_string(),
-                Self::JsonExtract => "json_extract".to_string(),
-                Self::JsonbExtract => "jsonb_extract".to_string(),
-                Self::JsonArrayLength => "json_array_length".to_string(),
-                Self::JsonArrowExtract => "->".to_string(),
-                Self::JsonArrowShiftExtract => "->>".to_string(),
-                Self::JsonObject => "json_object".to_string(),
-                Self::JsonbObject => "jsonb_object".to_string(),
-                Self::JsonType => "json_type".to_string(),
-                Self::JsonErrorPosition => "json_error_position".to_string(),
-                Self::JsonValid => "json_valid".to_string(),
-                Self::JsonPatch => "json_patch".to_string(),
-                Self::JsonbPatch => "jsonb_patch".to_string(),
-                Self::JsonRemove => "json_remove".to_string(),
-                Self::JsonbRemove => "jsonb_remove".to_string(),
-                Self::JsonReplace => "json_replace".to_string(),
-                Self::JsonbReplace => "jsonb_replace".to_string(),
-                Self::JsonInsert => "json_insert".to_string(),
-                Self::JsonbInsert => "jsonb_insert".to_string(),
-                Self::JsonPretty => "json_pretty".to_string(),
-                Self::JsonSet => "json_set".to_string(),
-                Self::JsonbSet => "jsonb_set".to_string(),
-                Self::JsonQuote => "json_quote".to_string(),
+                Self::Json => "json",
+                Self::Jsonb => "jsonb",
+                Self::JsonArray => "json_array",
+                Self::JsonbArray => "jsonb_array",
+                Self::JsonExtract => "json_extract",
+                Self::JsonbExtract => "jsonb_extract",
+                Self::JsonArrayLength => "json_array_length",
+                Self::JsonArrowExtract => "->",
+                Self::JsonArrowShiftExtract => "->>",
+                Self::JsonObject => "json_object",
+                Self::JsonbObject => "jsonb_object",
+                Self::JsonType => "json_type",
+                Self::JsonErrorPosition => "json_error_position",
+                Self::JsonValid => "json_valid",
+                Self::JsonPatch => "json_patch",
+                Self::JsonbPatch => "jsonb_patch",
+                Self::JsonRemove => "json_remove",
+                Self::JsonbRemove => "jsonb_remove",
+                Self::JsonReplace => "json_replace",
+                Self::JsonbReplace => "jsonb_replace",
+                Self::JsonInsert => "json_insert",
+                Self::JsonbInsert => "jsonb_insert",
+                Self::JsonPretty => "json_pretty",
+                Self::JsonSet => "json_set",
+                Self::JsonbSet => "jsonb_set",
+                Self::JsonQuote => "json_quote",
             }
         )
     }
@@ -164,8 +169,8 @@ pub enum VectorFunc {
     VectorSlice,
 }
 
-impl VectorFunc {
-    pub fn is_deterministic(&self) -> bool {
+impl Deterministic for VectorFunc {
+    fn is_deterministic(&self) -> bool {
         true
     }
 }
@@ -173,17 +178,17 @@ impl VectorFunc {
 impl Display for VectorFunc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str = match self {
-            Self::Vector => "vector".to_string(),
-            Self::Vector32 => "vector32".to_string(),
-            Self::Vector32Sparse => "vector32_sparse".to_string(),
-            Self::Vector64 => "vector64".to_string(),
-            Self::VectorExtract => "vector_extract".to_string(),
-            Self::VectorDistanceCos => "vector_distance_cos".to_string(),
-            Self::VectorDistanceL2 => "vector_distance_l2".to_string(),
-            Self::VectorDistanceJaccard => "vector_distance_jaccard".to_string(),
-            Self::VectorDistanceDot => "vector_distance_dot".to_string(),
-            Self::VectorConcat => "vector_concat".to_string(),
-            Self::VectorSlice => "vector_slice".to_string(),
+            Self::Vector => "vector",
+            Self::Vector32 => "vector32",
+            Self::Vector32Sparse => "vector32_sparse",
+            Self::Vector64 => "vector64",
+            Self::VectorExtract => "vector_extract",
+            Self::VectorDistanceCos => "vector_distance_cos",
+            Self::VectorDistanceL2 => "vector_distance_l2",
+            Self::VectorDistanceJaccard => "vector_distance_jaccard",
+            Self::VectorDistanceDot => "vector_distance_dot",
+            Self::VectorConcat => "vector_concat",
+            Self::VectorSlice => "vector_slice",
         };
         write!(f, "{str}")
     }
@@ -228,11 +233,18 @@ impl PartialEq for AggFunc {
     }
 }
 
-impl AggFunc {
-    pub fn is_deterministic(&self) -> bool {
+impl Deterministic for AggFunc {
+    fn is_deterministic(&self) -> bool {
         false // consider aggregate functions nondeterministic since they depend on the number of rows, not only the input arguments
     }
+}
+impl std::fmt::Display for AggFunc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
 
+impl AggFunc {
     pub fn num_args(&self) -> usize {
         match self {
             Self::Avg => 1,
@@ -342,8 +354,8 @@ pub enum ScalarFunc {
     StatGet,
 }
 
-impl ScalarFunc {
-    pub fn is_deterministic(&self) -> bool {
+impl Deterministic for ScalarFunc {
+    fn is_deterministic(&self) -> bool {
         match self {
             ScalarFunc::Cast => true,
             ScalarFunc::Changes => false, // depends on DB state
@@ -414,68 +426,68 @@ impl ScalarFunc {
 impl Display for ScalarFunc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str = match self {
-            Self::Cast => "cast".to_string(),
-            Self::Changes => "changes".to_string(),
-            Self::Char => "char".to_string(),
-            Self::Coalesce => "coalesce".to_string(),
-            Self::Concat => "concat".to_string(),
-            Self::ConcatWs => "concat_ws".to_string(),
-            Self::Glob => "glob".to_string(),
-            Self::IfNull => "ifnull".to_string(),
-            Self::Iif => "iif".to_string(),
-            Self::Instr => "instr".to_string(),
-            Self::Like => "like(2)".to_string(),
-            Self::Abs => "abs".to_string(),
-            Self::Upper => "upper".to_string(),
-            Self::Lower => "lower".to_string(),
-            Self::Random => "random".to_string(),
-            Self::RandomBlob => "randomblob".to_string(),
-            Self::Trim => "trim".to_string(),
-            Self::LTrim => "ltrim".to_string(),
-            Self::RTrim => "rtrim".to_string(),
-            Self::Round => "round".to_string(),
-            Self::Length => "length".to_string(),
-            Self::OctetLength => "octet_length".to_string(),
-            Self::Min => "min".to_string(),
-            Self::Max => "max".to_string(),
-            Self::Nullif => "nullif".to_string(),
-            Self::Sign => "sign".to_string(),
-            Self::Substr => "substr".to_string(),
-            Self::Substring => "substring".to_string(),
-            Self::Soundex => "soundex".to_string(),
-            Self::Date => "date".to_string(),
-            Self::Time => "time".to_string(),
-            Self::TotalChanges => "total_changes".to_string(),
-            Self::Typeof => "typeof".to_string(),
-            Self::Unicode => "unicode".to_string(),
-            Self::Quote => "quote".to_string(),
-            Self::SqliteVersion => "sqlite_version".to_string(),
-            Self::TursoVersion => "turso_version".to_string(),
-            Self::SqliteSourceId => "sqlite_source_id".to_string(),
-            Self::JulianDay => "julianday".to_string(),
-            Self::UnixEpoch => "unixepoch".to_string(),
-            Self::Hex => "hex".to_string(),
-            Self::Unhex => "unhex".to_string(),
-            Self::ZeroBlob => "zeroblob".to_string(),
-            Self::LastInsertRowid => "last_insert_rowid".to_string(),
-            Self::Replace => "replace".to_string(),
-            Self::DateTime => "datetime".to_string(),
+            Self::Cast => "cast",
+            Self::Changes => "changes",
+            Self::Char => "char",
+            Self::Coalesce => "coalesce",
+            Self::Concat => "concat",
+            Self::ConcatWs => "concat_ws",
+            Self::Glob => "glob",
+            Self::IfNull => "ifnull",
+            Self::Iif => "iif",
+            Self::Instr => "instr",
+            Self::Like => "like(2)",
+            Self::Abs => "abs",
+            Self::Upper => "upper",
+            Self::Lower => "lower",
+            Self::Random => "random",
+            Self::RandomBlob => "randomblob",
+            Self::Trim => "trim",
+            Self::LTrim => "ltrim",
+            Self::RTrim => "rtrim",
+            Self::Round => "round",
+            Self::Length => "length",
+            Self::OctetLength => "octet_length",
+            Self::Min => "min",
+            Self::Max => "max",
+            Self::Nullif => "nullif",
+            Self::Sign => "sign",
+            Self::Substr => "substr",
+            Self::Substring => "substring",
+            Self::Soundex => "soundex",
+            Self::Date => "date",
+            Self::Time => "time",
+            Self::TotalChanges => "total_changes",
+            Self::Typeof => "typeof",
+            Self::Unicode => "unicode",
+            Self::Quote => "quote",
+            Self::SqliteVersion => "sqlite_version",
+            Self::TursoVersion => "turso_version",
+            Self::SqliteSourceId => "sqlite_source_id",
+            Self::JulianDay => "julianday",
+            Self::UnixEpoch => "unixepoch",
+            Self::Hex => "hex",
+            Self::Unhex => "unhex",
+            Self::ZeroBlob => "zeroblob",
+            Self::LastInsertRowid => "last_insert_rowid",
+            Self::Replace => "replace",
+            Self::DateTime => "datetime",
             #[cfg(feature = "fs")]
             #[cfg(not(target_family = "wasm"))]
-            Self::LoadExtension => "load_extension".to_string(),
-            Self::StrfTime => "strftime".to_string(),
-            Self::Printf => "printf".to_string(),
-            Self::Likely => "likely".to_string(),
-            Self::TimeDiff => "timediff".to_string(),
-            Self::Likelihood => "likelihood".to_string(),
-            Self::TableColumnsJsonArray => "table_columns_json_array".to_string(),
-            Self::BinRecordJsonObject => "bin_record_json_object".to_string(),
-            Self::Attach => "attach".to_string(),
-            Self::Detach => "detach".to_string(),
-            Self::Unlikely => "unlikely".to_string(),
-            Self::StatInit => "stat_init".to_string(),
-            Self::StatPush => "stat_push".to_string(),
-            Self::StatGet => "stat_get".to_string(),
+            Self::LoadExtension => "load_extension",
+            Self::StrfTime => "strftime",
+            Self::Printf => "printf",
+            Self::Likely => "likely",
+            Self::TimeDiff => "timediff",
+            Self::Likelihood => "likelihood",
+            Self::TableColumnsJsonArray => "table_columns_json_array",
+            Self::BinRecordJsonObject => "bin_record_json_object",
+            Self::Attach => "attach",
+            Self::Detach => "detach",
+            Self::Unlikely => "unlikely",
+            Self::StatInit => "stat_init",
+            Self::StatPush => "stat_push",
+            Self::StatGet => "stat_get",
         };
         write!(f, "{str}")
     }
@@ -521,10 +533,13 @@ pub enum MathFuncArity {
     UnaryOrBinary,
 }
 
-impl MathFunc {
-    pub fn is_deterministic(&self) -> bool {
+impl Deterministic for MathFunc {
+    fn is_deterministic(&self) -> bool {
         true
     }
+}
+
+impl MathFunc {
     pub fn arity(&self) -> MathFuncArity {
         match self {
             Self::Pi => MathFuncArity::Nullary,
@@ -562,35 +577,35 @@ impl MathFunc {
 impl Display for MathFunc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str = match self {
-            Self::Acos => "acos".to_string(),
-            Self::Acosh => "acosh".to_string(),
-            Self::Asin => "asin".to_string(),
-            Self::Asinh => "asinh".to_string(),
-            Self::Atan => "atan".to_string(),
-            Self::Atan2 => "atan2".to_string(),
-            Self::Atanh => "atanh".to_string(),
-            Self::Ceil => "ceil".to_string(),
-            Self::Ceiling => "ceiling".to_string(),
-            Self::Cos => "cos".to_string(),
-            Self::Cosh => "cosh".to_string(),
-            Self::Degrees => "degrees".to_string(),
-            Self::Exp => "exp".to_string(),
-            Self::Floor => "floor".to_string(),
-            Self::Ln => "ln".to_string(),
-            Self::Log => "log".to_string(),
-            Self::Log10 => "log10".to_string(),
-            Self::Log2 => "log2".to_string(),
-            Self::Mod => "mod".to_string(),
-            Self::Pi => "pi".to_string(),
-            Self::Pow => "pow".to_string(),
-            Self::Power => "power".to_string(),
-            Self::Radians => "radians".to_string(),
-            Self::Sin => "sin".to_string(),
-            Self::Sinh => "sinh".to_string(),
-            Self::Sqrt => "sqrt".to_string(),
-            Self::Tan => "tan".to_string(),
-            Self::Tanh => "tanh".to_string(),
-            Self::Trunc => "trunc".to_string(),
+            Self::Acos => "acos",
+            Self::Acosh => "acosh",
+            Self::Asin => "asin",
+            Self::Asinh => "asinh",
+            Self::Atan => "atan",
+            Self::Atan2 => "atan2",
+            Self::Atanh => "atanh",
+            Self::Ceil => "ceil",
+            Self::Ceiling => "ceiling",
+            Self::Cos => "cos",
+            Self::Cosh => "cosh",
+            Self::Degrees => "degrees",
+            Self::Exp => "exp",
+            Self::Floor => "floor",
+            Self::Ln => "ln",
+            Self::Log => "log",
+            Self::Log10 => "log10",
+            Self::Log2 => "log2",
+            Self::Mod => "mod",
+            Self::Pi => "pi",
+            Self::Pow => "pow",
+            Self::Power => "power",
+            Self::Radians => "radians",
+            Self::Sin => "sin",
+            Self::Sinh => "sinh",
+            Self::Sqrt => "sqrt",
+            Self::Tan => "tan",
+            Self::Tanh => "tanh",
+            Self::Trunc => "trunc",
         };
         write!(f, "{str}")
     }
@@ -646,8 +661,8 @@ pub struct FuncCtx {
     pub arg_count: usize,
 }
 
-impl Func {
-    pub fn is_deterministic(&self) -> bool {
+impl Deterministic for Func {
+    fn is_deterministic(&self) -> bool {
         match self {
             Self::Agg(agg_func) => agg_func.is_deterministic(),
             Self::Scalar(scalar_func) => scalar_func.is_deterministic(),
@@ -659,7 +674,9 @@ impl Func {
             Self::AlterTable(_) => true,
         }
     }
+}
 
+impl Func {
     pub fn supports_star_syntax(&self) -> bool {
         match self {
             Self::Scalar(scalar_func) => {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::bail_parse_error;
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
-use crate::function::Func;
+use crate::function::{Deterministic, Func};
 use crate::index_method::IndexMethodConfiguration;
 use crate::numeric::Numeric;
 use crate::schema::{Column, Table, EXPR_INDEX_SENTINEL, RESERVED_TABLE_PREFIXES};
@@ -141,7 +141,7 @@ pub fn translate_create_index(
         index_method: index_method.clone(),
     });
 
-    if !idx.validate_where_expr(table) {
+    if !idx.validate_where_expr(table, resolver) {
         crate::bail_parse_error!(
             "Error: cannot use aggregate, window functions or reference other tables in WHERE clause of CREATE INDEX:\n {}",
             where_clause

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -15,6 +15,7 @@ use turso_ext::{ConstraintInfo, ConstraintUsage};
 use turso_parser::ast::{self, Expr, SortOrder, TriggerEvent};
 
 use crate::{
+    function::Deterministic,
     schema::{BTreeTable, Index, IndexColumn, Schema, Table, ROWID_SENTINEL},
     translate::{
         insert::ROWID_COLUMN,


### PR DESCRIPTION
This PR does some minor assorted cleanups and refactoring... mainly removing a lot of `.to_string()` that was unnecessary. Ran into this stuff when doing FTS work and thought I'd clean it up on another branch
