### PR TITLE
fix(core): fix ColumnUsedMask::is_only for overflow indices beyond vector length

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1078,6 +1078,10 @@ impl ColumnUsedMask {
             };
             let overflow_idx = (index - Self::INLINE_BITS) / 64;
             let bit = (index - Self::INLINE_BITS) % 64;
+            // The overflow vector must be long enough to contain the target index
+            if overflow_idx >= overflow.len() {
+                return false;
+            }
             overflow.iter().enumerate().all(|(i, &w)| {
                 if i == overflow_idx {
                     w == (1 << bit)


### PR DESCRIPTION
## Summary

- Fixed bug in `ColumnUsedMask::is_only()` where it incorrectly returned `true` for indices beyond the overflow vector length
- Added bounds check to return `false` when the target overflow index doesn't exist

Fixes #5202

🤖 Generated with [Claude Code](https://claude.ai/claude-code)