### PR TITLE
Rewrite printf for full SQLite compatibility

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -267,7 +267,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | min(X,Y,...)                 | ✅ Yes     |                                                      |
 | nullif(X,Y)                  | ✅ Yes     |                                                      |
 | octet_length(X)              | ✅ Yes     |                                                      |
-| printf(FORMAT,...)           | ✅ Yes     | Still need support additional modifiers              |
+| printf(FORMAT,...)           | ✅ Yes     |                                                      |
 | quote(X)                     | ✅ Yes     |                                                      |
 | random()                     | ✅ Yes     |                                                      |
 | randomblob(N)                | ✅ Yes     |                                                      |

--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -1,308 +1,1358 @@
-use core::f64;
 use std::fmt::Write;
+use std::iter::{repeat_n, Peekable};
+use std::str;
+use std::str::Chars;
 
-use crate::numeric::Numeric;
+use crate::numeric::{format_float, str_to_i64, Numeric};
 use crate::types::Value;
 use crate::vdbe::Register;
-use crate::LimboError;
 
-fn get_exponential_formatted_str(number: &f64, uppercase: bool) -> crate::Result<String> {
-    // TODO: Implement ryu or zmij style algorithm somewhere in the library and use it here instead
-    let mut result = String::with_capacity(24);
-    write!(&mut result, "{number:.6e}",).expect("write! to a String cannot fail; it panics on OOM");
+#[derive(Default, Clone)]
+struct FormatFlags {
+    left_justify: bool,
+    force_sign: bool,
+    space_sign: bool,
+    zero_pad: bool,
+    alternate: bool,
+    comma_sep: bool,
+    alt_form_2: bool,
+}
 
-    let parts = result.split_once('e');
+struct FormatSpec {
+    flags: FormatFlags,
+    width: Option<usize>,
+    precision: Option<usize>,
+    spec_type: char,
+}
 
-    match parts {
-        Some((mantissa, exponent)) => {
-            match exponent.parse::<i32>() {
-                Ok(exponent_number) => {
-                    // we have mantissa in result[..pos]
-                    if uppercase {
-                        result.truncate(mantissa.len());
-                        result.push('E');
-                    } else {
-                        // we already have 'e' after mantissa
-                        result.truncate(mantissa.len() + 1);
-                    }
-                    write!(&mut result, "{exponent_number:+03}").unwrap();
-                    Ok(result)
-                }
-                Err(_) => Err(LimboError::InternalError(
-                    "unable to parse exponential expression's exponent".into(),
-                )),
+/// Consume flag characters after '%', returning the FormatFlags.
+/// In SQLite, later flags override earlier ones for +/space conflicts.
+fn parse_flags(chars: &mut Peekable<Chars>) -> FormatFlags {
+    let mut flags = FormatFlags::default();
+    while let Some(&c) = chars.peek() {
+        match c {
+            '-' => {
+                flags.left_justify = true;
             }
+            '+' => {
+                flags.force_sign = true;
+                flags.space_sign = false;
+            }
+            ' ' => {
+                flags.space_sign = true;
+                flags.force_sign = false;
+            }
+            '0' => {
+                flags.zero_pad = true;
+            }
+            '#' => {
+                flags.alternate = true;
+            }
+            ',' => {
+                flags.comma_sep = true;
+            }
+            '!' => {
+                flags.alt_form_2 = true;
+            }
+            _ => break,
         }
-        None => Err(LimboError::InternalError(
-            "unable to parse exponential expression".into(),
-        )),
+        chars.next();
+    }
+    flags
+}
+
+/// Parse a decimal integer from the character stream.
+fn parse_number(chars: &mut Peekable<Chars>) -> Option<usize> {
+    let mut n: usize = 0;
+    let mut found = false;
+    while let Some(&c) = chars.peek() {
+        if let Some(d) = c.to_digit(10) {
+            n = n.saturating_mul(10).saturating_add(d as usize);
+            found = true;
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    if found {
+        Some(n)
+    } else {
+        None
     }
 }
 
-// TODO: Support %!.3s. flags: - + 0 ! ,
-#[inline(always)]
+/// Maximum width/precision to prevent OOM from adversarial format strings.
+/// SQLite uses int for width and caps output at SQLITE_MAX_LENGTH (1 billion),
+/// but we use a tighter limit since f64 only has ~17 meaningful digits anyway.
+const MAX_WIDTH: usize = 1_000_000;
+
+/// Parse a full format specifier after the initial '%'.
+/// May consume arguments from `values` for `*` width/precision.
+fn parse_format_spec(
+    chars: &mut Peekable<Chars>,
+    values: &[Register],
+    args_index: &mut usize,
+) -> FormatSpec {
+    let mut flags = parse_flags(chars);
+
+    // Width — SQLite casts * width to C int (int32)
+    let width = if chars.peek() == Some(&'*') {
+        chars.next();
+        let w = get_arg_i64(values, args_index) as i32;
+        if w < 0 {
+            // Negative width means left-justify
+            flags.left_justify = true;
+            // SQLite: width = width >= -2147483647 ? -width : 0
+            if w > i32::MIN {
+                Some(((-w) as usize).min(MAX_WIDTH))
+            } else {
+                Some(0)
+            }
+        } else {
+            Some((w as usize).min(MAX_WIDTH))
+        }
+    } else {
+        parse_number(chars).map(|w| w.min(MAX_WIDTH))
+    };
+
+    // Precision — SQLite casts * precision to C int (int32), then negates if negative.
+    // For i32::MIN, negation wraps back to i32::MIN (still negative), treated as 0.
+    let precision = if chars.peek() == Some(&'.') {
+        chars.next();
+        if chars.peek() == Some(&'*') {
+            chars.next();
+            let p = get_arg_i64(values, args_index) as i32;
+            let p = if p < 0 { p.wrapping_neg() } else { p };
+            Some((p.max(0) as usize).min(MAX_WIDTH))
+        } else {
+            Some(parse_number(chars).unwrap_or(0).min(MAX_WIDTH))
+        }
+    } else {
+        None
+    };
+
+    // Skip length modifiers (l, ll, h, hh) - ignored in SQL context
+    while matches!(chars.peek(), Some(&'l') | Some(&'h')) {
+        chars.next();
+    }
+
+    // Type character
+    let spec_type = chars.next().unwrap_or('\0');
+
+    FormatSpec {
+        flags,
+        width,
+        precision,
+        spec_type,
+    }
+}
+
+// ── Coercion helpers ────────────────────────────────────────────
+
+/// Get the next argument as i64 (for * width/precision), advancing args_index.
+fn get_arg_i64(values: &[Register], args_index: &mut usize) -> i64 {
+    if *args_index >= values.len() {
+        return 0;
+    }
+    let val = coerce_to_i64(values[*args_index].get_value());
+    *args_index += 1;
+    val
+}
+
+/// Coerce a Value to i64 for integer specifiers.
+fn coerce_to_i64(value: &Value) -> i64 {
+    match value {
+        Value::Numeric(Numeric::Integer(i)) => *i,
+        Value::Numeric(Numeric::Float(f)) => f64::from(*f) as i64,
+        Value::Text(t) => str_to_i64(t.as_str()).unwrap_or(0),
+        Value::Blob(b) => {
+            let s = String::from_utf8_lossy(b);
+            str_to_i64(s.as_ref()).unwrap_or(0)
+        }
+        Value::Null => 0,
+    }
+}
+
+/// Coerce a Value to f64 for float specifiers.
+fn coerce_to_f64(value: &Value) -> f64 {
+    match value {
+        Value::Numeric(Numeric::Float(f)) => f64::from(*f),
+        _ => match Option::<Numeric>::from(value) {
+            Some(Numeric::Integer(i)) => i as f64,
+            Some(Numeric::Float(f)) => f.into(),
+            None => 0.0,
+        },
+    }
+}
+
+/// Coerce a Value to String for string specifiers.
+fn coerce_to_string(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::Numeric(Numeric::Integer(i)) => i.to_string(),
+        Value::Numeric(Numeric::Float(f)) => format_float(f64::from(*f)),
+        Value::Text(t) => t.as_str().to_string(),
+        Value::Blob(b) => String::from_utf8_lossy(b).to_string(),
+    }
+}
+
+// ── Formatting helpers ──────────────────────────────────────────
+
+/// Insert comma separators into a digit string (e.g. "1234567" → "1,234,567").
+fn insert_commas(digits: &str) -> String {
+    let bytes = digits.as_bytes();
+    let len = bytes.len();
+    if len <= 3 {
+        return digits.to_string();
+    }
+    let mut result = String::with_capacity(len + len / 3);
+    let first_group = len % 3;
+    if first_group > 0 {
+        result.push_str(&digits[..first_group]);
+    }
+    for chunk in digits.as_bytes()[first_group..].chunks(3) {
+        if !result.is_empty() {
+            result.push(',');
+        }
+        // digits is always ASCII [0-9], guaranteed valid UTF-8
+        result.push_str(str::from_utf8(chunk).expect("digit string is ASCII"));
+    }
+    result
+}
+
+/// Apply width padding to content. `sign_prefix` is prepended before content
+/// and is part of the total width calculation.
+/// `zero_overrides_left`: when true, the `0` flag takes priority over `-` (SQLite
+/// integer specifiers %d/%u/%x/%o). For float specifiers, pass false so that `-`
+/// overrides `0` per standard C behavior.
+fn apply_width(
+    output: &mut String,
+    sign_prefix: &str,
+    content: &str,
+    width: Option<usize>,
+    flags: &FormatFlags,
+    zero_overrides_left: bool,
+) {
+    // Use character count, not byte count, for width — SQLite counts characters.
+    let total_len = sign_prefix.chars().count() + content.chars().count();
+    let w = width.unwrap_or(0);
+    if total_len >= w {
+        output.push_str(sign_prefix);
+        output.push_str(content);
+        return;
+    }
+    let pad_len = w - total_len;
+    if flags.zero_pad && (zero_overrides_left || !flags.left_justify) {
+        output.push_str(sign_prefix);
+        for _ in 0..pad_len {
+            output.push('0');
+        }
+        output.push_str(content);
+    } else if flags.left_justify {
+        output.push_str(sign_prefix);
+        output.push_str(content);
+        for _ in 0..pad_len {
+            output.push(' ');
+        }
+    } else {
+        for _ in 0..pad_len {
+            output.push(' ');
+        }
+        output.push_str(sign_prefix);
+        output.push_str(content);
+    }
+}
+
+/// Compute sign prefix for a numeric value.
+fn sign_prefix(negative: bool, flags: &FormatFlags) -> &'static str {
+    if negative {
+        "-"
+    } else if flags.force_sign {
+        "+"
+    } else if flags.space_sign {
+        " "
+    } else {
+        ""
+    }
+}
+
+/// Strip trailing zeros from a decimal number string, but always keep at least
+/// one digit after the decimal point. E.g. "3.140000" → "3.14", "1.000000" → "1.0".
+/// If there is no decimal point, appends ".0".
+fn ensure_decimal_strip_zeros(s: &str) -> String {
+    if s.contains('.') {
+        let trimmed = s.trim_end_matches('0');
+        // Keep at least one digit after '.'
+        if trimmed.ends_with('.') {
+            format!("{trimmed}0")
+        } else {
+            trimmed.to_string()
+        }
+    } else {
+        format!("{s}.0")
+    }
+}
+
+/// Build exponential mantissa from decoded digits: first digit, optional '.',
+/// then `precision` more digits (sqlite3.c:32581-32602 in etEXP path).
+/// Returns (mantissa_string, flag_dp).
+fn build_exp_mantissa(digits: &[u8], precision: usize, flags: &FormatFlags) -> (String, bool) {
+    let mut mantissa = String::new();
+    mantissa.push((b'0' + digits.first().copied().unwrap_or(0)) as char);
+
+    let flag_dp = precision > 0 || flags.alternate || flags.alt_form_2;
+    if flag_dp {
+        mantissa.push('.');
+    }
+    let mut j = 1_usize;
+    for _ in 0..precision {
+        if j < digits.len() {
+            mantissa.push((b'0' + digits[j]) as char);
+            j += 1;
+        } else {
+            mantissa.push('0');
+        }
+    }
+    (mantissa, flag_dp)
+}
+
+/// SQLite RTZ (Remove Trailing Zeros) — strip trailing zeros after the decimal
+/// point. If `keep_dot_zero` is true (alt_form_2 / `!` flag), a bare "." becomes
+/// ".0"; otherwise the dot is also removed. (sqlite3.c:32604-32613)
+fn strip_trailing_zeros(s: &mut String, keep_dot_zero: bool) {
+    let trimmed = s.trim_end_matches('0');
+    *s = if trimmed.ends_with('.') {
+        if keep_dot_zero {
+            format!("{trimmed}0")
+        } else {
+            trimmed.trim_end_matches('.').to_string()
+        }
+    } else {
+        trimmed.to_string()
+    };
+}
+
+/// Pad a digit string to at least `min_digits` characters with leading zeros.
+fn pad_with_precision(digits: String, precision: Option<usize>) -> String {
+    let min_digits = precision.unwrap_or(1);
+    if digits.len() < min_digits {
+        "0".repeat(min_digits - digits.len()) + &digits
+    } else {
+        digits
+    }
+}
+
+/// Dekker-style double-double multiplication, ported from SQLite's `dekkerMul2`
+/// (sqlite3.c:36334). Multiplies the double-double number x = (x[0], x[1])
+/// by the double-double constant (y, yy).
+fn dekker_mul2(x: &mut [f64; 2], y: f64, yy: f64) {
+    let hx = f64::from_bits(x[0].to_bits() & 0xffff_ffff_fc00_0000);
+    let tx = x[0] - hx;
+    let hy = f64::from_bits(y.to_bits() & 0xffff_ffff_fc00_0000);
+    let ty = y - hy;
+    let p = hx * hy;
+    let q = hx * ty + tx * hy;
+    let c = p + q;
+    let cc = p - c + q + tx * ty;
+    let cc = x[0] * yy + x[1] * y + cc;
+    x[0] = c + cc;
+    x[1] = c - x[0] + cc;
+}
+
+/// Decode a positive finite float into significant decimal digits and a
+/// decimal point position, then round to `i_round` significant digits
+/// (capped at `max_round`).
+///
+/// This is a faithful port of SQLite's `sqlite3FpDecode` (sqlite3.c:36884).
+/// It uses Dekker-style double-double arithmetic to scale the value into a
+/// u64-representable range, producing the same digit sequences as SQLite.
+///
+/// * `i_round` – for `%f` pass `-(precision as i32)`, for `%e` pass
+///   `precision + 1`, for `%g` pass `precision`.
+/// * `max_round` – typically 16 (or 26 with `!` flag).
+///
+/// Returns `(digits, iDP)` where `digits` is a non-empty vector of digit
+/// values 0–9 (trailing zeros stripped) and `iDP` is the number of digits
+/// before the decimal point.
+fn fp_decode(r: f64, i_round: i32, max_round: usize) -> (Vec<u8>, i32) {
+    debug_assert!(r > 0.0);
+
+    // SQLite (sqlite3.c:32502-32505): infinity with zero-pad is represented
+    // as digit '9' at decimal position 1000 (i.e. 9 * 10^999).
+    if r.is_infinite() {
+        return (vec![9], 1000);
+    }
+
+    let mut rr = [r, 0.0_f64];
+    let mut exp: i32 = 0;
+
+    // Scale r into [9.223_372_036_854_774_784e17, 9.223_372_036_854_774_784e18]
+    // using Dekker multiplication with error-compensation constants.
+    // Constants are copied verbatim from sqlite3.c:36930-36955.
+    #[allow(clippy::excessive_precision)]
+    if rr[0] > 9.223_372_036_854_774_784e+18 {
+        while rr[0] > 9.223_372_036_854_774_784e+118 {
+            exp += 100;
+            dekker_mul2(&mut rr, 1.0e-100, -1.999_189_980_260_288_361_96e-117);
+        }
+        while rr[0] > 9.223_372_036_854_774_784e+28 {
+            exp += 10;
+            dekker_mul2(&mut rr, 1.0e-10, -3.643_219_731_549_774_157_9e-27);
+        }
+        while rr[0] > 9.223_372_036_854_774_784e+18 {
+            exp += 1;
+            dekker_mul2(&mut rr, 1.0e-01, -5.551_115_123_125_782_702_1e-18);
+        }
+    } else {
+        while rr[0] < 9.223_372_036_854_774_784e-83 {
+            exp -= 100;
+            dekker_mul2(&mut rr, 1.0e+100, -1.590_289_110_975_991_804_6e+83);
+        }
+        while rr[0] < 9.223_372_036_854_774_784e+07 {
+            exp -= 10;
+            dekker_mul2(&mut rr, 1.0e+10, 0.0);
+        }
+        while rr[0] < 9.223_372_036_854_774_78e+17 {
+            exp -= 1;
+            dekker_mul2(&mut rr, 1.0e+01, 0.0);
+        }
+    }
+
+    // Convert double-double to u64
+    let v: u64 = if rr[1] < 0.0 {
+        (rr[0] as u64).wrapping_sub((-rr[1]) as u64)
+    } else {
+        (rr[0] as u64).wrapping_add(rr[1] as u64)
+    };
+
+    // Extract decimal digits from u64
+    let mut buf = Vec::with_capacity(20);
+    let mut temp = v;
+    while temp > 0 {
+        buf.push((temp % 10) as u8);
+        temp /= 10;
+    }
+    buf.reverse();
+
+    let n = buf.len();
+    let mut dp = n as i32 + exp;
+
+    // ── Rounding (sqlite3.c:36968-36997) ──────────────────────────
+    let mut i_round = i_round;
+    if i_round <= 0 {
+        i_round = dp - i_round;
+        if i_round == 0 && !buf.is_empty() && buf[0] >= 5 {
+            buf.insert(0, 0);
+            dp += 1;
+            i_round = 1;
+        }
+    }
+
+    let n = buf.len();
+    if i_round > 0 && ((i_round as usize) < n || n > max_round) {
+        let i_round = if (i_round as usize) > max_round {
+            max_round
+        } else {
+            i_round as usize
+        };
+
+        let mut carried_past = false;
+        if i_round < n && buf[i_round] >= 5 {
+            let mut j = i_round;
+            loop {
+                if j == 0 {
+                    buf.insert(0, 1);
+                    dp += 1;
+                    carried_past = true;
+                    break;
+                }
+                j -= 1;
+                buf[j] += 1;
+                if buf[j] <= 9 {
+                    break;
+                }
+                buf[j] = 0;
+            }
+        }
+
+        let keep = if carried_past { i_round + 1 } else { i_round };
+        buf.truncate(keep);
+    }
+
+    // Trim trailing zeros (sqlite3.c:37001-37003)
+    while buf.len() > 1 && *buf.last().unwrap() == 0 {
+        buf.pop();
+    }
+
+    (buf, dp)
+}
+
+/// Build a fixed-point decimal string from a positive float, extracting
+/// significant digits via `fp_decode` (a faithful port of SQLite's
+/// `sqlite3FpDecode`) then placing them according to the `etFLOAT` layout.
+fn format_fixed_from_digits(abs_f: f64, precision: usize, max_sig: usize) -> String {
+    if abs_f == 0.0 {
+        return if precision == 0 {
+            "0".to_string()
+        } else {
+            format!("0.{}", "0".repeat(precision))
+        };
+    }
+
+    let i_round = -(precision as i32);
+    let (digits, dp) = fp_decode(abs_f, i_round, max_sig);
+
+    // ── Integer part (sqlite3.c:32581-32588) ───────────────────────
+    let mut result = String::new();
+    let mut j: usize = 0;
+    if dp <= 0 {
+        result.push('0');
+    } else {
+        for _ in 0..dp {
+            if j < digits.len() {
+                result.push((b'0' + digits[j]) as char);
+                j += 1;
+            } else {
+                result.push('0');
+            }
+        }
+    }
+
+    if precision == 0 {
+        return result;
+    }
+
+    // ── Fractional part (sqlite3.c:32591-32602) ────────────────────
+    result.push('.');
+
+    // Leading zeros for numbers < 1 (e2 < 0 in SQLite, dp <= 0 here)
+    let mut e2 = dp - 1;
+    let mut frac_remaining = precision;
+    e2 += 1; // mirrors the for(e2++;...) in SQLite
+    while e2 < 0 && frac_remaining > 0 {
+        result.push('0');
+        frac_remaining -= 1;
+        e2 += 1;
+    }
+
+    // Significant digits
+    while frac_remaining > 0 {
+        if j < digits.len() {
+            result.push((b'0' + digits[j]) as char);
+            j += 1;
+        } else {
+            result.push('0');
+        }
+        frac_remaining -= 1;
+    }
+
+    result
+}
+
+/// Limit a formatted numeric string to `max_sig` significant digits, rounding
+/// at the boundary. This matches SQLite's behavior of not showing IEEE 754
+/// mantissa noise beyond the float's representable precision.
+#[cfg(test)]
+fn limit_significant_digits(s: &str, max_sig: usize) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut result: Vec<char> = chars.clone();
+
+    // Find positions of all digits and track significant digit count
+    let mut digit_positions: Vec<usize> = Vec::new();
+    let mut sig_count = 0;
+    let mut first_nonzero = false;
+    for (i, &c) in chars.iter().enumerate() {
+        if !c.is_ascii_digit() {
+            continue;
+        }
+        if c != '0' || first_nonzero {
+            first_nonzero = true;
+            sig_count += 1;
+        }
+        digit_positions.push(i);
+    }
+
+    if sig_count <= max_sig {
+        return s.to_string();
+    }
+
+    // Find the index in digit_positions where the (max_sig+1)th significant digit is
+    let mut sig_seen = 0;
+    let mut round_pos = None; // position of the (max_sig+1)th sig digit
+    let mut last_sig_pos = None; // position of the max_sig-th sig digit
+    let mut first_nonzero2 = false;
+    for &pos in &digit_positions {
+        let c = chars[pos];
+        if c != '0' || first_nonzero2 {
+            first_nonzero2 = true;
+            sig_seen += 1;
+        }
+        if sig_seen == max_sig {
+            last_sig_pos = Some(pos);
+        }
+        if sig_seen == max_sig + 1 {
+            round_pos = Some(pos);
+            break;
+        }
+    }
+
+    let (Some(round_pos), Some(_last_sig_pos)) = (round_pos, last_sig_pos) else {
+        return s.to_string();
+    };
+
+    // Check if we need to round up (digit at round_pos >= 5)
+    let round_digit = chars[round_pos].to_digit(10).unwrap();
+
+    // Zero out all digits from round_pos onward
+    for &pos in &digit_positions {
+        if pos >= round_pos {
+            result[pos] = '0';
+        }
+    }
+
+    // If round digit >= 5, propagate carry backwards
+    if round_digit >= 5 {
+        // Walk backwards through digit positions before round_pos
+        let mut carry = true;
+        for &pos in digit_positions.iter().rev() {
+            if pos >= round_pos {
+                continue;
+            }
+            if !carry {
+                break;
+            }
+            let d = result[pos].to_digit(10).unwrap() + 1;
+            if d >= 10 {
+                result[pos] = '0';
+            } else {
+                result[pos] = char::from_digit(d, 10).unwrap();
+                carry = false;
+            }
+        }
+        // If carry propagated past all digits, insert a '1' before the first digit
+        if carry {
+            let first_digit_pos = digit_positions[0];
+            result.insert(first_digit_pos, '1');
+        }
+    }
+
+    result.into_iter().collect()
+}
+
+/// Handle NaN and non-zero_pad Infinity for float specifiers.
+/// NaN: zero_pad → "null", otherwise → "NaN"
+/// Infinity (non-zero_pad): "Inf"/"-Inf"/"+Inf"
+/// Infinity with zero_pad is NOT handled here — it falls through to normal
+/// formatting where fp_decode returns digits=[9], dp=1000 (sqlite3.c:32502-32505).
+fn format_special_float(output: &mut String, f: f64, spec: &FormatSpec) {
+    // Width padding uses spaces only (SQLite breaks out before zero-pad code).
+    let mut space_flags = spec.flags.clone();
+    space_flags.zero_pad = false;
+
+    if f.is_nan() {
+        let text = if spec.flags.zero_pad { "null" } else { "NaN" };
+        apply_width(output, "", text, spec.width, &space_flags, false);
+        return;
+    }
+
+    // Non-zero_pad infinity
+    let prefix = sign_prefix(f < 0.0, &spec.flags);
+    apply_width(output, prefix, "Inf", spec.width, &space_flags, false);
+}
+
+// ── Per-specifier formatters ────────────────────────────────────
+
+fn format_signed_int(output: &mut String, value: &Value, spec: &FormatSpec) {
+    let i = coerce_to_i64(value);
+    let negative = i < 0;
+    let digits = i.unsigned_abs().to_string();
+
+    let mut padded = pad_with_precision(digits, spec.precision);
+
+    let prefix = sign_prefix(negative, &spec.flags);
+
+    if spec.flags.comma_sep && spec.flags.zero_pad {
+        // SQLite: zero-pad digits to (width - prefix.len()), then insert commas.
+        // Commas are not counted in the width. Left-justify is ignored when
+        // both comma and zero-pad are set.
+        let w = spec.width.unwrap_or(0);
+        let digit_target = w.saturating_sub(prefix.len());
+        if padded.len() < digit_target {
+            padded = "0".repeat(digit_target - padded.len()) + &padded;
+        }
+        output.push_str(prefix);
+        output.push_str(&insert_commas(&padded));
+    } else if spec.flags.comma_sep {
+        padded = insert_commas(&padded);
+        apply_width(output, prefix, &padded, spec.width, &spec.flags, true);
+    } else {
+        apply_width(output, prefix, &padded, spec.width, &spec.flags, true);
+    }
+}
+
+fn format_unsigned_int(output: &mut String, value: &Value, spec: &FormatSpec) {
+    let i = coerce_to_i64(value);
+    let u = i as u64;
+    let digits = u.to_string();
+
+    let mut padded = pad_with_precision(digits, spec.precision);
+
+    if spec.flags.comma_sep && spec.flags.zero_pad {
+        // SQLite: zero-pad digits to width, then insert commas.
+        // Commas are not counted in the width. Left-justify is ignored when
+        // both comma and zero-pad are set.
+        let w = spec.width.unwrap_or(0);
+        if padded.len() < w {
+            padded = "0".repeat(w - padded.len()) + &padded;
+        }
+        output.push_str(&insert_commas(&padded));
+    } else if spec.flags.comma_sep {
+        padded = insert_commas(&padded);
+        apply_width(output, "", &padded, spec.width, &spec.flags, true);
+    } else {
+        apply_width(output, "", &padded, spec.width, &spec.flags, true);
+    }
+}
+
+fn format_hex(output: &mut String, value: &Value, spec: &FormatSpec, uppercase: bool) {
+    let i = coerce_to_i64(value);
+    let u = i as u64;
+    let digits = if uppercase {
+        format!("{u:X}")
+    } else {
+        format!("{u:x}")
+    };
+
+    let padded = pad_with_precision(digits, spec.precision);
+
+    let prefix = if spec.flags.alternate && u != 0 {
+        // SQLite: %p always uses lowercase "0x" prefix even with uppercase digits.
+        // %X uses "0X". Both from aPrefix[] in sqlite3.c:32037.
+        if uppercase && spec.spec_type != 'p' {
+            "0X"
+        } else {
+            "0x"
+        }
+    } else {
+        ""
+    };
+
+    // In SQLite, when # and 0 flags are both set, width applies to digits only
+    // and the prefix is added on top (not counted in width).
+    if spec.flags.alternate && spec.flags.zero_pad && !prefix.is_empty() {
+        let w = spec.width.unwrap_or(0);
+        let zero_padded = if padded.len() < w {
+            "0".repeat(w - padded.len()) + &padded
+        } else {
+            padded
+        };
+        output.push_str(prefix);
+        output.push_str(&zero_padded);
+    } else {
+        apply_width(output, prefix, &padded, spec.width, &spec.flags, true);
+    }
+}
+
+fn format_octal(output: &mut String, value: &Value, spec: &FormatSpec) {
+    let i = coerce_to_i64(value);
+    let u = i as u64;
+    let digits = format!("{u:o}");
+
+    let padded = pad_with_precision(digits, spec.precision);
+
+    // SQLite always adds "0" prefix for octal with # flag when value is non-zero,
+    // even if precision padding already added leading zeros.
+    let prefix = if spec.flags.alternate && u != 0 {
+        "0"
+    } else {
+        ""
+    };
+
+    // In SQLite, when # and 0 flags are both set, width applies to digits only
+    // and the prefix is added on top (not counted in width).
+    if spec.flags.alternate && spec.flags.zero_pad && !prefix.is_empty() {
+        let w = spec.width.unwrap_or(0);
+        let zero_padded = if padded.len() < w {
+            "0".repeat(w - padded.len()) + &padded
+        } else {
+            padded
+        };
+        output.push_str(prefix);
+        output.push_str(&zero_padded);
+    } else {
+        apply_width(output, prefix, &padded, spec.width, &spec.flags, true);
+    }
+}
+
+fn format_float_decimal(output: &mut String, value: &Value, spec: &FormatSpec) {
+    let f = coerce_to_f64(value);
+
+    // SQLite source (sqlite3.c:32497-32518): special float handling.
+    // NaN and non-zero_pad Inf break out before normal formatting.
+    // Inf with zero_pad falls through to normal code with digits=[9], dp=1000.
+    if f.is_nan() || (f.is_infinite() && !spec.flags.zero_pad) {
+        format_special_float(output, f, spec);
+        return;
+    }
+
+    // Cap precision to avoid extreme allocations
+    let precision = spec.precision.unwrap_or(6).min(1000);
+    let negative = f < 0.0;
+    let abs_f = f.abs();
+
+    // SQLite source: sqlite3FpDecode uses 16 sig digits, or 26 with ! flag
+    let max_sig = if spec.flags.alt_form_2 { 26 } else { 16 };
+
+    // Build the base decimal string using digit extraction (matches SQLite's
+    // sqlite3FpDecode + etFLOAT formatting).  This replaces the previous
+    // approach of Rust's format! + limit_significant_digits, which could
+    // round the leading digit differently for very large numbers.
+    let formatted = if spec.flags.alt_form_2 && precision == 0 {
+        // %!.0f: force decimal point with one zero, e.g. "3.0"
+        let mut s = format_fixed_from_digits(abs_f, 0, max_sig);
+        s.push_str(".0");
+        s
+    } else if precision == 0 {
+        let mut s = format_fixed_from_digits(abs_f, 0, max_sig);
+        if spec.flags.alternate {
+            s.push('.');
+        }
+        s
+    } else {
+        let s = format_fixed_from_digits(abs_f, precision, max_sig);
+        if spec.flags.alt_form_2 {
+            ensure_decimal_strip_zeros(&s)
+        } else {
+            s
+        }
+    };
+
+    // Apply comma separator to integer part
+    let content = if spec.flags.comma_sep {
+        if let Some(dot_pos) = formatted.find('.') {
+            let int_part = &formatted[..dot_pos];
+            let frac_part = &formatted[dot_pos..];
+            insert_commas(int_part) + frac_part
+        } else {
+            insert_commas(&formatted)
+        }
+    } else {
+        formatted
+    };
+
+    // SQLite 3.51+ (sqlite3.c:32520-32532): Suppress minus sign for %f with #
+    // when displayed value is zero and no +/space flag is set.
+    let negative =
+        if negative && spec.flags.alternate && !spec.flags.force_sign && !spec.flags.space_sign {
+            !content.bytes().all(|b| b == b'0' || b == b'.' || b == b',')
+        } else {
+            negative
+        };
+
+    let prefix = sign_prefix(negative, &spec.flags);
+    apply_width(output, prefix, &content, spec.width, &spec.flags, false);
+}
+
+fn format_exponential(output: &mut String, value: &Value, spec: &FormatSpec, uppercase: bool) {
+    let f = coerce_to_f64(value);
+
+    if f.is_nan() || (f.is_infinite() && !spec.flags.zero_pad) {
+        format_special_float(output, f, spec);
+        return;
+    }
+
+    format_exponential_inner(output, f, spec, uppercase);
+}
+
+fn format_exponential_inner(output: &mut String, f: f64, spec: &FormatSpec, uppercase: bool) {
+    let precision = spec.precision.unwrap_or(6).min(1000);
+    let negative = f < 0.0;
+    let abs_f = f.abs();
+    let e_char = if uppercase { 'E' } else { 'e' };
+    let max_sig = if spec.flags.alt_form_2 { 26 } else { 16 };
+
+    // Handle zero specially (fp_decode requires positive finite input)
+    if abs_f == 0.0 {
+        let flag_dp = precision > 0 || spec.flags.alternate || spec.flags.alt_form_2;
+        let mut mantissa = "0".to_string();
+        if flag_dp {
+            mantissa.push('.');
+            for _ in 0..precision {
+                mantissa.push('0');
+            }
+        }
+        if spec.flags.alt_form_2 {
+            mantissa = ensure_decimal_strip_zeros(&mantissa);
+        }
+        let content = format!("{mantissa}{e_char}+00");
+        let prefix = sign_prefix(negative, &spec.flags);
+        apply_width(output, prefix, &content, spec.width, &spec.flags, false);
+        return;
+    }
+
+    // Use fp_decode with iRound = precision+1 (total significant digits for %e)
+    let i_round = (precision + 1) as i32;
+    let (digits, dp) = fp_decode(abs_f, i_round, max_sig);
+    let exp = dp - 1;
+
+    let (mut mantissa, flag_dp) = build_exp_mantissa(&digits, precision, &spec.flags);
+
+    // RTZ (remove trailing zeros): only with ! flag for %e (sqlite3.c:32557)
+    if spec.flags.alt_form_2 && flag_dp {
+        strip_trailing_zeros(&mut mantissa, true);
+    }
+
+    let content = format!("{mantissa}{e_char}{exp:+03}");
+    let prefix = sign_prefix(negative, &spec.flags);
+    apply_width(output, prefix, &content, spec.width, &spec.flags, false);
+}
+
+fn format_general(output: &mut String, value: &Value, spec: &FormatSpec, uppercase: bool) {
+    let f = coerce_to_f64(value);
+
+    if f.is_nan() || (f.is_infinite() && !spec.flags.zero_pad) {
+        format_special_float(output, f, spec);
+        return;
+    }
+
+    format_general_inner(output, f, spec, uppercase);
+}
+
+fn format_general_inner(output: &mut String, f: f64, spec: &FormatSpec, uppercase: bool) {
+    // SQLite: if precision == 0, set to 1 (line 32491)
+    let precision = spec.precision.unwrap_or(6).clamp(1, 1000);
+    let negative = f < 0.0;
+    let abs_f = f.abs();
+    let e_char = if uppercase { 'E' } else { 'e' };
+    let max_sig = if spec.flags.alt_form_2 { 26 } else { 16 };
+
+    // Handle zero specially
+    if abs_f == 0.0 {
+        let flag_rtz = !spec.flags.alternate;
+        let flag_dp = precision > 1 || spec.flags.alternate || spec.flags.alt_form_2;
+        let mut s = "0".to_string();
+        if flag_dp {
+            s.push('.');
+            for _ in 1..precision {
+                s.push('0');
+            }
+        }
+        if flag_rtz && flag_dp {
+            strip_trailing_zeros(&mut s, spec.flags.alt_form_2);
+        }
+        let prefix = sign_prefix(negative, &spec.flags);
+        apply_width(output, prefix, &s, spec.width, &spec.flags, false);
+        return;
+    }
+
+    // Call fp_decode with iRound = precision (significant digits for %g)
+    let (digits, dp) = fp_decode(abs_f, precision as i32, max_sig);
+    let exp = dp - 1;
+
+    // SQLite: precision-- then check (lines 32547-32555)
+    let precision = precision - 1;
+    // flag_rtz for generic: ON unless # flag (line 32549)
+    let flag_rtz = !spec.flags.alternate;
+
+    let use_exp = exp < -4 || exp > precision as i32;
+
+    let content = if use_exp {
+        // ── Exponential notation ──────────────────────────────────
+        let (mut mantissa, flag_dp) = build_exp_mantissa(&digits, precision, &spec.flags);
+        if flag_rtz && flag_dp {
+            strip_trailing_zeros(&mut mantissa, spec.flags.alt_form_2);
+        }
+        format!("{mantissa}{e_char}{exp:+03}")
+    } else {
+        // ── Fixed-point notation ──────────────────────────────────
+        // SQLite: precision = precision - exp (line 32553), giving digits after decimal
+        let frac_precision = if precision as i32 > exp {
+            (precision as i32 - exp) as usize
+        } else {
+            0
+        };
+
+        // Build fixed-point string from decoded digits
+        let mut s = String::new();
+        let mut j: usize = 0;
+
+        // Integer part
+        if dp <= 0 {
+            s.push('0');
+        } else {
+            for _ in 0..dp {
+                if j < digits.len() {
+                    s.push((b'0' + digits[j]) as char);
+                    j += 1;
+                } else {
+                    s.push('0');
+                }
+            }
+        }
+
+        let flag_dp = frac_precision > 0 || spec.flags.alternate || spec.flags.alt_form_2;
+        if flag_dp {
+            s.push('.');
+        }
+
+        // Leading zeros for numbers < 1
+        let mut e2 = dp - 1;
+        let mut frac_remaining = frac_precision;
+        e2 += 1;
+        while e2 < 0 && frac_remaining > 0 {
+            s.push('0');
+            frac_remaining -= 1;
+            e2 += 1;
+        }
+
+        // Significant digits in fractional part
+        while frac_remaining > 0 {
+            if j < digits.len() {
+                s.push((b'0' + digits[j]) as char);
+                j += 1;
+            } else {
+                s.push('0');
+            }
+            frac_remaining -= 1;
+        }
+
+        if flag_rtz && flag_dp {
+            strip_trailing_zeros(&mut s, spec.flags.alt_form_2);
+        }
+
+        s
+    };
+
+    // Apply comma separator to integer part (only meaningful for fixed-point)
+    let content = if spec.flags.comma_sep {
+        if let Some(dot_pos) = content.find('.') {
+            let int_part = &content[..dot_pos];
+            let frac_part = &content[dot_pos..];
+            insert_commas(int_part) + frac_part
+        } else if !content.contains('e') && !content.contains('E') {
+            insert_commas(&content)
+        } else {
+            content
+        }
+    } else {
+        content
+    };
+
+    let prefix = sign_prefix(negative, &spec.flags);
+    apply_width(output, prefix, &content, spec.width, &spec.flags, false);
+}
+
+fn format_string(output: &mut String, value: &Value, spec: &FormatSpec) {
+    // For blobs, truncate at first NUL byte (SQLite behavior)
+    let s = match value {
+        Value::Blob(b) => {
+            let end = b.iter().position(|&byte| byte == 0).unwrap_or(b.len());
+            String::from_utf8_lossy(&b[..end]).to_string()
+        }
+        _ => coerce_to_string(value),
+    };
+    let truncated = if let Some(prec) = spec.precision {
+        // Truncate by character count (not bytes). SQLite uses bytes by default
+        // and chars with !, but since blobs are already lossy-converted to UTF-8,
+        // character-based truncation avoids mid-char splits.
+        if let Some((byte_idx, _)) = s.char_indices().nth(prec) {
+            &s[..byte_idx]
+        } else {
+            &s
+        }
+    } else {
+        &s
+    };
+
+    // Zero-pad flag is ignored for string specifiers
+    let mut flags = spec.flags.clone();
+    flags.zero_pad = false;
+    apply_width(output, "", truncated, spec.width, &flags, false);
+}
+
+fn format_char(output: &mut String, value: &Value, spec: &FormatSpec) {
+    // In SQLite SQL context, %c takes the first character of the string representation
+    let c = match value {
+        Value::Text(t) => t.value.chars().next().unwrap_or('\0'),
+        _ => {
+            let s = coerce_to_string(value);
+            s.chars().next().unwrap_or('\0')
+        }
+    };
+
+    // NUL character produces no output (matches SQLite behavior)
+    if c == '\0' {
+        return;
+    }
+
+    // Precision on %c repeats the character that many times (default 1)
+    let repeat = spec.precision.unwrap_or(1).max(1);
+    let s: String = repeat_n(c, repeat).collect();
+
+    // Zero-pad flag is ignored for char specifiers
+    let mut flags = spec.flags.clone();
+    flags.zero_pad = false;
+    apply_width(output, "", &s, spec.width, &flags, false);
+}
+
+/// Escape control characters (0x00-0x1f, 0x7f) as \uXXXX for %#q/%#Q.
+fn escape_control_chars(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_control() {
+            write!(result, "\\u{:04x}", c as u32).unwrap();
+        } else if c == '\\' {
+            result.push_str("\\\\");
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+fn format_sql_quote(output: &mut String, value: &Value, spec: &FormatSpec) {
+    // %q: double single quotes; NULL → (NULL). Supports width/precision.
+    // %#q: also escape control characters as \uXXXX.
+    let mut flags = spec.flags.clone();
+    flags.zero_pad = false;
+    match value {
+        Value::Null => {
+            let truncated = truncate_to_precision("(NULL)", spec.precision);
+            apply_width(output, "", truncated, spec.width, &flags, false);
+        }
+        _ => {
+            let s = coerce_to_string(value);
+            let truncated = truncate_to_precision(&s, spec.precision);
+            let mut escaped = truncated.replace('\'', "''");
+            if spec.flags.alternate {
+                escaped = escape_control_chars(&escaped);
+            }
+            apply_width(output, "", &escaped, spec.width, &flags, false);
+        }
+    }
+}
+
+fn format_sql_quote_wrap(output: &mut String, value: &Value, spec: &FormatSpec) {
+    // %Q: like %q but wrapped in quotes; NULL → unquoted NULL. Supports width/precision.
+    // %#Q: also escape control characters as \uXXXX.
+    let mut flags = spec.flags.clone();
+    flags.zero_pad = false;
+    match value {
+        Value::Null => {
+            let truncated = truncate_to_precision("NULL", spec.precision);
+            apply_width(output, "", truncated, spec.width, &flags, false);
+        }
+        _ => {
+            let s = coerce_to_string(value);
+            let truncated = truncate_to_precision(&s, spec.precision);
+            let mut escaped = truncated.replace('\'', "''");
+            // %#Q: escape control chars and wrap with unistr('...') if any are present.
+            let use_unistr = if spec.flags.alternate {
+                let has_ctrl = escaped.bytes().any(|b| b <= 0x1f);
+                if has_ctrl {
+                    escaped = escape_control_chars(&escaped);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            let mut quoted = String::with_capacity(escaped.len() + 10);
+            if use_unistr {
+                quoted.push_str("unistr('");
+            } else {
+                quoted.push('\'');
+            }
+            quoted.push_str(&escaped);
+            if use_unistr {
+                quoted.push_str("')");
+            } else {
+                quoted.push('\'');
+            }
+            apply_width(output, "", &quoted, spec.width, &flags, false);
+        }
+    }
+}
+
+fn format_sql_identifier(output: &mut String, value: &Value, spec: &FormatSpec) {
+    // %w: double double-quotes (no wrapping quotes in SQL context); NULL → (NULL).
+    let mut flags = spec.flags.clone();
+    flags.zero_pad = false;
+    match value {
+        Value::Null => {
+            let truncated = truncate_to_precision("(NULL)", spec.precision);
+            apply_width(output, "", truncated, spec.width, &flags, false);
+        }
+        _ => {
+            let s = coerce_to_string(value);
+            let truncated = truncate_to_precision(&s, spec.precision);
+            let escaped = truncated.replace('"', "\"\"");
+            apply_width(output, "", &escaped, spec.width, &flags, false);
+        }
+    }
+}
+
+fn format_ordinal(output: &mut String, value: &Value, spec: &FormatSpec) {
+    // %r: format integer as ordinal (1st, 2nd, 3rd, 4th, ...)
+    let i = coerce_to_i64(value);
+    let negative = i < 0;
+    let abs = i.unsigned_abs();
+    let suffix = match (abs % 100, abs % 10) {
+        (11..=13, _) => "th",
+        (_, 1) => "st",
+        (_, 2) => "nd",
+        (_, 3) => "rd",
+        _ => "th",
+    };
+    let mut digits = abs.to_string();
+    // Precision is the total width of digits+suffix, not just digits.
+    let digit_prec = spec.precision.map(|p| p.saturating_sub(suffix.len()));
+    digits = pad_with_precision(digits, digit_prec);
+    let prefix = sign_prefix(negative, &spec.flags);
+
+    // Zero-pad: pad the digit portion to fill width (0 overrides - like integers)
+    if spec.flags.zero_pad {
+        let w = spec.width.unwrap_or(0);
+        let content_chars = prefix.len() + digits.len() + suffix.len();
+        if content_chars < w {
+            digits = "0".repeat(w - content_chars) + &digits;
+        }
+        output.push_str(prefix);
+        output.push_str(&digits);
+        output.push_str(suffix);
+    } else {
+        let content = format!("{digits}{suffix}");
+        apply_width(output, prefix, &content, spec.width, &spec.flags, false);
+    }
+}
+
+/// Truncate a string to at most `precision` characters.
+fn truncate_to_precision(s: &str, precision: Option<usize>) -> &str {
+    match precision {
+        Some(prec) => {
+            // Truncate by character count. SQLite uses byte count by default
+            // and character count with the ! flag, but since Turso is UTF-8 only,
+            // character-based truncation is always correct for our strings.
+            if let Some((byte_idx, _)) = s.char_indices().nth(prec) {
+                &s[..byte_idx]
+            } else {
+                s
+            }
+        }
+        _ => s,
+    }
+}
+
+// ── Main entry point ────────────────────────────────────────────
+
 pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
     if values.is_empty() {
         return Ok(Value::Null);
     }
+
     // SQLite converts the format argument to text if not already text.
-    // Non-text formats get converted via their string representation,
-    // e.g. PRINTF(1, 'a') returns "1" not NULL.
     let format_value = values[0].get_value();
-    let format_string: String;
+    let fmt_owned: String;
     let format_str = match &format_value {
         Value::Text(t) => t.as_str(),
         Value::Null => return Ok(Value::Null),
         Value::Numeric(Numeric::Integer(i)) => {
-            format_string = i.to_string();
-            format_string.as_str()
+            fmt_owned = i.to_string();
+            fmt_owned.as_str()
         }
         Value::Numeric(Numeric::Float(f)) => {
-            format_string = f64::from(*f).to_string();
-            format_string.as_str()
+            fmt_owned = format_float(f64::from(*f));
+            fmt_owned.as_str()
         }
         Value::Blob(b) => {
-            // Blob to string - use lossy UTF-8 conversion like SQLite
-            format_string = String::from_utf8_lossy(b).to_string();
-            format_string.as_str()
+            fmt_owned = String::from_utf8_lossy(b).to_string();
+            fmt_owned.as_str()
         }
     };
 
     let mut result = String::new();
     let mut args_index = 1;
     let mut chars = format_str.chars().peekable();
+    // Track whether any output or specifier processing happened. SQLite's
+    // internal StrAccum buffer stays NULL until something triggers allocation
+    // (any literal text, %%, trailing %, or any specifier including %n).
+    // When an unknown specifier triggers early return before any allocation,
+    // the result is NULL. Otherwise it's the accumulated text (possibly "").
+    let mut touched = false;
 
     while let Some(c) = chars.next() {
         if c != '%' {
+            touched = true;
             result.push(c);
             continue;
         }
 
-        match chars.next() {
-            Some('%') => {
-                result.push('%');
-                continue;
-            }
-            Some('d') | Some('i') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                let value = &values[args_index].get_value();
-                match value {
-                    Value::Numeric(Numeric::Integer(i)) => result.push_str(&i.to_string()),
-                    Value::Numeric(Numeric::Float(f)) => {
-                        let truncated_val = f64::from(*f) as i64;
-                        result.push_str(&truncated_val.to_string());
-                    }
-                    _ => result.push('0'),
-                }
+        // Check for %%
+        if chars.peek() == Some(&'%') {
+            touched = true;
+            chars.next();
+            result.push('%');
+            continue;
+        }
+
+        // Trailing '%' at end of format string is preserved
+        if chars.peek().is_none() {
+            result.push('%');
+            break;
+        }
+
+        // Parse the full format specifier
+        let spec = parse_format_spec(&mut chars, values, &mut args_index);
+
+        // Get the argument value (or use NULL if missing)
+        let needs_arg = !matches!(spec.spec_type, 'n' | '\0');
+        let null_val = Value::Null;
+        let arg = if needs_arg {
+            if args_index < values.len() {
+                let v = values[args_index].get_value();
                 args_index += 1;
+                v
+            } else {
+                &null_val
             }
-            Some('u') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                let value = &values[args_index].get_value();
-                match value {
-                    Value::Numeric(Numeric::Integer(_)) => {
-                        let converted_value = value.as_uint();
-                        write!(result, "{converted_value}")
-                            .expect("write! to a String cannot fail; it panics on OOM");
-                    }
-                    _ => result.push('0'),
-                }
-                args_index += 1;
-            }
-            Some('s') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                match &values[args_index].get_value() {
-                    Value::Text(t) => result.push_str(t.as_str()),
-                    Value::Null => (),
-                    v => write!(result, "{v}")
-                        .expect("write! to a String cannot fail; it panics on OOM"),
-                }
-                args_index += 1;
-            }
-            Some('f') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                let value = &values[args_index].get_value();
-                match value {
-                    Value::Numeric(Numeric::Float(f)) => write!(result, "{:.6}", f64::from(*f))
-                        .expect("write! to a String cannot fail; it panics on OOM"),
-                    Value::Numeric(Numeric::Integer(i)) => write!(result, "{:.6}", *i as f64)
-                        .expect("write! to a String cannot fail; it panics on OOM"),
-                    _ => result.push_str("0.000000"),
-                }
-                args_index += 1;
-            }
-            Some('e') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                let value = &values[args_index].get_value();
-                match value {
-                    Value::Numeric(Numeric::Float(f)) => {
-                        let f = f64::from(*f);
-                        match get_exponential_formatted_str(&f, false) {
-                            Ok(str) => result.push_str(&str),
-                            Err(e) => return Err(e),
-                        }
-                    }
-                    Value::Numeric(Numeric::Integer(i)) => {
-                        let f = *i as f64;
-                        match get_exponential_formatted_str(&f, false) {
-                            Ok(str) => result.push_str(&str),
-                            Err(e) => return Err(e),
-                        }
-                    }
-                    Value::Text(s) => {
-                        let number: f64 = s
-                            .as_str()
-                            .trim_start()
-                            .trim_end_matches(|c: char| !c.is_numeric())
-                            .parse()
-                            .unwrap_or(0.0);
-                        match get_exponential_formatted_str(&number, false) {
-                            Ok(str) => result.push_str(&str),
-                            Err(e) => return Err(e),
-                        };
-                    }
-                    _ => result.push_str("0.000000e+00"),
-                }
-                args_index += 1;
-            }
-            Some('E') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                let value = &values[args_index].get_value();
-                match value {
-                    Value::Numeric(Numeric::Float(f)) => {
-                        let f = f64::from(*f);
-                        match get_exponential_formatted_str(&f, true) {
-                            Ok(str) => result.push_str(&str),
-                            Err(e) => return Err(e),
-                        }
-                    }
-                    Value::Numeric(Numeric::Integer(i)) => {
-                        let f = *i as f64;
-                        match get_exponential_formatted_str(&f, true) {
-                            Ok(str) => result.push_str(&str),
-                            Err(e) => return Err(e),
-                        }
-                    }
-                    Value::Text(s) => {
-                        let number: f64 = s
-                            .as_str()
-                            .trim_start()
-                            .trim_end_matches(|c: char| !c.is_numeric())
-                            .parse()
-                            .unwrap_or(0.0);
-                        match get_exponential_formatted_str(&number, true) {
-                            Ok(str) => result.push_str(&str),
-                            Err(e) => return Err(e),
-                        };
-                    }
-                    _ => result.push_str("0.000000e+00"),
-                }
-                args_index += 1;
-            }
-            Some('c') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                let value = &values[args_index].get_value();
-                let char: char = match value {
-                    Value::Text(s) => s.value.chars().next().unwrap_or('\0'),
-                    _ => {
-                        let as_str = format!("{value}");
-                        as_str.chars().next().unwrap_or('\0')
-                    }
-                };
-                if char != '\0' {
-                    result.push(char);
-                }
-                args_index += 1;
-            }
-            Some('x') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                let value = &values[args_index].get_value();
-                match value {
-                    Value::Numeric(Numeric::Float(f)) => {
-                        write!(result, "{:x}", f64::from(*f) as i64)
-                            .expect("write! to a String cannot fail; it panics on OOM")
-                    }
-                    Value::Numeric(Numeric::Integer(i)) => write!(result, "{i:x}")
-                        .expect("write! to a String cannot fail; it panics on OOM"),
-                    Value::Text(s) => {
-                        let i: i64 = s.as_str().parse::<i64>().unwrap_or(0);
-                        write!(result, "{i:x}")
-                            .expect("write! to a String cannot fail; it panics on OOM")
-                    }
-                    _ => result.push('0'),
-                }
-                args_index += 1;
-            }
-            Some('X') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                let value = &values[args_index].get_value();
-                match value {
-                    Value::Numeric(Numeric::Float(f)) => {
-                        write!(result, "{:X}", f64::from(*f) as i64)
-                            .expect("write! to a String cannot fail; it panics on OOM")
-                    }
-                    Value::Numeric(Numeric::Integer(i)) => write!(result, "{i:X}")
-                        .expect("write! to a String cannot fail; it panics on OOM"),
-                    Value::Text(s) => {
-                        let i: i64 = s.as_str().parse::<i64>().unwrap_or(0);
-                        write!(result, "{i:X}")
-                            .expect("write! to a String cannot fail; it panics on OOM");
-                    }
-                    _ => result.push('0'),
-                }
-                args_index += 1;
-            }
-            Some('o') => {
-                if args_index >= values.len() {
-                    return Err(LimboError::InvalidArgument("not enough arguments".into()));
-                }
-                let value = &values[args_index].get_value();
-                match value {
-                    Value::Numeric(Numeric::Float(f)) => {
-                        write!(result, "{:o}", f64::from(*f) as i64)
-                            .expect("write! to a String cannot fail; it panics on OOM")
-                    }
-                    Value::Numeric(Numeric::Integer(i)) => write!(result, "{i:o}")
-                        .expect("write! to a String cannot fail; it panics on OOM"),
-                    Value::Text(s) => {
-                        let i: i64 = s.as_str().parse::<i64>().unwrap_or(0);
-                        write!(result, "{i:o}")
-                            .expect("write! to a String cannot fail; it panics on OOM");
-                    }
-                    _ => result.push('0'),
-                }
-                args_index += 1;
-            }
-            None => {
-                return Err(LimboError::InvalidArgument(
-                    "incomplete format specifier".into(),
-                ))
-            }
+        } else {
+            &null_val
+        };
+
+        match spec.spec_type {
+            'd' | 'i' => format_signed_int(&mut result, arg, &spec),
+            'u' => format_unsigned_int(&mut result, arg, &spec),
+            'f' => format_float_decimal(&mut result, arg, &spec),
+            'e' => format_exponential(&mut result, arg, &spec, false),
+            'E' => format_exponential(&mut result, arg, &spec, true),
+            'g' => format_general(&mut result, arg, &spec, false),
+            'G' => format_general(&mut result, arg, &spec, true),
+            'x' => format_hex(&mut result, arg, &spec, false),
+            'X' => format_hex(&mut result, arg, &spec, true),
+            'o' => format_octal(&mut result, arg, &spec),
+            'p' => format_hex(&mut result, arg, &spec, true),
+            's' | 'z' => format_string(&mut result, arg, &spec),
+            'c' => format_char(&mut result, arg, &spec),
+            'q' => format_sql_quote(&mut result, arg, &spec),
+            'Q' => format_sql_quote_wrap(&mut result, arg, &spec),
+            'w' => format_sql_identifier(&mut result, arg, &spec),
+            'r' => format_ordinal(&mut result, arg, &spec),
+            'n' => { /* silently ignored, no arg consumed */ }
             _ => {
-                return Err(LimboError::InvalidFormatter(
-                    "this formatter is not supported".into(),
-                ));
+                // Unknown specifier: return NULL if nothing was processed
+                // before this point, otherwise return accumulated text.
+                // This matches SQLite where the internal buffer (zText) stays
+                // NULL until any append is attempted.
+                if !touched {
+                    return Ok(Value::Null);
+                }
+                break;
             }
         }
+        touched = true;
     }
