### PR TITLE
Fix STRICT tables incorrectly rejecting NULL values

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1641,6 +1641,10 @@ pub fn op_type_check(
             } else if col.is_rowid_alias() && matches!(reg.get_value(), Value::Null) {
                 // Handle INTEGER PRIMARY KEY for null as usual (Rowid will be auto-assigned)
                 return Ok(());
+            } else if matches!(reg.get_value(), Value::Null) {
+                // STRICT only enforces type affinity on non-NULL values.
+                // NULL is valid in any column without NOT NULL constraint.
+                return Ok(());
             }
             let col_affinity = col.affinity();
             let ty_str = &col.ty_str;

--- a/testing/runner/tests/strict.sqltest
+++ b/testing/runner/tests/strict.sqltest
@@ -1,0 +1,59 @@
+@database :memory:
+
+@requires strict "uses STRICT tables"
+test strict-null-integer-column {
+    CREATE TABLE t1 (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER) STRICT;
+    INSERT INTO t1 (a) VALUES (5);
+    SELECT id, a, b FROM t1;
+}
+expect {
+    1|5|
+}
+
+@requires strict "uses STRICT tables"
+test strict-null-text-column {
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, first TEXT, last TEXT) STRICT;
+    INSERT INTO t2 (first) VALUES ('John');
+    SELECT id, first, last FROM t2;
+}
+expect {
+    1|John|
+}
+
+@requires strict "uses STRICT tables"
+test strict-null-real-column {
+    CREATE TABLE t3 (id INTEGER PRIMARY KEY, a REAL, b REAL) STRICT;
+    INSERT INTO t3 (a) VALUES (3.14);
+    SELECT id, a, b FROM t3;
+}
+expect {
+    1|3.14|
+}
+
+@requires strict "uses STRICT tables"
+test strict-null-blob-column {
+    CREATE TABLE t4 (id INTEGER PRIMARY KEY, a BLOB, b BLOB) STRICT;
+    INSERT INTO t4 (a) VALUES (X'CAFE');
+    SELECT id, hex(a), b FROM t4;
+}
+expect {
+    1|CAFE|
+}
+
+@requires strict "uses STRICT tables"
+test strict-explicit-null-insert {
+    CREATE TABLE t5 (id INTEGER PRIMARY KEY, a INTEGER, b TEXT) STRICT;
+    INSERT INTO t5 VALUES (1, NULL, NULL);
+    SELECT * FROM t5;
+}
+expect {
+    1||
+}
+
+@requires strict "uses STRICT tables"
+test strict-not-null-still-enforced {
+    CREATE TABLE t6 (id INTEGER PRIMARY KEY, a INTEGER NOT NULL) STRICT;
+    INSERT INTO t6 (id) VALUES (1);
+}
+expect error {
+}


### PR DESCRIPTION
STRICT tables were rejecting NULL values in columns that don't have a NOT NULL constraint (e.g. "cannot store NULL value in INTEGER column"). In SQLite, STRICT only enforces type affinity on non-NULL values — NULL is valid in any column unless it has an explicit NOT NULL constraint.

The bug was in op_type_check: after handling rowid alias and primary key NULLs, other NULL values fell through to the type-matching logic where NULL doesn't match INTEGER/TEXT/REAL/BLOB, triggering a false error. Fixed by adding an early return for NULL values in non-PK columns.

Tests are added on strict.sqltest (will add more tests as we go)

## Description of AI Usage

Simple fix, described the problem and it was pretty much one-shotted by CC.
