### PR TITLE
fix(parser): reject ?0 parameter with proper error instead of panicking

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -188,6 +188,11 @@ impl<'a> Parser<'a> {
             let variable_id = variable_str
                 .parse::<u32>()
                 .map_err(|e| Error::Custom(format!("non-integer positional variable id: {e}")))?;
+            if variable_id == 0 {
+                return Err(Error::Custom(
+                    "variable number must be between ?1 and ?250000".to_string(),
+                ));
+            }
             self.last_variable_id = variable_id;
             Ok(Expr::Variable(from_bytes(token)))
         }

--- a/testing/select.test
+++ b/testing/select.test
@@ -1531,3 +1531,8 @@ do_execsql_test_on_specific_db {:memory:} values-select-empty-db {
 do_execsql_test_on_specific_db {:memory:} select-sqlite-schema-empty-db {
   select group_concat(name) over () from sqlite_schema;
 } {}
+
+# Test that ?0 is rejected with a proper error message (issue #4556)
+do_execsql_test_error select-param-zero-invalid {
+  SELECT ?0
+} {.*variable number must be between.*}


### PR DESCRIPTION
The parser was accepting ?0 as a valid positional parameter (since 0 is a valid u32), but core/parameters.rs later tries to parse it as NonZero<usize> which panics. This fix validates in the parser that positional parameters must be >= 1, returning a proper error message matching SQLite's behavior.

Fixes #4556

Generated with [Claude Code](https://claude.ai/code)