### PR TITLE
Avoid panic in DecrJumpZero on non-integer register

### DIFF
--- a/testing/runner/tests/limit.sqltest
+++ b/testing/runner/tests/limit.sqltest
@@ -38,3 +38,12 @@ test limit-in-subquery {
 expect {
     1
 }
+
+test limit-non-integer-datatype-mismatch {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), (2);
+    SELECT x FROM t LIMIT (SELECT 'abc');
+}
+expect error {
+    datatype mismatch
+}


### PR DESCRIPTION
## Description

- Fix `DecrJumpZero` execution so it no longer panics on non-integer register values.
- Replace the `unreachable!` branch with a returned `LimboError::InternalError`.
- Add a regression test in `core/vdbe/execute.rs` to ensure this path fails gracefully (error) rather than crashing.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Issue #4676 reports a panic:
  `entered unreachable code: DecrJumpZero on non-integer register`

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #4676

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
