### PR TITLE
fix: Prevent WAL read lock leak in reset_internal_states

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2244,8 +2244,10 @@ impl WalFile {
     }
 
     fn reset_internal_states(&self) {
-        self.max_frame_read_lock_index
-            .store(NO_LOCK_HELD, Ordering::Release);
+        // NOTE: Do NOT reset max_frame_read_lock_index here!
+        // The read lock must be released via end_read_tx() which both unlocks
+        // the actual lock AND sets the index to NO_LOCK_HELD. Resetting the index
+        // here without releasing the lock causes a lock leak.
         self.ongoing_checkpoint.write().reset();
         self.syncing.store(false, Ordering::Release);
     }


### PR DESCRIPTION
## Summary

- `reset_internal_states()` was resetting `max_frame_read_lock_index` to `NO_LOCK_HELD` without actually unlocking the shared read lock slot. This caused `end_read_tx()` to skip the unlock (it checks the index first), permanently leaking the read lock.
- A leaked read lock blocks all Restart/Truncate checkpoints indefinitely.
- The fix removes the index reset from `reset_internal_states()` — the read lock lifecycle is solely managed by `end_read_tx()`.
- Adds a regression test that triggers rollback while holding a read lock, then verifies a Restart checkpoint succeeds (it would return `Busy` with the old code).

## Test plan

- [x] New test `test_wal_rollback_does_not_leak_read_lock` passes with fix
- [x] New test fails without fix (checkpoint returns `Busy` due to leaked lock)
- [ ] Existing WAL tests pass (`cargo test -p turso_core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)