### PR TITLE
Fix JSON panics and incompatibility issues

### DIFF
--- a/testing/system/json.test
+++ b/testing/system/json.test
@@ -1827,10 +1827,68 @@ do_execsql_test_error json_tree_3_arguments {
 # TODO add key and path columns back when 
 # https://www.sqlite.org/forum/forumpost/48f5763d8c is addressed.
 do_execsql_test json-tree-nested-object {
-  select fullkey, j.value from generate_series(0,2) s 
+  select fullkey, j.value from generate_series(0,2) s
   join json_tree('{"a": [1,2,3]}', '$.a[' || s.value || ']') j;
 } {
 {$.a[0]|1}
 {$.a[1]|2}
 {$.a[2]|3}
 }
+
+# Malformed JSON edge cases - must error like SQLite
+do_execsql_test_in_memory_any_error json-malformed-empty-string {
+  SELECT json('');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-plus-only {
+  SELECT json('+');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-minus-only {
+  SELECT json('-');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-double-minus {
+  SELECT json('--1');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-double-plus {
+  SELECT json('++1');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-incomplete-exponent {
+  SELECT json('1e');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-incomplete-exponent-plus {
+  SELECT json('1e+');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-incomplete-exponent-minus {
+  SELECT json('1e-');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-hex-no-digits {
+  SELECT json('0x');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-leading-zeros {
+  SELECT json('00');
+}
+
+do_execsql_test_in_memory_any_error json-malformed-leading-zero-digit {
+  SELECT json('01');
+}
+
+# NaN should be converted to null (JSON5 extension, SQLite behavior)
+do_execsql_test json-nan-to-null-upper {
+  SELECT json('NaN');
+} {null}
+
+do_execsql_test json-nan-to-null-lower {
+  SELECT json('nan');
+} {null}
+
+do_execsql_test json-nan-to-null-mixed {
+  SELECT json('nAn');
+} {null}


### PR DESCRIPTION
1. serialize_int5 panicked on multi-byte UTF-8 when slicing strings → Use as_bytes().get() (byte indices may not be char boundaries)
2. serialize_int5 accepted non-numeric INT5 content → Validate content is decimal digits or reject with error
3. serialize_int5 accepted empty string or lone '+'/'-' → Require non-empty and at least one digit after sign
4. Jsonb::to_string() silently returned empty string on errors → Return Result<String> and propagate errors
5. deserialize_number accepted lone '-' as valid → require that at least 1 digit seen
6. deserialize_number accepted incomplete exponents (1e, 1e+) → require digit after exponent/sign
7. deserialize_null_or_nan rejected valid NaN input → Change pos + 3 >= len to pos + 3 > len (off-by-one)
8. atom_from_value quote stripping → Use strip_prefix/strip_suffix and error if missing
9. push_object_key silently accepted unquoted keys → Return error if quotes missing
10. get_json swallowed serialization errors → Propagate errors

Closes #4750 