### PR TITLE
fix/mvcc: unignore ignored tests, remove test that tested nothing

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -849,6 +849,10 @@ fn test_recovery_overwrites_torn_tail_on_next_append() {
 /// and a torn short `.db-log`), bootstrap repairs the log header and initializes metadata.
 /// Why this matters: Startup must recover this pre-bootstrap crash residue state instead of failing closed.
 #[test]
+#[cfg_attr(
+    feature = "checksum",
+    ignore = "byte-level tamper caught by checksum layer"
+)]
 fn test_bootstrap_repairs_torn_short_log_before_metadata_init() {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let db_path = temp_dir


### PR DESCRIPTION
- unignore test_concurrent_writes
- unignore test_cursor_with_btree_and_mvcc_fuzz + make it less noisy
- remove test_batch_writes; tested nothing
- unignore and fix test_bootstrap_repairs_torn_short log
    * exercises a recovery scenario where db is in MVCC mode, it has no mvcc metadata table and has a torn log header -> should repair.