### PR TITLE
Fix bug when empty namespace is provided in go sync driver

### DIFF
--- a/bindings/go/driver_sync.go
+++ b/bindings/go/driver_sync.go
@@ -382,12 +382,12 @@ func (d *TursoSyncDb) processIoQueue(ctx context.Context) error {
 }
 
 func buildHostname(baseURL, namespace string) (string, error) {
-	if namespace == "" {
-		return baseURL, nil
-	}
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return "", err
+	}
+	if namespace == "" {
+		return u.Host, nil
 	}
 	return namespace + "." + u.Host, nil
 }


### PR DESCRIPTION
when namespace was empty it would add the Scheme to the URL