### PR TITLE
bindings/wasm: Switch to notification-based I/O completion

### DIFF
--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -235,9 +235,9 @@ class Database {
   }
 
   async io() {
-    // we do not spin this.db.ioLoopAsync() 
-    // because all IO we use in JS SDK (MemoryIO, PlatformIO) are synchronous 
-    // so this call will only degrade performance for no reason
+    // For WASM browser builds, ioStep awaits a promise that resolves when
+    // the OPFS Worker completes the I/O (via IONotifier in wasm-common).
+    // For in-memory / Node.js builds, ioStep is a no-op since I/O is synchronous.
     await this.ioStep();
   }
 }
@@ -493,9 +493,6 @@ class Statement {
   }
 
   async io() {
-    // we do not spin this.db.ioLoopAsync() 
-    // because all IO we use in JS SDK (MemoryIO, PlatformIO) are synchronous 
-    // so this call will only degrade performance for no reason
     await this.ioStep();
   }
 

--- a/bindings/javascript/packages/wasm/promise-bundle.ts
+++ b/bindings/javascript/packages/wasm/promise-bundle.ts
@@ -1,5 +1,5 @@
 import { DatabasePromise, DatabaseOpts, SqliteError, } from "@tursodatabase/database-common"
-import { registerFileAtWorker, unregisterFileAtWorker } from "@tursodatabase/database-wasm-common";
+import { registerFileAtWorker, unregisterFileAtWorker, ioNotifier } from "@tursodatabase/database-wasm-common";
 import { initThreadPool, MainWorker, Database as NativeDatabase } from "./index-bundle.js";
 
 async function init(): Promise<Worker> {
@@ -13,7 +13,10 @@ async function init(): Promise<Worker> {
 class Database extends DatabasePromise {
     #worker: Worker | null;
     constructor(path: string, opts: DatabaseOpts = {}) {
-        super(new NativeDatabase(path, opts) as unknown as any)
+        super(
+            new NativeDatabase(path, opts) as unknown as any,
+            () => ioNotifier.waitForCompletion(),
+        )
     }
     /**
      * connect database and pre-open necessary files in the OPFS

--- a/bindings/javascript/packages/wasm/promise-turbopack-hack.ts
+++ b/bindings/javascript/packages/wasm/promise-turbopack-hack.ts
@@ -1,5 +1,5 @@
 import { DatabasePromise, DatabaseOpts, SqliteError, } from "@tursodatabase/database-common"
-import { registerFileAtWorker, unregisterFileAtWorker } from "@tursodatabase/database-wasm-common";
+import { registerFileAtWorker, unregisterFileAtWorker, ioNotifier } from "@tursodatabase/database-wasm-common";
 import { initThreadPool, MainWorker, Database as NativeDatabase } from "./index-turbopack-hack.js";
 
 async function init(): Promise<Worker> {
@@ -13,7 +13,10 @@ async function init(): Promise<Worker> {
 class Database extends DatabasePromise {
     #worker: Worker | null;
     constructor(path: string, opts: DatabaseOpts = {}) {
-        super(new NativeDatabase(path, opts) as unknown as any)
+        super(
+            new NativeDatabase(path, opts) as unknown as any,
+            () => ioNotifier.waitForCompletion(),
+        )
     }
     /**
      * connect database and pre-open necessary files in the OPFS

--- a/bindings/javascript/packages/wasm/promise-vite-dev-hack.ts
+++ b/bindings/javascript/packages/wasm/promise-vite-dev-hack.ts
@@ -1,5 +1,5 @@
 import { DatabasePromise, DatabaseOpts, SqliteError, } from "@tursodatabase/database-common"
-import { registerFileAtWorker, unregisterFileAtWorker } from "@tursodatabase/database-wasm-common";
+import { registerFileAtWorker, unregisterFileAtWorker, ioNotifier } from "@tursodatabase/database-wasm-common";
 import { initThreadPool, MainWorker, Database as NativeDatabase } from "./index-vite-dev-hack.js";
 
 async function init(): Promise<Worker> {
@@ -13,7 +13,10 @@ async function init(): Promise<Worker> {
 class Database extends DatabasePromise {
     #worker: Worker | null;
     constructor(path: string, opts: DatabaseOpts = {}) {
-        super(new NativeDatabase(path, opts) as unknown as any)
+        super(
+            new NativeDatabase(path, opts) as unknown as any,
+            () => ioNotifier.waitForCompletion(),
+        )
     }
     /**
      * connect database and pre-open necessary files in the OPFS

--- a/bindings/javascript/packages/wasm/promise.test.ts
+++ b/bindings/javascript/packages/wasm/promise.test.ts
@@ -1,9 +1,19 @@
-import { expect, test, afterAll } from 'vitest'
+import { expect, test, afterAll, beforeEach, afterEach } from 'vitest'
 import { connect, Database } from './promise-default.js'
 import { MainWorker } from './index-default.js'
 
+beforeEach((ctx) => {
+    console.log(`[test:start] ${ctx.task.name}`);
+})
+
+afterEach((ctx) => {
+    console.log(`[test:end] ${ctx.task.name} (${ctx.task.result?.state})`);
+})
+
 afterAll(() => {
+    console.log('[afterAll] terminating MainWorker');
     MainWorker?.terminate();
+    console.log('[afterAll] MainWorker terminated');
 })
 
 test('vector-test', async () => {
@@ -172,7 +182,7 @@ test('on-disk db', async () => {
     expect(stmt2.columns()).toEqual([{ name: "x", column: null, database: null, table: null, type: null }]);
     const rows2 = await stmt2.all([1]);
     expect(rows2).toEqual([{ x: 1 }, { x: 3 }]);
-    db2.close();
+    await db2.close();
 })
 
 // attach is not supported in browser for now

--- a/bindings/javascript/packages/wasm/vitest.config.ts
+++ b/bindings/javascript/packages/wasm/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     },
   },
   test: {
+    testTimeout: 120_000,
     browser: {
       enabled: true,
       provider: 'playwright',

--- a/bindings/javascript/sync/packages/wasm/promise-bundle.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-bundle.ts
@@ -1,4 +1,4 @@
-import { registerFileAtWorker, unregisterFileAtWorker } from "@tursodatabase/database-wasm-common"
+import { registerFileAtWorker, unregisterFileAtWorker, ioNotifier } from "@tursodatabase/database-wasm-common"
 import { DatabasePromise } from "@tursodatabase/database-common"
 import { ProtocolIo, run, DatabaseOpts, EncryptionOpts, RunOpts, DatabaseRowMutation, DatabaseRowStatement, DatabaseRowTransformResult, DatabaseStats, SyncEngineGuards, Runner, runner } from "@tursodatabase/sync-common";
 import { SyncEngine, SyncEngineProtocolVersion, initThreadPool, MainWorker, Database as NativeDatabase } from "./index-bundle.js";
@@ -46,7 +46,10 @@ class Database extends DatabasePromise {
     #worker: Worker | null;
     constructor(opts: DatabaseOpts) {
         if (opts.url == null) {
-            super(new NativeDatabase(opts.path, { tracing: opts.tracing }) as any);
+            super(
+                new NativeDatabase(opts.path, { tracing: opts.tracing }) as any,
+                () => ioNotifier.waitForCompletion(),
+            );
             this.#engine = null;
             return;
         }

--- a/bindings/javascript/sync/packages/wasm/promise-default.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-default.ts
@@ -1,4 +1,4 @@
-import { registerFileAtWorker, unregisterFileAtWorker } from "@tursodatabase/database-wasm-common"
+import { registerFileAtWorker, unregisterFileAtWorker, ioNotifier } from "@tursodatabase/database-wasm-common"
 import { DatabasePromise } from "@tursodatabase/database-common"
 import { ProtocolIo, run, DatabaseOpts, EncryptionOpts, RunOpts, DatabaseRowMutation, DatabaseRowStatement, DatabaseRowTransformResult, DatabaseStats, SyncEngineGuards, Runner, runner } from "@tursodatabase/sync-common";
 import { SyncEngine, SyncEngineProtocolVersion, initThreadPool, MainWorker, Database as NativeDatabase } from "./index-default.js";
@@ -46,7 +46,10 @@ class Database extends DatabasePromise {
     #worker: Worker | null;
     constructor(opts: DatabaseOpts) {
         if (opts.url == null) {
-            super(new NativeDatabase(opts.path, { tracing: opts.tracing }) as any);
+            super(
+                new NativeDatabase(opts.path, { tracing: opts.tracing }) as any,
+                () => ioNotifier.waitForCompletion(),
+            );
             this.#engine = null;
             return;
         }

--- a/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
@@ -1,4 +1,4 @@
-import { registerFileAtWorker, unregisterFileAtWorker } from "@tursodatabase/database-wasm-common"
+import { registerFileAtWorker, unregisterFileAtWorker, ioNotifier } from "@tursodatabase/database-wasm-common"
 import { DatabasePromise } from "@tursodatabase/database-common"
 import { ProtocolIo, run, DatabaseOpts, EncryptionOpts, RunOpts, DatabaseRowMutation, DatabaseRowStatement, DatabaseRowTransformResult, DatabaseStats, SyncEngineGuards, Runner, runner } from "@tursodatabase/sync-common";
 import { SyncEngine, SyncEngineProtocolVersion, initThreadPool, MainWorker, Database as NativeDatabase } from "./index-turbopack-hack.js";
@@ -46,7 +46,10 @@ class Database extends DatabasePromise {
     #worker: Worker | null;
     constructor(opts: DatabaseOpts) {
         if (opts.url == null) {
-            super(new NativeDatabase(opts.path, { tracing: opts.tracing }) as any);
+            super(
+                new NativeDatabase(opts.path, { tracing: opts.tracing }) as any,
+                () => ioNotifier.waitForCompletion(),
+            );
             this.#engine = null;
             return;
         }

--- a/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
@@ -1,4 +1,4 @@
-import { registerFileAtWorker, unregisterFileAtWorker } from "@tursodatabase/database-wasm-common"
+import { registerFileAtWorker, unregisterFileAtWorker, ioNotifier } from "@tursodatabase/database-wasm-common"
 import { DatabasePromise } from "@tursodatabase/database-common"
 import { ProtocolIo, run, DatabaseOpts, EncryptionOpts, RunOpts, DatabaseRowMutation, DatabaseRowStatement, DatabaseRowTransformResult, DatabaseStats, SyncEngineGuards, Runner, runner } from "@tursodatabase/sync-common";
 import { SyncEngine, SyncEngineProtocolVersion, initThreadPool, MainWorker, Database as NativeDatabase } from "./index-vite-dev-hack.js";
@@ -46,7 +46,10 @@ class Database extends DatabasePromise {
     #worker: Worker | null;
     constructor(opts: DatabaseOpts) {
         if (opts.url == null) {
-            super(new NativeDatabase(opts.path, { tracing: opts.tracing }) as any);
+            super(
+                new NativeDatabase(opts.path, { tracing: opts.tracing }) as any,
+                () => ioNotifier.waitForCompletion(),
+            );
             this.#engine = null;
             return;
         }


### PR DESCRIPTION
When the VDBE returns STEP_IO ("I/O is in flight, come back later"), the JS step loop calls `await this.ioStep()` to yield before retrying. Previously ioStep was `async () => {}` -- a no-op that only yields to the microtask queue then immediately retries. But OPFS I/O completions arrive as Worker message events, which are macrotasks. Microtasks always run before macrotasks, so the loop spins forever without ever letting the browser process the Worker's response.

Add an IONotifier in wasm-common. The step loop now calls `await ioNotifier.waitForCompletion()` which parks on a promise. When the OPFS Worker responds, completeOpfs() fires and calls ioNotifier.notify(), resolving the parked promise. The step loop wakes up and retries, finding the I/O completed. Instead of blindly yielding and hoping the Worker response has arrived, the loop now waits on the actual completion event.

For in-memory databases, ioStep stays as a no-op because MemoryIO completes synchronously -- there is no Worker involved, so the IONotifier would never fire.

Also fix missing `await` on db2.close() in the on-disk browser test, and add a 30s stall warning for worker requests.