### PR TITLE
fix: nullif/instr/concat should alloc regs for both args upfront

### DIFF
--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -39,6 +39,11 @@ do_execsql_test concat_ws-complex-args {
   select concat_ws(',', 'a' || 'b', 'b' || 'c', 'c' || 'd');
 } {ab,bc,cd}
 
+# Regression test: CONCAT with complex first argument that allocates internal registers
+do_execsql_test concat-complex-first-arg {
+  select concat((1 IN (2,3)), 'hello', 'world')
+} {0helloworld}
+
 do_execsql_test char {
   select char(108, 105)
 } {li}


### PR DESCRIPTION
classic bug