### PR TITLE
Reject duplicate CTE names in WITH clause

### DIFF
--- a/testing/runner/tests/cte.sqltest
+++ b/testing/runner/tests/cte.sqltest
@@ -633,6 +633,16 @@ expect error {
     duplicate WITH table name
 }
 
+test cte-duplicate-name-view {
+    CREATE TABLE cte_dup_table(x);
+    CREATE VIEW cte_dup_view AS
+        WITH cte AS (SELECT 1), cte AS (SELECT 2)
+        SELECT * FROM cte_dup_table;
+}
+expect error {
+    duplicate WITH table name
+}
+
 # @skip-if sqlite "sqlite supports recursive CTEs"
 # test cte-recursive-unsupported {
 #     WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM cnt WHERE x<5) SELECT * FROM cnt;


### PR DESCRIPTION
## Description

 - reject duplicate CTE names during parsing to match SQLite behavior
 - add sqltest coverage for duplicate CTEs in CREATE VIEW
 - add parser regression case for duplicate CTEs in CREATE VIEW

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

SQLite rejects duplicate CTE names and otherwise reports a malformed schema when loading. Align parser behavior so invalid views cannot be created.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5098

## Description of AI Usage

Pr body

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
