### PR TITLE
Change crate types in Dockerfile to restore Antithesis instrumentation

### DIFF
--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -90,6 +90,15 @@ COPY --from=planner /app/sdk-kit ./sdk-kit/
 COPY --from=planner /app/sdk-kit-macros ./sdk-kit-macros/
 COPY --from=planner /app/tools ./tools/
 
+# Remove cdylib and staticlib from this line: `crate-type = ["lib", "cdylib", "staticlib"]`
+# This is because somehow we lose llvm sanitizer coverage if the crate is not just a lib.
+RUN for f in sdk-kit/Cargo.toml sync/sdk-kit/Cargo.toml; do \
+        grep -qF 'crate-type = ["lib", "cdylib", "staticlib"]' "$f" \
+        || { echo "ERROR: expected crate-type not found in $f"; exit 1; }; \
+    done \
+    && sed -i 's/crate-type = \["lib", "cdylib", "staticlib"\]/crate-type = ["lib"]/' \
+        sdk-kit/Cargo.toml sync/sdk-kit/Cargo.toml
+
 RUN if [ "$antithesis" = "true" ]; then \
         cp /opt/antithesis/libvoidstar.so /usr/lib/libvoidstar.so && \
         export RUSTFLAGS="--cfg=tokio_unstable -Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -L/usr/lib/ -lvoidstar" && \


### PR DESCRIPTION
## Description

In https://github.com/tursodatabase/turso/commit/94baf2564 we had a regression where our Antithesis instrumentation went down from 180K code locations to 20K:

<img width="283" height="174" alt="image" src="https://github.com/user-attachments/assets/2c6ee18c-6b4b-44c3-9fa7-9b4e11cce320" />

The regression was cause by this line in both `sdk-kit/Cargo.toml` and `sync/sdk-kit/Cargo.toml`:

```
crate-type = ["lib", "cdylib", "staticlib"]
```

It looks like for some reason, the compiler can't inject proper [SanitizerCoverage](https://clang.llvm.org/docs/SanitizerCoverage.html) guards into the compiled binary if the crate is also `cdylib` and `staticlib`. I tried to verify this in compiled binaries, but I gave up because of slow compilation times and because my solution was already working.

Without those lib types in `sdk-kit/Cargo.toml`, instrumentation goes up to 150K; and also modifying `sync/sdk-kit/Cargo.toml` makes it go up to 257K.

This has a concrete impact on the number of "behaviours" found by Antithesis. Before this fix, a 4-hour test run found 59 behaviours:

<img width="890" height="322" alt="image" src="https://github.com/user-attachments/assets/fad33266-bb94-4595-8867-23c3595926e6" />


With this fix, a 15-minute test run finds 115 behaviours.

<img width="1009" height="307" alt="image" src="https://github.com/user-attachments/assets/cee2b930-8273-41e9-8dd9-b27235069b29" />


This fix in this PR is a huge kludge, but the alternative was to separate each crate in two: a core crate, and a ffi wrapper. This would have been much more invasive.

## Description of AI Usage

Claude identified the crate type as a possible source of the bug and wrote the Dockerfile patch.