### PR TITLE
core/mvcc: Prevent duplicate rowid allocation in concurrent transactions

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8072,6 +8072,9 @@ fn new_rowid_inner(
                                 new_rowid,
                                 prev_rowid,
                             } => {
+                                // Mark pending BEFORE releasing lock so other threads
+                                // see the pending count when they acquire the lock.
+                                mvcc_cursor.mark_pending_rowid();
                                 // we allocated a rowid, so no need to hold lock anymore
                                 mvcc_cursor.end_new_rowid();
                                 // mvcc allocator for table ws initialized, we can set result inmediatly
@@ -8142,38 +8145,67 @@ fn new_rowid_inner(
                 };
 
                 // Initialize table's max rowid in MVCC if enabled.
-                // For concurrent transactions, initialize to the *allocated* rowid
-                // (current_max + 1) so that another concurrent thread calling
-                // get_next_rowid() won't get the same value. For other modes,
-                // initialize to current_max to match SQLite's rowid behavior.
-                if mv_store.is_some() {
+                // When there are in-flight rowid allocations from other threads
+                // (pending_inserts > 0), we must account for them by taking
+                // max(cursor_max, allocator_max) to avoid re-issuing a rowid.
+                let effective_max = if mv_store.is_some() {
                     let is_concurrent = matches!(
                         program.connection.get_mv_tx(),
                         Some((_, TransactionMode::Concurrent))
                     );
-                    let init_value = if is_concurrent || program.connection.get_auto_commit()
-                    {
-                        match current_max {
-                            Some(rowid) if rowid < MAX_ROWID => Some(rowid + 1),
-                            None => Some(1),
-                            _ => current_max,
-                        }
-                    } else {
-                        current_max
-                    };
+                    let use_alloc_max = is_concurrent || program.connection.get_auto_commit();
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut() as &mut dyn Any;
                     if let Some(mvcc_cursor) = cursor.downcast_mut::<MvCursor>() {
+                        let effective = if is_concurrent
+                            || (use_alloc_max && mvcc_cursor.has_pending_inserts())
+                        {
+                            // In concurrent mode, ALWAYS consult the allocator's max_rowid.
+                            // Between INSERT and COMMIT, a thread's row is invisible to other
+                            // snapshots but the pending counter is already cleared (cursor
+                            // lifetime < transaction lifetime). The allocator's preserved
+                            // max_rowid is the only reliable source.
+                            //
+                            // In autocommit mode, only consult alloc_max when there are
+                            // in-flight allocations (pending > 0) to preserve SQLite rowid
+                            // compatibility in single-threaded mode.
+                            let alloc_max = mvcc_cursor.get_allocator_max_rowid();
+                            match (current_max, alloc_max) {
+                                (Some(a), Some(b)) => Some(a.max(b)),
+                                (a @ Some(_), None) | (None, a @ Some(_)) => a,
+                                (None, None) => None,
+                            }
+                        } else {
+                            current_max
+                        };
+                        let init_value = if use_alloc_max {
+                            match effective {
+                                Some(rowid) if rowid < MAX_ROWID => Some(rowid + 1),
+                                None => Some(1),
+                                _ => effective,
+                            }
+                        } else {
+                            current_max
+                        };
                         mvcc_cursor.initialize_max_rowid(init_value)?;
-                    };
-                }
+                        mvcc_cursor.mark_pending_rowid();
+                        effective
+                    } else {
+                        current_max
+                    }
+                } else {
+                    current_max
+                };
 
                 if *prev_largest_reg > 0 {
                     state.registers[*prev_largest_reg] =
                         Register::Value(Value::from_i64(current_max.unwrap_or(0)));
                 }
 
