### PR TITLE
fix: eagerly remove ORDER BY if single aggregate, no groups/windows

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1090,8 +1090,7 @@ pub fn emit_query<'a>(
 
     program.preassign_label_to_next_insn(after_main_loop_label);
 
-    let mut order_by_necessary =
-        !plan.order_by.is_empty() && !plan.contains_constant_false_condition;
+    let order_by_necessary = !plan.order_by.is_empty() && !plan.contains_constant_false_condition;
     let order_by = &plan.order_by;
 
     // Handle GROUP BY and aggregation processing
@@ -1108,8 +1107,6 @@ pub fn emit_query<'a>(
     } else if !plan.aggregates.is_empty() {
         // Handle aggregation without GROUP BY (or HAVING without GROUP BY)
         emit_ungrouped_aggregation(program, t_ctx, plan)?;
-        // Single row result for aggregates without GROUP BY, so ORDER BY not needed
-        order_by_necessary = false;
     } else if plan.window.is_some() {
         emit_window_results(program, t_ctx, plan)?;
     }

--- a/turso-test-runner/tests/orderby/memory.sqltest
+++ b/turso-test-runner/tests/orderby/memory.sqltest
@@ -85,3 +85,25 @@ expect {
     2
 }
 
+# Single-row aggregate queries (aggregates without GROUP BY) produce exactly one row,
+# so sqlite removes ORDER BY entirely because it's meaningless - this also means validation
+# of the ORDER BY is skipped. In these examples, the ORDER BY contains an invalid subquery
+# where the column counts don't match: a IN (SELECT a, b, c FROM t). This would normally fail
+# validation but doesn't since the ORDER BY is removed.
+test orderby_single_row_aggregate_optimization {
+    CREATE TABLE t(a, b, c);
+    SELECT COUNT(a) FROM t ORDER BY COALESCE(a IN (SELECT a, b, c FROM t), b);
+}
+expect {
+    0
+}
+
+test orderby_single_row_aggregate_with_data {
+    CREATE TABLE t(a, b, c);
+    INSERT INTO t VALUES (1, 2, 3), (4, 5, 6);
+    SELECT COUNT(a) FROM t ORDER BY COALESCE(a IN (SELECT a, b, c FROM t), b);
+}
+expect {
+    2
+}
+


### PR DESCRIPTION
Single-row aggregate queries (aggregates without GROUP BY) produce exactly one row, so sqlite removes ORDER BY entirely because it's meaningless - this also means validation of the ORDER BY is skipped. For example, if the ORDER BY contains an invalid subquery where the column counts don't match: a IN (SELECT a, b, c FROM t), this would normally fail validation but doesn't since the ORDER BY is removed.

Found using @pedrocarlo 's new testing tool https://github.com/tursodatabase/turso/pull/4642
