### PR TITLE
fix: ALTER COLUMN from NUMERIC to TEXT causes corruption from SQLite's POV

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -2411,6 +2411,7 @@ fn emit_program_for_update(
         &mut plan.table_references,
         &plan.set_clauses,
         plan.cdc_update_alter_statement.as_deref(),
+        &plan.affinity_overrides,
         &plan.indexes_to_update,
         plan.returning.as_ref(),
         plan.ephemeral_plan.as_ref(),
@@ -2674,6 +2675,7 @@ fn emit_update_insns<'a>(
     table_references: &mut TableReferences,
     set_clauses: &[(usize, Box<ast::Expr>)],
     cdc_update_alter_statement: Option<&str>,
+    affinity_overrides: &HashMap<usize, Affinity>,
     indexes_to_update: &[Arc<Index>],
     returning: Option<&'a Vec<ResultSetColumn>>,
     ephemeral_plan: Option<&SelectPlan>,
@@ -2850,7 +2852,12 @@ fn emit_update_insns<'a>(
     // use the converted values.
     if let Some(btree_table) = target_table.table.btree() {
         if !btree_table.is_strict {
-            let affinity = btree_table.columns.iter().map(|c| c.affinity());
+            let affinity = btree_table.columns.iter().enumerate().map(|(idx, c)| {
+                affinity_overrides
+                    .get(&idx)
+                    .copied()
+                    .unwrap_or_else(|| c.affinity())
+            });
 
             // Only emit Affinity if there's meaningful affinity to apply
             if affinity.clone().any(|a| a != Affinity::Blob) {
@@ -3095,8 +3102,12 @@ fn emit_update_insns<'a>(
                     if ic.expr.is_some() {
                         Affinity::Blob.aff_mask()
                     } else {
-                        target_table.table.columns()[ic.pos_in_table]
-                            .affinity()
+                        affinity_overrides
+                            .get(&ic.pos_in_table)
+                            .copied()
+                            .unwrap_or_else(|| {
+                                target_table.table.columns()[ic.pos_in_table].affinity()
+                            })
                             .aff_mask()
                     }
                 })
@@ -3449,8 +3460,10 @@ fn emit_update_insns<'a>(
                 if ic.expr.is_some() {
                     Affinity::Blob.aff_mask()
                 } else {
-                    target_table.table.columns()[ic.pos_in_table]
-                        .affinity()
+                    affinity_overrides
+                        .get(&ic.pos_in_table)
+                        .copied()
+                        .unwrap_or_else(|| target_table.table.columns()[ic.pos_in_table].affinity())
                         .aff_mask()
                 }
             })
@@ -3732,7 +3745,14 @@ fn emit_update_insns<'a>(
             .table
             .columns()
             .iter()
