### PR TITLE
autofix: Aggregate COLLATE leaks to subsequent aggregates in same query

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -193,10 +193,18 @@ fn emit_collseq_if_needed(
                         reg: None,
                         collation: c,
                     });
+                    return;
                 }
             }
         }
     }
+
+    // Always emit a CollSeq to reset to BINARY default, preventing collation
+    // from a previous aggregate leaking into this one.
+    program.emit_insn(Insn::CollSeq {
+        reg: None,
+        collation: CollationSeq::Binary,
+    });
 }
 
 /// Emits the bytecode for handling duplicates in a distinct aggregate.

--- a/testing/runner/tests/collate.sqltest
+++ b/testing/runner/tests/collate.sqltest
@@ -726,3 +726,51 @@ test collate_concat_binary_comparison {
 expect {
     0
 }
+
+# Tests for aggregate COLLATE not leaking to subsequent aggregates (#5539)
+
+setup agg_collate_schema {
+    CREATE TABLE t_agg(a TEXT, b TEXT);
+    INSERT INTO t_agg VALUES ('z', 'a');
+    INSERT INTO t_agg VALUES ('a', 'Z');
+}
+
+@setup agg_collate_schema
+test agg_collate_no_leak_min_max {
+    SELECT MIN(a COLLATE NOCASE), MAX(b) FROM t_agg;
+}
+expect {
+    a|a
+}
+
+@setup agg_collate_schema
+test agg_collate_no_leak_max_min {
+    SELECT MAX(a COLLATE NOCASE), MIN(b) FROM t_agg;
+}
+expect {
+    z|Z
+}
+
+@setup agg_collate_schema
+test agg_collate_no_leak_three_aggs {
+    SELECT MIN(a COLLATE NOCASE), MAX(b), MIN(b) FROM t_agg;
+}
+expect {
+    a|a|Z
+}
+
+@setup agg_collate_schema
+test agg_collate_explicit_nocase_both {
+    SELECT MIN(a COLLATE NOCASE), MAX(b COLLATE NOCASE) FROM t_agg;
+}
+expect {
+    a|Z
+}
+
+@setup agg_collate_schema
+test agg_collate_no_leak_with_count {
+    SELECT MIN(a COLLATE NOCASE), MAX(b), COUNT(*) FROM t_agg;
+}
+expect {
+    a|a|2
+}

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
@@ -24,46 +24,48 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                  p5  comment
-   0          Init             0  41   0                       0  Start at 41
+   0          Init             0  43   0                       0  Start at 43
    1          Null             0   9  10                       0  r[9..10]=NULL
    2          Integer          0   6   0                       0  r[6]=0; clear group by abort flag
    3          Null             0   7   0                       0  r[7]=NULL; initialize group by comparison registers to NULL
-   4          Gosub           15  37   0                       0  ; go to clear accumulator subroutine
+   4          Gosub           15  39   0                       0  ; go to clear accumulator subroutine
    5          OpenRead         0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
    6          OpenRead         1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
-   7          Rewind           1  24   0                       0  Rewind index idx_sales_category
+   7          Rewind           1  26   0                       0  Rewind index idx_sales_category
    8            DeferredSeek   1   0   0                       0
    9            Column         0   1  12                       0  r[12]=sales.category
   10            Column         0   4  13                       0  r[13]=sales.amount
   11            Column         0   4  14                       0  r[14]=sales.amount
   12            Compare        7  12   1  k(1, Binary)         0  r[7..7]==r[12..12]
   13            Jump          14  18  14                       0  ; start new group if comparison is not equal
-  14            Gosub          4  28   0                       0  ; check if ended group had data, and output if so
+  14            Gosub          4  30   0                       0  ; check if ended group had data, and output if so
   15            Move          12   7   1                       0  r[7..7]=r[12..12]
-  16            IfPos          6  40   0                       0  r[6]>0 -> r[6]-=0, goto 40; check abort flag
-  17            Gosub         15  37   0                       0  ; goto clear accumulator subroutine
-  18            AggStep        0  13   9  min                  0  accum=r[9] step(r[13])
-  19            AggStep        0  14  10  max                  0  accum=r[10] step(r[14])
-  20            If             5  22   0                       0  if r[5] goto 22; don't emit group columns if continuing existing group
-  21            Column         0   1   8                       0  r[8]=sales.category
-  22            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
-  23          Next             1   8   0                       0
-  24          Gosub            4  28   0                       0  ; emit row for final group
-  25          Goto             0  40   0                       0  ; group by finished
-  26          Integer          1   6   0                       0  r[6]=1
-  27        Return             4   0   0                       0
-  28        IfPos              5  30   0                       0  r[5]>0 -> r[5]-=0, goto 30; output group by row subroutine start
-  29      Return               4   0   0                       0
-  30      AggFinal             0   9   0  min                  0  accum=r[9]
-  31      AggFinal             0  10   0  max                  0  accum=r[10]
-  32      Copy                 8   1   0                       0  r[1]=r[8]
-  33      Copy                 9   2   0                       0  r[2]=r[9]
-  34      Copy                10   3   0                       0  r[3]=r[10]
-  35      ResultRow            1   3   0                       0  output=r[1..3]
-  36    Return                 4   0   0                       0
-  37    Null                   0   8  10                       0  r[8..10]=NULL; clear accumulator subroutine start
-  38    Integer                0   5   0                       0  r[5]=0
-  39  Return                  15   0   0                       0
-  40  Halt                     0   0   0                       0
-  41  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
-  42  Goto                     0   1   0                       0
+  16            IfPos          6  42   0                       0  r[6]>0 -> r[6]-=0, goto 42; check abort flag
+  17            Gosub         15  39   0                       0  ; goto clear accumulator subroutine
+  18            CollSeq        0   0   0  Binary               0  collation=Binary
+  19            AggStep        0  13   9  min                  0  accum=r[9] step(r[13])
+  20            CollSeq        0   0   0  Binary               0  collation=Binary
+  21            AggStep        0  14  10  max                  0  accum=r[10] step(r[14])
+  22            If             5  24   0                       0  if r[5] goto 24; don't emit group columns if continuing existing group
+  23            Column         0   1   8                       0  r[8]=sales.category
+  24            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
+  25          Next             1   8   0                       0
+  26          Gosub            4  30   0                       0  ; emit row for final group
+  27          Goto             0  42   0                       0  ; group by finished
+  28          Integer          1   6   0                       0  r[6]=1
+  29        Return             4   0   0                       0
+  30        IfPos              5  32   0                       0  r[5]>0 -> r[5]-=0, goto 32; output group by row subroutine start
+  31      Return               4   0   0                       0
+  32      AggFinal             0   9   0  min                  0  accum=r[9]
+  33      AggFinal             0  10   0  max                  0  accum=r[10]
+  34      Copy                 8   1   0                       0  r[1]=r[8]
+  35      Copy                 9   2   0                       0  r[2]=r[9]
+  36      Copy                10   3   0                       0  r[3]=r[10]
+  37      ResultRow            1   3   0                       0  output=r[1..3]
+  38    Return                 4   0   0                       0
+  39    Null                   0   8  10                       0  r[8..10]=NULL; clear accumulator subroutine start
+  40    Integer                0   5   0                       0  r[5]=0
+  41  Return                  15   0   0                       0
+  42  Halt                     0   0   0                       0
+  43  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
+  44  Goto                     0   1   0                       0

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
@@ -19,20 +19,22 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4      p5  comment
-   0  Init          0  15   0           0  Start at 15
+   0  Init          0  17   0           0  Start at 17
    1  Null          0   3   4           0  r[3..4]=NULL
    2  OpenRead      0   3   0  k(2,B)   0  index=idx_sales_amount, root=3, iDb=0
-   3  Rewind        0   9   0           0  Rewind index idx_sales_amount
+   3  Rewind        0  11   0           0  Rewind index idx_sales_amount
    4    Column      0   0   5           0  r[5]=idx_sales_amount.amount
-   5    AggStep     0   5   3  min      0  accum=r[3] step(r[5])
-   6    Column      0   0   6           0  r[6]=idx_sales_amount.amount
-   7    AggStep     0   6   4  max      0  accum=r[4] step(r[6])
-   8  Next          0   4   0           0
-   9  AggFinal      0   3   0  min      0  accum=r[3]
-  10  AggFinal      0   4   0  max      0  accum=r[4]
-  11  Copy          3   1   0           0  r[1]=r[3]
-  12  Copy          4   2   0           0  r[2]=r[4]
-  13  ResultRow     1   2   0           0  output=r[1..2]
-  14  Halt          0   0   0           0
-  15  Transaction   0   1   8           0  iDb=0 tx_mode=Read
-  16  Goto          0   1   0           0
+   5    CollSeq     0   0   0  Binary   0  collation=Binary
+   6    AggStep     0   5   3  min      0  accum=r[3] step(r[5])
+   7    Column      0   0   6           0  r[6]=idx_sales_amount.amount
+   8    CollSeq     0   0   0  Binary   0  collation=Binary
+   9    AggStep     0   6   4  max      0  accum=r[4] step(r[6])
+  10  Next          0   4   0           0
+  11  AggFinal      0   3   0  min      0  accum=r[3]
+  12  AggFinal      0   4   0  max      0  accum=r[4]
+  13  Copy          3   1   0           0  r[1]=r[3]
+  14  Copy          4   2   0           0  r[2]=r[4]
+  15  ResultRow     1   2   0           0  output=r[1..2]
+  16  Halt          0   0   0           0
+  17  Transaction   0   1   8           0  iDb=0 tx_mode=Read
+  18  Goto          0   1   0           0

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
@@ -29,7 +29,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                  p5  comment
-   0          Init             0  56   0                       0  Start at 56
+   0          Init             0  58   0                       0  Start at 58
    1          InitCoroutine    1  38   2                       0
    2          Null             0   9   0                       0  r[9]=NULL
    3          Integer          0   6   0                       0  r[6]=0; clear group by abort flag
@@ -69,21 +69,23 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   37  EndCoroutine             1   0   0                       0
   38  Null                     0  17  19                       0  r[17..19]=NULL
   39  InitCoroutine            1   0   2                       0
-  40    Yield                  1  48   0                       0
+  40    Yield                  1  50   0                       0
   41    Copy                   3  20   0                       0  r[20]=r[3]
   42    AggStep                0  20  17  avg                  0  accum=r[17] step(r[20])
   43    Copy                   3  21   0                       0  r[21]=r[3]
-  44    AggStep                0  21  18  max                  0  accum=r[18] step(r[21])
-  45    Copy                   3  22   0                       0  r[22]=r[3]
-  46    AggStep                0  22  19  min                  0  accum=r[19] step(r[22])
-  47  Goto                     0  40   0                       0
-  48  AggFinal                 0  17   0  avg                  0  accum=r[17]
-  49  AggFinal                 0  18   0  max                  0  accum=r[18]
-  50  AggFinal                 0  19   0  min                  0  accum=r[19]
-  51  Copy                    17  14   0                       0  r[14]=r[17]
-  52  Copy                    18  15   0                       0  r[15]=r[18]
-  53  Copy                    19  16   0                       0  r[16]=r[19]
-  54  ResultRow               14   3   0                       0  output=r[14..16]
-  55  Halt                     0   0   0                       0
-  56  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
-  57  Goto                     0   1   0                       0
+  44    CollSeq                0   0   0  Binary               0  collation=Binary
+  45    AggStep                0  21  18  max                  0  accum=r[18] step(r[21])
+  46    Copy                   3  22   0                       0  r[22]=r[3]
+  47    CollSeq                0   0   0  Binary               0  collation=Binary
+  48    AggStep                0  22  19  min                  0  accum=r[19] step(r[22])
+  49  Goto                     0  40   0                       0
+  50  AggFinal                 0  17   0  avg                  0  accum=r[17]
+  51  AggFinal                 0  18   0  max                  0  accum=r[18]
+  52  AggFinal                 0  19   0  min                  0  accum=r[19]
+  53  Copy                    17  14   0                       0  r[14]=r[17]
+  54  Copy                    18  15   0                       0  r[15]=r[18]
+  55  Copy                    19  16   0                       0  r[16]=r[19]
+  56  ResultRow               14   3   0                       0  output=r[14..16]
+  57  Halt                     0   0   0                       0
+  58  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
+  59  Goto                     0   1   0                       0

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
@@ -23,36 +23,38 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4                  p5  comment
-   0  Init          0  30   0                       0  Start at 30
+   0  Init          0  32   0                       0  Start at 32
    1  Null          0   7  12                       0  r[7..12]=NULL
    2  OpenRead      0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
-   3  Rewind        0  16   0                       0  Rewind table sales
+   3  Rewind        0  18   0                       0  Rewind table sales
    4    AggStep     0  13   7  count                0  accum=r[7] step(r[13])
    5    Column      0   4  14                       0  r[14]=sales.amount
    6    AggStep     0  14   8  sum                  0  accum=r[8] step(r[14])
    7    Column      0   4  15                       0  r[15]=sales.amount
    8    AggStep     0  15   9  avg                  0  accum=r[9] step(r[15])
    9    Column      0   4  16                       0  r[16]=sales.amount
-  10    AggStep     0  16  10  min                  0  accum=r[10] step(r[16])
-  11    Column      0   4  17                       0  r[17]=sales.amount
-  12    AggStep     0  17  11  max                  0  accum=r[11] step(r[17])
-  13    Column      0   5  18                       0  r[18]=sales.quantity
-  14    AggStep     0  18  12  sum                  0  accum=r[12] step(r[18])
-  15  Next          0   4   0                       0
-  16  AggFinal      0   7   0  count                0  accum=r[7]
-  17  AggFinal      0   8   0  sum                  0  accum=r[8]
-  18  AggFinal      0   9   0  avg                  0  accum=r[9]
-  19  AggFinal      0  10   0  min                  0  accum=r[10]
-  20  AggFinal      0  11   0  max                  0  accum=r[11]
-  21  AggFinal      0  12   0  sum                  0  accum=r[12]
-  22  Copy          7   1   0                       0  r[1]=r[7]
-  23  Copy          8   2   0                       0  r[2]=r[8]
-  24  Copy          9   3   0                       0  r[3]=r[9]
-  25  Copy         10   4   0                       0  r[4]=r[10]
-  26  Copy         11   5   0                       0  r[5]=r[11]
-  27  Copy         12   6   0                       0  r[6]=r[12]
-  28  ResultRow     1   6   0                       0  output=r[1..6]
-  29  Halt          0   0   0                       0
-  30  Transaction   0   1   8                       0  iDb=0 tx_mode=Read
-  31  Integer       1  13   0                       0  r[13]=1
-  32  Goto          0   1   0                       0
+  10    CollSeq     0   0   0  Binary               0  collation=Binary
+  11    AggStep     0  16  10  min                  0  accum=r[10] step(r[16])
+  12    Column      0   4  17                       0  r[17]=sales.amount
+  13    CollSeq     0   0   0  Binary               0  collation=Binary
+  14    AggStep     0  17  11  max                  0  accum=r[11] step(r[17])
+  15    Column      0   5  18                       0  r[18]=sales.quantity
+  16    AggStep     0  18  12  sum                  0  accum=r[12] step(r[18])
+  17  Next          0   4   0                       0
+  18  AggFinal      0   7   0  count                0  accum=r[7]
+  19  AggFinal      0   8   0  sum                  0  accum=r[8]
+  20  AggFinal      0   9   0  avg                  0  accum=r[9]
+  21  AggFinal      0  10   0  min                  0  accum=r[10]
+  22  AggFinal      0  11   0  max                  0  accum=r[11]
+  23  AggFinal      0  12   0  sum                  0  accum=r[12]
+  24  Copy          7   1   0                       0  r[1]=r[7]
+  25  Copy          8   2   0                       0  r[2]=r[8]
+  26  Copy          9   3   0                       0  r[3]=r[9]
+  27  Copy         10   4   0                       0  r[4]=r[10]
+  28  Copy         11   5   0                       0  r[5]=r[11]
+  29  Copy         12   6   0                       0  r[6]=r[12]
+  30  ResultRow     1   6   0                       0  output=r[1..6]
+  31  Halt          0   0   0                       0
+  32  Transaction   0   1   8                       0  iDb=0 tx_mode=Read
+  33  Integer       1  13   0                       0  r[13]=1
+  34  Goto          0   1   0                       0

--- a/testing/runner/tests/snapshot_tests/analyze/snapshots/analyze__max-after-analyze.snap
+++ b/testing/runner/tests/snapshot_tests/analyze/snapshots/analyze__max-after-analyze.snap
@@ -14,17 +14,18 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4                p5  comment
-   0  Init             0  12   0                     0  Start at 12
+   0  Init             0  13   0                     0  Start at 13
    1  Null             0   2   0                     0  r[2]=NULL
    2  OpenRead         0   2   0  k(6,B,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   3  Rewind           0   8   0                     0  Rewind table products
+   3  Rewind           0   9   0                     0  Rewind table products
    4    Column         0   4   3                     0  r[3]=products.price
    5    RealAffinity   3   0   0                     0
-   6    AggStep        0   3   2  max                0  accum=r[2] step(r[3])
-   7  Next             0   4   0                     0
-   8  AggFinal         0   2   0  max                0  accum=r[2]
-   9  Copy             2   1   0                     0  r[1]=r[2]
-  10  ResultRow        1   1   0                     0  output=r[1]
-  11  Halt             0   0   0                     0
-  12  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
-  13  Goto             0   1   0                     0
+   6    CollSeq        0   0   0  Binary             0  collation=Binary
+   7    AggStep        0   3   2  max                0  accum=r[2] step(r[3])
+   8  Next             0   4   0                     0
+   9  AggFinal         0   2   0  max                0  accum=r[2]
+  10  Copy             2   1   0                     0  r[1]=r[2]
+  11  ResultRow        1   1   0                     0  output=r[1]
+  12  Halt             0   0   0                     0
+  13  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
+  14  Goto             0   1   0                     0

--- a/testing/runner/tests/snapshot_tests/analyze/snapshots/analyze__min-after-analyze.snap
+++ b/testing/runner/tests/snapshot_tests/analyze/snapshots/analyze__min-after-analyze.snap
@@ -14,17 +14,18 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4                p5  comment
-   0  Init             0  12   0                     0  Start at 12
+   0  Init             0  13   0                     0  Start at 13
    1  Null             0   2   0                     0  r[2]=NULL
    2  OpenRead         0   2   0  k(6,B,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   3  Rewind           0   8   0                     0  Rewind table products
+   3  Rewind           0   9   0                     0  Rewind table products
    4    Column         0   4   3                     0  r[3]=products.price
    5    RealAffinity   3   0   0                     0
-   6    AggStep        0   3   2  min                0  accum=r[2] step(r[3])
-   7  Next             0   4   0                     0
-   8  AggFinal         0   2   0  min                0  accum=r[2]
-   9  Copy             2   1   0                     0  r[1]=r[2]
-  10  ResultRow        1   1   0                     0  output=r[1]
-  11  Halt             0   0   0                     0
-  12  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
-  13  Goto             0   1   0                     0
+   6    CollSeq        0   0   0  Binary             0  collation=Binary
+   7    AggStep        0   3   2  min                0  accum=r[2] step(r[3])
+   8  Next             0   4   0                     0
+   9  AggFinal         0   2   0  min                0  accum=r[2]
+  10  Copy             2   1   0                     0  r[1]=r[2]
+  11  ResultRow        1   1   0                     0  output=r[1]
+  12  Halt             0   0   0                     0
+  13  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
+  14  Goto             0   1   0                     0

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -31,8 +31,8 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4              p5  comment
-   0            Init             0  90   0                   0  Start at 90
-   1            Once            57   0   0                   0  goto 57
+   0            Init             0  91   0                   0  Start at 91
+   1            Once            58   0   0                   0  goto 58
    2            BeginSubrtn      2   0   0                   0  r[2]=NULL
    3            Null             0   1   0                   0  r[1]=NULL
    4            OpenEphemeral    0   1   0                   0  cursor=0 is_table=true
@@ -77,50 +77,51 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   43    OpenDup                  3   0   0                   0  new_cursor=3, original_cursor=0
   44    Null                     0  22   0                   0  r[22]=NULL
   45    Integer                  1  23   0                   0  r[23]=1; LIMIT counter
-  46    IfNot                   23  53   0                   0  if !r[23] goto 53
-  47    Rewind                   3  53   0                   0  Rewind  ephemeral()
+  46    IfNot                   23  54   0                   0  if !r[23] goto 54
+  47    Rewind                   3  54   0                   0  Rewind  ephemeral()
   48      Column                 3   0  19                   0  r[19]=ephemeral().column 0
   49      Column                 3   1  20                   0  r[20]=ephemeral().column 1
   50      Copy                  20  24   0                   0  r[24]=r[20]
-  51      AggStep                0  24  22  max              0  accum=r[22] step(r[24])
-  52    Next                     3  48   0                   0
-  53    AggFinal                 0  22   0  max              0  accum=r[22]
-  54    Copy                    22  21   0                   0  r[21]=r[22]
-  55    Copy                    21   1   0                   0  r[1]=r[21]
-  56  Return                     2   0   1                   0
-  57  OpenDup                    4   0   0                   0  new_cursor=4, original_cursor=0
-  58  OpenEphemeral              5   0   0                   0  cursor=5 is_table=false
-  59  Rewind                     4  68   0                   0  Rewind  ephemeral()
-  60    Column                   4   0  26                   0  r[26]=ephemeral().column 0
-  61    Column                   4   1  27                   0  r[27]=ephemeral().column 1
-  62    Copy                    26  28   0                   0  r[28]=r[26]
-  63    Copy                    27  29   0                   0  r[29]=r[27]
-  64    RowId                    4  30   0                   0  r[30]=ephemeral().rowid
-  65    MakeRecord              28   3  25                   0  r[25]=mkrec(r[28..30]); for ephemeral_subquery_t5
-  66    IdxInsert                5  25  28                   0  key=r[25]
-  67  Next                       4  60   0                   0
-  68  OpenRead                   6   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  69  Rewind                     6  89   0                   0  Rewind table products
-  70    Column                   6   3  37                   0  r[37]=products.price
-  71    RealAffinity            37   0   0                   0
-  72    Copy                     1  39   0                   0  r[39]=r[1]
-  73    Multiply                39  40  38                   0  r[38]=r[39]*r[40]
-  74    Le                      37  38  88  Binary           0  if r[37]<=r[38] goto 88
-  75    Column                   6   2  41                   0  r[41]=products.category_id
-  76    IsNull                  41  88   0                   0  if (r[41]==NULL) goto 88
-  77    Affinity                41   1   0                   0  r[41..42] = D
-  78    SeekGE                   5  88  41                   0  key=[41..41]
-  79      IdxGT                  5  88  41                   0  key=[41..41]
-  80      Column                 5   0  31                   0  r[31]=ephemeral(ephemeral_subquery_t5).category_id
-  81      Column                 5   1  32                   0  r[32]=ephemeral(ephemeral_subquery_t5).avg_price
-  82      Column                 6   1  33                   0  r[33]=products.name
-  83      Column                 6   3  34                   0  r[34]=products.price
-  84      RealAffinity          34   0   0                   0
-  85      Column                 5   1  35                   0  r[35]=ephemeral(ephemeral_subquery_t5).avg_price
-  86      ResultRow             33   3   0                   0  output=r[33..35]
-  87    Next                     5  79   0                   0
-  88  Next                       6  70   0                   0
-  89  Halt                       0   0   0                   0
-  90  Transaction                0   1  11                   0  iDb=0 tx_mode=Read
-  91  Real                       0  40   0  0.8              0  r[40]=0.8
-  92  Goto                       0   1   0                   0
+  51      CollSeq                0   0   0  Binary           0  collation=Binary
+  52      AggStep                0  24  22  max              0  accum=r[22] step(r[24])
+  53    Next                     3  48   0                   0
+  54    AggFinal                 0  22   0  max              0  accum=r[22]
+  55    Copy                    22  21   0                   0  r[21]=r[22]
+  56    Copy                    21   1   0                   0  r[1]=r[21]
+  57  Return                     2   0   1                   0
+  58  OpenDup                    4   0   0                   0  new_cursor=4, original_cursor=0
+  59  OpenEphemeral              5   0   0                   0  cursor=5 is_table=false
+  60  Rewind                     4  69   0                   0  Rewind  ephemeral()
+  61    Column                   4   0  26                   0  r[26]=ephemeral().column 0
+  62    Column                   4   1  27                   0  r[27]=ephemeral().column 1
+  63    Copy                    26  28   0                   0  r[28]=r[26]
+  64    Copy                    27  29   0                   0  r[29]=r[27]
+  65    RowId                    4  30   0                   0  r[30]=ephemeral().rowid
+  66    MakeRecord              28   3  25                   0  r[25]=mkrec(r[28..30]); for ephemeral_subquery_t5
+  67    IdxInsert                5  25  28                   0  key=r[25]
+  68  Next                       4  61   0                   0
+  69  OpenRead                   6   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  70  Rewind                     6  90   0                   0  Rewind table products
+  71    Column                   6   3  37                   0  r[37]=products.price
+  72    RealAffinity            37   0   0                   0
+  73    Copy                     1  39   0                   0  r[39]=r[1]
+  74    Multiply                39  40  38                   0  r[38]=r[39]*r[40]
+  75    Le                      37  38  89  Binary           0  if r[37]<=r[38] goto 89
+  76    Column                   6   2  41                   0  r[41]=products.category_id
+  77    IsNull                  41  89   0                   0  if (r[41]==NULL) goto 89
+  78    Affinity                41   1   0                   0  r[41..42] = D
+  79    SeekGE                   5  89  41                   0  key=[41..41]
+  80      IdxGT                  5  89  41                   0  key=[41..41]
+  81      Column                 5   0  31                   0  r[31]=ephemeral(ephemeral_subquery_t5).category_id
+  82      Column                 5   1  32                   0  r[32]=ephemeral(ephemeral_subquery_t5).avg_price
+  83      Column                 6   1  33                   0  r[33]=products.name
+  84      Column                 6   3  34                   0  r[34]=products.price
+  85      RealAffinity          34   0   0                   0
+  86      Column                 5   1  35                   0  r[35]=ephemeral(ephemeral_subquery_t5).avg_price
+  87      ResultRow             33   3   0                   0  output=r[33..35]
+  88    Next                     5  80   0                   0
+  89  Next                       6  71   0                   0
+  90  Halt                       0   0   0                   0
+  91  Transaction                0   1  11                   0  iDb=0 tx_mode=Read
+  92  Real                       0  40   0  0.8              0  r[40]=0.8
+  93  Goto                       0   1   0                   0

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
@@ -22,35 +22,36 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode             p1  p2  p3  p4              p5  comment
-   0    Init              0  29   0                   0  Start at 29
-   1    Once             17   0   0                   0  goto 17
+   0    Init              0  30   0                   0  Start at 30
+   1    Once             18   0   0                   0  goto 18
    2    BeginSubrtn       2   0   0                   0  r[2]=NULL
    3    Null              0   1   0                   0  r[1]=NULL
    4    Null              0   4   0                   0  r[4]=NULL
    5    Integer           1   5   0                   0  r[5]=1; LIMIT counter
-   6    IfNot             5  13   0                   0  if !r[5] goto 13
+   6    IfNot             5  14   0                   0  if !r[5] goto 14
    7    OpenRead          0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   8    Rewind            0  13   0                   0  Rewind table products
+   8    Rewind            0  14   0                   0  Rewind table products
    9      Column          0   3   6                   0  r[6]=products.price
   10      RealAffinity    6   0   0                   0
-  11      AggStep         0   6   4  max              0  accum=r[4] step(r[6])
-  12    Next              0   9   0                   0
-  13    AggFinal          0   4   0  max              0  accum=r[4]
-  14    Copy              4   3   0                   0  r[3]=r[4]
-  15    Copy              3   1   0                   0  r[1]=r[3]
-  16  Return              2   0   1                   0
-  17  OpenRead            1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  18  Rewind              1  28   0                   0  Rewind table products
-  19    Column            1   3  11                   0  r[11]=products.price
-  20    RealAffinity     11   0   0                   0
-  21    Le               11  12  27  Binary           0  if r[11]<=r[12] goto 27
-  22    Column            1   1   7                   0  r[7]=products.name
-  23    Column            1   3   8                   0  r[8]=products.price
-  24    RealAffinity      8   0   0                   0
-  25    Copy              1   9   0                   0  r[9]=r[1]
-  26    ResultRow         7   3   0                   0  output=r[7..9]
-  27  Next                1  19   0                   0
-  28  Halt                0   0   0                   0
-  29  Transaction         0   1  11                   0  iDb=0 tx_mode=Read
-  30  Integer           100  12   0                   0  r[12]=100
-  31  Goto                0   1   0                   0
+  11      CollSeq         0   0   0  Binary           0  collation=Binary
+  12      AggStep         0   6   4  max              0  accum=r[4] step(r[6])
+  13    Next              0   9   0                   0
+  14    AggFinal          0   4   0  max              0  accum=r[4]
+  15    Copy              4   3   0                   0  r[3]=r[4]
+  16    Copy              3   1   0                   0  r[1]=r[3]
+  17  Return              2   0   1                   0
+  18  OpenRead            1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  19  Rewind              1  29   0                   0  Rewind table products
+  20    Column            1   3  11                   0  r[11]=products.price
+  21    RealAffinity     11   0   0                   0
+  22    Le               11  12  28  Binary           0  if r[11]<=r[12] goto 28
+  23    Column            1   1   7                   0  r[7]=products.name
+  24    Column            1   3   8                   0  r[8]=products.price
+  25    RealAffinity      8   0   0                   0
+  26    Copy              1   9   0                   0  r[9]=r[1]
+  27    ResultRow         7   3   0                   0  output=r[7..9]
+  28  Next                1  20   0                   0
+  29  Halt                0   0   0                   0
+  30  Transaction         0   1  11                   0  iDb=0 tx_mode=Read
+  31  Integer           100  12   0                   0  r[12]=100
+  32  Goto                0   1   0                   0

--- a/testing/runner/tests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
+++ b/testing/runner/tests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
@@ -26,106 +26,108 @@ QUERY PLAN
       `--SCAN employees USING INDEX idx_employees_department
 
 BYTECODE
-addr  opcode              p1  p2  p3  p4                     p5  comment
-   0      Init             0  98   0                          0  Start at 98
-   1      InitCoroutine    1  61   2                          0
-   2      InitCoroutine    2  14   3                          0
-   3      OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   4      OpenRead         1   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
-   5      Rewind           1  13   0                          0  Rewind index idx_employees_department
-   6        DeferredSeek   1   0   0                          0
-   7        Column         0   2   3                          0  r[3]=employees.department
-   8        IdxRowId       1   4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
-   9        Column         0   1   5                          0  r[5]=employees.name
-  10        Column         0   3   6                          0  r[6]=employees.salary
-  11        Yield          2   0   0                          0
-  12      Next             1   6   0                          0
-  13      EndCoroutine     2   0   0                          0
-  14      OpenEphemeral    2   1   0                          0  cursor=2 is_table=true
-  15      OpenDup          3   2   0                          0  new_cursor=3, original_cursor=2
-  16      Null             0  27   0                          0  r[27]=NULL
-  17      Null             0  28   0                          0  r[28]=NULL
-  18      InitCoroutine    2   0   3                          0
-  19        Yield          2  38   0                          0
-  20        Compare        3  28   1  k(1, Binary)            0  r[3..3]==r[28..28]; compare partition keys to detect new partition
-  21        Jump          22  25  22                          0
-  22        Gosub         29  39   0                          0  ; detected new partition
-  23        Null           0  27   0                          0  r[27]=NULL
-  24        Copy           3  28   0                          0  r[28]=r[3]
-  25        NotNull       27  27   0                          0  r[27]!=NULL -> goto 27
-  26        Null           0  15  18                          0  r[15..18]=NULL; reset accumulator registers
-  27        MakeRecord     3   4  30                          0  r[30]=mkrec(r[3..6])
-  28        NewRowid       3  27   0                          0  r[27]=rowid
-  29        Insert         3  30  27  buffer_table_window_1   0  intkey=r[27] data=r[30]
-  30        AggStep        0  31  15  count                   0  accum=r[15] step(r[31])
-  31        Copy           6  32   0                          0  r[32]=r[6]
-  32        AggStep        0  32  16  min                     0  accum=r[16] step(r[32])
-  33        Copy           6  33   0                          0  r[33]=r[6]
-  34        AggStep        0  33  17  max                     0  accum=r[17] step(r[33])
-  35        Copy           6  34   0                          0  r[34]=r[6]
-  36        AggStep        0  34  18  avg                     0  accum=r[18] step(r[34])
-  37      Goto             0  19   0                          0
-  38      Null             0  29   0                          0  r[29]=NULL; return remaining buffered rows
-  39      Rewind           2  58   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  40      AggValue         0  15  19  count                   0  accum=r[15] dest=r[19]
-  41      AggValue         0  16  20  min                     0  accum=r[16] dest=r[20]
-  42      AggValue         0  17  21  max                     0  accum=r[17] dest=r[21]
-  43      AggValue         0  18  22  avg                     0  accum=r[18] dest=r[22]
-  44        Column         2   1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
-  45        Column         2   2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
-  46        Column         2   0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
-  47        Column         2   3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
-  48        Copy          23   7   0                          0  r[7]=r[23]
-  49        Copy          24   8   0                          0  r[8]=r[24]
-  50        Copy          25   9   0                          0  r[9]=r[25]
-  51        Copy          26  10   0                          0  r[10]=r[26]
-  52        Copy          19  11   0                          0  r[11]=r[19]
-  53        Copy          20  12   0                          0  r[12]=r[20]
-  54        Copy          21  13   0                          0  r[13]=r[21]
-  55        Copy          22  14   0                          0  r[14]=r[22]
-  56        Yield          1   0   0                          0
-  57      Next             2  44   0                          0
-  58      ResetSorter      2   0   0                          0  cursor=2
-  59    Return            29   0   1                          0
-  60    EndCoroutine       1   0   0                          0
-  61    OpenEphemeral      4   1   0                          0  cursor=4 is_table=true
-  62    OpenDup            5   4   0                          0  new_cursor=5, original_cursor=4
-  63    Null               0  54   0                          0  r[54]=NULL
-  64    InitCoroutine      1   0   2                          0
-  65      Yield            1  73   0                          0
-  66      NotNull         54  68   0                          0  r[54]!=NULL -> goto 68
-  67      Null             0  44  44                          0  r[44..44]=NULL; reset accumulator registers
-  68      MakeRecord       7   8  56                          0  r[56]=mkrec(r[7..14])
-  69      NewRowid         5  54   0                          0  r[54]=rowid
-  70      Insert           5  56  54  buffer_table_window_0   0  intkey=r[54] data=r[56]
-  71      AggStep          0  57  44  count                   0  accum=r[44] step(r[57])
-  72    Goto               0  65   0                          0
-  73    Null               0  55   0                          0  r[55]=NULL; return remaining buffered rows
-  74    Rewind             4  95   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  75    AggValue           0  44  45  count                   0  accum=r[44] dest=r[45]
-  76      Column           4   0  46                          0  r[46]=ephemeral(buffer_table_window_0).emp_id
-  77      Column           4   1  47                          0  r[47]=ephemeral(buffer_table_window_0).name
-  78      Column           4   2  48                          0  r[48]=ephemeral(buffer_table_window_0).department
-  79      Column           4   3  49                          0  r[49]=ephemeral(buffer_table_window_0).salary
-  80      Column           4   4  50                          0  r[50]=ephemeral(buffer_table_window_0).column 4
-  81      Column           4   5  51                          0  r[51]=ephemeral(buffer_table_window_0).column 5
-  82      Column           4   6  52                          0  r[52]=ephemeral(buffer_table_window_0).column 6
-  83      Column           4   7  53                          0  r[53]=ephemeral(buffer_table_window_0).column 7
-  84      Copy            46  35   0                          0  r[35]=r[46]
-  85      Copy            47  36   0                          0  r[36]=r[47]
-  86      Copy            48  37   0                          0  r[37]=r[48]
-  87      Copy            49  38   0                          0  r[38]=r[49]
-  88      Copy            45  39   0                          0  r[39]=r[45]
-  89      Copy            50  40   0                          0  r[40]=r[50]
-  90      Copy            51  41   0                          0  r[41]=r[51]
-  91      Copy            52  42   0                          0  r[42]=r[52]
-  92      Copy            53  43   0                          0  r[43]=r[53]
-  93      ResultRow       35   9   0                          0  output=r[35..43]
-  94    Next               4  76   0                          0
-  95    ResetSorter        4   0   0                          0  cursor=4
-  96  Return              55   0   1                          0
-  97  Halt                 0   0   0                          0
-  98  Transaction          0   1   7                          0  iDb=0 tx_mode=Read
-  99  Integer              1  31   0                          0  r[31]=1
- 100  Integer              1  57   0                          0  r[57]=1
- 101  Goto                 0   1   0                          0
+addr  opcode              p1   p2  p3  p4                     p5  comment
+   0      Init             0  100   0                          0  Start at 100
+   1      InitCoroutine    1   63   2                          0
+   2      InitCoroutine    2   14   3                          0
+   3      OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   4      OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   5      Rewind           1   13   0                          0  Rewind index idx_employees_department
+   6        DeferredSeek   1    0   0                          0
+   7        Column         0    2   3                          0  r[3]=employees.department
+   8        IdxRowId       1    4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
+   9        Column         0    1   5                          0  r[5]=employees.name
+  10        Column         0    3   6                          0  r[6]=employees.salary
+  11        Yield          2    0   0                          0
+  12      Next             1    6   0                          0
+  13      EndCoroutine     2    0   0                          0
+  14      OpenEphemeral    2    1   0                          0  cursor=2 is_table=true
+  15      OpenDup          3    2   0                          0  new_cursor=3, original_cursor=2
+  16      Null             0   27   0                          0  r[27]=NULL
+  17      Null             0   28   0                          0  r[28]=NULL
+  18      InitCoroutine    2    0   3                          0
+  19        Yield          2   40   0                          0
+  20        Compare        3   28   1  k(1, Binary)            0  r[3..3]==r[28..28]; compare partition keys to detect new partition
+  21        Jump          22   25  22                          0
+  22        Gosub         29   41   0                          0  ; detected new partition
+  23        Null           0   27   0                          0  r[27]=NULL
+  24        Copy           3   28   0                          0  r[28]=r[3]
+  25        NotNull       27   27   0                          0  r[27]!=NULL -> goto 27
+  26        Null           0   15  18                          0  r[15..18]=NULL; reset accumulator registers
+  27        MakeRecord     3    4  30                          0  r[30]=mkrec(r[3..6])
+  28        NewRowid       3   27   0                          0  r[27]=rowid
+  29        Insert         3   30  27  buffer_table_window_1   0  intkey=r[27] data=r[30]
+  30        AggStep        0   31  15  count                   0  accum=r[15] step(r[31])
+  31        Copy           6   32   0                          0  r[32]=r[6]
+  32        CollSeq        0    0   0  Binary                  0  collation=Binary
+  33        AggStep        0   32  16  min                     0  accum=r[16] step(r[32])
+  34        Copy           6   33   0                          0  r[33]=r[6]
+  35        CollSeq        0    0   0  Binary                  0  collation=Binary
+  36        AggStep        0   33  17  max                     0  accum=r[17] step(r[33])
+  37        Copy           6   34   0                          0  r[34]=r[6]
+  38        AggStep        0   34  18  avg                     0  accum=r[18] step(r[34])
+  39      Goto             0   19   0                          0
+  40      Null             0   29   0                          0  r[29]=NULL; return remaining buffered rows
+  41      Rewind           2   60   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  42      AggValue         0   15  19  count                   0  accum=r[15] dest=r[19]
+  43      AggValue         0   16  20  min                     0  accum=r[16] dest=r[20]
+  44      AggValue         0   17  21  max                     0  accum=r[17] dest=r[21]
+  45      AggValue         0   18  22  avg                     0  accum=r[18] dest=r[22]
+  46        Column         2    1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
+  47        Column         2    2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
+  48        Column         2    0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
+  49        Column         2    3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
+  50        Copy          23    7   0                          0  r[7]=r[23]
+  51        Copy          24    8   0                          0  r[8]=r[24]
+  52        Copy          25    9   0                          0  r[9]=r[25]
+  53        Copy          26   10   0                          0  r[10]=r[26]
+  54        Copy          19   11   0                          0  r[11]=r[19]
+  55        Copy          20   12   0                          0  r[12]=r[20]
+  56        Copy          21   13   0                          0  r[13]=r[21]
+  57        Copy          22   14   0                          0  r[14]=r[22]
+  58        Yield          1    0   0                          0
+  59      Next             2   46   0                          0
+  60      ResetSorter      2    0   0                          0  cursor=2
+  61    Return            29    0   1                          0
+  62    EndCoroutine       1    0   0                          0
+  63    OpenEphemeral      4    1   0                          0  cursor=4 is_table=true
+  64    OpenDup            5    4   0                          0  new_cursor=5, original_cursor=4
+  65    Null               0   54   0                          0  r[54]=NULL
+  66    InitCoroutine      1    0   2                          0
+  67      Yield            1   75   0                          0
+  68      NotNull         54   70   0                          0  r[54]!=NULL -> goto 70
+  69      Null             0   44  44                          0  r[44..44]=NULL; reset accumulator registers
+  70      MakeRecord       7    8  56                          0  r[56]=mkrec(r[7..14])
+  71      NewRowid         5   54   0                          0  r[54]=rowid
+  72      Insert           5   56  54  buffer_table_window_0   0  intkey=r[54] data=r[56]
+  73      AggStep          0   57  44  count                   0  accum=r[44] step(r[57])
+  74    Goto               0   67   0                          0
+  75    Null               0   55   0                          0  r[55]=NULL; return remaining buffered rows
+  76    Rewind             4   97   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  77    AggValue           0   44  45  count                   0  accum=r[44] dest=r[45]
+  78      Column           4    0  46                          0  r[46]=ephemeral(buffer_table_window_0).emp_id
+  79      Column           4    1  47                          0  r[47]=ephemeral(buffer_table_window_0).name
+  80      Column           4    2  48                          0  r[48]=ephemeral(buffer_table_window_0).department
+  81      Column           4    3  49                          0  r[49]=ephemeral(buffer_table_window_0).salary
+  82      Column           4    4  50                          0  r[50]=ephemeral(buffer_table_window_0).column 4
+  83      Column           4    5  51                          0  r[51]=ephemeral(buffer_table_window_0).column 5
+  84      Column           4    6  52                          0  r[52]=ephemeral(buffer_table_window_0).column 6
+  85      Column           4    7  53                          0  r[53]=ephemeral(buffer_table_window_0).column 7
+  86      Copy            46   35   0                          0  r[35]=r[46]
+  87      Copy            47   36   0                          0  r[36]=r[47]
+  88      Copy            48   37   0                          0  r[37]=r[48]
+  89      Copy            49   38   0                          0  r[38]=r[49]
+  90      Copy            45   39   0                          0  r[39]=r[45]
+  91      Copy            50   40   0                          0  r[40]=r[50]
+  92      Copy            51   41   0                          0  r[41]=r[51]
+  93      Copy            52   42   0                          0  r[42]=r[52]
+  94      Copy            53   43   0                          0  r[43]=r[53]
+  95      ResultRow       35    9   0                          0  output=r[35..43]
+  96    Next               4   78   0                          0
+  97    ResetSorter        4    0   0                          0  cursor=4
+  98  Return              55    0   1                          0
+  99  Halt                 0    0   0                          0
+ 100  Transaction          0    1   7                          0  iDb=0 tx_mode=Read
+ 101  Integer              1   31   0                          0  r[31]=1
+ 102  Integer              1   57   0                          0  r[57]=1
+ 103  Goto                 0    1   0                          0


### PR DESCRIPTION
emit_collseq_if_needed only emitted a CollSeq instruction when an expression had an explicit COLLATE clause or table-level collation. It did not emit CollSeq BINARY to reset the collation for aggregates without explicit collation, so NOCASE set by a prior aggregate (e.g. MIN(a COLLATE NOCASE)) persisted and affected subsequent aggregates like MAX(b).

Now emit_collseq_if_needed always emits a CollSeq instruction, defaulting to BINARY when no explicit or table-level collation is found. This matches SQLite's bytecode behavior.

Closes #5539

## Human note

This is what SQLite does.

```sql
sqlite> create table sales (amount);
sqlite> explain SELECT
          MIN(amount) as min_sale,
          MAX(amount) as max_sale
      FROM
          sales;
addr  opcode         p1    p2    p3    p4             p5  comment      
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     16    0                    0   Start at 16
1     Null           0     1     3                    0   r[1..3]=NULL
2     OpenRead       0     2     0     1              0   root=2 iDb=0; sales
3     Rewind         0     11    0                    0   
4       Column         0     0     4                    0   r[4]= cursor 0 column 0
5       CollSeq        0     0     0     BINARY-8       0   
6       AggStep        0     4     2     min(1)         1   accum=r[2] step(r[4])
7       Column         0     0     4                    0   r[4]= cursor 0 column 0
8       CollSeq        0     0     0     BINARY-8       0   
9       AggStep        0     4     3     max(1)         1   accum=r[3] step(r[4])
10    Next           0     4     0                    1   
11    AggFinal       2     1     0     min(1)         0   accum=r[2] N=1
12    AggFinal       3     1     0     max(1)         0   accum=r[3] N=1
13    Copy           2     5     1                    0   r[5..6]=r[2..3]
14    ResultRow      5     2     0                    0   output=r[5..6]
15    Halt           0     0     0                    0   
16    Transaction    0     0     1     0              1   usesStmtJournal=0
17    Goto           0     1     0                    0 
```