### PR TITLE
core/translate: Remove spurious Affinity instruction from integrity_check

### DIFF
--- a/testing/runner/tests/integrity_check/memory.sqltest
+++ b/testing/runner/tests/integrity_check/memory.sqltest
@@ -126,3 +126,46 @@ expect {
     ok
 }
 
+# Test integrity_check after ALTER TABLE ADD COLUMN with type-mismatched default
+# and CREATE INDEX. Rows inserted before ADD COLUMN have the raw default value
+# (integer 0) while the column affinity is TEXT. The integrity check must not
+# apply affinity to the column values when verifying index membership, matching
+# SQLite's behavior.
+test integrity-check-alter-table-default-index {
+    CREATE TABLE t6(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t6 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+    ALTER TABLE t6 ADD COLUMN c TEXT DEFAULT 0;
+    CREATE INDEX idx_t6_c ON t6(c);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+# Same test but with a composite index including DESC ordering
+test integrity-check-alter-table-default-desc-index {
+    CREATE TABLE t7(a INTEGER PRIMARY KEY, b TEXT, c NUMERIC NOT NULL);
+    INSERT INTO t7 VALUES (1, 'x', 10), (2, 'y', 20), (3, 'z', 30);
+    ALTER TABLE t7 ADD COLUMN d TEXT DEFAULT 0;
+    CREATE INDEX idx_t7_composite ON t7(b, c DESC, d DESC);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+# Test with rows inserted both before and after ALTER TABLE ADD COLUMN
+test integrity-check-alter-table-mixed-rows {
+    CREATE TABLE t8(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t8 VALUES (1, 'old1'), (2, 'old2');
+    ALTER TABLE t8 ADD COLUMN c TEXT DEFAULT 0;
+    INSERT INTO t8 VALUES (3, 'new1', 'hello');
+    INSERT INTO t8 VALUES (4, 'new2', NULL);
+    INSERT INTO t8(a, b) VALUES (5, 'new3');
+    CREATE INDEX idx_t8_c ON t8(c);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+

--- a/testing/runner/tests/integrity_check/snapshots/snapshot_plans__integrity-check-multi-table-vdbe.snap
+++ b/testing/runner/tests/integrity_check/snapshots/snapshot_plans__integrity-check-multi-table-vdbe.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode        p1   p2   p3  p4                                       p5  comment
-   0  Init           0  163    0                                            0  Start at 163
+   0  Init           0  159    0                                            0  Start at 159
    1  Integer       99    2    0                                            0  r[2]=99
    2  Integer        0    3    0                                            0  r[3]=0
    3  IntegrityCk  100    0    0                                            0  roots=[5, 7, 6, 2, 4, 3, 1] message_register=4
@@ -31,7 +31,7 @@ addr  opcode        p1   p2   p3  p4                                       p5  c
   14  OpenRead       2    6    0  k(2,B)                                    0  =idx_t2_y, root=6, iDb=0
   15  Integer        0    7    0                                            0  r[7]=0
   16  Integer        0    8    0                                            0  r[8]=0
-  17  Rewind         0   65    0                                            0  Rewind table t2
+  17  Rewind         0   63    0                                            0  Rewind table t2
   18    AddImm       8    1    0                                            0  r[8]=r[8]+1
   19    Column       0    1    9                                            0  r[9]=t2.y
   20    NotNull      9   26    0                                            0  r[9]!=NULL -> goto 26
@@ -51,132 +51,128 @@ addr  opcode        p1   p2   p3  p4                                       p5  c
   34    Column       0    1   15                                            0  r[15]=t2.y
   35    Function     0   15   13  lower                                     0  r[13]=func(r[15])
   36    RowId        0   14    0                                            0  r[14]=t2.rowid
-  37    Affinity    13    1    0                                            0  r[13..14] = A
-  38    Found        1   49   13                                            0  if found goto 49
-  39    String8      0    4    0  row                                       0  r[4]='row '
-  40    Concat       8    4    4                                            0  r[4]=r[4] + r[8]
-  41    String8      0    5    0   missing from index                       0  r[5]=' missing from index '
-  42    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
-  43    String8      0    5    0  idx_t2_expr                               0  r[5]='idx_t2_expr'
-  44    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
-  45    Integer      1    3    0                                            0  r[3]=1
-  46    ResultRow    4    1    0                                            0  output=r[4]
-  47    IfPos        2   49    1                                            0  r[2]>0 -> r[2]-=1, goto 49
-  48    Halt         0    0    0                                            0
-  49    AddImm       7    1    0                                            0  r[7]=r[7]+1
-  50    Column       0    1   16                                            0  r[16]=t2.y
-  51    RowId        0   17    0                                            0  r[17]=t2.rowid
-  52    Affinity    16    1    0                                            0  r[16..17] = B
-  53    Found        2   64   16                                            0  if found goto 64
-  54    String8      0    4    0  row                                       0  r[4]='row '
-  55    Concat       8    4    4                                            0  r[4]=r[4] + r[8]
-  56    String8      0    5    0   missing from index                       0  r[5]=' missing from index '
+  37    Found        1   48   13                                            0  if found goto 48
+  38    String8      0    4    0  row                                       0  r[4]='row '
+  39    Concat       8    4    4                                            0  r[4]=r[4] + r[8]
+  40    String8      0    5    0   missing from index                       0  r[5]=' missing from index '
+  41    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
+  42    String8      0    5    0  idx_t2_expr                               0  r[5]='idx_t2_expr'
+  43    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
+  44    Integer      1    3    0                                            0  r[3]=1
+  45    ResultRow    4    1    0                                            0  output=r[4]
+  46    IfPos        2   48    1                                            0  r[2]>0 -> r[2]-=1, goto 48
+  47    Halt         0    0    0                                            0
+  48    AddImm       7    1    0                                            0  r[7]=r[7]+1
+  49    Column       0    1   16                                            0  r[16]=t2.y
+  50    RowId        0   17    0                                            0  r[17]=t2.rowid
+  51    Found        2   62   16                                            0  if found goto 62
+  52    String8      0    4    0  row                                       0  r[4]='row '
+  53    Concat       8    4    4                                            0  r[4]=r[4] + r[8]
+  54    String8      0    5    0   missing from index                       0  r[5]=' missing from index '
+  55    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
+  56    String8      0    5    0  idx_t2_y                                  0  r[5]='idx_t2_y'
   57    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
-  58    String8      0    5    0  idx_t2_y                                  0  r[5]='idx_t2_y'
-  59    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
-  60    Integer      1    3    0                                            0  r[3]=1
-  61    ResultRow    4    1    0                                            0  output=r[4]
-  62    IfPos        2   64    1                                            0  r[2]>0 -> r[2]-=1, goto 64
-  63    Halt         0    0    0                                            0
-  64  Next           0   18    0                                            0
-  65  Count          1   18    0                                            0
-  66  Eq            18    6   72                                            0  if r[18]==r[6] goto 72
-  67  String8        0    4    0  wrong # of entries in index idx_t2_expr   0  r[4]='wrong # of entries in index idx_t2_expr'
-  68  Integer        1    3    0                                            0  r[3]=1
-  69  ResultRow      4    1    0                                            0  output=r[4]
-  70  IfPos          2   72    1                                            0  r[2]>0 -> r[2]-=1, goto 72
-  71  Halt           0    0    0                                            0
-  72  Close          1    0    0                                            0
-  73  Count          2   19    0                                            0
-  74  Eq            19    7   80                                            0  if r[19]==r[7] goto 80
-  75  String8        0    4    0  wrong # of entries in index idx_t2_y      0  r[4]='wrong # of entries in index idx_t2_y'
-  76  Integer        1    3    0                                            0  r[3]=1
-  77  ResultRow      4    1    0                                            0  output=r[4]
-  78  IfPos          2   80    1                                            0  r[2]>0 -> r[2]-=1, goto 80
-  79  Halt           0    0    0                                            0
-  80  Close          2    0    0                                            0
-  81  Close          0    0    0                                            0
-  82  OpenRead       3    2    0  k(2,B,B)                                  0  table=t1, root=2, iDb=0
-  83  OpenRead       4    4    0  k(2,B)                                    0  =idx_t1_b_u, root=4, iDb=0
-  84  Integer        0   20    0                                            0  r[20]=0
-  85  OpenRead       5    3    0  k(2,B)                                    0  =idx_t1_b, root=3, iDb=0
-  86  Integer        0   21    0                                            0  r[21]=0
-  87  Integer        0   22    0                                            0  r[22]=0
-  88  Rewind         3  136    0                                            0  Rewind table t1
-  89    AddImm      22    1    0                                            0  r[22]=r[22]+1
-  90    Column       3    1   23                                            0  r[23]=t1.b
-  91    NotNull     23   97    0                                            0  r[23]!=NULL -> goto 97
-  92    String8      0    4    0  NULL value in t1.b                        0  r[4]='NULL value in t1.b'
-  93    Integer      1    3    0                                            0  r[3]=1
-  94    ResultRow    4    1    0                                            0  output=r[4]
-  95    IfPos        2   97    1                                            0  r[2]>0 -> r[2]-=1, goto 97
-  96    Halt         0    0    0                                            0
-  97    AddImm      20    1    0                                            0  r[20]=r[20]+1
-  98    Column       3    1   24                                            0  r[24]=t1.b
-  99    RowId        3   25    0                                            0  r[25]=t1.rowid
- 100    Affinity    24    1    0                                            0  r[24..25] = B
- 101    Found        4  112   24                                            0  if found goto 112
- 102    String8      0    4    0  row                                       0  r[4]='row '
- 103    Concat      22    4    4                                            0  r[4]=r[4] + r[22]
- 104    String8      0    5    0   missing from index                       0  r[5]=' missing from index '
- 105    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
- 106    String8      0    5    0  idx_t1_b_u                                0  r[5]='idx_t1_b_u'
- 107    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
- 108    Integer      1    3    0                                            0  r[3]=1
- 109    ResultRow    4    1    0                                            0  output=r[4]
- 110    IfPos        2  112    1                                            0  r[2]>0 -> r[2]-=1, goto 112
- 111    Halt         0    0    0                                            0
- 112    Next         4  114    0                                            0
- 113    Goto         0  120    0                                            0
- 114    IdxGT        4  120   24                                            0  key=[24..24]
- 115    String8      0    4    0  non-unique entry in index idx_t1_b_u      0  r[4]='non-unique entry in index idx_t1_b_u'
- 116    Integer      1    3    0                                            0  r[3]=1
- 117    ResultRow    4    1    0                                            0  output=r[4]
- 118    IfPos        2  120    1                                            0  r[2]>0 -> r[2]-=1, goto 120
- 119    Halt         0    0    0                                            0
- 120    AddImm      21    1    0                                            0  r[21]=r[21]+1
- 121    Column       3    1   26                                            0  r[26]=t1.b
- 122    RowId        3   27    0                                            0  r[27]=t1.rowid
- 123    Affinity    26    1    0                                            0  r[26..27] = B
- 124    Found        5  135   26                                            0  if found goto 135
- 125    String8      0    4    0  row                                       0  r[4]='row '
- 126    Concat      22    4    4                                            0  r[4]=r[4] + r[22]
- 127    String8      0    5    0   missing from index                       0  r[5]=' missing from index '
- 128    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
- 129    String8      0    5    0  idx_t1_b                                  0  r[5]='idx_t1_b'
- 130    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
- 131    Integer      1    3    0                                            0  r[3]=1
- 132    ResultRow    4    1    0                                            0  output=r[4]
- 133    IfPos        2  135    1                                            0  r[2]>0 -> r[2]-=1, goto 135
- 134    Halt         0    0    0                                            0
- 135  Next           3   89    0                                            0
- 136  Count          4   28    0                                            0
- 137  Eq            28   20  143                                            0  if r[28]==r[20] goto 143
- 138  String8        0    4    0  wrong # of entries in index idx_t1_b_u    0  r[4]='wrong # of entries in index idx_t1_b_u'
- 139  Integer        1    3    0                                            0  r[3]=1
- 140  ResultRow      4    1    0                                            0  output=r[4]
- 141  IfPos          2  143    1                                            0  r[2]>0 -> r[2]-=1, goto 143
- 142  Halt           0    0    0                                            0
- 143  Close          4    0    0                                            0
- 144  Count          5   29    0                                            0
- 145  Eq            29   21  151                                            0  if r[29]==r[21] goto 151
- 146  String8        0    4    0  wrong # of entries in index idx_t1_b      0  r[4]='wrong # of entries in index idx_t1_b'
- 147  Integer        1    3    0                                            0  r[3]=1
- 148  ResultRow      4    1    0                                            0  output=r[4]
- 149  IfPos          2  151    1                                            0  r[2]>0 -> r[2]-=1, goto 151
- 150  Halt           0    0    0                                            0
- 151  Close          5    0    0                                            0
- 152  Close          3    0    0                                            0
- 153  OpenRead       6    1    0  k(6,B,B,B,B,B)                            0  table=sqlite_schema, root=1, iDb=0
- 154  Integer        0   30    0                                            0  r[30]=0
- 155  Rewind         6  158    0                                            0  Rewind table sqlite_schema
- 156    AddImm      30    1    0                                            0  r[30]=r[30]+1
- 157  Next           6  156    0                                            0
- 158  Close          6    0    0                                            0
- 159  If             3  162    0                                            0  if r[3] goto 162
- 160  String8        0    4    0  ok                                        0  r[4]='ok'
- 161  ResultRow      4    1    0                                            0  output=r[4]
- 162  Halt           0    0    0                                            0
- 163  Transaction    0    1    6                                            0  iDb=0 tx_mode=Read
- 164  Integer        0   12    0                                            0  r[12]=0
- 165  Goto           0    1    0                                            0
+  58    Integer      1    3    0                                            0  r[3]=1
+  59    ResultRow    4    1    0                                            0  output=r[4]
+  60    IfPos        2   62    1                                            0  r[2]>0 -> r[2]-=1, goto 62
+  61    Halt         0    0    0                                            0
+  62  Next           0   18    0                                            0
+  63  Count          1   18    0                                            0
+  64  Eq            18    6   70                                            0  if r[18]==r[6] goto 70
+  65  String8        0    4    0  wrong # of entries in index idx_t2_expr   0  r[4]='wrong # of entries in index idx_t2_expr'
+  66  Integer        1    3    0                                            0  r[3]=1
+  67  ResultRow      4    1    0                                            0  output=r[4]
+  68  IfPos          2   70    1                                            0  r[2]>0 -> r[2]-=1, goto 70
+  69  Halt           0    0    0                                            0
+  70  Close          1    0    0                                            0
+  71  Count          2   19    0                                            0
+  72  Eq            19    7   78                                            0  if r[19]==r[7] goto 78
+  73  String8        0    4    0  wrong # of entries in index idx_t2_y      0  r[4]='wrong # of entries in index idx_t2_y'
+  74  Integer        1    3    0                                            0  r[3]=1
+  75  ResultRow      4    1    0                                            0  output=r[4]
+  76  IfPos          2   78    1                                            0  r[2]>0 -> r[2]-=1, goto 78
+  77  Halt           0    0    0                                            0
+  78  Close          2    0    0                                            0
+  79  Close          0    0    0                                            0
+  80  OpenRead       3    2    0  k(2,B,B)                                  0  table=t1, root=2, iDb=0
+  81  OpenRead       4    4    0  k(2,B)                                    0  =idx_t1_b_u, root=4, iDb=0
+  82  Integer        0   20    0                                            0  r[20]=0
+  83  OpenRead       5    3    0  k(2,B)                                    0  =idx_t1_b, root=3, iDb=0
+  84  Integer        0   21    0                                            0  r[21]=0
+  85  Integer        0   22    0                                            0  r[22]=0
+  86  Rewind         3  132    0                                            0  Rewind table t1
+  87    AddImm      22    1    0                                            0  r[22]=r[22]+1
+  88    Column       3    1   23                                            0  r[23]=t1.b
+  89    NotNull     23   95    0                                            0  r[23]!=NULL -> goto 95
+  90    String8      0    4    0  NULL value in t1.b                        0  r[4]='NULL value in t1.b'
+  91    Integer      1    3    0                                            0  r[3]=1
+  92    ResultRow    4    1    0                                            0  output=r[4]
+  93    IfPos        2   95    1                                            0  r[2]>0 -> r[2]-=1, goto 95
+  94    Halt         0    0    0                                            0
+  95    AddImm      20    1    0                                            0  r[20]=r[20]+1
+  96    Column       3    1   24                                            0  r[24]=t1.b
+  97    RowId        3   25    0                                            0  r[25]=t1.rowid
+  98    Found        4  109   24                                            0  if found goto 109
+  99    String8      0    4    0  row                                       0  r[4]='row '
+ 100    Concat      22    4    4                                            0  r[4]=r[4] + r[22]
+ 101    String8      0    5    0   missing from index                       0  r[5]=' missing from index '
+ 102    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
+ 103    String8      0    5    0  idx_t1_b_u                                0  r[5]='idx_t1_b_u'
+ 104    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
+ 105    Integer      1    3    0                                            0  r[3]=1
+ 106    ResultRow    4    1    0                                            0  output=r[4]
+ 107    IfPos        2  109    1                                            0  r[2]>0 -> r[2]-=1, goto 109
+ 108    Halt         0    0    0                                            0
+ 109    Next         4  111    0                                            0
+ 110    Goto         0  117    0                                            0
+ 111    IdxGT        4  117   24                                            0  key=[24..24]
+ 112    String8      0    4    0  non-unique entry in index idx_t1_b_u      0  r[4]='non-unique entry in index idx_t1_b_u'
+ 113    Integer      1    3    0                                            0  r[3]=1
+ 114    ResultRow    4    1    0                                            0  output=r[4]
+ 115    IfPos        2  117    1                                            0  r[2]>0 -> r[2]-=1, goto 117
+ 116    Halt         0    0    0                                            0
+ 117    AddImm      21    1    0                                            0  r[21]=r[21]+1
+ 118    Column       3    1   26                                            0  r[26]=t1.b
+ 119    RowId        3   27    0                                            0  r[27]=t1.rowid
+ 120    Found        5  131   26                                            0  if found goto 131
+ 121    String8      0    4    0  row                                       0  r[4]='row '
+ 122    Concat      22    4    4                                            0  r[4]=r[4] + r[22]
+ 123    String8      0    5    0   missing from index                       0  r[5]=' missing from index '
+ 124    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
+ 125    String8      0    5    0  idx_t1_b                                  0  r[5]='idx_t1_b'
+ 126    Concat       5    4    4                                            0  r[4]=r[4] + r[5]
+ 127    Integer      1    3    0                                            0  r[3]=1
+ 128    ResultRow    4    1    0                                            0  output=r[4]
+ 129    IfPos        2  131    1                                            0  r[2]>0 -> r[2]-=1, goto 131
+ 130    Halt         0    0    0                                            0
+ 131  Next           3   87    0                                            0
+ 132  Count          4   28    0                                            0
+ 133  Eq            28   20  139                                            0  if r[28]==r[20] goto 139
+ 134  String8        0    4    0  wrong # of entries in index idx_t1_b_u    0  r[4]='wrong # of entries in index idx_t1_b_u'
+ 135  Integer        1    3    0                                            0  r[3]=1
+ 136  ResultRow      4    1    0                                            0  output=r[4]
+ 137  IfPos          2  139    1                                            0  r[2]>0 -> r[2]-=1, goto 139
+ 138  Halt           0    0    0                                            0
+ 139  Close          4    0    0                                            0
+ 140  Count          5   29    0                                            0
+ 141  Eq            29   21  147                                            0  if r[29]==r[21] goto 147
+ 142  String8        0    4    0  wrong # of entries in index idx_t1_b      0  r[4]='wrong # of entries in index idx_t1_b'
+ 143  Integer        1    3    0                                            0  r[3]=1
+ 144  ResultRow      4    1    0                                            0  output=r[4]
+ 145  IfPos          2  147    1                                            0  r[2]>0 -> r[2]-=1, goto 147
+ 146  Halt           0    0    0                                            0
+ 147  Close          5    0    0                                            0
+ 148  Close          3    0    0                                            0
+ 149  OpenRead       6    1    0  k(6,B,B,B,B,B)                            0  table=sqlite_schema, root=1, iDb=0
+ 150  Integer        0   30    0                                            0  r[30]=0
+ 151  Rewind         6  154    0                                            0  Rewind table sqlite_schema
+ 152    AddImm      30    1    0                                            0  r[30]=r[30]+1
+ 153  Next           6  152    0                                            0
+ 154  Close          6    0    0                                            0
+ 155  If             3  158    0                                            0  if r[3] goto 158
+ 156  String8        0    4    0  ok                                        0  r[4]='ok'
+ 157  ResultRow      4    1    0                                            0  output=r[4]
+ 158  Halt           0    0    0                                            0
+ 159  Transaction    0    1    6                                            0  iDb=0 tx_mode=Read
+ 160  Integer        0   12    0                                            0  r[12]=0
+ 161  Goto           0    1    0                                            0

--- a/testing/runner/tests/integrity_check/snapshots/snapshot_plans__integrity-check-vdbe.snap
+++ b/testing/runner/tests/integrity_check/snapshots/snapshot_plans__integrity-check-vdbe.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode        p1   p2   p3  p4                                   p5  comment
-   0  Init           0  121    0                                        0  Start at 121
+   0  Init           0  118    0                                        0  Start at 118
    1  Integer       99    2    0                                        0  r[2]=99
    2  Integer        0    3    0                                        0  r[3]=0
    3  IntegrityCk  100    0    0                                        0  roots=[2, 5, 4, 3, 1] message_register=4
@@ -33,7 +33,7 @@ addr  opcode        p1   p2   p3  p4                                   p5  comme
   16  OpenRead       3    3    0  k(2,B)                                0  =idx_t_b, root=3, iDb=0
   17  Integer        0    8    0                                        0  r[8]=0
   18  Integer        0    9    0                                        0  r[9]=0
-  19  Rewind         0   93    0                                        0  Rewind table t
+  19  Rewind         0   90    0                                        0  Rewind table t
   20    AddImm       9    1    0                                        0  r[9]=r[9]+1
   21    Column       0    1   10                                        0  r[10]=t.b
   22    NotNull     10   28    0                                        0  r[10]!=NULL -> goto 28
@@ -50,91 +50,88 @@ addr  opcode        p1   p2   p3  p4                                   p5  comme
   33    IfPos        2   35    1                                        0  r[2]>0 -> r[2]-=1, goto 35
   34    Halt         0    0    0                                        0
   35    Column       0    3   14                                        0  r[14]=t.d
-  36    IsNull      14   53    0                                        0  if (r[14]==NULL) goto 53
+  36    IsNull      14   52    0                                        0  if (r[14]==NULL) goto 52
   37    AddImm       6    1    0                                        0  r[6]=r[6]+1
   38    Column       0    3   17                                        0  r[17]=t.d
   39    Function     0   17   15  lower                                 0  r[15]=func(r[17])
   40    RowId        0   16    0                                        0  r[16]=t.rowid
-  41    Affinity    15    1    0                                        0  r[15..16] = A
-  42    Found        1   53   15                                        0  if found goto 53
-  43    String8      0    4    0  row                                   0  r[4]='row '
-  44    Concat       9    4    4                                        0  r[4]=r[4] + r[9]
-  45    String8      0    5    0   missing from index                   0  r[5]=' missing from index '
-  46    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
-  47    String8      0    5    0  idx_t_expr_partial                    0  r[5]='idx_t_expr_partial'
-  48    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
-  49    Integer      1    3    0                                        0  r[3]=1
-  50    ResultRow    4    1    0                                        0  output=r[4]
-  51    IfPos        2   53    1                                        0  r[2]>0 -> r[2]-=1, goto 53
-  52    Halt         0    0    0                                        0
-  53    AddImm       7    1    0                                        0  r[7]=r[7]+1
-  54    Column       0    2   18                                        0  r[18]=t.c
-  55    RowId        0   19    0                                        0  r[19]=t.rowid
-  56    Affinity    18    1    0                                        0  r[18..19] = D
-  57    Found        2   68   18                                        0  if found goto 68
-  58    String8      0    4    0  row                                   0  r[4]='row '
-  59    Concat       9    4    4                                        0  r[4]=r[4] + r[9]
-  60    String8      0    5    0   missing from index                   0  r[5]=' missing from index '
+  41    Found        1   52   15                                        0  if found goto 52
+  42    String8      0    4    0  row                                   0  r[4]='row '
+  43    Concat       9    4    4                                        0  r[4]=r[4] + r[9]
+  44    String8      0    5    0   missing from index                   0  r[5]=' missing from index '
+  45    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
+  46    String8      0    5    0  idx_t_expr_partial                    0  r[5]='idx_t_expr_partial'
+  47    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
+  48    Integer      1    3    0                                        0  r[3]=1
+  49    ResultRow    4    1    0                                        0  output=r[4]
+  50    IfPos        2   52    1                                        0  r[2]>0 -> r[2]-=1, goto 52
+  51    Halt         0    0    0                                        0
+  52    AddImm       7    1    0                                        0  r[7]=r[7]+1
+  53    Column       0    2   18                                        0  r[18]=t.c
+  54    RowId        0   19    0                                        0  r[19]=t.rowid
+  55    Found        2   66   18                                        0  if found goto 66
+  56    String8      0    4    0  row                                   0  r[4]='row '
+  57    Concat       9    4    4                                        0  r[4]=r[4] + r[9]
+  58    String8      0    5    0   missing from index                   0  r[5]=' missing from index '
+  59    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
+  60    String8      0    5    0  idx_t_c                               0  r[5]='idx_t_c'
   61    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
-  62    String8      0    5    0  idx_t_c                               0  r[5]='idx_t_c'
-  63    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
-  64    Integer      1    3    0                                        0  r[3]=1
-  65    ResultRow    4    1    0                                        0  output=r[4]
-  66    IfPos        2   68    1                                        0  r[2]>0 -> r[2]-=1, goto 68
-  67    Halt         0    0    0                                        0
-  68    IsNull      18   77    0                                        0  if (r[18]==NULL) goto 77
-  69    Next         2   71    0                                        0
-  70    Goto         0   77    0                                        0
-  71    IdxGT        2   77   18                                        0  key=[18..18]
-  72    String8      0    4    0  non-unique entry in index idx_t_c     0  r[4]='non-unique entry in index idx_t_c'
-  73    Integer      1    3    0                                        0  r[3]=1
-  74    ResultRow    4    1    0                                        0  output=r[4]
-  75    IfPos        2   77    1                                        0  r[2]>0 -> r[2]-=1, goto 77
-  76    Halt         0    0    0                                        0
-  77    AddImm       8    1    0                                        0  r[8]=r[8]+1
-  78    Column       0    1   20                                        0  r[20]=t.b
-  79    RowId        0   21    0                                        0  r[21]=t.rowid
-  80    Affinity    20    1    0                                        0  r[20..21] = B
-  81    Found        3   92   20                                        0  if found goto 92
-  82    String8      0    4    0  row                                   0  r[4]='row '
-  83    Concat       9    4    4                                        0  r[4]=r[4] + r[9]
-  84    String8      0    5    0   missing from index                   0  r[5]=' missing from index '
-  85    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
-  86    String8      0    5    0  idx_t_b                               0  r[5]='idx_t_b'
-  87    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
-  88    Integer      1    3    0                                        0  r[3]=1
-  89    ResultRow    4    1    0                                        0  output=r[4]
-  90    IfPos        2   92    1                                        0  r[2]>0 -> r[2]-=1, goto 92
-  91    Halt         0    0    0                                        0
-  92  Next           0   20    0                                        0
-  93  Close          1    0    0                                        0
-  94  Count          2   22    0                                        0
-  95  Eq            22    7  101                                        0  if r[22]==r[7] goto 101
-  96  String8        0    4    0  wrong # of entries in index idx_t_c   0  r[4]='wrong # of entries in index idx_t_c'
-  97  Integer        1    3    0                                        0  r[3]=1
-  98  ResultRow      4    1    0                                        0  output=r[4]
-  99  IfPos          2  101    1                                        0  r[2]>0 -> r[2]-=1, goto 101
- 100  Halt           0    0    0                                        0
- 101  Close          2    0    0                                        0
- 102  Count          3   23    0                                        0
- 103  Eq            23    8  109                                        0  if r[23]==r[8] goto 109
- 104  String8        0    4    0  wrong # of entries in index idx_t_b   0  r[4]='wrong # of entries in index idx_t_b'
- 105  Integer        1    3    0                                        0  r[3]=1
- 106  ResultRow      4    1    0                                        0  output=r[4]
- 107  IfPos          2  109    1                                        0  r[2]>0 -> r[2]-=1, goto 109
- 108  Halt           0    0    0                                        0
- 109  Close          3    0    0                                        0
- 110  Close          0    0    0                                        0
- 111  OpenRead       4    1    0  k(6,B,B,B,B,B)                        0  table=sqlite_schema, root=1, iDb=0
- 112  Integer        0   24    0                                        0  r[24]=0
- 113  Rewind         4  116    0                                        0  Rewind table sqlite_schema
- 114    AddImm      24    1    0                                        0  r[24]=r[24]+1
- 115  Next           4  114    0                                        0
- 116  Close          4    0    0                                        0
- 117  If             3  120    0                                        0  if r[3] goto 120
- 118  String8        0    4    0  ok                                    0  r[4]='ok'
- 119  ResultRow      4    1    0                                        0  output=r[4]
- 120  Halt           0    0    0                                        0
- 121  Transaction    0    1    4                                        0  iDb=0 tx_mode=Read
- 122  Integer        0   13    0                                        0  r[13]=0
- 123  Goto           0    1    0                                        0
+  62    Integer      1    3    0                                        0  r[3]=1
+  63    ResultRow    4    1    0                                        0  output=r[4]
+  64    IfPos        2   66    1                                        0  r[2]>0 -> r[2]-=1, goto 66
+  65    Halt         0    0    0                                        0
+  66    IsNull      18   75    0                                        0  if (r[18]==NULL) goto 75
+  67    Next         2   69    0                                        0
+  68    Goto         0   75    0                                        0
+  69    IdxGT        2   75   18                                        0  key=[18..18]
+  70    String8      0    4    0  non-unique entry in index idx_t_c     0  r[4]='non-unique entry in index idx_t_c'
+  71    Integer      1    3    0                                        0  r[3]=1
+  72    ResultRow    4    1    0                                        0  output=r[4]
+  73    IfPos        2   75    1                                        0  r[2]>0 -> r[2]-=1, goto 75
+  74    Halt         0    0    0                                        0
+  75    AddImm       8    1    0                                        0  r[8]=r[8]+1
+  76    Column       0    1   20                                        0  r[20]=t.b
+  77    RowId        0   21    0                                        0  r[21]=t.rowid
+  78    Found        3   89   20                                        0  if found goto 89
+  79    String8      0    4    0  row                                   0  r[4]='row '
+  80    Concat       9    4    4                                        0  r[4]=r[4] + r[9]
+  81    String8      0    5    0   missing from index                   0  r[5]=' missing from index '
+  82    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
+  83    String8      0    5    0  idx_t_b                               0  r[5]='idx_t_b'
+  84    Concat       5    4    4                                        0  r[4]=r[4] + r[5]
+  85    Integer      1    3    0                                        0  r[3]=1
+  86    ResultRow    4    1    0                                        0  output=r[4]
+  87    IfPos        2   89    1                                        0  r[2]>0 -> r[2]-=1, goto 89
+  88    Halt         0    0    0                                        0
+  89  Next           0   20    0                                        0
+  90  Close          1    0    0                                        0
+  91  Count          2   22    0                                        0
+  92  Eq            22    7   98                                        0  if r[22]==r[7] goto 98
+  93  String8        0    4    0  wrong # of entries in index idx_t_c   0  r[4]='wrong # of entries in index idx_t_c'
+  94  Integer        1    3    0                                        0  r[3]=1
+  95  ResultRow      4    1    0                                        0  output=r[4]
+  96  IfPos          2   98    1                                        0  r[2]>0 -> r[2]-=1, goto 98
+  97  Halt           0    0    0                                        0
+  98  Close          2    0    0                                        0
+  99  Count          3   23    0                                        0
+ 100  Eq            23    8  106                                        0  if r[23]==r[8] goto 106
+ 101  String8        0    4    0  wrong # of entries in index idx_t_b   0  r[4]='wrong # of entries in index idx_t_b'
+ 102  Integer        1    3    0                                        0  r[3]=1
+ 103  ResultRow      4    1    0                                        0  output=r[4]
+ 104  IfPos          2  106    1                                        0  r[2]>0 -> r[2]-=1, goto 106
+ 105  Halt           0    0    0                                        0
+ 106  Close          3    0    0                                        0
+ 107  Close          0    0    0                                        0
+ 108  OpenRead       4    1    0  k(6,B,B,B,B,B)                        0  table=sqlite_schema, root=1, iDb=0
+ 109  Integer        0   24    0                                        0  r[24]=0
+ 110  Rewind         4  113    0                                        0  Rewind table sqlite_schema
+ 111    AddImm      24    1    0                                        0  r[24]=r[24]+1
+ 112  Next           4  111    0                                        0
+ 113  Close          4    0    0                                        0
+ 114  If             3  117    0                                        0  if r[3] goto 117
+ 115  String8        0    4    0  ok                                    0  r[4]='ok'
+ 116  ResultRow      4    1    0                                        0  output=r[4]
+ 117  Halt           0    0    0                                        0
+ 118  Transaction    0    1    4                                        0  iDb=0 tx_mode=Read
+ 119  Integer        0   13    0                                        0  r[13]=0
+ 120  Goto           0    1    0                                        0

--- a/testing/runner/tests/integrity_check/snapshots/snapshot_plans__quick-check-multi-table-vdbe.snap
+++ b/testing/runner/tests/integrity_check/snapshots/snapshot_plans__quick-check-multi-table-vdbe.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode        p1   p2  p3  p4                                       p5  comment
-   0  Init           0  111   0                                            0  Start at 111
+   0  Init           0  107   0                                            0  Start at 107
    1  Integer       99    2   0                                            0  r[2]=99
    2  Integer        0    3   0                                            0  r[3]=0
    3  IntegrityCk  100    0   0                                            0  roots=[5, 7, 6, 2, 4, 3, 1] message_register=4
@@ -31,7 +31,7 @@ addr  opcode        p1   p2  p3  p4                                       p5  co
   14  OpenRead       2    6   0  k(2,B)                                    0  =idx_t2_y, root=6, iDb=0
   15  Integer        0    7   0                                            0  r[7]=0
   16  Integer        0    8   0                                            0  r[8]=0
-  17  Rewind         0   43   0                                            0  Rewind table t2
+  17  Rewind         0   41   0                                            0  Rewind table t2
   18    AddImm       8    1   0                                            0  r[8]=r[8]+1
   19    Column       0    1   9                                            0  r[9]=t2.y
   20    NotNull      9   26   0                                            0  r[9]!=NULL -> goto 26
@@ -51,80 +51,76 @@ addr  opcode        p1   p2  p3  p4                                       p5  co
   34    Column       0    1  15                                            0  r[15]=t2.y
   35    Function     0   15  13  lower                                     0  r[13]=func(r[15])
   36    RowId        0   14   0                                            0  r[14]=t2.rowid
-  37    Affinity    13    1   0                                            0  r[13..14] = A
-  38    AddImm       7    1   0                                            0  r[7]=r[7]+1
-  39    Column       0    1  16                                            0  r[16]=t2.y
-  40    RowId        0   17   0                                            0  r[17]=t2.rowid
-  41    Affinity    16    1   0                                            0  r[16..17] = B
-  42  Next           0   18   0                                            0
-  43  Count          1   18   0                                            0
-  44  Eq            18    6  50                                            0  if r[18]==r[6] goto 50
-  45  String8        0    4   0  wrong # of entries in index idx_t2_expr   0  r[4]='wrong # of entries in index idx_t2_expr'
-  46  Integer        1    3   0                                            0  r[3]=1
-  47  ResultRow      4    1   0                                            0  output=r[4]
-  48  IfPos          2   50   1                                            0  r[2]>0 -> r[2]-=1, goto 50
-  49  Halt           0    0   0                                            0
-  50  Close          1    0   0                                            0
-  51  Count          2   19   0                                            0
-  52  Eq            19    7  58                                            0  if r[19]==r[7] goto 58
-  53  String8        0    4   0  wrong # of entries in index idx_t2_y      0  r[4]='wrong # of entries in index idx_t2_y'
-  54  Integer        1    3   0                                            0  r[3]=1
-  55  ResultRow      4    1   0                                            0  output=r[4]
-  56  IfPos          2   58   1                                            0  r[2]>0 -> r[2]-=1, goto 58
-  57  Halt           0    0   0                                            0
-  58  Close          2    0   0                                            0
-  59  Close          0    0   0                                            0
-  60  OpenRead       3    2   0  k(2,B,B)                                  0  table=t1, root=2, iDb=0
-  61  OpenRead       4    4   0  k(2,B)                                    0  =idx_t1_b_u, root=4, iDb=0
-  62  Integer        0   20   0                                            0  r[20]=0
-  63  OpenRead       5    3   0  k(2,B)                                    0  =idx_t1_b, root=3, iDb=0
-  64  Integer        0   21   0                                            0  r[21]=0
-  65  Integer        0   22   0                                            0  r[22]=0
-  66  Rewind         3   84   0                                            0  Rewind table t1
-  67    AddImm      22    1   0                                            0  r[22]=r[22]+1
-  68    Column       3    1  23                                            0  r[23]=t1.b
-  69    NotNull     23   75   0                                            0  r[23]!=NULL -> goto 75
-  70    String8      0    4   0  NULL value in t1.b                        0  r[4]='NULL value in t1.b'
-  71    Integer      1    3   0                                            0  r[3]=1
-  72    ResultRow    4    1   0                                            0  output=r[4]
-  73    IfPos        2   75   1                                            0  r[2]>0 -> r[2]-=1, goto 75
-  74    Halt         0    0   0                                            0
-  75    AddImm      20    1   0                                            0  r[20]=r[20]+1
-  76    Column       3    1  24                                            0  r[24]=t1.b
-  77    RowId        3   25   0                                            0  r[25]=t1.rowid
-  78    Affinity    24    1   0                                            0  r[24..25] = B
-  79    AddImm      21    1   0                                            0  r[21]=r[21]+1
-  80    Column       3    1  26                                            0  r[26]=t1.b
-  81    RowId        3   27   0                                            0  r[27]=t1.rowid
-  82    Affinity    26    1   0                                            0  r[26..27] = B
-  83  Next           3   67   0                                            0
-  84  Count          4   28   0                                            0
-  85  Eq            28   20  91                                            0  if r[28]==r[20] goto 91
-  86  String8        0    4   0  wrong # of entries in index idx_t1_b_u    0  r[4]='wrong # of entries in index idx_t1_b_u'
-  87  Integer        1    3   0                                            0  r[3]=1
-  88  ResultRow      4    1   0                                            0  output=r[4]
-  89  IfPos          2   91   1                                            0  r[2]>0 -> r[2]-=1, goto 91
-  90  Halt           0    0   0                                            0
-  91  Close          4    0   0                                            0
-  92  Count          5   29   0                                            0
-  93  Eq            29   21  99                                            0  if r[29]==r[21] goto 99
-  94  String8        0    4   0  wrong # of entries in index idx_t1_b      0  r[4]='wrong # of entries in index idx_t1_b'
-  95  Integer        1    3   0                                            0  r[3]=1
-  96  ResultRow      4    1   0                                            0  output=r[4]
-  97  IfPos          2   99   1                                            0  r[2]>0 -> r[2]-=1, goto 99
-  98  Halt           0    0   0                                            0
-  99  Close          5    0   0                                            0
- 100  Close          3    0   0                                            0
- 101  OpenRead       6    1   0  k(6,B,B,B,B,B)                            0  table=sqlite_schema, root=1, iDb=0
- 102  Integer        0   30   0                                            0  r[30]=0
- 103  Rewind         6  106   0                                            0  Rewind table sqlite_schema
- 104    AddImm      30    1   0                                            0  r[30]=r[30]+1
- 105  Next           6  104   0                                            0
- 106  Close          6    0   0                                            0
- 107  If             3  110   0                                            0  if r[3] goto 110
- 108  String8        0    4   0  ok                                        0  r[4]='ok'
- 109  ResultRow      4    1   0                                            0  output=r[4]
- 110  Halt           0    0   0                                            0
- 111  Transaction    0    1   6                                            0  iDb=0 tx_mode=Read
- 112  Integer        0   12   0                                            0  r[12]=0
- 113  Goto           0    1   0                                            0
+  37    AddImm       7    1   0                                            0  r[7]=r[7]+1
+  38    Column       0    1  16                                            0  r[16]=t2.y
+  39    RowId        0   17   0                                            0  r[17]=t2.rowid
+  40  Next           0   18   0                                            0
+  41  Count          1   18   0                                            0
+  42  Eq            18    6  48                                            0  if r[18]==r[6] goto 48
+  43  String8        0    4   0  wrong # of entries in index idx_t2_expr   0  r[4]='wrong # of entries in index idx_t2_expr'
+  44  Integer        1    3   0                                            0  r[3]=1
+  45  ResultRow      4    1   0                                            0  output=r[4]
+  46  IfPos          2   48   1                                            0  r[2]>0 -> r[2]-=1, goto 48
+  47  Halt           0    0   0                                            0
+  48  Close          1    0   0                                            0
+  49  Count          2   19   0                                            0
+  50  Eq            19    7  56                                            0  if r[19]==r[7] goto 56
+  51  String8        0    4   0  wrong # of entries in index idx_t2_y      0  r[4]='wrong # of entries in index idx_t2_y'
+  52  Integer        1    3   0                                            0  r[3]=1
+  53  ResultRow      4    1   0                                            0  output=r[4]
+  54  IfPos          2   56   1                                            0  r[2]>0 -> r[2]-=1, goto 56
+  55  Halt           0    0   0                                            0
+  56  Close          2    0   0                                            0
+  57  Close          0    0   0                                            0
+  58  OpenRead       3    2   0  k(2,B,B)                                  0  table=t1, root=2, iDb=0
+  59  OpenRead       4    4   0  k(2,B)                                    0  =idx_t1_b_u, root=4, iDb=0
+  60  Integer        0   20   0                                            0  r[20]=0
+  61  OpenRead       5    3   0  k(2,B)                                    0  =idx_t1_b, root=3, iDb=0
+  62  Integer        0   21   0                                            0  r[21]=0
+  63  Integer        0   22   0                                            0  r[22]=0
+  64  Rewind         3   80   0                                            0  Rewind table t1
+  65    AddImm      22    1   0                                            0  r[22]=r[22]+1
+  66    Column       3    1  23                                            0  r[23]=t1.b
+  67    NotNull     23   73   0                                            0  r[23]!=NULL -> goto 73
+  68    String8      0    4   0  NULL value in t1.b                        0  r[4]='NULL value in t1.b'
+  69    Integer      1    3   0                                            0  r[3]=1
+  70    ResultRow    4    1   0                                            0  output=r[4]
+  71    IfPos        2   73   1                                            0  r[2]>0 -> r[2]-=1, goto 73
+  72    Halt         0    0   0                                            0
+  73    AddImm      20    1   0                                            0  r[20]=r[20]+1
+  74    Column       3    1  24                                            0  r[24]=t1.b
+  75    RowId        3   25   0                                            0  r[25]=t1.rowid
+  76    AddImm      21    1   0                                            0  r[21]=r[21]+1
+  77    Column       3    1  26                                            0  r[26]=t1.b
+  78    RowId        3   27   0                                            0  r[27]=t1.rowid
+  79  Next           3   65   0                                            0
+  80  Count          4   28   0                                            0
+  81  Eq            28   20  87                                            0  if r[28]==r[20] goto 87
+  82  String8        0    4   0  wrong # of entries in index idx_t1_b_u    0  r[4]='wrong # of entries in index idx_t1_b_u'
+  83  Integer        1    3   0                                            0  r[3]=1
+  84  ResultRow      4    1   0                                            0  output=r[4]
+  85  IfPos          2   87   1                                            0  r[2]>0 -> r[2]-=1, goto 87
+  86  Halt           0    0   0                                            0
+  87  Close          4    0   0                                            0
+  88  Count          5   29   0                                            0
+  89  Eq            29   21  95                                            0  if r[29]==r[21] goto 95
+  90  String8        0    4   0  wrong # of entries in index idx_t1_b      0  r[4]='wrong # of entries in index idx_t1_b'
+  91  Integer        1    3   0                                            0  r[3]=1
+  92  ResultRow      4    1   0                                            0  output=r[4]
+  93  IfPos          2   95   1                                            0  r[2]>0 -> r[2]-=1, goto 95
+  94  Halt           0    0   0                                            0
+  95  Close          5    0   0                                            0
+  96  Close          3    0   0                                            0
+  97  OpenRead       6    1   0  k(6,B,B,B,B,B)                            0  table=sqlite_schema, root=1, iDb=0
+  98  Integer        0   30   0                                            0  r[30]=0
+  99  Rewind         6  102   0                                            0  Rewind table sqlite_schema
+ 100    AddImm      30    1   0                                            0  r[30]=r[30]+1
+ 101  Next           6  100   0                                            0
+ 102  Close          6    0   0                                            0
+ 103  If             3  106   0                                            0  if r[3] goto 106
+ 104  String8        0    4   0  ok                                        0  r[4]='ok'
+ 105  ResultRow      4    1   0                                            0  output=r[4]
+ 106  Halt           0    0   0                                            0
+ 107  Transaction    0    1   6                                            0  iDb=0 tx_mode=Read
+ 108  Integer        0   12   0                                            0  r[12]=0
+ 109  Goto           0    1   0                                            0

--- a/testing/runner/tests/integrity_check/snapshots/snapshot_plans__quick-check-vdbe.snap
+++ b/testing/runner/tests/integrity_check/snapshots/snapshot_plans__quick-check-vdbe.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode        p1  p2  p3  p4                                   p5  comment
-   0  Init           0  79   0                                        0  Start at 79
+   0  Init           0  76   0                                        0  Start at 76
    1  Integer       99   2   0                                        0  r[2]=99
    2  Integer        0   3   0                                        0  r[3]=0
    3  IntegrityCk  100   0   0                                        0  roots=[2, 5, 4, 3, 1] message_register=4
@@ -33,7 +33,7 @@ addr  opcode        p1  p2  p3  p4                                   p5  comment
   16  OpenRead       3   3   0  k(2,B)                                0  =idx_t_b, root=3, iDb=0
   17  Integer        0   8   0                                        0  r[8]=0
   18  Integer        0   9   0                                        0  r[9]=0
-  19  Rewind         0  51   0                                        0  Rewind table t
+  19  Rewind         0  48   0                                        0  Rewind table t
   20    AddImm       9   1   0                                        0  r[9]=r[9]+1
   21    Column       0   1  10                                        0  r[10]=t.b
   22    NotNull     10  28   0                                        0  r[10]!=NULL -> goto 28
@@ -50,49 +50,46 @@ addr  opcode        p1  p2  p3  p4                                   p5  comment
   33    IfPos        2  35   1                                        0  r[2]>0 -> r[2]-=1, goto 35
   34    Halt         0   0   0                                        0
   35    Column       0   3  14                                        0  r[14]=t.d
-  36    IsNull      14  42   0                                        0  if (r[14]==NULL) goto 42
+  36    IsNull      14  41   0                                        0  if (r[14]==NULL) goto 41
   37    AddImm       6   1   0                                        0  r[6]=r[6]+1
   38    Column       0   3  17                                        0  r[17]=t.d
   39    Function     0  17  15  lower                                 0  r[15]=func(r[17])
   40    RowId        0  16   0                                        0  r[16]=t.rowid
-  41    Affinity    15   1   0                                        0  r[15..16] = A
-  42    AddImm       7   1   0                                        0  r[7]=r[7]+1
-  43    Column       0   2  18                                        0  r[18]=t.c
-  44    RowId        0  19   0                                        0  r[19]=t.rowid
-  45    Affinity    18   1   0                                        0  r[18..19] = D
-  46    AddImm       8   1   0                                        0  r[8]=r[8]+1
-  47    Column       0   1  20                                        0  r[20]=t.b
-  48    RowId        0  21   0                                        0  r[21]=t.rowid
-  49    Affinity    20   1   0                                        0  r[20..21] = B
-  50  Next           0  20   0                                        0
-  51  Close          1   0   0                                        0
-  52  Count          2  22   0                                        0
-  53  Eq            22   7  59                                        0  if r[22]==r[7] goto 59
-  54  String8        0   4   0  wrong # of entries in index idx_t_c   0  r[4]='wrong # of entries in index idx_t_c'
-  55  Integer        1   3   0                                        0  r[3]=1
-  56  ResultRow      4   1   0                                        0  output=r[4]
-  57  IfPos          2  59   1                                        0  r[2]>0 -> r[2]-=1, goto 59
-  58  Halt           0   0   0                                        0
-  59  Close          2   0   0                                        0
-  60  Count          3  23   0                                        0
-  61  Eq            23   8  67                                        0  if r[23]==r[8] goto 67
-  62  String8        0   4   0  wrong # of entries in index idx_t_b   0  r[4]='wrong # of entries in index idx_t_b'
-  63  Integer        1   3   0                                        0  r[3]=1
-  64  ResultRow      4   1   0                                        0  output=r[4]
-  65  IfPos          2  67   1                                        0  r[2]>0 -> r[2]-=1, goto 67
-  66  Halt           0   0   0                                        0
-  67  Close          3   0   0                                        0
-  68  Close          0   0   0                                        0
-  69  OpenRead       4   1   0  k(6,B,B,B,B,B)                        0  table=sqlite_schema, root=1, iDb=0
-  70  Integer        0  24   0                                        0  r[24]=0
-  71  Rewind         4  74   0                                        0  Rewind table sqlite_schema
-  72    AddImm      24   1   0                                        0  r[24]=r[24]+1
-  73  Next           4  72   0                                        0
-  74  Close          4   0   0                                        0
-  75  If             3  78   0                                        0  if r[3] goto 78
-  76  String8        0   4   0  ok                                    0  r[4]='ok'
-  77  ResultRow      4   1   0                                        0  output=r[4]
-  78  Halt           0   0   0                                        0
-  79  Transaction    0   1   4                                        0  iDb=0 tx_mode=Read
-  80  Integer        0  13   0                                        0  r[13]=0
-  81  Goto           0   1   0                                        0
+  41    AddImm       7   1   0                                        0  r[7]=r[7]+1
+  42    Column       0   2  18                                        0  r[18]=t.c
+  43    RowId        0  19   0                                        0  r[19]=t.rowid
+  44    AddImm       8   1   0                                        0  r[8]=r[8]+1
+  45    Column       0   1  20                                        0  r[20]=t.b
+  46    RowId        0  21   0                                        0  r[21]=t.rowid
+  47  Next           0  20   0                                        0
+  48  Close          1   0   0                                        0
+  49  Count          2  22   0                                        0
+  50  Eq            22   7  56                                        0  if r[22]==r[7] goto 56
+  51  String8        0   4   0  wrong # of entries in index idx_t_c   0  r[4]='wrong # of entries in index idx_t_c'
+  52  Integer        1   3   0                                        0  r[3]=1
+  53  ResultRow      4   1   0                                        0  output=r[4]
+  54  IfPos          2  56   1                                        0  r[2]>0 -> r[2]-=1, goto 56
+  55  Halt           0   0   0                                        0
+  56  Close          2   0   0                                        0
+  57  Count          3  23   0                                        0
+  58  Eq            23   8  64                                        0  if r[23]==r[8] goto 64
+  59  String8        0   4   0  wrong # of entries in index idx_t_b   0  r[4]='wrong # of entries in index idx_t_b'
+  60  Integer        1   3   0                                        0  r[3]=1
+  61  ResultRow      4   1   0                                        0  output=r[4]
+  62  IfPos          2  64   1                                        0  r[2]>0 -> r[2]-=1, goto 64
+  63  Halt           0   0   0                                        0
+  64  Close          3   0   0                                        0
+  65  Close          0   0   0                                        0
+  66  OpenRead       4   1   0  k(6,B,B,B,B,B)                        0  table=sqlite_schema, root=1, iDb=0
+  67  Integer        0  24   0                                        0  r[24]=0
+  68  Rewind         4  71   0                                        0  Rewind table sqlite_schema
+  69    AddImm      24   1   0                                        0  r[24]=r[24]+1
+  70  Next           4  69   0                                        0
+  71  Close          4   0   0                                        0
+  72  If             3  75   0                                        0  if r[3] goto 75
+  73  String8        0   4   0  ok                                    0  r[4]='ok'
+  74  ResultRow      4   1   0                                        0  output=r[4]
+  75  Halt           0   0   0                                        0
+  76  Transaction    0   1   4                                        0  iDb=0 tx_mode=Read
+  77  Integer        0  13   0                                        0  r[13]=0
+  78  Goto           0   1   0                                        0


### PR DESCRIPTION
The integrity check bytecode emitted an Insn::Affinity instruction between Column/RowId and Found when verifying index entries against table rows. SQLite does not do this — it searches the index with the raw column value exactly as stored.

This caused false "row missing from index" errors when a column added via ALTER TABLE ADD COLUMN had a type-mismatched default value. For example, `ALTER TABLE t ADD COLUMN c TEXT DEFAULT 0` stores integer 0 as the raw default for pre-existing rows. CREATE INDEX also stores integer 0 in the index (no affinity applied). But the integrity check's Affinity instruction converted integer 0 to string "0" (TEXT affinity) before searching the index, so Found failed to match — a false positive.

The fix removes the Affinity instruction from the integrity check bytecode, matching SQLite's behavior: Column → RowId → Found with no affinity conversion in between.

Spotted by Claude Code

Fixes #5524