### PR TITLE
Replace GPL-2.0 bloom crate with MIT-licensed fastbloom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,12 +425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,15 +477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bloom"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
-dependencies = [
- "bit-vec",
 ]
 
 [[package]]
@@ -1641,6 +1626,18 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.2",
+ "libm",
+ "rand 0.9.2",
+ "siphasher",
+]
 
 [[package]]
 name = "fastrand"
@@ -4681,6 +4678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5531,7 +5534,6 @@ dependencies = [
  "antithesis_sdk",
  "arc-swap",
  "bitflags 2.9.4",
- "bloom",
  "branches",
  "built",
  "bumpalo",
@@ -5544,6 +5546,7 @@ dependencies = [
  "either",
  "env_logger 0.11.7",
  "fallible-iterator",
+ "fastbloom",
  "hex",
  "intrusive-collections",
  "io-uring",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -87,7 +87,6 @@ intrusive-collections = "0.9.7"
 roaring = "0.11.2"
 simsimd = "6.5.3"
 arc-swap = "1.7"
-bloom = "0.3.2"
 rustc-hash = "2.0"
 either = { workspace = true }
 tracing-subscriber.workspace = true
@@ -95,6 +94,7 @@ rapidhash = "4.1.1"
 branches = { version = "0.4.3", default-features = false }
 bumpalo = { version = "3", features = ["collections"] }
 smallvec = "1.15.1"
+fastbloom = "0.14.1"
 
 [target.'cfg(loom)'.dependencies]
 loom = { workspace = true }

--- a/core/vdbe/bloom_filter.rs
+++ b/core/vdbe/bloom_filter.rs
@@ -1,4 +1,4 @@
-use bloom::{BloomFilter as BloomFilterInner, ASMS};
+use fastbloom::BloomFilter as BloomFilterInner;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
@@ -38,7 +38,8 @@ impl BloomFilter {
     /// Creates a new bloom filter with the specified expected item count and false positive rate.
     pub fn with_capacity(expected_items: u32, false_positive_rate: f32) -> Self {
         Self {
-            inner: BloomFilterInner::with_rate(false_positive_rate, expected_items),
+            inner: BloomFilterInner::with_false_pos(false_positive_rate as f64)
+                .expected_items(expected_items as usize),
             count: 0,
         }
     }


### PR DESCRIPTION
The `bloom` crate (v0.3.2) is licensed under GPL-2.0, which is incompatible with the MIT license used by this project. This commit replaces it with `fastbloom` (v0.14.1), which is MIT-licensed.

Fixes #4612

Generated with [Claude Code](https://claude.ai/claude-code)