### PR TITLE
fix: NEW.rowid_alias in UPDATE Trigger WHEN Clause Evaluates to NULL

### DIFF
--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -793,7 +793,14 @@ fn rewrite_trigger_expr_for_when_clause(
                 // Handle NEW.column references
                 if ns.eq_ignore_ascii_case("new") {
                     if let Some(new_regs) = &ctx.new_registers {
-                        if let Some((idx, _)) = table.get_column(&col) {
+                        if let Some((idx, col_def)) = table.get_column(&col) {
+                            if col_def.is_rowid_alias() {
+                                // Rowid alias columns map to the rowid register (last element)
+                                *e = Expr::Register(
+                                    *new_regs.last().expect("NEW registers must be provided"),
+                                );
+                                return Ok(WalkControl::Continue);
+                            }
                             if idx < new_regs.len() {
                                 *e = Expr::Register(new_regs[idx]);
                                 return Ok(WalkControl::Continue);

--- a/testing/runner/tests/trigger.sqltest
+++ b/testing/runner/tests/trigger.sqltest
@@ -1021,3 +1021,36 @@ expect {
     new_row|1.0
 }
 
+# https://github.com/tursodatabase/turso/issues/5177
+# NEW.rowid_alias in UPDATE trigger WHEN clause should not be NULL
+test trigger-new-rowid-alias-when-clause {
+    CREATE TABLE t_5177 (id INTEGER PRIMARY KEY, val TEXT, counter INTEGER DEFAULT 0);
+    INSERT INTO t_5177 VALUES(1, 'a', 0), (2, 'b', 0), (3, 'c', 0);
+    CREATE TRIGGER tr_5177 AFTER UPDATE ON t_5177 WHEN NEW.id = 2 BEGIN
+      UPDATE t_5177 SET counter = counter + 1 WHERE id = NEW.id;
+    END;
+    UPDATE t_5177 SET val = 'updated' WHERE id = 2;
+    SELECT * FROM t_5177 ORDER BY id;
+}
+expect {
+    1|a|0
+    2|updated|1
+    3|c|0
+}
+
+# NEW.rowid_alias in BEFORE UPDATE trigger WHEN clause
+test trigger-new-rowid-alias-when-clause-before {
+    CREATE TABLE t_5177b (id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE log_5177b (msg TEXT);
+    INSERT INTO t_5177b VALUES(1, 'a'), (2, 'b');
+    CREATE TRIGGER tr_5177b BEFORE UPDATE ON t_5177b WHEN NEW.id = 1 BEGIN
+      INSERT INTO log_5177b VALUES('triggered for id 1');
+    END;
+    UPDATE t_5177b SET val = 'updated' WHERE id = 1;
+    UPDATE t_5177b SET val = 'updated' WHERE id = 2;
+    SELECT * FROM log_5177b;
+}
+expect {
+    triggered for id 1
+}
+


### PR DESCRIPTION
In UPDATE trigger WHEN clauses, NEW.<rowid_alias_column> resolved to NULL instead of the actual rowid value because the WHEN clause rewriter used the positional column register (which stores NULL for rowid alias columns) rather than the rowid register at the end of the array. Add is_rowid_alias() check to map to the correct register, matching the pattern already used in rewrite_trigger_expr_for_subprogram().

Closes #5177