### PR TITLE
Fix missing STRICT keyword in BTreeTable::to_sql()

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -361,7 +361,7 @@ fn update_pragma(
                         ast::CreateTableBody::ColumnsAndConstraints {
                             columns: turso_cdc_table_columns(),
                             constraints: vec![],
-                            options: ast::TableOptions::NONE,
+                            options: ast::TableOptions::empty(),
                         },
                         program,
                         &connection,

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -29,11 +29,10 @@ fn validate(body: &ast::CreateTableBody, connection: &Connection) -> Result<()> 
         options, columns, ..
     } = &body
     {
-        if options.contains(ast::TableOptions::WITHOUT_ROWID) {
+        if options.contains_without_rowid() {
             bail_parse_error!("WITHOUT ROWID tables are not supported");
         }
-        if options.contains(ast::TableOptions::STRICT) && !connection.experimental_strict_enabled()
-        {
+        if options.contains_strict() && !connection.experimental_strict_enabled() {
             bail_parse_error!(
                 "STRICT tables are an experimental feature. Enable them with --experimental-strict flag"
             );

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1273,18 +1273,49 @@ pub enum TableConstraint {
     },
 }
 
-bitflags::bitflags! {
-    /// `CREATE TABLE` options
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct TableOptions: u8 {
-        /// None
-        const NONE = 0;
-        /// `WITHOUT ROWID`
-        const WITHOUT_ROWID = 1;
-        /// `STRICT`
-        const STRICT = 2;
+/// `CREATE TABLE` options with preserved original text
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TableOptions {
+    /// Original text for WITHOUT ROWID option (e.g., "WITHOUT ROWID", "without rowid", "WiThOuT rOwId")
+    pub without_rowid_text: Option<String>,
+    /// Original text for STRICT option (e.g., "STRICT", "strict", "StRiCt")
+    pub strict_text: Option<String>,
+}
+
+impl TableOptions {
+    /// Create empty table options
+    pub fn empty() -> Self {
+        Self {
+            without_rowid_text: None,
+            strict_text: None,
+        }
     }
+
+    /// Check if table has WITHOUT ROWID option
+    pub fn contains_without_rowid(&self) -> bool {
+        self.without_rowid_text.is_some()
+    }
+
+    /// Check if table has STRICT option
+    pub fn contains_strict(&self) -> bool {
+        self.strict_text.is_some()
+    }
+
+    /// For backward compatibility with bitflags interface
+    pub fn contains(&self, flag: TableOptionsFlag) -> bool {
+        match flag {
+            TableOptionsFlag::WithoutRowid => self.contains_without_rowid(),
+            TableOptionsFlag::Strict => self.contains_strict(),
+        }
+    }
+}
+
+/// Flags for table options (used for backward compatibility)
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TableOptionsFlag {
+    WithoutRowid,
+    Strict,
 }
 
 /// Sort orders

--- a/parser/src/ast/fmt.rs
+++ b/parser/src/ast/fmt.rs
@@ -1492,12 +1492,17 @@ impl ToTokens for CreateTableBody {
                     comma(constraints, s, context)?;
                 }
                 s.append(TK_RP, None)?;
-                if options.contains(TableOptions::WITHOUT_ROWID) {
-                    s.append(TK_WITHOUT, None)?;
-                    s.append(TK_ID, Some("ROWID"))?;
+                // Use the original text if available
+                if let Some(ref without_rowid) = options.without_rowid_text {
+                    // Split "WITHOUT ROWID" back into tokens
+                    let parts: Vec<&str> = without_rowid.split_whitespace().collect();
+                    if parts.len() == 2 {
+                        s.append(TK_WITHOUT, None)?;
+                        s.append(TK_ID, Some(parts[1]))?;
+                    }
                 }
-                if options.contains(TableOptions::STRICT) {
-                    s.append(TK_ID, Some("STRICT"))?;
+                if let Some(ref strict) = options.strict_text {
+                    s.append(TK_ID, Some(strict))?;
                 }
                 Ok(())
             }


### PR DESCRIPTION
Previously, BTreeTable::to_sql() failed to include the STRICT keyword when reconstructing SQL statements, causing a mismatch between the stored SQL in sqlite_schema and the actual table definition. This broke compatibility with SQLite, which always preserves the complete CREATE TABLE statement.

Additionally, SQLite preserves the exact capitalization of keywords as typed by users (e.g., "sTrIcT" remains "sTrIcT"), while Turso was normalizing them to uppercase.

To fix both issues, this commit refactors TableOptions from a bitflags struct to store the original text strings. This allows us to:
1. Include STRICT (and WITHOUT ROWID) in reconstructed SQL
2. Preserve the original capitalization exactly as SQLite does

Changes:
- Refactored TableOptions from bitflags to struct with original text fields
- Updated parser to capture and store original token text
- Modified Display/ToTokens to output the preserved text
- Fixed BTreeTable::to_sql() to include STRICT keyword
- Added tests to verify STRICT keyword appears in reconstructed SQL

This ensures full SQLite compatibility for SQL storage and retrieval.

## Description of AI Usage

Claude Code was used in an interactive session. I have prompted it to find out issues with our current implementation of strict. It found the fact that to_sql() was not including it, and therefore it was not in the output. Then it tried a version where the keyword STRICT was added for strict tables, and I guided it through a refactor to preserve capitalization, like SQLite.
