### PR TITLE
Adjust order of operations in CheckpointPhase::Finalize

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3489,18 +3489,19 @@ impl Pager {
                 CheckpointPhase::Finalize { clear_page_cache } => {
                     let mut state = self.checkpoint_state.write();
                     let mut res = state.result.take().expect("result should be set");
-
-                    // Release checkpoint guard
-                    res.release_guard();
+                    state.phase = CheckpointPhase::NotCheckpointing;
 
                     // Clear page cache only if requested (explicit checkpoints do this, auto-checkpoint does not)
                     if clear_page_cache {
                         self.page_cache.write().clear(false).map_err(|e| {
+                            res.release_guard();
                             LimboError::InternalError(format!("Failed to clear page cache: {e:?}"))
                         })?;
                     }
 
-                    state.phase = CheckpointPhase::NotCheckpointing;
+                    // Release checkpoint guard
+                    res.release_guard();
+
                     return Ok(IOResult::Done(res));
                 }
             }


### PR DESCRIPTION
Not sure this ever matters in practice, but at least failure to clear page cache would leave state.phase unchanged.