### PR TITLE
fix: Align REAL→INTEGER cast with SQLite clamp semantics

### DIFF
--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -509,7 +509,7 @@ pub fn is_space(byte: u8) -> bool {
     matches!(byte, b' ' | b'\t' | b'\n' | b'\r' | b'\x0c')
 }
 
-fn real_to_i64(r: f64) -> i64 {
+pub(crate) fn real_to_i64(r: f64) -> i64 {
     if r < -9223372036854774784.0 {
         i64::MIN
     } else if r > 9223372036854774784.0 {

--- a/testing/runner/tests/scalar-functions.sqltest
+++ b/testing/runner/tests/scalar-functions.sqltest
@@ -1099,6 +1099,27 @@ expect {
     mbo
 }
 
+test substr-large-float-clamp {
+    SELECT substr('abcdefghijklmnopqrstuvwxyz', 18446744073709551488);
+}
+expect {
+}
+
+test cast-real-overflow-clamp {
+    SELECT CAST(9223372036854775808 AS INTEGER);
+}
+expect {
+    9223372036854775807
+}
+
+# 2^64 - 128 rounds to 2^64 in f64, so it clamps to i64::MAX.
+test cast-real-overflow-clamp-rounded {
+    SELECT CAST(18446744073709551488 AS INTEGER);
+}
+expect {
+    9223372036854775807
+}
+
 test substring-3-args {
     SELECT substring('limbo', 1, 3);
 }


### PR DESCRIPTION
## Description

Align REAL→INTEGER casts with SQLite clamping and update/add sqltests for large REAL inputs in CAST and substr.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

As per the issue #5242, 
```
 SELECT substr('abcdefghijklmnopqrstuvwxyz', 18446744073709551488);
  -- Turso: (empty string)
  -- SQLite (3.50.4/3.51.x): (empty string)

  SELECT CAST(18446744073709551488 AS INTEGER);
  -- Turso: 9223372036854775807
  -- SQLite (3.50.4/3.51.x): 9223372036854775807
```

This behaviour doesn't align with the sql, fixed the overflow issue following the sql version 3.50. I added tests and also checked it using building the cli.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

Used codex cli to add comments. 

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
