### PR TITLE
fix: INSERT OR IGNORE + CHECK Failure Does Not Update sqlite_sequence

### DIFF
--- a/testing/runner/tests/insert_or_ignore_autoincrement.sqltest
+++ b/testing/runner/tests/insert_or_ignore_autoincrement.sqltest
@@ -1,0 +1,43 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT CHECK(id < 5), val TEXT);
+    INSERT INTO t(val) VALUES('row1');
+}
+
+@setup schema
+test insert-or-ignore-check-failure-updates-sequence {
+    INSERT OR IGNORE INTO t(id, val) VALUES(10, 'row10');
+    SELECT * FROM sqlite_sequence;
+}
+expect {
+    t|10
+}
+
+@setup schema
+test insert-or-ignore-check-failure-does-not-insert-row {
+    INSERT OR IGNORE INTO t(id, val) VALUES(10, 'row10');
+    SELECT * FROM t;
+}
+expect {
+    1|row1
+}
+
+@setup schema
+test insert-or-ignore-check-pass-updates-sequence {
+    INSERT OR IGNORE INTO t(id, val) VALUES(3, 'row3');
+    SELECT * FROM sqlite_sequence;
+}
+expect {
+    t|3
+}
+
+@setup schema
+test insert-or-ignore-check-pass-inserts-row {
+    INSERT OR IGNORE INTO t(id, val) VALUES(3, 'row3');
+    SELECT * FROM t;
+}
+expect {
+    1|row1
+    3|row3
+}


### PR DESCRIPTION
When INSERT OR IGNORE fails due to a CHECK constraint on an AUTOINCREMENT table with an explicit rowid, sqlite_sequence was not being updated. SQLite updates sqlite_sequence even when the row is not inserted due to CHECK failure with IGNORE conflict resolution.

The fix emits a sqlite_sequence update before CHECK constraint evaluation for AUTOINCREMENT tables with explicit rowid values, matching SQLite's behavior.

Closes #5173