### PR TITLE
Add REGEXP operator support

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -222,7 +222,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | COLLATE                   | 🚧 Partial | Custom Collations not supported          |
 | (NOT) LIKE                | ✅ Yes     |                                          |
 | (NOT) GLOB                | ✅ Yes     |                                          |
-| (NOT) REGEXP              | ❌ No      |                                          |
+| (NOT) REGEXP              | ✅ Yes     |                                          |
 | (NOT) MATCH               | ❌ No      |                                          |
 | IS (NOT)                  | ✅ Yes     |                                          |
 | IS (NOT) DISTINCT FROM    | ✅ Yes     |                                          |

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -226,6 +226,7 @@ impl Database {
         crate::series::register_extension(&mut ext_api);
         #[cfg(feature = "time")]
         crate::time::register_extension(&mut ext_api);
+        crate::regexp::register_extension(&mut ext_api);
         #[cfg(feature = "fs")]
         {
             let vfslist = add_builtin_vfs_extensions(Some(ext_api)).map_err(|e| e.to_string())?;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -23,6 +23,7 @@ pub mod mvcc;
 mod parameters;
 mod pragma;
 mod pseudo;
+mod regexp;
 pub mod schema;
 #[cfg(feature = "series")]
 mod series;

--- a/core/regexp.rs
+++ b/core/regexp.rs
@@ -1,0 +1,28 @@
+use crate::ext::register_scalar_function;
+use turso_ext::{scalar, ExtensionApi, Value, ValueType};
+
+pub fn register_extension(ext_api: &mut ExtensionApi) {
+    unsafe {
+        register_scalar_function(ext_api.ctx, c"regexp".as_ptr(), regexp);
+    }
+}
+
+#[scalar(name = "regexp")]
+fn regexp(args: &[Value]) -> Value {
+    match (args[0].value_type(), args[1].value_type()) {
+        (ValueType::Text, ValueType::Text) => {
+            let Some(pattern) = args[0].to_text() else {
+                return Value::null();
+            };
+            let Some(haystack) = args[1].to_text() else {
+                return Value::null();
+            };
+            let re = match regex::Regex::new(pattern) {
+                Ok(re) => re,
+                Err(_) => return Value::null(),
+            };
+            Value::from_integer(re.is_match(haystack) as i64)
+        }
+        _ => Value::null(),
+    }
+}

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -73,11 +73,8 @@ def null(res):
 def test_regexp():
     turso = TestTursoShell(test_data)
     extension_path = "./target/debug/liblimbo_regexp"
-    # before extension loads, assert no function
-    turso.run_test_fn(
-        "SELECT regexp('a.c', 'abc');",
-        lambda res: "Parse error: no such function" in res,
-    )
+    # regexp() is a built-in, verify it works before loading the extension
+    turso.run_test_fn("SELECT regexp('a.c', 'abc');", true)
     turso.run_test_fn(f".load {extension_path}", null)
     console.info(f"Extension {extension_path} loaded successfully.")
     turso.run_test_fn("SELECT regexp('a.c', 'abc');", true)

--- a/testing/runner/turso-tests/regexp.sqltest
+++ b/testing/runner/turso-tests/regexp.sqltest
@@ -1,0 +1,120 @@
+@database :memory:
+
+test regexp_operator_basic_match {
+    SELECT 'hello' REGEXP 'h.*o';
+}
+expect {
+    1
+}
+
+test regexp_operator_no_match {
+    SELECT 'hello' REGEXP '^world$';
+}
+expect {
+    0
+}
+
+test regexp_not_operator {
+    SELECT 'hello' NOT REGEXP 'h.*o';
+    SELECT 'hello' NOT REGEXP '^world$';
+}
+expect {
+    0
+    1
+}
+
+test regexp_function_call {
+    SELECT regexp('h.*o', 'hello');
+    SELECT regexp('^world$', 'hello');
+}
+expect {
+    1
+    0
+}
+
+test regexp_in_where {
+    CREATE TABLE t1(a TEXT, b INTEGER);
+    INSERT INTO t1 VALUES ('abc', 1), ('def', 2), ('abcdef', 3), ('xyz', 4);
+    SELECT b FROM t1 WHERE a REGEXP '^abc';
+}
+expect {
+    1
+    3
+}
+
+test regexp_not_in_where {
+    CREATE TABLE t2(a TEXT, b INTEGER);
+    INSERT INTO t2 VALUES ('abc', 1), ('def', 2), ('abcdef', 3), ('xyz', 4);
+    SELECT b FROM t2 WHERE a NOT REGEXP '^abc';
+}
+expect {
+    2
+    4
+}
+
+test regexp_in_select {
+    CREATE TABLE t3(a TEXT, b INTEGER);
+    INSERT INTO t3 VALUES ('abc', 1), ('def', 2), ('abcdef', 3), ('xyz', 4);
+    SELECT a, a REGEXP 'def$' FROM t3;
+}
+expect {
+    abc|0
+    def|1
+    abcdef|1
+    xyz|0
+}
+
+test regexp_in_case {
+    CREATE TABLE t4(a TEXT);
+    INSERT INTO t4 VALUES ('abc'), ('def'), ('abcdef'), ('xyz');
+    SELECT CASE WHEN a REGEXP '^a' THEN 'starts_a' ELSE 'other' END FROM t4;
+}
+expect {
+    starts_a
+    other
+    starts_a
+    other
+}
+
+test regexp_null_handling {
+    SELECT NULL REGEXP 'abc';
+    SELECT 'abc' REGEXP NULL;
+    SELECT regexp(NULL, 'abc');
+    SELECT regexp('abc', NULL);
+}
+expect {
+
+
+
+
+}
+
+test regexp_integer_operands {
+    SELECT 123 REGEXP '1.*3';
+    SELECT 456 REGEXP '1.*3';
+}
+expect {
+
+
+}
+
+test regexp_complex_patterns {
+    SELECT 'test@example.com' REGEXP '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$';
+    SELECT '2024-01-15' REGEXP '^\d{4}-\d{2}-\d{2}$';
+    SELECT 'hello world' REGEXP '\bworld\b';
+}
+expect {
+    1
+    1
+    1
+}
+
+test regexp_in_subquery {
+    CREATE TABLE t5(a TEXT);
+    INSERT INTO t5 VALUES ('abc'), ('def'), ('abcdef'), ('xyz');
+    SELECT * FROM (SELECT a, a REGEXP 'def' AS matches FROM t5) sub WHERE matches = 1;
+}
+expect {
+    def|1
+    abcdef|1
+}


### PR DESCRIPTION
Translate X REGEXP Y to regexp(Y, X) function call, matching SQLite semantics. The regexp() function is resolved through the Resolver (SymbolTable), not hardcoded as a ScalarFunc, so users can override it by loading their own extension.

Register a built-in regexp implementation via the extension API (same mechanism as uuid/series/time) so it works out of the box.

Note that tests live under turso-tests, because there's no canonical regexp implementation in sqlite, so it is pointless to compare.

In practice we'll always have the regexp function loaded, but it is still good to have a unit test that makes sure we don't completely crap out and produce the right error message in case we don't.


## Description of AI Usage

Claude Code helped me understand how regexp works in SQLite, and wrote the tests.