### PR TITLE
fix: avoid cursor panic in SUM(TRUE IS TRUE)

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -961,21 +961,21 @@ pub fn translate_expr(
                     null_value,
                     invert,
                 });
-                return Ok(target_register);
+                Ok(target_register)
+            } else {
+                binary_expr_shared(
+                    program,
+                    referenced_tables,
+                    e1,
+                    e2,
+                    op,
+                    target_register,
+                    resolver,
+                    None,
+                    emit_binary_insn,
+                )?;
+                Ok(target_register)
             }
-
-            binary_expr_shared(
-                program,
-                referenced_tables,
-                e1,
-                e2,
-                op,
-                target_register,
-                resolver,
-                None,
-                emit_binary_insn,
-            )?;
-            Ok(target_register)
         }
         ast::Expr::Case {
             base,

--- a/testing/runner/tests/agg-functions/is-true.sqltest
+++ b/testing/runner/tests/agg-functions/is-true.sqltest
@@ -1,0 +1,14 @@
+@database :memory:
+
+test sum-is-true-ungrouped-and-join {
+    CREATE TABLE t0(c0 INT NOT NULL);
+    CREATE TABLE t1(c0 INT NOT NULL);
+    INSERT INTO t0 VALUES (1), (2);
+    INSERT INTO t1 VALUES (10), (20);
+    SELECT SUM(true IS TRUE) FROM t1;
+    SELECT SUM(true IS TRUE) FROM t1 INNER JOIN t0 ON (true);
+}
+expect {
+    2
+    4
+}


### PR DESCRIPTION
translate_expr() returned early for IS TRUE/IS FALSE, leaving a constant span open so aggregate loop opcodes were incorrectly hoisted into init-time execution. 

This caused Next to run before OpenRead and panic with "cursor id N is None". Close the span correctly by removing the early return path, and add a sqltest regression that covers ungrouped and JOIN variants of SUM(true IS TRUE).

Closes #4883