### PR TITLE
Fix panic and wrong results for window function in EXISTS subquery

### DIFF
--- a/testing/runner/tests/window/memory.sqltest
+++ b/testing/runner/tests/window/memory.sqltest
@@ -28,3 +28,17 @@ expect {
     banana|3
 }
 
+test window-in-exists-subquery-referencing-outer-column {
+    CREATE TABLE t1 (a);
+    INSERT INTO t1 VALUES (1), (2), (3);
+    SELECT * FROM (SELECT a FROM t1) as subq
+    WHERE EXISTS (
+      SELECT count(1) OVER (ORDER BY subq.a) FROM t1
+    );
+}
+expect {
+    1
+    2
+    3
+}
+


### PR DESCRIPTION
## Summary
- Fix panic at `ResultSetColumn::name()` when a window function in an EXISTS subquery references an outer query column (e.g. `ORDER BY subq.a`)

## Test plan
- [x] New regression test in `testing/runner/tests/window/memory.sqltest`
- [x] `make -C testing/runner run-rust` — 129 passed
- [x] `cargo clippy --workspace --all-features --all-targets -- --deny=warnings` — clean
- [x] `cargo test` — 1120 passed (10 pre-existing vector distance failures unrelated)

Closes #5068

🤖 Generated with [Claude Code](https://claude.com/claude-code)