### PR TITLE
Avoid modulo-by-zero in WAL frame API fuzz rollback

### DIFF
--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -341,7 +341,7 @@ fn test_wal_frame_api_no_schema_changes_fuzz(db: TempDatabase) {
                         synced_frame = *committed;
                     }
                 }
-                if rng.next_u32() % 10 == 0 {
+                if rng.next_u32() % 10 == 0 && synced_frame > 0 {
                     synced_frame = rng.next_u32() as u64 % synced_frame;
                 }
                 let rows: Vec<(i64,)> = conn2.exec_rows("SELECT COUNT(*) FROM t");


### PR DESCRIPTION
## Description

  - Fixes a panic in test_wal_frame_api_no_schema_changes_fuzz caused by % synced_frame when synced_frame == 0.
  - Adds a guard so rollback randomization only runs modulo when synced_frame > 0.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

- Issue #3497 reports intermittent fuzz failures:
      - attempt to calculate the remainder with a divisor of zero

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #3497

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
