### PR TITLE
fix: ALTER TABLE RENAME COLUMN Fails on Case Mismatch #5246

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6093,8 +6093,7 @@ pub fn op_function(
                                     let column = columns
                                         .iter_mut()
                                         .find(|column| {
-                                            column.col_name.as_str()
-                                                == original_rename_from.as_str()
+                                            normalize_ident(column.col_name.as_str()) == rename_from
                                         })
                                         .expect("column being renamed should be present");
 

--- a/testing/runner/tests/alter_table.sqltest
+++ b/testing/runner/tests/alter_table.sqltest
@@ -20,6 +20,16 @@ expect {
     CREATE INDEX i ON t (b)
 }
 
+# https://github.com/tursodatabase/turso/issues/5246
+test alter-table-rename-column-case-insensitive {
+    CREATE TABLE t (a INT);
+    ALTER TABLE t RENAME COLUMN A TO b;
+    SELECT sql FROM sqlite_schema;
+}
+expect {
+    CREATE TABLE t (b INT)
+}
+
 test alter-table-rename-quoted-column {
     CREATE TABLE t (a INTEGER);
     ALTER TABLE t RENAME a TO "ab cd";


### PR DESCRIPTION
Use case-insensitive comparison (normalize_ident) when looking up the column to rename in CREATE TABLE schema rewriting. Previously the lookup used exact case match against the user-provided column name, which panicked when the case differed from the original definition.

Closes #5246