### PR TITLE
fix: correctly jump to second OR expression if first expression is NULL

### DIFF
--- a/testing/runner/tests/in-null-or.sqltest
+++ b/testing/runner/tests/in-null-or.sqltest
@@ -1,0 +1,80 @@
+@database :memory:
+
+# Regression tests for IN/NOT IN with NULL in list combined with OR.
+# When IN/NOT IN evaluates to NULL (due to NULL in the list and no match),
+# the OR right-hand side must still be evaluated.
+
+setup in_null_or {
+    CREATE TABLE t1 (a INTEGER PRIMARY KEY, b INTEGER);
+    INSERT INTO t1 VALUES(1, 1);
+    INSERT INTO t1 VALUES(2, 0);
+    INSERT INTO t1 VALUES(3, NULL);
+}
+
+@setup in_null_or
+test in-null-or-truthy {
+    SELECT a FROM t1 WHERE 5 IN (NULL, 3) OR b ORDER BY a;
+}
+expect {
+    1
+}
+
+@setup in_null_or
+test in-null-or-falsy {
+    SELECT a FROM t1 WHERE 5 IN (NULL, 3) OR 0;
+}
+expect {
+}
+
+@setup in_null_or
+test not-in-null-or-truthy {
+    SELECT a FROM t1 WHERE 5 NOT IN (NULL, 3) OR b ORDER BY a;
+}
+expect {
+    1
+}
+
+@setup in_null_or
+test in-null-or-column-multiple-rows {
+    SELECT a FROM t1 WHERE 5 IN (NULL, 3) OR a > 1 ORDER BY a;
+}
+expect {
+    2
+    3
+}
+
+@setup in_null_or
+test in-null-or-subquery {
+    SELECT a FROM t1 WHERE 5 IN (NULL, 3) OR (SELECT 1) ORDER BY a;
+}
+expect {
+    1
+    2
+    3
+}
+
+@setup in_null_or
+test in-null-or-with-offset {
+    SELECT a FROM t1 WHERE 5 IN (NULL, 3) OR 1 ORDER BY a LIMIT 10 OFFSET 2;
+}
+expect {
+    3
+}
+
+@setup in_null_or
+test in-match-or-null {
+    SELECT a FROM t1 WHERE 3 IN (NULL, 3) OR b ORDER BY a;
+}
+expect {
+    1
+    2
+    3
+}
+
+@setup in_null_or
+test in-null-column-or {
+    SELECT a FROM t1 WHERE a IN (NULL, 99) OR b ORDER BY a;
+}
+expect {
+    1
+}

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
@@ -1,48 +1,13 @@
 ---
 source: tpch.sqltest
-expression: |-
-  select
-          sum(l_extendedprice* (1 - l_discount)) as revenue
-      from
-          lineitem,
-          part
-      where
-          (
-              p_partkey = l_partkey
-              and p_brand = 'Brand#22'
-              and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
-              and l_quantity >= 8 and l_quantity <= 8 + 10
-              and p_size between 1 and 5
-              and l_shipmode in ('AIR', 'AIR REG')
-              and l_shipinstruct = 'DELIVER IN PERSON'
-          )
-          or
-          (
-              p_partkey = l_partkey
-              and p_brand = 'Brand#23'
-              and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
-              and l_quantity >= 10 and l_quantity <= 10 + 10
-              and p_size between 1 and 10
-              and l_shipmode in ('AIR', 'AIR REG')
-              and l_shipinstruct = 'DELIVER IN PERSON'
-          )
-          or
-          (
-              p_partkey = l_partkey
-              and p_brand = 'Brand#12'
-              and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
-              and l_quantity >= 24 and l_quantity <= 24 + 10
-              and p_size between 1 and 15
-              and l_shipmode in ('AIR', 'AIR REG')
-              and l_shipinstruct = 'DELIVER IN PERSON'
-          );
+expression: "select\n        sum(l_extendedprice* (1 - l_discount)) as revenue\n    from\n        lineitem,\n        part\n    where\n        (\n            p_partkey = l_partkey\n            and p_brand = 'Brand#22'\n            and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')\n            and l_quantity >= 8 and l_quantity <= 8 + 10\n            and p_size between 1 and 5\n            and l_shipmode in ('AIR', 'AIR REG')\n            and l_shipinstruct = 'DELIVER IN PERSON'\n        )\n        or\n        (\n            p_partkey = l_partkey\n            and p_brand = 'Brand#23'\n            and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')\n            and l_quantity >= 10 and l_quantity <= 10 + 10\n            and p_size between 1 and 10\n            and l_shipmode in ('AIR', 'AIR REG')\n            and l_shipinstruct = 'DELIVER IN PERSON'\n        )\n        or\n        (\n            p_partkey = l_partkey\n            and p_brand = 'Brand#12'\n            and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')\n            and l_quantity >= 24 and l_quantity <= 24 + 10\n            and p_size between 1 and 15\n            and l_shipmode in ('AIR', 'AIR REG')\n            and l_shipinstruct = 'DELIVER IN PERSON'\n        );"
 info:
   statement_type: SELECT
   tables:
