### PR TITLE
Reject FILTER clauses in view definitions

### DIFF
--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -288,6 +288,7 @@ impl IncrementalView {
         select: &ast::Select,
         schema: &Schema,
     ) -> Result<ViewColumnSchema> {
+        crate::util::validate_select_for_unsupported_features(select)?;
         // Use the shared function to extract columns with full table context
         extract_view_columns(select, schema)
     }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1127,7 +1127,7 @@ impl Schema {
                             select,
                             ..
                         } => {
-                            crate::util::validate_view_select(&select)?;
+                            crate::util::validate_select_for_unsupported_features(&select)?;
 
                             // Extract actual columns from the SELECT statement
                             let view_column_schema =

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -267,7 +267,7 @@ pub fn translate_create_view(
         )));
     }
 
-    crate::util::validate_view_select(select_stmt)?;
+    crate::util::validate_select_for_unsupported_features(select_stmt)?;
 
     // Reconstruct the SQL string
     let sql = create_view_to_str(&view_name.as_ident(), select_stmt);

--- a/testing/runner/tests/views.sqltest
+++ b/testing/runner/tests/views.sqltest
@@ -264,6 +264,15 @@ expect error {
     FILTER clause is not supported yet in aggregate functions
 }
 
+@skip-if sqlite "sqlite supports ORDER BY in aggregate functions"
+test view-rejects-aggregate-order-by {
+    CREATE TABLE t(val INT);
+    CREATE VIEW v AS SELECT SUM(val ORDER BY val) FROM t;
+}
+expect error {
+    ORDER BY clause is not supported yet in aggregate functions
+}
+
 test view-self-circle-detection {
     CREATE VIEW v AS SELECT * FROM v;
     SELECT * FROM v;


### PR DESCRIPTION
## Description

 - Validate CREATE VIEW select statements to reject unsupported FILTER clauses.
 - Validate view definitions during schema load to prevent invalid views from being accepted.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

 CREATE VIEW previously accepted FILTER clauses and stored unexecutable SQL in sqlite_schema, leading to runtime errors on SELECT. This change ensures invalid view definitions fail early and consistently

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5161

## Description of AI Usage

Used codex for validating my approach and fixing codes along with pr body.

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
