### PR TITLE
autofix: DELETE with LIMIT ignores OFFSET clause

### DIFF
--- a/testing/runner/tests/delete-limit-offset.sqltest
+++ b/testing/runner/tests/delete-limit-offset.sqltest
@@ -1,0 +1,112 @@
+@database :memory:
+
+# Tests for DELETE with LIMIT and OFFSET clauses
+# SQLite CI build does not enable DELETE ... LIMIT/OFFSET, so these are tursodb-only
+
+setup schema {
+    CREATE TABLE t(id INTEGER PRIMARY KEY);
+    INSERT INTO t VALUES (1),(2),(3),(4),(5);
+}
+
+# Reproducer from issue #5542: OFFSET was being ignored
+@setup schema
+@skip-if sqlite "SQLite build in CI does not enable DELETE ... LIMIT/OFFSET"
+@cross-check-integrity
+test delete-limit-offset-basic {
+    DELETE FROM t LIMIT 1 OFFSET 2;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1
+    2
+    4
+    5
+}
+
+# Delete multiple rows with offset
+@setup schema
+@skip-if sqlite "SQLite build in CI does not enable DELETE ... LIMIT/OFFSET"
+@cross-check-integrity
+test delete-limit-offset-multiple {
+    DELETE FROM t LIMIT 2 OFFSET 1;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1
+    4
+    5
+}
+
+# OFFSET 0 should behave same as no offset
+@setup schema
+@skip-if sqlite "SQLite build in CI does not enable DELETE ... LIMIT/OFFSET"
+@cross-check-integrity
+test delete-limit-offset-zero {
+    DELETE FROM t LIMIT 1 OFFSET 0;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    2
+    3
+    4
+    5
+}
+
+# OFFSET beyond all rows - nothing deleted
+@setup schema
+@skip-if sqlite "SQLite build in CI does not enable DELETE ... LIMIT/OFFSET"
+@cross-check-integrity
+test delete-limit-offset-beyond-rows {
+    DELETE FROM t LIMIT 1 OFFSET 5;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+}
+
+# LIMIT larger than remaining rows after offset
+@setup schema
+@skip-if sqlite "SQLite build in CI does not enable DELETE ... LIMIT/OFFSET"
+@cross-check-integrity
+test delete-limit-offset-limit-exceeds {
+    DELETE FROM t LIMIT 10 OFFSET 3;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1
+    2
+    3
+}
+
+# DELETE with LIMIT only (no OFFSET) still works
+@setup schema
+@skip-if sqlite "SQLite build in CI does not enable DELETE ... LIMIT/OFFSET"
+@cross-check-integrity
+test delete-limit-no-offset {
+    DELETE FROM t LIMIT 2;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    3
+    4
+    5
+}
+
+# DELETE with LIMIT and OFFSET combined with WHERE clause
+@setup schema
+@skip-if sqlite "SQLite build in CI does not enable DELETE ... LIMIT/OFFSET"
+@cross-check-integrity
+test delete-limit-offset-with-where {
+    DELETE FROM t WHERE id > 1 LIMIT 1 OFFSET 1;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1
+    2
+    4
+    5
+}


### PR DESCRIPTION
The DELETE emitter was passing `&None` for the offset parameter in the `init_limit` call, causing the OFFSET register to never be initialized. Additionally, the `IfPos` instruction to skip offset rows was missing from the delete loop body.

This fix:
1. Passes `&plan.offset` to `init_limit` (matching SELECT and UPDATE)
2. Adds the `IfPos` skip instruction in `emit_delete_insns` to skip offset rows before deleting (matching the UPDATE pattern)

Closes #5542
Generated with Turso Auto-fixer :robot: :tm: 