### PR TITLE
Refactor AggContext to use flat payload representation

### DIFF
--- a/perf/tpc-h/run.sh
+++ b/perf/tpc-h/run.sh
@@ -80,12 +80,7 @@ run_queries() {
             if [ -n "$output_diff" ]; then
                 echo "Output difference:"
                 echo "$output_diff"
-                # Ignore differences for query 1 due to floating point precision incompatibility
-                if [ "$query_file" = "$QUERIES_DIR/1.sql" ]; then
-                    echo "Ignoring output difference for query 1 (known floating point precision incompatibility)"
-                else
-                    mode_exit_code=1
-                fi
+                mode_exit_code=1
             else
                 echo "No output difference"
             fi


### PR DESCRIPTION
Replace individual AggContext variants (Avg, Sum, Count, Max, Min, GroupConcat) with a unified Builtin(Vec<Value>) payload representation. External aggregates retain their own variant for FFI state.

This refactoring extracts the aggregate logic into three shared functions:
- init_agg_payload: Initialize payload with default values (this happened before in AggStep)
- update_agg_payload: Process a row and update aggregate state (AggStep)
- finalize_agg_payload: Compute final result from payload (AggFinal)

This also fixes a longstanding floating point incompatibility where AVG() was not using KBN summation like SUM() was.

---

The new design enables code sharing between register-based (sort-stream) and hash-based aggregation strategies, as the same payload format can be stored in registers or hash table entries.

Sort-stream aggregation is the SQlite way; hash aggregation is coming in follow-up PRs.

---

Really recommend turning on [x] Hide whitespace for this PR

---

Extracted from https://github.com/tursodatabase/turso/pull/4777 and modified to remove the worst AI slop