### PR TITLE
fix: Panic on Scalar Subquery Referencing Rowid of Derived Table #5249

### DIFF
--- a/testing/runner/tests/subquery/expressions.sqltest
+++ b/testing/runner/tests/subquery/expressions.sqltest
@@ -698,3 +698,15 @@ test subquery-is-distinct-from {
 expect {
     1|1|1
 }
+
+# =============================================================================
+# Scalar subquery referencing rowid of derived table (#5249)
+# Derived tables (FROM-clause subqueries) don't have a rowid, so this should
+# return an error "no such column: rowid"
+# =============================================================================
+
+test scalar-subquery-rowid-derived-table {
+    SELECT (SELECT t.rowid) FROM (SELECT 1) t;
+}
+expect error {
+}


### PR DESCRIPTION
Handle RowId expressions for derived tables (FROM-clause subqueries) which don't have BTree cursors. The RowId arm now checks the table type and uses safe cursor resolution for FromClauseSubquery tables, falling back to NULL when no cursor is available (coroutine-based subqueries). Also adds safe outer-query-scope handling for BTree tables in RowId, matching the pattern used by the Column handler.

Closes #5249