### PR TITLE
Fix panic when CTE with indexed subquery is referenced twice

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -203,6 +203,8 @@ pub fn translate_alter_table(
                             internal_id: TableInternalId::from(0),
                             table: Table::BTree(Arc::new(btree.clone())),
                             col_used_mask: ColumnUsedMask::default(),
+                            cte_select: None,
+                            cte_explicit_columns: vec![],
                         }],
                     );
                     let where_copy = index

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -707,6 +707,8 @@ fn add_ephemeral_table_to_update_plan(
                 internal_id: table.internal_id,
                 table: table.table.clone(),
                 col_used_mask: table.col_used_mask.clone(),
+                cte_select: None,
+                cte_explicit_columns: vec![],
             });
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -721,6 +721,12 @@ pub struct OuterQueryReference {
     /// i.e., if the subquery depends on tables T and U,
     /// then both T and U need to be in scope for the subquery to be evaluated.
     pub col_used_mask: ColumnUsedMask,
+    /// Original CTE SELECT AST for re-planning. When a CTE is referenced
+    /// multiple times, each reference needs a fresh plan with unique
+    /// internal_ids to avoid cursor key collisions.
+    pub cte_select: Option<ast::Select>,
+    /// Explicit column names from WITH t(a, b) AS (...) syntax.
+    pub cte_explicit_columns: Vec<String>,
 }
 
 impl OuterQueryReference {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -391,6 +391,8 @@ fn plan_cte(
             internal_id: referenced_table.internal_id,
             table: referenced_table.table.clone(),
             col_used_mask: ColumnUsedMask::default(),
+            cte_select: None,
+            cte_explicit_columns: vec![],
         });
     }
 
@@ -473,6 +475,9 @@ pub fn plan_ctes_as_outer_refs(
             );
         }
 
+        // Clone the CTE select AST before planning, so we can store it for re-planning
+        let cte_select_ast = cte.select.clone();
+
         // Plan the CTE SELECT
         let cte_plan = prepare_select_plan(
             cte.select,
@@ -508,6 +513,8 @@ pub fn plan_ctes_as_outer_refs(
             internal_id: joined_table.internal_id,
             table: joined_table.table,
             col_used_mask: ColumnUsedMask::default(),
+            cte_select: Some(cte_select_ast),
+            cte_explicit_columns: explicit_columns,
         });
     }
 
@@ -569,6 +576,8 @@ fn parse_from_clause_table(
                     internal_id: cte_table.internal_id,
                     table: cte_table.table,
                     col_used_mask: ColumnUsedMask::default(),
+                    cte_select: Some(cte_def.select.clone()),
+                    cte_explicit_columns: cte_def.explicit_columns.clone(),
                 });
             }
 
@@ -676,18 +685,56 @@ fn parse_table(
                 ast::As::Elided(id) => id,
             })
             .map(|a| normalize_ident(a.as_str()));
-        let internal_id = program.table_reference_counter.next();
-        table_references.add_joined_table(JoinedTable {
-            op: Operation::default_scan_for(&outer_ref.table),
-            table: outer_ref.table.clone(),
-            identifier: alias.unwrap_or(normalized_qualified_name),
-            internal_id,
-            join_info: None,
-            col_used_mask: ColumnUsedMask::default(),
-            column_use_counts: Vec::new(),
-            expression_index_usages: Vec::new(),
-            database_id,
-        });
+        // Clone fields we need before dropping the borrow on table_references.
+        let cte_select = outer_ref.cte_select.clone();
+        let cte_explicit_columns = outer_ref.cte_explicit_columns.clone();
+        let outer_table = outer_ref.table.clone();
+
+        if let Some(cte_ast) = cte_select {
+            // Re-plan the CTE from its original AST to get fresh internal_ids.
+            // This prevents cursor key collisions when the same CTE is
+            // referenced multiple times in the same scope.
+            let cte_plan = prepare_select_plan(
+                cte_ast,
+                resolver,
+                program,
+                table_references.outer_query_refs(),
+                QueryDestination::placeholder_for_subquery(),
+                connection,
+            )?;
+            let explicit_cols = if cte_explicit_columns.is_empty() {
+                None
+            } else {
+                Some(cte_explicit_columns.as_slice())
+            };
+            // Use the CTE name for the subquery name so query plans show
+            // "SCAN cte_name AS alias" instead of just "SCAN alias".
+            let mut jt = JoinedTable::new_subquery_from_plan(
+                normalized_qualified_name.clone(),
+                cte_plan,
+                None,
+                program.table_reference_counter.next(),
+                explicit_cols,
+            )?;
+            if let Some(alias) = alias {
+                jt.identifier = alias;
+            }
+            jt.database_id = database_id;
+            table_references.add_joined_table(jt);
+        } else {
+            let internal_id = program.table_reference_counter.next();
+            table_references.add_joined_table(JoinedTable {
+                op: Operation::default_scan_for(&outer_table),
+                table: outer_table,
+                identifier: alias.unwrap_or(normalized_qualified_name),
+                internal_id,
+                join_info: None,
+                col_used_mask: ColumnUsedMask::default(),
+                column_use_counts: Vec::new(),
+                expression_index_usages: Vec::new(),
+                database_id,
+            });
+        }
         return Ok(());
     }
 
