### PR TITLE
Fix CLI exit code on query failure

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -520,10 +520,12 @@ impl Limbo {
 
         let conn = self.conn.clone();
         let runner = conn.query_runner(input.as_bytes());
+        let had_error_before = self.had_query_error;
         for output in runner {
             if self
                 .print_query_result(input, output, stats.as_mut())
                 .is_err()
+                || self.had_query_error != had_error_before
             {
                 self.had_query_error = true;
                 break;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -63,7 +63,8 @@ fn main() -> anyhow::Result<()> {
         return run_sync_server(app);
     }
 
-    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+    let interactive_stdin = std::io::IsTerminal::is_terminal(&std::io::stdin());
+    if interactive_stdin {
         let mut rl = Editor::with_config(rustyline_config())?;
         if HISTORY_FILE.exists() {
             rl.load_history(HISTORY_FILE.as_path())?;
@@ -104,6 +105,9 @@ fn main() -> anyhow::Result<()> {
                 anyhow::bail!(err)
             }
         }
+    }
+    if !interactive_stdin && app.has_query_error() {
+        std::process::exit(1);
     }
     Ok(())
 }

--- a/cli/tests/non_interactive_exit_code.rs
+++ b/cli/tests/non_interactive_exit_code.rs
@@ -1,0 +1,80 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn sql_argument_returns_exit_code_one_on_query_failure() {
+    let status = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .arg("select 'one'; select * from t; select 'two';")
+        .status()
+        .expect("failed to run tursodb");
+
+    assert_eq!(status.code(), Some(1));
+}
+
+#[test]
+fn sql_argument_returns_exit_code_zero_on_success() {
+    let status = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .arg("select 'one'; select 'two';")
+        .status()
+        .expect("failed to run tursodb");
+
+    assert_eq!(status.code(), Some(0));
+}
+
+#[test]
+fn sql_argument_stops_execution_after_first_error() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .arg("select 'one'; select * from t; select 'two';")
+        .output()
+        .expect("failed to run tursodb");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("one"), "first query should execute");
+    assert!(!stdout.contains("two"), "query after error should not execute");
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
+fn piped_stdin_returns_exit_code_one_on_query_failure() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to run tursodb");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"select * from nonexistent;\n")
+        .unwrap();
+
+    let status = child.wait().expect("failed to wait");
+    assert_eq!(status.code(), Some(1));
+}
+
+#[test]
+fn piped_stdin_returns_exit_code_zero_on_success() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to run tursodb");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"select 1;\n")
+        .unwrap();
+
+    let status = child.wait().expect("failed to wait");
+    assert_eq!(status.code(), Some(0));
+}

--- a/testing/runner/src/backends/cli.rs
+++ b/testing/runner/src/backends/cli.rs
@@ -227,32 +227,31 @@ impl CliDatabaseInstance {
             .map_err(|_| BackendError::Timeout(self.timeout))?
             .map_err(|e| BackendError::Execute(format!("failed to read output: {e}")))?;
 
-        // Parse stdout
+        // Parse stdout/stderr and check exit code
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let exit_success = output.status.success();
 
-        // Check for errors in stderr
-        if !stderr.is_empty() && (stderr.contains("Error") || stderr.contains("error")) {
-            return Ok(QueryResult::error(stderr.trim().to_string()));
-        }
+        // Detect errors from output text
+        let has_stderr_error =
+            !stderr.is_empty() && (stderr.contains("Error") || stderr.contains("error"));
+        let has_stdout_error =
+            stdout.contains("× ") || stdout.contains("error:") || stdout.contains("Error:");
 
-        // Check for errors in stdout (tursodb outputs errors like "× Parse error: ...")
-        if stdout.contains("× ") || stdout.contains("error:") || stdout.contains("Error:") {
-            return Ok(QueryResult::error(stdout.trim().to_string()));
-        }
-
-        if !output.status.success() {
-            let stderr = stderr.trim();
-            if !stderr.is_empty() {
-                return Ok(QueryResult::error(stderr.to_string()));
-            }
-            if !stdout.trim().is_empty() {
-                return Ok(QueryResult::error(stdout.trim().to_string()));
-            }
-            return Ok(QueryResult::error(format!(
-                "command exited with status {}",
-                output.status
-            )));
+        if has_stderr_error || has_stdout_error || !exit_success {
+            // Extract the best error message available
+            let error_msg = if has_stderr_error {
+                stderr.trim().to_string()
+            } else if has_stdout_error {
+                stdout.trim().to_string()
+            } else if !stderr.trim().is_empty() {
+                stderr.trim().to_string()
+            } else if !stdout.trim().is_empty() {
+                stdout.trim().to_string()
+            } else {
+                format!("command exited with status {}", output.status)
+            };
+            return Ok(QueryResult::error(error_msg));
         }
 
         let mut rows = parse_list_output(&stdout);


### PR DESCRIPTION
## Description

Return exit code 1 from the CLI when a query fails in non-interactive mode, matching sqlite3 behavior.

**cli/app.rs** — Track query errors via a `had_query_error` flag on the `Limbo` struct, set at both prepare-time (in `run_query`) and step-time (in `handle_step_error`).

**cli/main.rs** — In non-interactive mode, exit with code 1 if any query failed. Covers both the SQL command-line argument path and the piped stdin path.

**testing/runner/src/backends/cli.rs** — Unify the three independent error detection stages (stderr text, stdout text, exit code) into a single check. Previously exit code was never cross-validated against error text because the text checks returned early. Now a non-zero exit code alone is sufficient to detect an error.

**cli/tests/non_interactive_exit_code.rs** — Integration tests covering:
- SQL argument: exit code 1 on failure, exit code 0 on success
- SQL argument: execution stops after the first error
- Piped stdin: exit code 1 on failure, exit code 0 on success

## Motivation and context

Fixes #5215

## Description of AI Usage

Used GPT 5.3 Codex to explore the issue and learn the codebase, [link to prompt](https://gist.github.com/aalhour/34c0ea4edf0d3ada098a9a5200758d34).