### PR TITLE
Add VSCode syntax highlighter for .sqltest files

### DIFF
--- a/turso-test-runner/syntax-highlighter/vscode/README.md
+++ b/turso-test-runner/syntax-highlighter/vscode/README.md
@@ -1,0 +1,10 @@
+# SQLTest Syntax Highlighting for VS Code
+
+Syntax highlighting for Turso's `.sqltest` test files.
+
+## Installation
+
+1. Open VS Code (or your preferred VS Code fork)
+2. Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
+3. Run `Developer: Install Extension from Location...`
+4. Select the `turso-test-runner/syntax-highlighter/vscode` directory

--- a/turso-test-runner/syntax-highlighter/vscode/language-configuration.json
+++ b/turso-test-runner/syntax-highlighter/vscode/language-configuration.json
@@ -1,0 +1,22 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["{", "}"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "\"", "close": "\"" }
+  ],
+  "surroundingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "\"", "close": "\"" }
+  ],
+  "folding": {
+    "markers": {
+      "start": "\\{",
+      "end": "\\}"
+    }
+  }
+}

--- a/turso-test-runner/syntax-highlighter/vscode/package.json
+++ b/turso-test-runner/syntax-highlighter/vscode/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "vscode-sqltest",
+  "displayName": "SQLTest Syntax Highlighting",
+  "description": "Syntax highlighting for Turso's .sqltest test files",
+  "version": "0.1.0",
+  "publisher": "turso",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/limbo"
+  },
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "sqltest",
+        "aliases": [
+          "SQLTest",
+          "sqltest"
+        ],
+        "extensions": [
+          ".sqltest"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "sqltest",
+        "scopeName": "source.sqltest",
+        "path": "./syntaxes/sqltest.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.sql": "sql"
+        }
+      }
+    ]
+  }
+}

--- a/turso-test-runner/syntax-highlighter/vscode/syntaxes/sqltest.tmLanguage.json
+++ b/turso-test-runner/syntax-highlighter/vscode/syntaxes/sqltest.tmLanguage.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "SQLTest",
+  "scopeName": "source.sqltest",
+  "patterns": [
+    { "include": "#comment" },
+    { "include": "#database-declaration" },
+    { "include": "#setup-block" },
+    { "include": "#test-decorator" },
+    { "include": "#test-block" },
+    { "include": "#expect-block" }
+  ],
+  "repository": {
+    "comment": {
+      "name": "comment.line.number-sign.sqltest",
+      "match": "#.*$"
+    },
+    "database-declaration": {
+      "name": "meta.database-declaration.sqltest",
+      "begin": "(@database)\\s+",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.directive.sqltest" }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "name": "constant.language.sqltest",
+          "match": ":(memory|temp|default|default-no-rowidalias):"
+        },
+        {
+          "name": "storage.modifier.sqltest",
+          "match": "\\breadonly\\b"
+        },
+        {
+          "name": "string.unquoted.path.sqltest",
+          "match": "[a-zA-Z0-9_./-]+\\.[a-zA-Z0-9]+"
+        }
+      ]
+    },
+    "setup-block": {
+      "name": "meta.setup-block.sqltest",
+      "begin": "\\b(setup)\\s+([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(\\{)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.sqltest" },
+        "2": { "name": "entity.name.function.sqltest" },
+        "3": { "name": "punctuation.section.block.begin.sqltest" }
+      },
+      "end": "(\\})",
+      "endCaptures": {
+        "1": { "name": "punctuation.section.block.end.sqltest" }
+      },
+      "contentName": "source.sql",
+      "patterns": [
+        { "include": "source.sql" }
+      ]
+    },
+    "test-decorator": {
+      "patterns": [
+        { "include": "#decorator-setup" },
+        { "include": "#decorator-skip" },
+        { "include": "#decorator-skip-if" },
+        { "include": "#decorator-backend" }
+      ]
+    },
+    "decorator-setup": {
+      "name": "meta.decorator.setup.sqltest",
+      "match": "(@setup)\\s+([a-zA-Z_][a-zA-Z0-9_-]*)",
+      "captures": {
+        "1": { "name": "keyword.control.directive.sqltest" },
+        "2": { "name": "entity.name.function.sqltest" }
+      }
+    },
+    "decorator-skip": {
+      "name": "meta.decorator.skip.sqltest",
+      "begin": "(@skip)\\s+(\")",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.directive.sqltest" },
+        "2": { "name": "punctuation.definition.string.begin.sqltest" }
+      },
+      "end": "(\")",
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.string.end.sqltest" }
+      },
+      "contentName": "string.quoted.double.sqltest",
+      "patterns": [
+        {
+          "name": "constant.character.escape.sqltest",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "decorator-skip-if": {
+      "name": "meta.decorator.skip-if.sqltest",
+      "begin": "(@skip-if)\\s+(mvcc)\\s+(\")",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.directive.sqltest" },
+        "2": { "name": "constant.language.sqltest" },
+        "3": { "name": "punctuation.definition.string.begin.sqltest" }
+      },
+      "end": "(\")",
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.string.end.sqltest" }
+      },
+      "contentName": "string.quoted.double.sqltest",
+      "patterns": [
+        {
+          "name": "constant.character.escape.sqltest",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "decorator-backend": {
+      "name": "meta.decorator.backend.sqltest",
+      "match": "(@backend)\\s+(rust|cli)",
+      "captures": {
+        "1": { "name": "keyword.control.directive.sqltest" },
+        "2": { "name": "constant.language.sqltest" }
+      }
+    },
+    "test-block": {
+      "name": "meta.test-block.sqltest",
+      "begin": "\\b(test)\\s+([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(\\{)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.sqltest" },
+        "2": { "name": "entity.name.function.sqltest" },
+        "3": { "name": "punctuation.section.block.begin.sqltest" }
+      },
+      "end": "(\\})",
+      "endCaptures": {
+        "1": { "name": "punctuation.section.block.end.sqltest" }
+      },
+      "contentName": "source.sql",
+      "patterns": [
+        { "include": "source.sql" }
+      ]
+    },
+    "expect-block": {
+      "name": "meta.expect-block.sqltest",
+      "begin": "\\b(expect)(?:\\s+(error|pattern|unordered|raw))?\\s*(\\{)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.sqltest" },
+        "2": { "name": "storage.modifier.sqltest" },
+        "3": { "name": "punctuation.section.block.begin.sqltest" }
+      },
+      "end": "(\\})",
+      "endCaptures": {
+        "1": { "name": "punctuation.section.block.end.sqltest" }
+      },
+      "patterns": [
+        { "include": "#expect-content" }
+      ]
+    },
+    "expect-content": {
+      "patterns": [
+        {
+          "name": "punctuation.separator.pipe.sqltest",
+          "match": "\\|"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fun little 5min Claude oneshot side project. Adds syntax highlighting for our custom .sqltest format by @pedrocarlo that was recently taken into use to replace TCL.

<img width="342" height="265" alt="Screenshot 2026-01-14 at 21 58 52" src="https://github.com/user-attachments/assets/f3cb3c3b-f4af-4c81-b98f-f3a4cebb87f5" />
