### PR TITLE
bindings/rust: return error on out of bounds Row::get access

### DIFF
--- a/bindings/rust/src/rows.rs
+++ b/bindings/rust/src/rows.rs
@@ -47,9 +47,14 @@ pub struct Row {
 }
 
 impl Row {
-    pub fn get_value(&self, index: usize) -> Result<Value> {
-        let value = &self.values[index];
-        match value {
+    pub fn get_value(&self, idx: usize) -> Result<Value> {
+        let val = self.values.get(idx).ok_or_else(|| {
+            Error::Misuse(format!(
+                "column index {idx} out of bounds (row has {} columns)",
+                self.values.len()
+            ))
+        })?;
+        match val {
             turso_sdk_kit::rsapi::Value::Integer(i) => Ok(Value::Integer(*i)),
             turso_sdk_kit::rsapi::Value::Null => Ok(Value::Null),
             turso_sdk_kit::rsapi::Value::Float(f) => Ok(Value::Real(*f)),
@@ -62,7 +67,12 @@ impl Row {
     where
         T: turso_sdk_kit::rsapi::FromValue,
     {
-        let val = &self.values[idx];
+        let val = self.values.get(idx).ok_or_else(|| {
+            Error::Misuse(format!(
+                "column index {idx} out of bounds (row has {} columns)",
+                self.values.len()
+            ))
+        })?;
         T::from_sql(val.clone()).map_err(|err| Error::ConversionFailure(err.to_string()))
     }
 


### PR DESCRIPTION
Replace direct vector indexing with `.get()` in `Row::get_value()` and `Row::get<T>()` to return an error instead of panicking on out of bounds access. This aligns behavior with `rusqlite::Row::get`.

Closes #4339

---

Original author has not updated the PR #4357 and doesn't allow maintainers to edit, so I couldn't rebase it myself. I added them as co-author