### PR TITLE
core/storage: Reject non-UTF-8 encoded databases on open

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -97,6 +97,8 @@ pub enum LimboError {
     PlanningError(String),
     #[error("Checkpoint failed: {0}")]
     CheckpointFailed(String),
+    #[error("Unsupported text encoding: {0}. Only UTF-8 is supported.")]
+    UnsupportedEncoding(String),
 }
 
 #[cfg(target_family = "unix")]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1058,6 +1058,13 @@ impl Database {
 
         let header: HeaderRefMut = self.io.block(|| HeaderRefMut::from_pager(&pager))?;
         let header_mut = header.borrow_mut();
+
+        if !header_mut.text_encoding.is_utf8() {
+            return Err(LimboError::UnsupportedEncoding(
+                header_mut.text_encoding.to_string(),
+            ));
+        }
+
         let (read_version, write_version) = { (header_mut.read_version, header_mut.write_version) };
 
         if encryption_key.is_none() && header_mut.magic != SQLITE_HEADER {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -261,10 +261,16 @@ pub struct TextEncoding(U32BE);
 
 impl TextEncoding {
     #![allow(non_upper_case_globals)]
+    // SQLite doesn't write the text encoding bytes until the first table is written, so when
+    // opening an empty SQLite file, the encoding bytes will be 0. SQLite considers this to mean UTF-8.
     pub const Unset: Self = Self(U32BE::new(0));
     pub const Utf8: Self = Self(U32BE::new(1));
     pub const Utf16Le: Self = Self(U32BE::new(2));
     pub const Utf16Be: Self = Self(U32BE::new(3));
+
+    pub fn is_utf8(&self) -> bool {
+        self == &Self::Utf8 || self == &Self::Unset
+    }
 }
 
 impl std::fmt::Display for TextEncoding {


### PR DESCRIPTION
Turso only supports UTF-8 encoding. This change adds validation during database header parsing to check the text_encoding field (bytes 56-59) and return a clear `UnsupportedEncoding` error when the database uses UTF-16LE or UTF-16BE encoding instead of silently failing later.

Closes #4932

Generated with [Claude Code](https://claude.ai/code)