### PR TITLE
simulator: add generated columns support

### DIFF
--- a/sql_generation/generation/generated_expr.rs
+++ b/sql_generation/generation/generated_expr.rs
@@ -1,0 +1,331 @@
+//! Expression generation for generated columns.
+
+use std::collections::HashSet;
+
+use rand::Rng;
+use turso_core::collect_column_refs;
+use turso_parser::ast::{self, Expr, Name, Operator, UnaryOperator};
+
+use crate::model::table::{Column, ColumnType};
+
+/// Generates a type-compatible expression for a generated column.
+///
+/// This function creates expressions that can reference ANY column in the table
+/// (including forward references and other generated columns), matching SQLite behavior.
+///
+/// Returns (expression, set of column indices referenced).
+pub fn generate_column_expr_with_refs<R: Rng + ?Sized>(
+    rng: &mut R,
+    all_columns: &[Column],
+    current_col_idx: usize,
+    target_type: &ColumnType,
+    max_depth: usize,
+) -> (ast::Expr, HashSet<usize>) {
+    let mut refs = HashSet::new();
+    let expr = generate_expr_inner(
+        rng,
+        all_columns,
+        current_col_idx,
+        target_type,
+        max_depth,
+        &mut refs,
+    );
+    (expr, refs)
+}
+
+fn generate_expr_inner<R: Rng + ?Sized>(
+    rng: &mut R,
+    all_columns: &[Column],
+    current_col_idx: usize,
+    target_type: &ColumnType,
+    depth: usize,
+    refs: &mut HashSet<usize>,
+) -> ast::Expr {
+    // Find columns that are type-compatible (excluding self)
+    let compatible_cols: Vec<(usize, &Column)> = all_columns
+        .iter()
+        .enumerate()
+        .filter(|(idx, col)| {
+            *idx != current_col_idx && types_compatible(&col.column_type, target_type)
+        })
+        .collect();
+
+    // Base case: depth 0 or no compatible columns
+    if depth == 0 || compatible_cols.is_empty() {
+        // Try a column reference first if we have compatible columns
+        if !compatible_cols.is_empty() && rng.random_bool(0.7) {
+            let (idx, col) = compatible_cols[rng.random_range(0..compatible_cols.len())];
+            refs.insert(idx);
+            return Expr::Id(Name::from_string(&col.name));
+        }
+        // Otherwise, use a literal
+        return generate_literal(rng, target_type);
+    }
+
+    // Choose what kind of expression to generate
+    let choice = rng.random_range(0..10);
+    match choice {
+        // Column reference (40% chance)
+        0..=3 => {
+            let (idx, col) = compatible_cols[rng.random_range(0..compatible_cols.len())];
+            refs.insert(idx);
+            Expr::Id(Name::from_string(&col.name))
+        }
+        // Binary operation (30% chance)
+        4..=6 => {
+            if let Some(op) = pick_binary_op(rng, target_type) {
+                let lhs = generate_expr_inner(
+                    rng,
+                    all_columns,
+                    current_col_idx,
+                    target_type,
+                    depth - 1,
+                    refs,
+                );
+                let rhs = generate_expr_inner(
+                    rng,
+                    all_columns,
+                    current_col_idx,
+                    target_type,
+                    depth - 1,
+                    refs,
+                );
+                // Wrap subexpressions in parentheses to ensure correct evaluation order
+                // when the shadow model evaluates the expression tree directly
+                let lhs = if matches!(lhs, Expr::Binary(..)) {
+                    Expr::Parenthesized(vec![Box::new(lhs)])
+                } else {
+                    lhs
+                };
+                let rhs = if matches!(rhs, Expr::Binary(..)) {
+                    Expr::Parenthesized(vec![Box::new(rhs)])
+                } else {
+                    rhs
+                };
+                Expr::Binary(Box::new(lhs), op, Box::new(rhs))
+            } else if !compatible_cols.is_empty() && rng.random_bool(0.7) {
+                let (idx, col) = compatible_cols[rng.random_range(0..compatible_cols.len())];
+                refs.insert(idx);
+                Expr::Id(Name::from_string(&col.name))
+            } else {
+                generate_literal(rng, target_type)
+            }
+        }
+        // Unary operation (15% chance)
+        7..=8 => {
+            if let Some(op) = pick_unary_op(rng, target_type) {
+                let inner = generate_expr_inner(
+                    rng,
+                    all_columns,
+                    current_col_idx,
+                    target_type,
+                    depth - 1,
+                    refs,
+                );
+                // Wrap binary sub-expressions in parentheses to preserve semantics
+                // when the expression is displayed as SQL and re-parsed.
+                // E.g., Unary(-, Binary(a, -, b)) means "-(a - b)" but without parens
+                // would display as "- a - b" which parses as "(-a) - b"
+                let inner = if matches!(inner, Expr::Binary(..)) {
+                    Expr::Parenthesized(vec![Box::new(inner)])
+                } else {
+                    inner
+                };
+                Expr::Unary(op, Box::new(inner))
+            } else {
+                // Fall back to literal
+                generate_literal(rng, target_type)
+            }
+        }
+        // Parenthesized expression (5% chance)
+        9 => {
+            let inner = generate_expr_inner(
+                rng,
+                all_columns,
+                current_col_idx,
+                target_type,
+                depth - 1,
+                refs,
+            );
+            Expr::Parenthesized(vec![Box::new(inner)])
+        }
+        // Literal (10% implicit from other branches)
+        _ => generate_literal(rng, target_type),
+    }
+}
+
+/// Check if two column types are compatible for expressions.
+fn types_compatible(source: &ColumnType, target: &ColumnType) -> bool {
+    match (source, target) {
+        // Integer and Float are interchangeable
+        (ColumnType::Integer, ColumnType::Integer)
+        | (ColumnType::Integer, ColumnType::Float)
+        | (ColumnType::Float, ColumnType::Integer)
+        | (ColumnType::Float, ColumnType::Float) => true,
+        // Text only with Text
+        (ColumnType::Text, ColumnType::Text) => true,
+        // Blob only with Blob
+        (ColumnType::Blob, ColumnType::Blob) => true,
+        _ => false,
+    }
+}
+
+/// Generate a type-appropriate literal.
+fn generate_literal<R: Rng + ?Sized>(rng: &mut R, target_type: &ColumnType) -> Expr {
+    match target_type {
+        ColumnType::Integer => {
+            // Use smaller integer values to avoid overflow in expressions
+            let val = rng.random_range(-1000i64..1000);
+            Expr::Literal(ast::Literal::Numeric(val.to_string()))
+        }
+        ColumnType::Float => {
+            let val = rng.random_range(-1000.0f64..1000.0);
+            Expr::Literal(ast::Literal::Numeric(format!("{val:.4}")))
+        }
+        ColumnType::Text => {
+            // Generate a simple text literal
+            let text = format!("gen_{}", rng.random_range(0..100));
+            Expr::Literal(ast::Literal::String(format!("'{text}'")))
+        }
+        ColumnType::Blob => {
+            // Generate a simple blob literal
+            let bytes: Vec<u8> = (0..4).map(|_| rng.random()).collect();
+            Expr::Literal(ast::Literal::Blob(hex::encode(bytes)))
+        }
+    }
+}
+
+// TODO: Extend expression generation to include more operators (/, %, bitwise,
+// comparison, LIKE, BETWEEN, IN) and expression types (CASE, function calls)
+// to improve fuzzer coverage of generated column expressions.
+
+/// Pick an appropriate binary operator for the target type.
+fn pick_binary_op<R: Rng + ?Sized>(rng: &mut R, target_type: &ColumnType) -> Option<Operator> {
+    match target_type {
+        ColumnType::Integer | ColumnType::Float => {
+            // Numeric operations
+            let ops = [Operator::Add, Operator::Subtract, Operator::Multiply];
+            Some(ops[rng.random_range(0..ops.len())])
+        }
+        ColumnType::Text | ColumnType::Blob => None,
+    }
+}
+
+/// Pick an appropriate unary operator for the target type (if any).
+fn pick_unary_op<R: Rng + ?Sized>(rng: &mut R, target_type: &ColumnType) -> Option<UnaryOperator> {
+    match target_type {
+        ColumnType::Integer | ColumnType::Float => {
+            if rng.random_bool(0.5) {
+                Some(UnaryOperator::Negative)
+            } else {
+                Some(UnaryOperator::Positive)
+            }
+        }
+        // No meaningful unary ops for text/blob
+        _ => None,
+    }
+}
+
+/// Extract all column references from an expression.
+pub fn extract_column_refs(expr: &ast::Expr) -> HashSet<String> {
+    collect_column_refs(expr).into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_extract_column_refs() {
+        // Create a simple expression: a + b
+        let expr = Expr::Binary(
+            Box::new(Expr::Id(Name::from_string("a"))),
+            Operator::Add,
+            Box::new(Expr::Id(Name::from_string("b"))),
+        );
+        let refs = extract_column_refs(&expr);
+        assert!(refs.contains("a"));
+        assert!(refs.contains("b"));
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_column_refs_expr_name() {
+        // Test that Expr::Name is also recognized as a column reference
+        let expr = Expr::Binary(
+            Box::new(Expr::Name(Name::from_string("a"))),
+            Operator::Subtract,
+            Box::new(Expr::Name(Name::from_string("b"))),
+        );
+        let refs = extract_column_refs(&expr);
+        assert!(refs.contains("a"), "Should find column 'a' in Expr::Name");
+        assert!(refs.contains("b"), "Should find column 'b' in Expr::Name");
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_column_refs_mixed() {
+        // Test mixed Expr::Id and Expr::Name
+        let expr = Expr::Binary(
+            Box::new(Expr::Id(Name::from_string("a"))),
+            Operator::Add,
+            Box::new(Expr::Name(Name::from_string("b"))),
+        );
+        let refs = extract_column_refs(&expr);
+        assert!(refs.contains("a"));
+        assert!(refs.contains("b"));
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_column_refs_normalizes_case() {
+        let expr = Expr::Binary(
+            Box::new(Expr::Id(Name::from_string("A"))),
+            Operator::Add,
+            Box::new(Expr::Id(Name::from_string("b"))),
+        );
+        let refs = extract_column_refs(&expr);
+        assert!(refs.contains("a"));
+        assert!(refs.contains("b"));
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_generate_column_expr() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let columns = vec![
+            Column {
+                name: "col_a".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![],
+            },
+            Column {
+                name: "col_b".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![],
+            },
+            Column {
+                name: "col_c".to_string(),
+                column_type: ColumnType::Text,
+                constraints: vec![],
+            },
+        ];
+
+        // Generate expression for column at index 1 (col_b)
+        let (expr, refs) = generate_column_expr_with_refs(
+            &mut rng,
+            &columns,
+            1, // current column index
+            &ColumnType::Integer,
+            2,
+        );
+
+        // Should not reference itself (col_b at index 1)
+        assert!(!refs.contains(&1));
+
+        // Expression should be valid
+        assert!(!matches!(expr, Expr::Id(name) if name.as_str() == "col_b"));
+    }
+}

--- a/sql_generation/generation/mod.rs
+++ b/sql_generation/generation/mod.rs
@@ -4,6 +4,7 @@ use anarchist_readable_name_generator_lib::readable_name_custom;
 use rand::{distr::uniform::SampleUniform, Rng};
 
 pub mod expr;
+pub mod generated_expr;
 pub mod opts;
 pub mod predicate;
 pub mod query;
@@ -201,7 +202,7 @@ pub fn pick_unique<'a, T: PartialEq, R: Rng + ?Sized>(
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use crate::{
         generation::{GenerationContext, Opts},
         model::table::Table,
@@ -211,6 +212,17 @@ mod tests {
     pub struct TestContext {
         pub opts: Opts,
         pub tables: Vec<Table>,
+    }
+
+    impl TestContext {
+        /// Create a test context with generated columns disabled.
+        /// These tests create random values for all columns, which doesn't work correctly
+        /// with generated columns since their values should be computed from expressions.
+        pub fn no_gencol() -> Self {
+            let mut ctx = Self::default();
+            ctx.opts.table.generated_columns.enable = false;
+            ctx
+        }
     }
 
     impl GenerationContext for TestContext {

--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -38,6 +38,8 @@ pub struct TableOpts {
     /// Range of numbers of columns to generate
     #[garde(custom(range_struct_min(1)))]
     pub column_range: Range<u32>,
+    #[garde(dive)]
+    pub generated_columns: GeneratedColumnOpts,
 }
 
 impl Default for TableOpts {
@@ -46,6 +48,36 @@ impl Default for TableOpts {
             large_table: Default::default(),
             // Up to 10 columns
             column_range: 1..11,
+            generated_columns: Default::default(),
+        }
+    }
+}
+
+/// Options for generating columns with GENERATED constraints
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Validate)]
+#[serde(deny_unknown_fields, default)]
+pub struct GeneratedColumnOpts {
+    /// Enable generated column generation
+    #[garde(skip)]
+    pub enable: bool,
+    /// Probability of a column being generated (0.0 - 1.0)
+    #[garde(range(min = 0.0, max = 1.0))]
+    pub generated_column_prob: f64,
+    /// Probability of a generated column being STORED vs VIRTUAL (0.0 - 1.0)
+    #[garde(range(min = 0.0, max = 1.0))]
+    pub stored_prob: f64,
+    /// Maximum expression depth for generated column expressions (1-10)
+    #[garde(range(min = 1, max = 10))]
+    pub max_expr_depth: usize,
+}
+
+impl Default for GeneratedColumnOpts {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            generated_column_prob: 0.2,
+            stored_prob: 0.5,
+            max_expr_depth: 3,
         }
     }
 }

--- a/sql_generation/generation/predicate/binary.rs
+++ b/sql_generation/generation/predicate/binary.rs
@@ -483,7 +483,7 @@ mod tests {
     fn fuzz_true_binary_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let table = Table::arbitrary(&mut rng, context);
@@ -511,7 +511,7 @@ mod tests {
     fn fuzz_false_binary_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let table = Table::arbitrary(&mut rng, context);
@@ -539,7 +539,7 @@ mod tests {
     fn fuzz_true_binary_simple_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let mut table = Table::arbitrary(&mut rng, context);
@@ -569,7 +569,7 @@ mod tests {
     fn fuzz_false_binary_simple_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let mut table = Table::arbitrary(&mut rng, context);

--- a/sql_generation/generation/predicate/mod.rs
+++ b/sql_generation/generation/predicate/mod.rs
@@ -187,7 +187,7 @@ mod tests {
     fn fuzz_arbitrary_table_true_simple_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let table = Table::arbitrary(&mut rng, context);
@@ -216,7 +216,7 @@ mod tests {
     fn fuzz_arbitrary_table_false_simple_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let table = Table::arbitrary(&mut rng, context);
@@ -245,7 +245,7 @@ mod tests {
     fn fuzz_arbitrary_row_table_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let table = Table::arbitrary(&mut rng, context);
@@ -273,7 +273,7 @@ mod tests {
     fn fuzz_arbitrary_true_table_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let mut table = Table::arbitrary(&mut rng, context);
@@ -302,7 +302,7 @@ mod tests {
     fn fuzz_arbitrary_false_table_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let mut table = Table::arbitrary(&mut rng, context);

--- a/sql_generation/generation/predicate/unary.rs
+++ b/sql_generation/generation/predicate/unary.rs
@@ -276,7 +276,7 @@ mod tests {
     fn fuzz_true_unary_simple_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let mut table = Table::arbitrary(&mut rng, context);
@@ -306,7 +306,7 @@ mod tests {
     fn fuzz_false_unary_simple_predicate() {
         let seed = get_seed();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let context = &TestContext::default();
+        let context = &TestContext::no_gencol();
 
         for _ in 0..10000 {
             let mut table = Table::arbitrary(&mut rng, context);

--- a/sql_generation/generation/table.rs
+++ b/sql_generation/generation/table.rs
@@ -1,8 +1,11 @@
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use indexmap::IndexSet;
 use rand::Rng;
+use turso_parser::ast::{ColumnConstraint, Name as AstName};
 
+use crate::generation::generated_expr::generate_column_expr_with_refs;
 use crate::generation::{pick, readable_name_custom, Arbitrary, GenerationContext};
 use crate::model::table::{Column, ColumnType, Name, Table};
 
@@ -44,13 +47,98 @@ impl Table {
             column_set.insert(Column::arbitrary(rng, context));
         }
 
+        let mut columns: Vec<Column> = Vec::from_iter(column_set);
+
+        // Pass 2: Add generated column constraints if enabled
+        if opts.generated_columns.enable && columns.len() >= 2 {
+            let gen_opts = &opts.generated_columns;
+
+            // Track dependencies between columns: col_idx -> set of column indices it references
+            let mut dependencies: HashMap<usize, HashSet<usize>> = HashMap::new();
+
+            for i in 0..columns.len() {
+                // Count non-generated columns so far
+                let non_generated_count = columns.iter().filter(|c| !c.is_generated()).count();
+
+                // Must keep at least one non-generated column
+                if non_generated_count <= 1 {
+                    continue;
+                }
+
+                // Randomly decide if this column should be generated
+                if !rng.random_bool(gen_opts.generated_column_prob) {
+                    continue;
+                }
+
+                // Generate expression referencing other columns
+                let (expr, refs) = generate_column_expr_with_refs(
+                    rng,
+                    &columns,
+                    i,
+                    &columns[i].column_type,
+                    gen_opts.max_expr_depth,
+                );
+
+                // Check if adding this would create a cycle
+                if would_create_cycle(&dependencies, i, &refs) {
+                    continue;
+                }
+
+                // Record dependencies
+                dependencies.insert(i, refs);
+
+                // Decide if STORED or VIRTUAL
+                let typ = if rng.random_bool(gen_opts.stored_prob) {
+                    Some(AstName::from_string("STORED"))
+                } else {
+                    None
+                };
+
+                // Add the generated constraint
+                columns[i].constraints.push(ColumnConstraint::Generated {
+                    expr: Box::new(expr),
+                    typ,
+                });
+            }
+        }
+
         Table {
             rows: Vec::new(),
             name,
-            columns: Vec::from_iter(column_set),
+            columns,
             indexes: vec![],
         }
     }
+}
+
+/// Check if adding a new dependency would create a cycle.
+fn would_create_cycle(
+    deps: &HashMap<usize, HashSet<usize>>,
+    new_col: usize,
+    new_refs: &HashSet<usize>,
+) -> bool {
+    // DFS from each referenced column to see if we can reach new_col
+    for &ref_col in new_refs {
+        if can_reach(deps, ref_col, new_col) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if we can reach 'to' from 'from' via dependencies.
+fn can_reach(deps: &HashMap<usize, HashSet<usize>>, from: usize, to: usize) -> bool {
+    if from == to {
+        return true;
+    }
+    if let Some(refs) = deps.get(&from) {
+        for &r in refs {
+            if can_reach(deps, r, to) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 impl Arbitrary for Table {

--- a/sql_generation/model/query/select.rs
+++ b/sql_generation/model/query/select.rs
@@ -304,10 +304,17 @@ impl Select {
                                 ast::ResultColumn::Expr(expr.0.clone().into_boxed(), None)
                             }
                             ResultColumn::Star => ast::ResultColumn::Star,
-                            ResultColumn::Column(name) => ast::ResultColumn::Expr(
-                                ast::Expr::Id(ast::Name::exact(name.clone())).into_boxed(),
-                                None,
-                            ),
+                            ResultColumn::Column(name) => {
+                                let expr = if let Some((table, col)) = name.split_once('.') {
+                                    ast::Expr::Qualified(
+                                        ast::Name::exact(table.to_string()),
+                                        ast::Name::exact(col.to_string()),
+                                    )
+                                } else {
+                                    ast::Expr::Id(ast::Name::exact(name.clone()))
+                                };
+                                ast::ResultColumn::Expr(expr.into_boxed(), None)
+                            }
                         })
                         .collect(),
                     from: self.body.select.from.as_ref().map(|f| f.to_sql_ast()),
@@ -335,10 +342,18 @@ impl Select {
                                         ast::ResultColumn::Expr(expr.0.clone().into_boxed(), None)
                                     }
                                     ResultColumn::Star => ast::ResultColumn::Star,
-                                    ResultColumn::Column(name) => ast::ResultColumn::Expr(
-                                        ast::Expr::Id(ast::Name::exact(name.clone())).into_boxed(),
-                                        None,
-                                    ),
+                                    ResultColumn::Column(name) => {
+                                        let expr = if let Some((table, col)) = name.split_once('.')
+                                        {
+                                            ast::Expr::Qualified(
+                                                ast::Name::exact(table.to_string()),
+                                                ast::Name::exact(col.to_string()),
+                                            )
+                                        } else {
+                                            ast::Expr::Id(ast::Name::exact(name.clone()))
+                                        };
+                                        ast::ResultColumn::Expr(expr.into_boxed(), None)
+                                    }
                                 })
                                 .collect(),
                             from: compound.select.from.as_ref().map(|f| f.to_sql_ast()),


### PR DESCRIPTION
## Summary

Extends the SQL generation and simulator models to produce and validate tables with generated columns.

- Adds generated column definitions to `sql_generation` random schema builder
- Updates simulator table models to track virtual/stored generated columns
- Validates that generated column values are correctly computed during simulation runs

### Stacked PRs

This is **PR 2 of 3** in a stacked PR chain:
1. #4838 — Core implementation → targets `main`
2. **Simulator support** (this PR) → targets `generated-columns`
3. Fuzzer/differential oracle support → targets `generated-columns-simulator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)