### PR TITLE
Fix deadlock in MVCC mode when loading extensions on file databases

### DIFF
--- a/core/ext/dynamic.rs
+++ b/core/ext/dynamic.rs
@@ -60,7 +60,7 @@ impl Connection {
                 })?
                 .push((Arc::new(lib), api_ref));
             if self.is_db_initialized() {
-                self.parse_schema_rows()?;
+                self.reparse_schema_after_extension_load()?;
             }
             Ok(())
         } else {


### PR DESCRIPTION
## Background

CI job `test-limbo` is hanging.

## Problem

`load_extension` re-parsed schema rows inside `with_schema_mut` which takes a write lock on the schema.

when `handle_schema_row` returned a benign error like "table already exists", the `Statement` was dropped while the write lock was still held. In MVCC mode specifically, this results in a call to `rollback_tx()` which takes a read lock on the parking-lot RwLock on `schema` and deadlocks.

## Fix

collect the schema rows and let the `Statement` drop before processing the rows.

also: instead of swallowing all errors from reparsing the schema, only accept extension errors and "table already exists" parse errors and fail on any other kinds.