### PR TITLE
fix: handle CAST without type name for SQLite compatibility

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -962,9 +962,12 @@ pub fn translate_expr(
             Ok(target_register)
         }
         ast::Expr::Cast { expr, type_name } => {
-            let type_name = type_name.as_ref().unwrap(); // TODO: why is this optional?
             translate_expr(program, referenced_tables, expr, target_register, resolver)?;
-            let type_affinity = Affinity::affinity(&type_name.name);
+            // SQLite allows CAST(x AS) without a type name, treating it as NUMERIC affinity
+            let type_affinity = type_name
+                .as_ref()
+                .map(|t| Affinity::affinity(&t.name))
+                .unwrap_or(Affinity::Numeric);
             program.emit_insn(Insn::Cast {
                 reg: target_register,
                 affinity: type_affinity,

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -981,6 +981,32 @@ do_execsql_test cast-null-to-any {
   SELECT CAST(NULL AS INTEGER), CAST(NULL AS TEXT), CAST(NULL AS BLOB), CAST(NULL AS REAL), CAST(NULL AS NUMERIC);
 } {||||}
 
+# CAST without type name - SQLite treats this as NUMERIC affinity
+# https://github.com/tursodatabase/turso/issues/4550
+do_execsql_test cast-without-type-integer {
+  SELECT CAST(1 AS);
+} {1}
+
+do_execsql_test cast-without-type-text-numeric {
+  SELECT CAST('hello' AS);
+} {0}
+
+do_execsql_test cast-without-type-text-integer-string {
+  SELECT CAST('123' AS);
+} {123}
+
+do_execsql_test cast-without-type-text-real-string {
+  SELECT typeof(CAST('123.45' AS)), CAST('123.45' AS);
+} {real|123.45}
+
+do_execsql_test cast-without-type-null {
+  SELECT CAST(NULL AS);
+} {}
+
+do_execsql_test cast-without-type-in-expression {
+  SELECT 1 WHERE CAST(1 AS) = 1;
+} {1}
+
 # CAST smoke test in where clause
 do_execsql_test cast-in-where {
   select age from users where age = cast('45' as integer) limit 1;


### PR DESCRIPTION
SQLite allows `CAST(expr AS)` syntax without a type name and treats it as NUMERIC affinity. Previously this caused a panic due to `unwrap()` on `None`. Now we default to `Affinity::Numeric` when `type_name` is `None`.

Fixes #4550

---
Generated with [Claude Code](https://claude.ai/code)