### PR TITLE
fix: more recursive read locks detected by shuttle with mvcc

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -271,8 +271,9 @@ impl Connection {
         let syms = self.syms.read();
         let pager = self.pager.load().clone();
         let mode = QueryMode::Normal;
+        let schema = self.schema.read().clone();
         let program = translate::translate(
-            self.schema.read().deref(),
+            &schema,
             stmt,
             pager.clone(),
             self.clone(),
@@ -451,8 +452,9 @@ impl Connection {
                 .trim();
             let mode = QueryMode::new(&cmd);
             let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
+            let schema = self.schema.read().clone();
             let program = translate::translate(
-                self.schema.read().deref(),
+                &schema,
                 stmt,
                 pager.clone(),
                 self.clone(),
@@ -498,8 +500,9 @@ impl Connection {
         let pager = self.pager.load().clone();
         let mode = QueryMode::new(&cmd);
         let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
+        let schema = self.schema.read().clone();
         let program = translate::translate(
-            self.schema.read().deref(),
+            &schema,
             stmt,
             pager.clone(),
             self.clone(),
@@ -534,8 +537,9 @@ impl Connection {
                 .trim();
             let mode = QueryMode::new(&cmd);
             let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
+            let schema = self.schema.read().clone();
             let program = translate::translate(
-                self.schema.read().deref(),
+                &schema,
                 stmt,
                 pager.clone(),
                 self.clone(),
@@ -565,8 +569,9 @@ impl Connection {
             .trim();
         let mode = QueryMode::new(&cmd);
         let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
+        let schema = self.schema.read().clone();
         let program = translate::translate(
-            self.schema.read().deref(),
+            &schema,
             stmt,
             pager.clone(),
             self.clone(),

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -295,8 +295,9 @@ impl Statement {
             #[cfg(debug_assertions)]
             turso_assert_eq!(QueryMode::new(&cmd), mode);
             let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
+            let schema = conn.schema.read().clone();
             translate::translate(
-                conn.schema.read().deref(),
+                &schema,
                 stmt,
                 self.pager.clone(),
                 conn.clone(),


### PR DESCRIPTION
## Description
More recursive read locks caught by `shuttle` in `turso-stress` in MVCC


## Description of AI Usage
Identify deadlock
