### PR TITLE
fix: Expression Index Key Computed From Pre-Affinity Value During UPDATE

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -256,14 +256,18 @@ macro_rules! expect_arguments_even {
 /// Compute the affinity for an IN expression.
 /// For `x IN (y1, y2, ..., yN)`, the affinity is determined by the LHS expression `x`.
 /// This follows SQLite's `exprINAffinity()` function.
-fn in_expr_affinity(lhs: &ast::Expr, referenced_tables: Option<&TableReferences>) -> Affinity {
+fn in_expr_affinity(
+    lhs: &ast::Expr,
+    referenced_tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
+) -> Affinity {
     // For parenthesized expressions (vectors), we take the first element's affinity
     // since scalar IN comparisons only use the first element
     match lhs {
         Expr::Parenthesized(exprs) if !exprs.is_empty() => {
-            get_expr_affinity(&exprs[0], referenced_tables)
+            get_expr_affinity(&exprs[0], referenced_tables, resolver)
         }
-        _ => get_expr_affinity(lhs, referenced_tables),
+        _ => get_expr_affinity(lhs, referenced_tables, resolver),
     }
 }
 
@@ -288,7 +292,7 @@ fn translate_in_list(
 
     // Compute the affinity for the IN comparison based on the LHS expression
     // This follows SQLite's exprINAffinity() approach
-    let affinity = in_expr_affinity(lhs, referenced_tables);
+    let affinity = in_expr_affinity(lhs, referenced_tables, Some(resolver));
     let cmp_flags = CmpInsFlags::default().with_affinity(affinity);
 
     if condition_metadata.jump_target_when_false != condition_metadata.jump_target_when_null {
@@ -3092,6 +3096,7 @@ fn binary_expr_shared(
         e1,
         e2,
         referenced_tables,
+        Some(resolver),
     )?;
 
     if let BinaryEmitMode::Condition(metadata) = emit_mode {
@@ -3124,6 +3129,7 @@ fn emit_binary_expr_scalar(
                     &ast::Expr,
                     Option<&TableReferences>,
                     Option<ConditionMetadata>,
+                    Option<&Resolver>,
                 ) -> Result<()>,
             None,
         ),
@@ -3139,6 +3145,7 @@ fn emit_binary_expr_scalar(
                     &ast::Expr,
                     Option<&TableReferences>,
                     Option<ConditionMetadata>,
+                    Option<&Resolver>,
                 ) -> Result<()>,
             Some(metadata),
         ),
@@ -3159,6 +3166,7 @@ fn emit_binary_expr_scalar(
             e2,
             referenced_tables,
             condition_metadata,
+            Some(resolver),
         )?;
         if op.is_comparison() {
             program.reset_collation();
@@ -3214,6 +3222,7 @@ fn emit_binary_expr_scalar(
             e2,
             referenced_tables,
             condition_metadata,
+            Some(resolver),
         )?;
         // Only reset collation for comparison operators, which consume it.
         // Non-comparison operators (Concat, Add, etc.) must propagate the
@@ -3238,6 +3247,7 @@ fn emit_binary_expr_row_valued(
     lhs_expr: &Expr,
     rhs_expr: &Expr,
     referenced_tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
 ) -> Result<()> {
     enum RowOrderingOp {
         Less,
@@ -3259,8 +3269,13 @@ fn emit_binary_expr_row_valued(
         let done_label = program.allocate_label();
         for i in 0..arity {
             let next_label = program.allocate_label();
-            let (affinity, collation) =
-                row_component_affinity_collation(lhs_expr, rhs_expr, i, referenced_tables)?;
+            let (affinity, collation) = row_component_affinity_collation(
+                lhs_expr,
+                rhs_expr,
+                i,
+                referenced_tables,
+                resolver,
+            )?;
             program.emit_insn(Insn::Eq {
                 lhs: lhs_start + i,
                 rhs: rhs_start + i,
@@ -3332,8 +3347,13 @@ fn emit_binary_expr_row_valued(
             let null_result_label = program.allocate_label();
             for i in 0..arity {
                 let next_cmp_label = program.allocate_label();
-                let (aff, collation) =
-                    row_component_affinity_collation(lhs_expr, rhs_expr, i, referenced_tables)?;
+                let (aff, collation) = row_component_affinity_collation(
+                    lhs_expr,
+                    rhs_expr,
+                    i,
+                    referenced_tables,
+                    resolver,
+                )?;
                 let lhs = lhs_start + i;
                 let rhs = rhs_start + i;
                 program.emit_insn(Insn::IsNull {
@@ -3444,6 +3464,7 @@ fn row_component_affinity_collation(
     rhs_expr: &Expr,
     idx: usize,
     referenced_tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
 ) -> Result<(Affinity, Option<CollationSeq>)> {
     // If one side is a decomposable row literal and the other is not, still prefer
     // the component that is available instead of falling back both sides.
@@ -3453,7 +3474,7 @@ fn row_component_affinity_collation(
     let lhs_for_cmp = row_value_component_expr(lhs_expr, idx)?.unwrap_or(lhs_expr);
     let rhs_for_cmp = row_value_component_expr(rhs_expr, idx)?.unwrap_or(rhs_expr);
     Ok((
-        comparison_affinity(lhs_for_cmp, rhs_for_cmp, referenced_tables),
+        comparison_affinity(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver),
         comparison_collation(lhs_for_cmp, rhs_for_cmp, referenced_tables)?,
     ))
 }
@@ -3503,10 +3524,11 @@ fn emit_binary_insn(
     rhs_expr: &Expr,
     referenced_tables: Option<&TableReferences>,
     _: Option<ConditionMetadata>,
+    resolver: Option<&Resolver>,
 ) -> Result<()> {
     let mut affinity = Affinity::Blob;
     if op.is_comparison() {
-        affinity = comparison_affinity(lhs_expr, rhs_expr, referenced_tables);
+        affinity = comparison_affinity(lhs_expr, rhs_expr, referenced_tables, resolver);
     }
 
     match op {
@@ -3761,12 +3783,13 @@ fn emit_binary_condition_insn(
     rhs_expr: &Expr,
     referenced_tables: Option<&TableReferences>,
     condition_metadata: Option<ConditionMetadata>,
+    resolver: Option<&Resolver>,
 ) -> Result<()> {
     let condition_metadata = condition_metadata
         .expect("condition metadata must be provided for emit_binary_insn_conditional");
     let mut affinity = Affinity::Blob;
     if op.is_comparison() {
-        affinity = comparison_affinity(lhs_expr, rhs_expr, referenced_tables);
+        affinity = comparison_affinity(lhs_expr, rhs_expr, referenced_tables, resolver);
     }
 
     let opposite_op = match op {
@@ -5094,6 +5117,7 @@ where
 pub fn get_expr_affinity(
     expr: &ast::Expr,
     referenced_tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
 ) -> Affinity {
     match expr {
         ast::Expr::Column { table, column, .. } => {
@@ -5115,12 +5139,23 @@ pub fn get_expr_affinity(
             }
         }
         ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
-            get_expr_affinity(exprs.first().unwrap(), referenced_tables)
+            get_expr_affinity(exprs.first().unwrap(), referenced_tables, resolver)
         }
-        ast::Expr::Collate(expr, _) => get_expr_affinity(expr, referenced_tables),
+        ast::Expr::Collate(expr, _) => get_expr_affinity(expr, referenced_tables, resolver),
         // Literals have NO affinity in SQLite!
         ast::Expr::Literal(_) => Affinity::Blob, // No affinity!
-        _ => Affinity::Blob,                     // This may need to change. For now this works.
+        ast::Expr::Register(reg) => {
+            // During UPDATE expression index evaluation, column references are
+            // rewritten to Expr::Register. Look up the original column affinity
+            // from the resolver's register_affinities map.
+            if let Some(resolver) = resolver {
+                if let Some(aff) = resolver.register_affinities.get(reg) {
+                    return *aff;
+                }
+            }
+            Affinity::Blob
+        }
+        _ => Affinity::Blob, // This may need to change. For now this works.
     }
 }
 
@@ -5128,10 +5163,11 @@ pub fn comparison_affinity(
     lhs_expr: &ast::Expr,
     rhs_expr: &ast::Expr,
     referenced_tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
 ) -> Affinity {
-    let mut aff = get_expr_affinity(lhs_expr, referenced_tables);
+    let mut aff = get_expr_affinity(lhs_expr, referenced_tables, resolver);
 
-    aff = compare_affinity(rhs_expr, aff, referenced_tables);
+    aff = compare_affinity(rhs_expr, aff, referenced_tables, resolver);
 
     // If no affinity determined (both operands are literals), default to BLOB
     if !aff.has_affinity() {
@@ -5145,8 +5181,9 @@ pub fn compare_affinity(
     expr: &ast::Expr,
     other_affinity: Affinity,
     referenced_tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
 ) -> Affinity {
-    let expr_affinity = get_expr_affinity(expr, referenced_tables);
+    let expr_affinity = get_expr_affinity(expr, referenced_tables, resolver);
 
     if expr_affinity.has_affinity() && other_affinity.has_affinity() {
         // Both sides have affinity - use numeric if either is numeric

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -519,7 +519,7 @@ fn emit_hash_build_phase(
     for join_key in hash_join_op.join_keys.iter() {
         let build_expr = join_key.get_build_expr(predicates);
         let probe_expr = join_key.get_probe_expr(predicates);
-        let affinity = comparison_affinity(build_expr, probe_expr, Some(table_references));
+        let affinity = comparison_affinity(build_expr, probe_expr, Some(table_references), None);
         key_affinities.push(affinity.aff_mask());
     }
 

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -119,7 +119,7 @@ impl Constraint {
         let mut affinity = Affinity::Blob;
         if op.as_ast_operator().is_some_and(|op| op.is_comparison()) && self.table_col_pos.is_some()
         {
-            affinity = comparison_affinity(lhs, rhs, referenced_tables);
+            affinity = comparison_affinity(lhs, rhs, referenced_tables, None);
         }
 
         if side == BinaryExprSide::Lhs {
@@ -1544,7 +1544,7 @@ fn analyze_binary_term_for_index(
     // Compute the affinity for the constraining expression
     let affinity = if let Some(ast_op) = operator.as_ast_operator() {
         if ast_op.is_comparison() && table_col_pos.is_some() {
-            comparison_affinity(lhs, rhs, Some(table_references))
+            comparison_affinity(lhs, rhs, Some(table_references), None)
         } else {
             Affinity::Blob
         }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -42,7 +42,7 @@ fn infer_type_from_expr(
     expr: &ast::Expr,
     tables: Option<&TableReferences>,
 ) -> (Type, &'static str) {
-    let affinity = get_expr_affinity(expr, tables);
+    let affinity = get_expr_affinity(expr, tables, None);
     match affinity {
         Affinity::Integer => (Type::Integer, "INTEGER"),
         Affinity::Real => (Type::Real, "REAL"),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -511,11 +511,13 @@ fn get_subquery_parser<'a>(
                     lhs_columns
                         .enumerate()
                         .map(|(i, lhs_expr)| {
-                            let lhs_affinity = get_expr_affinity(lhs_expr, Some(referenced_tables));
+                            let lhs_affinity =
+                                get_expr_affinity(lhs_expr, Some(referenced_tables), None);
                             compare_affinity(
                                 &plan.result_columns[i].expr,
                                 lhs_affinity,
                                 Some(&plan.table_references),
+                                None,
                             )
                             .aff_mask()
                         })

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10618,13 +10618,11 @@ fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
                             return true;
                         }
                         Value::Numeric(Numeric::Float(fl)) => {
-                            // For Numeric affinity, try to convert float to int if exact
-                            if affinity == Affinity::Numeric {
-                                return try_float_to_integer_affinity(value, f64::from(fl));
-                            } else {
-                                *value = Value::Numeric(Numeric::Float(fl));
-                                return true;
-                            }
+                            // For both Numeric and Integer affinity, try to convert
+                            // float to int if exact. SQLite treats INTEGER identically
+                            // to NUMERIC here: both enter applyNumericAffinity() with
+                            // bTryForInt=1 (sqlite/src/vdbe.c:403-408).
+                            return try_float_to_integer_affinity(value, f64::from(fl));
                         }
                         other => {
                             *value = other;

--- a/testing/runner/tests/update_expression_index_affinity.sqltest
+++ b/testing/runner/tests/update_expression_index_affinity.sqltest
@@ -1,0 +1,140 @@
+@database :memory:
+@skip-file-if mvcc "expression indexes are not supported with mvcc"
+
+# Tests for expression index key computation during UPDATE.
+# The expression index key must be computed from post-affinity values
+# so that INSERT and DELETE paths see consistent types.
+# Regression tests for GitHub issue #5428.
+
+# Reproducer 1: CAST expression index with INT affinity column.
+# '0.0' with INT affinity should become Integer(0), so
+# CAST(0 AS TEXT) = '0', not CAST(0.0 AS TEXT) = '0.0'.
+test cast-expr-index-int-affinity {
+    CREATE TABLE t0 (c0 INT);
+    INSERT INTO t0 VALUES (0);
+    CREATE INDEX idx ON t0 (CAST(c0 AS TEXT));
+    UPDATE t0 SET c0 = '0.0';
+    UPDATE t0 SET c0 = 1;
+    SELECT * FROM t0;
+    PRAGMA integrity_check;
+}
+expect {
+    1
+    ok
+}
+
+# Reproducer 2: Comparison expression index with TEXT affinity column.
+# The comparison c0 = 0 must use TEXT affinity in both OLD and NEW
+# image paths during UPDATE.
+test comparison-expr-index-text-affinity {
+    CREATE TABLE t0 (c0 TEXT);
+    INSERT INTO t0 VALUES ('x');
+    CREATE INDEX i0 ON t0(c0 = 0);
+    UPDATE t0 SET c0 = 0;
+    UPDATE t0 SET c0 = 1;
+    SELECT * FROM t0;
+    PRAGMA integrity_check;
+}
+expect {
+    1
+    ok
+}
+
+# Multiple sequential updates on CAST expression index.
+test cast-expr-index-multiple-updates {
+    CREATE TABLE t1 (c0 INT);
+    INSERT INTO t1 VALUES (0);
+    CREATE INDEX idx1 ON t1 (CAST(c0 AS TEXT));
+    UPDATE t1 SET c0 = '1.0';
+    UPDATE t1 SET c0 = '2.5';
+    UPDATE t1 SET c0 = 3;
+    SELECT * FROM t1;
+    PRAGMA integrity_check;
+}
+expect {
+    3
+    ok
+}
+
+# Comparison expression index with NUMERIC affinity.
+test comparison-expr-index-numeric-affinity {
+    CREATE TABLE t2 (c0 NUMERIC);
+    INSERT INTO t2 VALUES (1);
+    CREATE INDEX i2 ON t2 (c0 > 5);
+    UPDATE t2 SET c0 = 10;
+    UPDATE t2 SET c0 = 3;
+    SELECT * FROM t2;
+    PRAGMA integrity_check;
+}
+expect {
+    3
+    ok
+}
+
+# Expression index with INTEGER affinity and float-like text values.
+test expr-index-int-affinity-float-text {
+    CREATE TABLE t3 (c0 INT);
+    INSERT INTO t3 VALUES (0);
+    CREATE INDEX idx3 ON t3 (CAST(c0 AS TEXT));
+    UPDATE t3 SET c0 = '5.0';
+    SELECT CAST(c0 AS TEXT) FROM t3;
+    PRAGMA integrity_check;
+    UPDATE t3 SET c0 = '10.0';
+    SELECT CAST(c0 AS TEXT) FROM t3;
+    PRAGMA integrity_check;
+}
+expect {
+    5
+    ok
+    10
+    ok
+}
+
+# Expression index with NULL values.
+test expr-index-null-values {
+    CREATE TABLE t4 (c0 INT);
+    INSERT INTO t4 VALUES (NULL);
+    CREATE INDEX idx4 ON t4 (CAST(c0 AS TEXT));
+    UPDATE t4 SET c0 = '0.0';
+    UPDATE t4 SET c0 = NULL;
+    SELECT c0 IS NULL FROM t4;
+    PRAGMA integrity_check;
+}
+expect {
+    1
+    ok
+}
+
+# Multiple rows with expression index.
+test expr-index-multi-row {
+    CREATE TABLE t5 (id INTEGER PRIMARY KEY, c0 INT);
+    INSERT INTO t5 VALUES (1, 10);
+    INSERT INTO t5 VALUES (2, 20);
+    CREATE INDEX idx5 ON t5 (CAST(c0 AS TEXT));
+    UPDATE t5 SET c0 = '30.0' WHERE id = 1;
+    UPDATE t5 SET c0 = '40.0' WHERE id = 2;
+    UPDATE t5 SET c0 = 50 WHERE id = 1;
+    SELECT id, c0 FROM t5 ORDER BY id;
+    PRAGMA integrity_check;
+}
+expect {
+    1|50
+    2|40
+    ok
+}
+
+# Comparison expression index with multiple updates changing truth value.
+test comparison-expr-index-truth-value-changes {
+    CREATE TABLE t6 (c0 TEXT);
+    INSERT INTO t6 VALUES ('hello');
+    CREATE INDEX i6 ON t6 (c0 = 'world');
+    UPDATE t6 SET c0 = 'world';
+    UPDATE t6 SET c0 = 'hello';
+    UPDATE t6 SET c0 = 'world';
+    SELECT * FROM t6;
+    PRAGMA integrity_check;
+}
+expect {
+    world
+    ok
+}


### PR DESCRIPTION
    Two root causes fixed:
    
    1. INTEGER affinity in apply_affinity_char did not call
       try_float_to_integer_affinity when text parsed to a float,
       so '0.0' with INT column became Float(0.0) instead of Integer(0).
       CAST expression index keys then differed between insert and delete paths.
    
    2. rewrite_where_for_update_registers replaced column references with
       Expr::Register(n) for expression index new-image evaluation, losing
       the column's affinity info. Comparison instructions (Eq, etc.) then
       used wrong affinity flags, producing different results between old
       and new image paths.
    
    Fix: make Integer affinity also try float-to-int conversion (matching
    SQLite vdbe.c:403-408), and store register-to-column-affinity mappings
    on Resolver so get_expr_affinity can resolve Expr::Register nodes.

Closes #5428