### PR TITLE
Implement PRAGMA function_list with enum-derived function probing

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -155,7 +155,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | PRAGMA freelist_count            | ✅ Yes        |                                              |
 | PRAGMA full_column_names         | Not Needed | deprecated in SQLite                         |
 | PRAGMA fullsync                  | ❌ No         |                                              |
-| PRAGMA function_list             | ❌ No         |                                              |
+| PRAGMA function_list             | ✅ Yes        |                                              |
 | PRAGMA hard_heap_limit           | ❌ No         |                                              |
 | PRAGMA ignore_check_constraints  | ❌ No         |                                              |
 | PRAGMA incremental_vacuum        | ❌ No         |                                              |

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1571,6 +1571,23 @@ impl Connection {
         self.syms.read().vtab_modules.keys().cloned().collect()
     }
 
+    /// Returns external (extension) functions: (name, is_aggregate, argc)
+    pub fn get_syms_functions(&self) -> Vec<(String, bool, i32)> {
+        self.syms
+            .read()
+            .functions
+            .values()
+            .map(|f| {
+                let is_agg = matches!(f.func, function::ExtFunc::Aggregate { .. });
+                let argc = match &f.func {
+                    function::ExtFunc::Aggregate { argc, .. } => *argc as i32,
+                    function::ExtFunc::Scalar(_) => -1,
+                };
+                (f.name.clone(), is_agg, argc)
+            })
+            .collect()
+    }
+
     pub(crate) fn syms_generation(&self) -> u64 {
         self.syms_generation.load(Ordering::SeqCst)
     }

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -155,6 +155,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["foreign_keys"],
         ),
+        FunctionList => Pragma::new(
+            PragmaFlags::Result0,
+            &["name", "builtin", "type", "enc", "narg", "flags"],
+        ),
         PragmaName::CacheSpill => Pragma::new(
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["cache_spill"],

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -10,6 +10,7 @@ use turso_parser::ast::{PragmaName, QualifiedName};
 use super::integrity_check::{
     translate_integrity_check, translate_quick_check, MAX_INTEGRITY_CHECK_ERRORS,
 };
+use crate::function::Func;
 use crate::pragma::pragma_for;
 use crate::schema::Schema;
 use crate::storage::encryption::{CipherMode, EncryptionKey};
@@ -484,6 +485,14 @@ fn update_pragma(
             connection.set_temp_store(temp_store);
             Ok((program, TransactionMode::None))
         }
+        PragmaName::FunctionList => query_pragma(
+            PragmaName::FunctionList,
+            resolver,
+            Some(value),
+            pager,
+            connection,
+            program,
+        ),
     }
 }
 
@@ -610,6 +619,49 @@ fn query_pragma(
             }
 
             program.add_pragma_result_column(pragma.to_string());
+            Ok((program, TransactionMode::None))
+        }
+        PragmaName::FunctionList => {
+            // 6 columns: name, builtin, type, enc, narg, flags
+            let base_reg = register;
+            program.alloc_registers(5);
+
+            const SQLITE_DETERMINISTIC: i64 = 0x800;
+            const SQLITE_INNOCUOUS: i64 = 0x200000;
+
+            // Built-in functions
+            for entry in Func::builtin_function_list() {
+                let mut flags: i64 = 0;
+                if entry.deterministic {
+                    flags |= SQLITE_DETERMINISTIC;
+                }
+                flags |= SQLITE_INNOCUOUS;
+
+                program.emit_string8(entry.name, base_reg);
+                program.emit_int(1, base_reg + 1); // builtin = 1
+                program.emit_string8(entry.func_type.to_string(), base_reg + 2);
+                program.emit_string8("utf8".to_string(), base_reg + 3);
+                program.emit_int(entry.narg as i64, base_reg + 4);
+                program.emit_int(flags, base_reg + 5);
+                program.emit_result_row(base_reg, 6);
+            }
+
+            // External (extension) functions
+            for (name, is_agg, argc) in connection.get_syms_functions() {
+                let func_type = if is_agg { "a" } else { "s" };
+                program.emit_string8(name, base_reg);
+                program.emit_int(0, base_reg + 1); // builtin = 0
+                program.emit_string8(func_type.to_string(), base_reg + 2);
+                program.emit_string8("utf8".to_string(), base_reg + 3);
+                program.emit_int(argc as i64, base_reg + 4);
+                program.emit_int(0, base_reg + 5); // flags = 0 for extensions
+                program.emit_result_row(base_reg, 6);
+            }
+
+            let pragma_meta = pragma_for(&pragma);
+            for col_name in pragma_meta.columns.iter() {
+                program.add_pragma_result_column(col_name.to_string());
+            }
             Ok((program, TransactionMode::None))
         }
         PragmaName::PageCount => {

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1514,6 +1514,8 @@ pub enum PragmaName {
     FreelistCount,
     /// Enable or disable foreign key constraint enforcement
     ForeignKeys,
+    /// List all SQL functions known to the database connection
+    FunctionList,
     /// Use F_FULLFSYNC instead of fsync on macOS (only supported on macOS)
     #[cfg(target_vendor = "apple")]
     Fullfsync,

--- a/testing/runner/tests/pragma/default.sqltest
+++ b/testing/runner/tests/pragma/default.sqltest
@@ -247,3 +247,32 @@ test pragma-temp-store-set-file {
 expect {
 		1
 }
+
+test pragma-function-list-has-abs {
+    SELECT name, builtin, type, enc, narg, flags FROM pragma_function_list WHERE name = 'abs';
+}
+expect {
+    abs|1|s|utf8|1|2099200
+}
+
+test pragma-function-list-has-count {
+    SELECT name, builtin, type, narg FROM pragma_function_list WHERE name = 'count' ORDER BY narg;
+}
+expect {
+    count|1|w|0
+    count|1|w|1
+}
+
+test pragma-function-list-scalar {
+    SELECT name, builtin, type, enc, narg, flags FROM pragma_function_list WHERE name = 'upper';
+}
+expect {
+    upper|1|s|utf8|1|2099200
+}
+
+test pragma-function-list-aggregate {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'avg';
+}
+expect {
+    avg|w|1
+}

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -107,7 +107,7 @@ simulator covers and tests.
 | PRAGMA freelist_count            | No         |                                                  |
 | PRAGMA full_column_names         | Not Needed | deprecated in SQLite                             |
 | PRAGMA fullsync                  | No         |                                                  |
-| PRAGMA function_list             | No         |                                                  |
+| PRAGMA function_list             | Yes        |                                                  |
 | PRAGMA hard_heap_limit           | No         |                                                  |
 | PRAGMA ignore_check_constraints  | No         |                                                  |
 | PRAGMA incremental_vacuum        | No         |                                                  |


### PR DESCRIPTION
Derive the function list from strum::EnumIter on all function enums (ScalarFunc, AggFunc, MathFunc, JsonFunc, VectorFunc, FtsFunc) instead of maintaining a manual list. Each enum provides arities() to emit per-arity rows matching SQLite output format. Internal functions and JSON operator variants are filtered out via is_internal().
