### PR TITLE
add update or replace to sim and fix update or replace ordering

### DIFF
--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -67,6 +67,10 @@ Use if-statements only when both branches are expected paths.
 - Don't create abstractions for one-time operations
 - Three similar lines > premature abstraction
 
+## Index Mutations
+
+When code involves index inserts, deletes, or conflict resolution, double-check the ordering against SQLite. Wrong ordering causes index inconsistencies. and easy to miss.
+
 ## Ensure understanding of IO model
 
 - [Async IO model](../async-io-model/SKILL.md)

--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -47,7 +47,7 @@ impl Default for TableOpts {
     fn default() -> Self {
         Self {
             large_table: Default::default(),
-            rowid_alias_prob: 0.05,
+            rowid_alias_prob: 0.15,
             // Up to 10 columns
             column_range: 1..11,
         }
@@ -200,13 +200,25 @@ impl Default for InsertOpts {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Validate)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Validate)]
 #[serde(deny_unknown_fields, default)]
 pub struct UpdateOpts {
     #[garde(skip)]
     pub padding_size: Option<usize>,
     #[garde(skip)]
     pub force_late_failure: bool,
+    #[garde(range(min = 0.0, max = 1.0))]
+    pub or_replace_prob: f64,
+}
+
+impl Default for UpdateOpts {
+    fn default() -> Self {
+        Self {
+            padding_size: None,
+            force_late_failure: false,
+            or_replace_prob: 0.1,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Validate)]

--- a/sql_generation/generation/value/mod.rs
+++ b/sql_generation/generation/value/mod.rs
@@ -50,7 +50,13 @@ impl ArbitraryFrom<&ColumnType> for SimValue {
         let value = match column_type {
             ColumnType::Integer => Value::from_i64(rng.random_range(i64::MIN..i64::MAX)),
             ColumnType::Float => Value::from_f64(rng.random_range(-1e10..1e10)),
-            ColumnType::Text => Value::build_text(gen_random_text(rng)),
+            ColumnType::Text => {
+                if rng.random_ratio(1, 100) {
+                    Value::build_text(String::new())
+                } else {
+                    Value::build_text(gen_random_text(rng))
+                }
+            }
             ColumnType::Blob => Value::Blob(gen_random_text(rng).into_bytes()),
         };
         SimValue(value)

--- a/sql_generation/generation/value/pattern.rs
+++ b/sql_generation/generation/value/pattern.rs
@@ -17,6 +17,9 @@ impl ArbitraryFromMaybe<&SimValue> for LikeValue {
             value @ Value::Text(..) => {
                 let t = value.to_string();
                 let mut t = t.chars().collect::<Vec<_>>();
+                if t.is_empty() {
+                    return Some(Self(SimValue(Value::build_text("%".to_string()))));
+                }
                 // Remove a number of characters, either insert `_` for each character removed, or
                 // insert one `%` for the whole substring
                 let mut i = 0;

--- a/testing/runner/tests/update_or_replace_rowid_secondary_index.sqltest
+++ b/testing/runner/tests/update_or_replace_rowid_secondary_index.sqltest
@@ -1,0 +1,50 @@
+@database :memory:
+
+# Regression: UPDATE OR REPLACE must not corrupt secondary indexes when a rowid/PK
+# conflict is resolved via REPLACE.
+
+@cross-check-integrity
+test update-or-replace-rowid-conflict-preserves-secondary-index {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, c TEXT, payload TEXT);
+    CREATE INDEX idx_c ON t(c);
+
+    INSERT INTO t VALUES (1, 'x', 'old'), (2, 'y', 'new');
+
+    -- Move row 2 onto rowid 1 (PK conflict) and match the indexed column value so
+    -- the secondary index entry key would collide if conflict resolution is ordered
+    -- incorrectly.
+    UPDATE OR REPLACE t
+      SET id = 1,
+          c = 'x',
+          payload = 'new'
+      WHERE id = 2;
+
+    SELECT id, c, payload FROM t ORDER BY id;
+    PRAGMA integrity_check;
+}
+expect {
+    1|x|new
+    ok
+}
+
+test update-or-replace-rowid-no-conflict-preserves-secondary-index {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, c TEXT, payload TEXT);
+    CREATE INDEX idx_c ON t(c);
+
+    INSERT INTO t VALUES (1, 'x', 'old'), (2, 'y', 'new');
+
+    -- No PK conflict. This should behave like a normal UPDATE.
+    UPDATE OR REPLACE t
+      SET id = 3,
+          c = 'z',
+          payload = 'new'
+      WHERE id = 2;
+
+    SELECT id, c, payload FROM t ORDER BY id;
+    PRAGMA integrity_check;
+}
+expect {
+    1|x|old
+    3|z|new
+    ok
+}

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -87,8 +87,8 @@ impl Property {
                         }
                         Query::Update(Update {
                             table: t,
-                            set_values: _,
                             predicate,
+                            ..
                         }) if t == &table.name && predicate.test(row, table) => {
                             // The inserted row will not be updated.
                             None

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -113,6 +113,7 @@ impl Profile {
                         update: UpdateOpts {
                             padding_size: Some(20_000),
                             force_late_failure: true,
+                            or_replace_prob: 0.0,
                         },
                         ..Default::default()
                     },
@@ -135,6 +136,15 @@ impl Profile {
             io: IOProfile {
                 fault: FaultProfile {
                     enable: false,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            query: QueryProfile {
+                gen_opts: Opts {
+                    query: QueryOpts {
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 ..Default::default()

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -248,12 +248,20 @@ pub fn execute_interaction_turso(
 
             stack.push(results);
             // TODO: skip integrity check with mvcc
-            if !env.profile.experimental_mvcc && env.rng.random_ratio(1, 10) {
-                let SimConnection::LimboConnection(conn) = &mut env.connections[connection_index]
-                else {
-                    unreachable!()
-                };
-                limbo_integrity_check(conn)?;
+            if !env.profile.experimental_mvcc && !env.opts.disable_integrity_check {
+                if matches!(
+                    query,
+                    Query::Update(u)
+                        if matches!(u.or_conflict, Some(turso_parser::ast::ResolveType::Replace))
+                ) || env.rng.random_ratio(1, 10)
+                {
+                    let SimConnection::LimboConnection(conn) =
+                        &mut env.connections[connection_index]
+                    else {
+                        unreachable!()
+                    };
+                    limbo_integrity_check(conn)?;
+                }
             }
             env.update_conn_last_interaction(connection_index, Some(query));
         }
@@ -310,7 +318,10 @@ pub fn execute_interaction_turso(
             // Reset fault injection
             env.io.inject_fault(false);
             // TODO: skip integrity check with mvcc
-            if !env.profile.experimental_mvcc && env.rng.random_ratio(1, 10) {
+            if !env.profile.experimental_mvcc
+                && !env.opts.disable_integrity_check
+                && env.rng.random_ratio(1, 10)
+            {
                 limbo_integrity_check(&conn)?;
             }
         }

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -248,20 +248,19 @@ pub fn execute_interaction_turso(
 
             stack.push(results);
             // TODO: skip integrity check with mvcc
-            if !env.profile.experimental_mvcc && !env.opts.disable_integrity_check {
-                if matches!(
+            if !env.profile.experimental_mvcc
+                && !env.opts.disable_integrity_check
+                && (matches!(
                     query,
                     Query::Update(u)
                         if matches!(u.or_conflict, Some(turso_parser::ast::ResolveType::Replace))
-                ) || env.rng.random_ratio(1, 10)
-                {
-                    let SimConnection::LimboConnection(conn) =
-                        &mut env.connections[connection_index]
-                    else {
-                        unreachable!()
-                    };
-                    limbo_integrity_check(conn)?;
-                }
+                ) || env.rng.random_ratio(1, 10))
+            {
+                let SimConnection::LimboConnection(conn) = &mut env.connections[connection_index]
+                else {
+                    unreachable!()
+                };
+                limbo_integrity_check(conn)?;
             }
             env.update_conn_last_interaction(connection_index, Some(query));
         }


### PR DESCRIPTION
```NOTE: this do not qualify for turso challenge, this  is a general simulator improvement. - update or replace is added after 0.4.4```

In update or replace , we handled the rowid conflict too late; we updated indexes first, then deleted the conflicting row. If the new row and the conflicting row shared
  indexed values, this could leave stale entries in secondary indexes (and NotExists could also move the table cursor onto the wrong row). Fix: delete the conflicting row (and its index
  entries) before the index update loop, then re-seek back to the row being updated.
  
  
  ```
   cargo run --bin limbo_sim -- --maximum-tests 1000 --seed 4939548460769627338
   
   Error: failed with error: 'InternalError("Integrity Check Failed: row 1 missing from index idx_approachable_klassen_827_gregario_320403\nwrong # of entries in index idx_approachable_klassen_827_gregario_320403")'
   ```