### PR TITLE
fix: UPDATE RETURNING correlated subquery uses pre-UPDATE values

### DIFF
--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -2523,6 +2523,20 @@ fn emit_program_for_update(
         Vec::new()
     };
 
+    // Drain RETURNING subqueries so they aren't evaluated during the main loop scan.
+    // RETURNING subqueries must be emitted after Insert so that correlated column
+    // references read post-UPDATE values from the cursor.
+    {
+        let mut i = 0;
+        while i < plan.non_from_clause_subqueries.len() {
+            if plan.non_from_clause_subqueries[i].is_returning {
+                update_subqueries.push(plan.non_from_clause_subqueries.remove(i));
+            } else {
+                i += 1;
+            }
+        }
+    }
+
     // Initialize the main loop
     init_loop(
         program,
@@ -3055,9 +3069,11 @@ fn emit_update_insns<'a>(
     // is positioned via NotExists. In the ephemeral path, these subqueries were kept
     // in the main plan (not moved to the ephemeral plan) and need the write cursor
     // to be positioned so correlated references resolve correctly.
+    // RETURNING subqueries are skipped here and emitted after Insert so that
+    // correlated column references read post-UPDATE values from the cursor.
     for subquery in non_from_clause_subqueries
         .iter_mut()
-        .filter(|s| !s.has_been_evaluated())
+        .filter(|s| !s.has_been_evaluated() && !s.is_returning)
     {
         let subquery_plan = subquery.consume_plan(EvalAt::Loop(0));
         emit_non_from_clause_subquery(
@@ -4216,6 +4232,22 @@ fn emit_update_insns<'a>(
                 }
                 program.preassign_label_to_next_insn(after_trigger_done);
             }
+        }
+
+        // Emit RETURNING subqueries after Insert so that correlated column
+        // references read post-UPDATE values from the cursor.
+        for subquery in non_from_clause_subqueries
+            .iter_mut()
+            .filter(|s| !s.has_been_evaluated() && s.is_returning)
+        {
+            let subquery_plan = subquery.consume_plan(EvalAt::Loop(0));
+            emit_non_from_clause_subquery(
+                program,
+                &t_ctx.resolver,
+                *subquery_plan,
+                &subquery.query_type,
+                subquery.correlated,
+            )?;
         }
 
         // Emit RETURNING results if specified

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2237,6 +2237,10 @@ pub struct NonFromClauseSubquery {
     pub query_type: SubqueryType,
     pub state: SubqueryState,
     pub correlated: bool,
+    /// Whether this subquery originates from a RETURNING clause.
+    /// RETURNING subqueries must be evaluated after the Insert instruction
+    /// so that correlated column references read post-UPDATE values.
+    pub is_returning: bool,
 }
 
 impl NonFromClauseSubquery {

--- a/testing/runner/tests/update-returning-correlated-subquery.sqltest
+++ b/testing/runner/tests/update-returning-correlated-subquery.sqltest
@@ -1,0 +1,76 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER);
+    CREATE TABLE lookup(k INTEGER PRIMARY KEY, v TEXT);
+    INSERT INTO t1 VALUES(1, 10);
+    INSERT INTO lookup VALUES(10, 'old_value'), (20, 'new_value');
+}
+
+setup multi_row {
+    CREATE TABLE t2(a INTEGER PRIMARY KEY, b INTEGER);
+    CREATE TABLE lookup2(k INTEGER PRIMARY KEY, v TEXT);
+    INSERT INTO t2 VALUES(1, 10), (2, 20), (3, 30);
+    INSERT INTO lookup2 VALUES(10, 'ten'), (20, 'twenty'), (30, 'thirty');
+    INSERT INTO lookup2 VALUES(100, 'hundred'), (200, 'two_hundred'), (300, 'three_hundred');
+}
+
+@setup schema
+test update-returning-correlated-subquery-basic {
+    UPDATE t1 SET b = 20 WHERE a = 1
+    RETURNING b, (SELECT v FROM lookup WHERE k = b) as looked_up;
+}
+expect {
+    20|new_value
+}
+
+@setup multi_row
+test update-returning-correlated-subquery-multi-row {
+    UPDATE t2 SET b = b * 10
+    RETURNING a, b, (SELECT v FROM lookup2 WHERE k = b) as label;
+}
+expect {
+    1|100|hundred
+    2|200|two_hundred
+    3|300|three_hundred
+}
+
+@setup multi_row
+test update-returning-correlated-subquery-unmodified-column {
+    UPDATE t2 SET b = 999
+    RETURNING a, (SELECT v FROM lookup2 WHERE k = a) as by_pk;
+}
+expect {
+    1|
+    2|
+    3|
+}
+
+@setup schema
+test update-returning-direct-and-subquery {
+    UPDATE t1 SET b = 20 WHERE a = 1
+    RETURNING a, b, (SELECT v FROM lookup WHERE k = b) as sub_val;
+}
+expect {
+    1|20|new_value
+}
+
+@setup schema
+test update-returning-correlated-subquery-null-result {
+    UPDATE t1 SET b = 999 WHERE a = 1
+    RETURNING b, (SELECT v FROM lookup WHERE k = b) as looked_up;
+}
+expect {
+    999|
+}
+
+@setup schema
+test update-returning-multiple-correlated-subqueries {
+    UPDATE t1 SET b = 20 WHERE a = 1
+    RETURNING
+        (SELECT v FROM lookup WHERE k = b) as by_new_b,
+        (SELECT k FROM lookup WHERE k = b) as matching_k;
+}
+expect {
+    new_value|20
+}


### PR DESCRIPTION
## Motivation and context
Closes #5493


## Description of AI Usage
Generated by Turso Agent
