### PR TITLE
Fix user-defined columns named oid/rowid/_rowid_ resolving to internal rowid

### DIFF
--- a/testing/runner/src/parser/mod.rs
+++ b/testing/runner/src/parser/mod.rs
@@ -1120,7 +1120,6 @@ expect {
         assert!(file.tests[0].modifiers.skip.is_none());
     }
 
-
     #[test]
     fn test_parse_backend_specific_expectations() {
         let input = r#"

--- a/testing/runner/tests/select/memory.sqltest
+++ b/testing/runner/tests/select/memory.sqltest
@@ -1017,6 +1017,43 @@ expect {
     2|2|2|2|2|2|2|2|2|2|2|2
 }
 
+# User-defined columns named oid/rowid/_rowid_ take precedence over rowid aliases
+test oid-column-overrides-rowid-alias {
+    CREATE TABLE t1 (oid TEXT, name TEXT);
+    INSERT INTO t1 VALUES ('my-oid', 'alice');
+    SELECT t1.oid FROM t1;
+}
+expect {
+    my-oid
+}
+
+test rowid-column-overrides-rowid-alias {
+    CREATE TABLE t2 (rowid TEXT, val INTEGER);
+    INSERT INTO t2 VALUES ('custom-rowid', 42);
+    SELECT t2.rowid FROM t2;
+}
+expect {
+    custom-rowid
+}
+
+test _rowid_-column-overrides-rowid-alias {
+    CREATE TABLE t3 (_rowid_ TEXT, val INTEGER);
+    INSERT INTO t3 VALUES ('custom', 42);
+    SELECT t3._rowid_ FROM t3;
+}
+expect {
+    custom
+}
+
+test rowid-alias-still-works-without-user-column {
+    CREATE TABLE t4 (a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t4 VALUES (100, 'hello');
+    SELECT t4.oid FROM t4;
+}
+expect {
+    100
+}
+
 test null-in-search {
     CREATE TABLE t_x_asc (id INTEGER PRIMARY KEY, x);
     CREATE INDEX t_x_asc_idx ON t_x_asc(x ASC);


### PR DESCRIPTION
The Expr::Qualified handler called parse_row_id() before checking whether the table has a user-defined column with that name. This caused `SELECT t.oid FROM t` to return the internal rowid instead of the user column when a column named `oid` exists. SQLite spec says user columns take precedence over rowid aliases.



## Description of AI Usage

Found this by accident when working on something else with CC. Then asked CC, who fixed the bug as part of the other task without being asked (I should tweet about it and say it is becoming sentient), to create a reproducer, add tests, etc, on a clean tree
