### PR TITLE
test: Make simulator work for materialized views

### DIFF
--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -288,3 +288,372 @@ impl WriteRow {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::incremental::operator::{create_dbsp_state_index, DbspStateCursors};
+    use crate::storage::btree::{BTreeCursor, CursorTrait};
+    use crate::storage::pager::CreateBTreeFlags;
+    use crate::sync::Arc;
+    use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult};
+    use crate::util::IOExt;
+    use crate::{Database, MemoryIO, IO};
+
+    fn create_test_pager() -> (Arc<crate::Pager>, i64, i64) {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io.clone(), ":memory:").unwrap();
+        let conn = db.connect().unwrap();
+        let pager = conn.pager.load().clone();
+        let _ = pager.io.block(|| pager.allocate_page1());
+
+        let table_root = pager
+            .io
+            .block(|| pager.btree_create(&CreateBTreeFlags::new_table()))
+            .unwrap() as i64;
+        let index_root = pager
+            .io
+            .block(|| pager.btree_create(&CreateBTreeFlags::new_index()))
+            .unwrap() as i64;
+
+        (pager, table_root, index_root)
+    }
+
+    /// Verify that every table row has a matching index entry by scanning the
+    /// table and seeking each row's key in the index. Returns the number of
+    /// verified rows.
+    fn verify_index_integrity(pager: &Arc<crate::Pager>, cursors: &mut DbspStateCursors) -> usize {
+        pager.io.block(|| cursors.table_cursor.rewind()).unwrap();
+        let mut count = 0;
+
+        loop {
+            if cursors.table_cursor.is_empty() {
+                break;
+            }
+
+            let record = loop {
+                match cursors.table_cursor.record().unwrap() {
+                    IOResult::Done(r) => break r,
+                    IOResult::IO(io) => io.wait(&*pager.io).unwrap(),
+                }
+            };
+            let record = record.unwrap().to_owned();
+            let values: Vec<Value> = record.get_values_owned().unwrap();
+
+            let rowid = loop {
+                match cursors.table_cursor.rowid().unwrap() {
+                    IOResult::Done(r) => break r.unwrap(),
+                    IOResult::IO(io) => io.wait(&*pager.io).unwrap(),
+                }
+            };
+
+            // Build the index key: first 3 columns (operator_id, zset_id, element_id)
+            let index_key: Vec<Value> = values[..3].to_vec();
+            let index_record = ImmutableRecord::from_values(&index_key, index_key.len());
+
+            let seek_result = pager
+                .io
+                .block(|| {
+                    cursors.index_cursor.seek(
+                        SeekKey::IndexKey(&index_record),
+                        SeekOp::GE { eq_only: true },
+                    )
+                })
+                .unwrap();
+
+            assert!(
+                matches!(seek_result, SeekResult::Found),
+                "Index entry not found for table rowid={rowid}, key={index_key:?}"
+            );
+
+            // Verify the index entry points to the correct rowid
+            let index_rowid = pager
+                .io
+                .block(|| cursors.index_cursor.rowid())
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                index_rowid, rowid,
+                "Index rowid mismatch: expected {rowid}, got {index_rowid}"
+            );
+
+            count += 1;
+            pager.io.block(|| cursors.table_cursor.next()).unwrap();
+        }
+        count
+    }
+
+    /// Simulates the scenario where an I/O yield occurs during the table insert
+    /// in InsertNew, and the index cursor is left in a stale position.
+    ///
+    /// Without the SeekForInsertIndex fix, InsertIndex uses the cursor position
+    /// left over from the GetRecord seek, which may be wrong after an I/O yield.
+    /// With the fix, SeekForInsertIndex re-seeks the index cursor before insert.
+    ///
+    /// This test reproduces the issue by:
+    /// 1. Inserting several entries to populate the B-tree
+    /// 2. For a new entry, manually performing the GetRecord + table insert steps
+    /// 3. Moving the index cursor to a different position (simulating stale state
+    ///    from I/O yield)
+    /// 4. Continuing from the InsertIndex state
+    /// 5. Verifying the index is correct
+    #[test]
+    fn test_write_row_stale_index_cursor_after_simulated_io_yield() {
+        let (pager, table_root, index_root) = create_test_pager();
+        let table_cursor = BTreeCursor::new_table(pager.clone(), table_root, 5);
+        let index_def = create_dbsp_state_index(index_root);
+        let index_cursor = BTreeCursor::new_index(pager.clone(), index_root, &index_def, 4);
+        let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
+
+        let op_id = 1i64;
+        let zset_id = 1i64;
+
+        // Insert some entries normally to populate the B-tree
+        for i in 1..=10 {
+            let mut wr = WriteRow::new();
+            let ik = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+            ];
+            let rv = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+                Value::Null,
+            ];
+            pager
+                .io
+                .block(|| wr.write_row(&mut cursors, ik.clone(), rv.clone(), 1))
+                .unwrap();
+        }
+
+        // Now simulate inserting element_id=20 with a simulated I/O yield.
+        // Step 1: Manually perform the table insert (what InsertNew does)
+        let new_elem_id = 20i64;
+        let rowid = 11i64; // next rowid after 10 entries
+
+        // Seek and insert into table
+        pager
+            .io
+            .block(|| {
+                cursors
+                    .table_cursor
+                    .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: false })
+            })
+            .unwrap();
+        let complete_record = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(new_elem_id),
+            Value::Null,
+            Value::from_i64(1), // weight=1
+        ];
+        let immutable_record =
+            ImmutableRecord::from_values(&complete_record, complete_record.len());
+        let btree_key = BTreeKey::new_table_rowid(rowid, Some(&immutable_record));
+        pager
+            .io
+            .block(|| cursors.table_cursor.insert(&btree_key))
+            .unwrap();
+
+        // Step 2: Simulate I/O yield invalidating the index cursor.
+        // Move the index cursor to element_id=1 (a wrong position for inserting element_id=20).
+        let wrong_key = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(1i64),
+        ];
+        let wrong_record = ImmutableRecord::from_values(&wrong_key, wrong_key.len());
+        pager
+            .io
+            .block(|| {
+                cursors.index_cursor.seek(
+                    SeekKey::IndexKey(&wrong_record),
+                    SeekOp::GE { eq_only: false },
+                )
+            })
+            .unwrap();
+
+        // Step 3: Continue from InsertIndex state (what happens after I/O yield resumes)
+        let index_key = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(new_elem_id),
+        ];
+        let record_values = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(new_elem_id),
+            Value::Null,
+        ];
+        let mut wr = WriteRow::InsertIndex { rowid };
+        pager
+            .io
+            .block(|| wr.write_row(&mut cursors, index_key.clone(), record_values.clone(), 1))
+            .unwrap();
+
+        // Step 4: Verify the index entry for element_id=20 exists and points to
+        // the correct rowid
+        let search_key = vec![
+            Value::from_i64(op_id),
+            Value::from_i64(zset_id),
+            Value::from_i64(new_elem_id),
+        ];
+        let search_record = ImmutableRecord::from_values(&search_key, search_key.len());
+        let seek_result = pager
+            .io
+            .block(|| {
+                cursors.index_cursor.seek(
+                    SeekKey::IndexKey(&search_record),
+                    SeekOp::GE { eq_only: true },
+                )
+            })
+            .unwrap();
+        assert!(
+            matches!(seek_result, SeekResult::Found),
+            "Index entry not found for element_id={new_elem_id} after simulated I/O yield"
+        );
+        let found_rowid = pager
+            .io
+            .block(|| cursors.index_cursor.rowid())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            found_rowid, rowid,
+            "Index entry for element_id={new_elem_id} points to wrong rowid: expected {rowid}, got {found_rowid}"
+        );
+
+        // Also verify ALL entries are intact (the wrong cursor position might have
+        // corrupted an existing entry)
+        let count = verify_index_integrity(&pager, &mut cursors);
+        assert_eq!(
+            count, 11,
+            "Expected 11 rows (10 original + 1 new), found {count}"
+        );
+    }
+
+    #[test]
+    fn test_write_row_many_entries_index_integrity() {
+        let (pager, table_root, index_root) = create_test_pager();
+        let table_cursor = BTreeCursor::new_table(pager.clone(), table_root, 5);
+        let index_def = create_dbsp_state_index(index_root);
+        let index_cursor = BTreeCursor::new_index(pager.clone(), index_root, &index_def, 4);
+        let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
+
+        let op_id = 1i64;
+        let zset_id = 1i64;
+
+        // Insert 200+ entries with distinct element_ids to force multi-page B-tree.
+        // Each entry is a new group, so WriteRow takes the InsertNew path every time.
+        let n = 250;
+        for i in 1..=n {
+            let mut wr = WriteRow::new();
+            let index_key = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+            ];
+            let record_values = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+                Value::Null,
+            ];
+            pager
+                .io
+                .block(|| wr.write_row(&mut cursors, index_key.clone(), record_values.clone(), 1))
+                .unwrap();
+        }
+
+        let count = verify_index_integrity(&pager, &mut cursors);
+        assert_eq!(count, n as usize, "Expected {n} rows, found {count}");
+    }
+
+    /// Test WriteRow with interleaved inserts and updates across many groups.
+    /// First inserts create new entries (InsertNew path), then updates modify
+    /// existing entries (UpdateExisting path). The alternation stresses cursor
+    /// positioning between the "found" and "not found" index seek paths.
+    #[test]
+    fn test_write_row_interleaved_insert_update_index_integrity() {
+        let (pager, table_root, index_root) = create_test_pager();
+        let table_cursor = BTreeCursor::new_table(pager.clone(), table_root, 5);
+        let index_def = create_dbsp_state_index(index_root);
+        let index_cursor = BTreeCursor::new_index(pager.clone(), index_root, &index_def, 4);
+        let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
+
+        let op_id = 1i64;
+        let zset_id = 1i64;
+        let n = 150;
+
+        // Phase 1: Insert n entries
+        for i in 1..=n {
+            let mut wr = WriteRow::new();
+            let index_key = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+            ];
+            let record_values = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+                Value::Null,
+            ];
+            pager
+                .io
+                .block(|| wr.write_row(&mut cursors, index_key.clone(), record_values.clone(), 1))
+                .unwrap();
+        }
+
+        // Phase 2: Interleave updates to existing entries with inserts of new entries
+        for i in 1..=n {
+            // Update existing entry i (weight +1 → UpdateExisting path)
+            let mut wr = WriteRow::new();
+            let index_key = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+            ];
+            let record_values = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(i),
+                Value::Null,
+            ];
+            pager
+                .io
+                .block(|| wr.write_row(&mut cursors, index_key.clone(), record_values.clone(), 1))
+                .unwrap();
+
+            // Insert a new entry n+i (InsertNew path)
+            let mut wr2 = WriteRow::new();
+            let new_id = n + i;
+            let index_key2 = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(new_id),
+            ];
+            let record_values2 = vec![
+                Value::from_i64(op_id),
+                Value::from_i64(zset_id),
+                Value::from_i64(new_id),
+                Value::Null,
+            ];
+            pager
+                .io
+                .block(|| {
+                    wr2.write_row(&mut cursors, index_key2.clone(), record_values2.clone(), 1)
+                })
+                .unwrap();
+        }
+
+        let count = verify_index_integrity(&pager, &mut cursors);
+        assert_eq!(
+            count,
+            (2 * n) as usize,
+            "Expected {} rows, found {count}",
+            2 * n
+        );
+    }
+}

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4747,7 +4747,7 @@ impl WalFile {
     /// because we might overwrite content the reader is reading from the database file.
     ///
     /// A checkpoint must never overwrite a page in the main DB file if some
-    /// active reader might still need to read that page from the WAL.  
+    /// active reader might still need to read that page from the WAL.
     /// Concretely: the checkpoint may only copy frames `<= aReadMark[k]` for
     /// every in-use reader slot `k > 0`.
     ///

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -9743,4 +9743,63 @@ pub mod test {
             "checkpoint must succeed after rollback, not return Busy"
         );
     }
+
+    /// Regression test: rollback calls reset_internal_states(). If that function
+    /// resets max_frame_read_lock_index to NO_LOCK_HELD without actually releasing
+    /// the shared read lock, end_read_tx() becomes a no-op and the lock leaks.
+    /// A leaked read lock permanently blocks Restart/Truncate checkpoints.
+    #[test]
+    fn test_wal_rollback_does_not_leak_read_lock() {
+        let (db, _path) = get_database();
+        let conn1 = db.connect().unwrap();
+        let conn2 = db.connect().unwrap();
+
+        conn1
+            .execute("create table test(id integer primary key, value text)")
+            .unwrap();
+        bulk_inserts(&conn1, 5, 10);
+
+        // conn2: begin read tx — acquires a shared read lock on a non-zero slot
+        // (non-zero because the WAL has un-checkpointed frames)
+        {
+            let pager = conn2.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.begin_read_tx().unwrap();
+        }
+        assert!(
+            !check_read_lock_slot(&conn2, 0),
+            "conn2 should hold a non-zero read lock slot (WAL has frames)"
+        );
+
+        // conn2: begin write tx, then rollback — triggers reset_internal_states()
+        {
+            let pager = conn2.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.begin_write_tx().unwrap();
+        }
+        {
+            let pager = conn2.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.rollback(None);
+            wal.end_write_tx();
+        }
+
+        // conn2: end read tx — must actually release the shared read lock
+        {
+            let pager = conn2.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.end_read_tx();
+        }
+
+        // If the read lock leaked, this Restart checkpoint will return Busy.
+        let result = {
+            let pager = conn1.pager.load();
+            run_checkpoint_until_done(&pager, CheckpointMode::Restart)
+        };
+        assert!(
+            result.everything_backfilled(),
+            "Restart checkpoint should succeed after conn2 released its read lock, \
+             but it didn't — read lock was leaked by rollback/reset_internal_states"
+        );
+    }
 }

