### PR TITLE
add `@release` to gate certain tests to only be ran in release mode

### DIFF
--- a/testing/runner/src/main.rs
+++ b/testing/runner/src/main.rs
@@ -228,6 +228,8 @@ async fn run_tests(
     snapshot_filter: Option<String>,
     cross_check_binary: Option<PathBuf>,
 ) -> ExitCode {
+    let release = !cfg!(debug_assertions);
+
     // Resolve paths, trying to add .sqltest extension if missing
     let mut resolved_paths = Vec::new();
     let mut missing = Vec::new();
@@ -318,6 +320,7 @@ async fn run_tests(
     let mut config = RunnerConfig::default()
         .with_max_jobs(jobs)
         .with_mvcc(mvcc)
+        .with_release(release)
         .with_snapshot_update_mode(snapshot_mode);
     if let Some(f) = filter {
         config = config.with_filter(f);

--- a/testing/runner/src/parser/ast.rs
+++ b/testing/runner/src/parser/ast.rs
@@ -149,6 +149,8 @@ pub struct CaseModifiers {
     /// If true, cross-check the resulting database file with another binary's
     /// `PRAGMA integrity_check` after the test passes.
     pub cross_check_integrity: bool,
+    /// If true, only run this test in release mode.
+    pub release: bool,
 }
 
 /// A snapshot test case (for EXPLAIN output)

--- a/testing/runner/src/parser/lexer.rs
+++ b/testing/runner/src/parser/lexer.rs
@@ -130,6 +130,10 @@ pub enum Token {
     #[token("@cross-check-integrity")]
     AtCrossCheckIntegrity,
 
+    /// `@release` - only run this test in release mode
+    #[token("@release")]
+    AtRelease,
+
     /// `@<identifier>` - for backend-specific expect blocks (e.g., @js, @cli, @rust)
     /// Uses priority 0 so specific @ tokens like @database take precedence
     #[regex(r"@[a-zA-Z][a-zA-Z0-9_-]*", |lex| {
@@ -243,6 +247,7 @@ impl fmt::Display for Token {
             Token::CustomTypes => write!(f, "custom_types"),
             Token::AtBackend => write!(f, "@backend"),
             Token::AtCrossCheckIntegrity => write!(f, "@cross-check-integrity"),
+            Token::AtRelease => write!(f, "@release"),
             Token::AtIdentifier(s) => write!(f, "@{s}"),
             Token::Setup => write!(f, "setup"),
             Token::Test => write!(f, "test"),
@@ -307,7 +312,7 @@ pub fn tokenize(input: &str) -> Result<Vec<SpannedToken>, LexerError> {
 /// Suggest a fix for an invalid token
 fn suggest_fix(slice: &str) -> Option<String> {
     if slice.starts_with('@') {
-        Some("Valid directives are: @database, @setup, @skip, @skip-if, @skip-file, @skip-file-if, @requires, @requires-file, @backend, @cross-check-integrity. Did you mean one of these?".to_string())
+        Some("Valid directives are: @database, @setup, @skip, @skip-if, @skip-file, @skip-file-if, @requires, @requires-file, @backend, @cross-check-integrity, @release. Did you mean one of these?".to_string())
     } else if slice.starts_with(':') {
         Some(
             "Database specifiers are :memory:, :temp:, :default:, or :default-no-rowidalias:"

--- a/testing/runner/src/parser/mod.rs
+++ b/testing/runner/src/parser/mod.rs
@@ -77,6 +77,7 @@ impl Parser {
                     | Token::AtRequires
                     | Token::AtBackend
                     | Token::AtCrossCheckIntegrity
+                    | Token::AtRelease
                     | Token::Test
                     | Token::Snapshot
                     | Token::SnapshotEqp,
@@ -205,6 +206,7 @@ impl Parser {
         let mut backend = None;
         let mut requires = Vec::new();
         let mut cross_check_integrity = false;
+        let mut release = false;
 
         // Parse decorators
         loop {
@@ -260,6 +262,11 @@ impl Parser {
                     cross_check_integrity = true;
                     self.skip_newlines_and_comments();
                 }
+                Some(Token::AtRelease) => {
+                    self.advance();
+                    release = true;
+                    self.skip_newlines_and_comments();
+                }
                 _ => break,
             }
         }
@@ -285,6 +292,7 @@ impl Parser {
                         backend,
                         requires,
                         cross_check_integrity,
+                        release,
                     },
                 }))
             }
@@ -356,6 +364,7 @@ impl Parser {
                         backend,
                         requires,
                         cross_check_integrity,
+                        release,
                     },
                 }))
             }

--- a/testing/runner/syntax-highlighter/vscode/syntaxes/sqltest.tmLanguage.json
+++ b/testing/runner/syntax-highlighter/vscode/syntaxes/sqltest.tmLanguage.json
@@ -128,7 +128,9 @@
         { "include": "#decorator-skip" },
         { "include": "#decorator-skip-if" },
         { "include": "#decorator-backend" },
-        { "include": "#decorator-requires" }
+        { "include": "#decorator-requires" },
+        { "include": "#decorator-release" },
+        { "include": "#decorator-cross-check-integrity" }
       ]
     },
     "decorator-setup": {
@@ -205,6 +207,20 @@
           "match": "\\\\."
         }
       ]
+    },
+    "decorator-release": {
+      "name": "meta.decorator.release.sqltest",
+      "match": "(@release)",
+      "captures": {
+        "1": { "name": "keyword.control.directive.sqltest" }
+      }
+    },
+    "decorator-cross-check-integrity": {
+      "name": "meta.decorator.cross-check-integrity.sqltest",
+      "match": "(@cross-check-integrity)",
+      "captures": {
+        "1": { "name": "keyword.control.directive.sqltest" }
+      }
     },
     "test-block": {
       "name": "meta.test-block.sqltest",

--- a/testing/runner/tests/big.sqltest
+++ b/testing/runner/tests/big.sqltest
@@ -1,6 +1,7 @@
 @database iso.db
 @skip-file-if sqlite "run heavy test only on tursodb"
 
+@release
 @backend cli
 test big-db {
     DROP TABLE IF EXISTS t;


### PR DESCRIPTION
## Description
Gates `big.sqltest` to only run in release mode, which is what is ran in CI

## Motivation and context
Certain tests takes too long to run locally


## Description of AI Usage
Claude did it