### PR TITLE
Add STRICT table support to differential fuzzer

### DIFF
--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -178,7 +178,12 @@ fn to_prop_schema(schema: &sql_gen::Schema) -> sql_gen_prop::Schema {
                 col
             })
             .collect();
-        builder = builder.add_table(sql_gen_prop::Table::new(table.name.clone(), columns));
+        let prop_table = if table.strict {
+            sql_gen_prop::Table::new_strict(table.name.clone(), columns)
+        } else {
+            sql_gen_prop::Table::new(table.name.clone(), columns)
+        };
+        builder = builder.add_table(prop_table);
     }
     for index in &schema.indexes {
         let mut idx = sql_gen_prop::Index::new(

--- a/testing/differential-oracle/sql_gen/src/ast.rs
+++ b/testing/differential-oracle/sql_gen/src/ast.rs
@@ -800,6 +800,7 @@ pub struct CreateTableStmt {
     pub table: String,
     pub columns: Vec<ColumnDefStmt>,
     pub if_not_exists: bool,
+    pub strict: bool,
 }
 
 impl fmt::Display for CreateTableStmt {
@@ -817,7 +818,13 @@ impl fmt::Display for CreateTableStmt {
             write!(f, "{col}")?;
         }
 
-        write!(f, ")")
+        write!(f, ")")?;
+
+        if self.strict {
+            write!(f, " STRICT")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/testing/differential-oracle/sql_gen/src/generate/stmt.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/stmt.rs
@@ -660,10 +660,22 @@ pub fn generate_create_table<C: Capabilities>(
         }
     };
 
+    let strict = ctx.gen_bool_with_prob(create_table_config.strict_probability);
+
+    // STRICT tables don't allow untyped (Null) columns — convert to Integer.
+    if strict {
+        for col in &mut columns {
+            if col.data_type == DataType::Null {
+                col.data_type = DataType::Integer;
+            }
+        }
+    }
+
     Ok(Stmt::CreateTable(CreateTableStmt {
         table: qualified_table_name,
         columns,
         if_not_exists: ctx.gen_bool_with_prob(create_table_config.if_not_exists_probability),
+        strict,
     }))
 }
 

--- a/testing/differential-oracle/sql_gen/src/policy.rs
+++ b/testing/differential-oracle/sql_gen/src/policy.rs
@@ -1492,6 +1492,9 @@ pub struct CreateTableConfig {
     /// Probability of CHECK constraint on a column.
     pub check_constraint_probability: f64,
 
+    /// Probability of generating a STRICT table.
+    pub strict_probability: f64,
+
     // Stubs (not yet implemented, probability 0.0)
     /// Probability of FOREIGN KEY.
     pub foreign_key_probability: f64,
@@ -1516,6 +1519,7 @@ impl Default for CreateTableConfig {
             default_probability: 0.2,
             if_not_exists_probability: 0.5,
             check_constraint_probability: 0.15,
+            strict_probability: 0.2,
             // Stubs
             foreign_key_probability: 0.0,
             autoincrement_probability: 0.0,

--- a/testing/differential-oracle/sql_gen/src/schema.rs
+++ b/testing/differential-oracle/sql_gen/src/schema.rs
@@ -111,6 +111,7 @@ pub struct Table {
     /// `None` means the main database.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub database: Option<String>,
+    pub strict: bool,
 }
 
 impl Table {
@@ -119,6 +120,16 @@ impl Table {
             name: name.into(),
             columns,
             database: None,
+            strict: false,
+        }
+    }
+
+    pub fn new_strict(name: impl Into<String>, columns: Vec<ColumnDef>) -> Self {
+        Self {
+            name: name.into(),
+            columns,
+            database: None,
+            strict: true,
         }
     }
 

--- a/testing/differential-oracle/sql_gen_prop/schema.rs
+++ b/testing/differential-oracle/sql_gen_prop/schema.rs
@@ -122,6 +122,7 @@ pub struct Table {
     /// `None` means the main database.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database: Option<String>,
+    pub strict: bool,
 }
 
 impl Table {
@@ -130,6 +131,16 @@ impl Table {
             name: name.into(),
             columns,
             database: None,
+            strict: false,
+        }
+    }
+
+    pub fn new_strict(name: impl Into<String>, columns: Vec<ColumnDef>) -> Self {
+        Self {
+            name: name.into(),
+            columns,
+            database: None,
+            strict: true,
         }
     }
 


### PR DESCRIPTION
Generate CREATE TABLE ... STRICT statements with configurable probability (default 20%), use literal-only INSERT/UPDATE values for strict tables to avoid type mismatches, detect STRICT via sqlite_master introspection, and enable the experimental-strict flag on the Turso database connection.

Rename the confusingly-named strict() profile methods to high_constraints() to avoid collision with SQLite STRICT semantics.


## Description of AI Usage

Commit itself was generated with Claude Code. Then I manually ran the fuzzer a couple of times (--loop 500) to make sure that strict tables were generated and that it was passing.