### PR TITLE
fix affinity calculation for index seeks, subqueries and ctes

### DIFF
--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -18,8 +18,8 @@ use super::{
     plan::{
         Aggregate, DistinctCtx, Distinctness, EvalAt, HashJoinOp, IterationDirection,
         JoinOrderMember, JoinedTable, MultiIndexScanOp, NonFromClauseSubquery, Operation,
-        QueryDestination, Scan, Search, SeekDef, SeekKeyComponent, SelectPlan, SetOperation,
-        TableReferences, WhereTerm,
+        QueryDestination, Scan, Search, SeekDef, SeekKey, SeekKeyComponent, SelectPlan,
+        SetOperation, TableReferences, WhereTerm,
     },
 };
 use crate::{
@@ -2362,6 +2362,51 @@ pub fn close_loop(
     Ok(())
 }
 
+/// Build the affinity string for an index seek, skipping positions where the
+/// probe expression already has the right type (mirroring SQLite's optimization
+/// via `sqlite3ExprNeedsNoAffinityChange`).
+///
+/// For each seek key position the index column affinity is checked against the
+/// probe expression. If the expression already matches (e.g. a string literal
+/// seeking a TEXT column), NONE is used so OP_Affinity becomes a no-op for that
+/// slot. When every slot is NONE the caller can skip the instruction entirely.
+fn index_seek_affinities(
+    idx: &Index,
+    tables: &TableReferences,
+    seek_def: &SeekDef,
+    seek_key: &SeekKey,
+) -> String {
+    let table = tables
+        .joined_tables()
+        .iter()
+        .find(|jt| jt.table.get_name() == idx.table_name)
+        .expect("index source table not found in table references");
+
+    idx.columns
+        .iter()
+        .zip(seek_def.iter(seek_key))
+        .map(|(ic, key_component)| {
+            // Expression index columns (e.g. CREATE INDEX ON t(a+b)) have no
+            // corresponding table column; their affinity is BLOB/NONE.
+            let col_aff = if ic.expr.is_some() {
+                Affinity::Blob
+            } else {
+                table
+                    .table
+                    .get_column_at(ic.pos_in_table)
+                    .expect("index column position out of bounds")
+                    .affinity()
+            };
+            match key_component {
+                SeekKeyComponent::Expr(expr) if col_aff.expr_needs_no_affinity_change(expr) => {
+                    affinity::SQLITE_AFF_NONE
+                }
+                _ => col_aff.aff_mask(),
+            }
+        })
+        .collect()
+}
+
 /// Emits instructions for an index seek. See e.g. [crate::translate::plan::SeekDef]
 /// for more details about the seek definition.
 ///
@@ -2463,19 +2508,13 @@ fn emit_seek(
     }
     let num_regs = seek_def.size(&seek_def.start);
 
-    if is_index {
-        let affinities: String = seek_def
-            .iter_affinity(&seek_def.start)
-            .map(|affinity| affinity.aff_mask())
-            .collect();
+    if let Some(idx) = seek_index {
+        let affinities = index_seek_affinities(idx, tables, seek_def, &seek_def.start);
         if affinities.chars().any(|c| c != affinity::SQLITE_AFF_NONE) {
             program.emit_insn(Insn::Affinity {
                 start_reg,
                 count: std::num::NonZeroUsize::new(num_regs).unwrap(),
-                affinities: seek_def
-                    .iter_affinity(&seek_def.start)
-                    .map(|affinity| affinity.aff_mask())
-                    .collect(),
+                affinities,
             });
         }
     }
@@ -2599,11 +2638,8 @@ fn emit_seek_termination(
             // Apply affinity to the end key (same as we do for start key).
             // Without this, e.g. BETWEEN '15' AND '35' on a numeric column would
             // compare '35' as a string against numeric values, causing incorrect results.
-            if is_index {
-                let affinities: String = seek_def
-                    .iter_affinity(&seek_def.end)
-                    .map(|affinity| affinity.aff_mask())
-                    .collect();
+            if let Some(idx) = seek_index {
+                let affinities = index_seek_affinities(idx, tables, seek_def, &seek_def.end);
                 if affinities.chars().any(|c| c != affinity::SQLITE_AFF_NONE) {
                     program.emit_insn(Insn::Affinity {
                         start_reg,

--- a/testing/runner/tests/join/memory.sqltest
+++ b/testing/runner/tests/join/memory.sqltest
@@ -477,3 +477,62 @@ expect {
     32|10089|20016|
 }
 
+# Regression test for: https://github.com/tursodatabase/turso/issues/5282
+# JOIN returns zero rows when seeking a TEXT index with integer probe values.
+# The optimizer scans t_int (INTEGER affinity) and seeks idx_text_val (TEXT
+# affinity).  The OP_Affinity before the seek must use the index column's
+# affinity (TEXT) so the integer probe is coerced to text before seeking.
+test join-text-index-integer-probe {
+    CREATE TABLE t_text(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX idx_text_val ON t_text(val);
+    INSERT INTO t_text VALUES (1, '100'), (2, '200');
+    CREATE TABLE t_int(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE INDEX idx_int_val ON t_int(val);
+    INSERT INTO t_int VALUES (10, 100), (20, 200);
+    -- Broken before fix: scans t_int, seeks idx_text_val with integer probes
+    SELECT COUNT(*) FROM t_int i JOIN t_text t ON i.val = t.val;
+}
+expect {
+    2
+}
+
+test join-text-index-integer-probe-reversed {
+    CREATE TABLE t_text(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX idx_text_val ON t_text(val);
+    INSERT INTO t_text VALUES (1, '100'), (2, '200');
+    CREATE TABLE t_int(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE INDEX idx_int_val ON t_int(val);
+    INSERT INTO t_int VALUES (10, 100), (20, 200);
+    -- Reversed scan order (already worked before fix)
+    SELECT COUNT(*) FROM t_text t JOIN t_int i ON t.val = i.val;
+}
+expect {
+    2
+}
+
+test join-text-index-integer-probe-no-index {
+    CREATE TABLE t_text(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t_text VALUES (1, '100'), (2, '200');
+    CREATE TABLE t_int(id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO t_int VALUES (10, 100), (20, 200);
+    -- Without indexes, should still work
+    SELECT COUNT(*) FROM t_int i JOIN t_text t ON i.val = t.val;
+}
+expect {
+    2
+}
+
+# Range seek on TEXT index with integer probes — exercises the end-key affinity
+# path in emit_seek_termination (same underlying fix as the equality case above).
+test text-index-range-seek-integer-probes {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX idx_t_val ON t(val);
+    INSERT INTO t VALUES (1, '50'), (2, '100'), (3, '150'), (4, '200'), (5, '250');
+    SELECT val FROM t WHERE val BETWEEN 100 AND 200 ORDER BY val;
+}
+expect {
+    100
+    150
+    200
+}
+

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__aggregation-with-join.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__aggregation-with-join.snap
@@ -1,15 +1,27 @@
 ---
 source: aggregation.sqltest
-expression: "SELECT\n        p.category,\n        COUNT(o.order_id) as num_orders,\n        SUM(o.total_amount) as total_revenue,\n        AVG(o.quantity) as avg_quantity_per_order\n    FROM\n        products p\n        LEFT JOIN orders o ON p.product_id = o.product_id\n    GROUP BY\n        p.category\n    ORDER BY\n        total_revenue DESC;"
+expression: |-
+  SELECT
+          p.category,
+          COUNT(o.order_id) as num_orders,
+          SUM(o.total_amount) as total_revenue,
+          AVG(o.quantity) as avg_quantity_per_order
+      FROM
+          products p
+          LEFT JOIN orders o ON p.product_id = o.product_id
+      GROUP BY
+          p.category
+      ORDER BY
+          total_revenue DESC;
 info:
   statement_type: SELECT
   tables:
-    - orders
-    - p.product_id
-    - products
+  - orders
+  - p.product_id
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN products AS p

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__composite-index-first-column-only.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__composite-index-first-column-only.snap
@@ -1,13 +1,16 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, order_date, total_amount\n    FROM orders\n    WHERE customer_id = 100;"
+expression: |-
+  SELECT id, order_date, total_amount
+      FROM orders
+      WHERE customer_id = 100;
 info:
   statement_type: SELECT
   tables:
-    - orders
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH orders USING INDEX idx_orders_customer_date

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__composite-index-full-usage.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__composite-index-full-usage.snap
@@ -1,13 +1,16 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, status, total_amount\n    FROM orders\n    WHERE customer_id = 100 AND order_date = '2024-01-15';"
+expression: |-
+  SELECT id, status, total_amount
+      FROM orders
+      WHERE customer_id = 100 AND order_date = '2024-01-15';
 info:
   statement_type: SELECT
   tables:
-    - orders
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH orders USING INDEX idx_orders_customer_date

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__composite-index-order-by-match.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__composite-index-order-by-match.snap
@@ -1,13 +1,17 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, order_date, total_amount\n    FROM orders\n    WHERE customer_id = 100\n    ORDER BY order_date;"
+expression: |-
+  SELECT id, order_date, total_amount
+      FROM orders
+      WHERE customer_id = 100
+      ORDER BY order_date;
 info:
   statement_type: SELECT
   tables:
-    - orders
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SEARCH orders USING INDEX idx_orders_customer_date

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__composite-index-range-on-second.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__composite-index-range-on-second.snap
@@ -1,13 +1,16 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, order_date, total_amount\n    FROM orders\n    WHERE customer_id = 100 AND order_date >= '2024-01-01' AND order_date < '2024-02-01';"
+expression: |-
+  SELECT id, order_date, total_amount
+      FROM orders
+      WHERE customer_id = 100 AND order_date >= '2024-01-01' AND order_date < '2024-02-01';
 info:
   statement_type: SELECT
   tables:
-    - orders
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH orders USING INDEX idx_orders_customer_date

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__covering-index-all-columns.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__covering-index-all-columns.snap
@@ -1,13 +1,16 @@
 ---
 source: indexes.sqltest
-expression: "SELECT warehouse_id, product_id, quantity\n    FROM inventory\n    WHERE warehouse_id = 1 AND product_id = 500;"
+expression: |-
+  SELECT warehouse_id, product_id, quantity
+      FROM inventory
+      WHERE warehouse_id = 1 AND product_id = 500;
 info:
   statement_type: SELECT
   tables:
-    - inventory
+  - inventory
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH inventory USING INDEX idx_inventory_covering

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__covering-index-subset.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__covering-index-subset.snap
@@ -1,13 +1,16 @@
 ---
 source: indexes.sqltest
-expression: "SELECT warehouse_id, quantity\n    FROM inventory\n    WHERE warehouse_id = 1;"
+expression: |-
+  SELECT warehouse_id, quantity
+      FROM inventory
+      WHERE warehouse_id = 1;
 info:
   statement_type: SELECT
   tables:
-    - inventory
+  - inventory
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH inventory USING INDEX idx_inventory_covering

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__covering-index-with-aggregation.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__covering-index-with-aggregation.snap
@@ -1,13 +1,17 @@
 ---
 source: indexes.sqltest
-expression: "SELECT warehouse_id, SUM(quantity) as total_qty\n    FROM inventory\n    WHERE warehouse_id = 1\n    GROUP BY warehouse_id;"
+expression: |-
+  SELECT warehouse_id, SUM(quantity) as total_qty
+      FROM inventory
+      WHERE warehouse_id = 1
+      GROUP BY warehouse_id;
 info:
   statement_type: SELECT
   tables:
-    - inventory
+  - inventory
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH inventory USING INDEX idx_inventory_covering

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__join-with-index.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__join-with-index.snap
@@ -1,15 +1,19 @@
 ---
 source: indexes.sqltest
-expression: "SELECT o.id, o.order_date, i.quantity\n    FROM orders o\n    JOIN inventory i ON o.id = i.product_id\n    WHERE o.customer_id = 100;"
+expression: |-
+  SELECT o.id, o.order_date, i.quantity
+      FROM orders o
+      JOIN inventory i ON o.id = i.product_id
+      WHERE o.customer_id = 100;
 info:
   statement_type: SELECT
   tables:
-    - inventory
-    - o.id
-    - orders
+  - inventory
+  - o.id
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SEARCH o USING INDEX idx_orders_customer_date

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__multiple-indexes-choice.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__multiple-indexes-choice.snap
@@ -1,13 +1,16 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, sku, name, price\n    FROM products\n    WHERE category = 'Electronics' AND price < 100;"
+expression: |-
+  SELECT id, sku, name, price
+      FROM products
+      WHERE category = 'Electronics' AND price < 100;
 info:
   statement_type: SELECT
   tables:
-    - products
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH products USING INDEX idx_products_category

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__non-covering-needs-table-lookup.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__non-covering-needs-table-lookup.snap
@@ -1,13 +1,16 @@
 ---
 source: indexes.sqltest
-expression: "SELECT warehouse_id, product_id, quantity, last_updated\n    FROM inventory\n    WHERE warehouse_id = 1 AND product_id = 500;"
+expression: |-
+  SELECT warehouse_id, product_id, quantity, last_updated
+      FROM inventory
+      WHERE warehouse_id = 1 AND product_id = 500;
 info:
   statement_type: SELECT
   tables:
-    - inventory
+  - inventory
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH inventory USING INDEX idx_inventory_covering

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__or-different-columns.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__or-different-columns.snap
@@ -17,31 +17,29 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode        p1  p2  p3  p4                p5  comment
-   0  Init           0  26   0                     0  Start at 26
+   0  Init           0  24   0                     0  Start at 24
    1  OpenRead       0  11   0  k(6,B,B,B,B,B,B)   0  table=events, root=11, iDb=0
    2  OpenRead       1  14   0  k(2,B)             0  index=idx_events_type, root=14, iDb=0
    3  OpenRead       2  12   0  k(2,B)             0  index=idx_events_severity, root=12, iDb=0
    4  Null           0   5   0                     0  r[5]=NULL
    5  String8        0   6   0  ERROR              0  r[6]='ERROR'
-   6  Affinity       6   1   0                     0  r[6..7] = B
-   7  SeekGE         1  12   6                     0  key=[6..6]
-   8    IdxGT        1  12   6                     0  key=[6..6]
-   9    IdxRowId     1   4   0                     0  r[4]=cursor 1 for index idx_events_type.rowid
-  10    RowSetAdd    5   4   0                     0
-  11  Next           1   8   0                     0
-  12  Integer        8   7   0                     0  r[7]=8
-  13  Affinity       7   1   0                     0  r[7..8] = D
-  14  SeekGT         2  18   7                     0  key=[7..7]
-  15    IdxRowId     2   4   0                     0  r[4]=cursor 2 for index idx_events_severity.rowid
-  16    RowSetAdd    5   4   0                     0
-  17  Next           2  15   0                     0
-  18    RowSetRead   5  25   4                     0
-  19    SeekRowid    0   4  20                     0  if (r[4]!=cursor 0 for table events.rowid) goto 20
-  20    RowId        0   1   0                     0  r[1]=events.rowid
-  21    Column       0   1   2                     0  r[2]=events.event_type
-  22    Column       0   2   3                     0  r[3]=events.severity
-  23    ResultRow    1   3   0                     0  output=r[1..3]
-  24  Goto           0  18   0                     0
-  25  Halt           0   0   0                     0
-  26  Transaction    0   1  14                     0  iDb=0 tx_mode=Read
-  27  Goto           0   1   0                     0
+   6  SeekGE         1  11   6                     0  key=[6..6]
+   7    IdxGT        1  11   6                     0  key=[6..6]
+   8    IdxRowId     1   4   0                     0  r[4]=cursor 1 for index idx_events_type.rowid
+   9    RowSetAdd    5   4   0                     0
+  10  Next           1   7   0                     0
+  11  Integer        8   7   0                     0  r[7]=8
+  12  SeekGT         2  16   7                     0  key=[7..7]
+  13    IdxRowId     2   4   0                     0  r[4]=cursor 2 for index idx_events_severity.rowid
+  14    RowSetAdd    5   4   0                     0
+  15  Next           2  13   0                     0
+  16    RowSetRead   5  23   4                     0
+  17    SeekRowid    0   4  18                     0  if (r[4]!=cursor 0 for table events.rowid) goto 18
+  18    RowId        0   1   0                     0  r[1]=events.rowid
+  19    Column       0   1   2                     0  r[2]=events.event_type
+  20    Column       0   2   3                     0  r[3]=events.severity
+  21    ResultRow    1   3   0                     0  output=r[1..3]
+  22  Goto           0  16   0                     0
+  23  Halt           0   0   0                     0
+  24  Transaction    0   1  14                     0  iDb=0 tx_mode=Read
+  25  Goto           0   1   0                     0

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__or-same-column.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__or-same-column.snap
@@ -17,32 +17,30 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode        p1  p2  p3  p4                p5  comment
-   0  Init           0  27   0                     0  Start at 27
+   0  Init           0  25   0                     0  Start at 25
    1  OpenRead       0  11   0  k(6,B,B,B,B,B,B)   0  table=events, root=11, iDb=0
    2  OpenRead       1  14   0  k(2,B)             0  index=idx_events_type, root=14, iDb=0
    3  OpenRead       2  14   0  k(2,B)             0  index=idx_events_type, root=14, iDb=0
    4  Null           0   5   0                     0  r[5]=NULL
    5  String8        0   6   0  ERROR              0  r[6]='ERROR'
-   6  Affinity       6   1   0                     0  r[6..7] = B
-   7  SeekGE         1  12   6                     0  key=[6..6]
-   8    IdxGT        1  12   6                     0  key=[6..6]
-   9    IdxRowId     1   4   0                     0  r[4]=cursor 1 for index idx_events_type.rowid
-  10    RowSetAdd    5   4   0                     0
-  11  Next           1   8   0                     0
-  12  String8        0   7   0  CRITICAL           0  r[7]='CRITICAL'
-  13  Affinity       7   1   0                     0  r[7..8] = B
-  14  SeekGE         1  19   7                     0  key=[7..7]
-  15    IdxGT        1  19   7                     0  key=[7..7]
-  16    IdxRowId     1   4   0                     0  r[4]=cursor 1 for index idx_events_type.rowid
-  17    RowSetAdd    5   4   0                     0
-  18  Next           1  15   0                     0
-  19    RowSetRead   5  26   4                     0
-  20    SeekRowid    0   4  21                     0  if (r[4]!=cursor 0 for table events.rowid) goto 21
-  21    RowId        0   1   0                     0  r[1]=events.rowid
-  22    Column       0   1   2                     0  r[2]=events.event_type
-  23    Column       0   2   3                     0  r[3]=events.severity
-  24    ResultRow    1   3   0                     0  output=r[1..3]
-  25  Goto           0  19   0                     0
-  26  Halt           0   0   0                     0
-  27  Transaction    0   1  14                     0  iDb=0 tx_mode=Read
-  28  Goto           0   1   0                     0
+   6  SeekGE         1  11   6                     0  key=[6..6]
+   7    IdxGT        1  11   6                     0  key=[6..6]
+   8    IdxRowId     1   4   0                     0  r[4]=cursor 1 for index idx_events_type.rowid
+   9    RowSetAdd    5   4   0                     0
+  10  Next           1   7   0                     0
+  11  String8        0   7   0  CRITICAL           0  r[7]='CRITICAL'
+  12  SeekGE         1  17   7                     0  key=[7..7]
+  13    IdxGT        1  17   7                     0  key=[7..7]
+  14    IdxRowId     1   4   0                     0  r[4]=cursor 1 for index idx_events_type.rowid
+  15    RowSetAdd    5   4   0                     0
+  16  Next           1  13   0                     0
+  17    RowSetRead   5  24   4                     0
+  18    SeekRowid    0   4  19                     0  if (r[4]!=cursor 0 for table events.rowid) goto 19
+  19    RowId        0   1   0                     0  r[1]=events.rowid
+  20    Column       0   1   2                     0  r[2]=events.event_type
+  21    Column       0   2   3                     0  r[3]=events.severity
+  22    ResultRow    1   3   0                     0  output=r[1..3]
+  23  Goto           0  17   0                     0
+  24  Halt           0   0   0                     0
+  25  Transaction    0   1  14                     0  iDb=0 tx_mode=Read
+  26  Goto           0   1   0                     0

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-between.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-between.snap
@@ -1,13 +1,13 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, event_type, severity FROM events WHERE severity BETWEEN 3 AND 7;"
+expression: SELECT id, event_type, severity FROM events WHERE severity BETWEEN 3 AND 7;
 info:
   statement_type: SELECT
   tables:
-    - events
+  - events
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH events USING INDEX idx_events_severity

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-greater-equal.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-greater-equal.snap
@@ -1,13 +1,13 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, event_type, severity FROM events WHERE severity >= 5;"
+expression: SELECT id, event_type, severity FROM events WHERE severity >= 5;
 info:
   statement_type: SELECT
   tables:
-    - events
+  - events
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH events USING INDEX idx_events_severity

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-greater-than.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-greater-than.snap
@@ -1,13 +1,13 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, event_type, severity FROM events WHERE severity > 5;"
+expression: SELECT id, event_type, severity FROM events WHERE severity > 5;
 info:
   statement_type: SELECT
   tables:
-    - events
+  - events
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH events USING INDEX idx_events_severity

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-less-equal.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-less-equal.snap
@@ -1,13 +1,13 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, event_type, severity FROM events WHERE severity <= 3;"
+expression: SELECT id, event_type, severity FROM events WHERE severity <= 3;
 info:
   statement_type: SELECT
   tables:
-    - events
+  - events
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH events USING INDEX idx_events_severity

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-less-than.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-less-than.snap
@@ -1,13 +1,13 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, event_type, severity FROM events WHERE severity < 3;"
+expression: SELECT id, event_type, severity FROM events WHERE severity < 3;
 info:
   statement_type: SELECT
   tables:
-    - events
+  - events
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH events USING INDEX idx_events_severity

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-timestamp.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-timestamp.snap
@@ -1,13 +1,16 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, event_type, timestamp\n    FROM events\n    WHERE timestamp >= '2024-01-01' AND timestamp < '2024-02-01';"
+expression: |-
+  SELECT id, event_type, timestamp
+      FROM events
+      WHERE timestamp >= '2024-01-01' AND timestamp < '2024-02-01';
 info:
   statement_type: SELECT
   tables:
-    - events
+  - events
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH events USING INDEX idx_events_timestamp

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-with-equality.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__range-scan-with-equality.snap
@@ -1,13 +1,16 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, name, price\n    FROM products\n    WHERE category = 'Electronics' AND price BETWEEN 100 AND 500;"
+expression: |-
+  SELECT id, name, price
+      FROM products
+      WHERE category = 'Electronics' AND price BETWEEN 100 AND 500;
 info:
   statement_type: SELECT
   tables:
-    - products
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH products USING INDEX idx_products_category

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__simple-index-equality-lookup.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__simple-index-equality-lookup.snap
@@ -1,13 +1,13 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, name, price FROM products WHERE sku = 'ABC123';"
+expression: SELECT id, name, price FROM products WHERE sku = 'ABC123';
 info:
   statement_type: SELECT
   tables:
-    - products
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH products USING INDEX idx_products_sku

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__simple-index-with-filter.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__simple-index-with-filter.snap
@@ -1,13 +1,13 @@
 ---
 source: indexes.sqltest
-expression: "SELECT id, name, price FROM products WHERE sku = 'ABC123' AND stock_qty > 0;"
+expression: SELECT id, name, price FROM products WHERE sku = 'ABC123' AND stock_qty > 0;
 info:
   statement_type: SELECT
   tables:
-    - products
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH products USING INDEX idx_products_sku

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__four-table-join-with-aggregation.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__four-table-join-with-aggregation.snap
@@ -1,19 +1,35 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        c.name AS customer_name,\n        c.city,\n        COUNT(DISTINCT o.order_id) AS order_count,\n        SUM(oi.quantity * oi.unit_price) AS total_spent\n    FROM\n        customers c\n    INNER JOIN orders o ON c.customer_id = o.customer_id\n    INNER JOIN order_items oi ON o.order_id = oi.order_id\n    INNER JOIN products p ON oi.product_id = p.product_id\n    WHERE\n        p.category = 'Electronics'\n    GROUP BY\n        c.customer_id, c.name, c.city\n    ORDER BY\n        total_spent DESC;"
+expression: |-
+  SELECT
+          c.name AS customer_name,
+          c.city,
+          COUNT(DISTINCT o.order_id) AS order_count,
+          SUM(oi.quantity * oi.unit_price) AS total_spent
+      FROM
+          customers c
+      INNER JOIN orders o ON c.customer_id = o.customer_id
+      INNER JOIN order_items oi ON o.order_id = oi.order_id
+      INNER JOIN products p ON oi.product_id = p.product_id
+      WHERE
+          p.category = 'Electronics'
+      GROUP BY
+          c.customer_id, c.name, c.city
+      ORDER BY
+          total_spent DESC;
 info:
   statement_type: SELECT
   tables:
-    - c.customer_id
-    - customers
-    - o.order_id
-    - oi.product_id
-    - order_items
-    - orders
-    - products
+  - c.customer_id
+  - customers
+  - o.order_id
+  - oi.product_id
+  - order_items
+  - orders
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__index-assisted-join-order-items.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__index-assisted-join-order-items.snap
@@ -1,17 +1,29 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        o.order_id,\n        o.order_date,\n        oi.item_id,\n        oi.quantity,\n        p.name AS product_name\n    FROM\n        orders o\n    INNER JOIN order_items oi ON o.order_id = oi.order_id\n    INNER JOIN products p ON oi.product_id = p.product_id\n    WHERE\n        o.order_id = 100;"
+expression: |-
+  SELECT
+          o.order_id,
+          o.order_date,
+          oi.item_id,
+          oi.quantity,
+          p.name AS product_name
+      FROM
+          orders o
+      INNER JOIN order_items oi ON o.order_id = oi.order_id
+      INNER JOIN products p ON oi.product_id = p.product_id
+      WHERE
+          o.order_id = 100;
 info:
   statement_type: SELECT
   tables:
-    - o.order_id
-    - oi.product_id
-    - order_items
-    - orders
-    - products
+  - o.order_id
+  - oi.product_id
+  - order_items
+  - orders
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SEARCH o USING INTEGER PRIMARY KEY (rowid=?)

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__index-assisted-join-product-lookup.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__index-assisted-join-product-lookup.snap
@@ -1,19 +1,32 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        p.name AS product_name,\n        p.category,\n        oi.quantity,\n        o.order_date,\n        c.name AS customer_name\n    FROM\n        products p\n    INNER JOIN order_items oi ON p.product_id = oi.product_id\n    INNER JOIN orders o ON oi.order_id = o.order_id\n    INNER JOIN customers c ON o.customer_id = c.customer_id\n    WHERE\n        p.product_id = 500;"
+expression: |-
+  SELECT
+          p.name AS product_name,
+          p.category,
+          oi.quantity,
+          o.order_date,
+          c.name AS customer_name
+      FROM
+          products p
+      INNER JOIN order_items oi ON p.product_id = oi.product_id
+      INNER JOIN orders o ON oi.order_id = o.order_id
+      INNER JOIN customers c ON o.customer_id = c.customer_id
+      WHERE
+          p.product_id = 500;
 info:
   statement_type: SELECT
   tables:
-    - customers
-    - o.customer_id
-    - oi.order_id
-    - order_items
-    - orders
-    - p.product_id
-    - products
+  - customers
+  - o.customer_id
+  - oi.order_id
+  - order_items
+  - orders
+  - p.product_id
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SEARCH p USING INTEGER PRIMARY KEY (rowid=?)

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__index-assisted-join-single-customer.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__index-assisted-join-single-customer.snap
@@ -1,15 +1,25 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        c.name,\n        o.order_id,\n        o.order_date,\n        o.total_amount\n    FROM\n        customers c\n    INNER JOIN orders o ON c.customer_id = o.customer_id\n    WHERE\n        c.customer_id = 42;"
+expression: |-
+  SELECT
+          c.name,
+          o.order_id,
+          o.order_date,
+          o.total_amount
+      FROM
+          customers c
+      INNER JOIN orders o ON c.customer_id = o.customer_id
+      WHERE
+          c.customer_id = 42;
 info:
   statement_type: SELECT
   tables:
-    - c.customer_id
-    - customers
-    - orders
+  - c.customer_id
+  - customers
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__join-with-exists.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__join-with-exists.snap
@@ -1,14 +1,27 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        c.customer_id,\n        c.name,\n        c.city\n    FROM\n        customers c\n    WHERE\n        EXISTS (\n            SELECT 1\n            FROM orders o\n            WHERE o.customer_id = c.customer_id\n            AND o.total_amount > 1000\n        );"
+expression: |-
+  SELECT
+          c.customer_id,
+          c.name,
+          c.city
+      FROM
+          customers c
+      WHERE
+          EXISTS (
+              SELECT 1
+              FROM orders o
+              WHERE o.customer_id = c.customer_id
+              AND o.total_amount > 1000
+          );
 info:
   statement_type: SELECT
   tables:
-    - customers
-    - orders
+  - customers
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN customers AS c

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-basic.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-basic.snap
@@ -1,15 +1,23 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        c.customer_id,\n        c.name,\n        o.order_id,\n        o.order_date\n    FROM\n        customers c\n    LEFT OUTER JOIN orders o ON c.customer_id = o.customer_id;"
+expression: |-
+  SELECT
+          c.customer_id,
+          c.name,
+          o.order_id,
+          o.order_date
+      FROM
+          customers c
+      LEFT OUTER JOIN orders o ON c.customer_id = o.customer_id;
 info:
   statement_type: SELECT
   tables:
-    - c.customer_id
-    - customers
-    - orders
+  - c.customer_id
+  - customers
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN customers AS c

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-chained.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-chained.snap
@@ -1,19 +1,29 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        c.name AS customer_name,\n        o.order_id,\n        oi.item_id,\n        p.name AS product_name\n    FROM\n        customers c\n    LEFT OUTER JOIN orders o ON c.customer_id = o.customer_id\n    LEFT OUTER JOIN order_items oi ON o.order_id = oi.order_id\n    LEFT OUTER JOIN products p ON oi.product_id = p.product_id;"
+expression: |-
+  SELECT
+          c.name AS customer_name,
+          o.order_id,
+          oi.item_id,
+          p.name AS product_name
+      FROM
+          customers c
+      LEFT OUTER JOIN orders o ON c.customer_id = o.customer_id
+      LEFT OUTER JOIN order_items oi ON o.order_id = oi.order_id
+      LEFT OUTER JOIN products p ON oi.product_id = p.product_id;
 info:
   statement_type: SELECT
   tables:
-    - c.customer_id
-    - customers
-    - o.order_id
-    - oi.product_id
-    - order_items
-    - orders
-    - products
+  - c.customer_id
+  - customers
+  - o.order_id
+  - oi.product_id
+  - order_items
+  - orders
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN customers AS c

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-find-nulls.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-find-nulls.snap
@@ -1,15 +1,24 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        c.customer_id,\n        c.name,\n        c.email\n    FROM\n        customers c\n    LEFT OUTER JOIN orders o ON c.customer_id = o.customer_id\n    WHERE\n        o.order_id IS NULL;"
+expression: |-
+  SELECT
+          c.customer_id,
+          c.name,
+          c.email
+      FROM
+          customers c
+      LEFT OUTER JOIN orders o ON c.customer_id = o.customer_id
+      WHERE
+          o.order_id IS NULL;
 info:
   statement_type: SELECT
   tables:
-    - c.customer_id
-    - customers
-    - orders
+  - c.customer_id
+  - customers
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN customers AS c

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
@@ -1,15 +1,27 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        c.customer_id,\n        c.name,\n        COUNT(o.order_id) AS order_count,\n        COALESCE(SUM(o.total_amount), 0) AS total_spent\n    FROM\n        customers c\n    LEFT OUTER JOIN orders o ON c.customer_id = o.customer_id\n    GROUP BY\n        c.customer_id, c.name\n    ORDER BY\n        total_spent DESC;"
+expression: |-
+  SELECT
+          c.customer_id,
+          c.name,
+          COUNT(o.order_id) AS order_count,
+          COALESCE(SUM(o.total_amount), 0) AS total_spent
+      FROM
+          customers c
+      LEFT OUTER JOIN orders o ON c.customer_id = o.customer_id
+      GROUP BY
+          c.customer_id, c.name
+      ORDER BY
+          total_spent DESC;
 info:
   statement_type: SELECT
   tables:
-    - c.customer_id
-    - customers
-    - orders
+  - c.customer_id
+  - customers
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN customers AS c

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__multi-table-join-complex-filter.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__multi-table-join-complex-filter.snap
@@ -1,13 +1,34 @@
 ---
 source: joins.sqltest
-expression: "SELECT\n        c.name,\n        o.order_id,\n        o.order_date,\n        p.name AS product_name,\n        p.category\n    FROM\n        customers c,\n        orders o,\n        order_items oi,\n        products p\n    WHERE\n        c.customer_id = o.customer_id\n        AND o.order_id = oi.order_id\n        AND oi.product_id = p.product_id\n        AND c.city = 'New York'\n        AND o.order_date >= '2024-01-01'\n        AND p.price > 50\n    ORDER BY\n        o.order_date DESC,\n        p.name;"
+expression: |-
+  SELECT
+          c.name,
+          o.order_id,
+          o.order_date,
+          p.name AS product_name,
+          p.category
+      FROM
+          customers c,
+          orders o,
+          order_items oi,
+          products p
+      WHERE
+          c.customer_id = o.customer_id
+          AND o.order_id = oi.order_id
+          AND oi.product_id = p.product_id
+          AND c.city = 'New York'
+          AND o.order_date >= '2024-01-01'
+          AND p.price > 50
+      ORDER BY
+          o.order_date DESC,
+          p.name;
 info:
   statement_type: SELECT
   tables:
-    - customers
+  - customers
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN customers AS c

--- a/testing/runner/tests/snapshot_tests/setops/snapshots/setops__union-all-filtered.snap
+++ b/testing/runner/tests/snapshot_tests/setops/snapshots/setops__union-all-filtered.snap
@@ -1,14 +1,17 @@
 ---
 source: setops.sqltest
-expression: "SELECT name, department FROM current_employees WHERE department = 'Engineering'\n    UNION ALL\n    SELECT name, department FROM former_employees WHERE department = 'Engineering';"
+expression: |-
+  SELECT name, department FROM current_employees WHERE department = 'Engineering'
+      UNION ALL
+      SELECT name, department FROM former_employees WHERE department = 'Engineering';
 info:
   statement_type: SELECT
   tables:
-    - current_employees
-    - former_employees
+  - current_employees
+  - former_employees
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--COMPOUND QUERY

--- a/testing/runner/tests/snapshot_tests/sorting/snapshots/sorting__order-by-index-with-range.snap
+++ b/testing/runner/tests/snapshot_tests/sorting/snapshots/sorting__order-by-index-with-range.snap
@@ -1,13 +1,17 @@
 ---
 source: sorting.sqltest
-expression: "SELECT id, name, price\n    FROM products\n    WHERE price BETWEEN 10 AND 100\n    ORDER BY price;"
+expression: |-
+  SELECT id, name, price
+      FROM products
+      WHERE price BETWEEN 10 AND 100
+      ORDER BY price;
 info:
   statement_type: SELECT
   tables:
-    - products
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 `--SEARCH products USING INDEX idx_products_price

--- a/testing/runner/tests/snapshot_tests/sorting/snapshots/sorting__order-by-with-where.snap
+++ b/testing/runner/tests/snapshot_tests/sorting/snapshots/sorting__order-by-with-where.snap
@@ -1,13 +1,17 @@
 ---
 source: sorting.sqltest
-expression: "SELECT id, name, price\n    FROM products\n    WHERE category = 'Electronics'\n    ORDER BY price;"
+expression: |-
+  SELECT id, name, price
+      FROM products
+      WHERE category = 'Electronics'
+      ORDER BY price;
 info:
   statement_type: SELECT
   tables:
-    - products
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SEARCH products USING INDEX idx_products_category_price

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
@@ -1,14 +1,21 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT o.id, o.order_date, o.total_amount\n    FROM orders o\n    WHERE (\n        SELECT count(*)\n        FROM order_items oi\n        WHERE oi.order_id = o.id\n    ) >= 3;"
+expression: |-
+  SELECT o.id, o.order_date, o.total_amount
+      FROM orders o
+      WHERE (
+          SELECT count(*)
+          FROM order_items oi
+          WHERE oi.order_id = o.id
+      ) >= 3;
 info:
   statement_type: SELECT
   tables:
-    - order_items
-    - orders
+  - order_items
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN orders AS o

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
@@ -1,13 +1,20 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT p.id, p.name, p.price\n    FROM products p\n    WHERE p.price > (\n        SELECT avg(p2.price)\n        FROM products p2\n        WHERE p2.category_id = p.category_id\n    );"
+expression: |-
+  SELECT p.id, p.name, p.price
+      FROM products p
+      WHERE p.price > (
+          SELECT avg(p2.price)
+          FROM products p2
+          WHERE p2.category_id = p.category_id
+      );
 info:
   statement_type: SELECT
   tables:
-    - products
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN products AS p
@@ -27,7 +34,7 @@ addr  opcode              p1  p2  p3  p4              p5  comment
    9      OpenRead         2   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
   10      Column           0   2   9                   0  r[9]=products.category_id
   11      IsNull           9  20   0                   0  if (r[9]==NULL) goto 20
-  12      Affinity         9   1   0                   0  r[9..10] = C
+  12      Affinity         9   1   0                   0  r[9..10] = D
   13      SeekGE           2  20   9                   0  key=[9..9]
   14        IdxGT          2  20   9                   0  key=[9..9]
   15        DeferredSeek   2   1   0                   0

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -107,7 +107,7 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   74    Le                      37  38  88  Binary           0  if r[37]<=r[38] goto 88
   75    Column                   6   2  41                   0  r[41]=products.category_id
   76    IsNull                  41  88   0                   0  if (r[41]==NULL) goto 88
-  77    Affinity                41   1   0                   0  r[41..42] = C
+  77    Affinity                41   1   0                   0  r[41..42] = D
   78    SeekGE                   5  88  41                   0  key=[41..41]
   79      IdxGT                  5  88  41                   0  key=[41..41]
   80      Column                 5   0  31                   0  r[31]=ephemeral_subquery_t5.category_id

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-chained.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-chained.snap
@@ -96,7 +96,7 @@ addr  opcode                  p1  p2  p3  p4            p5  comment
   57    Le                    32  33  70  Binary         0  if r[32]<=r[33] goto 70
   58    Copy                  13  34   0                 0  r[34]=r[13]
   59    IsNull                34  70   0                 0  if (r[34]==NULL) goto 70
-  60    Affinity              34   1   0                 0  r[34..35] = C
+  60    Affinity              34   1   0                 0  r[34..35] = D
   61    SeekGE                 0  70  34                 0  key=[34..34]
   62      IdxGT                0  70  34                 0  key=[34..34]
   63      Column               0   0   1                 0  r[1]=ephemeral_subquery_t2.id

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -110,7 +110,7 @@ addr  opcode            p1  p2  p3  p4            p5  comment
   65    Yield           12  79   0                 0
   66    Copy            18  36   0                 0  r[36]=r[18]
   67    IsNull          36  78   0                 0  if (r[36]==NULL) goto 78
-  68    Affinity        36   1   0                 0  r[36..37] = C
+  68    Affinity        36   1   0                 0  r[36..37] = D
   69    SeekGE           6  78  36                 0  key=[36..36]
   70      IdxGT          6  78  36                 0  key=[36..36]
   71      Column         6   0  31                 0  r[31]=ephemeral_subquery_t8.customer_id

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-self-join.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-self-join.snap
@@ -32,7 +32,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4              p5  comment
-   0  Init             0  60   0                   0  Start at 60
+   0  Init             0  61   0                   0  Start at 61
    1  OpenEphemeral    0   1   0                   0  cursor=0 is_table=true
    2  OpenRead         1   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
    3  Rewind           1  16   0                   0  Rewind table employees
@@ -64,34 +64,35 @@ addr  opcode          p1  p2  p3  p4              p5  comment
   29    MakeRecord    21   5  16                   0  r[16]=mkrec(r[21..25]); for ephemeral_subquery_t4
   30    IdxInsert      4  16  21                   0  key=r[16]
   31  Next             3  20   0                   0
-  32  Rewind           2  59   0                   0  Rewind
+  32  Rewind           2  60   0                   0  Rewind
   33    Column         2   0  12                   0  r[12]=.column 0
   34    Column         2   1  13                   0  r[13]=.column 1
   35    Column         2   2  14                   0  r[14]=.column 2
   36    Column         2   3  15                   0  r[15]=.column 3
   37    Copy          14  34   0                   0  r[34]=r[14]
-  38    IsNull        34  58   0                   0  if (r[34]==NULL) goto 58
-  39    SeekGE         4  58  34                   0  key=[34..34]
-  40      IdxGT        4  58  34                   0  key=[34..34]
-  41      Column       4   0  26                   0  r[26]=ephemeral_subquery_t4.department
-  42      Column       4   1  27                   0  r[27]=ephemeral_subquery_t4.id
-  43      Column       4   2  28                   0  r[28]=ephemeral_subquery_t4.name
-  44      Column       4   3  29                   0  r[29]=ephemeral_subquery_t4.salary
-  45      Copy        12  36   0                   0  r[36]=r[12]
-  46      Column       4   1  37                   0  r[37]=ephemeral_subquery_t4.id
-  47      Ge          36  37  57  Binary           0  if r[36]>=r[37] goto 57
-  48      Copy        15  39   0                   0  r[39]=r[15]
-  49      Column       4   3  41                   0  r[41]=ephemeral_subquery_t4.salary
-  50      Multiply    41  42  40                   0  r[40]=r[41]*r[42]
-  51      Le          39  40  57  Binary           0  if r[39]<=r[40] goto 57
-  52      Copy        13  30   0                   0  r[30]=r[13]
-  53      Copy        15  31   0                   0  r[31]=r[15]
-  54      Column       4   2  32                   0  r[32]=ephemeral_subquery_t4.name
-  55      Column       4   3  33                   0  r[33]=ephemeral_subquery_t4.salary
-  56      ResultRow   30   4   0                   0  output=r[30..33]
-  57    Next           4  40   0                   0
-  58  Next             2  33   0                   0
-  59  Halt             0   0   0                   0
-  60  Transaction      0   1  11                   0  iDb=0 tx_mode=Read
-  61  Real             0  42   0  1.5              0  r[42]=1.5
-  62  Goto             0   1   0                   0
+  38    IsNull        34  59   0                   0  if (r[34]==NULL) goto 59
+  39    Affinity      34   1   0                   0  r[34..35] = B
+  40    SeekGE         4  59  34                   0  key=[34..34]
+  41      IdxGT        4  59  34                   0  key=[34..34]
+  42      Column       4   0  26                   0  r[26]=ephemeral_subquery_t4.department
+  43      Column       4   1  27                   0  r[27]=ephemeral_subquery_t4.id
+  44      Column       4   2  28                   0  r[28]=ephemeral_subquery_t4.name
+  45      Column       4   3  29                   0  r[29]=ephemeral_subquery_t4.salary
+  46      Copy        12  36   0                   0  r[36]=r[12]
+  47      Column       4   1  37                   0  r[37]=ephemeral_subquery_t4.id
+  48      Ge          36  37  58  Binary           0  if r[36]>=r[37] goto 58
+  49      Copy        15  39   0                   0  r[39]=r[15]
+  50      Column       4   3  41                   0  r[41]=ephemeral_subquery_t4.salary
+  51      Multiply    41  42  40                   0  r[40]=r[41]*r[42]
+  52      Le          39  40  58  Binary           0  if r[39]<=r[40] goto 58
+  53      Copy        13  30   0                   0  r[30]=r[13]
+  54      Copy        15  31   0                   0  r[31]=r[15]
+  55      Column       4   2  32                   0  r[32]=ephemeral_subquery_t4.name
+  56      Column       4   3  33                   0  r[33]=ephemeral_subquery_t4.salary
+  57      ResultRow   30   4   0                   0  output=r[30..33]
+  58    Next           4  41   0                   0
+  59  Next             2  33   0                   0
+  60  Halt             0   0   0                   0
+  61  Transaction      0   1  11                   0  iDb=0 tx_mode=Read
+  62  Real             0  42   0  1.5              0  r[42]=1.5
+  63  Goto             0   1   0                   0

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__exists-correlated.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__exists-correlated.snap
@@ -1,14 +1,22 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT c.id, c.name\n    FROM customers c\n    WHERE EXISTS (\n        SELECT 1\n        FROM orders o\n        WHERE o.customer_id = c.id\n            AND o.total_amount > 500\n    );"
+expression: |-
+  SELECT c.id, c.name
+      FROM customers c
+      WHERE EXISTS (
+          SELECT 1
+          FROM orders o
+          WHERE o.customer_id = c.id
+              AND o.total_amount > 500
+      );
 info:
   statement_type: SELECT
   tables:
-    - customers
-    - orders
+  - customers
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN customers AS c

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__exists-multiple-conditions.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__exists-multiple-conditions.snap
@@ -1,16 +1,25 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT p.id, p.name, p.price\n    FROM products p\n    WHERE EXISTS (\n        SELECT 1\n        FROM order_items oi\n        JOIN orders o ON o.id = oi.order_id\n        WHERE oi.product_id = p.id\n            AND o.order_date >= '2024-01-01'\n    );"
+expression: |-
+  SELECT p.id, p.name, p.price
+      FROM products p
+      WHERE EXISTS (
+          SELECT 1
+          FROM order_items oi
+          JOIN orders o ON o.id = oi.order_id
+          WHERE oi.product_id = p.id
+              AND o.order_date >= '2024-01-01'
+      );
 info:
   statement_type: SELECT
   tables:
-    - o.id
-    - order_items
-    - orders
-    - products
+  - o.id
+  - order_items
+  - orders
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN products AS p

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__not-exists-never-ordered.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__not-exists-never-ordered.snap
@@ -1,14 +1,21 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT p.id, p.name, p.stock\n    FROM products p\n    WHERE NOT EXISTS (\n        SELECT 1\n        FROM order_items oi\n        WHERE oi.product_id = p.id\n    );"
+expression: |-
+  SELECT p.id, p.name, p.stock
+      FROM products p
+      WHERE NOT EXISTS (
+          SELECT 1
+          FROM order_items oi
+          WHERE oi.product_id = p.id
+      );
 info:
   statement_type: SELECT
   tables:
-    - order_items
-    - products
+  - order_items
+  - products
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN products AS p

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__not-exists-no-orders.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__not-exists-no-orders.snap
@@ -1,14 +1,21 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT c.id, c.name, c.email\n    FROM customers c\n    WHERE NOT EXISTS (\n        SELECT 1\n        FROM orders o\n        WHERE o.customer_id = c.id\n    );"
+expression: |-
+  SELECT c.id, c.name, c.email
+      FROM customers c
+      WHERE NOT EXISTS (
+          SELECT 1
+          FROM orders o
+          WHERE o.customer_id = c.id
+      );
 info:
   statement_type: SELECT
   tables:
-    - customers
-    - orders
+  - customers
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN customers AS c

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
@@ -1,14 +1,18 @@
 ---
 source: subqueries.sqltest
-expression: "SELECT\n        c.name,\n        (SELECT count(*) FROM orders WHERE customer_id = c.id) AS order_count\n    FROM customers c;"
+expression: |-
+  SELECT
+          c.name,
+          (SELECT count(*) FROM orders WHERE customer_id = c.id) AS order_count
+      FROM customers c;
 info:
   statement_type: SELECT
   tables:
-    - customers
-    - orders
+  - customers
+  - orders
   setup_blocks:
-    - schema
-  database: ":memory:"
+  - schema
+  database: ':memory:'
 ---
 QUERY PLAN
 |--SCAN customers AS c

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q21-suppliers-kept-waiting.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q21-suppliers-kept-waiting.snap
@@ -92,7 +92,7 @@ addr  opcode                           p1   p2  p3  p4                          
   28                  OpenRead          8   10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
   29                  OpenRead          9   11   0  k(3,B,B)                                0  index=sqlite_autoindex_lineitem_1, root=11, iDb=0
   30                  Column            4    0  41                                          0  r[41]=lineitem.l_orderkey
-  31                  Affinity         41    1   0                                          0  r[41..42] = C
+  31                  Affinity         41    1   0                                          0  r[41..42] = D
   32                  SeekGE            9   41  41                                          0  key=[41..41]
   33                    IdxGT           9   41  41                                          0  key=[41..41]
   34                    DeferredSeek    9    8   0                                          0
@@ -110,7 +110,7 @@ addr  opcode                           p1   p2  p3  p4                          
   46                OpenRead           10   10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
   47                OpenRead           11   11   0  k(3,B,B)                                0  index=sqlite_autoindex_lineitem_1, root=11, iDb=0
   48                Column              4    0  63                                          0  r[63]=lineitem.l_orderkey
-  49                Affinity           63    1   0                                          0  r[63..64] = C
+  49                Affinity           63    1   0                                          0  r[63..64] = D
   50                SeekGE             11   62  63                                          0  key=[63..63]
   51                  IdxGT            11   62  63                                          0  key=[63..63]
   52                  DeferredSeek     11   10   0                                          0

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q9-product-type-profit.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q9-product-type-profit.snap
@@ -75,7 +75,7 @@ addr  opcode                    p1  p2  p3  p4                                  
   20            SeekRowid        5  11  43                                          0  if (r[11]!=cursor 5 for table orders.rowid) goto 43
   21            Column           2   1  12                                          0  r[12]=lineitem.l_partkey
   22            Column           2   2  13                                          0  r[13]=lineitem.l_suppkey
-  23            Affinity        12   2   0                                          0  r[12..14] = C, C
+  23            Affinity        12   2   0                                          0  r[12..14] = D, D
   24            SeekGE           4  43  12                                          0  key=[12..13]
   25              IdxGT          4  43  12                                          0  key=[12..13]
   26              DeferredSeek   4   3   0                                          0


### PR DESCRIPTION
The OP_Affinity instruction before index seeks was using comparison affinities from the seek definition, but it should use the index column's declared affinity (matching SQLite's sqlite3IndexAffinityStr). This caused integer probe values to not be coerced to text when seeking a TEXT index, resulting in zero rows.

Additionally, materialized subquery/CTE ephemeral indexes were not applying any affinity when inserting values, causing cross-type seeks to fail (e.g. integer probe against text CTE values). Now the comparison affinity is passed through to MakeRecord's affinity_str.

The Affinity instruction is also now skipped when the probe expression's type already matches the index column (e.g. string literal on TEXT index, integer literal on INTEGER index).

Closes #5282

## Note

Autofixer made a too narrow fix, so refined it locally.

## Note on snapshot changes

- Many snapshots changed simply because the snapshot formatter has changed in between those snapshots being put into place
- The `C -> D` affinity changes (Numeric -> Integer) fix the Affinity instruction in those cases to correctly use integer affinity.