### PR TITLE
fix: handle parse errors gracefully in LIMIT clause

### DIFF
--- a/testing/select.test
+++ b/testing/select.test
@@ -1077,6 +1077,16 @@ do_execsql_test_in_memory_any_error limit-column-reference-error {
   SELECT * FROM t LIMIT (t.a);
 }
 
+# Regression test for https://github.com/tursodatabase/turso/issues/4554
+# LIMIT clause with hex/underscore numeric literals should work
+do_execsql_test_on_specific_db {:memory:} limit-hex-literal {
+  SELECT 1 LIMIT 0x10;
+} {1}
+
+do_execsql_test_on_specific_db {:memory:} limit-underscore-literal {
+  SELECT 1 LIMIT 1_2_3;
+} {1}
+
 do_execsql_test select-binary-collation {
   SELECT 'a' = 'A';
   SELECT 'a' = 'a';


### PR DESCRIPTION
Fixes #4554

Replace `.unwrap()` with `?` operator when parsing f64 in the LIMIT clause, matching the error handling pattern used in the OFFSET clause. This prevents panics when the parser accepts numeric literal formats (hex, underscore-separated) that Rust's `parse::<f64>()` cannot handle.

Generated with [Claude Code](https://claude.ai/code)