### PR TITLE
Make MVCC Elle check errors fail CI build

### DIFF
--- a/.github/workflows/elle.yml
+++ b/.github/workflows/elle.yml
@@ -84,21 +84,11 @@ jobs:
           if [ "${{ matrix.mvcc }}" = "true" ]; then
             MVCC_FLAG="--enable-mvcc"
           fi
-          if ./target/debug/turso_whopper \
+          ./target/debug/turso_whopper \
             --elle ${{ matrix.elle_model }} \
             --elle-output elle-history.edn \
             --max-steps "$MAX_STEPS" \
-            $MVCC_FLAG; then
-            echo "SIMULATION_OK=true" >> "$GITHUB_ENV"
-          else
-            echo "::warning::Simulation failed (model=${{ matrix.elle_model }}, mvcc=${{ matrix.mvcc }})"
-            echo "SIMULATION_OK=false" >> "$GITHUB_ENV"
-            if [ "${{ matrix.mvcc }}" != "true" ]; then
-              exit 1
-            fi
-            echo "### ⚠️ MVCC simulation failed" >> "$GITHUB_STEP_SUMMARY"
-            echo "The MVCC Elle simulation failed. This is expected and non-blocking." >> "$GITHUB_STEP_SUMMARY"
-          fi
+            $MVCC_FLAG
 
       - name: Setup Leiningen
         run: |
@@ -123,7 +113,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y graphviz
 
       - name: Run Elle analysis
-        if: env.SIMULATION_OK == 'true'
         run: |
           ELLE_JAR=$(ls -t /tmp/elle-cli/target/*-standalone.jar | head -1)
           mkdir -p elle-results
@@ -135,16 +124,7 @@ jobs:
           if [ "${{ matrix.mvcc }}" = "true" ]; then
             CONSISTENCY_FLAG="--consistency-models snapshot-isolation"
           fi
-          if java -jar "$ELLE_JAR" --model ${{ matrix.elle_model }} $CONSISTENCY_FLAG --verbose --directory elle-results elle-history.edn; then
-            echo "Elle analysis passed"
-          else
-            echo "::warning::Elle analysis found consistency violations (model=${{ matrix.elle_model }}, mvcc=${{ matrix.mvcc }})"
-            if [ "${{ matrix.mvcc }}" != "true" ]; then
-              exit 1
-            fi
-            echo "### ⚠️ MVCC Elle analysis found consistency violations" >> "$GITHUB_STEP_SUMMARY"
-            echo "This is expected and non-blocking." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          java -jar "$ELLE_JAR" --model ${{ matrix.elle_model }} $CONSISTENCY_FLAG --verbose --directory elle-results elle-history.edn
 
       - name: Upload Elle results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
MVCC Elle failures were previously treated as non-blocking warnings. Now both simulation and analysis failures fail the build for all matrix entries, removing the special-casing for MVCC.