### PR TITLE
bindings/rust: add sync-rustls feature for pure-Rust TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,10 +2384,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3438,10 +3450,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3656,6 +3668,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -4675,10 +4693,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -4861,7 +4892,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5409,7 +5453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -6134,6 +6178,7 @@ dependencies = [
  "bytes",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "mimalloc",
@@ -6803,6 +6848,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -15,14 +15,18 @@ workspace = true
 [features]
 default = ["mimalloc"]
 mimalloc = ["dep:mimalloc"]
-sync = [
+# Base sync deps shared by both TLS backends (not meant to be activated directly)
+_sync_base = [
     "dep:hyper",
     "dep:tokio",
-    "dep:hyper-tls",
     "dep:hyper-util",
     "dep:http-body-util",
     "dep:bytes",
 ]
+# Original sync feature uses native-tls (OpenSSL on Linux)
+sync = ["_sync_base", "dep:hyper-tls"]
+# Pure-Rust TLS via rustls -- no OpenSSL needed
+sync-rustls = ["_sync_base", "dep:hyper-rustls"]
 
 [dependencies]
 turso_sdk_kit = { workspace = true }
@@ -35,6 +39,13 @@ mimalloc = { workspace = true, optional = true }
 hyper = { version = "1.8.1", features = ["http1"], optional = true }
 tokio = { workspace = true, features = ["full"], optional = true }
 hyper-tls = { version = "0.6.0", optional = true }
+hyper-rustls = { version = "0.27", optional = true, default-features = false, features = [
+    "http1",
+    "tls12",
+    "ring",
+    "native-tokio",
+    "webpki-tokio",
+] }
 hyper-util = { version = "0.1.19", features = [
     "http1",
     "tokio",

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -42,7 +42,7 @@ mod rows;
 pub mod transaction;
 pub mod value;
 
-#[cfg(feature = "sync")]
+#[cfg(any(feature = "sync", feature = "sync-rustls"))]
 pub mod sync;
 
 pub use connection::Connection;


### PR DESCRIPTION
## Summary

- Add a `sync-rustls` feature to the Rust bindings as an alternative to the existing `sync` feature, using `hyper-rustls` (rustls) instead of `hyper-tls` (native-tls/OpenSSL)
- Refactor the `sync` feature into `_sync_base` (shared deps) + `sync` (native-tls) + `sync-rustls` (rustls) to avoid dependency duplication
- Use `#[cfg]` conditionals in `sync.rs` to select the appropriate `HttpsConnector` at compile time

## Motivation

The current `sync` feature requires OpenSSL development libraries to be installed on the build system (`libssl-dev` on Debian/Ubuntu, `openssl-devel` on Fedora). This is a friction point for:

- **Nix-based builds** where avoiding system-level C dependencies simplifies the derivation
- **Static linking** scenarios where a pure-Rust TLS stack is preferred
- **Cross-compilation** where matching the target's OpenSSL version can be challenging
- **Minimal container images** that don't ship OpenSSL

The `sync-rustls` feature provides a drop-in alternative that requires zero system TLS libraries.

## Changes

| File | Change |
|------|--------|
| `bindings/rust/Cargo.toml` | Refactored features; added `hyper-rustls` optional dep |
| `bindings/rust/src/lib.rs` | Gate `sync` module on `any(feature = "sync", feature = "sync-rustls")` |
| `bindings/rust/src/sync.rs` | `#[cfg]` conditionals on `HttpsConnector` import and construction |
| `Cargo.lock` | Updated with new dependencies |

## Usage

```toml
# Before (requires OpenSSL):
turso = { version = "...", features = ["sync"] }

# After (pure Rust, no OpenSSL):
turso = { version = "...", features = ["sync-rustls"] }
```

## Testing

- `cargo check -p turso --features sync-rustls --no-default-features` compiles cleanly
- The existing `sync` feature is unchanged and fully backward-compatible
- The two features are mutually exclusive via `#[cfg]` gates (enabling both would cause a duplicate definition error, which is the desired behavior since they provide the same type)