### PR TITLE
fix(vdbe): handle blob arguments in CONCAT and CONCAT_WS functions

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1048,7 +1048,7 @@ impl Value {
         for val in registers {
             match val {
                 Value::Null => continue,
-                Value::Blob(_) => todo!("TODO concat blob"),
+                // Blobs are converted to text using lossy UTF-8 conversion (via Display)
                 v => result.push_str(&format!("{v}")),
             }
         }
@@ -1064,12 +1064,16 @@ impl Value {
             .next()
             .expect("registers should have at least one element after length check")
         {
-            Value::Null | Value::Blob(_) => return Value::Null,
+            Value::Null => return Value::Null,
+            // Blobs are converted to text using lossy UTF-8 conversion (via Display)
             v => format!("{v}"),
         };
 
         let parts = registers.filter_map(|val| match val {
-            Value::Text(_) | Value::Integer(_) | Value::Float(_) => Some(format!("{val}")),
+            // Blobs are converted to text using lossy UTF-8 conversion (via Display)
+            Value::Text(_) | Value::Integer(_) | Value::Float(_) | Value::Blob(_) => {
+                Some(format!("{val}"))
+            }
             _ => None,
         });
 

--- a/turso-test-runner/tests/concat.sqltest
+++ b/turso-test-runner/tests/concat.sqltest
@@ -40,3 +40,31 @@ test concat-blob {
 expect {
     0102
 }
+
+test concat-function-blob {
+    SELECT CONCAT(X'41', X'42');
+}
+expect {
+    AB
+}
+
+test concat-function-blob-mixed {
+    SELECT CONCAT('hello', X'20', 'world');
+}
+expect {
+    hello world
+}
+
+test concat-ws-blob-values {
+    SELECT CONCAT_WS(',', X'41', X'42');
+}
+expect {
+    A,B
+}
+
+test concat-ws-blob-separator {
+    SELECT CONCAT_WS(X'2C', 'a', 'b');
+}
+expect {
+    a,b
+}


### PR DESCRIPTION
## Summary
- CONCAT() with blob arguments was panicking due to an unimplemented `todo!()` macro
- CONCAT_WS() was silently dropping blob arguments instead of converting them to text
- Now both functions convert blobs to text using lossy UTF-8 conversion, matching SQLite behavior

## Test plan
- [x] Added 4 new tests in `turso-test-runner/tests/concat.sqltest`
- [x] All 415 tests pass (`make -C turso-test-runner test-sqlite`)
- [x] `cargo clippy` passes with no warnings

## Examples
```sql
-- Before: panic, After: 'AB'
SELECT CONCAT(X'41', X'42');

-- Before: '', After: 'A,B'
SELECT CONCAT_WS(',', X'41', X'42');

-- Before: NULL, After: 'a,b'
SELECT CONCAT_WS(X'2C', 'a', 'b');
```

🤖 Generated with [Claude Code](https://claude.ai/code)