### PR TITLE
fix(core): Handle PRAGMA cache_size overflow (fixes #5250)

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1270,7 +1270,10 @@ fn update_cache_size(
     let mut cache_size_unformatted: i64 = value;
 
     let mut cache_size = if cache_size_unformatted < 0 {
-        let kb = cache_size_unformatted.abs().saturating_mul(1024);
+        let kb = cache_size_unformatted
+            .checked_abs()
+            .unwrap_or(i64::MAX)
+            .saturating_mul(1024);
         let page_size = pager
             .io
             .block(|| pager.with_header(|header| header.page_size))


### PR DESCRIPTION
The update_cache_size function no longer panics when PRAGMA cache_size is set to i64::MIN. Invalidly large cache size requests are now gracefully clamped to the minimum safe cache size (200 pages) instead of causing a crash. A new integration test verifies this behavior.

## Description

<!-- 
Handling for PRAGMA cache_size Panics on i64::MIN Due to Negate Overflow 
-->

## Motivation and context

<!-- 
https://github.com/tursodatabase/turso/issues/5250
-->


## Description of AI Usage

<!-- 
-->
