### PR TITLE
pin compiler and runner versions for codspeed benchmark

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     # Allow this job to fail without failing the entire CI run
     continue-on-error: true
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
 
       - name: Setup mold linker
         uses: rui314/setup-mold@v1


### PR DESCRIPTION
## Motivation and context
Want to try and minimize variance in our simulation benchmarks

https://codspeed.io/docs/instruments/cpu/regression-causes

The codspeed team also told me they are looking into why some benchmarks have more than 25% variance for us.

