### PR TITLE
core/mvcc: Fix MVCC checkpoint panic when deleting index keys in inte…

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -5148,7 +5148,7 @@ impl CursorTrait for BTreeCursor {
                             self.state = CursorState::None;
                             return Ok(IOResult::Done(()));
                         }
-                    } else if self.reusable_immutable_record.is_none() {
+                    } else if !self.has_record() {
                         self.state = CursorState::None;
                         return Ok(IOResult::Done(()));
                     }


### PR DESCRIPTION
…rior B-tree nodes

During MVCC checkpoint, DeleteRowStateMachine seeks for index keys to delete from the on-disk B-tree. In index B-trees (unlike table B+trees), records can reside in interior nodes, not just leaves. When a key lives in an interior cell, the seek descends to the leaf but doesn't find it there, returning SeekResult::TryAdvance with has_record=false.

The old code only checked for NotFound and treated everything else (including TryAdvance) as success, then called cursor.delete(). The delete's guard for index pages used `reusable_immutable_record.is_none()` which was always false after a seek (since invalidate_record() lazily creates the buffer), so it proceeded to DeterminePostBalancingSeekKey where record() returned None because has_record was false, hitting an unreachable!() panic.

Fix:

1. Handle TryAdvance in DeleteRowStateMachine by adding an Advance state that calls cursor.next(), which naturally moves up from the leaf to the interior cell where the key actually is. The write lock is released before acquiring the read lock to check has_record, avoiding a deadlock on the RwLock.

2. Fix the guard in DeleteState::Start to use !self.has_record() instead of self.reusable_immutable_record.is_none(), consistent with the table page check and correctly reflecting cursor validity.

Fixes: #5016