-  - lineitem
+    - lineitem
   setup_blocks:
-  - schema
-  database: ':memory:'
+    - schema
+  database: ":memory:"
 ---
 QUERY PLAN
 |--SCAN lineitem
@@ -50,108 +15,102 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4                                     p5  comment
-   0  Init          0  69   0                                          0  Start at 69
+   0  Init          0  63   0                                          0  Start at 63
    1  Null          0   2   0                                          0  r[2]=NULL
    2  OpenRead      0  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
    3  OpenRead      1   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
-   4  Rewind        0  65   0                                          0  Rewind table lineitem
+   4  Rewind        0  59   0                                          0  Rewind table lineitem
    5    Column      0  14   3                                          0  r[3]=lineitem.l_shipmode
    6    Eq          3   4   8  Binary                                  0  if r[3]==r[4] goto 8
-   7    Ne          3   5  64  Binary                                  0  if r[3]!=r[5] goto 64
+   7    Ne          3   5  58  Binary                                  0  if r[3]!=r[5] goto 58
    8    Column      0  13   7                                          0  r[7]=lineitem.l_shipinstruct
-   9    Ne          7   8  64  Binary                                  0  if r[7]!=r[8] goto 64
+   9    Ne          7   8  58  Binary                                  0  if r[7]!=r[8] goto 58
   10    Column      0   1   9                                          0  r[9]=lineitem.l_partkey
-  11    SeekRowid   1   9  64                                          0  if (r[9]!=cursor 1 for table part.rowid) goto 64
+  11    SeekRowid   1   9  58                                          0  if (r[9]!=cursor 1 for table part.rowid) goto 58
   12    Column      1   3  11                                          0  r[11]=part.p_brand
-  13    Ne         11  12  28  Binary                                  0  if r[11]!=r[12] goto 28
+  13    Ne         11  12  25  Binary                                  0  if r[11]!=r[12] goto 25
   14    Column      1   6  13                                          0  r[13]=part.p_container
