### PR TITLE
add duration and fix notebook name

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -9,6 +9,11 @@ on:
         required: false
         default: ""
         type: string
+      duration:
+        description: "Duration in minutes (default 4 hours)"
+        required: false
+        default: 240
+        type: number
   schedule:
     - cron: "0 0 * * *"
 
@@ -46,7 +51,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
       uses: antithesishq/antithesis-trigger-action@v0.5
       with:
-        notebook_name: Limbo Test
+        notebook_name: limbo
         tenant: ${{ secrets.ANTITHESIS_TENANT }}
         username: ${{ secrets.ANTITHESIS_USERNAME }}
         password: ${{ secrets.ANTITHESIS_PASSWORD }}
@@ -55,9 +60,5 @@ jobs:
         images: ${{ secrets.ANTITHESIS_DOCKER_REPO }}/limbo-workload:antithesis-latest
         description: "Turso - ${{ github.event_name }} on ${{ github.ref_name }} by ${{ github.actor }}"
         email_recipients: ${{ secrets.ANTITHESIS_EMAIL }}
-        test_name: ${{ github.event.inputs.test_name }}
         additional_parameters: |-
-          branch=${{ github.ref_name }}
-          commit_message=${{ github.event.head_commit.message }}
-          who_triggered_this=${{ github.actor }}
-          gh_actions_run_id=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          antithesis.duration=${{ github.event.inputs.duration }}


### PR DESCRIPTION
## Description

This adds a configurable duration to the Antithesis test runs and fixes some parameters. `test_name` is picked up from the inputs ([source](https://github.com/antithesishq/antithesis-trigger-action/blob/main/src/main.ts#L120)), so it wasn't required in the job.

I misunderstood what the `additional_parameters` did, I thought they were arbitrary key-value pairs, turns out they're an escape hatch to the underlying API ([source](https://github.com/antithesishq/antithesis-trigger-action/blob/main/src/main.ts#L160)). The `antithesis.duration` parameter is the one to use and is in minutes (sources: [this](https://github.com/guergabo/antithesis-cli/blob/7808437f0d6254bfb2785621b1f83b3a78d42829/cli/run.go#L77) and a slack conversation with them).

`notebook_name` is `limbo` for us (see [here](https://github.com/antithesishq/antithesis-trigger-action/blob/main/src/main.ts#L74) and [here](https://github.com/tursodatabase/turso/blob/main/scripts/antithesis/launch.sh#L13)).