### PR TITLE
fix: INSERT ... RETURNING panics with multi-column scalar subquery #5243

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -4917,6 +4917,14 @@ pub fn process_returning_clause(
                     BindingBehavior::TryResultColumnsFirst,
                 )?;
 
+                let vec_size = expr_vector_size(expr)?;
+                if vec_size != 1 {
+                    crate::bail_parse_error!(
+                        "sub-select returns {} columns - expected 1",
+                        vec_size
+                    );
+                }
+
                 result_columns.push(ResultSetColumn {
                     expr: expr.as_ref().clone(),
                     alias: alias.as_ref().map(alias_to_string),

--- a/testing/runner/tests/returning.sqltest
+++ b/testing/runner/tests/returning.sqltest
@@ -1988,3 +1988,36 @@ test insert-returning-aggregate-count {
 expect error {
 }
 
+# RETURNING with multi-column scalar subquery (should error)
+test insert-returning-multi-column-subquery {
+    CREATE TABLE t (x);
+    INSERT INTO t VALUES (1) RETURNING (SELECT 1, 2);
+}
+expect error {
+}
+
+test update-returning-multi-column-subquery {
+    CREATE TABLE t (x);
+    INSERT INTO t VALUES (1);
+    UPDATE t SET x = 2 RETURNING (SELECT 1, 2);
+}
+expect error {
+}
+
+test delete-returning-multi-column-subquery {
+    CREATE TABLE t (x);
+    INSERT INTO t VALUES (1);
+    DELETE FROM t RETURNING (SELECT 1, 2);
+}
+expect error {
+}
+
+# RETURNING with single-column scalar subquery (should work)
+test insert-returning-single-column-subquery {
+    CREATE TABLE t (x);
+    INSERT INTO t VALUES (1) RETURNING (SELECT 42);
+}
+expect {
+    42
+}
+


### PR DESCRIPTION
Validate that each expression in a RETURNING clause returns exactly 1 value, matching SQLite's behavior. Previously, a scalar subquery returning multiple columns (e.g. `RETURNING (SELECT 1, 2)`) would cause an index-out-of-bounds panic in op_copy due to insufficient register allocation in emit_returning_results.

Closes #5243