### PR TITLE
Lower Windows CI test timeout from 60 to 20 minutes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,7 @@ jobs:
           RUST_LOG: ${{ runner.debug && 'turso_core::storage=trace' || '' }}
           LOCAL_SYNC_SERVER: "../../target/debug/tursodb"
         run: cargo nextest run --workspace --all-features --locked --no-fail-fast -E 'not binary(fuzz_tests)' --failure-output=final
-        timeout-minutes: ${{ matrix.os == 'windows-latest' && 60 || 20 }}
+        timeout-minutes: 20
       - name: Test integrity_check corruption and short reads (no checksum feature because it interferes with the test)
         run: cargo nextest run -p core_tester --locked --no-fail-fast -E 'test(integrity_check) | test(short_read)' --failure-output=final
         timeout-minutes: 5


### PR DESCRIPTION
Windows nextest normally completes in ~7-8 minutes, same ballpark as Linux (2 min) and macOS (3 min). The 60-minute timeout just delays detection of hung tests. Use the same 20-minute timeout for all platforms.