### PR TITLE
fix: propagate affinity for `IN` Subquery

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -263,6 +263,7 @@ fn emit_compound_select(
                 plan.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id: dedupe_index.0,
                     index: dedupe_index.1.clone(),
+                    affinity_str: None,
                     is_delete: false,
                 };
                 let compound_select = Plan::CompoundSelect {
@@ -286,6 +287,7 @@ fn emit_compound_select(
                 right_most.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id: dedupe_index.0,
                     index: dedupe_index.1.clone(),
+                    affinity_str: None,
                     is_delete: false,
                 };
 
@@ -316,6 +318,7 @@ fn emit_compound_select(
                 plan.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id: left_cursor_id,
                     index: left_index.clone(),
+                    affinity_str: None,
                     is_delete: false,
                 };
 
@@ -324,6 +327,7 @@ fn emit_compound_select(
                 right_most.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id: right_cursor_id,
                     index: right_index,
+                    affinity_str: None,
                     is_delete: false,
                 };
                 let compound_select = Plan::CompoundSelect {
@@ -372,6 +376,7 @@ fn emit_compound_select(
                 plan.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id,
                     index: index.clone(),
+                    affinity_str: None,
                     is_delete: false,
                 };
                 let compound_select = Plan::CompoundSelect {
@@ -394,6 +399,7 @@ fn emit_compound_select(
                 right_most.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id,
                     index: index.clone(),
+                    affinity_str: None,
                     is_delete: true,
                 };
                 emit_explain!(program, true, "EXCEPT USING TEMP B-TREE".to_owned());

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -335,6 +335,9 @@ pub enum QueryDestination {
         cursor_id: CursorID,
         /// The index that will be used to store the results.
         index: Arc<Index>,
+        /// Optional MakeRecord affinity string to apply before inserting keys.
+        /// For `IN (SELECT ...)` this must match the left-hand side expression affinity.
+        affinity_str: Option<Arc<String>>,
         /// Whether this is a delete operation that will remove the index entries
         is_delete: bool,
     },

--- a/core/translate/result_row.rs
+++ b/core/translate/result_row.rs
@@ -139,6 +139,7 @@ pub fn emit_columns_to_destination(
         QueryDestination::EphemeralIndex {
             cursor_id: index_cursor_id,
             index: dedupe_index,
+            affinity_str,
             is_delete,
         } => {
             if *is_delete {
@@ -211,7 +212,7 @@ pub fn emit_columns_to_destination(
                     count: to_u16(record_count),
                     dest_reg: to_u16(record_reg),
                     index_name: Some(dedupe_index.name.clone()),
-                    affinity_str: None,
+                    affinity_str: affinity_str.as_ref().map(|s| (**s).clone()),
                 });
                 program.emit_insn(Insn::IdxInsert {
                     cursor_id: *index_cursor_id,

--- a/core/translate/values.rs
+++ b/core/translate/values.rs
@@ -231,12 +231,13 @@ fn emit_values_to_index(
     start_reg: usize,
     row_len: usize,
 ) -> Result<()> {
-    let (cursor_id, index, is_delete) = match &plan.query_destination {
+    let (cursor_id, index, affinity_str, is_delete) = match &plan.query_destination {
         QueryDestination::EphemeralIndex {
             cursor_id,
             index,
+            affinity_str,
             is_delete,
-        } => (cursor_id, index, is_delete),
+        } => (cursor_id, index, affinity_str, is_delete),
         _ => unreachable!(),
     };
 
@@ -287,7 +288,7 @@ fn emit_values_to_index(
             count: to_u16(record_count),
             dest_reg: to_u16(record_reg),
             index_name: Some(index.name.clone()),
-            affinity_str: None,
+            affinity_str: affinity_str.as_ref().map(|s| (**s).clone()),
         });
         program.emit_insn(Insn::IdxInsert {
             cursor_id: *cursor_id,

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -21,7 +21,7 @@ bitflags = { workspace = true }
 miette = { workspace = true }
 strum = { workspace = true }
 strum_macros = {workspace = true }
-serde = { workspace = true , optional = true, features = ["derive"] }
+serde = { workspace = true , optional = true, features = ["derive", "rc"] }
 thiserror = { workspace = true }
 turso_macros = { workspace = true }
 memchr = "2.7.6"

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1,6 +1,8 @@
 pub mod check;
 pub mod fmt;
 
+use std::sync::Arc;
+
 use crate::lexer::is_keyword;
 use strum_macros::{EnumIter, EnumString};
 
@@ -515,7 +517,12 @@ pub enum SubqueryType {
     },
     /// IN subquery; result is stored in an ephemeral index.
     /// Example: x <NOT> IN (SELECT ...)
-    In { cursor_id: usize },
+    In {
+        cursor_id: usize,
+        /// Affinity string used by the IN operator probe and ephemeral materialization.
+        /// Mirrors SQLite's exprINAffinity behavior.
+        affinity_str: Arc<String>,
+    },
 }
 
 impl Expr {

--- a/testing/runner/tests/affinity.sqltest
+++ b/testing/runner/tests/affinity.sqltest
@@ -133,6 +133,39 @@ expect {
     3
 }
 
+test affinity-in-subquery-cast-text {
+    CREATE TABLE t1 (id INTEGER PRIMARY KEY, v REAL);
+    INSERT INTO t1 VALUES (893900, 835162.5053372835);
+    SELECT id FROM t1 WHERE id IN (SELECT CAST(id AS TEXT) FROM t1);
+}
+expect {
+    893900
+}
+
+test affinity-in-subquery-group-concat {
+    CREATE TABLE t1 (id INTEGER PRIMARY KEY, v REAL);
+    INSERT INTO t1 VALUES (1, 1.0), (2, 2.0), (3, 3.0);
+    SELECT id FROM t1 WHERE id IN (
+        SELECT GROUP_CONCAT(id) FROM t1 GROUP BY v ORDER BY v DESC LIMIT 1
+    );
+}
+expect {
+    3
+}
+
+test affinity-in-subquery-text-lhs-integer-rhs {
+    CREATE TABLE t_text (a TEXT);
+    CREATE TABLE t_int (i INTEGER);
+    INSERT INTO t_text VALUES ('1'), ('01'), ('1.0'), ('abc');
+    INSERT INTO t_int VALUES (1);
+    SELECT a FROM t_text WHERE a IN (SELECT i FROM t_int) ORDER BY a;
+}
+expect {
+    01
+    1
+    1.0
+}
+
 # ============================================
 # Multiple columns with different affinities
 # ============================================

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__subquery-with-index.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__subquery-with-index.snap
@@ -1,14 +1,17 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, sku, name\n    FROM products\n    WHERE id IN (SELECT product_id FROM inventory WHERE warehouse_id = 1);"
+expression: |-
+  SELECT id, sku, name
+      FROM products
+      WHERE id IN (SELECT product_id FROM inventory WHERE warehouse_id = 1);
 info:
   statement_type: SELECT
   tables:
-    - inventory
-    - products
+  - inventory
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SEARCH inventory USING INDEX idx_inventory_covering
@@ -31,7 +34,7 @@ addr  opcode         p1  p2  p3  p4                  p5  comment
   12  Rewind          2  35   0                       0  Rewind table products
   13    Integer       0   7   0                       0  r[7]=0
   14    RowId         2   8   0                       0  r[8]=products.rowid
-  15    Affinity      8   1   0                       0  r[8..9] = D
+  15    Affinity      8   1   0                       0  r[8..9] = C
   16    NotFound      0  18   8                       0  if not found goto 18
   17    Goto          0  24   0                       0
   18    Rewind        0  26   0                       0  Rewind  ephemeral_index_where_sub_t2

--- a/testing/runner/tests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
+++ b/testing/runner/tests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
@@ -37,7 +37,7 @@ addr  opcode          p1  p2  p3  p4            p5  comment
   15    DeferredSeek   3   2   0                 0
   16    Integer        0   6   0                 0  r[6]=0
   17    Column         3   0   7                 0  r[7]=idx_orders_user_id.user_id
-  18    Affinity       7   1   0                 0  r[7..8] = D
+  18    Affinity       7   1   0                 0  r[7..8] = C
   19    NotFound       0  21   7                 0  if not found goto 21
   20    Goto           0  27   0                 0
   21    Rewind         0  29   0                 0  Rewind  ephemeral_index_where_sub_t2

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -73,7 +73,7 @@ addr  opcode            p1  p2  p3  p4            p5  comment
   28  Rewind             4  50   0                 0  Rewind table customers
   29    Integer          0  20   0                 0  r[20]=0
   30    RowId            4  21   0                 0  r[21]=customers.rowid
-  31    Affinity        21   1   0                 0  r[21..22] = D
+  31    Affinity        21   1   0                 0  r[21..22] = C
   32    NotFound         0  34  21                 0  if not found goto 34
   33    Goto             0  40   0                 0
   34    Rewind           0  42   0                 0  Rewind  ephemeral_index_where_sub_t4

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
@@ -1,14 +1,22 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT c.id, c.name\n    FROM customers c\n    WHERE c.id IN (\n        SELECT o.customer_id\n        FROM orders o\n        GROUP BY o.customer_id\n        HAVING sum(o.total_amount) > 1000\n    );"
+expression: |-
+  SELECT c.id, c.name
+      FROM customers c
+      WHERE c.id IN (
+          SELECT o.customer_id
+          FROM orders o
+          GROUP BY o.customer_id
+          HAVING sum(o.total_amount) > 1000
+      );
 info:
   statement_type: SELECT
   tables:
-    - customers
-    - orders
+  - customers
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN orders AS o USING INDEX idx_orders_customer
@@ -61,7 +69,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   42  Rewind                     3  64   0                 0  Rewind table customers
   43    Integer                  0  18   0                 0  r[18]=0
   44    RowId                    3  19   0                 0  r[19]=customers.rowid
-  45    Affinity                19   1   0                 0  r[19..20] = D
+  45    Affinity                19   1   0                 0  r[19..20] = C
   46    NotFound                 0  48  19                 0  if not found goto 48
   47    Goto                     0  54   0                 0
   48    Rewind                   0  56   0                 0  Rewind  ephemeral_index_where_sub_t2

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-simple.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-simple.snap
@@ -1,14 +1,21 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT id, name, price\n    FROM products\n    WHERE category_id IN (\n        SELECT id\n        FROM categories\n        WHERE name LIKE '%Electronics%'\n    );"
+expression: |-
+  SELECT id, name, price
+      FROM products
+      WHERE category_id IN (
+          SELECT id
+          FROM categories
+          WHERE name LIKE '%Electronics%'
+      );
 info:
   statement_type: SELECT
   tables:
-    - categories
-    - products
+  - categories
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN categories
@@ -33,7 +40,7 @@ addr  opcode          p1  p2  p3  p4              p5  comment
   14    Integer        0   9   0                   0  r[9]=0
   15    Column         2   2  10                   0  r[10]=products.category_id
   16    IsNull        10  20   0                   0  if (r[10]==NULL) goto 20
-  17    Affinity      10   1   0                   0  r[10..11] = D
+  17    Affinity      10   1   0                   0  r[10..11] = C
   18    NotFound       0  20  10                   0  if not found goto 20
   19    Goto           0  26   0                   0
   20    Rewind         0  28   0                   0  Rewind  ephemeral_index_where_sub_t2

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__not-in-subquery.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__not-in-subquery.snap
@@ -1,13 +1,20 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT id, name, department\n    FROM employees\n    WHERE id NOT IN (\n        SELECT DISTINCT manager_id\n        FROM employees\n        WHERE manager_id IS NOT NULL\n    );"
+expression: |-
+  SELECT id, name, department
+      FROM employees
+      WHERE id NOT IN (
+          SELECT DISTINCT manager_id
+          FROM employees
+          WHERE manager_id IS NOT NULL
+      );
 info:
   statement_type: SELECT
   tables:
-    - employees
+  - employees
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN employees USING COVERING INDEX idx_employees_manager
@@ -32,7 +39,7 @@ addr  opcode                  p1  p2  p3  p4              p5  comment
   14  Rewind                   2  36   0                   0  Rewind table employees
   15    Integer                0   7   0                   0  r[7]=0
   16    RowId                  2   8   0                   0  r[8]=employees.rowid
-  17    Affinity               8   1   0                   0  r[8..9] = D
+  17    Affinity               8   1   0                   0  r[8..9] = C
   18    Found                  0  27   8                   0  if found goto 27
   19    Rewind                 0  25   0                   0  Rewind  ephemeral_index_where_sub_t2
   20      Column               0   0   9                   0  r[9]=ephemeral_index_where_sub_t2.manager_id

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
@@ -47,7 +47,7 @@ addr  opcode           p1  p2  p3  p4              p5  comment
   14    Integer         0   8   0                   0  r[8]=0
   15    Column          2   2   9                   0  r[9]=products.category_id
   16    IsNull          9  20   0                   0  if (r[9]==NULL) goto 20
-  17    Affinity        9   1   0                   0  r[9..10] = D
+  17    Affinity        9   1   0                   0  r[9..10] = C
   18    NotFound        0  20   9                   0  if not found goto 20
   19    Goto            0  26   0                   0
   20    Rewind          0  28   0                   0  Rewind  ephemeral_index_where_sub_t2

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q16-parts-supplier.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q16-parts-supplier.snap
@@ -88,7 +88,7 @@ addr  opcode                            p1   p2  p3  p4                         
   37              IdxGT                  5   61  42                                 0  key=[42..42]
   38              Integer                0   43   0                                 0  r[43]=0
   39              Column                 5    1  44                                 0  r[44]=sqlite_autoindex_partsupp_1.ps_suppkey
-  40              Affinity              44    1   0                                 0  r[44..45] = D
+  40              Affinity              44    1   0                                 0  r[44..45] = C
   41              Found                  0   50  44                                 0  if found goto 50
   42              Rewind                 0   48   0                                 0  Rewind  ephemeral_index_where_sub_t3
   43                Column               0    0  45                                 0  r[45]=ephemeral_index_where_sub_t3.s_suppkey

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q18-large-volume-customer.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q18-large-volume-customer.snap
@@ -105,7 +105,7 @@ addr  opcode                           p1   p2  p3  p4                          
   51          Rewind                    6   85   0                                                 0  Rewind table orders
   52            Integer                 0   45   0                                                 0  r[45]=0
   53            RowId                   6   46   0                                                 0  r[46]=orders.rowid
-  54            Affinity               46    1   0                                                 0  r[46..47] = D
+  54            Affinity               46    1   0                                                 0  r[46..47] = C
   55            NotFound                0   57  46                                                 0  if not found goto 57
   56            Goto                    0   63   0                                                 0
   57            Rewind                  0   65   0                                                 0  Rewind  ephemeral_index_where_sub_t4

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
@@ -101,7 +101,7 @@ addr  opcode           p1   p2  p3  p4                                     p5  c
   39    Return          8    0   1                                          0
   40    Integer         0   27   0                                          0  r[27]=0
   41    Column          3    0  28                                          0  r[28]=partsupp.ps_partkey
-  42    Affinity       28    1   0                                          0  r[28..29] = D
+  42    Affinity       28    1   0                                          0  r[28..29] = C
   43    NotFound        0   45  28                                          0  if not found goto 45
   44    Goto            0   51   0                                          0
   45    Rewind          0   53   0                                          0  Rewind  ephemeral_index_where_sub_t5
@@ -129,7 +129,7 @@ addr  opcode           p1   p2  p3  p4                                     p5  c
   67  Rewind            6   94   0                                          0  Rewind table supplier
   68    Integer         0   37   0                                          0  r[37]=0
   69    RowId           6   38   0                                          0  r[38]=supplier.rowid
-  70    Affinity       38    1   0                                          0  r[38..39] = D
+  70    Affinity       38    1   0                                          0  r[38..39] = C
   71    NotFound        1   73  38                                          0  if not found goto 73
   72    Goto            0   79   0                                          0
   73    Rewind          1   81   0                                          0  Rewind  ephemeral_index_where_sub_t3


### PR DESCRIPTION
## Description
Caught by differential fuzzer

Fix SQLite compatibility for `IN (SELECT ...)` affinity handling in the differential fuzzer reproducer, and optimize affinity-string storage by using `Arc<String>`.


## Root Cause
`IN (SELECT ...)` used an ephemeral index path that did not consistently apply SQLite-equivalent IN comparison affinity when materializing and probing the RHS set.

## Changed
- Compute IN affinity using SQLite-style comparison affinity rules from LHS and subquery result expression.
- Store this affinity string on the subquery plan/state and use it in both:
  - RHS ephemeral index materialization (`MakeRecord` affinity)
  - LHS probe-time coercion (`Affinity` before `Found/NotFound`, and NULL-check loop comparisons)

## Description of AI Usage
Generated by Codex
