### PR TITLE
Add "release-official" compilation profile

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Build rust native library
-        run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--release'
+        run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official'
       
       - name: Upload rust native library
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -161,7 +161,7 @@ jobs:
         with:
           working-directory: ${{ env.working-directory }}
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --profile release-official --out dist --find-interpreter
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -192,7 +192,7 @@ jobs:
         with:
           working-directory: ${{ env.working-directory }}
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --profile release-official --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,13 @@ codegen-units = 4
 panic = "abort"
 lto = "thin"
 
+# Official release profile - maximum optimization for published binaries
+# Use for CLI releases, PyPI, npm, Maven, NuGet, etc.
+[profile.release-official]
+inherits = "release"
+codegen-units = 1
+lto = true
+
 # override settings for sdk-kit release profiles in order to reduce size of produced binaries
 # otherwise, some platforms will have enormous libs (150MB+)
 [profile.lib-release]
@@ -139,8 +146,7 @@ lto = false               # LTO hides function boundaries
 codegen-units = 16        # Less cross-unit inlining
 
 [profile.dist]
-inherits = "release"
-lto = "thin"
+inherits = "release-official"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(shuttle)'] }

--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -1,7 +1,7 @@
 RELEASE_DIR := libs
 TEMP_DIR := temp
 
-CARGO_BUILD := cargo build --release
+CARGO_BUILD := cargo build --profile release-official
 
 MACOS_X86_DIR := $(RELEASE_DIR)/macos_x86
 MACOS_ARM64_DIR := $(RELEASE_DIR)/macos_arm64
@@ -16,14 +16,14 @@ macos_x86:
 	@echo "Building release version for macOS x86_64..."
 	@mkdir -p $(TEMP_DIR) $(MACOS_X86_DIR)
 	@CARGO_TARGET_DIR=$(TEMP_DIR) $(CARGO_BUILD) --target x86_64-apple-darwin
-	@cp $(TEMP_DIR)/x86_64-apple-darwin/release/lib_turso_java.dylib $(MACOS_X86_DIR)
+	@cp $(TEMP_DIR)/x86_64-apple-darwin/release-official/lib_turso_java.dylib $(MACOS_X86_DIR)
 	@rm -rf $(TEMP_DIR)
 
 macos_arm64:
 	@echo "Building release version for macOS ARM64..."
 	@mkdir -p $(TEMP_DIR) $(MACOS_ARM64_DIR)
 	@CARGO_TARGET_DIR=$(TEMP_DIR) $(CARGO_BUILD) --target aarch64-apple-darwin
-	@cp $(TEMP_DIR)/aarch64-apple-darwin/release/lib_turso_java.dylib $(MACOS_ARM64_DIR)
+	@cp $(TEMP_DIR)/aarch64-apple-darwin/release-official/lib_turso_java.dylib $(MACOS_ARM64_DIR)
 	@rm -rf $(TEMP_DIR)
 
 # windows generates file with name `_turso_java.dll` unlike others, so we manually add prefix
@@ -31,14 +31,14 @@ windows:
 	@echo "Building release version for Windows..."
 	@mkdir -p $(TEMP_DIR) $(WINDOWS_DIR)
 	@CARGO_TARGET_DIR=$(TEMP_DIR) $(CARGO_BUILD) --target x86_64-pc-windows-gnu
-	@cp $(TEMP_DIR)/x86_64-pc-windows-gnu/release/_turso_java.dll $(WINDOWS_DIR)/lib_turso_java.dll
+	@cp $(TEMP_DIR)/x86_64-pc-windows-gnu/release-official/_turso_java.dll $(WINDOWS_DIR)/lib_turso_java.dll
 	@rm -rf $(TEMP_DIR)
 
 linux_x86:
 	@echo "Building release version for linux x86_64..."
 	@mkdir -p $(TEMP_DIR) $(LINUX_X86_DIR)
 	@CARGO_TARGET_DIR=$(TEMP_DIR) $(CARGO_BUILD) --target x86_64-unknown-linux-gnu
