### PR TITLE
fix: COLLATE Specification Lost in Concatenation with CHECK #5171

### DIFF
--- a/testing/runner/tests/collate.sqltest
+++ b/testing/runner/tests/collate.sqltest
@@ -641,3 +641,40 @@ expect {
     CHERRY
 }
 
+# =============================================================================
+# COLLATION PROPAGATION THROUGH CONCAT (||)
+# =============================================================================
+# These tests verify that COLLATE specifications propagate through
+# non-comparison operators like concatenation (||), so that the collation
+# is correctly applied to any parent comparison.
+
+test collate_concat_check_constraint_nocase {
+    CREATE TABLE t(name TEXT CHECK((name COLLATE NOCASE || '') <> 'admin'));
+    INSERT INTO t VALUES ('Admin');
+}
+expect error {
+}
+
+test collate_concat_check_constraint_allows_valid {
+    CREATE TABLE t(name TEXT CHECK((name COLLATE NOCASE || '') <> 'admin'));
+    INSERT INTO t VALUES ('bob');
+    SELECT name FROM t;
+}
+expect {
+    bob
+}
+
+test collate_concat_nocase_comparison {
+    SELECT (('Hello' COLLATE NOCASE || '') = 'hello');
+}
+expect {
+    1
+}
+
+test collate_concat_binary_comparison {
+    SELECT (('Hello' COLLATE BINARY || '') = 'hello');
+}
+expect {
+    0
+}
+


### PR DESCRIPTION
In emit_binary_expr_scalar, the collation context was unconditionally reset after emitting any binary operation. For non-comparison operators like Concat (||), this discarded the COLLATE specification before it could propagate to the parent comparison expression.

Now we only reset collation after comparison operators (which consume it), allowing non-comparison operators to propagate collation upward.

Closes #5171