### PR TITLE
fix(cli): prevent extra space in multiline readline input

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1629,7 +1629,9 @@ impl Limbo {
             self.read_state.process(&self.input_buff[prev_len..]);
         }
 
-        let _ = self.input_buff.write_char(' ');
+        if !self.input_buff.ends_with(char::is_whitespace) {
+            let _ = self.input_buff.write_char('\n');
+        }
         Ok(())
     }
 

--- a/testing/runner/tests/issue_5116.sqltest
+++ b/testing/runner/tests/issue_5116.sqltest
@@ -1,0 +1,22 @@
+@database :memory:
+
+test setup_db_for_cli_test_workaround_parser {
+    -- This test just initializes the database connection so subsequent tests can reuse it
+    -- and work around parser limitation on consecutive decorators.
+}
+expect {
+}
+
+@backend cli
+test issue_5116_multiline_string {
+    CREATE TABLE t(a);
+    INSERT INTO t VALUES('a
+b');
+    SELECT length(a) FROM t;
+    SELECT a FROM t;
+}
+expect {
+    3
+    a
+    b
+}


### PR DESCRIPTION
Fixes #5116 by checking if input buffer already ends in whitespace. Changed default separator from space to newline to preserve formatting in string literals.

Description
This PR fixes a bug in the Turso CLI's readline implementation where multi-line strings were being corrupted. When a user enters a multi-line string, the CLI was previously appending a simple space ' ' between lines, which can break formatting or logic within the string.

I have modified cli/app.rs to:

Check if the current input buffer ends in whitespace before appending a separator.

Change the default line separator from a space to a newline '\n', ensuring that multi-line SQL statements and strings retain their structure.

Motivation and context
Proper handling of multi-line strings is essential for complex SQL queries and data entry. This change ensures that the CLI behaves consistently with standard SQL formatting expectations.

Description of AI Usage
This PR was created with the assistance of Gemini.

Assistance Level: AI-assisted. The AI helped identify the specific logic in cli/app.rs that caused the string corruption and suggested the logic for the whitespace check.

Process: I used Gemini to walk through the repository structure, analyze the readline buffer handling, and verify the fix with a reproduction script. I manually reviewed and tested all code changes to ensure they meet the project's standards.
