### PR TITLE
fix: convert text and blobs into bytes for correct parsing of strings into numbers

### DIFF
--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -281,8 +281,7 @@ impl ParsedNumber {
     }
 }
 
-pub fn try_for_float(text: &str) -> (NumericParseResult, ParsedNumber) {
-    let bytes = text.as_bytes();
+pub fn try_for_float(bytes: &[u8]) -> (NumericParseResult, ParsedNumber) {
     if bytes.is_empty() {
         return (NumericParseResult::NotNumeric, ParsedNumber::None);
     }
@@ -541,7 +540,7 @@ pub fn apply_numeric_affinity(val: ValueRef, try_for_int: bool) -> Option<ValueR
     };
 
     let text_str = text.as_str();
-    let (parse_result, parsed_value) = try_for_float(text_str);
+    let (parse_result, parsed_value) = try_for_float(text_str.as_bytes());
 
     // Only convert if we have a complete valid number (not just a prefix)
     match parse_result {
@@ -633,7 +632,7 @@ mod tests {
         // This test verifies that try_for_float uses high-precision arithmetic
         // to avoid rounding errors when computing significand * 10^exponent.
         // Naive f64 multiplication accumulates errors; Dekker double-double fixes this.
-        let (_, parsed) = try_for_float("12345678901234567e-5");
+        let (_, parsed) = try_for_float(b"12345678901234567e-5");
         let expected: f64 = "12345678901234567e-5".parse().unwrap();
         assert_eq!(
             parsed.as_float().unwrap().to_bits(),

--- a/testing/runner/tests/agg-functions/sum-blob-types.sqltest
+++ b/testing/runner/tests/agg-functions/sum-blob-types.sqltest
@@ -1,0 +1,67 @@
+@database :memory:
+
+# SUM/TOTAL of blob values should convert blob bytes to text (interpreting raw
+# bytes as characters) then parse the leading numeric portion as a number.
+# Blobs with non-UTF-8 bytes must still parse the leading digits correctly,
+# matching SQLite behavior.
+
+test total-blob-ascii-digit-prefix {
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY, b BLOB);
+    INSERT INTO t1 VALUES (1, X'3941');
+    SELECT TOTAL(b) FROM t1;
+}
+expect {
+    9.0
+}
+expect @js {
+    9
+}
+
+test total-blob-non-utf8-with-leading-digit {
+    CREATE TABLE t2 (a INTEGER PRIMARY KEY, b BLOB);
+    INSERT INTO t2 VALUES (1, X'395E459F');
+    SELECT TOTAL(b) FROM t2;
+}
+expect {
+    9.0
+}
+expect @js {
+    9
+}
+
+test total-blob-long-non-utf8-with-leading-digit {
+    CREATE TABLE t3 (a INTEGER PRIMARY KEY, b BLOB);
+    INSERT INTO t3 VALUES (1, X'395E459FF9CE1328346F9BF1CDD0604D');
+    SELECT TOTAL(b) FROM t3;
+}
+expect {
+    9.0
+}
+expect @js {
+    9
+}
+
+test total-blob-no-leading-digit {
+    CREATE TABLE t4 (a INTEGER PRIMARY KEY, b BLOB);
+    INSERT INTO t4 VALUES (1, X'4655');
+    SELECT TOTAL(b) FROM t4;
+}
+expect {
+    0.0
+}
+expect @js {
+    0
+}
+
+test sum-blob-non-utf8-with-leading-digit {
+    CREATE TABLE t5 (a INTEGER PRIMARY KEY, b BLOB);
+    INSERT INTO t5 VALUES (1, X'399F4142');
+    INSERT INTO t5 VALUES (2, X'3339');
+    SELECT typeof(SUM(b)), SUM(b) FROM t5;
+}
+expect {
+    real|48.0
+}
+expect @js {
+    real|48
+}


### PR DESCRIPTION
## Description

Caught by differential fuzzer

Stacked on top of #5054 

**Bug**: `TOTAL()`/`SUM()` on BLOB values containing non-UTF-8 bytes returned `0.0` instead of parsing the leading numeric portion of the blob's byte representation.

**Root cause**: The blob-to-float conversion used `std::str::from_utf8()` which rejects non-UTF-8 bytes entirely, falling back to `0.0`. SQLite treats blob bytes as raw characters and parses leading digits regardless of encoding validity.

**Example**: `TOTAL(X'395E459F')` — byte `0x39` is ASCII `'9'`, so the result should be `9.0`. Turso returned `0.0` because byte `0x9F` is invalid UTF-8, causing the whole conversion to fail.

**Fix**: Changed `try_for_float` in `core/vdbe/affinity.rs` to accept `&[u8]` instead of `&str`, eliminating the UTF-8 validation gate. The function already operated on bytes internally, so this was a one-line signature change. Updated the two call sites in `core/vdbe/execute.rs` (AVG accumulator and SUM/TOTAL step) to pass blob bytes directly.

**Test**: Added `testing/runner/tests/agg-functions/sum-blob-types.sqltest` covering blobs with ASCII digit prefixes, non-UTF-8 bytes, long blobs, and non-numeric blobs.


## Description of AI Usage
Generated by Claude