### PR TITLE
sim: test fsyncing, drop pending writes to simulate powerloss/crash

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4070,7 +4070,7 @@ impl Pager {
             }
             AllocatePage1State::Syncing { page, completion } => {
                 if !completion.finished() {
-                    io_yield_one!(completion.clone());
+                    io_yield_one!(completion);
                 }
                 if !completion.succeeded() {
                     let err = completion

--- a/testing/runner/src/parser/mod.rs
+++ b/testing/runner/src/parser/mod.rs
@@ -1120,7 +1120,6 @@ expect {
         assert!(file.tests[0].modifiers.skip.is_none());
     }
 
-
     #[test]
     fn test_parse_backend_specific_expectations() {
         let input = r#"

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -19,7 +19,7 @@ use sql_generation::{
             transaction::{Begin, Commit, Rollback},
             update::{SetValue, Update},
         },
-        table::SimValue,
+        table::{Column, ColumnType, SimValue, Table as GenTable},
     },
 };
 use strum::IntoEnumIterator;
@@ -32,11 +32,12 @@ use crate::{
     model::{
         Query, QueryCapabilities, QueryDiscriminants, ResultSet,
         interactions::{
-            Assertion, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
+            Assertion, Fault, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
         },
         metrics::Remaining,
         property::{InteractiveQueryInfo, Property, PropertyDiscriminants},
     },
+    runner::cli::IoBackend,
     runner::env::SimulatorEnv,
 };
 
@@ -229,7 +230,9 @@ impl Property {
             Property::Queries { .. } => {
                 unreachable!("No extensional querie generation for `Property::Queries`")
             }
-            Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => {
+            Property::FsyncNoWait { .. }
+            | Property::CrashAfterWalSyncDoesNotLoseData { .. }
+            | Property::FaultyQuery { .. } => {
                 unreachable!("No extensional queries")
             }
             Property::SelectLimit { .. }
@@ -922,6 +925,51 @@ impl Property {
                     InteractionType::FsyncQuery(query.clone()),
                 )]
             }
+            Property::CrashAfterWalSyncDoesNotLoseData { create, insert } => {
+                let table_name = insert.table().to_string();
+                let table_dependency = table_name.clone();
+                let table_name_in_closure = table_name.clone();
+                let expected_row = vec![SimValue(types::Value::Integer(1))];
+                let assumption = InteractionType::Assumption(Assertion::new(
+                    format!("wal is durable for table {table_name}"),
+                    move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
+                        let wal_table = env
+                            .durability
+                            .wal_durable
+                            .iter()
+                            .find(|t| t.name == table_name_in_closure);
+                        match wal_table {
+                            Some(t) if t.rows.contains(&expected_row) => Ok(Ok(())),
+                            Some(_) => Ok(Err(
+                                "wal durable state does not include the expected row".into(),
+                            )),
+                            None => Ok(Err(
+                                "wal durable state does not include the expected table".into(),
+                            )),
+                        }
+                    },
+                    vec![table_dependency],
+                ));
+
+                vec![
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::Create(
+                        create.clone(),
+                    ))),
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::Begin(
+                        Begin::Immediate,
+                    ))),
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::Insert(
+                        insert.clone(),
+                    ))),
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::Commit(
+                        Commit,
+                    ))),
+                    InteractionBuilder::with_interaction(assumption),
+                    InteractionBuilder::with_interaction(InteractionType::Fault(
+                        Fault::PowerLossRecoverAndVerify,
+                    )),
+                ]
+            }
             Property::FaultyQuery { query } => {
                 let query_clone = query.clone();
                 // A fault may not occur as we first signal we want a fault injected,
@@ -1571,6 +1619,40 @@ fn property_fsync_no_wait<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_crash_after_wal_sync_does_not_lose_data<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    _query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    let mut table_name;
+    loop {
+        table_name = format!("crash_wal_{}", rng.random_range(0..u32::MAX));
+        if !ctx.tables().iter().any(|t| t.name == table_name) {
+            break;
+        }
+    }
+
+    let table = GenTable {
+        name: table_name.clone(),
+        columns: vec![Column {
+            name: "x".to_string(),
+            column_type: ColumnType::Integer,
+            constraints: Vec::new(),
+        }],
+        rows: Vec::new(),
+        indexes: Vec::new(),
+    };
+
+    let create = Create { table };
+    let insert = Insert::Values {
+        table: table_name,
+        values: vec![vec![SimValue(types::Value::Integer(1))]],
+    };
+
+    Property::CrashAfterWalSyncDoesNotLoseData { create, insert }
+}
+
 fn property_faulty_query<R: rand::Rng + ?Sized>(
     rng: &mut R,
     query_distr: &QueryDistribution,
@@ -1607,6 +1689,9 @@ impl PropertyDiscriminants {
                 property_union_all_preserves_cardinality
             }
             PropertyDiscriminants::FsyncNoWait => property_fsync_no_wait,
+            PropertyDiscriminants::CrashAfterWalSyncDoesNotLoseData => {
+                property_crash_after_wal_sync_does_not_lose_data
+            }
             PropertyDiscriminants::FaultyQuery => property_faulty_query,
             PropertyDiscriminants::Queries => {
                 unreachable!("should not try to generate queries property")
@@ -1703,6 +1788,17 @@ impl PropertyDiscriminants {
                     0
                 }
             }
+            PropertyDiscriminants::CrashAfterWalSyncDoesNotLoseData => {
+                if env.profile.experimental_mvcc
+                    || !env.profile.io.enable
+                    || env.io_backend != IoBackend::Memory
+                    || env.opts.disable_crash_after_wal_sync
+                {
+                    0
+                } else {
+                    1
+                }
+            }
             PropertyDiscriminants::FaultyQuery => {
                 if env.profile.io.enable
                     && env.profile.io.fault.enable
@@ -1752,6 +1848,9 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::WhereTrueFalseNull => QueryCapabilities::SELECT,
             PropertyDiscriminants::UnionAllPreservesCardinality => QueryCapabilities::SELECT,
             PropertyDiscriminants::FsyncNoWait => QueryCapabilities::all(),
+            PropertyDiscriminants::CrashAfterWalSyncDoesNotLoseData => {
+                QueryCapabilities::CREATE.union(QueryCapabilities::INSERT)
+            }
             PropertyDiscriminants::FaultyQuery => QueryCapabilities::all(),
             PropertyDiscriminants::Queries => panic!("queries property should not be generated"),
         }

--- a/testing/simulator/main.rs
+++ b/testing/simulator/main.rs
@@ -206,11 +206,12 @@ fn run_simulator(
         let mut env_guard = env.lock().unwrap();
         if matches!(&result, SandboxedResult::Panicked { .. }) && env_guard.has_crashed() {
             if cli_opts.crash_dump {
-                tracing::info!("Crash detected, dumping db/wal files for inspection (--crash-dump)...");
+                tracing::info!(
+                    "Crash detected, dumping db/wal files for inspection (--crash-dump)..."
+                );
                 env_guard.persist_crash_files().unwrap_or_else(|e| {
                     tracing::error!("Failed to persist crash files: {}", e);
                 });
-                let db_path = env_guard.get_db_path();
                 std::process::exit(0);
             }
             tracing::info!("Panic was caused by crash injection, attempting recovery...");

--- a/testing/simulator/main.rs
+++ b/testing/simulator/main.rs
@@ -216,7 +216,7 @@ fn run_simulator(
                     tracing::error!("Crash recovery failed: {}", e);
                     // Keep original panic result with recovery failure info
                     SandboxedResult::Panicked {
-                        error: format!("{e}"),
+                        error: e.to_string(),
                         last_execution: match &result {
                             SandboxedResult::Panicked { last_execution, .. } => *last_execution,
                             _ => unreachable!(),

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -830,15 +830,6 @@ impl InteractionType {
 fn reopen_database(env: &mut SimulatorEnv) {
     // 1. Close all connections without default checkpoint-on-close behavior
     // to expose bugs related to how we handle WAL
-    reopen_database_impl(env, false);
-}
-
-#[allow(dead_code)]
-fn reopen_database_with_checkpoint(env: &mut SimulatorEnv) {
-    reopen_database_impl(env, true);
-}
-
-fn reopen_database_impl(env: &mut SimulatorEnv, checkpoint_on_close: bool) {
     let mvcc = env.profile.experimental_mvcc;
     let num_conns = env.connections.len();
 
@@ -850,11 +841,6 @@ fn reopen_database_impl(env: &mut SimulatorEnv, checkpoint_on_close: bool) {
         }
     }
 
-    if checkpoint_on_close {
-        for conn in &mut env.connections {
-            conn.disconnect();
-        }
-    }
     env.connections.clear();
 
     // Clear all open files

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -830,6 +830,15 @@ impl InteractionType {
 fn reopen_database(env: &mut SimulatorEnv) {
     // 1. Close all connections without default checkpoint-on-close behavior
     // to expose bugs related to how we handle WAL
+    reopen_database_impl(env, false);
+}
+
+#[allow(dead_code)]
+fn reopen_database_with_checkpoint(env: &mut SimulatorEnv) {
+    reopen_database_impl(env, true);
+}
+
+fn reopen_database_impl(env: &mut SimulatorEnv, checkpoint_on_close: bool) {
     let mvcc = env.profile.experimental_mvcc;
     let num_conns = env.connections.len();
 
@@ -841,6 +850,11 @@ fn reopen_database(env: &mut SimulatorEnv) {
         }
     }
 
+    if checkpoint_on_close {
+        for conn in &mut env.connections {
+            conn.disconnect();
+        }
+    }
     env.connections.clear();
 
     // Clear all open files

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -179,6 +179,15 @@ pub enum Property {
     FsyncNoWait {
         query: Query,
     },
+
+    /// CrashAfterWalSyncDoesNotLoseData simulates a power loss after the WAL has been
+    /// successfully synced and verifies that WAL-durable data can be recovered.
+    ///
+    /// this is intended for the simulator's in-memory IO backend only.
+    CrashAfterWalSyncDoesNotLoseData {
+        create: Create,
+        insert: Insert,
+    },
     FaultyQuery {
         query: Query,
     },
@@ -221,7 +230,9 @@ impl Property {
             | Property::DeleteSelect { queries, .. }
             | Property::DropSelect { queries, .. }
             | Property::Queries { queries } => Some(queries),
-            Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
+            Property::FsyncNoWait { .. }
+            | Property::CrashAfterWalSyncDoesNotLoseData { .. }
+            | Property::FaultyQuery { .. } => None,
             Property::SelectLimit { .. }
             | Property::SelectSelectOptimizer { .. }
             | Property::WhereTrueFalseNull { .. }

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -163,6 +163,12 @@ pub struct SimulatorCLI {
     pub keep_files: bool,
     #[clap(
         long,
+        help = "On crash, persist db/wal files and exit without recovery (for manual inspection)",
+        default_value_t = false
+    )]
+    pub crash_dump: bool,
+    #[clap(
+        long,
         help = "Disable the SQLite integrity check at the end of a simulation",
         default_value_t = normal_or_miri(false, true)
     )]

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -143,6 +143,12 @@ pub struct SimulatorCLI {
     pub disable_union_all_preserves_cardinality: bool,
     #[clap(long, help = "disable FsyncNoWait Property", default_value_t = true)]
     pub disable_fsync_no_wait: bool,
+    #[clap(
+        long,
+        help = "disable CrashAfterWalSyncDoesNotLoseData Property",
+        default_value_t = false
+    )]
+    pub disable_crash_after_wal_sync: bool,
     #[clap(long, help = "disable FaultyQuery Property")]
     pub disable_faulty_query: bool,
     #[clap(long, help = "disable Reopen-Database fault")]
@@ -163,12 +169,6 @@ pub struct SimulatorCLI {
     pub keep_files: bool,
     #[clap(
         long,
-        help = "On crash, persist db/wal files and exit without recovery (for manual inspection)",
-        default_value_t = false
-    )]
-    pub crash_dump: bool,
-    #[clap(
-        long,
         help = "Disable the SQLite integrity check at the end of a simulation",
         default_value_t = normal_or_miri(false, true)
     )]
@@ -183,10 +183,6 @@ pub struct SimulatorCLI {
     #[clap(long, default_value_t = ProfileType::Default)]
     /// Profile selector for Simulation run
     pub profile: ProfileType,
-
-    #[clap(long)]
-    #[serde(default)]
-    pub crash_fuzz: bool,
 }
 
 #[derive(Parser, Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -177,6 +177,10 @@ pub struct SimulatorCLI {
     #[clap(long, default_value_t = ProfileType::Default)]
     /// Profile selector for Simulation run
     pub profile: ProfileType,
+
+    #[clap(long)]
+    #[serde(default)]
+    pub crash_fuzz: bool,
 }
 
 #[derive(Parser, Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -99,7 +99,10 @@ impl DurabilityState {
                 if file_type == FileType::Wal && *new_len == 0 && !self.wal_durable.is_empty() {
                     let count = self.wal_durable.len();
                     self.db_durable = std::mem::take(&mut self.wal_durable);
-                    tracing::info!("DURABILITY: checkpoint complete - {} tables DB-durable", count);
+                    tracing::info!(
+                        "DURABILITY: checkpoint complete - {} tables DB-durable",
+                        count
+                    );
                 }
             }
         }
