### PR TITLE
Reject reserved JSONB element types

### DIFF
--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -262,9 +262,7 @@ impl TryFrom<u8> for ElementType {
             10 => Ok(Self::TEXTRAW),
             11 => Ok(Self::ARRAY),
             12 => Ok(Self::OBJECT),
-            13 => Ok(Self::RESERVED1),
-            14 => Ok(Self::RESERVED2),
-            15 => Ok(Self::RESERVED3),
+            13..=15 => bail_parse_error!("Invalid element type: {}", value),
             _ => bail_parse_error!("Failed to recognize jsonvalue type"),
         }
     }
@@ -3624,6 +3622,14 @@ mod tests {
         ]);
         let err = minus_only_int5.to_string().unwrap_err();
         assert!(err.to_string().contains("malformed JSON"));
+    }
+
+    #[test]
+    fn test_reserved_element_types_rejected() {
+        for value in [13_u8, 14, 15] {
+            let err = ElementType::try_from(value).unwrap_err();
+            assert!(err.to_string().contains("Invalid element type"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Reject reserved JSONB element types (13–15) during parsing and add a regression unit test to ensure they are reported as invalid rather than reaching unreachable code paths.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

SQLancer uncovered a crash caused by reserved JSONB element types being accepted by `TryFrom<u8>` and later hitting `unreachable!()` during type string conversion. This change makes parsing reject those reserved types early, preventing the panic and matching existing “malformed JSON” behavior.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #4488

## Description of AI Usage

Only for pr body description

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
