### PR TITLE
core/mvcc: is_end_visible, don't read speculatively

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3495,8 +3495,8 @@ fn is_end_visible(
                 // transaction can see a row version if the end is a TXId only if it isn't the same transaction.
                 // Source: https://avi.im/blag/2023/hekaton-paper-typo/
                 TransactionState::Active => current_tx.tx_id != other_tx.tx_id,
-                // Table 2 (Hekaton): If TS > RT, V is visible. If TS < RT, T speculatively ignores V.
-                TransactionState::Preparing(end_ts) => current_tx.begin_ts < end_ts,
+                // Here we differ from Hekaton. We don't allow speculative read from another tx.
+                TransactionState::Preparing(_) => current_tx.tx_id != other_tx.tx_id,
                 TransactionState::Committed(committed_ts) => current_tx.begin_ts < committed_ts,
                 TransactionState::Aborted => true,
                 // Table 2 (Hekaton): Reread V's End field. In this codebase Terminated is only


### PR DESCRIPTION
## Description

In https://github.com/tursodatabase/turso/pull/5145 before changing `Preparing` visibility check was changed on speculative reads based on Hekaton. This is not safe because we need to track TX abort between txns to allow this. Instead we will not allow speculative reads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MVCC visibility rules; while the change is small, it can affect read semantics and potentially alter concurrency behavior under load.
> 
> **Overview**
> Adjusts MVCC `is_end_visible` so row versions whose `end` references a `Preparing` transaction are **not** speculatively considered visible based on that transaction’s provisional timestamp.
> 
> Instead, `Preparing(_)` now behaves like `Active` for end-visibility: a version is only considered visible when the end transaction is *not* the current transaction, preventing cross-transaction speculative reads/ignores that would require commit-dependency tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65b77e14b8c82b93b048a4ca966c22572ad77c95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->