### PR TITLE
fix: avoid exponential CTE re-planning during query compilation

### DIFF
--- a/turso-test-runner/tests/cte.sqltest
+++ b/turso-test-runner/tests/cte.sqltest
@@ -25,6 +25,25 @@ expect {
     1
 }
 
+# Test for long CTE chains - regression test for exponential re-planning issue
+# See: https://github.com/tursodatabase/turso/issues/4887
+test cte-chain-long {
+    CREATE TABLE t (x INT);
+    INSERT INTO t VALUES (1);
+    WITH
+      c1 AS (SELECT x FROM t),
+      c2 AS (SELECT x FROM c1),
+      c3 AS (SELECT x FROM c2),
+      c4 AS (SELECT x FROM c3),
+      c5 AS (SELECT x FROM c4),
+      c6 AS (SELECT x FROM c5),
+      c7 AS (SELECT x FROM c6)
+    SELECT * FROM c7;
+}
+expect {
+    1
+}
+
 # =============================================================================
 # CTE with compound SELECT (UNION, UNION ALL, INTERSECT, EXCEPT)
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes the exponential O(~2^n) complexity in CTE planning by adding memoization. Chained CTEs like `c1 -> c2 -> ... -> c7` now compile in linear time.

The issue was that `plan_cte()` recursively planned dependencies without checking if they were already planned and added to `outer_query_refs`.

## Test plan

- [x] Added regression test `cte-chain-long` with 7 chained CTEs
- [x] All existing CTE tests pass
- [x] Clippy passes

Closes #4887

🤖 Generated with [Claude Code](https://claude.ai/claude-code)