### PR TITLE
stress: handle I/O error gracefully instead of panicking

### DIFF
--- a/stress/main.rs
+++ b/stress/main.rs
@@ -781,6 +781,11 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         println!("Error (busy snapshot): {e}");
                         retry_counter += 1;
                     }
+                    Err(turso::Error::IoError(kind)) => {
+                        eprintln!("I/O error ({kind:?}), stopping");
+                        stop = true;
+                        break;
+                    }
                     Err(e) => {
                         panic!("Error creating table: {e}");
                     }


### PR DESCRIPTION
Stop the stress run when encountering I/O errors during table creation, similar to how disk full and database full errors are handled. Discovered by Antithesis.