### PR TITLE
fix: add `changes` support to MVCC and adjust code to always emit it in one place only

### DIFF
--- a/testing/runner/tests/changes.sqltest
+++ b/testing/runner/tests/changes.sqltest
@@ -1,6 +1,5 @@
 @database :memory:
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-on-basic-insert {
     create table temp (t1 integer, primary key (t1));
     insert into temp values (1);
@@ -10,7 +9,6 @@ expect {
     1
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-on-multiple-row-insert {
     create table temp (t1 integer, primary key (t1));
     insert into temp values (1), (2), (3);
@@ -20,7 +18,6 @@ expect {
     3
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-shows-most-recent {
     create table temp (t1 integer, primary key (t1));
     insert into temp values (1), (2), (3);
@@ -31,7 +28,6 @@ expect {
     4
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 # github.com/tursodatabase/turso/issues/3259
 test changes-doesnt-track-indexes {
     create table users (id integer primary key, name text, age integer);
@@ -45,7 +41,6 @@ expect {
     6
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 # https://github.com/tursodatabase/turso/issues/3688
 test changes-1_69 {
     create table t(id integer primary key, value text);
@@ -59,7 +54,6 @@ expect {
     1
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-delete-doesnt-track-indexes {
     create table t (a int);
     create index idx on t(a);
@@ -71,7 +65,6 @@ expect {
     2
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-on-delete {
     create table temp (t1 integer, primary key (t1));
     insert into temp values (1), (2), (3), (4), (5);
@@ -82,7 +75,6 @@ expect {
     3
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-on-update {
     create table temp (t1 integer, t2 text, primary key (t1));
     insert into temp values (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd');
@@ -93,7 +85,6 @@ expect {
     3
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-on-update-rowid {
     create table temp (t1 integer primary key, t2 text);
     insert into temp values (1, 'a'), (2, 'b'), (3, 'c');
@@ -104,7 +95,6 @@ expect {
     1
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-resets-after-select {
     create table temp (t1 integer, primary key (t1));
     insert into temp values (1), (2), (3);
@@ -118,7 +108,6 @@ expect {
     3
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-on-delete-no-match {
     create table temp (t1 integer, primary key (t1));
     insert into temp values (1), (2), (3);
@@ -129,7 +118,6 @@ expect {
     0
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-on-update-no-match {
     create table temp (t1 integer, t2 text, primary key (t1));
     insert into temp values (1, 'a'), (2, 'b');
@@ -140,7 +128,6 @@ expect {
     0
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-on-delete-all {
     create table temp (t1 integer, primary key (t1));
     insert into temp values (1), (2), (3), (4), (5), (6);
@@ -151,7 +138,6 @@ expect {
     6
 }
 
-@skip-if mvcc "changes not supported in MVCC mode"
 test changes-mixed-operations {
     create table temp (t1 integer, t2 text, primary key (t1));
     insert into temp values (1, 'a'), (2, 'b'), (3, 'c');

--- a/testing/runner/tests/total-changes.sqltest
+++ b/testing/runner/tests/total-changes.sqltest
@@ -1,5 +1,4 @@
 @database :memory:
-@skip-file-if mvcc "total_changes not supported in MVCC mode"
 
 test total-changes-on-basic-insert {
     create table temp (t1 integer, primary key (t1));


### PR DESCRIPTION
## Description
Fixes https://github.com/tursodatabase/turso/issues/5289

Adjust the code so that we only `set_changes` after we commit on any journal mode


## Description of AI Usage
Location to change detected by Claude