-                match current_max {
+                // For concurrent/autocommit with MVCC and in-flight allocations,
+                // use effective_max (accounts for other threads' pending rowids).
+                // Otherwise use cursor_max as usual.
+                match effective_max {
                     Some(rowid) if rowid < MAX_ROWID => {
                         // Can use sequential
                         state.registers[*rowid_reg] = Register::Value(Value::from_i64(rowid + 1));


### PR DESCRIPTION
## Summary

Fixes three related race conditions in the MVCC rowid allocator that caused index corruption (`wrong # of entries in index`) during concurrent transactions.

The root cause in all three cases is the same: two concurrent threads allocate the **same implicit rowid** via `NewRowid`. The second INSERT overwrites the first's table row (since rowid is the B-tree key), but both threads' index entries persist — leaving the index with more entries than the table.

## Investigation

The bug was found via the deterministic stress test (`turso_stress` under Shuttle). Three different seeds exposed three variants of the same underlying race:

- **Seed `4764849810078954235`** — exposed Race 1
- **Seed `7821798442386493438`** — exposed Race 2 (Race 1 fix alone was insufficient)
- **Seed `1091878726830009260`** — exposed Race 3 (Races 1+2 fix alone was insufficient)

Each seed was analyzed by tracing the `NewRowid` state machine interleavings between two threads, identifying the exact point where both threads converge on the same rowid value.

The differential fuzz test (`named_savepoint_differential_fuzz_mvcc`) was used throughout to ensure exact SQLite rowid compatibility in single-threaded mode — any fix that caused rowid drift relative to SQLite was rejected.

## Race Conditions and Fixes

### Race 1: ReadingMaxRowid init vs register mismatch

`ReadingMaxRowid` initialized the allocator to `cursor_max` but set the register to `cursor_max + 1`. The next `get_next_rowid()` call returned `cursor_max + 1` again — a duplicate.

**Fix:** For concurrent/autocommit transactions, initialize the allocator to `cursor_max + 1` (the allocated value) instead of `cursor_max`.

### Race 2: In-flight allocation invisible to cursor after invalidation

Thread A allocates rowid N via the `Next` path and releases the allocator lock. Thread B issues a DELETE (invalidating the allocator), then INSERTs. Thread B's cursor doesn't see Thread A's un-inserted row, reads `cursor_max = N-1`, and gets `register = N` — duplicating Thread A.

**Fix:** Added a `pending_inserts: AtomicI64` counter on `RowidAllocator`. When `pending > 0`, `ReadingMaxRowid` uses `max(cursor_max, allocator.max_rowid)` to account for in-flight allocations. The counter is incremented at allocation time (before releasing the lock) and decremented at INSERT completion and in the cursor's `Drop` impl.

### Race 3: Committed-but-invisible row after cursor drop

Thread A allocates rowid N, INSERTs it (clearing the pending counter), but hasn't COMMITted. The cursor is dropped when the INSERT statement finishes (cursor lifetime < transaction lifetime), so `pending_inserts = 0`. Thread B's MVCC snapshot cannot see Thread A's uncommitted row, enters `ReadingMaxRowid`, sees `cursor_max = N-1`, skips the `alloc_max` check (`pending = 0`), and gets `register = N` — duplicate.

**Fix:** In `BEGIN CONCURRENT` mode, **always** consult the allocator's `max_rowid` regardless of the pending counter. The `pending_inserts` check is retained for autocommit mode to preserve exact SQLite rowid compatibility (validated by the differential fuzz test).

## Files Changed

- **`core/vdbe/execute.rs`** — `ReadingMaxRowid` logic: compute `effective_max = max(cursor_max, alloc_max)` in concurrent mode; `mark_pending_rowid` in the `Next` path before releasing the lock
- **`core/mvcc/cursor.rs`** — `has_pending_rowid` flag, `mark/clear_pending_rowid()` methods, cleanup in `start_new_rowid()`, `insert()`, and `Drop` impl
- **`core/mvcc/database/mod.rs`** — `pending_inserts` field on `RowidAllocator`, `increment/decrement/has_pending/current_max_rowid` methods

## Test Plan

- [x] Stress test seed `4764849810078954235` (Race 1) — PASSED
- [x] Stress test seed `7821798442386493438` (Race 2) — PASSED
- [x] Stress test seed `1091878726830009260` (Race 3) — PASSED
- [x] Differential fuzz `named_savepoint_differential_fuzz_mvcc` — PASSED (SQLite compat)
- [x] Full fuzz suite (121 tests) — PASSED
- [x] All MVCC integration tests (154 tests) — PASSED
- [x] Clippy clean

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)