### PR TITLE
stress: Use single Database object

### DIFF
--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -689,16 +689,17 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
 
     let vfs_option = opts.vfs.clone();
 
+    let mut builder = Builder::new_local(&db_file);
+    if let Some(ref vfs) = vfs_option {
+        builder = builder.with_io(vfs.clone());
+    }
+    let db = Arc::new(Mutex::new(builder.build().await?));
+
     for thread in 0..opts.nr_threads {
         if stop {
             break;
         }
         let db_file = db_file.clone();
-        let mut builder = Builder::new_local(&db_file);
-        if let Some(ref vfs) = vfs_option {
-            builder = builder.with_io(vfs.clone());
-        }
-        let db = Arc::new(Mutex::new(builder.build().await?));
         let conn = db.lock().await.connect()?;
 
         match opts.tx_mode {


### PR DESCRIPTION
The Database object is process-wide and shareable across threads. This has no practical impact because we internally ensure that every thread sees the same Database object. However, the weird usage confuses AI coding assistants, for example, and likely humans, so let's fix that.