### PR TITLE
Replace panic/todo/unimplemented with proper errors

### DIFF
--- a/core/index_method/backing_btree.rs
+++ b/core/index_method/backing_btree.rs
@@ -5,7 +5,7 @@ use crate::{
         IndexMethod, IndexMethodAttachment, IndexMethodConfiguration, IndexMethodCursor,
         IndexMethodDefinition, BACKING_BTREE_INDEX_METHOD_NAME,
     },
-    Result,
+    LimboError, Result,
 };
 
 /// Special 'backing_btree' index method which can be used by other custom index methods
@@ -40,6 +40,8 @@ impl IndexMethodAttachment for BackingBTreeIndexMethodAttachment {
     }
 
     fn init(&self) -> Result<Box<dyn IndexMethodCursor>> {
-        panic!("init is not supported for backing_btree index method")
+        Err(LimboError::InternalError(
+            "init is not supported for backing_btree index method".to_string(),
+        ))
     }
 }

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -162,7 +162,7 @@ pub(crate) fn open_table_cursor(connection: &Connection, table: &str) -> Result<
             "table {table} not found",
         )));
     };
-    let cursor = BTreeCursor::new_table(pager, table.get_root_page(), table.columns().len());
+    let cursor = BTreeCursor::new_table(pager, table.get_root_page()?, table.columns().len());
     Ok(cursor)
 }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1581,11 +1581,15 @@ pub enum Table {
 }
 
 impl Table {
-    pub fn get_root_page(&self) -> i64 {
+    pub fn get_root_page(&self) -> crate::Result<i64> {
         match self {
-            Table::BTree(table) => table.root_page,
-            Table::Virtual(_) => unimplemented!(),
-            Table::FromClauseSubquery(_) => unimplemented!(),
+            Table::BTree(table) => Ok(table.root_page),
+            Table::Virtual(_) => Err(crate::LimboError::InternalError(
+                "Virtual tables do not have a root page".to_string(),
+            )),
+            Table::FromClauseSubquery(_) => Err(crate::LimboError::InternalError(
+                "FROM clause subqueries do not have a root page".to_string(),
+            )),
         }
     }
 
@@ -2235,7 +2239,9 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 has_rowid = false;
             }
         }
-        CreateTableBody::AsSelect(_) => todo!(),
+        CreateTableBody::AsSelect(_) => {
+            crate::bail_parse_error!("CREATE TABLE AS SELECT is not supported")
+        }
     };
 
     // flip is_rowid_alias back to false if the table has multiple primary key columns

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2085,7 +2085,9 @@ impl Pager {
                     }
                 }
                 AutoVacuumMode::Incremental => {
-                    unimplemented!()
+                    return Err(LimboError::InternalError(
+                        "Incremental auto-vacuum is not supported".to_string(),
+                    ));
                 }
             }
         }

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1689,7 +1689,9 @@ fn emit_delete_insns<'a>(
             } => program.resolve_cursor_id(&CursorKey::index(internal_id, index.clone())),
         },
         Operation::IndexMethodQuery(_) => {
-            panic!("access through IndexMethod is not supported for delete statements")
+            return Err(crate::LimboError::InternalError(
+                "IndexMethod access is not supported for DELETE statements".to_string(),
+            ));
         }
         Operation::HashJoin(_) => {
             unreachable!("access through HashJoin is not supported for delete statements")
@@ -2678,7 +2680,9 @@ fn emit_update_insns<'a>(
             ),
         },
         Operation::IndexMethodQuery(_) => {
-            panic!("access through IndexMethod is not supported for update operations")
+            return Err(crate::LimboError::InternalError(
+                "IndexMethod access is not supported for UPDATE operations".to_string(),
+            ));
         }
         Operation::HashJoin(_) => {
             unreachable!("access through HashJoin is not supported for update operations")

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5069,7 +5069,9 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
         Expr::Parenthesized(exprs) => exprs.len(),
         Expr::Qualified(..) => 1,
         Expr::Raise(..) => crate::bail_parse_error!("RAISE is not supported"),
-        Expr::Subquery(_) => todo!(),
+        Expr::Subquery(_) => {
+            crate::bail_parse_error!("Scalar subquery is not supported in this context")
+        }
         Expr::Unary(unary_operator, expr) => {
             let evs_expr = expr_vector_size(expr)?;
             if evs_expr != 1 {

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -285,7 +285,7 @@ pub fn init_loop(
                         if let Some(table_cursor_id) = table_cursor_id {
                             program.emit_insn(Insn::OpenRead {
                                 cursor_id: table_cursor_id,
-                                root_page: table.table.get_root_page(),
+                                root_page: table.table.get_root_page()?,
                                 db: table.database_id,
                             });
                         }
@@ -297,7 +297,7 @@ pub fn init_loop(
 
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id: table_cursor_id,
-                            root_page: table.table.get_root_page().into(),
+                            root_page: table.table.get_root_page()?.into(),
                             db: table.database_id,
                         });
 
@@ -325,7 +325,9 @@ pub fn init_loop(
                         }
                     }
                     _ => {
-                        unimplemented!()
+                        return Err(crate::LimboError::InternalError(
+                            "INSERT mode is not supported for Search operations".to_string(),
+                        ));
                     }
                 }
 
@@ -353,7 +355,10 @@ pub fn init_loop(
                                 });
                             }
                             _ => {
-                                unimplemented!()
+                                return Err(crate::LimboError::InternalError(
+                                    "INSERT mode is not supported for indexed Search operations"
+                                        .to_string(),
+                                ));
                             }
                         }
                     }
