### PR TITLE
Fix: handle multiplication overflow in time_date

### DIFF
--- a/core/time/mod.rs
+++ b/core/time/mod.rs
@@ -202,9 +202,10 @@ fn time_date_internal(args: &[Value]) -> Value {
         FixedOffset::east_opt(0).unwrap(),
     );
 
-    let t = tri!(t);
-
-    t.into_blob()
+    match tri!(t) {
+        Some(t) => t.into_blob(),
+        None => Value::null(),
+    }
 }
 
 #[scalar(name = "time_date")]
@@ -835,7 +836,10 @@ fn time_trunc(args: &[Value]) -> Value {
 
             let field = tri!(TimeRoundField::from_str(field));
 
-            tri!(t.trunc_field(field)).into_blob()
+            match tri!(t.trunc_field(field)) {
+                Some(t) => t.into_blob(),
+                None => Value::null(),
+            }
         }
         ValueType::Integer => {
             let duration = ok_tri!(args[1].to_integer());

--- a/testing/runner/tests/scalar-functions-datetime.sqltest
+++ b/testing/runner/tests/scalar-functions-datetime.sqltest
@@ -2110,6 +2110,13 @@ test overflows-with-large-days-modifier {
 expect {
 }
 
+@skip-if sqlite "time_date is a custom Limbo function not supported in standard SQLite"
+test time_date-overflow-issue-5251 {
+    SELECT time_date(2147483647, 2147483647, 2147483647);
+}
+expect {
+}
+
 # Invalid date and time
 test invalid-date {
     SELECT date('2024-07-21 24:00:00');


### PR DESCRIPTION
## Description

This PR fixes a thread panic in the `time_date` function caused by integer overflow when handling extremely large inputs.

- Updated `core/time/internal.rs` to use `checked_mul`
- Changed internal run types to `Result<Option<Time>>` so that calculations resulting in an overflow return a SQL `NULL`
- Propagated these changes to the `trunc_field` logic and the main SQL function interface in `core/time/mod.rs` to ensure `Value::nul()` is returned correctly.
- Added a new test case in `scalar-functions-datetime.sqltest` to verify that large offsets no longer crash / panic.


## Motivation and context

Just had some free time and got an issue to work on.

Fixes: #5251


## Description of AI Usage

No AI tools were used