### PR TITLE
fix: Panic on Unresolved Table Reference in UPSERT DO UPDATE SET #5281

### DIFF
--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -1238,7 +1238,16 @@ fn rewrite_expr_to_registers(
                             if let Some(r) = col_reg_from_row_image(&c) {
                                 *expr = Expr::Register(r);
                             }
+                            return Ok(WalkControl::Continue);
                         }
+                    }
+
+                    // In UPSERT DO UPDATE context (allow_excluded=true), a qualified
+                    // reference that doesn't match the target table or EXCLUDED is
+                    // invalid. Return a graceful error instead of leaving it
+                    // unresolved (which would panic later in translate_expr).
+                    if allow_excluded {
+                        bail_parse_error!("no such column: {}.{}", ns, c);
                     }
                 }
                 // Unqualified id -> row image (CURRENT/NEW depending on caller)

--- a/testing/runner/tests/trigger_on_conflict.sqltest
+++ b/testing/runner/tests/trigger_on_conflict.sqltest
@@ -264,3 +264,59 @@ expect {
     insert trigger: original
     insert trigger: replaced
 }
+
+# =============================================================================
+# Trigger with UPSERT referencing NEW.column
+# NEW.column in a trigger body's UPSERT DO UPDATE SET should resolve to
+# the trigger's NEW row, not cause a panic.
+# https://github.com/tursodatabase/turso/issues/5281
+# =============================================================================
+
+test trigger-upsert-new-column {
+    CREATE TABLE balances(id INTEGER PRIMARY KEY, amount INTEGER);
+    CREATE TABLE transactions(id INTEGER PRIMARY KEY, account_id INTEGER, delta INTEGER);
+    INSERT INTO balances VALUES (1, 100);
+    CREATE TRIGGER apply_txn AFTER INSERT ON transactions BEGIN
+      INSERT INTO balances VALUES (NEW.account_id, NEW.delta)
+        ON CONFLICT(id) DO UPDATE SET amount = amount + NEW.delta;
+    END;
+    INSERT INTO transactions VALUES (1, 1, 50);
+    SELECT * FROM balances;
+}
+expect {
+    1|150
+}
+
+# NEW.column in UPSERT DO UPDATE WHERE inside a trigger
+test trigger-upsert-new-in-where {
+    CREATE TABLE balances(id INTEGER PRIMARY KEY, amount INTEGER);
+    CREATE TABLE transactions(id INTEGER PRIMARY KEY, account_id INTEGER, delta INTEGER);
+    INSERT INTO balances VALUES (1, 100);
+    CREATE TRIGGER apply_txn AFTER INSERT ON transactions BEGIN
+      INSERT INTO balances VALUES (NEW.account_id, NEW.delta)
+        ON CONFLICT(id) DO UPDATE SET amount = amount + NEW.delta
+        WHERE NEW.delta > 0;
+    END;
+    INSERT INTO transactions VALUES (1, 1, 50);
+    SELECT * FROM balances;
+}
+expect {
+    1|150
+}
+
+# NEW.column in UPSERT where delta is negative and WHERE filters it out
+test trigger-upsert-new-in-where-no-update {
+    CREATE TABLE balances(id INTEGER PRIMARY KEY, amount INTEGER);
+    CREATE TABLE transactions(id INTEGER PRIMARY KEY, account_id INTEGER, delta INTEGER);
+    INSERT INTO balances VALUES (1, 100);
+    CREATE TRIGGER apply_txn AFTER INSERT ON transactions BEGIN
+      INSERT INTO balances VALUES (NEW.account_id, NEW.delta)
+        ON CONFLICT(id) DO UPDATE SET amount = amount + NEW.delta
+        WHERE NEW.delta > 0;
+    END;
+    INSERT INTO transactions VALUES (1, 1, -50);
+    SELECT * FROM balances;
+}
+expect {
+    1|100
+}

--- a/testing/runner/tests/upsert.sqltest
+++ b/testing/runner/tests/upsert.sqltest
@@ -575,3 +575,27 @@ test upsert-unique-update-rowid-change-preserves-unique {
 }
 expect error {
 }
+
+# Referencing a table other than the target or EXCLUDED in UPSERT DO UPDATE
+# should produce a graceful error, not a panic.
+# https://github.com/tursodatabase/turso/issues/5281
+test upsert-unresolved-table-reference {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE other(id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO t VALUES (1, 10);
+    INSERT INTO t VALUES (1, 20) ON CONFLICT(id) DO UPDATE SET val = other.val;
+}
+expect error {
+    .*no such column.*
+}
+
+# Same for DO UPDATE WHERE clause referencing another table.
+test upsert-unresolved-table-in-where {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE other(id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO t VALUES (1, 10);
+    INSERT INTO t VALUES (1, 20) ON CONFLICT(id) DO UPDATE SET val = excluded.val WHERE other.val > 0;
+}
+expect error {
+    .*no such column.*
+}


### PR DESCRIPTION
Two root causes:

1. In UPSERT DO UPDATE SET/WHERE, referencing a table other than the target or `excluded` (e.g. `other.val`) left the Qualified AST node unresolved, which later hit an unreachable!() panic in translate_expr. Fix: return a "no such column" error in rewrite_expr_to_registers when a qualified reference doesn't match the target table or EXCLUDED in UPSERT context.

2. In trigger bodies containing INSERT...ON CONFLICT DO UPDATE, NEW/OLD references in the UPSERT clause were not being rewritten to Variable expressions (trigger parameters). The SELECT part was rewritten but the upsert was cloned without rewriting. Fix: add rewrite_upsert_exprs_for_subprogram to walk all expressions in the Upsert clause (SET exprs, WHERE clauses) and rewrite NEW/OLD references before compilation.

Closes #5281