### PR TITLE
fix(mvcc): propagate header changes on commit for header-only writes

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2861,6 +2861,7 @@ fn new_tx(tx_id: TxID, begin_ts: u64, state: TransactionState) -> Transaction {
         commit_dep_counter: AtomicU64::new(0),
         abort_now: AtomicBool::new(false),
         commit_dep_set: Mutex::new(HashSet::default()),
+        header_dirty: AtomicBool::new(false),
     }
 }
 
@@ -4238,6 +4239,7 @@ fn transaction_display() {
         commit_dep_counter: AtomicU64::new(0),
         abort_now: AtomicBool::new(false),
         commit_dep_set: Mutex::new(HashSet::default()),
+        header_dirty: AtomicBool::new(false),
     };
 
     let expected = "{ state: Preparing(20250915), id: 42, begin_ts: 20250914, write_set: [RowID { table_id: MVTableId(-2), row_id: Int(11) }, RowID { table_id: MVTableId(-2), row_id: Int(13) }], read_set: [RowID { table_id: MVTableId(-2), row_id: Int(17) }, RowID { table_id: MVTableId(-2), row_id: Int(19) }] }";

--- a/testing/runner/tests/pragma/memory.sqltest
+++ b/testing/runner/tests/pragma/memory.sqltest
@@ -148,7 +148,6 @@ expect {
     0
 }
 
-@skip-if mvcc "user_version not implemented for mvcc"
 @cross-check-integrity
 test pragma-user-version-update {
     PRAGMA user_version = 42;
@@ -158,7 +157,6 @@ expect {
     42
 }
 
-@skip-if mvcc "user_version not implemented for mvcc"
 test pragma-user-version-negative-value {
     PRAGMA user_version = -10;
     PRAGMA user_version;
@@ -167,7 +165,6 @@ expect {
     -10
 }
 
-@skip-if mvcc "user_version not implemented for mvcc"
 test pragma-user-version-float-value {
     PRAGMA user_version = 10.9;
     PRAGMA user_version;
@@ -183,7 +180,6 @@ expect {
     0
 }
 
-@skip-if mvcc "application_id not implemented for mvcc"
 @cross-check-integrity
 test pragma-application-id-update {
     PRAGMA application_id = 12345;
@@ -193,7 +189,6 @@ expect {
     12345
 }
 
-@skip-if mvcc "application_id not implemented for mvcc"
 test pragma-application-id-float-value {
     PRAGMA application_id = 10.9;
     PRAGMA application_id;
@@ -202,7 +197,6 @@ expect {
     10
 }
 
-@skip-if mvcc "application_id not implemented for mvcc"
 test pragma-application-id-large-value {
     PRAGMA application_id = 2147483647;
     PRAGMA application_id;
@@ -211,7 +205,6 @@ expect {
     2147483647
 }
 
-@skip-if mvcc "application_id not implemented for mvcc"
 test pragma-application-id-negative-value {
     PRAGMA application_id = -23;
     PRAGMA application_id;


### PR DESCRIPTION
The MVCC commit state machine has a "read-only fast path" that skips CommitEnd when write_set is empty. CommitEnd is responsible for copying the transaction-local header to MvStore::global_header. Operations like PRAGMA user_version only modify the database header via with_header_mut without inserting any rows, so write_set stays empty and the fast path discards the header change.

Add a header_dirty flag to Transaction, set it in with_header_mut when a transaction-local header is modified, and check it alongside write_set.is_empty() in both early-exit points of the commit state machine. When header_dirty is true, the commit proceeds through CommitEnd which propagates the modified header to global_header.

## Description of AI Usage

I found this because this failed in an existing attach test when running on mvcc. But as it turns out, it is not attach-specific and the following test that I am adding here fails too, without any attach involved.