### PR TITLE
perf octet

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -194,10 +194,9 @@ impl Value {
 
     pub fn exec_octet_length(&self) -> Self {
         match self {
-            Value::Text(_) | Value::Integer(_) | Value::Float(_) => {
-                Value::Integer(self.to_string().into_bytes().len() as i64)
-            }
+            Value::Text(s) => Value::Integer(s.as_str().len() as i64),
             Value::Blob(blob) => Value::Integer(blob.len() as i64),
+            Value::Integer(_) | Value::Float(_) => Value::Integer(self.to_string().len() as i64),
             _ => self.to_owned(),
         }
     }


### PR DESCRIPTION
## Description
eliminate allocs in octet_length
Before:
<img width="1089" height="472" alt="image" src="https://github.com/user-attachments/assets/084c5e77-bbc0-41a6-9cdb-a72e7be1fbaa" />
After:
<img width="1097" height="81" alt="image" src="https://github.com/user-attachments/assets/8bb10cf1-2b11-431e-967c-aec157972101" />

## Motivation and context
Add simple perf fixes by using divan and codspeed


## Description of AI Usage
Asked Gemini to improve performance.