### PR TITLE
add regression tests for correlated subqueries registers fix

### DIFF
--- a/testing/runner/tests/insert.sqltest
+++ b/testing/runner/tests/insert.sqltest
@@ -1868,3 +1868,51 @@ expect {
     4|75|B
 }
 
+# https://github.com/tursodatabase/turso/issues/3974
+test insert-select-multiple-correlated-subqueries {
+    CREATE TABLE products(id INTEGER PRIMARY KEY, name TEXT, price REAL);
+    CREATE TABLE sales(id INTEGER PRIMARY KEY, product_id INTEGER, quantity INTEGER);
+    CREATE TABLE summary(product_id INTEGER PRIMARY KEY, name TEXT, total_quantity INTEGER, avg_price REAL);
+    INSERT INTO products VALUES (1, 'A', 10.0), (2, 'B', 20.0), (3, 'C', 30.0);
+    INSERT INTO sales VALUES (1, 1, 5), (2, 1, 10), (3, 2, 15), (4, 3, 20);
+    INSERT INTO summary(product_id, name, total_quantity, avg_price)
+    SELECT
+        p.id,
+        p.name,
+        (SELECT SUM(quantity) FROM sales WHERE product_id = p.id),
+        (SELECT AVG(price) FROM products WHERE id = p.id)
+    FROM products p;
+    SELECT * FROM summary ORDER BY product_id;
+}
+expect {
+    1|A|15|10.0
+    2|B|15|20.0
+    3|C|20|30.0
+}
+expect @js {
+    1|A|15|10
+    2|B|15|20
+    3|C|20|30
+}
+
+# https://github.com/tursodatabase/turso/issues/3974
+test insert-select-two-correlated-subqueries {
+    CREATE TABLE p(id INT PRIMARY KEY, x INT);
+    CREATE TABLE q(pid INT, val INT);
+    CREATE TABLE r(a INT, b INT, c INT);
+    INSERT INTO p VALUES (1,10),(2,20),(3,30);
+    INSERT INTO q VALUES (1,100),(1,101),(2,200),(3,300);
+    INSERT INTO r
+    SELECT
+        p.id,
+        (SELECT val FROM q WHERE pid = p.id LIMIT 1),
+        (SELECT x FROM p AS p2 WHERE p2.id = p.id)
+    FROM p;
+    SELECT * FROM r ORDER BY a;
+}
+expect {
+    1|100|10
+    2|200|20
+    3|300|30
+}
+


### PR DESCRIPTION
## Description
Closes https://github.com/tursodatabase/turso/issues/3974 . 

Fix was implemented in #5351 

This PR just adds regressions tests to prove the fix


## Description of AI Usage
Test written by claude
