### PR TITLE
fix: read non-aggregate columns during AggStep for mixed expressions

### DIFF
--- a/testing/runner/tests/agg-functions/memory.sqltest
+++ b/testing/runner/tests/agg-functions/memory.sqltest
@@ -102,3 +102,12 @@ expect {
     1|null||
 }
 
+test case-when-aggregate-returns-column-value {
+    CREATE TABLE t1(a INTEGER, b TEXT);
+    INSERT INTO t1 VALUES (42, 'hello');
+    SELECT CASE WHEN SUM(1) THEN a ELSE b END FROM t1;
+}
+expect {
+    42
+}
+


### PR DESCRIPTION
CASE WHEN SUM(1) THEN a ELSE b END returned NULL because column references inside aggregate-containing expressions were only read after the aggregation loop when the cursor was past the last row. Pre-read them into the register cache during AggStep while the cursor is still valid.

## Motivation and context

Caught by the differential fuzzer. We were returning null here
