### PR TITLE
Fix DEFAULT value handling in integrity check

### DIFF
--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -8,6 +8,9 @@ use crate::{
 };
 use std::sync::Arc;
 
+use super::emitter::Resolver;
+use super::expr::translate_expr;
+
 /// Maximum number of errors to report with integrity check. If we exceed this number we will short
 /// circuit the procedure and return early to not waste time. SQLite uses 100 as the default.
 pub const MAX_INTEGRITY_CHECK_ERRORS: usize = 100;
@@ -17,9 +20,10 @@ pub const MAX_INTEGRITY_CHECK_ERRORS: usize = 100;
 pub fn translate_integrity_check(
     schema: &Schema,
     program: &mut ProgramBuilder,
+    resolver: &Resolver,
     max_errors: usize,
 ) -> crate::Result<()> {
-    translate_integrity_check_impl(schema, program, max_errors, false)
+    translate_integrity_check_impl(schema, program, resolver, max_errors, false)
 }
 
 /// Translate PRAGMA quick_check.
@@ -27,15 +31,39 @@ pub fn translate_integrity_check(
 pub fn translate_quick_check(
     schema: &Schema,
     program: &mut ProgramBuilder,
+    resolver: &Resolver,
     max_errors: usize,
 ) -> crate::Result<()> {
-    translate_integrity_check_impl(schema, program, max_errors, true)
+    translate_integrity_check_impl(schema, program, resolver, max_errors, true)
 }
+
+// FIXME: This entire integrity check implementation is architecturally wrong.
+//
+// SQLite generates proper VDBE bytecode for integrity_check: it opens cursors,
+// iterates with Rewind/Next, reads columns with OP_Column (which has a P4 parameter
+// for default values), and uses Found to check index entries. Each of these is a
+// separate instruction that the VM executes.
+//
+// Our implementation instead uses a single monolithic IntegrityCk instruction that
+// does everything internally in execute.rs. This means we can't leverage the existing
+// Column instruction's default value handling, and instead have to hack around it by
+// pre-evaluating default expressions to registers and passing them to the instruction.
+// Also who knows what other hacks we might need to add in the future.
+//
+// The proper fix would be to refactor integrity_check to emit bytecode like SQLite does:
+// - OpenRead cursors for tables and indexes
+// - Rewind/Next loops to iterate
+// - Column instructions with P4 defaults for reading values
+// - Found/NotFound for index lookups
+//
+// This would eliminate the need for the IntegrityCk mega-instruction and make the
+// implementation consistent with the rest of the VDBE.
 
 /// Internal implementation for both integrity_check and quick_check.
 fn translate_integrity_check_impl(
     schema: &Schema,
     program: &mut ProgramBuilder,
+    resolver: &Resolver,
     max_errors: usize,
     quick: bool,
 ) -> crate::Result<()> {
@@ -52,15 +80,42 @@ fn translate_integrity_check_impl(
                 for index in indexes.iter() {
                     if index.root_page > 0 {
                         root_pages.push(index.root_page);
+
+                        let column_positions: Vec<usize> =
+                            index.columns.iter().map(|c| c.pos_in_table).collect();
+
+                        // Allocate contiguous registers for default values of indexed columns.
+                        // For columns added via ALTER TABLE ADD COLUMN with DEFAULT, old rows
+                        // don't physically have these columns, so we need the defaults.
+                        //
+                        // FIXME: This is a hack. SQLite passes defaults via P4 to OP_Column.
+                        // We pre-evaluate them here because our monolithic IntegrityCk doesn't
+                        // use OP_Column internally. See the FIXME comment above.
+                        let default_values_start_reg =
+                            program.alloc_registers(column_positions.len());
+                        for (i, &pos) in column_positions.iter().enumerate() {
+                            let target_reg = default_values_start_reg + i;
+                            let col = &btree_table.columns[pos];
+                            if let Some(default_expr) = col.default.as_ref() {
+                                // Evaluate the default expression to the register.
+                                // Pass None for table references since defaults must be
+                                // constant expressions (no column references allowed).
+                                translate_expr(program, None, default_expr, target_reg, resolver)?;
+                            } else {
+                                // No default specified, use NULL
+                                program.emit_insn(Insn::Null {
+                                    dest: target_reg,
+                                    dest_end: None,
+                                });
+                            }
+                        }
+
                         table_indexes.push(IntegrityCheckIndex {
                             name: index.name.clone(),
                             root_page: index.root_page,
                             unique: index.unique,
-                            column_positions: index
-                                .columns
-                                .iter()
-                                .map(|c| c.pos_in_table)
-                                .collect(),
+                            column_positions,
+                            default_values_start_reg,
                             index_info: Arc::new(IndexInfo::new_from_index(index)),
                         });
                     }

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -52,6 +52,11 @@ pub struct IntegrityCheckIndex {
     pub unique: bool,
     /// Column positions in the table (for building index keys from table rows)
     pub column_positions: Vec<usize>,
+    /// Starting register containing default values for indexed columns.
+    /// Used for columns added via ALTER TABLE ADD COLUMN with DEFAULT - old rows
+    /// don't physically have these columns, so we use these pre-evaluated defaults.
+    /// The registers are contiguous: [default_values_start_reg..default_values_start_reg + column_positions.len())
+    pub default_values_start_reg: usize,
     /// Index info for cursor operations (sort order, collation, etc)
     pub index_info: std::sync::Arc<crate::types::IndexInfo>,
 }


### PR DESCRIPTION
In integrity check row-index validation (i.e. validate that all table rows are in all indexes), default values were not supplied in index seek keys (instead NULLs were applied), meaning integrity check couldn't find any row in any index if that row had a NULL value but a DEFAULT value defined on the table. For example after ADD COLUMN all values for that column are NULLs in the actual data.

Fixed with a hack, left a massive comment about it.

With any luck, this is responsible for all 45 antithesis failures 🤡 