### PR TITLE
cleanup: centralize optimizer params and make them loadable from json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6033,6 +6033,7 @@ dependencies = [
  "rustix 1.0.7",
  "ryu",
  "serde",
+ "serde_json",
  "shuttle",
  "simsimd",
  "smallvec",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,7 @@ test_helper = []
 bench = []
 fts = ["dep:tantivy"]
 codspeed = ["bench"]
+optimizer_params = ["serde", "dep:serde_json"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.5", optional = true }
@@ -77,6 +78,7 @@ uncased = "0.9.10"
 strum_macros = { workspace = true }
 bitflags = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
 paste = "1.0.15"
 uuid = { version = "1.11.0", features = ["v4", "v5", "v7"], optional = true }
 tempfile = { workspace = true }

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -20,7 +20,7 @@ use std::{
 use turso_ext::{ConstraintInfo, ConstraintOp};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
 
-use super::cost::ESTIMATED_HARDCODED_ROWS_PER_TABLE;
+use super::cost_params::CostModelParams;
 
 /// Represents a single condition derived from a `WHERE` clause term
 /// that constrains a specific column of a table.
@@ -207,26 +207,6 @@ pub struct TableConstraints {
     pub candidates: Vec<ConstraintUseCandidate>,
 }
 
-/// In lieu of statistics, we estimate that an equality filter on an unindexed column will reduce the output set to 10% of its size.
-const SELECTIVITY_EQ_FALLBACK_UNINDEXED: f64 = 0.1;
-/// In lieu of statistics, we estimate that an equality filter on an indexed column will reduce the output set to 1% of its size (users are likely to create indexes on columns that are very selective).
-const SELECTIVITY_EQ_FALLBACK_INDEXED: f64 = 0.01;
-/// In lieu of statistics, we estimate that a range filter will reduce the output set to 40% of its size.
-const SELECTIVITY_RANGE_FALLBACK: f64 = 0.4;
-/// IS NULL - null values are typically rare.
-const SELECTIVITY_IS_NULL: f64 = 0.1;
-/// IS NOT NULL - most values are typically not null.
-const SELECTIVITY_IS_NOT_NULL: f64 = 0.9;
-/// In lieu of statistics, we estimate that other filters will reduce the output set to 90% of its size.
-const SELECTIVITY_OTHER: f64 = 0.9;
-/// In lieu of statistics, we estimate that a LIKE filter will reduce the output set to 20% of its size.
-const SELECTIVITY_LIKE: f64 = 0.2;
-/// In lieu of statistics, we estimate that a NOT LIKE filter will reduce the output set to 20% of its size.
-const SELECTIVITY_NOT_LIKE: f64 = 0.2;
-/// SQLite estimates IN subqueries return 25 rows (where.c line 3230).
-/// Used when we don't have the actual list length.
-const ESTIMATED_IN_SUBQUERY_ROWS: f64 = 25.0;
-
 /// Estimate selectivity for IN expressions given the number of values and table row count.
 fn estimate_in_selectivity(in_list_len: f64, row_count: f64, not: bool) -> f64 {
     let selectivity = (in_list_len / row_count).min(1.0);
@@ -254,6 +234,7 @@ fn estimate_selectivity(
     column_pos: Option<usize>,
     available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
     op: ConstraintOperator,
+    params: &CostModelParams,
 ) -> f64 {
     // Get ANALYZE stats for this table if available
     let table_stats = schema.analyze_stats.table_stats(table_name);
@@ -268,7 +249,7 @@ fn estimate_selectivity(
                 1.0 / row_count as f64
             } else {
                 // Fallback: use hardcoded estimate based on expected table size
-                1.0 / ESTIMATED_HARDCODED_ROWS_PER_TABLE as f64
+                1.0 / params.rows_per_table_fallback
             };
 
             if is_pk_or_rowid_alias {
@@ -303,7 +284,7 @@ fn estimate_selectivity(
                                         }
                                     }
                                 } else {
-                                    return SELECTIVITY_EQ_FALLBACK_INDEXED;
+                                    return params.sel_eq_indexed;
                                 }
                             }
                         }
@@ -311,26 +292,24 @@ fn estimate_selectivity(
                 }
                 // Fallback: use hardcoded selectivity for non-indexed columns
                 // Don't scale by row_count - keep it distinct from PK selectivity
-                SELECTIVITY_EQ_FALLBACK_UNINDEXED
+                params.sel_eq_unindexed
             } else {
-                SELECTIVITY_EQ_FALLBACK_UNINDEXED
+                params.sel_eq_unindexed
             }
         }
         ConstraintOperator::AstNativeOperator(ast::Operator::Greater)
         | ConstraintOperator::AstNativeOperator(ast::Operator::GreaterEquals)
         | ConstraintOperator::AstNativeOperator(ast::Operator::Less)
