### PR TITLE
core: per-database MVCC transactions for attached databases

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -77,7 +77,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 |---------------------------|---------|-----------------------------------------------------------------------------------|
 | ALTER TABLE               | ✅ Yes     |                                                                                   |
 | ANALYZE                   | ✅ Yes     |                                                                                   |
-| ATTACH DATABASE           | 🚧 Partial | Only for reads. All modifications will currently fail to find the table           |
+| ATTACH DATABASE           | ✅ Yes     |                                                                                   |
 | BEGIN TRANSACTION         | ✅ Yes     |                                                                                   |
 | COMMIT TRANSACTION        | ✅ Yes     |                                                                                   |
 | CHECK                     | ✅ Yes     |                                                                                   |

--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -47,7 +47,8 @@ fn bench(c: &mut Criterion) {
         b.to_async(FuturesExecutor).iter(|| async {
             let conn = db.conn.clone();
             let tx_id = db.mvcc_store.begin_tx(conn.get_pager()).unwrap();
-            db.mvcc_store.rollback_tx(tx_id, conn.get_pager(), &conn);
+            db.mvcc_store
+                .rollback_tx(tx_id, conn.get_pager(), &conn, turso_core::MAIN_DB_ID);
         })
     });
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1279,6 +1279,7 @@ impl Database {
             attached_databases: RwLock::new(DatabaseCatalog::new()),
             query_only: AtomicBool::new(false),
             mv_tx: RwLock::new(None),
+            attached_mv_txs: RwLock::new(HashMap::default()),
             view_transaction_states: AllViewsTxState::new(),
             metrics: RwLock::new(ConnectionMetrics::new()),
             nestedness: AtomicI32::new(0),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2128,8 +2128,12 @@ fn test_rollback() {
         .unwrap()
         .unwrap();
     assert_eq!(row3, row4);
-    db.mvcc_store
-        .rollback_tx(tx1, db.conn.pager.load().clone(), &db.conn);
+    db.mvcc_store.rollback_tx(
+        tx1,
+        db.conn.pager.load().clone(),
+        &db.conn,
+        crate::MAIN_DB_ID,
+    );
     let tx2 = db
         .mvcc_store
         .begin_tx(db.conn.pager.load().clone())
@@ -2383,7 +2387,7 @@ fn test_lost_update() {
     ));
     // hack: in the actual tursodb database we rollback the mvcc tx ourselves, so manually roll it back here
     db.mvcc_store
-        .rollback_tx(tx3, conn3.pager.load().clone(), &conn3);
+        .rollback_tx(tx3, conn3.pager.load().clone(), &conn3, crate::MAIN_DB_ID);
 
     commit_tx(db.mvcc_store.clone(), &conn2, tx2).unwrap();
     assert!(matches!(
@@ -3390,7 +3394,12 @@ fn test_commit_dep_threaded_abort_cascades() {
     signal_rx.recv().unwrap();
 
     // Abort writer → cascade: sets AbortNow on reader, decrements counter
-    mvcc_store.rollback_tx(writer_tx_id, writer_conn.pager.load().clone(), &writer_conn);
+    mvcc_store.rollback_tx(
+        writer_tx_id,
+        writer_conn.pager.load().clone(),
+        &writer_conn,
+        crate::MAIN_DB_ID,
+    );
 
     let (rows, commit_result) = reader_handle.join().unwrap();
 
@@ -3493,7 +3502,12 @@ fn test_commit_dep_threaded_multiple_dependents_abort() {
     barrier.wait();
 
     // Abort writer → cascade to ALL readers
-    mvcc_store.rollback_tx(writer_tx_id, writer_conn.pager.load().clone(), &writer_conn);
+    mvcc_store.rollback_tx(
+        writer_tx_id,
+        writer_conn.pager.load().clone(),
+        &writer_conn,
+        crate::MAIN_DB_ID,
+    );
 
     for handle in handles {
         let (rows, commit_result) = handle.join().unwrap();
@@ -3687,7 +3701,12 @@ fn test_commit_dep_threaded_readonly_abort_cascades() {
     signal_rx.recv().unwrap();
 
     // Abort writer → cascade to read-only reader
-    mvcc_store.rollback_tx(writer_tx_id, writer_conn.pager.load().clone(), &writer_conn);
+    mvcc_store.rollback_tx(
+        writer_tx_id,
+        writer_conn.pager.load().clone(),
+        &writer_conn,
+        crate::MAIN_DB_ID,
+    );
 
     let (rows, commit_result) = reader_handle.join().unwrap();
 
@@ -4390,8 +4409,12 @@ fn test_auto_checkpoint_busy_is_ignored() {
     commit_tx(db.mvcc_store.clone(), &db.conn, tx1).unwrap();
 
     // Cleanup: release the read lock held by tx2.
-    db.mvcc_store
-        .rollback_tx(tx2, db.conn.pager.load().clone(), &db.conn);
+    db.mvcc_store.rollback_tx(
+        tx2,
+        db.conn.pager.load().clone(),
+        &db.conn,
+        crate::MAIN_DB_ID,
+    );
 }
 
 /// What this test checks: Core MVCC read/write semantics hold for this operation sequence.
@@ -5422,8 +5445,12 @@ fn test_gc_integration_rollback_creates_aborted_garbage() {
         .unwrap();
     let row = generate_simple_string_row((-2).into(), 1, "will_rollback");
     db.mvcc_store.insert(tx1, row).unwrap();
-    db.mvcc_store
-        .rollback_tx(tx1, db.conn.pager.load().clone(), &db.conn);
+    db.mvcc_store.rollback_tx(
+        tx1,
+        db.conn.pager.load().clone(),
+        &db.conn,
+        crate::MAIN_DB_ID,
+    );
 
     // Rollback should leave aborted garbage (begin=None, end=None).
     let entry = db

--- a/core/mvcc/mod.rs
+++ b/core/mvcc/mod.rs
@@ -96,7 +96,12 @@ mod tests {
                         match commit_tx_no_conn(&db, tx, &conn) {
                             Ok(()) => break,
                             Err(LimboError::Busy) => {
-                                mvcc_store.rollback_tx(tx, conn.pager.load().clone(), &conn);
+                                mvcc_store.rollback_tx(
+                                    tx,
+                                    conn.pager.load().clone(),
+                                    &conn,
+                                    crate::MAIN_DB_ID,
+                                );
                                 std::thread::yield_now();
                                 continue;
                             }
@@ -117,7 +122,12 @@ mod tests {
                         match commit_tx_no_conn(&db, tx, &conn) {
                             Ok(()) => break,
                             Err(LimboError::Busy) => {
-                                mvcc_store.rollback_tx(tx, conn.pager.load().clone(), &conn);
+                                mvcc_store.rollback_tx(
+                                    tx,
+                                    conn.pager.load().clone(),
+                                    &conn,
+                                    crate::MAIN_DB_ID,
+                                );
                                 std::thread::yield_now();
                                 continue;
                             }
@@ -157,7 +167,12 @@ mod tests {
                         match commit_tx_no_conn(&db, tx, &conn) {
                             Ok(()) => break,
                             Err(LimboError::Busy) => {
-                                mvcc_store.rollback_tx(tx, conn.pager.load().clone(), &conn);
+                                mvcc_store.rollback_tx(
+                                    tx,
+                                    conn.pager.load().clone(),
+                                    &conn,
+                                    crate::MAIN_DB_ID,
+                                );
                                 std::thread::yield_now();
                                 continue;
                             }
@@ -178,7 +193,12 @@ mod tests {
                         match commit_tx_no_conn(&db, tx, &conn) {
                             Ok(()) => break,
                             Err(LimboError::Busy) => {
-                                mvcc_store.rollback_tx(tx, conn.pager.load().clone(), &conn);
+                                mvcc_store.rollback_tx(
+                                    tx,
+                                    conn.pager.load().clone(),
+                                    &conn,
+                                    crate::MAIN_DB_ID,
+                                );
                                 std::thread::yield_now();
                                 continue;
                             }
@@ -243,7 +263,12 @@ mod tests {
                     if let Err(e) = mvcc_store.upsert(tx, row.clone()) {
                         tracing::trace!("upsert failed: {e}");
                         failed_upserts += 1;
-                        mvcc_store.rollback_tx(tx, conn.pager.load().clone(), &conn);
+                        mvcc_store.rollback_tx(
+                            tx,
+                            conn.pager.load().clone(),
+                            &conn,
+                            crate::MAIN_DB_ID,
+                        );
                         continue;
                     }
                     let committed_row = mvcc_store.read(tx, &id).unwrap();
@@ -251,7 +276,12 @@ mod tests {
                         Ok(()) => {}
                         Err(LimboError::Busy | LimboError::WriteWriteConflict) => {
                             failed_commits += 1;
-                            mvcc_store.rollback_tx(tx, conn.pager.load().clone(), &conn);
+                            mvcc_store.rollback_tx(
+                                tx,
+                                conn.pager.load().clone(),
+                                &conn,
+                                crate::MAIN_DB_ID,
+                            );
                             continue;
                         }
                         Err(e) => panic!("unexpected commit error: {e:?}"),

--- a/core/translate/attach.rs
+++ b/core/translate/attach.rs
@@ -24,11 +24,6 @@ pub fn translate_attach(
             "ATTACH is an experimental feature. Enable with --experimental-attach flag".to_string(),
         ));
     }
-    if connection.mvcc_enabled() {
-        return Err(crate::LimboError::ParseError(
-            "ATTACH is not supported in MVCC mode".to_string(),
-        ));
-    }
     // SQLite treats ATTACH as a function call to sqlite_attach(filename, dbname, key)
     // We'll allocate registers for the arguments and call the function
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -116,9 +116,17 @@ pub fn translate_pragma(
     match mode {
         TransactionMode::None => {}
         TransactionMode::Read => {
+            if crate::is_attached_db(database_id) {
+                let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
+                program.begin_read_on_database(database_id, schema_cookie);
+            }
             program.begin_read_operation();
         }
         TransactionMode::Write => {
+            if crate::is_attached_db(database_id) {
+                let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
+                program.begin_write_on_database(database_id, schema_cookie);
+            }
             program.begin_write_operation();
         }
         TransactionMode::Concurrent => {

--- a/docs/sql-reference/statements/attach-database.mdx
+++ b/docs/sql-reference/statements/attach-database.mdx
@@ -29,7 +29,7 @@ ATTACH opens the database file at `filename` and makes its tables accessible thr
 Every connection has a built-in schema named `main` for its primary database. The names `main` and `temp` are reserved and cannot be used as schema names for attached databases.
 
 <Info>
-This feature is experimental and must be [enabled before use](/docs/sql-reference/experimental-features). Attached databases are currently **read-only**. All write operations (INSERT, UPDATE, DELETE, CREATE TABLE, etc.) on tables in attached databases will fail. Use ATTACH for cross-database queries and data migration reads.
+This feature is experimental and must be [enabled before use](/docs/sql-reference/experimental-features). Attached databases support both read and write operations (INSERT, UPDATE, DELETE, CREATE TABLE, etc.). The attached database's journal mode must match the main database's journal mode (e.g., both WAL or both MVCC).
 </Info>
 
 ## Examples

--- a/testing/runner/turso-tests/attach/default.sqltest
+++ b/testing/runner/turso-tests/attach/default.sqltest
@@ -1,6 +1,5 @@
 @database :default:
 @database :default-no-rowidalias:
-@skip-file-if mvcc "attach is not supported in mvcc mode"
 
 # Test attach reserved name - main (should fail)
 test attach-reserved-main {

--- a/testing/runner/turso-tests/attach/memory.sqltest
+++ b/testing/runner/turso-tests/attach/memory.sqltest
@@ -1,5 +1,4 @@
 @database :memory:
-@skip-file-if mvcc "attach not supported in MVCC mode"
 
 # Test querying attached in-memory database
 test attach-db-query {

--- a/testing/runner/turso-tests/attach/writes.sqltest
+++ b/testing/runner/turso-tests/attach/writes.sqltest
@@ -1,6 +1,5 @@
 @database :memory:
 
-@skip-file-if mvcc "attach not supported in MVCC mode"
 
 # =============================================================================
 # Basic DDL on attached database
@@ -995,6 +994,7 @@ expect {
 # CREATE/DROP VIEW on attached database
 # =============================================================================
 
+@skip-if mvcc "views not supported in MVCC mode"
 test attach-write-create-view {
     ATTACH ':memory:' AS aux;
     CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT, value INTEGER);
@@ -1007,6 +1007,7 @@ expect {
     bob|20
 }
 
+@skip-if mvcc "views not supported in MVCC mode"
 test attach-write-drop-view {
     ATTACH ':memory:' AS aux;
     CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, name TEXT);
@@ -1425,6 +1426,7 @@ expect error {
 # CDC (CHANGE DATA CAPTURE) WITH ATTACHED DATABASES
 # =============================================================================
 
+@skip-if mvcc "CDC not supported in MVCC mode"
 test attach-write-cdc-insert {
     CREATE TABLE turso_cdc(change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB);
     PRAGMA capture_data_changes_conn('full');
@@ -1437,6 +1439,7 @@ expect {
     t1|1
 }
 
+@skip-if mvcc "CDC not supported in MVCC mode"
 test attach-write-cdc-delete {
     CREATE TABLE turso_cdc(change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB);
     PRAGMA capture_data_changes_conn('full');
@@ -1453,6 +1456,7 @@ expect {
     t1|-1
 }
 
+@skip-if mvcc "CDC not supported in MVCC mode"
 test attach-write-cdc-update {
     CREATE TABLE turso_cdc(change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB);
     PRAGMA capture_data_changes_conn('full');

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -26,6 +26,28 @@ use crate::runner::memory::io::MemorySimIO;
 const DEFAULT_CACHE_SIZE: usize = 2000;
 use super::cli::SimulatorCLI;
 
+/// Pre-create attached DB files with MVCC journal mode so that journal modes
+/// are compatible when ATTACH happens later during simulation.
+fn enable_mvcc_on_attached_dbs(io: &Arc<dyn SimIO>, aux_paths: impl Iterator<Item = PathBuf>) {
+    for aux_path in aux_paths {
+        let aux_db = Database::open_file_with_flags(
+            io.clone(),
+            aux_path.to_str().unwrap(),
+            turso_core::OpenFlags::default(),
+            turso_core::DatabaseOpts::new().with_attach(true),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("Failed to open aux DB {aux_path:?}: {e}"));
+        let aux_conn = aux_db
+            .connect()
+            .expect("Failed to connect to aux DB for MVCC setup");
+        aux_conn
+            .execute("PRAGMA journal_mode = 'experimental_mvcc'")
+            .expect("Failed to enable MVCC on aux DB");
+        aux_conn.close().expect("Failed to close aux DB connection");
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum SimulationType {
     Default,
@@ -804,6 +826,7 @@ impl SimulatorEnv {
             std::fs::remove_file(&wal_path).unwrap();
         }
 
+        // Remove MVCC logical log file
         let log_path = db_path.with_extension("db-log");
         if log_path.exists() {
             std::fs::remove_file(&log_path).unwrap();
@@ -842,6 +865,23 @@ impl SimulatorEnv {
                 panic!("error opening simulator test file {db_path:?}: {e:?}");
             }
         };
+
+        // Re-enable MVCC mode if the profile says to use MVCC
+        if self.profile.experimental_mvcc {
+            let conn = db
+                .connect()
+                .expect("Failed to create connection for MVCC setup");
+            conn.execute("PRAGMA journal_mode = 'experimental_mvcc'")
+                .expect("Failed to enable MVCC mode");
+
+            enable_mvcc_on_attached_dbs(
+                &io,
+                self.attached_dbs
+                    .iter()
+                    .map(|name| self.get_aux_db_path(name)),
+            );
+        }
+
         self.io = io;
         self.db = Some(db);
     }
@@ -932,6 +972,7 @@ impl SimulatorEnv {
             std::fs::remove_file(&wal_path).unwrap();
         }
 
+        // Remove MVCC logical log file
         let log_path = db_path.with_extension("db-log");
         if log_path.exists() {
             std::fs::remove_file(&log_path).unwrap();
@@ -1025,6 +1066,13 @@ impl SimulatorEnv {
                 .expect("Failed to create connection for MVCC setup");
             conn.execute("PRAGMA journal_mode = 'experimental_mvcc'")
                 .expect("Failed to enable MVCC mode");
+
+            enable_mvcc_on_attached_dbs(
+                &io,
+                attached_dbs
+                    .iter()
+                    .map(|name| paths.aux_db(&simulation_type, &SimulationPhase::Test, name)),
+            );
         }
 
         let connections = (0..profile.max_connections)

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1,6 +1,48 @@
 use crate::common::{ExecRows, TempDatabase};
+use std::path::Path;
 use std::sync::Arc;
-use turso_core::StepResult;
+use turso_core::{Database, DatabaseOpts, OpenFlags, StepResult};
+
+/// Create a new database file at `path` with MVCC journal mode enabled.
+/// This is needed because ATTACH requires the attached DB's journal mode
+/// to match the main DB's journal mode.
+fn create_mvcc_db(io: &Arc<dyn turso_core::io::IO + Send>, path: &Path) -> anyhow::Result<()> {
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        path.to_str().unwrap(),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?;
+    let conn = db.connect()?;
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+    conn.close()?;
+    Ok(())
+}
+
+/// CREATE TABLE on an attached MVCC database must not deadlock.
+/// op_parse_schema must release the database_schemas lock before executing the
+/// nested statement that reads sqlite_schema, since reprepare() also acquires
+/// that lock and parking_lot RwLock is not re-entrant.
+#[turso_macros::test]
+fn test_mvcc_create_table_on_attached_db(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("CREATE TABLE aux.test_table (id INTEGER PRIMARY KEY, name TEXT)")?;
+
+    // Verify the table works
+    conn.execute("INSERT INTO aux.test_table VALUES (1, 'hello')")?;
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT id, name FROM aux.test_table");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0], (1, "hello".to_string()));
+
+    Ok(())
+}
 
 #[turso_macros::test(mvcc)]
 fn test_newrowid_mvcc_concurrent(tmp_db: TempDatabase) -> anyhow::Result<()> {
@@ -99,10 +141,9 @@ fn test_newrowid_mvcc_concurrent(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
-// Regression test: statement-level rollback (from FK constraint violation)
-// must clean up tx.write_set so that commit validation doesn't find stale
-// entries pointing to pre-existing committed versions and panic with
-// "there is another row insterted and not updated/deleted from before".
+/// Statement-level rollback from an FK constraint violation must clean up
+/// tx.write_set so that commit validation does not find stale entries pointing
+/// to pre-existing committed versions.
 #[turso_macros::test]
 fn test_stmt_rollback_cleans_write_set(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let _ = env_logger::try_init();
@@ -125,23 +166,20 @@ fn test_stmt_rollback_cleans_write_set(tmp_db: TempDatabase) -> anyhow::Result<(
     conn2.execute("PRAGMA foreign_keys = ON")?;
     conn2.execute("BEGIN CONCURRENT")?;
 
-    // DELETE from parent fails due to FK constraint. This triggers
-    // statement-level rollback which undoes the MVCC version changes,
-    // but before the fix, rollback_first_savepoint didn't clean up
-    // tx.write_set — leaving stale entries.
+    // DELETE from parent fails due to FK constraint, triggering
+    // statement-level rollback of the MVCC version changes.
     let result = conn2.execute("DELETE FROM parent WHERE id = 1");
     assert!(result.is_err(), "DELETE should fail due to FK constraint");
 
-    // COMMIT should succeed. Before the fix this panicked at commit
-    // validation because the stale write_set entry pointed to a
-    // pre-existing committed version.
+    // COMMIT must succeed — the write_set should be clean after the
+    // statement rollback.
     conn2.execute("COMMIT")?;
 
     Ok(())
 }
 
-// Same as test_stmt_rollback_cleans_write_set but with an index on the
-// child table, exercising the index version rollback path as well.
+/// Same as test_stmt_rollback_cleans_write_set but with an index on the
+/// child table, exercising the index version rollback path as well.
 #[turso_macros::test]
 fn test_stmt_rollback_cleans_write_set_with_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let _ = env_logger::try_init();
@@ -171,12 +209,9 @@ fn test_stmt_rollback_cleans_write_set_with_index(tmp_db: TempDatabase) -> anyho
     Ok(())
 }
 
-/// Regression test: upgrading an existing MVCC transaction from read->write must not
-/// leak an extra blocking-checkpoint read lock.
-///
-/// Before the fix, this sequence left `blocking_checkpoint_lock` with a stale reader:
-/// BEGIN (deferred) -> read statement (starts tx) -> write statement (upgrade) -> COMMIT.
-/// A following checkpoint then failed with `database is locked`.
+/// Upgrading an existing MVCC transaction from read to write must not leak an
+/// extra blocking-checkpoint read lock.  The sequence BEGIN -> SELECT -> INSERT ->
+/// COMMIT must leave checkpoint unblocked.
 #[turso_macros::test(mvcc)]
 fn test_mvcc_read_to_write_upgrade_does_not_block_checkpoint(
     tmp_db: TempDatabase,
@@ -193,5 +228,473 @@ fn test_mvcc_read_to_write_upgrade_does_not_block_checkpoint(
     let conn2 = tmp_db.connect_limbo();
     conn2.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
 
+    Ok(())
+}
+
+/// DETACH must clean up any active MVCC transaction on the attached database.
+/// An uncommitted insert followed by ROLLBACK + DETACH + re-ATTACH must not
+/// show the uncommitted data.
+#[turso_macros::test]
+fn test_detach_rollbacks_active_mvcc_tx(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_detach.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("CREATE TABLE aux.t(x INTEGER)")?;
+
+    // Insert a committed row first so we can verify it survives
+    conn.execute("INSERT INTO aux.t VALUES (1)")?;
+
+    // Begin explicit transaction and insert into attached DB, then DETACH
+    // without committing. DETACH should rollback the uncommitted insert and
+    // clean up the MVCC transaction in the attached MvStore.
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO aux.t VALUES (99)")?;
+    // Need to rollback first (SQLite also requires this before DETACH)
+    conn.execute("ROLLBACK")?;
+    conn.execute("DETACH aux")?;
+
+    // Re-attach and verify only the committed row persists
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT x FROM aux.t");
+    assert_eq!(
+        rows,
+        vec![(1,)],
+        "Only the committed row should survive; uncommitted insert from rolled-back tx should be gone"
+    );
+
+    Ok(())
+}
+
+/// ATTACH must reject databases whose journal mode differs from the main database.
+/// Here the main DB uses MVCC while the attached DB uses WAL.
+#[turso_macros::test]
+fn test_attach_rejects_incompatible_journal_mode(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    // Main DB uses MVCC
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    // Attached DB is created in default WAL mode (no MVCC)
+    let aux_path = tmp_db.path.with_extension("aux_wal.db");
+    let aux_db = Database::open_file_with_flags(
+        tmp_db.io.clone(),
+        aux_path.to_str().unwrap(),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?;
+    let aux_conn = aux_db.connect()?;
+    aux_conn.execute("CREATE TABLE t(x INTEGER)")?;
+    aux_conn.close()?;
+
+    // ATTACH should fail because main=MVCC but attached=WAL
+    let result = conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()));
+    assert!(
+        result.is_err(),
+        "ATTACH should fail with incompatible journal modes"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("journal mode"),
+        "Error should mention journal mode incompatibility, got: {err}"
+    );
+
+    Ok(())
+}
+
+/// ATTACH must reject databases whose journal mode differs from the main database.
+/// Here the main DB uses WAL while the attached DB uses MVCC.
+#[turso_macros::test]
+fn test_attach_rejects_mvcc_attached_on_wal_main(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    // Main DB stays in default WAL mode
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE main_t(x INTEGER)")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_mvcc.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    // ATTACH should fail because main=WAL but attached=MVCC
+    let result = conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()));
+    assert!(
+        result.is_err(),
+        "ATTACH should fail with incompatible journal modes"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("journal mode"),
+        "Error should mention journal mode incompatibility, got: {err}"
+    );
+
+    Ok(())
+}
+
+/// ROLLBACK must revert changes on attached MVCC databases, not just the main DB.
+#[turso_macros::test]
+fn test_mvcc_rollback_reverts_attached_db(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_rb.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("CREATE TABLE aux.t(x INTEGER)")?;
+
+    // Begin explicit transaction, insert, then rollback
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO aux.t VALUES (1)")?;
+    conn.execute("ROLLBACK")?;
+
+    // The insert should have been rolled back — table should be empty
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT x FROM aux.t");
+    assert!(
+        rows.is_empty(),
+        "ROLLBACK should have reverted the INSERT on the attached DB, but found {rows:?}"
+    );
+
+    Ok(())
+}
+
+/// Dropping a connection with an active MVCC transaction must clean up both main
+/// and attached DB transactions, so that subsequent connections can checkpoint and
+/// commit without being blocked by stale MVCC state.
+#[turso_macros::test]
+fn test_drop_cleans_up_mvcc_transactions(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_drop.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("CREATE TABLE aux.t(x INTEGER)")?;
+
+    // Start an explicit transaction and write to the attached DB, then
+    // drop the connection without committing or rolling back.
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO aux.t VALUES (1)")?;
+    drop(conn);
+
+    // A new connection must be able to use the database normally — the
+    // dropped connection's MVCC state should have been cleaned up.
+    let conn2 = tmp_db.connect_limbo();
+    conn2.pragma_update("journal_mode", "'experimental_mvcc'")?;
+    conn2.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn2.execute("INSERT INTO aux.t VALUES (2)")?;
+    conn2.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+    let rows: Vec<(i64,)> = conn2.exec_rows("SELECT x FROM aux.t");
+    assert_eq!(rows, vec![(2,)], "Only post-drop insert should be visible");
+
+    Ok(())
+}
+
+/// A single transaction that writes to both the main DB and an attached MVCC
+/// database must commit changes to both.  Note: WAL mode does not provide
+/// cross-file transactionality — each DB commits independently.
+#[turso_macros::test]
+fn test_cross_database_transaction(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_cross.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("CREATE TABLE main_t(x INTEGER)")?;
+    conn.execute("CREATE TABLE aux.aux_t(y INTEGER)")?;
+
+    // Write to both databases in a single transaction
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO main_t VALUES (1)")?;
+    conn.execute("INSERT INTO aux.aux_t VALUES (2)")?;
+    conn.execute("COMMIT")?;
+
+    // Both tables should have the committed data
+    let main_rows: Vec<(i64,)> = conn.exec_rows("SELECT x FROM main_t");
+    assert_eq!(main_rows, vec![(1,)]);
+    let aux_rows: Vec<(i64,)> = conn.exec_rows("SELECT y FROM aux.aux_t");
+    assert_eq!(aux_rows, vec![(2,)]);
+
+    // A second connection should also see the committed data
+    let conn2 = tmp_db.connect_limbo();
+    conn2.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    let main_rows: Vec<(i64,)> = conn2.exec_rows("SELECT x FROM main_t");
+    assert_eq!(main_rows, vec![(1,)]);
+    let aux_rows: Vec<(i64,)> = conn2.exec_rows("SELECT y FROM aux.aux_t");
+    assert_eq!(aux_rows, vec![(2,)]);
+
+    Ok(())
+}
+
+/// Within an explicit transaction, a SELECT on an attached MVCC database followed
+/// by an INSERT must upgrade the attached DB's MVCC transaction from read to
+/// write mode so that the commit succeeds.
+#[turso_macros::test]
+fn test_attached_mvcc_read_to_write_upgrade(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_upgrade.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("CREATE TABLE aux.t(x INTEGER)")?;
+
+    // Begin an explicit transaction, read first (starts Read tx on aux),
+    // then write (must upgrade to Write tx on aux).
+    conn.execute("BEGIN")?;
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM aux.t");
+    assert_eq!(rows, vec![(0,)]);
+    conn.execute("INSERT INTO aux.t VALUES (1)")?;
+    conn.execute("COMMIT")?;
+
+    // Verify the insert was committed
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT x FROM aux.t");
+    assert_eq!(rows, vec![(1,)]);
+
+    Ok(())
+}
+
+/// Statement-level rollback on an attached MVCC database must clean up the
+/// MvStore write_set via the savepoint mechanism.  An FK constraint violation
+/// triggers a statement rollback; the subsequent COMMIT must succeed because
+/// the stale write_set entries were undone by the savepoint rollback.
+#[turso_macros::test]
+fn test_stmt_rollback_on_attached_mvcc_db(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_savepoint.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("PRAGMA foreign_keys = ON")?;
+
+    // Setup parent/child tables with FK constraint on the attached DB
+    conn.execute("CREATE TABLE aux.parent(id INTEGER PRIMARY KEY)")?;
+    conn.execute(
+        "CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))",
+    )?;
+    conn.execute("INSERT INTO aux.parent VALUES (1)")?;
+    conn.execute("INSERT INTO aux.child VALUES (1, 1)")?;
+
+    // Open a concurrent transaction on a second connection
+    let conn2 = tmp_db.connect_limbo();
+    conn2.execute("PRAGMA foreign_keys = ON")?;
+    conn2.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn2.execute("BEGIN CONCURRENT")?;
+
+    // DELETE from parent fails due to FK constraint — triggers statement-level
+    // rollback of the MVCC version changes on the attached DB's MvStore.
+    let result = conn2.execute("DELETE FROM aux.parent WHERE id = 1");
+    assert!(result.is_err(), "DELETE should fail due to FK constraint");
+
+    // COMMIT must succeed — the write_set should be clean after the
+    // statement savepoint rollback on the attached MvStore.
+    conn2.execute("COMMIT")?;
+
+    // Verify original data is intact
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT id FROM aux.parent");
+    assert_eq!(rows, vec![(1,)]);
+
+    Ok(())
+}
+
+/// Same as test_stmt_rollback_on_attached_mvcc_db but with an index on the
+/// child table, exercising the index version rollback path on the attached DB.
+#[turso_macros::test]
+fn test_stmt_rollback_on_attached_mvcc_db_with_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_savepoint_idx.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("PRAGMA foreign_keys = ON")?;
+
+    conn.execute("CREATE TABLE aux.parent(id INTEGER PRIMARY KEY)")?;
+    conn.execute(
+        "CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))",
+    )?;
+    conn.execute("CREATE INDEX aux.idx_child_parent ON child(parent_id)")?;
+    conn.execute("INSERT INTO aux.parent VALUES (1)")?;
+    conn.execute("INSERT INTO aux.child VALUES (1, 1)")?;
+
+    let conn2 = tmp_db.connect_limbo();
+    conn2.execute("PRAGMA foreign_keys = ON")?;
+    conn2.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn2.execute("BEGIN CONCURRENT")?;
+
+    // DELETE from parent fails due to FK constraint. With the index on
+    // child(parent_id), the rollback must also undo index version changes
+    // on the attached MvStore.
+    let result = conn2.execute("DELETE FROM aux.parent WHERE id = 1");
+    assert!(result.is_err(), "DELETE should fail due to FK constraint");
+
+    conn2.execute("COMMIT")?;
+
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT id FROM aux.parent");
+    assert_eq!(rows, vec![(1,)]);
+
+    Ok(())
+}
+
+/// A deferred FK constraint violation detected at autocommit time must roll back
+/// changes on attached MVCC databases, not just the main DB.  The attached DB
+/// should be unchanged after the failed autocommit statement.
+#[turso_macros::test]
+fn test_deferred_fk_violation_rolls_back_attached_mvcc(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_deferred_fk.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("PRAGMA foreign_keys = ON")?;
+
+    // Both tables on the attached DB with a DEFERRED FK constraint.
+    conn.execute("CREATE TABLE aux.parent(id INTEGER PRIMARY KEY)")?;
+    conn.execute(
+        "CREATE TABLE aux.child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED)",
+    )?;
+    conn.execute("INSERT INTO aux.parent VALUES (1)")?;
+
+    // In autocommit mode, insert a child row referencing a non-existent parent.
+    // The deferred FK check fires at commit (halt) and must roll back the
+    // insert on the attached DB.
+    let result = conn.execute("INSERT INTO aux.child VALUES (1, 999)");
+    assert!(
+        result.is_err(),
+        "INSERT with invalid deferred FK should fail at autocommit"
+    );
+
+    // The attached DB must be empty — the deferred FK rollback should have
+    // reverted the insert.
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT id FROM aux.child");
+    assert!(
+        rows.is_empty(),
+        "Deferred FK rollback should have reverted the INSERT on the attached DB, but found {rows:?}"
+    );
+
+    // The connection should still be usable for subsequent operations.
+    conn.execute("INSERT INTO aux.child VALUES (1, 1)")?;
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT id FROM aux.child");
+    assert_eq!(rows, vec![(1,)]);
+
+    Ok(())
+}
+
+/// ROLLBACK TO a named savepoint must revert changes on attached MVCC databases,
+/// not just the main DB.
+#[turso_macros::test]
+fn test_named_savepoint_rollback_reverts_attached_mvcc(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_named_sp.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("CREATE TABLE main_t(x INTEGER)")?;
+    conn.execute("CREATE TABLE aux.aux_t(y INTEGER)")?;
+
+    // Insert a baseline row before the savepoint
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO main_t VALUES (1)")?;
+    conn.execute("INSERT INTO aux.aux_t VALUES (1)")?;
+
+    // Open a named savepoint, insert more data, then rollback to it
+    conn.execute("SAVEPOINT sp1")?;
+    conn.execute("INSERT INTO main_t VALUES (2)")?;
+    conn.execute("INSERT INTO aux.aux_t VALUES (2)")?;
+
+    conn.execute("ROLLBACK TO sp1")?;
+
+    // The rows inserted after the savepoint should be gone on both DBs
+    conn.execute("RELEASE sp1")?;
+    conn.execute("COMMIT")?;
+
+    let main_rows: Vec<(i64,)> = conn.exec_rows("SELECT x FROM main_t ORDER BY x");
+    assert_eq!(
+        main_rows,
+        vec![(1,)],
+        "Main DB should only have pre-savepoint row"
+    );
+
+    let aux_rows: Vec<(i64,)> = conn.exec_rows("SELECT y FROM aux.aux_t ORDER BY y");
+    assert_eq!(
+        aux_rows,
+        vec![(1,)],
+        "Attached DB should only have pre-savepoint row"
+    );
+
+    Ok(())
+}
+
+/// RELEASE of a named savepoint that started a transaction must commit changes
+/// on both main and attached MVCC databases.
+#[turso_macros::test]
+fn test_named_savepoint_release_commits_attached_mvcc(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'experimental_mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_named_sp_rel.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("CREATE TABLE main_t(x INTEGER)")?;
+    conn.execute("CREATE TABLE aux.aux_t(y INTEGER)")?;
+
+    // SAVEPOINT in autocommit mode starts a transaction; RELEASE commits it.
+    conn.execute("SAVEPOINT sp1")?;
+    conn.execute("INSERT INTO main_t VALUES (1)")?;
+    conn.execute("INSERT INTO aux.aux_t VALUES (2)")?;
+    conn.execute("RELEASE sp1")?;
+
+    // Both databases should have the committed data
+    let main_rows: Vec<(i64,)> = conn.exec_rows("SELECT x FROM main_t");
+    assert_eq!(main_rows, vec![(1,)]);
+
+    let aux_rows: Vec<(i64,)> = conn.exec_rows("SELECT y FROM aux.aux_t");
+    assert_eq!(aux_rows, vec![(2,)]);
+
+    // A second connection should also see the committed data
+    let conn2 = tmp_db.connect_limbo();
+    conn2.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    let main_rows: Vec<(i64,)> = conn2.exec_rows("SELECT x FROM main_t");
+    assert_eq!(main_rows, vec![(1,)]);
+    let aux_rows: Vec<(i64,)> = conn2.exec_rows("SELECT y FROM aux.aux_t");
+    assert_eq!(aux_rows, vec![(2,)]);
+
+    Ok(())
+}
+
+/// Attaching a :memory: database must succeed even when the main DB uses MVCC,
+/// since in-memory databases do not have a journal mode to conflict with.
+#[turso_macros::test(mvcc)]
+fn test_attach_memory_db_always_allowed(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    // Main is MVCC (via test attribute), :memory: should still attach fine
+    conn.execute("ATTACH ':memory:' AS mem_aux")?;
+    conn.execute("CREATE TABLE mem_aux.t(x INTEGER)")?;
+    conn.execute("INSERT INTO mem_aux.t VALUES (42)")?;
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT x FROM mem_aux.t");
+    assert_eq!(rows, vec![(42,)]);
     Ok(())
 }


### PR DESCRIPTION
Each attached database now gets its own independent MvStore with its own .db-log file when the main database uses MVCC mode. This enables full MVCC isolation across all databases in a session.

Key changes:
- Split MVCC transaction storage: mv_tx for main DB (hot path), attached_mv_txs SmallVec for attached DBs (cold path)
- op_open_read/op_open_write/op_transaction use per-DB MvStore lookup
- commit_txn_mvcc iterates all databases with active MVCC transactions
- rollback handles attached MVCC transactions before clearing state
- Removed hardcoded MVCC block in ATTACH translation
- Removed @skip-file-if mvcc from ATTACH test files