@@ -364,7 +369,7 @@ pub fn init_loop(
                     if let Some(table_cursor_id) = table_cursor_id {
                         program.emit_insn(Insn::OpenRead {
                             cursor_id: table_cursor_id,
-                            root_page: table.table.get_root_page(),
+                            root_page: table.table.get_root_page()?,
                             db: table.database_id,
                         });
                     }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -616,7 +616,9 @@ fn parse_from_clause_table(
             &args,
             connection,
         ),
-        _ => todo!(),
+        ast::SelectTable::Sub(..) => {
+            crate::bail_parse_error!("Parenthesized FROM clause subqueries are not supported")
+        }
     }
 }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5769,7 +5769,10 @@ pub fn op_function(
                         let ast::Cmd::Stmt(stmt) =
                             parser.next().expect("parser should have next item")?
                         else {
-                            todo!()
+                            return Err(LimboError::InternalError(
+                                "Unexpected command during ALTER TABLE RENAME processing"
+                                    .to_string(),
+                            ));
                         };
 
                         match stmt {
@@ -5817,7 +5820,10 @@ pub fn op_function(
                                     options,
                                 } = body
                                 else {
-                                    todo!()
+                                    return Err(LimboError::InternalError(
+                                        "CREATE TABLE AS SELECT schemas cannot be altered"
+                                            .to_string(),
+                                    ));
                                 };
 
                                 let mut any_change = false;
@@ -5948,7 +5954,10 @@ pub fn op_function(
                         let ast::Cmd::Stmt(stmt) =
                             parser.next().expect("parser should have next item")?
                         else {
-                            todo!()
+                            return Err(LimboError::InternalError(
+                                "Unexpected command during ALTER TABLE RENAME COLUMN processing"
+                                    .to_string(),
+                            ));
                         };
 
                         match stmt {
@@ -6005,7 +6014,10 @@ pub fn op_function(
                                     options,
                                 } = body
                                 else {
-                                    todo!()
+                                    return Err(LimboError::InternalError(
+                                        "CREATE TABLE AS SELECT schemas cannot be altered"
+                                            .to_string(),
+                                    ));
                                 };
 
                                 let normalized_tbl_name = normalize_ident(tbl_name.name.as_str());
@@ -7968,9 +7980,15 @@ pub fn op_reset_sorter(
             return_if_io!(cursor.clear_btree());
         }
         CursorType::Sorter => {
-            unimplemented!("ResetSorter is not supported for sorter cursors yet")
+            return Err(LimboError::InternalError(
+                "ResetSorter is not supported for sorter cursors".to_string(),
+            ));
         }
-        _ => panic!("ResetSorter is not supported for {cursor_type:?}"),
+        _ => {
+            return Err(LimboError::InternalError(format!(
+                "ResetSorter is not supported for {cursor_type:?}"
+            )));
+        }
     }
 
     state.pc += 1;
@@ -7985,7 +8003,9 @@ pub fn op_drop_table(
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(DropTable { db, table_name, .. }, insn);
     if *db > 0 {
-        todo!("temp databases not implemented yet");
+        return Err(LimboError::InternalError(
+            "Temporary databases are not implemented".to_string(),
+        ));
     }
     let conn = program.connection.clone();
     let is_mvcc = conn.mv_store().is_some();
@@ -8880,9 +8900,15 @@ pub fn op_open_dup(
             // In principle, we could implement OpenDup for BTreeIndex,
             // but doing so now would create dead code since we have no use case,
             // and it wouldn't be possible to test it.
-            unimplemented!("OpenDup is not supported for BTreeIndex yet")
+            return Err(LimboError::InternalError(
+                "OpenDup is not supported for BTreeIndex".to_string(),
+            ));
         }
-        _ => panic!("OpenDup is not supported for {cursor_type:?}"),
+        _ => {
+            return Err(LimboError::InternalError(format!(
+                "OpenDup is not supported for {cursor_type:?}"
+            )));
+        }
     }
 
     state.pc += 1;


### PR DESCRIPTION
## Description

Convert 20 panic points to return Result errors instead of panicking:
- CREATE TABLE AS SELECT now returns ParseError
- Parenthesized FROM clause subqueries return ParseError
- EXISTS/Subquery in expr_vector_size return ParseError
- Incremental auto-vacuum returns InternalError
- ALTER TABLE schema processing returns InternalError
- ResetSorter/OpenDup cursor type errors return InternalError
- IndexMethod DELETE/UPDATE returns InternalError
- INSERT mode in Search operations returns InternalError
- Table::get_root_page() now returns Result<i64>
- backing_btree init returns InternalError

Also adds unsupported.sqltest with tests for user-facing errors.

## Motivation and context

1. Panicking is bad for users
2. Panicking makes it harder to fuzz Turso, since failing prevents state exploration

## Description of AI Usage

Claude did this.