### PR TITLE
core/vdbe: move mutable fields from Program to ProgramState

### DIFF
--- a/core/statement.rs
+++ b/core/statement.rs
@@ -87,7 +87,7 @@ impl Statement {
     }
 
     pub fn n_change(&self) -> i64 {
-        self.program
+        self.state
             .n_change
             .load(crate::sync::atomic::Ordering::SeqCst)
     }
@@ -451,7 +451,7 @@ impl Statement {
         // as abort uses auto_txn_cleanup value - it needs to be called before state.reset
         self.program.abort(&self.pager, None, &mut self.state);
         self.state.reset(max_registers, max_cursors);
-        self.program.n_change.store(0, Ordering::SeqCst);
+        self.state.n_change.store(0, Ordering::SeqCst);
         self.busy = false;
         self.busy_handler_state = None;
     }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,7 +1,6 @@
-use crate::sync::RwLock;
 use std::{
     collections::{HashMap, HashSet},
-    sync::{atomic::AtomicI64, Arc},
+    sync::Arc,
 };
 
 use tracing::{instrument, Level};
@@ -40,7 +39,7 @@ impl TableRefIdCounter {
     }
 }
 
-use super::{BranchOffset, CursorID, ExplainState, Insn, InsnReference, JumpTarget, Program};
+use super::{BranchOffset, CursorID, Insn, InsnReference, JumpTarget, Program};
 
 /// A key that uniquely identifies a cursor.
 /// The key is a pair of table reference id and index.
@@ -1340,7 +1339,6 @@ impl ProgramBuilder {
             comments: self.comments,
             connection,
             parameters: self.parameters,
-            n_change: AtomicI64::new(0),
             change_cnt_on,
             result_columns: self.result_columns,
             table_references: self.table_references,
@@ -1351,7 +1349,6 @@ impl ProgramBuilder {
             is_subprogram: self.is_subprogram,
             contains_trigger_subprograms,
             resolve_type: self.resolve_type,
-            explain_state: RwLock::new(ExplainState::default()),
         })
     }
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6235,7 +6235,7 @@ pub fn op_insert(
                 };
                 if let Some(rowid) = maybe_rowid {
                     program.connection.update_last_rowid(rowid);
-                    program
+                    state
                         .n_change
                         .fetch_add(1, crate::sync::atomic::Ordering::SeqCst);
                 }
@@ -6442,7 +6442,7 @@ pub fn op_delete(
     if !is_part_of_update {
         // DELETEs do not count towards the total changes if they are part of an UPDATE statement,
         // i.e. the DELETE and subsequent INSERT of a row are the same "change".
-        program
+        state
             .n_change
             .fetch_add(1, crate::sync::atomic::Ordering::SeqCst);
     }


### PR DESCRIPTION
## Description

In order to make Program clonable we need to move non-clonable fields outside. Program should remain immutable in theory so this makes it work like that.


## Description of AI Usage

Told claude to move n_changes and explain_state while I was heating up my food.
