### PR TITLE
fix: move subqueries to ephemeral plan when WHERE clause is moved

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -757,7 +757,8 @@ fn add_ephemeral_table_to_update_plan(
         distinctness: super::plan::Distinctness::NonDistinct,
         values: vec![],
         window: None,
-        non_from_clause_subqueries: vec![],
+        // Move subqueries from the main plan to the ephemeral plan since the WHERE clause was moved
+        non_from_clause_subqueries: plan.non_from_clause_subqueries.drain(..).collect(),
     };
 
     plan.ephemeral_plan = Some(ephemeral_plan);


### PR DESCRIPTION
When UPDATE uses an ephemeral plan, the WHERE clause is drained to it but subqueries were left on the main plan, causing 'subquery must be correlated' panic for uncorrelated subqueries.

Simplified example: UPDATE t SET a = 1 WHERE NOT EXISTS (SELECT x FROM t LIMIT 1)

Found using @pedrocarlo 's new testing tool https://github.com/tursodatabase/turso/pull/4642
