### PR TITLE
fix: Use pure-rust for macos for aegis to prevent macos compilation issues

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -111,11 +111,11 @@ loom = { workspace = true }
 [target.'cfg(shuttle)'.dependencies]
 shuttle = { workspace = true }
 
-# Use pure-rust for Android to avoid C cross-compilation issues
-[target.'cfg(target_os = "android")'.dependencies]
+# Use pure-rust for Android and MacOS to avoid C cross-compilation issues
+[target.'cfg(any(target_os = "android", target_os = "macos"))'.dependencies]
 aegis = { version = "0.9.5", features = ["pure-rust"] }
 
-[target.'cfg(not(target_os = "android"))'.dependencies]
+[target.'cfg(not(any(target_os = "android", target_os = "macos")))'.dependencies]
 aegis = "0.9.5"
 
 [build-dependencies]


### PR DESCRIPTION
## Description

The MacOS build was failing to a compilation error with Aegis. I noticed Android had a similar problem with Aegis. Using pure-rust for Aegis fixed their issue, and it also fixed the issue on MacOS as well.

## Motivation and context

Closes #5518 
Issue discussion here: https://discord.com/channels/1258658826257961020/1475218240916427053

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->