### PR TITLE
Add Mobibench evaluation: SQLite vs Turso

### DIFF
--- a/perf/mobibench/README.md
+++ b/perf/mobibench/README.md
@@ -1,0 +1,70 @@
+# Mobibench: SQLite vs Turso
+
+Experimental evaluation comparing SQLite and Turso using
+[Mobibench](https://github.com/penberg/Mobibench), inspired by
+Purohith et al., "The Dangers and Complexities of SQLite Benchmarking"
+(APSys'17).
+
+## Build
+
+Build Turso from the repo root:
+
+```
+cargo build --release
+```
+
+Clone and build the benchmark binaries:
+
+```
+cd perf/mobibench
+git clone git@github.com:penberg/Mobibench.git
+cd Mobibench/shell
+LIBS=sqlite3.c make && mv mobibench mobibench-sqlite3
+make clean
+LIBS="../../../../target/release/libturso_sqlite3.a -lm" make && mv mobibench mobibench-turso
+```
+
+## Run evaluation
+
+From `perf/mobibench/`:
+
+```
+./run-eval.sh
+```
+
+Runs Insert, Update, and Delete workloads (5 iterations each) under
+WAL journal mode + FULL synchronous for both SQLite and Turso.
+
+Results are written to `plot/results.csv`.
+
+Override the number of runs with `RUNS=10 ./run-eval.sh`.
+
+## Generate plot
+
+```
+cd plot
+uv run python plot.py
+```
+
+Produces `plot/mobibench.pdf` — a grouped bar chart comparing
+SQLite and Turso across Insert/Update/Delete operations.
+
+## Mobibench parameters
+
+| Flag | Description | Value |
+|---|---|---|
+| `-d` | DB mode | 0=insert, 1=update, 2=delete |
+| `-j` | Journal mode | 3 (WAL) |
+| `-s` | Sync mode | 2 (FULL) |
+| `-y` | File sync | 2 (fsync) |
+| `-n` | Transactions | 1000 |
+| `-t` | Threads | 1 |
+| `-f` | File size (KB) | 1024 |
+| `-r` | Record size (KB) | 4 |
+
+## Manual runs
+
+```
+./Mobibench/shell/mobibench-sqlite3 -p mobibench-data -f 1024 -r 4 -a 0 -y 2 -t 1 -d 0 -n 1000 -j 3 -s 2
+./Mobibench/shell/mobibench-turso   -p mobibench-data -f 1024 -r 4 -a 0 -y 2 -t 1 -d 0 -n 1000 -j 3 -s 2
+```

--- a/perf/mobibench/plot/plot.py
+++ b/perf/mobibench/plot/plot.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Grouped bar chart comparing SQLite and Turso transaction performance
+using Mobibench (WAL + FULL synchronous).
+
+Usage: uv run python plot.py [results.csv]
+"""
+
+import sys
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import scienceplots  # noqa: F401
+
+csv_path = sys.argv[1] if len(sys.argv) > 1 else "results.csv"
+df = pd.read_csv(csv_path)
+
+operations = ["Insert", "Update", "Delete"]
+systems = ["Turso", "SQLite"]
+
+means = {}
+stds = {}
+for sys_name in systems:
+    means[sys_name] = []
+    stds[sys_name] = []
+    for op in operations:
+        subset = df[(df["system"] == sys_name) & (df["operation"] == op)]
+        means[sys_name].append(subset["tps"].mean())
+        stds[sys_name].append(subset["tps"].std())
+
+plt.style.use(["science", "no-latex"])
+plt.rcParams.update({
+    "font.family": "serif",
+    "font.size": 10,
+})
+
+fig, ax = plt.subplots(figsize=(5, 3.5))
+
+x = np.arange(len(operations))
+bar_width = 0.3
+
+ax.bar(
+    x - bar_width / 2, means["Turso"], bar_width,
+    yerr=stds["Turso"], capsize=3,
+    label="Turso", color="#2E7D32",
+    edgecolor="black", linewidth=0.5,
+)
+ax.bar(
+    x + bar_width / 2, means["SQLite"], bar_width,
+    yerr=stds["SQLite"], capsize=3,
+    label="SQLite", color="#1976D2",
+    edgecolor="black", linewidth=0.5, hatch="///",
+)
+
+ax.set_xticks(x)
+ax.set_xticklabels(operations)
+ax.set_ylabel("Transactions / sec")
+ax.legend(frameon=True)
+
+ax.grid(True, axis="y", alpha=0.3, linestyle="-", linewidth=0.5)
+ax.set_axisbelow(True)
+
+fig.tight_layout()
+fig.savefig("mobibench.pdf", dpi=300, bbox_inches="tight")
+print("Saved mobibench.pdf")

--- a/perf/mobibench/plot/pyproject.toml
+++ b/perf/mobibench/plot/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "mobibench-plot"
+version = "0.1.0"
+description = "Mobibench SQLite vs Turso benchmark plotting"
+requires-python = ">=3.13"
+dependencies = [
+    "matplotlib>=3.10.5",
+    "pandas>=2.3.2",
+    "scienceplots>=2.1.1",
+]

--- a/perf/mobibench/run-eval.sh
+++ b/perf/mobibench/run-eval.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Mobibench evaluation: SQLite vs Turso
+#
+# Measures Insert/Update/Delete throughput (TPS) for both systems
+# under WAL journal mode + FULL synchronous — the recommended
+# production configuration.
+#
+# Output: plot/results.csv (one row per run)
+
+set -euo pipefail
+
+MOBIBENCH_DIR="$(cd "$(dirname "$0")" && pwd)"
+SQLITE_BIN="$MOBIBENCH_DIR/Mobibench/shell/mobibench-sqlite3"
+TURSO_BIN="$MOBIBENCH_DIR/Mobibench/shell/mobibench-turso"
+DATA_DIR="$MOBIBENCH_DIR/mobibench-data"
+RESULTS="$MOBIBENCH_DIR/plot/results.csv"
+RUNS=${RUNS:-5}
+
+for bin in "$SQLITE_BIN" "$TURSO_BIN"; do
+    if [ ! -x "$bin" ]; then
+        echo "ERROR: $bin not found. Build it first (see README.md)."
+        exit 1
+    fi
+done
+
+extract_tps() {
+    grep "Transactions/sec" | sed 's/.*\t//' | awk '{print $1}'
+}
+
+run_one() {
+    local bin="$1"
+    local db_mode="$2"  # -d: 0=insert, 1=update, 2=delete
+
+    rm -rf "$DATA_DIR"
+    mkdir -p "$DATA_DIR"
+    "$bin" -p "$DATA_DIR" -f 1024 -r 4 -a 0 -y 2 -t 1 \
+           -d "$db_mode" -n 1000 -j 3 -s 2 \
+           -T 1 -D 1 -q 2>&1 | extract_tps
+}
+
+echo "system,operation,run,tps" > "$RESULTS"
+
+for dmode in 0 1 2; do
+    case $dmode in
+        0) label="Insert" ;;
+        1) label="Update" ;;
+        2) label="Delete" ;;
+    esac
+
+    for system in sqlite turso; do
+        if [ "$system" = "sqlite" ]; then
+            bin="$SQLITE_BIN"
+            sys_label="SQLite"
+        else
+            bin="$TURSO_BIN"
+            sys_label="Turso"
+        fi
+
+        for run in $(seq 1 "$RUNS"); do
+            echo -n "  $sys_label $label run $run/$RUNS ... "
+            tps=$(run_one "$bin" "$dmode")
+            echo "$sys_label,$label,$run,$tps" >> "$RESULTS"
+            echo "${tps} TPS"
+        done
+    done
+done
+
+echo ""
+echo "Results written to $RESULTS"
+rm -rf "$DATA_DIR"


### PR DESCRIPTION
Benchmark runner and plotting scripts for comparing SQLite and Turso transaction throughput (Insert/Update/Delete) using Mobibench under WAL + FULL synchronous configuration.