### PR TITLE
Give Antithesis tests better names

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -32,3 +32,5 @@ jobs:
 
     - name: Launch experiment
       run: bash ./scripts/antithesis/launch.sh
+      env:
+        ANTITHESIS_TRIGGER: ${{ github.event_name }}

--- a/scripts/antithesis/launch.sh
+++ b/scripts/antithesis/launch.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
 
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+COMMIT=$(git rev-parse --short HEAD)
+
+if [ "$ANTITHESIS_TRIGGER" = "workflow_dispatch" ]; then
+  TEST_TYPE="manual test"
+else
+  TEST_TYPE="scheduled test"
+fi
+
 curl --fail -u "$ANTITHESIS_USER:$ANTITHESIS_PASSWD" \
   -X POST https://$ANTITHESIS_TENANT.antithesis.com/api/v1/launch/limbo \
-  -d "{\"params\": { \"antithesis.description\":\"basic_test on main\",
+  -d "{\"params\": { \"antithesis.description\":\"$TEST_TYPE on $BRANCH @ $COMMIT\",
       \"custom.duration\":\"4\",
       \"antithesis.config_image\":\"$ANTITHESIS_DOCKER_REPO/limbo-config:antithesis-latest\",
       \"antithesis.images\":\"$ANTITHESIS_DOCKER_REPO/limbo-workload:antithesis-latest\",


### PR DESCRIPTION
## Description

Currently, all our Antithesis tests are just called `basic_test on main`. It doesn't say which commit they were on, which branch, or how they were launched. This PR fixes this. The screenshot below shows a regular test, and one that I lauched from a branch yesterday.

<img width="677" height="202" alt="image" src="https://github.com/user-attachments/assets/e07d6cc0-2321-407a-8e92-cad79f974cce" />

Since, I've also changed it so that it'll say either "scheduled test" or "manual test"

## Description of AI Usage

Clauded