### PR TITLE
remove NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/react-native.yml
+++ b/.github/workflows/react-native.yml
@@ -191,8 +191,6 @@ jobs:
             npm publish --dry-run
           fi
         working-directory: ${{ env.working-directory }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish (dry-run)
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Now we get an error during publish:

```
npm error need auth You need to authorize this machine using `npm adduser`
```