### PR TITLE
fix: Panic on CREATE TABLE with UNIQUE ... ON CONFLICT IGNORE #5221

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1980,9 +1980,14 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 if let ast::TableConstraint::PrimaryKey {
                     columns,
                     auto_increment,
-                    ..
+                    conflict_clause,
                 } = &c.constraint
                 {
+                    if conflict_clause.is_some() {
+                        crate::bail_parse_error!(
+                            "ON CONFLICT not implemented for PRIMARY KEY constraint"
+                        );
+                    }
                     if !primary_key_columns.is_empty() {
                         crate::bail_parse_error!(
                             "table \"{}\" has more than one primary key",
@@ -2016,7 +2021,9 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 } = &c.constraint
                 {
                     if conflict_clause.is_some() {
-                        unimplemented!("ON CONFLICT not implemented");
+                        crate::bail_parse_error!(
+                            "ON CONFLICT not implemented for UNIQUE constraint"
+                        );
                     }
                     let mut unique_columns = Vec::with_capacity(columns.len());
                     for column in columns {

--- a/testing/runner/turso-tests/on_conflict_constraint.sqltest
+++ b/testing/runner/turso-tests/on_conflict_constraint.sqltest
@@ -1,0 +1,41 @@
+@database :memory:
+
+# https://github.com/tursodatabase/turso/issues/5221
+# ON CONFLICT clause on table-level UNIQUE constraint should return an error
+# (not yet implemented, was previously panicking with unimplemented!())
+
+test create-table-unique-on-conflict-ignore {
+    CREATE TABLE t(a, b, UNIQUE(a) ON CONFLICT IGNORE);
+}
+expect error {
+}
+
+test create-table-unique-on-conflict-replace {
+    CREATE TABLE t(a, b, UNIQUE(a) ON CONFLICT REPLACE);
+}
+expect error {
+}
+
+test create-table-unique-on-conflict-abort {
+    CREATE TABLE t(a, b, UNIQUE(a) ON CONFLICT ABORT);
+}
+expect error {
+}
+
+test create-table-unique-on-conflict-rollback {
+    CREATE TABLE t(a, b, UNIQUE(a) ON CONFLICT ROLLBACK);
+}
+expect error {
+}
+
+test create-table-unique-on-conflict-fail {
+    CREATE TABLE t(a, b, UNIQUE(a) ON CONFLICT FAIL);
+}
+expect error {
+}
+
+test create-table-primary-key-on-conflict-ignore {
+    CREATE TABLE t(a, b, PRIMARY KEY(a) ON CONFLICT IGNORE);
+}
+expect error {
+}


### PR DESCRIPTION
Replace unimplemented!() with bail_parse_error!() for ON CONFLICT clauses on table-level UNIQUE and PRIMARY KEY constraints. This returns a proper error instead of panicking.

Closes #5221

### Note on tests

Since this test lives in turso-tests, it is not run against sqlite (sqlite ofc accepts this syntax)