### PR TITLE
Fix panic on ROLLBACK TO by replacing assert! with bail_parse_error

### DIFF
--- a/core/translate/rollback.rs
+++ b/core/translate/rollback.rs
@@ -1,7 +1,9 @@
 use turso_parser::ast::Name;
 
 use crate::{
-    bail_parse_error, vdbe::{builder::ProgramBuilder, insn::Insn}, Result
+    bail_parse_error,
+    vdbe::{builder::ProgramBuilder, insn::Insn},
+    Result,
 };
 
 pub fn translate_rollback(
@@ -12,7 +14,7 @@ pub fn translate_rollback(
     if txn_name.is_some() || savepoint_name.is_some() {
         bail_parse_error!("txn_name and savepoint not supported yet");
     }
- 
+
     program.emit_insn(Insn::AutoCommit {
         auto_commit: true,
         rollback: true,


### PR DESCRIPTION
## Description

Replace the assert! in translate_rollback with bail_parse_error! to prevent a runtime panic when executing ROLLBACK TO <savepoint>.

Previously, the translator would panic if either txn_name or savepoint_name was present. This change preserves the existing unsupported-feature behavior but returns a graceful parse error instead of crashing.

This aligns the behavior of ROLLBACK with the adjacent SAVEPOINT and RELEASE handlers.

Fixes #5229.

## Motivation and context
ROLLBACK TO <savepoint> is syntactically accepted by the parser, but not yet supported by the translator. The existing implementation used assert!, which caused the process to panic instead of returning a structured error.

Panicking on valid (but unsupported) SQL input is undesirable in a database engine, as it can terminate long-running processes and lead to poor error handling behavior.

This change ensures:

ROLLBACK; continues to function normally

ROLLBACK TO x; returns a parse error

No panic occurs

This improves robustness and aligns with expected error-handling conventions.


## Description of AI Usage

AI was used as a development assistant to:

Analyze the cause of the panic

Reason about boolean condition equivalence when replacing assert!

Validate the correct conditional logic (is_some() || is_some() vs is_none() && is_none())

Confirm testing strategy before opening the PR

The change itself is small and was fully reviewed and verified manually, including local compilation and CLI testing to confirm that the panic was replaced with a graceful parse error.

The contributor remains fully responsible for the correctness and intent of the change.