### PR TITLE
add ReadableName strategy for differential fuzzer so that we mostly generate readable identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5100,6 +5100,7 @@ checksum = "d372029cb5195f9ab4e4b9aef550787dce78b124fcaee8d82519925defcd6f0d"
 name = "sql_gen_prop"
 version = "0.5.0-pre.1"
 dependencies = [
+ "anarchist-readable-name-generator-lib",
  "proptest",
  "serde",
  "strum",

--- a/testing/differential-oracle/sql_gen_prop/Cargo.toml
+++ b/testing/differential-oracle/sql_gen_prop/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib.rs"
 proptest = "1.9"
 strum.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
+anarchist-readable-name-generator-lib = "0.2.0"
 
 [lints]
 workspace = true

--- a/testing/differential-oracle/sql_gen_prop/schema.rs
+++ b/testing/differential-oracle/sql_gen_prop/schema.rs
@@ -306,3 +306,5 @@ impl Schema {
             .collect()
     }
 }
+
+// GENERATION


### PR DESCRIPTION
## Description
Generate more readable identifiers for differential fuzzer. 70% of the times it generates readable identifiers, 30% of the times it generates the crazy names. 
