### PR TITLE
Reject column-level multi-column FK refs in ALTER TABLE

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2240,6 +2240,13 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                             clause,
                             defer_clause,
                         } => {
+                            if clause.columns.len() > 1 {
+                                crate::bail_parse_error!(
+                                    "foreign key on {} should reference only one column of table {}",
+                                    name,
+                                    clause.tbl_name.as_str()
+                                );
+                            }
                             let fk = ForeignKey {
                                 parent_table: normalize_ident(clause.tbl_name.as_str()),
                                 parent_columns: clause

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -585,6 +585,12 @@ pub fn translate_alter_table(
                         clause,
                         defer_clause,
                     } => {
+                        if clause.columns.len() > 1 {
+                            return Err(LimboError::ParseError(format!(
+                                "foreign key on {new_column_name} should reference only one column of table {}",
+                                clause.tbl_name.as_str()
+                            )));
+                        }
                         let fk = ForeignKey {
                             parent_table: normalize_ident(clause.tbl_name.as_str()),
                             parent_columns: clause

--- a/testing/runner/tests/alter_table.sqltest
+++ b/testing/runner/tests/alter_table.sqltest
@@ -66,6 +66,14 @@ expect {
     1|0
 }
 
+test alter-table-add-column-invalid-multi-column-fk {
+    CREATE TABLE t(a, c);
+    CREATE TABLE s(a);
+    ALTER TABLE s ADD COLUMN b REFERENCES t(a, c);
+}
+expect error {
+}
+
 test alter-table-add-column-default {
     CREATE TABLE test (a);
     INSERT INTO test VALUES (1), (2), (3);
@@ -355,4 +363,3 @@ test alter-add-column-invalid-collation {
 expect error {
     no such collation sequence: compile_options
 }
-

--- a/testing/runner/tests/foreign_keys.sqltest
+++ b/testing/runner/tests/foreign_keys.sqltest
@@ -14,6 +14,14 @@ expect {
     11|
 }
 
+test fk-column-constraint-multi-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(a, c);
+    CREATE TABLE s(a REFERENCES t(a, c));
+}
+expect error {
+}
+
 test fk-insert-child-missing-parent {
     PRAGMA foreign_keys=ON;
     CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT);
@@ -2441,4 +2449,3 @@ test fk-drop-column-composite-fk-fails {
 }
 expect error {
 }
-

--- a/testing/runner/turso-tests/alter_column.sqltest
+++ b/testing/runner/turso-tests/alter_column.sqltest
@@ -386,16 +386,6 @@ expect {
     CREATE TABLE s (a, b, FOREIGN KEY (b) REFERENCES s(a))
 }
 
-test alter-table-add-column-with-composite-fk-updates-schema {
-    CREATE TABLE t(a, c);
-    CREATE TABLE s(a);
-    ALTER TABLE s ADD COLUMN b REFERENCES t(a, c);
-    SELECT sql FROM sqlite_schema WHERE name = 's';
-}
-expect {
-    CREATE TABLE s (a, b, FOREIGN KEY (b) REFERENCES t(a, c))
-}
-
 # NOT NULL column without default on EMPTY table should succeed (SQLite behavior)
 test alter-table-add-notnull-col-empty-table {
     CREATE TABLE t (a);
@@ -517,4 +507,3 @@ test alter-table-add-parens-default {
 expect {
     1|123|-456
 }
-


### PR DESCRIPTION
## Description

- Reject column-level foreign key references that list multiple parent columns in `ALTER TABLE ADD COLUMN` and `CREATE TABLE` column constraints.
  - Add regression coverage for both ALTER TABLE and CREATE TABLE cases.
  - Remove the invalid multi-column FK case from turso-specific alter_column sqltest 
    
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

- Aligns behavior with SQLite, which rejects column-level FKs that reference more than one parent column.
  - Prevents invalid schema definitions from being accepted during `ALTER TABLE ADD COLUMN`

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #4423
## Description of AI Usage

PR body

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