@@ -820,7 +823,11 @@ impl SimulatorEnv {
 
         let latency_prof = &self.profile.io.latency;
         let crash_config = (self.opts.crash_at_io_op > 0).then_some(self.opts.crash_at_io_op);
-        let latency = if crash_config.is_some() { 0 } else { latency_prof.latency_probability };
+        let latency = if crash_config.is_some() {
+            0
+        } else {
+            latency_prof.latency_probability
+        };
         let io: Arc<dyn SimIO> = match self.io_backend {
             IoBackend::Memory => Arc::new(MemorySimIO::new(
                 self.opts.seed,
@@ -831,7 +838,15 @@ impl SimulatorEnv {
                 crash_config,
             )),
             _ => Arc::new(
-                SimulatorIO::new(self.opts.seed, self.opts.page_size, latency, latency_prof.min_tick, latency_prof.max_tick, self.io_backend).unwrap(),
+                SimulatorIO::new(
+                    self.opts.seed,
+                    self.opts.page_size,
+                    latency,
+                    latency_prof.min_tick,
+                    latency_prof.max_tick,
+                    self.io_backend,
+                )
+                .unwrap(),
             ),
         };
 
@@ -981,7 +996,11 @@ impl SimulatorEnv {
         let latency_prof = &profile.io.latency;
         let io_backend = cli_opts.io_backend;
         let crash_config = (opts.crash_at_io_op > 0).then_some(opts.crash_at_io_op);
-        let latency = if crash_config.is_some() { 0 } else { latency_prof.latency_probability };
+        let latency = if crash_config.is_some() {
+            0
+        } else {
+            latency_prof.latency_probability
+        };
         let io: Arc<dyn SimIO> = match io_backend {
             IoBackend::Memory => Arc::new(MemorySimIO::new(
                 opts.seed,
@@ -992,7 +1011,15 @@ impl SimulatorEnv {
                 crash_config,
             )),
             _ => Arc::new(
-                SimulatorIO::new(opts.seed, opts.page_size, latency, latency_prof.min_tick, latency_prof.max_tick, io_backend).unwrap(),
+                SimulatorIO::new(
+                    opts.seed,
+                    opts.page_size,
+                    latency,
+                    latency_prof.min_tick,
+                    latency_prof.max_tick,
+                    io_backend,
+                )
+                .unwrap(),
             ),
         };
 
@@ -1193,8 +1220,8 @@ impl SimulatorEnv {
             .map_err(|e| format!("persist failed: {e}"))?;
 
         let db_path = self.get_db_path();
-        let sqlite_conn = rusqlite::Connection::open(&db_path)
-            .map_err(|e| format!("reopen failed: {e}"))?;
+        let sqlite_conn =
+            rusqlite::Connection::open(&db_path).map_err(|e| format!("reopen failed: {e}"))?;
 
         let integrity: String = sqlite_conn
             .query_row("PRAGMA integrity_check", [], |row| row.get(0))
@@ -1227,7 +1254,11 @@ impl SimulatorEnv {
             let actual: Vec<Vec<SimValue>> = stmt
                 .query_map([], |row| {
                     Ok((0..col_count)
-                        .map(|i| Self::rusqlite_to_simvalue(row.get::<_, rusqlite::types::Value>(i).unwrap()))
+                        .map(|i| {
+                            Self::rusqlite_to_simvalue(
+                                row.get::<_, rusqlite::types::Value>(i).unwrap(),
+                            )
+                        })
                         .collect())
                 })
                 .map_err(|e| format!("table '{}': {e}", table.name))?

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1203,9 +1203,7 @@ impl SimulatorEnv {
         }
         self.db = None;
         self.io.discard_all_pending();
-        self.io
-            .persist_files()
-            .map_err(|e| format!("failed: {e}"))
+        self.io.persist_files().map_err(|e| format!("failed: {e}"))
     }
 
     /// Attempt crash recovery: reopen database, run integrity_check, verify durable data.

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1255,9 +1255,7 @@ impl SimulatorEnv {
             .for_each(|conn| *conn = SimConnection::Disconnected);
 
         match self.type_ {
-            SimulationType::Differential => {
-                Ok(())
-            }
+            SimulationType::Differential => Ok(()),
             SimulationType::Default | SimulationType::Doublecheck => {
                 let db_path = self.get_db_path();
                 let db = Database::open_file_with_flags(

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1196,6 +1196,18 @@ impl SimulatorEnv {
         self.io.has_crashed()
     }
 
+    pub fn persist_crash_files(&mut self) -> Result<(), String> {
+        self.io.close_files();
+        for conn in &mut self.connections {
+            conn.disconnect();
+        }
+        self.db = None;
+        self.io.discard_all_pending();
+        self.io
+            .persist_files()
+            .map_err(|e| format!("failed: {e}"))
+    }
+
     /// Attempt crash recovery: reopen database, run integrity_check, verify durable data.
     pub fn attempt_crash_recovery(&mut self) -> Result<(), String> {
         let expected_tables = self.durability.expected_recoverable();

--- a/testing/simulator/runner/memory/io.rs
+++ b/testing/simulator/runner/memory/io.rs
@@ -197,7 +197,7 @@ impl Operation {
                         PendingWrite::Truncate { len } => Some(*len),
                         _ => None,
                     })
-                    .last();
+                    .next_back();
 
                 let had_content = !file.durable_buffer.borrow().is_empty()
                     || file

--- a/testing/simulator/runner/memory/io.rs
+++ b/testing/simulator/runner/memory/io.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -7,9 +7,59 @@ use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use turso_core::{Clock, Completion, IO, MonotonicInstant, OpenFlags, Result, WallClockInstant};
 
-use crate::runner::SimIO;
 use crate::runner::clock::SimulatorClock;
-use crate::runner::memory::file::MemorySimFile;
+use crate::runner::memory::file::{MemorySimFile, PendingWrite};
+use crate::runner::{DurableIOEvent, SimIO};
+
+#[derive(Debug)]
+struct CrashState {
+    crash_at: u64,
+    count: Cell<u64>,
+    crashed: Cell<bool>,
+}
+
+impl CrashState {
+    fn new(crash_at: u64) -> Self {
+        Self {
+            crash_at,
+            count: Cell::new(0),
+            crashed: Cell::new(false),
+        }
+    }
+
+    fn check(&self) -> bool {
+        if self.crashed.get() {
+            return true;
+        }
+        let n = self.count.get() + 1;
+        self.count.set(n);
+        if n == self.crash_at {
+            self.crashed.set(true);
+            return true;
+        }
+        false
+    }
+
+    fn has_crashed(&self) -> bool {
+        self.crashed.get()
+    }
+
+    fn count(&self) -> u64 {
+        self.count.get()
+    }
+}
+
+fn check_crash(state: &Option<CrashState>, op: &str, path: &str) -> bool {
+    let Some(s) = state else { return false };
+    if s.has_crashed() {
+        return true;
+    }
+    if s.check() {
+        tracing::warn!("CRASH at IO #{} ({}) file={}", s.count(), op, path);
+        return true;
+    }
+    false
+}
 
 /// File descriptor
 pub type Fd = String;
@@ -60,18 +110,37 @@ pub struct Operation {
 }
 
 impl Operation {
-    fn do_operation(self, files: &IndexMap<Fd, Arc<MemorySimFile>>) {
+    fn do_operation(
+        self,
+        files: &IndexMap<Fd, Arc<MemorySimFile>>,
+        durable_events: &RefCell<Vec<DurableIOEvent>>,
+        crash_state: &Option<CrashState>,
+    ) {
         let fd = self.fd;
         match self.op {
             OperationType::Read { completion, offset } => {
                 let file = files.get(fd.as_str()).unwrap();
-                let file_buf = file.buffer.borrow_mut();
+                let durable = file.durable_buffer.borrow();
+                let pending = file.pending_writes.borrow();
+
+                let mut effective_data = durable.clone();
+                for write in pending.iter() {
+                    write.apply_to(&mut effective_data);
+                }
+
                 let buffer = completion.as_read().buf.clone();
                 let buf_size = {
                     let buf = buffer.as_mut_slice();
                     // TODO: check for sector faults here
-
-                    buf.copy_from_slice(&file_buf[offset..][0..buf.len()]);
+                    let read_end = (offset + buf.len()).min(effective_data.len());
+                    if offset < effective_data.len() {
+                        let available = read_end - offset;
+                        buf[..available].copy_from_slice(&effective_data[offset..read_end]);
+                        // Zero-fill any remaining buffer space
+                        buf[available..].fill(0);
+                    } else {
+                        buf.fill(0);
+                    }
                     buf.len() as i32
                 };
                 completion.complete(buf_size);
@@ -81,35 +150,90 @@ impl Operation {
                 completion,
                 offset,
             } => {
+                if check_crash(crash_state, "pwrite", fd.as_str()) {
+                    completion.abort();
+                    return;
+                }
+
                 let file = files.get(fd.as_str()).unwrap();
-                let buf_size = file.write_buf(buffer.as_slice(), offset);
-                completion.complete(buf_size as i32);
+                file.write_buf(buffer.as_slice(), offset);
+                completion.complete(buffer.len() as i32);
             }
             OperationType::WriteV {
                 buffers,
                 completion,
                 offset,
             } => {
-                if buffers.is_empty() {
+                assert!(!buffers.is_empty(), "WriteV called with empty buffers");
+                if check_crash(crash_state, "pwritev", fd.as_str()) {
+                    completion.abort();
                     return;
                 }
+
                 let file = files.get(fd.as_str()).unwrap();
                 let mut pos = offset;
-                let written = buffers.into_iter().fold(0, |written, buffer| {
-                    let buf_size = file.write_buf(buffer.as_slice(), pos);
-                    pos += buf_size;
-                    written + buf_size
-                });
-                completion.complete(written as i32);
+                let mut total = 0;
+
+                for buffer in buffers {
+                    file.write_buf(buffer.as_slice(), pos);
+                    pos += buffer.len();
+                    total += buffer.len();
+                }
+
+                completion.complete(total as i32);
             }
             OperationType::Sync { completion, .. } => {
-                // There is no Sync for in memory
+                if check_crash(crash_state, "fsync", fd.as_str()) {
+                    completion.complete(-1);
+                    return;
+                }
+
+                let file = files.get(fd.as_str()).unwrap();
+                let pending_truncate = file
+                    .pending_writes
+                    .borrow()
+                    .iter()
+                    .filter_map(|w| match w {
+                        PendingWrite::Truncate { len } => Some(*len),
+                        _ => None,
+                    })
+                    .last();
+
+                let had_content = !file.durable_buffer.borrow().is_empty()
+                    || file
+                        .pending_writes
+                        .borrow()
+                        .iter()
+                        .any(|w| matches!(w, PendingWrite::Write { .. }));
+
+                file.flush_pending();
+
+                let durable_size = file.durable_buffer.borrow().len();
+                durable_events.borrow_mut().push(DurableIOEvent::Sync {
+                    file_path: fd.to_string(),
+                    had_content,
+                    durable_size,
+                });
+
+                if let Some(len) = pending_truncate {
+                    durable_events
+                        .borrow_mut()
+                        .push(DurableIOEvent::TruncateSynced {
+                            file_path: fd.to_string(),
+                            new_len: len,
+                        });
+                }
                 completion.complete(0);
             }
             OperationType::Truncate { completion, len } => {
+                if check_crash(crash_state, "ftruncate", fd.as_str()) {
+                    completion.complete(-1);
+                    return;
+                }
                 let file = files.get(fd.as_str()).unwrap();
-                let mut file_buf = file.buffer.borrow_mut();
-                file_buf.truncate(len);
+                file.pending_writes
+                    .borrow_mut()
+                    .push(PendingWrite::Truncate { len });
                 completion.complete(0);
             }
         }
@@ -128,6 +252,10 @@ pub struct MemorySimIO {
     seed: u64,
     latency_probability: u8,
     clock: Arc<SimulatorClock>,
+    /// Crash state for crash-at-write-N
+    crash_state: Option<CrashState>,
+    /// Events are pushed on sync/truncate, consumed by take_durable_events
+    durable_events: RefCell<Vec<DurableIOEvent>>,
 }
 
 unsafe impl Send for MemorySimIO {}
@@ -140,9 +268,12 @@ impl MemorySimIO {
         latency_probability: u8,
         min_tick: u64,
         max_tick: u64,
+        crash_at_io_op: Option<u64>,
     ) -> Self {
         let files = RefCell::new(IndexMap::new());
         let rng = RefCell::new(ChaCha8Rng::seed_from_u64(seed));
+        let crash_state = crash_at_io_op.map(CrashState::new);
+
         Self {
             callbacks: Arc::new(Mutex::new(Vec::new())),
             timeouts: Arc::new(Mutex::new(Vec::new())),
@@ -156,6 +287,8 @@ impl MemorySimIO {
                 min_tick,
                 max_tick,
             )),
+            crash_state,
+            durable_events: RefCell::new(Vec::new()),
         }
     }
 }
@@ -198,14 +331,26 @@ impl SimIO for MemorySimIO {
     }
 
     fn persist_files(&self) -> anyhow::Result<()> {
-        let files = self.files.borrow();
-        for (file_path, file) in files.iter() {
-            if file_path.ends_with(".db") || file_path.ends_with("wal") || file_path.ends_with("lg")
-            {
-                std::fs::write(file_path, &*file.buffer.borrow())?;
+        for (path, file) in self.files.borrow().iter() {
+            if path.ends_with(".db") || path.ends_with("wal") || path.ends_with("lg") {
+                std::fs::write(path, &*file.durable_buffer.borrow())?;
             }
         }
         Ok(())
+    }
+
+    fn has_crashed(&self) -> bool {
+        self.crash_state.as_ref().is_some_and(|s| s.has_crashed())
+    }
+
+    fn discard_all_pending(&self) {
+        for file in self.files.borrow().values() {
+            file.discard_pending();
+        }
+    }
+
+    fn take_durable_events(&self) -> Vec<DurableIOEvent> {
+        self.durable_events.borrow_mut().drain(..).collect()
     }
 }
 
@@ -271,7 +416,7 @@ impl IO for MemorySimIO {
                     completion.abort();
                     continue;
                 }
-                callback.do_operation(&files);
+                callback.do_operation(&files, &self.durable_events, &self.crash_state);
             } else {
                 timeouts.push(callback);
             }

--- a/testing/simulator/runner/mod.rs
+++ b/testing/simulator/runner/mod.rs
@@ -61,6 +61,5 @@ pub trait SimIO: turso_core::IO {
         Vec::new()
     }
 
-    
     fn simulate_power_loss(&self) {}
 }

--- a/testing/simulator/runner/mod.rs
+++ b/testing/simulator/runner/mod.rs
@@ -12,6 +12,41 @@ pub mod memory;
 
 pub const FAULT_ERROR_MSG: &str = "Injected Fault";
 
+/// IO event that affects durability tracking.
+/// Used to precisely track what data is durable after each IO operation.
+#[derive(Debug, Clone)]
+pub enum DurableIOEvent {
+    Sync {
+        file_path: String,
+        /// True if file had content before sync (for WAL: had frames). else false.
+        had_content: bool,
+        durable_size: usize,
+    },
+    TruncateSynced { file_path: String, new_len: usize },
+}
+
+pub const WAL_HEADER_SIZE: usize = 32;
+
+/// turso have no shm - todo when we support it
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileType {
+    Database,
+    Wal,
+    Other,
+}
+
+impl FileType {
+    pub fn from_path(path: &str) -> Self {
+        if path.ends_with(".db") {
+            FileType::Database
+        } else if path.ends_with("-wal") {
+            FileType::Wal
+        } else {
+            FileType::Other
+        }
+    }
+}
+
 pub trait SimIO: turso_core::IO {
     fn inject_fault(&self, fault: bool);
 
@@ -22,4 +57,16 @@ pub trait SimIO: turso_core::IO {
     fn close_files(&self);
 
     fn persist_files(&self) -> anyhow::Result<()>;
+
+    fn has_crashed(&self) -> bool {
+        false
+    }
+
+    /// after this, only durable data remains. Default: no-op.
+    fn discard_all_pending(&self) {}
+
+    /// this provides precise tracking of what data is durable after each IO operation.
+    fn take_durable_events(&self) -> Vec<DurableIOEvent> {
+        Vec::new()
+    }
 }

--- a/testing/simulator/runner/mod.rs
+++ b/testing/simulator/runner/mod.rs
@@ -22,7 +22,10 @@ pub enum DurableIOEvent {
         had_content: bool,
         durable_size: usize,
     },
-    TruncateSynced { file_path: String, new_len: usize },
+    TruncateSynced {
+        file_path: String,
+        new_len: usize,
+    },
 }
 
 pub const WAL_HEADER_SIZE: usize = 32;

--- a/testing/simulator/runner/mod.rs
+++ b/testing/simulator/runner/mod.rs
@@ -18,17 +18,12 @@ pub const FAULT_ERROR_MSG: &str = "Injected Fault";
 pub enum DurableIOEvent {
     Sync {
         file_path: String,
-        /// True if file had content before sync (for WAL: had frames). else false.
-        had_content: bool,
-        durable_size: usize,
-    },
-    TruncateSynced {
-        file_path: String,
-        new_len: usize,
+        /// Durable size before the sync.
+        prev_durable_size: usize,
+        /// Durable size after the sync.
+        new_durable_size: usize,
     },
 }
-
-pub const WAL_HEADER_SIZE: usize = 32;
 
 /// turso have no shm - todo when we support it
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -61,15 +56,11 @@ pub trait SimIO: turso_core::IO {
 
     fn persist_files(&self) -> anyhow::Result<()>;
 
-    fn has_crashed(&self) -> bool {
-        false
-    }
-
-    /// after this, only durable data remains. Default: no-op.
-    fn discard_all_pending(&self) {}
-
     /// this provides precise tracking of what data is durable after each IO operation.
     fn take_durable_events(&self) -> Vec<DurableIOEvent> {
         Vec::new()
     }
+
+    
+    fn simulate_power_loss(&self) {}
 }


### PR DESCRIPTION
discord discussion: https://discord.com/channels/1258658826257961020/1321869557459058778/1461029406481846272

### The Problem
TL;DR: If Turso crashes after writing to the WAL but before syncing the main DB file, the database file remains 0 bytes on disk while a valid WAL exists. On reopen/recovery, both SQLite and Turso detect the 0-byte DB file and incorrectly delete/zero out the WAL, resulting in data loss.

### Fix

Added sync_db_file() method to sync the main database file after writing page 1
Modified allocate_page1_state machine to include a Syncing state that ensures fsync completes before marking page 1 as allocated
This ensures the DB file is durably written to disk before any WAL operations can proceed

### Verification
```
 Clone verification branch (isolated to avoid merge conflicts)
git clone github.com/pavan-nambi/sim_verify

# Run simulator with specific seed that reproduces the bug
cargo run --bin limbo_sim -- \
  --crash-fuzz \
  --maximum-tests 100 \
  --io-backend memory \
  --seed 8695788232174134326 \
  --disable-faulty-query \
  --crash-dump

check file sizes
ls -lh /home/pavan/Documents/github/test/turso/.bugbase/8695788232174134326/

# Attempt to open database (demonstrates data loss)
cargo run --bin tursodb /home/pavan/Documents/github/test/turso/.bugbase/8695788232174134326/test.db
.tables

# both db and wal are 0
ls -lh /home/pavan/Documents/github/test/turso/.bugbase/8695788232174134326/

```

## future work

add pragma wal_checkpoint to sql_generation
