### PR TITLE
bindings/rust: Replace step() busy-poll with sleep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,6 +6187,7 @@ version = "0.6.0-pre.1"
 dependencies = [
  "anyhow",
  "bytes",
+ "futures-timer",
  "http-body-util",
  "hyper",
  "hyper-tls",
@@ -6196,6 +6197,7 @@ dependencies = [
  "rand_chacha 0.9.0",
  "reqwest",
  "serde_json",
+ "shuttle",
  "tempfile",
  "thiserror 2.0.16",
  "tokio",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = { workspace = true }
 tracing-subscriber.workspace = true
 tracing.workspace = true
 mimalloc = { workspace = true, optional = true }
+futures-timer = "3"
 
 hyper = { version = "1.8.1", features = ["http1"], optional = true }
 tokio = { workspace = true, features = ["full"], optional = true }
@@ -41,6 +42,9 @@ hyper-util = { version = "0.1.19", features = [
 ], optional = true }
 http-body-util = { version = "0.1.3", optional = true }
 bytes = { version = "1.11.0", optional = true }
+
+[target.'cfg(shuttle)'.dependencies]
+shuttle = { workspace = true }
 
 [[example]]
 name = "sync_example"

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -53,10 +53,12 @@ pub use params::params_from_iter;
 pub use params::IntoParams;
 
 use std::fmt::Debug;
-use std::future::Future;
+use std::future::poll_fn;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::Poll;
+use std::time::Duration;
+
 
 // Re-exports rows
 pub use crate::rows::{Row, Rows};
@@ -283,78 +285,88 @@ pub struct Statement {
     inner: Arc<Mutex<Box<turso_sdk_kit::rsapi::TursoStatement>>>,
 }
 
-struct Execute {
-    stmt: Statement,
-}
-
-assert_send_sync!(Execute);
-
-impl Future for Execute {
-    type Output = Result<u64>;
-
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        match self.stmt.step(None, cx)? {
-            Poll::Ready(_) => {
-                let n_change = self.stmt.inner.lock().unwrap().n_change();
-                Poll::Ready(Ok(n_change as u64))
-            }
-            Poll::Pending => Poll::Pending,
-        }
-    }
+/// Result of a single step operation, used internally to handle async IO.
+enum StepResult {
+    Row(Row),
+    Done,
+    BusyWait(Duration),
 }
 
 impl Statement {
-    fn step(
-        &self,
-        columns: Option<usize>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Result<Option<Row>>> {
-        let mut stmt = self.inner.lock().unwrap();
-        match stmt.step(Some(cx.waker()))? {
-            turso_sdk_kit::rsapi::TursoStatusCode::Row => {
-                if let Some(columns) = columns {
-                    let mut values = Vec::with_capacity(columns);
-                    for i in 0..columns {
-                        let value = stmt.row_value(i)?;
-                        values.push(value.to_owned());
+    async fn step(&self, columns: Option<usize>) -> Result<Option<Row>> {
+        loop {
+            let result = poll_fn(|cx| {
+                let mut stmt = self.inner.lock().unwrap();
+                let status = stmt.step(Some(cx.waker()))?;
+                match status {
+                    turso_sdk_kit::rsapi::TursoStatusCode::Row => {
+                        if let Some(columns) = columns {
+                            let mut values = Vec::with_capacity(columns);
+                            for i in 0..columns {
+                                let value = stmt.row_value(i)?;
+                                values.push(value.to_owned());
+                            }
+                            Poll::Ready(Ok(StepResult::Row(Row { values })))
+                        } else {
+                            Poll::Ready(Err(Error::Misuse(
+                                "unexpected row during execution".to_string(),
+                            )))
+                        }
                     }
-                    Poll::Ready(Ok(Some(Row { values })))
-                } else {
-                    Poll::Ready(Err(Error::Misuse(
-                        "unexpected row during execution".to_string(),
-                    )))
+                    turso_sdk_kit::rsapi::TursoStatusCode::Done => {
+                        Poll::Ready(Ok(StepResult::Done))
+                    }
+                    turso_sdk_kit::rsapi::TursoStatusCode::Io => {
+                        if let Some(delay) = stmt.get_busy_delay() {
+                            return Poll::Ready(Ok(StepResult::BusyWait(delay)));
+                        }
+                        stmt.run_io()?;
+                        if let Some(extra_io) = &self.conn.extra_io {
+                            drop(stmt);
+                            extra_io(cx.waker().clone())?;
+                        }
+                        // Yield to the runtime for cooperative scheduling.
+                        // The waker was already called by IOCompletion::set_waker()
+                        // inside program.step(), so we will be re-polled.
+                        Poll::Pending
+                    }
                 }
-            }
-            turso_sdk_kit::rsapi::TursoStatusCode::Done => Poll::Ready(Ok(None)),
-            turso_sdk_kit::rsapi::TursoStatusCode::Io => {
-                stmt.run_io()?;
-                if let Some(extra_io) = &self.conn.extra_io {
-                    extra_io(cx.waker().clone())?;
+            })
+            .await?;
+
+            match result {
+                StepResult::Row(row) => return Ok(Some(row)),
+                StepResult::Done => return Ok(None),
+                StepResult::BusyWait(delay) => {
+                    #[cfg(shuttle)]
+                    {
+                        let _ = delay;
+                        shuttle::future::yield_now().await;
+                    }
+                    #[cfg(not(shuttle))]
+                    futures_timer::Delay::new(delay).await;
                 }
-                Poll::Pending
             }
         }
     }
     /// Query the database with this prepared statement.
     pub async fn query(&mut self, params: impl IntoParams) -> Result<Rows> {
         self.reset()?;
-
-        let mut stmt = self.inner.lock().unwrap();
-        let params = params.into_params()?;
-        match params {
-            params::Params::None => (),
-            params::Params::Positional(values) => {
-                for (i, value) in values.into_iter().enumerate() {
-                    stmt.bind_positional(i + 1, value.into())?;
+        {
+            let mut stmt = self.inner.lock().unwrap();
+            let params = params.into_params()?;
+            match params {
+                params::Params::None => (),
+                params::Params::Positional(values) => {
+                    for (i, value) in values.into_iter().enumerate() {
+                        stmt.bind_positional(i + 1, value.into())?;
+                    }
                 }
-            }
-            params::Params::Named(values) => {
-                for (name, value) in values.into_iter() {
-                    let position = stmt.named_position(name)?;
-                    stmt.bind_positional(position, value.into())?;
+                params::Params::Named(values) => {
+                    for (name, value) in values.into_iter() {
+                        let position = stmt.named_position(name)?;
+                        stmt.bind_positional(position, value.into())?;
+                    }
                 }
             }
         }
@@ -386,8 +398,9 @@ impl Statement {
             }
         }
 
-        let execute = Execute { stmt: self.clone() };
-        execute.await
+        self.step(None).await?;
+        let n_change = self.inner.lock().unwrap().n_change();
+        Ok(n_change as u64)
     }
 
     /// Returns the number of columns in the result set.

--- a/bindings/rust/src/rows.rs
+++ b/bindings/rust/src/rows.rs
@@ -1,15 +1,16 @@
-use crate::{assert_send_sync, Column, Error, Result, Statement, Value};
+use crate::{Column, Error, Result, Statement, Value};
 use std::fmt::Debug;
-use std::future::Future;
 
 /// Results of a prepared statement query.
 pub struct Rows {
     inner: Statement,
+    columns: usize,
 }
 
 impl Rows {
     pub(crate) fn new(inner: Statement) -> Self {
-        Self { inner }
+        let columns = inner.inner.lock().unwrap().column_count();
+        Self { inner, columns }
     }
 
     /// Returns the number of columns in the result set.
@@ -39,30 +40,7 @@ impl Rows {
 
     /// Fetch the next row of this result set.
     pub async fn next(&mut self) -> Result<Option<Row>> {
-        struct Next {
-            columns: usize,
-            stmt: Statement,
-        }
-
-        impl Future for Next {
-            type Output = Result<Option<Row>>;
-
-            fn poll(
-                self: std::pin::Pin<&mut Self>,
-                cx: &mut std::task::Context<'_>,
-            ) -> std::task::Poll<Self::Output> {
-                self.stmt.step(Some(self.columns), cx)
-            }
-        }
-
-        assert_send_sync!(Next);
-
-        let next = Next {
-            columns: self.inner.inner.lock().unwrap().column_count(),
-            stmt: self.inner.clone(),
-        };
-
-        next.await
+        self.inner.step(Some(self.columns)).await
     }
 }
 

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -5,6 +5,7 @@ use std::{
     ops::Deref,
     sync::{atomic::Ordering, Arc},
     task::Waker,
+    time::Duration,
 };
 
 use tracing::{instrument, Level};
@@ -157,9 +158,6 @@ impl Statement {
         if let Some(busy_state) = self.busy_handler_state.as_ref() {
             if self.pager.io.current_time_monotonic() < busy_state.timeout() {
                 // Yield the query as the timeout has not been reached yet
-                if let Some(waker) = waker {
-                    waker.wake_by_ref();
-                }
                 return Ok(StepResult::IO);
             }
         }
@@ -212,9 +210,6 @@ impl Statement {
             // Invoke the busy handler to determine if we should retry
             if busy_state.invoke(&handler, now) {
                 // Handler says retry, yield with IO to wait for timeout
-                if let Some(waker) = waker {
-                    waker.wake_by_ref();
-                }
                 res = Ok(StepResult::IO);
                 #[cfg(shuttle)]
                 crate::thread::spin_loop();
@@ -243,6 +238,21 @@ impl Statement {
     #[inline]
     pub fn step_with_waker(&mut self, waker: &Waker) -> Result<StepResult> {
         self._step(Some(waker))
+    }
+
+    /// Returns the remaining delay before the busy handler timeout expires.
+    ///
+    /// This is used by async callers to schedule a proper sleep instead of
+    /// busy-spinning. Returns `None` if there is no pending busy timeout.
+    pub fn get_busy_delay(&self) -> Option<Duration> {
+        let busy_state = self.busy_handler_state.as_ref()?;
+        let now = self.pager.io.current_time_monotonic();
+        let delay = busy_state.get_delay(now);
+        if delay.is_zero() {
+            None
+        } else {
+            Some(delay)
+        }
     }
 
     pub fn run_ignore_rows(&mut self) -> Result<()> {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1060,6 +1060,15 @@ impl TursoStatement {
         self.statement._io().step()?;
         Ok(())
     }
+
+    /// Returns the remaining delay before the busy handler timeout expires.
+    ///
+    /// This is used by async callers to schedule a proper sleep instead of
+    /// busy-spinning. Returns `None` if there is no pending busy timeout.
+    pub fn get_busy_delay(&self) -> Option<Duration> {
+        self.statement.get_busy_delay()
+    }
+
     /// get row value reference currently pointed by the statement
     /// note, that this row will no longer be valid after execution of methods like [Self::step]/[Self::execute]/[Self::finalize]/[Self::reset]
     #[inline]


### PR DESCRIPTION
Currently, step() just busy-loops if the database is locked because of a write transaction, which consumes a lot of CPU for no gain. Let's switch to sleeping like SQLite does. The way it works is that the core returns I/O step result, but then at the Rust binding level, we check if there's some busy sleeping needed, and use the proper async sleeping interfaces to make sure we play well with the async runtime.