### PR TITLE
fix: mvcc: DDL statement inside BEGIN CONCURRENT returns a confusing error #3380

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7983,8 +7983,9 @@ pub fn op_open_write(
                 ));
             };
             if !mv_store.is_exclusive_tx(&tx_id) {
-                // Schema changes in MVCC mode require an exclusive transaction
-                return Err(LimboError::TableLocked);
+                return Err(LimboError::TxError(
+                    "DDL statements require an exclusive transaction (use BEGIN instead of BEGIN CONCURRENT)".to_string(),
+                ));
             }
         }
     }

--- a/testing/runner/turso-tests/mvcc_feature_compat.sqltest
+++ b/testing/runner/turso-tests/mvcc_feature_compat.sqltest
@@ -38,3 +38,58 @@ test mvcc-rejects-cdc {
 expect error {
     CDC is not supported in MVCC mode
 }
+
+# DDL statements inside BEGIN CONCURRENT should produce a clear error message
+# instead of the confusing "database table is locked".
+
+test mvcc-create-table-in-begin-concurrent {
+    PRAGMA journal_mode = 'experimental_mvcc';
+    BEGIN CONCURRENT;
+    CREATE TABLE t5(x);
+}
+expect error {
+    DDL statements require an exclusive transaction
+}
+
+test mvcc-create-index-in-begin-concurrent {
+    PRAGMA journal_mode = 'experimental_mvcc';
+    CREATE TABLE t6(x INTEGER);
+    BEGIN CONCURRENT;
+    CREATE INDEX idx6 ON t6(x);
+}
+expect error {
+    DDL statements require an exclusive transaction
+}
+
+test mvcc-drop-table-in-begin-concurrent {
+    PRAGMA journal_mode = 'experimental_mvcc';
+    CREATE TABLE t7(x);
+    BEGIN CONCURRENT;
+    DROP TABLE t7;
+}
+expect error {
+    DDL statements require an exclusive transaction
+}
+
+test mvcc-alter-table-in-begin-concurrent {
+    PRAGMA journal_mode = 'experimental_mvcc';
+    CREATE TABLE t9(x);
+    BEGIN CONCURRENT;
+    ALTER TABLE t9 ADD COLUMN y;
+}
+expect error {
+    DDL statements require an exclusive transaction
+}
+
+test mvcc-ddl-works-in-exclusive-transaction {
+    PRAGMA journal_mode = 'experimental_mvcc';
+    BEGIN;
+    CREATE TABLE t8(x INTEGER);
+    INSERT INTO t8 VALUES (42);
+    COMMIT;
+    SELECT * FROM t8;
+}
+expect {
+    experimental_mvcc
+    42
+}

--- a/tests/integration/fuzz_transaction/mod.rs
+++ b/tests/integration/fuzz_transaction/mod.rs
@@ -656,6 +656,7 @@ async fn multiple_connections_fuzz(opts: FuzzOptions) {
                 || e_string.contains("has no column named")
                 || e_string.contains("no such column:")
                 || e_string.contains("cannot drop column")
+                || e_string.contains("DDL statements require an exclusive transaction")
         };
         let requires_rollback = |e: &turso::Error| -> bool {
             let e_string = e.to_string();


### PR DESCRIPTION
## Description
DDL operations (CREATE TABLE, CREATE INDEX, DROP TABLE, ALTER TABLE) inside a BEGIN CONCURRENT transaction now return a clear error message: "DDL statements require an exclusive transaction (use BEGIN instead of BEGIN CONCURRENT)" instead of the confusing "database table is locked".

## Motivation and context
Closes #3380


## Description of AI Usage
Generated with Turso Agent