### PR TITLE
sdk-kit: Export busy snapshot error to callers

### DIFF
--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -18,6 +18,12 @@ pub enum PyTursoStatusCode {
     Io = 3,
 }
 create_exception!(turso, Busy, PyException, "database is locked");
+create_exception!(
+    turso,
+    BusySnapshot,
+    PyException,
+    "database snapshot is stale"
+);
 create_exception!(turso, Interrupt, PyException, "interrupted");
 create_exception!(turso, Error, PyException, "generic error");
 create_exception!(turso, Misuse, PyException, "API misuse");
@@ -31,6 +37,7 @@ create_exception!(turso, IoError, PyException, "I/O error");
 pub(crate) fn turso_error_to_py_err(err: TursoError) -> PyErr {
     match err {
         rsapi::TursoError::Busy(message) => Busy::new_err(message),
+        rsapi::TursoError::BusySnapshot(message) => BusySnapshot::new_err(message),
         rsapi::TursoError::Interrupt(message) => Interrupt::new_err(message),
         rsapi::TursoError::Error(message) => Error::new_err(message),
         rsapi::TursoError::Misuse(message) => Misuse::new_err(message),

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -88,6 +88,8 @@ pub enum Error {
     #[error("{0}")]
     Busy(String),
     #[error("{0}")]
+    BusySnapshot(String),
+    #[error("{0}")]
     Interrupt(String),
     #[error("{0}")]
     Error(String),
@@ -111,6 +113,7 @@ impl From<turso_sdk_kit::rsapi::TursoError> for Error {
     fn from(value: turso_sdk_kit::rsapi::TursoError) -> Self {
         match value {
             turso_sdk_kit::rsapi::TursoError::Busy(err) => Error::Busy(err),
+            turso_sdk_kit::rsapi::TursoError::BusySnapshot(err) => Error::BusySnapshot(err),
             turso_sdk_kit::rsapi::TursoError::Interrupt(err) => Error::Interrupt(err),
             turso_sdk_kit::rsapi::TursoError::Error(err) => Error::Error(err),
             turso_sdk_kit::rsapi::TursoError::Misuse(err) => Error::Misuse(err),

--- a/perf/throughput/turso/src/main.rs
+++ b/perf/throughput/turso/src/main.rs
@@ -227,7 +227,7 @@ async fn worker_thread(
                         .await
                     {
                         Ok(_) => insert_count += 1,
-                        Err(turso::Error::Error(msg)) if msg.contains("snapshot is stale") => {
+                        Err(turso::Error::BusySnapshot(_)) => {
                             eprintln!("[Thread {thread_id}] Snapshot is stale during INSERT, rolling back transaction");
                             conn.execute("ROLLBACK", ())
                                 .await

--- a/sdk-kit/src/bindings.rs
+++ b/sdk-kit/src/bindings.rs
@@ -34,6 +34,7 @@ pub enum turso_status_code_t {
     TURSO_IO = 3,
     TURSO_BUSY = 4,
     TURSO_INTERRUPT = 5,
+    TURSO_BUSY_SNAPSHOT = 6,
     TURSO_ERROR = 127,
     TURSO_MISUSE = 128,
     TURSO_CONSTRAINT = 129,

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -297,6 +297,7 @@ pub enum TursoStatusCode {
 #[derive(Debug, Clone)]
 pub enum TursoError {
     Busy(String),
+    BusySnapshot(String),
     Interrupt(String),
     Error(String),
     Misuse(String),
@@ -334,6 +335,7 @@ impl TursoError {
     pub fn to_capi_code(&self) -> capi::c::turso_status_code_t {
         match self {
             TursoError::Busy(_) => capi::c::turso_status_code_t::TURSO_BUSY,
+            TursoError::BusySnapshot(_) => capi::c::turso_status_code_t::TURSO_BUSY_SNAPSHOT,
             TursoError::Interrupt(_) => capi::c::turso_status_code_t::TURSO_INTERRUPT,
             TursoError::Error(_) => capi::c::turso_status_code_t::TURSO_ERROR,
             TursoError::Misuse(_) => capi::c::turso_status_code_t::TURSO_MISUSE,
@@ -351,6 +353,7 @@ impl Display for TursoError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TursoError::Busy(s)
+            | TursoError::BusySnapshot(s)
             | TursoError::Interrupt(s)
             | TursoError::Error(s)
             | TursoError::Misuse(s)
@@ -384,6 +387,9 @@ impl From<LimboError> for TursoError {
             LimboError::DatabaseFull(e) => TursoError::DatabaseFull(e),
             LimboError::ReadOnly => TursoError::Readonly("database is readonly".to_string()),
             LimboError::Busy => TursoError::Busy("database is locked".to_string()),
+            LimboError::BusySnapshot => TursoError::BusySnapshot(
+                "database snapshot is stale, rollback and retry the transaction".to_string(),
+            ),
             LimboError::CompletionError(turso_core::CompletionError::IOError(kind)) => {
                 TursoError::IoError(kind)
             }

--- a/stress/main.rs
+++ b/stress/main.rs
@@ -776,8 +776,7 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         stop = true;
                         break;
                     }
-                    Err(turso::Error::Error(e)) if e.contains("snapshot is stale") => {
-                        // fixme: refactor BusySnapshot to a separate error instead of using string comparison bullshit
+                    Err(turso::Error::BusySnapshot(e)) => {
                         println!("Error (busy snapshot): {e}");
                         retry_counter += 1;
                     }
@@ -863,6 +862,9 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         }
                         turso::Error::Busy(e) => {
                             println!("thread#{thread} Error[WARNING] executing query: {e}");
+                        }
+                        turso::Error::BusySnapshot(e) => {
+                            println!("thread#{thread} Error[WARNING] busy snapshot: {e}");
                         }
                         turso::Error::Error(e) => {
                             if opts.verbose {


### PR DESCRIPTION
Busy snapshot is an error that the caller handles by retrying the transaction, for example. Let's add an explicit turso::Error enum variant for that to avoid having to do a string comparison on the error message of turso::Error::Error.