### PR TITLE
wip/fix: Panic on Multi-Column Subquery in Comparison Expression #5231

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5058,6 +5058,9 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
             if evs_left != evs_right {
                 crate::bail_parse_error!("all arguments to binary operator {operator} must return the same number of values. Got: ({evs_left}) {operator} ({evs_right})");
             }
+            if evs_left != 1 {
+                crate::bail_parse_error!("sub-select returns {} columns - expected 1", evs_left);
+            }
             1
         }
         Expr::Register(_) => 1,

--- a/testing/runner/turso-tests/multi-column-subquery-comparison.sqltest
+++ b/testing/runner/turso-tests/multi-column-subquery-comparison.sqltest
@@ -1,0 +1,50 @@
+@database :memory:
+
+# Multi-column subquery in comparison expression should error (not panic)
+# Regression test for https://github.com/tursodatabase/turso/issues/5231
+
+test multi-column-subquery-eq {
+    SELECT (SELECT 1, 2) = (SELECT 1, 2);
+}
+expect error {
+}
+
+test multi-column-subquery-ne {
+    SELECT (SELECT 1, 2) != (SELECT 3, 4);
+}
+expect error {
+}
+
+test multi-column-subquery-lt {
+    SELECT (SELECT 1, 2) < (SELECT 3, 4);
+}
+expect error {
+}
+
+test multi-column-subquery-addition {
+    SELECT (SELECT 1, 2) + (SELECT 3, 4);
+}
+expect error {
+}
+
+# Single-column subquery comparison should still work
+test single-column-subquery-eq {
+    SELECT (SELECT 1) = (SELECT 1);
+}
+expect {
+    1
+}
+
+test single-column-subquery-ne {
+    SELECT (SELECT 1) = (SELECT 2);
+}
+expect {
+    0
+}
+
+test single-column-subquery-arithmetic {
+    SELECT (SELECT 1) + (SELECT 2);
+}
+expect {
+    3
+}


### PR DESCRIPTION
Validate that both operands of a binary expression return exactly 1 value in expr_vector_size(). Previously, (SELECT 1, 2) = (SELECT 1, 2) passed validation because both sides had equal vector sizes, but binary_expr_shared only allocated 1 register per side while each multi-column subquery wrote multiple values via Copy, causing an index-out-of-bounds panic.

Closes #5231

## Notes 

Bad error message by autofixer. If we do this, then we should explicitly return a parse error saying we do not YET SUPPORT multiple columns being compared like this.