### PR TITLE
Disallow WITHOUT ROWID tables

### DIFF
--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -29,6 +29,9 @@ fn validate(body: &ast::CreateTableBody, connection: &Connection) -> Result<()> 
         options, columns, ..
     } = &body
     {
+        if options.contains(ast::TableOptions::WITHOUT_ROWID) {
+            bail_parse_error!("WITHOUT ROWID tables are not supported");
+        }
         if options.contains(ast::TableOptions::STRICT) && !connection.experimental_strict_enabled()
         {
             bail_parse_error!(

--- a/tests/integration/query_processing/test_ddl.rs
+++ b/tests/integration/query_processing/test_ddl.rs
@@ -122,3 +122,42 @@ fn test_allow_drop_unreferenced_columns(tmp_db: TempDatabase) -> anyhow::Result<
 
     Ok(())
 }
+
+/// WITHOUT ROWID tables are not supported
+#[turso_macros::test]
+fn test_create_table_without_rowid_not_supported(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let conn = tmp_db.connect_limbo();
+
+    let res = conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT) WITHOUT ROWID");
+    assert!(
+        res.is_err(),
+        "Expected error when creating WITHOUT ROWID table"
+    );
+    assert!(
+        res.unwrap_err()
+            .to_string()
+            .contains("WITHOUT ROWID tables are not supported"),
+        "Expected error message about WITHOUT ROWID not being supported"
+    );
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_create_table_without_rowid_composite_pk(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let conn = tmp_db.connect_limbo();
+
+    let res = conn.execute("CREATE TABLE t(a TEXT, b INT, PRIMARY KEY(a, b)) WITHOUT ROWID");
+    assert!(
+        res.is_err(),
+        "Expected error when creating WITHOUT ROWID table with composite primary key"
+    );
+    assert!(
+        res.unwrap_err()
+            .to_string()
+            .contains("WITHOUT ROWID tables are not supported"),
+        "Expected error message about WITHOUT ROWID not being supported"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Absolutely blows my mind that this wasn't checked. I have been hallucinating for months that we had this explicitly disallowed everywhere already.

At least one `sqlancer` corruption case was due to this.

## Details

Used these scripts

```bash
./scripts/run-sqlancer.sh 2>&1 | strings | tee /tmp/output.log
```

```bash
for FILE in /tmp/sqlancer-limbo/databases/*.db; do
  result=$(sqlite3 -readonly "$FILE" 'pragma integrity_check')
  if [ "$result" != "ok" ]; then
    echo "database: $FILE ($(date -r "$FILE"))"
    echo "$result"
  fi
done
``` 

And then asked Claude to use `scripts/corruption-debug-tools` to find the first corrupt frame and look at what's in it