### PR TITLE
Fix sync replay generator

### DIFF
--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -382,8 +382,7 @@ impl DatabaseReplayGenerator {
         table_name: &str,
         columns: usize,
     ) -> Result<ReplayInfo> {
-        let (column_names, pk_column_indices) =
-            self.table_columns_info(coro, table_name).await?;
+        let (column_names, pk_column_indices) = self.table_columns_info(coro, table_name).await?;
         // The CDC record may have fewer columns than the current schema
         // (e.g. records captured before ALTER TABLE ADD COLUMN).
         // Only reference columns present in the record.
@@ -418,8 +417,9 @@ impl DatabaseReplayGenerator {
         if !self.opts.use_implicit_rowid {
             let col_list = record_columns.join(", ");
             let placeholders = ["?"].repeat(columns).join(",");
-            let query =
-                format!("INSERT INTO {table_name}({col_list}) VALUES ({placeholders}){conflict_clause}");
+            let query = format!(
+                "INSERT INTO {table_name}({col_list}) VALUES ({placeholders}){conflict_clause}"
+            );
             return Ok(ReplayInfo {
                 change_type: DatabaseChangeType::Insert,
                 query,

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -1587,9 +1587,7 @@ mod tests {
                 conn1
                     .execute("INSERT INTO t VALUES ('a', 'alpha')")
                     .unwrap();
-                conn1
-                    .execute("INSERT INTO t VALUES ('b', 'beta')")
-                    .unwrap();
+                conn1.execute("INSERT INTO t VALUES ('b', 'beta')").unwrap();
                 conn1
                     .execute("ALTER TABLE t ADD COLUMN z TEXT DEFAULT NULL")
                     .unwrap();
@@ -1697,9 +1695,7 @@ mod tests {
                 conn1
                     .execute("INSERT INTO t VALUES ('a', 'alpha')")
                     .unwrap();
-                conn1
-                    .execute("INSERT INTO t VALUES ('b', 'beta')")
-                    .unwrap();
+                conn1.execute("INSERT INTO t VALUES ('b', 'beta')").unwrap();
 
                 // Target: post-ALTER schema with 3 columns (set up without CDC)
                 let conn2 = db2.connect_untracked().unwrap();
@@ -1979,12 +1975,8 @@ mod tests {
                 conn1
                     .execute("INSERT INTO t VALUES ('a', 'alpha')")
                     .unwrap();
-                conn1
-                    .execute("INSERT INTO t VALUES ('b', 'beta')")
-                    .unwrap();
-                conn1
-                    .execute("DELETE FROM t WHERE x = 'a'")
-                    .unwrap();
+                conn1.execute("INSERT INTO t VALUES ('b', 'beta')").unwrap();
+                conn1.execute("DELETE FROM t WHERE x = 'a'").unwrap();
 
                 // Target: post-ALTER schema with both rows present
                 let conn2 = db2.connect_untracked().unwrap();


### PR DESCRIPTION
## Summary

- Fix `DatabaseReplayGenerator` to use explicit column lists in INSERT/UPDATE queries so that CDC records captured before `ALTER TABLE ADD COLUMN` can be replayed into a schema that already has the new column
- Previously, `upsert_query` generated `INSERT INTO t VALUES (?,?,?)` without column names — this fails when the target table has more columns than the CDC record (e.g. after ALTER TABLE ADD COLUMN)
- Previously, `update_query` iterated over all schema column names but indexed into the CDC record's `columns` bool slice which had fewer entries — causing an out-of-bounds panic
- Both functions now truncate `column_names` to match the CDC record's column count, always use explicit column names in INSERT, scope the ON CONFLICT clause to record columns only, and return a clear error if the PK column index falls outside the record range

🤖 Generated with [Claude Code](https://claude.com/claude-code)