### PR TITLE
fix json_set blob

### DIFF
--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -297,11 +297,18 @@ where
             )
         })?;
 
-        let path = json_path_from_db_value(&first, true)?;
-
         let second = args.next().ok_or_else(|| {
             crate::LimboError::InternalError("args should have second element in loop".to_string())
         })?;
+
+        if second.as_value_ref().value_type() == ValueType::Blob {
+            return Err(crate::LimboError::Constraint(
+                "JSON cannot hold BLOB values".to_string(),
+            ));
+        }
+
+        let path = json_path_from_db_value(&first, true)?;
+
         let value = convert_dbtype_to_jsonb(second, Conv::NotStrict)?;
         let mut op = SetOperation::new(value);
         if let Some(path) = path {

--- a/testing/runner/tests/json/default.sqltest
+++ b/testing/runner/tests/json/default.sqltest
@@ -1523,6 +1523,13 @@ expect {
     {"user":{"profile":{"name":"Alice","age":25}}}
 }
 
+test json_set_blob_value {
+    SELECT json_set(3906369340027029955, '$.' || char(8) || '' || CAST(zeroblob(27) AS TEXT) || '5!""!!!$.' || char(6) || '62=!""%!!!!!!QQQQQQQQQQ' || char(13) || CAST(zeroblob(3) AS TEXT), x'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00');
+}
+expect error {
+    .*JSON cannot hold BLOB values.*
+}
+
 test json_set_field_empty_object {
     SELECT json_set('{}', '$.field', 'value');
 }


### PR DESCRIPTION
## Description
bug in json_set: 
```sql
SELECT json_set(3906369340027029955, '$.' || char(8) || '' || CAST(zeroblob(27) AS TEXT) || '5!""!!!$.' || char(6) || '62=!""%!!!!!!QQQQQQQQQQ' || char(13) || CAST(zeroblob(3) AS TEXT), x'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00');
```
returns: Error: Parse error: Bad json path: $5!""!!!$.62=!""%!!!!!!QQQQQQQQQQ
should be: Runtime error: JSON cannot hold BLOB values

## Motivation and context
Error found in fuzzer: https://github.com/tursodatabase/turso/actions/runs/21549477883/job/62095979070?pr=4949


## Description of AI Usage
Asked gemini to fix it.