### PR TITLE
Replace panic! and assert! with turso_macros assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6401,12 +6401,14 @@ dependencies = [
  "indicatif",
  "rand 0.9.2",
  "rusqlite",
+ "serde_json",
  "shuttle",
  "tempfile",
  "tokio",
  "tracing-appender",
  "tracing-subscriber",
  "turso",
+ "turso_macros",
 ]
 
 [[package]]

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2332,7 +2332,7 @@ impl BTreeCursor {
 
                     if overflows {
                         *write_state = WriteState::Balancing;
-                        turso_assert!(matches!(self.balance_state.sub_state, BalanceSubState::Start), "no balancing operation should be in progress during insert", { "state": format!("{:?}", self.state), "sub_state": format!("{:?}", self.balance_state.sub_state) });
+                        turso_assert!(matches!(self.balance_state.sub_state, BalanceSubState::Start), "no balancing operation should be in progress during insert", { "state": self.state, "sub_state": self.balance_state.sub_state });
                         // If we balance, we must save the cursor position and seek to it later.
                         self.save_context(CursorContext::seek_eq_only(bkey));
                     } else {
@@ -2375,7 +2375,7 @@ impl BTreeCursor {
                     };
                     if overflows || underflows {
                         *write_state = WriteState::Balancing;
-                        turso_assert!(matches!(self.balance_state.sub_state, BalanceSubState::Start), "no balancing operation should be in progress during overwrite", { "state": format!("{:?}", self.state), "sub_state": format!("{:?}", self.balance_state.sub_state) });
+                        turso_assert!(matches!(self.balance_state.sub_state, BalanceSubState::Start), "no balancing operation should be in progress during overwrite", { "state": self.state, "sub_state": self.balance_state.sub_state });
                         // If we balance, we must save the cursor position and seek to it later.
                         self.save_context(CursorContext::seek_eq_only(bkey));
                     } else {
@@ -5419,7 +5419,7 @@ impl CursorTrait for BTreeCursor {
                             }
                         }
                         let balance_both = leaf_underflows && interior_overflows_or_underflows;
-                        turso_assert!(matches!(self.balance_state.sub_state, BalanceSubState::Start), "no balancing operation should be in progress during delete", { "sub_state": format!("{:?}", self.balance_state.sub_state) });
+                        turso_assert!(matches!(self.balance_state.sub_state, BalanceSubState::Start), "no balancing operation should be in progress during delete", { "sub_state": self.balance_state.sub_state });
                         let post_balancing_seek_key = post_balancing_seek_key
                             .take()
                             .expect("post_balancing_seek_key should be Some");

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -925,7 +925,7 @@ impl ProgramBuilder {
     /// reordering the emitted instructions.
     #[inline]
     pub fn preassign_label_to_next_insn(&mut self, label: BranchOffset) {
-        turso_assert!(label.is_label(), "BranchOffset should be a label", { "label": format!("{:?}", label) });
+        turso_assert!(label.is_label(), "BranchOffset should be a label", { "label": label });
         self._resolve_label(label, self.offset().sub(1u32), JumpTarget::AfterThisInsn);
     }
 

--- a/testing/stress/Cargo.toml
+++ b/testing/stress/Cargo.toml
@@ -33,10 +33,12 @@ tokio = { workspace = true, features = ["full"] }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 turso = { workspace = true }
+turso_macros = { workspace = true }
 rusqlite = { workspace = true }
 
 [target.'cfg(antithesis)'.dependencies]
 antithesis_sdk = { workspace = true, features = ["full"] }
+serde_json = { workspace = true }
 
 [target.'cfg(shuttle)'.dependencies]
 shuttle = { workspace = true }


### PR DESCRIPTION
## Description

This PR replaces all instances of `panic!` and `assert!` macros with structured assertion macros from `turso_macros` (`turso_assert!` and `turso_assert_unreachable!`). These macros provide better error context by including structured metadata about the failure conditions.

This will make turso-stress failures easier to read, instead of them looking like this:

<img width="829" height="503" alt="image" src="https://github.com/user-attachments/assets/e9ba3a5e-0f12-43fb-807d-0e9534fb75ea" />
