### PR TITLE
fix: LIMIT With i64::MIN Panics Due to Subtract Overflow in DecrJumpZ…

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3735,7 +3735,7 @@ pub fn op_decr_jump_zero(
     }
     match state.registers[*reg].get_value() {
         Value::Numeric(Numeric::Integer(n)) => {
-            let n = n - 1;
+            let n = n.saturating_sub(1);
             state.registers[*reg] = Register::Value(Value::from_i64(n));
             if n == 0 {
                 state.pc = target_pc.as_offset_int();

--- a/testing/runner/tests/limit.sqltest
+++ b/testing/runner/tests/limit.sqltest
@@ -1,0 +1,32 @@
+@database :memory:
+
+test limit-i64-min-no-panic {
+    SELECT 1 LIMIT -9223372036854775808;
+}
+expect {
+    1
+}
+
+test limit-negative-no-limit {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT x FROM t LIMIT -1;
+}
+expect {
+    1
+    2
+    3
+}
+
+test limit-zero {
+    SELECT 1 LIMIT 0;
+}
+expect {
+}
+
+test limit-one {
+    SELECT 1 UNION ALL SELECT 2 LIMIT 1;
+}
+expect {
+    1
+}


### PR DESCRIPTION
…ero #5253

Use saturating_sub(1) instead of plain subtraction in DecrJumpZero to prevent integer overflow when the limit register contains i64::MIN. Negative limits mean "no limit" per SQLite docs, so saturating at i64::MIN (never reaching zero) correctly skips the jump.

Closes #5253