### PR TITLE
fix: handle PRAGMA database_list with argument without panicking

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -82,6 +82,7 @@ pub fn translate_pragma(
             | PragmaName::TableInfo
             | PragmaName::TableXinfo
             | PragmaName::IntegrityCheck
+            | PragmaName::DatabaseList
             | PragmaName::QuickCheck => {
                 query_pragma(pragma, resolver, Some(*value), pager, connection, program)?
             }

--- a/testing/runner/turso-tests/attach/memory.sqltest
+++ b/testing/runner/turso-tests/attach/memory.sqltest
@@ -59,3 +59,10 @@ expect {
 expect @js {
     1|hat|79|1
 }
+
+test database-list-with-arg {
+    PRAGMA database_list('t1');
+}
+expect {
+    0|main|
+}


### PR DESCRIPTION
Closes #5303 


## Description

This PR fixes PRAGMA database_list panic, by routing it to `query_pragma`

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
