### PR TITLE
core/mvcc: Increase op count and tx payload size in logical log tx record format

### DIFF
--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -810,7 +810,7 @@ impl StreamingLogicalLogReader {
         // Chained CRC: seed from running_crc (derived from salt, or previous frame's CRC)
         let mut running_crc = crc32c::crc32c_append(self.running_crc, &header_bytes);
         let mut payload_bytes_read: u64 = 0;
-        let mut parsed_ops = Vec::with_capacity(op_count as usize);
+        let mut parsed_ops = Vec::with_capacity((op_count as usize).min(1024));
 
         for _ in 0..op_count {
             let op_bytes = match self.try_consume_fixed::<6>(io)? {


### PR DESCRIPTION
Major oversight in logical log format - allows only `u16` records per transaction, which is way too low.

- increase transaction op_count field u16 -> u32
- increase transaction payload_size field from u32 -> u64

Closes #5652