### PR TITLE
core/vdbe/sorter: Propagate write errors instead of corrupting data

### DIFF
--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -251,7 +251,9 @@ impl Sorter {
                         if self.chunks.iter().any(|chunk| {
                             matches!(*chunk.io_state.read(), SortedChunkIOState::WriteError)
                         }) {
-                            return Err(CompletionError::IOError(std::io::ErrorKind::WriteZero).into());
+                            return Err(
+                                CompletionError::IOError(std::io::ErrorKind::WriteZero).into()
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
### Cherry-picked from #4503

When sorter chunk writes failed (e.g., file too large), the completion handler was setting WriteComplete even though the write didn't succeed. This caused the sorter to continue with corrupted/missing data, leading to "Corrupt database: Invalid varint" errors.

Now we properly track WriteError state and return an error before attempting to read back from chunks that weren't fully written.

