### PR TITLE
Reset ProgramState::once on statement reset

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -528,6 +528,7 @@ impl ProgramState {
         self.last_compare = None;
         self.deferred_seeks.iter_mut().for_each(|s| *s = None);
         self.ended_coroutine.clear();
+        self.once.clear();
         self.regex_cache.like.clear();
         self.execution_state = ProgramExecutionState::Init;
         self.current_collation = None;


### PR DESCRIPTION
## Description

`ProgramState::once` wasn't reset when a statement was reset, so expressions weren't being evaluated when the statement was used after being reset.

## Motivation and context

Claude suspects that this might be related to https://github.com/tursodatabase/turso/issues/4602. Regardless, it's a bug.

## Description of AI Usage

Found and fixed by Claude Code while investigating https://github.com/tursodatabase/turso/issues/4602