--- a/sql_generation/generation/mod.rs
+++ b/sql_generation/generation/mod.rs
@@ -211,11 +211,16 @@ mod tests {
     pub struct TestContext {
         pub opts: Opts,
         pub tables: Vec<Table>,
+        pub views: Vec<crate::model::view::View>,
     }
 
     impl GenerationContext for TestContext {
         fn tables(&self) -> &Vec<Table> {
             &self.tables
+        }
+
+        fn views(&self) -> &Vec<crate::model::view::View> {
+            &self.views
         }
 
         fn opts(&self) -> &Opts {

--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -9,11 +9,12 @@ use rand::distr::weighted::WeightedIndex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::model::table::Table;
+use crate::model::{table::Table, view::View};
 
 /// Trait used to provide context to generation functions
 pub trait GenerationContext {
     fn tables(&self) -> &Vec<Table>;
+    fn views(&self) -> &Vec<View>;
     fn opts(&self) -> &Opts;
 }
 

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -60,10 +60,17 @@ impl Arbitrary for FromClause {
                 }
 
                 let predicate = Predicate::arbitrary_from(rng, context, &table);
+                // Randomly select join type, with higher probability for INNER (most common)
+                let join_type = match rng.random_range(0..10u8) {
+                    0..=6 => JoinType::Inner, // 70%
+                    7..=8 => JoinType::Left,  // 20%
+                    9 => JoinType::Cross,     // 10%
+                    _ => JoinType::Inner,
+                };
                 Some(JoinedTable {
                     table: joined_table_name,
                     alias: None,
-                    join_type: JoinType::Inner,
+                    join_type,
                     on: predicate,
                 })
             })

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -3,6 +3,7 @@ use crate::generation::{
     ArbitrarySized, GenerationContext, InsertOpts,
 };
 use crate::model::query::alter_table::{AlterTable, AlterTableType, AlterTableTypeDiscriminants};
+use crate::model::query::insert::ConflictAction;
 use crate::model::query::predicate::Predicate;
 use crate::model::query::select::{
     CompoundOperator, CompoundSelect, Distinctness, FromClause, OrderBy, ResultColumn, SelectBody,
@@ -244,6 +245,21 @@ impl Arbitrary for Select {
     }
 }
 
+/// Generate an optional conflict action with ~20% probability.
+/// Only generates REPLACE or IGNORE as these are the most commonly used.
+fn maybe_conflict_action<R: Rng + ?Sized>(rng: &mut R) -> Option<ConflictAction> {
+    if rng.random_bool(0.2) {
+        // Prefer REPLACE (for IVM bug testing) but also generate IGNORE
+        Some(if rng.random_bool(0.7) {
+            ConflictAction::Replace
+        } else {
+            ConflictAction::Ignore
+        })
+    } else {
+        None
+    }
+}
+
 impl Arbitrary for Insert {
     fn arbitrary<R: Rng + ?Sized, C: GenerationContext>(rng: &mut R, env: &C) -> Self {
         let insert_opts = &env.opts().query.insert;
@@ -295,6 +311,7 @@ impl Arbitrary for Insert {
             Some(Insert::Select {
                 table: table.name.clone(),
                 select: Box::new(select),
+                conflict: maybe_conflict_action(rng),
             })
         };
 
@@ -312,6 +329,7 @@ impl Arbitrary for Insert {
             Some(Insert::Select {
                 table: select_table.name.clone(),
                 select: Box::new(select),
+                conflict: maybe_conflict_action(rng),
             })
         };
 
@@ -383,6 +401,7 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
         table: table.name.clone(),
         values,
         on_conflict: None,
+        conflict: None,
     })
 }
 
@@ -554,6 +573,7 @@ fn gen_insert_upsert_values<R: Rng + ?Sized, C: GenerationContext>(
             target_column: target_col.name.clone(),
             assignments,
         }),
+        conflict: None,
     })
 }
 

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -61,13 +61,14 @@ impl Arbitrary for FromClause {
                 let predicate = Predicate::arbitrary_from(rng, context, &table);
                 Some(JoinedTable {
                     table: joined_table_name,
+                    alias: None,
                     join_type: JoinType::Inner,
                     on: predicate,
                 })
             })
             .collect();
         FromClause {
-            table: SelectTable::Table(table.name.clone()),
+            table: SelectTable::Table(table.name.clone(), None),
             joins,
         }
     }
@@ -227,6 +228,7 @@ impl Arbitrary for Select {
         }
 
         Self {
+            with: None,
             body: SelectBody {
                 select: Box::new(first),
                 compounds: rest
@@ -272,6 +274,7 @@ impl Arbitrary for Insert {
 
             for _ in 1..nesting_depth {
                 select = Select {
+                    with: None,
                     body: SelectBody {
                         select: Box::new(SelectInner {
                             distinctness: Distinctness::All,

--- a/sql_generation/model/mod.rs
+++ b/sql_generation/model/mod.rs
@@ -1,2 +1,3 @@
 pub mod query;
 pub mod table;
+pub mod view;

--- a/sql_generation/model/query/create_materialized_view.rs
+++ b/sql_generation/model/query/create_materialized_view.rs
@@ -1,0 +1,31 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use super::select::Select;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateMaterializedView {
+    pub name: String,
+    pub select: Select,
+}
+
+impl Display for CreateMaterializedView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CREATE MATERIALIZED VIEW {} AS {}",
+            self.name, self.select
+        )
+    }
+}
+
+impl CreateMaterializedView {
+    /// Convert to a regular CreateView (for rusqlite oracle)
+    pub fn to_regular_view(&self) -> super::create_view::CreateView {
+        super::create_view::CreateView {
+            name: self.name.clone(),
+            select: self.select.clone(),
+        }
+    }
+}

--- a/sql_generation/model/query/create_view.rs
+++ b/sql_generation/model/query/create_view.rs
@@ -1,0 +1,17 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use super::select::Select;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateView {
+    pub name: String,
+    pub select: Select,
+}
+
+impl Display for CreateView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CREATE VIEW {} AS {}", self.name, self.select)
+    }
+}

--- a/sql_generation/model/query/drop_view.rs
+++ b/sql_generation/model/query/drop_view.rs
@@ -1,0 +1,34 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DropView {
+    pub name: String,
+}
+
+impl Display for DropView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DROP VIEW {}", self.name)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DropMaterializedView {
+    pub name: String,
+}
+
+impl Display for DropMaterializedView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DROP VIEW {}", self.name)
+    }
+}
+
+impl DropMaterializedView {
+    /// Convert to a regular DropView (for rusqlite oracle)
+    pub fn to_regular_drop_view(&self) -> DropView {
+        DropView {
+            name: self.name.clone(),
+        }
+    }
+}

--- a/sql_generation/model/query/insert.rs
+++ b/sql_generation/model/query/insert.rs
@@ -6,6 +6,34 @@ use crate::model::table::SimValue;
 
 use super::select::Select;
 
+/// Conflict resolution action for INSERT statements.
+/// Maps to SQLite's INSERT OR {action} syntax.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ConflictAction {
+    /// INSERT OR REPLACE - replaces the existing row on conflict
+    Replace,
+    /// INSERT OR IGNORE - silently ignores the insert on conflict
+    Ignore,
+    /// INSERT OR ABORT - aborts the current statement (default behavior)
+    Abort,
+    /// INSERT OR ROLLBACK - rolls back the entire transaction on conflict
+    Rollback,
+    /// INSERT OR FAIL - fails but keeps prior changes in the transaction
+    Fail,
+}
+
+impl Display for ConflictAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConflictAction::Replace => write!(f, "REPLACE"),
+            ConflictAction::Ignore => write!(f, "IGNORE"),
+            ConflictAction::Abort => write!(f, "ABORT"),
+            ConflictAction::Rollback => write!(f, "ROLLBACK"),
+            ConflictAction::Fail => write!(f, "FAIL"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OnConflict {
     pub target_column: String,
@@ -25,10 +53,14 @@ pub enum Insert {
         values: Vec<Vec<SimValue>>,
         #[serde(default)]
         on_conflict: Option<OnConflict>,
+        /// Optional conflict resolution (INSERT OR REPLACE, etc.)
+        conflict: Option<ConflictAction>,
     },
     Select {
         table: String,
         select: Box<Select>,
+        /// Optional conflict resolution (INSERT OR REPLACE, etc.)
+        conflict: Option<ConflictAction>,
     },
 }
 
@@ -54,8 +86,13 @@ impl Display for Insert {
                 table,
                 values,
                 on_conflict,
+                conflict,
             } => {
-                write!(f, "INSERT INTO {table} VALUES ")?;
+                write!(f, "INSERT ")?;
+                if let Some(action) = conflict {
+                    write!(f, "OR {action} ")?;
+                }
+                write!(f, "INTO {table} VALUES ")?;
                 for (i, row) in values.iter().enumerate() {
                     if i != 0 {
                         write!(f, ", ")?;
@@ -74,8 +111,16 @@ impl Display for Insert {
                 }
                 Ok(())
             }
-            Insert::Select { table, select } => {
-                write!(f, "INSERT INTO {table} ")?;
+            Insert::Select {
+                table,
+                select,
+                conflict,
+            } => {
+                write!(f, "INSERT ")?;
+                if let Some(action) = conflict {
+                    write!(f, "OR {action} ")?;
+                }
+                write!(f, "INTO {table} ")?;
                 write!(f, "{select}")
             }
         }

--- a/sql_generation/model/query/mod.rs
+++ b/sql_generation/model/query/mod.rs
@@ -6,7 +6,7 @@ pub use delete::Delete;
 pub use drop::Drop;
 pub use drop_index::DropIndex;
 pub use drop_view::{DropMaterializedView, DropView};
-pub use insert::{Insert, OnConflict, UpdateSetItem};
+pub use insert::{ConflictAction, Insert, OnConflict, UpdateSetItem};
 pub use select::{Cte, Select, WithClause};
 
 pub mod alter_table;

--- a/sql_generation/model/query/mod.rs
+++ b/sql_generation/model/query/mod.rs
@@ -1,17 +1,23 @@
 pub use create::Create;
 pub use create_index::CreateIndex;
+pub use create_materialized_view::CreateMaterializedView;
+pub use create_view::CreateView;
 pub use delete::Delete;
 pub use drop::Drop;
 pub use drop_index::DropIndex;
+pub use drop_view::{DropMaterializedView, DropView};
 pub use insert::{Insert, OnConflict, UpdateSetItem};
-pub use select::Select;
+pub use select::{Cte, Select, WithClause};
 
 pub mod alter_table;
 pub mod create;
 pub mod create_index;
+pub mod create_materialized_view;
+pub mod create_view;
 pub mod delete;
 pub mod drop;
 pub mod drop_index;
+pub mod drop_view;
 pub mod insert;
 pub mod pragma;
 pub mod predicate;

--- a/sql_generation/model/query/pragma.rs
+++ b/sql_generation/model/query/pragma.rs
@@ -6,12 +6,20 @@ use serde::{Deserialize, Serialize};
 pub enum Pragma {
     AutoVacuumMode(VacuumMode),
     ForeignKeyList(String),
+    CaptureDataChanges(CdcMode),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum VacuumMode {
     None,
     Incremental,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum CdcMode {
+    #[default]
+    Off,
     Full,
 }
 
@@ -25,12 +33,19 @@ impl Display for Pragma {
                     VacuumMode::Full => "full",
                 };
 
-                write!(f, "PRAGMA auto_vacuum={mode}")?;
-                Ok(())
+                write!(f, "PRAGMA auto_vacuum={mode}")
             }
             Pragma::ForeignKeyList(table_name) => {
                 let table_name = table_name.replace('\'', "''");
                 write!(f, "PRAGMA foreign_key_list('{table_name}')")
+            }
+            Pragma::CaptureDataChanges(cdc_mode) => {
+                let mode = match cdc_mode {
+                    CdcMode::Off => "off",
+                    CdcMode::Full => "full",
+                };
+
+                write!(f, "PRAGMA unstable_capture_data_changes_conn('{mode}')")
             }
         }
     }

--- a/sql_generation/model/query/select.rs
+++ b/sql_generation/model/query/select.rs
@@ -19,8 +19,10 @@ use super::predicate::Predicate;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum ResultColumn {
-    /// expression
+    /// expression (with optional alias)
     Expr(Predicate),
+    /// expression with alias: expr AS name
+    ExprAs(Predicate, String),
     /// `*`
     Star,
     /// column name
@@ -31,13 +33,37 @@ impl Display for ResultColumn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ResultColumn::Expr(expr) => write!(f, "({expr})"),
+            ResultColumn::ExprAs(expr, alias) => write!(f, "({expr}) AS {alias}"),
             ResultColumn::Star => write!(f, "*"),
             ResultColumn::Column(name) => write!(f, "{name}"),
         }
     }
 }
