### PR TITLE
core: Use fast monotonic time when possible

### DIFF
--- a/bindings/javascript/src/browser.rs
+++ b/bindings/javascript/src/browser.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use turso_core::{Clock, Completion, File, Instant, IO};
+use turso_core::{Clock, Completion, File, MonotonicInstant, WallClockInstant, IO};
 
 pub struct NoopTask;
 
@@ -82,12 +82,12 @@ impl Opfs {
 }
 
 impl Clock for Opfs {
-    fn now(&self) -> Instant {
-        let now = chrono::Local::now();
-        Instant {
-            secs: now.timestamp(),
-            micros: now.timestamp_subsec_micros(),
-        }
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        MonotonicInstant::now()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        WallClockInstant::now()
     }
 }
 

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -1,4 +1,5 @@
-use crate::{io::clock::DefaultClock, Clock, Completion, File, Instant, OpenFlags, Result, IO};
+use crate::io::clock::{DefaultClock, MonotonicInstant, WallClockInstant};
+use crate::{Clock, Completion, File, OpenFlags, Result, IO};
 use crate::sync::RwLock;
 use std::io::{Read, Seek, Write};
 use crate::sync::Arc;
@@ -43,8 +44,12 @@ impl IO for GenericIO {
 }
 
 impl Clock for GenericIO {
-    fn now(&self) -> Instant {
-        DefaultClock.now()
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        DefaultClock.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        DefaultClock.current_time_wall_clock()
     }
 }
 

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::arc_with_non_send_sync)]
 
 use super::{common, Completion, CompletionInner, File, OpenFlags, IO};
