### PR TITLE
fix: Panic on INSERT INTO t(nonexistent) SELECT ... FROM t #5226

### DIFF
--- a/testing/runner/tests/insert.sqltest
+++ b/testing/runner/tests/insert.sqltest
@@ -1843,3 +1843,11 @@ expect {
     133|a133
 }
 
+# https://github.com/tursodatabase/turso/issues/5226
+test insert-select-nonexistent-column {
+    CREATE TABLE t(a);
+    INSERT INTO t(x) SELECT a FROM t;
+}
+expect error {
+}
+


### PR DESCRIPTION
Closes #5226

The ephemeral table path in init_source_emission called .unwrap() on the column lookup before build_insertion could validate column names. Replace the unwrap with proper error propagation that returns a parse error for nonexistent columns.