### PR TITLE
Fix LEFT JOIN with virtual tables producing wrong results

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -2745,6 +2745,14 @@ impl Cursor {
             _ => panic!("Cursor is not an IndexMethod cursor"),
         }
     }
+
+    pub fn set_null_flag(&mut self, flag: bool) {
+        match self {
+            Self::BTree(cursor) => cursor.set_null_flag(flag),
+            Self::Virtual(cursor) => cursor.set_null_flag(flag),
+            _ => panic!("set_null_flag on unexpected cursor type"),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -442,17 +442,13 @@ pub fn op_null(
 }
 
 pub fn op_null_row(
-    program: &Program,
+    _program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(NullRow { cursor_id }, insn);
-    {
-        let cursor = must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "NullRow");
-        let cursor = cursor.as_btree_mut();
-        cursor.set_null_flag(true);
-    }
+    state.get_cursor(*cursor_id).set_null_flag(true);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/testing/runner/src/parser/mod.rs
+++ b/testing/runner/src/parser/mod.rs
@@ -1120,7 +1120,6 @@ expect {
         assert!(file.tests[0].modifiers.skip.is_none());
     }
 
-
     #[test]
     fn test_parse_backend_specific_expectations() {
         let input = r#"

--- a/testing/runner/tests/virtual-table-left-join.sqltest
+++ b/testing/runner/tests/virtual-table-left-join.sqltest
@@ -1,0 +1,56 @@
+@database :memory:
+
+@skip-if mvcc "panic: transaction should exist in txs map"
+test left-join-virtual-table-matching {
+    CREATE TABLE t1 (id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO t1 VALUES (0, 'alice');
+    INSERT INTO t1 VALUES (1, 'bob');
+    SELECT t1.name, p.name as col_name
+    FROM t1
+    LEFT JOIN pragma_table_info('t1') p ON p.cid = t1.id;
+}
+expect {
+    alice|id
+    bob|name
+}
+
+@skip-if mvcc "panic: transaction should exist in txs map"
+test left-join-virtual-table-null {
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO t2 VALUES (0, 'alice');
+    INSERT INTO t2 VALUES (99, 'nobody');
+    SELECT t2.name, p.name as col_name
+    FROM t2
+    LEFT JOIN pragma_table_info('t2') p ON p.cid = t2.id;
+}
+expect {
+    alice|id
+    nobody|
+}
+
+@skip-if mvcc "panic: transaction should exist in txs map"
+test left-join-virtual-table-on-left-matching {
+    CREATE TABLE t3 (id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO t3 VALUES (0, 'alice');
+    INSERT INTO t3 VALUES (1, 'bob');
+    SELECT p.name as col_name, t3.name
+    FROM pragma_table_info('t3') p
+    LEFT JOIN t3 ON t3.id = p.cid;
+}
+expect {
+    id|alice
+    name|bob
+}
+
+@skip-if mvcc "panic: transaction should exist in txs map"
+test left-join-virtual-table-on-left-null {
+    CREATE TABLE t4 (id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO t4 VALUES (0, 'alice');
+    SELECT p.name as col_name, t4.name
+    FROM pragma_table_info('t4') p
+    LEFT JOIN t4 ON t4.id = p.cid;
+}
+expect {
+    id|alice
+    name|
+}


### PR DESCRIPTION
LEFT JOIN with a virtual table on the right side silently dropped unmatched rows instead of emitting NULLs. Two independent bugs combined to cause this:

1. Virtual table argument predicates (e.g. the 't2' in pragma_table_info('t2')) were added to the WHERE clause with from_outer_join=None. The optimizer's outer-join simplification pass saw these as ordinary WHERE filters that reject NULLs and rewrote the LEFT JOIN into an INNER JOIN. With the join type downgraded, the optimizer freely reordered the virtual table to the outer loop, causing unmatched left-side rows to be dropped entirely.

   Fix: when building WhereTerm entries for vtab argument predicates, look up the table's join_info and propagate its outer-join id so the simplification pass correctly skips them.

2. op_null_row used must_be_btree_cursor! which panics on virtual table cursors. Even after fixing the join order, NullRow on the virtual table cursor would crash.

   Fix: match on Cursor::Virtual in op_null_row and add null_flag support to VirtualTableCursor (struct wrapping an inner enum). column() returns Value::Null when the flag is set; next() and filter() clear it.

In tests, we also add virtual tables to the left side of the join to make sure we have good coverage, although those were working already.

## Description of AI Usage

Found this by accident when working on something else with CC. Then asked CC, who fixed the bug as part of the other task without being asked (I should tweet about it and say it is becoming sentient), to create a reproducer, add tests, etc, on a clean tree