### PR TITLE
fix: Panic on ALTER TABLE ADD COLUMN With Invalid Collation Name #5305

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -529,7 +529,7 @@ pub fn translate_alter_table(
                 ));
             }
             let constraints = col_def.constraints.clone();
-            let column = Column::from(&col_def);
+            let column = Column::try_from(&col_def)?;
 
             // SQLite is very strict about what constitutes a "constant" default for
             // ALTER TABLE ADD COLUMN. It only allows literals and signed literals,

--- a/core/util.rs
+++ b/core/util.rs
@@ -837,7 +837,10 @@ pub fn columns_from_create_table_body(
         ));
     };
 
-    Ok(columns.iter().map(Into::into).collect())
+    columns
+        .iter()
+        .map(Column::try_from)
+        .collect::<crate::Result<Vec<Column>>>()
 }
 
 #[derive(Debug, Default, PartialEq)]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10471,7 +10471,7 @@ pub fn op_alter_column(
             .expect("column being ALTERed should be named")
             .clone()
     };
-    let new_column = crate::schema::Column::from(definition.as_ref());
+    let new_column = crate::schema::Column::try_from(definition.as_ref())?;
     let new_name = definition.col_name.as_str().to_owned();
 
     conn.with_schema_mut(|schema| {

--- a/testing/runner/tests/alter_table.sqltest
+++ b/testing/runner/tests/alter_table.sqltest
@@ -338,3 +338,11 @@ expect {
     1|3.14
 }
 
+test alter-add-column-invalid-collation {
+    CREATE TABLE t(c1 INTEGER);
+    ALTER TABLE t ADD COLUMN c2 INTEGER COLLATE compile_options;
+}
+expect error {
+    no such collation sequence: compile_options
+}
+


### PR DESCRIPTION
Convert `From<&ColumnDefinition> for Column` to `TryFrom` so that `CollationSeq::new()` errors propagate instead of panicking via `.expect()`. This ensures invalid collation names in ALTER TABLE ADD COLUMN return a proper error ("no such collation sequence: ...") matching SQLite behavior.

Closes #5305