### PR TITLE
github: Improve license check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,9 +22,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check licenses
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-deny
+      - run: cargo deny check licenses
 
   cargo-fmt-check:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
The license checker was failing with:

```
error: override toolchain '1.88.0-x86_64-unknown-linux-musl' is not installed: the toolchain file at '/github/workspace/rust-toolchain.toml' specifies an uninstalled toolchain
Default host: x86_64-unknown-linux-musl
rustup home:  /usr/local/rustup

installed toolchains
--------------------
1.85.0-x86_64-unknown-linux-musl (default)

active toolchain
----------------
info: syncing channel updates for '1.88.0-x86_64-unknown-linux-musl'
error: could not download file from 'https://static.rust-lang.org/dist/channel-rust-1.88.0.toml.sha256' to '/usr/local/rustup/tmp/psoa9oxgjq1vjcch_file': failed to make network request: error sending request for url (https://static.rust-lang.org/dist/channel-rust-1.88.0.toml.sha256): client error (Connect): tcp connect error: Network unreachable (os error 101): Network unreachable (os error 101)
```

The cargo-deny-action@v2 Docker container ships with Rust 1.85.0 but our rust-toolchain.toml requires 1.88.0, causing it to update the toolchain and sometimes fail because of crappy networking.

However, using Docker for this seems like an overkill when we can just install `cargo-deny` directly and run it.