### PR TITLE
fix: GROUP BY sort order for extra columns 

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -27,6 +27,9 @@ make test-single TEST=select.test
 # SQL test runner
 make -C testing/runner run-cli
 
+# OR
+cargo run -p test-runner -- run <test-file or directory>
+
 # Rust unit/integration tests (full workspace)
 cargo test
 ```

--- a/testing/runner/tests/groupby/memory.sqltest
+++ b/testing/runner/tests/groupby/memory.sqltest
@@ -238,3 +238,33 @@ expect {
     Y|70
     X|30
 }
+
+# Regression: GROUP BY with more columns than ORDER BY DESC + LIMIT/OFFSET
+# When the optimizer reorders GROUP BY exprs to put ORDER BY columns first,
+# the sort_order for remaining GROUP BY columns (not in ORDER BY) must
+# default to ASC. Previously they kept stale values from the pre-reorder
+# sort_order, causing incorrect tie-breaking within equal ORDER BY groups.
+test groupby_desc_tiebreak_extra_columns {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t VALUES (1, 'x'), (2, 'x'), (3, 'x'), (4, 'y'), (5, 'z');
+    SELECT a, GROUP_CONCAT(a) FROM t GROUP BY a, b ORDER BY b DESC;
+}
+expect {
+    5|5
+    4|4
+    1|1
+    2|2
+    3|3
+}
+
+test groupby_desc_tiebreak_extra_columns_limit_offset {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t VALUES (1, 'x'), (2, 'x'), (3, 'x'), (4, 'y'), (5, 'z');
+    SELECT a, GROUP_CONCAT(a) FROM t GROUP BY a, b ORDER BY b DESC LIMIT 4 OFFSET 1;
+}
+expect {
+    4|4
+    1|1
+    2|2
+    3|3
+}

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q18-large-volume-customer.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q18-large-volume-customer.snap
@@ -92,7 +92,7 @@ addr  opcode                           p1   p2  p3  p4                          
   38            Integer                 0    3   0                                                 0  r[3]=0
   39          Return                   11    0   0                                                 0
   40          Null                      0   35   0                                                 0  r[35]=NULL
-  41          SorterOpen                3    6   0  k(5,-B,B,B,B,-B)                               0  cursor=3
+  41          SorterOpen                3    6   0  k(5,-B,B,B,B,B)                                0  cursor=3
   42          Integer                   0   24   0                                                 0  r[24]=0; clear group by abort flag
   43          Null                      0   25  29                                                 0  r[25..29]=NULL; initialize group by comparison registers to NULL
   44          Gosub                    43  125   0                                                 0  ; go to clear accumulator subroutine


### PR DESCRIPTION
## Description

- When the optimizer reorders GROUP BY expressions to put ORDER BY columns first, the `sort_order` array was not correspondingly updated. Remaining GROUP BY columns (not in ORDER BY) kept stale values from the pre-reorder array, causing incorrect tie-breaking (DESC instead of ASC) within groups with equal ORDER BY keys.
- After the reorder + overwrite loop, explicitly reset remaining sort_order positions to ASC, matching SQLite's tie-breaking semantics.
- Added regression tests for GROUP BY with extra columns + ORDER BY DESC, with and without LIMIT/OFFSET.


## Description of AI Usage
Generate by Claude
