### PR TITLE
mac: introduce PRAGMA fullfsync

### DIFF
--- a/bindings/javascript/src/browser.rs
+++ b/bindings/javascript/src/browser.rs
@@ -233,7 +233,11 @@ impl File for OpfsFile {
         Ok(c)
     }
 
-    fn sync(&self, c: turso_core::Completion) -> turso_core::Result<turso_core::Completion> {
+    fn sync(
+        &self,
+        c: turso_core::Completion,
+        _sync_type: turso_core::io::FileSyncType,
+    ) -> turso_core::Result<turso_core::Completion> {
         let web_worker = is_web_worker_safe();
         tracing::debug!("sync({}, is_web_worker={})", self.handle, web_worker);
         let handle = self.handle;

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1379,6 +1379,16 @@ impl Connection {
             .store(value, crate::sync::atomic::Ordering::SeqCst);
     }
 
+    /// Get the sync type setting.
+    pub fn get_sync_type(&self) -> crate::io::FileSyncType {
+        self.pager.load().get_sync_type()
+    }
+
+    /// Set the sync type (for PRAGMA fullfsync).
+    pub fn set_sync_type(&self, value: crate::io::FileSyncType) {
+        self.pager.load().set_sync_type(value);
+    }
+
     /// Creates a HashSet of modules that have been loaded
     pub fn get_syms_vtab_mods(&self) -> std::collections::HashSet<String> {
         self.syms.read().vtab_modules.keys().cloned().collect()

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -93,7 +93,7 @@ impl File for GenericFile {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn sync(&self, c: Completion) -> Result<Completion> {
+    fn sync(&self, c: Completion, _sync_type: crate::io::FileSyncType) -> Result<Completion> {
         let file = self.file.write();
         file.sync_all()?;
         c.complete(0);

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -781,7 +781,7 @@ impl File for UringFile {
         Ok(c)
     }
 
-    fn sync(&self, c: Completion) -> Result<Completion> {
+    fn sync(&self, c: Completion, _sync_type: crate::io::FileSyncType) -> Result<Completion> {
         trace!("sync()");
         let sync = with_fd!(self, |fd| {
             io_uring::opcode::Fsync::new(fd)

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -1,5 +1,6 @@
 use super::{Buffer, Clock, Completion, File, OpenFlags, IO};
 use crate::io::clock::{DefaultClock, MonotonicInstant, WallClockInstant};
+use crate::io::FileSyncType;
 use crate::sync::Mutex;
 use crate::turso_assert;
 use crate::Result;
@@ -176,7 +177,7 @@ impl File for MemoryFile {
         Ok(c)
     }
 
-    fn sync(&self, c: Completion) -> Result<Completion> {
+    fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
         tracing::debug!("sync(path={})", self.path);
         // no-op
         c.complete(0);

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -2,6 +2,7 @@ use super::{Completion, File, OpenFlags, IO};
 use crate::error::LimboError;
 use crate::io::clock::{Clock, DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::io::common;
+use crate::io::FileSyncType;
 use crate::Result;
 use crate::sync::Mutex;
 use rustix::{
@@ -309,18 +310,22 @@ impl File for UnixFile {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn sync(&self, c: Completion) -> Result<Completion> {
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> Result<Completion> {
         let file = self.file.lock();
 
         let result = unsafe {
-            #[cfg(not(target_vendor = "apple"))]
-            {
-                libc::fsync(file.as_raw_fd())
-            }
-
             #[cfg(target_vendor = "apple")]
             {
-                libc::fcntl(file.as_raw_fd(), libc::F_FULLFSYNC)
+                match sync_type {
+                    FileSyncType::Fsync => libc::fsync(file.as_raw_fd()),
+                    FileSyncType::FullFsync => libc::fcntl(file.as_raw_fd(), libc::F_FULLFSYNC),
+                }
+            }
+            #[cfg(not(target_vendor = "apple"))]
+            {
+                // FullFsync has no effect on non-Apple platforms
+                let _ = sync_type;
+                libc::fsync(file.as_raw_fd())
             }
         };
 
@@ -328,11 +333,13 @@ impl File for UnixFile {
             let e = std::io::Error::last_os_error();
             Err(e.into())
         } else {
+            #[cfg(target_vendor = "apple")]
+            match sync_type {
+                FileSyncType::FullFsync => trace!("fcntl(F_FULLFSYNC)"),
+                FileSyncType::Fsync => trace!("fsync"),
+            }
             #[cfg(not(target_vendor = "apple"))]
             trace!("fsync");
-
-            #[cfg(target_vendor = "apple")]
-            trace!("fcntl(F_FULLSYNC)");
 
             c.complete(0);
             Ok(c)

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -1,4 +1,4 @@
-use super::{Buffer, Completion, File, OpenFlags, IO};
+use super::{Buffer, Completion, File, FileSyncType, OpenFlags, IO};
 use crate::ext::VfsMod;
 use crate::io::clock::{Clock, DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::io::CompletionInner;
@@ -166,7 +166,7 @@ impl File for VfsFileImpl {
         Ok(c)
     }
 
-    fn sync(&self, c: Completion) -> Result<Completion> {
+    fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
         if self.vfs.is_null() {
             c.complete(-1);
             return Err(LimboError::ExtensionError("VFS is null".to_string()));

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -1,4 +1,5 @@
 use crate::io::clock::{DefaultClock, MonotonicInstant, WallClockInstant};
+use crate::io::FileSyncType;
 use crate::{Clock, Completion, File, LimboError, OpenFlags, Result, IO};
 use crate::sync::RwLock;
 use std::io::{Read, Seek, Write};
@@ -93,7 +94,7 @@ impl File for WindowsFile {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn sync(&self, c: Completion) -> Result<Completion> {
+    fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
         let file = self.file.write();
         file.sync_all()?;
         c.complete(0);

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -933,7 +933,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     self.state = CommitState::EndCommitLogicalLog { end_ts: *end_ts };
                     return Ok(TransitionResult::Continue);
                 }
-                let c = mvcc_store.storage.sync()?;
+                let c = mvcc_store.storage.sync(self.pager.get_sync_type())?;
                 self.state = CommitState::EndCommitLogicalLog { end_ts: *end_ts };
                 // if Completion Completed without errors we can continue
                 if c.succeeded() {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1,5 +1,6 @@
 // FIXME: remove this once we add recovery
 #![allow(dead_code)]
+use crate::io::FileSyncType;
 use crate::sync::Arc;
 use crate::sync::RwLock;
 use crate::{
@@ -218,11 +219,11 @@ impl LogicalLog {
         Ok(c)
     }
 
-    pub fn sync(&mut self) -> Result<Completion> {
+    pub fn sync(&mut self, sync_type: FileSyncType) -> Result<Completion> {
         let completion = Completion::new_sync(move |_| {
             tracing::debug!("logical_log_sync finish");
         });
-        let c = self.file.sync(completion)?;
+        let c = self.file.sync(completion, sync_type)?;
         Ok(c)
     }
 

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -1,3 +1,4 @@
+use crate::io::FileSyncType;
 use crate::sync::Arc;
 use crate::sync::RwLock;
 use std::fmt::Debug;
@@ -28,8 +29,8 @@ impl Storage {
         todo!()
     }
 
-    pub fn sync(&self) -> Result<Completion> {
-        self.logical_log.write().sync()
+    pub fn sync(&self, sync_type: FileSyncType) -> Result<Completion> {
+        self.logical_log.write().sync(sync_type)
     }
 
     pub fn truncate(&self) -> Result<Completion> {

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -155,6 +155,11 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["cache_spill"],
         ),
+        #[cfg(target_vendor = "apple")]
+        PragmaName::Fullfsync => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["fullfsync"],
+        ),
     }
 }
 

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -1,4 +1,5 @@
 use crate::error::LimboError;
+use crate::io::FileSyncType;
 use crate::storage::checksum::ChecksumContext;
 use crate::storage::encryption::EncryptionContext;
 use crate::sync::Arc;
@@ -82,7 +83,7 @@ pub trait DatabaseStorage: Send + Sync {
         io_ctx: &IOContext,
         c: Completion,
     ) -> Result<Completion>;
-    fn sync(&self, c: Completion) -> Result<Completion>;
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> Result<Completion>;
     fn size(&self) -> Result<u64>;
     fn truncate(&self, len: usize, c: Completion) -> Result<Completion>;
 }
@@ -250,8 +251,8 @@ impl DatabaseStorage for DatabaseFile {
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
-    fn sync(&self, c: Completion) -> Result<Completion> {
-        self.file.sync(c)
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> Result<Completion> {
+        self.file.sync(c, sync_type)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1483,6 +1483,9 @@ pub enum PragmaName {
     FreelistCount,
     /// Enable or disable foreign key constraint enforcement
     ForeignKeys,
+    /// Use F_FULLFSYNC instead of fsync on macOS (only supported on macOS)
+    #[cfg(target_vendor = "apple")]
+    Fullfsync,
     /// Run integrity check on the database file
     IntegrityCheck,
     /// `journal_mode` pragma

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -7,6 +7,7 @@ use bytes::BytesMut;
 use prost::Message;
 use roaring::RoaringBitmap;
 use turso_core::{
+    io::FileSyncType,
     types::{Text, WalFrameInfo},
     Buffer, Completion, LimboError, OpenFlags, Value,
 };
@@ -200,7 +201,7 @@ pub async fn db_bootstrap<IO: SyncEngineIo, Ctx>(
     let c = Completion::new_sync(move |_| {
         // todo(sivukhin): we need to error out in case of failed sync
     });
-    let c = db.sync(c)?;
+    let c = db.sync(c, FileSyncType::Fsync)?;
     while !c.succeeded() {
         ctx.coro.yield_(SyncEngineIoResult::IO).await?;
     }
@@ -381,7 +382,7 @@ pub async fn wal_pull_to_file_v1<IO: SyncEngineIo, Ctx>(
     let c = Completion::new_sync(move |_| {
         // todo(sivukhin): we need to error out in case of failed sync
     });
-    let c = frames_file.sync(c)?;
+    let c = frames_file.sync(c, FileSyncType::Fsync)?;
     while !c.succeeded() {
         ctx.coro.yield_(SyncEngineIoResult::IO).await?;
     }
@@ -600,7 +601,7 @@ pub async fn wal_pull_to_file_legacy<IO: SyncEngineIo, Ctx>(
     let c = Completion::new_sync(move |_| {
         // todo(sivukhin): we need to error out in case of failed sync
     });
-    let c = frames_file.sync(c)?;
+    let c = frames_file.sync(c, FileSyncType::Fsync)?;
     while !c.succeeded() {
         ctx.coro.yield_(SyncEngineIoResult::IO).await?;
     }

--- a/sync/engine/src/sparse_io.rs
+++ b/sync/engine/src/sparse_io.rs
@@ -5,8 +5,8 @@ use std::{
 
 use tracing::{instrument, Level};
 use turso_core::{
-    io::clock::DefaultClock, Buffer, Clock, Completion, File, MonotonicInstant, OpenFlags, Result,
-    WallClockInstant, IO,
+    io::{clock::DefaultClock, FileSyncType},
+    Buffer, Clock, Completion, File, MonotonicInstant, OpenFlags, Result, WallClockInstant, IO,
 };
 
 pub struct SparseLinuxIo {}
@@ -95,7 +95,7 @@ impl File for SparseLinuxFile {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
-    fn sync(&self, c: Completion) -> Result<Completion> {
+    fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
         let file = self.file.write().unwrap();
         file.sync_all()?;
         c.complete(0);

--- a/testing/concurrent-simulator/io.rs
+++ b/testing/concurrent-simulator/io.rs
@@ -303,7 +303,7 @@ impl File for SimulatorFile {
         Ok(c)
     }
 
-    fn sync(&self, c: Completion) -> Result<Completion> {
+    fn sync(&self, c: Completion, _sync_type: turso_core::io::FileSyncType) -> Result<Completion> {
         // No-op for memory files
         c.complete(0);
         Ok(c)

--- a/testing/simulator/runner/memory/file.rs
+++ b/testing/simulator/runner/memory/file.rs
@@ -226,7 +226,7 @@ impl File for MemorySimFile {
         Ok(c)
     }
 
-    fn sync(&self, c: Completion) -> Result<Completion> {
+    fn sync(&self, c: Completion, _sync_type: turso_core::io::FileSyncType) -> Result<Completion> {
         self.io_tracker.borrow_mut().sync_calls += 1;
         let op = OperationType::Sync {
             completion: c.clone(),


### PR DESCRIPTION
let's align with sqlite and use the default less-durable fsync on mac on synchronous mode FULL, because F_FULLFSYNC is incredibly slow. however slow you think it is, it's slower.

introduce mac-only `PRAGMA fullfsync` that controls whether to use F_FULLFSYNC.

this was a surprisingly invasive change due to having to thread the fullfsync flag everywhere. i put it in pager to reduce some of the drilling, and in fact it's on pager in sqlite too.

Closes #4760