### PR TITLE
Fix race in checkpoint path with multiple connections

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -393,6 +393,7 @@ pub fn op_checkpoint(
         }
     }
     let step_result = program.connection.pager.load().checkpoint(
+        &program.connection.checkpoint_state,
         *checkpoint_mode,
         program.connection.get_sync_mode(),
         true,
@@ -9887,6 +9888,7 @@ fn op_journal_mode_inner(
                 } else {
                     // WAL checkpoint
                     let checkpoint_result = pager.checkpoint(
+                        &program.connection.checkpoint_state,
                         CheckpointMode::Truncate {
                             upper_bound_inclusive: None,
                         },


### PR DESCRIPTION
## Situation:

Conn A: acquires write lock (`pager.checkpoint_state.write()`), sets phase = Checkpoint, calls wal.checkpoint(), hits I/O -> `return_if_io!` returns, lock released.

Conn B: acquires write lock, sees phase = Checkpoint, continues where A left off

Conn A: resumes, acquires write lock, sees whatever phase B left it in. (in this case, `Finalized` which triggers panic)


(logs from prod deployment of `v0.4.1`)
<img width="683" height="63" alt="image" src="https://github.com/user-attachments/assets/0ff04b06-96fd-421e-b35c-17714b012f97" />

## Solution:

Give each connection their own `CheckpointState`.. since the WAL itself has an exclusive checkpoint lock.. only 1 can checkpoint at a time anyway, but the `State` itself shouldn't be shared between connections.