### PR TITLE
core/mvcc: Add support for synchronous off mode

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -816,6 +816,7 @@ impl Connection {
                 mv_store.clone(),
                 self.clone(),
                 true,
+                self.get_sync_mode(),
             ));
             io.as_ref().block(|| ckpt_sm.step(&()))
         } else {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -30,7 +30,7 @@ use crate::IOExt;
 use crate::LimboError;
 use crate::Result;
 use crate::ValueRef;
-use crate::{Connection, Pager};
+use crate::{Connection, Pager, SyncMode};
 use crossbeam_skiplist::map::Entry;
 use crossbeam_skiplist::{SkipMap, SkipSet};
 use std::collections::HashMap;
@@ -506,6 +506,8 @@ pub struct CommitStateMachine<Clock: LogicalClock> {
     commit_coordinator: Arc<CommitCoordinator>,
     header: Arc<RwLock<Option<DatabaseHeader>>>,
     pager: Arc<Pager>,
+    /// The synchronous mode for fsync operations. When set to Off, fsync is skipped.
+    sync_mode: SyncMode,
     _phantom: PhantomData<Clock>,
 }
 
@@ -548,6 +550,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         connection: Arc<Connection>,
         commit_coordinator: Arc<CommitCoordinator>,
         header: Arc<RwLock<Option<DatabaseHeader>>>,
+        sync_mode: SyncMode,
     ) -> Self {
         let pager = connection.pager.load().clone();
         Self {
@@ -560,6 +563,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             commit_coordinator,
             pager,
             header,
+            sync_mode,
             _phantom: PhantomData,
         }
     }
@@ -821,6 +825,12 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
             }
 
             CommitState::SyncLogicalLog { end_ts } => {
+                // Skip fsync when synchronous mode is off
+                if self.sync_mode == SyncMode::Off {
+                    tracing::debug!("Skipping fsync of logical log (synchronous=off)");
+                    self.state = CommitState::EndCommitLogicalLog { end_ts: *end_ts };
+                    return Ok(TransitionResult::Continue);
+                }
                 let c = mvcc_store.storage.sync()?;
                 self.state = CommitState::EndCommitLogicalLog { end_ts: *end_ts };
                 // if Completion Completed without errors we can continue
@@ -890,6 +900,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         mvcc_store.clone(),
                         self.connection.clone(),
                         false,
+                        self.connection.get_sync_mode(),
                     ));
                     let state_machine = Mutex::new(state_machine);
                     self.state = CommitState::Checkpoint { state_machine };
@@ -2194,6 +2205,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 connection.clone(),
                 self.commit_coordinator.clone(),
                 self.global_header.clone(),
+                connection.get_sync_mode(),
             ));
         Ok(state_machine)
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -363,6 +363,7 @@ pub fn op_checkpoint(
             mv_store.clone(),
             program.connection.clone(),
             true,
+            program.connection.get_sync_mode(),
         ));
         let CheckpointResult {
             num_attempted,
@@ -10756,6 +10757,7 @@ fn op_journal_mode_inner(
                                 mv_store.clone(),
                                 program.connection.clone(),
                                 true,
+                                program.connection.get_sync_mode(),
                             )));
                     }
 


### PR DESCRIPTION
The `PRAGMA synchronous = 'off'` mode is important for some workloads, such as AgentFS that have a durability model that's different from default Turso one. Add support for that in the MVCC mode too.