### PR TITLE
Fix datetime modifier UTF-8 slicing panic

### DIFF
--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -179,6 +179,9 @@ fn get_digits(z: &str, digits: usize, min_val: i32, max_val: i32) -> Option<(i32
     if z.len() < digits {
         return None;
     }
+    if !z.is_char_boundary(digits) {
+        return None;
+    }
     let bytes = z.as_bytes();
     if !bytes.iter().take(digits).all(|b| b.is_ascii_digit()) {
         return None;
@@ -642,6 +645,11 @@ fn parse_arithmetic_modifier(p: &mut DateTime, z: &str) -> Result<()> {
     if clean_z.len() >= 10
         && clean_z.as_bytes().get(4) == Some(&b'-')
         && clean_z.as_bytes().get(7) == Some(&b'-')
+        && clean_z.is_char_boundary(4)
+        && clean_z.is_char_boundary(5)
+        && clean_z.is_char_boundary(7)
+        && clean_z.is_char_boundary(8)
+        && clean_z.is_char_boundary(10)
     {
         let y_res = get_digits(&clean_z[0..4], 4, 0, 9999);
         let m_res = get_digits(&clean_z[5..7], 2, 0, 11);

--- a/turso-test-runner/tests/scalar-functions-datetime.sqltest
+++ b/turso-test-runner/tests/scalar-functions-datetime.sqltest
@@ -2164,6 +2164,12 @@ test datetime-multibyte-utf8-greek {
 expect {
 }
 
+test datetime-multibyte-modifier-arithmetic {
+    SELECT datetime('2024-01-01', '88:------ӄ');
+}
+expect {
+}
+
 # Invalid Leap Years
 test date-leapyear-floor {
     SELECT date('2000-02-31', 'floor');
@@ -2441,4 +2447,3 @@ test strftime-format-bool-false {
 expect {
     0
 }
-


### PR DESCRIPTION
A fuzz test found this panic:

```
thread '<unnamed>' (7206) panicked at /home/runner/_work/turso/turso/core/functions/datetime.rs:648:40:
byte index 10 is not a char boundary; it is inside 'ӄ' (bytes 9..11) of `88:------ӄ`
```

## Description of AI usage

Codex wrote this, I just gave it the panic.