### PR TITLE
fix: prevent panic on multi-byte UTF-8 in datetime functions

### DIFF
--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -994,8 +994,8 @@ fn strip_timezone_suffix(s: &str) -> &str {
     // Check +HH:MM or -HH:MM (length >= 6)
     if s.len() >= 6 {
         let idx = s.len() - 6;
-        let c = s.chars().nth(idx).unwrap();
-        if (c == '+' || c == '-') && s[idx + 3..].starts_with(':') {
+        let c = s.as_bytes()[idx];
+        if (c == b'+' || c == b'-') && s.as_bytes()[idx + 3] == b':' {
             let h_part = &s[idx + 1..idx + 3];
             let m_part = &s[idx + 4..];
 

--- a/testing/scalar-functions-datetime.test
+++ b/testing/scalar-functions-datetime.test
@@ -1117,3 +1117,26 @@ do_execsql_test datetime-trailing-garbage-rejected {
 do_execsql_test datetime-trailing-garbage-date-rejected {
   SELECT datetime('2024-01-15 10:30:45.123xyz');
 } {{}}
+
+# Regression tests for multi-byte UTF-8 characters (issue #4551)
+# These should return NULL, not panic
+
+do_execsql_test datetime-multibyte-utf8-emoji {
+  SELECT datetime('2024-01-01 🎉🎉');
+} {{}}
+
+do_execsql_test date-multibyte-utf8-chinese {
+  SELECT date('2024-01-01 中文字');
+} {{}}
+
+do_execsql_test time-multibyte-utf8-japanese {
+  SELECT time('2024-01-01 日本語');
+} {{}}
+
+do_execsql_test julianday-multibyte-utf8-cyrillic {
+  SELECT julianday('2024-01-01 Привет');
+} {{}}
+
+do_execsql_test datetime-multibyte-utf8-greek {
+  SELECT datetime('2024-01-01 αβγδεζ');
+} {{}}


### PR DESCRIPTION
The `strip_timezone_suffix` function was mixing byte length with character indexing, causing a panic on multi-byte UTF-8 strings.

Fixes #4551

Generated with [Claude Code](https://claude.ai/code)