### PR TITLE
Fix CLI ".open" command to preserve experimental flags

### DIFF
--- a/testing/cli_tests/cli_test_cases.py
+++ b/testing/cli_tests/cli_test_cases.py
@@ -372,7 +372,7 @@ def test_parse_error():
 
 
 def test_tables_with_attached_db():
-    shell = TestTursoShell(flags="-q --experimental-attach")
+    shell = TestTursoShell()
     shell.execute_dot(".open :memory:")
     shell.execute_dot("CREATE TABLE orders(a);")
     shell.execute_dot("ATTACH DATABASE 'testing/system/testing.db' AS attached;")


### PR DESCRIPTION
remove redundant --experimental-attach from test_tables_with_attached_db since limbo-sqlite3 already passes it. this was causing `test-limbo` to hang.

also: open_db() was using Database::open_file() with default DatabaseOpts, clearing experimental flags when `.open` was used. Store db_opts in Limbo struct and reuse them