### PR TITLE
core/mvcc: Fix transaction end version visibility check

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1164,8 +1164,8 @@ fn test_snapshot_isolation_tx_visible1() {
     ));
 
     // begin visible:   timestamp < current_tx.begin_ts
-    // end invisible:   transaction aborted
-    assert!(!rv_visible(
+    // end visible:     transaction aborted, delete never happened (Table 2)
+    assert!(rv_visible(
         Some(TxTimestampOrID::Timestamp(0)),
         Some(TxTimestampOrID::TxID(3))
     ));
@@ -1186,8 +1186,8 @@ fn test_snapshot_isolation_tx_visible1() {
     assert!(!rv_visible(Some(TxTimestampOrID::TxID(7)), None));
 
     // begin visible:   timestamp < current_tx.begin_ts
-    // end invisible:     transaction preparing
-    assert!(!rv_visible(
+    // end visible:     transaction preparing with TS(8) > RT(4) (Table 2)
+    assert!(rv_visible(
         Some(TxTimestampOrID::Timestamp(0)),
         Some(TxTimestampOrID::TxID(5))
     ));


### PR DESCRIPTION
## Description

`is_end_visible` had incorrect return values in case of `Preparing`, `Aborted` and `Terminated`. Based on the paper:

 | TE's state | Old code | New code (Table 2) | Rationale |
  |---|---|---|---|
  | Preparing(TS) | `false` | `current_tx.begin_ts < end_ts` | If TS > RT, the delete hasn't taken effect yet → visible. If TS < RT, speculatively ignore. |
  | Aborted | `false` | `true` | The deleting transaction aborted, so the delete never happened → version is visible. |
  | Terminated | `false` | `true` | In this codebase, Terminated is only reachable from Aborted. The abort rollback resets `end` to `None`, so the version is visible. |

I saw this reproducing in one `turso_stress` run where txn tried to read a version, but some other txn aborted a `DELETE` so this first txn wasn't able to see aborted version which should because delete never happened.