### PR TITLE
Rust bindings support experimental strict tables

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -138,6 +138,7 @@ pub struct Builder {
     enable_encryption: bool,
     enable_triggers: bool,
     enable_attach: bool,
+    enable_strict: bool,
     vfs: Option<String>,
     encryption_opts: Option<turso_sdk_kit::rsapi::EncryptionOpts>,
 }
@@ -150,6 +151,7 @@ impl Builder {
             enable_encryption: false,
             enable_triggers: false,
             enable_attach: false,
+            enable_strict: false,
             vfs: None,
             encryption_opts: None,
         }
@@ -175,6 +177,11 @@ impl Builder {
         self
     }
 
+    pub fn experimental_strict(mut self, strict_enabled: bool) -> Self {
+        self.enable_strict = strict_enabled;
+        self
+    }
+
     pub fn with_io(mut self, vfs: String) -> Self {
         self.vfs = Some(vfs);
         self
@@ -189,6 +196,9 @@ impl Builder {
         }
         if self.enable_attach {
             features.push("attach");
+        }
+        if self.enable_strict {
+            features.push("strict");
         }
         if features.is_empty() {
             return None;

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1269,3 +1269,51 @@ async fn test_once_not_cleared_on_reset_with_coroutine() {
         "Second execution should return 1, not Null. Bug: state.once not cleared in reset()"
     );
 }
+
+#[tokio::test]
+async fn test_experimental_strict_tables() {
+    // Test that STRICT tables work when the experimental flag is enabled
+    let db = Builder::new_local(":memory:")
+        .experimental_strict(true)
+        .build()
+        .await
+        .unwrap();
+    let conn = db.connect().unwrap();
+
+    // Create a STRICT table
+    conn.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT) STRICT",
+        (),
+    )
+    .await
+    .unwrap();
+
+    // Insert valid data
+    conn.execute("INSERT INTO users VALUES (1, 'Alice')", ())
+        .await
+        .unwrap();
+
+    // Query the data
+    let mut rows = conn.query("SELECT id, name FROM users", ()).await.unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 1);
+    assert_eq!(row.get::<String>(1).unwrap(), "Alice");
+}
+
+#[tokio::test]
+async fn test_strict_tables_without_experimental_flag() {
+    // Test that STRICT tables fail without the experimental flag
+    let db = Builder::new_local(":memory:").build().await.unwrap();
+    let conn = db.connect().unwrap();
+
+    // Attempt to create a STRICT table should fail
+    let result = conn
+        .execute(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT) STRICT",
+            (),
+        )
+        .await;
+
+    // Verify the error message mentions experimental feature
+    assert!(matches!(result, Err(Error::Error(_))));
+}


### PR DESCRIPTION
## Description
`STRICT` tables were recently put behind the `strict` experimental flag. This PR exposes that flag in the rust bindings the same way the `attach` and `triggers` flags are.

## Motivation and context
Motivated by me hitting the intentional error introduced here: https://github.com/tursodatabase/turso/pull/2891

## Description of AI Usage

Claude one-shot a working change, and then I made small tweaks to match surrounding code.
