### PR TITLE
fix: backward table scan skips rows on deep B-trees (ORDER BY DESC)

### DIFF
--- a/testing/runner/tests/btree-backward-scan.sqltest
+++ b/testing/runner/tests/btree-backward-scan.sqltest
@@ -1,0 +1,18 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/5277
+# ORDER BY rowid DESC silently drops rows when the table B-tree has 3+ levels.
+# The going_upwards flag in get_prev_record was never cleared when descending
+# between interior pages, causing rightmost subtrees to be skipped.
+
+test backward-scan-deep-btree {
+    PRAGMA page_size = 512;
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t SELECT value, printf('val_%06d', value) FROM generate_series(1, 1800);
+    SELECT count(*) FROM (SELECT * FROM t ORDER BY a DESC);
+    SELECT min(a), max(a) FROM (SELECT * FROM t ORDER BY a DESC);
+}
+expect {
+    1800
+    1|1800
+}


### PR DESCRIPTION
## Description
Fixes https://github.com/tursodatabase/turso/issues/5277

The issue itself already told us how to solve this problem, but I guess I just supervised the AI and made sure the fix makes sense. 

The going_upwards flag in get_prev_record was never cleared when
descending from an interior page to a left child. On the next iteration,
the rightmost pointer check (cell_idx == i32::MAX && !self.going_upwards)
was skipped, so that interior page's entire rightmost subtree was never
visited. This caused 28+ consecutive rows to be silently dropped at each
interior page boundary in tables with 3+ level B-trees.

Fix: reset going_upwards = false before descending to the left child page.

EDIT: 
Did a small change to remove these ad-hoc `going_upwards` assignments, and just have them be encapsulated in a function.


## Description of AI Usage
Claude
