### PR TITLE
fix: Subquery in Trigger Body UPDATE SET Creates Poison Trigger

### DIFF
--- a/testing/runner/tests/trigger.sqltest
+++ b/testing/runner/tests/trigger.sqltest
@@ -1054,3 +1054,23 @@ expect {
     triggered for id 1
 }
 
+# https://github.com/tursodatabase/turso/issues/5175
+# Subquery in trigger body UPDATE SET clause
+test trigger-update-set-subquery {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY);
+    CREATE TABLE counter(n INTEGER);
+    INSERT INTO counter VALUES(0);
+    INSERT INTO t1 VALUES(1);
+    CREATE TRIGGER tr1 AFTER INSERT ON t1 BEGIN
+      UPDATE counter SET n = (SELECT max(id) FROM t1);
+    END;
+    INSERT INTO t1 VALUES(2);
+    SELECT * FROM t1 ORDER BY id;
+    SELECT * FROM counter;
+}
+expect {
+    1
+    2
+    2
+}
+

--- a/testing/runner/tests/update.sqltest
+++ b/testing/runner/tests/update.sqltest
@@ -875,3 +875,31 @@ expect {
     1
     ok
 }
+
+# https://github.com/tursodatabase/turso/issues/5175
+# UPDATE SET with scalar subquery
+test update-set-subquery {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE t2(n INTEGER);
+    INSERT INTO t1 VALUES(1, 10), (2, 20), (3, 30);
+    INSERT INTO t2 VALUES(0);
+    UPDATE t2 SET n = (SELECT max(val) FROM t1);
+    SELECT * FROM t2;
+}
+expect {
+    30
+}
+
+# UPDATE SET with correlated scalar subquery
+test update-set-correlated-subquery {
+    CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT, category_id INTEGER);
+    CREATE TABLE categories(id INTEGER PRIMARY KEY, name TEXT, item_count INTEGER);
+    INSERT INTO items VALUES(1, 'a', 1), (2, 'b', 1), (3, 'c', 2);
+    INSERT INTO categories VALUES(1, 'cat1', 0), (2, 'cat2', 0);
+    UPDATE categories SET item_count = (SELECT count(*) FROM items WHERE items.category_id = categories.id);
+    SELECT id, item_count FROM categories ORDER BY id;
+}
+expect {
+    1|2
+    2|1
+}


### PR DESCRIPTION
Add subquery planning for UPDATE SET clause expressions. Previously, subqueries in SET clauses (e.g. UPDATE t SET col = (SELECT ...)) were never planned, causing them to hit the "Subquery is not supported in this position" error at translation time. This affected both regular UPDATE statements and trigger body UPDATE statements.

The fix adds plan_subqueries_from_set_clauses() which follows the same pattern as existing subquery planning for WHERE, VALUES, and RETURNING clauses.

Closes #5175