-use crate::io::clock::{Clock, DefaultClock, Instant};
+use crate::io::clock::{Clock, DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::storage::wal::CKPT_BATCH_PAGES;
 use crate::{turso_assert, CompletionError, LimboError, Result};
 use crate::sync::Mutex;
@@ -625,8 +625,12 @@ impl IO for UringIO {
 }
 
 impl Clock for UringIO {
-    fn now(&self) -> Instant {
-        DefaultClock.now()
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        DefaultClock.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        DefaultClock.current_time_wall_clock()
     }
 }
 

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -1,9 +1,8 @@
 use super::{Buffer, Clock, Completion, File, OpenFlags, IO};
-use crate::turso_assert;
-use crate::{io::clock::DefaultClock, Result};
-
-use crate::io::clock::Instant;
+use crate::io::clock::{DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::sync::Mutex;
+use crate::turso_assert;
+use crate::Result;
 use std::{
     cell::{Cell, UnsafeCell},
     collections::{BTreeMap, HashMap},
@@ -36,8 +35,12 @@ impl Default for MemoryIO {
 }
 
 impl Clock for MemoryIO {
-    fn now(&self) -> Instant {
-        DefaultClock.now()
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        DefaultClock.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        DefaultClock.current_time_wall_clock()
     }
 }
 

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -1,6 +1,6 @@
 use super::{Completion, File, OpenFlags, IO};
 use crate::error::LimboError;
-use crate::io::clock::{Clock, DefaultClock, Instant};
+use crate::io::clock::{Clock, DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::io::common;
 use crate::Result;
 use crate::sync::Mutex;
@@ -26,8 +26,12 @@ impl UnixIO {
 }
 
 impl Clock for UnixIO {
-    fn now(&self) -> Instant {
-        DefaultClock.now()
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        DefaultClock.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        DefaultClock.current_time_wall_clock()
     }
 }
 

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -1,6 +1,6 @@
 use super::{Buffer, Completion, File, OpenFlags, IO};
 use crate::ext::VfsMod;
-use crate::io::clock::{Clock, DefaultClock, Instant};
+use crate::io::clock::{Clock, DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::io::CompletionInner;
 use crate::sync::Arc;
 use crate::{LimboError, Result};
@@ -9,8 +9,12 @@ use std::ptr::NonNull;
 use turso_ext::{BufferRef, IOCallback, SendPtr, VfsFileImpl, VfsImpl};
 
 impl Clock for VfsMod {
-    fn now(&self) -> Instant {
-        DefaultClock.now()
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        DefaultClock.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        DefaultClock.current_time_wall_clock()
     }
 }
 

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -1,6 +1,5 @@
-use crate::{
-    io::clock::DefaultClock, Clock, Completion, File, Instant, LimboError, OpenFlags, Result, IO,
-};
+use crate::io::clock::{DefaultClock, MonotonicInstant, WallClockInstant};
+use crate::{Clock, Completion, File, LimboError, OpenFlags, Result, IO};
 use crate::sync::RwLock;
 use std::io::{Read, Seek, Write};
 use crate::sync::Arc;
@@ -45,8 +44,12 @@ impl IO for WindowsIO {
 }
 
 impl Clock for WindowsIO {
-    fn now(&self) -> Instant {
-        DefaultClock.now()
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        DefaultClock.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        DefaultClock.current_time_wall_clock()
     }
 }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -74,7 +74,7 @@ use crate::{incremental::view::AllViewsTxState, translate::emitter::TransactionM
 use arc_swap::{ArcSwap, ArcSwapOption};
 use core::str;
 pub use error::{CompletionError, LimboError};
-pub use io::clock::{Clock, Instant};
+pub use io::clock::{Clock, MonotonicInstant, WallClockInstant};
 #[cfg(all(feature = "fs", target_family = "unix", not(miri)))]
 pub use io::UnixIO;
 #[cfg(all(feature = "fs", target_os = "linux", feature = "io_uring", not(miri)))]

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -119,7 +119,7 @@ impl Statement {
     fn _step(&mut self, waker: Option<&Waker>) -> Result<StepResult> {
         // If we're waiting for a busy handler timeout, check if we can proceed
         if let Some(busy_state) = self.busy_handler_state.as_ref() {
-            if self.pager.io.now() < busy_state.timeout() {
+            if self.pager.io.current_time_monotonic() < busy_state.timeout() {
                 // Yield the query as the timeout has not been reached yet
                 if let Some(waker) = waker {
                     waker.wake_by_ref();
@@ -169,7 +169,7 @@ impl Statement {
 
         // Handle busy result by invoking the busy handler
         if matches!(res, Ok(StepResult::Busy)) {
-            let now = self.pager.io.now();
+            let now = self.pager.io.current_time_monotonic();
             let handler = self.program.connection.get_busy_handler();
 
             // Initialize or get existing busy handler state

--- a/simulator/runner/file.rs
+++ b/simulator/runner/file.rs
@@ -47,7 +47,7 @@ pub(crate) struct SimulatorFile {
 type IoOperation = Box<dyn FnOnce(&SimulatorFile) -> Result<turso_core::Completion>>;
 
 pub struct DelayedIo {
-    pub time: turso_core::Instant,
+    pub time: turso_core::WallClockInstant,
     pub op: IoOperation,
 }
 
@@ -97,7 +97,7 @@ impl SimulatorFile {
     }
 
     #[instrument(skip_all, level = Level::TRACE)]
-    fn generate_latency_duration(&self) -> Option<turso_core::Instant> {
+    fn generate_latency_duration(&self) -> Option<turso_core::WallClockInstant> {
         let mut rng = self.rng.borrow_mut();
         // Chance to introduce some latency
         rng.random_bool(self.latency_probability as f64 / 100.0)
@@ -109,7 +109,7 @@ impl SimulatorFile {
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn run_queued_io(&self, now: turso_core::Instant) -> Result<()> {
+    pub fn run_queued_io(&self, now: turso_core::WallClockInstant) -> Result<()> {
         let mut queued_io = self.queued_io.borrow_mut();
         for io in queued_io.extract_if(.., |item| item.time <= now) {
             let _c = (io.op)(self)?;

--- a/simulator/runner/io.rs
+++ b/simulator/runner/io.rs
@@ -5,7 +5,7 @@ use std::{
 
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use turso_core::{Clock, IO, Instant, OpenFlags, PlatformIO, Result};
+use turso_core::{Clock, IO, MonotonicInstant, OpenFlags, PlatformIO, Result, WallClockInstant};
 
 use crate::runner::{SimIO, cli::IoBackend, clock::SimulatorClock, file::SimulatorFile};
 
@@ -99,7 +99,11 @@ impl SimIO for SimulatorIO {
 }
 
 impl Clock for SimulatorIO {
-    fn now(&self) -> Instant {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        MonotonicInstant::now()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
         self.clock.now().into()
     }
 }
@@ -139,7 +143,7 @@ impl IO for SimulatorIO {
     }
 
     fn step(&self) -> Result<()> {
-        let now = self.now();
+        let now = self.current_time_wall_clock();
         for file in self.files.borrow().iter() {
             file.run_queued_io(now)?;
         }

--- a/simulator/runner/memory/file.rs
+++ b/simulator/runner/memory/file.rs
@@ -119,7 +119,7 @@ impl MemorySimFile {
     }
 
     #[instrument(skip_all, level = Level::TRACE)]
-    fn generate_latency(&self) -> Option<turso_core::Instant> {
+    fn generate_latency(&self) -> Option<turso_core::WallClockInstant> {
         let mut rng = self.rng.borrow_mut();
         // Chance to introduce some latency
         rng.random_bool(self.latency_probability as f64 / 100.0)

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -256,7 +256,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     revert_since_wal_watermark: 0,
                     last_pushed_change_id_hint: 0,
                     last_pushed_pull_gen_hint: 0,
-                    last_pull_unix_time: Some(io.now().secs),
+                    last_pull_unix_time: Some(io.current_time_wall_clock().secs),
                     last_push_unix_time: None,
                     partial_bootstrap_server_revision: if partial {
                         Some(revision.clone())
@@ -712,7 +712,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
         let file = acquire_slot(&self.changes_file)?;
 
-        let now = self.io.now();
+        let now = self.io.current_time_wall_clock();
         let revision = self.meta().synced_revision.clone();
         let ctx = &SyncOperationCtx::new(coro, &self.sync_engine_io, self.meta().remote_url());
         let next_revision = wal_pull_to_file(
@@ -1011,7 +1011,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
         self.update_meta(coro, |m| {
             m.last_pushed_change_id_hint = change_id;
-            m.last_push_unix_time = Some(self.io.now().secs);
+            m.last_push_unix_time = Some(self.io.current_time_wall_clock().secs);
         })
         .await?;
 

--- a/sync/engine/src/sparse_io.rs
+++ b/sync/engine/src/sparse_io.rs
@@ -5,7 +5,8 @@ use std::{
 
 use tracing::{instrument, Level};
 use turso_core::{
-    io::clock::DefaultClock, Buffer, Clock, Completion, File, Instant, OpenFlags, Result, IO,
+    io::clock::DefaultClock, Buffer, Clock, Completion, File, MonotonicInstant, OpenFlags, Result,
+    WallClockInstant, IO,
 };
 
 pub struct SparseLinuxIo {}
@@ -45,8 +46,12 @@ impl IO for SparseLinuxIo {
 }
 
 impl Clock for SparseLinuxIo {
-    fn now(&self) -> Instant {
-        DefaultClock.now()
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        DefaultClock.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        DefaultClock.current_time_wall_clock()
     }
 }
 

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -73,7 +73,7 @@ pub struct DbSyncStatus {
 }
 
 pub struct DbChangesStatus {
-    pub time: turso_core::Instant,
+    pub time: turso_core::WallClockInstant,
     pub revision: DatabasePullRevision,
     pub file_slot: Option<MutexSlot<Arc<dyn turso_core::File>>>,
 }

--- a/whopper/io.rs
+++ b/whopper/io.rs
@@ -6,7 +6,9 @@ use std::fs::{File as StdFile, OpenOptions};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use tracing::debug;
-use turso_core::{Clock, Completion, File, IO, Instant, OpenFlags, Result};
+use turso_core::{
+    Clock, Completion, File, IO, MonotonicInstant, OpenFlags, Result, WallClockInstant,
+};
 
 #[derive(Debug, Clone)]
 pub struct IOFaultConfig {
@@ -71,9 +73,13 @@ impl Drop for SimulatorIO {
 }
 
 impl Clock for SimulatorIO {
-    fn now(&self) -> Instant {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        MonotonicInstant::now()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
         let micros = self.time.load(Ordering::Relaxed);
-        Instant {
+        WallClockInstant {
             secs: (micros / 1_000_000) as i64,
             micros: (micros % 1_000_000) as u32,
         }


### PR DESCRIPTION
Replace expensive chrono::Local::now() calls with std::time::Instant where we can. In particular, the timeout checking in Statement::step() shows up high in CPU profiles. The Clock trait now has two methods: current_time_monotonic() for cheap timeout checks, and current_time_wall_clock() for timestamps that need to be deterministic in simulation.