### PR TITLE
Add MVCC Antithesis stress test configurations

### DIFF
--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -136,6 +136,8 @@ COPY ./testing/antithesis/bank-test/*.py /opt/antithesis/test/v1/bank-test/
 COPY ./testing/antithesis/stress-composer/*.py /opt/antithesis/test/v1/stress-composer/
 COPY ./testing/antithesis/stress /opt/antithesis/test/v1/stress
 COPY ./testing/antithesis/stress-io_uring /opt/antithesis/test/v1/stress-io_uring
+COPY ./testing/antithesis/stress-mvcc /opt/antithesis/test/v1/stress-mvcc
+COPY ./testing/antithesis/stress-io_uring-mvcc /opt/antithesis/test/v1/stress-io_uring-mvcc
 COPY ./testing/antithesis/stress-unreliable /opt/antithesis/test/v1/stress-unreliable
 RUN chmod 777 -R /opt/antithesis/test/v1
 

--- a/testing/antithesis/stress-io_uring-mvcc/singleton_driver_stress.sh
+++ b/testing/antithesis/stress-io_uring-mvcc/singleton_driver_stress.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/bin/turso_stress --nr-threads 2 --nr-iterations 10000 --vfs io_uring --tx-mode concurrent

--- a/testing/antithesis/stress-mvcc/singleton_driver_stress.sh
+++ b/testing/antithesis/stress-mvcc/singleton_driver_stress.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/bin/turso_stress --nr-threads 2 --nr-iterations 10000 --tx-mode concurrent


### PR DESCRIPTION
Add stress-mvcc and stress-io_uring-mvcc Antithesis test configurations that run turso_stress with --tx-mode concurrent.

Please note that issue #5004, for example, triggers under Antithesis. However, it probably makes sense to merge this early rather than late so that we discover any new issues while we hunt down the known issues.