### PR TITLE
fix: Panic When IN Subquery Used in LIMIT Expression #5247

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -788,7 +788,7 @@ pub fn translate_expr(
                             lhs_column_regs_start + i,
                             resolver,
                         )?;
-                        if !lhs_column.is_nonnull(referenced_tables.as_ref().unwrap()) {
+                        if !referenced_tables.is_some_and(|tables| lhs_column.is_nonnull(tables)) {
                             // If LHS is NULL, we need to check if ephemeral is empty first.
                             // - If empty: IN returns FALSE, NOT IN returns TRUE
                             // - If not empty: result is NULL (unknown)

--- a/testing/runner/tests/limit.sqltest
+++ b/testing/runner/tests/limit.sqltest
@@ -30,3 +30,10 @@ test limit-one {
 expect {
     1
 }
+
+test limit-in-subquery {
+    SELECT 1 LIMIT (1 IN (SELECT 1));
+}
+expect {
+    1
+}


### PR DESCRIPTION
When an IN subquery appeared in a LIMIT expression, `referenced_tables` was `None` (since LIMIT has no table context), causing an unwrap() panic at expr.rs:791. Use `is_some_and()` to safely handle the None case by conservatively assuming the expression may be null.

Closes #5247