### PR TITLE
fix `is_nonnull` check for primary key columns

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1862,7 +1862,9 @@ impl Optimizable for ast::Expr {
                     .expect("table not found");
                 let columns = table_ref.columns();
                 let column = &columns[*column];
-                column.primary_key() || column.notnull()
+                // Only INTEGER PRIMARY KEY (rowid alias) is implicitly NOT NULL.
+                // Other PRIMARY KEY types (e.g., TEXT PRIMARY KEY) can contain NULL.
+                column.is_rowid_alias() || column.notnull()
             }
             Expr::RowId { .. } => true,
             Expr::InList { lhs, rhs, .. } => {

--- a/turso-test-runner/tests/subquery/memory.sqltest
+++ b/turso-test-runner/tests/subquery/memory.sqltest
@@ -849,3 +849,41 @@ test subquery-column-affinity-inheritance-text {
 expect {
     0
 }
+
+# TEXT PRIMARY KEY can contain NULL (unlike INTEGER PRIMARY KEY which is rowid alias).
+# NOT IN subquery with NULL in TEXT PRIMARY KEY should return NULL, not 0.
+# Regression test: is_nonnull() must check is_rowid_alias(), not primary_key().
+test subquery-not-in-text-primary-key-null {
+    create table t(a TEXT PRIMARY KEY);
+    insert into t values (NULL);
+    insert into t values ('x');
+    select a, a NOT IN (SELECT a FROM t) from t order by a;
+}
+expect {
+    |
+    x|0
+}
+
+# Same test with IN (not NOT IN)
+test subquery-in-text-primary-key-null {
+    create table t(a TEXT PRIMARY KEY);
+    insert into t values (NULL);
+    insert into t values ('x');
+    select a, a IN (SELECT a FROM t) from t order by a;
+}
+expect {
+    |
+    x|1
+}
+
+# INTEGER PRIMARY KEY cannot contain NULL (auto-assigns rowid)
+test subquery-not-in-integer-primary-key-null {
+    create table t(a INTEGER PRIMARY KEY);
+    insert into t values (NULL);
+    insert into t values (2);
+    select a, a NOT IN (SELECT a FROM t) from t order by a;
+}
+expect {
+    1|0
+    2|0
+}


### PR DESCRIPTION
## Description
Found with differential fuzzer.

We incorrectly assumed that Primary Keys were always not null. This is only true for `rowid_alias` (e.g Integer Primary Key)


## Description of AI Usage
Investigate the bug