### PR TITLE
fix: do not do unchecked indexing to non-static page offsets #4736

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -180,6 +180,35 @@ macro_rules! bail_corrupt_error {
     };
 }
 
+/// Bounds-checked buffer slicing that returns `LimboError::Corrupt` on out-of-bounds.
+///
+/// Accepts any range expression: `buf, pos..`, `buf, start..end`, etc.
+#[macro_export]
+macro_rules! slice_in_bounds_or_corrupt {
+    ($buf:expr, $range:expr) => {
+        $buf.get($range).ok_or_else(|| {
+            $crate::error::cold_return($crate::error::LimboError::Corrupt(format!(
+                "range {:?} out of bounds for buffer size {}",
+                $range,
+                $buf.len()
+            )))
+        })?
+    };
+}
+
+/// Asserts a condition or bails with `LimboError::Corrupt`.
+///
+/// Usage:
+///   `assert_or_bail_corrupt!(condition, "message {}", arg)`
+#[macro_export]
+macro_rules! assert_or_bail_corrupt {
+    ($cond:expr, $($arg:tt)*) => {
+        if !($cond) {
+            $crate::bail_corrupt_error!($($arg)*);
+        }
+    };
+}
+
 #[macro_export]
 macro_rules! bail_constraint_error {
     ($($arg:tt)*) => {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2957,7 +2957,7 @@ impl BTreeCursor {
                                     parent_max_local,
                                     parent_min_local,
                                     parent_page_type,
-                                );
+                                )?;
                             let buf = parent_contents.as_ptr();
                             &buf[cell_start..cell_start + cell_len]
                         };
@@ -3046,7 +3046,7 @@ impl BTreeCursor {
                                     max_local,
                                     min_local,
                                     page_type,
-                                );
+                                )?;
                             let buf = old_page_contents.as_ptr();
                             let cell_buf = &mut buf[cell_start..cell_start + cell_len];
                             // TODO(pere): make this reference and not copy
@@ -7691,7 +7691,7 @@ fn defragment_page(page: &PageContent, usable_space: usize, max_frag_bytes: isiz
             max_local,
             min_local,
             page_type,
-        );
+        )?;
 
         if pc > last_offset {
             is_physically_sorted = false;


### PR DESCRIPTION

## Description

Replace panicking unchecked buffer indexing with bounds-checked access throughout the btree read path. Corrupt cell pointers or varint data now return LimboError::Corrupt instead of causing index-out-of-bounds panics.

Changes:
- pager.rs: Add bounds checks in cell_table_interior_read_rowid, cell_table_leaf_read_rowid, cell_index_read_payload_ptr, and _cell_get_raw_region_faster (now returns Result)
- sqlite3_ondisk.rs: Add bounds checks in read_btree_cell for all page types; make read_payload return Result with cell_len < 4 check
- btree.rs: Update callers of _cell_get_raw_region_faster for Result
- integrity_check.rs: Add tests for corrupt cell pointers on leaf and interior pages, and for SELECT on corrupt pages; update existing cell overflow test to assert no panic


## Motivation and context
Closes #4736



## Description of AI Usage
Generate by Turso Agent
