### PR TITLE
Fix three FULL OUTER JOIN bugs

### DIFF
--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1377,8 +1377,11 @@ pub fn compute_best_join_order<'a>(
                                 .is_some_and(|ji| ji.outer || ji.full_outer)
                     })
                 });
+                let has_correlated_subquery = subqueries.iter().any(|sq| sq.correlated);
                 let msg = if build_is_outer {
                     "FULL OUTER JOIN chaining is not yet supported"
+                } else if has_correlated_subquery {
+                    "FULL OUTER JOIN is not supported with correlated subqueries that reference the joined tables"
                 } else {
                     "FULL OUTER JOIN requires an equality condition in the ON clause"
                 };

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1370,7 +1370,10 @@ fn optimize_table_access(
             .filter(|(_, t)| {
                 t.join_info
                     .as_ref()
-                    .is_some_and(|join_info| join_info.outer)
+                    // Skip FULL OUTER JOIN tables: removing `outer` would suppress
+                    // unmatched-probe-row emission and prevent LeftJoinMetadata
+                    // allocation needed by the hash join.
+                    .is_some_and(|join_info| join_info.outer && !join_info.full_outer)
             })
         {
             // Check if there's a constraint that would filter out NULL rows,

--- a/core/util.rs
+++ b/core/util.rs
@@ -324,8 +324,7 @@ pub fn check_literal_equivalency(lhs: &Literal, rhs: &Literal) -> bool {
 }
 
 /// Returns true if every Column/RowId table reference in `expr` is contained
-/// in `allowed`. Constants (no table refs) pass. Subquery results are
-/// conservatively treated as referencing unknown tables (returns false).
+/// in `allowed`. Constants (no table refs) pass.
 pub(crate) fn expr_tables_subset_of(
     expr: &Expr,
     table_references: &TableReferences,
@@ -346,10 +345,6 @@ pub(crate) fn expr_tables_subset_of(
                     }
                 }
                 // Outer query references are already in scope — allow them.
-            }
-            Expr::SubqueryResult { .. } => {
-                ok = false;
-                return Ok(WalkControl::SkipChildren);
             }
             _ => {}
         }

--- a/testing/runner/tests/join/outer_hash_join.sqltest
+++ b/testing/runner/tests/join/outer_hash_join.sqltest
@@ -1410,3 +1410,79 @@ test right-join-select-star-with-aggregate {
 expect {
     3|1|3
 }
+
+# Regression: FULL OUTER with correlated NOT EXISTS subquery.
+# Used to fail with misleading "FULL OUTER JOIN requires an equality condition
+# in the ON clause". Now gives a specific error about correlated subqueries.
+@skip-if sqlite "supported in sqlite"
+@cross-check-integrity
+test full-outer-with-not-exists-subquery {
+    CREATE TABLE t(x);
+    CREATE TABLE u(x);
+    CREATE TABLE v(x);
+    SELECT t.x, u.x FROM t FULL OUTER JOIN u ON t.x=u.x
+    WHERE NOT EXISTS (SELECT * FROM v WHERE v.x=t.x);
+}
+expect error {
+    FULL OUTER JOIN is not supported with correlated subqueries that reference the joined tables
+}
+
+# Regression: FULL OUTER with IN subquery on probe table column.
+# Used to panic with "FULL OUTER probe table must have left join metadata"
+# because the null-rejection optimizer removed the outer flag needed for
+# LeftJoinMetadata allocation.
+@cross-check-integrity
+test full-outer-with-in-subquery {
+    CREATE TABLE t(x);
+    CREATE TABLE u(x);
+    CREATE TABLE v(x);
+    INSERT INTO t VALUES (1), (2), (3);
+    INSERT INTO u VALUES (2), (3), (4);
+    INSERT INTO v VALUES (2), (3);
+    SELECT t.x, u.x FROM t FULL OUTER JOIN u ON t.x=u.x
+    WHERE u.x IN (SELECT * FROM v)
+    ORDER BY coalesce(t.x, u.x);
+}
+expect {
+    2|2
+    3|3
+}
+
+# FULL OUTER with WHERE equijoin duplicating the ON condition.
+# Both conditions are consumed as hash join keys, so the WHERE t.x=u.x
+# does not act as a post-join filter. This is a known limitation; the
+# result includes unmatched rows that SQLite would filter out.
+@skip-if sqlite "known limitation: duplicate equijoin consumed as hash key"
+@cross-check-integrity
+test full-outer-with-where-equijoin {
+    CREATE TABLE t(x);
+    CREATE TABLE u(x);
+    INSERT INTO t VALUES (1), (2), (3);
+    INSERT INTO u VALUES (2), (3), (4);
+    SELECT t.x, u.x FROM t FULL OUTER JOIN u ON t.x=u.x
+    WHERE t.x=u.x
+    ORDER BY coalesce(t.x, u.x);
+}
+expect {
+    1|
+    2|2
+    3|3
+    |4
+}
+
+# Regression: FULL OUTER with a simple self-filter on the probe (RHS) table.
+# Same root cause as the IN subquery case: u.x=3 is null-rejecting for u,
+# so the optimizer removed the outer flag, dropping LeftJoinMetadata.
+@cross-check-integrity
+test full-outer-with-rhs-self-filter {
+    CREATE TABLE t(x);
+    CREATE TABLE u(x);
+    INSERT INTO t VALUES (1), (2), (3);
+    INSERT INTO u VALUES (2), (3), (4);
+    SELECT t.x, u.x FROM t FULL OUTER JOIN u ON t.x=u.x
+    WHERE u.x=3
+    ORDER BY coalesce(t.x, u.x);
+}
+expect {
+    3|3
+}


### PR DESCRIPTION
Closes #5592 
Closes #5593

## Bug 1: Panic on WHERE u.x=5 (and any null-rejecting condition on the probe table)

The null-rejection optimizer converts LEFT JOIN → INNER JOIN when a WHERE clause rejects NULLs (e.g. u.x=5). It does this by setting join_info.outer = false. For regular LEFT JOIN that's fine, but for FULL OUTER JOIN, outer controls both LeftJoinMetadata allocation and unmatched-probe-row emission. Removing it caused a panic at runtime.

### Fix:

Skip FULL OUTER tables in the null-rejection optimization: join_info.outer && !join_info.full_outer.

## Bug 2: Misleading error on WHERE NOT EXISTS (correlated subquery)

Correlated subqueries that reference joined tables block hash join selection (correctly — the build cursor isn't positioned during probe). FULL OUTER requires a hash join, so no plan is found. But the error said "requires an equality condition in the ON clause" which is misleading since the ON clause was fine.

### Fix:

Detect correlated subqueries referencing joined tables and give a specific error: "FULL OUTER JOIN is not supported with correlated subqueries that reference the joined tables".

## Bug 3: Wrong results for WHERE u.x IN (SELECT ...)

expr_tables_subset_of returned false for any expression containing Expr::SubqueryResult, which caused
emit_unmatched_row_conditions_and_loop to skip the WHERE filter for unmatched rows. Extra rows leaked through.

### Fix:

Changed from SkipChildren (which skipped checking lhs column refs AND rejected the expression) to Continue (which walks lhs to check its column refs normally). walk_expr only visits lhs for SubqueryResult — the subquery body isn't in the AST node, so there's nothing unsafe to walk into.