### PR TITLE
perf remove allocs for abs_text_numeric

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -286,8 +286,8 @@ impl Value {
             Value::Numeric(Numeric::Float(non_nan)) => Value::from_f64(f64::from(*non_nan).abs()),
             _ => {
                 let s = match self {
-                    Value::Text(text) => text.to_string(),
-                    Value::Blob(blob) => String::from_utf8_lossy(blob).to_string(),
+                    Value::Text(text) => std::borrow::Cow::Borrowed(text.as_str()),
+                    Value::Blob(blob) => String::from_utf8_lossy(blob),
                     _ => unreachable!(),
                 };
 


### PR DESCRIPTION
## Description
perf remove allocs for abs_text_numeric
before:
<img width="1042" height="261" alt="image" src="https://github.com/user-attachments/assets/930f9615-48d4-4325-a2aa-d4681205f9f8" />

after:
<img width="1045" height="75" alt="image" src="https://github.com/user-attachments/assets/8b1e6998-1c62-44cc-8493-cc8f5a022dcf" />


## Motivation and context
perf remove allocs for abs_text_numeric


## Description of AI Usage
Asked gemini for potential perf gains.