### PR TITLE
fix/pager: properly reuse last empty trunk page for page allocation

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -77,6 +77,16 @@ pub const INTERIOR_PAGE_HEADER_SIZE_BYTES: usize = 12;
 pub const LEAF_PAGE_HEADER_SIZE_BYTES: usize = 8;
 pub const LEFT_CHILD_PTR_SIZE_BYTES: usize = 4;
 
+// Freelist trunk page layout:
+// - Bytes 0-3: Page number of next freelist trunk page (0 if none)
+// - Bytes 4-7: Number of leaf page pointers on this trunk page
+// - Bytes 8+: Array of 4-byte leaf page pointers
+pub const FREELIST_TRUNK_OFFSET_NEXT_TRUNK_PTR: usize = 0;
+pub const FREELIST_TRUNK_OFFSET_LEAF_COUNT: usize = 4;
+pub const FREELIST_TRUNK_OFFSET_FIRST_LEAF_PTR: usize = 8;
+pub const FREELIST_TRUNK_HEADER_SIZE: usize = 8;
+pub const FREELIST_LEAF_PTR_SIZE: usize = 4;
+
 #[derive(PartialEq, Eq, Zeroable, Pod, Clone, Copy, Debug)]
 #[repr(transparent)]
 /// Read/Write file format version.


### PR DESCRIPTION
When a single page is freed into an empty freelist, it becomes the trunk page with no leaf pointers and no next trunk pointer. The trunk page ITSELF should be reusable for allocation.

The bug was that when allocating a page and finding a trunk with:
- no leaf pointers (number_of_freelist_leaves == 0)
- no next trunk (next_trunk_page_id == 0)

The old code would incorrectly treat this as "empty freelist" and allocate a new page at the end of the database file, leaving the trunk page permanently stuck in the freelist.

---

Also adds some freelist validation to integrity_check and extracts freelist related constants for reuse.