### PR TITLE
Fix panic in sum() with large floating-point values

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3766,12 +3766,16 @@ pub fn op_decr_jump_zero(
 fn apply_kbn_step(acc: &mut Value, r: f64, state: &mut SumAggState) {
     let s = acc.as_float();
     let t = s + r;
-    let correction = if s.abs() > r.abs() {
-        (s - t) + r
-    } else {
-        (r - t) + s
-    };
-    state.r_err += correction;
+    // When t is infinite, the KBN correction computes inf - inf = NaN,
+    // which is meaningless. Skip compensation in that case.
+    if t.is_finite() {
+        let correction = if s.abs() > r.abs() {
+            (s - t) + r
+        } else {
+            (r - t) + s
+        };
+        state.r_err += correction;
+    }
     *acc = Value::from_f64(t);
 }
 
@@ -3929,12 +3933,16 @@ fn update_agg_payload(
             // Use Kahan-Babuška-Neumaier compensation for better floating-point precision
             let s = sum_val.as_float();
             let t = s + val;
-            let correction = if s.abs() > val.abs() {
-                (s - t) + val
-            } else {
-                (val - t) + s
-            };
-            *r_err_val = Value::from_f64(r_err + correction);
+            // When t is infinite, the KBN correction computes inf - inf = NaN,
+            // which is meaningless. Skip compensation in that case.
+            if t.is_finite() {
+                let correction = if s.abs() > val.abs() {
+                    (s - t) + val
+                } else {
+                    (val - t) + s
+                };
+                *r_err_val = Value::from_f64(r_err + correction);
+            }
             *sum_val = Value::from_f64(t);
             *count = count.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
         }

--- a/testing/runner/tests/agg-functions/sum-large-float.sqltest
+++ b/testing/runner/tests/agg-functions/sum-large-float.sqltest
@@ -1,0 +1,22 @@
+@database :memory:
+
+test sum-large-float-infinity {
+    SELECT sum(x) FROM (SELECT 1e308 x UNION ALL SELECT 1e308 UNION ALL SELECT 0);
+}
+expect {
+    Inf
+}
+
+test total-large-float-infinity {
+    SELECT total(x) FROM (SELECT 1e308 x UNION ALL SELECT 1e308 UNION ALL SELECT 0);
+}
+expect {
+    Inf
+}
+
+test avg-large-float-infinity {
+    SELECT avg(x) FROM (SELECT 1e308 x UNION ALL SELECT 1e308 UNION ALL SELECT 0);
+}
+expect {
+    Inf
+}


### PR DESCRIPTION
When sum()/total()/avg() accumulate values that overflow to infinity, the Kahan-Babuška-Neumaier compensation step computes inf - inf = NaN. Value::from_f64(NaN) converts to Value::Null, and a later as_float() call panics on Null.

Fix by skipping the KBN correction when the running sum is infinite, since compensation is meaningless for infinite values. This applies to both the standalone apply_kbn_step helper and the inline KBN in the Avg handler.

Closes #5230 

## Notes

generated by turso-autofixer