### PR TITLE
Fix prepare panic on comment/whitespace-only SQL

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -232,9 +232,15 @@ impl Connection {
         let sql = sql.as_ref();
         tracing::debug!("Preparing: {}", sql);
         let mut parser = Parser::new(sql.as_bytes());
-        let cmd = parser.next_cmd()?;
+        let cmd = match parser.next_cmd()? {
+            Some(cmd) => cmd,
+            None => {
+                return Err(LimboError::InvalidArgument(
+                    "The supplied SQL string contains no statements".to_string(),
+                ));
+            }
+        };
         let syms = self.syms.read();
-        let cmd = cmd.expect("Successful parse on nonempty input string should produce a command");
         let byte_offset_end = parser.offset();
         let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
             .unwrap()


### PR DESCRIPTION
## Description

 Handle `prepare()` on comment/whitespace/semicolon-only SQL by returning `InvalidArgument` instead of panicking. Add integration coverage for empty-statement inputs and invalid nested-comment syntax.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Prevent user-triggerable panics in `prepare()`

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #4558


## Description of AI Usage

Pr body after code validation

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
