### PR TITLE
Improve support for attach databases

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1034,7 +1034,7 @@ impl Connection {
 
     /// Check if a specific attached database is read only or not, by its index
     pub fn is_readonly(&self, index: usize) -> bool {
-        if index == 0 {
+        if index <= 1 {
             self.db.is_readonly()
         } else {
             let db = self.attached_databases.read().get_database_by_index(index);
@@ -1282,6 +1282,34 @@ impl Connection {
         f(schema)
     }
 
+    /// Mutate the schema for a specific database (main or attached).
+    pub(crate) fn with_database_schema_mut<T>(
+        &self,
+        database_id: usize,
+        f: impl FnOnce(&mut Schema) -> T,
+    ) -> T {
+        if database_id < 2 {
+            self.with_schema_mut(f)
+        } else {
+            let db = {
+                let attached_dbs = self.attached_databases.read();
+                let (db, _pager) = attached_dbs
+                    .index_to_data
+                    .get(&database_id)
+                    .expect("Database ID should be valid");
+                db.clone()
+            };
+            let result = {
+                let mut schema_guard = db.schema.lock();
+                let schema = Arc::make_mut(&mut *schema_guard);
+                f(schema)
+            };
+            // Invalidate the cache so with_schema() picks up the new version
+            self.database_schemas.write().remove(&database_id);
+            result
+        }
+    }
+
     pub fn is_db_initialized(&self) -> bool {
         self.db.initialized()
     }
@@ -1291,6 +1319,16 @@ impl Connection {
             self.pager.load().clone()
         } else {
             self.attached_databases.read().get_pager_by_index(index)
+        }
+    }
+
+    /// Get the database name for a given database index.
+    /// Returns "main" for index 0, "temp" for index 1, and the alias for attached databases.
+    pub(crate) fn get_database_name_by_index(&self, index: usize) -> Option<String> {
+        match index {
+            0 => Some("main".to_string()),
+            1 => Some("temp".to_string()),
+            _ => self.attached_databases.read().get_name_by_index(index),
         }
     }
 
@@ -1341,8 +1379,7 @@ impl Connection {
         } else {
             Arc::new(PlatformIO::new()?)
         };
-        // FIXME: for now, only support read only attach
-        let main_db_flags = self.db.open_flags | OpenFlags::ReadOnly;
+        let main_db_flags = self.db.open_flags;
         let db = Self::from_uri_attached(path, db_opts, main_db_flags, io)?;
         let pager = Arc::new(db.init_pager(None)?);
         self.attached_databases.write().insert(alias, (db, pager));
@@ -1364,17 +1401,24 @@ impl Connection {
 
         // Remove from attached databases
         let mut attached_dbs = self.attached_databases.write();
-        if attached_dbs.remove(alias).is_none() {
-            return Err(LimboError::InvalidArgument(format!(
-                "no such database: {alias}"
-            )));
-        }
+        let database_id = match attached_dbs.remove(alias) {
+            Some(id) => id,
+            None => {
+                return Err(LimboError::InvalidArgument(format!(
+                    "no such database: {alias}"
+                )));
+            }
+        };
+
+        // Invalidate the cached schema for this database index so that a future
+        // ATTACH reusing the same index won't see stale schema entries.
+        self.database_schemas.write().remove(&database_id);
 
         Ok(())
     }
 
     // Get an attached database by alias name
-    fn get_attached_database(&self, alias: &str) -> Option<(usize, Arc<Database>)> {
+    pub(crate) fn get_attached_database(&self, alias: &str) -> Option<(usize, Arc<Database>)> {
         self.attached_databases.read().get_database_by_name(alias)
     }
 
@@ -1385,6 +1429,16 @@ impl Connection {
             .name_to_index
             .keys()
             .cloned()
+            .collect()
+    }
+
+    /// Get all attached database pagers (excludes main/temp databases)
+    pub fn get_all_attached_pagers(&self) -> Vec<Arc<Pager>> {
+        let catalog = self.attached_databases.read();
+        catalog
+            .index_to_data
+            .values()
+            .map(|(_db, pager)| pager.clone())
             .collect()
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1655,6 +1655,13 @@ impl DatabaseCatalog {
             .map(|(db, _pager)| db.clone())
     }
 
+    fn get_name_by_index(&self, index: usize) -> Option<String> {
+        self.name_to_index
+            .iter()
+            .find(|(_, &idx)| idx == index)
+            .map(|(name, _)| name.clone())
+    }
+
     fn get_database_by_name(&self, s: &str) -> Option<(usize, Arc<Database>)> {
         match self.name_to_index.get(s) {
             None => None,

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -99,6 +99,7 @@ fn default_requires_empty_table(expr: &ast::Expr) -> bool {
 /// 1. Checks if the table has any rows (Rewind)
 /// 2. Evaluates the CHECK expression with the column reference substituted by the DEFAULT
 /// 3. Halts with a CHECK constraint error if the result is false
+#[allow(clippy::too_many_arguments)]
 fn emit_add_column_check_validation(
     program: &mut ProgramBuilder,
     btree: &crate::schema::BTreeTable,
@@ -107,6 +108,7 @@ fn emit_add_column_check_validation(
     column: &Column,
     constraints: &[ast::NamedColumnConstraint],
     resolver: &Resolver,
+    database_id: usize,
 ) -> Result<()> {
     // Determine the effective default value. If no DEFAULT, existing rows get NULL,
     // which always passes CHECK per SQL standard (NULL is not false).
@@ -139,7 +141,7 @@ fn emit_add_column_check_validation(
     program.emit_insn(Insn::OpenRead {
         cursor_id: check_cursor_id,
         root_page: original_btree.root_page,
-        db: 0,
+        db: database_id,
     });
 
     let skip_check_label = program.allocate_label();
@@ -215,17 +217,25 @@ pub fn translate_alter_table(
     connection: &Arc<crate::Connection>,
     input: &str,
 ) -> Result<()> {
-    program.begin_write_operation();
     let ast::AlterTable {
-        name: table_name,
+        name: qualified_name,
         body: alter_table,
     } = alter;
-    let table_name = table_name.name.as_str();
+    let database_id = connection.resolve_database_id(&qualified_name)?;
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
+    program.begin_write_operation();
+    let table_name = qualified_name.name.as_str();
+    let schema_version = connection.with_schema(database_id, |s| s.schema_version);
     validate(&alter_table, table_name)?;
 
-    let table_indexes = resolver.schema.get_indices(table_name).collect::<Vec<_>>();
+    let table_indexes = connection.with_schema(database_id, |s| {
+        s.get_indices(table_name).cloned().collect::<Vec<_>>()
+    });
 
-    let Some(table) = resolver.schema.get_table(table_name) else {
+    let Some(table) = connection.with_schema(database_id, |s| s.get_table(table_name)) else {
         return Err(LimboError::ParseError(format!(
             "no such table: {table_name}"
         )));
@@ -240,6 +250,7 @@ pub fn translate_alter_table(
                 new_name_norm,
                 resolver,
                 connection,
+                database_id,
             );
         }
     }
@@ -248,7 +259,9 @@ pub fn translate_alter_table(
     };
 
     // Check if this table has dependent materialized views
-    let dependent_views = resolver.schema.get_dependent_materialized_views(table_name);
+    let dependent_views = connection.with_schema(database_id, |s| {
+        s.get_dependent_materialized_views(table_name)
+    });
     if !dependent_views.is_empty() {
         return Err(LimboError::ParseError(format!(
             "cannot alter table \"{table_name}\": it has dependent materialized view(s): {}",
@@ -404,7 +417,10 @@ pub fn translate_alter_table(
             // References in VIEWs are checked in the VDBE layer op_drop_column instruction.
 
             // Check if any trigger owned by this table references the column being dropped
-            for trigger in resolver.schema.get_triggers_for_table(table_name) {
+            let triggers_for_table: Vec<_> = connection.with_schema(database_id, |s| {
+                s.get_triggers_for_table(table_name).cloned().collect()
+            });
+            for trigger in &triggers_for_table {
                 if trigger_references_column(trigger, &btree, column_name)? {
                     return Err(LimboError::ParseError(format!(
                         "cannot drop column \"{column_name}\": it is referenced in trigger {}",
@@ -451,7 +467,7 @@ pub fn translate_alter_table(
                     program.emit_insn(Insn::OpenWrite {
                         cursor_id,
                         root_page: RegisterOrLiteral::Literal(root_page),
-                        db: 0,
+                        db: database_id,
                     });
 
                     program.cursor_loop(cursor_id, |program, rowid| {
@@ -505,13 +521,14 @@ pub fn translate_alter_table(
                     });
 
                     program.emit_insn(Insn::SetCookie {
-                        db: 0,
+                        db: database_id,
                         cookie: Cookie::SchemaVersion,
-                        value: resolver.schema.schema_version as i32 + 1,
+                        value: schema_version as i32 + 1,
                         p5: 0,
                     });
 
                     program.emit_insn(Insn::DropColumn {
+                        db: database_id,
                         table: table_name,
                         column_index: dropped_index,
                     })
@@ -713,7 +730,7 @@ pub fn translate_alter_table(
                 program.emit_insn(Insn::OpenRead {
                     cursor_id: check_cursor_id,
                     root_page: original_btree.root_page,
-                    db: 0,
+                    db: database_id,
                 });
 
                 let skip_error_label = program.allocate_label();
@@ -745,6 +762,7 @@ pub fn translate_alter_table(
                 &column,
                 &constraints,
                 resolver,
+                database_id,
             )?;
 
             translate_update_for_schema_change(
@@ -755,12 +773,13 @@ pub fn translate_alter_table(
                 input,
                 |program| {
                     program.emit_insn(Insn::SetCookie {
-                        db: 0,
+                        db: database_id,
                         cookie: Cookie::SchemaVersion,
-                        value: resolver.schema.schema_version as i32 + 1,
+                        value: schema_version as i32 + 1,
                         p5: 0,
                     });
                     program.emit_insn(Insn::AddColumn {
+                        db: database_id,
                         table: table_name.to_owned(),
                         column: Box::new(column),
                         check_constraints: btree.check_constraints.clone(),
@@ -771,14 +790,13 @@ pub fn translate_alter_table(
         ast::AlterTableBody::RenameTo(new_name) => {
             let new_name = new_name.as_str();
 
-            if resolver.schema.get_table(new_name).is_some()
-                || resolver
-                    .schema
-                    .indexes
-                    .values()
-                    .flatten()
-                    .any(|index| index.name == normalize_ident(new_name))
-            {
+            if connection.with_schema(database_id, |s| {
+                s.get_table(new_name).is_some()
+                    || s.indexes
+                        .values()
+                        .flatten()
+                        .any(|index| index.name == normalize_ident(new_name))
+            }) {
                 return Err(LimboError::ParseError(format!(
                     "there is already another table or index with this name: {new_name}"
                 )));
@@ -799,7 +817,7 @@ pub fn translate_alter_table(
             program.emit_insn(Insn::OpenWrite {
                 cursor_id,
                 root_page: RegisterOrLiteral::Literal(sqlite_schema.root_page),
-                db: 0,
+                db: database_id,
             });
 
             program.cursor_loop(cursor_id, |program, rowid| {
@@ -860,13 +878,14 @@ pub fn translate_alter_table(
             });
 
             program.emit_insn(Insn::SetCookie {
-                db: 0,
+                db: database_id,
                 cookie: Cookie::SchemaVersion,
-                value: resolver.schema.schema_version as i32 + 1,
+                value: schema_version as i32 + 1,
                 p5: 0,
             });
 
             program.emit_insn(Insn::RenameTable {
+                db: database_id,
                 from: table_name.to_owned(),
                 to: new_name.to_owned(),
             });
@@ -959,16 +978,20 @@ pub fn translate_alter_table(
             if rename {
                 // Find all triggers that might reference this column
                 let target_table_name_norm = normalize_ident(table_name);
-                for trigger in resolver.schema.triggers.values().flatten() {
+                let all_triggers: Vec<_> = connection.with_schema(database_id, |s| {
+                    s.triggers.values().flatten().cloned().collect()
+                });
+                for trigger in &all_triggers {
                     let trigger_table_name_norm = normalize_ident(&trigger.table_name);
 
                     // SQLite fails RENAME COLUMN if a trigger's WHEN clause references the column
                     // or if trigger commands contain qualified references to the trigger table (e.g., t.x)
                     if trigger_table_name_norm == target_table_name_norm {
                         let column_name_norm = normalize_ident(from);
-                        let trigger_table = resolver
-                            .schema
-                            .get_btree_table(&trigger_table_name_norm)
+                        let trigger_table = connection
+                            .with_schema(database_id, |s| {
+                                s.get_btree_table(&trigger_table_name_norm)
+                            })
                             .ok_or_else(|| {
                                 LimboError::ParseError(format!(
                                     "trigger table not found: {trigger_table_name_norm}"
@@ -1014,9 +1037,10 @@ pub fn translate_alter_table(
 
                     if trigger_table_name_norm == target_table_name_norm {
                         // Trigger is on the table being renamed - check for references
-                        let trigger_table = resolver
-                            .schema
-                            .get_btree_table(&trigger_table_name_norm)
+                        let trigger_table = connection
+                            .with_schema(database_id, |s| {
+                                s.get_btree_table(&trigger_table_name_norm)
+                            })
                             .ok_or_else(|| {
                                 LimboError::ParseError(format!(
                                     "trigger table not found: {trigger_table_name_norm}"
@@ -1074,7 +1098,7 @@ pub fn translate_alter_table(
             program.emit_insn(Insn::OpenWrite {
                 cursor_id,
                 root_page: RegisterOrLiteral::Literal(sqlite_schema.root_page),
-                db: 0,
+                db: database_id,
             });
 
             program.cursor_loop(cursor_id, |program, rowid| {
@@ -1175,12 +1199,13 @@ pub fn translate_alter_table(
             }
 
             program.emit_insn(Insn::SetCookie {
-                db: 0,
+                db: database_id,
                 cookie: Cookie::SchemaVersion,
-                value: resolver.schema.schema_version as i32 + 1,
+                value: schema_version as i32 + 1,
                 p5: 0,
             });
             program.emit_insn(Insn::AlterColumn {
+                db: database_id,
                 table: table_name.to_owned(),
                 column_index,
                 definition: Box::new(definition),
@@ -1199,7 +1224,9 @@ fn translate_rename_virtual_table(
     new_name_norm: String,
     resolver: &Resolver,
     connection: &Arc<crate::Connection>,
+    database_id: usize,
 ) -> Result<()> {
+    let schema_version = connection.with_schema(database_id, |s| s.schema_version);
     program.begin_write_operation();
     let vtab_cur = program.alloc_cursor_id(CursorType::VirtualTable(vtab));
     program.emit_insn(Insn::VOpen {
@@ -1223,7 +1250,7 @@ fn translate_rename_virtual_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: schema_cur,
         root_page: RegisterOrLiteral::Literal(sqlite_schema.root_page),
-        db: 0,
+        db: database_id,
     });
 
     program.cursor_loop(schema_cur, |program, rowid| {
@@ -1283,13 +1310,14 @@ fn translate_rename_virtual_table(
 
     // Bump schema cookie
     program.emit_insn(Insn::SetCookie {
-        db: 0,
+        db: database_id,
         cookie: Cookie::SchemaVersion,
-        value: resolver.schema.schema_version as i32 + 1,
+        value: schema_version as i32 + 1,
         p5: 0,
     });
 
     program.emit_insn(Insn::RenameTable {
+        db: database_id,
         from: old_name.to_owned(),
         to: new_name_norm,
     });

--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -15,66 +15,77 @@ use crate::{
         builder::{CursorType, ProgramBuilder},
         insn::{to_u16, CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
     },
-    Result,
+    Connection, Result,
 };
 use turso_parser::ast;
 
-pub fn translate_analyze(
-    target_opt: Option<ast::QualifiedName>,
-    resolver: &Resolver,
-    program: &mut ProgramBuilder,
-) -> Result<()> {
-    // Collect all analyze targets up front so we can create/open sqlite_stat1 just once.
-    let analyze_targets: Vec<(Arc<BTreeTable>, Option<Arc<Index>>)> = match target_opt {
+/// A table paired with an optional specific index to analyze.
+type AnalyzeTarget = (Arc<BTreeTable>, Option<Arc<Index>>);
+
+/// Resolve the target database_id and collect analyze targets from the QualifiedName.
+///
+/// ANALYZE can target:
+/// - Nothing (None): analyze all tables in main (database_id = 0)
+/// - A database name ("main", "aux"): analyze all tables in that database
+/// - A table name: analyze all indexes on that table
+/// - A qualified table name (db.table): analyze in the specified database
+/// - An index name: analyze just that index
+fn resolve_analyze_targets(
+    target_opt: &Option<ast::QualifiedName>,
+    connection: &Arc<Connection>,
+) -> Result<(usize, Vec<AnalyzeTarget>)> {
+    match target_opt {
         Some(target) => {
             let normalized = normalize_ident(target.name.as_str());
-            let db_normalized = target
-                .db_name
-                .as_ref()
-                .map(|db| normalize_ident(db.as_str()));
-            let target_is_main =
-                normalized.eq_ignore_ascii_case("main") || db_normalized.as_deref() == Some("main");
-            if target_is_main {
-                resolver
-                    .schema
-                    .tables
-                    .iter()
-                    .filter_map(|(name, table)| {
-                        if RESERVED_TABLE_PREFIXES
-                            .iter()
-                            .any(|prefix| name.starts_with(prefix))
-                        {
-                            return None;
-                        }
-                        table.btree().map(|bt| (bt, None))
-                    })
-                    .collect()
-            } else if let Some(table) = resolver.schema.get_btree_table(&normalized) {
-                vec![(
-                    table, None, // analyze the whole table and its indexes
-                )]
-            } else {
-                // Try to find an index by this name.
-                let mut found: Option<(Arc<BTreeTable>, Arc<Index>)> = None;
-                for (table_name, indexes) in resolver.schema.indexes.iter() {
-                    if let Some(index) = indexes
-                        .iter()
-                        .find(|idx| idx.name.eq_ignore_ascii_case(&normalized))
-                    {
-                        if let Some(table) = resolver.schema.get_btree_table(table_name) {
-                            found = Some((table, index.clone()));
-                            break;
-                        }
-                    }
+
+            // If db_name is specified, resolve to that database
+            if let Some(db_name) = &target.db_name {
+                let database_id = connection.resolve_database_id(target)?;
+                let db_normalized = normalize_ident(db_name.as_str());
+
+                // "ANALYZE db.table" — the name part is the table/index
+                // But first check if the name is actually a database name too (shouldn't be with db_name set)
+                let targets = resolve_targets_in_db(&normalized, database_id, connection)?;
+                if targets.is_empty() {
+                    bail_parse_error!("no such table or index: {}.{}", db_normalized, normalized);
                 }
-                let Some((table, index)) = found else {
-                    bail_parse_error!("no such table or index: {}", target.name);
-                };
-                vec![(table, Some(index))]
+                return Ok((database_id, targets));
             }
+
+            // No db_name — check if the name is a database name first
+            if normalized.eq_ignore_ascii_case("main") {
+                let targets = collect_all_tables_in_db(0, connection);
+                return Ok((0, targets));
+            }
+
+            // Check if it's an attached database name
+            if let Some((db_id, _)) = connection.get_attached_database(&normalized) {
+                let targets = collect_all_tables_in_db(db_id, connection);
+                return Ok((db_id, targets));
+            }
+
+            // Not a database name — search main schema for table/index
+            let targets = resolve_targets_in_db(&normalized, 0, connection)?;
+            if targets.is_empty() {
+                bail_parse_error!("no such table or index: {}", target.name);
+            }
+            Ok((0, targets))
         }
-        None => resolver
-            .schema
+        None => {
+            // ANALYZE with no target — analyze all tables in main
+            let targets = collect_all_tables_in_db(0, connection);
+            Ok((0, targets))
+        }
+    }
+}
+
+/// Collect all user tables in the given database.
+fn collect_all_tables_in_db(
+    database_id: usize,
+    connection: &Arc<Connection>,
+) -> Vec<AnalyzeTarget> {
+    connection.with_schema(database_id, |schema| {
+        schema
             .tables
             .iter()
             .filter_map(|(name, table)| {
@@ -86,8 +97,53 @@ pub fn translate_analyze(
                 }
                 table.btree().map(|bt| (bt, None))
             })
-            .collect(),
-    };
+            .collect()
+    })
+}
+
+/// Resolve a name as a table or index within a specific database.
+fn resolve_targets_in_db(
+    name: &str,
+    database_id: usize,
+    connection: &Arc<Connection>,
+) -> Result<Vec<AnalyzeTarget>> {
+    // Try as a table first
+    let table_opt: Option<Arc<BTreeTable>> =
+        connection.with_schema(database_id, |s| s.get_btree_table(name));
+    if let Some(table) = table_opt {
+        return Ok(vec![(table, None)]);
+    }
+
+    // Try as an index
+    let found: Option<(Arc<BTreeTable>, Arc<Index>)> =
+        connection.with_schema(database_id, |schema| {
+            for (table_name, indexes) in schema.indexes.iter() {
+                if let Some(index) = indexes
+                    .iter()
+                    .find(|idx| idx.name.eq_ignore_ascii_case(name))
+                {
+                    if let Some(table) = schema.get_btree_table(table_name) {
+                        return Some((table, index.clone()));
+                    }
+                }
+            }
+            None
+        });
+    if let Some((table, index)) = found {
+        return Ok(vec![(table, Some(index))]);
+    }
+
+    Ok(vec![])
+}
+
+pub fn translate_analyze(
+    target_opt: Option<ast::QualifiedName>,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+    connection: &Arc<Connection>,
+) -> Result<()> {
+    // Resolve the target database and collect analyze targets.
+    let (database_id, analyze_targets) = resolve_analyze_targets(&target_opt, connection)?;
 
     if analyze_targets.is_empty() {
         return Ok(());
@@ -106,7 +162,9 @@ pub fn translate_analyze(
     let sqlite_stat1_btreetable: Arc<BTreeTable>;
     let sqlite_stat1_source: RegisterOrLiteral<_>;
 
-    if let Some(sqlite_stat1) = resolver.schema.get_btree_table("sqlite_stat1") {
+    let stat1_table: Option<Arc<BTreeTable>> =
+        connection.with_schema(database_id, |s| s.get_btree_table("sqlite_stat1"));
+    if let Some(sqlite_stat1) = stat1_table {
         sqlite_stat1_btreetable = sqlite_stat1.clone();
         sqlite_stat1_source = RegisterOrLiteral::Literal(sqlite_stat1.root_page);
     } else {
@@ -126,7 +184,7 @@ pub fn translate_analyze(
         // implemented.
         let table_root_reg = program.alloc_register();
         program.emit_insn(Insn::CreateBtree {
-            db: 0,
+            db: database_id,
             root: table_root_reg,
             flags: CreateBTreeFlags::new_table(),
         });
@@ -136,12 +194,14 @@ pub fn translate_analyze(
         sqlite_stat1_btreetable = Arc::new(BTreeTable::from_sql(sql, 0)?);
         sqlite_stat1_source = RegisterOrLiteral::Register(table_root_reg);
 
-        let table = resolver.schema.get_btree_table(SQLITE_TABLEID).unwrap();
+        let table = connection
+            .with_schema(database_id, |s| s.get_btree_table(SQLITE_TABLEID))
+            .unwrap();
         let sqlite_schema_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(table));
         program.emit_insn(Insn::OpenWrite {
             cursor_id: sqlite_schema_cursor_id,
             root_page: 1i64.into(),
-            db: 0,
+            db: database_id,
         });
 
         // Add the table entry to sqlite_schema
@@ -160,15 +220,16 @@ pub fn translate_analyze(
         let parse_schema_where_clause =
             "tbl_name = 'sqlite_stat1' AND type != 'trigger'".to_string();
         program.emit_insn(Insn::ParseSchema {
-            db: sqlite_schema_cursor_id,
+            db: database_id,
             where_clause: Some(parse_schema_where_clause),
         });
 
         // Bump schema cookie so subsequent statements reparse schema.
+        let schema_version = connection.with_schema(database_id, |s| s.schema_version);
         program.emit_insn(Insn::SetCookie {
-            db: 0,
+            db: database_id,
             cookie: Cookie::SchemaVersion,
-            value: resolver.schema.schema_version as i32 + 1,
+            value: schema_version as i32 + 1,
             p5: 0,
         });
     };
@@ -179,7 +240,7 @@ pub fn translate_analyze(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: stat_cursor,
         root_page: sqlite_stat1_source,
-        db: 0,
+        db: database_id,
     });
 
     for (target_table, target_index) in analyze_targets {
@@ -282,7 +343,7 @@ pub fn translate_analyze(
         program.emit_insn(Insn::OpenRead {
             cursor_id: target_cursor,
             root_page: target_table.root_page,
-            db: 0,
+            db: database_id,
         });
         let rowid_reg = program.alloc_register();
         let tablename_reg = program.alloc_register();
@@ -345,15 +406,15 @@ pub fn translate_analyze(
         // Emit index stats for this table (or for a single index target).
         let indexes: Vec<Arc<Index>> = match target_index {
             Some(idx) => vec![idx],
-            None => resolver
-                .schema
-                .get_indices(&target_table.name)
-                .filter(|idx| idx.index_method.is_none()) // skip custom for now
-                .cloned()
-                .collect(),
+            None => connection.with_schema(database_id, |s| {
+                s.get_indices(&target_table.name)
+                    .filter(|idx| idx.index_method.is_none()) // skip custom for now
+                    .cloned()
+                    .collect()
+            }),
         };
         for index in indexes {
-            emit_index_stats(program, stat_cursor, &target_table, &index);
+            emit_index_stats(program, stat_cursor, &target_table, &index, database_id);
         }
     }
 
@@ -375,6 +436,7 @@ fn emit_index_stats(
     stat_cursor: usize,
     table: &Arc<BTreeTable>,
     index: &Arc<Index>,
+    database_id: usize,
 ) {
     let n_cols = index.columns.len();
     if n_cols == 0 {
@@ -386,7 +448,7 @@ fn emit_index_stats(
     program.emit_insn(Insn::OpenRead {
         cursor_id: idx_cursor,
         root_page: index.root_page,
-        db: 0,
+        db: database_id,
     });
 
     // Allocate registers contiguously for stat_push(accum, chng):

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -34,24 +34,24 @@ pub fn emit_guarded_fk_decrement(
 
 /// Open a read cursor on an index and return its cursor id.
 #[inline]
-pub fn open_read_index(program: &mut ProgramBuilder, idx: &Arc<Index>) -> usize {
+pub fn open_read_index(program: &mut ProgramBuilder, idx: &Arc<Index>, db: usize) -> usize {
     let icur = program.alloc_cursor_id(CursorType::BTreeIndex(idx.clone()));
     program.emit_insn(Insn::OpenRead {
         cursor_id: icur,
         root_page: idx.root_page,
-        db: 0,
+        db,
     });
     icur
 }
 
 /// Open a read cursor on a table and return its cursor id.
 #[inline]
-pub fn open_read_table(program: &mut ProgramBuilder, tbl: &Arc<BTreeTable>) -> usize {
+pub fn open_read_table(program: &mut ProgramBuilder, tbl: &Arc<BTreeTable>, db: usize) -> usize {
     let tcur = program.alloc_cursor_id(CursorType::BTreeTable(tbl.clone()));
     program.emit_insn(Insn::OpenRead {
         cursor_id: tcur,
         root_page: tbl.root_page,
-        db: 0,
+        db,
     });
     tcur
 }
@@ -131,12 +131,13 @@ fn table_scan_match_any<F>(
     child_cols: &[String],
     parent_key_start: usize,
     self_exclude_rowid: Option<usize>,
+    database_id: usize,
     mut on_match: F,
 ) -> Result<()>
 where
     F: FnMut(&mut ProgramBuilder) -> Result<()>,
 {
-    let ccur = open_read_table(program, child_tbl);
+    let ccur = open_read_table(program, child_tbl, database_id);
     let done = program.allocate_label();
     program.emit_insn(Insn::Rewind {
         cursor_id: ccur,
@@ -287,7 +288,6 @@ pub fn stabilize_new_row_for_fk(
 #[allow(clippy::too_many_arguments)]
 pub fn emit_parent_key_change_checks(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     table_btree: &BTreeTable,
     indexes_to_update: impl Iterator<Item = impl AsRef<Index>>,
     cursor_id: usize,
@@ -296,11 +296,13 @@ pub fn emit_parent_key_change_checks(
     rowid_new_reg: usize,
     rowid_set_clause_reg: Option<usize>,
     set_clauses: &[(usize, Box<Expr>)],
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
     let updated_positions: HashSet<usize> = set_clauses.iter().map(|(i, _)| *i).collect();
-    let incoming = resolver
-        .schema
-        .resolved_fks_referencing(&table_btree.name)?;
+    let incoming = connection.with_schema(database_id, |s| {
+        s.resolved_fks_referencing(&table_btree.name)
+    })?;
     let affects_pk = incoming
         .iter()
         .any(|r| r.parent_key_may_change(&updated_positions, table_btree));
@@ -314,9 +316,10 @@ pub fn emit_parent_key_change_checks(
         emit_rowid_pk_change_check(
             program,
             &incoming,
-            resolver,
             old_rowid_reg,
             rowid_set_clause_reg.unwrap_or(old_rowid_reg),
+            database_id,
+            connection,
         )?;
     }
 
@@ -328,9 +331,10 @@ pub fn emit_parent_key_change_checks(
             old_rowid_reg,
             rowid_new_reg,
             &incoming,
-            resolver,
             table_btree,
             index.as_ref(),
+            database_id,
+            connection,
         )?;
     }
     Ok(())
@@ -340,9 +344,10 @@ pub fn emit_parent_key_change_checks(
 pub fn emit_rowid_pk_change_check(
     program: &mut ProgramBuilder,
     incoming: &[ResolvedFkRef],
-    resolver: &Resolver,
     old_rowid_reg: usize,
     new_rowid_reg: usize,
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
     let skip = program.allocate_label();
     program.emit_insn(Insn::Eq {
@@ -366,7 +371,15 @@ pub fn emit_rowid_pk_change_check(
         extra_amount: 0,
     });
 
-    emit_fk_parent_pk_change_counters(program, incoming, resolver, old_pk, new_pk, 1)?;
+    emit_fk_parent_pk_change_counters(
+        program,
+        incoming,
+        old_pk,
+        new_pk,
+        1,
+        database_id,
+        connection,
+    )?;
     program.preassign_label_to_next_insn(skip);
     Ok(())
 }
@@ -395,9 +408,10 @@ pub fn emit_parent_index_key_change_checks(
     old_rowid_reg: usize,
     new_rowid_reg: usize,
     incoming: &[ResolvedFkRef],
-    resolver: &Resolver,
     table_btree: &BTreeTable,
     index: &Index,
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
     // Only process FKs that:
     // 1. Reference this specific index (OLD/NEW key vectors are built from this index's columns)
@@ -480,7 +494,15 @@ pub fn emit_parent_index_key_change_checks(
     }
 
     program.preassign_label_to_next_insn(changed);
-    emit_fk_parent_pk_change_counters(program, &matching_fks, resolver, old_key, new_key, idx_len)?;
+    emit_fk_parent_pk_change_counters(
+        program,
+        &matching_fks,
+        old_key,
+        new_key,
+        idx_len,
+        database_id,
+        connection,
+    )?;
     program.preassign_label_to_next_insn(skip);
     Ok(())
 }
@@ -491,27 +513,30 @@ pub fn emit_parent_index_key_change_checks(
 pub fn emit_fk_parent_pk_change_counters(
     program: &mut ProgramBuilder,
     incoming: &[ResolvedFkRef],
-    resolver: &Resolver,
     old_pk_start: usize,
     new_pk_start: usize,
     n_cols: usize,
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
     for fk_ref in incoming {
         emit_fk_parent_key_probe(
             program,
-            resolver,
             fk_ref,
             old_pk_start,
             n_cols,
             ParentProbePass::Old,
+            database_id,
+            connection,
         )?;
         emit_fk_parent_key_probe(
             program,
-            resolver,
             fk_ref,
             new_pk_start,
             n_cols,
             ParentProbePass::New,
+            database_id,
+            connection,
         )?;
     }
     Ok(())
@@ -528,11 +553,12 @@ enum ParentProbePass {
 /// For NO ACTION on OLD pass: increments FK violation counter
 fn emit_fk_parent_key_probe(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     fk_ref: &ResolvedFkRef,
     parent_key_start: usize,
     n_cols: usize,
     pass: ParentProbePass,
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
     let child_tbl = &fk_ref.child_table;
     let child_cols = &fk_ref.fk.child_columns;
@@ -568,7 +594,10 @@ fn emit_fk_parent_key_probe(
     };
 
     // Prefer exact child index on (child_cols...)
-    let idx = resolver.schema.get_indices(&child_tbl.name).find(|ix| {
+    let indices: Vec<_> = connection.with_schema(database_id, |s| {
+        s.get_indices(&child_tbl.name).cloned().collect()
+    });
+    let idx = indices.iter().find(|ix| {
         ix.columns.len() == child_cols.len()
             && ix
                 .columns
@@ -578,7 +607,7 @@ fn emit_fk_parent_key_probe(
     });
 
     if let Some(ix) = idx {
-        let icur = open_read_index(program, ix);
+        let icur = open_read_index(program, ix, database_id);
         let probe = copy_with_affinity(program, parent_key_start, n_cols, ix, child_tbl);
 
         // FOUND => on_match; NOT FOUND => no-op
@@ -591,6 +620,7 @@ fn emit_fk_parent_key_probe(
             child_cols,
             parent_key_start,
             None,
+            database_id,
             on_match,
         )?;
     }
@@ -643,13 +673,14 @@ fn build_parent_key(
 #[allow(clippy::too_many_arguments)]
 pub fn emit_fk_child_update_counters(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     child_tbl: &BTreeTable,
     child_table_name: &str,
     child_cursor_id: usize,
     new_start_reg: usize,
     new_rowid_reg: usize,
     updated_cols: &HashSet<usize>,
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
     // Helper: materialize OLD tuple for this FK; returns (start_reg, ncols) or None if any component is NULL.
     let load_old_tuple =
@@ -682,7 +713,9 @@ pub fn emit_fk_child_update_counters(
             Some((start, n))
         };
 
-    for fk_ref in resolver.schema.resolved_fks_for_child(child_table_name)? {
+    for fk_ref in
+        connection.with_schema(database_id, |s| s.resolved_fks_for_child(child_table_name))?
+    {
         // If the child-side FK columns did not change, there is nothing to do.
         if !fk_ref.child_key_changed(updated_cols, child_tbl) {
             continue;
@@ -695,11 +728,10 @@ pub fn emit_fk_child_update_counters(
             if let Some((old_start, _)) = load_old_tuple(program, &fk_ref.child_cols) {
                 if fk_ref.parent_uses_rowid {
                     // Parent key is rowid: probe parent table by rowid
-                    let parent_tbl = resolver
-                        .schema
-                        .get_btree_table(&fk_ref.fk.parent_table)
+                    let parent_tbl = connection
+                        .with_schema(database_id, |s| s.get_btree_table(&fk_ref.fk.parent_table))
                         .expect("parent btree");
-                    let pcur = open_read_table(program, &parent_tbl);
+                    let pcur = open_read_table(program, &parent_tbl, database_id);
 
                     // first FK col is the rowid value
                     let rid = program.alloc_register();
@@ -732,15 +764,14 @@ pub fn emit_fk_child_update_counters(
                     program.preassign_label_to_next_insn(join);
                 } else {
                     // Parent key is a unique index: use index probe and guarded decrement on NOT FOUND
-                    let parent_tbl = resolver
-                        .schema
-                        .get_btree_table(&fk_ref.fk.parent_table)
+                    let parent_tbl = connection
+                        .with_schema(database_id, |s| s.get_btree_table(&fk_ref.fk.parent_table))
                         .expect("parent btree");
                     let idx = fk_ref
                         .parent_unique_index
                         .as_ref()
                         .expect("parent unique index required");
-                    let icur = open_read_index(program, idx);
+                    let icur = open_read_index(program, idx, database_id);
 
                     // Copy OLD tuple and apply parent index affinities
                     let probe = copy_with_affinity(program, old_start, ncols, idx, &parent_tbl);
@@ -778,11 +809,10 @@ pub fn emit_fk_child_update_counters(
         }
 
         if fk_ref.parent_uses_rowid {
-            let parent_tbl = resolver
-                .schema
-                .get_btree_table(&fk_ref.fk.parent_table)
+            let parent_tbl = connection
+                .with_schema(database_id, |s| s.get_btree_table(&fk_ref.fk.parent_table))
                 .expect("parent btree");
-            let pcur = open_read_table(program, &parent_tbl);
+            let pcur = open_read_table(program, &parent_tbl, database_id);
 
             // Take the first child column value from NEW image
             let (i_child, col_child) = child_tbl.get_column(&fk_ref.child_cols[0]).unwrap();
@@ -815,15 +845,14 @@ pub fn emit_fk_child_update_counters(
             program.emit_insn(Insn::Close { cursor_id: pcur });
             emit_fk_violation(program, &fk_ref.fk)?;
         } else {
-            let parent_tbl = resolver
-                .schema
-                .get_btree_table(&fk_ref.fk.parent_table)
+            let parent_tbl = connection
+                .with_schema(database_id, |s| s.get_btree_table(&fk_ref.fk.parent_table))
                 .expect("parent btree");
             let idx = fk_ref
                 .parent_unique_index
                 .as_ref()
                 .expect("parent unique index required");
-            let icur = open_read_index(program, idx);
+            let icur = open_read_index(program, idx, database_id);
 
             // Build NEW probe (in FK child column order, aligns with parent index columns)
             let probe = {
@@ -877,14 +906,16 @@ pub fn emit_fk_child_update_counters(
 /// Raises a violation if any child row references the parent key.
 /// For RESTRICT: emits immediate HALT
 /// For NO ACTION: increments FK violation counter (checked at statement/transaction end)
+#[allow(clippy::too_many_arguments)]
 fn emit_fk_delete_parent_existence_check_single(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     fk_ref: &ResolvedFkRef,
     parent_bt: &Arc<BTreeTable>,
     parent_table_name: &str,
     parent_cursor_id: usize,
     parent_rowid_reg: usize,
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
     let is_self_ref = fk_ref
         .child_table
@@ -917,17 +948,17 @@ fn emit_fk_delete_parent_existence_check_single(
 
     let child_cols = &fk_ref.fk.child_columns;
     let child_idx = if !is_self_ref {
-        resolver
-            .schema
-            .get_indices(&fk_ref.child_table.name)
-            .find(|idx| {
-                idx.columns.len() == child_cols.len()
-                    && idx
-                        .columns
-                        .iter()
-                        .zip(child_cols.iter())
-                        .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
-            })
+        let indices: Vec<_> = connection.with_schema(database_id, |s| {
+            s.get_indices(&fk_ref.child_table.name).cloned().collect()
+        });
+        indices.into_iter().find(|idx| {
+            idx.columns.len() == child_cols.len()
+                && idx
+                    .columns
+                    .iter()
+                    .zip(child_cols.iter())
+                    .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
+        })
     } else {
         None
     };
@@ -942,8 +973,8 @@ fn emit_fk_delete_parent_existence_check_single(
         Ok(())
     };
 
-    if let Some(idx) = child_idx {
-        let icur = open_read_index(program, idx);
+    if let Some(ref idx) = child_idx {
+        let icur = open_read_index(program, idx, database_id);
         let probe = copy_with_affinity(program, parent_key_start, ncols, idx, &fk_ref.child_table);
         index_probe(
             program,
@@ -967,6 +998,7 @@ fn emit_fk_delete_parent_existence_check_single(
             } else {
                 None
             },
+            database_id,
             |p| {
                 emit_violation(p)?;
                 Ok(())
@@ -980,7 +1012,6 @@ fn emit_fk_delete_parent_existence_check_single(
 #[allow(clippy::too_many_arguments)]
 pub fn emit_fk_update_parent_actions(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     table_btree: &BTreeTable,
     indexes_to_update: impl Iterator<Item = impl AsRef<Index>>,
     cursor_id: usize,
@@ -989,11 +1020,13 @@ pub fn emit_fk_update_parent_actions(
     rowid_new_reg: usize,
     rowid_set_clause_reg: Option<usize>,
     set_clauses: &[(usize, Box<Expr>)],
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
     let updated_positions: HashSet<usize> = set_clauses.iter().map(|(i, _)| *i).collect();
-    let incoming = resolver
-        .schema
-        .resolved_fks_referencing(&table_btree.name)?;
+    let incoming = connection.with_schema(database_id, |s| {
+        s.resolved_fks_referencing(&table_btree.name)
+    })?;
     let affects_pk = incoming
         .iter()
         .any(|r| r.parent_key_may_change(&updated_positions, table_btree));
@@ -1028,9 +1061,10 @@ pub fn emit_fk_update_parent_actions(
                         emit_rowid_pk_change_check(
                             program,
                             &[fk_ref.clone()],
-                            resolver,
                             old_rowid_reg,
                             rowid_set_clause_reg.unwrap_or(old_rowid_reg),
+                            database_id,
+                            connection,
                         )?;
                     }
 
@@ -1042,9 +1076,10 @@ pub fn emit_fk_update_parent_actions(
                             old_rowid_reg,
                             rowid_new_reg,
                             &[fk_ref.clone()],
-                            resolver,
                             table_btree,
                             index.as_ref(),
+                            database_id,
+                            connection,
                         )?;
                     }
                 }
@@ -1063,9 +1098,10 @@ pub fn emit_fk_update_parent_actions(
             emit_rowid_pk_change_check(
                 program,
                 &incoming,
-                resolver,
                 old_rowid_reg,
                 rowid_set_clause_reg.unwrap_or(old_rowid_reg),
+                database_id,
+                connection,
             )?;
         }
 
@@ -1077,9 +1113,10 @@ pub fn emit_fk_update_parent_actions(
                 old_rowid_reg,
                 rowid_new_reg,
                 &incoming,
-                resolver,
                 table_btree,
                 index.as_ref(),
+                database_id,
+                connection,
             )?;
         }
     }
@@ -1281,20 +1318,26 @@ fn emit_fk_action_subprogram(
     Ok(())
 }
 
+/// Build a QualifiedName with db_name set for non-main databases.
+fn qualified_table_name(table_name: &str, db_name: Option<&str>) -> QualifiedName {
+    QualifiedName {
+        db_name: db_name.map(Name::from_string),
+        name: Name::from_string(table_name),
+        alias: None,
+    }
+}
+
 /// Generate a DELETE statement AST for CASCADE DELETE:
 /// DELETE FROM child_table WHERE fk_col1 = ?1 AND fk_col2 = ?2 ...
 fn generate_cascade_delete_stmt(
     child_table: &str,
     child_cols: &[String],
     ctx: &FkSubprogramContext,
+    db_name: Option<&str>,
 ) -> ast::Stmt {
     ast::Stmt::Delete {
         with: None,
-        tbl_name: QualifiedName {
-            db_name: None,
-            name: Name::from_string(child_table),
-            alias: None,
-        },
+        tbl_name: qualified_table_name(child_table, db_name),
         indexed: None,
         where_clause: Some(Box::new(build_fk_match_where_clause(child_cols, ctx))),
         returning: vec![],
@@ -1309,6 +1352,7 @@ fn generate_set_null_stmt(
     child_table: &str,
     child_cols: &[String],
     ctx: &FkSubprogramContext,
+    db_name: Option<&str>,
 ) -> ast::Stmt {
     // Build SET clause: fk_col1 = NULL, fk_col2 = NULL ...
     let sets: Vec<ast::Set> = child_cols
@@ -1321,11 +1365,7 @@ fn generate_set_null_stmt(
     ast::Stmt::Update(ast::Update {
         with: None,
         or_conflict: None,
-        tbl_name: QualifiedName {
-            db_name: None,
-            name: Name::from_string(child_table),
-            alias: None,
-        },
+        tbl_name: qualified_table_name(child_table, db_name),
         indexed: None,
         sets,
         from: None,
@@ -1342,6 +1382,7 @@ fn generate_set_default_stmt(
     child_table: &BTreeTable,
     child_cols: &[String],
     ctx: &FkSubprogramContext,
+    db_name: Option<&str>,
 ) -> ast::Stmt {
     // Build SET clause: if no default is defined for a column, we use NULL
     let sets: Vec<ast::Set> = child_cols
@@ -1362,11 +1403,7 @@ fn generate_set_default_stmt(
     ast::Stmt::Update(ast::Update {
         with: None,
         or_conflict: None,
-        tbl_name: QualifiedName {
-            db_name: None,
-            name: Name::from_string(&child_table.name),
-            alias: None,
-        },
+        tbl_name: qualified_table_name(&child_table.name, db_name),
         indexed: None,
         sets,
         from: None,
@@ -1383,6 +1420,7 @@ fn generate_cascade_update_stmt(
     child_table: &str,
     child_cols: &[String],
     ctx: &FkSubprogramContext,
+    db_name: Option<&str>,
 ) -> ast::Stmt {
     // Build SET clause
     let sets: Vec<ast::Set> = child_cols
@@ -1403,11 +1441,7 @@ fn generate_cascade_update_stmt(
     ast::Stmt::Update(ast::Update {
         with: None,
         or_conflict: None,
-        tbl_name: QualifiedName {
-            db_name: None,
-            name: Name::from_string(child_table),
-            alias: None,
-        },
+        tbl_name: qualified_table_name(child_table, db_name),
         indexed: None,
         sets,
         from: None,
@@ -1452,10 +1486,21 @@ fn fire_fk_cascade_delete(
     fk_ref: &ResolvedFkRef,
     connection: &Arc<Connection>,
     ctx: &FkActionContext,
+    database_id: usize,
 ) -> Result<()> {
+    let db_name = if database_id > 0 {
+        connection.get_database_name_by_index(database_id)
+    } else {
+        None
+    };
     let child_cols = &fk_ref.fk.child_columns;
     let subprog_ctx = FkSubprogramContext::new(child_cols.len(), false);
-    let stmt = generate_cascade_delete_stmt(&fk_ref.child_table.name, child_cols, &subprog_ctx);
+    let stmt = generate_cascade_delete_stmt(
+        &fk_ref.child_table.name,
+        child_cols,
+        &subprog_ctx,
+        db_name.as_deref(),
+    );
     emit_fk_action_subprogram(
         program,
         resolver,
@@ -1474,10 +1519,21 @@ fn fire_fk_set_null(
     fk_ref: &ResolvedFkRef,
     connection: &Arc<Connection>,
     ctx: &FkActionContext,
+    database_id: usize,
 ) -> Result<()> {
+    let db_name = if database_id > 0 {
+        connection.get_database_name_by_index(database_id)
+    } else {
+        None
+    };
     let child_cols = &fk_ref.fk.child_columns;
     let subprog_ctx = FkSubprogramContext::new(child_cols.len(), false);
-    let stmt = generate_set_null_stmt(&fk_ref.child_table.name, child_cols, &subprog_ctx);
+    let stmt = generate_set_null_stmt(
+        &fk_ref.child_table.name,
+        child_cols,
+        &subprog_ctx,
+        db_name.as_deref(),
+    );
     emit_fk_action_subprogram(program, resolver, connection, stmt, ctx, "fk set null")
 }
 
@@ -1489,10 +1545,21 @@ fn fire_fk_set_default(
     fk_ref: &ResolvedFkRef,
     connection: &Arc<Connection>,
     ctx: &FkActionContext,
+    database_id: usize,
 ) -> Result<()> {
+    let db_name = if database_id > 0 {
+        connection.get_database_name_by_index(database_id)
+    } else {
+        None
+    };
     let child_cols = &fk_ref.fk.child_columns;
     let subprog_ctx = FkSubprogramContext::new(child_cols.len(), false);
-    let stmt = generate_set_default_stmt(&fk_ref.child_table, child_cols, &subprog_ctx);
+    let stmt = generate_set_default_stmt(
+        &fk_ref.child_table,
+        child_cols,
+        &subprog_ctx,
+        db_name.as_deref(),
+    );
     emit_fk_action_subprogram(program, resolver, connection, stmt, ctx, "fk set default")
 }
 
@@ -1504,11 +1571,22 @@ fn fire_fk_cascade_update(
     fk_ref: &ResolvedFkRef,
     connection: &Arc<Connection>,
     ctx: &FkActionContext,
+    database_id: usize,
 ) -> Result<()> {
+    let db_name = if database_id > 0 {
+        connection.get_database_name_by_index(database_id)
+    } else {
+        None
+    };
     let child_cols = &fk_ref.fk.child_columns;
     // CASCADE UPDATE needs new params for the SET clause
     let subprog_ctx = FkSubprogramContext::new(child_cols.len(), true);
-    let stmt = generate_cascade_update_stmt(&fk_ref.child_table.name, child_cols, &subprog_ctx);
+    let stmt = generate_cascade_update_stmt(
+        &fk_ref.child_table.name,
+        child_cols,
+        &subprog_ctx,
+        db_name.as_deref(),
+    );
     emit_fk_action_subprogram(
         program,
         resolver,
@@ -1528,16 +1606,15 @@ pub fn fire_fk_delete_actions(
     parent_cursor_id: usize,
     parent_rowid_reg: usize,
     connection: &Arc<Connection>,
+    database_id: usize,
 ) -> Result<()> {
-    let parent_bt = resolver
-        .schema
-        .get_btree_table(parent_table_name)
+    let parent_bt = connection
+        .with_schema(database_id, |s| s.get_btree_table(parent_table_name))
         .ok_or_else(|| LimboError::InternalError("parent not btree".into()))?;
 
-    for fk_ref in resolver
-        .schema
-        .resolved_fks_referencing(parent_table_name)?
-    {
+    for fk_ref in connection.with_schema(database_id, |s| {
+        s.resolved_fks_referencing(parent_table_name)
+    })? {
         let parent_cols = get_fk_parent_cols(&fk_ref, &parent_bt);
         let ncols = parent_cols.len();
         let key_regs_start = program.alloc_registers(ncols);
@@ -1558,22 +1635,23 @@ pub fn fire_fk_delete_actions(
             RefAct::NoAction | RefAct::Restrict => {
                 emit_fk_delete_parent_existence_check_single(
                     program,
-                    resolver,
                     &fk_ref,
                     &parent_bt,
                     parent_table_name,
                     parent_cursor_id,
                     parent_rowid_reg,
+                    database_id,
+                    connection,
                 )?;
             }
             RefAct::Cascade => {
-                fire_fk_cascade_delete(program, resolver, &fk_ref, connection, &ctx)?;
+                fire_fk_cascade_delete(program, resolver, &fk_ref, connection, &ctx, database_id)?;
             }
             RefAct::SetNull => {
-                fire_fk_set_null(program, resolver, &fk_ref, connection, &ctx)?;
+                fire_fk_set_null(program, resolver, &fk_ref, connection, &ctx, database_id)?;
             }
             RefAct::SetDefault => {
-                fire_fk_set_default(program, resolver, &fk_ref, connection, &ctx)?;
+                fire_fk_set_default(program, resolver, &fk_ref, connection, &ctx, database_id)?;
             }
         }
     }
@@ -1594,16 +1672,15 @@ pub fn fire_fk_update_actions(
     new_values_start: usize,
     new_rowid_reg: usize,
     connection: &Arc<Connection>,
+    database_id: usize,
 ) -> Result<()> {
-    let parent_bt = resolver
-        .schema
-        .get_btree_table(parent_table_name)
+    let parent_bt = connection
+        .with_schema(database_id, |s| s.get_btree_table(parent_table_name))
         .ok_or_else(|| LimboError::InternalError("parent not btree".into()))?;
 
-    for fk_ref in resolver
-        .schema
-        .resolved_fks_referencing(parent_table_name)?
-    {
+    for fk_ref in connection.with_schema(database_id, |s| {
+        s.resolved_fks_referencing(parent_table_name)
+    })? {
         let parent_cols = get_fk_parent_cols(&fk_ref, &parent_bt);
         let ncols = parent_cols.len();
 
@@ -1653,13 +1730,13 @@ pub fn fire_fk_update_actions(
                 // which is called BEFORE the update using the counter-based approach.
             }
             RefAct::Cascade => {
-                fire_fk_cascade_update(program, resolver, &fk_ref, connection, &ctx)?;
+                fire_fk_cascade_update(program, resolver, &fk_ref, connection, &ctx, database_id)?;
             }
             RefAct::SetNull => {
-                fire_fk_set_null(program, resolver, &fk_ref, connection, &ctx)?;
+                fire_fk_set_null(program, resolver, &fk_ref, connection, &ctx, database_id)?;
             }
             RefAct::SetDefault => {
-                fire_fk_set_default(program, resolver, &fk_ref, connection, &ctx)?;
+                fire_fk_set_default(program, resolver, &fk_ref, connection, &ctx, database_id)?;
             }
         }
 
@@ -1686,18 +1763,18 @@ pub fn emit_fk_drop_table_check(
     resolver: &mut Resolver,
     parent_table_name: &str,
     connection: &Arc<Connection>,
+    database_id: usize,
 ) -> Result<()> {
-    let parent_tbl = resolver
-        .schema
-        .get_btree_table(parent_table_name)
+    let parent_tbl = connection
+        .with_schema(database_id, |s| s.get_btree_table(parent_table_name))
         .ok_or_else(|| {
             LimboError::InternalError(format!("parent table {parent_table_name} not found"))
         })?;
 
     // Get all FK references to this parent table
-    let fk_refs = resolver
-        .schema
-        .resolved_fks_referencing(parent_table_name)?;
+    let fk_refs = connection.with_schema(database_id, |s| {
+        s.resolved_fks_referencing(parent_table_name)
+    })?;
 
     if fk_refs.is_empty() {
         return Ok(());
@@ -1725,7 +1802,7 @@ pub fn emit_fk_drop_table_check(
     let rowset_reg = program.alloc_register();
     program.emit_null(rowset_reg, None);
 
-    let parent_cur = open_read_table(program, &parent_tbl);
+    let parent_cur = open_read_table(program, &parent_tbl, database_id);
     let collect_done = program.allocate_label();
 
     program.emit_insn(Insn::Rewind {
@@ -1762,7 +1839,7 @@ pub fn emit_fk_drop_table_check(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: parent_write_cur,
         root_page: parent_tbl.root_page.into(),
-        db: 0,
+        db: database_id,
     });
 
     let rowset_done = program.allocate_label();
@@ -1804,13 +1881,13 @@ pub fn emit_fk_drop_table_check(
 
         match fk_ref.fk.on_delete {
             RefAct::Cascade => {
-                fire_fk_cascade_delete(program, resolver, fk_ref, connection, &ctx)?;
+                fire_fk_cascade_delete(program, resolver, fk_ref, connection, &ctx, database_id)?;
             }
             RefAct::SetNull => {
-                fire_fk_set_null(program, resolver, fk_ref, connection, &ctx)?;
+                fire_fk_set_null(program, resolver, fk_ref, connection, &ctx, database_id)?;
             }
             RefAct::SetDefault => {
-                fire_fk_set_default(program, resolver, fk_ref, connection, &ctx)?;
+                fire_fk_set_default(program, resolver, fk_ref, connection, &ctx, database_id)?;
             }
             RefAct::NoAction | RefAct::Restrict => {
                 // These are handled below in the check_fk_refs loop
@@ -1839,7 +1916,7 @@ pub fn emit_fk_drop_table_check(
         )?;
 
         // Scan child table for matching rows
-        let child_cur = open_read_table(program, child_tbl);
+        let child_cur = open_read_table(program, child_tbl, database_id);
         let child_done = program.allocate_label();
 
         program.emit_insn(Insn::Rewind {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
-    schema::{self, BTreeTable, ColDef, Column, Index, IndexColumn, ResolvedFkRef, Schema, Table},
+    schema::{self, BTreeTable, ColDef, Column, Index, IndexColumn, ResolvedFkRef, Table},
     sync::Arc,
     translate::{
         emitter::{
@@ -153,22 +153,29 @@ pub struct InsertEmitCtx<'a> {
     pub cdc_table: Option<(usize, Arc<BTreeTable>)>,
     /// Autoincrement sequence table info
     pub autoincrement_meta: Option<AutoincMeta>,
+    /// The database index (0 = main, 1 = temp, 2+ = attached)
+    pub database_id: usize,
 }
 
 impl<'a> InsertEmitCtx<'a> {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         program: &mut ProgramBuilder,
-        resolver: &Resolver,
+        _resolver: &Resolver,
         table: &'a Arc<BTreeTable>,
         on_conflict: Option<ResolveType>,
         cdc_table: Option<(usize, Arc<BTreeTable>)>,
         num_values: usize,
         temp_table_ctx: Option<TempTableCtx>,
+        database_id: usize,
+        connection: &Arc<crate::Connection>,
     ) -> Result<Self> {
         // allocate cursor id's for each btree index cursor we'll need to populate the indexes
-        let indices = resolver.schema.get_indices(table.name.as_str());
+        let indices: Vec<_> = connection.with_schema(database_id, |s| {
+            s.get_indices(table.name.as_str()).cloned().collect()
+        });
         let mut idx_cursors = Vec::new();
-        for idx in indices {
+        for idx in &indices {
             idx_cursors.push((
                 idx.name.clone(),
                 idx.root_page,
@@ -199,6 +206,7 @@ impl<'a> InsertEmitCtx<'a> {
             cdc_table,
             num_values,
             autoincrement_meta: None,
+            database_id,
         })
     }
 }
@@ -249,8 +257,9 @@ pub fn translate_insert(
         // for RETURNING clause subqueries - handled below via with_for_returning.
     }
 
+    let database_id = connection.resolve_database_id(&tbl_name)?;
     let table_name = &tbl_name.name;
-    let table = match resolver.schema.get_table(table_name.as_str()) {
+    let table = match connection.with_schema(database_id, |s| s.get_table(table_name.as_str())) {
         Some(table) => table,
         None => crate::bail_parse_error!("no such table: {}", table_name),
     };
@@ -287,10 +296,15 @@ pub fn translate_insert(
     )?;
 
     if inserting_multiple_rows && btree_table.has_autoincrement {
-        ensure_sequence_initialized(program, resolver.schema, &btree_table)?;
+        ensure_sequence_initialized(program, connection, &btree_table, database_id)?;
     }
 
     let cdc_table = prepare_cdc_if_necessary(program, resolver.schema, table.get_name())?;
+
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
 
     let mut table_references = TableReferences::new(
         vec![JoinedTable {
@@ -306,7 +320,7 @@ pub fn translate_insert(
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
+            database_id,
         }],
         vec![],
     );
@@ -336,10 +350,10 @@ pub fn translate_insert(
     let mut result_columns =
         process_returning_clause(&mut returning, &mut table_references, connection)?;
     let has_fks = fk_enabled
-        && (resolver.schema.has_child_fks(table_name.as_str())
-            || resolver
-                .schema
-                .any_resolved_fks_referencing(table_name.as_str()));
+        && (connection.with_schema(database_id, |s| s.has_child_fks(table_name.as_str()))
+            || connection.with_schema(database_id, |s| {
+                s.any_resolved_fks_referencing(table_name.as_str())
+            }));
 
     let mut ctx = InsertEmitCtx::new(
         program,
@@ -349,6 +363,8 @@ pub fn translate_insert(
         cdc_table,
         values.len(),
         None,
+        database_id,
+        connection,
     )?;
 
     init_source_emission(
@@ -361,6 +377,7 @@ pub fn translate_insert(
         body,
         &columns,
         &table_references,
+        database_id,
     )?;
     let has_upsert = !upsert_actions.is_empty();
 
@@ -402,21 +419,23 @@ pub fn translate_insert(
     let has_user_provided_rowid = insertion.key.is_provided_by_user();
 
     if ctx.table.has_autoincrement {
-        init_autoincrement(program, &mut ctx, resolver)?;
+        init_autoincrement(program, &mut ctx, connection)?;
     }
 
     // Fire BEFORE INSERT triggers
 
-    let relevant_before_triggers = get_relevant_triggers_type_and_time(
-        resolver.schema,
-        TriggerEvent::Insert,
-        TriggerTime::Before,
-        None,
-        &btree_table,
-    );
-    let has_relevant_before_triggers = relevant_before_triggers.clone().count() > 0;
+    let relevant_before_triggers: Vec<_> = connection.with_schema(database_id, |s| {
+        get_relevant_triggers_type_and_time(
+            s,
+            TriggerEvent::Insert,
+            TriggerTime::Before,
+            None,
+            &btree_table,
+        )
+        .collect()
+    });
 
-    if has_relevant_before_triggers {
+    if !relevant_before_triggers.is_empty() {
         // Build NEW registers: for rowid alias columns, use the rowid register; otherwise use column register
         let new_registers: Vec<usize> = insertion
             .col_mappings
@@ -458,7 +477,14 @@ pub fn translate_insert(
             )
         };
         for trigger in relevant_before_triggers {
-            fire_trigger(program, resolver, trigger, &trigger_ctx, connection)?;
+            fire_trigger(
+                program,
+                resolver,
+                trigger,
+                &trigger_ctx,
+                connection,
+                database_id,
+            )?;
         }
     }
 
@@ -486,7 +512,7 @@ pub fn translate_insert(
 
     program.preassign_label_to_next_insn(ctx.key_labels.key_generation);
 
-    emit_rowid_generation(program, resolver, &ctx, &insertion)?;
+    emit_rowid_generation(program, &ctx, &insertion, connection)?;
 
     program.preassign_label_to_next_insn(ctx.key_labels.key_ready_for_check);
 
@@ -547,10 +573,11 @@ pub fn translate_insert(
     // Build a list of upsert constraints/indexes we need to run preflight
     // checks against, in the proper order of evaluation,
     let constraints = build_constraints_to_check(
-        resolver,
         table_name.as_str(),
         &upsert_actions,
         has_user_provided_rowid,
+        connection,
+        ctx.database_id,
     );
 
     // We need to separate index handling and insertion into a `preflight` and a
@@ -595,17 +622,18 @@ pub fn translate_insert(
     // IGNORE/ROLLBACK). REPLACE inserts eagerly in the preflight phase because it needs
     // to delete-then-insert per index.
     if has_upsert || !on_replace {
-        emit_commit_phase(program, resolver, &insertion, &ctx)?;
+        emit_commit_phase(program, resolver, &insertion, &ctx, connection)?;
     }
 
     if has_fks {
         // Child-side check must run before Insert (may HALT or increment deferred counter)
         emit_fk_child_insert_checks(
             program,
-            resolver,
             &btree_table,
             insertion.first_col_register(),
             insertion.key_register(),
+            database_id,
+            connection,
         )?;
     }
 
@@ -626,15 +654,17 @@ pub fn translate_insert(
     });
 
     // Fire AFTER INSERT triggers
-    let relevant_after_triggers = get_relevant_triggers_type_and_time(
-        resolver.schema,
-        TriggerEvent::Insert,
-        TriggerTime::After,
-        None,
-        &btree_table,
-    );
-    let has_relevant_after_triggers = relevant_after_triggers.clone().count() > 0;
-    if has_relevant_after_triggers {
+    let relevant_after_triggers: Vec<_> = connection.with_schema(database_id, |s| {
+        get_relevant_triggers_type_and_time(
+            s,
+            TriggerEvent::Insert,
+            TriggerTime::After,
+            None,
+            &btree_table,
+        )
+        .collect()
+    });
+    if !relevant_after_triggers.is_empty() {
         // Build NEW registers: for rowid alias columns, use the rowid register; otherwise use column register
         let new_registers_after: Vec<usize> = insertion
             .col_mappings
@@ -667,7 +697,14 @@ pub fn translate_insert(
             TriggerContext::new(btree_table.clone(), Some(new_registers_after), None)
         };
         for trigger in relevant_after_triggers {
-            fire_trigger(program, resolver, trigger, &trigger_ctx_after, connection)?;
+            fire_trigger(
+                program,
+                resolver,
+                trigger,
+                &trigger_ctx_after,
+                connection,
+                database_id,
+            )?;
         }
     }
 
@@ -677,10 +714,11 @@ pub fn translate_insert(
         // them, even for immediate/self-ref FKs.
         emit_parent_side_fk_decrement_on_insert(
             program,
-            resolver,
             &btree_table,
             &insertion,
             on_replace,
+            database_id,
+            connection,
         )?;
     }
 
@@ -702,7 +740,8 @@ pub fn translate_insert(
 
         emit_update_sqlite_sequence(
             program,
-            resolver.schema,
+            connection,
+            ctx.database_id,
             seq_cursor_id,
             r_seq_rowid,
             table_name_reg,
@@ -870,8 +909,12 @@ fn emit_commit_phase(
     resolver: &Resolver,
     insertion: &Insertion,
     ctx: &InsertEmitCtx,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
-    for index in resolver.schema.get_indices(ctx.table.name.as_str()) {
+    let indices: Vec<_> = connection.with_schema(ctx.database_id, |s| {
+        s.get_indices(ctx.table.name.as_str()).cloned().collect()
+    });
+    for index in &indices {
         let idx_cursor_id = ctx
             .idx_cursors
             .iter()
@@ -948,7 +991,7 @@ fn translate_rows_and_open_tables(
         program.emit_insn(Insn::OpenWrite {
             cursor_id: ctx.cursor_id,
             root_page: RegisterOrLiteral::Literal(ctx.table.root_page),
-            db: 0,
+            db: ctx.database_id,
         });
 
         translate_rows_single(program, values, insertion, resolver)?;
@@ -959,7 +1002,7 @@ fn translate_rows_and_open_tables(
         program.emit_insn(Insn::OpenWrite {
             cursor_id: idx_cursor.2,
             root_page: idx_cursor.1.into(),
-            db: 0,
+            db: ctx.database_id,
         });
     }
     Ok(())
@@ -967,9 +1010,9 @@ fn translate_rows_and_open_tables(
 
 fn emit_rowid_generation(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     ctx: &InsertEmitCtx,
     insertion: &Insertion,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
     if let Some(AutoincMeta {
         r_seq,
@@ -1027,7 +1070,8 @@ fn emit_rowid_generation(
 
         emit_update_sqlite_sequence(
             program,
-            resolver.schema,
+            connection,
+            ctx.database_id,
             seq_cursor_id,
             r_seq_rowid,
             table_name_reg,
@@ -1091,11 +1135,10 @@ fn resolve_upserts(
 fn init_autoincrement(
     program: &mut ProgramBuilder,
     ctx: &mut InsertEmitCtx,
-    resolver: &Resolver,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
-    let seq_table = resolver
-        .schema
-        .get_btree_table("sqlite_sequence")
+    let seq_table = connection
+        .with_schema(ctx.database_id, |s| s.get_btree_table("sqlite_sequence"))
         .ok_or_else(|| {
             crate::error::LimboError::InternalError("sqlite_sequence table not found".to_string())
         })?;
@@ -1103,7 +1146,7 @@ fn init_autoincrement(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: seq_cursor_id,
         root_page: seq_table.root_page.into(),
-        db: 0,
+        db: ctx.database_id,
     });
 
     let table_name_reg = program.emit_string8_new_reg(ctx.table.name.clone());
@@ -1430,6 +1473,7 @@ fn init_source_emission<'a>(
     body: InsertBody,
     columns: &'a [ast::Name],
     table_references: &TableReferences,
+    database_id: usize,
 ) -> Result<()> {
     let required_column_count = if columns.is_empty() {
         table.columns().len()
@@ -1446,12 +1490,9 @@ fn init_source_emission<'a>(
         }
     }
     // Check if INSERT triggers exist - if so, we need to use ephemeral table for VALUES with more than one row
-    let has_insert_triggers = has_relevant_triggers_type_only(
-        resolver.schema,
-        TriggerEvent::Insert,
-        None,
-        ctx.table.as_ref(),
-    );
+    let has_insert_triggers = connection.with_schema(database_id, |s| {
+        has_relevant_triggers_type_only(s, TriggerEvent::Insert, None, ctx.table.as_ref())
+    });
 
     let (num_values, cursor_id) = match body {
         InsertBody::Select(select, _) => {
@@ -1598,13 +1639,13 @@ fn init_source_emission<'a>(
                     program.emit_insn(Insn::OpenWrite {
                         cursor_id,
                         root_page: RegisterOrLiteral::Literal(ctx.table.root_page),
-                        db: 0,
+                        db: ctx.database_id,
                     });
                 } else {
                     program.emit_insn(Insn::OpenWrite {
                         cursor_id,
                         root_page: RegisterOrLiteral::Literal(ctx.table.root_page),
-                        db: 0,
+                        db: ctx.database_id,
                     });
 
                     program.preassign_label_to_next_insn(ctx.loop_labels.loop_start);
@@ -2431,19 +2472,22 @@ fn translate_virtual_table_insert(
 ///  makes sure that an AUTOINCREMENT table has a sequence row in `sqlite_sequence`, inserting one with 0 if missing.
 fn ensure_sequence_initialized(
     program: &mut ProgramBuilder,
-    schema: &Schema,
+    connection: &Arc<Connection>,
     table: &schema::BTreeTable,
+    database_id: usize,
 ) -> Result<()> {
-    let seq_table = schema.get_btree_table("sqlite_sequence").ok_or_else(|| {
-        crate::error::LimboError::InternalError("sqlite_sequence table not found".to_string())
-    })?;
+    let seq_table = connection
+        .with_schema(database_id, |s| s.get_btree_table("sqlite_sequence"))
+        .ok_or_else(|| {
+            crate::error::LimboError::InternalError("sqlite_sequence table not found".to_string())
+        })?;
 
     let seq_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(seq_table.clone()));
 
     program.emit_insn(Insn::OpenWrite {
         cursor_id: seq_cursor_id,
         root_page: seq_table.root_page.into(),
-        db: 0,
+        db: database_id,
     });
 
     let table_name_reg = program.emit_string8_new_reg(table.name.clone());
@@ -2717,10 +2761,11 @@ struct PreflightCtx<'a, 'b> {
 }
 
 fn build_constraints_to_check(
-    resolver: &Resolver,
     table_name: &str,
     upsert_actions: &[(ResolvedUpsertTarget, BranchOffset, Box<Upsert>)],
     has_user_provided_rowid: bool,
+    connection: &Arc<crate::Connection>,
+    database_id: usize,
 ) -> ConstraintsToCheck {
     let mut constraints_to_check = Vec::new();
     if has_user_provided_rowid {
@@ -2731,7 +2776,10 @@ fn build_constraints_to_check(
             .position(|(target, ..)| matches!(target, ResolvedUpsertTarget::PrimaryKey));
         constraints_to_check.push((ResolvedUpsertTarget::PrimaryKey, position));
     }
-    for index in resolver.schema.get_indices(table_name) {
+    let indices: Vec<_> = connection.with_schema(database_id, |s| {
+        s.get_indices(table_name).cloned().collect()
+    });
+    for index in &indices {
         let position = upsert_actions
             .iter()
             .position(|(target, ..)| matches!(target, ResolvedUpsertTarget::Index(x) if Arc::ptr_eq(x, index)));
@@ -2759,7 +2807,8 @@ fn build_constraints_to_check(
 
 fn emit_update_sqlite_sequence(
     program: &mut ProgramBuilder,
-    schema: &Schema,
+    connection: &Arc<Connection>,
+    database_id: usize,
     seq_cursor_id: usize,
     r_seq_rowid: usize,
     table_name_reg: usize,
@@ -2778,7 +2827,9 @@ fn emit_update_sqlite_sequence(
         extra_amount: 0,
     });
 
-    let seq_table = schema.get_btree_table("sqlite_sequence").unwrap();
+    let seq_table = connection
+        .with_schema(database_id, |s| s.get_btree_table("sqlite_sequence"))
+        .unwrap();
     let affinity_str = seq_table
         .columns
         .iter()
@@ -2853,6 +2904,7 @@ fn emit_replace_delete_conflicting_row(
             ctx.cursor_id,
             ctx.conflict_rowid_reg,
             connection,
+            ctx.database_id,
         )?;
     }
 
@@ -2973,12 +3025,15 @@ fn emit_replace_delete_conflicting_row(
 /// verify that the referenced parent key exists.
 pub fn emit_fk_child_insert_checks(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     child_tbl: &BTreeTable,
     new_start_reg: usize,
     new_rowid_reg: usize,
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> crate::Result<()> {
-    for fk_ref in resolver.schema.resolved_fks_for_child(&child_tbl.name)? {
+    for fk_ref in
+        connection.with_schema(database_id, |s| s.resolved_fks_for_child(&child_tbl.name))?
+    {
         let is_self_ref = fk_ref.fk.parent_table.eq_ignore_ascii_case(&child_tbl.name);
 
         // Short-circuit if any NEW component is NULL
@@ -2995,12 +3050,11 @@ pub fn emit_fk_child_insert_checks(
                 target_pc: fk_ok,
             });
         }
-        let parent_tbl = resolver
-            .schema
-            .get_btree_table(&fk_ref.fk.parent_table)
+        let parent_tbl = connection
+            .with_schema(database_id, |s| s.get_btree_table(&fk_ref.fk.parent_table))
             .expect("parent btree");
         if fk_ref.parent_uses_rowid {
-            let pcur = open_read_table(program, &parent_tbl);
+            let pcur = open_read_table(program, &parent_tbl, database_id);
 
             // first child col carries rowid
             let (i_child, col_child) = child_tbl.get_column(&fk_ref.child_cols[0]).unwrap();
@@ -3050,7 +3104,7 @@ pub fn emit_fk_child_insert_checks(
                 .parent_unique_index
                 .as_ref()
                 .expect("parent unique index required");
-            let icur = open_read_index(program, idx);
+            let icur = open_read_index(program, idx, database_id);
             let ncols = fk_ref.child_cols.len();
 
             // Build NEW child probe from child NEW values, apply parent-index affinities.
@@ -3227,15 +3281,15 @@ fn build_parent_key_image_for_insert(
 /// “repair” a prior child-insert count recorded earlier in the same statement.
 pub fn emit_parent_side_fk_decrement_on_insert(
     program: &mut ProgramBuilder,
-    resolver: &Resolver,
     parent_table: &BTreeTable,
     insertion: &Insertion,
     force_immediate: bool,
+    database_id: usize,
+    connection: &Arc<Connection>,
 ) -> crate::Result<()> {
-    for pref in resolver
-        .schema
-        .resolved_fks_referencing(&parent_table.name)?
-    {
+    for pref in connection.with_schema(database_id, |s| {
+        s.resolved_fks_referencing(&parent_table.name)
+    })? {
         let is_self_ref = pref
             .child_table
             .name
@@ -3249,7 +3303,10 @@ pub fn emit_parent_side_fk_decrement_on_insert(
 
         let child_tbl = &pref.child_table;
         let child_cols = &pref.fk.child_columns;
-        let idx = resolver.schema.get_indices(&child_tbl.name).find(|ix| {
+        let indices: Vec<_> = connection.with_schema(database_id, |s| {
+            s.get_indices(&child_tbl.name).cloned().collect()
+        });
+        let idx = indices.iter().find(|ix| {
             ix.columns.len() == child_cols.len()
                 && ix
                     .columns
@@ -3259,7 +3316,7 @@ pub fn emit_parent_side_fk_decrement_on_insert(
         });
 
         if let Some(ix) = idx {
-            let icur = open_read_index(program, ix);
+            let icur = open_read_index(program, ix, database_id);
             // Copy key into probe regs and apply child-index affinities
             let probe_start = program.alloc_registers(n_cols);
             for i in 0..n_cols {
@@ -3297,7 +3354,7 @@ pub fn emit_parent_side_fk_decrement_on_insert(
             program.resolve_label(skip, program.offset());
         } else {
             // fallback scan :(
-            let ccur = open_read_table(program, child_tbl);
+            let ccur = open_read_table(program, child_tbl, database_id);
             let done = program.allocate_label();
             program.emit_insn(Insn::Rewind {
                 cursor_id: ccur,

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -159,7 +159,7 @@ pub fn translate_inner(
         ast::Stmt::AlterTable(alter) => {
             translate_alter_table(alter, resolver, program, connection, input)?;
         }
-        ast::Stmt::Analyze { name } => translate_analyze(name, resolver, program)?,
+        ast::Stmt::Analyze { name } => translate_analyze(name, resolver, program, connection)?,
         ast::Stmt::Attach { expr, db_name, key } => {
             attach::translate_attach(&expr, resolver, &db_name, &key, program, connection.clone())?;
         }
@@ -225,7 +225,7 @@ pub fn translate_inner(
             columns,
             ..
         } => view::translate_create_view(
-            &view_name.name,
+            &view_name,
             resolver,
             &select,
             &columns,
@@ -235,7 +235,7 @@ pub fn translate_inner(
         ast::Stmt::CreateMaterializedView {
             view_name, select, ..
         } => view::translate_create_materialized_view(
-            &view_name.name,
+            &view_name,
             resolver,
             &select,
             connection.clone(),
@@ -276,7 +276,7 @@ pub fn translate_inner(
         ast::Stmt::DropIndex {
             if_exists,
             idx_name,
-        } => translate_drop_index(idx_name.name.as_str(), resolver, if_exists, program)?,
+        } => translate_drop_index(&idx_name, resolver, if_exists, program, connection)?,
         ast::Stmt::DropTable {
             if_exists,
             tbl_name,
@@ -284,19 +284,11 @@ pub fn translate_inner(
         ast::Stmt::DropTrigger {
             if_exists,
             trigger_name,
-        } => trigger::translate_drop_trigger(
-            resolver.schema,
-            trigger_name.name.as_str(),
-            if_exists,
-            program,
-            connection.clone(),
-        )?,
+        } => trigger::translate_drop_trigger(connection, &trigger_name, if_exists, program)?,
         ast::Stmt::DropView {
             if_exists,
             view_name,
-        } => {
-            view::translate_drop_view(resolver.schema, view_name.name.as_str(), if_exists, program)?
-        }
+        } => view::translate_drop_view(connection, resolver, &view_name, if_exists, program)?,
         ast::Stmt::Pragma { .. } => {
             bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")
         }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -70,8 +70,18 @@ pub fn translate_pragma(
         Err(_) => bail_parse_error!("Not a valid pragma name"),
     };
 
+    let database_id = connection.resolve_database_id(name)?;
+
     let mode = match body {
-        None => query_pragma(pragma, resolver, None, pager, connection, program)?,
+        None => query_pragma(
+            pragma,
+            resolver,
+            None,
+            pager,
+            connection,
+            database_id,
+            program,
+        )?,
         Some(ast::PragmaBody::Equals(value) | ast::PragmaBody::Call(value)) => match pragma {
             // These pragmas take a parameter but are queries, not setters
             PragmaName::IndexInfo
@@ -82,10 +92,24 @@ pub fn translate_pragma(
             | PragmaName::TableXinfo
             | PragmaName::IntegrityCheck
             | PragmaName::DatabaseList
-            | PragmaName::QuickCheck => {
-                query_pragma(pragma, resolver, Some(*value), pager, connection, program)?
-            }
-            _ => update_pragma(pragma, resolver, *value, pager, connection, program)?,
+            | PragmaName::QuickCheck => query_pragma(
+                pragma,
+                resolver,
+                Some(*value),
+                pager,
+                connection,
+                database_id,
+                program,
+            )?,
+            _ => update_pragma(
+                pragma,
+                resolver,
+                *value,
+                pager,
+                connection,
+                database_id,
+                program,
+            )?,
         },
     };
     match mode {
@@ -110,6 +134,7 @@ fn update_pragma(
     value: ast::Expr,
     pager: Arc<Pager>,
     connection: Arc<crate::Connection>,
+    database_id: usize,
     program: &mut ProgramBuilder,
 ) -> crate::Result<TransactionMode> {
     let parse_pragma_enabled = |expr: &ast::Expr| -> bool {
@@ -136,7 +161,7 @@ fn update_pragma(
             };
 
             program.emit_insn(Insn::SetCookie {
-                db: 0,
+                db: database_id,
                 cookie: Cookie::ApplicationId,
                 value: app_id_value,
                 p5: 1,
@@ -181,7 +206,7 @@ fn update_pragma(
 
             let result_reg = program.alloc_register();
             program.emit_insn(Insn::JournalMode {
-                db: 0,
+                db: database_id,
                 dest: result_reg,
                 new_mode: Some(mode_str),
             });
@@ -197,6 +222,7 @@ fn update_pragma(
             Some(value),
             pager,
             connection,
+            database_id,
             program,
         ),
         PragmaName::ModuleList => Ok(TransactionMode::None),
@@ -206,6 +232,7 @@ fn update_pragma(
             None,
             pager,
             connection,
+            database_id,
             program,
         ),
         PragmaName::MaxPageCount => {
@@ -218,7 +245,7 @@ fn update_pragma(
 
             let result_reg = program.alloc_register();
             program.emit_insn(Insn::MaxPgcnt {
-                db: 0,
+                db: database_id,
                 dest: result_reg,
                 new_max: max_page_count_value,
             });
@@ -235,7 +262,7 @@ fn update_pragma(
             };
 
             program.emit_insn(Insn::SetCookie {
-                db: 0,
+                db: database_id,
                 cookie: Cookie::UserVersion,
                 value: version_value,
                 p5: 1,
@@ -324,7 +351,7 @@ fn update_pragma(
             }
             let largest_root_page_number_reg = program.alloc_register();
             program.emit_insn(Insn::ReadCookie {
-                db: 0,
+                db: database_id,
                 dest: largest_root_page_number_reg,
                 cookie: Cookie::LargestRootPageNumber,
             });
@@ -340,7 +367,7 @@ fn update_pragma(
             });
             program.resolve_label(set_cookie_label, program.offset());
             program.emit_insn(Insn::SetCookie {
-                db: 0,
+                db: database_id,
                 cookie: Cookie::IncrementalVacuum,
                 value: auto_vacuum_mode - 1,
                 p5: 0,
@@ -381,6 +408,7 @@ fn update_pragma(
             Some(value),
             pager,
             connection,
+            database_id,
             program,
         ),
         PragmaName::FreelistCount => query_pragma(
@@ -389,6 +417,7 @@ fn update_pragma(
             Some(value),
             pager,
             connection,
+            database_id,
             program,
         ),
         PragmaName::EncryptionKey => {
@@ -498,6 +527,7 @@ fn update_pragma(
             Some(value),
             pager,
             connection,
+            database_id,
             program,
         ),
     }
@@ -509,6 +539,7 @@ fn query_pragma(
     value: Option<ast::Expr>,
     pager: Arc<Pager>,
     connection: Arc<crate::Connection>,
+    database_id: usize,
     program: &mut ProgramBuilder,
 ) -> crate::Result<TransactionMode> {
     let schema = resolver.schema;
@@ -516,7 +547,7 @@ fn query_pragma(
     match pragma {
         PragmaName::ApplicationId => {
             program.emit_insn(Insn::ReadCookie {
-                db: 0,
+                db: database_id,
                 dest: register,
                 cookie: Cookie::ApplicationId,
             });
@@ -582,7 +613,7 @@ fn query_pragma(
         PragmaName::JournalMode => {
             // Use the JournalMode opcode to get the current journal mode
             program.emit_insn(Insn::JournalMode {
-                db: 0,
+                db: database_id,
                 dest: register,
                 new_mode: None,
             });
@@ -608,7 +639,7 @@ fn query_pragma(
 
             program.alloc_registers(2);
             program.emit_insn(Insn::Checkpoint {
-                database: 0,
+                database: database_id,
                 checkpoint_mode: mode,
                 dest: register,
             });
@@ -673,7 +704,7 @@ fn query_pragma(
         }
         PragmaName::PageCount => {
             program.emit_insn(Insn::PageCount {
-                db: 0,
+                db: database_id,
                 dest: register,
             });
             program.emit_result_row(register, 1);
@@ -682,7 +713,7 @@ fn query_pragma(
         }
         PragmaName::MaxPageCount => {
             program.emit_insn(Insn::MaxPgcnt {
-                db: 0,
+                db: database_id,
                 dest: register,
                 new_max: 0, // 0 means just return current max
             });
@@ -926,15 +957,17 @@ fn query_pragma(
             // we need 6 registers, but first register was allocated at the beginning  of the "query_pragma" function
             program.alloc_registers(5);
             if let Some(name) = name {
-                if let Some(table) = schema.get_table(&name) {
-                    emit_columns_for_table_info(program, table.columns(), base_reg, false);
-                } else if let Some(view_mutex) = schema.get_materialized_view(&name) {
-                    let view = view_mutex.lock();
-                    let flat_columns = view.column_schema.flat_columns();
-                    emit_columns_for_table_info(program, &flat_columns, base_reg, false);
-                } else if let Some(view) = schema.get_view(&name) {
-                    emit_columns_for_table_info(program, &view.columns, base_reg, false);
-                }
+                connection.with_schema(database_id, |db_schema| {
+                    if let Some(table) = db_schema.get_table(&name) {
+                        emit_columns_for_table_info(program, table.columns(), base_reg, false);
+                    } else if let Some(view_mutex) = db_schema.get_materialized_view(&name) {
+                        let view = view_mutex.lock();
+                        let flat_columns = view.column_schema.flat_columns();
+                        emit_columns_for_table_info(program, &flat_columns, base_reg, false);
+                    } else if let Some(view) = db_schema.get_view(&name) {
+                        emit_columns_for_table_info(program, &view.columns, base_reg, false);
+                    }
+                });
             }
             let col_names = ["cid", "name", "type", "notnull", "dflt_value", "pk"];
             for name in col_names {
@@ -952,15 +985,17 @@ fn query_pragma(
             // we need 7 registers, but first register was allocated at the beginning  of the "query_pragma" function
             program.alloc_registers(6);
             if let Some(name) = name {
-                if let Some(table) = schema.get_table(&name) {
-                    emit_columns_for_table_info(program, table.columns(), base_reg, true);
-                } else if let Some(view_mutex) = schema.get_materialized_view(&name) {
-                    let view = view_mutex.lock();
-                    let flat_columns = view.column_schema.flat_columns();
-                    emit_columns_for_table_info(program, &flat_columns, base_reg, true);
-                } else if let Some(view) = schema.get_view(&name) {
-                    emit_columns_for_table_info(program, &view.columns, base_reg, true);
-                }
+                connection.with_schema(database_id, |db_schema| {
+                    if let Some(table) = db_schema.get_table(&name) {
+                        emit_columns_for_table_info(program, table.columns(), base_reg, true);
+                    } else if let Some(view_mutex) = db_schema.get_materialized_view(&name) {
+                        let view = view_mutex.lock();
+                        let flat_columns = view.column_schema.flat_columns();
+                        emit_columns_for_table_info(program, &flat_columns, base_reg, true);
+                    } else if let Some(view) = db_schema.get_view(&name) {
+                        emit_columns_for_table_info(program, &view.columns, base_reg, true);
+                    }
+                });
             }
             let col_names = [
                 "cid",
@@ -978,7 +1013,7 @@ fn query_pragma(
         }
         PragmaName::UserVersion => {
             program.emit_insn(Insn::ReadCookie {
-                db: 0,
+                db: database_id,
                 dest: register,
                 cookie: Cookie::UserVersion,
             });
@@ -988,7 +1023,7 @@ fn query_pragma(
         }
         PragmaName::SchemaVersion => {
             program.emit_insn(Insn::ReadCookie {
-                db: 0,
+                db: database_id,
                 dest: register,
                 cookie: Cookie::SchemaVersion,
             });

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -181,6 +181,11 @@ pub fn translate_create_table(
     program: &mut ProgramBuilder,
     connection: &Connection,
 ) -> Result<()> {
+    let database_id = connection.resolve_database_id(&tbl_name)?;
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
     let normalized_tbl_name = normalize_ident(tbl_name.name.as_str());
     if temporary {
         bail_parse_error!("TEMPORARY table not supported yet");
@@ -207,7 +212,9 @@ pub fn translate_create_table(
     }
 
     // Check for name conflicts with existing schema objects
-    if let Some(object_type) = resolver.schema.get_object_type(&normalized_tbl_name) {
+    if let Some(object_type) =
+        connection.with_schema(database_id, |s| s.get_object_type(&normalized_tbl_name))
+    {
         match object_type {
             // IF NOT EXISTS suppresses errors for table/view conflicts
             SchemaObjectType::Table | SchemaObjectType::View if if_not_exists => {
@@ -266,19 +273,17 @@ pub fn translate_create_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1i64.into(),
-        db: 0,
+        db: database_id,
     });
     let cdc_table = prepare_cdc_if_necessary(program, resolver.schema, SQLITE_TABLEID)?;
 
     let created_sequence_table = if has_autoincrement
-        && resolver
-            .schema
-            .get_table(SQLITE_SEQUENCE_TABLE_NAME)
-            .is_none()
-    {
+        && connection.with_schema(database_id, |s| {
+            s.get_table(SQLITE_SEQUENCE_TABLE_NAME).is_none()
+        }) {
         let seq_table_root_reg = program.alloc_register();
         program.emit_insn(Insn::CreateBtree {
-            db: 0,
+            db: database_id,
             root: seq_table_root_reg,
             flags: CreateBTreeFlags::new_table(),
         });
@@ -310,7 +315,7 @@ pub fn translate_create_table(
 
     let table_root_reg = program.alloc_register();
     program.emit_insn(Insn::CreateBtree {
-        db: 0,
+        db: database_id,
         root: table_root_reg,
         flags: CreateBTreeFlags::new_table(),
     });
@@ -343,7 +348,7 @@ pub fn translate_create_table(
     if let Some(index_regs) = index_regs.as_ref() {
         for index_reg in index_regs.iter() {
             program.emit_insn(Insn::CreateBtree {
-                db: 0,
+                db: database_id,
                 root: *index_reg,
                 flags: CreateBTreeFlags::new_index(),
             });
@@ -355,7 +360,7 @@ pub fn translate_create_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1i64.into(),
-        db: 0,
+        db: database_id,
     });
 
     let cdc_table = prepare_cdc_if_necessary(program, resolver.schema, SQLITE_TABLEID)?;
@@ -394,11 +399,11 @@ pub fn translate_create_table(
     }
 
     program.resolve_label(parse_schema_label, program.offset());
-    // TODO: SetCookie
+    let schema_version = connection.with_schema(database_id, |s| s.schema_version);
     program.emit_insn(Insn::SetCookie {
-        db: 0,
+        db: database_id,
         cookie: Cookie::SchemaVersion,
-        value: resolver.schema.schema_version as i32 + 1,
+        value: schema_version as i32 + 1,
         p5: 0,
     });
 
@@ -410,7 +415,7 @@ pub fn translate_create_table(
     }
 
     program.emit_insn(Insn::ParseSchema {
-        db: sqlite_schema_cursor_id,
+        db: database_id,
         where_clause: Some(parse_schema_where_clause),
     });
 
@@ -759,6 +764,7 @@ pub fn translate_drop_table(
     program: &mut ProgramBuilder,
     connection: &Arc<Connection>,
 ) -> Result<()> {
+    let database_id = connection.resolve_database_id(&tbl_name)?;
     let name = tbl_name.name.as_str();
     let opts = ProgramBuilderOpts {
         num_cursors: 4,
@@ -766,7 +772,13 @@ pub fn translate_drop_table(
         approx_num_labels: 4,
     };
     program.extend(&opts);
-    let Some(table) = resolver.schema.get_table(name) else {
+
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
+
+    let Some(table) = connection.with_schema(database_id, |s| s.get_table(name)) else {
         if if_exists {
             return Ok(());
         }
@@ -775,8 +787,10 @@ pub fn translate_drop_table(
     validate_drop_table(resolver, name, connection)?;
     // Check if foreign keys are enabled and if this table is referenced by foreign keys
     // Fire FK actions (CASCADE, SET NULL, SET DEFAULT) or check for violations (RESTRICT, NO ACTION)
-    if connection.foreign_keys_enabled() && resolver.schema.any_resolved_fks_referencing(name) {
-        emit_fk_drop_table_check(program, resolver, name, connection)?;
+    if connection.foreign_keys_enabled()
+        && connection.with_schema(database_id, |s| s.any_resolved_fks_referencing(name))
+    {
+        emit_fk_drop_table_check(program, resolver, name, connection, database_id)?;
     }
     let cdc_table = prepare_cdc_if_necessary(program, resolver.schema, SQLITE_TABLEID)?;
 
@@ -797,7 +811,7 @@ pub fn translate_drop_table(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id_0,
         root_page: 1i64.into(),
-        db: 0,
+        db: database_id,
     });
 
     //  1. Remove all entries from the schema table related to the table we are dropping (including triggers)
@@ -889,9 +903,13 @@ pub fn translate_drop_table(
         if index.index_method.is_some() && !index.is_backing_btree_index() {
             // Index methods without backing btree need special destroy handling
             let cursor_id = program.alloc_cursor_index(None, index)?;
-            program.emit_insn(Insn::IndexMethodDestroy { db: 0, cursor_id });
+            program.emit_insn(Insn::IndexMethodDestroy {
+                db: database_id,
+                cursor_id,
+            });
         } else {
             program.emit_insn(Insn::Destroy {
+                db: database_id,
                 root: index.root_page,
                 former_root_reg: 0, //  no autovacuum (https://www.sqlite.org/opcode.html#Destroy)
                 is_temp: 0,
@@ -909,6 +927,7 @@ pub fn translate_drop_table(
     match table.as_ref() {
         Table::BTree(table) => {
             program.emit_insn(Insn::Destroy {
+                db: database_id,
                 root: table.root_page,
                 former_root_reg: table_name_and_root_page_register,
                 is_temp: 0,
@@ -926,7 +945,7 @@ pub fn translate_drop_table(
             }
             program.emit_insn(Insn::VDestroy {
                 table_name: vtab.name.clone(),
-                db: 0, // TODO change this for multiple databases
+                db: database_id,
             });
         }
         Table::FromClauseSubquery(..) => panic!("FromClauseSubquery can't be dropped"),
@@ -978,7 +997,7 @@ pub fn translate_drop_table(
         program.emit_insn(Insn::OpenRead {
             cursor_id: sqlite_schema_cursor_id_1,
             root_page: 1i64,
-            db: 0,
+            db: database_id,
         });
 
         let schema_column_0_register = program.alloc_register();
@@ -1035,7 +1054,7 @@ pub fn translate_drop_table(
         program.emit_insn(Insn::OpenWrite {
             cursor_id: sqlite_schema_cursor_id_1,
             root_page: 1i64.into(),
-            db: 0,
+            db: database_id,
         });
 
         // Loop to copy over row id's from the ephemeral table and then re-insert into the schema table with the correct root page
@@ -1111,7 +1130,7 @@ pub fn translate_drop_table(
         program.emit_insn(Insn::OpenWrite {
             cursor_id: seq_cursor_id,
             root_page: seq_table.root_page.into(),
-            db: 0,
+            db: database_id,
         });
 
         let end_loop_label = program.allocate_label();
@@ -1205,16 +1224,17 @@ pub fn translate_drop_table(
 
     // Drop the in-memory structures for the table
     program.emit_insn(Insn::DropTable {
-        db: 0,
+        db: database_id,
         _p2: 0,
         _p3: 0,
         table_name: tbl_name.name.as_str().to_string(),
     });
 
+    let current_schema_version = connection.with_schema(database_id, |s| s.schema_version);
     program.emit_insn(Insn::SetCookie {
-        db: 0,
+        db: database_id,
         cookie: Cookie::SchemaVersion,
-        value: resolver.schema.schema_version as i32 + 1,
+        value: current_schema_version as i32 + 1,
         p5: 0,
     });
 

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -43,7 +43,7 @@ pub fn translate_select(
         query_destination,
         connection,
     )?;
-    optimize_plan(program, &mut select_plan, resolver.schema)?;
+    optimize_plan(program, &mut select_plan, resolver.schema, connection)?;
     let num_result_cols;
     let opts = match &select_plan {
         Plan::Select(select) => {

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -101,6 +101,11 @@ pub fn translate_create_trigger(
         ));
     }
 
+    let database_id = connection.resolve_database_id(&trigger_name)?;
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
     program.begin_write_operation();
     let normalized_trigger_name = normalize_ident(trigger_name.name.as_str());
     let normalized_table_name = normalize_ident(tbl_name.name.as_str());
@@ -110,11 +115,10 @@ pub fn translate_create_trigger(
     }
 
     // Check if trigger already exists
-    if resolver
-        .schema
-        .get_trigger_for_table(&normalized_table_name, &normalized_trigger_name)
-        .is_some()
-    {
+    if connection.with_schema(database_id, |s| {
+        s.get_trigger_for_table(&normalized_table_name, &normalized_trigger_name)
+            .is_some()
+    }) {
         if if_not_exists {
             return Ok(());
         }
@@ -122,7 +126,9 @@ pub fn translate_create_trigger(
     }
 
     // Verify the table exists
-    if resolver.schema.get_table(&normalized_table_name).is_none() {
+    if connection.with_schema(database_id, |s| {
+        s.get_table(&normalized_table_name).is_none()
+    }) {
         bail_parse_error!("no such table: {}", normalized_table_name);
     }
 
@@ -150,7 +156,7 @@ pub fn translate_create_trigger(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1i64.into(),
-        db: 0,
+        db: database_id,
     });
 
     // Add the trigger entry to sqlite_schema
@@ -167,16 +173,17 @@ pub fn translate_create_trigger(
     )?;
 
     // Update schema version
+    let schema_version = connection.with_schema(database_id, |s| s.schema_version);
     program.emit_insn(Insn::SetCookie {
-        db: 0,
+        db: database_id,
         cookie: Cookie::SchemaVersion,
-        value: (resolver.schema.schema_version + 1) as i32,
+        value: (schema_version + 1) as i32,
         p5: 0,
     });
 
     // Parse schema to load the new trigger
     program.emit_insn(Insn::ParseSchema {
-        db: sqlite_schema_cursor_id,
+        db: database_id,
         where_clause: Some(format!("name = '{normalized_trigger_name}'")),
     });
 
@@ -185,11 +192,10 @@ pub fn translate_create_trigger(
 
 /// Translate DROP TRIGGER statement
 pub fn translate_drop_trigger(
-    schema: &crate::schema::Schema,
-    trigger_name: &str,
+    connection: &Arc<Connection>,
+    trigger_name: &ast::QualifiedName,
     if_exists: bool,
     program: &mut ProgramBuilder,
-    connection: Arc<Connection>,
 ) -> Result<()> {
     // Check if experimental triggers are enabled
     if !connection.experimental_triggers_enabled() {
@@ -199,11 +205,18 @@ pub fn translate_drop_trigger(
         ));
     }
 
+    let database_id = connection.resolve_database_id(trigger_name)?;
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
     program.begin_write_operation();
-    let normalized_trigger_name = normalize_ident(trigger_name);
+    let normalized_trigger_name = normalize_ident(trigger_name.name.as_str());
 
     // Check if trigger exists
-    if schema.get_trigger(&normalized_trigger_name).is_none() {
+    if connection.with_schema(database_id, |s| {
+        s.get_trigger(&normalized_trigger_name).is_none()
+    }) {
         if if_exists {
             return Ok(());
         }
@@ -217,13 +230,13 @@ pub fn translate_drop_trigger(
     };
     program.extend(&opts);
 
-    // Open cursor to sqlite_schema table
-    let table = schema.get_btree_table(SQLITE_TABLEID).unwrap();
+    // Open cursor to sqlite_schema table (structure is the same for all databases)
+    let table = connection.with_schema(0, |s| s.get_btree_table(SQLITE_TABLEID).unwrap());
     let sqlite_schema_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(table));
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1i64.into(),
-        db: 0,
+        db: database_id,
     });
 
     let search_loop_label = program.allocate_label();
@@ -300,15 +313,16 @@ pub fn translate_drop_trigger(
     program.preassign_label_to_next_insn(rewind_done_label);
 
     // Update schema version
+    let schema_version = connection.with_schema(database_id, |s| s.schema_version);
     program.emit_insn(Insn::SetCookie {
-        db: 0,
+        db: database_id,
         cookie: Cookie::SchemaVersion,
-        value: (schema.schema_version + 1) as i32,
+        value: (schema_version + 1) as i32,
         p5: 0,
     });
 
     program.emit_insn(Insn::DropTrigger {
-        db: 0,
+        db: database_id,
         trigger_name: normalized_trigger_name,
     });
 

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -79,6 +79,8 @@ struct TriggerSubprogramContext {
     table: Arc<BTreeTable>,
     /// Override conflict resolution for statements within this trigger.
     override_conflict: Option<ast::ResolveType>,
+    /// Database name for the trigger's database (used to qualify unqualified table names in body)
+    db_name: Option<ast::Name>,
 }
 
 impl TriggerSubprogramContext {
@@ -273,7 +275,7 @@ fn trigger_cmd_to_stmt_for_subprogram(
                 with: None,
                 or_conflict: effective_or_conflict,
                 tbl_name: QualifiedName {
-                    db_name: None,
+                    db_name: subprogram_ctx.db_name.clone(),
                     name: tbl_name.clone(),
                     alias: None,
                 },
@@ -315,7 +317,7 @@ fn trigger_cmd_to_stmt_for_subprogram(
                 with: None,
                 or_conflict: effective_or_conflict,
                 tbl_name: QualifiedName {
-                    db_name: None,
+                    db_name: subprogram_ctx.db_name.clone(),
                     name: tbl_name.clone(),
                     alias: None,
                 },
@@ -344,7 +346,7 @@ fn trigger_cmd_to_stmt_for_subprogram(
 
             Ok(ast::Stmt::Delete {
                 tbl_name: QualifiedName {
-                    db_name: None,
+                    db_name: subprogram_ctx.db_name.clone(),
                     name: tbl_name.clone(),
                     alias: None,
                 },
@@ -548,6 +550,7 @@ fn execute_trigger_commands(
     trigger: &Arc<Trigger>,
     ctx: &TriggerContext,
     connection: &Arc<crate::Connection>,
+    database_id: usize,
 ) -> Result<bool> {
     if connection.trigger_is_compiling(trigger) {
         // Do not recursively compile the same trigger
@@ -579,11 +582,21 @@ fn execute_trigger_commands(
         })
         .map(ParamMap);
 
+    // For triggers on attached databases, resolve the database name so unqualified
+    // table references in the trigger body are correctly qualified to the trigger's database.
+    let db_name = if database_id == 0 {
+        None
+    } else {
+        connection
+            .get_database_name_by_index(database_id)
+            .map(ast::Name::exact)
+    };
     let subprogram_ctx = TriggerSubprogramContext {
         new_param_map,
         old_param_map,
         table: ctx.table.clone(),
         override_conflict: ctx.override_conflict,
+        db_name,
     };
     let mut subprogram_builder = ProgramBuilder::new_for_trigger(
         QueryMode::Normal,
@@ -747,6 +760,7 @@ pub fn fire_trigger(
     trigger: Arc<Trigger>,
     ctx: &TriggerContext,
     connection: &Arc<crate::Connection>,
+    database_id: usize,
 ) -> Result<()> {
     // Evaluate WHEN clause if present
     if let Some(mut when_expr) = trigger.when_clause.clone() {
@@ -764,12 +778,12 @@ pub fn fire_trigger(
         });
 
         // Execute trigger commands if WHEN clause is true
-        execute_trigger_commands(program, resolver, &trigger, ctx, connection)?;
+        execute_trigger_commands(program, resolver, &trigger, ctx, connection, database_id)?;
 
         program.preassign_label_to_next_insn(skip_label);
     } else {
         // No WHEN clause - always execute
-        execute_trigger_commands(program, resolver, &trigger, ctx, connection)?;
+        execute_trigger_commands(program, resolver, &trigger, ctx, connection, database_id)?;
     }
 
     Ok(())

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -81,7 +81,7 @@ pub fn translate_update(
         }
     }
 
-    optimize_plan(program, &mut plan, resolver.schema)?;
+    optimize_plan(program, &mut plan, resolver.schema, connection)?;
     let opts = ProgramBuilderOpts {
         num_cursors: 1,
         approx_num_insns: 20,
@@ -122,7 +122,7 @@ pub fn translate_update_for_schema_change(
         }
     }
 
-    optimize_plan(program, &mut plan, resolver.schema)?;
+    optimize_plan(program, &mut plan, resolver.schema, connection)?;
     let opts = ProgramBuilderOpts {
         num_cursors: 1,
         approx_num_insns: 20,
@@ -190,12 +190,17 @@ pub fn prepare_update_plan(
     connection: &Arc<crate::Connection>,
     is_internal_schema_change: bool,
 ) -> crate::Result<Plan> {
+    let database_id = connection.resolve_database_id(&body.tbl_name)?;
     let schema = resolver.schema;
     let table_name = &body.tbl_name.name;
-    let table = match schema.get_table(table_name.as_str()) {
+    let table = match connection.with_schema(database_id, |s| s.get_table(table_name.as_str())) {
         Some(table) => table,
         None => bail_parse_error!("Parse error: no such table: {}", table_name),
     };
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
     validate_update(
         schema,
         &body,
@@ -236,7 +241,7 @@ pub fn prepare_update_plan(
         col_used_mask: ColumnUsedMask::default(),
         column_use_counts: Vec::new(),
         expression_index_usages: Vec::new(),
-        database_id: 0,
+        database_id,
     }];
     let mut table_references = TableReferences::new(joined_tables, vec![]);
 
@@ -369,18 +374,21 @@ pub fn prepare_update_plan(
 
     // Check what indexes will need to be updated by checking set_clauses and see
     // if a column is contained in an index.
-    let indexes = schema.get_indices(table_name);
+    let indexes: Vec<_> = connection.with_schema(database_id, |s| {
+        s.get_indices(table_name).cloned().collect()
+    });
     let updated_cols: HashSet<usize> = set_clauses.iter().map(|(i, _)| *i).collect();
     let rowid_alias_used = set_clauses
         .iter()
         .any(|(idx, _)| *idx == ROWID_SENTINEL || columns[*idx].is_rowid_alias());
     let indexes_to_update = if rowid_alias_used {
         // If the rowid alias is used in the SET clause, we need to update all indexes
-        indexes.cloned().collect()
+        indexes
     } else {
         // otherwise we need to update the indexes whose columns are set in the SET clause,
         // or if the colunns used in the partial index WHERE clause are being updated
         indexes
+            .into_iter()
             .filter_map(|idx| {
                 let mut needs = idx.columns.iter().any(|c| {
                     c.expr.as_ref().map_or_else(
@@ -413,7 +421,7 @@ pub fn prepare_update_plan(
                     }
                 }
                 if needs {
-                    Some(idx.clone())
+                    Some(idx)
                 } else {
                     None
                 }

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -1,4 +1,4 @@
-use crate::schema::{Schema, SchemaObjectType, DBSP_TABLE_PREFIX};
+use crate::schema::{SchemaObjectType, DBSP_TABLE_PREFIX};
 use crate::storage::pager::CreateBTreeFlags;
 use crate::sync::Arc;
 use crate::translate::emitter::Resolver;
@@ -10,7 +10,7 @@ use crate::{Connection, Result};
 use turso_parser::ast;
 
 pub fn translate_create_materialized_view(
-    view_name: &ast::Name,
+    view_name: &ast::QualifiedName,
     resolver: &Resolver,
     select_stmt: &ast::Select,
     connection: Arc<Connection>,
@@ -24,14 +24,23 @@ pub fn translate_create_materialized_view(
         ));
     }
 
-    let normalized_view_name = normalize_ident(view_name.as_str());
+    let database_id = connection.resolve_database_id(view_name)?;
+    // The DBSP incremental maintenance runtime (populate_from_table, etc.) assumes
+    // the main database pager/schema. Block attached databases until that is fixed.
+    if database_id != 0 {
+        crate::bail_parse_error!("materialized views are not supported on attached databases");
+    }
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
+
+    let normalized_view_name = normalize_ident(view_name.name.as_str());
 
     // Check if view already exists
-    if resolver
-        .schema
-        .get_materialized_view(&normalized_view_name)
-        .is_some()
-    {
+    if connection.with_schema(database_id, |s| {
+        s.get_materialized_view(&normalized_view_name).is_some()
+    }) {
         return Err(crate::LimboError::ParseError(format!(
             "View {normalized_view_name} already exists"
         )));
@@ -42,19 +51,20 @@ pub fn translate_create_materialized_view(
     // storing invalid view definitions
     use crate::incremental::view::IncrementalView;
     use crate::schema::BTreeTable;
-    let view_column_schema =
-        IncrementalView::validate_and_extract_columns(select_stmt, resolver.schema)?;
+    let view_column_schema = connection.with_schema(database_id, |s| {
+        IncrementalView::validate_and_extract_columns(select_stmt, s)
+    })?;
     let view_columns = view_column_schema.flat_columns();
 
     // Reconstruct the SQL string for storage
-    let sql = create_materialized_view_to_str(&view_name.as_ident(), select_stmt);
+    let sql = create_materialized_view_to_str(&view_name.name.as_ident(), select_stmt);
 
     // Create a btree for storing the materialized view state
     // This btree will hold the materialized rows (row_id -> values)
     let view_root_reg = program.alloc_register();
 
     program.emit_insn(Insn::CreateBtree {
-        db: 0,
+        db: database_id,
         root: view_root_reg,
         flags: CreateBTreeFlags::new_table(),
     });
@@ -64,7 +74,7 @@ pub fn translate_create_materialized_view(
     let dbsp_state_root_reg = program.alloc_register();
 
     program.emit_insn(Insn::CreateBtree {
-        db: 0,
+        db: database_id,
         root: dbsp_state_root_reg,
         flags: CreateBTreeFlags::new_table(),
     });
@@ -92,7 +102,7 @@ pub fn translate_create_materialized_view(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: view_cursor_id,
         root_page: RegisterOrLiteral::Register(view_root_reg),
-        db: 0,
+        db: database_id,
     });
 
     // Clear any existing data in the btree
@@ -123,12 +133,12 @@ pub fn translate_create_materialized_view(
     program.preassign_label_to_next_insn(clear_done_label);
 
     // Open cursor to sqlite_schema table
-    let table = resolver.schema.get_btree_table(SQLITE_TABLEID).unwrap();
+    let table = connection.with_schema(database_id, |s| s.get_btree_table(SQLITE_TABLEID).unwrap());
     let sqlite_schema_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(table));
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1i64.into(),
-        db: 0,
+        db: database_id,
     });
 
     // Add the materialized view entry to sqlite_schema
@@ -182,7 +192,7 @@ pub fn translate_create_materialized_view(
     // Since the table has PRIMARY KEY (operator_id, zset_id, element_id), we need an index
     let dbsp_index_root_reg = program.alloc_register();
     program.emit_insn(Insn::CreateBtree {
-        db: 0,
+        db: database_id,
         root: dbsp_index_root_reg,
         flags: CreateBTreeFlags::new_index(),
     });
@@ -207,16 +217,17 @@ pub fn translate_create_materialized_view(
 
     // Parse schema to load the new view and DBSP state table
     program.emit_insn(Insn::ParseSchema {
-        db: sqlite_schema_cursor_id,
+        db: database_id,
         where_clause: Some(format!(
             "name = '{normalized_view_name}' OR name = '{dbsp_table_name}' OR name = '{dbsp_index_name}'"
         )),
     });
 
+    let schema_version = connection.with_schema(database_id, |s| s.schema_version);
     program.emit_insn(Insn::SetCookie {
-        db: 0,
+        db: database_id,
         cookie: Cookie::SchemaVersion,
-        value: (resolver.schema.schema_version + 1) as i32,
+        value: (schema_version + 1) as i32,
         p5: 0,
     });
 
@@ -235,17 +246,24 @@ fn create_materialized_view_to_str(view_name: &str, select_stmt: &ast::Select) -
 }
 
 pub fn translate_create_view(
-    view_name: &ast::Name,
+    view_name: &ast::QualifiedName,
     resolver: &Resolver,
     select_stmt: &ast::Select,
     _columns: &[ast::IndexedColumn],
-    _connection: Arc<Connection>,
+    connection: Arc<Connection>,
     program: &mut ProgramBuilder,
 ) -> Result<()> {
-    let normalized_view_name = normalize_ident(view_name.as_str());
+    let database_id = connection.resolve_database_id(view_name)?;
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
+    let normalized_view_name = normalize_ident(view_name.name.as_str());
 
     // Check for name conflicts with existing schema objects
-    if let Some(object_type) = resolver.schema.get_object_type(&normalized_view_name) {
+    if let Some(object_type) =
+        connection.with_schema(database_id, |s| s.get_object_type(&normalized_view_name))
+    {
         let type_str = match object_type {
             SchemaObjectType::Table => "table",
             SchemaObjectType::View => "view",
@@ -257,18 +275,16 @@ pub fn translate_create_view(
     }
 
     // Also check materialized views (not in get_object_type since they're stored differently)
-    if resolver
-        .schema
-        .get_materialized_view(&normalized_view_name)
-        .is_some()
-    {
+    if connection.with_schema(database_id, |s| {
+        s.get_materialized_view(&normalized_view_name).is_some()
+    }) {
         return Err(crate::LimboError::ParseError(format!(
             "view {normalized_view_name} already exists"
         )));
     }
 
     // Reconstruct the SQL string
-    let sql = create_view_to_str(&view_name.as_ident(), select_stmt);
+    let sql = create_view_to_str(&view_name.name.as_ident(), select_stmt);
 
     // Open cursor to sqlite_schema table
     let table = resolver.schema.get_btree_table(SQLITE_TABLEID).unwrap();
@@ -276,7 +292,7 @@ pub fn translate_create_view(
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1i64.into(),
-        db: 0,
+        db: database_id,
     });
 
     // Add the view entry to sqlite_schema
@@ -294,14 +310,15 @@ pub fn translate_create_view(
 
     // Parse schema to load the new view
     program.emit_insn(Insn::ParseSchema {
-        db: sqlite_schema_cursor_id,
+        db: database_id,
         where_clause: Some(format!("name = '{normalized_view_name}'")),
     });
 
+    let schema_version = connection.with_schema(database_id, |s| s.schema_version);
     program.emit_insn(Insn::SetCookie {
-        db: 0,
+        db: database_id,
         cookie: Cookie::SchemaVersion,
-        value: (resolver.schema.schema_version + 1) as i32,
+        value: (schema_version + 1) as i32,
         p5: 0,
     });
 
@@ -313,16 +330,26 @@ fn create_view_to_str(view_name: &str, select_stmt: &ast::Select) -> String {
 }
 
 pub fn translate_drop_view(
-    schema: &Schema,
-    view_name: &str,
+    connection: &Arc<Connection>,
+    resolver: &Resolver,
+    view_name: &ast::QualifiedName,
     if_exists: bool,
     program: &mut ProgramBuilder,
 ) -> Result<()> {
-    let normalized_view_name = normalize_ident(view_name);
+    let database_id = connection.resolve_database_id(view_name)?;
+    if database_id >= 2 {
+        let schema_cookie = connection.with_schema(database_id, |s| s.schema_version);
+        program.begin_write_on_database(database_id, schema_cookie);
+    }
+    let normalized_view_name = normalize_ident(view_name.name.as_str());
 
     // Check if view exists (either regular or materialized)
-    let is_regular_view = schema.get_view(&normalized_view_name).is_some();
-    let is_materialized_view = schema.is_materialized_view(&normalized_view_name);
+    let (is_regular_view, is_materialized_view) = connection.with_schema(database_id, |s| {
+        (
+            s.get_view(&normalized_view_name).is_some(),
+            s.is_materialized_view(&normalized_view_name),
+        )
+    });
     let view_exists = is_regular_view || is_materialized_view;
 
     if !view_exists && !if_exists {
@@ -339,10 +366,13 @@ pub fn translate_drop_view(
     // If this is a materialized view, we need to destroy its btree as well
     // and also clean up the associated DBSP state table and index
     let dbsp_table_name = if is_materialized_view {
-        if let Some(table) = schema.get_table(&normalized_view_name) {
+        if let Some(table) =
+            connection.with_schema(database_id, |s| s.get_table(&normalized_view_name))
+        {
             if let Some(btree_table) = table.btree() {
                 // Destroy the btree for the materialized view
                 program.emit_insn(Insn::Destroy {
+                    db: database_id,
                     root: btree_table.root_page,
                     former_root_reg: 0, // No autovacuum
                     is_temp: 0,
@@ -362,9 +392,12 @@ pub fn translate_drop_view(
     // Destroy DBSP state table and index btrees if this is a materialized view
     if let Some(ref dbsp_table_name) = dbsp_table_name {
         // Destroy DBSP indexes first
-        let dbsp_indexes: Vec<_> = schema.get_indices(dbsp_table_name).collect();
-        for index in dbsp_indexes {
+        let dbsp_indexes: Vec<_> = connection.with_schema(database_id, |s| {
+            s.get_indices(dbsp_table_name).cloned().collect()
+        });
+        for index in &dbsp_indexes {
             program.emit_insn(Insn::Destroy {
+                db: database_id,
                 root: index.root_page,
                 former_root_reg: 0, // No autovacuum
                 is_temp: 0,
@@ -372,9 +405,12 @@ pub fn translate_drop_view(
         }
 
         // Destroy DBSP state table btree
-        if let Some(dbsp_table) = schema.get_table(dbsp_table_name) {
+        if let Some(dbsp_table) =
+            connection.with_schema(database_id, |s| s.get_table(dbsp_table_name))
+        {
             if let Some(dbsp_btree_table) = dbsp_table.btree() {
                 program.emit_insn(Insn::Destroy {
+                    db: database_id,
                     root: dbsp_btree_table.root_page,
                     former_root_reg: 0, // No autovacuum
                     is_temp: 0,
@@ -383,13 +419,13 @@ pub fn translate_drop_view(
         }
     }
 
-    // Open cursor to sqlite_schema table
-    let schema_table = schema.get_btree_table(SQLITE_TABLEID).unwrap();
+    // Open cursor to sqlite_schema table (structure is the same for all databases)
+    let schema_table = connection.with_schema(0, |s| s.get_btree_table(SQLITE_TABLEID).unwrap());
     let sqlite_schema_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(schema_table));
     program.emit_insn(Insn::OpenWrite {
         cursor_id: sqlite_schema_cursor_id,
         root_page: 1i64.into(),
-        db: 0,
+        db: database_id,
     });
 
     // Allocate registers for searching
@@ -582,23 +618,24 @@ pub fn translate_drop_view(
 
     // Remove the view from the in-memory schema
     program.emit_insn(Insn::DropView {
-        db: 0,
+        db: database_id,
         view_name: normalized_view_name,
     });
 
     // Update schema version (increment schema cookie)
+    let schema_version = connection.with_schema(database_id, |s| s.schema_version);
     let schema_version_reg = program.alloc_register();
     program.emit_insn(Insn::Integer {
         dest: schema_version_reg,
-        value: (schema.schema_version + 1) as i64,
+        value: (schema_version + 1) as i64,
     });
     program.emit_insn(Insn::SetCookie {
-        db: 0,
+        db: database_id,
         cookie: Cookie::SchemaVersion,
-        value: (schema.schema_version + 1) as i32,
+        value: (schema_version + 1) as i32,
         p5: 1, // update version
     });
 
-    program.epilogue(schema);
+    program.epilogue(resolver.schema);
     Ok(())
 }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1394,6 +1394,7 @@ pub fn insn_to_row(
                 "".to_string()
             ),
             Insn::Destroy {
+                db,
                 root,
                 former_root_reg,
                 is_temp,
@@ -1405,7 +1406,7 @@ pub fn insn_to_row(
                 Value::build_text(""),
                 0,
                 format!(
-                    "root iDb={root} former_root={former_root_reg} is_temp={is_temp}"
+                    "root iDb={db} former_root={former_root_reg} is_temp={is_temp}"
                 ),
             ),
             Insn::ResetSorter { cursor_id } => (
@@ -1846,7 +1847,7 @@ pub fn insn_to_row(
                 0,
                 format!("affinity(r[{}]={:?})", *reg, affinity),
             ),
-            Insn::RenameTable { from, to } => (
+            Insn::RenameTable { db: _, from, to } => (
                 "RenameTable",
                 0,
                 0,
@@ -1855,7 +1856,7 @@ pub fn insn_to_row(
                 0,
                 format!("rename_table({from}, {to})"),
             ),
-            Insn::DropColumn { table, column_index } => (
+            Insn::DropColumn { db: _, table, column_index } => (
                 "DropColumn",
                 0,
                 0,
@@ -1864,7 +1865,7 @@ pub fn insn_to_row(
                 0,
                 format!("drop_column({table}, {column_index})"),
             ),
-            Insn::AddColumn { table, column, .. } => (
+            Insn::AddColumn { db: _, table, column, .. } => (
                 "AddColumn",
                 0,
                 0,
@@ -1873,7 +1874,7 @@ pub fn insn_to_row(
                 0,
                 format!("add_column({table}, {column:?})"),
             ),
-            Insn::AlterColumn { table, column_index, definition: column, rename } => (
+            Insn::AlterColumn { db: _, table, column_index, definition: column, rename } => (
                 "AlterColumn",
                 0,
                 0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1053,6 +1053,8 @@ pub enum Insn {
 
     /// Deletes an entire database table or index whose root page in the database file is given by P1.
     Destroy {
+        /// The database index (0 = main, 1 = temp, 2+ = attached)
+        db: usize,
         /// The root page of the table/index to destroy
         root: i64,
         /// Register to store the former value of any moved root page (for AUTOVACUUM)
@@ -1321,19 +1323,23 @@ pub enum Insn {
         tables: Vec<IntegrityCheckTable>,
     },
     RenameTable {
+        db: usize,
         from: String,
         to: String,
     },
     DropColumn {
+        db: usize,
         table: String,
         column_index: usize,
     },
     AddColumn {
+        db: usize,
         table: String,
         column: Box<Column>,
         check_constraints: Vec<CheckConstraint>,
     },
     AlterColumn {
+        db: usize,
         table: String,
         column_index: usize,
         definition: Box<turso_parser::ast::ColumnDefinition>,

--- a/testing/differential-oracle/fuzzer/schema.rs
+++ b/testing/differential-oracle/fuzzer/schema.rs
@@ -165,6 +165,221 @@ impl SchemaIntrospector {
         Ok(result)
     }
 
+    /// Introspect schema from a Turso connection, including attached databases.
+    pub fn from_turso_with_attached(conn: &Arc<turso_core::Connection>) -> Result<Schema> {
+        let table_names = Self::get_table_names_turso(conn)?;
+        let mut builder = SchemaBuilder::new();
+
+        for table_name in table_names {
+            let columns = Self::get_columns_turso(conn, &table_name)?;
+            if !columns.is_empty() {
+                builder = builder.add_table(Table::new(table_name, columns));
+            }
+        }
+
+        // Discover attached databases
+        let attached_dbs = Self::get_attached_databases_turso(conn)?;
+        for db_name in &attached_dbs {
+            builder = builder.add_database(db_name.clone());
+            let tables = Self::get_table_names_turso_db(conn, db_name)?;
+            for table_name in tables {
+                let query = format!("PRAGMA {db_name}.table_info(\"{table_name}\")");
+                let columns = Self::get_columns_turso_query(conn, &query)?;
+                if !columns.is_empty() {
+                    builder =
+                        builder.add_table(Table::new(table_name, columns).in_database(db_name));
+                }
+            }
+        }
+
+        Ok(builder.build())
+    }
+
+    /// Introspect schema from a SQLite connection, including attached databases.
+    pub fn from_sqlite_with_attached(conn: &rusqlite::Connection) -> Result<Schema> {
+        let table_names = Self::get_table_names_sqlite(conn)?;
+        let mut builder = SchemaBuilder::new();
+
+        for table_name in table_names {
+            let columns = Self::get_columns_sqlite(conn, &table_name)?;
+            if !columns.is_empty() {
+                builder = builder.add_table(Table::new(table_name, columns));
+            }
+        }
+
+        // Discover attached databases
+        let attached_dbs = Self::get_attached_databases_sqlite(conn)?;
+        for db_name in &attached_dbs {
+            builder = builder.add_database(db_name.clone());
+            let query = format!(
+                "SELECT name FROM {db_name}.sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+            );
+            let mut stmt = conn
+                .prepare(&query)
+                .context("Failed to query attached table names")?;
+            let tables = stmt
+                .query_map([], |row| row.get::<_, String>(0))
+                .context("Failed to query attached tables")?
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .context("Failed to collect attached table names")?;
+
+            for table_name in tables {
+                let col_query = format!("PRAGMA {db_name}.table_info(\"{table_name}\")");
+                let mut col_stmt = conn
+                    .prepare(&col_query)
+                    .context("Failed to prepare attached PRAGMA")?;
+                let columns = col_stmt
+                    .query_map([], |row| {
+                        let name: String = row.get(1)?;
+                        let type_str: String =
+                            row.get::<_, String>(2).unwrap_or_else(|_| "TEXT".into());
+                        let notnull: i64 = row.get(3)?;
+                        let pk: i64 = row.get(5)?;
+                        Ok((name, type_str, notnull != 0, pk != 0))
+                    })
+                    .context("Failed to query attached columns")?
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .context("Failed to collect attached columns")?;
+
+                let mut result = Vec::new();
+                for (name, type_str, notnull, pk) in columns {
+                    let data_type = Self::parse_type(&type_str.to_uppercase());
+                    let mut column = ColumnDef::new(name, data_type);
+                    if notnull || pk {
+                        column = column.not_null();
+                    }
+                    if pk {
+                        column = column.primary_key();
+                    }
+                    result.push(column);
+                }
+
+                if !result.is_empty() {
+                    builder =
+                        builder.add_table(Table::new(table_name, result).in_database(db_name));
+                }
+            }
+        }
+
+        Ok(builder.build())
+    }
+
+    /// Get names of attached databases (excluding "main" and "temp") from Turso.
+    fn get_attached_databases_turso(conn: &Arc<turso_core::Connection>) -> Result<Vec<String>> {
+        let mut databases = Vec::new();
+        let mut rows = conn
+            .query("PRAGMA database_list")
+            .context("Failed to query database_list")?
+            .context("Expected rows from PRAGMA database_list")?;
+
+        rows.run_with_row_callback(|row| {
+            if let turso_core::Value::Text(name) = row.get_value(1) {
+                let name = name.as_str();
+                if name != "main" && name != "temp" {
+                    databases.push(name.to_string());
+                }
+            }
+            Ok(())
+        })
+        .context("Failed to iterate database_list")?;
+
+        Ok(databases)
+    }
+
+    /// Get names of attached databases (excluding "main" and "temp") from SQLite.
+    fn get_attached_databases_sqlite(conn: &rusqlite::Connection) -> Result<Vec<String>> {
+        let mut stmt = conn
+            .prepare("PRAGMA database_list")
+            .context("Failed to prepare database_list query")?;
+
+        let databases = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .context("Failed to query database_list")?
+            .filter_map(|r| r.ok())
+            .filter(|name| name != "main" && name != "temp")
+            .collect();
+
+        Ok(databases)
+    }
+
+    /// Get table names from a specific attached database in Turso.
+    fn get_table_names_turso_db(
+        conn: &Arc<turso_core::Connection>,
+        db_name: &str,
+    ) -> Result<Vec<String>> {
+        let mut tables = Vec::new();
+        let query = format!(
+            "SELECT name FROM {db_name}.sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        );
+        let mut rows = conn
+            .query(&query)
+            .context("Failed to query attached table names")?
+            .context("Expected rows from query")?;
+
+        rows.run_with_row_callback(|row| {
+            if let turso_core::Value::Text(name) = row.get_value(0) {
+                tables.push(name.as_str().to_string());
+            }
+            Ok(())
+        })
+        .context("Failed to iterate attached table names")?;
+
+        Ok(tables)
+    }
+
+    /// Get columns from a Turso connection using a custom PRAGMA query.
+    fn get_columns_turso_query(
+        conn: &Arc<turso_core::Connection>,
+        query: &str,
+    ) -> Result<Vec<ColumnDef>> {
+        let mut columns = Vec::new();
+        let mut rows = conn
+            .query(query)
+            .context("Failed to query column info")?
+            .context("Expected rows from PRAGMA")?;
+
+        rows.run_with_row_callback(|row| {
+            let name = match row.get_value(1) {
+                turso_core::Value::Text(s) => s.as_str().to_string(),
+                _ => return Ok(()),
+            };
+
+            let type_str = match row.get_value(2) {
+                turso_core::Value::Text(s) => s.as_str().to_uppercase(),
+                _ => "TEXT".to_string(),
+            };
+
+            let notnull = match row.get_value(3) {
+                turso_core::Value::Numeric(turso_core::Numeric::Integer(i)) => *i != 0,
+                _ => false,
+            };
+
+            let pk = match row.get_value(5) {
+                turso_core::Value::Numeric(turso_core::Numeric::Integer(i)) => *i != 0,
+                _ => false,
+            };
+
+            let data_type = Self::parse_type(&type_str);
+            let mut column = ColumnDef::new(name, data_type);
+
+            if !notnull && !pk {
+                // Column is nullable (default)
+            } else {
+                column = column.not_null();
+            }
+
+            if pk {
+                column = column.primary_key();
+            }
+
+            columns.push(column);
+            Ok(())
+        })
+        .context("Failed to iterate columns")?;
+
+        Ok(columns)
+    }
+
     fn parse_type(type_str: &str) -> DataType {
         // SQLite type affinity rules (simplified)
         let upper = type_str.to_uppercase();

--- a/testing/differential-oracle/sql_gen_prop/delete.rs
+++ b/testing/differential-oracle/sql_gen_prop/delete.rs
@@ -51,7 +51,7 @@ pub fn delete_for_table(
     schema: &Schema,
     profile: &StatementProfile,
 ) -> BoxedStrategy<DeleteStatement> {
-    let table_name = table.name.clone();
+    let table_name = table.qualified_name();
 
     optional_where_clause(table, schema, profile)
         .prop_map(move |where_clause| DeleteStatement {

--- a/testing/differential-oracle/sql_gen_prop/drop_table.rs
+++ b/testing/differential-oracle/sql_gen_prop/drop_table.rs
@@ -27,7 +27,7 @@ impl fmt::Display for DropTableStatement {
 
 /// Generate a DROP TABLE statement for a specific table.
 pub fn drop_table_for_table(table: &TableRef) -> BoxedStrategy<DropTableStatement> {
-    let table_name = table.name.clone();
+    let table_name = table.qualified_name();
 
     any::<bool>()
         .prop_map(move |if_exists| DropTableStatement {
@@ -44,7 +44,7 @@ pub fn drop_table_for_schema(schema: &Schema) -> BoxedStrategy<DropTableStatemen
         "Schema must have at least one table"
     );
 
-    let table_names: Vec<String> = schema.tables.iter().map(|t| t.name.clone()).collect();
+    let table_names: Vec<String> = schema.tables.iter().map(|t| t.qualified_name()).collect();
 
     (proptest::sample::select(table_names), any::<bool>())
         .prop_map(|(table_name, if_exists)| DropTableStatement {

--- a/testing/differential-oracle/sql_gen_prop/insert.rs
+++ b/testing/differential-oracle/sql_gen_prop/insert.rs
@@ -83,7 +83,7 @@ pub fn insert_for_table(
     schema: &Schema,
     profile: &StatementProfile,
 ) -> BoxedStrategy<InsertStatement> {
-    let table_name = table.name.clone();
+    let table_name = table.qualified_name();
     let columns = table.columns.clone();
     let functions = builtin_functions();
 

--- a/testing/differential-oracle/sql_gen_prop/select.rs
+++ b/testing/differential-oracle/sql_gen_prop/select.rs
@@ -280,7 +280,7 @@ pub fn select_single_column_for_table(
     schema: &Schema,
     profile: &StatementProfile,
 ) -> BoxedStrategy<SelectStatement> {
-    let table_name = table.name.clone();
+    let table_name = table.qualified_name();
     let col_names: Vec<String> = table.columns.iter().map(|c| c.name.clone()).collect();
 
     let select_profile = profile.select_profile();
@@ -402,7 +402,7 @@ pub fn select_for_table(
             // Pick a source to query from (could be original table or a CTE)
             proptest::sample::select(sources).prop_flat_map(move |source| {
                 let with_clause = with_for_closure.clone();
-                let source_name = source.name.clone();
+                let source_name = source.qualified_name();
 
                 select_body_for_source(&source, &schema, &profile).prop_map(
                     move |(columns, where_clause, order_by, limit, offset)| SelectStatement {

--- a/testing/differential-oracle/sql_gen_prop/update.rs
+++ b/testing/differential-oracle/sql_gen_prop/update.rs
@@ -91,7 +91,7 @@ pub fn update_for_table(
     schema: &Schema,
     profile: &StatementProfile,
 ) -> BoxedStrategy<UpdateStatement> {
-    let table_name = table.name.clone();
+    let table_name = table.qualified_name();
     let updatable: Vec<ColumnDef> = table.updatable_columns().cloned().collect();
     let functions = builtin_functions();
 

--- a/testing/differential-oracle/sql_gen_prop/view.rs
+++ b/testing/differential-oracle/sql_gen_prop/view.rs
@@ -80,7 +80,7 @@ pub fn create_view(schema: &Schema) -> BoxedStrategy<CreateViewStatement> {
     )
         .prop_map(|(if_not_exists, view_name, table)| {
             // Generate a simple SELECT * FROM table
-            let select_sql = format!("SELECT * FROM {}", table.name);
+            let select_sql = format!("SELECT * FROM {}", table.qualified_name());
             CreateViewStatement {
                 if_not_exists,
                 view_name,

--- a/testing/runner/turso-tests/attach/default.sqltest
+++ b/testing/runner/turso-tests/attach/default.sqltest
@@ -3,7 +3,7 @@
 
 # Test attach reserved name - main (should fail)
 test attach-reserved-main {
-    ATTACH DATABASE "database/testing_small.db" AS main
+    ATTACH DATABASE ':memory:' AS main
 }
 expect error {
     in use
@@ -11,7 +11,7 @@ expect error {
 
 # Test attach reserved name - temp (should fail)
 test attach-reserved-temp {
-    ATTACH DATABASE "database/testing_small.db" AS temp
+    ATTACH DATABASE ':memory:' AS temp
 }
 expect error {
     in use
@@ -19,8 +19,8 @@ expect error {
 
 # Test attach duplicate database name - arbitrary (should fail)
 test attach-duplicate-name {
-    ATTACH DATABASE "database/testing_small.db" as small;
-    ATTACH DATABASE "database/testing_small.db" as small;
+    ATTACH DATABASE ':memory:' as small;
+    ATTACH DATABASE ':memory:' as small;
 }
 expect error {
     in use
@@ -36,11 +36,10 @@ expect error {
 
 # Test queries after detach (should fail for detached database)
 test query-after-detach {
-    ATTACH DATABASE "database/testing_small.db" as small;
+    ATTACH DATABASE ':memory:' as small;
     DETACH DATABASE small;
     select * from small.sqlite_schema;
 }
 expect error {
     no such
 }
-

--- a/testing/runner/turso-tests/attach/memory.sqltest
+++ b/testing/runner/turso-tests/attach/memory.sqltest
@@ -1,9 +1,11 @@
 @database :memory:
 
 @skip-if mvcc "attach not supported in MVCC mode"
-# Test querying attached file database
+# Test querying attached in-memory database
 test attach-db-query {
-    ATTACH DATABASE "database/testing_small.db" AS small;
+    ATTACH DATABASE ':memory:' AS small;
+    CREATE TABLE small.demo (id INTEGER, value TEXT);
+    INSERT INTO small.demo VALUES (1, 'A'), (2, ''), (3, 'B'), (4, ''), (5, 'C');
     SELECT value FROM small.demo where id = 1;
 }
 expect {
@@ -12,7 +14,7 @@ expect {
 
 # Test detach database
 test detach-database {
-    ATTACH DATABASE "database/testing_small.db" AS small;
+    ATTACH DATABASE ':memory:' AS small;
     DETACH DATABASE small;
     pragma database_list;
 }
@@ -34,7 +36,9 @@ expect {
 @skip-if mvcc "attach not supported in MVCC mode"
 # Test join between main and attached database
 test attach-cross-database-join {
-    ATTACH DATABASE "database/testing_small.db" as small;
+    ATTACH DATABASE ':memory:' as small;
+    CREATE TABLE small.demo (id INTEGER, value TEXT);
+    INSERT INTO small.demo VALUES (1, 'A'), (2, ''), (3, 'B'), (4, ''), (5, 'C');
     create table joiners (id int, otherid int);
     insert into joiners (id, otherid) values (1,1);
     insert into joiners (id, otherid) values (3,3);
@@ -50,7 +54,9 @@ expect {
 test attach-from-memory-db {
     CREATE TABLE t(a);
     INSERT INTO t SELECT value from generate_series(1,10);
-    ATTACH DATABASE 'database/testing.db' as a;
+    ATTACH DATABASE ':memory:' as a;
+    CREATE TABLE a.products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    INSERT INTO a.products VALUES (1, 'hat', 79.0);
     SELECT * from a.products, t LIMIT 1;
 }
 expect {

--- a/testing/runner/turso-tests/attach/writes.sqltest
+++ b/testing/runner/turso-tests/attach/writes.sqltest
@@ -1,0 +1,1469 @@
+@database :memory:
+
+@skip-file-if mvcc "attach not supported in MVCC mode"
+
+# =============================================================================
+# Basic DDL on attached database
+# =============================================================================
+
+test attach-write-create-table {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT, value REAL);
+    SELECT count(*) FROM aux.t1;
+}
+expect {
+    0
+}
+
+test attach-write-create-table-if-not-exists {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY);
+    CREATE TABLE IF NOT EXISTS aux.t1(id INTEGER PRIMARY KEY);
+    SELECT count(*) FROM aux.t1;
+}
+expect {
+    0
+}
+
+test attach-write-drop-table {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY);
+    INSERT INTO aux.t1 VALUES(1);
+    DROP TABLE aux.t1;
+    SELECT count(*) FROM aux.sqlite_schema WHERE type='table' AND name='t1';
+}
+expect {
+    0
+}
+
+test attach-write-drop-table-if-exists {
+    ATTACH ':memory:' AS aux;
+    DROP TABLE IF EXISTS aux.t1;
+    SELECT 'ok';
+}
+expect {
+    ok
+}
+
+# =============================================================================
+# Indexes on attached database
+# =============================================================================
+
+test attach-write-create-index {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT, value REAL);
+    CREATE INDEX aux.idx_t1_name ON t1(name);
+    SELECT count(*) FROM aux.sqlite_schema WHERE type='index' AND name='idx_t1_name';
+}
+expect {
+    1
+}
+
+test attach-write-create-unique-index {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE UNIQUE INDEX aux.idx_t1_name ON t1(name);
+    INSERT INTO aux.t1 VALUES(1, 'hello');
+    INSERT INTO aux.t1 VALUES(2, 'world');
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|hello
+    2|world
+}
+
+test attach-write-unique-index-violation {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE UNIQUE INDEX aux.idx_t1_name ON t1(name);
+    INSERT INTO aux.t1 VALUES(1, 'hello');
+    INSERT INTO aux.t1 VALUES(2, 'hello');
+}
+expect error {
+    UNIQUE constraint failed
+}
+
+test attach-write-drop-index {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX aux.idx_t1_name ON t1(name);
+    DROP INDEX aux.idx_t1_name;
+    SELECT count(*) FROM aux.sqlite_schema WHERE type='index' AND name='idx_t1_name';
+}
+expect {
+    0
+}
+
+test attach-write-multi-column-index {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(a INTEGER, b TEXT, c REAL);
+    CREATE INDEX aux.idx_t1_ab ON t1(a, b);
+    INSERT INTO aux.t1 VALUES(1, 'x', 1.0);
+    INSERT INTO aux.t1 VALUES(2, 'y', 2.0);
+    INSERT INTO aux.t1 VALUES(1, 'z', 3.0);
+    SELECT a, b FROM aux.t1 WHERE a = 1 ORDER BY b;
+}
+expect {
+    1|x
+    1|z
+}
+
+test attach-write-index-used-after-insert {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX aux.idx_name ON t1(name);
+    INSERT INTO aux.t1 VALUES(1, 'charlie');
+    INSERT INTO aux.t1 VALUES(2, 'alice');
+    INSERT INTO aux.t1 VALUES(3, 'bob');
+    SELECT id FROM aux.t1 WHERE name = 'bob';
+}
+expect {
+    3
+}
+
+test attach-write-index-maintained-on-delete {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX aux.idx_name ON t1(name);
+    INSERT INTO aux.t1 VALUES(1, 'a');
+    INSERT INTO aux.t1 VALUES(2, 'b');
+    INSERT INTO aux.t1 VALUES(3, 'c');
+    DELETE FROM aux.t1 WHERE id = 2;
+    SELECT id FROM aux.t1 WHERE name = 'b';
+}
+expect {
+}
+
+test attach-write-index-maintained-on-update {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX aux.idx_name ON t1(name);
+    INSERT INTO aux.t1 VALUES(1, 'old');
+    UPDATE aux.t1 SET name = 'new' WHERE id = 1;
+    SELECT id FROM aux.t1 WHERE name = 'new';
+}
+expect {
+    1
+}
+
+# =============================================================================
+# Basic DML: INSERT
+# =============================================================================
+
+test attach-write-insert-basic {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'hello');
+    INSERT INTO aux.t1 VALUES(2, 'world');
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|hello
+    2|world
+}
+
+test attach-write-insert-multiple-values {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|a
+    2|b
+    3|c
+}
+
+test attach-write-insert-default-values {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT DEFAULT 'unnamed');
+    INSERT INTO aux.t1(id) VALUES(1);
+    SELECT * FROM aux.t1;
+}
+expect {
+    1|unnamed
+}
+
+test attach-write-insert-or-ignore {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+    INSERT INTO aux.t1 VALUES(1, 'hello');
+    INSERT OR IGNORE INTO aux.t1 VALUES(2, 'hello');
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|hello
+}
+
+test attach-write-insert-or-replace {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'old');
+    INSERT OR REPLACE INTO aux.t1 VALUES(1, 'new');
+    SELECT * FROM aux.t1;
+}
+expect {
+    1|new
+}
+
+test attach-write-insert-autoincrement {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);
+    INSERT INTO aux.t1(name) VALUES('a');
+    INSERT INTO aux.t1(name) VALUES('b');
+    INSERT INTO aux.t1(name) VALUES('c');
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|a
+    2|b
+    3|c
+}
+
+test attach-write-insert-autoincrement-gap {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);
+    INSERT INTO aux.t1(name) VALUES('a');
+    INSERT INTO aux.t1(name) VALUES('b');
+    DELETE FROM aux.t1 WHERE id = 2;
+    INSERT INTO aux.t1(name) VALUES('c');
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|a
+    3|c
+}
+
+# =============================================================================
+# Basic DML: UPDATE
+# =============================================================================
+
+test attach-write-update-basic {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'old');
+    UPDATE aux.t1 SET name = 'new' WHERE id = 1;
+    SELECT * FROM aux.t1;
+}
+expect {
+    1|new
+}
+
+test attach-write-update-multiple-rows {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT, status INTEGER);
+    INSERT INTO aux.t1 VALUES(1, 'a', 0),(2, 'b', 0),(3, 'c', 1);
+    UPDATE aux.t1 SET status = 1 WHERE status = 0;
+    SELECT id, status FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|1
+    2|1
+    3|1
+}
+
+test attach-write-update-no-match {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'hello');
+    UPDATE aux.t1 SET name = 'changed' WHERE id = 999;
+    SELECT * FROM aux.t1;
+}
+expect {
+    1|hello
+}
+
+# =============================================================================
+# Basic DML: DELETE
+# =============================================================================
+
+test attach-write-delete-basic {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'a'),(2, 'b'),(3, 'c');
+    DELETE FROM aux.t1 WHERE id = 2;
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|a
+    3|c
+}
+
+test attach-write-delete-all {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'a'),(2, 'b');
+    DELETE FROM aux.t1;
+    SELECT count(*) FROM aux.t1;
+}
+expect {
+    0
+}
+
+test attach-write-delete-no-match {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'a');
+    DELETE FROM aux.t1 WHERE id = 999;
+    SELECT count(*) FROM aux.t1;
+}
+expect {
+    1
+}
+
+# =============================================================================
+# Fully qualified names
+# =============================================================================
+
+test attach-write-fully-qualified-insert {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'fq');
+    SELECT * FROM aux.t1;
+}
+expect {
+    1|fq
+}
+
+test attach-write-fully-qualified-update {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'old');
+    UPDATE aux.t1 SET val = 'new' WHERE id = 1;
+    SELECT * FROM aux.t1;
+}
+expect {
+    1|new
+}
+
+test attach-write-fully-qualified-delete {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'del');
+    DELETE FROM aux.t1 WHERE id = 1;
+    SELECT count(*) FROM aux.t1;
+}
+expect {
+    0
+}
+
+test attach-write-main-qualified {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.m1 VALUES(1, 'main_val');
+    SELECT * FROM main.m1;
+}
+expect {
+    1|main_val
+}
+
+# =============================================================================
+# Cross-database operations
+# =============================================================================
+
+test attach-write-cross-db-join {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.m1 VALUES(1, 'main1'),(2, 'main2');
+    INSERT INTO aux.a1 VALUES(1, 'aux1'),(2, 'aux2');
+    SELECT m.val, a.val FROM main.m1 m JOIN aux.a1 a ON m.id = a.id ORDER BY m.id;
+}
+expect {
+    main1|aux1
+    main2|aux2
+}
+
+test attach-write-cross-db-insert-select {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.m1 VALUES(1, 'x'),(2, 'y');
+    INSERT INTO aux.a1 SELECT * FROM main.m1;
+    SELECT * FROM aux.a1 ORDER BY id;
+}
+expect {
+    1|x
+    2|y
+}
+
+test attach-write-cross-db-insert-select-reverse {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.a1 VALUES(10, 'from_aux');
+    INSERT INTO main.m1 SELECT * FROM aux.a1;
+    SELECT * FROM main.m1;
+}
+expect {
+    10|from_aux
+}
+
+test attach-write-cross-db-subquery {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.m1 VALUES(1, 'yes'),(2, 'no'),(3, 'yes');
+    INSERT INTO aux.a1 SELECT * FROM main.m1 WHERE val = 'yes';
+    SELECT * FROM aux.a1 ORDER BY id;
+}
+expect {
+    1|yes
+    3|yes
+}
+
+# Skipped: correlated subquery in UPDATE SET clause is a pre-existing limitation
+# test attach-write-cross-db-update-from-other {
+#     ATTACH ':memory:' AS aux;
+#     CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+#     CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, new_val TEXT);
+#     INSERT INTO main.m1 VALUES(1, 'old');
+#     INSERT INTO aux.a1 VALUES(1, 'new');
+#     UPDATE main.m1 SET val = (SELECT new_val FROM aux.a1 WHERE aux.a1.id = main.m1.id);
+#     SELECT * FROM main.m1;
+# }
+# expect {
+#     1|new
+# }
+
+test attach-write-cross-db-delete-with-subquery {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY);
+    INSERT INTO main.m1 VALUES(1, 'keep'),(2, 'delete'),(3, 'keep');
+    INSERT INTO aux.a1 VALUES(2);
+    DELETE FROM main.m1 WHERE id IN (SELECT id FROM aux.a1);
+    SELECT * FROM main.m1 ORDER BY id;
+}
+expect {
+    1|keep
+    3|keep
+}
+
+# =============================================================================
+# Multiple attached databases
+# =============================================================================
+
+test attach-write-multi-attach {
+    ATTACH ':memory:' AS aux1;
+    ATTACH ':memory:' AS aux2;
+    CREATE TABLE aux1.t1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux2.t2(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux1.t1 VALUES(1, 'from_aux1');
+    INSERT INTO aux2.t2 VALUES(1, 'from_aux2');
+    SELECT * FROM aux1.t1;
+    SELECT * FROM aux2.t2;
+}
+expect {
+    1|from_aux1
+    1|from_aux2
+}
+
+test attach-write-multi-attach-cross-join {
+    ATTACH ':memory:' AS aux1;
+    ATTACH ':memory:' AS aux2;
+    CREATE TABLE aux1.t1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux2.t2(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux1.t1 VALUES(1, 'a1');
+    INSERT INTO aux2.t2 VALUES(1, 'a2');
+    SELECT t1.val, t2.val FROM aux1.t1 JOIN aux2.t2 ON t1.id = t2.id;
+}
+expect {
+    a1|a2
+}
+
+test attach-write-multi-attach-insert-between {
+    ATTACH ':memory:' AS aux1;
+    ATTACH ':memory:' AS aux2;
+    CREATE TABLE aux1.t1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux2.t2(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux1.t1 VALUES(1, 'hello'),(2, 'world');
+    INSERT INTO aux2.t2 SELECT * FROM aux1.t1;
+    SELECT * FROM aux2.t2 ORDER BY id;
+}
+expect {
+    1|hello
+    2|world
+}
+
+# =============================================================================
+# Transactions across databases
+# =============================================================================
+
+test attach-write-transaction-commit {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, val TEXT);
+    BEGIN;
+    INSERT INTO main.m1 VALUES(1, 'main_val');
+    INSERT INTO aux.a1 VALUES(1, 'aux_val');
+    COMMIT;
+    SELECT * FROM main.m1;
+    SELECT * FROM aux.a1;
+}
+expect {
+    1|main_val
+    1|aux_val
+}
+
+test attach-write-transaction-rollback {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.m1 VALUES(0, 'before');
+    INSERT INTO aux.a1 VALUES(0, 'before');
+    BEGIN;
+    INSERT INTO main.m1 VALUES(1, 'rolled_back');
+    INSERT INTO aux.a1 VALUES(1, 'rolled_back');
+    ROLLBACK;
+    SELECT count(*) FROM main.m1;
+    SELECT count(*) FROM aux.a1;
+}
+expect {
+    1
+    1
+}
+
+test attach-write-transaction-rollback-preserves-prior {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'committed');
+    BEGIN;
+    INSERT INTO aux.t1 VALUES(2, 'will_rollback');
+    ROLLBACK;
+    SELECT * FROM aux.t1;
+}
+expect {
+    1|committed
+}
+
+test attach-write-autocommit-insert {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'auto1');
+    INSERT INTO aux.t1 VALUES(2, 'auto2');
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|auto1
+    2|auto2
+}
+
+test attach-write-begin-immediate-commit {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(x INTEGER);
+    BEGIN IMMEDIATE;
+    INSERT INTO aux.t1 VALUES (10);
+    INSERT INTO aux.t1 VALUES (20);
+    COMMIT;
+    SELECT x FROM aux.t1 ORDER BY x;
+}
+expect {
+    10
+    20
+}
+
+test attach-write-begin-immediate-rollback {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(x INTEGER);
+    INSERT INTO aux.t1 VALUES (1);
+    BEGIN IMMEDIATE;
+    INSERT INTO aux.t1 VALUES (2);
+    ROLLBACK;
+    SELECT x FROM aux.t1 ORDER BY x;
+}
+expect {
+    1
+}
+
+test attach-write-cross-db-begin-commit {
+    CREATE TABLE main_t(a INTEGER);
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.aux_t(b INTEGER);
+    BEGIN;
+    INSERT INTO main_t VALUES (100);
+    INSERT INTO aux.aux_t VALUES (200);
+    COMMIT;
+    SELECT a FROM main_t;
+    SELECT b FROM aux.aux_t;
+}
+expect {
+    100
+    200
+}
+
+test attach-write-cross-db-begin-rollback {
+    CREATE TABLE main_t(a INTEGER);
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.aux_t(b INTEGER);
+    INSERT INTO main_t VALUES (1);
+    INSERT INTO aux.aux_t VALUES (2);
+    BEGIN;
+    INSERT INTO main_t VALUES (10);
+    INSERT INTO aux.aux_t VALUES (20);
+    ROLLBACK;
+    SELECT a FROM main_t;
+    SELECT b FROM aux.aux_t;
+}
+expect {
+    1
+    2
+}
+
+# =============================================================================
+# Constraint failures
+# =============================================================================
+
+test attach-write-pk-violation {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'first');
+    INSERT INTO aux.t1 VALUES(1, 'duplicate');
+}
+expect error {
+    UNIQUE constraint failed
+}
+
+test attach-write-not-null-violation {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT NOT NULL);
+    INSERT INTO aux.t1 VALUES(1, NULL);
+}
+expect error {
+    NOT NULL constraint failed
+}
+
+test attach-write-unique-violation {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT UNIQUE);
+    INSERT INTO aux.t1 VALUES(1, 'dup');
+    INSERT INTO aux.t1 VALUES(2, 'dup');
+}
+expect error {
+    UNIQUE constraint failed
+}
+
+test attach-write-constraint-no-partial-commit {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT NOT NULL);
+    INSERT INTO aux.t1 VALUES(1, 'ok');
+    INSERT INTO aux.t1 VALUES(2, NULL);
+    SELECT count(*) FROM aux.t1;
+}
+expect error {
+    NOT NULL constraint failed
+}
+
+test attach-write-check-constraint {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val INTEGER CHECK(val > 0));
+    INSERT INTO aux.t1 VALUES(1, 10);
+    INSERT INTO aux.t1 VALUES(2, -1);
+}
+expect error {
+    CHECK constraint failed
+}
+
+# =============================================================================
+# Transaction failure in one database
+# =============================================================================
+
+test attach-write-txn-error-rollback {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, val TEXT NOT NULL);
+    BEGIN;
+    INSERT INTO main.m1 VALUES(1, 'main_ok');
+    INSERT INTO aux.a1 VALUES(1, NULL);
+}
+expect error {
+    NOT NULL constraint failed
+}
+
+# =============================================================================
+# Schema introspection on attached database
+# =============================================================================
+
+test attach-write-schema-introspection {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE aux.t2(a INTEGER, b REAL);
+    SELECT name FROM aux.sqlite_schema WHERE type='table' ORDER BY name;
+}
+expect {
+    t1
+    t2
+}
+
+test attach-write-schema-with-index {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX aux.idx1 ON t1(name);
+    SELECT type, name, tbl_name FROM aux.sqlite_schema ORDER BY name;
+}
+expect {
+    index|idx1|t1
+    table|t1|t1
+}
+
+# =============================================================================
+# Main and attached tables with same name
+# =============================================================================
+
+test attach-write-same-table-name {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.t1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.t1 VALUES(1, 'main');
+    INSERT INTO aux.t1 VALUES(1, 'aux');
+    SELECT val FROM main.t1;
+    SELECT val FROM aux.t1;
+}
+expect {
+    main
+    aux
+}
+
+test attach-write-same-name-independent {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.t1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.t1 VALUES(1, 'main');
+    INSERT INTO aux.t1 VALUES(1, 'aux');
+    DELETE FROM aux.t1;
+    SELECT count(*) FROM main.t1;
+    SELECT count(*) FROM aux.t1;
+}
+expect {
+    1
+    0
+}
+
+# =============================================================================
+# Mixed reads and writes across databases
+# =============================================================================
+
+test attach-write-read-main-write-aux {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.m1 VALUES(1, 'source');
+    INSERT INTO aux.a1 SELECT * FROM main.m1;
+    SELECT val FROM aux.a1;
+}
+expect {
+    source
+}
+
+test attach-write-interleaved-operations {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.m1(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE aux.a1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.m1 VALUES(1, 'a');
+    INSERT INTO aux.a1 VALUES(1, 'b');
+    INSERT INTO main.m1 VALUES(2, 'c');
+    INSERT INTO aux.a1 VALUES(2, 'd');
+    SELECT val FROM main.m1 ORDER BY id;
+    SELECT val FROM aux.a1 ORDER BY id;
+}
+expect {
+    a
+    c
+    b
+    d
+}
+
+# =============================================================================
+# Edge cases
+# =============================================================================
+
+test attach-write-empty-string {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, '');
+    SELECT id, val, length(val) FROM aux.t1;
+}
+expect {
+    1||0
+}
+
+test attach-write-null-values {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, NULL);
+    SELECT id, val FROM aux.t1;
+}
+expect {
+    1|
+}
+
+test attach-write-large-insert {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f'),(7,'g'),(8,'h'),(9,'i'),(10,'j');
+    SELECT count(*) FROM aux.t1;
+}
+expect {
+    10
+}
+
+test attach-write-types {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(a INTEGER, b REAL, c TEXT, d BLOB);
+    INSERT INTO aux.t1 VALUES(42, 3.14, 'hello', X'DEADBEEF');
+    SELECT typeof(a), typeof(b), typeof(c), typeof(d) FROM aux.t1;
+}
+expect {
+    integer|real|text|blob
+}
+
+test attach-write-create-multiple-tables {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY);
+    CREATE TABLE aux.t2(id INTEGER PRIMARY KEY);
+    CREATE TABLE aux.t3(id INTEGER PRIMARY KEY);
+    INSERT INTO aux.t1 VALUES(1);
+    INSERT INTO aux.t2 VALUES(2);
+    INSERT INTO aux.t3 VALUES(3);
+    SELECT (SELECT id FROM aux.t1), (SELECT id FROM aux.t2), (SELECT id FROM aux.t3);
+}
+expect {
+    1|2|3
+}
+
+test attach-write-table-with-many-columns {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.wide(a INT, b INT, c INT, d INT, e INT, f TEXT, g TEXT, h TEXT);
+    INSERT INTO aux.wide VALUES(1,2,3,4,5,'x','y','z');
+    SELECT * FROM aux.wide;
+}
+expect {
+    1|2|3|4|5|x|y|z
+}
+
+# =============================================================================
+# Write to attached then detach
+# =============================================================================
+
+test attach-write-then-detach {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'test');
+    SELECT * FROM aux.t1;
+    DETACH DATABASE aux;
+    SELECT 'detached_ok';
+}
+expect {
+    1|test
+    detached_ok
+}
+
+test attach-write-query-after-detach-fails {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY);
+    INSERT INTO aux.t1 VALUES(1);
+    DETACH DATABASE aux;
+    SELECT * FROM aux.t1;
+}
+expect error {
+    no such
+}
+
+# =============================================================================
+# Indexes with DML interactions
+# =============================================================================
+
+test attach-write-index-after-bulk-insert {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, category TEXT, value INTEGER);
+    INSERT INTO aux.t1 VALUES(1,'a',10),(2,'b',20),(3,'a',30),(4,'c',40),(5,'a',50);
+    CREATE INDEX aux.idx_cat ON t1(category);
+    SELECT id FROM aux.t1 WHERE category = 'a' ORDER BY id;
+}
+expect {
+    1
+    3
+    5
+}
+
+test attach-write-index-with-update-and-delete {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT, score INTEGER);
+    CREATE INDEX aux.idx_score ON t1(score);
+    INSERT INTO aux.t1 VALUES(1,'alice',100),(2,'bob',200),(3,'charlie',150);
+    UPDATE aux.t1 SET score = 250 WHERE name = 'alice';
+    DELETE FROM aux.t1 WHERE name = 'bob';
+    SELECT name, score FROM aux.t1 WHERE score >= 150 ORDER BY score;
+}
+expect {
+    charlie|150
+    alice|250
+}
+
+test attach-write-composite-index-range-query {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.orders(id INTEGER PRIMARY KEY, customer_id INTEGER, amount REAL);
+    CREATE INDEX aux.idx_cust_amt ON orders(customer_id, amount);
+    INSERT INTO aux.orders VALUES(1,10,5.00),(2,10,15.00),(3,20,10.00),(4,10,25.00),(5,20,30.00);
+    SELECT id, CAST(amount AS INTEGER) FROM aux.orders WHERE customer_id = 10 AND amount > 10.0 ORDER BY amount;
+}
+expect {
+    2|15
+    4|25
+}
+
+test attach-write-index-on-text-column {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, tag TEXT);
+    CREATE INDEX aux.idx_tag ON t1(tag);
+    INSERT INTO aux.t1 VALUES(1,'beta'),(2,'alpha'),(3,'gamma'),(4,'alpha');
+    SELECT id FROM aux.t1 WHERE tag = 'alpha' ORDER BY id;
+}
+expect {
+    2
+    4
+}
+
+test attach-write-multiple-indexes-same-table {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, a TEXT, b INTEGER, c REAL);
+    CREATE INDEX aux.idx_a ON t1(a);
+    CREATE INDEX aux.idx_b ON t1(b);
+    CREATE INDEX aux.idx_c ON t1(c);
+    INSERT INTO aux.t1 VALUES(1,'x',10,1.1),(2,'y',20,2.2),(3,'x',30,3.3);
+    SELECT id FROM aux.t1 WHERE a = 'x' ORDER BY id;
+    SELECT id FROM aux.t1 WHERE b > 15 ORDER BY id;
+}
+expect {
+    1
+    3
+    2
+    3
+}
+
+# =============================================================================
+# ALTER TABLE on attached database
+# =============================================================================
+
+test attach-write-alter-table-add-column {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'alice');
+    ALTER TABLE aux.t1 ADD COLUMN age INTEGER;
+    INSERT INTO aux.t1 VALUES(2, 'bob', 30);
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|alice|
+    2|bob|30
+}
+
+test attach-write-alter-table-rename {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'alice');
+    ALTER TABLE aux.t1 RENAME TO t2;
+    SELECT * FROM aux.t2 ORDER BY id;
+}
+expect {
+    1|alice
+}
+
+test attach-write-alter-table-drop-column {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT, extra TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'alice', 'remove_me');
+    ALTER TABLE aux.t1 DROP COLUMN extra;
+    SELECT * FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|alice
+}
+
+test attach-write-alter-table-rename-column {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, old_name TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'alice');
+    ALTER TABLE aux.t1 RENAME COLUMN old_name TO new_name;
+    SELECT id, new_name FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|alice
+}
+
+# =============================================================================
+# CREATE/DROP VIEW on attached database
+# =============================================================================
+
+test attach-write-create-view {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT, value INTEGER);
+    INSERT INTO aux.t1 VALUES(1, 'alice', 10), (2, 'bob', 20);
+    CREATE VIEW aux.v1 AS SELECT name, value FROM aux.t1 WHERE value > 5;
+    SELECT * FROM aux.v1 ORDER BY name;
+}
+expect {
+    alice|10
+    bob|20
+}
+
+test attach-write-drop-view {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE VIEW aux.v1 AS SELECT name FROM aux.t1;
+    DROP VIEW aux.v1;
+    SELECT count(*) FROM aux.t1;
+}
+expect {
+    0
+}
+
+test attach-write-drop-view-if-exists {
+    ATTACH ':memory:' AS aux;
+    DROP VIEW IF EXISTS aux.nonexistent;
+    SELECT 'ok';
+}
+expect {
+    ok
+}
+
+# =============================================================================
+# PRAGMA on attached database
+# =============================================================================
+
+test attach-write-pragma-max-page-count {
+    ATTACH ':memory:' AS aux;
+    PRAGMA main.max_page_count = 500;
+    PRAGMA aux.max_page_count = 1000;
+    PRAGMA main.max_page_count;
+    PRAGMA aux.max_page_count;
+}
+expect {
+    500
+    1000
+    500
+    1000
+}
+
+test attach-write-pragma-user-version {
+    ATTACH ':memory:' AS aux;
+    PRAGMA main.user_version = 100;
+    PRAGMA aux.user_version = 200;
+    PRAGMA main.user_version;
+    PRAGMA aux.user_version;
+}
+expect {
+    100
+    200
+}
+
+test attach-write-pragma-application-id {
+    ATTACH ':memory:' AS aux;
+    PRAGMA main.application_id = 111;
+    PRAGMA aux.application_id = 222;
+    PRAGMA main.application_id;
+    PRAGMA aux.application_id;
+}
+expect {
+    111
+    222
+}
+
+test attach-write-pragma-table-info {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    PRAGMA aux.table_info("t1");
+}
+expect {
+    0|id|INTEGER|0||1
+    1|val|TEXT|0||0
+}
+
+
+# =============================================================================
+# CREATE/DROP TRIGGER on attached database
+# =============================================================================
+
+@requires trigger "uses triggers"
+test attach-write-create-trigger-schema {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(x INTEGER);
+    CREATE TRIGGER aux.trg1 AFTER INSERT ON t1 BEGIN SELECT 1; END;
+    SELECT count(*) FROM aux.sqlite_schema WHERE type='trigger' AND name='trg1';
+}
+expect {
+    1
+}
+
+@requires trigger "uses triggers"
+test attach-write-drop-trigger {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(x INTEGER);
+    CREATE TRIGGER aux.trg1 AFTER INSERT ON t1 BEGIN SELECT 1; END;
+    DROP TRIGGER aux.trg1;
+    SELECT count(*) FROM aux.sqlite_schema WHERE type='trigger';
+}
+expect {
+    0
+}
+
+@requires trigger "uses triggers"
+test attach-write-drop-trigger-if-exists {
+    ATTACH ':memory:' AS aux;
+    DROP TRIGGER IF EXISTS aux.nonexistent;
+    SELECT 'ok';
+}
+expect {
+    ok
+}
+
+# =============================================================================
+# FOREIGN KEYS ON ATTACHED DATABASES (same-database references)
+# =============================================================================
+
+test attach-write-fk-insert-violation {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));
+    INSERT INTO aux.parent VALUES (1, 'Alice');
+    INSERT INTO aux.child VALUES (1, 1);
+    INSERT INTO aux.child VALUES (2, 999);
+}
+expect error {
+    FOREIGN KEY constraint failed
+}
+
+test attach-write-fk-insert-valid {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));
+    INSERT INTO aux.parent VALUES (1, 'Alice');
+    INSERT INTO aux.parent VALUES (2, 'Bob');
+    INSERT INTO aux.child VALUES (1, 1);
+    INSERT INTO aux.child VALUES (2, 2);
+    SELECT c.id, p.name FROM aux.child c JOIN aux.parent p ON c.parent_id = p.id ORDER BY c.id;
+}
+expect {
+    1|Alice
+    2|Bob
+}
+
+test attach-write-fk-delete-violation {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));
+    INSERT INTO aux.parent VALUES (1, 'Alice');
+    INSERT INTO aux.child VALUES (1, 1);
+    DELETE FROM aux.parent WHERE id = 1;
+}
+expect error {
+    FOREIGN KEY constraint failed
+}
+
+test attach-write-fk-update-violation {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));
+    INSERT INTO aux.parent VALUES (1, 'Alice');
+    INSERT INTO aux.child VALUES (1, 1);
+    UPDATE aux.parent SET id = 99 WHERE id = 1;
+}
+expect error {
+    FOREIGN KEY constraint failed
+}
+
+test attach-write-fk-drop-table-with-references {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));
+    INSERT INTO aux.parent VALUES (1);
+    INSERT INTO aux.child VALUES (1, 1);
+    DROP TABLE aux.parent;
+}
+expect error {
+    FOREIGN KEY constraint failed
+}
+
+test attach-write-fk-in-transaction {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));
+    BEGIN;
+    INSERT INTO aux.parent VALUES (1);
+    INSERT INTO aux.parent VALUES (2);
+    INSERT INTO aux.child VALUES (1, 1);
+    INSERT INTO aux.child VALUES (2, 2);
+    COMMIT;
+    SELECT count(*) FROM aux.child;
+}
+expect {
+    2
+}
+
+test attach-write-fk-violation-in-transaction {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));
+    INSERT INTO aux.parent VALUES (1);
+    BEGIN;
+    INSERT INTO aux.child VALUES (1, 999);
+}
+expect error {
+    FOREIGN KEY constraint failed
+}
+
+# =============================================================================
+# ANALYZE ON ATTACHED DATABASES
+# =============================================================================
+
+test attach-write-analyze-basic {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(a INTEGER PRIMARY KEY, b TEXT, c REAL);
+    CREATE INDEX aux.idx_t1_b ON t1(b);
+    INSERT INTO aux.t1 VALUES (1, 'hello', 1.0);
+    INSERT INTO aux.t1 VALUES (2, 'world', 2.0);
+    INSERT INTO aux.t1 VALUES (3, 'hello', 3.0);
+    ANALYZE aux;
+    SELECT tbl, idx, stat FROM aux.sqlite_stat1 WHERE idx IS NOT NULL ORDER BY tbl, idx;
+}
+expect {
+    t1|idx_t1_b|3 2
+}
+
+test attach-write-analyze-table {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE INDEX aux.idx_b ON t1(b);
+    INSERT INTO aux.t1 VALUES (1, 'a');
+    INSERT INTO aux.t1 VALUES (2, 'b');
+    INSERT INTO aux.t1 VALUES (3, 'c');
+    ANALYZE aux.t1;
+    SELECT tbl, idx, stat FROM aux.sqlite_stat1 WHERE idx IS NOT NULL ORDER BY tbl, idx;
+}
+expect {
+    t1|idx_b|3 1
+}
+
+test attach-write-analyze-index {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE INDEX aux.idx_b ON t1(b);
+    INSERT INTO aux.t1 VALUES (1, 'x');
+    INSERT INTO aux.t1 VALUES (2, 'y');
+    ANALYZE aux.idx_b;
+    SELECT tbl, idx, stat FROM aux.sqlite_stat1 WHERE idx IS NOT NULL ORDER BY tbl, idx;
+}
+expect {
+    t1|idx_b|2 1
+}
+
+# =============================================================================
+# FK CASCADE / SET NULL / SET DEFAULT ON ATTACHED DATABASES (same-database)
+# =============================================================================
+
+test attach-write-fk-cascade-delete {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id) ON DELETE CASCADE);
+    INSERT INTO aux.parent VALUES (1, 'Alice');
+    INSERT INTO aux.parent VALUES (2, 'Bob');
+    INSERT INTO aux.child VALUES (1, 1);
+    INSERT INTO aux.child VALUES (2, 1);
+    INSERT INTO aux.child VALUES (3, 2);
+    DELETE FROM aux.parent WHERE id = 1;
+    SELECT * FROM aux.child ORDER BY id;
+}
+expect {
+    3|2
+}
+
+test attach-write-fk-cascade-update {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id) ON UPDATE CASCADE);
+    INSERT INTO aux.parent VALUES (1, 'Alice');
+    INSERT INTO aux.child VALUES (1, 1);
+    UPDATE aux.parent SET id = 99 WHERE id = 1;
+    SELECT * FROM aux.child;
+}
+expect {
+    1|99
+}
+
+test attach-write-fk-set-null-delete {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id) ON DELETE SET NULL);
+    INSERT INTO aux.parent VALUES (1, 'Alice');
+    INSERT INTO aux.parent VALUES (2, 'Bob');
+    INSERT INTO aux.child VALUES (1, 1);
+    INSERT INTO aux.child VALUES (2, 2);
+    DELETE FROM aux.parent WHERE id = 1;
+    SELECT * FROM aux.child ORDER BY id;
+}
+expect {
+    1|
+    2|2
+}
+
+test attach-write-fk-cascade-in-transaction {
+    ATTACH ':memory:' AS aux;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE aux.parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id) ON DELETE CASCADE);
+    INSERT INTO aux.parent VALUES (1, 'Alice');
+    INSERT INTO aux.parent VALUES (2, 'Bob');
+    INSERT INTO aux.child VALUES (1, 1);
+    INSERT INTO aux.child VALUES (2, 2);
+    BEGIN;
+    DELETE FROM aux.parent WHERE id = 1;
+    DELETE FROM aux.parent WHERE id = 2;
+    COMMIT;
+    SELECT count(*) FROM aux.child;
+}
+expect {
+    0
+}
+
+# =============================================================================
+# SCHEMA CACHE INVALIDATION ON DETACH/REATTACH
+# =============================================================================
+
+test attach-write-detach-reattach-fresh-schema {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'old_db');
+    SELECT val FROM aux.t1;
+    DETACH DATABASE aux;
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t2(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO aux.t2 VALUES(1, 'new_db');
+    SELECT name FROM aux.t2;
+}
+expect {
+    old_db
+    new_db
+}
+
+test attach-write-detach-reattach-old-table-gone {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'hello');
+    SELECT val FROM aux.t1;
+    DETACH DATABASE aux;
+    ATTACH ':memory:' AS aux;
+    SELECT * FROM aux.t1;
+}
+expect error {
+    no such table
+}
+
+test attach-write-detach-reattach-same-table-name {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'first_db');
+    SELECT val FROM aux.t1;
+    DETACH DATABASE aux;
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.t1 VALUES(1, 'second_db');
+    SELECT val FROM aux.t1;
+}
+expect {
+    first_db
+    second_db
+}
+
+# =============================================================================
+# CROSS-DATABASE FK REJECTION
+# =============================================================================
+
+test attach-write-cross-db-fk-rejected {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE main_parent(id INTEGER PRIMARY KEY);
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES main_parent(id));
+    INSERT INTO main_parent VALUES (1);
+    INSERT INTO aux.child VALUES (1, 1);
+}
+expect error {
+}
+
+test attach-write-cross-db-fk-rejected-reverse {
+    PRAGMA foreign_keys = ON;
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.aux_parent(id INTEGER PRIMARY KEY);
+    CREATE TABLE main_child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES aux_parent(id));
+    INSERT INTO aux.aux_parent VALUES (1);
+    INSERT INTO main_child VALUES (1, 1);
+}
+expect error {
+}
+
+test attach-write-update-unique-constraint {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(a INTEGER PRIMARY KEY, b TEXT UNIQUE);
+    INSERT INTO aux.t1 VALUES (1, 'hello');
+    INSERT INTO aux.t1 VALUES (2, 'world');
+    UPDATE aux.t1 SET b = 'same';
+}
+expect error {
+    UNIQUE constraint failed: t1.b
+}
+
+# =============================================================================
+# CDC (CHANGE DATA CAPTURE) WITH ATTACHED DATABASES
+# =============================================================================
+
+test attach-write-cdc-insert {
+    CREATE TABLE turso_cdc(change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB);
+    PRAGMA unstable_capture_data_changes_conn('full');
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(x INTEGER, y TEXT);
+    INSERT INTO aux.t1 VALUES (1, 'hello');
+    SELECT table_name, change_type FROM turso_cdc WHERE table_name != 'sqlite_schema';
+}
+expect {
+    t1|1
+}
+
+test attach-write-cdc-delete {
+    CREATE TABLE turso_cdc(change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB);
+    PRAGMA unstable_capture_data_changes_conn('full');
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(x INTEGER);
+    INSERT INTO aux.t1 VALUES (1);
+    INSERT INTO aux.t1 VALUES (2);
+    DELETE FROM aux.t1 WHERE x = 1;
+    SELECT table_name, change_type FROM turso_cdc WHERE table_name != 'sqlite_schema' ORDER BY change_id;
+}
+expect {
+    t1|1
+    t1|1
+    t1|-1
+}
+
+test attach-write-cdc-update {
+    CREATE TABLE turso_cdc(change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB);
+    PRAGMA unstable_capture_data_changes_conn('full');
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(x INTEGER, y TEXT);
+    INSERT INTO aux.t1 VALUES (1, 'old');
+    UPDATE aux.t1 SET y = 'new' WHERE x = 1;
+    SELECT table_name, change_type FROM turso_cdc WHERE table_name != 'sqlite_schema' ORDER BY change_id;
+}
+expect {
+    t1|1
+    t1|0
+}
+

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -150,6 +150,7 @@ impl TempDatabaseBuilder {
         self
     }
 
+    #[allow(dead_code)]
     pub fn with_io_uring(mut self, enable: bool) -> Self {
         self.io_uring = enable;
         self


### PR DESCRIPTION
## Description

Improves support for attach databases. Still marked as experimental, though. There's more work to do that I am aware of , and I am already reviewing.

## Motivation and context

Attach. In the past I wanted to have a smarter attach for writes that guaranteed consistency across databases, but will settle for SQLite's semantics now

## Description of AI Usage

Most of it is just making sure that database_id is not hardcoded to zero in the various places where that happens. And guess who's really good at that?

Attach is then added to the differential fuzzer (which caught some stuff already!)