### PR TITLE
fix: assign no affinity to compound SELECT subquery columns

### DIFF
--- a/turso-test-runner/tests/affinity.sqltest
+++ b/turso-test-runner/tests/affinity.sqltest
@@ -370,3 +370,29 @@ expect @js {
     real|100000
     real|-100000
 }
+
+test affinity-compound-select-text-int-comparison {
+    SELECT x, x = 2 FROM (SELECT CAST(2 AS TEXT) AS x UNION ALL SELECT 2.0);
+}
+expect {
+    2|0
+    2.0|1
+}
+expect @js {
+    2|0
+    2|1
+}
+
+test affinity-compound-select-no-affinity {
+    SELECT typeof(x), x, x = 2, x = '2' FROM (SELECT CAST(2 AS TEXT) AS x UNION ALL SELECT 2 UNION ALL SELECT 2.0);
+}
+expect {
+    text|2|0|1
+    integer|2|1|0
+    real|2.0|1|0
+}
+expect @js {
+    text|2|0|1
+    integer|2|1|0
+    real|2|1|0
+}


### PR DESCRIPTION
## Summary

- Fix wrong comparison results between text and integer values in UNION ALL subqueries
- Compound SELECT subquery columns now get BLOB (no affinity) instead of inheriting the leftmost SELECT's inferred type

Closes https://github.com/tursodatabase/turso/issues/4927

## Problem

```sql
SELECT x, x = 2 FROM (SELECT CAST(2 AS TEXT) AS x UNION ALL SELECT 2.0);
```

| | `x` | `x = 2` |
|---|---|---|
| **SQLite** | `2` / `2.0` | `0` / `1` |
| **Turso (before)** | `2` / `2.0` | `1` / `0` |

The bug was in `new_subquery_from_plan` (`core/translate/plan.rs`), which inferred column types from the leftmost SELECT's expressions. For `CAST(2 AS TEXT)`, this gave the column TEXT affinity. With TEXT affinity, `x = 2` coerced integer `2` to text `"2"`, producing `text "2" = text "2" -> 1` (wrong).

## SQLite docs

From [Datatypes In SQLite — §3.3.1 Column Affinity For Compound Views](https://sqlite.org/datatype3.html):

> When the SELECT statement that implements a VIEW or FROM-clause subquery is a compound SELECT then the affinity of each column of the VIEW or subquery will be the affinity of the corresponding result column for one of the individual SELECT statements that make up the compound. However, **it is indeterminate which of the SELECT statements will be used to determine affinity**.

Since the affinity is indeterminate across constituent SELECTs, the safe and correct behavior is to assign no affinity (BLOB) to compound SELECT columns. This avoids type coercion and lets values compare by their storage classes, matching SQLite's observed behavior.

## Fix

When `new_subquery_from_plan` handles a `CompoundSelect`, it now assigns `Type::Blob` / `"BLOB"` to all columns instead of calling `infer_type_from_expr` on the leftmost SELECT.

## Test plan

- [x] Added `affinity-compound-select-text-int-comparison` sqltest
- [x] Added `affinity-compound-select-no-affinity` sqltest
- [x] `cargo build` passes
- [x] `cargo clippy` passes
- [x] `make -C turso-test-runner run-cli` — all 239 tests pass