### PR TITLE
cli/sync: add read timeout to prevent deadlock on Windows

### DIFF
--- a/bindings/python/tests/utils.py
+++ b/bindings/python/tests/utils.py
@@ -53,7 +53,11 @@ class TursoServer:
                     rc = self._server.poll()
                     if rc is not None:
                         stderr = self._server.stderr.read().decode(errors="replace")
-                        if "os error 10013" in stderr or "address already in use" in stderr.lower():
+                        if (
+                            "os error 10013" in stderr
+                            or "os error 10048" in stderr
+                            or "address already in use" in stderr.lower()
+                        ):
                             break  # retry with a different port
                         raise RuntimeError(
                             f"sync server exited with code {rc} before accepting connections\nstderr: {stderr}"

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -86,6 +86,7 @@ impl TursoSyncServer {
 
     fn handle_connection(&self, mut stream: TcpStream) -> Result<()> {
         stream.set_nonblocking(false)?;
+        stream.set_read_timeout(Some(std::time::Duration::from_secs(30)))?;
 
         let mut buffer = [0u8; 8192];
         let mut request_data = Vec::new();


### PR DESCRIPTION
## Summary

- Add 30-second read timeout to sync server TCP stream in `cli/sync_server.rs` to prevent indefinite hang when Windows leaves half-open TCP connections after client disconnect
- Add Windows `WSAEADDRINUSE` (`os error 10048`) to the port retry logic in `bindings/python/tests/utils.py`

## Motivation and Contect
- Determine why CI tests for Python code were failing only on Windows. 

## LLM Usage
Claude Code assisted in writing this code, and generated the details included below. 

## Evidence
Both issues observed in CI run `58479384622` on `feature/sqlalchemy-driver`:
- **Windows 3.9**: `test_pull` crashed because the retry logic didn't recognize `os error 10048`
- **Windows 3.13**: 8 tests passed, then the 9th hung for 268s until `KeyboardInterrupt`

Reproduced on a Windows 11 PC over SSH:
- **Without fix**: sync tests hang at test 6, never complete
- **With fix**: all 9 sync tests pass (277s total — the 30s timeouts fire on stalled connections and the server recovers gracefully)
- **Linux**: unaffected in both cases (TCP teardown is clean, `read()` returns 0 immediately)

## Root Cause

The sync server handles connections sequentially in a loop. After accepting a connection, it calls `stream.set_nonblocking(false)` then does a blocking `stream.read()`. Without a read timeout, if a client disconnects and Windows doesn't send FIN/RST promptly, the `read()` blocks forever and the server can never accept new connections.

## Test plan

- [x] Reproduced hang on Windows 11 without fix
- [x] Confirmed fix resolves hang on Windows 11 (9/9 pass)
- [x] Linux sync tests pass (16/16, 5x stress = 80/80)
- [x] Full Python test suite on Linux (289 pass, 1 skip)
- [x] No orphan tursodb processes after test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)