### PR TITLE
fix: json_valid() With Zero Arguments Panics Instead of Returning Error

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1217,14 +1217,17 @@ pub fn translate_expr(
                             func_ctx,
                         )
                     }
-                    JsonFunc::JsonValid => translate_function(
-                        program,
-                        args,
-                        referenced_tables,
-                        resolver,
-                        target_register,
-                        func_ctx,
-                    ),
+                    JsonFunc::JsonValid => {
+                        let args = expect_arguments_exact!(args, 1, j);
+                        translate_function(
+                            program,
+                            args,
+                            referenced_tables,
+                            resolver,
+                            target_register,
+                            func_ctx,
+                        )
+                    }
                     JsonFunc::JsonPatch | JsonFunc::JsonbPatch => {
                         let args = expect_arguments_exact!(args, 2, j);
                         translate_function(

--- a/testing/runner/tests/json/default.sqltest
+++ b/testing/runner/tests/json/default.sqltest
@@ -1272,6 +1272,12 @@ expect {
     0
 }
 
+test json_valid_no_args {
+    SELECT json_valid();
+}
+expect error {
+}
+
 test json-patch-basic-1 {
     select json_patch('{"a":1}', '{"b":2}');
 }


### PR DESCRIPTION
Closes #5248

(working on an issue autofixer - here's a test)