### PR TITLE
Fix bug in hash join table mask calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/target.noindex
 /.idea
 /.vscode
 /.sqlite3

--- a/tests/integration/query_processing/test_hash_join_materialization.rs
+++ b/tests/integration/query_processing/test_hash_join_materialization.rs
@@ -1,4 +1,5 @@
 use crate::common::{limbo_exec_rows, TempDatabase};
+use core_tester::common::sqlite_exec_rows;
 use rusqlite::types::Value;
 
 fn value_as_i64(value: &Value) -> Option<i64> {
@@ -189,4 +190,96 @@ fn hash_join_materialization_does_not_read_unrewound_probe_cursor() {
             _ => {}
         }
     }
+}
+
+#[test]
+/// Regression: losing a JOIN predicate during hash-join materialization.
+///
+/// Before, the constraint t3.a = sub_t4.a was removed due to incorrect
+/// table masks in build_materialized_build_input_plan, causing both the
+/// hash join materialization subplan and the main query plan to mark the
+/// constraint as consumed, so it was never evaluated anywhere, resulting
+/// in extra rows.
+fn hash_join_preserves_join_predicates_after_outer_join_conversion() {
+    let _ = env_logger::try_init();
+    let tmp_db = TempDatabase::new_empty();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+    let conn = tmp_db.connect_limbo();
+    let schema = [
+        "CREATE TABLE t1(id INTEGER PRIMARY KEY, a INT, b INT, c INT, d INT)",
+        "CREATE TABLE t2(id INTEGER PRIMARY KEY, a INT, b INT, c INT, d INT)",
+        "CREATE TABLE t3(id INTEGER PRIMARY KEY, a INT, b INT, c INT, d INT)",
+        "CREATE TABLE t4(id INTEGER PRIMARY KEY, a INT, b INT, c INT, d INT)",
+    ];
+    for stmt in &schema {
+        limbo_exec_rows(&conn, stmt);
+        sqlite_conn.execute(stmt, []).unwrap();
+    }
+
+    sqlite_conn.execute("BEGIN", []).unwrap();
+    conn.execute("BEGIN").unwrap();
+    for id in 1..=200_i64 {
+        let t1 = format!(
+            "INSERT INTO t1(id,a,b,c,d) VALUES ({id}, {}, {}, {}, {})",
+            id % 20,
+            id % 10,
+            id % 25,
+            id % 5
+        );
+        let t2 = format!(
+            "INSERT INTO t2(id,a,b,c,d) VALUES ({id}, {}, {}, {}, {})",
+            id % 20,
+            id % 7,
+            id % 11,
+            id % 5
+        );
+        let t3 = format!(
+            "INSERT INTO t3(id,a,b,c,d) VALUES ({id}, {}, {}, {}, {})",
+            id % 20,
+            id % 9,
+            id % 13,
+            id % 5
+        );
+        let t4 = format!(
+            "INSERT INTO t4(id,a,b,c,d) VALUES ({id}, {}, {}, {}, {})",
+            id % 20,
+            id % 4,
+            id % 17,
+            id % 6
+        );
+        conn.execute(&t1).unwrap();
+        conn.execute(&t2).unwrap();
+        conn.execute(&t3).unwrap();
+        conn.execute(&t4).unwrap();
+        sqlite_conn.execute(&t1, []).unwrap();
+        sqlite_conn.execute(&t2, []).unwrap();
+        sqlite_conn.execute(&t3, []).unwrap();
+        sqlite_conn.execute(&t4, []).unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+    sqlite_conn.execute("COMMIT", []).unwrap();
+
+    let query = "SELECT t1.id, t2.id, t3.id, sub_t4.a \
+FROM t1 \
+JOIN t2 ON t1.d = t2.d \
+JOIN t3 ON t2.a = t3.a \
+LEFT JOIN (SELECT a, sum(b) AS sum_b, max(c) AS max_c, count(*) AS cnt FROM t4 GROUP BY a) AS sub_t4 \
+  ON t3.a = sub_t4.a \
+WHERE t1.c IS NOT NULL AND sub_t4.a = 15 \
+ORDER BY t1.id, t2.id, t3.id, sub_t4.a LIMIT 50";
+
+    let explain_rows = limbo_exec_rows(&conn, &format!("EXPLAIN {query}"));
+    let has_hash = explain_rows.iter().any(|row| {
+        row.get(1)
+            .and_then(value_as_text)
+            .is_some_and(|op| op == "HashBuild" || op == "HashProbe")
+    });
+    assert!(has_hash, "expected hash join in EXPLAIN output");
+
+    let sqlite_rows = sqlite_exec_rows(&sqlite_conn, query);
+    let limbo_rows = limbo_exec_rows(&conn, query);
+    assert_eq!(
+        sqlite_rows, limbo_rows,
+        "Mismatch after outer join conversion with hash join materialization"
+    );
 }


### PR DESCRIPTION
A bug in `build_materialized_build_input_plan` caused both the hash build materialization subplan and the
main plan to drop a join constraint so it was never evaluated
-> too many rows returned.

The bug was that the table masks between "what we don't evaluate in subplan" vs "what we don't evaluate in main plan" were not symmetrical.

I actually introduced this bug in #4885 when fixing another hash-join related bug :)

--- 

Also contains a join-reordering optimization which i decided to
leave in this PR, because I originally thought it fixed the bug,
but it only stopped it from happening in my specific error case
(see regression test in this commit)