### PR TITLE
fix: Panic on Scalar Subquery Referencing CTE by Original Name After Alias

### DIFF
--- a/testing/runner/tests/cte.sqltest
+++ b/testing/runner/tests/cte.sqltest
@@ -836,3 +836,40 @@ test subquery-aggregate-empty-result-non-agg-columns {
 expect {
     0||
 }
+
+# =============================================================================
+# Scalar subquery referencing CTE by original name after alias (#5225)
+# =============================================================================
+
+# When a CTE is aliased in FROM, scalar subqueries should still be able to
+# reference it by its original name.
+test cte-alias-scalar-subquery-original-name {
+    WITH c AS (SELECT 1 x) SELECT (SELECT c.x) FROM c t;
+}
+expect {
+    1
+}
+
+# Scalar subquery using the alias name should also work.
+test cte-alias-scalar-subquery-alias-name {
+    WITH c AS (SELECT 1 x) SELECT (SELECT t.x) FROM c t;
+}
+expect {
+    1
+}
+
+# Multiple CTE columns with alias, scalar subquery uses original name.
+test cte-alias-scalar-subquery-multi-col {
+    WITH c AS (SELECT 1 x, 2 y) SELECT (SELECT c.x), (SELECT c.y) FROM c t;
+}
+expect {
+    1|2
+}
+
+# Multiple aliased CTEs with scalar subqueries referencing original names.
+test cte-multi-alias-scalar-subquery {
+    WITH a AS (SELECT 1 x), b AS (SELECT 2 y) SELECT (SELECT a.x), (SELECT b.y) FROM a t1, b t2;
+}
+expect {
+    1|2
+}


### PR DESCRIPTION
Closes #5225

## Notes on automated solution

Seems to be a bad fix that breaks other CTE test cases, and agent didn't properly run tests.