### PR TITLE
Add new antithesis assertions

### DIFF
--- a/core/assert.rs
+++ b/core/assert.rs
@@ -1,35 +1,3 @@
-/// turso_assert! is a direct replacement for assert! builtin macros which under the hood
-/// uses Antithesis SDK to guide Antithesis simulator if --cfg antithesis is enabled
-#[cfg(not(antithesis))]
-#[macro_export]
-macro_rules! turso_assert {
-    ($cond:expr, $msg:literal, $($optional:tt)+) => {
-        assert!($cond, $msg, $($optional)+);
-    };
-    ($cond:expr, $msg:literal) => {
-        assert!($cond, $msg);
-    };
-}
-
-#[cfg(antithesis)]
-#[macro_export]
-macro_rules! turso_assert {
-    ($cond:expr, $msg:literal, $($optional:tt)+) => {
-        {
-            let __cond = $cond;
-            antithesis_sdk::assert_always_or_unreachable!(__cond, $msg);
-            assert!(__cond, $msg, $($optional)+);
-        }
-    };
-    ($cond:expr, $msg:literal) => {
-        {
-            let __cond = $cond;
-            antithesis_sdk::assert_always_or_unreachable!(__cond, $msg);
-            assert!(__cond, $msg);
-        }
-    };
-}
-
 /// Assert that a type implements Send at compile time.
 /// Usage: assert_send!(MyType);
 /// Usage: assert_send!(Type1, Type2, Type3);

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -110,6 +110,25 @@ pub use storage::{
 };
 use tracing::{instrument, Level};
 use turso_macros::{match_ignore_ascii_case, AtomicEnum};
+
+pub use turso_macros::turso_assert;
+pub use turso_macros::turso_assert_all;
+pub use turso_macros::turso_assert_eq;
+pub use turso_macros::turso_assert_greater_than;
+pub use turso_macros::turso_assert_greater_than_or_equal;
+pub use turso_macros::turso_assert_less_than;
+pub use turso_macros::turso_assert_less_than_or_equal;
+pub use turso_macros::turso_assert_ne;
+pub use turso_macros::turso_assert_reachable;
+pub use turso_macros::turso_assert_some;
+pub use turso_macros::turso_assert_sometimes;
+pub use turso_macros::turso_assert_sometimes_greater_than;
+pub use turso_macros::turso_assert_sometimes_greater_than_or_equal;
+pub use turso_macros::turso_assert_sometimes_less_than;
+pub use turso_macros::turso_assert_sometimes_less_than_or_equal;
+pub use turso_macros::turso_assert_unreachable;
+pub use turso_macros::turso_debug_assert;
+pub use turso_macros::turso_soft_unreachable;
 use turso_parser::{ast, ast::Cmd, parser::Parser};
 pub use types::IOResult;
 pub use types::Value;

