### PR TITLE
Add more tests to foreign_keys.sqltest

### DIFF
--- a/testing/runner/tests/foreign_keys.sqltest
+++ b/testing/runner/tests/foreign_keys.sqltest
@@ -2524,3 +2524,74 @@ test fk-immediate-noop-update-null {
 expect {
     ok
 }
+
+# Issue #5409: deferred FK not enforced at COMMIT when UPDATE touches NULL FK row
+test fk-deferred-update-null-row-does-not-clear-violation {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id TEXT PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid TEXT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 'missing');
+    INSERT INTO c VALUES(2, NULL);
+    UPDATE c SET pid = pid WHERE id=2;
+    COMMIT;
+}
+expect error {
+}
+
+# Variant: UPDATE on NULL FK row should not decrement counter (INTEGER PK parent)
+test fk-deferred-update-null-ipk-parent-does-not-clear {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 999);
+    INSERT INTO c VALUES(2, NULL);
+    UPDATE c SET pid = pid WHERE id=2;
+    COMMIT;
+}
+expect error {
+}
+
+# UPDATE on violating row itself should NOT resolve (pid stays 'missing')
+test fk-deferred-noop-update-on-violating-row {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id TEXT PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid TEXT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 'missing');
+    UPDATE c SET pid = pid WHERE id=1;
+    COMMIT;
+}
+expect error {
+}
+
+# Multiple NULL rows updated should not affect deferred counter
+test fk-deferred-update-multiple-null-rows {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id TEXT PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid TEXT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    BEGIN;
+    INSERT INTO c VALUES(1, 'missing');
+    INSERT INTO c VALUES(2, NULL);
+    INSERT INTO c VALUES(3, NULL);
+    UPDATE c SET pid = pid WHERE pid IS NULL;
+    COMMIT;
+}
+expect error {
+}
+
+# Verify that updating a NULL FK to a valid value still works correctly
+test fk-deferred-update-null-to-valid {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id TEXT PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid TEXT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES('exists');
+    BEGIN;
+    INSERT INTO c VALUES(1, 'missing');
+    INSERT INTO c VALUES(2, NULL);
+    UPDATE c SET pid = 'exists' WHERE id=2;
+    COMMIT;
+}
+expect error {
+}


### PR DESCRIPTION
Add more tests to foreign_keys.sqltest

Issues #5409 and #5410 were concurrently already fixed while this branch
was in progress, so onboarding the tests from this one.

Closes #5409