-  15    BitAnd     13  13  14                                          0  r[14]=r[13]&r[13]
-  16    Eq         13  15  22  Binary                                  0  if r[13]==r[15] goto 22
-  17    Eq         13  16  22  Binary                                  0  if r[13]==r[16] goto 22
-  18    Eq         13  17  22  Binary                                  0  if r[13]==r[17] goto 22
-  19    Eq         13  18  22  Binary                                  0  if r[13]==r[18] goto 22
-  20    IsNull     14  64   0                                          0  if (r[14]==NULL) goto 64
-  21    Goto        0  28   0                                          0
-  22    Column      0   4  20                                          0  r[20]=lineitem.l_quantity
-  23    Lt         20  21  28  Binary                                  0  if r[20]<r[21] goto 28
-  24    Column      0   4  23                                          0  r[23]=lineitem.l_quantity
-  25    Gt         23  24  28  Binary                                  0  if r[23]>r[24] goto 28
-  26    Column      1   5  28                                          0  r[28]=part.p_size
-  27    Le         28  29  57  Binary                                  0  if r[28]<=r[29] goto 57
-  28    Column      1   3  31                                          0  r[31]=part.p_brand
-  29    Ne         31  32  44  Binary                                  0  if r[31]!=r[32] goto 44
-  30    Column      1   6  33                                          0  r[33]=part.p_container
-  31    BitAnd     33  33  34                                          0  r[34]=r[33]&r[33]
-  32    Eq         33  35  38  Binary                                  0  if r[33]==r[35] goto 38
-  33    Eq         33  36  38  Binary                                  0  if r[33]==r[36] goto 38
-  34    Eq         33  37  38  Binary                                  0  if r[33]==r[37] goto 38
-  35    Eq         33  38  38  Binary                                  0  if r[33]==r[38] goto 38
-  36    IsNull     34  64   0                                          0  if (r[34]==NULL) goto 64
-  37    Goto        0  44   0                                          0
-  38    Column      0   4  40                                          0  r[40]=lineitem.l_quantity
-  39    Lt         40  41  44  Binary                                  0  if r[40]<r[41] goto 44
-  40    Column      0   4  43                                          0  r[43]=lineitem.l_quantity
-  41    Gt         43  44  44  Binary                                  0  if r[43]>r[44] goto 44
-  42    Column      1   5  47                                          0  r[47]=part.p_size
-  43    Le         47  48  57  Binary                                  0  if r[47]<=r[48] goto 57
-  44    Column      1   3  50                                          0  r[50]=part.p_brand
-  45    Ne         50  51  64  Binary                                  0  if r[50]!=r[51] goto 64
-  46    Column      1   6  52                                          0  r[52]=part.p_container
-  47    Eq         52  53  51  Binary                                  0  if r[52]==r[53] goto 51
-  48    Eq         52  54  51  Binary                                  0  if r[52]==r[54] goto 51
-  49    Eq         52  55  51  Binary                                  0  if r[52]==r[55] goto 51
-  50    Ne         52  56  64  Binary                                  0  if r[52]!=r[56] goto 64
-  51    Column      0   4  58                                          0  r[58]=lineitem.l_quantity
-  52    Lt         58  59  64  Binary                                  0  if r[58]<r[59] goto 64
-  53    Column      0   4  61                                          0  r[61]=lineitem.l_quantity
-  54    Gt         61  62  64  Binary                                  0  if r[61]>r[62] goto 64
-  55    Column      1   5  66                                          0  r[66]=part.p_size
-  56    Gt         66  67  64  Binary                                  0  if r[66]>r[67] goto 64
-  57    Column      1   5  70                                          0  r[70]=part.p_size
-  58    Gt         69  70  64  Binary                                  0  if r[69]>r[70] goto 64
-  59    Column      0   5  72                                          0  r[72]=lineitem.l_extendedprice
-  60    Column      0   6  75                                          0  r[75]=lineitem.l_discount
-  61    Subtract   74  75  73                                          0  r[73]=r[74]-r[75]
-  62    Multiply   72  73  71                                          0  r[71]=r[72]*r[73]
-  63    AggStep     0  71   2  sum                                     0  accum=r[2] step(r[71])
-  64  Next          0   5   0                                          0
-  65  AggFinal      0   2   0  sum                                     0  accum=r[2]
-  66  Copy          2   1   0                                          0  r[1]=r[2]
-  67  ResultRow     1   1   0                                          0  output=r[1]
-  68  Halt          0   0   0                                          0
-  69  Transaction   0   1   8                                          0  iDb=0 tx_mode=Read
-  70  String8       0   4   0  AIR                                     0  r[4]='AIR'
-  71  String8       0   5   0  AIR REG                                 0  r[5]='AIR REG'
-  72  String8       0   8   0  DELIVER IN PERSON                       0  r[8]='DELIVER IN PERSON'
-  73  String8       0  12   0  Brand#22                                0  r[12]='Brand#22'
-  74  String8       0  15   0  SM CASE                                 0  r[15]='SM CASE'
-  75  String8       0  16   0  SM BOX                                  0  r[16]='SM BOX'
-  76  String8       0  17   0  SM PACK                                 0  r[17]='SM PACK'
-  77  String8       0  18   0  SM PKG                                  0  r[18]='SM PKG'
-  78  Integer       8  21   0                                          0  r[21]=8
-  79  Integer       8  25   0                                          0  r[25]=8
-  80  Integer      10  26   0                                          0  r[26]=10
-  81  Add          25  26  24                                          0  r[24]=r[25]+r[26]
-  82  Integer       5  29   0                                          0  r[29]=5
-  83  String8       0  32   0  Brand#23                                0  r[32]='Brand#23'
-  84  String8       0  35   0  MED BAG                                 0  r[35]='MED BAG'
-  85  String8       0  36   0  MED BOX                                 0  r[36]='MED BOX'
-  86  String8       0  37   0  MED PKG                                 0  r[37]='MED PKG'
-  87  String8       0  38   0  MED PACK                                0  r[38]='MED PACK'
-  88  Integer      10  41   0                                          0  r[41]=10
-  89  Integer      10  45   0                                          0  r[45]=10
-  90  Add          45  45  44                                          0  r[44]=r[45]+r[45]
-  91  Integer      10  48   0                                          0  r[48]=10
-  92  String8       0  51   0  Brand#12                                0  r[51]='Brand#12'
-  93  String8       0  53   0  LG CASE                                 0  r[53]='LG CASE'
-  94  String8       0  54   0  LG BOX                                  0  r[54]='LG BOX'
-  95  String8       0  55   0  LG PACK                                 0  r[55]='LG PACK'
-  96  String8       0  56   0  LG PKG                                  0  r[56]='LG PKG'
-  97  Integer      24  59   0                                          0  r[59]=24
-  98  Integer      24  63   0                                          0  r[63]=24
-  99  Integer      10  64   0                                          0  r[64]=10
- 100  Add          63  64  62                                          0  r[62]=r[63]+r[64]
- 101  Integer      15  67   0                                          0  r[67]=15
- 102  Integer       1  69   0                                          0  r[69]=1
- 103  Integer       1  74   0                                          0  r[74]=1
- 104  Goto          0   1   0                                          0
+  15    Eq         13  14  19  Binary                                  0  if r[13]==r[14] goto 19
+  16    Eq         13  15  19  Binary                                  0  if r[13]==r[15] goto 19
+  17    Eq         13  16  19  Binary                                  0  if r[13]==r[16] goto 19
+  18    Ne         13  17  25  Binary                                  0  if r[13]!=r[17] goto 25
+  19    Column      0   4  19                                          0  r[19]=lineitem.l_quantity
+  20    Lt         19  20  25  Binary                                  0  if r[19]<r[20] goto 25
+  21    Column      0   4  22                                          0  r[22]=lineitem.l_quantity
+  22    Gt         22  23  25  Binary                                  0  if r[22]>r[23] goto 25
+  23    Column      1   5  27                                          0  r[27]=part.p_size
+  24    Le         27  28  51  Binary                                  0  if r[27]<=r[28] goto 51
+  25    Column      1   3  30                                          0  r[30]=part.p_brand
+  26    Ne         30  31  38  Binary                                  0  if r[30]!=r[31] goto 38
+  27    Column      1   6  32                                          0  r[32]=part.p_container
+  28    Eq         32  33  32  Binary                                  0  if r[32]==r[33] goto 32
+  29    Eq         32  34  32  Binary                                  0  if r[32]==r[34] goto 32
+  30    Eq         32  35  32  Binary                                  0  if r[32]==r[35] goto 32
+  31    Ne         32  36  38  Binary                                  0  if r[32]!=r[36] goto 38
+  32    Column      0   4  38                                          0  r[38]=lineitem.l_quantity
+  33    Lt         38  39  38  Binary                                  0  if r[38]<r[39] goto 38
+  34    Column      0   4  41                                          0  r[41]=lineitem.l_quantity
+  35    Gt         41  42  38  Binary                                  0  if r[41]>r[42] goto 38
+  36    Column      1   5  45                                          0  r[45]=part.p_size
+  37    Le         45  46  51  Binary                                  0  if r[45]<=r[46] goto 51
+  38    Column      1   3  48                                          0  r[48]=part.p_brand
+  39    Ne         48  49  58  Binary                                  0  if r[48]!=r[49] goto 58
+  40    Column      1   6  50                                          0  r[50]=part.p_container
+  41    Eq         50  51  45  Binary                                  0  if r[50]==r[51] goto 45
+  42    Eq         50  52  45  Binary                                  0  if r[50]==r[52] goto 45
+  43    Eq         50  53  45  Binary                                  0  if r[50]==r[53] goto 45
+  44    Ne         50  54  58  Binary                                  0  if r[50]!=r[54] goto 58
+  45    Column      0   4  56                                          0  r[56]=lineitem.l_quantity
+  46    Lt         56  57  58  Binary                                  0  if r[56]<r[57] goto 58
+  47    Column      0   4  59                                          0  r[59]=lineitem.l_quantity
+  48    Gt         59  60  58  Binary                                  0  if r[59]>r[60] goto 58
+  49    Column      1   5  64                                          0  r[64]=part.p_size
+  50    Gt         64  65  58  Binary                                  0  if r[64]>r[65] goto 58
+  51    Column      1   5  68                                          0  r[68]=part.p_size
+  52    Gt         67  68  58  Binary                                  0  if r[67]>r[68] goto 58
+  53    Column      0   5  70                                          0  r[70]=lineitem.l_extendedprice
+  54    Column      0   6  73                                          0  r[73]=lineitem.l_discount
+  55    Subtract   72  73  71                                          0  r[71]=r[72]-r[73]
+  56    Multiply   70  71  69                                          0  r[69]=r[70]*r[71]
+  57    AggStep     0  69   2  sum                                     0  accum=r[2] step(r[69])
+  58  Next          0   5   0                                          0
+  59  AggFinal      0   2   0  sum                                     0  accum=r[2]
+  60  Copy          2   1   0                                          0  r[1]=r[2]
+  61  ResultRow     1   1   0                                          0  output=r[1]
+  62  Halt          0   0   0                                          0
+  63  Transaction   0   1   8                                          0  iDb=0 tx_mode=Read
+  64  String8       0   4   0  AIR                                     0  r[4]='AIR'
+  65  String8       0   5   0  AIR REG                                 0  r[5]='AIR REG'
+  66  String8       0   8   0  DELIVER IN PERSON                       0  r[8]='DELIVER IN PERSON'
+  67  String8       0  12   0  Brand#22                                0  r[12]='Brand#22'
+  68  String8       0  14   0  SM CASE                                 0  r[14]='SM CASE'
+  69  String8       0  15   0  SM BOX                                  0  r[15]='SM BOX'
+  70  String8       0  16   0  SM PACK                                 0  r[16]='SM PACK'
+  71  String8       0  17   0  SM PKG                                  0  r[17]='SM PKG'
+  72  Integer       8  20   0                                          0  r[20]=8
+  73  Integer       8  24   0                                          0  r[24]=8
+  74  Integer      10  25   0                                          0  r[25]=10
+  75  Add          24  25  23                                          0  r[23]=r[24]+r[25]
+  76  Integer       5  28   0                                          0  r[28]=5
+  77  String8       0  31   0  Brand#23                                0  r[31]='Brand#23'
+  78  String8       0  33   0  MED BAG                                 0  r[33]='MED BAG'
+  79  String8       0  34   0  MED BOX                                 0  r[34]='MED BOX'
+  80  String8       0  35   0  MED PKG                                 0  r[35]='MED PKG'
+  81  String8       0  36   0  MED PACK                                0  r[36]='MED PACK'
+  82  Integer      10  39   0                                          0  r[39]=10
+  83  Integer      10  43   0                                          0  r[43]=10
+  84  Add          43  43  42                                          0  r[42]=r[43]+r[43]
+  85  Integer      10  46   0                                          0  r[46]=10
+  86  String8       0  49   0  Brand#12                                0  r[49]='Brand#12'
+  87  String8       0  51   0  LG CASE                                 0  r[51]='LG CASE'
+  88  String8       0  52   0  LG BOX                                  0  r[52]='LG BOX'
+  89  String8       0  53   0  LG PACK                                 0  r[53]='LG PACK'
+  90  String8       0  54   0  LG PKG                                  0  r[54]='LG PKG'
+  91  Integer      24  57   0                                          0  r[57]=24
+  92  Integer      24  61   0                                          0  r[61]=24
+  93  Integer      10  62   0                                          0  r[62]=10
+  94  Add          61  62  60                                          0  r[60]=r[61]+r[62]
+  95  Integer      15  65   0                                          0  r[65]=15
+  96  Integer       1  67   0                                          0  r[67]=1
+  97  Integer       1  72   0                                          0  r[72]=1
+  98  Goto          0   1   0                                          0


### PR DESCRIPTION
## Description
Caught by differential fuzzer

We were not passing the correct jump label for Binary `OR` expression, so we were not jumping to the second expression if the first one evaluated to false


## Description of AI Usage
Generated by Claude
