### PR TITLE
fix(parser): reject duplicate PRIMARY KEY clauses on a single column

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -3414,6 +3414,7 @@ impl<'a> Parser<'a> {
         in_alter: bool,
     ) -> Result<Vec<NamedColumnConstraint>> {
         let mut result = vec![];
+        let mut has_primary_key = false;
 
         loop {
             let name = match self.peek()? {
@@ -3464,6 +3465,13 @@ impl<'a> Parser<'a> {
                                     .to_owned(),
                             ));
                         }
+
+                        if has_primary_key {
+                            return Err(Error::Custom(
+                                "multiple PRIMARY KEY constraints on a single column".to_owned(),
+                            ));
+                        }
+                        has_primary_key = true;
 
                         result.push(NamedColumnConstraint {
                             name,

--- a/testing/create_table.test
+++ b/testing/create_table.test
@@ -46,6 +46,11 @@ do_execsql_test_in_memory_any_error create_table_multiple_table_primary_keys {
     CREATE TABLE t(a,b,c,d,primary key(a,b), primary key(c,d));
 }
 
+# https://github.com/tursodatabase/turso/issues/4674
+do_execsql_test_in_memory_any_error create_table_duplicate_primary_key_clause {
+    CREATE TABLE t(a primary key primary key);
+}
+
 # https://github.com/tursodatabase/turso/issues/3282
 do_execsql_test_on_specific_db {:memory:} col-named-rowid {
   create table t(rowid, a);


### PR DESCRIPTION
Fixes #4674

Previously, Turso allowed statements like `CREATE TABLE t(a primary key primary key);` which was invalid and caused SQLite's integrity check to fail. The fix adds validation in `parse_named_column_constraints()` to track whether a PRIMARY KEY constraint has already been seen and returns an error if a duplicate is encountered.

---
Generated with [Claude Code](https://claude.ai/code)