### PR TITLE
Pretty print elle status progress

### DIFF
--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -327,6 +327,10 @@ pub struct Stats {
     pub updates: usize,
     pub deletes: usize,
     pub integrity_checks: usize,
+    /// Elle-mode: write operations (append + rw-write)
+    pub elle_writes: usize,
+    /// Elle-mode: read operations (list-read + rw-read)
+    pub elle_reads: usize,
 }
 
 /// Result of a single simulation step.

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -83,8 +83,13 @@ fn main() -> anyhow::Result<()> {
 
     let max_steps = whopper.max_steps;
     let progress_interval = max_steps / 10;
+    let elle_mode = args.elle.is_some();
     let progress_stages = [
-        "       .             I/U/D/C",
+        if elle_mode {
+            "       .             W/R"
+        } else {
+            "       .             I/U/D/C"
+        },
         "       .             ",
         "       .             ",
         "       |             ",
@@ -111,14 +116,15 @@ fn main() -> anyhow::Result<()> {
 
         if progress_interval > 0 && whopper.current_step % progress_interval == 0 {
             let stats = &whopper.stats;
-            println!(
-                "{}{}/{}/{}/{}",
-                progress_stages[progress_index],
-                stats.inserts,
-                stats.updates,
-                stats.deletes,
-                stats.integrity_checks
-            );
+            let counts = if elle_mode {
+                format!("{}/{}", stats.elle_writes, stats.elle_reads)
+            } else {
+                format!(
+                    "{}/{}/{}/{}",
+                    stats.inserts, stats.updates, stats.deletes, stats.integrity_checks
+                )
+            };
+            println!("{}{}", progress_stages[progress_index], counts);
             progress_index += 1;
         }
     }

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -214,6 +214,12 @@ impl Operation {
             Operation::CreateElleTable { table_name } => {
                 ctx.sim_state.elle_tables.insert(table_name.clone(), ());
             }
+            Operation::ElleAppend { .. } | Operation::ElleRwWrite { .. } => {
+                ctx.stats.elle_writes += 1;
+            }
+            Operation::ElleRead { .. } | Operation::ElleRwRead { .. } => {
+                ctx.stats.elle_reads += 1;
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Description

So that we can do: 

```
cargo run --bin turso_whopper -- --elle list-append --elle-output elle-la.edn
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/turso_whopper --elle list-append --elle-output elle-la.edn`
mode = fast
seed = 6659750700646575003
       .             W/R
       .             565/1494
       .             1096/2961
       |             1585/4260
       |             2050/5646
      ╱|╲            2478/6994
     ╱╲|╱╲           2946/8298
    ╱╲╱|╲╱╲          3385/9607
   ╱╲╱╲|╱╲╱╲         3820/10888
  ╱╲╱╲╱|╲╱╲╱╲        4247/12215
 ╱╲╱╲╱╲|╱╲╱╲╱╲       4697/13463

Elle history exported to: elle-la.edn
```