@@ -1009,6 +1056,8 @@ pub fn parse_from(
                 internal_id: cte_table.internal_id,
                 table: cte_table.table,
                 col_used_mask: ColumnUsedMask::default(),
+                cte_select: Some(cte_def.select.clone()),
+                cte_explicit_columns: cte_def.explicit_columns.clone(),
             });
         }
     }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -249,6 +249,8 @@ fn plan_subqueries_with_outer_query_access<'a>(
                 identifier: t.identifier.clone(),
                 internal_id: t.internal_id,
                 col_used_mask: ColumnUsedMask::default(),
+                cte_select: None,
+                cte_explicit_columns: vec![],
             })
             .chain(
                 referenced_tables
@@ -259,6 +261,8 @@ fn plan_subqueries_with_outer_query_access<'a>(
                         identifier: t.identifier.clone(),
                         internal_id: t.internal_id,
                         col_used_mask: ColumnUsedMask::default(),
+                        cte_select: t.cte_select.clone(),
+                        cte_explicit_columns: t.cte_explicit_columns.clone(),
                     }),
             )
             .collect::<Vec<_>>()

--- a/testing/runner/tests/cte.sqltest
+++ b/testing/runner/tests/cte.sqltest
@@ -557,6 +557,33 @@ expect {
 }
 
 # =============================================================================
+# CTE referenced twice in subquery with indexed table (issue #5074)
+# =============================================================================
+
+test cte-dual-ref-indexed-subquery-empty {
+    CREATE TABLE t(a);
+    CREATE INDEX i ON t(a);
+    WITH c AS (SELECT 0 c0 FROM(SELECT*FROM t)x)
+    SELECT*FROM(SELECT*FROM c,c c2 JOIN(SELECT 1)u ON c2.c0=0)y;
+}
+expect {
+}
+
+test cte-dual-ref-indexed-subquery {
+    CREATE TABLE t(a);
+    CREATE INDEX i ON t(a);
+    INSERT INTO t VALUES (1),(2);
+    WITH c AS (SELECT 0 c0 FROM(SELECT*FROM t)x)
+    SELECT*FROM(SELECT*FROM c,c c2 JOIN(SELECT 1)u ON c2.c0=0)y;
+}
+expect {
+    0|0|1
+    0|0|1
+    0|0|1
+    0|0|1
+}
+
+# =============================================================================
 # Error cases
 # =============================================================================
 

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -1,18 +1,37 @@
 ---
 source: subqueries.sqltest
-expression: "WITH\n    expensive_products AS (\n        SELECT id, name, price\n        FROM products\n        WHERE price > 500\n    ),\n    large_orders AS (\n        SELECT id, customer_id, total_amount\n        FROM orders\n        WHERE total_amount > 1000\n    ),\n    vip_customers AS (\n        SELECT id, name\n        FROM customers\n        WHERE id IN (SELECT customer_id FROM large_orders)\n    )\n    SELECT v.name, l.total_amount\n    FROM vip_customers v\n    JOIN large_orders l ON l.customer_id = v.id;"
+expression: |-
+  WITH
+      expensive_products AS (
+          SELECT id, name, price
+          FROM products
+          WHERE price > 500
+      ),
+      large_orders AS (
+          SELECT id, customer_id, total_amount
+          FROM orders
+          WHERE total_amount > 1000
+      ),
+      vip_customers AS (
+          SELECT id, name
+          FROM customers
+          WHERE id IN (SELECT customer_id FROM large_orders)
+      )
+      SELECT v.name, l.total_amount
+      FROM vip_customers v
+      JOIN large_orders l ON l.customer_id = v.id;
 info:
   statement_type: WITH (CTE)
   tables:
-    - customers
-    - l.customer_id
-    - large_orders
-    - orders
-    - products
-    - vip_customers
+  - customers
+  - l.customer_id
+  - large_orders
+  - orders
+  - products
+  - vip_customers
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN vip_customers AS v
@@ -44,7 +63,7 @@ addr  opcode             p1  p2  p3  p4            p5  comment
   17  InitCoroutine       2   0   5                 0
   18    Yield             2  23   0                 0
   19    Copy              4   9   0                 0  r[9]=r[4]
