### PR TITLE
fix: cannot use index seek if the constraining expression references the same table being scanned

### DIFF
--- a/testing/runner/tests/not_between.sqltest
+++ b/testing/runner/tests/not_between.sqltest
@@ -1,0 +1,43 @@
+@database :memory:
+
+# Regression test: NOT BETWEEN with self-referencing expressions must not
+# be optimized into multi-index union seeks, because the seek key depends
+# on the current row and cannot be evaluated before scanning.
+
+test not-between-self-ref-group-by {
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY, b INTEGER, c INTEGER);
+    INSERT INTO t1 VALUES (1, 10, 100), (2, 20, 200), (3, NULL, 300), (4, 40, 400);
+    SELECT c, AVG(b) FROM t1 WHERE TYPEOF(b) NOT BETWEEN a AND a GROUP BY a, b, c;
+}
+expect {
+    100|10.0
+    200|20.0
+    300|
+    400|40.0
+}
+expect @js {
+    100|10
+    200|20
+    300|
+    400|40
+}
+
+test not-between-self-ref-no-group-by {
+    CREATE TABLE t2 (a INTEGER PRIMARY KEY, b INTEGER, c INTEGER);
+    INSERT INTO t2 VALUES (1, 10, 100), (2, 20, 200), (3, NULL, 300), (4, 40, 400);
+    SELECT * FROM t2 WHERE TYPEOF(b) NOT BETWEEN a AND a;
+}
+expect {
+    1|10|100
+    2|20|200
+    3||300
+    4|40|400
+}
+
+test between-self-ref-group-by {
+    CREATE TABLE t3 (a INTEGER PRIMARY KEY, b INTEGER, c INTEGER);
+    INSERT INTO t3 VALUES (1, 10, 100), (2, 20, 200), (3, NULL, 300), (4, 40, 400);
+    SELECT c, AVG(b) FROM t3 WHERE TYPEOF(b) BETWEEN a AND a GROUP BY a, b, c;
+}
+expect {
+}


### PR DESCRIPTION
## Description
Caught with differential fuzzer

# Bug: Multi-index union optimization incorrectly applied to self-referencing NOT BETWEEN

## Root Cause

The **multi-index union (OR-by-union) optimization** is incorrectly applied when the constraining expression (seek key) references columns from the **same table** being scanned.

## How it manifests

The query:

```sql
SELECT col_personable_annis, AVG(col_warmhearted_holloway)
FROM tbl_proficient_kauffman AS t347
WHERE TYPEOF(t347.col_warmhearted_holloway) NOT BETWEEN t347.col_gregarious_arabi AND t347.col_gregarious_arabi
GROUP BY col_gregarious_arabi, col_warmhearted_holloway, col_personable_annis
```

1. **BETWEEN rewrite** (`core/translate/expr.rs:4025-4049`): `TYPEOF(b) NOT BETWEEN a AND a` is rewritten to `(a > TYPEOF(b)) OR (TYPEOF(b) > a)`

2. **Multi-index union optimization** (`core/translate/optimizer/constraints.rs:1415`): `analyze_binary_term_for_index` sees both OR branches as indexable on `col_gregarious_arabi` (INTEGER PRIMARY KEY = rowid). It identifies `TYPEOF(col_warmhearted_holloway)` as the "constraining expression" (seek key) — but it **never checks whether that expression references the same table being scanned**.

3. **Incorrect bytecode**: The optimizer emits `SeekGT` instructions that compute `TYPEOF(b)` from an **unpositioned cursor** (before any scan), getting NULL. It then applies numeric affinity (converting the string `'null'` to something unusable for comparison) and seeks with that fixed value — finding no matching rows.

## The missing guard

The normal single-index code path in `usable_constraints_for_join_order` (line ~1347) has this check:

```rust
let other_side_refers_to_self = constraint.lhs_mask.contains_table(table_idx);
if other_side_refers_to_self {
    return None;
}
```

But `analyze_binary_term_for_index` (used by the multi-index union path) **does not have this check**. It computes `lhs_mask` (line 1492) but never validates that the constraining expression doesn't reference the scanned table.

## Minimal reproduction

```sql
CREATE TABLE t (a INTEGER PRIMARY KEY, b INTEGER, c INTEGER);
INSERT INTO t VALUES (1, 10, 100), (2, 20, 200), (3, NULL, 300), (4, 40, 400);

-- Returns 0 rows (wrong - should be 4)
SELECT c, AVG(b) FROM t WHERE TYPEOF(b) NOT BETWEEN a AND a GROUP BY a, b, c;

-- Returns 4 rows (correct - no GROUP BY, uses scan instead of multi-index union)
SELECT * FROM t WHERE TYPEOF(b) NOT BETWEEN a AND a;
```

## Fix

`core/translate/optimizer/constraints.rs`, function `analyze_binary_term_for_index` (~line 1493): after computing `lhs_mask`, add a check that the constraining expression doesn't reference the table being scanned. If it does, return `None` (not indexable for multi-index purposes).

```rust
// Cannot use index seek if the constraining expression references the same table
// being scanned, since the expression value varies per row and cannot be evaluated
// before the scan (e.g. TYPEOF(b) NOT BETWEEN a AND a where both columns are from
// the same table).
if let Some(table_pos) = table_references
    .joined_tables()
    .iter()
    .position(|t| t.internal_id == table_id)
{
    if lhs_mask.contains_table(table_pos) {
        return None;
    }
}
```


## Description of AI Usage
Generated with Claude
