### PR TITLE
Convert antithesis from feature to cfg flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ codegen-units = 16        # Less cross-unit inlining
 inherits = "release-official"
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(shuttle)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(shuttle)', 'cfg(antithesis)'] }
 
 [workspace.lints.clippy]
 or_fun_call = "deny"

--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -101,8 +101,8 @@ RUN for f in sdk-kit/Cargo.toml sync/sdk-kit/Cargo.toml; do \
 
 RUN if [ "$antithesis" = "true" ]; then \
         cp /opt/antithesis/libvoidstar.so /usr/lib/libvoidstar.so && \
-        export RUSTFLAGS="--cfg=tokio_unstable -Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -L/usr/lib/ -lvoidstar" && \
-        cargo build --bin turso_stress --features antithesis --profile antithesis; \
+        export RUSTFLAGS="--cfg=tokio_unstable --cfg=antithesis -Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -L/usr/lib/ -lvoidstar" && \
+        cargo build --bin turso_stress --profile antithesis; \
     else \
         cargo build --bin turso_stress --release; \
     fi

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [features]
 default = ["mimalloc"]
-antithesis = ["turso_sdk_kit/antithesis"]
 mimalloc = ["dep:mimalloc"]
 sync = [
     "dep:hyper",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,6 @@ path = "lib.rs"
 
 [features]
 default = ["fs", "uuid", "time", "json", "series", "encryption"]
-antithesis = ["dep:antithesis_sdk", "antithesis_sdk?/full"]
 tracing_release = ["tracing/release_max_level_info"]
 conn_raw_api = []
 fs = ["turso_ext/vfs"]
@@ -54,7 +53,6 @@ libloading = "0.8.6"
 tantivy = { version = "0.25.0", optional = true }
 
 [dependencies]
-antithesis_sdk = { workspace = true, optional = true }
 turso_ext = { workspace = true, features = ["core_only"] }
 cfg_block = "0.1.1"
 fallible-iterator = { workspace = true }
@@ -100,6 +98,9 @@ branches = { version = "0.4.3", default-features = false }
 bumpalo = { version = "3", features = ["collections"] }
 smallvec = "1.15.1"
 fastbloom = "0.14.1"
+
+[target.'cfg(antithesis)'.dependencies]
+antithesis_sdk = { workspace = true, features = ["full"] }
 
 [target.'cfg(loom)'.dependencies]
 loom = { workspace = true }

--- a/core/assert.rs
+++ b/core/assert.rs
@@ -1,6 +1,6 @@
 /// turso_assert! is a direct replacement for assert! builtin macros which under the hood
-/// uses Antithesis SDK to guide Antithesis simulator if --features antithesis is enabled
-#[cfg(not(feature = "antithesis"))]
+/// uses Antithesis SDK to guide Antithesis simulator if --cfg antithesis is enabled
+#[cfg(not(antithesis))]
 #[macro_export]
 macro_rules! turso_assert {
     ($cond:expr, $msg:literal, $($optional:tt)+) => {
@@ -11,7 +11,7 @@ macro_rules! turso_assert {
     };
 }
 
-#[cfg(feature = "antithesis")]
+#[cfg(antithesis)]
 #[macro_export]
 macro_rules! turso_assert {
     ($cond:expr, $msg:literal, $($optional:tt)+) => {

--- a/sdk-kit/Cargo.toml
+++ b/sdk-kit/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-antithesis = ["turso_core/antithesis"]
 encryption = ["turso_core/encryption"]
 
 [lib]

--- a/testing/stress/Cargo.toml
+++ b/testing/stress/Cargo.toml
@@ -22,10 +22,8 @@ path = "main.rs"
 
 [features]
 default = []
-antithesis = ["turso/antithesis", "dep:antithesis_sdk", "antithesis_sdk?/full"]
 
 [dependencies]
-antithesis_sdk = { workspace = true, optional = true }
 clap = { workspace = true, features = ["derive"] }
 hex = { workspace = true }
 indicatif = { workspace = true }
@@ -36,6 +34,9 @@ tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 turso = { workspace = true }
 rusqlite = { workspace = true }
+
+[target.'cfg(antithesis)'.dependencies]
+antithesis_sdk = { workspace = true, features = ["full"] }
 
 [target.'cfg(shuttle)'.dependencies]
 shuttle = { workspace = true }

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -3,9 +3,9 @@ mod opts;
 use clap::Parser;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use opts::{Opts, TxMode};
-#[cfg(not(feature = "antithesis"))]
+#[cfg(not(antithesis))]
 use rand::rngs::StdRng;
-#[cfg(not(feature = "antithesis"))]
+#[cfg(not(antithesis))]
 use rand::{Rng, SeedableRng};
 #[cfg(shuttle)]
 use shuttle::scheduler::Scheduler;
@@ -87,12 +87,12 @@ const NOUNS: &[&str] = &[
 ];
 
 /// RNG wrapper that works with both Shuttle and Antithesis
-#[cfg(not(feature = "antithesis"))]
+#[cfg(not(antithesis))]
 struct ThreadRng {
     rng: StdRng,
 }
 
-#[cfg(not(feature = "antithesis"))]
+#[cfg(not(antithesis))]
 impl ThreadRng {
     fn new(seed: u64) -> Self {
         Self {
@@ -105,10 +105,10 @@ impl ThreadRng {
     }
 }
 
-#[cfg(feature = "antithesis")]
+#[cfg(antithesis)]
 struct ThreadRng;
 
-#[cfg(feature = "antithesis")]
+#[cfg(antithesis)]
 impl ThreadRng {
     fn new(_seed: u64) -> Self {
         // Antithesis uses its own RNG, seed is ignored
@@ -618,7 +618,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 
 async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    #[cfg(feature = "antithesis")]
+    #[cfg(antithesis)]
     let global_seed: u64 = {
         if opts.seed.is_some() {
             eprintln!("Error: --seed is not supported under Antithesis");
@@ -628,7 +628,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         0 // Antithesis doesn't use seed-based RNG
     };
 
-    #[cfg(not(feature = "antithesis"))]
+    #[cfg(not(antithesis))]
     let global_seed: u64 = {
         // Under shuttle, opts.seed is already resolved in main()
         let seed = opts.seed.unwrap_or_else(rand::random);


### PR DESCRIPTION
## Description

Replace `--features antithesis` with `--cfg antithesis`. I want to modify our assertions so that under Antithesis they don't panic and instead exit gracefully after printing a message, like we currently have in our python parallel test commands. 

This is because I'm going to be doing some work in turso-stress that's going to make a lot of assertions fail, and if they panic, Antithesis registers it as two failures: the assertion failure, and a failure of the property "does not panic". Moreover, failures of "does not panic" are much harder to debug.

## Description of AI Usage

clauded