-  20    MakeRecord        9   1  10                 0  r[10]=mkrec(r[9..9]); for ephemeral_index_where_sub_t10
+  20    MakeRecord        9   1  10                 0  r[10]=mkrec(r[9..9]); for ephemeral_index_where_sub_t11
   21    IdxInsert         1  10   0                 8  key=r[10]
   22  Goto                0  18   0                 0
   23  OpenRead            3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
@@ -54,8 +73,8 @@ addr  opcode             p1  p2  p3  p4            p5  comment
   27    Affinity         14   1   0                 0  r[14..15] = D
   28    NotFound          1  30  14                 0  if not found goto 30
   29    Goto              0  36   0                 0
-  30    Rewind            1  38   0                 0  Rewind  ephemeral_index_where_sub_t10
-  31      Column          1   0  15                 0  r[15]=ephemeral_index_where_sub_t10.customer_id
+  30    Rewind            1  38   0                 0  Rewind  ephemeral_index_where_sub_t11
+  31      Column          1   0  15                 0  r[15]=ephemeral_index_where_sub_t11.customer_id
   32      Ne             14  15  34  Binary         0  if r[14]!=r[15] goto 34
   33      Goto            0  40   0                 0
   34    Next              1  31   0                 0

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
@@ -1,16 +1,28 @@
 ---
 source: subqueries.sqltest
-expression: "WITH order_totals AS (\n        SELECT customer_id, sum(total_amount) AS total\n        FROM orders\n        GROUP BY customer_id\n    )\n    SELECT\n        c.name,\n        ot.total,\n        (SELECT avg(total) FROM order_totals) AS avg_total\n    FROM customers c\n    JOIN order_totals ot ON ot.customer_id = c.id\n    WHERE ot.total > (SELECT avg(total) FROM order_totals);"
+expression: |-
+  WITH order_totals AS (
+          SELECT customer_id, sum(total_amount) AS total
+          FROM orders
+          GROUP BY customer_id
+      )
+      SELECT
+          c.name,
+          ot.total,
+          (SELECT avg(total) FROM order_totals) AS avg_total
+      FROM customers c
+      JOIN order_totals ot ON ot.customer_id = c.id
+      WHERE ot.total > (SELECT avg(total) FROM order_totals);
 info:
   statement_type: WITH (CTE)
   tables:
-    - customers
-    - order_totals
-    - orders
-    - ot.customer_id
+  - customers
+  - order_totals
+  - orders
+  - ot.customer_id
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN order_totals
@@ -85,12 +97,12 @@ addr  opcode                                       p1   p2   p3  p4            p
   59                    Integer                     0   27    0                 0  r[27]=0; clear group by abort flag
   60                    Null                        0   28    0                 0  r[28]=NULL; initialize group by comparison registers to NULL
   61                    Gosub                      34   91    0                 0  ; go to clear accumulator subroutine
-  62                    OpenRead                    0    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  63                    OpenRead                    2    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-  64                    Rewind                      1   80    0                 0  Rewind index idx_orders_customer
-  65                      DeferredSeek              1    0    0                 0
-  66                      Column                    0    1   32                 0  r[32]=orders.customer_id
-  67                      Column                    0    3   33                 0  r[33]=orders.total_amount
+  62                    OpenRead                    2    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  63                    OpenRead                    3    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+  64                    Rewind                      3   80    0                 0  Rewind index idx_orders_customer
+  65                      DeferredSeek              3    2    0                 0
+  66                      Column                    2    1   32                 0  r[32]=orders.customer_id
+  67                      Column                    2    3   33                 0  r[33]=orders.total_amount
   68                      RealAffinity             33    0    0                 0
   69                      Compare                  28   32    1  k(1, Binary)   0  r[28..28]==r[32..32]
   70                      Jump                     71   75   71                 0  ; start new group if comparison is not equal
@@ -100,9 +112,9 @@ addr  opcode                                       p1   p2   p3  p4            p
   74                      Gosub                    34   91    0                 0  ; goto clear accumulator subroutine
   75                      AggStep                   0   33   30  sum            0  accum=r[30] step(r[33])
   76                      If                       26   78    0                 0  if r[26] goto 78; don't emit group columns if continuing existing group
-  77                      Column                    0    1   29                 0  r[29]=orders.customer_id
+  77                      Column                    2    1   29                 0  r[29]=orders.customer_id
   78                      Integer                   1   26    0                 0  r[26]=1; indicate data in accumulator
-  79                    Next                        1   65    0                 0
+  79                    Next                        3   65    0                 0
   80                    Gosub                      25   84    0                 0  ; emit row for final group
   81                    Goto                        0   94    0                 0  ; group by finished
   82                    Integer                     1   27    0                 0  r[27]=1
