### PR TITLE
fix: INSERT with auto-assigned rowid skips explicit index on IPK column

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -2672,8 +2672,16 @@ fn emit_index_column_value_for_insert(
                 "Column not found in INSERT".to_string(),
             ));
         };
+        // For rowid alias columns (INTEGER PRIMARY KEY), the actual value lives
+        // in the key register, not the column register (which may hold NULL,
+        // e.g. when the rowid is auto-generated).
+        let src_reg = if cm.column.is_rowid_alias() {
+            insertion.key_register()
+        } else {
+            cm.register
+        };
         program.emit_insn(Insn::Copy {
-            src_reg: cm.register,
+            src_reg,
             dst_reg: dest_reg,
             extra_amount: 0,
         });

--- a/testing/runner/tests/insert_autorowid_index.sqltest
+++ b/testing/runner/tests/insert_autorowid_index.sqltest
@@ -1,0 +1,46 @@
+@database :memory:
+
+# Regression test for #5240: INSERT with auto-assigned rowid skips explicit
+# index on INTEGER PRIMARY KEY column.
+
+setup schema {
+    CREATE TABLE v0 (c1 INTEGER PRIMARY KEY, c2 TEXT, c3 INT, c4 TEXT);
+    CREATE INDEX i6 ON v0 (c1);
+}
+
+@setup schema
+test auto-rowid-upsert-index {
+    INSERT INTO v0 VALUES (10, 'av3 b', 10, 'a__');
+    INSERT INTO v0 (c4, c2, c2) VALUES ('v1', 18446744073709551615, 'hijklmnop')
+      ON CONFLICT DO UPDATE SET c2 = c4, c4 = c3;
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+@setup schema
+test auto-rowid-plain-insert-index {
+    INSERT INTO v0 VALUES (1, 'first', 10, 'a');
+    INSERT INTO v0 (c2) VALUES ('second');
+    INSERT INTO v0 (c2) VALUES ('third');
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+@setup schema
+test auto-rowid-index-values-correct {
+    INSERT INTO v0 VALUES (5, 'a', 1, 'x');
+    INSERT INTO v0 (c2, c3) VALUES ('b', 2);
+    INSERT INTO v0 (c2, c3) VALUES ('c', 3);
+    SELECT c1, c2, c3 FROM v0 ORDER BY c1;
+    PRAGMA integrity_check;
+}
+expect {
+    5|a|1
+    6|b|2
+    7|c|3
+    ok
+}


### PR DESCRIPTION
When a table has an INTEGER PRIMARY KEY with an explicit index on that column, inserting a row without specifying the primary key value failed to update the index. The index column value was read from the column register (which holds NULL for rowid alias columns) instead of the key register where the auto-generated rowid actually lives.

Fix emit_index_column_value_for_insert() to use the key register for rowid alias columns, matching the pattern used elsewhere in the insert path (triggers, CHECK constraints, etc.).

Closes #5240