### PR TITLE
don't pass wal rollback params seperately, update test to use sqlite's integrity_check

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -11,7 +11,7 @@ use crate::storage::{
         CELL_PTR_SIZE_BYTES, INTERIOR_PAGE_HEADER_SIZE_BYTES, LEAF_PAGE_HEADER_SIZE_BYTES,
         MINIMUM_CELL_SIZE,
     },
-    wal::{CheckpointResult, Wal, IOV_MAX},
+    wal::{CheckpointResult, RollbackTo, Wal, IOV_MAX},
 };
 use crate::types::{IOCompletions, WalState};
 use crate::util::IOExt as _;
@@ -1633,7 +1633,10 @@ impl Pager {
         if let Some(wal) = &self.wal {
             let wal_max_frame = savepoint.wal_max_frame.load(Ordering::SeqCst);
             let wal_checksum = *savepoint.wal_checksum.read();
-            wal.rollback(Some(wal_max_frame), Some(wal_checksum));
+            wal.rollback(Some(RollbackTo {
+                frame: wal_max_frame,
+                checksum: wal_checksum,
+            }));
         }
 
         Ok(true)
@@ -4132,7 +4135,7 @@ impl Pager {
         }
         if is_write {
             if let Some(wal) = self.wal.as_ref() {
-                wal.rollback(None, None);
+                wal.rollback(None);
             }
         }
     }

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -1563,12 +1563,12 @@ fn test_wal_savepoint_rollback_on_constraint_violation() {
         .unwrap();
     conn.execute("COMMIT").unwrap();
 
-    let stmt = conn.query("PRAGMA integrity_check").unwrap().unwrap();
-    println!("{stmt:?}");
-    let row = helper_read_single_row(stmt);
+    let rusqlite_conn = rusqlite::Connection::open(tmp_db.path.clone()).unwrap();
+    let result: String = rusqlite_conn
+        .pragma_query_value(None, "integrity_check", |row| row.get(0))
+        .unwrap();
     assert_eq!(
-        row[0],
-        Value::build_text("ok"),
+        result, "ok",
         "Database should pass integrity check after savepoint rollback"
     );
 


### PR DESCRIPTION
addresses review feedback from https://github.com/tursodatabase/turso/pull/4493
i was away when jussi reviewed it. so making pr now