### PR TITLE
sqlite3: Fix segfault in sqlite3_free_table()

### DIFF
--- a/sqlite3/include/sqlite3.h
+++ b/sqlite3/include/sqlite3.h
@@ -207,7 +207,7 @@ int sqlite_get_table_cb(void *context, int n_column, char **argv, char **colv);
 
 int sqlite3_get_table(sqlite3 *db, const char *sql, char ***paz_result, int *pn_row, int *pn_column, char **pz_err_msg);
 
-void sqlite3_free_table(char ***paz_result);
+void sqlite3_free_table(char **az_result);
 
 void sqlite3_result_null(void *_context);
 


### PR DESCRIPTION
sqlite3_free_table had the wrong C ABI signature (char*** instead of char**) and incorrectly cast the result pointer to a TabResult struct, causing it to reinterpret string pointers as Vec internal fields.

Rewrite sqlite3_get_table/sqlite3_free_table to follow SQLite's convention: store the entry count at position 0 of a raw C array and return &array[1], then step back in free_table to read the count.

Fixes #2838