### PR TITLE
fix: Align insert expr-index rewrite with between

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -2732,6 +2732,7 @@ pub fn rewrite_partial_index_where(
 
 /// For an index expression, rewrite column references to use the insertion registers.
 fn rewrite_index_expr_for_insertion(expr: &mut ast::Expr, insertion: &Insertion) -> Result<()> {
+    rewrite_between_expr(expr);
     let mut missing_column = None;
     let col_reg = |name: &str| -> Option<usize> {
         if ROWID_STRS.iter().any(|s| s.eq_ignore_ascii_case(name)) {

--- a/testing/runner/tests/expr-index-between-insert.sqltest
+++ b/testing/runner/tests/expr-index-between-insert.sqltest
@@ -1,0 +1,12 @@
+@database :memory:
+@skip-file-if mvcc "expression indexes are not supported in mvcc"
+
+test expr-index-between-insert {
+    CREATE TABLE t(a INTEGER, b INTEGER);
+    CREATE INDEX idx ON t(a BETWEEN 1 AND 10);
+    INSERT INTO t VALUES(5, 5);
+    SELECT * FROM t;
+}
+expect {
+    5|5
+}


### PR DESCRIPTION
## Description

- Fixed INSERT, changed `rewrite_index_expr_for_insertion` to call `rewrite_between_expr`
- Added regression sqltest covering CREATE INDEX with BETWEEN INSERT, SELECT

## Motivation and context

FIxes #5554 