### PR TITLE
Fix path not fsyncing the DB file after truncate checkpoint

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3391,6 +3391,8 @@ impl Pager {
                     let res = return_if_io!(wal.checkpoint(self, mode));
                     let mut state = self.checkpoint_state.write();
                     if matches!(mode, CheckpointMode::Truncate { .. })
+                        // `everything_backfilled` will be true for successful truncate checkpoint
+                        // as it will be all zeros, and we need to fsync+possibly trunc the db file
                         && res.everything_backfilled()
                     {
                         state.phase = CheckpointPhase::TruncateDbFile {


### PR DESCRIPTION
This PR fixes the issue where a TRUNCATE checkpoint does not trigger the DB file to be checkpointed, because truncate checkpoint always returns `0|0|0` and we were doing a check if `num_backfilled == 0 || crate::SyncMode::Off`.
### Before
```console
478324 pwrite64(3, "SQLite format 3\0\20\0\2\2\0@  \0\0\0\1\0\0\0\1"..., 4096, 0) = 4096
478324 pwrite64(4, "7\177\6\202\0-\342\30\0\0\20\0\0\0\0\0\323Sw\261\363!\360\6\206^V\346E6P~", 32, 0) = 32
478324 fsync(4)                         = 0
478324 pwrite64(4, "\0\0\0\1\0\0\0\0\323Sw\261\363!\360\6mzz\35\272f\251KSQLite f"..., 8240, 32) = 8240
478324 fsync(4)                         = 0
478324 pwrite64(4, "\0\0\0\2\0\0\0\2\323Sw\261\363!\360\6\220^1\357\336\211,\240\r\0\0\0\1\17\370\0"..., 4120, 8272) = 4120
478324 fsync(4)                         = 0
478324 pwrite64(3, "SQLite format 3\0\20\0\2\2\0@  \0\0\0\1\0\0\0\2"..., 8192, 0) = 8192
478324 ftruncate(4, 0)                  = 0
478324 fsync(4)                         = 0
478324 fsync(4)                         = 0
478324 ftruncate(4, 0)                  = 0
478324 fsync(4)                         = 0
```
### After:
```console
485993 pwrite64(3, "SQLite format 3\0\20\0\2\2\0@  \0\0\0\1\0\0\0\1"..., 4096, 0) = 4096
485993 pwrite64(4, "7\177\6\202\0-\342\30\0\0\20\0\0\0\0\0d<\266u\3128\201\273J\235?w\276\6O\346", 32, 0) = 32
485993 fsync(4)                         = 0
485993 pwrite64(4, "\0\0\0\1\0\0\0\0d<\266u\3128\201\273\340N\347Jn\311\200\253SQLite f"..., 8240, 32) = 8240
485993 fsync(4)                         = 0
485993 pwrite64(4, "\0\0\0\1\0\0\0\0d<\266u\3128\201\273T\3154\343\36\324\25\223SQLite f"..., 98880, 8272) = 98880
485993 fsync(4)                         = 0
485993 pwrite64(3, "SQLite format 3\0\20\0\2\2\0@  \0\0\0\1\0\0\0\30"..., 98304, 0) = 98304
485993 ftruncate(4, 0)                  = 0
485993 fsync(4)                         = 0
485993 fsync(3)                         = 0
485993 fsync(4)                         = 0
485993 ftruncate(4, 0)                  = 0
485993 fsync(4)                         = 0
485993 fsync(3)                         = 0
```