+
+/// WITH clause for Common Table Expressions (CTEs)
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WithClause {
+    /// Whether this is a recursive CTE (WITH RECURSIVE)
+    pub recursive: bool,
+    /// The CTEs defined in this WITH clause
+    pub ctes: Vec<Cte>,
+}
+
+/// A Common Table Expression (CTE)
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Cte {
+    /// Name of the CTE
+    pub name: String,
+    /// Column names for the CTE (optional, but required for recursive CTEs)
+    pub columns: Vec<String>,
+    /// The body of the CTE (a SelectBody, which can include UNION ALL for recursive CTEs)
+    pub body: SelectBody,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Select {
+    /// Optional WITH clause for CTEs
+    pub with: Option<WithClause>,
     pub body: SelectBody,
     pub limit: Option<usize>,
 }
@@ -55,6 +81,7 @@ impl Select {
 
     pub fn expr(expr: Predicate) -> Self {
         Select {
+            with: None,
             body: SelectBody {
                 select: Box::new(SelectInner {
                     distinctness: Distinctness::All,
@@ -77,12 +104,13 @@ impl Select {
         distinct: Distinctness,
     ) -> Self {
         Select {
+            with: None,
             body: SelectBody {
                 select: Box::new(SelectInner {
                     distinctness: distinct,
                     columns: result_columns,
                     from: Some(FromClause {
-                        table: SelectTable::Table(table),
+                        table: SelectTable::Table(table, None),
                         joins: Vec::new(),
                     }),
                     where_clause,
@@ -101,8 +129,170 @@ impl Select {
             select: Box::new(right.body.select.as_ref().clone()),
         });
         Select {
+            with: left.with,
             body,
             limit: left.limit.or(right.limit),
+        }
+    }
+
+    /// Create a SELECT with a WITH clause (CTE).
+    ///
+    /// # Arguments
+    /// * `with_clause` - The WITH clause containing CTEs
+    /// * `body` - The main SELECT body
+    /// * `limit` - Optional LIMIT clause
+    pub fn with_cte(with_clause: WithClause, body: SelectBody, limit: Option<usize>) -> Self {
+        Select {
+            with: Some(with_clause),
+            body,
+            limit,
+        }
+    }
+
+    /// Create a recursive CTE for parent-child hierarchy traversal.
+    ///
+    /// This generates SQL like:
+    /// ```sql
+    /// WITH RECURSIVE tree(id, parent_id, content, depth, path) AS (
+    ///     SELECT id, parent_id, content, 0, id FROM items WHERE parent_id IS NULL
+    ///     UNION ALL
+    ///     SELECT i.id, i.parent_id, i.content, t.depth + 1, t.path || '/' || i.id
+    ///     FROM items i INNER JOIN tree t ON i.parent_id = t.id
+    ///     WHERE t.depth < 10
+    /// )
+    /// SELECT * FROM tree ORDER BY path
+    /// ```
+    pub fn recursive_hierarchy_cte(
+        cte_name: String,
+        base_table: String,
+        id_column: String,
+        parent_column: String,
+        content_columns: Vec<String>,
+        _max_depth: u32,
+    ) -> Self {
+        // Don't specify CTE column list to match the pattern that works in the original test
+        // The original test uses `WITH RECURSIVE paths AS (...)` not `WITH RECURSIVE paths(id, parent_id, ...) AS (...)`
+        let cte_columns: Vec<String> = vec![];
+
+        // Build anchor result columns: SELECT id, parent_id, content, '/' || id as path
+        let mut anchor_columns: Vec<ResultColumn> = vec![
+            ResultColumn::Column(id_column.clone()),
+            ResultColumn::Column(parent_column.clone()),
+        ];
+        for col in &content_columns {
+            anchor_columns.push(ResultColumn::Column(col.clone()));
+        }
+        // path = '/' || id AS path (matches original test pattern)
+        anchor_columns.push(ResultColumn::ExprAs(
+            Predicate::concat(vec![
+                Predicate::literal_text("/"),
+                Predicate::column(id_column.clone()),
+            ]),
+            "path".to_string(),
+        ));
+
+        // Anchor: SELECT ... FROM base_table WHERE parent_column IS NULL
+        let anchor = SelectInner {
+            distinctness: Distinctness::All,
+            columns: anchor_columns,
+            from: Some(FromClause {
+                table: SelectTable::Table(base_table.clone(), None),
+                joins: Vec::new(),
+            }),
+            where_clause: Predicate::is_null(Predicate::column(parent_column.clone())),
+            order_by: None,
+        };
+
+        // Recursive: SELECT b.id, b.parent_id, b.content, p.path || '/' || b.id as path
+        // FROM base_table b INNER JOIN cte_name p ON b.parent_id = p.id
+        // Note: No depth column to avoid "non-equijoin" error in DBSP
+        let b_alias = "b".to_string();
+        let p_alias = "p".to_string();
+
+        let mut recursive_columns: Vec<ResultColumn> = vec![
+            ResultColumn::Expr(Predicate::qualified_column(&b_alias, &id_column)),
+            ResultColumn::Expr(Predicate::qualified_column(&b_alias, &parent_column)),
+        ];
+        for col in &content_columns {
+            recursive_columns.push(ResultColumn::Expr(Predicate::qualified_column(
+                &b_alias, col,
+            )));
+        }
+        // p.path || '/' || b.id AS path
+        recursive_columns.push(ResultColumn::ExprAs(
+            Predicate::concat(vec![
+                Predicate::qualified_column(&p_alias, "path"),
+                Predicate::literal_text("/"),
+                Predicate::qualified_column(&b_alias, &id_column),
+            ]),
+            "path".to_string(),
+        ));
+
+        // For the recursive part, we need a join.
+        // ON b.parent_id = p.id
+        // Use eq_bare (no parentheses) - DBSP parser requires bare equality in ON clauses
+        let join_condition = Predicate::eq_bare(
+            Predicate::qualified_column(&b_alias, &parent_column),
+            Predicate::qualified_column(&p_alias, &id_column),
+        );
+
+        let recursive = SelectInner {
+            distinctness: Distinctness::All,
+            columns: recursive_columns,
+            from: Some(FromClause {
+                table: SelectTable::Table(base_table.clone(), Some(b_alias)),
+                joins: vec![JoinedTable {
+                    join_type: JoinType::Inner,
+                    table: cte_name.clone(),
+                    alias: Some(p_alias),
+                    on: join_condition,
+                }],
+            }),
+            // No WHERE clause - any conditions cause "non-equijoin" error in DBSP
+            where_clause: Predicate::true_(),
+            order_by: None,
+        };
+
+        // CTE body: anchor UNION ALL recursive
+        let cte_body = SelectBody {
+            select: Box::new(anchor),
+            compounds: vec![CompoundSelect {
+                operator: CompoundOperator::UnionAll,
+                select: Box::new(recursive),
+            }],
+        };
+
+        let cte = Cte {
+            name: cte_name.clone(),
+            columns: cte_columns,
+            body: cte_body,
+        };
+
+        let with_clause = WithClause {
+            recursive: true,
+            ctes: vec![cte],
+        };
+
+        // Final SELECT * FROM cte_name
+        // Note: ORDER BY is not supported by DBSP compiler for IVM, so we don't use it
+        let final_body = SelectBody {
+            select: Box::new(SelectInner {
+                distinctness: Distinctness::All,
+                columns: vec![ResultColumn::Star],
+                from: Some(FromClause {
+                    table: SelectTable::Table(cte_name, None),
+                    joins: Vec::new(),
+                }),
+                where_clause: Predicate::true_(),
+                order_by: None,
+            }),
+            compounds: Vec::new(),
+        };
+
+        Select {
+            with: Some(with_clause),
+            body: final_body,
+            limit: None,
         }
     }
 
@@ -184,7 +374,8 @@ pub struct FromClause {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum SelectTable {
-    Table(String),
+    /// Table with optional alias: (table_name, optional_alias)
+    Table(String, Option<String>),
     Select(Select),
 }
 
@@ -224,9 +415,13 @@ impl FromClause {
     fn to_sql_ast(&self) -> ast::FromClause {
         ast::FromClause {
             select: Box::new(match &self.table {
-                SelectTable::Table(table) => {
-                    ast::SelectTable::Table(table_qualified_name(table), None, None)
-                }
+                SelectTable::Table(table, alias) => ast::SelectTable::Table(
+                    table_qualified_name(table),
+                    alias
+                        .as_ref()
+                        .map(|a| ast::As::As(ast::Name::from_string(a))),
+                    None,
+                ),
                 SelectTable::Select(select) => ast::SelectTable::Select(select.to_sql_ast(), None),
             }),
             joins: self
@@ -242,7 +437,9 @@ impl FromClause {
                     },
                     table: Box::new(ast::SelectTable::Table(
                         table_qualified_name(&join.table),
-                        None,
+                        join.alias
+                            .as_ref()
+                            .map(|a| ast::As::As(ast::Name::from_string(a))),
                         None,
                     )),
                     constraint: Some(ast::JoinConstraint::On(Box::new(join.on.0.clone()))),
@@ -260,7 +457,7 @@ impl FromClause {
     }
 
     pub fn into_join_table(&self, tables: &[Table]) -> JoinTable {
-        let self_table = if let SelectTable::Table(table) = &self.table {
+        let self_table = if let SelectTable::Table(table, _) = &self.table {
             table.clone()
         } else {
             unimplemented!("into_join_table is only implemented for Table");
@@ -313,10 +510,124 @@ impl FromClause {
     }
 }
 
+/// Convert a where clause predicate to AST Option, returning None for TRUE predicates
+fn where_clause_to_ast(predicate: &Predicate) -> Option<Box<ast::Expr>> {
+    // Check if predicate is a TRUE literal - if so, skip the WHERE clause
+    match &predicate.0 {
+        ast::Expr::Literal(ast::Literal::Keyword(kw)) if kw.eq_ignore_ascii_case("TRUE") => None,
+        _ => Some(predicate.0.clone().into_boxed()),
+    }
+}
+
+impl SelectBody {
+    /// Convert SelectBody to AST format (used for CTE bodies)
+    fn to_sql_ast(&self) -> ast::SelectBody {
+        ast::SelectBody {
+            select: ast::OneSelect::Select {
+                distinctness: if self.select.distinctness == Distinctness::Distinct {
+                    Some(ast::Distinctness::Distinct)
+                } else {
+                    None
+                },
+                columns: self
+                    .select
+                    .columns
+                    .iter()
+                    .map(|col| match col {
+                        ResultColumn::Expr(expr) => {
+                            ast::ResultColumn::Expr(expr.0.clone().into_boxed(), None)
+                        }
+                        ResultColumn::ExprAs(expr, alias) => ast::ResultColumn::Expr(
+                            expr.0.clone().into_boxed(),
+                            Some(ast::As::As(ast::Name::from_string(alias))),
+                        ),
+                        ResultColumn::Star => ast::ResultColumn::Star,
+                        ResultColumn::Column(name) => ast::ResultColumn::Expr(
+                            ast::Expr::Id(ast::Name::exact(name.clone())).into_boxed(),
+                            None,
+                        ),
+                    })
+                    .collect(),
+                from: self.select.from.as_ref().map(|f| f.to_sql_ast()),
+                where_clause: where_clause_to_ast(&self.select.where_clause),
+                group_by: None,
+                window_clause: Vec::new(),
+            },
+            compounds: self
+                .compounds
+                .iter()
+                .map(|compound| ast::CompoundSelect {
+                    operator: match compound.operator {
+                        CompoundOperator::Union => ast::CompoundOperator::Union,
+                        CompoundOperator::UnionAll => ast::CompoundOperator::UnionAll,
+                    },
+                    select: ast::OneSelect::Select {
+                        distinctness: if compound.select.distinctness == Distinctness::Distinct {
+                            Some(ast::Distinctness::Distinct)
+                        } else {
+                            None
+                        },
+                        columns: compound
+                            .select
+                            .columns
+                            .iter()
+                            .map(|col| match col {
+                                ResultColumn::Expr(expr) => {
+                                    ast::ResultColumn::Expr(expr.0.clone().into_boxed(), None)
+                                }
+                                ResultColumn::ExprAs(expr, alias) => ast::ResultColumn::Expr(
+                                    expr.0.clone().into_boxed(),
+                                    Some(ast::As::As(ast::Name::from_string(alias))),
+                                ),
+                                ResultColumn::Star => ast::ResultColumn::Star,
+                                ResultColumn::Column(name) => ast::ResultColumn::Expr(
+                                    ast::Expr::Id(ast::Name::exact(name.clone())).into_boxed(),
+                                    None,
+                                ),
+                            })
+                            .collect(),
+                        from: compound.select.from.as_ref().map(|f| f.to_sql_ast()),
+                        where_clause: where_clause_to_ast(&compound.select.where_clause),
+                        group_by: None,
+                        window_clause: Vec::new(),
+                    },
+                })
+                .collect(),
+        }
+    }
+}
+
 impl Select {
     pub fn to_sql_ast(&self) -> ast::Select {
+        let with_clause = self.with.as_ref().map(|w| ast::With {
+            recursive: w.recursive,
+            ctes: w
+                .ctes
+                .iter()
+                .map(|cte| ast::CommonTableExpr {
+                    tbl_name: ast::Name::from_string(&cte.name),
+                    columns: cte
+                        .columns
+                        .iter()
+                        .map(|col| ast::IndexedColumn {
+                            col_name: ast::Name::from_string(col),
+                            collation_name: None,
+                            order: None,
+                        })
+                        .collect(),
+                    materialized: ast::Materialized::Any,
+                    select: ast::Select {
+                        with: None,
+                        body: cte.body.to_sql_ast(),
+                        order_by: Vec::new(),
+                        limit: None,
+                    },
+                })
+                .collect(),
+        });
+
         ast::Select {
-            with: None,
+            with: with_clause,
             body: ast::SelectBody {
                 select: ast::OneSelect::Select {
                     distinctness: if self.body.select.distinctness == Distinctness::Distinct {
@@ -333,6 +644,10 @@ impl Select {
                             ResultColumn::Expr(expr) => {
                                 ast::ResultColumn::Expr(expr.0.clone().into_boxed(), None)
                             }
+                            ResultColumn::ExprAs(expr, alias) => ast::ResultColumn::Expr(
+                                expr.0.clone().into_boxed(),
+                                Some(ast::As::As(ast::Name::from_string(alias))),
+                            ),
                             ResultColumn::Star => ast::ResultColumn::Star,
                             ResultColumn::Column(name) => ast::ResultColumn::Expr(
                                 column_qualified_expr(name).into_boxed(),
@@ -341,7 +656,7 @@ impl Select {
                         })
                         .collect(),
                     from: self.body.select.from.as_ref().map(|f| f.to_sql_ast()),
-                    where_clause: Some(self.body.select.where_clause.0.clone().into_boxed()),
+                    where_clause: where_clause_to_ast(&self.body.select.where_clause),
                     group_by: None,
                     window_clause: Vec::new(),
                 },
@@ -355,7 +670,12 @@ impl Select {
                             CompoundOperator::UnionAll => ast::CompoundOperator::UnionAll,
                         },
                         select: ast::OneSelect::Select {
-                            distinctness: Some(compound.select.distinctness),
+                            distinctness: if compound.select.distinctness == Distinctness::Distinct
+                            {
+                                Some(ast::Distinctness::Distinct)
+                            } else {
+                                None
+                            },
                             columns: compound
                                 .select
                                 .columns
@@ -364,6 +684,10 @@ impl Select {
                                     ResultColumn::Expr(expr) => {
                                         ast::ResultColumn::Expr(expr.0.clone().into_boxed(), None)
                                     }
+                                    ResultColumn::ExprAs(expr, alias) => ast::ResultColumn::Expr(
+                                        expr.0.clone().into_boxed(),
+                                        Some(ast::As::As(ast::Name::from_string(alias))),
+                                    ),
                                     ResultColumn::Star => ast::ResultColumn::Star,
                                     ResultColumn::Column(name) => ast::ResultColumn::Expr(
                                         ast::Expr::Id(ast::Name::exact(name.clone())).into_boxed(),
@@ -372,7 +696,7 @@ impl Select {
                                 })
                                 .collect(),
                             from: compound.select.from.as_ref().map(|f| f.to_sql_ast()),
-                            where_clause: Some(compound.select.where_clause.0.clone().into_boxed()),
+                            where_clause: where_clause_to_ast(&compound.select.where_clause),
                             group_by: None,
                             window_clause: Vec::new(),
                         },
@@ -415,7 +739,7 @@ impl Display for Select {
 impl SelectTable {
     pub fn dependencies(&self) -> Vec<String> {
         match self {
-            SelectTable::Table(table) => vec![table.to_owned()],
+            SelectTable::Table(table, _) => vec![table.to_owned()],
             SelectTable::Select(select) => {
                 if let Some(from) = &select.body.select.from {
                     let mut dependencies = from.table.dependencies();
@@ -430,5 +754,94 @@ impl SelectTable {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_recursive_hierarchy_cte() {
+        let select = Select::recursive_hierarchy_cte(
+            "tree".to_string(),
+            "items".to_string(),
+            "id".to_string(),
+            "parent_id".to_string(),
+            vec!["content".to_string()],
+            10,
+        );
+
+        let sql = select.to_string();
+
+        // Verify key parts of the generated SQL
+        assert!(sql.contains("WITH RECURSIVE"), "Should have WITH RECURSIVE");
+        assert!(sql.contains("tree"), "Should reference CTE name 'tree'");
+        assert!(sql.contains("UNION ALL"), "Should have UNION ALL");
+        assert!(
+            sql.contains("parent_id IS NULL"),
+            "Anchor should check parent_id IS NULL"
+        );
+        assert!(sql.contains("path"), "Should have path column");
+        // Note: No depth column - causes "non-equijoin" error in DBSP
+        assert!(
+            !sql.contains("depth"),
+            "Should not have depth (causes non-equijoin error)"
+        );
+        // Note: ORDER BY is not supported by DBSP compiler for IVM
+        assert!(
+            !sql.contains("ORDER BY"),
+            "Should not have ORDER BY (not supported by DBSP)"
+        );
+    }
+
+    #[test]
+    fn test_select_with_cte() {
+        let cte_body = SelectBody {
+            select: Box::new(SelectInner {
+                distinctness: Distinctness::All,
+                columns: vec![ResultColumn::Star],
+                from: Some(FromClause {
+                    table: SelectTable::Table("users".to_string(), None),
+                    joins: Vec::new(),
+                }),
+                where_clause: Predicate::true_(),
+                order_by: None,
+            }),
+            compounds: Vec::new(),
+        };
+
+        let with_clause = WithClause {
+            recursive: false,
+            ctes: vec![Cte {
+                name: "active_users".to_string(),
+                columns: vec![],
+                body: cte_body,
+            }],
+        };
+
+        let main_body = SelectBody {
+            select: Box::new(SelectInner {
+                distinctness: Distinctness::All,
+                columns: vec![ResultColumn::Star],
+                from: Some(FromClause {
+                    table: SelectTable::Table("active_users".to_string(), None),
+                    joins: Vec::new(),
+                }),
+                where_clause: Predicate::true_(),
+                order_by: None,
+            }),
+            compounds: Vec::new(),
+        };
+
+        let select = Select::with_cte(with_clause, main_body, None);
+        let sql = select.to_string();
+
+        assert!(sql.contains("WITH"), "Should have WITH clause");
+        assert!(
+            !sql.contains("RECURSIVE"),
+            "Non-recursive CTE should not have RECURSIVE"
+        );
+        assert!(sql.contains("active_users"), "Should reference CTE name");
     }
 }

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -152,6 +152,8 @@ pub struct Index {
 pub struct JoinedTable {
     /// table name
     pub table: String,
+    /// optional table alias
+    pub alias: Option<String>,
     /// `JOIN` type
     pub join_type: JoinType,
     /// `ON` clause

--- a/sql_generation/model/view.rs
+++ b/sql_generation/model/view.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+use super::query::select::Select;
+
+/// Represents a view (regular or materialized) that has been created.
+/// Used for tracking views in the shadow state so we can generate
+/// DROP VIEW / DROP MATERIALIZED VIEW statements.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct View {
+    pub name: String,
+    pub select: Select,
+    pub materialized: bool,
+}
+
+impl View {
+    pub fn new(name: String, select: Select, materialized: bool) -> Self {
+        Self {
+            name,
+            select,
+            materialized,
+        }
+    }
+
+    pub fn materialized(name: String, select: Select) -> Self {
+        Self::new(name, select, true)
+    }
+
+    pub fn regular(name: String, select: Select) -> Self {
+        Self::new(name, select, false)
+    }
+}

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -849,6 +849,7 @@ impl Whopper {
                         opts: &self.opts,
                         enable_mvcc: self.context.enable_mvcc,
                         tables_vec: self.context.state.tables_vec(),
+                        views_vec: Vec::new(), // Views not yet tracked in simulator
                     };
 
                     // Generate operation from workload; skip current workload if it returned None

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -27,11 +27,17 @@ pub struct WorkloadContext<'a> {
     pub enable_mvcc: bool,
     /// Tables vec built from sim_state.tables for GenerationContext
     pub(crate) tables_vec: Vec<Table>,
+    /// Views vec built from sim_state.views for GenerationContext
+    pub(crate) views_vec: Vec<sql_generation::model::view::View>,
 }
 
 impl GenerationContext for WorkloadContext<'_> {
     fn tables(&self) -> &Vec<Table> {
         &self.tables_vec
+    }
+
+    fn views(&self) -> &Vec<sql_generation::model::view::View> {
+        &self.views_vec
     }
 
     fn opts(&self) -> &Opts {

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -32,7 +32,7 @@ use crate::{
         Assertion, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
     },
         metrics::Remaining,
-        property::{InteractiveQueryInfo, Property, PropertyDiscriminants},
+        property::{Property, PropertyDiscriminants},
     },
     runner::env::SimulatorEnv,
 };
@@ -168,10 +168,7 @@ impl Property {
                             // A row that holds for the predicate will not be inserted.
                             None
                         }
-                        Query::Insert(Insert::Select {
-                            table: t,
-                            select: _,
-                        }) if t == &table.name => {
+                        Query::Insert(Insert::Select { table: t, .. }) if t == &table.name => {
                             // A row that holds for the predicate will not be inserted.
                             None
                         }
@@ -467,14 +464,8 @@ impl Property {
                 row_index,
                 queries,
                 select,
-                interactive,
             } => {
-                let (table, values) = if let Insert::Values {
-                    table,
-                    values,
-                    on_conflict: None,
-                } = insert
-                {
+                let (table, values) = if let Insert::Values { table, values, .. } = insert {
                     (table, values)
                 } else {
                     unreachable!(
@@ -509,18 +500,9 @@ impl Property {
 
                 let assertion = InteractionType::Assertion(Assertion::new(
                     format!(
-                        "row [{:?}] should be found in table {}, interactive={} commit={}, rollback={}",
+                        "row [{:?}] should be found in table {}",
                         row.iter().map(|v| v.to_string()).collect::<Vec<String>>(),
                         insert.table(),
-                        interactive.is_some(),
-                        interactive
-                            .as_ref()
-                            .map(|i| i.end_with_commit)
-                            .unwrap_or(false),
-                        interactive
-                            .as_ref()
-                            .map(|i| !i.end_with_commit)
-                            .unwrap_or(false),
                     ),
                     move |stack: &Vec<ResultSet>, _| {
                         let rows = stack.last().unwrap();
@@ -1568,39 +1550,13 @@ fn property_insert_values_select<R: rand::Rng + ?Sized>(
         table: table.name.clone(),
         values: rows,
         on_conflict: None,
+        conflict: None,
     });
 
-    // Choose if we want queries to be executed in an interactive transaction
-    let interactive = if !mvcc && rng.random_bool(0.5) {
-        Some(InteractiveQueryInfo {
-            start_with_immediate: rng.random_bool(0.5),
-            end_with_commit: rng.random_bool(0.5),
-        })
-    } else {
-        None
-    };
-
+    // Generate 0-2 placeholder queries between INSERT and SELECT
+    // Transaction boundaries are now managed at the plan level, not here
     let amount = rng.random_range(0..3);
-
-    let mut queries = Vec::with_capacity(amount + 2);
-
-    if let Some(ref interactive) = interactive {
-        queries.push(Query::Begin(if interactive.start_with_immediate {
-            Begin::Immediate
-        } else {
-            Begin::Deferred
-        }));
-    }
-
-    queries.extend(std::iter::repeat_n(Query::Placeholder, amount));
-
-    if let Some(ref interactive) = interactive {
-        queries.push(if interactive.end_with_commit {
-            Query::Commit(Commit)
-        } else {
-            Query::Rollback(Rollback)
-        });
-    }
+    let queries = vec![Query::Placeholder; amount];
 
     // Select the row
     let select_query = Select::simple(
@@ -1613,7 +1569,6 @@ fn property_insert_values_select<R: rand::Rng + ?Sized>(
         row_index,
         queries,
         select: select_query,
-        interactive,
     }
 }
 

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -8,6 +8,7 @@
 use std::num::NonZeroUsize;
 
 use rand::distr::{Distribution, weighted::WeightedIndex};
+use rand::seq::IndexedRandom;
 use sql_generation::{
     generation::{Arbitrary, ArbitraryFrom, GenerationContext, pick, pick_index},
     model::{
@@ -227,6 +228,47 @@ impl Property {
                         unreachable!()
                     };
                     random_main_table_write(rng, ctx, write_kinds)
+                }
+            }
+            Property::IvmConsistency { .. } => {
+                // IvmConsistency generates DML queries that target base tables
+                // If scenario tables exist, prefer those; otherwise use any table
+                |rng: &mut R, ctx: &G, query_distr: &QueryDistribution, _property: &Property| {
+                    // Scenario base tables that trigger IVM on the matviews
+                    const SCENARIO_TABLES: &[&str] =
+                        &["navigation_history", "navigation_cursor", "blocks"];
+
+                    // Check if scenario tables exist in context
+                    let has_scenario_tables = ctx
+                        .tables()
+                        .iter()
+                        .any(|t| SCENARIO_TABLES.contains(&t.name.as_str()));
+
+                    // Only allow DML queries (INSERT, UPDATE, DELETE)
+                    let query = Query::arbitrary_from(rng, ctx, query_distr);
+
+                    match &query {
+                        Query::Insert(Insert::Values { table, .. })
+                        | Query::Insert(Insert::Select { table, .. })
+                        | Query::Update(Update { table, .. })
+                        | Query::Delete(Delete { table, .. }) => {
+                            if has_scenario_tables {
+                                // Only accept if it targets a scenario table
+                                if SCENARIO_TABLES.contains(&table.as_str()) {
+                                    Some(query)
+                                } else {
+                                    None
+                                }
+                            } else {
+                                // No scenario tables, accept any DML
+                                Some(query)
+                            }
+                        }
+                        _ => {
+                            // Not a DML query, try again
+                            None
+                        }
+                    }
                 }
             }
             Property::Queries { .. } => {
@@ -1183,6 +1225,105 @@ impl Property {
                 ),
                 ].into_iter().map(InteractionBuilder::with_interaction).collect()
             }
+            Property::IvmConsistency {
+                matview_name,
+                view_definition,
+                dml_queries,
+            } => {
+                let matview_name_clone = matview_name.clone();
+
+                // Build interactions:
+                // 1. Execute DML queries (transaction managed at plan level or implicitly)
+                // 2. SELECT * FROM matview_name
+                // 3. Execute view_definition directly (fresh computation)
+                // 4. Assert results match
+                //
+                // NOTE: We intentionally do NOT wrap in BEGIN/COMMIT here because:
+                // - The plan-level transaction batching may already have a transaction open
+                // - Nested transactions would cause "cannot start transaction within transaction"
+                // - Each DML will auto-commit if not in a transaction, which still tests IVM
+
+                let mut interactions = Vec::new();
+
+                // DML queries (with placeholder markers for extensional query generation)
+                for query in dml_queries {
+                    let mut builder =
+                        InteractionBuilder::with_interaction(InteractionType::Query(query.clone()));
+                    builder.property_meta(PropertyMetadata::new(self, true));
+                    interactions.push(builder);
+                }
+
+                // SELECT * FROM matview_name
+                let select_matview = InteractionType::Query(Query::Select(Select::simple(
+                    matview_name.clone(),
+                    sql_generation::model::query::predicate::Predicate::true_(),
+                )));
+                interactions.push(InteractionBuilder::with_interaction(select_matview));
+
+                // Execute view_definition directly (fresh computation)
+                let select_fresh = InteractionType::Query(Query::Select(view_definition.clone()));
+                interactions.push(InteractionBuilder::with_interaction(select_fresh));
+
+                // Assertion: results should match
+                let assertion = InteractionType::Assertion(Assertion::new(
+                    format!(
+                        "materialized view {matview_name_clone} should match fresh computation"
+                    ),
+                    move |stack: &Vec<ResultSet>, _env: &mut SimulatorEnv| {
+                        if stack.len() < 2 {
+                            return Err(LimboError::InternalError(
+                                "Not enough result sets on the stack".to_string(),
+                            ));
+                        }
+
+                        let matview_result = stack.get(stack.len() - 2).unwrap();
+                        let fresh_result = stack.last().unwrap();
+
+                        match (matview_result, fresh_result) {
+                            (Ok(matview_rows), Ok(fresh_rows)) => {
+                                // Sort rows for comparison (order may differ)
+                                let mut matview_sorted = matview_rows.clone();
+                                let mut fresh_sorted = fresh_rows.clone();
+                                matview_sorted.sort();
+                                fresh_sorted.sort();
+
+                                if matview_sorted.len() != fresh_sorted.len() {
+                                    return Ok(Err(format!(
+                                        "row count mismatch: matview has {} rows, fresh computation has {} rows",
+                                        matview_sorted.len(),
+                                        fresh_sorted.len()
+                                    )));
+                                }
+
+                                for (i, (matview_row, fresh_row)) in
+                                    matview_sorted.iter().zip(fresh_sorted.iter()).enumerate()
+                                {
+                                    if matview_row != fresh_row {
+                                        print_diff(
+                                            &[matview_row.clone()],
+                                            &[fresh_row.clone()],
+                                            "matview",
+                                            "fresh",
+                                        );
+                                        return Ok(Err(format!(
+                                            "row {i} mismatch: matview {matview_row:?} != fresh {fresh_row:?}"
+                                        )));
+                                    }
+                                }
+
+                                Ok(Ok(()))
+                            }
+                            (Err(e), _) | (_, Err(e)) => Err(LimboError::InternalError(format!(
+                                "Error comparing matview results: {e}"
+                            ))),
+                        }
+                    },
+                    vec![matview_name_clone.clone()],
+                ));
+                interactions.push(InteractionBuilder::with_interaction(assertion));
+
+                interactions
+            }
             Property::Queries { queries } => queries
                 .clone()
                 .into_iter()
@@ -1842,6 +1983,97 @@ fn property_faulty_query<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_ivm_consistency<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    _query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    use sql_generation::model::query::predicate::Predicate;
+
+    // Try to find an existing materialized view in the context
+    let matviews: Vec<_> = ctx.views().iter().filter(|v| v.materialized).collect();
+
+    let (matview_name, view_definition) = if let Some(matview) = matviews.choose(rng) {
+        // Use existing materialized view from context
+        (matview.name.clone(), matview.select.clone())
+    } else {
+        // No existing matviews - check for coordinated scenario tables
+        let scenario_table_names = ["navigation_history", "navigation_cursor", "blocks"];
+        let has_scenario_tables = scenario_table_names
+            .iter()
+            .any(|name| ctx.tables().iter().any(|t| t.name == *name));
+
+        if has_scenario_tables {
+            // Use scenario matviews
+            if ctx.tables().iter().any(|t| t.name == "navigation_history") {
+                // Generate view definition for current_focus
+                let view_def = Select {
+                    with: None,
+                    body: sql_generation::model::query::select::SelectBody {
+                        select: Box::new(sql_generation::model::query::select::SelectInner {
+                            distinctness: Distinctness::All,
+                            columns: vec![ResultColumn::Star],
+                            from: Some(sql_generation::model::query::select::FromClause {
+                                table: sql_generation::model::query::select::SelectTable::Table(
+                                    "navigation_cursor".to_string(),
+                                    Some("nc".to_string()),
+                                ),
+                                joins: vec![sql_generation::model::table::JoinedTable {
+                                    table: "navigation_history".to_string(),
+                                    alias: Some("nh".to_string()),
+                                    join_type: sql_generation::model::table::JoinType::Inner,
+                                    on: Predicate::eq_bare(
+                                        Predicate::qualified_column("nc", "history_id"),
+                                        Predicate::qualified_column("nh", "id"),
+                                    ),
+                                }],
+                            }),
+                            where_clause: Predicate::true_(),
+                            order_by: None,
+                        }),
+                        compounds: vec![],
+                    },
+                    limit: None,
+                };
+                ("current_focus".to_string(), view_def)
+            } else {
+                // Fallback: use blocks_with_paths or generate a simple matview
+                let view_def = Select::simple("blocks".to_string(), Predicate::true_());
+                ("blocks_with_paths".to_string(), view_def)
+            }
+        } else {
+            // No scenario tables, generate a simple property from any table
+            let tables = ctx.tables();
+            if tables.is_empty() {
+                // Fallback: create a minimal property
+                let view_def = Select::expr(Predicate::true_());
+                (
+                    format!("matview_{}", rng.random_range(1000..9999u32)),
+                    view_def,
+                )
+            } else {
+                let table = pick(tables, rng);
+                let view_def = Select::simple(table.name.clone(), Predicate::true_());
+                (
+                    format!("matview_{}", rng.random_range(1000..9999u32)),
+                    view_def,
+                )
+            }
+        }
+    };
+
+    // Generate 1-3 DML queries targeting base tables
+    let num_dml = rng.random_range(1..=3);
+    let dml_queries = vec![Query::Placeholder; num_dml];
+
+    Property::IvmConsistency {
+        matview_name,
+        view_definition,
+        dml_queries,
+    }
+}
+
 type PropertyGenFunc<R, G> = fn(&mut R, &QueryDistribution, &G, bool) -> Property;
 
 impl PropertyDiscriminants {
@@ -1869,6 +2101,7 @@ impl PropertyDiscriminants {
             }
             PropertyDiscriminants::FsyncNoWait => property_fsync_no_wait,
             PropertyDiscriminants::FaultyQuery => property_faulty_query,
+            PropertyDiscriminants::IvmConsistency => property_ivm_consistency,
             PropertyDiscriminants::Queries => {
                 unreachable!("should not try to generate queries property")
             }
@@ -1988,6 +2221,22 @@ impl PropertyDiscriminants {
                     0
                 }
             }
+            PropertyDiscriminants::IvmConsistency => {
+                // Generate if:
+                // 1. We have existing materialized views in context, OR
+                // 2. Coordinated matview scenario is enabled
+                // Either way, we need at least one table for DML operations
+                let has_matviews = ctx.views().iter().any(|v| v.materialized);
+                let coordinated_scenario = env.profile.query.enable_coordinated_matview_scenario;
+
+                if !ctx.tables().is_empty() && (has_matviews || coordinated_scenario) {
+                    // High weight to ensure IVM consistency is frequently tested
+                    // This is the primary property for catching IVM bugs
+                    50
+                } else {
+                    0
+                }
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("queries property should not be generated")
             }
@@ -2029,6 +2278,10 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::UnionAllPreservesCardinality => QueryCapabilities::SELECT,
             PropertyDiscriminants::FsyncNoWait => QueryCapabilities::all(),
             PropertyDiscriminants::FaultyQuery => QueryCapabilities::all(),
+            PropertyDiscriminants::IvmConsistency => QueryCapabilities::SELECT
+                .union(QueryCapabilities::INSERT)
+                .union(QueryCapabilities::UPDATE)
+                .union(QueryCapabilities::DELETE),
             PropertyDiscriminants::Queries => panic!("queries property should not be generated"),
         }
     }

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -12,7 +12,6 @@ use sql_generation::{
     generation::{Arbitrary, ArbitraryFrom, GenerationContext, pick, pick_index},
     model::{
         query::{
-            Create, Delete, Drop, Insert, Select,
             alter_table::{AlterTable, AlterTableType},
             predicate::Predicate,
             select::{CompoundOperator, CompoundSelect, ResultColumn, SelectBody, SelectInner},
@@ -29,12 +28,9 @@ use turso_parser::ast::{self, Distinctness};
 use crate::{
     common::print_diff,
     generation::{Shadow, WeightedDistribution, query::QueryDistribution},
-    model::{
-        Query, QueryCapabilities, QueryDiscriminants, ReleaseSavepoint, ResultSet,
-        RollbackToSavepoint, Savepoint,
-        interactions::{
-            Assertion, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
-        },
+    model::{ ReleaseSavepoint, RollbackToSavepoint, Savepoint, interactions::{
+        Assertion, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
+    },
         metrics::Remaining,
         property::{InteractiveQueryInfo, Property, PropertyDiscriminants},
     },
@@ -587,14 +583,15 @@ impl Property {
                 let table_name = create.table.name.clone();
 
                 let assertion = InteractionType::Assertion(Assertion::new("creating two tables with the name should result in a failure for the second query"
-                                    .to_string(), move |stack: &Vec<ResultSet>, env| {
+                                    .to_string(), move |stack: &Vec<ResultSet>, _env| {
                                 let last = stack.last().unwrap();
                                 match last {
                                     Ok(success) => Ok(Err(format!("expected table creation to fail but it succeeded: {success:?}"))),
                                     Err(e) => {
                                         if e.to_string().to_lowercase().contains(&format!("table {table_name} already exists")) {
-                                             // On error we rollback the transaction if there is any active here
-                                            env.rollback_conn(connection_index);
+                                            // Statement error does NOT roll back the transaction in SQLite.
+                                            // Only the failed statement is rejected; prior changes remain valid.
+                                            // Do NOT call rollback_conn() here.
                                             Ok(Ok(()))
                                         } else {
                                             Ok(Err(format!("expected table already exists error, got: {e}")))
@@ -949,24 +946,26 @@ impl Property {
                 // but no IO happens right after it
                 let assert = Assertion::new(
                     "fault occured".to_string(),
-                    move |stack, env: &mut SimulatorEnv| {
+                    move |stack, _env: &mut SimulatorEnv| {
                         let last = stack.last().unwrap();
                         match last {
                             Ok(_) => {
                                 let _ = query_clone
-                                    .shadow(&mut env.get_conn_tables_mut(connection_index));
+                                    .shadow(&mut _env.get_conn_tables_mut(connection_index));
                                 Ok(Ok(()))
                             }
                             Err(err) => {
-                                // We cannot make any assumptions about the error content; all we are about is, if the statement errored,
-                                // we don't shadow the results into the simulator env, i.e. we assume whatever the statement did was rolled back.
+                                // Statement-level I/O failures do NOT automatically roll back the
+                                // transaction in SQLite. Only the failed statement is rejected;
+                                // the transaction continues with prior changes intact.
+                                // We don't shadow this failed statement's results.
                                 tracing::error!("Fault injection produced error: {err}");
 
                                 if let LimboError::CheckpointFailed(msg) = err {
-                                    // Checkpoint failure means the transaction is committed because the WAL commit succeeded, so we DON'T rollback,
-                                    // and the results of the query are shadowed into the simulator environment
+                                    // Checkpoint failure means the transaction is committed because
+                                    // the WAL commit succeeded, so we shadow the query results.
                                     query_clone
-                                        .shadow(&mut env.get_conn_tables_mut(connection_index))
+                                        .shadow(&mut _env.get_conn_tables_mut(connection_index))
                                         .expect("Failed to shadow tables");
                                     tracing::error!(
                                         "Fault injection produced CheckpointFailed error: {msg}"
@@ -974,8 +973,8 @@ impl Property {
                                     return Ok(Ok(()));
                                 }
 
-                                // On error we rollback the transaction if there is any active here
-                                env.rollback_conn(connection_index);
+                                // Do NOT call rollback_conn() here. Statement errors don't roll
+                                // back the transaction - only the failed statement is rejected.
                                 Ok(Ok(()))
                             }
                         }
@@ -1035,6 +1034,7 @@ impl Property {
                 ]);
 
                 let select_tlp = Select {
+                    with: None,
                     body: SelectBody {
                         select: Box::new(SelectInner {
                             distinctness: select.body.select.distinctness,

--- a/testing/simulator/generation/query.rs
+++ b/testing/simulator/generation/query.rs
@@ -11,7 +11,6 @@ use sql_generation::{
     generation::{Arbitrary, ArbitraryFrom, GenerationContext, query::SelectFree},
     model::{
         query::{
-            Create, CreateIndex, Delete, DropIndex, Insert, Select,
             alter_table::AlterTable,
             pragma::{Pragma, VacuumMode},
             update::Update,
@@ -100,6 +99,104 @@ fn random_pragma<R: rand::Rng + ?Sized>(rng: &mut R, conn_ctx: &impl GenerationC
     Query::Pragma(Pragma::AutoVacuumMode(mode.clone()))
 }
 
+fn random_create_materialized_view<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    conn_ctx: &impl GenerationContext,
+) -> Query {
+    assert!(!conn_ctx.tables().is_empty());
+    let name = format!("matview_{}", rng.random_range(1000..9999u32));
+
+    // 30% chance to generate a recursive CTE matview if we can find a suitable table
+    if rng.random_bool(0.3) {
+        if let Some(select) = try_generate_recursive_cte_select(rng, conn_ctx, &name) {
+            return Query::CreateMaterializedView(CreateMaterializedView { name, select });
+        }
+    }
+
+    // Default: simple SELECT * FROM table
+    let table = conn_ctx.tables().choose(rng).unwrap();
+    let select = Select::simple(
+        table.name.clone(),
+        sql_generation::model::query::predicate::Predicate::true_(),
+    );
+    Query::CreateMaterializedView(CreateMaterializedView { name, select })
+}
+
+fn random_drop_materialized_view<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    conn_ctx: &impl GenerationContext,
+) -> Query {
+    // Try to find a materialized view to drop from the context
+    let matviews: Vec<_> = conn_ctx.views().iter().filter(|v| v.materialized).collect();
+    if let Some(view) = matviews.choose(rng) {
+        Query::DropMaterializedView(DropMaterializedView {
+            name: view.name.clone(),
+        })
+    } else {
+        // No matviews in context - generate a random name in the expected range
+        // This handles the case where matviews were created earlier in the same plan
+        // but shadow state hasn't been updated yet
+        let name = format!("matview_{}", rng.random_range(1000..9999u32));
+        Query::DropMaterializedView(DropMaterializedView { name })
+    }
+}
+
+/// Try to generate a recursive CTE SELECT for a hierarchical matview.
+/// Returns None if no suitable table is found (needs at least 2 INTEGER columns).
+fn try_generate_recursive_cte_select<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    conn_ctx: &impl GenerationContext,
+    cte_name: &str,
+) -> Option<Select> {
+    use sql_generation::model::table::ColumnType;
+
+    // Find tables with at least 2 INTEGER columns (for id and parent_id pattern)
+    let suitable_tables: Vec<_> = conn_ctx
+        .tables()
+        .iter()
+        .filter(|t| {
+            let int_cols: Vec<_> = t
+                .columns
+                .iter()
+                .filter(|c| matches!(c.column_type, ColumnType::Integer))
+                .collect();
+            int_cols.len() >= 2
+        })
+        .collect();
+
+    if suitable_tables.is_empty() {
+        return None;
+    }
+
+    let table = suitable_tables.choose(rng).unwrap();
+    let int_columns: Vec<_> = table
+        .columns
+        .iter()
+        .filter(|c| matches!(c.column_type, ColumnType::Integer))
+        .collect();
+
+    // Pick first INTEGER column as id, second as parent_id
+    let id_column = int_columns[0].name.clone();
+    let parent_column = int_columns[1].name.clone();
+
+    // Collect remaining columns as content columns
+    let content_columns: Vec<String> = table
+        .columns
+        .iter()
+        .filter(|c| c.name != id_column && c.name != parent_column)
+        .map(|c| c.name.clone())
+        .collect();
+
+    Some(Select::recursive_hierarchy_cte(
+        cte_name.to_string(),
+        table.name.clone(),
+        id_column,
+        parent_column,
+        content_columns,
+        10, // max_depth (unused but required by API)
+    ))
+}
+
 fn random_alter_table<R: rand::Rng + ?Sized>(
     rng: &mut R,
     conn_ctx: &impl GenerationContext,
@@ -162,6 +259,11 @@ impl QueryDiscriminants {
                 unreachable!("Query Placeholders should not be generated")
             }
             QueryDiscriminants::Pragma => random_pragma,
+            QueryDiscriminants::CreateMaterializedView => random_create_materialized_view,
+            QueryDiscriminants::DropMaterializedView => random_drop_materialized_view,
+            QueryDiscriminants::CreateView | QueryDiscriminants::DropView => {
+                unreachable!("regular view queries not yet implemented in generation")
+            }
         }
     }
 
@@ -189,7 +291,12 @@ impl QueryDiscriminants {
             QueryDiscriminants::Placeholder => {
                 unreachable!("Query Placeholders should not be generated")
             }
-            QueryDiscriminants::Pragma => remaining.pragma_count,
+            QueryDiscriminants::Pragma => remaining.pragma_count + remaining.enable_cdc,
+            QueryDiscriminants::CreateMaterializedView => remaining.create_matview,
+            QueryDiscriminants::DropMaterializedView => remaining.drop_matview,
+            QueryDiscriminants::CreateView | QueryDiscriminants::DropView => {
+                0 // regular view queries not yet implemented in generation
+            }
         }
     }
 }

--- a/testing/simulator/generation/query.rs
+++ b/testing/simulator/generation/query.rs
@@ -83,20 +83,25 @@ fn random_create_index<R: rand::Rng + ?Sized>(
 }
 
 fn random_pragma<R: rand::Rng + ?Sized>(rng: &mut R, conn_ctx: &impl GenerationContext) -> Query {
-    if !conn_ctx.tables().is_empty() && rng.random_bool(0.5) {
-        let table = conn_ctx.tables().choose(rng).unwrap();
-        return Query::Pragma(Pragma::ForeignKeyList(table.name.clone()));
+    use sql_generation::model::query::pragma::CdcMode;
+
+    // 50% chance of generating a CDC pragma, 50% chance of vacuum pragma
+    if rng.random_bool(0.5) {
+        Query::Pragma(Pragma::CaptureDataChanges(CdcMode::Full))
+    } else {
+        if !conn_ctx.tables().is_empty() && rng.random_bool(0.5) {
+            let table = conn_ctx.tables().choose(rng).unwrap();
+            return Query::Pragma(Pragma::ForeignKeyList(table.name.clone()));
+        }
+    
+        const ALL_MODES: [VacuumMode; 2] = [
+            VacuumMode::None,
+            // VacuumMode::Incremental, not implemented yet
+            VacuumMode::Full,
+        ];
+        let mode = ALL_MODES.choose(rng).unwrap();
+        Query::Pragma(Pragma::AutoVacuumMode(mode.clone()))
     }
-
-    const ALL_MODES: [VacuumMode; 2] = [
-        VacuumMode::None,
-        // VacuumMode::Incremental, not implemented yet
-        VacuumMode::Full,
-    ];
-
-    let mode = ALL_MODES.choose(rng).unwrap();
-
-    Query::Pragma(Pragma::AutoVacuumMode(mode.clone()))
 }
 
 fn random_create_materialized_view<R: rand::Rng + ?Sized>(

--- a/testing/simulator/main.rs
+++ b/testing/simulator/main.rs
@@ -14,7 +14,6 @@ use std::io::{IsTerminal, Write};
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
-use tracing_subscriber::EnvFilter;
 use tracing_subscriber::field::MakeExt;
 use tracing_subscriber::fmt::format;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -121,6 +120,12 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn testing_main(cli_opts: &mut SimulatorCLI, profile: &Profile) -> anyhow::Result<()> {
+    // Auto-enable differential testing if the profile requires it
+    if profile.differential_required && !cli_opts.differential && !cli_opts.doublecheck {
+        tracing::info!("Profile requires differential testing - enabling automatically");
+        cli_opts.differential = true;
+    }
+
     let mut bugbase = if cli_opts.disable_bugbase {
         None
     } else {

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -40,6 +40,9 @@ pub(crate) struct InteractionPlan {
     /// Tracks which connection has a pending (generated but not executed) transaction.
     /// Used in non-MVCC mode to prevent generating nested transactions.
     pending_txn_conn: Option<usize>,
+
+    /// Pending setup queries for coordinated matview scenario
+    pub coordinated_matview_scenario_queries: Option<Vec<Query>>,
 }
 
 impl InteractionPlan {
@@ -52,6 +55,7 @@ impl InteractionPlan {
             len_properties: 0,
             next_interaction_id: NonZeroUsize::new(1).unwrap(),
             pending_txn_conn: None,
+            coordinated_matview_scenario_queries: None,
         }
     }
 

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -36,6 +36,10 @@ pub(crate) struct InteractionPlan {
     /// This field is only necessary and valid when generating interactions. For static iteration, we do not care about this field
     len_properties: usize,
     next_interaction_id: NonZeroUsize,
+
+    /// Tracks which connection has a pending (generated but not executed) transaction.
+    /// Used in non-MVCC mode to prevent generating nested transactions.
+    pending_txn_conn: Option<usize>,
 }
 
 impl InteractionPlan {
@@ -47,7 +51,18 @@ impl InteractionPlan {
             mvcc,
             len_properties: 0,
             next_interaction_id: NonZeroUsize::new(1).unwrap(),
+            pending_txn_conn: None,
         }
+    }
+
+    /// Returns the connection index that has a pending (generated but not executed) transaction
+    pub fn pending_txn_conn(&self) -> Option<usize> {
+        self.pending_txn_conn
+    }
+
+    /// Sets the pending transaction connection
+    pub fn set_pending_txn_conn(&mut self, conn: Option<usize>) {
+        self.pending_txn_conn = conn;
     }
 
     /// Count of interactions

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -17,7 +17,6 @@ use turso_core::{Connection, Result, StepResult};
 use crate::{
     generation::Shadow,
     model::{
-        Query, ResultSet,
         metrics::InteractionStats,
         property::{Property, PropertyDiscriminants},
     },
@@ -872,6 +871,7 @@ fn reopen_database(env: &mut SimulatorEnv) {
     // 1. Close all connections without default checkpoint-on-close behavior
     // to expose bugs related to how we handle WAL
     let mvcc = env.profile.mvcc;
+    let enable_views = env.profile.enable_views;
     let num_conns = env.connections.len();
 
     // Clear shadow transaction state for all connections since reopening
@@ -906,13 +906,15 @@ fn reopen_database(env: &mut SimulatorEnv) {
         }
         SimulationType::Default | SimulationType::Doublecheck => {
             env.db = None;
+            let mut db_opts = turso_core::DatabaseOpts::new().with_autovacuum(true);
+            if mvcc || enable_views {
+                db_opts = db_opts.with_views(true);
+            }
             let db = match turso_core::Database::open_file_with_flags(
                 env.io.clone(),
                 env.get_db_path().to_str().expect("path should be 'to_str'"),
                 turso_core::OpenFlags::default(),
-                turso_core::DatabaseOpts::new()
-                    .with_autovacuum(true)
-                    .with_attach(true),
+                db_opts.with_attach(true),
                 None,
             ) {
                 Ok(db) => db,

--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -22,6 +22,7 @@ pub struct Remaining {
     pub drop_index: u32,
     pub pragma_count: u32,
     pub create_matview: u32,
+    pub drop_matview: u32,
     pub enable_cdc: u32,
 }
 

--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -4,7 +4,6 @@ use sql_generation::generation::GenerationContext;
 
 use crate::{
     model::{
-        Query,
         interactions::{Interaction, InteractionType},
     },
     profiles::query::QueryProfile,
@@ -22,6 +21,9 @@ pub struct Remaining {
     pub alter_table: u32,
     pub drop_index: u32,
     pub pragma_count: u32,
+    pub create_matview: u32,
+    pub drop_matview: u32,
+    pub enable_cdc: u32,
 }
 
 impl Remaining {
@@ -44,6 +46,9 @@ impl Remaining {
         let total_alter_table = (max_interactions * opts.alter_table_weight) / total_weight;
         let total_drop_index = (max_interactions * opts.drop_index) / total_weight;
         let total_pragma = (max_interactions * opts.pragma_weight) / total_weight;
+        let total_create_matview = (max_interactions * opts.create_matview_weight) / total_weight;
+        let total_drop_matview = (max_interactions * opts.drop_matview_weight) / total_weight;
+        let total_enable_cdc = (max_interactions * opts.enable_cdc_weight) / total_weight;
 
         let remaining_select = total_select
             .checked_sub(stats.select_count)
@@ -91,6 +96,26 @@ impl Remaining {
             remaining_drop_index = 0;
         }
 
+        let remaining_create_matview = total_create_matview
+            .checked_sub(stats.create_matview_count)
+            .unwrap_or_default();
+        let remaining_enable_cdc = total_enable_cdc
+            .checked_sub(stats.enable_cdc_count)
+            .unwrap_or_default();
+
+        // Calculate remaining drop matview from profile weight
+        // We can only drop matviews if more have been created than dropped in this plan
+        let net_matviews_created = stats
+            .create_matview_count
+            .saturating_sub(stats.drop_matview_count);
+        let remaining_drop_matview = if net_matviews_created > 0 {
+            total_drop_matview
+                .checked_sub(stats.drop_matview_count)
+                .unwrap_or_default()
+        } else {
+            0
+        };
+
         Remaining {
             select: remaining_select,
             insert: remaining_insert,
@@ -102,6 +127,9 @@ impl Remaining {
             alter_table: remaining_alter_table,
             drop_index: remaining_drop_index,
             pragma_count: remaining_pragma,
+            create_matview: remaining_create_matview,
+            drop_matview: remaining_drop_matview,
+            enable_cdc: remaining_enable_cdc,
         }
     }
 }
@@ -121,6 +149,9 @@ pub(crate) struct InteractionStats {
     pub alter_table_count: u32,
     pub drop_index_count: u32,
     pub pragma_count: u32,
+    pub create_matview_count: u32,
+    pub drop_matview_count: u32,
+    pub enable_cdc_count: u32,
 }
 
 impl InteractionStats {
@@ -152,6 +183,10 @@ impl InteractionStats {
             Query::DropIndex(_) => self.drop_index_count += 1,
             Query::Placeholder => {}
             Query::Pragma(_) => self.pragma_count += 1,
+            Query::CreateView(_) => {}
+            Query::CreateMaterializedView(_) => self.create_matview_count += 1,
+            Query::DropView(_) => {}
+            Query::DropMaterializedView(_) => self.drop_matview_count += 1,
         }
     }
 }
@@ -160,7 +195,7 @@ impl Display for InteractionStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Read: {}, Insert: {}, Delete: {}, Update: {}, Create: {}, CreateIndex: {}, Drop: {}, Begin: {}, Commit: {}, Rollback: {}, Alter Table: {}, Drop Index: {}",
+            "Read: {}, Insert: {}, Delete: {}, Update: {}, Create: {}, CreateIndex: {}, Drop: {}, Begin: {}, Commit: {}, Rollback: {}, Alter Table: {}, Drop Index: {}, CreateMatview: {}, DropMatview: {}",
             self.select_count,
             self.insert_count,
             self.delete_count,
@@ -173,6 +208,8 @@ impl Display for InteractionStats {
             self.rollback_count,
             self.alter_table_count,
             self.drop_index_count,
+            self.create_matview_count,
+            self.drop_matview_count,
         )
     }
 }

--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -22,7 +22,6 @@ pub struct Remaining {
     pub drop_index: u32,
     pub pragma_count: u32,
     pub create_matview: u32,
-    pub drop_matview: u32,
     pub enable_cdc: u32,
 }
 
@@ -195,7 +194,7 @@ impl Display for InteractionStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Read: {}, Insert: {}, Delete: {}, Update: {}, Create: {}, CreateIndex: {}, Drop: {}, Begin: {}, Commit: {}, Rollback: {}, Alter Table: {}, Drop Index: {}, CreateMatview: {}, DropMatview: {}",
+            "Read: {}, Insert: {}, Delete: {}, Update: {}, Create: {}, CreateIndex: {}, Drop: {}, Begin: {}, Commit: {}, Rollback: {}, Alter Table: {}, Drop Index: {}, CreateMatview: {}, DropMatview: {}, EnableCDC: {}",
             self.select_count,
             self.insert_count,
             self.delete_count,
@@ -210,6 +209,7 @@ impl Display for InteractionStats {
             self.drop_index_count,
             self.create_matview_count,
             self.drop_matview_count,
+            self.enable_cdc_count,
         )
     }
 }

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -983,7 +983,54 @@ impl Shadow for FromClause {
                     }
                     join_table.rows = new_rows;
                 }
-                _ => todo!(),
+                JoinType::Left => {
+                    let prev_rows = std::mem::take(&mut join_table.rows);
+                    let mut new_rows = Vec::new();
+                    let null_row: Vec<_> = joined_table
+                        .columns
+                        .iter()
+                        .map(|_| SimValue::NULL)
+                        .collect();
+
+                    for row1 in prev_rows.into_iter() {
+                        let mut has_match = false;
+                        for row2 in joined_table.rows.iter() {
+                            let combined_row =
+                                row1.iter().chain(row2.iter()).cloned().collect::<Vec<_>>();
+                            if join.on.test(&combined_row, &join_table) {
+                                new_rows.push(combined_row);
+                                has_match = true;
+                            }
+                        }
+                        if !has_match {
+                            let combined_row = row1
+                                .iter()
+                                .chain(null_row.iter())
+                                .cloned()
+                                .collect::<Vec<_>>();
+                            new_rows.push(combined_row);
+                        }
+                    }
+                    join_table.rows = new_rows;
+                }
+                JoinType::Cross => {
+                    let prev_rows = std::mem::take(&mut join_table.rows);
+                    let new_rows: Vec<_> = prev_rows
+                        .into_iter()
+                        .flat_map(|row1| {
+                            joined_table.rows.iter().map(move |row2| {
+                                row1.iter().chain(row2.iter()).cloned().collect::<Vec<_>>()
+                            })
+                        })
+                        .collect();
+                    join_table.rows = new_rows;
+                }
+                JoinType::Right | JoinType::Full => {
+                    panic!(
+                        "RIGHT and FULL joins are not implemented. \
+                         Generation should not produce these join types."
+                    );
+                }
             }
         }
         Ok(join_table)

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -491,6 +491,7 @@ impl Shadow for Query {
             Query::ReleaseSavepoint(release) => release.shadow(env),
             Query::Placeholder => Ok(vec![]),
             Query::Pragma(Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_)) => Ok(vec![]),
+            Query::Pragma(Pragma::CaptureDataChanges(_)) => Ok(vec![]),
         }
     }
 }

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -679,7 +679,7 @@ impl Shadow for Insert {
     //FIXME this doesn't handle type affinity
     fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         match self {
-            Insert::Select { table, select } => {
+            Insert::Select { table, select, .. } => {
                 let table_name = table.clone();
                 let raw_rows = select.shadow(tables)?;
 
@@ -702,6 +702,7 @@ impl Shadow for Insert {
                 table,
                 values,
                 on_conflict,
+                ..
             } => {
                 let table_name = table.clone();
 

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use sql_generation::model::query::select::SelectTable;
 use sql_generation::model::{
     query::{
-        Create, CreateIndex, Delete, Drop, DropIndex, Insert, Select,
         alter_table::{AlterTable, AlterTableType},
         pragma::Pragma,
         select::{CompoundOperator, FromClause, ResultColumn, SelectInner},
@@ -15,8 +14,8 @@ use sql_generation::model::{
         update::{SetValue, Update},
     },
     table::{Column, ColumnType, Index, JoinTable, JoinType, SimValue, Table, TableContext},
+    view::View,
 };
-use turso_core::Value;
 use turso_core::turso_assert_eq;
 use turso_parser::ast::Distinctness;
 
@@ -278,11 +277,15 @@ impl Display for ReleaseSavepoint {
 #[strum_discriminants(derive(Serialize, Deserialize))]
 pub enum Query {
     Create(Create),
+    CreateView(CreateView),
+    CreateMaterializedView(CreateMaterializedView),
     Select(Select),
     Insert(Insert),
     Delete(Delete),
     Update(Update),
     Drop(Drop),
+    DropView(DropView),
+    DropMaterializedView(DropMaterializedView),
     CreateIndex(CreateIndex),
     AlterTable(AlterTable),
     DropIndex(DropIndex),
@@ -324,6 +327,9 @@ impl Query {
         match self {
             Query::Select(select) => select.dependencies(),
             Query::Create(_) => IndexSet::new(),
+            Query::CreateView(view) => view.select.dependencies(),
+            Query::CreateMaterializedView(view) => view.select.dependencies(),
+            Query::DropView(_) | Query::DropMaterializedView(_) => IndexSet::new(),
             Query::Insert(Insert::Select { table, .. })
             | Query::Insert(Insert::Values { table, .. })
             | Query::Delete(Delete { table, .. })
@@ -353,6 +359,8 @@ impl Query {
     pub fn uses(&self) -> Vec<String> {
         match self {
             Query::Create(Create { table }) => vec![table.name.clone()],
+            Query::CreateView(view) => vec![view.name.clone()],
+            Query::CreateMaterializedView(view) => vec![view.name.clone()],
             Query::Select(select) => select.dependencies().into_iter().collect(),
             Query::Insert(Insert::Select { table, .. })
             | Query::Insert(Insert::Values { table, .. })
@@ -370,6 +378,8 @@ impl Query {
             | Query::DropIndex(DropIndex {
                 table_name: table, ..
             }) => vec![table.clone()],
+            Query::DropView(view) => vec![view.name.clone()],
+            Query::DropMaterializedView(view) => vec![view.name.clone()],
             Query::Begin(..) | Query::Commit(..) | Query::Rollback(..) => vec![],
             Query::Savepoint(..) | Query::RollbackToSavepoint(..) | Query::ReleaseSavepoint(..) => {
                 vec![]
@@ -397,8 +407,12 @@ impl Query {
         matches!(
             self,
             Self::Create(..)
+                | Self::CreateView(..)
+                | Self::CreateMaterializedView(..)
                 | Self::CreateIndex(..)
                 | Self::Drop(..)
+                | Self::DropView(..)
+                | Self::DropMaterializedView(..)
                 | Self::AlterTable(..)
                 | Self::DropIndex(..)
         )
@@ -424,11 +438,15 @@ impl Display for Query {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Create(create) => write!(f, "{create}"),
+            Self::CreateView(view) => write!(f, "{view}"),
+            Self::CreateMaterializedView(view) => write!(f, "{view}"),
             Self::Select(select) => write!(f, "{select}"),
             Self::Insert(insert) => write!(f, "{insert}"),
             Self::Delete(delete) => write!(f, "{delete}"),
             Self::Update(update) => write!(f, "{update}"),
             Self::Drop(drop) => write!(f, "{drop}"),
+            Self::DropView(view) => write!(f, "{view}"),
+            Self::DropMaterializedView(view) => write!(f, "{view}"),
             Self::CreateIndex(create_index) => write!(f, "{create_index}"),
             Self::AlterTable(alter_table) => write!(f, "{alter_table}"),
             Self::DropIndex(drop_index) => write!(f, "{drop_index}"),
@@ -453,11 +471,15 @@ impl Shadow for Query {
 
         match self {
             Query::Create(create) => create.shadow(env),
+            Query::CreateView(view) => view.shadow(env),
+            Query::CreateMaterializedView(view) => view.shadow(env),
             Query::Insert(insert) => insert.shadow(env),
             Query::Delete(delete) => delete.shadow(env),
             Query::Select(select) => select.shadow(env),
             Query::Update(update) => update.shadow(env),
             Query::Drop(drop) => drop.shadow(env),
+            Query::DropView(view) => view.shadow(env),
+            Query::DropMaterializedView(view) => view.shadow(env),
             Query::CreateIndex(create_index) => Ok(create_index.shadow(env)),
             Query::AlterTable(alter_table) => alter_table.shadow(env),
             Query::DropIndex(drop_index) => drop_index.shadow(env),
@@ -485,6 +507,10 @@ bitflags! {
         const CREATE_INDEX = 1 << 6;
         const ALTER_TABLE = 1 << 7;
         const DROP_INDEX = 1 << 8;
+        const CREATE_VIEW = 1 << 9;
+        const CREATE_MATERIALIZED_VIEW = 1 << 10;
+        const DROP_VIEW = 1 << 11;
+        const DROP_MATERIALIZED_VIEW = 1 << 12;
     }
 }
 
@@ -507,11 +533,15 @@ impl From<QueryDiscriminants> for QueryCapabilities {
     fn from(value: QueryDiscriminants) -> Self {
         match value {
             QueryDiscriminants::Create => Self::CREATE,
+            QueryDiscriminants::CreateView => Self::CREATE_VIEW,
+            QueryDiscriminants::CreateMaterializedView => Self::CREATE_MATERIALIZED_VIEW,
             QueryDiscriminants::Select => Self::SELECT,
             QueryDiscriminants::Insert => Self::INSERT,
             QueryDiscriminants::Delete => Self::DELETE,
             QueryDiscriminants::Update => Self::UPDATE,
             QueryDiscriminants::Drop => Self::DROP,
+            QueryDiscriminants::DropView => Self::DROP_VIEW,
+            QueryDiscriminants::DropMaterializedView => Self::DROP_MATERIALIZED_VIEW,
             QueryDiscriminants::CreateIndex => Self::CREATE_INDEX,
             QueryDiscriminants::AlterTable => Self::ALTER_TABLE,
             QueryDiscriminants::DropIndex => Self::DROP_INDEX,
@@ -535,10 +565,14 @@ impl QueryDiscriminants {
     pub const ALL_NO_TRANSACTION: &'_ [QueryDiscriminants] = &[
         QueryDiscriminants::Select,
         QueryDiscriminants::Create,
+        QueryDiscriminants::CreateView,
+        QueryDiscriminants::CreateMaterializedView,
         QueryDiscriminants::Insert,
         QueryDiscriminants::Update,
         QueryDiscriminants::Delete,
         QueryDiscriminants::Drop,
+        QueryDiscriminants::DropView,
+        QueryDiscriminants::DropMaterializedView,
         QueryDiscriminants::CreateIndex,
         QueryDiscriminants::AlterTable,
         QueryDiscriminants::DropIndex,
@@ -863,14 +897,35 @@ impl Shadow for FromClause {
     type Result = anyhow::Result<JoinTable>;
     fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         let mut join_table = match &self.table {
-            SelectTable::Table(table) => {
-                let first_table = tables
-                    .iter()
-                    .find(|t| t.name == *table)
-                    .context("Table not found")?;
-                JoinTable {
-                    tables: vec![first_table.clone()],
-                    rows: first_table.rows.clone(),
+            SelectTable::Table(table, _) => {
+                if let Some(first_table) = tables.iter().find(|t| t.name == *table) {
+                    JoinTable {
+                        tables: vec![first_table.clone()],
+                        rows: first_table.rows.clone(),
+                    }
+                } else if let Some((view_select, _)) = tables.find_view_select(table) {
+                    // Skip shadow evaluation if the view's SELECT references itself
+                    // (recursive CTE with same name as the matview). The shadow doesn't
+                    // model CTEs, so this would cause infinite recursion.
+                    let deps = view_select.dependencies();
+                    if deps.contains(table.as_str()) {
+                        return Ok(JoinTable {
+                            tables: vec![Table::anonymous(vec![])],
+                            rows: vec![],
+                        });
+                    }
+                    let result_tables: Vec<Table> = tables
+                        .iter()
+                        .filter(|t| deps.contains(t.name.as_str()))
+                        .cloned()
+                        .collect();
+                    let rows = view_select.shadow(tables)?;
+                    JoinTable {
+                        tables: result_tables,
+                        rows,
+                    }
+                } else {
+                    anyhow::bail!("Table not found: {table}");
                 }
             }
             SelectTable::Select(select) => {
@@ -889,10 +944,25 @@ impl Shadow for FromClause {
         };
 
         for join in &self.joins {
-            let joined_table = tables
-                .iter()
-                .find(|t| t.name == join.table)
-                .context("Joined table not found")?;
+            let joined_table = if let Some(t) = tables.iter().find(|t| t.name == join.table) {
+                t.clone()
+            } else if let Some((view_select, _)) = tables.find_view_select(&join.table) {
+                let rows = view_select.shadow(tables)?;
+                let deps = view_select.dependencies();
+                let columns: Vec<Column> = tables
+                    .iter()
+                    .filter(|t| deps.contains(t.name.as_str()))
+                    .flat_map(|t| t.columns.clone())
+                    .collect();
+                Table {
+                    name: join.table.clone(),
+                    columns,
+                    rows,
+                    indexes: vec![],
+                }
+            } else {
+                anyhow::bail!("Joined table not found: {}", join.table);
+            };
 
             join_table.tables.push(joined_table.clone());
 
@@ -1313,6 +1383,48 @@ impl Shadow for DropIndex {
         table
             .indexes
             .retain(|index| index.index_name != self.index_name);
+        Ok(vec![])
+    }
+}
+
+impl Shadow for CreateView {
+    type Result = anyhow::Result<Vec<Vec<SimValue>>>;
+
+    fn shadow(&self, tables: &mut ShadowTablesMut<'_>) -> Self::Result {
+        let view = View::regular(self.name.clone(), self.select.clone());
+        tables.record_create_view(view.clone());
+        tables.views_mut().push(view);
+        Ok(vec![])
+    }
+}
+
+impl Shadow for CreateMaterializedView {
+    type Result = anyhow::Result<Vec<Vec<SimValue>>>;
+
+    fn shadow(&self, tables: &mut ShadowTablesMut<'_>) -> Self::Result {
+        let view = View::materialized(self.name.clone(), self.select.clone());
+        tables.record_create_view(view.clone());
+        tables.views_mut().push(view);
+        Ok(vec![])
+    }
+}
+
+impl Shadow for DropView {
+    type Result = anyhow::Result<Vec<Vec<SimValue>>>;
+
+    fn shadow(&self, tables: &mut ShadowTablesMut<'_>) -> Self::Result {
+        tables.record_drop_view(self.name.clone());
+        tables.views_mut().retain(|v| v.name != self.name);
+        Ok(vec![])
+    }
+}
+
+impl Shadow for DropMaterializedView {
+    type Result = anyhow::Result<Vec<Vec<SimValue>>>;
+
+    fn shadow(&self, tables: &mut ShadowTablesMut<'_>) -> Self::Result {
+        tables.record_drop_view(self.name.clone());
+        tables.views_mut().retain(|v| v.name != self.name);
         Ok(vec![])
     }
 }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -193,6 +193,26 @@ pub enum Property {
     Queries {
         queries: Vec<Query>,
     },
+    /// IvmConsistency tests that incremental view maintenance produces the
+    /// same results as recomputing a materialized view from scratch.
+    /// The execution of the property is as follows:
+    ///     BEGIN IMMEDIATE
+    ///     DML_0 (INSERT/UPDATE/DELETE on base tables)
+    ///     DML_1
+    ///     ...
+    ///     DML_n
+    ///     COMMIT
+    ///     SELECT * FROM <matview_name>
+    ///     <view_definition> (fresh computation)
+    ///     ASSERT results match
+    IvmConsistency {
+        /// Name of the materialized view being tested
+        matview_name: String,
+        /// The SELECT that defines the view (for fresh computation)
+        view_definition: Select,
+        /// DML queries to execute in transaction (trigger IVM)
+        dml_queries: Vec<Query>,
+    },
 }
 
 impl Property {
@@ -213,6 +233,7 @@ impl Property {
                 | Property::DropSelect { .. }
                 | Property::SavepointRollback { .. }
                 | Property::Queries { .. }
+                | Property::IvmConsistency { .. }
         )
     }
 
@@ -224,6 +245,7 @@ impl Property {
             | Property::DropSelect { queries, .. }
             | Property::SavepointRollback { queries, .. }
             | Property::Queries { queries } => Some(queries),
+            Property::IvmConsistency { dml_queries, .. } => Some(dml_queries),
             Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
             Property::SelectLimit { .. }
             | Property::SelectSelectOptimizer { .. }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -33,8 +33,6 @@ pub enum Property {
         queries: Vec<Query>,
         /// The select query
         select: Select,
-        /// Interactive query information if any
-        interactive: Option<InteractiveQueryInfo>,
     },
     /// ReadYourUpdatesBack verifies UPDATE behavior for both success and failure cases.
     ///
@@ -195,12 +193,6 @@ pub enum Property {
     Queries {
         queries: Vec<Query>,
     },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct InteractiveQueryInfo {
-    pub start_with_immediate: bool,
-    pub end_with_commit: bool,
 }
 
 impl Property {

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -29,6 +29,9 @@ pub mod query;
 pub struct Profile {
     #[garde(skip)]
     pub mvcc: bool,
+    #[garde(skip)]
+    /// Enable views (including materialized views)
+    pub enable_views: bool,
     #[garde(range(min = 1, max = 64))]
     pub max_connections: usize,
     #[garde(dive)]
@@ -37,16 +40,21 @@ pub struct Profile {
     pub query: QueryProfile,
     #[garde(range(min = 200, max = 2000))]
     pub cache_size_pages: Option<usize>,
+    #[garde(skip)]
+    /// Require differential testing for this profile (verifies content correctness)
+    pub differential_required: bool,
 }
 
 impl Default for Profile {
     fn default() -> Self {
         Self {
             mvcc: false,
+            enable_views: false,
             max_connections: 10,
             io: Default::default(),
             query: Default::default(),
             cache_size_pages: Some(2000),
+            differential_required: false,
         }
     }
 }
@@ -219,8 +227,55 @@ impl Profile {
                 ..Default::default()
             },
             mvcc: true,
+            enable_views: false,
             max_connections: 2,
             cache_size_pages: Some(2000),
+            differential_required: false,
+        };
+        profile.validate().unwrap();
+        profile
+    }
+
+    /// Profile for testing materialized views with CDC enabled
+    /// Uses plan-level transaction batching to naturally test IVM with multiple
+    /// DML operations in a single transaction (targets bugs like JoinOperator panic)
+    /// Note: MVCC is disabled because views/matviews are not yet supported with MVCC
+    /// Note: differential_required=true ensures content correctness is verified
+    pub fn matview_cdc() -> Self {
+        let profile = Profile {
+            io: IOProfile {
+                fault: FaultProfile {
+                    enable: false,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            query: QueryProfile {
+                check_after_dml: false,
+                select_weight: 20,
+                create_table_weight: 10,
+                create_index_weight: 0,
+                insert_weight: 40,
+                update_weight: 10,
+                delete_weight: 5,
+                drop_table_weight: 0,
+                alter_table_weight: 0,
+                drop_index: 0,
+                pragma_weight: 0,
+                create_matview_weight: 30,
+                drop_matview_weight: 10,
+                enable_cdc_weight: 20,
+                // Higher probabilities to increase chance of multi-DML transactions
+                enable_transaction_batching: true,
+                transaction_batch_start_probability: 0.4,
+                transaction_batch_commit_probability: 0.25,
+                ..Default::default()
+            },
+            experimental_mvcc: false, // MVCC disabled: views not yet supported with MVCC
+            enable_views: true,       // Required for materialized views
+            max_connections: 1, // Single connection to avoid locking issues with BEGIN IMMEDIATE
+            cache_size_pages: Some(2000),
+            differential_required: true, // Verify matview content matches rusqlite view
         };
         profile.validate().unwrap();
         profile
@@ -235,9 +290,10 @@ impl Profile {
             ProfileType::SimpleMvcc => Self::simple_mvcc(),
             ProfileType::WriteStress => Self::write_stress(),
             ProfileType::SavepointStress => Self::savepoint_stress(),
+            ProfileType::MatviewCdc => Self::matview_cdc(),
             ProfileType::Custom(path) => {
-                Self::parse(path).with_context(|| "failed to parse JSON profile")?
-            }
+        Self::parse(path).with_context(|| "failed to parse JSON profile")?
+        }
         };
         Ok(profile)
     }
@@ -277,6 +333,7 @@ pub enum ProfileType {
     SimpleMvcc,
     WriteStress,
     SavepointStress,
+    MatviewCdc,
     #[strum(disabled)]
     Custom(PathBuf),
 }

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -43,6 +43,11 @@ pub struct Profile {
     #[garde(skip)]
     /// Require differential testing for this profile (verifies content correctness)
     pub differential_required: bool,
+    #[garde(skip)]
+    /// Probability (0.0-1.0) of running integrity check after each query.
+    /// Default is 0.1 (10%). Set to 0.0 to disable, 1.0 for every query.
+    /// Note: Integrity checks are skipped during write transactions and with MVCC.
+    pub integrity_check_probability: f64,
 }
 
 impl Default for Profile {
@@ -55,6 +60,7 @@ impl Default for Profile {
             query: Default::default(),
             cache_size_pages: Some(2000),
             differential_required: false,
+            integrity_check_probability: 0.1, // 10% by default
         }
     }
 }
@@ -231,6 +237,7 @@ impl Profile {
             max_connections: 2,
             cache_size_pages: Some(2000),
             differential_required: false,
+            integrity_check_probability: 0.0, // MVCC skips integrity checks anyway
         };
         profile.validate().unwrap();
         profile
@@ -276,6 +283,7 @@ impl Profile {
             max_connections: 1, // Single connection to avoid locking issues with BEGIN IMMEDIATE
             cache_size_pages: Some(2000),
             differential_required: true, // Verify matview content matches rusqlite view
+            integrity_check_probability: 0.1,
         };
         profile.validate().unwrap();
         profile

--- a/testing/simulator/profiles/query.rs
+++ b/testing/simulator/profiles/query.rs
@@ -31,6 +31,21 @@ pub struct QueryProfile {
     pub drop_index: u32,
     #[garde(skip)]
     pub pragma_weight: u32,
+    #[garde(skip)]
+    pub create_matview_weight: u32,
+    #[garde(skip)]
+    pub drop_matview_weight: u32,
+    #[garde(skip)]
+    pub enable_cdc_weight: u32,
+    /// Enable plan-level transaction batching (groups multiple DML ops in transactions)
+    #[garde(skip)]
+    pub enable_transaction_batching: bool,
+    /// Probability of starting a batch transaction (0.0-1.0)
+    #[garde(skip)]
+    pub transaction_batch_start_probability: f64,
+    /// Probability of committing when in transaction (0.0-1.0)
+    #[garde(skip)]
+    pub transaction_batch_commit_probability: f64,
 }
 
 impl Default for QueryProfile {
@@ -48,6 +63,12 @@ impl Default for QueryProfile {
             alter_table_weight: 2,
             drop_index: 2,
             pragma_weight: 2,
+            create_matview_weight: 0,
+            drop_matview_weight: 0,
+            enable_cdc_weight: 0,
+            enable_transaction_batching: true,
+            transaction_batch_start_probability: 0.3,
+            transaction_batch_commit_probability: 0.3,
         }
     }
 }
@@ -64,6 +85,9 @@ impl QueryProfile {
             + self.drop_table_weight
             + self.alter_table_weight
             + self.pragma_weight
+            + self.create_matview_weight
+            + self.drop_matview_weight
+            + self.enable_cdc_weight
     }
 }
 

--- a/testing/simulator/profiles/query.rs
+++ b/testing/simulator/profiles/query.rs
@@ -46,6 +46,9 @@ pub struct QueryProfile {
     /// Probability of committing when in transaction (0.0-1.0)
     #[garde(skip)]
     pub transaction_batch_commit_probability: f64,
+    /// Enable coordinated materialized view scenario (setup base tables + matviews first)
+    #[garde(skip)]
+    pub enable_coordinated_matview_scenario: bool,
 }
 
 impl Default for QueryProfile {
@@ -69,6 +72,7 @@ impl Default for QueryProfile {
             enable_transaction_batching: true,
             transaction_batch_start_probability: 0.3,
             transaction_batch_commit_probability: 0.3,
+            enable_coordinated_matview_scenario: false,
         }
     }
 }

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -11,15 +11,16 @@ use garde::Validate;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use sql_generation::generation::GenerationContext;
+use sql_generation::model::query::select::Select;
 use sql_generation::model::query::transaction::Rollback;
 use sql_generation::model::table::{SimValue, Table};
+use sql_generation::model::view::View;
 use tracing::trace;
 use turso_core::Database;
 
 use crate::generation::Shadow;
 use crate::model::Query;
 use crate::profiles::Profile;
-use crate::runner::SimIO;
 use crate::runner::cli::IoBackend;
 use crate::runner::io::SimulatorIO;
 use crate::runner::memory::io::MemorySimIO;
@@ -120,6 +121,12 @@ pub enum TxOperation {
         old_name: String,
         new_column: sql_generation::model::table::Column,
     },
+    CreateView {
+        view: View,
+    },
+    DropView {
+        view_name: String,
+    },
 }
 
 /// Database snapshot
@@ -127,6 +134,8 @@ pub enum TxOperation {
 pub struct Snapshot {
     /// The current state after applying transaction's changes (used for reads within the transaction)
     current_tables: Vec<Table>,
+    /// The current views after applying transaction's changes
+    current_views: Vec<View>,
     /// Operations recorded during this transaction, in order
     operations: Vec<TxOperation>,
     /// Named savepoint snapshots in this transaction.
@@ -306,17 +315,31 @@ impl TransactionTables {
                 new_column,
             });
     }
+
+    pub fn record_create_view(&mut self, view: View) {
+        self.expect_snapshot_mut()
+            .operations
+            .push(TxOperation::CreateView { view });
+    }
+
+    pub fn record_drop_view(&mut self, view_name: String) {
+        self.expect_snapshot_mut()
+            .operations
+            .push(TxOperation::DropView { view_name });
+    }
 }
 
 #[derive(Debug)]
 pub struct ShadowTables<'a> {
     commited_tables: &'a Vec<Table>,
+    commited_views: &'a Vec<View>,
     transaction_tables: Option<&'a TransactionTables>,
 }
 
 #[derive(Debug)]
 pub struct ShadowTablesMut<'a> {
     commited_tables: &'a mut Vec<Table>,
+    commited_views: &'a mut Vec<View>,
     transaction_tables: &'a mut Option<TransactionTables>,
 }
 
@@ -325,6 +348,12 @@ impl<'a> ShadowTables<'a> {
         self.transaction_tables
             .and_then(|v| v.as_snaphot_opt())
             .map_or(self.commited_tables, |v| &v.current_tables)
+    }
+
+    fn views(&self) -> &'a Vec<View> {
+        self.transaction_tables
+            .and_then(|v| v.as_snaphot_opt())
+            .map_or(self.commited_views, |v| &v.current_views)
     }
 }
 
@@ -351,6 +380,34 @@ where
             .as_mut()
             .map_or(self.commited_tables, |v| {
                 &mut v.expect_snapshot_mut().current_tables
+            })
+    }
+
+    /// Find a view by name and return a clone of its Select definition.
+    /// Uses a short-lived borrow so callers can still use &mut self afterwards.
+    pub fn find_view_select(&self, name: &str) -> Option<(Select, bool)> {
+        let views = self
+            .transaction_tables
+            .as_ref()
+            .map_or(&*self.commited_views, |v| &v.expect_snaphot().current_views);
+        views
+            .iter()
+            .find(|v| v.name == name)
+            .map(|v| (v.select.clone(), v.materialized))
+    }
+
+    #[allow(dead_code)]
+    pub fn views(&'a self) -> &'a Vec<View> {
+        self.transaction_tables
+            .as_ref()
+            .map_or(self.commited_views, |v| &v.expect_snaphot().current_views)
+    }
+
+    pub fn views_mut(&'b mut self) -> &'b mut Vec<View> {
+        self.transaction_tables
+            .as_mut()
+            .map_or(self.commited_views, |v| {
+                &mut v.expect_snapshot_mut().current_views
             })
     }
 
@@ -515,6 +572,20 @@ where
         Ok(())
     }
 
+    /// Record that a view was created during the current transaction
+    pub fn record_create_view(&mut self, view: View) {
+        if let Some(txn) = &mut *self.transaction_tables {
+            txn.record_create_view(view);
+        }
+    }
+
+    /// Record that a view was dropped during the current transaction
+    pub fn record_drop_view(&mut self, view_name: String) {
+        if let Some(txn) = &mut *self.transaction_tables {
+            txn.record_drop_view(view_name);
+        }
+    }
+
     /// Tries to upgrade the Transaction Mode
     #[inline]
     pub fn upgrade_transaction(&mut self, query: &Query) {
@@ -558,6 +629,7 @@ where
     pub fn create_snapshot(&mut self, transaction_mode: TransactionMode) {
         *self.transaction_tables = Some(TransactionTables::Snapshot(Snapshot {
             current_tables: self.commited_tables.clone(),
+            current_views: self.commited_views.clone(),
             operations: Vec::new(),
             savepoints: Vec::new(),
             transaction_mode,
@@ -780,6 +852,12 @@ where
                             }
                         }
                     }
+                    TxOperation::CreateView { view } => {
+                        self.commited_views.push(view.clone());
+                    }
+                    TxOperation::DropView { view_name } => {
+                        self.commited_views.retain(|v| &v.name != view_name);
+                    }
                 }
             }
         }
@@ -913,6 +991,8 @@ pub(crate) struct SimulatorEnv {
     pub committed_tables: Vec<Table>,
     /// Names of attached databases (e.g. ["aux0", "aux1", "aux2"])
     pub(crate) attached_dbs: Vec<String>,
+    // View data that is committed into the database
+    pub committed_views: Vec<View>,
 }
 
 impl UnwindSafe for SimulatorEnv {}
@@ -938,9 +1018,9 @@ impl SimulatorEnv {
             connection_last_query: self.connection_last_query,
             committed_tables: self.committed_tables.clone(),
             attached_dbs: self.attached_dbs.clone(),
+            committed_views: self.committed_views.clone(),
         }
     }
-
     pub(crate) fn clear(&mut self) {
         self.clear_tables();
         self.connections.iter_mut().for_each(|c| c.disconnect());
@@ -1004,13 +1084,15 @@ impl SimulatorEnv {
 
         self.db = None;
 
+        let mut db_opts = turso_core::DatabaseOpts::new().with_autovacuum(true);
+        if self.profile.enable_views || self.profile.experimental_mvcc {
+            db_opts = db_opts.with_views(true);
+        }
         let db = match Database::open_file_with_flags(
             io.clone(),
             db_path.to_str().unwrap(),
             turso_core::OpenFlags::default(),
-            turso_core::DatabaseOpts::new()
-                .with_autovacuum(true)
-                .with_attach(true),
+            db_opts.with_attach(true),
             None,
         ) {
             Ok(db) => db,
@@ -1037,6 +1119,17 @@ impl SimulatorEnv {
         }
 
         self.io = io;
+
+        // Switch to MVCC mode if the profile says to use MVCC
+        if self.profile.experimental_mvcc {
+            let conn = db
+                .connect()
+                .expect("Failed to create connection for MVCC setup");
+            conn.execute("PRAGMA journal_mode = 'experimental_mvcc'")
+                .expect("Failed to enable MVCC mode");
+            conn.close().expect("Failed to close MVCC setup connection");
+        }
+
         self.db = Some(db);
     }
 
@@ -1199,13 +1292,15 @@ impl SimulatorEnv {
             ),
         };
 
+        let mut db_opts = turso_core::DatabaseOpts::new().with_autovacuum(true);
+        if profile.enable_views || profile.experimental_mvcc {
+            db_opts = db_opts.with_views(true);
+        }
         let db = match Database::open_file_with_flags(
             io.clone(),
             db_path.to_str().unwrap(),
             turso_core::OpenFlags::default(),
-            turso_core::DatabaseOpts::new()
-                .with_autovacuum(true)
-                .with_attach(true),
+            db_opts.with_attach(true),
             None,
         ) {
             Ok(db) => db,
@@ -1228,6 +1323,7 @@ impl SimulatorEnv {
                     .iter()
                     .map(|name| paths.aux_db(&simulation_type, &SimulationPhase::Test, name)),
             );
+            conn.close().expect("Failed to close MVCC setup connection");
         }
 
         let connections = (0..profile.max_connections)
@@ -1247,6 +1343,7 @@ impl SimulatorEnv {
             io_backend,
             profile: profile.clone(),
             committed_tables: Vec::new(),
+            committed_views: Vec::new(),
             connection_tables: vec![None; profile.max_connections],
             connection_last_query: Bitmap::new(),
             attached_dbs,
@@ -1316,6 +1413,7 @@ impl SimulatorEnv {
     pub fn connection_context(&self, conn_index: usize) -> impl GenerationContext {
         struct ConnectionGenContext<'a> {
             tables: &'a Vec<sql_generation::model::table::Table>,
+            views: &'a Vec<View>,
             opts: &'a sql_generation::generation::Opts,
         }
 
@@ -1324,16 +1422,23 @@ impl SimulatorEnv {
                 self.tables
             }
 
+            fn views(&self) -> &Vec<View> {
+                self.views
+            }
+
             fn opts(&self) -> &sql_generation::generation::Opts {
                 self.opts
             }
         }
 
-        let tables = self.get_conn_tables(conn_index).tables();
+        let shadow = self.get_conn_tables(conn_index);
+        let tables = shadow.tables();
+        let views = shadow.views();
 
         ConnectionGenContext {
             opts: &self.profile.query.gen_opts,
             tables,
+            views,
         }
     }
 
@@ -1373,6 +1478,7 @@ impl SimulatorEnv {
         ShadowTables {
             transaction_tables: self.connection_tables.get(conn_index).unwrap().as_ref(),
             commited_tables: &self.committed_tables,
+            commited_views: &self.committed_views,
         }
     }
 
@@ -1380,6 +1486,7 @@ impl SimulatorEnv {
         ShadowTablesMut {
             transaction_tables: self.connection_tables.get_mut(conn_index).unwrap(),
             commited_tables: &mut self.committed_tables,
+            commited_views: &mut self.committed_views,
         }
     }
 }

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -28,6 +28,7 @@ use crate::{
         },
     },
 };
+use sql_generation::model::query::pragma::Pragma;
 
 use super::env::{SimConnection, SimulatorEnv};
 
@@ -41,6 +42,10 @@ fn translate_query_for_rusqlite(query: &Query) -> Option<Query> {
         }
         Query::DropMaterializedView(drop_matview) => {
             Some(Query::DropView(drop_matview.to_regular_drop_view()))
+        }
+        Query::Pragma(Pragma::CaptureDataChanges(_)) => {
+            // CDC pragma not supported in rusqlite, skip it
+            None
         }
         other => Some(other.clone()),
     }

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -10,13 +10,24 @@ use turso_core::{Connection, LimboError, Result, Value};
 ///
 /// - WriteWriteConflict: MVCC conflict, the DB rolled back the transaction
 /// - TxError: Transaction state error (e.g., BEGIN twice, COMMIT with no transaction)
+/// - Busy: Database is temporarily busy (e.g., another connection holds a lock)
+/// - BusySnapshot: Snapshot is stale, transaction needs to be retried
 fn is_recoverable_tx_error(err: &LimboError) -> bool {
-    matches!(err, LimboError::WriteWriteConflict | LimboError::TxError(_))
+    matches!(
+        err,
+        LimboError::WriteWriteConflict
+            | LimboError::TxError(_)
+            | LimboError::Busy
+            | LimboError::BusySnapshot
+    )
 }
 
 /// Returns true if the error indicates the transaction was rolled back by the database.
 fn error_causes_rollback(err: &LimboError) -> bool {
-    matches!(err, LimboError::WriteWriteConflict)
+    matches!(
+        err,
+        LimboError::WriteWriteConflict | LimboError::BusySnapshot
+    )
 }
 
 use crate::{
@@ -266,8 +277,7 @@ pub fn execute_interaction_turso(
             }
 
             stack.push(results);
-            // TODO: skip integrity check with mvcc
-            if !env.profile.mvcc && env.rng.random_ratio(1, 10) {
+            if should_run_integrity_check(env) {
                 let SimConnection::LimboConnection(conn) = &mut env.connections[connection_index]
                 else {
                     unreachable!()
@@ -313,7 +323,7 @@ pub fn execute_interaction_turso(
         InteractionType::Fault(_) => {
             interaction.execute_fault(env, connection_index)?;
         }
-        InteractionType::FaultyQuery(_) => {
+        InteractionType::FaultyQuery(query) => {
             let conn = {
                 let SimConnection::LimboConnection(conn) = &mut env.connections[connection_index]
                 else {
@@ -325,12 +335,42 @@ pub fn execute_interaction_turso(
                 .execute_faulty_query(&conn, env)
                 .inspect_err(|err| tracing::error!(?err));
 
-            stack.push(results);
-            // Reset fault injection
+            // Reset fault injection before handling errors
             env.io.inject_fault(false);
-            // TODO: skip integrity check with mvcc
-            if !env.profile.mvcc && env.rng.random_ratio(1, 10) {
+
+            // Handle errors similar to regular Query: recoverable tx errors continue,
+            // others fail the simulation
+            let skip_shadow = if let Err(err) = &results {
+                if is_recoverable_tx_error(err) {
+                    // Only rollback shadow state if the DB actually rolled back
+                    if error_causes_rollback(err) && env.conn_in_transaction(connection_index) {
+                        env.rollback_conn(connection_index);
+                    }
+                    true // skip shadowing this failed query
+                } else {
+                    // For non-recoverable errors during faulty query execution,
+                    // we don't fail the simulation since we expect faults to cause errors.
+                    // But we should skip shadowing to keep state consistent.
+                    tracing::warn!(
+                        "Non-recoverable error during faulty query, skipping shadow: {:?}",
+                        err
+                    );
+                    true
+                }
+            } else {
+                false
+            };
+
+            stack.push(results);
+
+            if should_run_integrity_check(env) {
                 limbo_integrity_check(&conn)?;
+            }
+
+            env.update_conn_last_interaction(connection_index, Some(query));
+
+            if skip_shadow {
+                return Ok(ExecutionContinuation::NextInteractionOutsideThisProperty);
             }
         }
     }
@@ -340,6 +380,23 @@ pub fn execute_interaction_turso(
         )));
     }
     Ok(ExecutionContinuation::NextInteraction)
+}
+
+/// Returns true if we should run an integrity check based on profile settings.
+/// MVCC mode always skips integrity checks (not yet supported).
+/// Otherwise uses the profile's integrity_check_probability.
+fn should_run_integrity_check(env: &mut SimulatorEnv) -> bool {
+    if env.profile.experimental_mvcc {
+        return false;
+    }
+    let prob = env.profile.integrity_check_probability;
+    if prob <= 0.0 {
+        return false;
+    }
+    if prob >= 1.0 {
+        return true;
+    }
+    env.rng.random_bool(prob)
 }
 
 fn limbo_integrity_check(conn: &Arc<Connection>) -> Result<()> {

--- a/tests/fuzz/rowid_alias.rs
+++ b/tests/fuzz/rowid_alias.rs
@@ -29,6 +29,7 @@ fn rng_from_time_or_env() -> (ChaCha8Rng, u64) {
 struct FuzzTestContext {
     opts: Opts,
     tables: Vec<Table>,
+    views: Vec<sql_generation::model::view::View>,
 }
 
 impl FuzzTestContext {
@@ -36,6 +37,7 @@ impl FuzzTestContext {
         Self {
             opts: Opts::default(),
             tables: Vec::new(),
+            views: Vec::new(),
         }
     }
 
@@ -47,6 +49,10 @@ impl FuzzTestContext {
 impl GenerationContext for FuzzTestContext {
     fn tables(&self) -> &Vec<Table> {
         &self.tables
+    }
+
+    fn views(&self) -> &Vec<sql_generation::model::view::View> {
+        &self.views
     }
 
     fn opts(&self) -> &Opts {


### PR DESCRIPTION
## Description


This adds the base simulator infrastructure for testing materialized views:
- SQL generation types for `CREATE VIEW`, `CREATE MATERIALIZED VIEW`, `DROP VIEW`
- Profile settings for view weights and CDC weights
- Database options for enabling views
- Shadow implementations for view operations

## Motivation and context

I ran into a few issues with `MATERIALIZED VIEW`s and began enhancing the simulator tests in order to detect these and possibly other issues.


## Description of AI Usage

I used Claude to create a reproducer for every bug I encounter in my app using Turso and then let another Claude instance in the Turso repo analyze why the bug was not uncovered by the simulator tests and then let it make enhancements that do detect the issue.
The general direction I'm steering Claude towards (where possible) is to make the existing operations more atomic and remove restrictions w.r.t. what kind of operations are produced and what data is used.