-        | ConstraintOperator::AstNativeOperator(ast::Operator::LessEquals) => {
-            SELECTIVITY_RANGE_FALLBACK
-        }
-        ConstraintOperator::AstNativeOperator(ast::Operator::Is) => SELECTIVITY_IS_NULL,
-        ConstraintOperator::AstNativeOperator(ast::Operator::IsNot) => SELECTIVITY_IS_NOT_NULL,
-        ConstraintOperator::Like { not: false } => SELECTIVITY_LIKE,
-        ConstraintOperator::Like { not: true } => SELECTIVITY_NOT_LIKE,
+        | ConstraintOperator::AstNativeOperator(ast::Operator::LessEquals) => params.sel_range,
+        ConstraintOperator::AstNativeOperator(ast::Operator::Is) => params.sel_is_null,
+        ConstraintOperator::AstNativeOperator(ast::Operator::IsNot) => params.sel_is_not_null,
+        ConstraintOperator::Like { not: false } => params.sel_like,
+        ConstraintOperator::Like { not: true } => params.sel_not_like,
         ConstraintOperator::In {
             not,
             estimated_values,
         } => estimate_in_selectivity(estimated_values, row_count as f64, not),
-        _ => SELECTIVITY_OTHER,
+        _ => params.sel_other,
     }
 }
 