+
     Ok(Value::build_text(result))
 }
 
@@ -338,24 +1388,19 @@ mod tests {
     #[test]
     fn test_printf_string_formatting() {
         let test_cases = vec![
-            // Simple string substitution
             (
                 vec![text("Hello, %s!"), text("World")],
                 text("Hello, World!"),
             ),
-            // Multiple string substitutions
             (
                 vec![text("%s %s!"), text("Hello"), text("World")],
                 text("Hello World!"),
             ),
-            // String with null value
             (
                 vec![text("Hello, %s!"), Register::Value(Value::Null)],
                 text("Hello, !"),
             ),
-            // String with number conversion
             (vec![text("Value: %s"), integer(42)], text("Value: 42")),
-            // Escaping percent sign
             (vec![text("100%% complete")], text("100% complete")),
         ];
         for (input, output) in test_cases {
@@ -366,16 +1411,12 @@ mod tests {
     #[test]
     fn test_printf_integer_formatting() {
         let test_cases = vec![
-            // Basic integer formatting
             (vec![text("Number: %d"), integer(42)], text("Number: 42")),
-            // Negative integer
             (vec![text("Number: %d"), integer(-42)], text("Number: -42")),
-            // Multiple integers
             (
                 vec![text("%d + %d = %d"), integer(2), integer(3), integer(5)],
                 text("2 + 3 = 5"),
             ),
-            // Non-numeric value defaults to 0
             (
                 vec![text("Number: %d"), text("not a number")],
                 text("Number: 0"),
@@ -387,92 +1428,108 @@ mod tests {
             (vec![text("Number: %i"), integer(42)], text("Number: 42")),
         ];
         for (input, output) in test_cases {
-            assert_eq!(exec_printf(&input).unwrap(), *output.get_value())
+            assert_eq!(exec_printf(&input).unwrap(), *output.get_value());
         }
     }
 
     #[test]
     fn test_printf_unsigned_integer_formatting() {
         let test_cases = vec![
-            // Basic
             (vec![text("Number: %u"), integer(42)], text("Number: 42")),
-            // Multiple numbers
-            (
-                vec![text("%u + %u = %u"), integer(2), integer(3), integer(5)],
-                text("2 + 3 = 5"),
-            ),
-            // Negative number should be represented as its uint representation
             (
                 vec![text("Negative: %u"), integer(-1)],
                 text("Negative: 18446744073709551615"),
             ),
-            // Non-numeric value defaults to 0
             (vec![text("NaN: %u"), text("not a number")], text("NaN: 0")),
         ];
         for (input, output) in test_cases {
-            assert_eq!(exec_printf(&input).unwrap(), *output.get_value())
+            assert_eq!(exec_printf(&input).unwrap(), *output.get_value());
         }
     }
 
     #[test]
     fn test_printf_float_formatting() {
         let test_cases = vec![
-            // Basic float formatting
             (
                 vec![text("Number: %f"), float(42.5)],
                 text("Number: 42.500000"),
             ),
-            // Negative float
             (
                 vec![text("Number: %f"), float(-42.5)],
                 text("Number: -42.500000"),
             ),
-            // Integer as float
             (
                 vec![text("Number: %f"), integer(42)],
                 text("Number: 42.000000"),
             ),
-            // Multiple floats
-            (
-                vec![text("%f + %f = %f"), float(2.5), float(3.5), float(6.0)],
-                text("2.500000 + 3.500000 = 6.000000"),
-            ),
-            // Non-numeric value defaults to 0.0
             (
                 vec![text("Number: %f"), text("not a number")],
                 text("Number: 0.000000"),
             ),
         ];
 
+        // Huge finite float must not overflow rounding to produce "inf"
+        let huge = exec_printf(&[text("%f"), float(1e308)]).unwrap();
+        let huge_str = match &huge {
+            Value::Text(t) => t.as_str().to_string(),
+            _ => panic!("expected text"),
+        };
+        assert!(huge_str.starts_with("9999999999999999"));
+        assert!(huge_str.ends_with(".000000"));
+        assert!(!huge_str.contains("inf"));
         for (input, expected) in test_cases {
             assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
         }
     }
 
     #[test]
+    fn test_printf_width_precision() {
+        let test_cases = vec![
+            (vec![text("%.2f"), float(4.002)], text("4.00")),
+            (vec![text("%05d"), integer(42)], text("00042")),
+            (vec![text("%.5d"), integer(42)], text("00042")),
+            (vec![text("%+d"), integer(42)], text("+42")),
+            (vec![text("%.3s"), text("hello")], text("hel")),
+            (vec![text("%08x"), integer(255)], text("000000ff")),
+            (vec![text("%#x"), integer(255)], text("0xff")),
+        ];
+        for (input, expected) in test_cases {
+            assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
+        }
+    }
+
+    #[test]
+    fn test_printf_dynamic_width() {
+        assert_eq!(
+            exec_printf(&[text("%.*f"), integer(2), float(3.14258)]).unwrap(),
+            *text("3.14").get_value()
+        );
+    }
+
+    #[test]
     fn test_printf_character_formatting() {
         let test_cases = vec![
-            // Simple character
             (vec![text("character: %c"), text("a")], text("character: a")),
-            // Character with string
             (
                 vec![text("character: %c"), text("this is a test")],
                 text("character: t"),
             ),
-            // Character with empty
-            (vec![text("character: %c"), text("")], text("character: ")),
-            // Character with integer
             (
                 vec![text("character: %c"), integer(123)],
                 text("character: 1"),
             ),
-            // Character with float
             (
                 vec![text("character: %c"), float(42.5)],
                 text("character: 4"),
             ),
+            // Empty string → NUL char → no output (matches SQLite)
+            (vec![text("character: %c"), text("")], text("character: ")),
+            // NULL → coerces to empty string → NUL → no output
+            (
+                vec![text("character: %c"), Register::Value(Value::Null)],
+                text("character: "),
+            ),
         ];
-
         for (input, expected) in test_cases {
             assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
         }
@@ -481,70 +1538,93 @@ mod tests {
     #[test]
     fn test_printf_exponential_formatting() {
         let test_cases = vec![
-            // Simple number
             (
                 vec![text("Exp: %e"), float(23000000.0)],
                 text("Exp: 2.300000e+07"),
             ),
-            // Negative number
             (
                 vec![text("Exp: %e"), float(-23000000.0)],
                 text("Exp: -2.300000e+07"),
             ),
-            // Non integer float
-            (
-                vec![text("Exp: %e"), float(250.375)],
-                text("Exp: 2.503750e+02"),
-            ),
-            // Positive, but smaller than zero
-            (
-                vec![text("Exp: %e"), float(0.0003235)],
-                text("Exp: 3.235000e-04"),
-            ),
-            // Zero
             (vec![text("Exp: %e"), float(0.0)], text("Exp: 0.000000e+00")),
-            // Uppercase "e"
+        ];
+        for (input, expected) in test_cases {
+            assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
+        }
+    }
+
+    #[test]
+    fn test_printf_general_formatting() {
+        let test_cases = vec![
+            (vec![text("%g"), float(100.0)], text("100")),
+            (vec![text("%g"), float(0.00123)], text("0.00123")),
+            (vec![text("%g"), float(1.0)], text("1")),
+            (vec![text("%g"), float(1.5)], text("1.5")),
+            (vec![text("%g"), float(0.0)], text("0")),
+            (vec![text("%g"), integer(42)], text("42")),
+            // Comma separator applies to %G decimal notation
+            (vec![text("%,G"), integer(1000)], text("1,000")),
             (
-                vec![text("Exp: %e"), float(0.0003235)],
-                text("Exp: 3.235000e-04"),
-            ),
-            // String with integer number
-            (
-                vec![text("Exp: %e"), text("123")],
-                text("Exp: 1.230000e+02"),
-            ),
-            // String with floating point number
-            (
-                vec![text("Exp: %e"), text("123.45")],
-                text("Exp: 1.234500e+02"),
-            ),
-            // String with number with leftmost zeroes
-            (
-                vec![text("Exp: %e"), text("00123")],
-                text("Exp: 1.230000e+02"),
-            ),
-            // String with text
-            (
-                vec![text("Exp: %e"), text("test")],
-                text("Exp: 0.000000e+00"),
-            ),
-            // String starting with number, but with text on the end
-            (
-                vec![text("Exp: %e"), text("123ab")],
-                text("Exp: 1.230000e+02"),
-            ),
-            // String starting with text, but with number on the end
-            (
-                vec![text("Exp: %e"), text("ab123")],
-                text("Exp: 0.000000e+00"),
-            ),
-            // String with exponential representation
-            (
-                vec![text("Exp: %e"), text("1.230000e+02")],
-                text("Exp: 1.230000e+02"),
+                vec![text("%,.20G"), float(1234567.89)],
+                text("1,234,567.89"),
             ),
         ];
+        for (input, expected) in test_cases {
+            assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
+        }
+    }
 
+    #[test]
+    fn test_printf_sql_quoting() {
+        assert_eq!(
+            exec_printf(&[text("%q"), text("it's")]).unwrap(),
+            *text("it''s").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%Q"), text("it's")]).unwrap(),
+            *text("'it''s'").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%Q"), Register::Value(Value::Null)]).unwrap(),
+            *text("NULL").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%q"), Register::Value(Value::Null)]).unwrap(),
+            *text("(NULL)").get_value()
+        );
+    }
+
+    #[test]
+    fn test_printf_comma_separator() {
+        assert_eq!(
+            exec_printf(&[text("%,d"), integer(1234567)]).unwrap(),
+            *text("1,234,567").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%,d"), integer(-1234567)]).unwrap(),
+            *text("-1,234,567").get_value()
+        );
+    }
+
+    #[test]
+    fn test_printf_edge_cases() {
+        let test_cases = vec![
+            (vec![text("")], text("")),
+            (vec![text("%%%%")], text("%%")),
+            (vec![text("No substitutions")], text("No substitutions")),
+            (
+                vec![text("%d%d%d"), integer(1), integer(2), integer(3)],
+                text("123"),
+            ),
+            // Trailing % is preserved
+            (vec![text("test%")], text("test%")),
+            // Unknown specifier: NULL if nothing processed before, else accumulated text
+            (vec![text("%d%j"), integer(42)], text("42")),
+            (vec![text("hello%j")], text("hello")),
+            (vec![text("%n%j")], text("")),
+            // Negative zero should not show minus sign
+            (vec![text("%f"), float(-0.0)], text("0.000000")),
+        ];
         for (input, expected) in test_cases {
             assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
         }
@@ -553,36 +1633,19 @@ mod tests {
     #[test]
     fn test_printf_hexadecimal_formatting() {
         let test_cases = vec![
-            // Simple number
             (vec![text("hex: %x"), integer(4)], text("hex: 4")),
-            // Bigger Number
-            (
-                vec![text("hex: %x"), integer(15565303546)],
-                text("hex: 39fc3aefa"),
-            ),
-            // Uppercase letters
             (
                 vec![text("hex: %X"), integer(15565303546)],
                 text("hex: 39FC3AEFA"),
             ),
-            // Negative
             (
                 vec![text("hex: %x"), integer(-15565303546)],
                 text("hex: fffffffc603c5106"),
             ),
-            // Float
             (vec![text("hex: %x"), float(42.5)], text("hex: 2a")),
-            // Negative Float
-            (
-                vec![text("hex: %x"), float(-42.5)],
-                text("hex: ffffffffffffffd6"),
-            ),
-            // Text
             (vec![text("hex: %x"), text("42")], text("hex: 2a")),
-            // Empty Text
             (vec![text("hex: %x"), text("")], text("hex: 0")),
         ];
-
         for (input, expected) in test_cases {
             assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
         }
@@ -591,131 +1654,485 @@ mod tests {
     #[test]
     fn test_printf_octal_formatting() {
         let test_cases = vec![
-            // Simple number
             (vec![text("octal: %o"), integer(4)], text("octal: 4")),
-            // Bigger Number
-            (
-                vec![text("octal: %o"), integer(15565303546)],
-                text("octal: 163760727372"),
-            ),
-            // Negative
-            (
-                vec![text("octal: %o"), integer(-15565303546)],
-                text("octal: 1777777777614017050406"),
-            ),
-            // Float
             (vec![text("octal: %o"), float(42.5)], text("octal: 52")),
-            // Negative Float
-            (
-                vec![text("octal: %o"), float(-42.5)],
-                text("octal: 1777777777777777777726"),
-            ),
-            // Text
             (vec![text("octal: %o"), text("42")], text("octal: 52")),
-            // Empty Text
-            (vec![text("octal: %o"), text("")], text("octal: 0")),
+            // # flag always adds "0" prefix when value is non-zero
+            (vec![text("%#o"), integer(8)], text("010")),
+            (vec![text("%#o"), integer(0)], text("0")),
+            // # flag with precision: "0" prefix added even if precision pads with zeros
+            (vec![text("%#.5o"), integer(8)], text("000010")),
+            (
+                vec![text("%#.20o"), integer(1000)],
+                text("000000000000000001750"),
+            ),
         ];
-
         for (input, expected) in test_cases {
             assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
         }
     }
 
-    #[test]
-    fn test_printf_mixed_formatting() {
-        let test_cases = vec![
-            // Mix of string and integer
-            (
-                vec![text("%s: %d"), text("Count"), integer(42)],
-                text("Count: 42"),
-            ),
-            // Mix of all types
-            (
-                vec![
-                    text("%s: %d (%f%%)"),
-                    text("Progress"),
-                    integer(75),
-                    float(75.5),
-                ],
-                text("Progress: 75 (75.500000%)"),
-            ),
-            // Complex format
-            (
-                vec![
-                    text("Name: %s, ID: %d, Score: %f"),
-                    text("John"),
-                    integer(123),
-                    float(95.5),
-                ],
-                text("Name: John, ID: 123, Score: 95.500000"),
-            ),
-        ];
+    // ── Bug fix regression tests ────────────────────────────────────
 
-        for (input, expected) in test_cases {
-            assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
-        }
+    #[test]
+    fn test_rounding_half_away_from_zero() {
+        // Bug 1: SQLite uses half-away-from-zero, not half-to-even
+        assert_eq!(
+            exec_printf(&[text("%.0f"), float(0.5)]).unwrap(),
+            *text("1").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%.0f"), float(2.5)]).unwrap(),
+            *text("3").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%.0f"), float(-0.5)]).unwrap(),
+            *text("-1").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%.0e"), float(2.5)]).unwrap(),
+            *text("3e+00").get_value()
+        );
     }
 
     #[test]
-    fn test_printf_error_cases() {
-        let error_cases = vec![
-            // Not enough arguments
-            vec![text("%d %d"), integer(42)],
-            // Invalid format string
-            vec![text("%z"), integer(42)],
-            // Incomplete format specifier
-            vec![text("incomplete %")],
-        ];
-
-        for case in error_cases {
-            assert!(exec_printf(&case).is_err());
-        }
+    fn test_alt_hex_zero_pad_width() {
+        // Bug 2: # flag with 0 flag - prefix not counted in width
+        assert_eq!(
+            exec_printf(&[text("%#08x"), integer(255)]).unwrap(),
+            *text("0x000000ff").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%#04x"), integer(255)]).unwrap(),
+            *text("0x00ff").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%#08o"), integer(8)]).unwrap(),
+            *text("000000010").get_value()
+        );
     }
 
     #[test]
-    fn test_get_exponential_formatted_str() {
-        let test_cases = vec![
-            (23000000.0, false, "2.300000e+07"),
-            (-23000000.0, false, "-2.300000e+07"),
-            (250.375, false, "2.503750e+02"),
-            (0.0003235, false, "3.235000e-04"),
-            (0.0, false, "0.000000e+00"),
-            (23000000.0, true, "2.300000E+07"),
-            (-23000000.0, true, "-2.300000E+07"),
-            (250.375, true, "2.503750E+02"),
-            (0.0003235, true, "3.235000E-04"),
-            (0.0, true, "0.000000E+00"),
-        ];
-
-        for (number, uppercase, expected) in test_cases {
-            let result = get_exponential_formatted_str(&number, uppercase).unwrap();
-            assert_eq!(result, expected);
-        }
+    fn test_alt_flag_forces_decimal_point() {
+        // Bug 3: # flag forces decimal point on %e and %g
+        assert_eq!(
+            exec_printf(&[text("%#.0e"), float(1.0)]).unwrap(),
+            *text("1.e+00").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%#.0g"), float(1.0)]).unwrap(),
+            *text("1.").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%#g"), float(100000.0)]).unwrap(),
+            *text("100000.").get_value()
+        );
     }
 
     #[test]
-    fn test_printf_edge_cases() {
-        let test_cases = vec![
-            // Empty format string
-            (vec![text("")], text("")),
-            // Only percent signs
-            (vec![text("%%%%")], text("%%")),
-            // String with no format specifiers
-            (vec![text("No substitutions")], text("No substitutions")),
-            // Multiple consecutive format specifiers
-            (
-                vec![text("%d%d%d"), integer(1), integer(2), integer(3)],
-                text("123"),
-            ),
-            // Format string with special characters
-            (
-                vec![text("Special chars: %s"), text("\n\t\r")],
-                text("Special chars: \n\t\r"),
-            ),
-        ];
+    fn test_g_threshold_rounding() {
+        // Bug 4: %g pre-rounding changes the exponent threshold
+        assert_eq!(
+            exec_printf(&[text("%g"), float(999999.5)]).unwrap(),
+            *text("1e+06").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%.1g"), float(9.5)]).unwrap(),
+            *text("1e+01").get_value()
+        );
+    }
 
-        for (input, expected) in test_cases {
-            assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
-        }
+    #[test]
+    fn test_zero_pad_ignored_for_strings() {
+        // Bug 5: 0 flag should be ignored for %s and %c
+        assert_eq!(
+            exec_printf(&[text("%05s"), text("hi")]).unwrap(),
+            *text("   hi").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%05c"), text("A")]).unwrap(),
+            *text("    A").get_value()
+        );
+    }
+
+    #[test]
+    fn test_q_width_precision() {
+        // Bug 6: %q/%Q/%w should respect width and precision
+        assert_eq!(
+            exec_printf(&[text("%.2q"), text("hello")]).unwrap(),
+            *text("he").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%10q"), text("hi")]).unwrap(),
+            *text("        hi").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%10Q"), text("hi")]).unwrap(),
+            *text("      'hi'").get_value()
+        );
+    }
+
+    #[test]
+    fn test_infinity_handling() {
+        // SQLite source (sqlite3.c:32502): infinity + flag_zeropad → 9-fill
+        // infinity without flag_zeropad → "Inf"
+        let inf_f = exec_printf(&[text("%020f"), float(f64::INFINITY)]).unwrap();
+        let inf_str = match &inf_f {
+            Value::Text(t) => t.as_str().to_string(),
+            _ => panic!("expected text"),
+        };
+        assert!(inf_str.starts_with("9000"));
+        assert_eq!(inf_str.len(), 1007); // 9 + 999 zeros + ".000000"
+
+        assert_eq!(
+            exec_printf(&[text("%020e"), float(f64::INFINITY)]).unwrap(),
+            *text("00000009.000000e+999").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%020g"), float(f64::INFINITY)]).unwrap(),
+            *text("000000000000009e+999").get_value()
+        );
+        // Without zero-pad → "Inf" (not 9-fill)
+        assert_eq!(
+            exec_printf(&[text("%e"), float(f64::INFINITY)]).unwrap(),
+            *text("Inf").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%G"), float(f64::INFINITY)]).unwrap(),
+            *text("Inf").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%f"), float(f64::INFINITY)]).unwrap(),
+            *text("Inf").get_value()
+        );
+        // With zero-pad but no width still triggers 9-fill
+        assert_eq!(
+            exec_printf(&[text("%0G"), float(f64::INFINITY)]).unwrap(),
+            *text("9E+999").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%0,G"), float(f64::INFINITY)]).unwrap(),
+            *text("9E+999").get_value()
+        );
+        // Negative infinity
+        assert_eq!(
+            exec_printf(&[text("%e"), float(f64::NEG_INFINITY)]).unwrap(),
+            *text("-Inf").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%020e"), float(f64::NEG_INFINITY)]).unwrap(),
+            *text("-0000009.000000e+999").get_value()
+        );
+        // # flag with %g infinity: RTZ disabled, so trailing zeros remain
+        assert_eq!(
+            exec_printf(&[text("%#0g"), float(f64::INFINITY)]).unwrap(),
+            *text("9.00000e+999").get_value()
+        );
+        // ! flag with %e infinity: RTZ enabled, strips to .0
+        assert_eq!(
+            exec_printf(&[text("%!0e"), float(f64::INFINITY)]).unwrap(),
+            *text("9.0e+999").get_value()
+        );
+        // ! flag with %f infinity: strips trailing fractional zeros
+        let inf_bang_f = exec_printf(&[text("%!0f"), float(f64::INFINITY)]).unwrap();
+        let inf_bang_str = match &inf_bang_f {
+            Value::Text(t) => t.as_str().to_string(),
+            _ => panic!("expected text"),
+        };
+        assert!(
+            inf_bang_str.ends_with(".0"),
+            "Infinity with %!0f should end with .0, got: ...{}",
+            &inf_bang_str[inf_bang_str.len().saturating_sub(10)..]
+        );
+    }
+
+    #[test]
+    fn test_significant_digits_limiting() {
+        // Default: 16 significant digits (hide IEEE noise)
+        assert_eq!(
+            exec_printf(&[text("%.20f"), float(1.0 / 3.0)]).unwrap(),
+            *text("0.33333333333333330000").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%.20e"), float(1.0 / 3.0)]).unwrap(),
+            *text("3.33333333333333300000e-01").get_value()
+        );
+        // ! flag: 26 significant digits max, trailing zeros stripped (sqlite3.c:32496).
+        // fp_decode extracts 19 digits from the u64; the ! flag's RTZ then strips
+        // the trailing '0', yielding 19 fractional characters.
+        assert_eq!(
+            exec_printf(&[text("%!.20f"), float(1.0 / 3.0)]).unwrap(),
+            *text("0.3333333333333333148").get_value()
+        );
+    }
+
+    #[test]
+    fn test_nan_handling() {
+        // Value::from_f64(NaN) returns Value::Null (NonNan rejects NaN),
+        // so NaN is treated as NULL which coerces to 0.0 for float formats.
+        // The NaN-specific formatting code (NaN/null output) is defense-in-depth
+        // that can't be triggered through the Value system.
+        assert_eq!(
+            exec_printf(&[text("%f"), float(f64::NAN)]).unwrap(),
+            *text("0.000000").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%e"), float(f64::NAN)]).unwrap(),
+            *text("0.000000e+00").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%g"), float(f64::NAN)]).unwrap(),
+            *text("0").get_value()
+        );
+    }
+
+    #[test]
+    fn test_blob_nul_truncation() {
+        // Bug 9: %s on blobs truncates at first NUL byte
+        let blob_val = Register::Value(Value::Blob(vec![0x48, 0x00, 0x4C])); // H\0L
+        let result = exec_printf(&[text("%s"), blob_val]).unwrap();
+        assert_eq!(result, *text("H").get_value());
+
+        let blob_hello = Register::Value(Value::Blob(b"Hello".to_vec()));
+        assert_eq!(
+            exec_printf(&[text("%s"), blob_hello]).unwrap(),
+            *text("Hello").get_value()
+        );
+    }
+
+    #[test]
+    fn test_limit_significant_digits_rounding() {
+        // Verify the rounding behavior of limit_significant_digits
+        assert_eq!(limit_significant_digits("123456789", 5), "123460000");
+        assert_eq!(limit_significant_digits("1.23456789", 5), "1.23460000");
+        assert_eq!(limit_significant_digits("0.001234", 3), "0.001230");
+        assert_eq!(limit_significant_digits("9.9999", 3), "10.0000");
+        assert_eq!(limit_significant_digits("0.099999", 4), "0.100000");
+    }
+
+    #[test]
+    fn test_i32_star_precision_wrapping() {
+        // i32::MIN as * precision wraps back to itself after negation → treated as 0
+        assert_eq!(
+            exec_printf(&[text("%.*d"), integer(-2147483648), integer(42)]).unwrap(),
+            *text("42").get_value()
+        );
+        // 4294967295 as i64 → -1 as i32 → wrapping_neg → 1
+        assert_eq!(
+            exec_printf(&[text("%.*d"), integer(4294967295), integer(42)]).unwrap(),
+            *text("42").get_value()
+        );
+    }
+
+    #[test]
+    fn test_comma_zero_pad_interaction() {
+        // When comma + zero_pad: zero-pad digits to width, then insert commas
+        // Width 15 = 15 digit positions, commas added on top
+        assert_eq!(
+            exec_printf(&[text("%0,15d"), integer(42)]).unwrap(),
+            *text("000,000,000,000,042").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%0,15u"), integer(42)]).unwrap(),
+            *text("000,000,000,000,042").get_value()
+        );
+        // Left-justify is ignored when comma + zero-pad are both set
+        assert_eq!(
+            exec_printf(&[text("%-0,15d"), integer(42)]).unwrap(),
+            *text("000,000,000,000,042").get_value()
+        );
+    }
+
+    #[test]
+    fn test_ordinal_format() {
+        assert_eq!(
+            exec_printf(&[text("%r"), integer(1)]).unwrap(),
+            *text("1st").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%r"), integer(2)]).unwrap(),
+            *text("2nd").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%r"), integer(3)]).unwrap(),
+            *text("3rd").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%r"), integer(11)]).unwrap(),
+            *text("11th").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%r"), integer(112)]).unwrap(),
+            *text("112th").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%.5r"), integer(-39)]).unwrap(),
+            *text("-039th").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("% r"), integer(42)]).unwrap(),
+            *text(" 42nd").get_value()
+        );
+        // Zero-pad pads the digits before the suffix
+        assert_eq!(
+            exec_printf(&[text("%010r"), integer(0)]).unwrap(),
+            *text("00000000th").get_value()
+        );
+    }
+
+    #[test]
+    fn test_q_null_precision_truncation() {
+        // Precision truncates the NULL literal representation
+        assert_eq!(
+            exec_printf(&[text("%.0q"), Register::Value(Value::Null)]).unwrap(),
+            *text("").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%.3q"), Register::Value(Value::Null)]).unwrap(),
+            *text("(NU").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%.0Q"), Register::Value(Value::Null)]).unwrap(),
+            *text("").get_value()
+        );
+    }
+
+    #[test]
+    fn test_q_null_width_padding() {
+        // Width applies to the NULL representation
+        assert_eq!(
+            exec_printf(&[text("%-10q"), Register::Value(Value::Null)]).unwrap(),
+            *text("(NULL)    ").get_value()
+        );
+    }
+
+    #[test]
+    fn test_unknown_specifier_returns_early() {
+        // Unknown specifier as first thing → NULL (SQLite's StrAccum never allocated)
+        assert_eq!(
+            exec_printf(&[text("%b"), integer(42)]).unwrap(),
+            Value::Null,
+        );
+        // Unknown specifier after literal text → accumulated text
+        assert_eq!(
+            exec_printf(&[text("hello%b"), integer(42)]).unwrap(),
+            *text("hello").get_value()
+        );
+        // Unknown specifier after %n → "" (StrAccum was allocated by %n processing)
+        assert_eq!(
+            exec_printf(&[text("%n%b"), integer(42)]).unwrap(),
+            *text("").get_value(),
+        );
+    }
+
+    #[test]
+    fn test_control_char_escaping_with_hash_q() {
+        // %#q escapes control characters as \uXXXX and doubles backslashes
+        assert_eq!(
+            exec_printf(&[text("%#q"), text("a\nb")]).unwrap(),
+            *text("a\\u000ab").get_value()
+        );
+        assert_eq!(
+            exec_printf(&[text("%#q"), text("a\tb")]).unwrap(),
+            *text("a\\u0009b").get_value()
+        );
+        // Backslash is doubled in escape mode
+        assert_eq!(
+            exec_printf(&[text("%#q"), text("a\\b")]).unwrap(),
+            *text("a\\\\b").get_value()
+        );
+    }
+
+    #[test]
+    fn test_hash_q_upper_unistr_wrapping() {
+        // %#Q wraps with unistr('...') when control chars are present
+        assert_eq!(
+            exec_printf(&[text("%#Q"), text("a\nb")]).unwrap(),
+            *text("unistr('a\\u000ab')").get_value()
+        );
+        // %#Q without control chars — no unistr wrapping
+        assert_eq!(
+            exec_printf(&[text("%#Q"), text("hello")]).unwrap(),
+            *text("'hello'").get_value()
+        );
+        // %Q without # — no unistr wrapping even with control chars
+        assert_eq!(
+            exec_printf(&[text("%Q"), text("a\nb")]).unwrap(),
+            *text("'a\nb'").get_value()
+        );
+    }
+
+    #[test]
+    fn test_very_small_float_no_nan() {
+        // 1e-300 with %G should not produce NaN — round_half_away_e must handle
+        // subnormal scale values from 10^(-309+) without dividing by ~0.
+        let result = exec_printf(&[text("%.*G"), integer(10), float(1e-300)]).unwrap();
+        assert_eq!(result, *text("1E-300").get_value());
+
+        // Also test with %e
+        let result = exec_printf(&[text("%.10e"), float(1e-300)]).unwrap();
+        assert!(
+            !result.to_string().contains("NaN"),
+            "1e-300 with %e should not produce NaN"
+        );
+
+        // And %g
+        let result = exec_printf(&[text("%.10g"), float(1e-300)]).unwrap();
+        assert!(
+            !result.to_string().contains("NaN"),
+            "1e-300 with %g should not produce NaN"
+        );
+    }
+
+    #[test]
+    fn test_large_float_f_format() {
+        // 1e308 with %f must produce leading digits "9999..." (matching SQLite's
+        // sqlite3FpDecode), NOT "1000..." (which Rust's format! produces).
+        let result = exec_printf(&[text("%.0f"), float(1e308)]).unwrap();
+        let s = result.to_string();
+        assert!(
+            s.starts_with("99999999999999990"),
+            "1e308 with %.0f should start with 9999..., got: {}",
+            &s[..s.len().min(40)]
+        );
+
+        // With commas too
+        let result = exec_printf(&[text("%,f"), float(1e308)]).unwrap();
+        let s = result.to_string();
+        assert!(
+            s.starts_with("99,999,999,999,999,990"),
+            "1e308 with %,f should start with 99,999..., got: {}",
+            &s[..s.len().min(40)]
+        );
+    }
+
+    #[test]
+    fn test_negative_zero_suppression() {
+        // SQLite 3.51+ (sqlite3.c:32520-32532): With # flag (no + or space),
+        // %f suppresses minus sign when displayed value rounds to zero.
+
+        // -0.0000001 with %#f displays as 0.000000 — suppress minus
+        let result = exec_printf(&[text("%#f"), float(-0.0000001)]).unwrap();
+        assert_eq!(result.to_string(), "0.000000");
+
+        // Same without # flag — keep minus
+        let result = exec_printf(&[text("%f"), float(-0.0000001)]).unwrap();
+        assert_eq!(result.to_string(), "-0.000000");
+
+        // With + flag, # doesn't suppress (flag_prefix is set)
+        let result = exec_printf(&[text("%#+f"), float(-0.0000001)]).unwrap();
+        assert_eq!(result.to_string(), "-0.000000");
+
+        // -0.5 rounds to -1, not zero — keep minus
+        let result = exec_printf(&[text("%#.0f"), float(-0.5)]).unwrap();
+        assert_eq!(result.to_string(), "-1.");
+
+        // -0.4 rounds to 0 — suppress
+        let result = exec_printf(&[text("%#.0f"), float(-0.4)]).unwrap();
+        assert_eq!(result.to_string(), "0.");
+
+        // -0.0000001 with comma separator
+        let result = exec_printf(&[text("%#,f"), float(-0.0000001)]).unwrap();
+        assert_eq!(result.to_string(), "0.000000");
     }
 }

--- a/testing/differential-oracle/fuzzer/Cargo.toml
+++ b/testing/differential-oracle/fuzzer/Cargo.toml
@@ -10,6 +10,10 @@ repository.workspace = true
 name = "differential_fuzzer"
 path = "main.rs"
 
+[[bin]]
+name = "printf_fuzzer"
+path = "printf_fuzzer.rs"
+
 [lib]
 path = "lib.rs"
 

--- a/testing/differential-oracle/fuzzer/lib.rs
+++ b/testing/differential-oracle/fuzzer/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod memory;
 pub mod oracle;
+pub mod printf_gen;
 pub mod runner;
 pub mod schema;
 

--- a/testing/differential-oracle/fuzzer/printf_fuzzer.rs
+++ b/testing/differential-oracle/fuzzer/printf_fuzzer.rs
@@ -1,0 +1,500 @@
+//! Printf differential fuzzer for Turso.
+//!
+//! Generates random `SELECT printf(...)` statements and compares results
+//! between Turso and SQLite. Focuses on corner cases to find divergences.
+
+use std::io::IsTerminal;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use differential_fuzzer::memory::MemorySimIO;
+use differential_fuzzer::oracle::{DifferentialOracle, QueryResult, Row};
+use differential_fuzzer::printf_gen::{EDGE_CASE_BATTERY, PrintfGenerator};
+use rand::RngCore;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use sql_gen_prop::SqlValue;
+use turso_core::Database;
+
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "Printf differential fuzzer for Turso vs SQLite"
+)]
+struct Args {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    /// Random seed for deterministic execution.
+    #[arg(short, long, default_value_t = rand::rng().next_u64())]
+    seed: u64,
+
+    /// Number of random statements to generate (in addition to edge case battery).
+    #[arg(short = 'n', long, default_value_t = 1000)]
+    num_statements: usize,
+
+    /// Print each statement and its results.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Continue running after failures instead of stopping.
+    #[arg(short, long)]
+    keep_going: bool,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Run the fuzzer in a loop with random seeds.
+    Loop {
+        /// Number of iterations (0 for infinite).
+        #[arg(default_value_t = 0)]
+        iterations: u64,
+    },
+}
+
+/// Check if two f64 values are "close enough" to account for different
+/// float-to-decimal algorithms (Rust vs SQLite's sqlite3FpDecode) producing
+/// different rounding at the last displayed digit.
+fn floats_close(a: f64, b: f64) -> bool {
+    if a == b {
+        return true;
+    }
+    if a.is_nan() && b.is_nan() {
+        return true;
+    }
+    if a.is_nan() || b.is_nan() || a.is_infinite() || b.is_infinite() {
+        return false;
+    }
+    let magnitude = a.abs().max(b.abs());
+    if magnitude == 0.0 {
+        return true;
+    }
+    let rel_diff = (a - b).abs() / magnitude;
+    // Tolerance: last-digit rounding in a 6+ significant digit display
+    // can differ by ~1e-6 relative. Use 1e-5 for safety margin.
+    rel_diff < 1e-5
+}
+
+/// Compare two text strings with tolerance for float rendering differences.
+///
+/// Different float-to-decimal algorithms (Rust vs SQLite's sqlite3FpDecode)
+/// can produce different decimal representations of the same f64 value.
+/// For example, 1e308 may render as "1.00000000000000000e+308" or
+/// "9.99999999999999900e+307" — both are correct.
+///
+/// When strings diverge inside a numeric literal, this function extracts the
+/// full numeric span from both, parses them as f64, and checks equality.
+fn fuzzy_text_eq(a: &str, b: &str) -> bool {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut ai = 0;
+    let mut bi = 0;
+
+    while ai < a.len() && bi < b.len() {
+        if a[ai] == b[bi] {
+            ai += 1;
+            bi += 1;
+            continue;
+        }
+
+        // Characters diverge. Try to extract numeric spans and compare as floats.
+        // One string may have more digits than the other (different sig digit counts),
+        // so a number can end right at the divergence in one string while continuing
+        // in the other. We detect numbers by checking start < end around the
+        // divergence, and guarantee progress by advancing at least 1 position.
+        let (a_num_start, a_has_dot) = find_number_start(&a, ai);
+        let (b_num_start, b_has_dot) = find_number_start(&b, bi);
+        let a_num_end = find_number_end(&a, ai, a_has_dot);
+        let b_num_end = find_number_end(&b, bi, b_has_dot);
+
+        if a_num_end > a_num_start && b_num_end > b_num_start {
+            let a_str: String = a[a_num_start..a_num_end].iter().collect();
+            let b_str: String = b[b_num_start..b_num_end].iter().collect();
+            if let (Ok(af), Ok(bf)) = (a_str.parse::<f64>(), b_str.parse::<f64>()) {
+                if floats_close(af, bf) {
+                    // Advance past the number, guaranteeing at least 1 step of progress
+                    ai = a_num_end.max(ai + 1);
+                    bi = b_num_end.max(bi + 1);
+                    continue;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // Both must be fully consumed
+    ai == a.len() && bi == b.len()
+}
+
+/// Walk backwards from `pos` to find the start of a numeric literal.
+/// Returns (start_position, whether_a_dot_was_found).
+fn find_number_start(chars: &[char], pos: usize) -> (usize, bool) {
+    let mut start = pos;
+    let mut has_dot = false;
+    while start > 0 {
+        let c = chars[start - 1];
+        if c.is_ascii_digit() {
+            start -= 1;
+        } else if c == '.' && !has_dot {
+            has_dot = true;
+            start -= 1;
+        } else if c == '+' || c == '-' || c == 'e' || c == 'E' {
+            start -= 1;
+        } else {
+            break;
+        }
+    }
+    (start, has_dot)
+}
+
+/// Walk forward from `pos` to find the end of a numeric literal.
+/// `already_has_dot`: whether the backward walk already found a decimal point.
+fn find_number_end(chars: &[char], pos: usize, already_has_dot: bool) -> usize {
+    let mut end = pos;
+    let mut has_dot = already_has_dot;
+    while end < chars.len() {
+        let c = chars[end];
+        if c.is_ascii_digit() {
+            end += 1;
+        } else if c == '.' && !has_dot {
+            has_dot = true;
+            end += 1;
+        } else if (c == 'e' || c == 'E') && end + 1 < chars.len() {
+            end += 1;
+            // Skip optional sign after exponent
+            if end < chars.len() && (chars[end] == '+' || chars[end] == '-') {
+                end += 1;
+            }
+        } else {
+            break;
+        }
+    }
+    end
+}
+
+/// Compare rows with fuzzy text comparison for float tolerance.
+fn rows_fuzzy_eq(a: &[Row], b: &[Row]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    for (ra, rb) in a.iter().zip(b.iter()) {
+        if ra.0.len() != rb.0.len() {
+            return false;
+        }
+        for (va, vb) in ra.0.iter().zip(rb.0.iter()) {
+            match (va, vb) {
+                (SqlValue::Text(ta), SqlValue::Text(tb)) => {
+                    if !fuzzy_text_eq(ta, tb) {
+                        // Different float-to-decimal algorithms can produce
+                        // representations of different length (e.g. "1E+308" vs
+                        // "9.999999999999999E+307"), which causes width padding
+                        // to differ. Retry with spaces stripped to catch this.
+                        let a_stripped: String = ta.chars().filter(|c| *c != ' ').collect();
+                        let b_stripped: String = tb.chars().filter(|c| *c != ' ').collect();
+                        if !fuzzy_text_eq(&a_stripped, &b_stripped) {
+                            return false;
+                        }
+                    }
+                }
+                _ => {
+                    if va != vb {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Format two text values showing the divergence point with context.
+fn fmt_text_diff(a: &str, b: &str) -> String {
+    // Find first byte where they diverge
+    let diverge = a
+        .bytes()
+        .zip(b.bytes())
+        .position(|(x, y)| x != y)
+        .unwrap_or_else(|| a.len().min(b.len()));
+
+    let ctx = 40; // chars of context around the divergence
+    let start = diverge.saturating_sub(ctx);
+    let end_a = (diverge + ctx).min(a.len());
+    let end_b = (diverge + ctx).min(b.len());
+
+    let prefix = if start > 0 { "..." } else { "" };
+    let suffix_a = if end_a < a.len() { "..." } else { "" };
+    let suffix_b = if end_b < b.len() { "..." } else { "" };
+
+    format!(
+        "diverge at byte {diverge} (len {}/{})\n    Turso:  {prefix}\"{}\"{suffix_a}\n    SQLite: {prefix}\"{}\"{suffix_b}",
+        a.len(),
+        b.len(),
+        &a[start..end_a],
+        &b[start..end_b],
+    )
+}
+
+/// Format a QueryResult pair for display, showing diffs for mismatched text.
+fn fmt_result_diff(turso: &QueryResult, sqlite: &QueryResult) -> String {
+    match (turso, sqlite) {
+        (QueryResult::Rows(t_rows), QueryResult::Rows(s_rows)) => {
+            for (tr, sr) in t_rows.iter().zip(s_rows.iter()) {
+                for (tv, sv) in tr.0.iter().zip(sr.0.iter()) {
+                    if let (SqlValue::Text(ta), SqlValue::Text(tb)) = (tv, sv) {
+                        if ta != tb {
+                            return fmt_text_diff(ta, tb);
+                        }
+                    }
+                }
+            }
+            // Fallback: length or non-text mismatch
+            format!("Turso: {turso:?}\n  SQLite: {sqlite:?}")
+        }
+        _ => format!("Turso: {turso:?}\n  SQLite: {sqlite:?}"),
+    }
+}
+
+struct FuzzerState {
+    turso_conn: Arc<turso_core::Connection>,
+    sqlite_conn: rusqlite::Connection,
+    #[expect(dead_code)]
+    turso_db: Arc<Database>,
+    #[expect(dead_code)]
+    io: Arc<MemorySimIO>,
+}
+
+impl FuzzerState {
+    fn new(seed: u64) -> Result<Self> {
+        let out_dir: PathBuf = "simulator-output".into();
+        if !out_dir.exists() {
+            std::fs::create_dir_all(&out_dir)?;
+        }
+
+        let io = Arc::new(MemorySimIO::new(seed));
+        let turso_db =
+            Database::open_file(io.clone(), out_dir.join("printf-test.db").to_str().unwrap())?;
+        let turso_conn = turso_db.connect()?;
+
+        let sqlite_conn =
+            rusqlite::Connection::open_in_memory().context("Failed to open SQLite database")?;
+
+        // Log bundled SQLite version for debugging version-dependent behavior
+        if let Ok(ver) =
+            sqlite_conn.query_row("SELECT sqlite_version()", [], |r| r.get::<_, String>(0))
+        {
+            tracing::info!("Bundled SQLite version: {ver}");
+        }
+
+        Ok(Self {
+            turso_conn,
+            sqlite_conn,
+            turso_db,
+            io,
+        })
+    }
+
+    /// Execute SQL on both engines and compare. Returns None on match, Some(reason) on mismatch.
+    /// Mismatch messages are truncated to avoid multi-MB log output.
+    fn check(&self, sql: &str) -> Option<String> {
+        let turso_result = DifferentialOracle::execute_turso(&self.turso_conn, sql);
+        let sqlite_result = DifferentialOracle::execute_sqlite(&self.sqlite_conn, sql);
+
+        // Turso is UTF-8 only; blob-to-string conversion differs from SQLite's raw
+        // byte handling. When blobs are involved, just verify both produce results.
+        let has_blob = sql.contains("X'");
+
+        match (&turso_result, &sqlite_result) {
+            (QueryResult::Rows(t_rows), QueryResult::Rows(s_rows)) => {
+                if has_blob {
+                    // Both produced rows — good enough for blob cases
+                    let _ = (t_rows, s_rows);
+                    None
+                } else if !rows_fuzzy_eq(t_rows, s_rows) {
+                    Some(format!(
+                        "Result mismatch:\n  {}",
+                        fmt_result_diff(&turso_result, &sqlite_result),
+                    ))
+                } else {
+                    None
+                }
+            }
+            (QueryResult::Ok, QueryResult::Ok) => None,
+            (QueryResult::Error(_), QueryResult::Error(_)) => {
+                // Both errored — acceptable
+                None
+            }
+            (QueryResult::Error(e), _) => Some(format!(
+                "Turso errored but SQLite succeeded:\n  Turso error: {e}\n  SQLite: {sqlite_result:?}"
+            )),
+            (_, QueryResult::Error(e)) => Some(format!(
+                "SQLite errored but Turso succeeded:\n  SQLite error: {e}\n  Turso: {turso_result:?}"
+            )),
+            _ => {
+                if format!("{turso_result:?}") != format!("{sqlite_result:?}") {
+                    Some(format!(
+                        "Result type mismatch:\n  {}",
+                        fmt_result_diff(&turso_result, &sqlite_result),
+                    ))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+fn run_single(args: &Args) -> Result<FuzzerStats> {
+    let state = FuzzerState::new(args.seed)?;
+    let mut stats = FuzzerStats::default();
+    let rng = ChaCha8Rng::seed_from_u64(args.seed);
+    let mut generator = PrintfGenerator::new(rng);
+
+    tracing::info!(
+        "Running printf fuzzer: seed={}, edge_cases={}, random={}",
+        args.seed,
+        EDGE_CASE_BATTERY.len(),
+        args.num_statements
+    );
+
+    // Phase 1: Run the hardcoded edge case battery
+    for sql in EDGE_CASE_BATTERY {
+        stats.total += 1;
+
+        if args.verbose {
+            tracing::info!("[edge] {sql}");
+        }
+
+        if let Some(reason) = state.check(sql) {
+            stats.failures += 1;
+            tracing::error!("FAIL: {sql}\n  {reason}");
+            if !args.keep_going {
+                tracing::error!(
+                    "Stopping on first failure (use --keep-going to continue). Seed: {}",
+                    args.seed
+                );
+                return Ok(stats);
+            }
+        } else {
+            stats.passed += 1;
+            if args.verbose {
+                tracing::info!("  PASS");
+            }
+        }
+    }
+
+    // Phase 2: Random generation
+    for i in 0..args.num_statements {
+        let sql = generator.gen_printf_sql();
+        stats.total += 1;
+
+        if args.verbose {
+            tracing::info!("[rand #{i}] {sql}");
+        }
+
+        if let Some(reason) = state.check(&sql) {
+            stats.failures += 1;
+            tracing::error!("FAIL: {sql}\n  {reason}");
+            if !args.keep_going {
+                tracing::error!(
+                    "Stopping on first failure (use --keep-going to continue). Seed: {}",
+                    args.seed
+                );
+                return Ok(stats);
+            }
+        } else {
+            stats.passed += 1;
+            if args.verbose {
+                tracing::info!("  PASS");
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+#[derive(Default)]
+struct FuzzerStats {
+    total: usize,
+    passed: usize,
+    failures: usize,
+}
+
+impl FuzzerStats {
+    fn print_summary(&self, seed: u64) {
+        if self.failures > 0 {
+            tracing::error!(
+                "FAILED: {}/{} passed, {} failures (seed: {seed})",
+                self.passed,
+                self.total,
+                self.failures
+            );
+        } else {
+            tracing::info!(
+                "PASSED: {}/{} passed (seed: {seed})",
+                self.passed,
+                self.total
+            );
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let mut subscriber = tracing_subscriber::fmt().with_env_filter(
+        tracing_subscriber::EnvFilter::from_default_env()
+            .add_directive(tracing::Level::INFO.into()),
+    );
+
+    if !std::io::stdin().is_terminal() {
+        subscriber = subscriber.with_ansi(false)
+    }
+    subscriber.init();
+
+    let mut args = Args::parse();
+
+    match args.command {
+        Some(Commands::Loop { iterations }) => {
+            let mut iteration = 0u64;
+            loop {
+                args.seed = rand::rng().next_u64();
+                tracing::info!("=== Iteration {}: seed {} ===", iteration + 1, args.seed);
+
+                let stats = run_single(&args)?;
+                stats.print_summary(args.seed);
+
+                if stats.failures > 0 {
+                    tracing::error!(
+                        "Reproduce with: cargo run --bin printf_fuzzer -- --seed {} -n {} --verbose",
+                        args.seed,
+                        args.num_statements
+                    );
+                    std::process::exit(1);
+                }
+
+                iteration += 1;
+                if iterations > 0 && iteration >= iterations {
+                    tracing::info!("Completed {} iterations successfully", iterations);
+                    break;
+                }
+            }
+            Ok(())
+        }
+        None => {
+            let stats = run_single(&args)?;
+            stats.print_summary(args.seed);
+
+            if stats.failures > 0 {
+                tracing::error!(
+                    "Reproduce with: cargo run --bin printf_fuzzer -- --seed {} -n {} --verbose",
+                    args.seed,
+                    args.num_statements
+                );
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+    }
+}

--- a/testing/differential-oracle/fuzzer/printf_gen.rs
+++ b/testing/differential-oracle/fuzzer/printf_gen.rs
@@ -1,0 +1,736 @@
+//! Adversarial printf SQL statement generator.
+//!
+//! Generates random `SELECT printf(...)` statements designed to find divergences
+//! between Turso and SQLite. Focuses on corner cases: type mismatches, missing
+//! arguments, extreme values, conflicting flags, and boundary precisions.
+
+use rand::Rng;
+use rand_chacha::ChaCha8Rng;
+
+/// Specifier types that printf supports.
+const SPECIFIER_TYPES: &[char] = &[
+    'd', 'i', 'u', 'f', 'e', 'E', 'g', 'G', 'x', 'X', 'o', 'p', 's', 'c', 'q', 'Q', 'w', 'n', 'r',
+];
+
+/// Flag characters.
+const FLAGS: &[char] = &['-', '+', ' ', '0', '#', ',', '!'];
+
+/// Hardcoded edge case SQL statements that are run every time.
+/// These are the known tricky cases that have caught real bugs.
+pub const EDGE_CASE_BATTERY: &[&str] = &[
+    // Missing arguments
+    "SELECT printf('%p')",
+    "SELECT printf('%d %d %d', 1)",
+    "SELECT printf('%f %s')",
+    // Type mismatches
+    "SELECT printf('%d', 'hello')",
+    "SELECT printf('%d', '')",
+    "SELECT printf('%d', '3.14abc')",
+    "SELECT printf('%f', 'not_a_number')",
+    "SELECT printf('%f', '42')",
+    "SELECT printf('%x', 'ff')",
+    "SELECT printf('%s', 42)",
+    "SELECT printf('%s', 3.14)",
+    // NULL handling
+    "SELECT printf('%s', NULL)",
+    "SELECT printf('%d', NULL)",
+    "SELECT printf('%f', NULL)",
+    "SELECT printf('%q', NULL)",
+    "SELECT printf('%Q', NULL)",
+    "SELECT printf('%w', NULL)",
+    "SELECT printf('%c', NULL)",
+    // Rounding half-away-from-zero
+    "SELECT printf('%.0f', 0.5)",
+    "SELECT printf('%.0f', 1.5)",
+    "SELECT printf('%.0f', 2.5)",
+    "SELECT printf('%.0f', 3.5)",
+    "SELECT printf('%.0f', 4.5)",
+    "SELECT printf('%.0f', -0.5)",
+    "SELECT printf('%.0f', -1.5)",
+    "SELECT printf('%.1f', 0.25)",
+    "SELECT printf('%.2f', 0.125)",
+    "SELECT printf('%.0e', 2.5)",
+    "SELECT printf('%.0e', 4.5)",
+    // %g threshold rounding
+    "SELECT printf('%g', 999999.5)",
+    "SELECT printf('%.1g', 9.5)",
+    "SELECT printf('%.2g', 99.5)",
+    "SELECT printf('%.3g', 999.5)",
+    // Infinity and NaN
+    "SELECT printf('%f', 1e308*10)",
+    "SELECT printf('%e', 1e308*10)",
+    "SELECT printf('%g', 1e308*10)",
+    "SELECT printf('%020f', 1e308*10)",
+    "SELECT printf('%020e', 1e308*10)",
+    "SELECT printf('%020g', 1e308*10)",
+    "SELECT printf('%+f', 1e308*10)",
+    "SELECT printf('%f', -(1e308*10))",
+    "SELECT printf('%020f', -(1e308*10))",
+    "SELECT printf('%f', 0.0/0.0)",
+    "SELECT printf('%e', 0.0/0.0)",
+    "SELECT printf('%g', 0.0/0.0)",
+    "SELECT printf('%d', 0.0/0.0)",
+    // Negative zero
+    "SELECT printf('%f', -0.0)",
+    "SELECT printf('%e', -0.0)",
+    "SELECT printf('%g', -0.0)",
+    "SELECT printf('%d', -0.0)",
+    // Alternate flag (#)
+    "SELECT printf('%#x', 255)",
+    "SELECT printf('%#X', 255)",
+    "SELECT printf('%#o', 8)",
+    "SELECT printf('%#08x', 255)",
+    "SELECT printf('%#04x', 255)",
+    "SELECT printf('%#08o', 8)",
+    "SELECT printf('%#.0f', 3.0)",
+    "SELECT printf('%#.0e', 1.0)",
+    "SELECT printf('%#.0g', 1.0)",
+    "SELECT printf('%#g', 100000.0)",
+    "SELECT printf('%#.1g', 1.0)",
+    "SELECT printf('%#x', 0)",
+    // Alt-form-2 (!)
+    "SELECT printf('%!f', 1.0)",
+    "SELECT printf('%!f', 3.14)",
+    "SELECT printf('%!f', 0.0)",
+    "SELECT printf('%!.0f', 3.0)",
+    "SELECT printf('%!e', 23000000.0)",
+    "SELECT printf('%!.0e', 23000000.0)",
+    "SELECT printf('%!g', 100.0)",
+    "SELECT printf('%!g', 0.0)",
+    "SELECT printf('%!g', 0.000001)",
+    // Zero-pad ignored for strings/chars
+    "SELECT printf('%05s', 'hi')",
+    "SELECT printf('%05c', 'A')",
+    "SELECT printf('%05q', 'hi')",
+    "SELECT printf('%05Q', 'hi')",
+    // Flag conflicts: 0 + -
+    "SELECT printf('%-010.2f', 3.14)",
+    "SELECT printf('%-010d', 42)",
+    // Flag conflicts: + and space
+    "SELECT printf('%+ d', 42)",
+    "SELECT printf('% +d', 42)",
+    // Significant digit limiting
+    "SELECT printf('%.20f', 1.0/3.0)",
+    "SELECT printf('%.20e', 1.0/3.0)",
+    "SELECT printf('%.20g', 1.0/3.0)",
+    "SELECT printf('%.15f', 1234567890.123456789)",
+    // Comma separator
+    "SELECT printf('%,d', 1234567)",
+    "SELECT printf('%,d', -1234567)",
+    "SELECT printf('%,.2f', 1234567.89)",
+    "SELECT printf('%,d', 999)",
+    // Width and precision
+    "SELECT printf('%10d', 42)",
+    "SELECT printf('%010d', 42)",
+    "SELECT printf('%.5d', 42)",
+    "SELECT printf('%10.5d', 42)",
+    "SELECT printf('%10s', 'hi')",
+    "SELECT printf('%-10s', 'hi')",
+    "SELECT printf('%.3s', 'hello')",
+    "SELECT printf('%10.3s', 'hello')",
+    // %q/%Q/%w with width/precision
+    "SELECT printf('%10q', 'hi')",
+    "SELECT printf('%-10q', 'hi')",
+    "SELECT printf('%.2q', 'hello')",
+    "SELECT printf('%10Q', 'hi')",
+    "SELECT printf('%.2Q', 'hello')",
+    "SELECT printf('%10w', 'hi')",
+    "SELECT printf('%.2w', 'hello')",
+    // Extreme integers
+    "SELECT printf('%d', 9223372036854775807)",
+    "SELECT printf('%d', -9223372036854775808)",
+    "SELECT printf('%u', -1)",
+    "SELECT printf('%x', -1)",
+    "SELECT printf('%o', -1)",
+    // Blob handling
+    "SELECT printf('%s', X'48656C6C6F')",
+    "SELECT printf('%s', X'48004C')",
+    "SELECT printf('%d', X'3432')",
+    // Trailing percent
+    "SELECT printf('test%')",
+    // Percent escape
+    "SELECT printf('100%% done')",
+    "SELECT printf('%%%%')",
+    // Multiple specifiers
+    "SELECT printf('%d %s %f', 42, 'hello', 3.14)",
+    "SELECT printf('%d|%d|%d', 1, 2, 3)",
+    // Dynamic width/precision
+    "SELECT printf('%*d', 10, 42)",
+    "SELECT printf('%*d', -10, 42)",
+    "SELECT printf('%.*f', 2, 3.14159)",
+    "SELECT printf('%*.*f', 10, 2, 3.14159)",
+    // %n (silently ignored)
+    "SELECT printf('%n')",
+    "SELECT printf('before%nafter')",
+    // Extra arguments (should be ignored)
+    "SELECT printf('%d', 1, 2, 3)",
+    "SELECT printf('hello', 1, 2)",
+    // Non-string format argument
+    "SELECT printf(123)",
+    "SELECT printf(3.14)",
+    "SELECT printf(NULL) IS NULL",
+    // Large precision on various types
+    "SELECT printf('%.50f', 1.0)",
+    "SELECT printf('%.0f', 1e20)",
+    "SELECT printf('%.50d', 42)",
+    // Precision 0 special cases
+    "SELECT printf('%.0f', 0.0)",
+    "SELECT printf('%.0g', 0.0)",
+    "SELECT printf('%.0e', 0.0)",
+    "SELECT printf('%.0d', 0)",
+    "SELECT printf('%.0x', 0)",
+    "SELECT printf('%.0o', 0)",
+    "SELECT printf('%.0s', 'hello')",
+];
+
+/// Adversarial printf SQL generator.
+pub struct PrintfGenerator {
+    rng: ChaCha8Rng,
+    /// Probability (0.0-1.0) that an argument will be a corner case.
+    corner_case_prob: f64,
+}
+
+impl PrintfGenerator {
+    pub fn new(rng: ChaCha8Rng) -> Self {
+        Self {
+            rng,
+            corner_case_prob: 0.5,
+        }
+    }
+
+    /// Generate a random printf SQL statement.
+    pub fn gen_printf_sql(&mut self) -> String {
+        let (format_str, specifiers) = self.gen_format_string();
+        let args = self.gen_args(&specifiers);
+
+        if args.is_empty() {
+            format!("SELECT printf('{format_str}')")
+        } else {
+            format!("SELECT printf('{}', {})", format_str, args.join(", "))
+        }
+    }
+
+    /// Generate a format string and return it along with the specifier chars
+    /// (needed so we can generate appropriately typed or mistyped args).
+    fn gen_format_string(&mut self) -> (String, Vec<SpecInfo>) {
+        let num_specifiers = self.rng.random_range(1..=4);
+        let mut format_str = String::new();
+        let mut specifiers = Vec::new();
+
+        for i in 0..num_specifiers {
+            // Sometimes add literal text between specifiers
+            if i > 0 && self.rng.random_bool(0.5) {
+                let literals = [" ", "|", ", ", " - ", ": ", "  "];
+                let lit = literals[self.rng.random_range(0..literals.len())];
+                format_str.push_str(lit);
+            }
+
+            // Occasionally insert %%
+            if self.rng.random_bool(0.1) {
+                format_str.push_str("%%");
+            }
+
+            let spec = self.gen_specifier();
+            format_str.push('%');
+
+            // Flags
+            for &flag in &spec.flags {
+                format_str.push(flag);
+            }
+
+            // Width
+            match spec.width {
+                Width::None => {}
+                Width::Fixed(n) => {
+                    format_str.push_str(&n.to_string());
+                }
+                Width::Dynamic => {
+                    format_str.push('*');
+                    specifiers.push(SpecInfo {
+                        spec_type: '*',
+                        flags: Vec::new(),
+                    });
+                }
+            }
+
+            // Precision
+            match spec.precision {
+                Precision::None => {}
+                Precision::Fixed(n) => {
+                    format_str.push('.');
+                    format_str.push_str(&n.to_string());
+                }
+                Precision::Dynamic => {
+                    format_str.push_str(".*");
+                    specifiers.push(SpecInfo {
+                        spec_type: '*',
+                        flags: Vec::new(),
+                    });
+                }
+            }
+
+            format_str.push(spec.spec_type);
+            specifiers.push(SpecInfo {
+                spec_type: spec.spec_type,
+                flags: spec.flags.clone(),
+            });
+        }
+
+        // Occasionally add trailing %
+        if self.rng.random_bool(0.05) {
+            format_str.push('%');
+        }
+
+        (format_str, specifiers)
+    }
+
+    /// Generate a single format specifier with random flags, width, precision, type.
+    fn gen_specifier(&mut self) -> Specifier {
+        // Type selection
+        let spec_type = if self.rng.random_bool(0.05) {
+            // 5% chance of unknown/invalid specifier
+            let invalid = ['y', 'j', 'b', 'a'];
+            invalid[self.rng.random_range(0..invalid.len())]
+        } else {
+            SPECIFIER_TYPES[self.rng.random_range(0..SPECIFIER_TYPES.len())]
+        };
+
+        // Flags - biased toward conflicting combinations
+        let mut flags = Vec::new();
+        if self.rng.random_bool(0.3) {
+            // Conflicting: 0 and -
+            flags.push('0');
+            flags.push('-');
+        } else {
+            for &flag in FLAGS {
+                if self.rng.random_bool(0.25) {
+                    flags.push(flag);
+                }
+            }
+        }
+        // Sometimes add + and space together (conflicting)
+        if self.rng.random_bool(0.15) && !flags.contains(&'+') && !flags.contains(&' ') {
+            flags.push('+');
+            flags.push(' ');
+        }
+
+        // Width
+        let width_roll: f64 = self.rng.random();
+        let width = if width_roll < 0.40 {
+            Width::None
+        } else if width_roll < 0.60 {
+            Width::Fixed(self.rng.random_range(1..=10))
+        } else if width_roll < 0.80 {
+            Width::Fixed(self.rng.random_range(10..=50))
+        } else if width_roll < 0.90 {
+            Width::Dynamic
+        } else {
+            Width::Fixed(self.rng.random_range(100..=1000))
+        };
+
+        // Precision - biased toward boundary values
+        let prec_roll: f64 = self.rng.random();
+        let precision = if prec_roll < 0.30 {
+            Precision::None
+        } else if prec_roll < 0.50 {
+            Precision::Fixed(0)
+        } else if prec_roll < 0.70 {
+            Precision::Fixed(self.rng.random_range(1..=6))
+        } else if prec_roll < 0.85 {
+            // Boundary: 15-16 is where IEEE precision breaks down
+            let boundary = [15, 16, 17, 20];
+            Precision::Fixed(boundary[self.rng.random_range(0..boundary.len())])
+        } else if prec_roll < 0.95 {
+            Precision::Fixed(self.rng.random_range(20..=50))
+        } else {
+            Precision::Dynamic
+        };
+
+        Specifier {
+            spec_type,
+            flags,
+            width,
+            precision,
+        }
+    }
+
+    /// Generate arguments for the given specifiers.
+    /// Deliberately introduces argument count mismatches.
+    fn gen_args(&mut self, specifiers: &[SpecInfo]) -> Vec<String> {
+        let arg_consuming: Vec<&SpecInfo> =
+            specifiers.iter().filter(|s| s.spec_type != 'n').collect();
+
+        if arg_consuming.is_empty() {
+            // No args needed, but sometimes generate extra
+            if self.rng.random_bool(0.2) {
+                return vec![self.gen_random_arg()];
+            }
+            return Vec::new();
+        }
+
+        let roll: f64 = self.rng.random();
+        if roll < 0.50 {
+            // Exact match
+            arg_consuming.iter().map(|s| self.gen_arg(s)).collect()
+        } else if roll < 0.70 {
+            // Too few args
+            let count = self.rng.random_range(0..arg_consuming.len());
+            arg_consuming[..count]
+                .iter()
+                .map(|s| self.gen_arg(s))
+                .collect()
+        } else if roll < 0.80 {
+            // Zero args despite having specifiers
+            Vec::new()
+        } else if roll < 0.90 {
+            // Too many args
+            let mut args: Vec<String> = arg_consuming.iter().map(|s| self.gen_arg(s)).collect();
+            let extra = self.rng.random_range(1..=3);
+            for _ in 0..extra {
+                args.push(self.gen_random_arg());
+            }
+            args
+        } else {
+            // All NULL args
+            vec!["NULL".to_string(); arg_consuming.len()]
+        }
+    }
+
+    /// Generate an argument for a specifier. Uses corner_case_prob to decide
+    /// whether to generate a matched or mismatched arg.
+    fn gen_arg(&mut self, spec: &SpecInfo) -> String {
+        if self.rng.random_bool(self.corner_case_prob) {
+            self.gen_corner_case_arg(spec)
+        } else {
+            self.gen_matched_arg(spec)
+        }
+    }
+
+    /// Generate an argument that matches the specifier's expected type.
+    fn gen_matched_arg(&mut self, spec: &SpecInfo) -> String {
+        match spec.spec_type {
+            '*' => {
+                // Width/precision: use small values to avoid GB-sized output
+                self.rng.random_range(-200..=500).to_string()
+            }
+            'd' | 'i' | 'u' | 'x' | 'X' | 'o' | 'p' | 'r' => self.gen_integer_arg(),
+            'f' | 'e' | 'E' | 'g' | 'G' => self.gen_float_arg(),
+            's' | 'c' | 'q' | 'Q' | 'w' => self.gen_string_arg(),
+            _ => self.gen_random_arg(),
+        }
+    }
+
+    /// Generate a deliberately wrong or extreme argument for a specifier.
+    fn gen_corner_case_arg(&mut self, spec: &SpecInfo) -> String {
+        let roll: f64 = self.rng.random();
+        if roll < 0.25 {
+            // NULL
+            "NULL".to_string()
+        } else if roll < 0.50 {
+            // Wrong type entirely
+            match spec.spec_type {
+                'd' | 'i' | 'u' | 'x' | 'X' | 'o' | 'p' | 'r' => {
+                    // Int specifier gets string or float
+                    if self.rng.random_bool(0.5) {
+                        self.gen_string_arg()
+                    } else {
+                        self.gen_float_arg()
+                    }
+                }
+                'f' | 'e' | 'E' | 'g' | 'G' => {
+                    // Float specifier gets string or integer
+                    if self.rng.random_bool(0.5) {
+                        self.gen_string_arg()
+                    } else {
+                        self.gen_integer_arg()
+                    }
+                }
+                's' | 'c' => {
+                    // String specifier gets int, float, or blob
+                    let r: f64 = self.rng.random();
+                    if r < 0.33 {
+                        self.gen_integer_arg()
+                    } else if r < 0.66 {
+                        self.gen_float_arg()
+                    } else {
+                        self.gen_blob_arg()
+                    }
+                }
+                'q' | 'Q' | 'w' => {
+                    // SQL quoting gets int, float, blob, or NULL
+                    let r: f64 = self.rng.random();
+                    if r < 0.25 {
+                        self.gen_integer_arg()
+                    } else if r < 0.50 {
+                        self.gen_float_arg()
+                    } else if r < 0.75 {
+                        self.gen_blob_arg()
+                    } else {
+                        "NULL".to_string()
+                    }
+                }
+                '*' => {
+                    // Dynamic width/precision gets string or negative
+                    if self.rng.random_bool(0.5) {
+                        self.gen_string_arg()
+                    } else {
+                        format!("{}", self.rng.random_range(-100..=0i64))
+                    }
+                }
+                _ => self.gen_random_arg(),
+            }
+        } else {
+            // Extreme value for the correct type
+            self.gen_extreme_arg(spec)
+        }
+    }
+
+    /// Generate an extreme but type-appropriate argument.
+    fn gen_extreme_arg(&mut self, spec: &SpecInfo) -> String {
+        match spec.spec_type {
+            '*' => {
+                // Width/precision args should be small to avoid huge output
+                let extremes: &[&str] = &[
+                    "0", "-1", "1", "5", "10", "20", "50", "100", "200", "-20", "-69", "500",
+                    "-500",
+                ];
+                extremes[self.rng.random_range(0..extremes.len())].to_string()
+            }
+            'd' | 'i' | 'u' | 'x' | 'X' | 'o' | 'p' | 'r' => {
+                let extremes: &[&str] = &[
+                    "0",
+                    "-1",
+                    "1",
+                    "9223372036854775807",  // i64::MAX
+                    "-9223372036854775808", // i64::MIN
+                    "256",
+                    "65536",
+                    "4294967296",
+                    "-2147483648", // i32::MIN
+                    "2147483647",  // i32::MAX
+                ];
+                extremes[self.rng.random_range(0..extremes.len())].to_string()
+            }
+            'f' | 'e' | 'E' | 'g' | 'G' => {
+                let extremes: &[&str] = &[
+                    "0.0",
+                    "-0.0",
+                    "0.5",
+                    "1.5",
+                    "2.5",
+                    "3.5",
+                    "4.5",
+                    "-0.5",
+                    "-1.5",
+                    "-2.5",
+                    "0.0/0.0",     // NaN
+                    "1e308*10",    // +Inf
+                    "-(1e308*10)", // -Inf
+                    "1.0/3.0",     // repeating decimal
+                    "1e20",
+                    "1e-300",
+                    "999999.5",             // %g threshold
+                    "9.5",                  // %.1g threshold
+                    "99.5",                 // %.2g threshold
+                    "0.25",                 // half-away boundary
+                    "0.125",                // half-away boundary
+                    "1234567890.123456789", // sig digit test
+                ];
+                extremes[self.rng.random_range(0..extremes.len())].to_string()
+            }
+            's' | 'c' | 'q' | 'Q' | 'w' => {
+                let extremes: &[&str] = &[
+                    "''",
+                    "'hello'",
+                    "'it''s a test'",
+                    "'42'",
+                    "'3.14'",
+                    "'-0'",
+                    "'1e5'",
+                    "'  spaces  '",
+                    "X'48004C'", // blob with NUL
+                    "X'FF80'",   // invalid UTF-8 blob
+                    "X'00'",     // just NUL
+                    "X''",       // empty blob
+                    "NULL",
+                ];
+                extremes[self.rng.random_range(0..extremes.len())].to_string()
+            }
+            _ => self.gen_random_arg(),
+        }
+    }
+
+    /// Generate a random integer SQL literal.
+    fn gen_integer_arg(&mut self) -> String {
+        let roll: f64 = self.rng.random();
+        if roll < 0.3 {
+            // Small integers
+            format!("{}", self.rng.random_range(-100..=100i64))
+        } else if roll < 0.6 {
+            // Common values
+            let common = [0, 1, -1, 42, -42, 255, 256, 1000];
+            format!("{}", common[self.rng.random_range(0..common.len())])
+        } else {
+            // Large/extreme values
+            let extreme: &[i64] = &[
+                i64::MAX,
+                i64::MIN,
+                i32::MAX as i64,
+                i32::MIN as i64,
+                u32::MAX as i64,
+            ];
+            format!("{}", extreme[self.rng.random_range(0..extreme.len())])
+        }
+    }
+
+    /// Generate a random float SQL literal (possibly as expression for NaN/Inf).
+    fn gen_float_arg(&mut self) -> String {
+        let roll: f64 = self.rng.random();
+        if roll < 0.3 {
+            // Small floats
+            format!("{:.6}", self.rng.random_range(-100.0..100.0f64))
+        } else if roll < 0.6 {
+            // Common values
+            let common = ["0.0", "1.0", "-1.0", "3.14", "-3.14", "0.5", "1.5", "2.5"];
+            common[self.rng.random_range(0..common.len())].to_string()
+        } else {
+            // Extreme values
+            let extreme = [
+                "0.0/0.0",     // NaN
+                "1e308*10",    // Inf
+                "-(1e308*10)", // -Inf
+                "-0.0",
+                "1e20",
+                "1e-10",
+                "1e308",
+                "1.0/3.0",
+                "999999.5",
+            ];
+            extreme[self.rng.random_range(0..extreme.len())].to_string()
+        }
+    }
+
+    /// Generate a random string SQL literal (properly escaped).
+    fn gen_string_arg(&mut self) -> String {
+        let roll: f64 = self.rng.random();
+        if roll < 0.3 {
+            // Simple strings
+            let simple = ["'hello'", "'world'", "'test'", "'abc'", "'A'", "'hi'"];
+            simple[self.rng.random_range(0..simple.len())].to_string()
+        } else if roll < 0.6 {
+            // Numeric strings (coercion tests)
+            let numeric = [
+                "'42'", "'3.14'", "'-0'", "'1e5'", "'0xff'", "'123abc'", "''",
+            ];
+            numeric[self.rng.random_range(0..numeric.len())].to_string()
+        } else {
+            // Strings with special chars
+            let special = [
+                "'it''s'",
+                "'he said \"hi\"'",
+                "'  spaces  '",
+                "'line1\nline2'",
+                "''",
+            ];
+            special[self.rng.random_range(0..special.len())].to_string()
+        }
+    }
+
+    /// Generate a random blob SQL literal.
+    fn gen_blob_arg(&mut self) -> String {
+        let blobs = [
+            "X'48656C6C6F'", // "Hello"
+            "X'48004C'",     // H\0L (NUL inside)
+            "X'FF80'",       // invalid UTF-8
+            "X'00'",         // just NUL
+            "X''",           // empty
+            "X'3432'",       // "42" as bytes
+        ];
+        blobs[self.rng.random_range(0..blobs.len())].to_string()
+    }
+
+    /// Generate a random argument of any type.
+    fn gen_random_arg(&mut self) -> String {
+        let roll: f64 = self.rng.random();
+        if roll < 0.25 {
+            self.gen_integer_arg()
+        } else if roll < 0.50 {
+            self.gen_float_arg()
+        } else if roll < 0.75 {
+            self.gen_string_arg()
+        } else if roll < 0.90 {
+            "NULL".to_string()
+        } else {
+            self.gen_blob_arg()
+        }
+    }
+}
+
+/// Internal representation of a format specifier during generation.
+struct Specifier {
+    spec_type: char,
+    flags: Vec<char>,
+    width: Width,
+    precision: Precision,
+}
+
+/// Info about a generated specifier, kept for argument generation.
+pub struct SpecInfo {
+    pub spec_type: char,
+    pub flags: Vec<char>,
+}
+
+#[derive(Clone)]
+enum Width {
+    None,
+    Fixed(usize),
+    Dynamic,
+}
+
+#[derive(Clone)]
+enum Precision {
+    None,
+    Fixed(usize),
+    Dynamic,
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng;
+
+    use super::*;
+
+    #[test]
+    fn test_generator_deterministic() {
+        let rng1 = ChaCha8Rng::seed_from_u64(42);
+        let rng2 = ChaCha8Rng::seed_from_u64(42);
+        let mut generator1 = PrintfGenerator::new(rng1);
+        let mut generator2 = PrintfGenerator::new(rng2);
+
+        for _ in 0..100 {
+            assert_eq!(generator1.gen_printf_sql(), generator2.gen_printf_sql());
+        }
+    }
+
+    #[test]
+    fn test_generator_produces_valid_sql() {
+        let rng = ChaCha8Rng::seed_from_u64(12345);
+        let mut generator = PrintfGenerator::new(rng);
+
+        for _ in 0..100 {
+            let sql = generator.gen_printf_sql();
+            assert!(sql.starts_with("SELECT printf("));
+            assert!(sql.ends_with(')'));
+        }
+    }
+
+    #[test]
+    fn test_edge_cases_are_valid_sql() {
+        for sql in EDGE_CASE_BATTERY {
+            assert!(
+                sql.starts_with("SELECT printf("),
+                "Invalid edge case: {sql}"
+            );
+        }
+    }
+}

--- a/testing/runner/tests/scalar-functions-printf.sqltest
+++ b/testing/runner/tests/scalar-functions-printf.sqltest
@@ -1,6 +1,9 @@
 @database :memory:
 
-# Basic string formatting
+# ============================================
+# Basic string formatting (no flags/width/precision)
+# ============================================
+
 test printf-basic-string {
     SELECT printf('Hello World!');
 }
@@ -13,13 +16,6 @@ test printf-string-replacement {
 }
 expect {
     Hello, Alice
-}
-
-test printf-string-substitution {
-    SELECT printf('Hello, %s!', 'World');
-}
-expect {
-    Hello, World!
 }
 
 test printf-multiple-strings {
@@ -50,8 +46,11 @@ expect {
     100% complete
 }
 
-# Integer formatting
-test printf-integer-replacement {
+# ============================================
+# Basic integer formatting
+# ============================================
+
+test printf-integer-basic {
     SELECT printf('Number: %d', 42);
 }
 expect {
@@ -65,7 +64,7 @@ expect {
     Number: -42
 }
 
-test printf-integer-arithmetic-expression {
+test printf-integer-arithmetic {
     SELECT printf('%d + %d = %d', 2, 3, 5);
 }
 expect {
@@ -79,19 +78,29 @@ expect {
     Number: 0
 }
 
-# Unsigned integer formatting
-test printf-unsigned-basic {
-    SELECT printf('Number: %u', 42);
+test printf-float-as-integer {
+    SELECT printf('Truncated: %d', 3.9);
+}
+expect {
+    Truncated: 3
+}
+
+test printf-i-specifier {
+    SELECT printf('Number: %i', 42);
 }
 expect {
     Number: 42
 }
 
-test printf-unsigned-arithmetic-expression {
-    SELECT printf('%u + %u = %u', 2, 3, 5);
+# ============================================
+# Unsigned integer formatting
+# ============================================
+
+test printf-unsigned-basic {
+    SELECT printf('Number: %u', 42);
 }
 expect {
-    2 + 3 = 5
+    Number: 42
 }
 
 test printf-unsigned-negative {
@@ -101,14 +110,17 @@ expect {
     Negative: 18446744073709551615
 }
 
-test printf-text-as-unsigned {
+test printf-unsigned-text {
     SELECT printf('NaN: %u', 'not a number');
 }
 expect {
     NaN: 0
 }
 
-# Float formatting
+# ============================================
+# Basic float formatting
+# ============================================
+
 test printf-float-basic {
     SELECT printf('Number: %f', 42.5);
 }
@@ -130,13 +142,6 @@ expect {
     Number: 42.000000
 }
 
-test printf-float-arithmetic {
-    SELECT printf('%f + %f = %f', 2.5, 3.5, 6.0);
-}
-expect {
-    2.500000 + 3.500000 = 6.000000
-}
-
 test printf-text-as-float {
     SELECT printf('Number: %f', 'not a number');
 }
@@ -144,243 +149,568 @@ expect {
     Number: 0.000000
 }
 
-# Character formatting
-test printf-char-single {
-    SELECT printf('character: %c', 'a');
+# ============================================
+# Width and precision - float
+# ============================================
+
+test printf-float-precision-2 {
+    SELECT printf('%.2f', 4.0020);
 }
 expect {
-    character: a
+    4.00
 }
 
-test printf-char-first-from-string {
-    SELECT printf('character: %c', 'this is a test');
+test printf-float-precision-0 {
+    SELECT printf('%.0f', 3.0);
 }
 expect {
-    character: t
+    3
 }
 
-test printf-char-empty-string {
-    SELECT printf('character: %c', '');
-}
-expect raw {
-character: 
-}
-
-test printf-char-from-integer {
-    SELECT printf('character: %c', 123);
+test printf-float-precision-10 {
+    SELECT printf('%.10f', 1.0/3.0);
 }
 expect {
-    character: 1
+    0.3333333333
 }
 
-test printf-char-from-float {
-    SELECT printf('character: %c', 42.5);
+test printf-float-width {
+    SELECT '|' || printf('%10f', 3.14) || '|';
 }
 expect {
-    character: 4
+    |  3.140000|
 }
 
-# Exponential notation formatting
-test printf-exp-large-number {
-    SELECT printf('Exp: %e', 23000000.0);
+test printf-float-width-precision {
+    SELECT '|' || printf('%10.2f', 3.14) || '|';
 }
 expect {
-    Exp: 2.300000e+07
+    |      3.14|
 }
 
-test printf-exp-negative-large {
-    SELECT printf('Exp: %e', -23000000.0);
+test printf-float-zero-pad {
+    SELECT printf('%010.2f', 3.14);
 }
 expect {
-    Exp: -2.300000e+07
+    0000003.14
 }
 
-test printf-exp-decimal-float {
-    SELECT printf('Exp: %e', 250.375);
+test printf-float-left-justify {
+    SELECT '|' || printf('%-10.2f', 3.14) || '|';
 }
 expect {
-    Exp: 2.503750e+02
+    |3.14      |
 }
 
-test printf-exp-small-positive {
-    SELECT printf('Exp: %e', 0.0003235);
+test printf-float-force-sign {
+    SELECT printf('%+.2f', 3.14);
 }
 expect {
-    Exp: 3.235000e-04
+    +3.14
 }
 
-test printf-exp-zero {
-    SELECT printf('Exp: %e', 0.0);
+test printf-float-force-sign-negative {
+    SELECT printf('%+.2f', -3.14);
 }
 expect {
-    Exp: 0.000000e+00
+    -3.14
 }
 
-test printf-exp-small-positive-duplicate {
-    SELECT printf('Exp: %e', 0.0003235);
+test printf-float-space-sign {
+    SELECT '|' || printf('% .2f', 3.14) || '|';
 }
 expect {
-    Exp: 3.235000e-04
+    | 3.14|
 }
 
-test printf-exp-string-integer {
-    SELECT printf('Exp: %e', '123');
+test printf-float-space-sign-negative {
+    SELECT printf('% .2f', -3.14);
 }
 expect {
-    Exp: 1.230000e+02
+    -3.14
 }
 
-test printf-exp-string-float {
-    SELECT printf('Exp: %e', '123.45');
+# ============================================
+# Width and precision - integer
+# ============================================
+
+test printf-int-width {
+    SELECT '|' || printf('%10d', 42) || '|';
 }
 expect {
-    Exp: 1.234500e+02
+    |        42|
 }
 
-test printf-exp-string-leading-zeros {
-    SELECT printf('Exp: %e', '00123');
+test printf-int-zero-pad {
+    SELECT printf('%05d', 42);
 }
 expect {
-    Exp: 1.230000e+02
+    00042
 }
 
-test printf-exp-string-text {
-    SELECT printf('Exp: %e', 'test');
+test printf-int-left-justify {
+    SELECT '|' || printf('%-10d', 42) || '|';
 }
 expect {
-    Exp: 0.000000e+00
+    |42        |
 }
 
-test printf-exp-string-number-suffix {
-    SELECT printf('Exp: %e', '123ab');
+test printf-int-force-sign {
+    SELECT printf('%+d', 42);
 }
 expect {
-    Exp: 1.230000e+02
+    +42
 }
 
-test printf-exp-string-text-prefix {
-    SELECT printf('Exp: %e', 'ab123');
+test printf-int-space-sign {
+    SELECT '|' || printf('% d', 42) || '|';
 }
 expect {
-    Exp: 0.000000e+00
+    | 42|
 }
 
-test printf-exp-string-exponential {
-    SELECT printf('Exp: %e', '1.230000e+02');
+test printf-int-precision {
+    SELECT printf('%.5d', 42);
 }
 expect {
-    Exp: 1.230000e+02
+    00042
 }
 
-# hexadecimal formatting
-test printf-hex-simple {
-    SELECT printf('hex: %x', 4);
+test printf-int-precision-zero-value {
+    SELECT printf('%.0d', 0);
 }
 expect {
-    hex: 4
+    0
 }
 
-test printf-hex-large-number {
-    SELECT printf('hex: %x', 15565303546);
+test printf-int-width-and-precision {
+    SELECT '|' || printf('%10.5d', 42) || '|';
 }
 expect {
-    hex: 39fc3aefa
+    |     00042|
 }
 
-test printf-hex-uppercase {
-    SELECT printf('hex: %X', 15565303546);
+# ============================================
+# Width and precision - string
+# ============================================
+
+test printf-string-width {
+    SELECT '|' || printf('%10s', 'hi') || '|';
 }
 expect {
-    hex: 39FC3AEFA
+    |        hi|
+}
+
+test printf-string-left-justify {
+    SELECT '|' || printf('%-10s', 'hi') || '|';
+}
+expect {
+    |hi        |
+}
+
+test printf-string-precision-truncate {
+    SELECT printf('%.3s', 'hello');
+}
+expect {
+    hel
+}
+
+test printf-string-width-and-precision {
+    SELECT '|' || printf('%10.3s', 'hello') || '|';
+}
+expect {
+    |       hel|
+}
+
+# ============================================
+# Dynamic width and precision with *
+# ============================================
+
+test printf-dynamic-width {
+    SELECT '|' || printf('%*d', 10, 42) || '|';
+}
+expect {
+    |        42|
+}
+
+test printf-dynamic-width-negative {
+    SELECT '|' || printf('%*d', -10, 42) || '|';
+}
+expect {
+    |42        |
+}
+
+test printf-dynamic-precision {
+    SELECT printf('%.*f', 2, 3.14159);
+}
+expect {
+    3.14
+}
+
+test printf-dynamic-width-and-precision {
+    SELECT '|' || printf('%*.*f', 10, 2, 3.14159) || '|';
+}
+expect {
+    |      3.14|
+}
+
+# ============================================
+# Hexadecimal formatting
+# ============================================
+
+test printf-hex-basic {
+    SELECT printf('%x', 255);
+}
+expect {
+    ff
+}
+
+test printf-hex-upper {
+    SELECT printf('%X', 255);
+}
+expect {
+    FF
+}
+
+test printf-hex-width-zero-pad {
+    SELECT printf('%08x', 255);
+}
+expect {
+    000000ff
+}
+
+test printf-hex-alternate {
+    SELECT printf('%#x', 255);
+}
+expect {
+    0xff
 }
 
 test printf-hex-negative {
-    SELECT printf('hex: %x', -15565303546);
+    SELECT printf('%x', -1);
 }
 expect {
-    hex: fffffffc603c5106
+    ffffffffffffffff
 }
 
-test printf-hex-float {
-    SELECT printf('hex: %x', 42.5);
+# ============================================
+# Pointer formatting (%p - uppercase hex in SQL context)
+# ============================================
+
+test printf-pointer-basic {
+    SELECT printf('%p', 42);
 }
 expect {
-    hex: 2a
+    2A
 }
 
-test printf-hex-negative-float {
-    SELECT printf('hex: %x', -42.5);
+test printf-pointer-zero {
+    SELECT printf('%p', 0);
 }
 expect {
-    hex: ffffffffffffffd6
+    0
 }
 
-test printf-hex-text {
-    SELECT printf('hex: %x', '42');
+test printf-hex-precision {
+    SELECT printf('%.8x', 255);
 }
 expect {
-    hex: 2a
+    000000ff
 }
 
-test printf-hex-empty-text {
-    SELECT printf('hex: %x', '');
+# ============================================
+# Octal formatting
+# ============================================
+
+test printf-octal-basic {
+    SELECT printf('%o', 8);
 }
 expect {
-    hex: 0
+    10
 }
 
-# octal formatting
-test printf-octal-simple {
-    SELECT printf('octal: %o', 4);
+test printf-octal-alternate {
+    SELECT printf('%#o', 8);
 }
 expect {
-    octal: 4
+    010
 }
 
-test printf-octal-large-number {
-    SELECT printf('octal: %o', 15565303546);
+test printf-octal-width {
+    SELECT '|' || printf('%10o', 8) || '|';
 }
 expect {
-    octal: 163760727372
+    |        10|
 }
 
-test printf-octal-negative {
-    SELECT printf('octal: %o', -15565303546);
+# ============================================
+# Exponential formatting
+# ============================================
+
+test printf-exp-basic {
+    SELECT printf('%e', 23000000.0);
 }
 expect {
-    octal: 1777777777614017050406
+    2.300000e+07
 }
 
-test printf-octal-float {
-    SELECT printf('octal: %o', 42.5);
+test printf-exp-uppercase {
+    SELECT printf('%E', 23000000.0);
 }
 expect {
-    octal: 52
+    2.300000E+07
 }
 
-test printf-octal-negative-float {
-    SELECT printf('octal: %o', -42.5);
+test printf-exp-precision {
+    SELECT printf('%.2e', 23000000.0);
 }
 expect {
-    octal: 1777777777777777777726
+    2.30e+07
 }
 
-test printf-octal-text {
-    SELECT printf('octal: %o', '42');
+test printf-exp-zero {
+    SELECT printf('%e', 0.0);
 }
 expect {
-    octal: 52
+    0.000000e+00
 }
 
-test printf-octal-empty-text {
-    SELECT printf('octal: %o', '');
+test printf-exp-small {
+    SELECT printf('%e', 0.0003235);
 }
 expect {
-    octal: 0
+    3.235000e-04
 }
 
-# mixed formatting
-test printf-mixed-string-integer {
+test printf-exp-negative {
+    SELECT printf('%e', -23000000.0);
+}
+expect {
+    -2.300000e+07
+}
+
+# ============================================
+# General float formatting (%g/%G)
+# ============================================
+
+test printf-g-basic {
+    SELECT printf('%g', 100.0);
+}
+expect {
+    100
+}
+
+test printf-g-small {
+    SELECT printf('%g', 0.00123);
+}
+expect {
+    0.00123
+}
+
+test printf-g-very-small {
+    SELECT printf('%g', 0.000001);
+}
+expect {
+    1e-06
+}
+
+test printf-g-large {
+    SELECT printf('%g', 1234567.0);
+}
+expect {
+    1.23457e+06
+}
+
+test printf-g-precision-2 {
+    SELECT printf('%.2g', 123.456);
+}
+expect {
+    1.2e+02
+}
+
+test printf-g-precision-3 {
+    SELECT printf('%.3g', 123.456);
+}
+expect {
+    123
+}
+
+test printf-g-trailing-zeros {
+    SELECT printf('%g', 1.0);
+}
+expect {
+    1
+}
+
+test printf-g-trailing-zeros-2 {
+    SELECT printf('%g', 1.50);
+}
+expect {
+    1.5
+}
+
+test printf-G-basic {
+    SELECT printf('%G', 0.000001);
+}
+expect {
+    1E-06
+}
+
+test printf-g-integer {
+    SELECT printf('%g', 42);
+}
+expect {
+    42
+}
+
+test printf-g-zero {
+    SELECT printf('%g', 0.0);
+}
+expect {
+    0
+}
+
+# ============================================
+# Character formatting (%c)
+# In SQL context, %c takes first char of string representation
+# ============================================
+
+test printf-char-from-string {
+    SELECT printf('%c', 'hello');
+}
+expect {
+    h
+}
+
+test printf-char-from-integer {
+    SELECT printf('%c', 65);
+}
+expect {
+    6
+}
+
+test printf-char-from-integer-single-digit {
+    SELECT printf('%c', 7);
+}
+expect {
+    7
+}
+
+test printf-char-width {
+    SELECT '|' || printf('%5c', 65) || '|';
+}
+expect {
+    |    6|
+}
+
+# ============================================
+# SQL quoting (%q, %Q, %w)
+# ============================================
+
+test printf-q-basic {
+    SELECT printf('%q', 'hello');
+}
+expect {
+    hello
+}
+
+test printf-q-with-quotes {
+    SELECT printf('%q', 'it''s');
+}
+expect {
+    it''s
+}
+
+test printf-q-null {
+    SELECT printf('%q', NULL);
+}
+expect {
+    (NULL)
+}
+
+test printf-Q-basic {
+    SELECT printf('%Q', 'hello');
+}
+expect {
+    'hello'
+}
+
+test printf-Q-with-quotes {
+    SELECT printf('%Q', 'it''s');
+}
+expect {
+    'it''s'
+}
+
+test printf-Q-null {
+    SELECT printf('%Q', NULL);
+}
+expect {
+    NULL
+}
+
+test printf-w-basic {
+    SELECT printf('%w', 'table_name');
+}
+expect {
+    table_name
+}
+
+test printf-w-with-double-quotes {
+    SELECT printf('%w', 'col"name');
+}
+expect {
+    col""name
+}
+
+# ============================================
+# Comma separator flag
+# ============================================
+
+test printf-comma-integer {
+    SELECT printf('%,d', 1234567);
+}
+expect {
+    1,234,567
+}
+
+test printf-comma-negative {
+    SELECT printf('%,d', -1234567);
+}
+expect {
+    -1,234,567
+}
+
+test printf-comma-float {
+    SELECT printf('%,.2f', 1234567.89);
+}
+expect {
+    1,234,567.89
+}
+
+test printf-comma-small {
+    SELECT printf('%,d', 999);
+}
+expect {
+    999
+}
+
+# ============================================
+# Alternate form (#)
+# ============================================
+
+test printf-alt-float-precision-0 {
+    SELECT printf('%#.0f', 3.0);
+}
+expect {
+    3.
+}
+
+# ============================================
+# Mixed formatting
+# ============================================
+
+test printf-mixed-basic {
     SELECT printf('%s: %d', 'Count', 42);
 }
 expect {
@@ -394,82 +724,29 @@ expect {
     Progress: 75 (75.500000%)
 }
 
-test printf-mixed-complex-format {
+test printf-mixed-complex {
     SELECT printf('Name: %s, ID: %d, Score: %f', 'John', 123, 95.5);
 }
 expect {
     Name: John, ID: 123, Score: 95.500000
 }
 
-test printf-mixed-string-exponential {
-    SELECT printf('Scientific: %s = %e', 'Large number', 123000.0);
+test printf-mixed-hex-pad {
+    SELECT printf('abc%03x', 10);
 }
 expect {
-    Scientific: Large number = 1.230000e+05
+    abc00a
 }
 
-test printf-mixed-integer-octal {
-    SELECT printf('Decimal %d is octal %o', 64, 64);
-}
-expect {
-    Decimal 64 is octal 100
-}
+# ============================================
+# Non-string format argument
+# ============================================
 
-test printf-mixed-exponential-float {
-    SELECT printf('Scientific %e equals %f', 0.00123, 0.00123);
-}
-expect {
-    Scientific 1.230000e-03 equals 0.001230
-}
-
-test printf-mixed-string-octal {
-    SELECT printf('Permission %s: %o', 'rwx', 755);
-}
-expect {
-    Permission rwx: 1363
-}
-
-test printf-mixed-exponential-integer {
-    SELECT printf('Value %e as integer %d', 42.7, 42);
-}
-expect {
-    Value 4.270000e+01 as integer 42
-}
-
-test printf-mixed-octal-hex {
-    SELECT printf('Octal %o is hex %x', 255, 255);
-}
-expect {
-    Octal 377 is hex ff
-}
-
-# Non-string format argument - should be converted to string
 test printf-format-integer {
     SELECT printf(123);
 }
 expect {
     123
-}
-
-test printf-format-integer-with-args {
-    SELECT printf(1, 'extra', 'args');
-}
-expect {
-    1
-}
-
-test printf-format-zero {
-    SELECT printf(0);
-}
-expect {
-    0
-}
-
-test printf-format-negative-integer {
-    SELECT printf(-42);
-}
-expect {
-    -42
 }
 
 test printf-format-float {
@@ -486,27 +763,6 @@ expect {
     1
 }
 
-test printf-format-null-with-args {
-    SELECT printf(NULL, 'a', 'b') IS NULL;
-}
-expect {
-    1
-}
-
-test printf-format-boolean-true {
-    SELECT printf(1 = 1);
-}
-expect {
-    1
-}
-
-test printf-format-boolean-false {
-    SELECT printf(1 = 0);
-}
-expect {
-    0
-}
-
 test printf-format-blob {
     SELECT printf(X'414243');
 }
@@ -514,3 +770,607 @@ expect {
     ABC
 }
 
+# ============================================
+# format() alias
+# ============================================
+
+test format-alias {
+    SELECT format('%.2f', 3.14);
+}
+expect {
+    3.14
+}
+
+# ============================================
+# Edge cases
+# ============================================
+
+test printf-empty-format {
+    SELECT printf('');
+}
+expect raw {
+
+}
+
+test printf-only-percent-escapes {
+    SELECT printf('%%%%');
+}
+expect {
+    %%
+}
+
+test printf-consecutive-specifiers {
+    SELECT printf('%d%d%d', 1, 2, 3);
+}
+expect {
+    123
+}
+
+test printf-text-numeric-prefix {
+    SELECT printf('%d', '123abc');
+}
+expect {
+    123
+}
+
+test printf-text-as-float-coerce {
+    SELECT printf('%f', '3.14');
+}
+expect {
+    3.140000
+}
+
+# ============================================
+# Alt-form-2 flag (!) - strip trailing zeros
+# ============================================
+
+test printf-altform2-float-basic {
+    SELECT printf('%!f', 3.14);
+}
+expect {
+    3.14
+}
+
+test printf-altform2-float-trailing {
+    SELECT printf('%!f', 1.0);
+}
+expect {
+    1.0
+}
+
+test printf-altform2-float-zero {
+    SELECT printf('%!f', 0.0);
+}
+expect {
+    0.0
+}
+
+test printf-altform2-float-precision-4 {
+    SELECT printf('%!.4f', 3.14);
+}
+expect {
+    3.14
+}
+
+test printf-altform2-float-precision-0 {
+    SELECT printf('%!.0f', 3.0);
+}
+expect {
+    3.0
+}
+
+test printf-altform2-float-negative {
+    SELECT printf('%!f', -3.14);
+}
+expect {
+    -3.14
+}
+
+test printf-altform2-float-sign {
+    SELECT printf('%!+f', 3.14);
+}
+expect {
+    +3.14
+}
+
+test printf-altform2-float-width {
+    SELECT '|' || printf('%!10.2f', 3.14) || '|';
+}
+expect {
+    |      3.14|
+}
+
+test printf-altform2-exp-basic {
+    SELECT printf('%!e', 23000000.0);
+}
+expect {
+    2.3e+07
+}
+
+test printf-altform2-exp-precision-0 {
+    SELECT printf('%!.0e', 23000000.0);
+}
+expect {
+    2.0e+07
+}
+
+test printf-altform2-exp-zero {
+    SELECT printf('%!e', 0.0);
+}
+expect {
+    0.0e+00
+}
+
+test printf-altform2-exp-precision-2 {
+    SELECT printf('%!.2e', 23000000.0);
+}
+expect {
+    2.3e+07
+}
+
+test printf-altform2-g-integer {
+    SELECT printf('%!g', 100.0);
+}
+expect {
+    100.0
+}
+
+test printf-altform2-g-zero {
+    SELECT printf('%!g', 0.0);
+}
+expect {
+    0.0
+}
+
+test printf-altform2-g-small-exp {
+    SELECT printf('%!g', 0.000001);
+}
+expect {
+    1.0e-06
+}
+
+test printf-altform2-g-has-decimal {
+    SELECT printf('%!g', 1.5);
+}
+expect {
+    1.5
+}
+
+test printf-altform2-g-negative {
+    SELECT printf('%!g', -100.0);
+}
+expect {
+    -100.0
+}
+
+# ============================================
+# Edge cases: large floats, infinity, neg zero, trailing %
+# ============================================
+
+test printf-float-large {
+    SELECT printf('%.0f', 1e20);
+}
+expect {
+    100000000000000000000
+}
+
+test printf-float-neg-zero {
+    SELECT printf('%f', -0.0);
+}
+expect {
+    0.000000
+}
+
+test printf-trailing-percent {
+    SELECT printf('test%');
+}
+expect {
+    test%
+}
+
+test printf-float-left-zero-combined {
+    SELECT '|' || printf('%-010.2f', 3.14) || '|';
+}
+expect {
+    |3.14      |
+}
+
+test printf-float-infinity {
+    SELECT printf('%f', 1e308*10);
+}
+expect {
+    Inf
+}
+
+test printf-float-neg-infinity {
+    SELECT printf('%f', -(1e308*10));
+}
+expect {
+    -Inf
+}
+
+test printf-exp-infinity {
+    SELECT printf('%e', 1e308*10);
+}
+expect {
+    Inf
+}
+
+test printf-g-infinity {
+    SELECT printf('%g', 1e308*10);
+}
+expect {
+    Inf
+}
+
+# ============================================
+# Rounding: half-away-from-zero (SQLite behavior)
+# ============================================
+
+# Half-away-from-zero rounding: these pass with SQLite 3.49.1+ but fail
+# with 3.43.2 (which uses half-to-even). Unclear which intermediate version
+# switched to half-away-from-zero via sqlite3FpDecode.
+test printf-round-half-away-0 {
+    SELECT printf('%.0f', 0.5);
+}
+expect {
+    1
+}
+
+test printf-round-half-away-1 {
+    SELECT printf('%.0f', 2.5);
+}
+expect {
+    3
+}
+
+test printf-round-half-away-2 {
+    SELECT printf('%.0f', 4.5);
+}
+expect {
+    5
+}
+
+test printf-round-half-away-neg {
+    SELECT printf('%.0f', -0.5);
+}
+expect {
+    -1
+}
+
+test printf-round-half-away-1dp {
+    SELECT printf('%.1f', 0.25);
+}
+expect {
+    0.3
+}
+
+test printf-round-half-away-2dp {
+    SELECT printf('%.2f', 0.125);
+}
+expect {
+    0.13
+}
+
+test printf-round-half-away-exp {
+    SELECT printf('%.0e', 2.5);
+}
+expect {
+    3e+00
+}
+
+# ============================================
+# # flag with hex/octal zero-pad width
+# ============================================
+
+test printf-alt-hex-zeropad-8 {
+    SELECT printf('%#08x', 255);
+}
+expect {
+    0x000000ff
+}
+
+test printf-alt-hex-zeropad-4 {
+    SELECT printf('%#04x', 255);
+}
+expect {
+    0x00ff
+}
+
+test printf-alt-hex-upper-zeropad {
+    SELECT printf('%#08X', 255);
+}
+expect {
+    0X000000FF
+}
+
+test printf-alt-octal-zeropad {
+    SELECT printf('%#08o', 8);
+}
+expect {
+    000000010
+}
+
+test printf-alt-hex-space-pad {
+    SELECT '|' || printf('%#8x', 255) || '|';
+}
+expect {
+    |    0xff|
+}
+
+# ============================================
+# # flag on %e and %g
+# ============================================
+
+test printf-alt-exp-precision-0 {
+    SELECT printf('%#.0e', 1.0);
+}
+expect {
+    1.e+00
+}
+
+test printf-alt-g-precision-0 {
+    SELECT printf('%#.0g', 1.0);
+}
+expect {
+    1.
+}
+
+test printf-alt-g-trailing {
+    SELECT printf('%#g', 100000.0);
+}
+expect {
+    100000.
+}
+
+test printf-alt-g-precision-1 {
+    SELECT printf('%#.1g', 1.0);
+}
+expect {
+    1.
+}
+
+# ============================================
+# %g pre-rounding threshold
+# ============================================
+
+test printf-g-threshold-round-up {
+    SELECT printf('%g', 999999.5);
+}
+expect {
+    1e+06
+}
+
+test printf-g-threshold-1sig {
+    SELECT printf('%.1g', 9.5);
+}
+expect {
+    1e+01
+}
+
+test printf-g-threshold-2sig {
+    SELECT printf('%.2g', 99.5);
+}
+expect {
+    1e+02
+}
+
+# ============================================
+# Zero-pad ignored for %s and %c
+# ============================================
+
+test printf-string-zeropad-ignored {
+    SELECT '|' || printf('%05s', 'hi') || '|';
+}
+expect {
+    |   hi|
+}
+
+test printf-char-zeropad-ignored {
+    SELECT '|' || printf('%05c', 'A') || '|';
+}
+expect {
+    |    A|
+}
+
+# ============================================
+# %q/%Q/%w width and precision
+# ============================================
+
+test printf-q-width {
+    SELECT '|' || printf('%10q', 'hi') || '|';
+}
+expect {
+    |        hi|
+}
+
+test printf-q-left-justify {
+    SELECT '|' || printf('%-10q', 'hi') || '|';
+}
+expect {
+    |hi        |
+}
+
+test printf-q-precision {
+    SELECT printf('%.2q', 'hello');
+}
+expect {
+    he
+}
+
+test printf-Q-width {
+    SELECT '|' || printf('%10Q', 'hi') || '|';
+}
+expect {
+    |      'hi'|
+}
+
+test printf-Q-left-justify {
+    SELECT '|' || printf('%-10Q', 'hi') || '|';
+}
+expect {
+    |'hi'      |
+}
+
+test printf-Q-precision {
+    SELECT printf('%.2Q', 'hello');
+}
+expect {
+    'he'
+}
+
+test printf-w-width {
+    SELECT '|' || printf('%10w', 'hi') || '|';
+}
+expect {
+    |        hi|
+}
+
+test printf-w-precision {
+    SELECT printf('%.2w', 'hello');
+}
+expect {
+    he
+}
+
+test printf-q-zeropad-ignored {
+    SELECT '|' || printf('%05q', 'hi') || '|';
+}
+expect {
+    |   hi|
+}
+
+test printf-Q-zeropad-ignored {
+    SELECT '|' || printf('%05Q', 'hi') || '|';
+}
+expect {
+    | 'hi'|
+}
+
+# ============================================
+# Infinity 9-fill with zero-pad
+# ============================================
+
+test printf-inf-zeropad-f {
+    SELECT length(printf('%020f', 1e308*10));
+}
+expect {
+    1007
+}
+
+test printf-inf-zeropad-f-prefix {
+    SELECT substr(printf('%020f', 1e308*10), 1, 5);
+}
+expect {
+    90000
+}
+
+test printf-inf-zeropad-e {
+    SELECT printf('%020e', 1e308*10);
+}
+expect {
+    00000009.000000e+999
+}
+
+test printf-inf-zeropad-g {
+    SELECT printf('%020g', 1e308*10);
+}
+expect {
+    000000000000009e+999
+}
+
+test printf-inf-neg-zeropad-e {
+    SELECT printf('%020e', -(1e308*10));
+}
+expect {
+    -0000009.000000e+999
+}
+
+test printf-inf-no-zeropad-e {
+    SELECT printf('%e', 1e308*10);
+}
+expect {
+    Inf
+}
+
+test printf-inf-no-zeropad-g {
+    SELECT printf('%g', 1e308*10);
+}
+expect {
+    Inf
+}
+
+# ============================================
+# Significant digits (IEEE 754 noise suppression)
+# ============================================
+
+test printf-sigdigits-f-20 {
+    SELECT printf('%.20f', 1.0/3.0);
+}
+expect {
+    0.33333333333333330000
+}
+
+test printf-sigdigits-e-20 {
+    SELECT printf('%.20e', 1.0/3.0);
+}
+expect {
+    3.33333333333333300000e-01
+}
+
+test printf-sigdigits-g-20 {
+    SELECT printf('%.20g', 1.0/3.0);
+}
+expect {
+    0.3333333333333333
+}
+
+test printf-sigdigits-f-15 {
+    SELECT printf('%.15f', 1234567890.123456789);
+}
+expect {
+    1234567890.123457000000000
+}
+
+# ============================================
+# NaN handling (treated as 0.0)
+# ============================================
+
+test printf-nan-f {
+    SELECT printf('%f', 0.0/0.0);
+}
+expect {
+    0.000000
+}
+
+test printf-nan-e {
+    SELECT printf('%e', 0.0/0.0);
+}
+expect {
+    0.000000e+00
+}
+
+test printf-nan-g {
+    SELECT printf('%g', 0.0/0.0);
+}
+expect {
+    0
+}
+
+# ============================================
+# Blob NUL truncation for %s
+# ============================================
+
+test printf-blob-s {
+    SELECT printf('%s', X'48656C6C6F');
+}
+expect {
+    Hello
+}
+
+test printf-blob-s-nul {
+    SELECT length(printf('%s', X'48004C'));
+}
+expect {
+    1
+}


### PR DESCRIPTION
The previous implementation only handled bare format specifiers (%d, %f, %s, etc.) with no support for width, precision, or flags. This rewrites printf to parse the full %[flags][width][.precision]type format grammar.

This implementation is almost entirely generated by Claude. Turns out, that printf is just the perfect thing for an LLM to implement: it is nothing but a collection of corner cases that have to be handled in a giant conditional fest.

I have used several agents, with different roles, to accomplish this, over the span of 4 days:

- first, a new implementation was generated.
- then, a differential fuzzer was written. Having a fuzzer just for this helps because we can go nuts on the corner cases, which is where the bugs are.
- Then we went into a loop of running the fuzzer, finding issues, fixing them, and adding to the unit tests as bugs were found

There was also another agent who had full access to the sqlite source code and would proactively scan the source code for sqlite and find edge cases we were not handling, as well as the adversarial reviewer.

After around 4 days on it, the fuzzer now run for very long periods of time without finding any issue.

I couldn't do this in the background, unfortunately, and had to stay around to steer the agents often. The most common reason for that were things that the fuzzer found to differ, but looking closely, should not differ. The most common example are differences in floating points that are just normal for the way floating points are.

One challenge here is that the behavior of printf changes a bit from sqlite version to sqlite version.


