### PR TITLE
add likely and unlikely compiler hints

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -1,3 +1,4 @@
+use branches::unlikely;
 use crate::sync::{atomic::Ordering, Arc};
 use intrusive_collections::{intrusive_adapter, LinkedList, LinkedListLink};
 use rustc_hash::FxHashMap;
@@ -338,7 +339,7 @@ impl PageCache {
         // However, if we do not evict that page from the page cache, we will return an unloaded page later which will trigger
         // assertions later on. This is worsened by the fact that page cache is not per `Statement`, so you can abort a completion
         // in one Statement, and trigger some error in the next one if we don't evict the page here.
-        if !page.is_loaded() && !page.is_locked() {
+        if unlikely(!page.is_loaded() && !page.is_locked()) {
             self.delete(*key)?;
             return Ok(None);
         }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1184,6 +1184,8 @@ pub fn read_varint(buf: &[u8]) -> Result<(u64, usize)> {
             }
         }
     }
+    // 9-byte varints are extremely rare - only needed for values >= 1<<56
+    branches::mark_unlikely();
     match buf.get(8) {
         Some(&c) => {
             // Values requiring 9 bytes must have non-zero in the top 8 bits (value >= 1<<56).

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
+use branches::mark_unlikely;
 use crate::sync::Mutex;
 use crate::sync::OnceLock;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1123,6 +1124,7 @@ impl Wal for WalFile {
                 TryBeginReadResult::Retry => {
                     cnt += 1;
                     if cnt > 100 {
+                        mark_unlikely();
                         return Err(LimboError::Busy);
                     }
                     // Progressive backoff: first 5 retries are immediate, then we

--- a/core/types.rs
+++ b/core/types.rs
@@ -1,4 +1,4 @@
-use branches::{mark_unlikely, unlikely};
+use branches::{likely, mark_unlikely, unlikely};
 use either::Either;
 #[cfg(feature = "serde")]
 use serde::Deserialize;
@@ -2078,7 +2078,8 @@ where
     let (first_serial_type, _) = read_varint(&payload[offset_1st_serialtype..])?;
 
     let serialtype_is_integer = matches!(first_serial_type, 1..=6 | 8 | 9);
-    if !serialtype_is_integer {
+    if unlikely(!serialtype_is_integer) {
+        mark_unlikely();
         return compare_records_generic(serialized, unpacked, index_info, 0, tie_breaker);
     }
 
@@ -2173,7 +2174,8 @@ where
     let (first_serial_type, _) = read_varint(&payload[offset_1st_serialtype..])?;
 
     let serialtype_is_string = first_serial_type >= 13 && (first_serial_type & 1) == 1;
-    if !serialtype_is_string {
+    if unlikely(!serialtype_is_string) {
+        mark_unlikely();
         return compare_records_generic(serialized, unpacked, index_info, 0, tie_breaker);
     }
 
@@ -2341,7 +2343,7 @@ where
             SortOrder::Desc => comparison.reverse(),
         };
 
-        if final_comparison != std::cmp::Ordering::Equal {
+        if likely(final_comparison != std::cmp::Ordering::Equal) {
             return Ok(final_comparison);
         }
 


### PR DESCRIPTION
## Description

This PR adds likely and unlikely compiler hints. These can be used by the compiler to reorder conditions in a way that will favour more likely paths. See the docs of the [branches crate](https://docs.rs/branches/latest/branches/) for more info.

## Results

TODO TPC-H looks generally faster, but this may be due to variance.

## Description of AI Usage

I asked Claude to write a plan for where to add likely and unlikely hints, and then got a DB and performance expert sub-agent to review it. I did this twice.