-            .map(|col| col.affinity().aff_mask())
+            .enumerate()
+            .map(|(idx, col)| {
+                affinity_overrides
+                    .get(&idx)
+                    .copied()
+                    .unwrap_or_else(|| col.affinity())
+                    .aff_mask()
+            })
             .collect::<String>();
 
         program.emit_insn(Insn::MakeRecord {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -613,6 +613,9 @@ pub struct UpdatePlan {
     // For ALTER TABLE turso-db emits appropriate DDL statement in the "updates" cell of CDC table
     // This field is present only for update plan created for ALTER TABLE when CDC mode has "updates" values
     pub cdc_update_alter_statement: Option<String>,
+    /// Per-column affinity overrides used by internal schema-change rewrites.
+    /// This allows ALTER COLUMN to reuse the UPDATE path while applying the target affinity.
+    pub affinity_overrides: HashMap<usize, Affinity>,
     /// Subqueries that appear in the WHERE clause (for non-ephemeral path)
     pub non_from_clause_subqueries: Vec<NonFromClauseSubquery>,
 }

--- a/testing/runner/turso-tests/alter_column.sqltest
+++ b/testing/runner/turso-tests/alter_column.sqltest
@@ -357,6 +357,77 @@ expect error {
     Parse error: must have at least one non-generated column
 }
 
+# Verify that changing column type affinity rewrites stored data so that
+# values conform to the new type. Without this, integrity_check reports
+# corruption (e.g. "NUMERIC value in t.y").
+test alter-column-numeric-to-text-converts-data {
+    CREATE TABLE t(x NUMERIC);
+    INSERT INTO t VALUES (1);
+    INSERT INTO t VALUES (2.5);
+    INSERT INTO t VALUES ('hello');
+    ALTER TABLE t ALTER COLUMN x TO y TEXT;
+    SELECT typeof(y), y FROM t ORDER BY rowid;
+}
+expect {
+    text|1
+    text|2.5
+    text|hello
+}
+
+test alter-column-integer-to-text-converts-data {
+    CREATE TABLE t(x INTEGER);
+    INSERT INTO t VALUES (42);
+    INSERT INTO t VALUES (0);
+    INSERT INTO t VALUES (-7);
+    ALTER TABLE t ALTER COLUMN x TO y TEXT;
+    SELECT typeof(y), y FROM t ORDER BY rowid;
+}
+expect {
+    text|42
+    text|0
+    text|-7
+}
+
+test alter-column-text-to-numeric-converts-data {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES ('100');
+    INSERT INTO t VALUES ('3.14');
+    INSERT INTO t VALUES ('not_a_number');
+    ALTER TABLE t ALTER COLUMN x TO y NUMERIC;
+    SELECT typeof(y), y FROM t ORDER BY rowid;
+}
+expect {
+    integer|100
+    real|3.14
+    text|not_a_number
+}
+
+test alter-column-integer-to-real-converts-data {
+    CREATE TABLE t(x INTEGER);
+    INSERT INTO t VALUES (5);
+    INSERT INTO t VALUES (-3);
+    ALTER TABLE t ALTER COLUMN x TO y REAL;
+    SELECT typeof(y), y FROM t ORDER BY rowid;
+}
+expect {
+    real|5.0
+    real|-3.0
+}
+expect @js {
+    real|5
+    real|-3
+}
+
+test alter-column-same-affinity-no-change {
+    CREATE TABLE t(x INTEGER);
+    INSERT INTO t VALUES (10);
+    ALTER TABLE t ALTER COLUMN x TO y INT;
+    SELECT typeof(y), y FROM t;
+}
+expect {
+    integer|10
+}
+
 test alter-column-to-generated-with-other-columns {
     CREATE TABLE t(a, b);
     ALTER TABLE t ALTER COLUMN a TO c AS (123);

--- a/tests/fuzz/alter_column_affinity.rs
+++ b/tests/fuzz/alter_column_affinity.rs
@@ -1,0 +1,109 @@
+//! Fuzz regression for ALTER COLUMN type rewrite.
+//!
+//! This exercises Turso's non-standard `ALTER COLUMN ... TO ...` path, which rewrites
+//! all table rows and must preserve both row contents and index consistency.
+
+#[cfg(test)]
+mod tests {
+    use core_tester::common::{
+        limbo_exec_rows, rng_from_time_or_env, rusqlite_integrity_check, TempDatabase,
+    };
+    use rand::Rng;
+
+    #[turso_macros::test]
+    fn alter_column_affinity_transition_matrix_fuzz(db: TempDatabase) {
+        let (mut rng, seed) = rng_from_time_or_env();
+        println!("alter_column_affinity_transition_matrix_fuzz seed: {seed}");
+
+        let rows = std::env::var("ALTER_COLUMN_FUZZ_ROWS")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(120);
+
+        let conn = db.connect_limbo();
+
+        const AFFINITIES: [(&str, &str); 5] = [
+            ("integer", "INTEGER"),
+            ("real", "REAL"),
+            ("numeric", "NUMERIC"),
+            ("text", "TEXT"),
+            ("blob", "BLOB"),
+        ];
+
+        let mut transition_idx = 0usize;
+        for (from_aff_name, from_decl_type) in AFFINITIES {
+            for (to_aff_name, to_decl_type) in AFFINITIES {
+                if from_aff_name == to_aff_name {
+                    continue;
+                }
+
+                let table_name = format!("t_{transition_idx}_{from_aff_name}_to_{to_aff_name}");
+                let create = format!(
+                    "CREATE TABLE {table_name}(id INTEGER PRIMARY KEY, v {from_decl_type}, payload TEXT)"
+                );
+                conn.execute(&create).unwrap();
+                conn.execute(&format!(
+                    "CREATE INDEX idx_{table_name}_v ON {table_name}(v)"
+                ))
+                .unwrap();
+                conn.execute(&format!(
+                    "CREATE INDEX idx_{table_name}_v_partial ON {table_name}(v) WHERE (id % 2) = 0"
+                ))
+                .unwrap();
+
+                for id in 1..=rows {
+                    let value_sql = match rng.random_range(0..8) {
+                        0 => "NULL".to_string(),
+                        1 => rng.random_range(-100_000..100_000).to_string(),
+                        2 => format!("{:.6}", rng.random_range(-1000.0..1000.0)),
+                        3 => format!("'{}'", rng.random_range(-50_000..50_000)),
+                        4 => format!("'t{}'", rng.random_range(0..10_000)),
+                        5 => "X'616263'".to_string(), // "abc"
+                        6 => "X'00FF10'".to_string(),
+                        _ => format!("'{}'", rng.random_range(0..10_000)),
+                    };
+                    let payload = format!("p{}", rng.random_range(0..1_000_000));
+                    let stmt = format!(
+                        "INSERT INTO {table_name}(id, v, payload) VALUES ({id}, {value_sql}, '{}')",
+                        payload
+                    );
+                    conn.execute(&stmt).unwrap();
+                }
+
+                let ids_before =
+                    limbo_exec_rows(&conn, &format!("SELECT id FROM {table_name} ORDER BY id"));
+                let count_before =
+                    limbo_exec_rows(&conn, &format!("SELECT COUNT(*) FROM {table_name}"));
+
+                conn.execute(&format!(
+                    "ALTER TABLE {table_name} ALTER COLUMN v TO v2 {to_decl_type}"
+                ))
+                .unwrap();
+
+                let ids_after =
+                    limbo_exec_rows(&conn, &format!("SELECT id FROM {table_name} ORDER BY id"));
+                let count_after =
+                    limbo_exec_rows(&conn, &format!("SELECT COUNT(*) FROM {table_name}"));
+                similar_asserts::assert_eq!(
+                    Before: ids_before,
+                    After: ids_after,
+                    "row id set changed after ALTER COLUMN rewrite {from_aff_name}->{to_aff_name} (seed: {seed})",
+                );
+                similar_asserts::assert_eq!(
+                    Before: count_before,
+                    After: count_after,
+                    "row count changed after ALTER COLUMN rewrite {from_aff_name}->{to_aff_name} (seed: {seed})",
+                );
+
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+                rusqlite_integrity_check(db.path.as_path()).unwrap_or_else(|e| {
+                    panic!(
+                        "SQLite integrity_check failed after transition {from_aff_name}->{to_aff_name}: {e}"
+                    )
+                });
+
+                transition_idx += 1;
+            }
+        }
+    }
+}

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -1,3 +1,4 @@
+pub mod alter_column_affinity;
 pub mod cte;
 pub mod grammar_generator;
 pub mod journal_mode;


### PR DESCRIPTION
When ALTER TABLE ALTER COLUMN changes a column's type affinity (e.g. NUMERIC to TEXT), rewrite existing table data so stored values conform to the new affinity. Previously only the schema metadata was updated, leaving numeric values in a column now declared as TEXT. SQLite's integrity_check would then report corruption.

The fix uses existing UPDATE translation paths to update all rows in the
table so that the column uses the new affinity in both the table and all
indexes.

Closes #3706