### PR TITLE
do not cache chunks for .tantivy-meta.lock file

### DIFF
--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1619,7 +1619,7 @@ const TANTIVY_META_LOCK_FILE: &str = ".tantivy-meta.lock";
 /// Since `open_write` calls `delete` first, caching the lock file would trigger a full chunk cache
 /// scan on every query, causing significant overhead.
 fn can_cache_chunks(path: &Path) -> bool {
-    path.as_str() != Ok(TANTIVY_META_LOCK_FILE)
+    path.as_os_str().to_str() != Some(TANTIVY_META_LOCK_FILE)
 }
 
 /// State machine for FTS cursor async operations


### PR DESCRIPTION
Otherwise this lead to bad performance since we invalidate chunk cache on every open_write of the lock file - which happens on every read request

Before change:
```
=== Repeated Query Benchmark (50 iterations) ===
Query "machine": 370.35ms total, 0.370ms avg
Query "learning": 368.46ms total, 0.368ms avg
Query "database": 362.83ms total, 0.363ms avg
Query "optimization": 366.04ms total, 0.366ms avg
Query "development": 362.36ms total, 0.362ms avg
Query "computing": 362.02ms total, 0.362ms avg
Query "science": 360.68ms total, 0.361ms avg
```

After change:
```
=== Repeated Query Benchmark (50 iterations) ===
Query "machine": 80.51ms total, 0.081ms avg
Query "learning": 76.79ms total, 0.077ms avg
Query "database": 79.76ms total, 0.080ms avg
Query "optimization": 79.33ms total, 0.079ms avg
Query "development": 80.18ms total, 0.080ms avg
Query "computing": 75.31ms total, 0.075ms avg
Query "science": 75.56ms total, 0.076ms avg
```