### PR TITLE
wip/fix: Panic on LEFT JOIN with Empty Table and Ungrouped Aggregate (Cur…

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1433,6 +1433,11 @@ pub fn op_column(
                         index_cursor_id: deferred.index_cursor_id,
                         table_cursor_id: deferred.table_cursor_id,
                     };
+                } else if state.cursors[*cursor_id].is_none() {
+                    // Cursor was never opened (e.g. OpenAutoindex inside a loop
+                    // that was skipped because the table was empty).
+                    state.registers[*dest] = Register::Value(Value::Null);
+                    break 'outer;
                 } else {
                     state.op_column_state = OpColumnState::GetColumn;
                 }

--- a/testing/runner/tests/join/memory.sqltest
+++ b/testing/runner/tests/join/memory.sqltest
@@ -394,6 +394,18 @@ expect {
     3|3
 }
 
+# Regression test for: https://github.com/tursodatabase/turso/issues/5233
+# LEFT JOIN with empty left table + ungrouped aggregate panics because
+# OpenAutoindex (inside the loop body) never executes when Rewind skips the loop,
+# but the post-loop aggregation path tries to read from the never-opened cursor.
+test left-join-empty-table-ungrouped-aggregate {
+    CREATE TABLE t(x);
+    SELECT b.x, COUNT(*) FROM t a LEFT JOIN t b ON a.x=b.x;
+}
+expect {
+    |0
+}
+
 @skip-if sqlite "sqlite supports full outer joins"
 test full-outer-join {
 	create table t(a);


### PR DESCRIPTION
…sor Never Opened) #5233

When a LEFT JOIN with an ON clause triggers an autoindex, the OpenAutoindex instruction is placed inside the loop body within a Once block. If the left table is empty, Rewind skips the loop entirely so OpenAutoindex never executes. The post-loop ungrouped aggregation path then tries to evaluate a Column instruction on the never-opened cursor, causing a panic.

Fix: in the Column opcode handler, check if the cursor is None (never opened) before accessing it, and return NULL in that case.

Closes #5233

## Notes on autofixer's solution

TODO(jussi): this is probably not the best fix. i'm pretty sure sqlite doesn't allow referring to unopened cursors, so we shouldn't either. verify behavior and fix properly.