### PR TITLE
add --experimental-attach flag to test runner backends

### DIFF
--- a/bindings/javascript/turso-sql-runner.mjs
+++ b/bindings/javascript/turso-sql-runner.mjs
@@ -81,7 +81,7 @@ async function main() {
 
     let db;
     try {
-        db = await connect(dbPath, { readonly });
+        db = await connect(dbPath, { readonly, experimental: ['triggers', 'attach'] });
         // Enable safe integers to preserve precision for large integers
         db.defaultSafeIntegers(true);
     } catch (err) {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -137,6 +137,7 @@ pub struct Builder {
     path: String,
     enable_encryption: bool,
     enable_triggers: bool,
+    enable_attach: bool,
     vfs: Option<String>,
     encryption_opts: Option<turso_sdk_kit::rsapi::EncryptionOpts>,
 }
@@ -148,6 +149,7 @@ impl Builder {
             path: path.to_string(),
             enable_encryption: false,
             enable_triggers: false,
+            enable_attach: false,
             vfs: None,
             encryption_opts: None,
         }
@@ -168,6 +170,11 @@ impl Builder {
         self
     }
 
+    pub fn experimental_attach(mut self, attach_enabled: bool) -> Self {
+        self.enable_attach = attach_enabled;
+        self
+    }
+
     pub fn with_io(mut self, vfs: String) -> Self {
         self.vfs = Some(vfs);
         self
@@ -179,6 +186,9 @@ impl Builder {
         }
         if self.enable_triggers {
             features.push("triggers");
+        }
+        if self.enable_attach {
+            features.push("attach");
         }
         if features.is_empty() {
             return None;

--- a/turso-test-runner/src/backends/cli.rs
+++ b/turso-test-runner/src/backends/cli.rs
@@ -183,6 +183,7 @@ impl CliDatabaseInstance {
             cmd.arg("--experimental-views");
             cmd.arg("--experimental-strict");
             cmd.arg("--experimental-triggers");
+            cmd.arg("--experimental-attach");
         }
 
         if self.readonly {

--- a/turso-test-runner/src/backends/rust.rs
+++ b/turso-test-runner/src/backends/rust.rs
@@ -93,6 +93,7 @@ impl SqlBackend for RustBackend {
         // Create the database using the Turso builder
         let db = Builder::new_local(&db_path)
             .experimental_triggers(true)
+            .experimental_attach(true)
             .build()
             .await
             .map_err(|e| BackendError::CreateDatabase(e.to_string()))?;


### PR DESCRIPTION
## Description

After the mark attach as experimental change (https://github.com/tursodatabase/turso/pull/4319), ATTACH/DETACH requires an explicit opt-in flag. Update CLI, Rust, and JS test runner backends to enable it so attach tests pass again.

## Description of AI Usage

Claude did this