-	@cp $(TEMP_DIR)/x86_64-unknown-linux-gnu/release/lib_turso_java.so $(LINUX_X86_DIR)
+	@cp $(TEMP_DIR)/x86_64-unknown-linux-gnu/release-official/lib_turso_java.so $(LINUX_X86_DIR)
 	@rm -rf $(TEMP_DIR)
 
 lint:

--- a/bindings/javascript/packages/native/package.json
+++ b/bindings/javascript/packages/native/package.json
@@ -29,7 +29,7 @@
     "vitest": "^3.2.4"
   },
   "scripts": {
-    "napi-build": "napi build --platform --release --esm --manifest-path ../../Cargo.toml --output-dir .",
+    "napi-build": "napi build --platform --profile release-official --esm --manifest-path ../../Cargo.toml --output-dir .",
     "napi-dirs": "napi create-npm-dirs",
     "napi-artifacts": "napi artifacts --output-dir .",
     "tsc-build": "npm exec tsc",

--- a/bindings/javascript/packages/wasm/package.json
+++ b/bindings/javascript/packages/wasm/package.json
@@ -38,7 +38,7 @@
     "vitest": "^3.2.4"
   },
   "scripts": {
-    "napi-build": "napi build --features browser --release --platform --target wasm32-wasip1-threads --no-js --manifest-path ../../Cargo.toml --output-dir . && rm index.d.ts turso.wasi* wasi* browser.js",
+    "napi-build": "napi build --features browser --profile release-official --platform --target wasm32-wasip1-threads --no-js --manifest-path ../../Cargo.toml --output-dir . && rm index.d.ts turso.wasi* wasi* browser.js",
     "tsc-build": "npm exec tsc && cp turso.wasm32-wasi.wasm ./dist/turso.wasm32-wasi.wasm && WASM_FILE=turso.wasm32-wasi.wasm JS_FILE=./dist/wasm-inline.js node ../../scripts/inline-wasm-base64.js && npm run bundle",
     "bundle": "vite build",
     "build": "npm run napi-build && npm run tsc-build",

--- a/bindings/javascript/sync/packages/native/package.json
+++ b/bindings/javascript/sync/packages/native/package.json
@@ -26,7 +26,7 @@
     "vitest": "^3.2.4"
   },
   "scripts": {
-    "napi-build": "napi build --platform --release --esm --manifest-path ../../Cargo.toml --output-dir .",
+    "napi-build": "napi build --platform --profile release-official --esm --manifest-path ../../Cargo.toml --output-dir .",
     "napi-dirs": "napi create-npm-dirs",
     "napi-artifacts": "napi artifacts --output-dir .",
     "tsc-build": "npm exec tsc",

--- a/bindings/javascript/sync/packages/wasm/package.json
+++ b/bindings/javascript/sync/packages/wasm/package.json
@@ -38,7 +38,7 @@
     "vitest": "^3.2.4"
   },
   "scripts": {
-    "napi-build": "napi build --features browser --release --platform --target wasm32-wasip1-threads --no-js --manifest-path ../../Cargo.toml --output-dir . && rm index.d.ts sync.wasi* wasi* browser.js",
+    "napi-build": "napi build --features browser --profile release-official --platform --target wasm32-wasip1-threads --no-js --manifest-path ../../Cargo.toml --output-dir . && rm index.d.ts sync.wasi* wasi* browser.js",
     "tsc-build": "npm exec tsc && cp sync.wasm32-wasi.wasm ./dist/sync.wasm32-wasi.wasm && WASM_FILE=sync.wasm32-wasi.wasm JS_FILE=./dist/wasm-inline.js node ../../../scripts/inline-wasm-base64.js && npm run bundle",
     "bundle": "vite build",
     "build": "npm run napi-build && npm run tsc-build",


### PR DESCRIPTION
## Background

PR #4725 changed the `release` profile to optimize for compilation speed at the cost of binary size and perhaps marginally performance

## Changes

introduce `release-official` profile which is used for official binary/library distributions - has full LTO + 1 CGE to match what `release` profile used to be