### PR TITLE
Unify error codes in LibsqlError for serverless package

### DIFF
--- a/packages/turso-serverless/src/error.ts
+++ b/packages/turso-serverless/src/error.ts
@@ -1,7 +1,17 @@
 export class DatabaseError extends Error {
-  constructor(message: string) {
+  /** Machine-readable error code (e.g., "SQLITE_CONSTRAINT") */
+  code?: string;
+  /** Raw numeric error code */
+  rawCode?: number;
+  /** Original error that caused this error */
+  declare cause?: Error;
+
+  constructor(message: string, code?: string, rawCode?: number, cause?: Error) {
     super(message);
     this.name = 'DatabaseError';
+    this.code = code;
+    this.rawCode = rawCode;
+    this.cause = cause;
     Object.setPrototypeOf(this, DatabaseError.prototype);
   }
 }

--- a/packages/turso-serverless/src/session.ts
+++ b/packages/turso-serverless/src/session.ts
@@ -81,7 +81,7 @@ export class Session {
     if (response.results && response.results[0]) {
       const result = response.results[0];
       if (result.type === "error") {
-        throw new DatabaseError(result.error?.message || 'Describe execution failed');
+        throw new DatabaseError(result.error?.message || 'Describe execution failed', result.error?.code);
       }
 
       if (result.response?.type === "describe" && result.response.result) {
@@ -214,7 +214,7 @@ export class Session {
           break;
         case 'step_error':
         case 'error':
-          throw new DatabaseError(entry.error?.message || 'SQL execution failed');
+          throw new DatabaseError(entry.error?.message || 'SQL execution failed', entry.error?.code);
       }
     }
 
@@ -296,7 +296,7 @@ export class Session {
           break;
         case 'step_error':
         case 'error':
-          throw new DatabaseError(entry.error?.message || 'Batch execution failed');
+          throw new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
       }
     }
 
@@ -332,7 +332,7 @@ export class Session {
     if (response.results && response.results[0]) {
       const result = response.results[0];
       if (result.type === "error") {
-        throw new DatabaseError(result.error?.message || 'Sequence execution failed');
+        throw new DatabaseError(result.error?.message || 'Sequence execution failed', result.error?.code);
       }
     }
   }


### PR DESCRIPTION
Add extendedCode field to LibsqlError and propagate server error codes through DatabaseError to the compat layer. Extended codes like SQLITE_CONSTRAINT_PRIMARYKEY are parsed into base code + extendedCode, consistent with the libsql-client-ts error handling.