### PR TITLE
core/vdbe: trim return text with integer and float

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -653,6 +653,13 @@ impl Value {
             (Value::Text(t), None) => {
                 Value::build_text(trim_type.trim(t.as_str(), &[' ']).to_string())
             }
+            // For Integer/Float without pattern, convert to text and trim spaces.
+            // TRIM() always returns TEXT in SQLite.
+            (Value::Integer(_) | Value::Float(_), None) => {
+                let text = self.to_string();
+                Value::build_text(trim_type.trim(&text, &[' ']).to_string())
+            }
+            // NULL and Blob return unchanged
             (reg, _) => reg.to_owned(),
         }
     }
@@ -1624,6 +1631,16 @@ mod tests {
         let input_str = Value::build_text("\na");
         let expected_str = Value::build_text("\na");
         assert_eq!(input_str.exec_trim(None), expected_str);
+
+        // TRIM on Integer should return TEXT (SQLite compatibility)
+        let input_int = Value::Integer(12345);
+        let expected_text = Value::build_text("12345");
+        assert_eq!(input_int.exec_trim(None), expected_text);
+
+        // TRIM on Float should return TEXT (SQLite compatibility)
+        let input_float = Value::Float(123.5);
+        let expected_text = Value::build_text("123.5");
+        assert_eq!(input_float.exec_trim(None), expected_text);
     }
 
     #[test]

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -419,6 +419,28 @@ do_execsql_test rtrim-no-match-pattern {
   SELECT rtrim('Limbo', 'xyz');
 } {Limbo}
 
+# TRIM always returns TEXT, even for numeric inputs.
+# This is important for expression indexes that use TRIM on numeric columns.
+do_execsql_test trim-integer-returns-text {
+  SELECT typeof(trim(42));
+} {text}
+
+do_execsql_test trim-float-returns-text {
+  SELECT typeof(trim(3.14));
+} {text}
+
+do_execsql_test ltrim-integer-returns-text {
+  SELECT typeof(ltrim(42));
+} {text}
+
+do_execsql_test rtrim-integer-returns-text {
+  SELECT typeof(rtrim(42));
+} {text}
+
+do_execsql_test trim-integer-with-pattern-returns-text {
+  SELECT typeof(trim(123, '1'));
+} {text}
+
 do_execsql_test round-float-no-precision {
   SELECT round(123.456);
 } {123.0}
@@ -1121,4 +1143,3 @@ do_execsql_test replace-test-zeroblob-quote {
 # do_execsql_test soundex-text {
 #  select soundex('Pfister'), soundex('husobee'), soundex('Tymczak'), soundex('Ashcraft'), soundex('Robert'), soundex('Rupert'), soundex('Rubin'), soundex('Kant'), soundex('Knuth'), soundex('x'), soundex('');
 # } {P236|H210|T522|A261|R163|R163|R150|K530|K530|X000|0000}
-


### PR DESCRIPTION
## Description

Trim without without a pattern on Integer and Float types should return text types like in SQLite (unlike null and blobs). This PR modifies the behaviour to match it.


## Description of AI Usage

Asked claude to run sqlancer until it failed and find out why. He found out a bug with TRIM with index expressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns string trim functions with SQLite’s return types for numeric inputs.
> 
> - Update `Value::_exec_trim` to convert `INTEGER`/`FLOAT` to text when no pattern is provided so `trim`/`ltrim`/`rtrim` return `TEXT`
> - Add Rust tests in `value.rs` for TRIM on integers/floats
> - Add SQL tests in `testing/scalar-functions.test` verifying `typeof(trim|ltrim|rtrim(...))` is `text`, including numeric with pattern
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a62e58cbccd75b91260158fd417be2a9408ad724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->