### PR TITLE
fix(parser): BETWEEN and LIKE operator precedence with IS NOT NULL

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1717,7 +1717,9 @@ impl<'a> Parser<'a> {
                     eat_assert!(self, TK_BETWEEN);
                     let start = self.parse_expr(pre)?;
                     eat_expect!(self, TK_AND);
-                    let end = self.parse_expr(pre)?;
+                    // Use pre + 1 so that same-precedence operators (like IS NOT NULL)
+                    // bind to the whole BETWEEN expression, not just the end value
+                    let end = self.parse_expr(pre + 1)?;
                     Box::new(Expr::Between {
                         lhs: result,
                         not,
@@ -1798,11 +1800,13 @@ impl<'a> Parser<'a> {
                         _ => unreachable!(),
                     };
 
-                    let expr = self.parse_expr(pre)?;
+                    // Use pre + 1 so that same-precedence operators (like IS NOT NULL)
+                    // bind to the whole LIKE expression, not just the pattern
+                    let expr = self.parse_expr(pre + 1)?;
                     let escape = if let Some(tok) = self.peek()? {
                         if tok.token_type == TK_ESCAPE {
                             eat_assert!(self, TK_ESCAPE);
-                            Some(self.parse_expr(pre)?)
+                            Some(self.parse_expr(pre + 1)?)
                         } else {
                             None
                         }

--- a/testing/select.test
+++ b/testing/select.test
@@ -1680,3 +1680,19 @@ do_execsql_test_on_specific_db {:memory:} select-sqlite-schema-empty-db {
 do_execsql_test_error select-param-zero-invalid {
   SELECT ?0
 } {.*variable number must be between.*}
+
+# Test BETWEEN ... AND ... IS NOT NULL operator precedence (issue #4653)
+# The IS NOT NULL should bind to the whole BETWEEN expression, not just the end value
+do_execsql_test_on_specific_db {:memory:} between-is-not-null-precedence {
+  SELECT 'x' BETWEEN 1 AND 2 IS NOT NULL;
+} {1}
+
+# Test LIKE ... IS NOT NULL operator precedence (issue #4653)
+do_execsql_test_on_specific_db {:memory:} like-is-not-null-precedence {
+  SELECT 'x' LIKE 'y' IS NOT NULL;
+} {1}
+
+# Test GLOB ... IS NOT NULL operator precedence (issue #4653)
+do_execsql_test_on_specific_db {:memory:} glob-is-not-null-precedence {
+  SELECT 'x' GLOB 'y' IS NOT NULL;
+} {1}


### PR DESCRIPTION
Fix precedence bug where `IS NOT NULL` incorrectly bound to sub-expressions instead of the whole BETWEEN/LIKE/GLOB expression.

Before: `'x' BETWEEN 1 AND 2 IS NOT NULL` parsed as `'x' BETWEEN 1 AND (2 IS NOT NULL)`
After:  `'x' BETWEEN 1 AND 2 IS NOT NULL` parsed as `('x' BETWEEN 1 AND 2) IS NOT NULL`

The fix uses `pre + 1` instead of `pre` when parsing the end expression of BETWEEN and the pattern/escape of LIKE/GLOB/REGEXP, preventing same-precedence operators from being included.

Fixes #4653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
