### PR TITLE
feat: Add materialized views support to Rust bindings and test runner

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -140,6 +140,7 @@ pub struct Builder {
     enable_attach: bool,
     enable_strict: bool,
     enable_index_method: bool,
+    enable_materialized_views: bool,
     vfs: Option<String>,
     encryption_opts: Option<turso_sdk_kit::rsapi::EncryptionOpts>,
 }
@@ -154,6 +155,7 @@ impl Builder {
             enable_attach: false,
             enable_strict: false,
             enable_index_method: false,
+            enable_materialized_views: false,
             vfs: None,
             encryption_opts: None,
         }
@@ -189,6 +191,11 @@ impl Builder {
         self
     }
 
+    pub fn experimental_materialized_views(mut self, enabled: bool) -> Self {
+        self.enable_materialized_views = enabled;
+        self
+    }
+
     pub fn with_io(mut self, vfs: String) -> Self {
         self.vfs = Some(vfs);
         self
@@ -209,6 +216,9 @@ impl Builder {
         }
         if self.enable_index_method {
             features.push("index_method");
+        }
+        if self.enable_materialized_views {
+            features.push("views");
         }
         if features.is_empty() {
             return None;

--- a/testing/runner/src/backends/rust.rs
+++ b/testing/runner/src/backends/rust.rs
@@ -55,7 +55,7 @@ impl SqlBackend for RustBackend {
     }
 
     fn capabilities(&self) -> HashSet<Capability> {
-        HashSet::from_iter([Capability::Trigger])
+        HashSet::from_iter([Capability::Trigger, Capability::MaterializedViews])
     }
 
     fn supports_snapshots(&self) -> bool {
@@ -95,6 +95,7 @@ impl SqlBackend for RustBackend {
             .experimental_triggers(true)
             .experimental_attach(true)
             .experimental_index_method(true)
+            .experimental_materialized_views(true)
             .build()
             .await
             .map_err(|e| BackendError::CreateDatabase(e.to_string()))?;


### PR DESCRIPTION
## Description

Allows enabling views in test backend.
This is required for upcoming matview tests.

## Motivation and context

I have a set of reproducer+fix pairs which all require enabling the views feature via
```
@requires-file materialized_views ""
```
in the `.sqltest` files, at least if I understood the test setup correctly.
If this is not necessary, please let me know the correct way to run `.sqltest` files that contain view tests.
