### PR TITLE
test reverting corruption bugfix to see if antithesis still finds it with debug logs enabled

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2212,15 +2212,10 @@ impl Pager {
         if is_write {
             self.clear_savepoints()
                 .expect("in practice, clear_savepoints() should never fail as it uses memory IO");
-            // IMPORTANT: rollback() must be called BEFORE end_write_tx() releases the write_lock.
-            // Otherwise, another thread could commit new frames to frame_cache between
-            // end_write_tx() and rollback(), and rollback() would incorrectly remove them.
-            self.rollback(schema_did_change, connection, is_write);
             wal.end_write_tx();
-        } else {
-            self.rollback(schema_did_change, connection, is_write);
         }
         wal.end_read_tx();
+        self.rollback(schema_did_change, connection, is_write);
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]


### PR DESCRIPTION
THIS IS ONLY DONE TO TEST WHETHER ANTITHESIS STILL FINDS THIS BUG AFTER WE ADDED DEBUG LOGS AND VERBOSE STRESS OUTPUT (in #4452). DO NOT MERGE.

Revert "Merge 'fix/pager&wal: ensure wal write lock held when rolling back frame_cache' from Jussi Saurio"

This reverts commit d766b0c65d6e1e8f79bc126080a34f17b3ec43f9, reversing changes made to 8c31152767db939d3afaed83395d549b234c0cea.