### PR TITLE
Fix --experimental-strict incorrectly enabling custom types

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -418,7 +418,7 @@ impl Connection {
             .get();
 
         // create fresh schema as some objects can be deleted
-        let mut fresh = Schema::with_options(self.experimental_strict_enabled());
+        let mut fresh = Schema::with_options(self.experimental_custom_types_enabled());
         fresh.schema_version = cookie;
 
         // Preserve existing views to avoid expensive repopulation.

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -192,6 +192,9 @@ impl DatabaseOpts {
 
     pub fn with_custom_types(mut self, enable: bool) -> Self {
         self.enable_custom_types = enable;
+        if enable {
+            self.enable_strict = true;
+        }
         self
     }
 
@@ -477,7 +480,7 @@ impl Database {
             path: path.into(),
             wal_path: wal_path.into(),
             schema: Arc::new(Mutex::new(Arc::new(Schema::with_options(
-                opts.enable_strict,
+                opts.enable_custom_types,
             )))),
             _shared_page_cache: shared_page_cache,
             shared_wal,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -461,7 +461,7 @@ impl Schema {
         Self::with_options(false)
     }
 
-    pub fn with_options(enable_strict: bool) -> Self {
+    pub fn with_options(enable_custom_types: bool) -> Self {
         let mut tables: HashMap<String, Arc<Table>> = HashMap::default();
         let has_indexes = HashSet::default();
         let indexes: HashMap<String, VecDeque<Arc<Index>>> = HashMap::default();
@@ -470,7 +470,7 @@ impl Schema {
             SCHEMA_TABLE_NAME.to_string(),
             Arc::new(Table::BTree(sqlite_schema_table().into())),
         );
-        for function in VirtualTable::builtin_functions(enable_strict) {
+        for function in VirtualTable::builtin_functions(enable_custom_types) {
             tables.insert(
                 function.name.to_owned(),
                 Arc::new(Table::Virtual(Arc::new((*function).clone()))),
@@ -499,7 +499,7 @@ impl Schema {
             dropped_root_pages: HashSet::default(),
             type_registry: {
                 let mut registry = HashMap::default();
-                if enable_strict {
+                if enable_custom_types {
                     bootstrap_builtin_types(&mut registry);
                 }
                 registry

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -79,7 +79,7 @@ impl VirtualTable {
         Arc::new(vtab)
     }
 
-    pub(crate) fn builtin_functions(enable_strict: bool) -> Vec<Arc<VirtualTable>> {
+    pub(crate) fn builtin_functions(enable_custom_types: bool) -> Vec<Arc<VirtualTable>> {
         let mut vtables: Vec<Arc<VirtualTable>> = PragmaVirtualTable::functions()
             .into_iter()
             .map(|(tab, schema)| {
@@ -104,7 +104,7 @@ impl VirtualTable {
         #[cfg(feature = "cli_only")]
         vtables.push(Self::btree_dump_virtual_table());
 
-        if enable_strict {
+        if enable_custom_types {
             vtables.push(Self::turso_types_virtual_table());
         }
 


### PR DESCRIPTION
Schema::with_options and VirtualTable::builtin_functions were gated on enable_strict, causing --experimental-strict to bootstrap the type registry and register the turso_types virtual table. Change both to gate on enable_custom_types instead, and make with_custom_types(true) imply enable_strict since custom types depend on STRICT tables.

Caught by @LeMikaelF 