### PR TITLE
core/vdbe: Allow leading + sign in numeric string parsing

### DIFF
--- a/core/util.rs
+++ b/core/util.rs
@@ -999,7 +999,7 @@ fn parse_numeric_str(text: &str) -> Result<(ValueType, &str), ()> {
     let mut end = 0;
     let mut has_decimal = false;
     let mut has_exponent = false;
-    if bytes[0] == b'-' {
+    if bytes[0] == b'-' || bytes[0] == b'+' {
         end = 1;
     }
     while end < bytes.len() {
@@ -1020,7 +1020,7 @@ fn parse_numeric_str(text: &str) -> Result<(ValueType, &str), ()> {
             _ => break,
         }
     }
-    if end == 0 || (end == 1 && bytes[0] == b'-') {
+    if end == 0 || (end == 1 && (bytes[0] == b'-' || bytes[0] == b'+')) {
         return Err(());
     }
     // edge case: if it ends with exponent, strip and cast valid digits as float
@@ -2374,6 +2374,7 @@ pub mod tests {
     fn test_parse_numeric_str_valid_integer() {
         assert_eq!(parse_numeric_str("123"), Ok((ValueType::Integer, "123")));
         assert_eq!(parse_numeric_str("-456"), Ok((ValueType::Integer, "-456")));
+        assert_eq!(parse_numeric_str("+789"), Ok((ValueType::Integer, "+789")));
         assert_eq!(
             parse_numeric_str("000789"),
             Ok((ValueType::Integer, "000789"))
@@ -2390,7 +2391,12 @@ pub mod tests {
             parse_numeric_str("-0.789"),
             Ok((ValueType::Float, "-0.789"))
         );
+        assert_eq!(
+            parse_numeric_str("+0.789"),
+            Ok((ValueType::Float, "+0.789"))
+        );
         assert_eq!(parse_numeric_str("1e10"), Ok((ValueType::Float, "1e10")));
+        assert_eq!(parse_numeric_str("+1e10"), Ok((ValueType::Float, "+1e10")));
         assert_eq!(
             parse_numeric_str("-1.23e-4"),
             Ok((ValueType::Float, "-1.23e-4"))
@@ -2416,6 +2422,7 @@ pub mod tests {
         assert_eq!(parse_numeric_str(""), Err(()));
         assert_eq!(parse_numeric_str("abc"), Err(()));
         assert_eq!(parse_numeric_str("-"), Err(()));
+        assert_eq!(parse_numeric_str("+"), Err(()));
         assert_eq!(parse_numeric_str("e10"), Err(()));
         assert_eq!(parse_numeric_str(".e10"), Err(()));
     }

--- a/testing/affinity.test
+++ b/testing/affinity.test
@@ -250,3 +250,26 @@ do_execsql_test_on_specific_db {:memory:} affinity-ascii-whitespace-1.1 {
   INSERT INTO nb1 VALUES ('12' || CHAR(160));
   SELECT TYPEOF(i), LENGTH(i) FROM nb1;
 } {text|3}
+
+# ============================================
+# REAL affinity with leading + sign
+# Strings with leading + should be converted to REAL
+# ============================================
+do_execsql_test_on_specific_db {:memory:} affinity-real-leading-plus-sign {
+  CREATE TABLE t0 (c0 REAL);
+  INSERT INTO t0 VALUES ('+3'), ('+3.14'), ('+1e5');
+  SELECT typeof(c0), c0 FROM t0 ORDER BY rowid;
+} {real|3.0
+real|3.14
+real|100000.0}
+
+do_execsql_test_on_specific_db {:memory:} affinity-real-mixed-signs {
+  CREATE TABLE t0 (c0 REAL);
+  INSERT INTO t0 VALUES ('+3'), ('-5'), ('+3.14'), ('-3.14'), ('+1e5'), ('-1e5');
+  SELECT typeof(c0), c0 FROM t0 ORDER BY rowid;
+} {real|3.0
+real|-5.0
+real|3.14
+real|-3.14
+real|100000.0
+real|-100000.0}


### PR DESCRIPTION
## Description

float and int affinities were not treated correctly with numbers with preceeding + sign like `+2`. This PR fixes that.


## Description of AI Usage

Claude the GOAT found it and fixed it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables parsing of numeric text with a leading `+` and validates affinity behavior.
> 
> - Update `parse_numeric_str` to accept leading `+`, including exponent edge cases, and adjust error checks
> - Expand unit tests to cover `+`-prefixed integers/floats and invalid solitary `+`
> - Add `affinity.test` cases ensuring REAL columns convert `'+3'`, `'+3.14'`, and `'+1e5'` (and mixed signs) to numeric values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 219b48d7d1bfcc8ae6e0c348309bde517bef5173. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->