### PR TITLE
fix(core): handle i64::MIN in PRAGMA cache_size to prevent panic (#5250)

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1270,7 +1270,12 @@ fn update_cache_size(
     let mut cache_size_unformatted: i64 = value;
 
     let mut cache_size = if cache_size_unformatted < 0 {
-        let kb = cache_size_unformatted.abs().saturating_mul(1024);
+        let abs_val = if cache_size_unformatted == i64::MIN {
+            i64::MAX
+        } else {
+            cache_size_unformatted.abs()
+        };
+        let kb = abs_val.saturating_mul(1024);
         let page_size = pager
             .io
             .block(|| pager.with_header(|header| header.page_size))

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -368,3 +368,11 @@ fn test_pragma_synchronous_normal(db: TempDatabase) {
     };
     assert_eq!(*count, 7, "all inserts should have succeeded");
 }
+
+#[turso_macros::test(mvcc)]
+fn test_pragma_cache_size_i64_min(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    // This value is i64::MIN
+    let result = conn.execute("PRAGMA cache_size=-9223372036854775808");
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Description
This PR fixes a panic that occurs when `PRAGMA cache_size` is set to `i64::MIN` (`-9223372036854775808`). 

The issue was caused by an implementation detail where `i64::MIN.abs()` was called, resulting in an overflow panic because `i64::MIN`'s absolute value cannot be represented in a signed 64-bit integer.

**Changes:**
- Modified [update_cache_size](cci:1://file:///d:/gsoc/turso/core/translate/pragma.rs:1264:0-1317:1) in [core/translate/pragma.rs](cci:7://file:///d:/gsoc/turso/core/translate/pragma.rs:0:0-0:0) to explicitly handle `i64::MIN` by clamping it to `i64::MAX` before processing.
- Added a new regression test [test_pragma_cache_size_i64_min](cci:1://file:///d:/gsoc/turso/tests/integration/pragma.rs:371:0-377:1) in [tests/integration/pragma.rs](cci:7://file:///d:/gsoc/turso/tests/integration/pragma.rs:0:0-0:0) to verify the fix.

## Motivation and context
This fixes issue #5250. 
Previously, executing `PRAGMA cache_size=-9223372036854775808` would crash the database process with an "attempt to negate with overflow" error. This PR ensures the database handles this edge case gracefully instead of crashing.

Closes #5250

## Description of AI Usage
I utilized the Antigravity AI assistant to help diagnose and resolve this issue.