### PR TITLE
ci/bench: increase timeout to 45mins as workaround

### DIFF
--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   bench:
     runs-on: nyrkio_perf_server_4cpu_ubuntu2404
-    timeout-minutes: 30
+    timeout-minutes: 45 # FIXME: make this run faster
     steps:
       - uses: actions/checkout@v3
       - uses: useblacksmith/setup-node@v5

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   bench:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45 # FIXME: make this run faster
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
this is only for CI green checkmark purposes, something else should be done about `bench` to make it take less time