### PR TITLE
adjust is_constant check for `IN` and `emit_no_constant_insn` to avoid panic in VDBE cursor

### DIFF
--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -619,11 +619,14 @@ impl ProgramBuilder {
         self.insns.push((insn, self.insns.len()));
     }
 
-    /// Emit an instruction that is guaranteed not to be in any constant span.
-    /// This ensures the instruction won't be hoisted when emit_constant_insns is called.
+    /// Emit an instruction that should not start or extend a constant span on its own.
+    /// If a parent constant span is already open, the instruction is emitted normally
+    /// within that span (the parent's `is_constant` classification takes precedence).
     #[instrument(skip(self), level = Level::DEBUG)]
     pub fn emit_no_constant_insn(&mut self, insn: Insn) {
-        self.constant_span_end_all();
+        if !self.constant_span_is_open() {
+            self.constant_span_end_all();
+        }
         self.emit_insn(insn);
     }
 

--- a/testing/runner/tests/coalesce/default.sqltest
+++ b/testing/runner/tests/coalesce/default.sqltest
@@ -1,0 +1,23 @@
+@database :default:
+@database :default-no-rowidalias:
+
+test coalesce-from-table {
+    select coalesce(NULL, 1) from users limit 1;
+}
+expect {
+    1
+}
+
+test coalesce-from-table-column {
+    select coalesce(NULL, age) from users where age = 94 limit 1;
+}
+expect {
+    94
+}
+
+test coalesce-from-table-multiple-columns {
+    select coalesce(NULL, age), coalesce(NULL, id) from users where age = 94 limit 1;
+}
+expect {
+    94|21
+}

--- a/testing/runner/tests/coalesce/memory.sqltest
+++ b/testing/runner/tests/coalesce/memory.sqltest
@@ -1,5 +1,4 @@
-@database :default:
-@database :default-no-rowidalias:
+@database :memory:
 
 test coalesce {
     select coalesce(NULL, 1);
@@ -45,24 +44,17 @@ expect {
     1
 }
 
-test coalesce-from-table {
-    select coalesce(NULL, 1) from users limit 1;
+# Regression: constant COALESCE with IN(...) must not generate jumps into unopened cursor loops.
+test coalesce-constant-in-orderby-regression {
+    DROP TABLE IF EXISTS coalesce_regression;
+    CREATE TABLE coalesce_regression (a INTEGER, b INTEGER);
+    INSERT INTO coalesce_regression VALUES (1, NULL), (2, 7);
+    SELECT COALESCE(LENGTH('a'), HEX(X'01') IN (X'02')), QUOTE(b)
+    FROM coalesce_regression
+    WHERE a
+    ORDER BY a DESC;
 }
 expect {
-    1
+    1|7
+    1|NULL
 }
-
-test coalesce-from-table-column {
-    select coalesce(NULL, age) from users where age = 94 limit 1;
-}
-expect {
-    94
-}
-
-test coalesce-from-table-multiple-columns {
-    select coalesce(NULL, age), coalesce(NULL, id) from users where age = 94 limit 1;
-}
-expect {
-    94|21
-}
-


### PR DESCRIPTION

## Description
Caught with differential fuzzer

Some instruction were getting constant hoisted but they referenced Columns. So just had to adjust the constant check in `IN` expressions and how we terminated constant spans


## Description of AI Usage
Generated with Claude