### PR TITLE
fix: Panic on Multi-Index OR Subquery with Multiple Outer Rows (Stale…

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -434,9 +434,11 @@ pub fn op_null(
             if let Some(dest_end) = dest_end {
                 for i in *dest..=*dest_end {
                     state.registers[i] = Register::Value(Value::Null);
+                    state.rowsets.remove(&i);
                 }
             } else {
                 state.registers[*dest] = Register::Value(Value::Null);
+                state.rowsets.remove(dest);
             }
         }
         _ => unreachable!("unexpected Insn {:?}", insn),

--- a/testing/runner/tests/multi-index-or-subquery.sqltest
+++ b/testing/runner/tests/multi-index-or-subquery.sqltest
@@ -1,0 +1,20 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t1(a INTEGER, b INTEGER);
+    CREATE INDEX idx_a ON t1(a);
+    CREATE INDEX idx_b ON t1(b);
+    INSERT INTO t1 VALUES(1,10);
+    CREATE TABLE t2(x);
+    INSERT INTO t2 VALUES(1);
+    INSERT INTO t2 VALUES(2);
+}
+
+@setup schema
+test multi-index-or-subquery-with-multiple-outer-rows {
+    SELECT t2.x, sub.a FROM t2, (SELECT a FROM t1 WHERE a=1 OR b=10) sub;
+}
+expect {
+    1|1
+    2|1
+}


### PR DESCRIPTION
… RowSet) #5234

When a Null instruction resets a register used as a RowSet, also remove the stale entry from state.rowsets. Previously, the RowSet remained in Smallest mode from the first coroutine iteration, causing a panic on RowSetAdd during subsequent iterations.

Closes #5234

## Notes

See if this overlaps with #5314 