### PR TITLE
fix: truncate ORDER BY after rowid when rowid is first

### DIFF
--- a/turso-test-runner/tests/orderby/memory.sqltest
+++ b/turso-test-runner/tests/orderby/memory.sqltest
@@ -107,3 +107,26 @@ expect {
     2
 }
 
+# SQLite truncates ORDER BY after a rowid/INTEGER PRIMARY KEY column since the table is
+# stored in rowid order and a unique column means no ties. This skips validation of
+# subsequent clauses, so even invalid constructs like multi-column IN subqueries pass.
+test orderby_rowid_truncation {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t VALUES (1, 'x'), (2, 'y');
+    SELECT a FROM t ORDER BY a DESC, b NOT IN (SELECT a, b FROM t);
+}
+expect {
+    2
+    1
+}
+
+test orderby_rowid_truncation_explicit_rowid {
+    CREATE TABLE t(a INTEGER, b TEXT);
+    INSERT INTO t VALUES (1, 'x'), (2, 'y');
+    SELECT a FROM t ORDER BY rowid DESC, b NOT IN (SELECT a, b FROM t);
+}
+expect {
+    2
+    1
+}
+


### PR DESCRIPTION
SQLite optimizes away ORDER BY clauses after a rowid/INTEGER PRIMARY KEY column when it's FIRST, since the table is stored in rowid order and ties are impossible. This optimization happens before validation, so invalid expressions after the rowid are never checked.

Example that SQLite accepts (and now Turso does too):
  SELECT a FROM t ORDER BY a DESC, b NOT IN (SELECT a, b FROM t)
  -- The multi-column IN is invalid but never validated because
  -- ORDER BY is truncated to just 'a DESC' first
  
Found this using @pedrocarlo 's new testing tool https://github.com/tursodatabase/turso/pull/4642