### PR TITLE
Fix SUM() type for BLOB inputs to return REAL

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4019,11 +4019,11 @@ fn update_agg_payload(
                 },
                 Value::Text(t) => {
                     let (parse_result, parsed_number) = try_for_float(t.as_str().as_bytes());
-                    handle_text_sum(acc, &mut sum_state, parsed_number, parse_result);
+                    handle_text_sum(acc, &mut sum_state, parsed_number, parse_result, false);
                 }
                 Value::Blob(b) => {
                     let (parse_result, parsed_number) = try_for_float(&b);
-                    handle_text_sum(acc, &mut sum_state, parsed_number, parse_result);
+                    handle_text_sum(acc, &mut sum_state, parsed_number, parse_result, true);
                 }
             }
             *r_err_val = Value::from_f64(sum_state.r_err);
@@ -10782,10 +10782,12 @@ fn handle_text_sum(
     sum_state: &mut SumAggState,
     parsed_number: ParsedNumber,
     parse_result: NumericParseResult,
+    force_approx: bool,
 ) {
     // SQLite treats text that only partially parses as numeric (ValidPrefixOnly)
-    // as approximate, so SUM returns real instead of integer.
-    let is_approx = matches!(parse_result, NumericParseResult::ValidPrefixOnly);
+    // as approximate, so SUM returns real instead of integer. Non-integer inputs
+    // (e.g. BLOB) should also force approximate results.
+    let is_approx = force_approx || matches!(parse_result, NumericParseResult::ValidPrefixOnly);
     match parsed_number {
         ParsedNumber::Integer(i) => {
             if is_approx {

--- a/testing/runner/tests/agg-functions/sum-blob-types.sqltest
+++ b/testing/runner/tests/agg-functions/sum-blob-types.sqltest
@@ -65,3 +65,15 @@ expect {
 expect @js {
     real|48
 }
+
+test sum-cast-text-to-blob-returns-real {
+    CREATE TABLE t6 (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t6 VALUES (1, '10'), (2, '20'), (3, '30');
+    SELECT typeof(SUM(CAST(val AS BLOB))), SUM(CAST(val AS BLOB)) FROM t6;
+}
+expect {
+    real|60.0
+}
+expect @js {
+    real|60
+}


### PR DESCRIPTION
## Description

- Treat BLOB inputs to SUM/TOTAL as approximate so aggregation returns REAL.
  - Add regression test for SUM(CAST(... AS BLOB)) type behavior.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

- SQLite returns REAL when any SUM() input is neither integer nor NULL; BLOB inputs were incorrectly preserving INTEGER.
 

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5148

## Description of AI Usage

Writing comments and pr body

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