@@ -135,12 +147,12 @@ addr  opcode                                       p1   p2   p3  p4            p
  109          Integer                               0   44    0                 0  r[44]=0; clear group by abort flag
  110          Null                                  0   45    0                 0  r[45]=NULL; initialize group by comparison registers to NULL
  111          Gosub                                51  141    0                 0  ; go to clear accumulator subroutine
- 112          OpenRead                              3    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
- 113          OpenRead                              4    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
- 114          Rewind                                4  130    0                 0  Rewind index idx_orders_customer
- 115            DeferredSeek                        4    3    0                 0
- 116            Column                              3    1   49                 0  r[49]=orders.customer_id
- 117            Column                              3    3   50                 0  r[50]=orders.total_amount
+ 112          OpenRead                              4    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+ 113          OpenRead                              5    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+ 114          Rewind                                5  130    0                 0  Rewind index idx_orders_customer
+ 115            DeferredSeek                        5    4    0                 0
+ 116            Column                              4    1   49                 0  r[49]=orders.customer_id
+ 117            Column                              4    3   50                 0  r[50]=orders.total_amount
  118            RealAffinity                       50    0    0                 0
  119            Compare                            45   49    1  k(1, Binary)   0  r[45..45]==r[49..49]
  120            Jump                              121  125  121                 0  ; start new group if comparison is not equal
@@ -150,9 +162,9 @@ addr  opcode                                       p1   p2   p3  p4            p
  124            Gosub                              51  141    0                 0  ; goto clear accumulator subroutine
  125            AggStep                             0   50   47  sum            0  accum=r[47] step(r[50])
  126            If                                 43  128    0                 0  if r[43] goto 128; don't emit group columns if continuing existing group
- 127            Column                              3    1   46                 0  r[46]=orders.customer_id
+ 127            Column                              4    1   46                 0  r[46]=orders.customer_id
  128            Integer                             1   43    0                 0  r[43]=1; indicate data in accumulator
- 129          Next                                  4  115    0                 0
+ 129          Next                                  5  115    0                 0
  130          Gosub                                42  134    0                 0  ; emit row for final group
  131          Goto                                  0  144    0                 0  ; group by finished
  132          Integer                               1   44    0                 0  r[44]=1
@@ -168,15 +180,15 @@ addr  opcode                                       p1   p2   p3  p4            p
  142    Integer                                     0   43    0                 0  r[43]=0
  143  Return                                       51    0    0                 0
  144  EndCoroutine                                 39    0    0                 0
- 145  OpenRead                                      5    6    0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+ 145  OpenRead                                      6    6    0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
  146  InitCoroutine                                39    0  108                 0
  147    Yield                                      39  158    0                 0
  148    Copy                                       41   56    0                 0  r[56]=r[41]
  149    Copy                                        1   57    0                 0  r[57]=r[1]
  150    Le                                         56   57  157  Binary         0  if r[56]<=r[57] goto 157
  151    Copy                                       40   58    0                 0  r[58]=r[40]
- 152    SeekRowid                                   5   58  157                 0  if (r[58]!=cursor 5 for table customers.rowid) goto 157
- 153    Column                                      5    1   52                 0  r[52]=customers.name
+ 152    SeekRowid                                   6   58  157                 0  if (r[58]!=cursor 6 for table customers.rowid) goto 157
+ 153    Column                                      6    1   52                 0  r[52]=customers.name
  154    Copy                                       41   53    0                 0  r[53]=r[41]
  155    Copy                                        2   54    0                 0  r[54]=r[2]
  156    ResultRow                                  52    3    0                 0  output=r[52..54]


### PR DESCRIPTION
## Summary

Fixes #5074.

- When a CTE was referenced multiple times via `outer_query_refs` (e.g. from a subquery), `parse_table` cloned the `Table` including its inner plan. Both clones shared the same `internal_id` values for their inner tables, causing cursor key collisions during cursor allocation. The second reference resolved to the first reference's cursor (which wasn't opened yet), panicking with `cursor id 0 is None`.
- Fix by storing the original CTE `Select` AST in `OuterQueryReference` (`cte_select` field) and re-planning from the AST on each reference instead of cloning, so each reference gets fresh `internal_id`s and independent cursor allocations.

## Test plan

- [x] Added 2 sqltest cases reproducing the exact issue (empty table + with data)
- [x] Verified tests panic before the fix, pass after
- [x] Updated 2 snapshot tests (cursor ID renumbering)
- [x] All 5798 sqltests pass
- [x] `cargo clippy` clean, `cargo fmt` clean
- [x] `cargo test` passes

Generated with [Claude Code](https://claude.com/claude-code)