@@ -375,12 +354,13 @@ fn estimate_column_ndv(
     column_pos: Option<usize>,
     is_rowid_expr: bool,
     available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    params: &CostModelParams,
 ) -> Option<f64> {
     let table_name = table_reference.table.get_name();
     let table_stats = schema.analyze_stats.table_stats(table_name);
     let row_count = table_stats
         .and_then(|s| s.row_count)
-        .unwrap_or(ESTIMATED_HARDCODED_ROWS_PER_TABLE as u64) as f64;
+        .unwrap_or(params.rows_per_table_fallback as u64) as f64;
 
     if is_rowid_expr {
         return Some(row_count.max(1.0));
@@ -426,9 +406,9 @@ fn estimate_column_ndv(
             .any(|index| index.column_table_pos_to_index_pos(column_pos).is_some())
     });
     let fallback_selectivity = if has_index {
-        SELECTIVITY_EQ_FALLBACK_INDEXED
+        params.sel_eq_indexed
     } else {
-        SELECTIVITY_EQ_FALLBACK_UNINDEXED
+        params.sel_eq_unindexed
     };
     let mut ndv = (1.0 / fallback_selectivity).max(1.0);
     if row_count > 0.0 {
@@ -444,6 +424,7 @@ fn estimate_join_eq_selectivity(
     other_ref: SimpleColumnRef,
     available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
     table_references: &TableReferences,
+    params: &CostModelParams,
 ) -> Option<f64> {
     column_pos?;
     let other_table = table_references.joined_tables().iter().find(|t| {
@@ -464,6 +445,7 @@ fn estimate_join_eq_selectivity(
         column_pos,
         false,
         available_indexes,
+        params,
     );
     let right_ndv = estimate_column_ndv(
         schema,
@@ -471,6 +453,7 @@ fn estimate_join_eq_selectivity(
         other_col_pos,
         other_is_rowid,
         available_indexes,
+        params,
     );
 
     let left_stats = schema
@@ -479,8 +462,8 @@ fn estimate_join_eq_selectivity(
     let right_stats = schema
         .analyze_stats
         .table_stats(other_table.table.get_name());
-    let left_ndv = join_ndv_with_fallback(left_stats, left_ndv);
-    let right_ndv = join_ndv_with_fallback(right_stats, right_ndv);
+    let left_ndv = join_ndv_with_fallback(left_stats, left_ndv, params);
+    let right_ndv = join_ndv_with_fallback(right_stats, right_ndv, params);
 
     let max_ndv = match (left_ndv, right_ndv) {
         (Some(left), Some(right)) => left.max(right),
@@ -503,6 +486,7 @@ fn estimate_generic_eq_join_selectivity(
     schema: &Schema,
     left_table: &JoinedTable,
     right_table: &JoinedTable,
+    params: &CostModelParams,
 ) -> Option<f64> {
     let left_stats = schema
         .analyze_stats
@@ -510,8 +494,8 @@ fn estimate_generic_eq_join_selectivity(
     let right_stats = schema
         .analyze_stats
         .table_stats(right_table.table.get_name());
-    let left_ndv = join_ndv_with_fallback(left_stats, None).unwrap_or(0.0);
-    let right_ndv = join_ndv_with_fallback(right_stats, None).unwrap_or(0.0);
+    let left_ndv = join_ndv_with_fallback(left_stats, None, params).unwrap_or(0.0);
+    let right_ndv = join_ndv_with_fallback(right_stats, None, params).unwrap_or(0.0);
 
     let max_ndv = left_ndv.max(right_ndv);
     if max_ndv <= 0.0 {
@@ -524,10 +508,14 @@ fn estimate_generic_eq_join_selectivity(
 ///
 /// If ANALYZE stats are missing, we fall back to sqrt(row_count). When we already
 /// have a column NDV, we clamp it to at least the fallback to avoid underestimates.
-fn join_ndv_with_fallback(stats: Option<&TableStat>, column_ndv: Option<f64>) -> Option<f64> {
+fn join_ndv_with_fallback(
+    stats: Option<&TableStat>,
+    column_ndv: Option<f64>,
+    params: &CostModelParams,
+) -> Option<f64> {
     let row_count = stats
         .and_then(|s| s.row_count)
-        .unwrap_or(ESTIMATED_HARDCODED_ROWS_PER_TABLE as u64) as f64;
+        .unwrap_or(params.rows_per_table_fallback as u64) as f64;
     let has_stats = stats.is_some() && stats.and_then(|s| s.row_count).is_some();
     let fallback_ndv = row_count.sqrt().max(1.0);
     if has_stats {
@@ -560,6 +548,7 @@ fn estimate_constraint_selectivity(
     available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
+    params: &CostModelParams,
 ) -> f64 {
     // Special-case: equality to another table's column is likely an equi-join.
     if operator.as_ast_operator() == Some(ast::Operator::Equals) {
@@ -577,6 +566,7 @@ fn estimate_constraint_selectivity(
                     other_ref,
                     available_indexes,
                     table_references,
+                    params,
                 ) {
                     return selectivity;
                 }
@@ -591,6 +581,7 @@ fn estimate_constraint_selectivity(
                             schema,
                             table_reference,
                             other_table,
+                            params,
                         ) {
                             return selectivity;
                         }
@@ -608,6 +599,7 @@ fn estimate_constraint_selectivity(
         column_pos,
         available_indexes,
         operator,
+        params,
     )
 }
 
@@ -638,6 +630,7 @@ pub fn constraints_from_where_clause(
     available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
+    params: &CostModelParams,
 ) -> Result<Vec<TableConstraints>> {
     let mut constraints = Vec::new();
 
@@ -704,6 +697,7 @@ pub fn constraints_from_where_clause(
                                     available_indexes,
                                     table_references,
                                     subqueries,
+                                    params,
                                 ),
                                 usable: true,
                             });
@@ -732,6 +726,7 @@ pub fn constraints_from_where_clause(
                                     available_indexes,
                                     table_references,
                                     subqueries,
+                                    params,
                                 ),
                                 usable: true,
                             });
@@ -754,6 +749,7 @@ pub fn constraints_from_where_clause(
                             available_indexes,
                             table_references,
                             subqueries,
+                            params,
                         );
                         tracing::debug!(
                             table = table_reference.table.get_name(),
@@ -795,6 +791,7 @@ pub fn constraints_from_where_clause(
                                     available_indexes,
                                     table_references,
                                     subqueries,
+                                    params,
                                 ),
                                 usable: true,
                             });
@@ -820,6 +817,7 @@ pub fn constraints_from_where_clause(
                                     available_indexes,
                                     table_references,
                                     subqueries,
+                                    params,
                                 ),
                                 usable: true,
                             });
@@ -842,6 +840,7 @@ pub fn constraints_from_where_clause(
                             available_indexes,
                             table_references,
                             subqueries,
+                            params,
                         );
                         tracing::debug!(
                             table = table_reference.table.get_name(),
@@ -878,7 +877,7 @@ pub fn constraints_from_where_clause(
                     .table_stats(table_reference.table.get_name());
                 let row_count = table_stats
                     .and_then(|s| s.row_count)
-                    .unwrap_or(ESTIMATED_HARDCODED_ROWS_PER_TABLE as u64)
+                    .unwrap_or(params.rows_per_table_fallback as u64)
                     as f64;
                 let selectivity = estimate_in_selectivity(estimated_values, row_count, *not);
 
@@ -935,13 +934,13 @@ pub fn constraints_from_where_clause(
                     .expect("subquery not found");
                 // Only use as constraint if NOT correlated
                 if !subquery.correlated {
-                    let estimated_values = ESTIMATED_IN_SUBQUERY_ROWS;
+                    let estimated_values = params.in_subquery_rows;
                     let table_stats = schema
                         .analyze_stats
                         .table_stats(table_reference.table.get_name());
                     let row_count = table_stats
                         .and_then(|s| s.row_count)
-                        .unwrap_or(ESTIMATED_HARDCODED_ROWS_PER_TABLE as u64)
+                        .unwrap_or(params.rows_per_table_fallback as u64)
                         as f64;
                     let selectivity = estimate_in_selectivity(estimated_values, row_count, *not_in);
 

--- a/core/translate/optimizer/cost_params.rs
+++ b/core/translate/optimizer/cost_params.rs
@@ -1,0 +1,421 @@
+/// Cost model parameters for query optimization.
+///
+/// These parameters control the heuristics used by the query optimizer for
+/// cost estimation. They can be tuned to improve plan selection for specific
+/// workloads (e.g., TPC-H).
+///
+/// # JSON Loading (requires `optimizer_params` feature)
+///
+/// When the `optimizer_params` feature is enabled, parameters can be loaded
+/// from a JSON file via the `TURSO_OPTIMIZER_PARAMS` environment variable.
+/// The JSON file does not need to specify all fields, and unspecified fields will use the default values.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct CostModelParams {
+    // === Cardinality Fallbacks (when no ANALYZE stats) ===
+    /// Assumed rows per table when statistics unavailable.
+    pub rows_per_table_fallback: f64,
+
+    /// Estimated rows per B-tree page (affects IO cost calculations).
+    pub rows_per_page: f64,
+
+    // === Selectivity Fallbacks ===
+    /// Selectivity for equality predicate on unindexed column (e.g., `x = 5`).
+    pub sel_eq_unindexed: f64,
+
+    /// Selectivity for equality predicate on indexed column.
+    /// Should be <= sel_eq_unindexed since indexes imply higher selectivity.
+    pub sel_eq_indexed: f64,
+
+    /// Selectivity for range predicates (>, >=, <, <=).
+    pub sel_range: f64,
+
+    /// Selectivity for IS NULL predicate.
+    pub sel_is_null: f64,
+
+    /// Selectivity for IS NOT NULL predicate.
+    pub sel_is_not_null: f64,
+
+    /// Selectivity for LIKE predicate.
+    pub sel_like: f64,
+
+    /// Selectivity for NOT LIKE predicate.
+    pub sel_not_like: f64,
+
+    /// Selectivity for other/unknown predicates.
+    pub sel_other: f64,
+
+    /// Estimated rows from IN subquery when actual count unknown.
+    /// Matches SQLite's estimate (where.c line 3230).
+    pub in_subquery_rows: f64,
+
+    // === Scan/Seek Cost Weights ===
+    /// Discount factor for repeated scans (cache benefit).
+    /// Range: [0, 1). Higher = more cache benefit assumed.
+    pub cache_reuse_factor: f64,
+
+    /// CPU cost per row processed (relative to page IO = 1.0).
+    pub cpu_cost_per_row: f64,
+
+    /// CPU cost per index seek (key comparisons).
+    pub cpu_cost_per_seek: f64,
+
+    /// Bonus subtracted from cost when using an index (encourages index usage).
+    pub index_bonus: f64,
+
+    /// Density multiplier for covering indexes (more rows fit per page
+    /// because only indexed columns are stored).
+    pub covering_index_density: f64,
+
+    // === Sort Cost ===
+    /// CPU cost per row for sorting (used in O(n log n) estimate).
+    /// This is used when estimating the cost saved by using an ordered index.
+    pub sort_cpu_per_row: f64,
+
+    // === Hash Join Cost ===
+    /// CPU cost to compute hash of a row.
+    pub hash_cpu_cost: f64,
+
+    /// CPU cost to insert row into hash table.
+    pub hash_insert_cost: f64,
+
+    /// CPU cost to probe hash table.
+    pub hash_lookup_cost: f64,
+
+    /// Estimated bytes per row for hash table spill estimation.
+    pub hash_bytes_per_row: f64,
+
+    /// Selectivity threshold for hash join build-side materialization.
+    /// Below this threshold, materialization may be beneficial.
+    pub hash_materialize_selectivity_threshold: f64,
+
+    /// Stricter selectivity threshold for nested hash probe operations.
+    pub hash_nested_probe_selectivity_threshold: f64,
+
+    // === Join Optimization ===
+    /// Selectivity heuristic factor for closed ranges (e.g., `x > 5 AND x < 10`).
+    /// Applied when both lower and upper bounds exist on an index column.
+    pub closed_range_selectivity_factor: f64,
+}
+
+impl CostModelParams {
+    /// Create default parameters as a const fn (for compile-time static).
+    pub const fn new() -> Self {
+        Self {
+            // Cardinality fallbacks
+            rows_per_table_fallback: 1_000_000.0,
+            rows_per_page: 50.0,
+
+            // Selectivity fallbacks
+            sel_eq_unindexed: 0.1,
+            sel_eq_indexed: 0.01,
+            sel_range: 0.4,
+            sel_is_null: 0.1,
+            sel_is_not_null: 0.9,
+            sel_like: 0.2,
+            sel_not_like: 0.2,
+            sel_other: 0.9,
+            in_subquery_rows: 25.0,
+
+            // Scan/Seek costs
+            cache_reuse_factor: 0.2,
+            cpu_cost_per_row: 0.001,
+            cpu_cost_per_seek: 0.01,
+            index_bonus: 0.5,
+            covering_index_density: 2.0,
+
+            // Sort costs
+            sort_cpu_per_row: 0.002,
+
+            // Hash join specific costs and thresholds
+            hash_cpu_cost: 0.001,
+            hash_insert_cost: 0.002,
+            hash_lookup_cost: 0.003,
+            hash_bytes_per_row: 100.0,
+            hash_materialize_selectivity_threshold: 0.5,
+            hash_nested_probe_selectivity_threshold: 0.15,
+
+            // Join optimization
+            closed_range_selectivity_factor: 0.2,
+        }
+    }
+}
+
+/// Compile-time static default parameters (zero runtime overhead).
+#[cfg(any(
+    not(feature = "optimizer_params"),
+    all(test, feature = "optimizer_params")
+))]
+pub static DEFAULT_PARAMS: CostModelParams = CostModelParams::new();
+
+impl Default for CostModelParams {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CostModelParams {
+    /// Load parameters from a JSON file.
+    ///
+    /// Returns default parameters if the file cannot be read, parsed, or validated.
+    #[cfg(feature = "optimizer_params")]
+    pub fn load_from_file(path: &std::path::Path) -> Self {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => match serde_json::from_str::<Self>(&contents) {
+                Ok(params) => {
+                    if let Err(e) = params.validate() {
+                        tracing::warn!(?path, error = %e, "Invalid cost params, using defaults");
+                        return Self::default();
+                    }
+                    tracing::info!(?path, "Loaded optimizer cost parameters from file");
+                    params
+                }
+                Err(e) => {
+                    tracing::warn!(?path, error = %e, "Failed to parse cost params JSON, using defaults");
+                    Self::default()
+                }
+            },
+            Err(e) => {
+                tracing::warn!(?path, error = %e, "Failed to read cost params file, using defaults");
+                Self::default()
+            }
+        }
+    }
+
+    /// Load parameters from the `TURSO_OPTIMIZER_PARAMS` environment variable path,
+    /// or return defaults if not set or loading fails.
+    #[cfg(feature = "optimizer_params")]
+    fn from_env_or_default() -> Self {
+        match std::env::var("TURSO_OPTIMIZER_PARAMS") {
+            Ok(path) => Self::load_from_file(std::path::Path::new(&path)),
+            Err(_) => Self::default(),
+        }
+    }
+}
+
+/// Lazily-loaded parameters from `TURSO_OPTIMIZER_PARAMS` env var (cached process-wide).
+/// Falls back to defaults if env var not set or loading fails.
+#[cfg(feature = "optimizer_params")]
+pub static LOADED_PARAMS: std::sync::LazyLock<CostModelParams> =
+    std::sync::LazyLock::new(CostModelParams::from_env_or_default);
+
+#[cfg(feature = "optimizer_params")]
+impl CostModelParams {
+    /// Validate that parameters are within sensible bounds.
+    ///
+    /// Returns an error message if any parameter is invalid.
+    #[cfg(feature = "optimizer_params")]
+    pub fn validate(&self) -> Result<(), String> {
+        // Selectivity must be in (0, 1]
+        let selectivity_params = [
+            ("sel_eq_unindexed", self.sel_eq_unindexed),
+            ("sel_eq_indexed", self.sel_eq_indexed),
+            ("sel_range", self.sel_range),
+            ("sel_is_null", self.sel_is_null),
+            ("sel_is_not_null", self.sel_is_not_null),
+            ("sel_like", self.sel_like),
+            ("sel_not_like", self.sel_not_like),
+            ("sel_other", self.sel_other),
+        ];
+
+        for (name, val) in selectivity_params {
+            if val <= 0.0 || val > 1.0 {
+                return Err(format!("{name} must be in (0, 1], got {val}"));
+            }
+        }
+
+        // Indexed selectivity should be <= unindexed (indexes are more selective)
+        if self.sel_eq_indexed > self.sel_eq_unindexed {
+            return Err(format!(
+                "sel_eq_indexed ({}) should be <= sel_eq_unindexed ({})",
+                self.sel_eq_indexed, self.sel_eq_unindexed
+            ));
+        }
+
+        // Positive value checks
+        if self.rows_per_table_fallback <= 0.0 {
+            return Err("rows_per_table_fallback must be positive".into());
+        }
+        if self.rows_per_page <= 0.0 {
+            return Err("rows_per_page must be positive".into());
+        }
+        if self.in_subquery_rows <= 0.0 {
+            return Err("in_subquery_rows must be positive".into());
+        }
+
+        // Cache reuse factor must be in [0, 1)
+        if self.cache_reuse_factor < 0.0 || self.cache_reuse_factor >= 1.0 {
+            return Err(format!(
+                "cache_reuse_factor must be in [0, 1), got {}",
+                self.cache_reuse_factor
+            ));
+        }
+
+        // Cost multipliers must be non-negative
+        let cost_params = [
+            ("cpu_cost_per_row", self.cpu_cost_per_row),
+            ("cpu_cost_per_seek", self.cpu_cost_per_seek),
+            ("sort_cpu_per_row", self.sort_cpu_per_row),
+            ("hash_cpu_cost", self.hash_cpu_cost),
+            ("hash_insert_cost", self.hash_insert_cost),
+            ("hash_lookup_cost", self.hash_lookup_cost),
+        ];
+
+        for (name, val) in cost_params {
+            if val < 0.0 {
+                return Err(format!("{name} must be non-negative, got {val}"));
+            }
+        }
+
+        // Covering index density must be >= 1.0
+        if self.covering_index_density < 1.0 {
+            return Err(format!(
+                "covering_index_density must be >= 1.0, got {}",
+                self.covering_index_density
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "optimizer_params"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_params_are_valid() {
+        let params = CostModelParams::default();
+        assert!(params.validate().is_ok());
+    }
+
+    #[test]
+    fn test_invalid_selectivity_rejected() {
+        let mut params = CostModelParams {
+            sel_eq_unindexed: 1.5,
+            ..Default::default()
+        };
+        assert!(params.validate().is_err());
+
+        params = CostModelParams {
+            sel_range: 0.0,
+            ..Default::default()
+        };
+        assert!(params.validate().is_err());
+
+        params = CostModelParams {
+            sel_is_null: -0.1,
+            ..Default::default()
+        };
+        assert!(params.validate().is_err());
+    }
+
+    #[test]
+    fn test_indexed_selectivity_constraint() {
+        let params = CostModelParams {
+            sel_eq_indexed: 0.5,
+            sel_eq_unindexed: 0.1,
+            ..Default::default()
+        };
+        assert!(params.validate().is_err());
+    }
+
+    #[test]
+    fn test_cache_reuse_bounds() {
+        let mut params = CostModelParams {
+            cache_reuse_factor: 1.0,
+            ..Default::default()
+        };
+        assert!(params.validate().is_err());
+
+        params.cache_reuse_factor = -0.1;
+        assert!(params.validate().is_err());
+
+        params.cache_reuse_factor = 0.99;
+        assert!(params.validate().is_ok());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_roundtrip() {
+        let params = CostModelParams::default();
+        let json = serde_json::to_string(&params).unwrap();
+        let parsed: CostModelParams = serde_json::from_str(&json).unwrap();
+        assert!((params.sel_eq_unindexed - parsed.sel_eq_unindexed).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_partial_json_uses_defaults() {
+        let defaults = CostModelParams::new();
+        let json = r#"{"sel_eq_unindexed": 0.05}"#;
+        let params: CostModelParams = serde_json::from_str(json).unwrap();
+        assert!((params.sel_eq_unindexed - 0.05).abs() < f64::EPSILON);
+        // Other fields should be defaults
+        assert!((params.sel_range - defaults.sel_range).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_load_from_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_cost_params.json");
+        let defaults = CostModelParams::new();
+
+        // Write a partial JSON file - unspecified fields should use defaults
+        let json = r#"{
+            "sel_eq_unindexed": 0.15,
+            "sel_eq_indexed": 0.005,
+            "rows_per_table_fallback": 500000.0
+        }"#;
+        std::fs::write(&path, json).unwrap();
+
+        let params = CostModelParams::load_from_file(&path);
+
+        // Specified values should be loaded
+        assert!((params.sel_eq_unindexed - 0.15).abs() < f64::EPSILON);
+        assert!((params.sel_eq_indexed - 0.005).abs() < f64::EPSILON);
+        assert!((params.rows_per_table_fallback - 500000.0).abs() < f64::EPSILON);
+
+        // Unspecified values should be defaults
+        assert!((params.sel_range - defaults.sel_range).abs() < f64::EPSILON);
+        assert!((params.rows_per_page - defaults.rows_per_page).abs() < f64::EPSILON);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_load_from_file_invalid_json_returns_defaults() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_invalid_cost_params.json");
+        let defaults = CostModelParams::new();
+
+        std::fs::write(&path, "not valid json {{{").unwrap();
+
+        let params = CostModelParams::load_from_file(&path);
+
+        // Should return defaults on parse error
+        assert!((params.sel_eq_unindexed - defaults.sel_eq_unindexed).abs() < f64::EPSILON);
+        assert!(
+            (params.rows_per_table_fallback - defaults.rows_per_table_fallback).abs()
+                < f64::EPSILON
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_load_from_file_missing_returns_defaults() {
+        let path = std::path::Path::new("/nonexistent/path/to/params.json");
+        let defaults = CostModelParams::new();
+
+        let params = CostModelParams::load_from_file(path);
+
+        // Should return defaults when file doesn't exist
+        assert!((params.sel_eq_unindexed - defaults.sel_eq_unindexed).abs() < f64::EPSILON);
+        assert!(
+            (params.rows_per_table_fallback - defaults.rows_per_table_fallback).abs()
+                < f64::EPSILON
+        );
+    }
+}

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -31,7 +31,7 @@ use crate::{
 use constraints::{
     constraints_from_where_clause, usable_constraints_for_join_order, Constraint, ConstraintRef,
 };
-use cost::{Cost, ESTIMATED_HARDCODED_ROWS_PER_TABLE};
+use cost::Cost;
 use join::{compute_best_join_order, BestJoinOrderResult};
 use lift_common_subexpressions::lift_common_subexpressions_from_binary_or_terms;
 use order::{compute_order_target, plan_satisfies_order_target, EliminatesSortBy};
@@ -55,6 +55,7 @@ use super::{
 pub(crate) mod access_method;
 pub(crate) mod constraints;
 pub(crate) mod cost;
+mod cost_params;
 pub(crate) mod join;
 pub(crate) mod lift_common_subexpressions;
 pub(crate) mod order;
@@ -333,6 +334,7 @@ fn collect_index_method_candidates(
     limit: &Option<Box<Expr>>,
     offset: &Option<Box<Expr>>,
     base_table_rows: &[RowCountEstimate],
+    params: &cost_params::CostModelParams,
 ) -> Result<Vec<IndexMethodCandidate>> {
     let mut candidates = Vec::new();
 
@@ -382,7 +384,7 @@ fn collect_index_method_candidates(
                     let base_rows = base_table_rows
                         .get(table_idx)
                         .map(|r| **r)
-                        .unwrap_or(ESTIMATED_HARDCODED_ROWS_PER_TABLE as f64);
+                        .unwrap_or(params.rows_per_table_fallback);
                     cursor.estimate_cost(pattern_match.pattern_idx, base_rows)
                 });
 
@@ -940,7 +942,11 @@ fn register_expression_index_usages_for_plan(
 }
 
 /// Derive a base row-count estimate for a table, preferring ANALYZE stats.
-fn base_row_estimate(schema: &Schema, table: &JoinedTable) -> RowCountEstimate {
+fn base_row_estimate(
+    schema: &Schema,
+    table: &JoinedTable,
+    params: &cost_params::CostModelParams,
+) -> RowCountEstimate {
     match &table.table {
         Table::BTree(btree) => {
             if let Some(stats) = schema.analyze_stats.table_stats(&btree.name) {
@@ -953,9 +959,9 @@ fn base_row_estimate(schema: &Schema, table: &JoinedTable) -> RowCountEstimate {
                     return RowCountEstimate::AnalyzeStats(rows as f64);
                 }
             }
-            RowCountEstimate::HardcodedFallback(ESTIMATED_HARDCODED_ROWS_PER_TABLE as f64)
+            RowCountEstimate::hardcoded_fallback(params)
         }
-        _ => RowCountEstimate::HardcodedFallback(ESTIMATED_HARDCODED_ROWS_PER_TABLE as f64),
+        _ => RowCountEstimate::hardcoded_fallback(params),
     }
 }
 
@@ -983,6 +989,13 @@ fn optimize_table_access(
     limit: &mut Option<Box<Expr>>,
     offset: &mut Option<Box<Expr>>,
 ) -> Result<Option<Vec<JoinOrderMember>>> {
+    // When optimizer_params feature is enabled, use lazily-loaded params (cached process-wide).
+    // Otherwise, use the compile-time static for zero overhead.
+    #[cfg(feature = "optimizer_params")]
+    let params: &cost_params::CostModelParams = &cost_params::LOADED_PARAMS;
+    #[cfg(not(feature = "optimizer_params"))]
+    let params: &cost_params::CostModelParams = &cost_params::DEFAULT_PARAMS;
+
     if table_references.joined_tables().is_empty() {
         return Ok(None);
     }
@@ -1034,7 +1047,7 @@ fn optimize_table_access(
     let base_table_rows_for_candidates = table_references
         .joined_tables()
         .iter()
-        .map(|t| base_row_estimate(schema, t))
+        .map(|t| base_row_estimate(schema, t, params))
         .collect::<Vec<_>>();
 
     let index_method_candidates = if !is_single_table {
@@ -1047,6 +1060,7 @@ fn optimize_table_access(
             limit,
             offset,
             &base_table_rows_for_candidates,
+            params,
         )?
     } else {
         Vec::new()
@@ -1058,12 +1072,13 @@ fn optimize_table_access(
         available_indexes,
         subqueries,
         schema,
+        params,
     )?;
 
     let base_table_rows = table_references
         .joined_tables()
         .iter()
-        .map(|t| base_row_estimate(schema, t))
+        .map(|t| base_row_estimate(schema, t, params))
         .collect::<Vec<_>>();
 
     // Currently the expressions we evaluate as constraints are binary expressions that will never be true for a NULL operand.
@@ -1114,6 +1129,7 @@ fn optimize_table_access(
         where_clause,
         subqueries,
         &index_method_candidates,
+        params,
     )?
     else {
         return Ok(None);


### PR DESCRIPTION
1. we have lots of tunables scattered in different files -> centralize them.
2. add `optimizer_params` compile-time feature that allows loading optimizer parameter overrides from a JSON file. plan is to use this feature to do some sensitivity analysis or potentially ML tuning of parameters