### PR TITLE
Add support for PRAGMA synchronous=NORMAL

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -213,6 +213,7 @@ enum TransactionState {
 #[derive(Debug, AtomicEnum, Clone, Copy, PartialEq, Eq)]
 pub enum SyncMode {
     Off = 0,
+    Normal = 1,
     Full = 2,
 }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -927,9 +927,10 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
             }
 
             CommitState::SyncLogicalLog { end_ts } => {
-                // Skip fsync when synchronous mode is off
-                if self.sync_mode == SyncMode::Off {
-                    tracing::debug!("Skipping fsync of logical log (synchronous=off)");
+                // Skip fsync when synchronous mode is not FULL.
+                // NORMAL mode skips fsync on commit (but still fsyncs on checkpoint).
+                if self.sync_mode != SyncMode::Full {
+                    tracing::debug!("Skipping fsync of logical log (synchronous!=full)");
                     self.state = CommitState::EndCommitLogicalLog { end_ts: *end_ts };
                     return Ok(TransitionResult::Continue);
                 }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -402,9 +402,23 @@ fn update_pragma(
         }
         PragmaName::Synchronous => {
             use crate::SyncMode;
-            let mode = match parse_pragma_enabled(&value) {
-                true => SyncMode::Full,
-                false => SyncMode::Off,
+            let mode = if let Expr::Literal(Literal::Numeric(n)) = &value {
+                match n.as_str() {
+                    "0" => SyncMode::Off,
+                    "1" => SyncMode::Normal,
+                    _ => SyncMode::Full, // SQLite defaults to NORMAL for invalid values, but we want to default to a higher durability level so deviating here.
+                }
+            } else {
+                let name_bytes = match &value {
+                    Expr::Literal(Literal::Keyword(name)) => name.as_bytes(),
+                    Expr::Name(name) | Expr::Id(name) => name.as_str().as_bytes(),
+                    _ => b"",
+                };
+                match_ignore_ascii_case!(match name_bytes {
+                    b"OFF" | b"0" => SyncMode::Off,
+                    b"NORMAL" | b"1" => SyncMode::Normal,
+                    _ => SyncMode::Full,
+                })
             };
             connection.set_sync_mode(mode);
             Ok((program, TransactionMode::None))


### PR DESCRIPTION
This mode:

- fsync WAL on tx commit? NO
- fsync WAL on checkpoint? YES
- fsync WAL on wal header restart? YES

This is needed for sqlite compatibility, and people often use it for benchmarking, so we don't want to appear 100x slower because we don't support this less durable mode