### PR TITLE
Make strict mode non-experimental

### DIFF
--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -220,7 +220,7 @@ fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
             for feature in experimental {
                 core_opts = match feature.as_str() {
                     "views" => core_opts.with_views(true),
-                    "strict" => core_opts.with_strict(true),
+                    "strict" => core_opts, // strict is always enabled, kept for backwards compatibility
                     "custom_types" => core_opts.with_custom_types(true),
                     "encryption" => core_opts.with_encryption(true),
                     "index_method" => core_opts.with_index_method(true),

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -138,7 +138,6 @@ pub struct Builder {
     enable_encryption: bool,
     enable_triggers: bool,
     enable_attach: bool,
-    enable_strict: bool,
     enable_custom_types: bool,
     enable_index_method: bool,
     enable_materialized_views: bool,
@@ -154,7 +153,6 @@ impl Builder {
             enable_encryption: false,
             enable_triggers: false,
             enable_attach: false,
-            enable_strict: false,
             enable_custom_types: false,
             enable_index_method: false,
             enable_materialized_views: false,
@@ -183,8 +181,8 @@ impl Builder {
         self
     }
 
-    pub fn experimental_strict(mut self, strict_enabled: bool) -> Self {
-        self.enable_strict = strict_enabled;
+    /// Kept for backwards compatibility. Strict tables are now always enabled.
+    pub fn experimental_strict(self, _strict_enabled: bool) -> Self {
         self
     }
 
@@ -217,9 +215,6 @@ impl Builder {
         }
         if self.enable_attach {
             features.push("attach");
-        }
-        if self.enable_strict {
-            features.push("strict");
         }
         if self.enable_custom_types {
             features.push("custom_types");

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1271,13 +1271,8 @@ async fn test_once_not_cleared_on_reset_with_coroutine() {
 }
 
 #[tokio::test]
-async fn test_experimental_strict_tables() {
-    // Test that STRICT tables work when the experimental flag is enabled
-    let db = Builder::new_local(":memory:")
-        .experimental_strict(true)
-        .build()
-        .await
-        .unwrap();
+async fn test_strict_tables() {
+    let db = Builder::new_local(":memory:").build().await.unwrap();
     let conn = db.connect().unwrap();
 
     // Create a STRICT table
@@ -1298,24 +1293,6 @@ async fn test_experimental_strict_tables() {
     let row = rows.next().await.unwrap().unwrap();
     assert_eq!(row.get::<i64>(0).unwrap(), 1);
     assert_eq!(row.get::<String>(1).unwrap(), "Alice");
-}
-
-#[tokio::test]
-async fn test_strict_tables_without_experimental_flag() {
-    // Test that STRICT tables fail without the experimental flag
-    let db = Builder::new_local(":memory:").build().await.unwrap();
-    let conn = db.connect().unwrap();
-
-    // Attempt to create a STRICT table should fail
-    let result = conn
-        .execute(
-            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT) STRICT",
-            (),
-        )
-        .await;
-
-    // Verify the error message mentions experimental feature
-    assert!(matches!(result, Err(Error::Error(_))));
 }
 
 // Helper to collect all integer values from a single-column query.

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -68,8 +68,6 @@ pub struct Opts {
     pub readonly: bool,
     #[clap(long, help = "Enable experimental views feature")]
     pub experimental_views: bool,
-    #[clap(long, help = "Enable experimental strict schema mode")]
-    pub experimental_strict: bool,
     #[clap(
         long,
         help = "Enable experimental custom types (CREATE TYPE / DROP TYPE)"
@@ -217,7 +215,6 @@ impl Limbo {
 
         let db_opts = turso_core::DatabaseOpts::new()
             .with_views(opts.experimental_views)
-            .with_strict(opts.experimental_strict)
             .with_custom_types(opts.experimental_custom_types)
             .with_encryption(opts.experimental_encryption)
             .with_index_method(opts.experimental_index_method)

--- a/cli/manuals/custom-types.md
+++ b/cli/manuals/custom-types.md
@@ -8,10 +8,10 @@ display_name: "custom types"
 
 Turso extends SQLite's STRICT table type system with user-defined custom types. Custom types let you define how values are encoded before storage and decoded when read, enforce domain constraints at the storage layer, attach operators, and provide defaults — all declared in pure SQL.
 
-Custom types work only with **STRICT** tables and require the `--experimental-strict` flag:
+Custom types work only with **STRICT** tables (which are always enabled):
 
 ```
-tursodb --experimental-strict mydb.db
+tursodb mydb.db
 ```
 
 Without this flag, `CREATE TYPE`, `DROP TYPE`, the `sqlite_turso_types` virtual table, and all built-in custom types (date, varchar, numeric, etc.) are unavailable. `PRAGMA list_types` will only show the five base SQLite types (INTEGER, REAL, TEXT, BLOB, ANY).
@@ -425,7 +425,7 @@ SELECT id, val FROM t1;
 
 ## Restrictions
 
-- Custom types require **STRICT** tables and the `--experimental-strict` flag.
+- Custom types require **STRICT** tables.
 - A type cannot be dropped while any table column uses it.
 - `CREATE TYPE IF NOT EXISTS` silently succeeds if the type already exists.
 - Encode/decode expressions use the identifier `value` to reference the input.

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1345,10 +1345,6 @@ impl Connection {
         self.db.experimental_index_method_enabled()
     }
 
-    pub fn experimental_strict_enabled(&self) -> bool {
-        self.db.experimental_strict_enabled()
-    }
-
     pub fn experimental_custom_types_enabled(&self) -> bool {
         self.db.experimental_custom_types_enabled()
     }
@@ -1512,12 +1508,10 @@ impl Connection {
         }
 
         let use_views = self.db.experimental_views_enabled();
-        let use_strict = self.db.experimental_strict_enabled();
         let use_custom_types = self.db.experimental_custom_types_enabled();
 
         let db_opts = DatabaseOpts::new()
             .with_views(use_views)
-            .with_strict(use_strict)
             .with_custom_types(use_custom_types);
         // Select the IO layer for the attached database:
         // - :memory: databases always get a fresh MemoryIO

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -388,7 +388,6 @@ mod tests {
             OpenFlags::default(),
             crate::DatabaseOpts {
                 enable_views: true,
-                enable_strict: false,
                 enable_custom_types: false,
                 enable_load_extension: false,
                 enable_encryption: false,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -166,7 +166,6 @@ pub const fn is_attached_db(database_id: usize) -> bool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct DatabaseOpts {
     pub enable_views: bool,
-    pub enable_strict: bool,
     pub enable_custom_types: bool,
     pub enable_encryption: bool,
     pub enable_index_method: bool,
@@ -193,16 +192,8 @@ impl DatabaseOpts {
         self
     }
 
-    pub fn with_strict(mut self, enable: bool) -> Self {
-        self.enable_strict = enable;
-        self
-    }
-
     pub fn with_custom_types(mut self, enable: bool) -> Self {
         self.enable_custom_types = enable;
-        if enable {
-            self.enable_strict = true;
-        }
         self
     }
 
@@ -1563,10 +1554,6 @@ impl Database {
 
     pub fn experimental_index_method_enabled(&self) -> bool {
         self.opts.enable_index_method
-    }
-
-    pub fn experimental_strict_enabled(&self) -> bool {
-        self.opts.enable_strict
     }
 
     pub fn experimental_custom_types_enabled(&self) -> bool {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -458,7 +458,7 @@ fn bootstrap_builtin_types(registry: &mut HashMap<String, Arc<TypeDef>>) {
 
 impl Schema {
     pub fn new() -> Self {
-        Self::with_options(false)
+        Self::with_options(true)
     }
 
     pub fn with_options(enable_custom_types: bool) -> Self {

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1236,7 +1236,8 @@ fn query_pragma(
             }
 
             // Custom types from the type registry are only shown when strict mode is enabled
-            if connection.experimental_strict_enabled() {
+            // Custom types are always shown since strict mode is always enabled
+            {
                 // Skip aliases where key != canonical name
                 let mut type_names: Vec<_> = schema
                     .type_registry

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -455,12 +455,7 @@ fn validate_check_types_in_expr(
     Ok(())
 }
 
-fn validate(
-    body: &ast::CreateTableBody,
-    table_name: &str,
-    connection: &Connection,
-    resolver: &Resolver,
-) -> Result<()> {
+fn validate(body: &ast::CreateTableBody, table_name: &str, resolver: &Resolver) -> Result<()> {
     if let ast::CreateTableBody::ColumnsAndConstraints {
         options,
         columns,
@@ -469,11 +464,6 @@ fn validate(
     {
         if options.contains_without_rowid() {
             bail_parse_error!("WITHOUT ROWID tables are not supported");
-        }
-        if options.contains_strict() && !connection.experimental_strict_enabled() {
-            bail_parse_error!(
-                "STRICT tables are an experimental feature. Enable them with --experimental-strict flag"
-            );
         }
         let column_names: Vec<&str> = columns.iter().map(|c| c.col_name.as_str()).collect();
         for i in 0..columns.len() {
@@ -606,7 +596,7 @@ pub fn translate_create_table(
     if temporary {
         bail_parse_error!("TEMPORARY table not supported yet");
     }
-    validate(&body, &normalized_tbl_name, connection, resolver)?;
+    validate(&body, &normalized_tbl_name, resolver)?;
 
     let opts = ProgramBuilderOpts {
         num_cursors: 1,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12176,8 +12176,7 @@ fn op_vacuum_into_inner(
                 let dest_opts = crate::DatabaseOpts::new()
                     .with_views(source_db.experimental_views_enabled())
                     .with_triggers(source_db.experimental_triggers_enabled())
-                    .with_index_method(source_db.experimental_index_method_enabled())
-                    .with_strict(source_db.experimental_strict_enabled());
+                    .with_index_method(source_db.experimental_index_method_enabled());
 
                 program.connection.execute("BEGIN")?;
                 // lets set the same meta values as source db

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -154,7 +154,6 @@ The SQL shell supports the following command line options:
 | `-V`, `--version` | Print version |
 | `--mcp` | Start a MCP server instead of the interactive shell |
 | `--experimental-encryption` | Enable experimental encryption at rest feature. **Note:** the feature is not production ready so do not use it for critical data right now. |
-| `--experimental-strict` | Enable experimental strict schema feature. **Note**: the feature is not production ready so do not use it for critical data right now. |
 | `--experimental-views` | Enable experimental views feature. **Note**: the feature is not production ready so do not use it for critical data right now. |
 
 ## Transactions

--- a/scripts/limbo-sqlite3
+++ b/scripts/limbo-sqlite3
@@ -7,7 +7,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 TURSODB="$PROJECT_ROOT/target/debug/tursodb"
 
 # Add experimental features for testing
-EXPERIMENTAL_FLAGS="--experimental-views --experimental-strict --experimental-triggers --experimental-attach"
+EXPERIMENTAL_FLAGS="--experimental-views --experimental-triggers --experimental-attach"
 
 # if RUST_LOG is non-empty, enable tracing output
 if [ -n "$RUST_LOG" ]; then

--- a/scripts/turso-mvcc-sqlite3
+++ b/scripts/turso-mvcc-sqlite3
@@ -8,7 +8,7 @@ TURSODB="$PROJECT_ROOT/target/debug/tursodb"
 
 # Add experimental features for testing
 # Note: MVCC is enabled via PRAGMA journal_mode = 'experimental_mvcc'
-EXPERIMENTAL_FLAGS="--experimental-views --experimental-strict --experimental-triggers --experimental-attach"
+EXPERIMENTAL_FLAGS="--experimental-views --experimental-triggers --experimental-attach"
 
 # if RUST_LOG is non-empty, enable tracing output
 if [ -n "$RUST_LOG" ]; then

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -637,7 +637,7 @@ impl TursoDatabase {
                             opts = match features {
                                 "views" => opts.with_views(true),
                                 "index_method" => opts.with_index_method(true),
-                                "strict" => opts.with_strict(true),
+                                "strict" => opts, // strict is always enabled, kept for backwards compatibility
                                 "custom_types" => opts.with_custom_types(true),
                                 "autovacuum" => opts.with_autovacuum(true),
                                 "triggers" => opts.with_triggers(true),

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -196,9 +196,7 @@ impl Fuzzer {
 
         // Create Turso in-memory database using MemorySimIO
         let io = Arc::new(MemorySimIO::new(config.seed));
-        let opts = turso_core::DatabaseOpts::new()
-            .with_attach(true)
-            .with_strict(true);
+        let opts = turso_core::DatabaseOpts::new().with_attach(true);
 
         let turso_db = Database::open_file_with_flags(
             io.clone(),

--- a/testing/runner/src/backends/cli.rs
+++ b/testing/runner/src/backends/cli.rs
@@ -192,7 +192,6 @@ impl CliDatabaseInstance {
             cmd.arg("-q"); // Quiet mode - suppress banner
             cmd.arg("-m").arg("list"); // List mode for pipe-separated output
             cmd.arg("--experimental-views");
-            cmd.arg("--experimental-strict");
             cmd.arg("--experimental-custom-types");
             cmd.arg("--experimental-triggers");
             cmd.arg("--experimental-attach");

--- a/testing/runner/tests/affinity.sqltest
+++ b/testing/runner/tests/affinity.sqltest
@@ -477,7 +477,6 @@ expect {
     1a|text
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test affinity-any-strict {
     CREATE TABLE t1 (c1 ANY) STRICT;

--- a/testing/runner/tests/alter_table.sqltest
+++ b/testing/runner/tests/alter_table.sqltest
@@ -373,7 +373,6 @@ expect error {
     error in table t_check2 after drop column: no such column: b
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-invalid-varchar {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -382,7 +381,6 @@ test strict-alter-add-column-invalid-varchar {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-invalid-datetime {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -391,7 +389,6 @@ test strict-alter-add-column-invalid-datetime {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-no-type {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -400,7 +397,6 @@ test strict-alter-add-column-no-type {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-integer {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -412,7 +408,6 @@ expect {
     1|42
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-text {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -424,7 +419,6 @@ expect {
     1|hello
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-any {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -436,7 +430,6 @@ expect {
     1|3.14
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-default-type-mismatch {
     CREATE TABLE t1(name TEXT) STRICT;
@@ -447,7 +440,6 @@ expect error {
     type mismatch on DEFAULT
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-default-integer-from-text {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -459,7 +451,6 @@ expect {
     integer|10
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-default-real-from-text {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -471,7 +462,6 @@ expect {
     real|1.25
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-default-text-from-integer {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -483,7 +473,6 @@ expect {
     text|123
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-default-integer-fractional {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -494,7 +483,6 @@ expect error {
     type mismatch on DEFAULT
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-default-real-nonnumeric {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -505,7 +493,6 @@ expect error {
     type mismatch on DEFAULT
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-default-text-blob {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -516,7 +503,6 @@ expect error {
     type mismatch on DEFAULT
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-default-blob-text {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -527,7 +513,6 @@ expect error {
     type mismatch on DEFAULT
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-alter-add-column-default-mismatch-empty-table {
     CREATE TABLE t(a INTEGER) STRICT;

--- a/testing/runner/tests/check_constraint.sqltest
+++ b/testing/runner/tests/check_constraint.sqltest
@@ -213,7 +213,6 @@ expect error {
 }
 
 # STRICT tables with CHECK constraints
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test check_constraint_strict_table_basic {
     CREATE TABLE employees (
@@ -241,7 +240,6 @@ test check_constraint_strict_type_violation {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test check_constraint_strict_numeric_string_coercion {
     CREATE TABLE employees (
@@ -256,7 +254,6 @@ expect {
     1|25|integer
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test check_constraint_strict_check_violation_after_coercion {
     CREATE TABLE employees (

--- a/testing/runner/tests/insert.sqltest
+++ b/testing/runner/tests/insert.sqltest
@@ -27,7 +27,6 @@ expect {
     4
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-basic-creation {
     CREATE TABLE test1 (id INTEGER, name TEXT, price REAL) STRICT;
@@ -52,7 +51,6 @@ expect {
 }
 
 # Reproducer for https://github.com/tursodatabase/turso/issues/2822
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-type-case-insensitivity {
     CREATE TABLE test1 (id integer, name text, price real) STRICT;
@@ -63,7 +61,6 @@ expect {
     1|item1|10.5
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-require-datatype {
     CREATE TABLE test2 (id INTEGER, name) STRICT;
@@ -71,7 +68,6 @@ test strict-require-datatype {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-valid-datatypes {
     CREATE TABLE test2 (id INTEGER, value DATETIME) STRICT;
@@ -79,7 +75,6 @@ test strict-valid-datatypes {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-type-enforcement {
     CREATE TABLE test3 (id INTEGER, name TEXT, price REAL) STRICT;
@@ -88,7 +83,6 @@ test strict-type-enforcement {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-type-coercion {
     CREATE TABLE test4 (id INTEGER, name TEXT, price REAL) STRICT;
@@ -99,7 +93,6 @@ expect {
     real|10.5
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-any-flexibility {
     CREATE TABLE test5 (id INTEGER, data ANY) STRICT;
@@ -114,7 +107,6 @@ expect {
     3|real
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-any-preservation {
     CREATE TABLE test6 (id INTEGER, code ANY) STRICT;
@@ -125,7 +117,6 @@ expect {
     text|000123
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-int-vs-integer-pk {
     CREATE TABLE test8 (id INT PRIMARY KEY, name TEXT) STRICT
@@ -134,7 +125,6 @@ test strict-int-vs-integer-pk {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-integer-pk-behavior {
     CREATE TABLE test9 (id INTEGER PRIMARY KEY, name TEXT) STRICT;
@@ -145,7 +135,6 @@ expect {
     1|test
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-mixed-inserts {
     CREATE TABLE test11 (
@@ -164,7 +153,6 @@ expect {
     2|item2|20.75|10|integer
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-basic {
     CREATE TABLE test1 (id INTEGER, name TEXT, price REAL) STRICT;
@@ -176,7 +164,6 @@ expect {
     1|item1|15.75
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-type-enforcement {
     CREATE TABLE test2 (id INTEGER, name TEXT, price REAL) STRICT;
@@ -186,7 +173,6 @@ test strict-update-type-enforcement {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-type-coercion {
     CREATE TABLE test3 (id INTEGER, name TEXT, price REAL) STRICT;
@@ -198,7 +184,6 @@ expect {
     1|real|15.75
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-any-flexibility {
     CREATE TABLE test4 (id INTEGER, data ANY) STRICT;
@@ -213,7 +198,6 @@ expect {
     2|real|3.14
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-any-preservation {
     CREATE TABLE test5 (id INTEGER, code ANY) STRICT;
@@ -225,7 +209,6 @@ expect {
     text|000123
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-not-null-constraint {
     CREATE TABLE test7 (id INTEGER, name TEXT NOT NULL) STRICT;
@@ -236,7 +219,6 @@ expect error {
 }
 
 # Uncomment following test case when unique constraint is added
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-pk-constraint {
     CREATE TABLE test8 (id INTEGER PRIMARY KEY, name TEXT) STRICT;
@@ -247,7 +229,6 @@ test strict-update-pk-constraint {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-multiple-columns {
     CREATE TABLE test9 (id INTEGER, name TEXT, price REAL, quantity INT) STRICT;
@@ -259,7 +240,6 @@ expect {
     1|updated|20.75|10
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-where-clause {
     CREATE TABLE test10 (id INTEGER, category TEXT, price REAL) STRICT;
@@ -274,8 +254,12 @@ expect {
     2|40.0
     3|30.0
 }
+expect @js {
+    1|20
+    2|40
+    3|30
+}
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-update-expression {
     CREATE TABLE test11 (id INTEGER, name TEXT, price REAL, discount REAL) STRICT;
@@ -286,8 +270,10 @@ test strict-update-expression {
 expect {
     1|90.0
 }
+expect @js {
+    1|90
+}
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-float-to-integer-basic {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -298,7 +284,6 @@ expect {
     42|integer
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-float-to-integer-zero {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -309,7 +294,6 @@ expect {
     0|integer
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-float-to-integer-negative {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -320,7 +304,6 @@ expect {
     -5|integer
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-float-to-integer-scientific {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -331,7 +314,6 @@ expect {
     100|integer
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-float-to-integer-fractional-error {
     CREATE TABLE t(a INTEGER) STRICT;
@@ -340,7 +322,6 @@ test strict-text-float-to-integer-fractional-error {
 expect error {
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-integer-to-real-basic {
     CREATE TABLE t(a REAL) STRICT;
@@ -350,8 +331,10 @@ test strict-text-integer-to-real-basic {
 expect {
     42.0|real
 }
+expect @js {
+    42|real
+}
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-integer-to-real-negative {
     CREATE TABLE t(a REAL) STRICT;
@@ -361,8 +344,10 @@ test strict-text-integer-to-real-negative {
 expect {
     -7.0|real
 }
+expect @js {
+    -7|real
+}
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-integer-to-real-zero {
     CREATE TABLE t(a REAL) STRICT;
@@ -372,8 +357,10 @@ test strict-text-integer-to-real-zero {
 expect {
     0.0|real
 }
+expect @js {
+    0|real
+}
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-float-to-real {
     CREATE TABLE t(a REAL) STRICT;
@@ -384,7 +371,6 @@ expect {
     3.14|real
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-text-string-to-real-error {
     CREATE TABLE t(a REAL) STRICT;

--- a/testing/runner/tests/pragma/table_list.sqltest
+++ b/testing/runner/tests/pragma/table_list.sqltest
@@ -29,7 +29,6 @@ expect {
     main|v1|view|2|0|0
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test pragma-table-list-strict {
     CREATE TABLE strict_t(a INTEGER, b TEXT) STRICT;

--- a/testing/runner/tests/strict.sqltest
+++ b/testing/runner/tests/strict.sqltest
@@ -1,6 +1,5 @@
 @database :memory:
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-null-integer-column {
     CREATE TABLE t1 (id INTEGER PRIMARY KEY, a INTEGER, b INTEGER) STRICT;
@@ -11,7 +10,6 @@ expect {
     1|5|
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-null-text-column {
     CREATE TABLE t2 (id INTEGER PRIMARY KEY, first TEXT, last TEXT) STRICT;
@@ -22,7 +20,6 @@ expect {
     1|John|
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-null-real-column {
     CREATE TABLE t3 (id INTEGER PRIMARY KEY, a REAL, b REAL) STRICT;
@@ -33,7 +30,6 @@ expect {
     1|3.14|
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-null-blob-column {
     CREATE TABLE t4 (id INTEGER PRIMARY KEY, a BLOB, b BLOB) STRICT;
@@ -44,7 +40,6 @@ expect {
     1|CAFE|
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-explicit-null-insert {
     CREATE TABLE t5 (id INTEGER PRIMARY KEY, a INTEGER, b TEXT) STRICT;
@@ -55,7 +50,6 @@ expect {
     1||
 }
 
-@requires strict "uses STRICT tables"
 @cross-check-integrity
 test strict-not-null-still-enforced {
     CREATE TABLE t6 (id INTEGER PRIMARY KEY, a INTEGER NOT NULL) STRICT;

--- a/testing/sqlright/collect_coverage.sh
+++ b/testing/sqlright/collect_coverage.sh
@@ -40,7 +40,7 @@ for testcase in "$CORPUS_DIR"/*; do
 
     LLVM_PROFILE_FILE="$COV_PROFILE_DIR/turso_${COUNT}.profraw" \
         timeout 5 "$COV_BINARY" -q -m list \
-        --experimental-views --experimental-strict --experimental-triggers \
+        --experimental-views --experimental-triggers \
         --experimental-index-method --experimental-autovacuum --experimental-attach \
         < "$testcase" > /dev/null 2>&1 || true
 

--- a/testing/sqlright/crash_reports/lib/executor.py
+++ b/testing/sqlright/crash_reports/lib/executor.py
@@ -47,7 +47,6 @@ class CrashExecutor:
                     "-q",  # Quiet mode
                     "-m", "list",  # List mode
                     "--experimental-views",
-                    "--experimental-strict",
                     "--experimental-triggers",
                     "--experimental-index-method",
                     "--experimental-autovacuum",

--- a/testing/sqlright/run.sh
+++ b/testing/sqlright/run.sh
@@ -55,7 +55,7 @@ mkdir -p "$RESULTS_DIR"
 
 AFL_CMD="$AFL -t 1000"  # 1 second timeout (normal queries finish in ~20ms)
 # Enable all experimental features to maximize attack surface
-AFL_TARGET="-- $TURSODB -q -m list --experimental-views --experimental-strict --experimental-triggers --experimental-index-method --experimental-autovacuum --experimental-attach --experimental-encryption"
+AFL_TARGET="-- $TURSODB -q -m list --experimental-views --experimental-triggers --experimental-index-method --experimental-autovacuum --experimental-attach --experimental-encryption"
 
 # Find the most recent run directory for this oracle (for --resume)
 if [ "$RESUME" = true ]; then

--- a/tests/fuzz/custom_types.rs
+++ b/tests/fuzz/custom_types.rs
@@ -233,7 +233,6 @@ mod tests {
                     .with_encryption(true)
                     .with_triggers(true)
                     .with_attach(true)
-                    .with_strict(true)
                     .with_custom_types(true),
             )
             .build();

--- a/tests/integration/custom_types.rs
+++ b/tests/integration/custom_types.rs
@@ -13,7 +13,6 @@ mod tests {
             .keep()
             .join("custom_types_reopen.db");
         let opts = turso_core::DatabaseOpts::new()
-            .with_strict(true)
             .with_custom_types(true)
             .with_encryption(true);
 
@@ -66,7 +65,6 @@ mod tests {
             .keep()
             .join("custom_types_schema_change.db");
         let opts = turso_core::DatabaseOpts::new()
-            .with_strict(true)
             .with_custom_types(true)
             .with_encryption(true);
 
@@ -132,7 +130,6 @@ mod tests {
             .keep()
             .join("custom_types_new_conn.db");
         let opts = turso_core::DatabaseOpts::new()
-            .with_strict(true)
             .with_custom_types(true)
             .with_encryption(true);
 
@@ -175,7 +172,6 @@ mod tests {
             .keep()
             .join("custom_types_upsert.db");
         let opts = turso_core::DatabaseOpts::new()
-            .with_strict(true)
             .with_custom_types(true)
             .with_encryption(true);
         let db = TempDatabase::new_with_existent_with_opts(&path, opts);
@@ -266,7 +262,6 @@ mod tests {
             .keep()
             .join("custom_types_multi_update.db");
         let opts = turso_core::DatabaseOpts::new()
-            .with_strict(true)
             .with_custom_types(true)
             .with_encryption(true);
         let db = TempDatabase::new_with_existent_with_opts(&path, opts);
@@ -330,7 +325,6 @@ mod tests {
             .join("custom_types_vacuum_src.db");
         let dest_path = path.with_file_name("custom_types_vacuum_dest.db");
         let opts = turso_core::DatabaseOpts::new()
-            .with_strict(true)
             .with_custom_types(true)
             .with_encryption(true);
 
@@ -388,7 +382,6 @@ mod tests {
             .keep()
             .join("custom_types_self_join.db");
         let opts = turso_core::DatabaseOpts::new()
-            .with_strict(true)
             .with_custom_types(true)
             .with_encryption(true);
         let db = TempDatabase::new_with_existent_with_opts(&path, opts);


### PR DESCRIPTION
PR #5104 added strict to the differential fuzzer.
I have caught a couple of issues, but most of the runs have been fine.

At this point, I am sure there are some issues with strict, but not more issues than the baseline. I'll argue that it doesn't make sense to make strict experimentaler than the rest of the project.