### PR TITLE
Fix REAL affinity to preserve non-numeric text

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10792,32 +10792,39 @@ fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
                 return false;
             }
 
-            Affinity::Real => {
-                if let Value::Numeric(Numeric::Integer(i)) = *value {
-                    *value = Value::from_f64(i as f64);
+            Affinity::Real => match value {
+                Value::Numeric(Numeric::Integer(i)) => {
+                    *value = Value::from_f64(*i as f64);
                     return true;
                 }
-                if let Value::Text(t) = value {
-                    let s = t.as_str();
-                    if s.starts_with("0x") {
+                Value::Numeric(Numeric::Float(_)) | Value::Null => {
+                    return true;
+                }
+                Value::Text(t) => {
+                    let text = trim_ascii_whitespace(t.as_str());
+                    if text.starts_with("0x") {
                         return false;
                     }
-                    if let Ok(num) = checked_cast_text_to_numeric(s, false) {
-                        match num {
-                            Value::Numeric(Numeric::Integer(i)) => {
-                                *value = Value::from_f64(i as f64);
-                            }
-                            other => {
-                                *value = other;
+
+                    let (parse_result, parsed_value) = try_for_float(text.as_bytes());
+                    let coerced = match parse_result {
+                        NumericParseResult::NotNumeric | NumericParseResult::ValidPrefixOnly => {
+                            return false;
+                        }
+                        NumericParseResult::PureInteger | NumericParseResult::HasDecimalOrExp => {
+                            match parsed_value {
+                                ParsedNumber::Integer(i) => Value::from_f64(i as f64),
+                                ParsedNumber::Float(f) => Value::from_f64(f),
+                                ParsedNumber::None => return false,
                             }
                         }
-                        return true;
-                    } else {
-                        return false;
-                    }
+                    };
+
+                    *value = coerced;
+                    return true;
                 }
-                return true;
-            }
+                _ => return true,
+            },
         }
     }
 

--- a/testing/runner/tests/affinity.sqltest
+++ b/testing/runner/tests/affinity.sqltest
@@ -104,6 +104,21 @@ expect {
 }
 
 # ============================================
+# REAL affinity: non-numeric text should remain TEXT
+# ============================================
+test affinity-real-non-numeric-text {
+    CREATE TABLE t1 (c DOUBLE);
+    INSERT INTO t1 VALUES ('23g'), ('1998-12-01'), ('.DEF'), ('3-three');
+    SELECT typeof(c), c FROM t1 ORDER BY rowid;
+}
+expect {
+    text|23g
+    text|1998-12-01
+    text|.DEF
+    text|3-three
+}
+
+# ============================================
 # IN clause with TEXT column: should apply TEXT affinity to comparison
 # ============================================
 test affinity-in-text-column {


### PR DESCRIPTION
## Description

- Adjust REAL affinity conversion to only coerce when the full text is a well-formed numeric literal, matching SQLite’s lossless affinity behavior in `core/vdbe/execute.rs`.
- Add regression coverage for non-numeric text in REAL/DOUBLE affinity in `testing/runner/tests/affinity.sqltest`.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

- Prevent silent data loss when inserting non-numeric text into REAL/DOUBLE columns by aligning with SQLite column-affinity rules.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5502

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
