### PR TITLE
fix: Panic on Scalar Subquery Referencing CTE by Original Name After Alias

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -328,6 +328,7 @@ pub fn translate_alter_table(
                             cte_select: None,
                             cte_explicit_columns: vec![],
                             cte_id: None,
+                            cte_definition_only: false,
                         }],
                     );
                     let where_copy = index

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -713,6 +713,7 @@ fn add_ephemeral_table_to_update_plan(
                 cte_select: None,
                 cte_explicit_columns: vec![],
                 cte_id: None,
+                cte_definition_only: false,
             });
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -733,6 +733,11 @@ pub struct OuterQueryReference {
     /// CTE ID if this is a CTE reference. Used to track CTE reference counts
     /// for materialization decisions.
     pub cte_id: Option<usize>,
+    /// When true, this entry is only for CTE definition lookup in subquery
+    /// FROM clauses, not for column resolution. This is set when the CTE
+    /// has been consumed by a FROM clause (with or without an alias), so
+    /// column resolution goes through the joined_table instead.
+    pub cte_definition_only: bool,
 }
 
 impl OuterQueryReference {
@@ -924,6 +929,21 @@ impl TableReferences {
             .find(|t| t.identifier == identifier)
     }
 
+    /// Marks the pre-planned [OuterQueryReference] with the given identifier as
+    /// "CTE definition only". This prevents it from being used for column
+    /// resolution while still allowing CTE definition lookup in subquery FROM
+    /// clauses. Called when a CTE is consumed by a FROM clause, since column
+    /// resolution is then handled by the joined_table entry instead.
+    pub fn mark_outer_query_ref_cte_definition_only(&mut self, identifier: &str) {
+        if let Some(outer_ref) = self
+            .outer_query_refs
+            .iter_mut()
+            .find(|t| t.identifier == identifier)
+        {
+            outer_ref.cte_definition_only = true;
+        }
+    }
+
     /// Returns the internal ID and immutable reference to the [Table] with the given identifier,
     pub fn find_table_and_internal_id_by_identifier(
         &self,
@@ -936,7 +956,7 @@ impl TableReferences {
             .or_else(|| {
                 self.outer_query_refs
                     .iter()
-                    .find(|t| t.identifier == identifier)
+                    .find(|t| t.identifier == identifier && !t.cte_definition_only)
                     .map(|t| (t.internal_id, &t.table))
             })
     }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -261,6 +261,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                     cte_select: None,
                     cte_explicit_columns: vec![],
                     cte_id,
+                    cte_definition_only: false,
                 }
             })
             .chain(
@@ -275,6 +276,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                         cte_select: t.cte_select.clone(),
                         cte_explicit_columns: t.cte_explicit_columns.clone(),
                         cte_id: t.cte_id, // Preserve CTE ID from outer query refs
+                        cte_definition_only: t.cte_definition_only,
                     }),
             )
             .collect::<Vec<_>>()

--- a/testing/runner/tests/cte.sqltest
+++ b/testing/runner/tests/cte.sqltest
@@ -905,3 +905,46 @@ test subquery-aggregate-empty-result-non-agg-columns {
 expect {
     0||
 }
+
+# =============================================================================
+# Scalar subquery referencing CTE by original name after alias (#5225)
+# =============================================================================
+
+# Scalar subquery using original CTE name when CTE is aliased should error
+test cte-alias-scalar-subquery-original-name {
+    WITH c AS (SELECT 1 x) SELECT (SELECT c.x) FROM c t;
+}
+expect error {
+}
+
+# Scalar subquery uses alias name (should work)
+test cte-alias-scalar-subquery-alias-name {
+    WITH c AS (SELECT 1 x) SELECT (SELECT t.x) FROM c t;
+}
+expect {
+    1
+}
+
+# Without alias, original CTE name works in scalar subquery
+test cte-no-alias-scalar-subquery {
+    WITH c AS (SELECT 1 x) SELECT (SELECT c.x) FROM c;
+}
+expect {
+    1
+}
+
+# Multiple columns referenced by alias in scalar subquery
+test cte-alias-scalar-subquery-multiple-columns {
+    WITH c AS (SELECT 1 x, 2 y) SELECT (SELECT t.x), (SELECT t.y) FROM c t;
+}
+expect {
+    1|2
+}
+
+# Multiple CTEs, each aliased, scalar subqueries reference alias names
+test cte-alias-scalar-subquery-multiple-ctes {
+    WITH a AS (SELECT 1 x), b AS (SELECT 2 y) SELECT (SELECT t1.x), (SELECT t2.y) FROM a t1, b t2;
+}
+expect {
+    1|2
+}


### PR DESCRIPTION
   When a CTE is pre-planned for scalar subquery visibility and then
   consumed by a FROM clause, the pre-planned outer_query_ref entry
   retained a stale internal_id. A scalar subquery resolving a column
   through that stale entry caused a panic in the emitter.

   Additionally, when a CTE is aliased (e.g. FROM c t), the original
   CTE name must not be usable as a column qualifier in scalar subqueries.
   SQLite rejects `(SELECT c.x)` with "no such column: c.x" when `c` is
   aliased as `t`, while still allowing the CTE name in subquery FROM
   clauses (e.g. EXISTS (SELECT 1 FROM c ...)).

   Fix: add `cte_definition_only` flag to OuterQueryReference. When a CTE
   is consumed by a FROM clause, its pre-planned outer_query_ref is marked
   cte_definition_only, which excludes it from column resolution while
   preserving CTE definition lookup for subquery FROM clauses. Column
   resolution goes through the joined_table entry instead, which carries
   the alias (or original name if unaliased) and the correct internal_id.

Closes #5225