### PR TITLE
fuzzer: add generated columns support to differential oracle

### DIFF
--- a/testing/differential-oracle/sql_gen_prop/insert.rs
+++ b/testing/differential-oracle/sql_gen_prop/insert.rs
@@ -21,6 +21,10 @@ pub struct InsertProfile {
     pub allow_aggregates: bool,
     /// Expression profile for value expressions.
     pub expression_profile: ExpressionProfile,
+    /// Probability (0-100) of including generated columns in INSERT.
+    /// This tests that both DBs reject the invalid INSERT consistently.
+    /// Default is 1 (1%).
+    pub include_generated_probability: u8,
 }
 
 impl Default for InsertProfile {
@@ -29,6 +33,7 @@ impl Default for InsertProfile {
             expression_max_depth: 2,
             allow_aggregates: false,
             expression_profile: ExpressionProfile::default(),
+            include_generated_probability: 1,
         }
     }
 }
@@ -49,6 +54,12 @@ impl InsertProfile {
     /// Builder method to set expression profile.
     pub fn with_expression_profile(mut self, profile: ExpressionProfile) -> Self {
         self.expression_profile = profile;
+        self
+    }
+
+    /// Builder method to set probability of including generated columns.
+    pub fn with_include_generated_probability(mut self, probability: u8) -> Self {
+        self.include_generated_probability = probability.min(100);
         self
     }
 }
@@ -78,41 +89,78 @@ impl fmt::Display for InsertStatement {
 }
 
 /// Generate an INSERT statement for a table with profile.
+///
+/// By default, generated columns are excluded from the INSERT statement since
+/// SQLite/Turso will reject attempts to set them. With `include_generated_probability`,
+/// we occasionally include them to test that both databases reject consistently.
 pub fn insert_for_table(
     table: &TableRef,
     schema: &Schema,
     profile: &StatementProfile,
 ) -> BoxedStrategy<InsertStatement> {
     let table_name = table.name.clone();
-    let columns = table.columns.clone();
+    let all_columns = table.columns.clone();
     let functions = builtin_functions();
+    let schema = schema.clone();
 
     // Extract profile values from the InsertProfile
     let insert_profile = profile.insert_profile();
     let expression_max_depth = insert_profile.expression_max_depth;
     let allow_aggregates = insert_profile.allow_aggregates;
+    let include_generated_prob = insert_profile.include_generated_probability;
 
-    let col_names: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
+    // Decide whether to include generated columns (for error testing)
+    (0u8..100)
+        .prop_flat_map(move |roll| {
+            let include_generated = roll < include_generated_prob;
 
-    // Build expression context (no column refs or subqueries for INSERT values)
-    let expr_profile = ExpressionProfile::default().with_subqueries_disabled();
-    let ctx = ExpressionContext::new(functions, schema.clone())
-        .with_max_depth(expression_max_depth)
-        .with_aggregates(allow_aggregates)
-        .with_profile(expr_profile);
+            // Select columns based on whether we're including generated columns
+            let columns: Vec<_> = if include_generated {
+                // Include all columns (will cause an error for generated columns)
+                all_columns.clone()
+            } else {
+                // Exclude generated columns (normal case)
+                all_columns
+                    .iter()
+                    .filter(|c| !c.is_generated())
+                    .cloned()
+                    .collect()
+            };
 
-    let value_strategies: Vec<BoxedStrategy<Expression>> = columns
-        .iter()
-        .map(|c| crate::expression::expression_for_type(Some(&c.data_type), &ctx))
-        .collect();
+            // Handle case where all columns are generated (rare but possible)
+            if columns.is_empty() {
+                return Just(InsertStatement {
+                    table: table_name.clone(),
+                    columns: vec![],
+                    values: vec![],
+                })
+                .boxed();
+            }
 
-    value_strategies
-        .into_iter()
-        .collect::<Vec<_>>()
-        .prop_map(move |values| InsertStatement {
-            table: table_name.clone(),
-            columns: col_names.clone(),
-            values,
+            let col_names: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
+
+            // Build expression context (no column refs or subqueries for INSERT values)
+            let expr_profile = ExpressionProfile::default().with_subqueries_disabled();
+            let ctx = ExpressionContext::new(functions.clone(), schema.clone())
+                .with_max_depth(expression_max_depth)
+                .with_aggregates(allow_aggregates)
+                .with_profile(expr_profile);
+
+            let value_strategies: Vec<BoxedStrategy<Expression>> = columns
+                .iter()
+                .map(|c| crate::expression::expression_for_type(Some(&c.data_type), &ctx))
+                .collect();
+
+            let table_name = table_name.clone();
+            value_strategies
+                .into_iter()
+                .collect::<Vec<_>>()
+                .prop_map(move |values| InsertStatement {
+                    table: table_name.clone(),
+                    columns: col_names.clone(),
+                    values,
+                })
+                .boxed()
         })
         .boxed()
 }

--- a/testing/differential-oracle/sql_gen_prop/lib.rs
+++ b/testing/differential-oracle/sql_gen_prop/lib.rs
@@ -62,7 +62,10 @@ pub use profile::{
     ExtendedExpressionProfile, ExtendedFunctionProfile, GenerationProfile, InsertProfile,
     SelectProfile, StatementProfile, UpdateProfile, ValueProfile, WeightedProfile,
 };
-pub use schema::{ColumnDef, DataType, Index, Schema, SchemaBuilder, Table, Trigger, View};
+pub use schema::{
+    Collation, ColumnDef, DataType, GeneratedColumn, GeneratedStorage, Index, Schema,
+    SchemaBuilder, Table, Trigger, View,
+};
 pub use select::{OrderByItem, OrderDirection, SelectStatement};
 pub use statement::{SqlStatement, StatementContext, StatementKind};
 pub use transaction::{


### PR DESCRIPTION
## Summary

Updates the differential oracle to generate schemas with generated columns and test them against SQLite for correctness validation.

- Extends fuzzer schema generation to include virtual and stored generated columns
- Adds generated column expressions to differential test queries
- Validates Limbo results match SQLite results for generated column scenarios

### Stacked PRs

This is **PR 3 of 3** in a stacked PR chain:
1. #4838 — Core implementation → targets `main`
2. Simulator support → targets `generated-columns`
3. **Fuzzer/differential oracle support** (this PR) → targets `generated-columns-simulator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)