### PR TITLE
fix: group concat did not convert values to text on output

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3692,7 +3692,7 @@ fn apply_kbn_step_int(acc: &mut Value, i: i64, state: &mut SumAggState) {
 /// - Total: [Float(0.0), Float(0.0), Integer(0), Integer(0)]  // same but starts at 0.0
 /// - Avg: [Float(0.0), Float(0.0), Integer(0)]  // sum, r_err, count - uses KBN like SUM
 /// - Min/Max: [Null]
-/// - GroupConcat/StringAgg: [Text("")]
+/// - GroupConcat/StringAgg: [Null] (becomes Text on first non-null value)
 /// - JsonGroupObject/JsonbGroupObject: [Blob([])]
 /// - JsonGroupArray/JsonbGroupArray: [Blob([])]
 fn init_agg_payload(func: &AggFunc, payload: &mut Vec<Value>) -> Result<()> {
@@ -3716,7 +3716,8 @@ fn init_agg_payload(func: &AggFunc, payload: &mut Vec<Value>) -> Result<()> {
         }
         AggFunc::Min | AggFunc::Max => payload.push(Value::Null),
         AggFunc::GroupConcat | AggFunc::StringAgg => {
-            payload.push(Value::build_text(""));
+            // Use Null as sentinel to distinguish "no values yet" from "accumulated empty string"
+            payload.push(Value::Null);
         }
         AggFunc::External(_) => {
             // External aggregates use ExternalAggState, not flat payload
@@ -3757,7 +3758,7 @@ fn init_agg_payload(func: &AggFunc, payload: &mut Vec<Value>) -> Result<()> {
 ///   - `approx`: 1 if result is approximate (float arithmetic used)
 ///   - `ovrfl`: 1 if integer overflow occurred (Total promotes to float, Sum errors)
 /// - **Min/Max**: `[current_extreme: Value]` - tracks min/max seen so far
-/// - **GroupConcat/StringAgg**: `[accumulated: Text]` - concatenated string
+/// - **GroupConcat/StringAgg**: `[accumulated: Null|Text]` - Null until first value, then Text
 /// - **JsonGroup***: `[raw_jsonb: Blob]` - accumulated raw JSONB bytes
 fn update_agg_payload(
     func: &AggFunc,
@@ -3951,12 +3952,12 @@ fn update_agg_payload(
             }
             let delimiter = maybe_arg2.unwrap_or_else(|| Value::build_text(","));
             let acc = &mut payload[0];
-            if acc.to_string().is_empty() {
-                // Convert arg to Text to ensure GROUP_CONCAT always returns TEXT type
+            if matches!(acc, Value::Null) {
+                // First non-null value: convert to Text
                 *acc = Value::build_text(arg.to_string());
             } else {
-                *acc += delimiter;
-                *acc += arg;
+                acc.exec_group_concat(&delimiter);
+                acc.exec_group_concat(&arg);
             }
         }
         AggFunc::External(_) => {

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1154,6 +1154,16 @@ impl Value {
         result.map(|v| v.to_owned()).unwrap_or(Value::Null)
     }
 
+    /// Concatenate another value onto this Text value, converting both to strings.
+    /// Used by GROUP_CONCAT/STRING_AGG to properly handle all value types.
+    /// Panics if self is not a Text value.
+    pub fn exec_group_concat(&mut self, other: &Value) {
+        let Value::Text(text) = self else {
+            panic!("concat_to_text must be called only on Value::Text");
+        };
+        text.value.to_mut().push_str(&other.to_string());
+    }
+
     pub fn exec_concat_strings<'a, T: Iterator<Item = &'a Self>>(registers: T) -> Self {
         let mut result = String::new();
         for val in registers {

--- a/turso-test-runner/tests/agg-functions/group-concat-types.sqltest
+++ b/turso-test-runner/tests/agg-functions/group-concat-types.sqltest
@@ -154,3 +154,248 @@ test string-agg-integer-separator {
 expect {
     a100b100c
 }
+
+# Mixed type permutation tests
+
+test group-concat-integer-and-text {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), ('hello'), (2);
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    1,hello,2
+}
+
+test group-concat-integer-and-text-type {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), ('hello'), (2);
+    SELECT typeof(GROUP_CONCAT(x)) FROM t;
+}
+expect {
+    text
+}
+
+test group-concat-real-and-integer {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1.5), (2), (3.7);
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    1.5,2,3.7
+}
+
+test group-concat-real-and-integer-type {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1.5), (2), (3.7);
+    SELECT typeof(GROUP_CONCAT(x)) FROM t;
+}
+expect {
+    text
+}
+
+test group-concat-text-and-real {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES ('abc'), (3.14), ('def');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    abc,3.14,def
+}
+
+test group-concat-blob-single {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (x'48454c4c4f');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    HELLO
+}
+
+test group-concat-blob-single-type {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (x'48454c4c4f');
+    SELECT typeof(GROUP_CONCAT(x)) FROM t;
+}
+expect {
+    text
+}
+
+test group-concat-blob-multiple {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (x'48454c4c4f'), (x'574f524c44');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    HELLO,WORLD
+}
+
+test group-concat-blob-and-text {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (x'48454c4c4f'), ('world');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    HELLO,world
+}
+
+test group-concat-blob-and-integer {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (x'4142'), (123), (x'4344');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    AB,123,CD
+}
+
+test group-concat-blob-and-real {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (x'4142'), (3.14);
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    AB,3.14
+}
+
+test group-concat-null-and-integer {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (NULL), (1), (NULL), (2);
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    1,2
+}
+
+test group-concat-null-and-text {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (NULL), ('a'), (NULL), ('b');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    a,b
+}
+
+test group-concat-null-and-blob {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (NULL), (x'4142'), (NULL);
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    AB
+}
+
+test group-concat-null-and-real {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (NULL), (1.5), (NULL), (2.5);
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    1.5,2.5
+}
+
+test group-concat-all-types-mixed {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), ('hello'), (3.14), (x'4142'), (NULL), (2);
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    1,hello,3.14,AB,2
+}
+
+test group-concat-all-types-mixed-type {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), ('hello'), (3.14), (x'4142'), (NULL), (2);
+    SELECT typeof(GROUP_CONCAT(x)) FROM t;
+}
+expect {
+    text
+}
+
+test group-concat-integer-text-real-blob {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (42), ('foo'), (2.718), (x'424152');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    42,foo,2.718,BAR
+}
+
+test group-concat-real-blob-text-integer {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1.1), (x'5858'), ('yy'), (99);
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    1.1,XX,yy,99
+}
+
+# Mixed types with custom separator
+
+test group-concat-mixed-types-custom-separator {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), ('a'), (2.5);
+    SELECT GROUP_CONCAT(x, ' | ') FROM t;
+}
+expect {
+    1 | a | 2.5
+}
+
+test group-concat-blob-text-integer-separator {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (x'4142'), ('cd'), (12);
+    SELECT GROUP_CONCAT(x, '-') FROM t;
+}
+expect {
+    AB-cd-12
+}
+
+# Empty string and mixed types
+
+test group-concat-empty-string-and-integer {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (''), (1), ('');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    ,1,
+}
+
+test group-concat-empty-string-and-blob {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (''), (x'4142'), ('');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    ,AB,
+}
+
+# Zero values with different types
+
+test group-concat-zero-integer-and-text {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (0), ('zero'), (0);
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    0,zero,0
+}
+
+test group-concat-zero-real-and-text {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (0.0), ('zero');
+    SELECT GROUP_CONCAT(x) FROM t;
+}
+expect {
+    0.0,zero
+}
+
+test group-concat-invalid-utf {
+    CREATE TABLE t(s TEXT);
+    INSERT INTO t VALUES (X'FF');
+    INSERT INTO t VALUES (X'C0C1'); 
+    select group_concat(s) from t;
+}
+expect {
+    �,��
+}
+
+


### PR DESCRIPTION
## Description
Group concat always outputs text. If we convert the args to text then the corresponding output will be text

## Description of AI Usage
Found and fixed the bug
