### PR TITLE
fix: "Cursor not found" when delete has a correlated subquery #5434

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -343,6 +343,7 @@ pub fn translate_alter_table(
                             cte_explicit_columns: vec![],
                             cte_id: None,
                             cte_definition_only: false,
+                            rowid_referenced: false,
                         }],
                     );
                     let where_copy = index

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -4712,6 +4712,10 @@ pub fn bind_and_rewrite_expr<'a>(
                                 parse_row_id(&normalized_id, tbl_id, || false)?
                             {
                                 *expr = row_id_expr;
+                                // Mark the table's rowid as referenced so correlated
+                                // subquery detection works correctly when a rowid
+                                // reference is the only link to the outer query.
+                                referenced_tables.mark_rowid_referenced(tbl_id);
                                 return Ok(WalkControl::Continue);
                             }
                         }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -736,6 +736,7 @@ fn add_ephemeral_table_to_update_plan(
                 cte_explicit_columns: vec![],
                 cte_id: None,
                 cte_definition_only: false,
+                rowid_referenced: false,
             });
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -747,6 +747,10 @@ pub struct OuterQueryReference {
     /// has been consumed by a FROM clause (with or without an alias), so
     /// column resolution goes through the joined_table instead.
     pub cte_definition_only: bool,
+    /// Whether the rowid of this table is referenced. Tracked separately from
+    /// col_used_mask because rowid is not a real column and setting a fake
+    /// column index in col_used_mask could mislead covering index decisions.
+    pub rowid_referenced: bool,
 }
 
 impl OuterQueryReference {
@@ -763,7 +767,7 @@ impl OuterQueryReference {
     /// Whether the OuterQueryReference is used by the current query scope.
     /// This is used primarily to determine at what loop depth a subquery should be evaluated.
     pub fn is_used(&self) -> bool {
-        !self.col_used_mask.is_empty()
+        !self.col_used_mask.is_empty() || self.rowid_referenced
     }
 }
 
@@ -1001,6 +1005,16 @@ impl TableReferences {
         } else {
             panic!("table with internal id {internal_id} not found in table references");
         }
+    }
+
+    /// Marks the rowid of a table as referenced. This is tracked separately
+    /// from column usage because rowid is not a real column.
+    pub fn mark_rowid_referenced(&mut self, internal_id: TableInternalId) {
+        if let Some(outer_query_ref) = self.find_outer_query_ref_by_internal_id_mut(internal_id) {
+            outer_query_ref.rowid_referenced = true;
+        }
+        // For joined tables, rowid references don't need special tracking
+        // since correlated subquery detection only looks at outer_query_refs.
     }
 
     pub fn contains_table(&self, table: &Table) -> bool {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -481,6 +481,7 @@ fn plan_cte(
             cte_explicit_columns: vec![],
             cte_id: Some(cte_definitions[ref_idx].cte_id),
             cte_definition_only: false,
+            rowid_referenced: false,
         });
     }
 
@@ -625,6 +626,7 @@ pub fn plan_ctes_as_outer_refs(
             cte_explicit_columns: explicit_columns,
             cte_id: None, // DML CTEs don't track CTE sharing (TODO: implement if needed)
             cte_definition_only: true,
+            rowid_referenced: false,
         });
     }
 
@@ -699,6 +701,7 @@ fn parse_from_clause_table(
                     cte_explicit_columns: cte_def.explicit_columns.clone(),
                     cte_id: Some(cte_def.cte_id),
                     cte_definition_only: false,
+                    rowid_referenced: false,
                 });
             }
 
@@ -1226,6 +1229,7 @@ pub fn parse_from(
                     cte_explicit_columns: cte_def.explicit_columns.clone(),
                     cte_id: Some(cte_def.cte_id),
                     cte_definition_only: false,
+                    rowid_referenced: false,
                 });
             }
         }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -288,6 +288,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                     cte_explicit_columns: vec![],
                     cte_id,
                     cte_definition_only: false,
+                    rowid_referenced: false,
                 }
             })
             .chain(
@@ -303,6 +304,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                         cte_explicit_columns: t.cte_explicit_columns.clone(),
                         cte_id: t.cte_id, // Preserve CTE ID from outer query refs
                         cte_definition_only: t.cte_definition_only,
+                        rowid_referenced: false,
                     }),
             )
             .collect::<Vec<_>>()

--- a/testing/runner/tests/delete-correlated-subquery-rowid.sqltest
+++ b/testing/runner/tests/delete-correlated-subquery-rowid.sqltest
@@ -1,0 +1,79 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE tt(a);
+    INSERT INTO tt VALUES (1);
+    INSERT INTO tt VALUES (2);
+    INSERT INTO tt VALUES (3);
+}
+
+@setup schema
+test delete-correlated-subquery-rowid-basic {
+    DELETE FROM tt WHERE a IN (SELECT a FROM tt tt1 WHERE tt1.rowid = tt.rowid);
+    SELECT * FROM tt;
+}
+expect {
+}
+
+setup partial-schema {
+    CREATE TABLE t2(a);
+    INSERT INTO t2 VALUES (10);
+    INSERT INTO t2 VALUES (20);
+    INSERT INTO t2 VALUES (30);
+    INSERT INTO t2 VALUES (40);
+}
+
+@setup partial-schema
+test delete-correlated-subquery-rowid-partial {
+    DELETE FROM t2 WHERE a IN (SELECT a FROM t2 x WHERE x.rowid = t2.rowid AND t2.rowid <= 2);
+    SELECT a FROM t2 ORDER BY a;
+}
+expect {
+    30
+    40
+}
+
+@setup schema
+test delete-correlated-subquery-underscore-rowid {
+    DELETE FROM tt WHERE a IN (SELECT a FROM tt t1 WHERE t1._rowid_ = tt._rowid_);
+    SELECT * FROM tt;
+}
+expect {
+}
+
+@setup schema
+test delete-correlated-subquery-oid {
+    DELETE FROM tt WHERE a IN (SELECT a FROM tt t1 WHERE t1.oid = tt.oid);
+    SELECT * FROM tt;
+}
+expect {
+}
+
+setup empty-schema {
+    CREATE TABLE t_empty(a);
+}
+
+@setup empty-schema
+test delete-correlated-subquery-empty-table {
+    DELETE FROM t_empty WHERE a IN (SELECT a FROM t_empty t1 WHERE t1.rowid = t_empty.rowid);
+    SELECT count(*) FROM t_empty;
+}
+expect {
+    0
+}
+
+setup null-schema {
+    CREATE TABLE t_null(a);
+    INSERT INTO t_null VALUES (NULL);
+    INSERT INTO t_null VALUES (1);
+    INSERT INTO t_null VALUES (NULL);
+}
+
+@setup null-schema
+test delete-correlated-subquery-with-nulls {
+    DELETE FROM t_null WHERE a IN (SELECT a FROM t_null t1 WHERE t1.rowid = t_null.rowid);
+    SELECT count(*) FROM t_null;
+}
+expect {
+    2
+}


### PR DESCRIPTION
When a correlated subquery references the outer table via a qualified rowid expression (e.g. tt.rowid), parse_row_id converted it to Expr::RowId but never called mark_column_used on the table reference. This left the outer query reference's col_used_mask empty, so is_correlated() returned false and the subquery was emitted before the outer table's cursor was opened, causing a panic.

Fix: introduce `OuterQueryReference::rowid_referenced` and set it after parse_row_id succeeds in the qualified column name path so the outer reference is correctly marked as used.

Closes #5434