### PR TITLE
`CHAR` should return `\0` for `NULL`

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1192,8 +1192,8 @@ impl Value {
 
     pub fn exec_char<'a, T: Iterator<Item = &'a Self>>(values: T) -> Self {
         let result: String = values
-            .filter_map(|x| {
-                if let Value::Integer(i) = x {
+            .filter_map(|x| match x {
+                Value::Integer(i) => {
                     // Convert integer to Unicode codepoint.
                     // For invalid codepoints (negative, surrogates, or > U+10FFFF),
                     // output U+FFFD (replacement character) to match SQLite behavior.
@@ -1202,9 +1202,10 @@ impl Value {
                     } else {
                         Some('\u{FFFD}')
                     }
-                } else {
-                    None
                 }
+                // NULL arguments produce NUL characters to match SQLite behavior.
+                Value::Null => Some('\0'),
+                _ => None,
             })
             .collect();
         Value::build_text(result)
@@ -1966,7 +1967,7 @@ mod tests {
                     .iter()
                     .map(|reg| reg.get_value())
             ),
-            Value::build_text("")
+            Value::build_text("\0")
         );
         assert_eq!(
             Value::exec_char(

--- a/turso-test-runner/tests/char.sqltest
+++ b/turso-test-runner/tests/char.sqltest
@@ -1,5 +1,46 @@
 @database :memory:
 
+test char {
+    select char(108, 105)
+}
+expect {
+    li
+}
+
+test char-nested {
+    select char(106 + 2, 105)
+}
+expect {
+    li
+}
+
+test char-empty {
+    select char()
+}
+expect {
+}
+
+test char-null {
+    select hex(char(null))
+}
+expect {
+    00
+}
+
+test char-non-integer {
+    select char('a')
+}
+expect {
+}
+
+# char() with unicode codepoints >= 256
+test char-unicode-256 {
+    select unicode(char(256))
+}
+expect {
+    256
+}
+
 test char-basic-ascii {
     SELECT CHAR(65, 66, 67);
 }
@@ -61,5 +102,26 @@ test char-over-max-replacement {
 }
 expect {
     EFBFBD
+}
+
+test char-null-produces-nul {
+    SELECT HEX(CHAR(NULL));
+}
+expect {
+    00
+}
+
+test char-null-in-middle {
+    SELECT HEX(CHAR(65, NULL, 66));
+}
+expect {
+    410042
+}
+
+test char-multiple-nulls {
+    SELECT HEX(CHAR(NULL, 65, NULL, NULL, 66, NULL));
+}
+expect {
+    004100004200
 }
 

--- a/turso-test-runner/tests/scalar-functions.sqltest
+++ b/turso-test-runner/tests/scalar-functions.sqltest
@@ -71,53 +71,6 @@ expect {
     0helloworld
 }
 
-test char {
-    select char(108, 105)
-}
-expect {
-    li
-}
-
-test char-nested {
-    select char(106 + 2, 105)
-}
-expect {
-    li
-}
-
-test char-empty {
-    select char()
-}
-expect {
-}
-
-test char-null {
-    select char(null)
-}
-expect {
-}
-
-test char-non-integer {
-    select char('a')
-}
-expect {
-}
-
-# char() with unicode codepoints >= 256
-test char-unicode-256 {
-    select unicode(char(256))
-}
-expect {
-    256
-}
-
-test char-unicode-emoji {
-    select unicode(char(128512))
-}
-expect {
-    128512
-}
-
 test abs {
     select abs(1);
 }


### PR DESCRIPTION
Found by the differential fuzzer