### PR TITLE
Add shuttle tests for IO trait

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -1125,6 +1125,7 @@ mod shuttle_tests {
                 let file = io
                     .open_file(path.to_str().unwrap(), OpenFlags::None, false)
                     .unwrap();
+                thread::yield_now();
                 // Write a byte to prove we got a valid file
                 let buf = Arc::new(Buffer::new(vec![0xAA]));
                 let c = Completion::new_write(|_| {});


### PR DESCRIPTION
## Description
Add shuttle tests for IO trait. These are mostly sanity and smoke tests to make sure we don't accidentally make our IO impls not `Send + Sync`

## Motivation and context
#1552 

## Description of AI Usage
Wrote the tests and I corrected and adjusted it to do more meaningful stuff and assert correctly
