### PR TITLE
Fix freelist_count dirty leak and add regression test

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3921,8 +3921,8 @@ impl Pager {
 
     pub fn freepage_list(&self) -> u32 {
         self.io
-            .block(|| HeaderRefMut::from_pager(self))
-            .map(|header_ref| header_ref.borrow_mut().freelist_pages.into())
+            .block(|| HeaderRef::from_pager(self))
+            .map(|header_ref| header_ref.borrow().freelist_pages.get())
             .unwrap_or(0)
     }
     // Providing a page is optional, if provided it will be used to avoid reading the page from disk.


### PR DESCRIPTION
## Description

PRAGMA freelist_count now reads the header without marking page 1 dirty, and a new regression test ensures freelist_count > 0 then verifies that BEGIN/ROLLBACK does not panic after reopening.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Fixes issue #5124 where PRAGMA freelist_count dirtied page 1 outside a write transaction, causing read-transaction rollback to panic (also seen on CLI Ctrl-D/Ctrl-C exit).

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5124


## Description of AI Usage

Writing test and pr body

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
