### PR TITLE
fix: correct operator precedence in replace() argument check

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1858,9 +1858,9 @@ pub fn translate_expr(
                             Ok(target_register)
                         }
                         ScalarFunc::Replace => {
-                            if !args.len() == 3 {
+                            if args.len() != 3 {
                                 crate::bail_parse_error!(
-                                    "function {}() requires exactly 3 arguments",
+                                    "wrong number of arguments to function {}()",
                                     srf.to_string()
                                 )
                             }

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -187,6 +187,18 @@ do_execsql_test replace-null {
   select replace('test', null, 'example')
 } {}
 
+do_execsql_test_error_content replace-wrong-arg-count-0 {
+  select replace()
+} {wrong number of arguments to function replace()}
+
+do_execsql_test_error_content replace-wrong-arg-count-2 {
+  select replace('a', 'b')
+} {wrong number of arguments to function replace()}
+
+do_execsql_test_error_content replace-wrong-arg-count-4 {
+  select replace('a', 'b', 'c', 'd')
+} {wrong number of arguments to function replace()}
+
 do_execsql_test hex {
   select hex('limbo')
 } {6C696D626F}


### PR DESCRIPTION
Fixes #4559

The condition `!args.len() == 3` was always false due to operator precedence - the `!` operator binds tighter than `==`. This caused the guard to never trigger, leading to a panic when accessing args[0] with an empty args list.

Fixed by using `args.len() != 3` and updated the error message to match the standard format.

Generated with [Claude Code](https://claude.ai/claude-code)