### PR TITLE
fix: No-op UPDATE causes datatype mismatch #5410

### DIFF
--- a/testing/runner/tests/foreign_keys.sqltest
+++ b/testing/runner/tests/foreign_keys.sqltest
@@ -2448,3 +2448,79 @@ test fk-drop-column-composite-fk-fails {
 }
 expect error {
 }
+
+# No-op UPDATE on NULL FK column with deferred FK should not error (#5410)
+test fk-deferred-noop-update-null {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, NULL);
+    UPDATE c SET pid = pid WHERE id=1;
+    SELECT 'ok';
+    ROLLBACK;
+}
+expect {
+    ok
+}
+
+# No-op UPDATE on non-NULL FK column with deferred FK and valid parent
+test fk-deferred-noop-update-valid-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES(1);
+    BEGIN;
+    INSERT INTO c VALUES(1, 1);
+    UPDATE c SET pid = pid WHERE id=1;
+    SELECT 'ok';
+    ROLLBACK;
+}
+expect {
+    ok
+}
+
+# UPDATE NULL FK column to NULL explicitly with deferred FK
+test fk-deferred-update-null-to-null {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, NULL);
+    UPDATE c SET pid = NULL WHERE id=1;
+    SELECT 'ok';
+    ROLLBACK;
+}
+expect {
+    ok
+}
+
+# Multiple rows with NULL FK, no-op UPDATE should succeed for all
+test fk-deferred-noop-update-null-multi-row {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, NULL);
+    INSERT INTO c VALUES(2, NULL);
+    INSERT INTO c VALUES(3, NULL);
+    UPDATE c SET pid = pid;
+    SELECT count(*) FROM c;
+    ROLLBACK;
+}
+expect {
+    3
+}
+
+# No-op UPDATE on NULL FK with immediate (non-deferred) FK should also succeed
+test fk-immediate-noop-update-null {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id));
+    INSERT INTO c VALUES(1, NULL);
+    UPDATE c SET pid = pid WHERE id=1;
+    SELECT 'ok';
+}
+expect {
+    ok
+}


### PR DESCRIPTION
In emit_fk_child_update_counters, load_old_tuple's null_jmp label was resolved to the same instruction as cont, making the IsNull check a no-op. When the OLD FK column was NULL, execution fell through into MustBeInt which errored on NULL. Fix by returning the null_jmp label unresolved so the caller resolves it after the FK check block.

Closes #5410
