### PR TITLE
turso-test-runner: fix flakiness with Rust bindings + MVCC combo

### DIFF
--- a/turso-test-runner/src/backends/cli.rs
+++ b/turso-test-runner/src/backends/cli.rs
@@ -184,7 +184,8 @@ impl CliDatabaseInstance {
             .spawn()
             .map_err(|e| BackendError::Execute(format!("failed to spawn tursodb: {}", e)))?;
 
-        // Prepend MVCC pragma if enabled (skip for readonly databases)
+        // Prepend MVCC pragma if enabled (skip for readonly databases).
+        // FIXME: readonly default DB tests do not exercise MVCC code paths.
         let sql_to_execute = if self.mvcc && is_turso_cli && !self.readonly {
             format!("PRAGMA journal_mode = 'experimental_mvcc';\n{}", sql)
         } else {

--- a/turso-test-runner/src/backends/js.rs
+++ b/turso-test-runner/src/backends/js.rs
@@ -148,7 +148,8 @@ impl JsDatabaseInstance {
             .spawn()
             .map_err(|e| BackendError::Execute(format!("failed to spawn node: {e}")))?;
 
-        // Prepend MVCC pragma if enabled (skip for readonly databases)
+        // Prepend MVCC pragma if enabled (skip for readonly databases).
+        // FIXME: readonly default DB tests do not exercise MVCC code paths.
         let sql_to_execute = if self.mvcc && !self.readonly {
             format!("PRAGMA journal_mode = 'experimental_mvcc';\n{sql}")
         } else {

--- a/turso-test-runner/src/backends/rust.rs
+++ b/turso-test-runner/src/backends/rust.rs
@@ -92,8 +92,10 @@ impl SqlBackend for RustBackend {
             .connect()
             .map_err(|e| BackendError::CreateDatabase(e.to_string()))?;
 
-        // Enable MVCC mode if requested (must be done before any transactions)
-        if self.mvcc {
+        // Enable MVCC mode if requested (must be done before any transactions).
+        // Match CLI/JS backends: skip MVCC for readonly databases.
+        // FIXME: readonly default DB tests do not exercise MVCC code paths.
+        if self.mvcc && !config.readonly {
             let mut rows = conn
                 .query("PRAGMA journal_mode = 'experimental_mvcc'", ())
                 .await


### PR DESCRIPTION
See the issue #4727 for an explanation.

Closes #4726 

For now, aligning the Rust bindings behavior with CLI&JS backends: don't enable MVCC pragma for Rust bindings either when the DB is readonly.
