### PR TITLE
vdbe: Resize deferred_seeks on program state reset

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -504,6 +504,7 @@ impl ProgramState {
         if let Some(max_cursors) = max_cursors {
             self.cursors.resize_with(max_cursors, || None);
             self.cursor_seqs.resize(max_cursors, 0);
+            self.deferred_seeks.resize(max_cursors, None);
         }
         if let Some(max_registers) = max_registers {
             self.registers


### PR DESCRIPTION
When resetting ProgramState with a larger max_cursors value, the deferred_seeks vector was not being resized, unlike cursors and cursor_seqs. This caused an index out of bounds panic in op_column when accessing deferred_seeks with a cursor_id larger than the original allocation.

Spotted by Whopper.