### PR TITLE
don't validate partial indexes in integrity_check since our integrity_check sucks

### DIFF
--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -133,6 +133,7 @@ fn translate_integrity_check_impl(
                             column_positions,
                             default_values_start_reg,
                             index_info: Arc::new(IndexInfo::new_from_index(index)),
+                            partial: index.where_clause.is_some(),
                         });
                     }
                 }

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -59,6 +59,8 @@ pub struct IntegrityCheckIndex {
     pub default_values_start_reg: usize,
     /// Index info for cursor operations (sort order, collation, etc)
     pub index_info: std::sync::Arc<crate::types::IndexInfo>,
+    /// Whether this is a partial index (has a WHERE clause)
+    pub partial: bool,
 }
 
 /// Flags provided to comparison instructions (e.g. Eq, Ne) which determine behavior related to NULL values.

--- a/testing/runner/tests/partial_idx.sqltest
+++ b/testing/runner/tests/partial_idx.sqltest
@@ -871,6 +871,44 @@ expect {
     456|2|0|1
 }
 
+# Partial index integrity_check should not report false "wrong # of entries"
+# when non-matching rows exist (issue #5158)
+test partial-index-integrity-check-non-matching-rows {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE INDEX idx1 ON t1(val) WHERE val > 500;
+    INSERT INTO t1 VALUES(1, 100);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+# Partial index integrity_check with mix of matching and non-matching rows
+test partial-index-integrity-check-mixed-rows {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE INDEX idx1 ON t1(val) WHERE val > 500;
+    INSERT INTO t1 VALUES(1, 100);
+    INSERT INTO t1 VALUES(2, 600);
+    INSERT INTO t1 VALUES(3, 200);
+    INSERT INTO t1 VALUES(4, 700);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+# Partial index integrity_check with only matching rows
+test partial-index-integrity-check-all-matching {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE INDEX idx1 ON t1(val) WHERE val > 500;
+    INSERT INTO t1 VALUES(1, 600);
+    INSERT INTO t1 VALUES(2, 700);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
 # Partial index with doubly qualified column reference in function
 test partial-index-doubly-qualified-column-in-function {
     CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT, flag INTEGER);


### PR DESCRIPTION
PRAGMA integrity_check was incorrectly comparing total table row count against partial index entry count. For partial indexes, only rows matching the WHERE predicate should be indexed, so the counts naturally differ.

Skip entry count comparison and row-index consistency checks for partial indexes since we can't easily evaluate the predicate expression in the integrity check's monolithic instruction.

Closes #5158

Related: #4590 😭 
