### PR TITLE
ci: add license checker to disallow GPL dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,15 @@ env:
   CARGO_NET_RETRY: 10
 
 jobs:
+  license-check:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check licenses
+
   cargo-fmt-check:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,49 @@
+# cargo-deny configuration
+# See: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Include all targets for comprehensive checking
+all-features = true
+# Exclude internal perf/testing crates from license checks
+exclude = [
+    "encryption-throughput",
+    "write-throughput",
+    "write-throughput-sqlite",
+]
+
+[licenses]
+# Use version 2 for modern cargo-deny behavior
+version = 2
+
+# Confidence threshold for license detection
+confidence-threshold = 0.95
+
+# List of explicitly allowed licenses
+# All other licenses are denied by default (including all GPL variants)
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "Unlicense",
+    "MPL-2.0",
+]
+
+# Clarification for ring crate which has a complex license
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+# Private crates (workspace members) are ignored
+[licenses.private]
+ignore = true
+registries = []


### PR DESCRIPTION
## Description

Add automated license compliance checking to the CI pipeline using cargo-deny. This introduces a new license-check job that verifies all dependencies use licenses compatible with the project's MIT license. 

- Add deny.toml configuration with an allowlist of compatible licenses.
- Add license-check job to rust.yml workflow using EmbarkStudios/cargo-deny-action@v2.
- Exclude internal perf crates (encryption-throughput, write-throughput, write-throughput-sqlite) from license checks

Allowed licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, BSL-1.0, ISC, Zlib, Unicode-3.0, CC0-1.0, Unlicense, MPL-2.0

## Motivation and context

This addresses the need to prevent GPL-licensed dependencies from being introduced into the codebase. Issue #4612 identified that the bloom crate (GPL-2.0) was previously a dependency, which is incompatible with the project's MIT license.

The license checker runs on every PR and push to main, automatically failing if any dependency uses a disallowed license (including all GPL variants).
Fixes #4619
Ref #4612


## Description of AI Usage

Used Claude Code to:

- Research cargo-deny configuration and best practices
- Test the configuration locally by adding a GPL crate and verifying it was correctly rejected
