### PR TITLE
fix: handle NULL properly in composite index seek/termination

### DIFF
--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -2424,7 +2424,7 @@ fn emit_seek(
         return Ok(());
     };
     // We allocated registers for the full index key, but our seek key might not use the full index key.
-    // See [crate::translate::optimizer::build_seek_def] for more details about in which cases we do and don't use the full index key.
+    // See [crate::translate::optimizer::build_seek_def] for boundary rewrites (including NULL sentinels).
     for (i, key) in seek_def.iter(&seek_def.start).enumerate() {
         let reg = start_reg + i;
         match key {
@@ -2448,6 +2448,7 @@ fn emit_seek(
                     });
                 }
             }
+            SeekKeyComponent::Null => program.emit_null(reg, None),
             SeekKeyComponent::None => unreachable!("None component is not possible in iterator"),
         }
     }
@@ -2613,6 +2614,7 @@ fn emit_seek_termination(
                 });
             }
         }
+        SeekKeyComponent::Null => program.emit_null(last_reg, None),
         SeekKeyComponent::None => {}
     }
     program.preassign_label_to_next_insn(loop_start);

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -2364,9 +2364,97 @@ fn build_seek_def(
 
     // pop last key as we will do some form of range search
     let last = key.pop().unwrap();
-
+    let has_upper_bound_only = last.upper_bound.is_some() && last.lower_bound.is_none();
+    let upper_bound_is_lt_or_le = matches!(
+        last.upper_bound.as_ref().map(|(op, _, _)| op),
+        Some(ast::Operator::Less | ast::Operator::LessEquals)
+    );
     // after that all key components must be equality constraints
     debug_assert!(key.iter().all(|k| k.eq.is_some()));
+
+    let has_prefix = !key.is_empty();
+    let apply_null_boundaries = |start: &mut SeekKey, end: &mut SeekKey| {
+        // Sometimes we must add an extra NULL to the key on purpose.
+        // We do this so scans over composite indexes match SQLite exactly.
+        let start_is_prefix_only = matches!(start.last_component, SeekKeyComponent::None);
+        let start_has_range_component = matches!(start.last_component, SeekKeyComponent::Expr(_));
+        let end_is_prefix_only = matches!(end.last_component, SeekKeyComponent::None);
+        let end_has_range_component = matches!(end.last_component, SeekKeyComponent::Expr(_));
+        let start_is_forward_ge = matches!(start.op, SeekOp::GE { .. })
+            && matches!(iter_dir, IterationDirection::Forwards);
+        let start_is_backward_le = matches!(start.op, SeekOp::LE { .. })
+            && matches!(iter_dir, IterationDirection::Backwards);
+        let end_is_forward_gt =
+            matches!(end.op, SeekOp::GT) && matches!(iter_dir, IterationDirection::Forwards);
+        let end_is_backward_lt =
+            matches!(end.op, SeekOp::LT) && matches!(iter_dir, IterationDirection::Backwards);
+        // 1) Choose a better starting point.
+        //
+        // Example:
+        //   INDEX(c1, c2 ASC)
+        //   WHERE c1='a' AND c2<=999
+        //
+        // If we start from key [c1='a'], we hit rows where c2 is NULL first.
+        // For this case we want to start right after that NULL boundary.
+        // So we:
+        // - use start key [c1='a', NULL]
+        // - change start op from GE to GT
+        // - for backward scans in the symmetric shape, change LE to LT
+        //
+        // We only do this for "< / <=" ranges that do not also have a lower bound.
+        if has_prefix
+            && start_is_prefix_only
+            && end_has_range_component
+            && start_is_forward_ge
+            && has_upper_bound_only
+            && upper_bound_is_lt_or_le
+        {
+            start.last_component = SeekKeyComponent::Null;
+            start.op = SeekOp::GT;
+        } else if has_prefix
+            && start_is_prefix_only
+            && end_has_range_component
+            && start_is_backward_le
+            && has_upper_bound_only
+            && upper_bound_is_lt_or_le
+        {
+            start.last_component = SeekKeyComponent::Null;
+            start.op = SeekOp::LT;
+        }
+
+        // 2) Choose a better stopping point.
+        //
+        // Example:
+        //   INDEX(c1, c2 DESC)
+        //   WHERE c1='a' AND c2<=999
+        //
+        // The stop check must also respect the NULL boundary for c2.
+        // So we:
+        // - use stop key [c1='a', NULL]
+        // - change end op from GT to GE
+        // - for backward scans, change LT to LE
+        //
+        // Same limit as above: only "< / <=" ranges with no lower bound.
+        if has_prefix
+            && end_is_prefix_only
+            && start_has_range_component
+            && end_is_forward_gt
+            && has_upper_bound_only
+            && upper_bound_is_lt_or_le
+        {
+            end.last_component = SeekKeyComponent::Null;
+            end.op = SeekOp::GE { eq_only: false };
+        } else if has_prefix
+            && end_is_prefix_only
+            && start_has_range_component
+            && end_is_backward_lt
+            && has_upper_bound_only
+            && upper_bound_is_lt_or_le
+        {
+            end.last_component = SeekKeyComponent::Null;
+            end.op = SeekOp::LE { eq_only: false };
+        }
+    };
 
     // For the commented examples below, keep in mind that since a descending index is laid out in reverse order, the comparison operators are reversed, e.g. LT becomes GT, LE becomes GE, etc.
     // Also keep in mind that index keys are compared based on the number of columns given, so for example:
@@ -2375,7 +2463,7 @@ fn build_seek_def(
     // - if key is GT(x:10, y:NULL), then (x=10, y=0) is GT because NULL is always LT in index key comparisons.
     Ok(match iter_dir {
         IterationDirection::Forwards => {
-            let (start, end) = match last.sort_order {
+            let (mut start, mut end) = match last.sort_order {
                 SortOrder::Asc => {
                     let start = match last.lower_bound {
                         // Forwards, Asc, GT: (x=10 AND y>20)
@@ -2487,6 +2575,7 @@ fn build_seek_def(
                     (start, end)
                 }
             };
+            apply_null_boundaries(&mut start, &mut end);
             SeekDef {
                 prefix: key,
                 iter_dir,
@@ -2495,7 +2584,7 @@ fn build_seek_def(
             }
         }
         IterationDirection::Backwards => {
-            let (start, end) = match last.sort_order {
+            let (mut start, mut end) = match last.sort_order {
                 SortOrder::Asc => {
                     let start = match last.upper_bound {
                         // Backwards, Asc, LT: (x=10 AND y<30)
@@ -2607,6 +2696,7 @@ fn build_seek_def(
                     (start, end)
                 }
             };
+            apply_null_boundaries(&mut start, &mut end);
             SeekDef {
                 prefix: key,
                 iter_dir,

--- a/testing/runner/tests/null/memory.sqltest
+++ b/testing/runner/tests/null/memory.sqltest
@@ -104,3 +104,86 @@ test null-comparison-desc-order-by {
 expect {
 }
 
+# Composite index: NULL in second column should not match range comparisons
+# https://github.com/tursodatabase/turso/issues/5358
+test composite-index-null-second-col-le {
+    CREATE TABLE t10(c1 TEXT, c2 TEXT);
+    CREATE INDEX t10_idx ON t10(c2, c1);
+    INSERT INTO t10(c2) VALUES ('a'), ('a');
+    SELECT * FROM t10 WHERE c2 = 'a' AND c1 <= 999;
+}
+expect {
+}
+
+test composite-index-null-second-col-lt {
+    CREATE TABLE t11(c1 TEXT, c2 TEXT);
+    CREATE INDEX t11_idx ON t11(c2, c1);
+    INSERT INTO t11(c2) VALUES ('a'), ('a');
+    SELECT * FROM t11 WHERE c2 = 'a' AND c1 < 999;
+}
+expect {
+}
+
+test composite-index-null-second-col-ge {
+    CREATE TABLE t12(c1 TEXT, c2 TEXT);
+    CREATE INDEX t12_idx ON t12(c2, c1);
+    INSERT INTO t12(c2) VALUES ('a'), ('a');
+    SELECT * FROM t12 WHERE c2 = 'a' AND c1 >= 0;
+}
+expect {
+}
+
+test composite-index-null-second-col-le-desc {
+    CREATE TABLE t12d(c1 TEXT, c2 TEXT);
+    CREATE INDEX t12d_idx ON t12d(c2, c1 DESC);
+    INSERT INTO t12d(c2) VALUES ('a'), ('a');
+    SELECT * FROM t12d WHERE c2 = 'a' AND c1 <= 999;
+}
+expect {
+}
+
+test composite-index-null-second-col-lt-desc {
+    CREATE TABLE t12e(c1 TEXT, c2 TEXT);
+    CREATE INDEX t12e_idx ON t12e(c2, c1 DESC);
+    INSERT INTO t12e(c2) VALUES ('a'), ('a');
+    SELECT * FROM t12e WHERE c2 = 'a' AND c1 < 999;
+}
+expect {
+}
+
+test composite-index-null-second-col-gt {
+    CREATE TABLE t13(c1 TEXT, c2 TEXT);
+    CREATE INDEX t13_idx ON t13(c2, c1);
+    INSERT INTO t13(c2) VALUES ('a'), ('a');
+    SELECT * FROM t13 WHERE c2 = 'a' AND c1 > 0;
+}
+expect {
+}
+
+# Composite index with mixed NULL and non-NULL values
+test composite-index-mixed-null-nonnull {
+    CREATE TABLE t14(c1 TEXT, c2 TEXT);
+    CREATE INDEX t14_idx ON t14(c2, c1);
+    INSERT INTO t14(c2) VALUES ('a'), ('a');
+    INSERT INTO t14 VALUES ('abc', 'a'), ('def', 'a');
+    SELECT c1, c2 FROM t14 WHERE c2 = 'a' AND c1 <= 'zzz';
+}
+expect {
+    abc|a
+    def|a
+}
+
+# Regression for simulator seed 16218053103538286000:
+# a prefix-only equality probe on the first column of a composite index must not
+# synthesize an extra NULL key component (that previously caused an OOB panic).
+test composite-index-prefix-eq-no-range-no-crash {
+    CREATE TABLE t15(a INT, b INT);
+    CREATE INDEX t15_idx ON t15(a DESC, b ASC);
+    INSERT INTO t15 VALUES (1, NULL), (1, 20), (2, 30);
+    SELECT a, b FROM t15 WHERE a = 1 LIMIT 4;
+}
+expect {
+    1|
+    1|20
+}
+

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -276,6 +276,20 @@ mod fuzz_tests {
                 rng.random_range(0..3000)
             ));
         }
+        // Add explicit NULL-bearing keys to exercise index ordering and seek/termination logic
+        // around NULLs in each indexed column position.
+        const NULL_KEY_ROWS: usize = 256;
+        for _ in 0..NULL_KEY_ROWS {
+            let y = rng.random_range(0..3000);
+            let z = rng.random_range(0..3000);
+            let x = rng.random_range(0..3000);
+            tuples.push(format!("(NULL, {y}, {z}, {})", rng.random_range(0..3000)));
+            tuples.push(format!("({x}, NULL, {z}, {})", rng.random_range(0..3000)));
+            tuples.push(format!("({x}, {y}, NULL, {})", rng.random_range(0..3000)));
+            tuples.push(format!("(NULL, NULL, {z}, {})", rng.random_range(0..3000)));
+            tuples.push(format!("({x}, NULL, NULL, {})", rng.random_range(0..3000)));
+            tuples.push(format!("(NULL, {y}, NULL, {})", rng.random_range(0..3000)));
+        }
         let insert = format!("INSERT INTO t VALUES {}", tuples.join(", "));
 
         let tmp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
Closes #5358

Some composite index range scans were accidentally including rows where the range column was NULL. This updates seek/stop boundaries to skip those NULL edge cases the same way SQLite does, and adds tests/fuzz data so we don’t regress again.

Mainly this means: in cases where there's a compound index like `CREATE INDEX foo ON t(a,b)` and both an equality constraint and range constraint like `WHERE a = 10 and b <= 100`, we were previously seeking to `GE a:10`, but this would include `(a=10, b=NULL)` which is wrong.

Rewrite that seek as `GT (a:10, b: NULL)` to skip those null-containing rows. Do similarly for the termination condition to end the index scan before any nulls are hit, and equally for the backwards iteration cases