### PR TITLE
simulator: add GROUP BY aggregate testing, fix SUM text overflow bug

### DIFF
--- a/bindings/javascript/turso-sql-runner.mjs
+++ b/bindings/javascript/turso-sql-runner.mjs
@@ -9,8 +9,8 @@
  * the @tursodatabase/database package is available.
  *
  * Known limitations:
- * - JavaScript's number type doesn't distinguish between 1 and 1.0, so float
- *   formatting may differ from the Rust backend for whole-number floats.
+ * - With safe_integers enabled, DB integers arrive as BigInt and floats as
+ *   number. Whole-number floats (e.g. 30.0) get ".0" appended to match SQLite.
  * - Very large integers (exceeding i64) may have precision loss as JavaScript
  *   numbers are IEEE 754 doubles with 53 bits of mantissa precision.
  */
@@ -43,13 +43,17 @@ function formatValue(value) {
         if (Number.isNaN(value)) {
             return '';  // SQLite returns NULL for NaN
         }
-        // For integers, use toString() directly
-        if (Number.isInteger(value)) {
-            return value.toString();
-        }
+        // With safe_integers enabled, all DB integers arrive as BigInt.
+        // Any `number` here came from a REAL column in the database.
         // SQLite uses %.15g format (15 significant digits, trailing zeros removed)
         // toPrecision gives significant digits, parseFloat removes trailing zeros
-        return parseFloat(value.toPrecision(15)).toString();
+        let str = parseFloat(value.toPrecision(15)).toString();
+        // Ensure float values always include a decimal point (e.g., 30 -> "30.0")
+        // to match SQLite output which distinguishes reals from integers.
+        if (!str.includes('.') && !str.includes('e') && !str.includes('E')) {
+            str += '.0';
+        }
+        return str;
     }
     if (value instanceof Uint8Array || Buffer.isBuffer(value)) {
         // Output blob as raw bytes (matches SQLite/Rust backend behavior)

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -63,8 +63,8 @@ simulator covers and tests.
 | SELECT ... WHERE ... LIKE | No      |                                                                                   |
 | SELECT ... LIMIT          | Partial | TODO                                                                              |
 | SELECT ... ORDER BY       | Partial | TODO                                                                              |
-| SELECT ... GROUP BY       | No      |                                                                                   |
-| SELECT ... HAVING         | No      |                                                                                   |
+| SELECT ... GROUP BY       | Partial | GROUP BY with COUNT, COUNT(*), SUM, MIN, MAX aggregates                           |
+| SELECT ... HAVING         | Partial | HAVING with COUNT(*) > N                                                          |
 | SELECT ... JOIN           | Partial | TODO                                                                              |
 | SELECT ... CROSS JOIN     | No      | SQLite CROSS JOIN means "do not reorder joins". We don't support that yet anyway. |
 | SELECT ... INNER JOIN     | Partial | TODO                                                                              |
@@ -288,14 +288,14 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | Function          | Status | Comment |
 | ----------------- | ------ | ------- |
 | avg(X)            | No     |         |
-| count()           | No     |         |
-| count(*)          | No     |         |
+| count()           | Yes    | via GroupByAggregateCheck property |
+| count(*)          | Yes    | via GroupByAggregateCheck property |
 | group_concat(X)   | No     |         |
 | group_concat(X,Y) | No     |         |
 | string_agg(X,Y)   | No     |         |
-| max(X)            | No     |         |
-| min(X)            | No     |         |
-| sum(X)            | No     |         |
+| max(X)            | Yes    | via GroupByAggregateCheck property |
+| min(X)            | Yes    | via GroupByAggregateCheck property |
+| sum(X)            | Yes    | via GroupByAggregateCheck property |
 | total(X)          | No     |         |
 
 #### Date and time functions

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -182,6 +182,20 @@ pub enum Property {
     FaultyQuery {
         query: Query,
     },
+    /// GroupByAggregateCheck verifies that GROUP BY with aggregate functions
+    /// returns the correct results by comparing the database output against
+    /// the shadow model's computed aggregates.
+    ///
+    /// Execution:
+    ///     SELECT <group_cols>, <agg_funcs> FROM <t> WHERE <pred> GROUP BY <group_cols> [HAVING ...]
+    ///
+    /// Assertion: results match shadow model's GROUP BY computation (unordered comparison).
+    GroupByAggregateCheck {
+        /// The GROUP BY + aggregate select query
+        select: Select,
+        /// Table name for dependency tracking
+        table: String,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -228,7 +242,8 @@ impl Property {
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
             | Property::TableHasExpectedContent { .. }
-            | Property::AllTableHaveExpectedContent { .. } => None,
+            | Property::AllTableHaveExpectedContent { .. }
+            | Property::GroupByAggregateCheck { .. } => None,
         }
     }
 }

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -145,6 +145,8 @@ pub struct SimulatorCLI {
     pub disable_fsync_no_wait: bool,
     #[clap(long, help = "disable FaultyQuery Property")]
     pub disable_faulty_query: bool,
+    #[clap(long, help = "disable GroupByAggregateCheck Property")]
+    pub disable_group_by_aggregate_check: bool,
     #[clap(long, help = "disable Reopen-Database fault")]
     pub disable_reopen_database: bool,
     #[clap(long = "latency-prob", help = "added IO latency probability", value_parser = clap::value_parser!(u8).range(0..=100))]

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -903,6 +903,7 @@ impl SimulatorEnv {
                 .disable_union_all_preserves_cardinality,
             disable_fsync_no_wait: cli_opts.disable_fsync_no_wait,
             disable_faulty_query: cli_opts.disable_faulty_query,
+            disable_group_by_aggregate_check: cli_opts.disable_group_by_aggregate_check,
             page_size: 4096, // TODO: randomize this too
             max_interactions: rng.random_range(cli_opts.minimum_tests..=cli_opts.maximum_tests),
             max_time_simulation: cli_opts.maximum_time,
@@ -1218,6 +1219,7 @@ pub(crate) struct SimulatorOpts {
     pub(crate) disable_union_all_preserves_cardinality: bool,
     pub(crate) disable_fsync_no_wait: bool,
     pub(crate) disable_faulty_query: bool,
+    pub(crate) disable_group_by_aggregate_check: bool,
     pub(crate) disable_reopen_database: bool,
     pub(crate) disable_integrity_check: bool,
 


### PR DESCRIPTION
## Summary

- **Simulator enhancement**: Add `GroupByAggregateCheck` property that generates GROUP BY queries with aggregate functions (COUNT, COUNT(*), SUM, MIN, MAX) and validates results against a shadow model and SQLite via differential testing
- **Bug fix**: `SUM()` on TEXT columns containing integers silently returned an imprecise float on integer overflow instead of erroring like SQLite

## Bug Details

When summing TEXT values whose integer representations overflow i64, `handle_text_sum()` silently promoted to float:

```sql
CREATE TABLE t(val TEXT);
INSERT INTO t VALUES ('9223372036854775807'), ('1');
SELECT SUM(val) FROM t;
-- SQLite: Runtime error: integer overflow
-- Turso (before fix): 9.22337203685478e+18
-- Turso (after fix): Runtime error: integer overflow
```

The INTEGER column path correctly returned `IntegerOverflow`, but the TEXT path in `handle_text_sum()` was missing the check. `TOTAL()` continues to correctly promote to float.

Root cause: `core/vdbe/execute.rs` `handle_text_sum()` line 10213 — overflow branch unconditionally promoted to float instead of checking whether the function is SUM (should error) or TOTAL (should promote).

## Changes

| File | Change |
|------|--------|
| `sql_generation/model/query/select.rs` | Add `AggFunc`, `AggregateExpr`, `GroupByClause` types; `qualified_column_expr()` helper |
| `sql_generation/generation/query.rs` | Add `gen_group_by_select()` generation |
| `testing/simulator/model/property.rs` | Add `GroupByAggregateCheck` property variant |
| `testing/simulator/generation/property.rs` | Property generation, weight, interactions, assertions |
| `testing/simulator/model/mod.rs` | Shadow state: `shadow_group_by()`, `compute_aggregate()`, `eval_having()` |
| `testing/simulator/runner/cli.rs` | `--disable-group-by-aggregate-check` flag |
| `testing/simulator/runner/env.rs` | Wire CLI flag to `SimulatorOpts` |
| `testing/simulator/COVERAGE.md` | Update GROUP BY, HAVING, aggregate coverage |
| `core/vdbe/execute.rs` | Fix `handle_text_sum()` to return `IntegerOverflow` for SUM |

## Test plan

- [x] `cargo test -p turso_core` — 1339 tests pass
- [x] `cargo clippy --workspace --all-features --all-targets -- --deny=warnings` — clean
- [x] `cargo fmt` — clean
- [x] Simulator standard mode: 5/5 loop iterations pass (5000 tests each)
- [x] Simulator differential mode: 5/5 loop iterations pass (5000 tests each)
- [x] Extended differential fuzzing: 10 iterations x 10000 tests = 100K tests pass
- [x] Bug reproduction verified: `SUM(text)` overflow now correctly errors
- [x] `TOTAL(text)` overflow still correctly promotes to float