### PR TITLE
fix: allow CTEs to shadow schema objects

### DIFF
--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -176,6 +176,10 @@ pub struct ProgramBuilder {
     /// Global count of references to each CTE across the entire query.
     /// Used to determine whether a CTE should be materialized (multi-ref) or use coroutine (single-ref).
     cte_reference_counts: HashMap<usize, usize>,
+    /// Stack of CTE names currently being planned. Used to detect circular
+    /// references in non-recursive CTEs and to prevent fallthrough to schema
+    /// resolution for same-named tables/views.
+    ctes_being_defined: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -401,6 +405,7 @@ impl ProgramBuilder {
             next_cte_id: 0,
             materialized_ctes: HashMap::default(),
             cte_reference_counts: HashMap::default(),
+            ctes_being_defined: Vec::new(),
         }
     }
 
@@ -442,6 +447,34 @@ impl ProgramBuilder {
     /// Used during emission to decide whether to materialize (multi-ref) or use coroutine (single-ref).
     pub fn get_cte_reference_count(&self, cte_id: usize) -> usize {
         self.cte_reference_counts.get(&cte_id).copied().unwrap_or(0)
+    }
+
+    /// Mark a CTE name as currently being planned. While on the stack,
+    /// `parse_table` will reject references to this name with "circular
+    /// reference" instead of falling through to schema resolution.
+    pub fn push_cte_being_defined(&mut self, name: String) {
+        self.ctes_being_defined.push(name);
+    }
+
+    /// Remove the most recently pushed CTE name after planning completes.
+    pub fn pop_cte_being_defined(&mut self) {
+        self.ctes_being_defined.pop();
+    }
+
+    /// Check whether a name refers to a CTE currently being planned.
+    pub fn is_cte_being_defined(&self, name: &str) -> bool {
+        self.ctes_being_defined.iter().any(|n| n == name)
+    }
+
+    /// Temporarily take the CTE-being-defined stack (e.g. during view
+    /// expansion, which should not see CTE context from the caller).
+    pub fn take_ctes_being_defined(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.ctes_being_defined)
+    }
+
+    /// Restore the CTE-being-defined stack after a context-isolated expansion.
+    pub fn restore_ctes_being_defined(&mut self, saved: Vec<String>) {
+        self.ctes_being_defined = saved;
     }
 
     pub fn set_resolve_type(&mut self, resolve_type: ResolveType) {

--- a/testing/runner/tests/cte.sqltest
+++ b/testing/runner/tests/cte.sqltest
@@ -649,6 +649,75 @@ expect error {
 #     Materialized CTEs are not yet supported
 # }
 
+setup cte_shadow_view {
+    CREATE VIEW v AS SELECT 1 as val;
+}
+
+setup cte_shadow_table {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('from_table');
+}
+
+# CTE can shadow a view (sqlite compat)
+@skip-if mvcc "views not supported in MVCC"
+@setup cte_shadow_view
+test cte-shadows-view {
+    WITH v AS (SELECT 'from_cte' as val) SELECT * FROM v;
+}
+expect {
+    from_cte
+}
+
+# CTE can shadow a table
+@setup cte_shadow_table
+test cte-shadows-table {
+    WITH t AS (SELECT 'from_cte' as x) SELECT * FROM t;
+}
+expect {
+    from_cte
+}
+
+# Self-referencing non-recursive CTE with same name as view = circular reference
+@skip-if mvcc "views not supported in MVCC"
+@setup cte_shadow_view
+test cte-circular-ref-view {
+    WITH v AS (SELECT * FROM v) SELECT * FROM v;
+}
+expect error {
+    circular reference: v
+}
+
+# Self-referencing non-recursive CTE with same name as table = circular reference
+@setup cte_shadow_table
+test cte-circular-ref-table {
+    WITH t AS (SELECT * FROM t) SELECT * FROM t;
+}
+expect error {
+    circular reference: t
+}
+
+# CTE shadows table but references different table
+@setup cte_shadow_table
+test cte-shadows-table-refs-other {
+    CREATE TABLE other(y TEXT);
+    INSERT INTO other VALUES('from_other');
+    WITH t AS (SELECT y as x FROM other) SELECT * FROM t;
+}
+expect {
+    from_other
+}
+
+# CTE does not leak into view expansion — view sees the real table
+@skip-if mvcc "views not supported in MVCC"
+@setup cte_shadow_table
+test cte-does-not-leak-into-view {
+    CREATE VIEW v AS SELECT * FROM t;
+    WITH t AS (SELECT 'from_cte' as x) SELECT * FROM v;
+}
+expect {
+    from_table
+}
+
 # =============================================================================
 # Multi-reference CTE with materialization - regression tests
 # =============================================================================


### PR DESCRIPTION
  track CTE names being planned on a stack
  in ProgramBuilder. When parse_table encounters a name on this stack, it
  returns "circular reference" (matching SQLite) instead of falling through
  to schema resolution (which caused infinite recursion for views).

  Also fix CTE context leaking into view expansion — views are pre-defined
  and should resolve against the schema only, not against CTEs from the
  calling query. Pass empty CTE definitions and temporarily clear the
  being-defined stack during view expansion.

Closes #5235