--- a/macros/src/assert.rs
+++ b/macros/src/assert.rs
@@ -1,0 +1,325 @@
+//! Procedural macros for turso assertions that integrate with Antithesis SDK.
+//!
+//! These proc macros solve the problem that Antithesis SDK requires actual string literals
+//! for messages (`$message:literal`), but `stringify!()` produces macro expansions, not literals.
+//! Proc macros can generate actual literal tokens via `quote!`.
+
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use syn::{
+    braced,
+    parse::{Parse, ParseStream},
+    Expr, LitStr, Token,
+};
+
+/// A single key-value pair from a details block: `"key": expr`
+pub struct DetailPair {
+    pub key: LitStr,
+    pub value: Expr,
+}
+
+/// Parsed details block: `{ "key1": expr1, "key2": expr2 }`
+pub struct DetailsList {
+    pub pairs: Vec<DetailPair>,
+}
+
+impl DetailsList {
+    /// Parse the contents of a braced details block from a ParseStream.
+    /// Expects the braces to already be consumed (i.e., receives the inner content).
+    pub fn parse_inner(content: ParseStream) -> syn::Result<Self> {
+        let mut pairs = Vec::new();
+        while !content.is_empty() {
+            let key: LitStr = content.parse()?;
+            content.parse::<Token![:]>()?;
+            let value: Expr = content.parse()?;
+            pairs.push(DetailPair { key, value });
+            if !content.peek(Token![,]) {
+                break;
+            }
+            content.parse::<Token![,]>()?;
+        }
+        Ok(DetailsList { pairs })
+    }
+}
+
+/// Input for condition-based assertions: turso_assert!, turso_debug_assert!, etc.
+/// Supports:
+/// - `(cond)`
+/// - `(cond, "msg")`
+/// - `(cond, "msg", { ... })` - Antithesis details
+/// - `(cond, "msg", fmt_arg1, fmt_arg2, ...)` - format arguments
+pub struct ConditionAssertInput {
+    pub condition: Expr,
+    pub message: Option<LitStr>,
+    pub details: Option<DetailsList>,
+    pub format_args: Option<TokenStream2>,
+}
+
+impl Parse for ConditionAssertInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let condition: Expr = input.parse()?;
+
+        if !input.peek(Token![,]) {
+            return Ok(ConditionAssertInput {
+                condition,
+                message: None,
+                details: None,
+                format_args: None,
+            });
+        }
+        input.parse::<Token![,]>()?;
+
+        if !input.peek(LitStr) {
+            // No message literal follows the comma - consume the rest as format args
+            // (shouldn't normally happen, but handle gracefully)
+            let rest: TokenStream2 = input.parse()?;
+            return Ok(ConditionAssertInput {
+                condition,
+                message: None,
+                details: None,
+                format_args: if rest.is_empty() { None } else { Some(rest) },
+            });
+        }
+
+        let message: LitStr = input.parse()?;
+
+        if !input.peek(Token![,]) {
+            return Ok(ConditionAssertInput {
+                condition,
+                message: Some(message),
+                details: None,
+                format_args: None,
+            });
+        }
+
+        // After message + comma, check if next is { for details
+        // We need to lookahead without consuming the comma yet
+        let fork = input.fork();
+        fork.parse::<Token![,]>()?;
+
+        if fork.peek(syn::token::Brace) {
+            // It's a details block: { "key": value, ... }
+            input.parse::<Token![,]>()?;
+            let content;
+            braced!(content in input);
+            let details = DetailsList::parse_inner(&content)?;
+            return Ok(ConditionAssertInput {
+                condition,
+                message: Some(message),
+                details: Some(details),
+                format_args: None,
+            });
+        }
+
+        // Otherwise it's format arguments - consume everything remaining
+        input.parse::<Token![,]>()?;
+        let rest: TokenStream2 = input.parse()?;
+        Ok(ConditionAssertInput {
+            condition,
+            message: Some(message),
+            details: None,
+            format_args: if rest.is_empty() { None } else { Some(rest) },
+        })
+    }
+}
+
+/// Input for message-only assertions: turso_assert_reachable!, turso_assert_unreachable!, etc.
+/// Supports:
+/// - `("msg")`
+/// - `("msg", { ... })`
+pub struct MessageAssertInput {
+    pub message: LitStr,
+    pub details: Option<DetailsList>,
+}
+
+impl Parse for MessageAssertInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let message: LitStr = input.parse()?;
+
+        let details = if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            if input.peek(syn::token::Brace) {
+                let content;
+                braced!(content in input);
+                Some(DetailsList::parse_inner(&content)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok(MessageAssertInput { message, details })
+    }
+}
+
+/// Input for comparison assertions: turso_assert_eq!, turso_assert_greater_than!, etc.
+/// Supports:
+/// - `(left, right)`
+/// - `(left, right, "msg")`
+/// - `(left, right, "msg", { ... })`
+pub struct ComparisonAssertInput {
+    pub left: Expr,
+    pub right: Expr,
+    pub message: Option<LitStr>,
+    pub details: Option<DetailsList>,
+}
+
+impl Parse for ComparisonAssertInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let left: Expr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let right: Expr = input.parse()?;
+
+        if !input.peek(Token![,]) {
+            return Ok(ComparisonAssertInput {
+                left,
+                right,
+                message: None,
+                details: None,
+            });
+        }
+        input.parse::<Token![,]>()?;
+
+        if !input.peek(LitStr) {
+            return Ok(ComparisonAssertInput {
+                left,
+                right,
+                message: None,
+                details: None,
+            });
+        }
+
+        let message: LitStr = input.parse()?;
+
+        let details = if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            if input.peek(syn::token::Brace) {
+                let content;
+                braced!(content in input);
+                Some(DetailsList::parse_inner(&content)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok(ComparisonAssertInput {
+            left,
+            right,
+            message: Some(message),
+            details,
+        })
+    }
+}
+
+/// Generate an auto-message for comparison assertions from the left/right expressions and operator.
+/// Braces are escaped so the message is safe to use as a format string in `assert!`.
+pub fn comparison_auto_message(left: &Expr, right: &Expr, op: &str) -> LitStr {
+    let left_str = left.to_token_stream().to_string();
+    let right_str = right.to_token_stream().to_string();
+    let msg = format!("{left_str} {op} {right_str}");
+    let msg = msg.replace('{', "{{").replace('}', "}}");
+    LitStr::new(&msg, Span::call_site())
+}
+
+/// Convert an expression to a string literal token.
+/// Braces are escaped so the message is safe to use as a format string in `assert!`.
+pub fn expr_to_lit_str(expr: &Expr) -> LitStr {
+    let expr_str = expr.to_token_stream().to_string();
+    let expr_str = expr_str.replace('{', "{{").replace('}', "}}");
+    LitStr::new(&expr_str, Span::call_site())
+}
+
+/// Generate the details JSON expression from structured pairs.
+pub fn details_json(details: &Option<DetailsList>) -> TokenStream2 {
+    match details {
+        Some(list) if !list.pairs.is_empty() => {
+            let keys: Vec<_> = list.pairs.iter().map(|p| &p.key).collect();
+            let vals: Vec<_> = list.pairs.iter().map(|p| &p.value).collect();
+            quote! { &serde_json::json!({ #( #keys: #vals ),* }) }
+        }
+        _ => quote! { &serde_json::json!({}) },
+    }
+}
+
+/// Generate format arguments that include details in the panic message.
+///
+/// With details:    `"{} | key1={:?}, key2={:?}", msg, val1, val2`
+/// Without details: `"{}", msg`
+///
+/// Uses `{:?}` (Debug) rather than `{}` (Display) because detail values may be
+/// types like `&[u8]` that implement Debug but not Display.
+pub fn details_format_args(msg: &LitStr, details: &Option<DetailsList>) -> TokenStream2 {
+    match details {
+        Some(list) if !list.pairs.is_empty() => {
+            let fmt_parts: Vec<String> = list
+                .pairs
+                .iter()
+                .map(|p| format!("{}={{:?}}", p.key.value()))
+                .collect();
+            let fmt = format!("{{}} | {}", fmt_parts.join(", "));
+            let fmt_lit = LitStr::new(&fmt, msg.span());
+            let vals: Vec<_> = list.pairs.iter().map(|p| &p.value).collect();
+            quote! { #fmt_lit, #msg, #(#vals),* }
+        }
+        _ => quote! { "{}", #msg },
+    }
+}
+
+/// A named condition: `field_name: condition_expr`
+pub struct NamedCondition {
+    pub condition: Expr,
+}
+
+/// Input for boolean guidance assertions: turso_assert_some!, turso_assert_all!
+/// Syntax:
+/// - `({field1: cond1, field2: cond2}, "message")`
+/// - `({field1: cond1, field2: cond2}, "message", { ... })`
+pub struct BooleanGuidanceInput {
+    pub conditions: Vec<NamedCondition>,
+    pub message: LitStr,
+    pub details: Option<DetailsList>,
+}
+
+impl Parse for BooleanGuidanceInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        braced!(content in input);
+
+        let mut conditions = Vec::new();
+        while !content.is_empty() {
+            let _name: syn::Ident = content.parse()?;
+            content.parse::<Token![:]>()?;
+            let condition: Expr = content.parse()?;
+            conditions.push(NamedCondition { condition });
+            if !content.peek(Token![,]) {
+                break;
+            }
+            content.parse::<Token![,]>()?;
+        }
+
+        input.parse::<Token![,]>()?;
+        let message: LitStr = input.parse()?;
+
+        let details = if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            if input.peek(syn::token::Brace) {
+                let content;
+                braced!(content in input);
+                Some(DetailsList::parse_inner(&content)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok(BooleanGuidanceInput {
+            conditions,
+            message,
+            details,
+        })
+    }
+}

--- a/testing/runner/src/parser/mod.rs
+++ b/testing/runner/src/parser/mod.rs
@@ -1120,7 +1120,6 @@ expect {
         assert!(file.tests[0].modifiers.skip.is_none());
     }
 
-
     #[test]
     fn test_parse_backend_specific_expectations() {
         let input = r#"

--- a/tests/integration/assert_details.rs
+++ b/tests/integration/assert_details.rs
@@ -1,0 +1,192 @@
+#[cfg(test)]
+#[allow(unexpected_cfgs)]
+mod tests {
+    fn panic_message(f: impl FnOnce() + std::panic::UnwindSafe) -> String {
+        let err = std::panic::catch_unwind(f).unwrap_err();
+        if let Some(s) = err.downcast_ref::<String>() {
+            s.clone()
+        } else if let Some(s) = err.downcast_ref::<&str>() {
+            s.to_string()
+        } else {
+            panic!("unexpected panic payload type");
+        }
+    }
+
+    #[test]
+    fn test_turso_assert_details_in_panic_message() {
+        let msg = panic_message(|| {
+            let page_id = 42;
+            turso_macros::turso_assert!(false, "page must be dirty", { "page_id": page_id });
+        });
+        assert!(
+            msg.contains("page must be dirty") && msg.contains("page_id=42"),
+            "expected details in panic message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_turso_assert_multiple_details() {
+        let msg = panic_message(|| {
+            let x = 1;
+            let y = 2;
+            turso_macros::turso_assert!(false, "check failed", { "x": x, "y": y });
+        });
+        assert!(
+            msg.contains("check failed") && msg.contains("x=1") && msg.contains("y=2"),
+            "expected all details in panic message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_turso_assert_no_details_still_works() {
+        let msg = panic_message(|| {
+            turso_macros::turso_assert!(false, "simple message");
+        });
+        assert!(
+            msg.contains("simple message"),
+            "expected message in panic, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_turso_assert_eq_details_in_panic_message() {
+        let msg = panic_message(|| {
+            let expected = 10;
+            turso_macros::turso_assert_eq!(1, 2, "values must match", { "expected": expected });
+        });
+        assert!(
+            msg.contains("values must match") && msg.contains("expected=10"),
+            "expected details in assert_eq panic message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_turso_assert_greater_than_details() {
+        let msg = panic_message(|| {
+            let limit = 100;
+            turso_macros::turso_assert_greater_than!(5, 10, "must be greater", { "limit": limit });
+        });
+        assert!(
+            msg.contains("must be greater") && msg.contains("limit=100"),
+            "expected details in assert_greater_than panic message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_turso_assert_string_detail_values() {
+        let msg = panic_message(|| {
+            let state = format!("{:?}", vec![1, 2, 3]);
+            turso_macros::turso_assert!(false, "bad state", { "state": state });
+        });
+        assert!(
+            msg.contains("bad state") && msg.contains("state="),
+            "expected string detail in panic message, got: {msg}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::nonminimal_bool)]
+    fn test_turso_assert_some_passes_when_one_true() {
+        turso_macros::turso_assert_some!(
+            {a: true, b: false},
+            "at least one should be true"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::nonminimal_bool)]
+    fn test_turso_assert_some_passes_when_all_true() {
+        turso_macros::turso_assert_some!(
+            {a: true, b: true},
+            "at least one should be true"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::nonminimal_bool)]
+    fn test_turso_assert_some_panics_when_none_true() {
+        let msg = panic_message(|| {
+            turso_macros::turso_assert_some!(
+                {a: false, b: false},
+                "at least one should be true"
+            );
+        });
+        assert!(
+            msg.contains("at least one should be true"),
+            "expected message in panic, got: {msg}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::nonminimal_bool)]
+    fn test_turso_assert_some_details_in_panic() {
+        let msg = panic_message(|| {
+            let table = "users";
+            turso_macros::turso_assert_some!(
+                {a: false, b: false},
+                "row must have data",
+                { "table": table }
+            );
+        });
+        assert!(
+            msg.contains("row must have data") && msg.contains("table="),
+            "expected details in panic message, got: {msg}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::nonminimal_bool)]
+    fn test_turso_assert_all_passes_when_all_true() {
+        turso_macros::turso_assert_all!(
+            {a: true, b: true},
+            "all should be true"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::nonminimal_bool)]
+    fn test_turso_assert_all_panics_when_one_false() {
+        let msg = panic_message(|| {
+            turso_macros::turso_assert_all!(
+                {a: true, b: false},
+                "all should be true"
+            );
+        });
+        assert!(
+            msg.contains("all should be true"),
+            "expected message in panic, got: {msg}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::nonminimal_bool)]
+    fn test_turso_assert_all_panics_when_all_false() {
+        let msg = panic_message(|| {
+            turso_macros::turso_assert_all!(
+                {a: false, b: false},
+                "all should be true"
+            );
+        });
+        assert!(
+            msg.contains("all should be true"),
+            "expected message in panic, got: {msg}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::nonminimal_bool)]
+    fn test_turso_assert_all_details_in_panic() {
+        let msg = panic_message(|| {
+            let magic = 0xDEAD;
+            turso_macros::turso_assert_all!(
+                {a: true, b: false},
+                "file must be well-formed",
+                { "magic": magic }
+            );
+        });
+        assert!(
+            msg.contains("file must be well-formed") && msg.contains("magic="),
+            "expected details in panic message, got: {msg}"
+        );
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+mod assert_details;
 mod common;
 mod functions;
 mod fuzz_transaction;


### PR DESCRIPTION
## Description

This PR improves our antithesis assertions to help guide the fuzzer towards interesting states:
* convert every existing assertion to a `turso_assert_*` assertion
* convert the `turso_assert_*` macros to proc macros (see reason below)
  * Since Antithesis identifies assertions by their message, they don't handle dynamically built strings well. They provide a last argument, `details`, in their assertions, that's meant to be a json object with the values you want to remember. In non-antithesis builds, 
* After non-soft Antithesis assertions in Antithesis builds, log the error and `exit(0)` instead of panicking. 

### Graceful exit on assertion failures

This is because if we also panic, Antithesis sees multiple errors instead of just one, it sees (1) the failing assertion, (2) the panic, (3) the crash, (4) a non-zero exit code. This makes the test reports hard to read, and also doesn't help with tracking, because Antithesis reports errors of various kinds as crashes.


<img width="631" height="83" alt="image" src="https://github.com/user-attachments/assets/4f0a2604-dcef-48e6-9872-a4fe95a05195" />


### Messages in assertions

The Antithesis SDK forces assertions to have a message. To avoid adding noise to the code by adding a message in every assertions, if no message is provided, the expression in the assertion is used as a message. To help disambiguate assertions in the UI, they are prepended with the file name:

<img width="780" height="440" alt="image" src="https://github.com/user-attachments/assets/374cc12a-b242-4b97-9896-2350d5891800" />

### Potential improvements

I added assertions for `>`, `>=`, `<`, `<=` and `!=`, because they can be used to provide guidance hints to the fuzzer. But because of a quirk in the way the SDK works internally, they were overwhelming the fuzzer ([slack thread](https://turso.slack.com/archives/C080L7H7K7U/p1770351138934469)). So I had to dumb down the macros to delegate to simple true/false assertions, but I'm hoping that we can restore the guidance hints in the future. Antithesis currently has an open ticket for this.

## Further work

These assertions will be used in https://github.com/tursodatabase/turso/pull/5103

## Description of AI Usage

In general, Claude wrote the code under my direction and I reviewed it, with many many iterations.