### PR TITLE
fix: allow float literals in ORDER BY clause

### DIFF
--- a/testing/orderby.test
+++ b/testing/orderby.test
@@ -277,3 +277,18 @@ FROM
 ORDER BY
 value;
  }
+
+# https://github.com/tursodatabase/turso/issues/4608
+# Float literals in ORDER BY should be treated as constant expressions, not column references.
+# They should not cause parse errors.
+do_execsql_test_on_specific_db {:memory:} orderby_float_literal {
+    SELECT 1 ORDER BY 0.5;
+} {1}
+
+do_execsql_test_on_specific_db {:memory:} orderby_float_literal_with_table {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (3), (1), (2);
+    SELECT x FROM t ORDER BY 0.5;
+} {3
+1
+2}


### PR DESCRIPTION
Float literals like `0.5` or `1.0` in ORDER BY clauses were causing parse errors because the code assumed all numeric literals were column references and tried to parse them as usize.

Per SQLite documentation, only constant integers should be treated as column references. Non-integer numeric literals (floats) should be treated as constant expressions, which is valid SQL.

Fixes #4608

Generated with [Claude Code](https://claude.ai/code)