### PR TITLE
fix: null coroutine registers in ungrouped aggregate empty-result path

### DIFF
--- a/testing/runner/tests/cte.sqltest
+++ b/testing/runner/tests/cte.sqltest
@@ -810,3 +810,29 @@ test cte-shadow-outer-unused {
 expect {
     12
 }
+
+# =============================================================================
+# CTE aggregate with empty result set
+# =============================================================================
+
+# Non-aggregate columns must be NULL when WHERE filters out all rows
+# from a CTE in a single-row aggregate query.
+test cte-aggregate-empty-result-non-agg-columns {
+    CREATE TABLE t(x INTEGER, y TEXT);
+    INSERT INTO t VALUES (1, 'a'), (2, 'b');
+    WITH cte AS (SELECT x, y FROM t)
+    SELECT CAST(TOTAL(y) AS INTEGER), x, x FROM cte WHERE x > 999;
+}
+expect {
+    0||
+}
+
+# Same behavior expected with FROM-clause subquery
+test subquery-aggregate-empty-result-non-agg-columns {
+    CREATE TABLE t(x INTEGER, y TEXT);
+    INSERT INTO t VALUES (1, 'a'), (2, 'b');
+    SELECT CAST(TOTAL(y) AS INTEGER), x, x FROM (SELECT x, y FROM t) sub WHERE x > 999;
+}
+expect {
+    0||
+}


### PR DESCRIPTION
When an ungrouped aggregate query (no GROUP BY) over a CTE or FROM-clause subquery has no rows matching the WHERE filter, non-aggregate columns must return NULL. For direct table access, Column on an exhausted cursor returns NULL naturally. But for coroutine-based sources, the output registers still hold stale values from the last yielded row.

For example, given:
  WITH cte AS (SELECT x, y FROM t) SELECT TOTAL(y), x, x FROM cte WHERE x > 999;
Turso returned 0.0|2|2 (leaking the last row x value) instead of 0.0|| (NULL for both non-aggregate columns), which is what SQLite returns.

Fix by emitting Null instructions for all FromClauseSubquery coroutine output registers before the post-loop expression evaluation.

## Motivation and context

Found this using the differential fuzzer