### PR TITLE
Add support for multi-process database access

### DIFF
--- a/.claude/skills/transaction-correctness/SKILL.md
+++ b/.claude/skills/transaction-correctness/SKILL.md
@@ -34,7 +34,7 @@ Checkpoint types:
 - **TRUNCATE**: Like RESTART, also truncates WAL file to zero length
 
 ### WAL-Index
-SQLite uses a shared memory file (`-shm`) for WAL index. **Turso does not** - it uses in-memory data structures (`frame_cache` hashmap, atomic read marks) since multi-process access is not supported.
+In exclusive mode (the default), Turso uses in-memory data structures (`frame_cache` hashmap, atomic read marks) instead of SQLite's shared memory file (`-shm`). In shared locking modes (`shared_reads`, `shared_writes`), Turso uses its own shared memory file (`-tshm`) that embeds both a coordination page and the WAL index segments for cross-process frame lookup.
 
 ## Concurrency Rules
 

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -66,7 +66,6 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 
 ### Limitations
 
-* ⛔️ Concurrent access from multiple processes is not supported.
 * ⛔️ Vacuum is not supported.
 
 ## SQLite query language
@@ -167,7 +166,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | PRAGMA journal_size_limit        | ❌ No         |                                              |
 | PRAGMA legacy_alter_table        | ❌ No         |                                              |
 | PRAGMA legacy_file_format        | ✅ Yes        |                                              |
-| PRAGMA locking_mode              | ❌ No         |                                              |
+| PRAGMA locking_mode              | ✅ Yes        | `normal` maps to `shared_writes` for SQLite compat. Also supports `exclusive` (default), `shared_reads`, `shared_writes`. Set via URI: `file:db.sqlite?locking=normal` |
 | PRAGMA max_page_count            | ✅ Yes        |                                              |
 | PRAGMA mmap_size                 | ❌ No         |                                              |
 | PRAGMA module_list               | ❌ No         |                                              |

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -220,7 +220,16 @@ impl Limbo {
             .with_attach(opts.experimental_attach)
             .with_unsafe_testing(opts.unsafe_testing);
 
-        let (io, conn) = if db_file.contains([':', '?', '&', '#']) {
+        // Normalize path?key=val to file:path?key=val so query parameters
+        // are parsed as URI options (e.g. ?locking=shared_reads) instead of
+        // being treated as part of the filename.
+        let db_file = if !db_file.starts_with("file:") && db_file.contains('?') {
+            format!("file:{db_file}")
+        } else {
+            db_file
+        };
+
+        let (io, conn) = if db_file.starts_with("file:") {
             Connection::from_uri(&db_file, db_opts)?
         } else {
             let flags = if opts.readonly {

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -92,6 +92,11 @@ pub struct Opts {
     pub experimental_attach: bool,
     #[clap(
         long,
+        help = "Enable experimental shared access (multi-process) feature"
+    )]
+    pub experimental_shared_access: bool,
+    #[clap(
+        long,
         help = "Enable unsafe testing features (e.g. sqlite_dbpage writes)"
     )]
     pub unsafe_testing: bool,
@@ -218,6 +223,7 @@ impl Limbo {
             .with_index_method(opts.experimental_index_method)
             .with_autovacuum(opts.experimental_autovacuum)
             .with_attach(opts.experimental_attach)
+            .with_shared_access(opts.experimental_shared_access)
             .with_unsafe_testing(opts.unsafe_testing);
 
         // Normalize path?key=val to file:path?key=val so query parameters

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -264,11 +264,23 @@ impl Connection {
         self.executing_triggers.write().pop();
     }
     pub fn prepare(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
-        self._prepare(sql)
+        // Check if the on-disk schema cookie differs from our in-memory
+        // schema (e.g. another process created/dropped/altered a table).
+        // Must be called outside any transaction because it starts its own
+        // read tx internally.
+        self.maybe_update_schema()?;
+        self.prepare_no_schema_check(sql)
     }
 
+    /// Prepare without checking the schema cookie. Used by reparse_schema
+    /// and helpers it calls (query_stored_type_definitions, refresh_analyze_stats)
+    /// which are already rebuilding the schema — calling maybe_update_schema
+    /// there would recurse back into reparse_schema.
     #[instrument(skip_all, level = Level::INFO)]
-    pub fn _prepare(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
+    pub(crate) fn prepare_no_schema_check(
+        self: &Arc<Connection>,
+        sql: impl AsRef<str>,
+    ) -> Result<Statement> {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
@@ -294,7 +306,6 @@ impl Connection {
         let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
             .unwrap()
             .trim();
-        self.maybe_update_schema();
         let pager = self.pager.load().clone();
         let mode = QueryMode::new(&cmd);
         let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
@@ -321,7 +332,7 @@ impl Connection {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
-        self.maybe_update_schema();
+        self.maybe_update_schema()?;
         let syms = self.syms.read();
         let pager = self.pager.load().clone();
         let mode = QueryMode::Normal;
@@ -357,13 +368,31 @@ impl Connection {
             .store(true, Ordering::SeqCst);
     }
 
+    /// Read the schema cookie from the pager header (page 1).
+    pub(crate) fn effective_schema_cookie(&self) -> Result<u32> {
+        let pager = self.pager.load();
+        pager
+            .io
+            .block(|| pager.with_header(|header| header.schema_cookie))
+            .map(|v| v.get())
+    }
+
     /// Parse schema from scratch if version of schema for the connection differs from the schema cookie in the root page
     /// This function must be called outside of any transaction because internally it will start transaction session by itself
-    #[allow(dead_code)]
     fn maybe_reparse_schema(self: &Arc<Connection>) -> Result<()> {
+        // MVCC tracks its own schema versioning through MvStore, not through
+        // the on-disk page 1 cookie. Comparing on-disk vs in-memory would
+        // falsely trigger reparse because MvStore changes aren't checkpointed
+        // to page 1 yet. Multi-process access is already incompatible with
+        // MVCC (guarded in header_validation), so external schema changes
+        // cannot happen.
+        if self.mvcc_enabled() {
+            return Ok(());
+        }
         let pager = self.pager.load().clone();
 
         // first, quickly read schema_version from the root page in order to check if schema changed
+        // (e.g. another process created/dropped/altered a table).
         pager.begin_read_tx()?;
         let on_disk_schema_version = pager
             .io
@@ -427,13 +456,12 @@ impl Connection {
     }
 
     pub(crate) fn reparse_schema(self: &Arc<Connection>) -> Result<()> {
-        let pager = self.pager.load().clone();
-
-        // read cookie before consuming statement program - otherwise we can end up reading cookie with closed transaction state
-        let cookie = pager
-            .io
-            .block(|| pager.with_header(|header| header.schema_cookie))?
-            .get();
+        // Read the on-disk schema cookie so the fresh schema carries the
+        // current version, avoiding spurious SchemaUpdated → reprepare loops.
+        let cookie = self.effective_schema_cookie().unwrap_or_else(|e| {
+            tracing::warn!("effective_schema_cookie failed in reparse_schema: {e}");
+            0
+        });
 
         // create fresh schema as some objects can be deleted
         let mut fresh = Schema::with_options(self.experimental_custom_types_enabled());
@@ -452,7 +480,7 @@ impl Connection {
             *schema = fresh.clone();
         });
 
-        let stmt = self.prepare("SELECT * FROM sqlite_schema")?;
+        let stmt = self.prepare_no_schema_check("SELECT * FROM sqlite_schema")?;
 
         // MVCC bootstrap connection gets the "baseline" from the DB file and ignores anything in MV store
         let mv_tx = if self.is_mvcc_bootstrap_connection() {
@@ -509,7 +537,7 @@ impl Connection {
                 "The supplied SQL string contains no statements".to_string(),
             ));
         }
-        self.maybe_update_schema();
+        self.maybe_update_schema()?;
         let sql = sql.as_ref();
         tracing::trace!("Preparing and executing batch: {}", sql);
         let mut parser = Parser::new(sql.as_bytes());
@@ -543,7 +571,7 @@ impl Connection {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
         let sql = sql.as_ref();
-        self.maybe_update_schema();
+        self.maybe_update_schema()?;
         tracing::trace!("Querying: {}", sql);
         let mut parser = Parser::new(sql.as_bytes());
         let cmd = parser.next_cmd()?;
@@ -596,7 +624,7 @@ impl Connection {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
         let sql = sql.as_ref();
-        self.maybe_update_schema();
+        self.maybe_update_schema()?;
         let mut parser = Parser::new(sql.as_bytes());
         while let Some(cmd) = parser.next_cmd()? {
             let syms = self.syms.read();
@@ -658,6 +686,11 @@ impl Connection {
         use crate::util::MEMORY_PATH;
         let opts = OpenOptions::parse(uri)?;
         let flags = opts.get_flags()?;
+        let db_opts = if let Some(locking) = opts.locking {
+            db_opts.with_locking_mode(locking)
+        } else {
+            db_opts
+        };
         if opts.path == MEMORY_PATH || matches!(opts.mode, OpenMode::Memory) {
             let io = Arc::new(MemoryIO::new());
             let db = Database::open_file_with_flags(io.clone(), MEMORY_PATH, flags, db_opts, None)?;
@@ -729,6 +762,11 @@ impl Connection {
         if encryption_opts.is_some() {
             db_opts = db_opts.with_encryption(true);
         }
+        let db_opts = if let Some(locking) = opts.locking {
+            db_opts.with_locking_mode(locking)
+        } else {
+            db_opts
+        };
         let io = opts.vfs.map(Database::io_for_vfs).unwrap_or(Ok(io))?;
         let db = Database::open_file_with_flags(
             io.clone(),
@@ -787,26 +825,35 @@ impl Connection {
         if !has_types_table {
             return Ok(Vec::new());
         }
-        let mut type_stmt = self.prepare(format!(
+        let mut type_stmt = self.prepare_no_schema_check(format!(
             "SELECT name, sql FROM {}",
             crate::schema::TURSO_TYPES_TABLE_NAME
         ))?;
         let mut type_rows = Vec::new();
-        type_stmt.run_with_row_callback(|row| {
+        type_stmt.run_with_row_callback_no_reprepare(|row| {
             type_rows.push(row.get::<&str>(1)?.to_string());
             Ok(())
         })?;
         Ok(type_rows)
     }
 
-    pub fn maybe_update_schema(&self) {
+    pub fn maybe_update_schema(self: &Arc<Connection>) -> Result<()> {
+        if self.get_tx_state() != TransactionState::None {
+            return Ok(());
+        }
+        // In shared locking modes another process may have changed the
+        // schema (CREATE/DROP/ALTER TABLE). Check the on-disk cookie and
+        // reparse if it differs. In exclusive mode no external changes are
+        // possible so skip the (potentially Busy) begin_read_tx call.
+        if self.db.locking_mode.is_shared() {
+            self.maybe_reparse_schema()?;
+        }
         let current_schema_version = self.schema.read().schema_version;
         let schema = self.db.schema.lock();
-        if matches!(self.get_tx_state(), TransactionState::None)
-            && current_schema_version != schema.schema_version
-        {
+        if current_schema_version != schema.schema_version {
             *self.schema.write() = schema.clone();
         }
+        Ok(())
     }
 
     /// Read schema version at current transaction

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -394,7 +394,9 @@ mod tests {
                 enable_index_method: false,
                 enable_autovacuum: false,
                 enable_attach: false,
+                enable_shared_access: false,
                 unsafe_testing: false,
+                locking_mode: Default::default(),
             },
             None,
         )?;

--- a/core/io/common.rs
+++ b/core/io/common.rs
@@ -2,52 +2,120 @@ pub const ENV_DISABLE_FILE_LOCK: &str = "LIMBO_DISABLE_FILE_LOCK";
 
 #[cfg(test)]
 pub mod tests {
+    use crate::io::OpenFlags;
     use crate::{Result, IO};
     use std::process::{Command, Stdio};
     use tempfile::NamedTempFile;
 
-    fn run_test_parent_process<T: IO>(create_io: fn() -> Result<T>) {
-        let temp_file: NamedTempFile = NamedTempFile::new().expect("Failed to create temp file");
-        let path = temp_file.path().to_str().unwrap().to_string();
-
-        // Parent process opens the file
-        let io1 = create_io().expect("Failed to create IO");
-        let _file1 = io1
-            .open_file(&path, crate::io::OpenFlags::None, false)
-            .expect("Failed to open file in parent process");
-
+    /// Spawn a child process that tries to open `path` with the given flags.
+    /// Returns true if the child opened successfully, false if it failed.
+    fn child_can_open(path: &str, child_flags: OpenFlags) -> bool {
         let current_exe = std::env::current_exe().expect("Failed to get current executable path");
-
-        // Spawn a child process and try to open the same file
+        let flags_str = if child_flags.contains(OpenFlags::SharedLock) {
+            "shared"
+        } else {
+            "exclusive"
+        };
         let child = Command::new(current_exe)
             .env("RUST_TEST_CHILD_PROCESS", "1")
-            .env("RUST_TEST_FILE_PATH", &path)
+            .env("RUST_TEST_FILE_PATH", path)
+            .env("RUST_TEST_LOCK_MODE", flags_str)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
             .expect("Failed to spawn child process");
-
         let output = child.wait_with_output().expect("Failed to wait on child");
-        assert!(
-            !output.status.success(),
-            "Child process should have failed to open the file"
-        );
+        output.status.success()
     }
 
-    fn run_test_child_process<T: IO>(create_io: fn() -> Result<T>) -> Result<()> {
+    /// Must be called at the start of every test that uses subprocess spawning.
+    /// If we ARE the child process, open the file with the requested flags and exit.
+    pub fn handle_child_process<T: IO>(create_io: fn() -> Result<T>) {
         if std::env::var("RUST_TEST_CHILD_PROCESS").is_ok() {
-            let path = std::env::var("RUST_TEST_FILE_PATH")?;
-            let io = create_io()?;
-            match io.open_file(&path, crate::io::OpenFlags::None, false) {
+            let path = std::env::var("RUST_TEST_FILE_PATH").unwrap();
+            let lock_mode = std::env::var("RUST_TEST_LOCK_MODE").unwrap_or_default();
+            let flags = if lock_mode == "shared" {
+                OpenFlags::SharedLock
+            } else {
+                OpenFlags::None
+            };
+            let io = create_io().unwrap();
+            match io.open_file(&path, flags, false) {
                 Ok(_) => std::process::exit(0),
                 Err(_) => std::process::exit(1),
             }
         }
-        Ok(())
     }
 
     pub fn test_multiple_processes_cannot_open_file<T: IO>(create_io: fn() -> Result<T>) {
-        run_test_child_process(create_io).unwrap();
-        run_test_parent_process(create_io);
+        handle_child_process(create_io);
+
+        let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        let path = temp_file.path().to_str().unwrap().to_string();
+
+        // Parent process opens the file (exclusive lock by default)
+        let io = create_io().expect("Failed to create IO");
+        let _file = io
+            .open_file(&path, OpenFlags::None, false)
+            .expect("Failed to open file in parent process");
+
+        assert!(
+            !child_can_open(&path, OpenFlags::None),
+            "Child with exclusive should have failed when parent holds exclusive"
+        );
+    }
+
+    /// Parent holds exclusive lock → child with shared lock should fail.
+    pub fn test_exclusive_blocks_shared<T: IO>(create_io: fn() -> Result<T>) {
+        handle_child_process(create_io);
+
+        let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        let path = temp_file.path().to_str().unwrap().to_string();
+
+        let io = create_io().expect("Failed to create IO");
+        let _file = io
+            .open_file(&path, OpenFlags::None, false)
+            .expect("Parent: exclusive open");
+
+        assert!(
+            !child_can_open(&path, OpenFlags::SharedLock),
+            "Child with shared lock should fail when parent holds exclusive"
+        );
+    }
+
+    /// Parent holds shared lock → child with exclusive lock should fail.
+    pub fn test_shared_blocks_exclusive<T: IO>(create_io: fn() -> Result<T>) {
+        handle_child_process(create_io);
+
+        let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        let path = temp_file.path().to_str().unwrap().to_string();
+
+        let io = create_io().expect("Failed to create IO");
+        let _file = io
+            .open_file(&path, OpenFlags::SharedLock, false)
+            .expect("Parent: shared open");
+
+        assert!(
+            !child_can_open(&path, OpenFlags::None),
+            "Child with exclusive lock should fail when parent holds shared"
+        );
+    }
+
+    /// Parent holds shared lock → child with shared lock should succeed.
+    pub fn test_shared_allows_shared<T: IO>(create_io: fn() -> Result<T>) {
+        handle_child_process(create_io);
+
+        let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        let path = temp_file.path().to_str().unwrap().to_string();
+
+        let io = create_io().expect("Failed to create IO");
+        let _file = io
+            .open_file(&path, OpenFlags::SharedLock, false)
+            .expect("Parent: shared open");
+
+        assert!(
+            child_can_open(&path, OpenFlags::SharedLock),
+            "Child with shared lock should succeed when parent holds shared"
+        );
     }
 }

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -1,17 +1,16 @@
 #![allow(clippy::arc_with_non_send_sync)]
 
-use super::{common, Completion, CompletionInner, File, OpenFlags, IO};
+use super::{common, unix, Completion, CompletionInner, File, OpenFlags, IO};
 use crate::io::clock::{Clock, DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::storage::wal::CKPT_BATCH_PAGES;
 use crate::sync::Mutex;
 use crate::turso_assert;
 use crate::error::io_error;
-use crate::{CompletionError, LimboError, Result};
-use rustix::fs::{self, FlockOperation, OFlags};
+use crate::{CompletionError, Result};
+use rustix::fs::{self, OFlags};
 use std::ptr::NonNull;
 use std::{
     collections::{HashMap, VecDeque},
-    io::ErrorKind,
     ops::Deref,
     os::{fd::AsFd, unix::io::AsRawFd},
     sync::Arc,
@@ -512,9 +511,12 @@ impl IO for UringIO {
             id,
         });
         if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
-            || !flags.contains(OpenFlags::ReadOnly)
+            && !flags.contains(OpenFlags::ReadOnly)
         {
-            uring_file.lock_file(true)?;
+            // SharedLock flag means shared fcntl lock (for multi-process modes).
+            // Otherwise exclusive lock (default, single-process).
+            let shared = flags.contains(OpenFlags::SharedLock);
+            uring_file.lock_file(!shared)?;
         }
         Ok(uring_file)
     }
@@ -698,40 +700,11 @@ crate::assert::assert_send_sync!(UringFile);
 
 impl File for UringFile {
     fn lock_file(&self, exclusive: bool) -> Result<()> {
-        let fd = self.file.as_fd();
-        // F_SETLK is a non-blocking lock. The lock will be released when the file is closed
-        // or the process exits or after an explicit unlock.
-        fs::fcntl_lock(
-            fd,
-            if exclusive {
-                FlockOperation::NonBlockingLockExclusive
-            } else {
-                FlockOperation::NonBlockingLockShared
-            },
-        )
-        .map_err(|e| {
-            let io_error = std::io::Error::from(e);
-            let message = match io_error.kind() {
-                ErrorKind::WouldBlock => {
-                    "Failed locking file. File is locked by another process".to_string()
-                }
-                _ => format!("Failed locking file, {io_error}"),
-            };
-            LimboError::LockingError(message)
-        })?;
-
-        Ok(())
+        unix::fcntl_lock(self.file.as_fd(), exclusive)
     }
 
     fn unlock_file(&self) -> Result<()> {
-        let fd = self.file.as_fd();
-        fs::fcntl_lock(fd, FlockOperation::NonBlockingUnlock).map_err(|e| {
-            LimboError::LockingError(format!(
-                "Failed to release file lock: {}",
-                std::io::Error::from(e)
-            ))
-        })?;
-        Ok(())
+        unix::fcntl_unlock(self.file.as_fd())
     }
 
     fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
@@ -884,5 +857,20 @@ mod tests {
     #[test]
     fn test_multiple_processes_cannot_open_file() {
         common::tests::test_multiple_processes_cannot_open_file(UringIO::new);
+    }
+
+    #[test]
+    fn test_exclusive_blocks_shared() {
+        common::tests::test_exclusive_blocks_shared(UringIO::new);
+    }
+
+    #[test]
+    fn test_shared_blocks_exclusive() {
+        common::tests::test_shared_blocks_exclusive(UringIO::new);
+    }
+
+    #[test]
+    fn test_shared_allows_shared() {
+        common::tests::test_shared_allows_shared(UringIO::new);
     }
 }

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -212,6 +212,9 @@ bitflags! {
         const None = 0b00000000;
         const Create = 0b0000001;
         const ReadOnly = 0b0000010;
+        /// Take a shared file lock instead of exclusive.
+        /// Used when locking_mode is SharedReads or SharedWrites.
+        const SharedLock = 0b0000100;
     }
 }
 

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -5,16 +5,52 @@ use crate::io::common;
 use crate::io::FileSyncType;
 use crate::Result;
 use crate::sync::Mutex;
-use rustix::{
-    fd::{AsFd, AsRawFd},
-    fs::{self, FlockOperation},
-};
+use rustix::fd::{AsFd, AsRawFd, BorrowedFd};
+use rustix::fs::FlockOperation;
 use std::os::fd::RawFd;
 
 use std::{io::ErrorKind, sync::Arc};
 #[cfg(feature = "fs")]
 use tracing::debug;
 use tracing::{instrument, trace, Level};
+
+/// Acquire an fcntl (POSIX) lock on the given file descriptor.
+/// Non-blocking: returns `LimboError::LockingError` if the lock is held.
+pub(crate) fn fcntl_lock(fd: BorrowedFd<'_>, exclusive: bool) -> Result<()> {
+    rustix::fs::fcntl_lock(
+        fd,
+        if exclusive {
+            FlockOperation::NonBlockingLockExclusive
+        } else {
+            FlockOperation::NonBlockingLockShared
+        },
+    )
+    .map_err(|e| {
+        let io_error = std::io::Error::from(e);
+        let message = match io_error.kind() {
+            ErrorKind::WouldBlock => {
+                "Failed to open database: file is locked by another process. \
+                 To enable multi-process access, all processes must open with: \
+                 file:database.db?locking=shared_reads \
+                 or PRAGMA locking_mode = shared_reads. \
+                 For concurrent writers, use shared_writes instead."
+                    .to_string()
+            }
+            _ => format!("Failed locking file, {io_error}"),
+        };
+        LimboError::LockingError(message)
+    })
+}
+
+/// Release an fcntl (POSIX) lock on the given file descriptor.
+pub(crate) fn fcntl_unlock(fd: BorrowedFd<'_>) -> Result<()> {
+    rustix::fs::fcntl_lock(fd, FlockOperation::NonBlockingUnlock).map_err(|e| {
+        LimboError::LockingError(format!(
+            "Failed to release file lock: {}",
+            std::io::Error::from(e)
+        ))
+    })
+}
 
 pub struct UnixIO {}
 
@@ -111,7 +147,10 @@ impl IO for UnixIO {
         if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
             && !flags.contains(OpenFlags::ReadOnly)
         {
-            unix_file.lock_file(true)?;
+            // SharedLock flag means shared fcntl lock (for multi-process modes).
+            // Otherwise exclusive lock (default, single-process).
+            let shared = flags.contains(OpenFlags::SharedLock);
+            unix_file.lock_file(!shared)?;
         }
         Ok(unix_file)
     }
@@ -134,41 +173,12 @@ pub struct UnixFile {
 impl File for UnixFile {
     fn lock_file(&self, exclusive: bool) -> Result<()> {
         let fd = self.file.lock();
-        let fd = fd.as_fd();
-        // F_SETLK is a non-blocking lock. The lock will be released when the file is closed
-        // or the process exits or after an explicit unlock.
-        fs::fcntl_lock(
-            fd,
-            if exclusive {
-                FlockOperation::NonBlockingLockExclusive
-            } else {
-                FlockOperation::NonBlockingLockShared
-            },
-        )
-        .map_err(|e| {
-            let io_error = std::io::Error::from(e);
-            let message = match io_error.kind() {
-                ErrorKind::WouldBlock => {
-                    "Failed locking file. File is locked by another process".to_string()
-                }
-                _ => format!("Failed locking file, {io_error}"),
-            };
-            LimboError::LockingError(message)
-        })?;
-
-        Ok(())
+        fcntl_lock(fd.as_fd(), exclusive)
     }
 
     fn unlock_file(&self) -> Result<()> {
         let fd = self.file.lock();
-        let fd = fd.as_fd();
-        fs::fcntl_lock(fd, FlockOperation::NonBlockingUnlock).map_err(|e| {
-            LimboError::LockingError(format!(
-                "Failed to release file lock: {}",
-                std::io::Error::from(e)
-            ))
-        })?;
-        Ok(())
+        fcntl_unlock(fd.as_fd())
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
@@ -377,6 +387,26 @@ mod tests {
 
     #[test]
     fn test_multiple_processes_cannot_open_file() {
+        // Default locking mode is exclusive, so a second process should
+        // fail to open the same database file.
         common::tests::test_multiple_processes_cannot_open_file(UnixIO::new);
+    }
+
+    #[test]
+    fn test_exclusive_blocks_shared() {
+        // Process holding exclusive lock must block a process trying shared lock.
+        common::tests::test_exclusive_blocks_shared(UnixIO::new);
+    }
+
+    #[test]
+    fn test_shared_blocks_exclusive() {
+        // Process holding shared lock must block a process trying exclusive lock.
+        common::tests::test_shared_blocks_exclusive(UnixIO::new);
+    }
+
+    #[test]
+    fn test_shared_allows_shared() {
+        // Two processes with shared locks should coexist.
+        common::tests::test_shared_allows_shared(UnixIO::new);
     }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -163,6 +163,50 @@ pub const fn is_attached_db(database_id: usize) -> bool {
 }
 
 /// Configuration for database features
+/// Controls how the database file is locked for multi-process access.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LockingMode {
+    /// Single-process exclusive access (default). No TSHM, no flock overhead.
+    #[default]
+    Exclusive,
+    /// Multiple processes can read, but only one process writes.
+    /// The write lock (flock) is acquired once and held permanently.
+    SharedReads,
+    /// Full multi-process read/write access.
+    /// Write lock (flock) is acquired and released per transaction.
+    SharedWrites,
+}
+
+impl LockingMode {
+    pub fn is_shared(self) -> bool {
+        matches!(self, LockingMode::SharedReads | LockingMode::SharedWrites)
+    }
+}
+
+impl std::fmt::Display for LockingMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LockingMode::Exclusive => write!(f, "exclusive"),
+            LockingMode::SharedReads => write!(f, "shared_reads"),
+            LockingMode::SharedWrites => write!(f, "shared_writes"),
+        }
+    }
+}
+
+impl std::str::FromStr for LockingMode {
+    type Err = LimboError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "exclusive" => Ok(LockingMode::Exclusive),
+            "shared_reads" => Ok(LockingMode::SharedReads),
+            "shared_writes" | "normal" => Ok(LockingMode::SharedWrites),
+            _ => Err(LimboError::InternalError(format!(
+                "invalid locking_mode: '{s}'. Expected: exclusive, shared_reads, shared_writes, or normal"
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct DatabaseOpts {
     pub enable_views: bool,
@@ -171,8 +215,10 @@ pub struct DatabaseOpts {
     pub enable_index_method: bool,
     pub enable_autovacuum: bool,
     pub enable_attach: bool,
+    pub enable_shared_access: bool,
     pub unsafe_testing: bool,
     enable_load_extension: bool,
+    pub locking_mode: LockingMode,
 }
 
 impl DatabaseOpts {
@@ -216,8 +262,18 @@ impl DatabaseOpts {
         self
     }
 
+    pub fn with_shared_access(mut self, enable: bool) -> Self {
+        self.enable_shared_access = enable;
+        self
+    }
+
     pub fn with_unsafe_testing(mut self, enable: bool) -> Self {
         self.unsafe_testing = enable;
+        self
+    }
+
+    pub fn with_locking_mode(mut self, mode: LockingMode) -> Self {
+        self.locking_mode = mode;
         self
     }
 }
@@ -376,6 +432,19 @@ pub struct Database {
 
     // Encryption
     encryption_cipher_mode: AtomicCipherMode,
+
+    // Multi-process coordination (64-bit Unix only)
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub(crate) tshm: Option<Arc<storage::tshm::Tshm>>,
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub(crate) wal_index: Option<Arc<storage::wal_index::WalIndex>>,
+
+    pub(crate) locking_mode: LockingMode,
+
+    /// Sentinel `-shm` file with fcntl byte-range locks that prevent
+    /// SQLite from operating on the same database in WAL mode.
+    #[cfg(unix)]
+    shm_sentinel: Option<storage::shm_sentinel::ShmSentinel>,
 }
 
 // SAFETY: This needs to be audited for thread safety.
@@ -496,6 +565,16 @@ impl Database {
             encryption_cipher_mode: AtomicCipherMode::new(
                 encryption_cipher_mode.unwrap_or(CipherMode::None),
             ),
+
+            #[cfg(all(unix, target_pointer_width = "64"))]
+            tshm: None,
+            #[cfg(all(unix, target_pointer_width = "64"))]
+            wal_index: None,
+
+            locking_mode: opts.locking_mode,
+
+            #[cfg(unix)]
+            shm_sentinel: None,
         };
 
         db.register_global_builtin_extensions()
@@ -556,6 +635,12 @@ impl Database {
         // lock that would conflict with an already-open Database in this process.
         if let Some(db) = Self::lookup_in_registry(path, &encryption_opts)? {
             return Ok(db);
+        }
+        // In shared locking modes, use a shared fcntl lock on the DB file.
+        // Write exclusion is handled by flock on the TSHM file instead.
+        let mut flags = flags;
+        if opts.locking_mode.is_shared() {
+            flags |= OpenFlags::SharedLock;
         }
         let file = io.open_file(path, flags, true)?;
         let db_file = Arc::new(DatabaseFile::new(file));
@@ -669,6 +754,17 @@ impl Database {
                     return Err(LimboError::InvalidArgument(
                         "Database is encrypted but no encryption options provided".to_string(),
                     ));
+                }
+
+                // Validate that the requested locking mode matches the existing instance.
+                // A mismatch silently ignoring the caller's intent could cause subtle bugs.
+                if opts.locking_mode != LockingMode::Exclusive
+                    && opts.locking_mode != db.locking_mode
+                {
+                    return Err(LimboError::InvalidArgument(format!(
+                        "Database already open with locking_mode={:?}, cannot reopen with {:?}",
+                        db.locking_mode, opts.locking_mode
+                    )));
                 }
 
                 // Found in registry, no need to hold lock
@@ -917,7 +1013,7 @@ impl Database {
                             .expect("conn must be initialized in Init phase");
                         // Sync the connection's schema from the database so it
                         // can query __turso_internal_types.
-                        conn.maybe_update_schema();
+                        let _ = conn.maybe_update_schema();
                         let load_result: Result<()> = (|| {
                             let type_sqls = conn.query_stored_type_definitions()?;
                             if !type_sqls.is_empty() {
@@ -1188,12 +1284,76 @@ impl Database {
         let shared_wal = WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?;
 
         let last_checksum_and_max_frame = shared_wal.read().last_checksum_and_max_frame();
-        let wal = Arc::new(WalFile::new(
-            self.io.clone(),
+
+        // Create and lock the SQLite -shm sentinel file to prevent SQLite
+        // from operating on the same database. Skipped for read-only opens:
+        // concurrent read-only access from both Turso and SQLite is safe
+        // (no writes = no corruption risk).
+        #[cfg(unix)]
+        if !self.path.starts_with(":memory:") && !self.open_flags.contains(OpenFlags::ReadOnly) {
+            let shm_path = format!("{}-shm", self.path);
+            self.shm_sentinel = Some(storage::shm_sentinel::ShmSentinel::open(&shm_path)?);
+        }
+
+        // Shared locking modes require the experimental flag.
+        if self.locking_mode.is_shared() && !self.opts.enable_shared_access {
+            return Err(LimboError::InvalidArgument(
+                "shared locking modes (shared_reads, shared_writes) require \
+                 --experimental-shared-access flag"
+                    .to_string(),
+            ));
+        }
+
+        // MVCC and shared locking modes are incompatible.
+        if open_mv_store && self.locking_mode.is_shared() {
+            return Err(LimboError::InternalError(
+                "cannot open MVCC database in shared locking mode (SharedReads or SharedWrites). MVCC and multi-process WAL coordination are incompatible.".to_string(),
+            ));
+        }
+
+        // Initialize multi-process coordination on supported platforms.
+        // Only open TSHM when in a shared locking mode (not exclusive).
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        if self.locking_mode.is_shared() && !self.path.starts_with(":memory:") {
+            let tshm_path = format!("{}-tshm", self.path);
+            let tshm = Arc::new(storage::tshm::Tshm::open(&tshm_path)?);
+
+            // Store our locking mode in TSHM slot 1 for mode discovery.
+            // If another process already set a different mode, fail.
+            let mode_val = storage::tshm::Tshm::locking_mode_to_value(self.locking_mode);
+            if let Err(existing) = tshm.try_set_locking_mode(mode_val) {
+                let existing_name = storage::tshm::Tshm::locking_mode_from_value(existing)
+                    .map(|m| m.to_string())
+                    .unwrap_or_else(|| format!("unknown({existing})"));
+                return Err(LimboError::LockingError(format!(
+                    "Database is open in {existing_name} mode by another process, \
+                     cannot use {mode}",
+                    mode = self.locking_mode,
+                )));
+            }
+
+            // In SharedReads mode, try to acquire the write lock permanently.
+            // If another process already holds it, that's fine — we just
+            // can't write. Writes will fail with Busy at begin_write_tx time.
+            if self.locking_mode == LockingMode::SharedReads {
+                let _ = tshm.write_lock();
+            }
+
+            self.tshm = Some(tshm);
+        }
+
+        // Open the shared WAL index (embedded in the tshm file after the coordination page).
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        if let Some(tshm) = &self.tshm {
+            let wal_index = Arc::new(storage::wal_index::WalIndex::open(tshm.fd())?);
+            self.wal_index = Some(wal_index);
+        }
+
+        let wal = self.make_wal(
             Arc::clone(&shared_wal),
             last_checksum_and_max_frame,
             pager.buffer_pool.clone(),
-        ));
+        );
 
         self.shared_wal = shared_wal;
         pager.set_wal(wal);
@@ -1387,6 +1547,33 @@ impl Database {
         }
     }
 
+    /// Build a WAL instance, wrapping in MultiProcessWal on supported platforms.
+    fn make_wal(
+        &self,
+        shared_wal: Arc<RwLock<WalFileShared>>,
+        last_checksum_and_max_frame: ((u32, u32), u64),
+        buffer_pool: Arc<BufferPool>,
+    ) -> Arc<dyn Wal> {
+        let wal_file = WalFile::new(
+            self.io.clone(),
+            shared_wal,
+            last_checksum_and_max_frame,
+            buffer_pool,
+        );
+
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        if let Some(tshm) = &self.tshm {
+            return Arc::new(storage::multi_process_wal::MultiProcessWal::new(
+                wal_file,
+                Arc::clone(tshm),
+                self.locking_mode,
+                self.wal_index.clone(),
+            ));
+        }
+
+        Arc::new(wal_file)
+    }
+
     fn init_pager(&self, requested_page_size: Option<usize>) -> Result<Pager> {
         let cipher = self.encryption_cipher_mode.get();
         let reserved_bytes = self.maybe_get_reserved_space_bytes()?.or_else(|| {
@@ -1416,12 +1603,11 @@ impl Database {
         }
 
         let pager_wal: Option<Arc<dyn Wal>> = if shared_wal.enabled.load(Ordering::SeqCst) {
-            Some(Arc::new(WalFile::new(
-                self.io.clone(),
+            Some(self.make_wal(
                 self.shared_wal.clone(),
                 shared_wal.last_checksum_and_max_frame(),
                 buffer_pool.clone(),
-            )))
+            ))
         } else {
             None
         };

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -59,6 +59,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NeedSchema | PragmaFlags::Result0 | PragmaFlags::SchemaReq,
             &["journal_mode"],
         ),
+        LockingMode => Pragma::new(
+            PragmaFlags::Result0 | PragmaFlags::NoColumns1,
+            &["locking_mode"],
+        ),
         LegacyFileFormat => {
             unreachable!("pragma_for() called with LegacyFileFormat, which is unsupported")
         }

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -294,6 +294,32 @@ impl Statement {
         Ok(())
     }
 
+    /// Like `run_with_row_callback`, but steps the program directly without
+    /// reprepare checks. Used by internal schema-loading code
+    /// (reparse_schema, gather_sqlite_stat1) that is already part of a
+    /// reparse operation — repreparing there would cycle back into
+    /// reparse_schema.
+    pub(crate) fn run_with_row_callback_no_reprepare(
+        &mut self,
+        mut func: impl FnMut(&Row) -> Result<()>,
+    ) -> Result<()> {
+        loop {
+            match self
+                .program
+                .step(&mut self.state, &self.pager, self.query_mode, None)?
+            {
+                vdbe::StepResult::Done => break,
+                vdbe::StepResult::IO => self.pager.io.step()?,
+                vdbe::StepResult::Row => {
+                    func(self.row().expect("row should be present"))?;
+                }
+                vdbe::StepResult::Interrupt => return Err(LimboError::Interrupt),
+                vdbe::StepResult::Busy => return Err(LimboError::Busy),
+            }
+        }
+        Ok(())
+    }
+
     /// Blocks execution, advances IO, and stops at any StepResult except IO
     /// You can optionally pass a handler to run after IO is advanced
     pub fn run_one_step_blocking(
@@ -346,7 +372,29 @@ impl Statement {
             }
         }
 
-        *conn.schema.write() = conn.db.clone_schema();
+        // Check if the DB-level schema is stale (e.g., another process created
+        // a table, incrementing the schema cookie on disk). If so, reparse
+        // from sqlite_schema on disk so we get the new table definitions.
+        if conn.mvcc_enabled() {
+            // MVCC tracks schema through MvStore, not the on-disk page 1 cookie.
+            // Comparing on-disk vs in-memory would falsely trigger reparse because
+            // MvStore changes aren't checkpointed to page 1 yet. Just clone the
+            // latest schema from Database.
+            *conn.schema.write() = conn.db.clone_schema();
+        } else {
+            let on_disk_cookie = conn.effective_schema_cookie().unwrap_or_else(|e| {
+                tracing::warn!("effective_schema_cookie failed during reprepare: {e}");
+                0
+            });
+            let db_cookie = conn.db.schema.lock().schema_version;
+            if on_disk_cookie != db_cookie {
+                conn.reparse_schema()?;
+                let schema = conn.schema.read().clone();
+                conn.db.update_schema_if_newer(schema);
+            } else {
+                *conn.schema.write() = conn.db.clone_schema();
+            }
+        }
         self.program = {
             let mut parser = Parser::new(self.program.sql.as_bytes());
             let cmd = parser.next_cmd()?;

--- a/core/stats.rs
+++ b/core/stats.rs
@@ -96,7 +96,7 @@ pub fn gather_sqlite_stat1(
     mv_tx: Option<(u64, TransactionMode)>,
 ) -> Result<AnalyzeStats> {
     let mut stats = AnalyzeStats::default();
-    let mut stmt = conn.prepare(STATS_QUERY)?;
+    let mut stmt = conn.prepare_no_schema_check(STATS_QUERY)?;
     stmt.set_mv_tx(mv_tx);
     load_sqlite_stat1_from_stmt(stmt, schema, &mut stats)?;
     Ok(stats)
@@ -130,7 +130,7 @@ fn load_sqlite_stat1_from_stmt(
     schema: &Schema,
     stats: &mut AnalyzeStats,
 ) -> Result<()> {
-    stmt.run_with_row_callback(|row| {
+    stmt.run_with_row_callback_no_reprepare(|row| {
         let table_name = row.get::<&str>(0)?;
         let idx_value = row.get::<&Value>(1)?;
         let stat_value = row.get::<&Value>(2)?;

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -16,16 +16,30 @@ pub(crate) mod checksum;
 pub mod database;
 pub(crate) mod encryption;
 pub(crate) mod journal_mode;
+#[cfg(test)]
+#[cfg(all(unix, target_pointer_width = "64"))]
+mod mp_generative_tests;
+#[cfg(test)]
+#[cfg(all(unix, target_pointer_width = "64"))]
+mod mp_tests;
+#[cfg(all(unix, target_pointer_width = "64"))]
+pub(crate) mod multi_process_wal;
 pub(crate) mod page_cache;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;
+#[cfg(unix)]
+pub(crate) mod shm_sentinel;
 #[allow(dead_code)]
 pub(super) mod slot_bitmap;
 pub mod sqlite3_ondisk;
 mod state_machines;
 pub(crate) mod subjournal;
+#[cfg(all(unix, target_pointer_width = "64"))]
+pub(crate) mod tshm;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod wal;
+#[cfg(all(unix, target_pointer_width = "64"))]
+pub(crate) mod wal_index;
 
 #[macro_export]
 macro_rules! return_corrupt {

--- a/core/storage/mp_generative_tests.rs
+++ b/core/storage/mp_generative_tests.rs
@@ -1,0 +1,2660 @@
+//! Generative stress test for multi-process WAL.
+//!
+//! Runs a seeded sequence of operations across multiple virtual processes,
+//! checking invariants at every step. Fully deterministic: given a seed,
+//! the exact same sequence replays every time.
+//!
+//! The shadow state tracks what every process should see. After every write
+//! commits, ALL processes must see the exact shadow state — this is a local
+//! database, not an eventually-consistent network system.
+//!
+//! Run with: `SEED=42 cargo test -p turso_core --lib mp_generative -- --test-threads=1`
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+
+use crate::io::{OpenFlags, PlatformIO, IO};
+use crate::numeric::Numeric;
+use crate::storage::database::DatabaseFile;
+use crate::storage::multi_process_wal::MultiProcessWal;
+use crate::storage::wal::CheckpointMode;
+use crate::types::Value;
+use crate::util::IOExt;
+use crate::{Connection, Database, DatabaseOpts, LimboError, LockingMode};
+
+// ---------------------------------------------------------------------------
+// Shadow state — the single source of truth
+// ---------------------------------------------------------------------------
+
+/// Snapshot of table contents: table_name → sorted list of (id, val).
+type TableSnapshot = BTreeMap<String, Vec<(i64, Option<String>)>>;
+
+/// A row in the shadow state: (id, val).
+/// `val` tracks the current TEXT value for the row so UPDATEs can be verified.
+#[derive(Clone, Debug, PartialEq)]
+struct ShadowRow {
+    id: i64,
+    val: Option<String>,
+}
+
+/// A table in the shadow state.
+#[derive(Clone, Debug)]
+struct ShadowTable {
+    rows: Vec<ShadowRow>,
+    next_id: i64,
+}
+
+/// Global shadow state — represents the committed state of the database.
+/// After every successful write, ALL processes must see this exact state.
+#[derive(Clone, Debug)]
+struct ShadowState {
+    tables: BTreeMap<String, ShadowTable>,
+    /// Monotonically increasing counter for unique table names.
+    name_counter: u64,
+}
+
+impl ShadowState {
+    fn new() -> Self {
+        Self {
+            tables: BTreeMap::new(),
+            name_counter: 0,
+        }
+    }
+
+    fn next_name(&mut self, prefix: &str) -> String {
+        self.name_counter += 1;
+        format!("{prefix}{}", self.name_counter)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Virtual process
+// ---------------------------------------------------------------------------
+
+struct VirtualProcess {
+    id: usize,
+    db: Option<Arc<Database>>,
+    conn: Option<Arc<Connection>>,
+    /// Whether this process is alive (not crashed).
+    alive: bool,
+    /// Whether this process is currently inside a BEGIN..COMMIT/ROLLBACK.
+    in_transaction: bool,
+    /// Pending shadow changes accumulated during a transaction.
+    /// On COMMIT these merge into the global shadow; on ROLLBACK they're discarded.
+    pending_inserts: Vec<(String, ShadowRow)>,
+    pending_updates: Vec<(String, i64, String)>,
+    pending_deletes: Vec<(String, i64)>,
+    /// Snapshot of committed tables at BEGIN time. The process sees this
+    /// frozen state + its own pending changes for the duration of the tx.
+    /// Set on BEGIN, cleared on COMMIT/ROLLBACK/crash.
+    snapshot_tables: Option<BTreeMap<String, ShadowTable>>,
+    /// Captured read snapshot: the actual row counts per table as seen by the
+    /// FIRST read in this transaction. Used by RepeatableRead to verify that
+    /// subsequent reads return consistent results (snapshot isolation).
+    /// Key: table name, Value: sorted list of (id, val) pairs.
+    tx_read_snapshot: Option<TableSnapshot>,
+}
+
+impl VirtualProcess {
+    fn conn(&self) -> &Arc<Connection> {
+        self.conn.as_ref().expect("process not alive")
+    }
+
+    /// Reset to crashed/dead state. Drops db/conn handles and discards
+    /// all pending shadow state.
+    fn reset(&mut self) {
+        self.alive = false;
+        self.db = None;
+        self.conn = None;
+        self.in_transaction = false;
+        self.pending_inserts.clear();
+        self.pending_updates.clear();
+        self.pending_deletes.clear();
+        self.snapshot_tables = None;
+        self.tx_read_snapshot = None;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Operations
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+enum Op {
+    Insert,
+    Update,
+    Delete,
+    Select,
+    Checkpoint,
+    CreateTable,
+    DropTable,
+    Crash,
+    Restart,
+    IntegrityCheck,
+    BeginTx,
+    Commit,
+    Rollback,
+    CheckpointThenVerify,
+    InsertConflict,
+    SqlCheckpoint,
+    GracefulClose,
+    CrashAndRestart,
+    ConstrainedCheckpoint,
+    /// Full checkpoint followed by immediate insert on the same process.
+    /// Forces try_restart_log_before_write which changes the WAL salt and
+    /// resets max_frame to 0.
+    CheckpointThenWrite,
+    /// CREATE INDEX on a random existing table — forces multi-page schema
+    /// changes (new B-tree root + sqlite_master update).
+    CreateIndex,
+    /// Corrupt WalIndex hash tables on a random process, exercising the
+    /// find_frame fallthrough safety net.
+    CorruptWalIndex,
+    /// Corrupt WalIndex hash tables but leave some readers alive. Tests the
+    /// cached_pgno_checksum check in find_frame: surviving readers must detect
+    /// the mismatch and fall through to inner.find_frame (never return wrong data).
+    CorruptWalIndexPartial,
+    /// Temporarily inject WalIndex append failures on a random process,
+    /// exercising the clear-and-fallback path in commit_prepared_frames.
+    InjectWalIndexFailure,
+    /// INSERT 50-200 rows in a single BEGIN..COMMIT transaction.
+    /// Stresses page splits, overflow pages, and large WAL writes.
+    BulkInsert,
+    /// Tight TRUNCATE→write→TRUNCATE→write cycle. Exercises WAL restart
+    /// (salt change) repeatedly, stressing cross-process salt detection.
+    RapidWalRestart,
+    /// Repeatable-read check: within a transaction, consecutive SELECTs
+    /// (with no writes by THIS process in between) must return identical
+    /// results. Catches real snapshot isolation violations.
+    RepeatableRead,
+    /// BEGIN → INSERT multiple rows → ROLLBACK. Exercises WalIndex
+    /// `rollback_to` which rebuilds hash tables, then verifies that a
+    /// subsequent write can reuse the rolled-back frame slots and that
+    /// all processes still see the pre-rollback data.
+    WriteAndRollback,
+    /// BEGIN → INSERT → SAVEPOINT → INSERT more → ROLLBACK TO savepoint →
+    /// COMMIT. Exercises WalIndex::rollback_to with a non-zero mid-transaction
+    /// frame, which rebuilds hash tables and recomputes pgno_checksum.
+    SavepointRollback,
+    /// Truncate checkpoint → read from ALL alive processes (no intervening
+    /// write). Exercises the WAL-empty read path where data must come from
+    /// the database file, not stale page cache or WAL frames.
+    ReadAfterTruncate,
+    /// Full checkpoint by one process, then a DIFFERENT process writes.
+    /// The writing process must detect the WAL restart and truncation
+    /// through TSHM observation and correctly sync its internal state.
+    CheckpointThenCrossWrite,
+    /// WalIndex append failure with injection kept active across recovery,
+    /// exercising the double-failure path in recover_wal_index where
+    /// populate_wal_index also fails.
+    InjectWalIndexDoubleFailure,
+    /// Large INSERT in a transaction with tiny page cache to force pager
+    /// spill via `append_frames_vectored`. Exercises `pending_spill_max_frame`
+    /// lifecycle: set by spill, committed by `finish_append_frames_commit`.
+    SpillAndCommit,
+    /// Same as SpillAndCommit but ROLLBACKs. Exercises cleanup of
+    /// `pending_spill_max_frame` and `cleanup_uncommitted` for spilled entries.
+    SpillAndRollback,
+    Noop,
+}
+
+impl Op {
+    fn weighted_list() -> Vec<(Op, u32)> {
+        vec![
+            (Op::Insert, 25),
+            (Op::Update, 10),
+            (Op::Delete, 8),
+            (Op::Select, 25),
+            (Op::Checkpoint, 10),
+            (Op::CreateTable, 3),
+            (Op::DropTable, 2),
+            (Op::Crash, 2),
+            (Op::Restart, 3),
+            (Op::IntegrityCheck, 5),
+            (Op::BeginTx, 5),
+            (Op::Commit, 4),
+            (Op::Rollback, 2),
+            (Op::CheckpointThenVerify, 5),
+            (Op::InsertConflict, 5),
+            (Op::SqlCheckpoint, 5),
+            (Op::GracefulClose, 2),
+            (Op::CrashAndRestart, 3),
+            (Op::ConstrainedCheckpoint, 5),
+            (Op::CheckpointThenWrite, 4),
+            (Op::CreateIndex, 3),
+            (Op::CorruptWalIndex, 1),
+            (Op::CorruptWalIndexPartial, 1),
+            (Op::InjectWalIndexFailure, 1),
+            (Op::BulkInsert, 4),
+            (Op::RapidWalRestart, 3),
+            (Op::RepeatableRead, 5),
+            (Op::WriteAndRollback, 3),
+            (Op::SavepointRollback, 2),
+            (Op::ReadAfterTruncate, 3),
+            (Op::CheckpointThenCrossWrite, 3),
+            (Op::InjectWalIndexDoubleFailure, 1),
+            (Op::SpillAndCommit, 3),
+            (Op::SpillAndRollback, 2),
+            (Op::Noop, 5),
+        ]
+    }
+
+    fn pick(rng: &mut ChaCha8Rng) -> Op {
+        let weights = Self::weighted_list();
+        let total: u32 = weights.iter().map(|(_, w)| w).sum();
+        let mut roll = rng.random_range(0..total);
+        for (op, w) in &weights {
+            if roll < *w {
+                return *op;
+            }
+            roll -= w;
+        }
+        Op::Noop
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Simulator
+// ---------------------------------------------------------------------------
+
+struct MpSimulator {
+    rng: ChaCha8Rng,
+    seed: u64,
+    locking_mode: LockingMode,
+    processes: Vec<VirtualProcess>,
+    _dir: tempfile::TempDir,
+    db_path: String,
+    shadow: ShadowState,
+    steps: usize,
+    max_wal_frame_seen: u64,
+    /// In SharedReads mode, tracks which process holds the permanent write
+    /// lock. None means no process currently owns it (e.g. after a crash).
+    /// In SharedWrites mode, this is always None (any process can write).
+    writer_owner: Option<usize>,
+    /// Whether to print per-step trace output (set via VERBOSE=1 env var).
+    verbose: bool,
+}
+
+/// Open a database bypassing the process-wide registry so each call
+/// creates a truly independent Database instance with its own fds and
+/// TSHM, simulating a separate OS process.
+fn open_bypass_registry(db_path: &str, mode: LockingMode) -> crate::Result<Arc<Database>> {
+    let wal_path = format!("{db_path}-wal");
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let mut flags = OpenFlags::default();
+    if mode.is_shared() {
+        flags |= OpenFlags::SharedLock;
+    }
+    let file = io.open_file(db_path, flags, true)?;
+    let db_file = Arc::new(DatabaseFile::new(file));
+    let opts = DatabaseOpts::new()
+        .with_locking_mode(mode)
+        .with_shared_access(mode.is_shared());
+    let mut state = crate::OpenDbAsyncState::new();
+    loop {
+        match Database::open_with_flags_bypass_registry_async(
+            &mut state,
+            io.clone(),
+            db_path,
+            Some(&wal_path),
+            db_file.clone(),
+            flags,
+            opts,
+            None,
+        )? {
+            crate::IOResult::Done(db) => return Ok(db),
+            crate::IOResult::IO(io_completion) => {
+                io_completion.wait(&*io)?;
+            }
+        }
+    }
+}
+
+impl MpSimulator {
+    fn new(seed: u64, num_processes: usize, steps: usize, mode: LockingMode) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // Create WAL-mode database.
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.pragma_update(None, "journal_mode", "wal").unwrap();
+        }
+
+        let db_path_str = db_path.to_str().unwrap().to_string();
+        let mut processes = Vec::new();
+        let mut writer_owner = None;
+        for i in 0..num_processes {
+            let db = open_bypass_registry(&db_path_str, mode).unwrap();
+            let conn = db.connect().unwrap();
+            if mode == LockingMode::SharedReads && writer_owner.is_none() {
+                writer_owner = Some(i);
+            }
+            processes.push(VirtualProcess {
+                id: i,
+                db: Some(db),
+                conn: Some(conn),
+                alive: true,
+                in_transaction: false,
+                pending_inserts: Vec::new(),
+                pending_updates: Vec::new(),
+                pending_deletes: Vec::new(),
+                snapshot_tables: None,
+                tx_read_snapshot: None,
+            });
+        }
+
+        let verbose = std::env::var("VERBOSE").is_ok_and(|v| v == "1");
+
+        Self {
+            rng: ChaCha8Rng::seed_from_u64(seed),
+            seed,
+            locking_mode: mode,
+            processes,
+            _dir: dir,
+            db_path: db_path_str,
+            shadow: ShadowState::new(),
+            steps,
+            max_wal_frame_seen: 0,
+            writer_owner,
+            verbose,
+        }
+    }
+
+    fn run(mut self) {
+        // Create at least one table so operations have something to work with.
+        let creator = self.writer_owner.unwrap_or(0);
+        self.do_create_table(creator, 0);
+
+        for step in 0..self.steps {
+            let op = Op::pick(&mut self.rng);
+            let alive_ids: Vec<usize> = self
+                .processes
+                .iter()
+                .filter(|p| p.alive)
+                .map(|p| p.id)
+                .collect();
+
+            if alive_ids.is_empty() {
+                self.do_restart(0, step);
+                continue;
+            }
+
+            let proc_idx = alive_ids[self.rng.random_range(0..alive_ids.len())];
+
+            if self.verbose {
+                eprintln!("step {step}: proc {proc_idx} op={op:?}");
+            }
+            match op {
+                Op::Insert => self.do_insert(proc_idx, step),
+                Op::Update => self.do_update(proc_idx, step),
+                Op::Delete => self.do_delete(proc_idx, step),
+                Op::Select => self.do_select(proc_idx, step),
+                Op::Checkpoint => self.do_checkpoint(proc_idx, step),
+                Op::CreateTable => self.do_create_table(proc_idx, step),
+                Op::DropTable => self.do_drop_table(proc_idx, step),
+                Op::Crash => self.do_crash(proc_idx, step),
+                Op::Restart => {
+                    let dead_ids: Vec<usize> = self
+                        .processes
+                        .iter()
+                        .filter(|p| !p.alive)
+                        .map(|p| p.id)
+                        .collect();
+                    if !dead_ids.is_empty() {
+                        let idx = dead_ids[self.rng.random_range(0..dead_ids.len())];
+                        self.do_restart(idx, step);
+                    }
+                }
+                Op::IntegrityCheck => self.do_integrity_check(proc_idx, step),
+                Op::BeginTx => self.do_begin_tx(proc_idx, step),
+                Op::Commit => self.do_commit(proc_idx, step),
+                Op::Rollback => self.do_rollback(proc_idx, step),
+                Op::CheckpointThenVerify => {
+                    self.do_checkpoint(proc_idx, step);
+                    self.verify_all_processes(&format!("step {step} (post-checkpoint verify)"));
+                }
+                Op::InsertConflict => self.do_insert_conflict(proc_idx, step),
+                Op::SqlCheckpoint => self.do_sql_checkpoint(proc_idx, step),
+                Op::GracefulClose => {
+                    self.do_graceful_close(proc_idx, step);
+                    // Immediately restart a dead process so the pool
+                    // stays populated.
+                    let dead_ids: Vec<usize> = self
+                        .processes
+                        .iter()
+                        .filter(|p| !p.alive)
+                        .map(|p| p.id)
+                        .collect();
+                    if !dead_ids.is_empty() {
+                        let idx = dead_ids[self.rng.random_range(0..dead_ids.len())];
+                        self.do_restart(idx, step);
+                    }
+                }
+                Op::CrashAndRestart => {
+                    // Rapid crash + restart of the same process. Stresses
+                    // TSHM state transitions and lock takeover paths.
+                    self.do_crash(proc_idx, step);
+                    self.do_restart(proc_idx, step);
+                }
+                Op::ConstrainedCheckpoint => self.do_constrained_checkpoint(proc_idx, step),
+                Op::CheckpointThenWrite => {
+                    self.do_checkpoint_then_write(proc_idx, step);
+                }
+                Op::CreateIndex => self.do_create_index(proc_idx, step),
+                Op::CorruptWalIndex => self.do_corrupt_wal_index(proc_idx, step),
+                Op::CorruptWalIndexPartial => {
+                    self.do_corrupt_wal_index_partial(proc_idx, step);
+                }
+                Op::InjectWalIndexFailure => {
+                    self.do_inject_wal_index_failure(proc_idx, step);
+                }
+                Op::BulkInsert => self.do_bulk_insert(proc_idx, step),
+                Op::RapidWalRestart => self.do_rapid_wal_restart(proc_idx, step),
+                Op::RepeatableRead => self.do_repeatable_read(proc_idx, step),
+                Op::WriteAndRollback => self.do_write_and_rollback(proc_idx, step),
+                Op::SavepointRollback => self.do_savepoint_rollback(proc_idx, step),
+                Op::ReadAfterTruncate => self.do_read_after_truncate(proc_idx, step),
+                Op::CheckpointThenCrossWrite => {
+                    self.do_checkpoint_then_cross_write(proc_idx, step);
+                }
+                Op::InjectWalIndexDoubleFailure => {
+                    self.do_inject_wal_index_double_failure(proc_idx, step);
+                }
+                Op::SpillAndCommit => {
+                    self.do_spill_transaction(proc_idx, step, true);
+                }
+                Op::SpillAndRollback => {
+                    self.do_spill_transaction(proc_idx, step, false);
+                }
+                Op::Noop => {}
+            }
+        }
+
+        // Commit any open transactions before final verification.
+        // If COMMIT fails (Busy), fall back to ROLLBACK so the process
+        // can participate in final verification.
+        for i in 0..self.processes.len() {
+            if self.processes[i].alive && self.processes[i].in_transaction {
+                self.do_commit(i, self.steps);
+                if self.processes[i].in_transaction {
+                    self.do_rollback(i, self.steps);
+                }
+            }
+        }
+
+        // Final: verify every alive process sees the exact shadow state.
+        self.verify_all_processes("final");
+    }
+
+    // --- Shadow verification ---
+
+    /// Verify that a process sees the expected shadow state.
+    /// Checks actual row IDs and values — catches data corruption and lost updates.
+    fn verify_shadow(
+        &self,
+        conn: &Arc<Connection>,
+        proc_idx: usize,
+        context: &str,
+        expected: &BTreeMap<String, ShadowTable>,
+    ) {
+        // Forward check: every shadow table exists in DB with correct rows.
+        for (table_name, table) in expected {
+            let sql = format!("SELECT id, val FROM {table_name} ORDER BY id");
+            let mut stmt = match conn.prepare(&sql) {
+                Ok(s) => s,
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("no such table") {
+                        panic!(
+                            "{context}: process {proc_idx} can't find table {table_name} \
+                             that exists in shadow state (seed={})",
+                            self.seed
+                        );
+                    }
+                    panic!(
+                        "{context}: process {proc_idx} failed to prepare SELECT on \
+                         {table_name}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            };
+            let rows = stmt.run_collect_rows().unwrap_or_else(|e| {
+                panic!(
+                    "{context}: process {proc_idx} failed to run SELECT on \
+                     {table_name}: {e} (seed={})",
+                    self.seed
+                );
+            });
+            let ctx = format!("{context}: {table_name}");
+            let actual = Self::parse_id_val_rows(&rows, &ctx, self.seed);
+
+            let mut expected: Vec<(i64, Option<String>)> =
+                table.rows.iter().map(|r| (r.id, r.val.clone())).collect();
+            expected.sort_by_key(|(id, _)| *id);
+
+            if actual != expected {
+                panic!(
+                    "{context}: process {proc_idx} data mismatch in {table_name}: \
+                     actual={actual:?}, expected={expected:?} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        // Reverse check: DB has no tables that the shadow doesn't know about.
+        let sql = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name";
+        let mut stmt = conn.prepare(sql).unwrap_or_else(|e| {
+            panic!(
+                "{context}: process {proc_idx} failed to query sqlite_master: {e} (seed={})",
+                self.seed
+            );
+        });
+        let rows = stmt.run_collect_rows().unwrap();
+        let db_tables: Vec<String> = rows
+            .iter()
+            .filter_map(|r| match r.first() {
+                Some(Value::Text(s)) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect();
+        let shadow_tables: Vec<String> = expected.keys().cloned().collect();
+        if db_tables != shadow_tables {
+            panic!(
+                "{context}: process {proc_idx} table set mismatch: \
+                 db={db_tables:?}, shadow={shadow_tables:?} (seed={})",
+                self.seed
+            );
+        }
+    }
+
+    /// Verify all alive, non-transacting processes see the committed state.
+    /// Uncommitted frames are NOT visible to other processes (no commit marker
+    /// on disk), so we verify against `self.shadow.tables` (committed only).
+    fn verify_all_processes(&self, context: &str) {
+        for p in &self.processes {
+            if !p.alive {
+                continue;
+            }
+            // Skip processes in a transaction — they see their own snapshot.
+            if p.in_transaction {
+                continue;
+            }
+            self.verify_shadow(p.conn(), p.id, context, &self.shadow.tables);
+        }
+    }
+
+    /// After a successful write by `writer_idx`, verify:
+    /// 1. The writer itself can read back the correct state (page cache consistency).
+    /// 2. Another alive, non-transacting process sees the committed state
+    ///    (uncommitted frames are NOT visible cross-process — no commit marker).
+    fn verify_cross_process_after_write(&self, writer_idx: usize, step: usize) {
+        // Self-verify: only for non-transacting writers. Within an explicit
+        // transaction, begin_write_tx may rescan the WAL, upgrading the read
+        // snapshot to include other processes' commits. The shadow's
+        // snapshot_tables (captured at BEGIN) can't track this, so
+        // writer_view() may not match reality. Autocommit writes always
+        // have an accurate shadow.
+        if !self.processes[writer_idx].in_transaction {
+            let writer = &self.processes[writer_idx];
+            let context = format!("step {step} (self-verify after write by proc {writer_idx})");
+            self.verify_shadow(writer.conn(), writer_idx, &context, &self.shadow.tables);
+        }
+
+        // Cross-verify: another non-transacting process sees committed state only.
+        let verifier = self
+            .processes
+            .iter()
+            .find(|p| p.alive && p.id != writer_idx && !p.in_transaction);
+        if let Some(p) = verifier {
+            let context = format!("step {step} (cross-verify after write by proc {writer_idx})");
+            self.verify_shadow(p.conn(), p.id, &context, &self.shadow.tables);
+        }
+    }
+
+    /// Returns true if any alive process has an open transaction (BEGIN without
+    /// COMMIT/ROLLBACK). Used to skip checkpoints and graceful closes: all
+    /// virtual processes share the same OS PID, so TSHM
+    /// min_reader_frame_excluding(my_pid) returns None and checkpoints have
+    /// no reader constraint. In real multi-process operation, different PIDs
+    /// would prevent the checkpoint from backfilling past the reader's slot.
+    /// An open transaction holds a persistent read lock, so ANY open tx
+    /// (even read-only) must block checkpoints that could truncate the WAL.
+    fn any_open_tx(&self) -> bool {
+        self.processes.iter().any(|p| p.alive && p.in_transaction)
+    }
+
+    /// Returns true if this process can attempt write operations.
+    /// In SharedReads mode, only the writer owner process can write.
+    fn is_writer(&self, proc_idx: usize) -> bool {
+        self.locking_mode != LockingMode::SharedReads || self.writer_owner == Some(proc_idx)
+    }
+
+    /// Returns true if the given process should skip an exclusive write
+    /// operation (checkpoint-then-write, rapid WAL restart, etc.).
+    fn should_skip_exclusive_write_op(&self, proc_idx: usize) -> bool {
+        !self.is_writer(proc_idx)
+            || self.processes[proc_idx].in_transaction
+            || self.any_open_tx()
+            || self.shadow.tables.is_empty()
+    }
+
+    /// Kill a process: reset its state and clear writer ownership if needed.
+    fn kill_process(&mut self, proc_idx: usize) {
+        self.processes[proc_idx].reset();
+        if self.writer_owner == Some(proc_idx) {
+            self.writer_owner = None;
+        }
+    }
+
+    // --- Common helpers ---
+
+    /// Parse query result rows into (id, val) tuples.
+    /// Panics with context on unexpected column types.
+    fn parse_id_val_rows(
+        rows: &[Vec<Value>],
+        context: &str,
+        seed: u64,
+    ) -> Vec<(i64, Option<String>)> {
+        rows.iter()
+            .map(|r| {
+                let id = match r.first() {
+                    Some(Value::Numeric(Numeric::Integer(v))) => *v,
+                    other => panic!("{context}: unexpected id type: {other:?} (seed={seed})"),
+                };
+                let val = match r.get(1) {
+                    Some(Value::Text(s)) => Some(s.to_string()),
+                    Some(Value::Null) | None => None,
+                    other => panic!("{context}: unexpected val type: {other:?} (seed={seed})"),
+                };
+                (id, val)
+            })
+            .collect()
+    }
+
+    /// Pick a random existing row, respecting snapshot isolation.
+    /// Returns (table_name, row_id) or None if no rows available.
+    fn pick_existing_row(&mut self, proc_idx: usize) -> Option<(String, i64)> {
+        let pick_tables = if self.processes[proc_idx].in_transaction {
+            match &self.processes[proc_idx].snapshot_tables {
+                Some(st) => st.clone(),
+                None => self.shadow.tables.clone(),
+            }
+        } else {
+            self.shadow.tables.clone()
+        };
+        let table_names: Vec<String> = pick_tables.keys().cloned().collect();
+        if table_names.is_empty() {
+            return None;
+        }
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let table = pick_tables.get(&table_name).unwrap();
+        if table.rows.is_empty() {
+            return None;
+        }
+        let row_idx = self.rng.random_range(0..table.rows.len());
+        let id = table.rows[row_idx].id;
+        // When in transaction, verify the row still exists in the global
+        // shadow. Another process may have deleted it after our snapshot.
+        if self.processes[proc_idx].in_transaction
+            && !self
+                .shadow
+                .tables
+                .get(&table_name)
+                .is_some_and(|t| t.rows.iter().any(|r| r.id == id))
+        {
+            return None;
+        }
+        Some((table_name, id))
+    }
+
+    // --- Write operation helper ---
+
+    /// Attempt a write operation. Returns Ok(true) if it succeeded,
+    /// Ok(false) if it was skipped or failed with an expected error,
+    /// or panics if the single-writer invariant is violated.
+    fn try_write(
+        &mut self,
+        proc_idx: usize,
+        step: usize,
+        op_name: &str,
+        sql: &str,
+    ) -> Result<bool, ()> {
+        let conn = self.processes[proc_idx].conn().clone();
+        match conn.execute(sql) {
+            Ok(_) => {
+                if self.locking_mode == LockingMode::SharedReads {
+                    if let Some(owner) = self.writer_owner {
+                        assert_eq!(
+                            owner, proc_idx,
+                            "step {step}: {op_name} succeeded on process {proc_idx}, \
+                             but writer_owner is process {owner}! \
+                             Two processes wrote simultaneously in SharedReads mode. \
+                             (seed={})",
+                            self.seed
+                        );
+                    } else {
+                        self.writer_owner = Some(proc_idx);
+                    }
+                }
+                Ok(true)
+            }
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => Ok(false),
+            Err(e) => {
+                let msg = e.to_string();
+                let msg_lower = msg.to_lowercase();
+                if msg_lower.contains("no such table") || msg_lower.contains("no such index") {
+                    Ok(false)
+                } else {
+                    panic!(
+                        "step {step}: {op_name} failed on process {proc_idx}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+        }
+    }
+
+    // --- Operation implementations ---
+
+    fn do_insert(&mut self, proc_idx: usize, step: usize) {
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let id = self.shadow.tables.get(&table_name).unwrap().next_id;
+
+        // 1 in 10 inserts use a large value to exercise overflow pages.
+        let large_val = if self.rng.random_range(0..10u32) == 0 {
+            let len = self.rng.random_range(2000..6000usize);
+            let c = (b'a' + self.rng.random_range(0..26u8)) as char;
+            Some(std::iter::repeat_n(c, len).collect::<String>())
+        } else {
+            None
+        };
+        let sql = if let Some(ref val) = large_val {
+            format!("INSERT INTO {table_name}(id, val) VALUES ({id}, '{val}')")
+        } else {
+            format!("INSERT INTO {table_name}(id) VALUES ({id})")
+        };
+        if let Ok(true) = self.try_write(proc_idx, step, "INSERT", &sql) {
+            // Always bump next_id globally to avoid PK conflicts, even if
+            // a transaction is later rolled back (gaps are harmless).
+            self.shadow.tables.get_mut(&table_name).unwrap().next_id += 1;
+            let row = ShadowRow { id, val: large_val };
+
+            if self.processes[proc_idx].in_transaction {
+                if self.verbose {
+                    eprintln!("  -> pending_insert({table_name}, id={id})");
+                }
+                self.processes[proc_idx]
+                    .pending_inserts
+                    .push((table_name, row));
+            } else {
+                if self.verbose {
+                    eprintln!("  -> shadow_insert({table_name}, id={id})");
+                }
+                self.shadow
+                    .tables
+                    .get_mut(&table_name)
+                    .unwrap()
+                    .rows
+                    .push(row);
+                self.verify_cross_process_after_write(proc_idx, step);
+            }
+        }
+    }
+
+    fn do_update(&mut self, proc_idx: usize, step: usize) {
+        let Some((table_name, id)) = self.pick_existing_row(proc_idx) else {
+            return;
+        };
+        let new_val = format!("v{}", self.rng.random_range(0..10000u32));
+        let sql = format!("UPDATE {table_name} SET val = '{new_val}' WHERE id = {id}");
+        if let Ok(true) = self.try_write(proc_idx, step, "UPDATE", &sql) {
+            if self.processes[proc_idx].in_transaction {
+                self.processes[proc_idx]
+                    .pending_updates
+                    .push((table_name, id, new_val));
+            } else {
+                // Update the shadow val for this row.
+                let table = self.shadow.tables.get_mut(&table_name).unwrap();
+                if let Some(row) = table.rows.iter_mut().find(|r| r.id == id) {
+                    row.val = Some(new_val);
+                }
+                self.verify_cross_process_after_write(proc_idx, step);
+            }
+        }
+    }
+
+    fn do_delete(&mut self, proc_idx: usize, step: usize) {
+        let Some((table_name, id)) = self.pick_existing_row(proc_idx) else {
+            return;
+        };
+        let sql = format!("DELETE FROM {table_name} WHERE id = {id}");
+        if let Ok(true) = self.try_write(proc_idx, step, "DELETE", &sql) {
+            if self.processes[proc_idx].in_transaction {
+                self.processes[proc_idx]
+                    .pending_deletes
+                    .push((table_name, id));
+            } else {
+                let table = self.shadow.tables.get_mut(&table_name).unwrap();
+                table.rows.retain(|r| r.id != id);
+                self.verify_cross_process_after_write(proc_idx, step);
+            }
+        }
+    }
+
+    fn do_select(&self, proc_idx: usize, step: usize) {
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+        // Don't verify processes in a transaction — they see a stale snapshot.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        let context = format!("step {step}");
+        self.verify_shadow(
+            self.processes[proc_idx].conn(),
+            proc_idx,
+            &context,
+            &self.shadow.tables,
+        );
+    }
+
+    fn do_checkpoint(&mut self, proc_idx: usize, step: usize) {
+        // In SharedReads mode, only the writer should checkpoint.
+        if !self.is_writer(proc_idx) {
+            return;
+        }
+        // Don't checkpoint while in a transaction.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        // Skip if another process has pending writes (see any_pending_write_tx doc).
+        if self.any_open_tx() {
+            return;
+        }
+
+        let conn = self.processes[proc_idx].conn().clone();
+        // Sometimes use upper_bound_inclusive for partial checkpoints.
+        let upper_bound = if self.rng.random_range(0..4u32) == 0 {
+            Some(self.rng.random_range(1..100u64))
+        } else {
+            None
+        };
+        let all_modes = [
+            CheckpointMode::Passive {
+                upper_bound_inclusive: upper_bound,
+            },
+            CheckpointMode::Full,
+            CheckpointMode::Restart,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: upper_bound,
+            },
+        ];
+        let mode = all_modes[self.rng.random_range(0..all_modes.len())];
+
+        let pager = conn.pager.load();
+        match pager
+            .io
+            .block(|| pager.checkpoint(mode, crate::SyncMode::Full, true))
+        {
+            Ok(_) => {}
+            Err(LimboError::Busy) => {}
+            Err(e) => {
+                panic!(
+                    "step {step}: checkpoint({mode:?}) failed unexpectedly on process \
+                     {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        // Check WAL isn't growing without bound.
+        if let Ok(state) = pager.wal_state() {
+            self.max_wal_frame_seen = self.max_wal_frame_seen.max(state.max_frame);
+            assert!(
+                state.max_frame < 10_000,
+                "step {step}: WAL grew excessively (max_frame={}, seed={})",
+                state.max_frame,
+                self.seed
+            );
+        }
+    }
+
+    /// Checkpoint with a synthetic external reader constraint.
+    /// Directly sets external_reader_max_frame on the inner WalFile to simulate
+    /// another process holding a reader at a specific frame. This exercises
+    /// determine_max_safe_checkpoint_frame and try_restart_log_before_write,
+    /// which are structurally unreachable in a single-process fuzzer via TSHM
+    /// (all virtual processes share the same PID).
+    fn do_constrained_checkpoint(&mut self, proc_idx: usize, step: usize) {
+        if !self.is_writer(proc_idx) {
+            return;
+        }
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        // NOTE: intentionally NOT guarded by any_open_tx(). The synthetic
+        // set_external_reader_max_frame simulates a cross-process reader
+        // constraint, which is the whole point of this operation. Passive
+        // checkpoint respects the constraint and does not truncate the WAL.
+
+        let conn = self.processes[proc_idx].conn().clone();
+        let pager = conn.pager.load();
+        let Some(wal) = pager.wal.as_ref() else {
+            return;
+        };
+
+        // Get current WAL state to pick a meaningful constraint frame.
+        let Ok(wal_state) = pager.wal_state() else {
+            return;
+        };
+        if wal_state.max_frame < 2 {
+            return;
+        }
+
+        // Downcast to MultiProcessWal to access the inner WalFile.
+        #[cfg(debug_assertions)]
+        let mp_wal = wal.as_any().downcast_ref::<MultiProcessWal>();
+        #[cfg(not(debug_assertions))]
+        let mp_wal: Option<&MultiProcessWal> = None;
+
+        let Some(mp_wal) = mp_wal else {
+            return;
+        };
+
+        // Pick a constraint frame somewhere in the WAL.
+        let constraint = self.rng.random_range(1..wal_state.max_frame);
+        mp_wal.inner().set_external_reader_max_frame(constraint);
+
+        // Run a Passive checkpoint — it must respect the constraint and not
+        // backfill past the external reader's frame.
+        let mode = CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        };
+        match pager
+            .io
+            .block(|| pager.checkpoint(mode, crate::SyncMode::Full, true))
+        {
+            Ok(_) => {}
+            Err(LimboError::Busy) => {}
+            Err(e) => {
+                panic!(
+                    "step {step}: constrained checkpoint failed on process \
+                     {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        // Clear the synthetic constraint.
+        mp_wal.inner().set_external_reader_max_frame(0);
+
+        // Verify all processes still see correct data.
+        self.verify_all_processes(&format!(
+            "step {step} (after constrained checkpoint, limit={constraint})"
+        ));
+    }
+
+    /// Full checkpoint + immediate insert on the same process.
+    /// This deterministically exercises try_restart_log_before_write:
+    /// checkpoint(Full) makes nbackfills == max_frame, then the next
+    /// begin_write_tx calls restart_log() which changes the WAL salt
+    /// and resets max_frame to 0. The subsequent insert uses the new salt.
+    /// Other processes must detect the salt change via TSHM and rescan.
+    fn do_checkpoint_then_write(&mut self, proc_idx: usize, step: usize) {
+        if self.should_skip_exclusive_write_op(proc_idx) {
+            return;
+        }
+
+        // Full checkpoint: backfill everything.
+        let conn = self.processes[proc_idx].conn().clone();
+        let pager = conn.pager.load();
+        match pager
+            .io
+            .block(|| pager.checkpoint(CheckpointMode::Full, crate::SyncMode::Full, true))
+        {
+            Ok(_) => {}
+            Err(LimboError::Busy) => return,
+            Err(e) => {
+                panic!(
+                    "step {step}: CheckpointThenWrite checkpoint failed on process \
+                     {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        // Immediately insert — this should trigger try_restart_log_before_write
+        // inside begin_write_tx, changing the WAL salt.
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let id = self.shadow.tables.get(&table_name).unwrap().next_id;
+        let sql = format!("INSERT INTO {table_name}(id) VALUES ({id})");
+
+        if let Ok(true) = self.try_write(proc_idx, step, "INSERT (post-restart)", &sql) {
+            if self.verbose {
+                eprintln!("  -> shadow_insert_checkpoint_then_write({table_name}, id={id})");
+            }
+            let table = self.shadow.tables.get_mut(&table_name).unwrap();
+            table.next_id += 1;
+            table.rows.push(ShadowRow { id, val: None });
+            // Cross-verify: other processes must detect the WAL restart
+            // and see the new row.
+            self.verify_cross_process_after_write(proc_idx, step);
+        }
+    }
+
+    /// CREATE INDEX on a random existing table. Forces multi-page schema
+    /// changes: creates a new B-tree root page and updates sqlite_master,
+    /// which stresses partial checkpoint behavior when schema pages are
+    /// split across checkpoint boundaries.
+    fn do_create_index(&mut self, proc_idx: usize, step: usize) {
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let idx_name = format!("idx_{}", self.shadow.name_counter);
+        self.shadow.name_counter += 1;
+        let sql = format!("CREATE INDEX IF NOT EXISTS {idx_name} ON {table_name}(val)");
+
+        if let Ok(true) = self.try_write(proc_idx, step, "CREATE INDEX", &sql) {
+            self.verify_cross_process_after_write(proc_idx, step);
+        }
+    }
+
+    /// INSERT 50-200 rows in a single BEGIN..COMMIT transaction.
+    /// Stresses page splits, B-tree rebalancing, overflow pages, and large
+    /// WAL writes. The entire batch must be atomically visible after COMMIT.
+    fn do_bulk_insert(&mut self, proc_idx: usize, step: usize) {
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+        // Don't start a bulk insert if already in a transaction.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        if !self.is_writer(proc_idx) {
+            return;
+        }
+
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let count = self.rng.random_range(20..80usize);
+
+        let conn = self.processes[proc_idx].conn().clone();
+        match conn.execute("BEGIN") {
+            Ok(_) => {}
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => return,
+            Err(e) => panic!(
+                "step {step}: BulkInsert BEGIN failed on process {proc_idx}: {e} (seed={})",
+                self.seed
+            ),
+        }
+
+        let mut inserted_rows = Vec::new();
+        let base_id = self.shadow.tables.get(&table_name).unwrap().next_id;
+        for i in 0..count {
+            let id = base_id + i as i64;
+            // Every 10th row uses a large value to exercise overflow pages.
+            let val = if i % 10 == 0 {
+                let len = self.rng.random_range(1000..2000usize);
+                let c = (b'a' + self.rng.random_range(0..26u8)) as char;
+                Some(std::iter::repeat_n(c, len).collect::<String>())
+            } else {
+                None
+            };
+            let sql = if let Some(ref v) = val {
+                format!("INSERT INTO {table_name}(id, val) VALUES ({id}, '{v}')")
+            } else {
+                format!("INSERT INTO {table_name}(id) VALUES ({id})")
+            };
+            match conn.execute(&sql) {
+                Ok(_) => {
+                    inserted_rows.push(ShadowRow { id, val });
+                }
+                Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                    // Lost the write lock mid-transaction — rollback.
+                    let _ = conn.execute("ROLLBACK");
+                    return;
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("no such table") {
+                        let _ = conn.execute("ROLLBACK");
+                        return;
+                    }
+                    panic!(
+                        "step {step}: BulkInsert INSERT failed on process {proc_idx}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+        }
+
+        match conn.execute("COMMIT") {
+            Ok(_) => {
+                // Bump next_id and add all rows to shadow.
+                let table = self.shadow.tables.get_mut(&table_name).unwrap();
+                table.next_id = base_id + count as i64;
+                for row in inserted_rows {
+                    table.rows.push(row);
+                }
+                if self.verbose {
+                    eprintln!("  -> bulk_insert({table_name}, {count} rows, base_id={base_id})");
+                }
+                self.verify_cross_process_after_write(proc_idx, step);
+            }
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                let _ = conn.execute("ROLLBACK");
+            }
+            Err(e) => {
+                panic!(
+                    "step {step}: BulkInsert COMMIT failed on process {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+    }
+
+    /// Tight TRUNCATE→write→TRUNCATE→write cycle. Each TRUNCATE checkpoint
+    /// resets the WAL (new salt, max_frame=0). The following write uses the
+    /// new salt. Other processes must detect the salt change and rescan.
+    /// Doing this 3 times in rapid succession stresses the salt change
+    /// detection path repeatedly.
+    fn do_rapid_wal_restart(&mut self, proc_idx: usize, step: usize) {
+        if self.should_skip_exclusive_write_op(proc_idx) {
+            return;
+        }
+
+        let conn = self.processes[proc_idx].conn().clone();
+        let pager = conn.pager.load();
+
+        for cycle in 0..3 {
+            // TRUNCATE checkpoint.
+            match pager.io.block(|| {
+                pager.checkpoint(
+                    CheckpointMode::Truncate {
+                        upper_bound_inclusive: None,
+                    },
+                    crate::SyncMode::Full,
+                    true,
+                )
+            }) {
+                Ok(_) => {}
+                Err(LimboError::Busy) => return,
+                Err(e) => {
+                    panic!(
+                        "step {step}: RapidWalRestart cycle {cycle} checkpoint failed on \
+                         process {proc_idx}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+
+            // Immediately insert — forces WAL restart with new salt.
+            let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+            let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+            let id = self.shadow.tables.get(&table_name).unwrap().next_id;
+            let sql = format!("INSERT INTO {table_name}(id) VALUES ({id})");
+
+            match self.try_write(proc_idx, step, "INSERT (wal-restart)", &sql) {
+                Ok(true) => {
+                    let table = self.shadow.tables.get_mut(&table_name).unwrap();
+                    table.next_id += 1;
+                    table.rows.push(ShadowRow { id, val: None });
+                }
+                Ok(false) => return,
+                Err(()) => unreachable!(),
+            }
+
+            // Cross-verify after each cycle — catches stale salt bugs.
+            self.verify_cross_process_after_write(proc_idx, step);
+        }
+
+        if self.verbose {
+            eprintln!("  -> rapid_wal_restart(3 cycles completed)");
+        }
+    }
+
+    /// Repeatable-read check: within a transaction, read all tables and
+    /// compare against what this process saw on its first read in this tx.
+    /// If the results differ (and this process hasn't done any writes since
+    /// the snapshot was captured), that's a real snapshot isolation violation.
+    ///
+    /// On the FIRST call after BEGIN, we capture the actual DB state as the
+    /// read snapshot. On subsequent calls, we re-read and compare. This
+    /// avoids the shadow-model inaccuracy of capturing at BEGIN time (since
+    /// DEFERRED BEGIN doesn't establish the snapshot until first read).
+    fn do_repeatable_read(&mut self, proc_idx: usize, step: usize) {
+        if !self.processes[proc_idx].in_transaction {
+            return;
+        }
+
+        let conn = self.processes[proc_idx].conn().clone();
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        if table_names.is_empty() {
+            return;
+        }
+
+        // Read current state from the DB.
+        let mut current_view: TableSnapshot = BTreeMap::new();
+        for table_name in &table_names {
+            let sql = format!("SELECT id, val FROM {table_name} ORDER BY id");
+            let mut stmt = match conn.prepare(&sql) {
+                Ok(s) => s,
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("no such table") {
+                        // Table might have been dropped — skip.
+                        continue;
+                    }
+                    panic!(
+                        "step {step}: RepeatableRead prepare failed on process \
+                         {proc_idx}, table {table_name}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            };
+            let rows = match stmt.run_collect_rows() {
+                Ok(r) => r,
+                Err(e) => {
+                    panic!(
+                        "step {step}: RepeatableRead query failed on process \
+                         {proc_idx}, table {table_name}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            };
+            let ctx = format!("step {step}: {table_name}");
+            let parsed = Self::parse_id_val_rows(&rows, &ctx, self.seed);
+            current_view.insert(table_name.clone(), parsed);
+        }
+
+        let process = &mut self.processes[proc_idx];
+        if process.tx_read_snapshot.is_none() {
+            // First read in this transaction — capture as baseline.
+            process.tx_read_snapshot = Some(current_view);
+            if self.verbose {
+                eprintln!("  -> repeatable_read: captured tx snapshot for proc {proc_idx}");
+            }
+        } else {
+            // Subsequent read — compare against baseline.
+            // Only compare tables that exist in both snapshots.
+            let baseline = process.tx_read_snapshot.as_ref().unwrap();
+            for (table_name, baseline_rows) in baseline {
+                if let Some(current_rows) = current_view.get(table_name) {
+                    if current_rows != baseline_rows {
+                        // Check if this process has pending changes to this table.
+                        // If so, the difference is expected and we can't compare.
+                        let has_pending =
+                            process.pending_inserts.iter().any(|(t, _)| t == table_name)
+                                || process.pending_deletes.iter().any(|(t, _)| t == table_name)
+                                || process
+                                    .pending_updates
+                                    .iter()
+                                    .any(|(t, _, _)| t == table_name);
+                        if !has_pending {
+                            panic!(
+                                "step {step}: SNAPSHOT ISOLATION VIOLATION on process \
+                                 {proc_idx}, table {table_name}!\n\
+                                 First read:  {baseline_rows:?}\n\
+                                 Second read: {current_rows:?}\n\
+                                 (seed={})",
+                                self.seed
+                            );
+                        }
+                    }
+                }
+            }
+            if self.verbose {
+                eprintln!("  -> repeatable_read: verified consistency for proc {proc_idx}");
+            }
+        }
+    }
+
+    /// Corrupt the WalIndex hash tables on a random process. This exercises
+    /// the find_frame fallthrough safety net: the WalIndex appears valid
+    /// (max_frame > 0, generation matches) but all hash lookups return None.
+    /// Subsequent reads must still succeed by falling through to inner.find_frame.
+    fn do_corrupt_wal_index(&mut self, proc_idx: usize, step: usize) {
+        let Some(db) = &self.processes[proc_idx].db else {
+            return;
+        };
+        let Some(wal_index) = &db.wal_index else {
+            return;
+        };
+        if wal_index.max_frame() == 0 {
+            return;
+        }
+
+        if self.verbose {
+            eprintln!(
+                "  -> corrupt_wal_index(proc={proc_idx}, max_frame={})",
+                wal_index.max_frame()
+            );
+        }
+        // corrupt_hash_tables zeroes ahash entries AND corrupts pgno_checksum.
+        wal_index.corrupt_hash_tables();
+
+        // verify_hash_integrity should detect the corruption and return an error.
+        // Recovery path: delete the tshm file and reopen. We don't test the
+        // full reopen cycle here (tested in mp_tests); just verify detection.
+        let result = wal_index.verify_hash_integrity();
+        assert!(
+            result.is_err(),
+            "step {step}: verify_hash_integrity should detect corruption \
+             (proc={proc_idx}, seed={})",
+            self.seed
+        );
+
+        // The WalIndex is shared mmap — corruption affects ALL processes.
+        // Mark every process as dead. Recovery requires deleting the tshm
+        // file and reopening (tested in mp_tests).
+        for p in &mut self.processes {
+            p.reset();
+        }
+        self.writer_owner = None;
+    }
+
+    /// Corrupt WalIndex hash tables but leave some reader processes alive.
+    /// This tests the cached_pgno_checksum check in find_frame: surviving
+    /// readers must detect the corruption (via verify_hash_integrity) and
+    /// return an error — never wrong data.
+    ///
+    /// Unlike do_corrupt_wal_index which kills ALL processes, this simulates
+    /// the scenario where a writer crashes after corrupting the WalIndex
+    /// and some readers still have the mmap'd shared memory.
+    fn do_corrupt_wal_index_partial(&mut self, proc_idx: usize, step: usize) {
+        let Some(db) = &self.processes[proc_idx].db else {
+            return;
+        };
+        let Some(wal_index) = &db.wal_index else {
+            return;
+        };
+        if wal_index.max_frame() == 0 {
+            return;
+        }
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+
+        if self.verbose {
+            eprintln!(
+                "  -> corrupt_wal_index_partial(proc={proc_idx}, max_frame={})",
+                wal_index.max_frame()
+            );
+        }
+
+        // Corrupt hash tables (zeroes ahash + sets pgno_checksum to 0xDEAD_BEEF).
+        wal_index.corrupt_hash_tables();
+
+        // Kill the corrupting process (simulates writer crash).
+        self.kill_process(proc_idx);
+
+        // Kill a random subset of OTHER processes, but leave at least one alive.
+        let alive_others: Vec<usize> = self
+            .processes
+            .iter()
+            .filter(|p| p.alive && p.id != proc_idx)
+            .map(|p| p.id)
+            .collect();
+
+        if alive_others.is_empty() {
+            // No other processes alive — restart one to test post-corruption open.
+            self.do_restart(proc_idx, step);
+            return;
+        }
+
+        // Kill random subset, keeping at least one survivor.
+        let max_kills = alive_others.len().saturating_sub(1);
+        let num_kills = if max_kills > 0 {
+            self.rng.random_range(0..=max_kills)
+        } else {
+            0
+        };
+        let mut to_kill = alive_others;
+        // Shuffle and take first num_kills.
+        for i in (1..to_kill.len()).rev() {
+            let j = self.rng.random_range(0..=i);
+            to_kill.swap(i, j);
+        }
+        for &kill_idx in &to_kill[..num_kills] {
+            self.kill_process(kill_idx);
+        }
+
+        // Surviving readers must detect corruption. Any SELECT must either
+        // return correct data or a Corrupt error — never wrong data.
+        // With the pgno_checksum check in find_frame, the first page lookup
+        // will detect the mismatch and call verify_hash_integrity, which
+        // returns Corrupt because corrupt_hash_tables changed pgno_checksum.
+        for p in &self.processes {
+            if !p.alive || p.in_transaction {
+                continue;
+            }
+            let conn = p.conn();
+            for table_name in self.shadow.tables.keys() {
+                let sql = format!("SELECT id, val FROM {table_name} ORDER BY id");
+                match conn.prepare(&sql) {
+                    Err(e) => {
+                        // Corruption detected at prepare — acceptable.
+                        let msg = e.to_string();
+                        assert!(
+                            msg.contains("corrupt") || msg.contains("Corrupt"),
+                            "step {step}: surviving process {} got unexpected error \
+                             (expected Corrupt): {e} (seed={})",
+                            p.id,
+                            self.seed
+                        );
+                    }
+                    Ok(mut stmt) => match stmt.run_collect_rows() {
+                        Err(e) => {
+                            let msg = e.to_string();
+                            assert!(
+                                msg.contains("corrupt") || msg.contains("Corrupt"),
+                                "step {step}: surviving process {} got unexpected error \
+                                 during SELECT (expected Corrupt): {e} (seed={})",
+                                p.id,
+                                self.seed
+                            );
+                        }
+                        Ok(rows) => {
+                            // If we got rows without error, they MUST be correct.
+                            let ctx = format!("step {step}: {table_name}");
+                            let actual = Self::parse_id_val_rows(&rows, &ctx, self.seed);
+                            let table = &self.shadow.tables[table_name];
+                            let mut expected: Vec<(i64, Option<String>)> =
+                                table.rows.iter().map(|r| (r.id, r.val.clone())).collect();
+                            expected.sort_by_key(|(id, _)| *id);
+                            assert_eq!(
+                                actual, expected,
+                                "step {step}: surviving process {} returned wrong data \
+                                 for {table_name} after WalIndex corruption! \
+                                 This is the exact bug we're testing against. (seed={})",
+                                p.id, self.seed
+                            );
+                        }
+                    },
+                }
+            }
+        }
+
+        // All surviving processes are now in a corrupted state — kill them.
+        // Recovery requires deleting the tshm file (tested by do_restart).
+        for p in &mut self.processes {
+            p.reset();
+        }
+        self.writer_owner = None;
+    }
+
+    /// Inject WalIndex append failures on a random process, then do a write.
+    /// The write succeeds (WAL frames are committed before WalIndex update),
+    /// but the WalIndex is cleared. Subsequent reads work because the cleared
+    /// WalIndex triggers the stale-generation fallback to inner.find_frame
+    /// (which was updated by inner.commit_prepared_frames).
+    /// No rescan_wal_from_disk — the inner frame_cache is current.
+    fn do_inject_wal_index_failure(&mut self, proc_idx: usize, step: usize) {
+        // Clone the Arc to avoid borrowing self immutably while we need &mut self.
+        let wal_index = self.processes[proc_idx]
+            .db
+            .as_ref()
+            .and_then(|db| db.wal_index.clone());
+        let Some(wal_index) = wal_index else {
+            return;
+        };
+        // Don't inject during a transaction — the shadow model gets confused.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+
+        // If WalIndex is empty (from a previous clear), skip injection.
+        // populate_wal_index in begin_write_tx would also fail, and that
+        // is a pre-commit failure (correctly propagated), not the post-commit
+        // WalIndex append failure we're testing here.
+        if wal_index.max_frame() == 0 {
+            return;
+        }
+
+        // Enable failure injection.
+        wal_index.inject_append_failure(true);
+
+        // Attempt a write — it should succeed at the WAL level. The WalIndex
+        // append fails and the index is cleared, but the data is committed.
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let id = self.shadow.tables.get(&table_name).unwrap().next_id;
+        let sql = format!("INSERT INTO {table_name}(id) VALUES ({id})");
+
+        let wrote = self.try_write(proc_idx, step, "INSERT (inject_failure)", &sql);
+
+        // Disable failure injection immediately.
+        wal_index.inject_append_failure(false);
+
+        if let Ok(true) = wrote {
+            if self.verbose {
+                eprintln!(
+                    "  -> inject_wal_index_failure: wrote id={id} to {table_name}, \
+                     wal_index cleared (no rescan)"
+                );
+            }
+            let table = self.shadow.tables.get_mut(&table_name).unwrap();
+            table.next_id += 1;
+            table.rows.push(ShadowRow { id, val: None });
+            // Verify ALL processes (not just 2) — the WalIndex was cleared,
+            // so every process must detect the stale generation and fall
+            // through to inner.find_frame correctly.
+            self.verify_all_processes(&format!(
+                "step {step} (after inject_wal_index_failure by proc {proc_idx})"
+            ));
+        }
+    }
+
+    /// BEGIN → INSERT multiple rows → ROLLBACK, then verify and do a normal
+    /// INSERT. Exercises WalIndex `rollback_to` which rebuilds hash tables,
+    /// and verifies that rolled-back frame slots can be reused by subsequent
+    /// writes.
+    fn do_write_and_rollback(&mut self, proc_idx: usize, step: usize) {
+        // Skip if already in a transaction.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+        // In SharedReads mode, only the writer can write.
+        if !self.is_writer(proc_idx) {
+            return;
+        }
+
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let num_rows = self.rng.random_range(3..=10usize);
+
+        let conn = self.processes[proc_idx].conn().clone();
+
+        // BEGIN
+        match conn.execute("BEGIN") {
+            Ok(_) => {}
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => return,
+            Err(e) => panic!(
+                "step {step}: WriteAndRollback BEGIN failed on process {proc_idx}: {e} (seed={})",
+                self.seed
+            ),
+        }
+
+        // INSERT multiple rows. Use next_id to get safe IDs but do NOT update
+        // the shadow — we will rollback.
+        let base_id = self.shadow.tables.get(&table_name).unwrap().next_id;
+        let mut inserted = 0;
+        for i in 0..num_rows {
+            let id = base_id + i as i64;
+            let sql = format!("INSERT INTO {table_name}(id) VALUES ({id})");
+            match conn.execute(&sql) {
+                Ok(_) => {
+                    inserted += 1;
+                }
+                Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                    // Lost write lock mid-transaction — rollback and bail.
+                    let _ = conn.execute("ROLLBACK");
+                    return;
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("no such table") {
+                        let _ = conn.execute("ROLLBACK");
+                        return;
+                    }
+                    panic!(
+                        "step {step}: WriteAndRollback INSERT failed on process {proc_idx}: \
+                         {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+        }
+
+        if inserted == 0 {
+            let _ = conn.execute("ROLLBACK");
+            return;
+        }
+
+        // ROLLBACK — triggers WalIndex rollback_to which rebuilds hash tables.
+        match conn.execute("ROLLBACK") {
+            Ok(_) => {}
+            Err(e) => {
+                panic!(
+                    "step {step}: WriteAndRollback ROLLBACK failed on process {proc_idx}: \
+                     {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        if self.verbose {
+            eprintln!(
+                "  -> write_and_rollback(proc={proc_idx}, table={table_name}, \
+                 {inserted} rows rolled back)"
+            );
+        }
+
+        // Shadow state should be unchanged — verify all processes see
+        // the pre-insert data.
+        self.verify_all_processes(&format!(
+            "step {step} (after WriteAndRollback on proc {proc_idx})"
+        ));
+
+        // Now do a normal INSERT (outside transaction) to verify the
+        // rolled-back frame slots are reusable and the WalIndex is consistent.
+        let post_id = self.shadow.tables.get(&table_name).unwrap().next_id;
+        // Bump next_id past the IDs we used for the rolled-back rows to
+        // avoid PK conflicts if the rollback was incomplete.
+        let safe_id = post_id.max(base_id + num_rows as i64);
+        let sql = format!("INSERT INTO {table_name}(id) VALUES ({safe_id})");
+
+        if let Ok(true) = self.try_write(proc_idx, step, "INSERT (post-rollback)", &sql) {
+            let table = self.shadow.tables.get_mut(&table_name).unwrap();
+            table.next_id = safe_id + 1;
+            table.rows.push(ShadowRow {
+                id: safe_id,
+                val: None,
+            });
+
+            if self.verbose {
+                eprintln!(
+                    "  -> write_and_rollback post-insert(proc={proc_idx}, \
+                     table={table_name}, id={safe_id})"
+                );
+            }
+
+            self.verify_all_processes(&format!(
+                "step {step} (after WriteAndRollback post-insert on proc {proc_idx})"
+            ));
+        }
+    }
+
+    /// BEGIN → INSERT (kept) → SAVEPOINT → INSERT more (discarded) →
+    /// ROLLBACK TO savepoint → RELEASE → COMMIT.
+    /// Exercises WalIndex::rollback_to with a mid-transaction frame,
+    /// which rebuilds segment hashes and recomputes pgno_checksum.
+    fn do_savepoint_rollback(&mut self, proc_idx: usize, step: usize) {
+        if self.processes[proc_idx].in_transaction || !self.is_writer(proc_idx) {
+            return;
+        }
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let conn = self.processes[proc_idx].conn().clone();
+
+        // BEGIN
+        match conn.execute("BEGIN") {
+            Ok(_) => {}
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => return,
+            Err(e) => panic!(
+                "step {step}: SavepointRollback BEGIN failed: {e} (seed={})",
+                self.seed
+            ),
+        }
+
+        // INSERT a row that we KEEP.
+        let keep_id = self.shadow.tables.get(&table_name).unwrap().next_id;
+        let keep_sql = format!("INSERT INTO {table_name}(id) VALUES ({keep_id})");
+        match conn.execute(&keep_sql) {
+            Ok(_) => {}
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                let _ = conn.execute("ROLLBACK");
+                return;
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("no such table") {
+                    let _ = conn.execute("ROLLBACK");
+                    return;
+                }
+                panic!(
+                    "step {step}: SavepointRollback INSERT(keep) failed: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        // SAVEPOINT
+        if conn.execute("SAVEPOINT sp1").is_err() {
+            let _ = conn.execute("ROLLBACK");
+            return;
+        }
+
+        // INSERT rows inside savepoint (these will be rolled back).
+        let n_discard = self.rng.random_range(3..=10usize);
+        let base_discard = keep_id + 1;
+        for i in 0..n_discard {
+            let id = base_discard + i as i64;
+            let sql = format!("INSERT INTO {table_name}(id) VALUES ({id})");
+            match conn.execute(&sql) {
+                Ok(_) => {}
+                Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                    let _ = conn.execute("ROLLBACK");
+                    return;
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("no such table") {
+                        let _ = conn.execute("ROLLBACK");
+                        return;
+                    }
+                    panic!(
+                        "step {step}: SavepointRollback INSERT(discard) failed: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+        }
+
+        // ROLLBACK TO savepoint — exercises WalIndex::rollback_to.
+        match conn.execute("ROLLBACK TO sp1") {
+            Ok(_) => {}
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK");
+                panic!(
+                    "step {step}: SavepointRollback ROLLBACK TO failed: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        // RELEASE savepoint
+        let _ = conn.execute("RELEASE sp1");
+
+        // COMMIT — should only contain keep_id.
+        match conn.execute("COMMIT") {
+            Ok(_) => {
+                let table = self.shadow.tables.get_mut(&table_name).unwrap();
+                table.next_id = base_discard + n_discard as i64;
+                table.rows.push(ShadowRow {
+                    id: keep_id,
+                    val: None,
+                });
+                if self.verbose {
+                    eprintln!(
+                        "  -> savepoint_rollback(proc={proc_idx}, table={table_name}, \
+                         kept id={keep_id}, discarded {n_discard} rows)"
+                    );
+                }
+                self.verify_cross_process_after_write(proc_idx, step);
+            }
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                let _ = conn.execute("ROLLBACK");
+            }
+            Err(e) => panic!(
+                "step {step}: SavepointRollback COMMIT failed: {e} (seed={})",
+                self.seed
+            ),
+        }
+    }
+
+    /// Truncate checkpoint → read from ALL alive processes without any
+    /// intervening write. After truncate the WAL is empty and data lives
+    /// only in the database file. Processes must detect the TSHM change,
+    /// invalidate page cache, and read from the DB file (not stale WAL).
+    fn do_read_after_truncate(&mut self, proc_idx: usize, step: usize) {
+        if self.should_skip_exclusive_write_op(proc_idx) {
+            return;
+        }
+
+        let conn = self.processes[proc_idx].conn().clone();
+        let pager = conn.pager.load();
+
+        // Truncate checkpoint — WAL becomes empty, data in DB file.
+        match pager.io.block(|| {
+            pager.checkpoint(
+                CheckpointMode::Truncate {
+                    upper_bound_inclusive: None,
+                },
+                crate::SyncMode::Full,
+                true,
+            )
+        }) {
+            Ok(_) => {}
+            Err(LimboError::Busy) => return,
+            Err(e) => {
+                panic!(
+                    "step {step}: ReadAfterTruncate checkpoint failed on \
+                     process {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        // Verify ALL alive non-transacting processes see correct data
+        // WITHOUT any intervening write. The WAL is empty — data must
+        // come from the database file, not stale page cache.
+        for p in &self.processes {
+            if !p.alive || p.in_transaction {
+                continue;
+            }
+            let context = format!(
+                "step {step} (ReadAfterTruncate: proc {} reading after \
+                 truncate by proc {proc_idx})",
+                p.id
+            );
+            self.verify_shadow(p.conn(), p.id, &context, &self.shadow.tables);
+        }
+
+        if self.verbose {
+            eprintln!("  -> read_after_truncate(checkpoint by proc {proc_idx}, all verified)");
+        }
+    }
+
+    /// Full checkpoint by one process, then a DIFFERENT process writes.
+    /// The writer must discover the WAL restart through TSHM observation,
+    /// sync its internal state, and produce correct results.
+    fn do_checkpoint_then_cross_write(&mut self, proc_idx: usize, step: usize) {
+        // SharedReads: only one process can write, so cross-write is impossible.
+        if self.locking_mode == LockingMode::SharedReads {
+            return;
+        }
+        if self.should_skip_exclusive_write_op(proc_idx) {
+            return;
+        }
+
+        // Full checkpoint by proc_idx.
+        let conn = self.processes[proc_idx].conn().clone();
+        let pager = conn.pager.load();
+        match pager
+            .io
+            .block(|| pager.checkpoint(CheckpointMode::Full, crate::SyncMode::Full, true))
+        {
+            Ok(_) => {}
+            Err(LimboError::Busy) => return,
+            Err(e) => {
+                panic!(
+                    "step {step}: CheckpointThenCrossWrite checkpoint failed on process \
+                     {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        // Pick a DIFFERENT alive, non-transacting process to write.
+        let writer_idx = self
+            .processes
+            .iter()
+            .find(|p| p.alive && p.id != proc_idx && !p.in_transaction)
+            .map(|p| p.id);
+        let Some(writer_idx) = writer_idx else {
+            return;
+        };
+
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let id = self.shadow.tables.get(&table_name).unwrap().next_id;
+        let sql = format!("INSERT INTO {table_name}(id) VALUES ({id})");
+
+        if let Ok(true) = self.try_write(writer_idx, step, "INSERT (cross-write)", &sql) {
+            if self.verbose {
+                eprintln!(
+                    "  -> checkpoint_then_cross_write: checkpoint by proc {proc_idx}, \
+                     write by proc {writer_idx}, table={table_name}, id={id}"
+                );
+            }
+            let table = self.shadow.tables.get_mut(&table_name).unwrap();
+            table.next_id += 1;
+            table.rows.push(ShadowRow { id, val: None });
+            self.verify_all_processes(&format!(
+                "step {step} (after CheckpointThenCrossWrite: checkpoint by proc {proc_idx}, \
+                 write by proc {writer_idx})"
+            ));
+        }
+    }
+
+    /// WalIndex append failure with injection kept active across recovery.
+    /// The first write triggers recover_wal_index, where populate_wal_index
+    /// ALSO fails (injection still active). This exercises the double-failure
+    /// path with cache invalidation. A second write forces a full rescan.
+    fn do_inject_wal_index_double_failure(&mut self, proc_idx: usize, step: usize) {
+        let wal_index = self.processes[proc_idx]
+            .db
+            .as_ref()
+            .and_then(|db| db.wal_index.clone());
+        let Some(wal_index) = wal_index else {
+            return;
+        };
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+        if wal_index.max_frame() == 0 {
+            return;
+        }
+
+        // Enable failure injection — stays active across both writes.
+        wal_index.inject_append_failure(true);
+
+        // First write: append_frame fails → recover_wal_index called →
+        // populate_wal_index also fails (injection active) → double failure
+        // path with cache invalidation.
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let id1 = self.shadow.tables.get(&table_name).unwrap().next_id;
+        let sql1 = format!("INSERT INTO {table_name}(id) VALUES ({id1})");
+
+        // Use conn.execute directly — try_write panics on InternalError,
+        // but populate_wal_index failing in begin_write_tx returns that.
+        let conn1 = self.processes[proc_idx].conn().clone();
+        let wrote1 = match conn1.execute(&sql1) {
+            Ok(_) => true,
+            Err(LimboError::Busy | LimboError::BusySnapshot) => false,
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("injected") || msg.contains("no such table") {
+                    false
+                } else {
+                    panic!(
+                        "step {step}: INSERT (double-fail-1) unexpected error on process \
+                         {proc_idx}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+        };
+
+        // Second write: begin_write_tx detects cached_writer_state=0 (reset
+        // by double failure), rescans from disk (succeeds), then
+        // populate_wal_index fails again. Inner frame_cache is correct.
+        let id2 = id1 + 1;
+        let sql2 = format!("INSERT INTO {table_name}(id) VALUES ({id2})");
+        let conn2 = self.processes[proc_idx].conn().clone();
+        let wrote2 = match conn2.execute(&sql2) {
+            Ok(_) => true,
+            Err(LimboError::Busy | LimboError::BusySnapshot) => false,
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("injected") || msg.contains("no such table") {
+                    false
+                } else {
+                    panic!(
+                        "step {step}: INSERT (double-fail-2) unexpected error on process \
+                         {proc_idx}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+        };
+
+        // Disable injection.
+        wal_index.inject_append_failure(false);
+
+        // Update shadow for successful writes.
+        let mut wrote_count = 0;
+        if wrote1 {
+            let table = self.shadow.tables.get_mut(&table_name).unwrap();
+            table.next_id += 1;
+            table.rows.push(ShadowRow { id: id1, val: None });
+            wrote_count += 1;
+        }
+        if wrote2 {
+            let table = self.shadow.tables.get_mut(&table_name).unwrap();
+            if table.next_id <= id2 {
+                table.next_id = id2 + 1;
+            }
+            table.rows.push(ShadowRow { id: id2, val: None });
+            wrote_count += 1;
+        }
+
+        if wrote_count > 0 {
+            if self.verbose {
+                eprintln!(
+                    "  -> inject_wal_index_double_failure: {wrote_count} writes succeeded \
+                     on proc {proc_idx}, table={table_name}"
+                );
+            }
+            self.verify_all_processes(&format!(
+                "step {step} (after inject_wal_index_double_failure by proc {proc_idx})"
+            ));
+        }
+    }
+
+    /// Large INSERT within a transaction with a tiny page cache, forcing
+    /// the pager to spill dirty pages via `append_frames_vectored`. This
+    /// exercises the `pending_spill_max_frame` lifecycle:
+    /// - `append_frames_vectored` sets pending_spill_max_frame (no commit_max_frame)
+    /// - `finish_append_frames_commit` commits the pending value
+    /// - Cross-process readers must see the committed data
+    ///
+    /// When `commit` is false, exercises the rollback path:
+    /// - `rollback(None)` clears pending_spill_max_frame and calls cleanup_uncommitted
+    /// - Cross-process readers must NOT see the rolled-back data
+    fn do_spill_transaction(&mut self, proc_idx: usize, step: usize, commit: bool) {
+        if !self.is_writer(proc_idx) {
+            return;
+        }
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+
+        let conn = self.processes[proc_idx].conn().clone();
+
+        // NOTE: We intentionally do NOT set a tiny cache_size here.
+        // PRAGMA cache_size = 10 causes data loss with the current pager
+        // (pre-existing bug unrelated to multi-process WAL). Instead, we
+        // rely on large row values below to trigger spilling under the
+        // default cache size.
+
+        // BEGIN
+        match conn.execute("BEGIN") {
+            Ok(_) => {}
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => return,
+            Err(e) => {
+                panic!(
+                    "step {step}: SpillTransaction BEGIN failed on process \
+                     {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+
+        // Insert many rows with large values to dirty many pages and
+        // potentially trigger spilling with the default cache size.
+        let count = self.rng.random_range(100..300usize);
+        let mut inserted_ids = Vec::new();
+        let base_id = self.shadow.tables.get(&table_name).unwrap().next_id;
+
+        for i in 0..count {
+            let id = base_id + i as i64;
+            // Large value (~500 bytes) to maximize page dirtying and
+            // increase the chance of triggering cache spill.
+            let val = format!("spill_{i:0>500}");
+            let sql = format!("INSERT INTO {table_name}(id, val) VALUES ({id}, '{val}')");
+            match conn.execute(&sql) {
+                Ok(_) => {
+                    inserted_ids.push(id);
+                }
+                Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                    let _ = conn.execute("ROLLBACK");
+                    return;
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("no such table") {
+                        let _ = conn.execute("ROLLBACK");
+                        return;
+                    }
+                    panic!(
+                        "step {step}: SpillTransaction INSERT failed on process \
+                         {proc_idx}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+        }
+
+        let op_name = if commit {
+            "SpillAndCommit"
+        } else {
+            "SpillAndRollback"
+        };
+
+        if commit {
+            match conn.execute("COMMIT") {
+                Ok(_) => {}
+                Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                    let _ = conn.execute("ROLLBACK");
+                    return;
+                }
+                Err(e) => {
+                    panic!(
+                        "step {step}: {op_name} COMMIT failed on process \
+                         {proc_idx}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+
+            // Update shadow state.
+            let table = self.shadow.tables.get_mut(&table_name).unwrap();
+            for &id in &inserted_ids {
+                let idx = id - base_id;
+                let val = format!("spill_{idx:0>500}");
+                table.rows.push(ShadowRow { id, val: Some(val) });
+            }
+            table.next_id = base_id + inserted_ids.len() as i64;
+
+            if self.verbose {
+                eprintln!(
+                    "  -> {op_name}: inserted {} rows into {table_name} on proc {proc_idx}",
+                    inserted_ids.len()
+                );
+            }
+
+            // Verify cross-process visibility.
+            self.verify_cross_process_after_write(proc_idx, step);
+        } else {
+            match conn.execute("ROLLBACK") {
+                Ok(_) => {}
+                Err(e) => {
+                    panic!(
+                        "step {step}: {op_name} ROLLBACK failed on process \
+                         {proc_idx}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+
+            if self.verbose {
+                eprintln!(
+                    "  -> {op_name}: rolled back {} rows from {table_name} on proc {proc_idx}",
+                    inserted_ids.len()
+                );
+            }
+
+            // Verify no data leaked — all processes see pre-rollback state.
+            self.verify_all_processes(&format!("step {step} (after {op_name} by proc {proc_idx})"));
+        }
+    }
+
+    fn do_create_table(&mut self, proc_idx: usize, step: usize) {
+        // Don't do DDL inside a transaction — the shadow model doesn't
+        // track pending DDL changes.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        let name = self.shadow.next_name("t");
+        let sql = format!("CREATE TABLE {name}(id INTEGER PRIMARY KEY, val TEXT)");
+        if let Ok(true) = self.try_write(proc_idx, step, "CREATE TABLE", &sql) {
+            self.shadow.tables.insert(
+                name,
+                ShadowTable {
+                    rows: Vec::new(),
+                    next_id: 1,
+                },
+            );
+            self.verify_cross_process_after_write(proc_idx, step);
+        }
+    }
+
+    fn do_drop_table(&mut self, proc_idx: usize, step: usize) {
+        if self.shadow.tables.len() <= 1 {
+            return;
+        }
+        // Don't do DDL inside a transaction — the shadow model doesn't
+        // track pending DDL changes.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        let name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let sql = format!("DROP TABLE {name}");
+        if let Ok(true) = self.try_write(proc_idx, step, "DROP TABLE", &sql) {
+            self.shadow.tables.remove(&name);
+            self.verify_cross_process_after_write(proc_idx, step);
+        }
+    }
+
+    /// Insert a duplicate PK to exercise the savepoint rollback path.
+    /// The INSERT must fail with a constraint violation, and the database
+    /// must remain consistent (shadow state unchanged).
+    fn do_insert_conflict(&mut self, proc_idx: usize, step: usize) {
+        if self.shadow.tables.is_empty() {
+            return;
+        }
+        // In SharedReads mode, only the writer can attempt writes.
+        if !self.is_writer(proc_idx) {
+            return;
+        }
+        // Skip conflict testing for in-transaction processes. Within an
+        // explicit transaction, begin_write_tx may rescan the WAL and
+        // upgrade the read snapshot to include other processes' commits,
+        // making the snapshot_tables (captured at BEGIN time) stale.
+        // The shadow model can't track this snapshot upgrade, so
+        // writer_view() may not match what the process actually sees.
+        // Conflict testing for autocommit processes (the common case)
+        // is unaffected and still exercises the savepoint rollback path.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+
+        let table_names: Vec<String> = self.shadow.tables.keys().cloned().collect();
+        if table_names.is_empty() {
+            return;
+        }
+        let table_name = table_names[self.rng.random_range(0..table_names.len())].clone();
+        let table = self.shadow.tables.get(&table_name).unwrap();
+        if table.rows.is_empty() {
+            return;
+        }
+        // Pick an existing row's ID to cause a PK conflict.
+        let existing_id = table.rows[self.rng.random_range(0..table.rows.len())].id;
+        let sql = format!("INSERT INTO {table_name}(id) VALUES ({existing_id})");
+
+        let conn = self.processes[proc_idx].conn().clone();
+        match conn.execute(&sql) {
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                // Another process holds the write lock — expected in SharedWrites.
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                // "no such table" can happen if another process dropped the
+                // table after our snapshot was captured and the schema was
+                // reloaded during write lock acquisition.
+                if !msg.contains("UNIQUE constraint") && !msg.contains("no such table") {
+                    panic!(
+                        "step {step}: INSERT conflict expected UNIQUE constraint error, \
+                         got: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+            Ok(_) => {
+                panic!(
+                    "step {step}: INSERT with duplicate PK {existing_id} into {table_name} \
+                     should have failed but succeeded (seed={})",
+                    self.seed
+                );
+            }
+        }
+        // Shadow state must be unchanged — verify the writing process sees correct data.
+        if !self.processes[proc_idx].in_transaction {
+            self.verify_shadow(
+                &conn,
+                proc_idx,
+                &format!("step {step} (after conflict)"),
+                &self.shadow.tables,
+            );
+        }
+    }
+
+    /// Checkpoint via PRAGMA wal_checkpoint(MODE) SQL — exercises the real
+    /// user-facing code path through the bytecode interpreter.
+    fn do_sql_checkpoint(&mut self, proc_idx: usize, step: usize) {
+        // In SharedReads mode, only the writer should checkpoint.
+        if !self.is_writer(proc_idx) {
+            return;
+        }
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        if self.any_open_tx() {
+            return;
+        }
+
+        let modes = ["PASSIVE", "FULL", "RESTART", "TRUNCATE"];
+        let mode_str = modes[self.rng.random_range(0..modes.len())];
+        let sql = format!("PRAGMA wal_checkpoint({mode_str})");
+
+        let conn = self.processes[proc_idx].conn().clone();
+        match conn.execute(&sql) {
+            Ok(_) => {}
+            Err(LimboError::Busy) => {}
+            Err(e) => {
+                panic!(
+                    "step {step}: PRAGMA wal_checkpoint({mode_str}) failed on process \
+                     {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+    }
+
+    /// Graceful close: calls Connection::close() which triggers
+    /// checkpoint_shutdown when it's the last connection. This exercises
+    /// a different code path from crash (which just drops).
+    fn do_graceful_close(&mut self, proc_idx: usize, step: usize) {
+        if !self.processes[proc_idx].alive {
+            return;
+        }
+        // Don't close during a transaction — would need rollback first.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        // Don't close while another process has an open transaction.
+        // Close triggers checkpoint_shutdown which can truncate the WAL,
+        // invalidating other processes' read snapshots. In real multi-process
+        // operation, TSHM reader slots prevent this; we simulate that here.
+        if self.any_open_tx() {
+            return;
+        }
+
+        let was_writer_owner = self.writer_owner == Some(proc_idx);
+        if was_writer_owner {
+            self.writer_owner = None;
+        }
+
+        let conn = self.processes[proc_idx].conn.take().unwrap();
+        match conn.close() {
+            Ok(_) => {}
+            Err(e) => {
+                // checkpoint_shutdown can fail with Busy if other processes
+                // are active — this is expected in multi-process scenarios.
+                let msg = e.to_string();
+                if !msg.contains("Busy") && !msg.to_lowercase().contains("busy") {
+                    panic!(
+                        "step {step}: close() failed on process {proc_idx}: {e} (seed={})",
+                        self.seed
+                    );
+                }
+            }
+        }
+        drop(conn);
+        self.kill_process(proc_idx);
+
+        // Verify remaining alive processes still see correct data.
+        self.verify_all_processes(&format!(
+            "step {step} (after graceful close of proc {proc_idx})"
+        ));
+    }
+
+    fn do_crash(&mut self, proc_idx: usize, step: usize) {
+        let process = &mut self.processes[proc_idx];
+        if !process.alive {
+            return;
+        }
+
+        tracing::debug!("step {step}: crashing process {proc_idx}");
+
+        let was_writer_owner = self.writer_owner == Some(proc_idx);
+
+        // Discard any pending transaction state — crash = implicit rollback.
+        self.kill_process(proc_idx);
+
+        // After the writer owner crashes, verify another alive process
+        // can take over writing.
+        if self.locking_mode == LockingMode::SharedReads && was_writer_owner {
+            self.verify_writer_takeover(proc_idx, step);
+        }
+    }
+
+    fn verify_writer_takeover(&mut self, crashed_proc: usize, step: usize) {
+        // Only use a non-transacting process for takeover verification.
+        // If the candidate is in a transaction, the INSERT would go into that
+        // transaction's uncommitted state, not be committed immediately.
+        let candidate = self
+            .processes
+            .iter()
+            .find(|p| p.alive && !p.in_transaction)
+            .map(|p| p.id);
+        let Some(alive_id) = candidate else {
+            // All alive processes are in transactions — can't verify takeover
+            // with an autocommit write. The actual takeover will be tested
+            // when a fresh process restarts later.
+            return;
+        };
+        let Some(table_name) = self.shadow.tables.keys().next().cloned() else {
+            return;
+        };
+        let id = self.shadow.tables.get(&table_name).unwrap().next_id;
+        let sql = format!("INSERT INTO {table_name}(id) VALUES ({id})");
+
+        match self.try_write(alive_id, step, "INSERT (takeover)", &sql) {
+            Ok(true) => {
+                if self.verbose {
+                    eprintln!("  -> shadow_insert_takeover({table_name}, id={id})");
+                }
+                let table = self.shadow.tables.get_mut(&table_name).unwrap();
+                table.next_id += 1;
+                table.rows.push(ShadowRow { id, val: None });
+            }
+            Ok(false) => {
+                panic!(
+                    "step {step}: writer takeover failed! Process {alive_id} could not write \
+                     after writer owner {crashed_proc} crashed. (seed={})",
+                    self.seed
+                );
+            }
+            Err(()) => unreachable!(),
+        }
+    }
+
+    fn do_restart(&mut self, proc_idx: usize, step: usize) {
+        if self.processes[proc_idx].alive {
+            return;
+        }
+
+        tracing::debug!("step {step}: restarting process {proc_idx}");
+        let db = match open_bypass_registry(&self.db_path, self.locking_mode) {
+            Ok(db) => db,
+            Err(crate::LimboError::Corrupt(_)) => {
+                // Corrupt tshm — delete and retry (user recovery path).
+                let tshm_path = format!("{}-tshm", self.db_path);
+                let _ = std::fs::remove_file(&tshm_path);
+                if self.verbose {
+                    eprintln!("  -> restart(proc={proc_idx}): corrupt tshm, deleted and retrying");
+                }
+                open_bypass_registry(&self.db_path, self.locking_mode).unwrap_or_else(|e| {
+                    panic!(
+                        "step {step}: failed to restart process {proc_idx} after tshm delete: \
+                         {e} (seed={})",
+                        self.seed
+                    );
+                })
+            }
+            Err(e) => {
+                panic!(
+                    "step {step}: failed to restart process {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        };
+        let conn = db.connect().unwrap();
+
+        // A freshly opened process sees committed data only
+        // (uncommitted frames have no commit marker on disk).
+        self.verify_shadow(
+            &conn,
+            proc_idx,
+            &format!("step {step} (restart)"),
+            &self.shadow.tables,
+        );
+
+        let process = &mut self.processes[proc_idx];
+        process.db = Some(db);
+        process.conn = Some(conn);
+        process.alive = true;
+        process.in_transaction = false;
+
+        if self.locking_mode == LockingMode::SharedReads && self.writer_owner.is_none() {
+            self.writer_owner = Some(proc_idx);
+        }
+    }
+
+    fn do_integrity_check(&self, proc_idx: usize, step: usize) {
+        // Skip integrity check during transaction — it may conflict.
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        let conn = self.processes[proc_idx].conn();
+        let mut stmt = conn.prepare("PRAGMA integrity_check").unwrap_or_else(|e| {
+            panic!(
+                "step {step}: integrity_check prepare failed on process {proc_idx}: {e} \
+                 (seed={})",
+                self.seed
+            );
+        });
+        let rows = stmt.run_collect_rows().unwrap_or_else(|e| {
+            panic!(
+                "step {step}: integrity_check failed on process {proc_idx}: {e} (seed={})",
+                self.seed
+            );
+        });
+        match &rows[0][0] {
+            Value::Text(s) => {
+                if s.as_ref() != "ok" {
+                    panic!(
+                        "step {step}: integrity_check failed on process {proc_idx} (seed={}): {s}",
+                        self.seed
+                    );
+                }
+            }
+            other => panic!(
+                "step {step}: unexpected integrity result: {other:?} (seed={})",
+                self.seed
+            ),
+        }
+    }
+
+    // --- Transaction operations ---
+
+    fn do_begin_tx(&mut self, proc_idx: usize, step: usize) {
+        if self.processes[proc_idx].in_transaction {
+            return;
+        }
+        let conn = self.processes[proc_idx].conn().clone();
+        match conn.execute("BEGIN") {
+            Ok(_) => {
+                self.processes[proc_idx].in_transaction = true;
+                // Capture the committed state as this process's snapshot.
+                self.processes[proc_idx].snapshot_tables = Some(self.shadow.tables.clone());
+            }
+            Err(LimboError::Busy) => {}
+            Err(e) => {
+                panic!(
+                    "step {step}: BEGIN failed on process {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+    }
+
+    fn do_commit(&mut self, proc_idx: usize, step: usize) {
+        if !self.processes[proc_idx].in_transaction {
+            return;
+        }
+        let conn = self.processes[proc_idx].conn().clone();
+        match conn.execute("COMMIT") {
+            Ok(_) => {
+                // Merge pending changes into global shadow state.
+                let pending_inserts = std::mem::take(&mut self.processes[proc_idx].pending_inserts);
+                let pending_deletes = std::mem::take(&mut self.processes[proc_idx].pending_deletes);
+                let pending_updates = std::mem::take(&mut self.processes[proc_idx].pending_updates);
+                self.processes[proc_idx].in_transaction = false;
+                self.processes[proc_idx].snapshot_tables = None;
+                self.processes[proc_idx].tx_read_snapshot = None;
+
+                for (table_name, row) in pending_inserts {
+                    if self.verbose {
+                        eprintln!("  -> commit_merge_insert({table_name}, id={})", row.id);
+                    }
+                    if let Some(table) = self.shadow.tables.get_mut(&table_name) {
+                        table.rows.push(row);
+                    }
+                    // If table was dropped during the tx, the insert was
+                    // already lost — skip silently.
+                }
+                for (table_name, id) in pending_deletes {
+                    if let Some(table) = self.shadow.tables.get_mut(&table_name) {
+                        table.rows.retain(|r| r.id != id);
+                    }
+                }
+                for (table_name, id, new_val) in pending_updates {
+                    if let Some(table) = self.shadow.tables.get_mut(&table_name) {
+                        if let Some(row) = table.rows.iter_mut().find(|r| r.id == id) {
+                            row.val = Some(new_val);
+                        }
+                    }
+                }
+
+                // The committing process is now non-transacting — verify
+                // it sees the updated committed state.
+                self.verify_cross_process_after_write(proc_idx, step);
+            }
+            Err(LimboError::Busy) | Err(LimboError::BusySnapshot) => {
+                // COMMIT failed due to contention or stale snapshot —
+                // transaction stays open, caller may retry or rollback.
+            }
+            Err(e) => {
+                panic!(
+                    "step {step}: COMMIT failed on process {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+    }
+
+    fn do_rollback(&mut self, proc_idx: usize, step: usize) {
+        if !self.processes[proc_idx].in_transaction {
+            return;
+        }
+        let conn = self.processes[proc_idx].conn().clone();
+        match conn.execute("ROLLBACK") {
+            Ok(_) => {
+                // Discard all pending changes.
+                self.processes[proc_idx].pending_inserts.clear();
+                self.processes[proc_idx].pending_updates.clear();
+                self.processes[proc_idx].pending_deletes.clear();
+                self.processes[proc_idx].in_transaction = false;
+                self.processes[proc_idx].snapshot_tables = None;
+                self.processes[proc_idx].tx_read_snapshot = None;
+            }
+            Err(e) => {
+                panic!(
+                    "step {step}: ROLLBACK failed on process {proc_idx}: {e} (seed={})",
+                    self.seed
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test entry points
+// ---------------------------------------------------------------------------
+
+fn pick_seed() -> u64 {
+    match std::env::var("SEED").ok().and_then(|s| s.parse().ok()) {
+        Some(seed) => seed,
+        None => {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64
+        }
+    }
+}
+
+#[test]
+fn test_mp_generative() {
+    let seed = pick_seed();
+    eprintln!("test_mp_generative: seed={seed}");
+    MpSimulator::new(seed, 4, 10_000, LockingMode::SharedWrites).run();
+}
+
+#[test]
+fn test_mp_generative_shared_reads() {
+    let seed = pick_seed();
+    eprintln!("test_mp_generative_shared_reads: seed={seed}");
+    MpSimulator::new(seed, 4, 10_000, LockingMode::SharedReads).run();
+}
+
+/// More processes = more contention on TSHM reader slots, write locks,
+/// and page cache. Tests scenarios with higher fan-out.
+#[test]
+fn test_mp_generative_many_processes() {
+    let seed = pick_seed();
+    eprintln!("test_mp_generative_many_processes: seed={seed}");
+    MpSimulator::new(seed, 8, 10_000, LockingMode::SharedWrites).run();
+}

--- a/core/storage/mp_tests.rs
+++ b/core/storage/mp_tests.rs
@@ -1,0 +1,2632 @@
+//! Multi-process WAL scenario tests.
+//!
+//! Each test simulates multiple "virtual processes" by opening separate
+//! `Database` instances on the same file. This gives:
+//! - Real flock behavior (separate OFDs = real mutual exclusion)
+//! - Real mmap behavior (same physical pages via kernel)
+//! - Deterministic operation ordering (sequential, single-thread)
+//!
+//! The only sharing between instances is through filesystem objects
+//! (WAL file + TSHM mmap), exactly as with real cross-process access.
+
+use std::sync::Arc;
+
+use crate::io::{OpenFlags, PlatformIO, IO};
+use crate::storage::database::DatabaseFile;
+use crate::storage::multi_process_wal::MultiProcessWal;
+use crate::storage::tshm::NUM_READER_SLOTS;
+use crate::storage::wal::CheckpointMode;
+use crate::types::Value;
+use crate::util::IOExt;
+use crate::{Connection, Database, DatabaseOpts, LimboError, LockingMode};
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+// ---------------------------------------------------------------------------
+
+/// Create a fresh WAL-mode database in a temp directory. Returns the Database,
+/// a Connection, and the directory path (kept alive to prevent cleanup).
+fn open_mp_database() -> (Arc<Database>, Arc<Connection>, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let mut db_path = dir.clone();
+    db_path.push("test.db");
+
+    // Create the database via rusqlite so the file exists and is WAL-mode.
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.pragma_update(None, "journal_mode", "wal").unwrap();
+    }
+
+    let (db, conn) = open_with_mode(&dir, LockingMode::SharedWrites);
+    (db, conn, dir)
+}
+
+/// Open another "virtual process" on the same database directory.
+fn open_second_process(dir: &std::path::Path) -> (Arc<Database>, Arc<Connection>) {
+    open_with_mode(dir, LockingMode::SharedWrites)
+}
+
+/// Open a "virtual process" on the given directory with a specific locking mode.
+///
+/// IMPORTANT: Bypasses the process-wide database registry to create a truly
+/// independent Database instance with its own file descriptors and TSHM,
+/// simulating a separate OS process. The default `open_file_with_flags`
+/// returns the same Arc<Database> from the registry, which defeats
+/// multi-process flock-based exclusion testing.
+fn try_open_with_mode(
+    dir: &std::path::Path,
+    mode: LockingMode,
+) -> crate::Result<(Arc<Database>, Arc<Connection>)> {
+    let mut db_path = dir.to_path_buf();
+    db_path.push("test.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let wal_path = format!("{db_path_str}-wal");
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let mut flags = OpenFlags::default();
+    if mode.is_shared() {
+        flags |= OpenFlags::SharedLock;
+    }
+    let file = io.open_file(db_path_str, flags, true).unwrap();
+    let db_file = Arc::new(DatabaseFile::new(file));
+    let opts = DatabaseOpts::new()
+        .with_locking_mode(mode)
+        .with_shared_access(mode.is_shared());
+    let mut state = crate::OpenDbAsyncState::new();
+    let db = loop {
+        match Database::open_with_flags_bypass_registry_async(
+            &mut state,
+            io.clone(),
+            db_path_str,
+            Some(&wal_path),
+            db_file.clone(),
+            flags,
+            opts,
+            None,
+        )? {
+            crate::IOResult::Done(db) => break db,
+            crate::IOResult::IO(io_completion) => {
+                io_completion.wait(&*io).unwrap();
+            }
+        }
+    };
+    let conn = db.connect()?;
+    Ok((db, conn))
+}
+
+fn open_with_mode(dir: &std::path::Path, mode: LockingMode) -> (Arc<Database>, Arc<Connection>) {
+    match try_open_with_mode(dir, mode) {
+        Ok(result) => result,
+        Err(e) => panic!("open_with_mode failed: {e}"),
+    }
+}
+
+/// Execute a SQL statement (no result rows expected).
+fn exec(conn: &Arc<Connection>, sql: &str) {
+    conn.execute(sql).unwrap();
+}
+
+/// Execute a SQL statement, collecting all result rows.
+fn query_rows(conn: &Arc<Connection>, sql: &str) -> Vec<Vec<Value>> {
+    let mut stmt = conn.prepare(sql).unwrap();
+    stmt.run_collect_rows().unwrap()
+}
+
+/// Execute a SQL query and return the single integer value from the first row.
+fn query_i64(conn: &Arc<Connection>, sql: &str) -> i64 {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let mut val: i64 = 0;
+    stmt.run_with_row_callback(|row| {
+        val = row.get(0).unwrap();
+        Ok(())
+    })
+    .unwrap();
+    val
+}
+
+/// Assert PRAGMA integrity_check returns "ok".
+fn assert_integrity_ok(conn: &Arc<Connection>) {
+    let rows = query_rows(conn, "PRAGMA integrity_check");
+    assert!(!rows.is_empty(), "integrity_check returned no rows");
+    match &rows[0][0] {
+        Value::Text(s) => assert_eq!(s.as_ref(), "ok", "integrity_check failed: {s}"),
+        other => panic!("unexpected integrity_check result: {other:?}"),
+    }
+}
+
+/// Run a passive checkpoint to completion via the pager.
+fn run_checkpoint(conn: &Arc<Connection>, mode: CheckpointMode) {
+    let pager = conn.pager.load();
+    pager
+        .io
+        .block(|| pager.checkpoint(mode, crate::SyncMode::Full, true))
+        .unwrap();
+}
+
+/// Get the current max_frame from the WAL.
+fn wal_max_frame(conn: &Arc<Connection>) -> u64 {
+    let pager = conn.pager.load();
+    pager.wal_state().unwrap().max_frame
+}
+
+// ---------------------------------------------------------------------------
+// S1: Snapshot Isolation (explicit transaction holds TSHM slot)
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s1_snapshot_isolation() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+    let (_db_r, conn_r) = open_second_process(&dir);
+
+    // Writer: create table and insert 2 rows.
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1,'a'), (2,'b')");
+
+    // Reader: BEGIN explicit transaction — claims TSHM slot.
+    exec(&conn_r, "BEGIN");
+    let count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(count, 2, "reader should see 2 rows at snapshot start");
+
+    // Writer: insert 2 more rows (committed, but reader holds snapshot).
+    exec(&conn_w, "INSERT INTO t VALUES (3,'c'), (4,'d')");
+
+    // Reader: still in same transaction — should see old snapshot.
+    let count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(count, 2, "reader should still see 2 rows within snapshot");
+
+    // Reader: COMMIT and re-query — should now see 4 rows.
+    exec(&conn_r, "COMMIT");
+    let count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(count, 4, "reader should see 4 rows after commit");
+
+    assert_integrity_ok(&conn_w);
+}
+
+// ---------------------------------------------------------------------------
+// S2: Checkpoint Respects Active Reader
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s2_checkpoint_respects_active_reader() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+    let (_db_r, conn_r) = open_second_process(&dir);
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+
+    // Writer: insert 100 rows.
+    exec(&conn_w, "BEGIN");
+    for i in 0..100 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+    }
+    exec(&conn_w, "COMMIT");
+
+    let max_after_first_batch = wal_max_frame(&conn_w);
+    assert!(max_after_first_batch > 0, "WAL should have frames");
+
+    // Reader: BEGIN — claims TSHM slot at current max_frame.
+    exec(&conn_r, "BEGIN");
+    let _count = query_i64(&conn_r, "SELECT count(*) FROM t");
+
+    // Writer: insert 100 more rows.
+    exec(&conn_w, "BEGIN");
+    for i in 100..200 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+    }
+    exec(&conn_w, "COMMIT");
+
+    // Checkpoint — should not backfill past the reader's snapshot frame.
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // The WAL should still have frames (reader holds snapshot).
+    let max_after_ckpt = wal_max_frame(&conn_w);
+    assert!(
+        max_after_ckpt > 0,
+        "WAL should still have frames while reader holds snapshot"
+    );
+
+    // Reader: COMMIT — releases TSHM slot.
+    exec(&conn_r, "COMMIT");
+
+    // Checkpoint again — should now be able to backfill everything.
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Verify all data is intact.
+    let count = query_i64(&conn_w, "SELECT count(*) FROM t");
+    assert_eq!(count, 200, "should have 200 rows after full checkpoint");
+    assert_integrity_ok(&conn_w);
+}
+
+// ---------------------------------------------------------------------------
+// S3: WAL Reset Blocked by Reader
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s3_wal_reset_blocked_by_reader() {
+    let (db_w, conn_w, dir) = open_mp_database();
+    let (_db_r, conn_r) = open_second_process(&dir);
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'a')");
+
+    // Checkpoint everything so WAL is fully backfilled.
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Reader: BEGIN — holds TSHM slot.
+    exec(&conn_r, "BEGIN");
+    let _count = query_i64(&conn_r, "SELECT count(*) FROM t");
+
+    // Writer: insert more data. This triggers try_restart_log_before_write
+    // which should NOT restart the WAL because the reader holds a slot.
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'b')");
+
+    // WAL should NOT have been restarted (max_frame should still be > 0).
+    let max_frame = db_w
+        .shared_wal
+        .read()
+        .max_frame
+        .load(std::sync::atomic::Ordering::Acquire);
+    assert!(
+        max_frame > 0,
+        "WAL should not have restarted while reader holds slot (max_frame={max_frame})"
+    );
+
+    // Reader: COMMIT — releases TSHM slot.
+    exec(&conn_r, "COMMIT");
+
+    // Writer: insert again. Now try_restart_log should succeed.
+    // First checkpoint so nbackfills == max_frame (restart precondition).
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Start a write tx to trigger try_restart_log.
+    {
+        let pager = conn_w.pager.load();
+        let wal = pager.wal.as_ref().unwrap();
+        wal.begin_read_tx().unwrap();
+        wal.begin_write_tx().unwrap();
+    }
+
+    // WAL should now have been restarted.
+    let max_final = db_w
+        .shared_wal
+        .read()
+        .max_frame
+        .load(std::sync::atomic::Ordering::Acquire);
+    assert_eq!(
+        max_final, 0,
+        "WAL should be restarted when no external readers (max_frame={max_final})"
+    );
+
+    {
+        let pager = conn_w.pager.load();
+        let wal = pager.wal.as_ref().unwrap();
+        wal.end_write_tx();
+        wal.end_read_tx();
+    }
+
+    assert_integrity_ok(&conn_w);
+}
+
+// ---------------------------------------------------------------------------
+// S4: Reader Crash Recovery
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s4_reader_crash_recovery() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'a'), (2, 'b')");
+
+    // Open a reader and BEGIN — claims TSHM slot.
+    let (db_r, conn_r) = open_second_process(&dir);
+    exec(&conn_r, "BEGIN");
+    let count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(count, 2);
+
+    // Crash the reader: drop both connection and database without commit.
+    // This leaves a stale TSHM slot.
+    drop(conn_r);
+    drop(db_r);
+
+    // Writer: insert more data.
+    exec(&conn_w, "INSERT INTO t VALUES (3, 'c')");
+
+    // Checkpoint should be limited by the stale slot (since PID is alive,
+    // the stale slot won't be auto-reclaimed in-process).
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Manually clear the stale slot (simulate OS PID reclaim in real multi-process).
+    if let Some(tshm) = &db_w.tshm {
+        // Find and release all reader slots.
+        tshm.reclaim_dead_slots();
+    }
+
+    // Checkpoint again — should now succeed fully.
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Verify data is intact.
+    let count = query_i64(&conn_w, "SELECT count(*) FROM t");
+    assert_eq!(count, 3);
+    assert_integrity_ok(&conn_w);
+}
+
+// ---------------------------------------------------------------------------
+// S5: Writer Crash Recovery
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s5_writer_crash_recovery() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    // Writer: create table and insert 10 committed rows.
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "BEGIN");
+    for i in 0..10 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+    }
+    exec(&conn_w, "COMMIT");
+
+    let count = query_i64(&conn_w, "SELECT count(*) FROM t");
+    assert_eq!(count, 10, "should have 10 committed rows");
+
+    // Writer: BEGIN a new transaction, insert 10 more rows, but do NOT commit.
+    exec(&conn_w, "BEGIN");
+    for i in 10..20 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+    }
+
+    // Crash the writer: drop without commit.
+    drop(conn_w);
+    drop(_db_w);
+
+    // New process opens the database — should see only the 10 committed rows.
+    let (_db_new, conn_new) = open_second_process(&dir);
+    let count = query_i64(&conn_new, "SELECT count(*) FROM t");
+    assert_eq!(
+        count, 10,
+        "new process should see only 10 committed rows, not 20 (got {count})"
+    );
+
+    assert_integrity_ok(&conn_new);
+}
+
+// ---------------------------------------------------------------------------
+// S6: No Checkpoint Livelock
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s6_no_checkpoint_livelock() {
+    let (_db_w, conn_w, _dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+
+    let mut prev_max_frame = 0u64;
+    let mut grew_unbounded = false;
+
+    for round in 0..100 {
+        exec(&conn_w, "BEGIN");
+        for i in 0..10 {
+            let id = round * 10 + i;
+            exec(&conn_w, &format!("INSERT INTO t VALUES ({id}, 'v{id}')"));
+        }
+        exec(&conn_w, "COMMIT");
+
+        run_checkpoint(
+            &conn_w,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            },
+        );
+
+        let mf = wal_max_frame(&conn_w);
+        // After a successful passive checkpoint with no readers, all frames
+        // should be backfilled. The WAL may still show non-zero max_frame
+        // until restart, but it should not be growing without bound.
+        if mf > prev_max_frame + 100 {
+            grew_unbounded = true;
+            break;
+        }
+        prev_max_frame = mf;
+    }
+
+    assert!(
+        !grew_unbounded,
+        "WAL grew without bound despite periodic checkpointing"
+    );
+
+    let count = query_i64(&conn_w, "SELECT count(*) FROM t");
+    assert_eq!(count, 1000, "should have 1000 rows");
+    assert_integrity_ok(&conn_w);
+}
+
+// ---------------------------------------------------------------------------
+// S7: Schema Visibility — Multiple Creates
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s7_schema_visibility_multiple_creates() {
+    let (_db_a, conn_a, dir) = open_mp_database();
+    let (_db_b, conn_b) = open_second_process(&dir);
+
+    // Process A creates tables one by one.
+    exec(&conn_a, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_a, "INSERT INTO t1 VALUES (1, 'hello')");
+
+    // Process B verifies t1 is visible.
+    let count = query_i64(&conn_b, "SELECT count(*) FROM t1");
+    assert_eq!(count, 1, "B should see t1 with 1 row");
+
+    exec(
+        &conn_a,
+        "CREATE TABLE t2(id INTEGER PRIMARY KEY, name TEXT)",
+    );
+    exec(&conn_a, "INSERT INTO t2 VALUES (1, 'world')");
+
+    // Process B verifies t2 is visible.
+    let count = query_i64(&conn_b, "SELECT count(*) FROM t2");
+    assert_eq!(count, 1, "B should see t2 with 1 row");
+
+    exec(
+        &conn_a,
+        "CREATE TABLE t3(id INTEGER PRIMARY KEY, data BLOB)",
+    );
+    exec(&conn_a, "INSERT INTO t3 VALUES (1, X'DEADBEEF')");
+
+    // Process B verifies t3 is visible.
+    let count = query_i64(&conn_b, "SELECT count(*) FROM t3");
+    assert_eq!(count, 1, "B should see t3 with 1 row");
+
+    // Process B can see all tables in schema.
+    let rows = query_rows(
+        &conn_b,
+        "SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name",
+    );
+    let names: Vec<String> = rows
+        .iter()
+        .map(|r| match &r[0] {
+            Value::Text(s) => s.to_string(),
+            _ => panic!("expected text"),
+        })
+        .collect();
+    assert_eq!(names, vec!["t1", "t2", "t3"]);
+
+    assert_integrity_ok(&conn_a);
+}
+
+// ---------------------------------------------------------------------------
+// S8: Schema Visibility — ALTER, DROP, and Indexes
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s8_schema_alter_drop_indexes() {
+    let (_db_a, conn_a, dir) = open_mp_database();
+    let (_db_b, conn_b) = open_second_process(&dir);
+
+    // Process A: create table with data.
+    exec(
+        &conn_a,
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b INTEGER)",
+    );
+    exec(&conn_a, "INSERT INTO t VALUES (1, 'hello', 42)");
+    exec(&conn_a, "INSERT INTO t VALUES (2, 'world', 99)");
+
+    // Process B sees data.
+    let count = query_i64(&conn_b, "SELECT count(*) FROM t");
+    assert_eq!(count, 2);
+
+    // Process A: CREATE INDEX.
+    exec(&conn_a, "CREATE INDEX idx_b ON t(b)");
+
+    // Process B: query using the indexed column.
+    let rows = query_rows(&conn_b, "SELECT a FROM t WHERE b = 42");
+    assert_eq!(rows.len(), 1);
+    match &rows[0][0] {
+        Value::Text(s) => assert_eq!(s.as_ref(), "hello"),
+        other => panic!("expected text, got {other:?}"),
+    }
+
+    // Process A: ALTER TABLE ADD COLUMN.
+    exec(&conn_a, "ALTER TABLE t ADD COLUMN c DEFAULT 0");
+
+    // Process B: sees new column.
+    let rows = query_rows(&conn_b, "SELECT c FROM t WHERE id = 1");
+    assert_eq!(rows.len(), 1);
+
+    // Process A: DROP INDEX.
+    exec(&conn_a, "DROP INDEX idx_b");
+
+    // Process B: query still works (just no index).
+    let rows = query_rows(&conn_b, "SELECT a FROM t WHERE b = 99");
+    assert_eq!(rows.len(), 1);
+    match &rows[0][0] {
+        Value::Text(s) => assert_eq!(s.as_ref(), "world"),
+        other => panic!("expected text, got {other:?}"),
+    }
+
+    // Process A: CREATE another INDEX.
+    exec(&conn_a, "CREATE INDEX idx_a ON t(a)");
+
+    // Process B: query using new index.
+    let rows = query_rows(&conn_b, "SELECT b FROM t WHERE a = 'hello'");
+    assert_eq!(rows.len(), 1);
+
+    // Process A: DROP TABLE.
+    exec(&conn_a, "DROP TABLE t");
+
+    // Process B: prepare should fail with "no such table".
+    let result = conn_b.prepare("SELECT * FROM t");
+    assert!(result.is_err(), "prepare should fail after DROP TABLE");
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("no such table"),
+        "error should mention 'no such table', got: {err_msg}"
+    );
+
+    assert_integrity_ok(&conn_a);
+}
+
+// ---------------------------------------------------------------------------
+// S9: Long-Running Reader
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s9_long_running_reader() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+    let (_db_r, conn_r) = open_second_process(&dir);
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+
+    // Insert initial rows.
+    exec(&conn_w, "BEGIN");
+    for i in 0..10 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+    }
+    exec(&conn_w, "COMMIT");
+
+    // Reader: BEGIN — snapshot at 10 rows.
+    exec(&conn_r, "BEGIN");
+    let snapshot_count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(snapshot_count, 10, "reader snapshot should see 10 rows");
+
+    // Writer: insert 50 batches of 100 rows each while reader holds snapshot.
+    for batch in 0..50 {
+        exec(&conn_w, "BEGIN");
+        for i in 0..100 {
+            let id = 10 + batch * 100 + i;
+            exec(&conn_w, &format!("INSERT INTO t VALUES ({id}, 'v{id}')"));
+        }
+        exec(&conn_w, "COMMIT");
+    }
+
+    // Reader: should still see snapshot-era count.
+    let count_during = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(
+        count_during, 10,
+        "reader should still see 10 rows during long writes"
+    );
+
+    // Reader: COMMIT — fresh query should see all rows.
+    exec(&conn_r, "COMMIT");
+    let final_count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(
+        final_count,
+        10 + 50 * 100,
+        "reader should see all 5010 rows after commit"
+    );
+
+    assert_integrity_ok(&conn_w);
+}
+
+// ---------------------------------------------------------------------------
+// S10: Multiple Readers at Different Snapshots
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_s10_multiple_readers_different_snapshots() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+
+    // Insert 10 rows.
+    exec(&conn_w, "BEGIN");
+    for i in 0..10 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+    }
+    exec(&conn_w, "COMMIT");
+
+    // R1: BEGIN at 10 rows.
+    let (_db_r1, conn_r1) = open_second_process(&dir);
+    exec(&conn_r1, "BEGIN");
+    let r1_count = query_i64(&conn_r1, "SELECT count(*) FROM t");
+    assert_eq!(r1_count, 10, "R1 should see 10 rows");
+
+    // Insert 10 more rows.
+    exec(&conn_w, "BEGIN");
+    for i in 10..20 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+    }
+    exec(&conn_w, "COMMIT");
+
+    // R2: BEGIN at 20 rows.
+    let (_db_r2, conn_r2) = open_second_process(&dir);
+    exec(&conn_r2, "BEGIN");
+    let r2_count = query_i64(&conn_r2, "SELECT count(*) FROM t");
+    assert_eq!(r2_count, 20, "R2 should see 20 rows");
+
+    // Insert 10 more rows.
+    exec(&conn_w, "BEGIN");
+    for i in 20..30 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+    }
+    exec(&conn_w, "COMMIT");
+
+    // R3: BEGIN at 30 rows.
+    let (_db_r3, conn_r3) = open_second_process(&dir);
+    exec(&conn_r3, "BEGIN");
+    let r3_count = query_i64(&conn_r3, "SELECT count(*) FROM t");
+    assert_eq!(r3_count, 30, "R3 should see 30 rows");
+
+    // Verify all readers still hold their snapshots simultaneously.
+    assert_eq!(
+        query_i64(&conn_r1, "SELECT count(*) FROM t"),
+        10,
+        "R1 snapshot should still be 10"
+    );
+    assert_eq!(
+        query_i64(&conn_r2, "SELECT count(*) FROM t"),
+        20,
+        "R2 snapshot should still be 20"
+    );
+    assert_eq!(
+        query_i64(&conn_r3, "SELECT count(*) FROM t"),
+        30,
+        "R3 snapshot should still be 30"
+    );
+
+    // Checkpoint — should be limited by R1 (oldest reader).
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+    // WAL should still have frames (R1 holds old snapshot).
+    let mf = wal_max_frame(&conn_w);
+    assert!(mf > 0, "WAL should have frames while R1 holds snapshot");
+
+    // R1: COMMIT.
+    exec(&conn_r1, "COMMIT");
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // R2: COMMIT.
+    exec(&conn_r2, "COMMIT");
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // R3: COMMIT.
+    exec(&conn_r3, "COMMIT");
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // All readers committed — verify final state.
+    let final_count = query_i64(&conn_w, "SELECT count(*) FROM t");
+    assert_eq!(final_count, 30, "should have 30 rows total");
+    assert_integrity_ok(&conn_w);
+}
+
+// ===========================================================================
+// Locking mode tests
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// LM1: Exclusive mode does not create TSHM file
+// ---------------------------------------------------------------------------
+#[test]
+fn test_locking_mode_exclusive_no_tshm() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let mut db_path = dir.clone();
+    db_path.push("test.db");
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.pragma_update(None, "journal_mode", "wal").unwrap();
+    }
+
+    let (_db, conn) = open_with_mode(&dir, LockingMode::Exclusive);
+    exec(&conn, "CREATE TABLE t(id INTEGER PRIMARY KEY)");
+    exec(&conn, "INSERT INTO t VALUES (1)");
+
+    // No TSHM file should exist.
+    let tshm_path = dir.join("test.db-tshm");
+    assert!(
+        !tshm_path.exists(),
+        "TSHM file should not exist in exclusive mode"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LM2: SharedWrites creates TSHM file
+// ---------------------------------------------------------------------------
+#[test]
+fn test_locking_mode_shared_writes_creates_tshm() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let mut db_path = dir.clone();
+    db_path.push("test.db");
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.pragma_update(None, "journal_mode", "wal").unwrap();
+    }
+
+    let (_db_a, conn_a) = open_with_mode(&dir, LockingMode::SharedWrites);
+    exec(&conn_a, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_a, "INSERT INTO t VALUES (1, 'a')");
+
+    // TSHM file should exist.
+    let tshm_path = dir.join("test.db-tshm");
+    assert!(
+        tshm_path.exists(),
+        "TSHM file should exist in shared_writes mode"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LM3: SharedReads creates TSHM file
+// ---------------------------------------------------------------------------
+#[test]
+fn test_locking_mode_shared_reads_creates_tshm() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let mut db_path = dir.clone();
+    db_path.push("test.db");
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.pragma_update(None, "journal_mode", "wal").unwrap();
+    }
+
+    let (_db, conn) = open_with_mode(&dir, LockingMode::SharedReads);
+    exec(&conn, "CREATE TABLE t(id INTEGER PRIMARY KEY)");
+    exec(&conn, "INSERT INTO t VALUES (1)");
+
+    let tshm_path = dir.join("test.db-tshm");
+    assert!(
+        tshm_path.exists(),
+        "TSHM file should exist in shared_reads mode"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LM4: Opening with a different locking mode than TSHM returns error
+// ---------------------------------------------------------------------------
+#[test]
+fn test_locking_mode_mismatch_rejected() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let mut db_path = dir.clone();
+    db_path.push("test.db");
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.pragma_update(None, "journal_mode", "wal").unwrap();
+    }
+
+    // First process opens with SharedWrites — TSHM records mode=2.
+    let (_db_a, conn_a) = open_with_mode(&dir, LockingMode::SharedWrites);
+    exec(&conn_a, "CREATE TABLE t(id INTEGER PRIMARY KEY)");
+    exec(&conn_a, "INSERT INTO t VALUES (1)");
+
+    // Second process tries SharedReads — should fail because TSHM says SharedWrites.
+    let err_msg = match try_open_with_mode(&dir, LockingMode::SharedReads) {
+        Ok(_) => panic!("Opening with mismatched locking mode should fail"),
+        Err(e) => format!("{e}"),
+    };
+    assert!(
+        err_msg.contains("locking") || err_msg.contains("Locking") || err_msg.contains("mode"),
+        "Error should mention locking mode mismatch, got: {err_msg}"
+    );
+}
+
+// ===========================================================================
+// Reader slot exhaustion tests
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// RS1: All reader slots full → new read returns BUSY
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_reader_slots_exhausted_returns_busy() {
+    let (db, conn, _dir) = open_mp_database();
+
+    exec(&conn, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn, "INSERT INTO t VALUES (1, 'hello')");
+
+    // Sanity: reads work before filling slots.
+    let count = query_i64(&conn, "SELECT count(*) FROM t");
+    assert_eq!(count, 1);
+
+    // Fill every TSHM reader slot. Use our own PID so pid_is_alive()
+    // returns true and the slots are not auto-reclaimed.
+    let tshm = db.tshm.as_ref().expect("SharedWrites DB must have TSHM");
+    let pid = std::process::id();
+    let mut slot_handles = Vec::with_capacity(NUM_READER_SLOTS);
+    for i in 0..NUM_READER_SLOTS {
+        match tshm.claim_reader_slot(pid, (i + 1) as u32) {
+            Some(h) => slot_handles.push(h),
+            None => panic!("failed to claim slot {i}, only got {}", slot_handles.len()),
+        }
+    }
+    assert_eq!(slot_handles.len(), NUM_READER_SLOTS);
+
+    // Now a SELECT should fail with BUSY — no reader slots available.
+    // Note: the query uses the existing connection (connect() itself also
+    // needs a slot to read the header, so we create it before filling slots).
+    let result = conn.execute("SELECT count(*) FROM t");
+    assert!(
+        result.is_err(),
+        "query should fail when all reader slots are full"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, LimboError::Busy),
+        "expected Busy error, got: {err}"
+    );
+
+    // Release a handful of slots.
+    for _ in 0..5 {
+        tshm.release_reader_slot(slot_handles.pop().unwrap());
+    }
+
+    // Now a read should succeed.
+    let count = query_i64(&conn, "SELECT count(*) FROM t");
+    assert_eq!(count, 1, "read should succeed after releasing slots");
+
+    // Cleanup: release remaining slots.
+    for h in slot_handles {
+        tshm.release_reader_slot(h);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RS2: Writes also fail when reader slots are exhausted (writes need a read tx)
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_reader_slots_exhausted_blocks_writes() {
+    let (db, conn, _dir) = open_mp_database();
+
+    exec(&conn, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn, "INSERT INTO t VALUES (1, 'hello')");
+
+    let tshm = db.tshm.as_ref().expect("SharedWrites DB must have TSHM");
+    let pid = std::process::id();
+    let mut slot_handles = Vec::with_capacity(NUM_READER_SLOTS);
+    for i in 0..NUM_READER_SLOTS {
+        slot_handles.push(
+            tshm.claim_reader_slot(pid, (i + 1) as u32)
+                .unwrap_or_else(|| panic!("failed to claim slot {i}")),
+        );
+    }
+
+    // INSERT also needs begin_read_tx under the hood, so it should fail too.
+    let result = conn.execute("INSERT INTO t VALUES (2, 'world')");
+    assert!(
+        result.is_err(),
+        "write should fail when all reader slots are full"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, LimboError::Busy),
+        "expected Busy error for write, got: {err}"
+    );
+
+    // Release one slot — write should now succeed.
+    tshm.release_reader_slot(slot_handles.pop().unwrap());
+    exec(&conn, "INSERT INTO t VALUES (2, 'world')");
+    let count = query_i64(&conn, "SELECT count(*) FROM t");
+    assert_eq!(count, 2, "write should succeed after releasing a slot");
+
+    // Cleanup.
+    for h in slot_handles {
+        tshm.release_reader_slot(h);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RS3: connect() also fails when reader slots are exhausted
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_reader_slots_exhausted_blocks_connect() {
+    let (db, conn, _dir) = open_mp_database();
+
+    exec(&conn, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn, "INSERT INTO t VALUES (1, 'hello')");
+
+    let tshm = db.tshm.as_ref().unwrap();
+    let pid = std::process::id();
+    let mut slot_handles = Vec::with_capacity(NUM_READER_SLOTS);
+    for i in 0..NUM_READER_SLOTS {
+        slot_handles.push(
+            tshm.claim_reader_slot(pid, (i + 1) as u32)
+                .unwrap_or_else(|| panic!("failed to claim slot {i}")),
+        );
+    }
+
+    // connect() needs a reader slot to read the header — should fail.
+    let result = db.connect();
+    assert!(
+        result.is_err(),
+        "connect() should fail when all reader slots are full"
+    );
+
+    // Release one slot — connect should now succeed.
+    tshm.release_reader_slot(slot_handles.pop().unwrap());
+    let conn2 = db.connect().unwrap();
+    let count = query_i64(&conn2, "SELECT count(*) FROM t");
+    assert_eq!(count, 1);
+
+    // Cleanup.
+    for h in slot_handles {
+        tshm.release_reader_slot(h);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RS4: Checkpoint can still run when reader slots are exhausted (it doesn't
+//      need a new reader slot itself).
+// ---------------------------------------------------------------------------
+#[test]
+fn test_mp_reader_slots_exhausted_checkpoint_still_works() {
+    let (db, conn, _dir) = open_mp_database();
+
+    exec(&conn, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    for i in 0..100 {
+        exec(&conn, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+    }
+
+    let tshm = db.tshm.as_ref().unwrap();
+    let pid = std::process::id();
+    let mut slot_handles = Vec::new();
+    for i in 0..NUM_READER_SLOTS {
+        match tshm.claim_reader_slot(pid, (i + 1) as u32) {
+            Some(h) => slot_handles.push(h),
+            None => break,
+        }
+    }
+
+    // Checkpoint should still work — it operates on the pager directly,
+    // not through begin_read_tx.
+    run_checkpoint(
+        &conn,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Release all and verify data integrity.
+    for h in slot_handles {
+        tshm.release_reader_slot(h);
+    }
+    let count = query_i64(&conn, "SELECT count(*) FROM t");
+    assert_eq!(count, 100);
+    assert_integrity_ok(&conn);
+}
+
+// ---------------------------------------------------------------------------
+// SharedReads: writer exclusion
+// ---------------------------------------------------------------------------
+
+/// Verify that in SharedReads mode, only the first process to open the
+/// database can write. A second process should get Busy on writes.
+#[test]
+fn test_shared_reads_writer_exclusion() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let mut db_path = dir.clone();
+    db_path.push("test.db");
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.pragma_update(None, "journal_mode", "wal").unwrap();
+    }
+
+    // Process 0 opens with SharedReads — gets the permanent write lock.
+    let (_db0, conn0) = open_with_mode(&dir, LockingMode::SharedReads);
+
+    // Process 1 opens with SharedReads — does NOT get the write lock.
+    let (_db1, conn1) = open_with_mode(&dir, LockingMode::SharedReads);
+
+    // Process 0 can write.
+    exec(&conn0, "CREATE TABLE t(id INTEGER PRIMARY KEY)");
+    exec(&conn0, "INSERT INTO t VALUES (1)");
+
+    // Process 1 cannot write — should fail with Busy.
+    let result = conn1.execute("INSERT INTO t VALUES (2)");
+    assert!(
+        result.is_err(),
+        "db1 should not be able to write when db0 holds the lock"
+    );
+}
+
+/// Regression test: after a Truncate checkpoint the WAL goes to 0 bytes.
+/// If another process writes new frames and then a *second* Truncate happens,
+/// a third process whose cached WAL state coincidentally matches the new
+/// (ckpt_seq=0, max_frame=1) would skip the rescan — leaving its frame_cache
+/// stale and unable to find the newly-written data.
+///
+/// We use two separate tables so the two write cycles produce WAL frames
+/// for *different* B-tree pages. This ensures the stale frame_cache from
+/// cycle 1 can't accidentally satisfy lookups for cycle 2's pages.
+///
+/// Timeline:
+///   1. P0 creates tables t1 and t2, Truncate → WAL = 0 bytes
+///   2. P1 inserts into t1 → WAL frame 1 maps t1's page
+///   3. P2 reads → caches WAL state (ckpt_seq=0, max_frame=1) with t1 mapping
+///   4. P0 Truncate → WAL = 0, t1 data in DB file
+///   5. P1 inserts into t2 → WAL frame 1 maps t2's page (same ckpt_seq/max!)
+///   6. P2 reads t2 → stale frame_cache has t1 mapping, not t2 → data invisible
+#[test]
+fn test_mp_stale_frame_cache_after_repeated_truncate() {
+    let (_db0, conn0, dir) = open_mp_database();
+    let (_db1, conn1) = open_second_process(&dir);
+    let (_db2, conn2) = open_second_process(&dir);
+
+    // Step 1: create both tables, checkpoint everything, then truncate.
+    exec(&conn0, "CREATE TABLE t1(id INTEGER PRIMARY KEY)");
+    exec(&conn0, "CREATE TABLE t2(id INTEGER PRIMARY KEY)");
+    run_checkpoint(
+        &conn0,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Step 2: P1 inserts into t1 → WAL frame 1 contains t1's leaf page.
+    exec(&conn1, "INSERT INTO t1 VALUES (1)");
+
+    // Step 3: P2 reads → rescans WAL, builds frame_cache with {t1_page → 1},
+    // caches WAL state as (ckpt_seq=0, max_frame=1).
+    assert_eq!(query_i64(&conn2, "SELECT count(*) FROM t1"), 1);
+
+    // Step 4: Truncate again → WAL = 0 bytes, t1 row now in DB file.
+    run_checkpoint(
+        &conn0,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Step 5: P1 inserts into t2 (different table, different page) → WAL
+    // frame 1 now maps t2's leaf page. On-disk state is still (0, 1).
+    exec(&conn1, "INSERT INTO t2 VALUES (100)");
+
+    // Step 6: P2 reads t2. Its cached WAL state is (0,1) from step 3.
+    // Disk WAL state is also (0,1) from step 5 — numerically identical!
+    // Without the fix: rescan skips, frame_cache still maps t1's page,
+    // t2's page not in cache → falls back to DB file → stale data (0 rows).
+    let count = query_i64(&conn2, "SELECT count(*) FROM t2");
+    assert_eq!(
+        count, 1,
+        "process 2 should see t2 row after repeated truncate"
+    );
+    assert_integrity_ok(&conn2);
+}
+
+/// Regression test: Restart checkpoint on a process that opened with an empty
+/// WAL writes an invalid header (page_size=0) and sets initialized=true,
+/// causing the next write to skip prepare_wal_start and crash in prepare_frames.
+#[test]
+fn test_mp_restart_checkpoint_on_empty_wal() {
+    let (db1, conn1, dir) = open_mp_database();
+
+    // P1 creates a table and writes data.
+    exec(&conn1, "CREATE TABLE t1 (id INTEGER PRIMARY KEY)");
+    exec(&conn1, "INSERT INTO t1 VALUES (1)");
+
+    // Truncate checkpoint → WAL is now 0 bytes, all data in DB file.
+    run_checkpoint(
+        &conn1,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // P2 opens while the WAL is empty. Its WalFileShared gets page_size=0.
+    let (_db2, conn2) = open_second_process(&dir);
+
+    // P2 does a Restart checkpoint on the empty WAL.
+    // Bug (now fixed): an eager header flush would set initialized=true with page_size=0.
+    run_checkpoint(&conn2, CheckpointMode::Restart);
+
+    // P2 tries to write. Without the fix: prepare_wal_start skips (initialized=true),
+    // prepare_frames panics on page_size=0.
+    exec(&conn2, "INSERT INTO t1 VALUES (2)");
+
+    // Verify data is visible.
+    assert_eq!(query_i64(&conn2, "SELECT count(*) FROM t1"), 2);
+
+    // Drop to avoid unused warnings.
+    drop(conn1);
+    drop(db1);
+}
+
+/// Regression test: stale WAL salt after checkpoint restart in multi-process.
+///
+/// Bug (before fix): MultiProcessWal::begin_write_tx() did not rescan the WAL
+/// from disk after acquiring the write lock. If another process checkpointed
+/// (restart mode, which changes the salt) and wrote new frames (flushing the
+/// new WAL header via prepare_wal_start), a stale writer would use the old
+/// salt. Its frame checksums were computed with the old salt but the durable
+/// WAL header had the new salt → salt mismatch → committed data lost.
+///
+/// Fix: begin_write_tx now rescans the WAL from disk after acquiring the
+/// inter-process lock. This updates the shared state (salt, max_frame, etc.)
+/// which causes the inner begin_write_tx to detect a stale snapshot via
+/// db_changed() and return BusySnapshot. The caller must then retry with a
+/// fresh read transaction, which picks up the correct salt.
+///
+/// Found via TLA+ model checking of the WAL checkpoint protocol.
+///
+/// Timeline:
+///   1. P_A writes row 1, commits
+///   2. P_B opens, starts explicit tx: BEGIN + SELECT (holds stale read tx)
+///   3. P_A checkpoints (Restart) and writes row 2 (new salt on disk)
+///   4. P_A closes
+///   5. P_B's INSERT is correctly rejected (BusySnapshot after rescan)
+///   6. P_B retries → succeeds with correct salt
+///   7. P_C opens and verifies all rows visible
+#[test]
+fn test_mp_stale_salt_after_checkpoint_restart() {
+    let (_db_a, conn_a, dir) = open_mp_database();
+
+    // Step 1: P_A creates table and writes initial data.
+    exec(&conn_a, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_a, "INSERT INTO t VALUES (1, 'from_a_1')");
+
+    // Step 2: P_B opens and starts an EXPLICIT transaction. The BEGIN + SELECT
+    // establishes a read tx that persists across subsequent statements. This
+    // is critical: without BEGIN, the INSERT would start a fresh implicit tx
+    // with begin_read_tx (triggering a TSHM rescan that picks up the new salt).
+    let (_db_b, conn_b) = open_second_process(&dir);
+    exec(&conn_b, "BEGIN");
+    let count = query_i64(&conn_b, "SELECT count(*) FROM t");
+    assert_eq!(count, 1, "P_B should see 1 row at snapshot start");
+
+    // Step 3: P_A does Restart checkpoint.
+    // This backfills row 1 to DB, generates new salt in memory, resets WAL.
+    run_checkpoint(&conn_a, CheckpointMode::Restart);
+
+    // Step 4: P_A writes row 2. This triggers prepare_wal_start which writes
+    // the new WAL header (with new salt) to disk, then writes the frame.
+    exec(&conn_a, "INSERT INTO t VALUES (2, 'from_a_2')");
+
+    // Verify P_A sees both rows.
+    let count = query_i64(&conn_a, "SELECT count(*) FROM t");
+    assert_eq!(count, 2, "P_A should see 2 rows");
+
+    // Step 5: P_A closes (graceful close releases write lock).
+    drop(conn_a);
+    drop(_db_a);
+
+    // Step 6: P_B tries to write within its stale explicit transaction.
+    // The fix: begin_write_tx rescans from disk, which updates shared state
+    // (new salt, new max_frame). db_changed() then detects the mismatch
+    // between P_B's stale local state and the fresh shared state, returning
+    // BusySnapshot. This prevents writing with the wrong salt.
+    let result = conn_b.execute("INSERT INTO t VALUES (3, 'from_b')");
+    assert!(
+        matches!(result, Err(LimboError::BusySnapshot)),
+        "expected BusySnapshot after stale explicit tx, got: {result:?}"
+    );
+
+    // Step 7: P_B must ROLLBACK the stale explicit tx before retrying.
+    // BusySnapshot doesn't auto-rollback in explicit transactions — the user
+    // must do it explicitly. Then the new implicit tx calls begin_read_tx
+    // which rescans from disk and picks up the correct salt.
+    exec(&conn_b, "ROLLBACK");
+    exec(&conn_b, "INSERT INTO t VALUES (3, 'from_b')");
+
+    // Step 8: P_C opens and verifies all rows are visible.
+    let (_db_c, conn_c) = open_second_process(&dir);
+
+    let count = query_i64(&conn_c, "SELECT count(*) FROM t");
+    assert_eq!(
+        count, 3,
+        "P_C should see all 3 rows after WAL rescan (got {count}). \
+         If only 2 rows are visible, P_B's write was lost due to stale WAL salt."
+    );
+
+    assert_integrity_ok(&conn_c);
+}
+
+/// Test: when WalIndex append_frame fails during commit, data must still be
+/// visible to other processes via the inner WAL's frame_cache.
+///
+/// Bug (C1): commit_prepared_frames silently swallows append_frame errors
+/// with `let _ =` and then calls commit_max_frame anyway, making the
+/// WalIndex inconsistent (max_frame covers frames not in the hash table).
+/// Subsequent find_frame trusts the WalIndex exclusively and returns None
+/// for those pages, causing committed data to be invisible.
+///
+/// This test injects a failure in append_frame, writes data, then verifies
+/// WalIndex append failure during commit_prepared_frames clears the WalIndex
+/// but the WAL commit succeeds (data is committed). The WalIndex is an
+/// optimization layer — its failure cannot un-commit WAL data.
+/// No rescan_wal_from_disk is performed (inner frame_cache is current).
+#[test]
+fn test_mp_wal_index_append_failure_clears_index_data_committed() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'initial')");
+
+    // Verify initial data visible.
+    assert_eq!(query_i64(&conn_w, "SELECT count(*) FROM t"), 1);
+
+    // Inject WalIndex append failure — simulates disk full / mmap failure
+    // during segment growth.
+    let wal_index = db_w
+        .wal_index
+        .as_ref()
+        .expect("SharedWrites should have WalIndex");
+    wal_index.inject_append_failure(true);
+
+    // Write succeeds — WAL frames are committed before the WalIndex update.
+    // The WalIndex gets cleared but the data is committed.
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'after_failure')");
+
+    // Stop injecting failures.
+    wal_index.inject_append_failure(false);
+
+    // WalIndex was cleared (max_frame == 0).
+    assert_eq!(wal_index.max_frame(), 0, "WalIndex should be cleared");
+
+    // Both rows visible — inner.find_frame works via stale-generation fallback.
+    assert_eq!(query_i64(&conn_w, "SELECT count(*) FROM t"), 2);
+
+    // Second process should also see both rows.
+    let (_db_r, conn_r) = open_second_process(&dir);
+    assert_eq!(
+        query_i64(&conn_r, "SELECT count(*) FROM t"),
+        2,
+        "Both rows visible to second process even after WalIndex failure"
+    );
+}
+
+/// Test: WalIndex salt mismatch mid-transaction triggers assertion.
+///
+/// Design: find_frame trusts the WalIndex exclusively when validated.
+/// If the WalIndex salt doesn't match the inner WAL salt (indicating
+/// the WalIndex is from a different WAL generation), this is a protocol
+/// violation that should crash rather than silently return wrong data.
+///
+/// Note: silent hash table corruption (zeroed hash entries without
+/// detectable integrity violation) is an inherent limitation of the
+/// current WalIndex design. Protection against that would require
+/// per-entry checksums (future work). The seqlock + generation counter
+/// + salt validation catch all protocol-level inconsistencies.
+#[test]
+fn test_mp_wal_index_salt_mismatch_after_restart_detected() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'hello')");
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'world')");
+
+    // Baseline: writer sees its own data.
+    assert_eq!(query_i64(&conn_w, "SELECT count(*) FROM t"), 2);
+
+    // Open a second process.
+    let (_db_r, conn_r) = open_second_process(&dir);
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 2);
+
+    // Truncate checkpoint → WAL goes to 0 bytes, WalIndex cleared.
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Write new data with the new salt.
+    exec(&conn_w, "INSERT INTO t VALUES (3, 'after_restart')");
+
+    // Reader detects the salt change via WalIndex and reads correctly.
+    let count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(count, 3, "Reader must see new data after WAL restart");
+}
+
+/// Test: uncommitted frames from an explicit transaction are NOT visible to
+/// other processes. WAL frames written inside an explicit tx have db_size==0
+/// (no commit marker), so other processes scanning the WAL stop at the last
+/// committed frame boundary. Only after COMMIT are the frames visible.
+#[test]
+fn test_mp_uncommitted_frames_not_visible_cross_process() {
+    let (_db_a, conn_a, dir) = open_mp_database();
+    let (_db_b, conn_b) = open_with_mode(&dir, LockingMode::SharedWrites);
+
+    // P_A: setup
+    exec(&conn_a, "CREATE TABLE t(id INTEGER PRIMARY KEY)");
+    exec(&conn_a, "INSERT INTO t VALUES (1)");
+
+    // P_B: verify sees row 1
+    let count = query_i64(&conn_b, "SELECT count(*) FROM t");
+    assert_eq!(count, 1, "P_B should see 1 row before tx");
+
+    // P_A: begin explicit tx, insert another row (uncommitted)
+    exec(&conn_a, "BEGIN");
+    exec(&conn_a, "INSERT INTO t VALUES (2)");
+
+    // P_B: should see only 1 row — uncommitted frames are invisible.
+    let count = query_i64(&conn_b, "SELECT count(*) FROM t");
+    assert_eq!(
+        count, 1,
+        "P_B should see only 1 row (uncommitted frames invisible), got {count}"
+    );
+
+    // P_A: commit — now the frame is visible.
+    exec(&conn_a, "COMMIT");
+
+    // P_B: should see both rows after commit.
+    let count = query_i64(&conn_b, "SELECT count(*) FROM t");
+    assert_eq!(count, 2, "P_B should see 2 rows after COMMIT, got {count}");
+}
+
+// ---------------------------------------------------------------------------
+// Rollback + WalIndex cross-process correctness
+// ---------------------------------------------------------------------------
+
+/// Test: ROLLBACK correctly updates WalIndex and cross-process reads
+/// see correct data after rollback.
+///
+/// Scenario: Process A inserts in an explicit transaction, then ROLLBACKs.
+/// The WalIndex must revert max_frame. Process B must NOT see the rolled-back
+/// data.
+#[test]
+fn test_mp_rollback_wal_index_cross_process() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    // Setup: create table and insert baseline data.
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'baseline')");
+
+    let (_db_r, conn_r) = open_second_process(&dir);
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 1);
+
+    // P_W: begin tx, insert rows.
+    exec(&conn_w, "BEGIN");
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'will_rollback')");
+    exec(&conn_w, "INSERT INTO t VALUES (3, 'will_rollback')");
+
+    // P_W: ROLLBACK — WalIndex must revert.
+    exec(&conn_w, "ROLLBACK");
+
+    // P_W: should see only baseline data.
+    assert_eq!(
+        query_i64(&conn_w, "SELECT count(*) FROM t"),
+        1,
+        "Writer should see only 1 row after rollback"
+    );
+
+    // P_R: should see only baseline data.
+    assert_eq!(
+        query_i64(&conn_r, "SELECT count(*) FROM t"),
+        1,
+        "Reader should see only 1 row after rollback"
+    );
+
+    // Verify data integrity — the baseline row should be intact.
+    let rows = query_rows(&conn_r, "SELECT val FROM t WHERE id = 1");
+    match &rows[0][0] {
+        crate::types::Value::Text(s) => assert_eq!(s.as_ref(), "baseline"),
+        other => panic!("unexpected val: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Truncate checkpoint + cross-process write
+// ---------------------------------------------------------------------------
+
+/// Test: Process A does Truncate checkpoint (WAL → 0 bytes), then
+/// Process B (opened before truncate) writes new data. B must detect
+/// the truncated/restarted WAL and handle it correctly.
+#[test]
+fn test_mp_truncate_then_cross_process_write() {
+    let (_db_a, conn_a, dir) = open_mp_database();
+
+    // Setup: create table and insert data.
+    exec(&conn_a, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_a, "INSERT INTO t VALUES (1, 'before_truncate')");
+
+    // Open P_B before the truncate — it has the old WAL state cached.
+    let (_db_b, conn_b) = open_second_process(&dir);
+    assert_eq!(query_i64(&conn_b, "SELECT count(*) FROM t"), 1);
+
+    // P_A: Truncate checkpoint — WAL goes to 0 bytes.
+    run_checkpoint(
+        &conn_a,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // P_B: write new data. Must detect the truncated WAL.
+    exec(&conn_b, "INSERT INTO t VALUES (2, 'after_truncate')");
+
+    // Both processes should see 2 rows.
+    assert_eq!(
+        query_i64(&conn_a, "SELECT count(*) FROM t"),
+        2,
+        "P_A should see 2 rows after truncate + cross-process write"
+    );
+    assert_eq!(
+        query_i64(&conn_b, "SELECT count(*) FROM t"),
+        2,
+        "P_B should see 2 rows after truncate + cross-process write"
+    );
+
+    // Integrity check on both.
+    assert_integrity_ok(&conn_a);
+    assert_integrity_ok(&conn_b);
+}
+
+// ---------------------------------------------------------------------------
+// Rapid open/close cycles
+// ---------------------------------------------------------------------------
+
+/// Test: 50 rapid open/close cycles on the same database.
+/// Catches fd, mmap, flock leaks that would accumulate silently.
+/// Final integrity check verifies no corruption from the churn.
+#[test]
+fn test_mp_rapid_open_close_cycles() {
+    let (_db, conn, dir) = open_mp_database();
+
+    // Setup: create table with data.
+    exec(&conn, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    for i in 1..=10 {
+        exec(&conn, &format!("INSERT INTO t VALUES ({i}, 'row{i}')"));
+    }
+
+    // 50 open/close cycles.
+    for cycle in 0..50 {
+        let (db_i, conn_i) = open_second_process(&dir);
+        let count = query_i64(&conn_i, "SELECT count(*) FROM t");
+        assert_eq!(count, 10, "cycle {cycle}: expected 10 rows, got {count}");
+        drop(conn_i);
+        drop(db_i);
+    }
+
+    // Final: original connection still works and data is intact.
+    assert_eq!(query_i64(&conn, "SELECT count(*) FROM t"), 10);
+    assert_integrity_ok(&conn);
+
+    // One more write after all the churn.
+    exec(&conn, "INSERT INTO t VALUES (11, 'after_churn')");
+    assert_eq!(query_i64(&conn, "SELECT count(*) FROM t"), 11);
+}
+
+// ---------------------------------------------------------------------------
+// WalIndex max_frame lag (inner > WalIndex)
+// ---------------------------------------------------------------------------
+
+/// Test: Simulate the window where inner WAL max_frame exceeds WalIndex's
+/// committed max_frame. Verify reads succeed via the fallthrough to
+/// inner.find_frame.
+///
+/// This tests the scenario where the WalIndex has some but not all entries
+/// (e.g., WAL restart/truncate changed the generation). find_frame detects
+/// `gen != cached_gen` and falls through to inner.find_frame.
+#[test]
+fn test_mp_wal_index_stale_generation_fallthrough() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    // Write ALL data before opening reader so its inner frame_cache has
+    // every frame from the initial WAL file read.
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'first')");
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'second')");
+    exec(&conn_w, "INSERT INTO t VALUES (3, 'third')");
+
+    // Open reader — reads WAL from disk during open, building frame_cache.
+    let (_db_r, conn_r) = open_second_process(&dir);
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 3);
+
+    // Clear the WalIndex — this bumps the generation AND zeros max_frame.
+    // The reader's cached_wal_index_generation is now stale.
+    let wal_index = db_w
+        .wal_index
+        .as_ref()
+        .expect("SharedWrites should have WalIndex");
+    let gen_before = wal_index.generation();
+    wal_index.clear(0, 0);
+    assert_ne!(
+        wal_index.generation(),
+        gen_before,
+        "clear() should bump generation"
+    );
+    assert_eq!(wal_index.max_frame(), 0);
+
+    // Reader queries — WalIndex has max_frame=0, so find_frame skips the
+    // WalIndex path entirely and falls through to inner.find_frame (which
+    // has the frame_cache from the initial WAL read).
+    let count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(
+        count, 3,
+        "Reader should see all 3 rows via inner fallthrough despite stale WalIndex"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Savepoint rollback (constraint violation) + WalIndex
+// ---------------------------------------------------------------------------
+
+/// Test: PK constraint violation triggers savepoint rollback which calls
+/// wal_index.rollback_to(). Verify the WalIndex returns to pre-violation
+/// state and cross-process reads are unaffected.
+#[test]
+fn test_mp_savepoint_rollback_wal_index() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'original')");
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'original')");
+
+    let wal_index = db_w
+        .wal_index
+        .as_ref()
+        .expect("SharedWrites should have WalIndex");
+    let max_before = wal_index.max_frame();
+
+    // Attempt duplicate PK — should fail with constraint violation.
+    let result = conn_w.execute("INSERT INTO t VALUES (1, 'duplicate')");
+    assert!(result.is_err(), "Duplicate PK insert should fail");
+
+    // WalIndex max_frame should return to pre-violation value.
+    let max_after = wal_index.max_frame();
+    assert_eq!(
+        max_before, max_after,
+        "WalIndex max_frame should revert after savepoint rollback \
+         (before={max_before}, after={max_after})"
+    );
+
+    // Cross-process read should see only the original 2 rows.
+    let (_db_r, conn_r) = open_second_process(&dir);
+    assert_eq!(
+        query_i64(&conn_r, "SELECT count(*) FROM t"),
+        2,
+        "Reader should see exactly 2 rows after constraint violation"
+    );
+
+    // Writer should still be able to write new data.
+    exec(&conn_w, "INSERT INTO t VALUES (3, 'after_violation')");
+    assert_eq!(query_i64(&conn_w, "SELECT count(*) FROM t"), 3);
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 3);
+
+    assert_integrity_ok(&conn_w);
+    assert_integrity_ok(&conn_r);
+}
+
+// ---------------------------------------------------------------------------
+// Helper: get rescan count from MultiProcessWal
+// ---------------------------------------------------------------------------
+
+/// Get the rescan_wal_from_disk call count from the inner WalFile of a
+/// connection's MultiProcessWal. Works by downcasting through the Wal
+/// trait object.
+fn mp_rescan_count(conn: &Arc<Connection>) -> u64 {
+    let pager = conn.pager.load();
+    let wal = pager.wal.as_ref().expect("pager has no WAL");
+    let mp_wal = wal
+        .as_any()
+        .downcast_ref::<MultiProcessWal>()
+        .expect("WAL is not MultiProcessWal");
+    mp_wal.inner().rescan_count()
+}
+
+// ---------------------------------------------------------------------------
+// WAL file reads on the read hot path
+// ---------------------------------------------------------------------------
+
+/// Test: begin_read_tx does NOT rescan the WAL from disk when TSHM state
+/// changes. Instead it syncs from the mmap'd WalIndex (zero I/O).
+#[test]
+fn test_mp_begin_read_tx_rescans_wal_on_tshm_change() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'hello')");
+
+    // Open a reader process.
+    let (_db_r, conn_r) = open_second_process(&dir);
+
+    // Initial read — may trigger a rescan during open/first read.
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 1);
+
+    // Record the rescan count AFTER the initial read settles.
+    let rescan_before = mp_rescan_count(&conn_r);
+
+    // Writer writes new data — this bumps the TSHM writer_state.
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'world')");
+
+    // Reader begins a new read transaction. With the WalIndex sync,
+    // begin_read_tx updates shared state from the mmap (zero I/O)
+    // instead of calling rescan_wal_from_disk.
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 2);
+
+    let rescan_after = mp_rescan_count(&conn_r);
+
+    assert_eq!(
+        rescan_after, rescan_before,
+        "rescan_wal_from_disk should NOT be called during begin_read_tx \
+         (before={rescan_before}, after={rescan_after}). \
+         The WalIndex sync replaces the full WAL rescan."
+    );
+}
+
+/// Test: find_frame uses the WalIndex exclusively when it is correctly
+/// populated. Clears the inner frame_cache after begin_read_tx and verifies
+/// reads still succeed — proving find_frame never falls through to inner.
+#[test]
+fn test_mp_find_frame_trusts_wal_index_exclusively() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    for i in 1..=20 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'row_{i}')"));
+    }
+
+    let wal_index = db_w
+        .wal_index
+        .as_ref()
+        .expect("SharedWrites should have WalIndex");
+    assert!(
+        wal_index.max_frame() > 0,
+        "WalIndex should be populated after writes"
+    );
+
+    // Open reader — its WalIndex points to the same mmap.
+    let (_db_r, conn_r) = open_second_process(&dir);
+
+    // Initial read — triggers begin_read_tx which syncs from WalIndex.
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 20);
+
+    // Clear the inner frame_cache. If find_frame fell through to
+    // inner.find_frame, lookups would fail (return None) and the reader
+    // would read stale pages from the DB file.
+    let pager = conn_r.pager.load();
+    let wal = pager.wal.as_ref().expect("pager has no WAL");
+    let mp_wal = wal
+        .as_any()
+        .downcast_ref::<MultiProcessWal>()
+        .expect("WAL is not MultiProcessWal");
+    mp_wal.inner().clear_frame_cache();
+
+    // Reads must still succeed — all lookups go through WalIndex only.
+    let rows = query_rows(&conn_r, "SELECT id, val FROM t ORDER BY id");
+    assert_eq!(rows.len(), 20);
+    for (i, row) in rows.iter().enumerate() {
+        let expected_id = (i + 1) as i64;
+        match &row[0] {
+            Value::Numeric(crate::numeric::Numeric::Integer(v)) => {
+                assert_eq!(*v, expected_id)
+            }
+            other => panic!("unexpected id type: {other:?}"),
+        }
+    }
+}
+
+/// Test: Repeated write→read cycles accumulate zero WAL rescans.
+/// The reader syncs from the WalIndex mmap (zero I/O) instead of
+/// rescanning the entire WAL file on every TSHM change.
+#[test]
+fn test_mp_rescan_count_scales_with_writes() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+
+    let (_db_r, conn_r) = open_second_process(&dir);
+
+    // Warm up: initial read.
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 0);
+
+    let rescan_start = mp_rescan_count(&conn_r);
+
+    let num_writes = 50;
+    for i in 1..=num_writes {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'row_{i}')"));
+        // Reader must see the new row — triggers begin_read_tx.
+        assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), i);
+    }
+
+    let rescan_end = mp_rescan_count(&conn_r);
+    let total_rescans = rescan_end - rescan_start;
+
+    assert_eq!(
+        total_rescans, 0,
+        "Expected zero rescans (WalIndex sync replaces WAL rescan), \
+         got {total_rescans}."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TOCTOU gap in begin_read_tx
+// ---------------------------------------------------------------------------
+
+/// Test: Demonstrates the TOCTOU window in MultiProcessWal::begin_read_tx.
+///
+/// The gap between `maybe_rescan_from_tshm()` and `claim_reader_slot()`:
+///
+/// ```text
+///   Reader                          Writer
+///   ------                          ------
+///   maybe_rescan_from_tshm()
+///     → reads WAL, gets max_frame=N
+///                                   write frame N+1
+///                                   checkpoint TRUNCATE
+///                                     → copies frames 1..N+1 to DB
+///                                     → truncates WAL to 0
+///                                   write frame 1 (new salt!)
+///   inner.begin_read_tx()
+///     → snapshots max_frame (stale!)
+///   claim_reader_slot(max_frame=N)
+///     → slot says "I need up to frame N"
+///     → but frame N has different content now (new salt)
+/// ```
+///
+/// This test exercises the window by having a writer do rapid
+/// checkpoint+write cycles while a reader opens read transactions.
+/// A snapshot violation (reader sees inconsistent data) would indicate
+/// the TOCTOU fired.
+///
+/// Because this is a race condition, a single run may not trigger it.
+/// The test runs many iterations to increase the probability.
+#[test]
+fn test_mp_toctou_begin_read_tx_stress() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    exec(
+        &conn_w,
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER)",
+    );
+
+    // Insert initial data.
+    exec(&conn_w, "INSERT INTO t VALUES (1, 100)");
+
+    let (_db_r, conn_r) = open_second_process(&dir);
+
+    // Warm up reader.
+    assert_eq!(query_i64(&conn_r, "SELECT val FROM t WHERE id = 1"), 100);
+
+    // Run many write→checkpoint→write→read cycles.
+    // The idea: each cycle does a TRUNCATE checkpoint (which changes the WAL
+    // salt and resets frames to 0) followed by a write (new frame 1 with new
+    // salt). If the reader's begin_read_tx rescans before the checkpoint but
+    // claims its slot after the new write, it has a stale view.
+    for cycle in 0..200 {
+        let new_val = 1000 + cycle;
+
+        // Update the row.
+        exec(
+            &conn_w,
+            &format!("UPDATE t SET val = {new_val} WHERE id = 1"),
+        );
+
+        // Checkpoint TRUNCATE — copies WAL to DB, truncates WAL.
+        // Ignore Busy — another reader may block the checkpoint.
+        let pager_w = conn_w.pager.load();
+        let _ = pager_w.io.block(|| {
+            pager_w.checkpoint(
+                CheckpointMode::Truncate {
+                    upper_bound_inclusive: None,
+                },
+                crate::SyncMode::Full,
+                true,
+            )
+        });
+
+        // Write again — this creates frame 1 with a new salt (if the
+        // checkpoint succeeded and restarted the WAL).
+        let next_val = new_val + 1;
+        exec(
+            &conn_w,
+            &format!("UPDATE t SET val = {next_val} WHERE id = 1"),
+        );
+
+        // Reader: the value must be either new_val or next_val,
+        // NEVER the old value from a previous cycle or garbage.
+        let reader_val = query_i64(&conn_r, "SELECT val FROM t WHERE id = 1");
+        assert!(
+            reader_val == new_val as i64 || reader_val == next_val as i64,
+            "TOCTOU detected at cycle {cycle}: reader saw val={reader_val}, \
+             expected {new_val} or {next_val}. The reader's begin_read_tx \
+             rescanned the WAL before the checkpoint but claimed its slot \
+             after the WAL was restarted with a new salt."
+        );
+    }
+}
+
+/// Test: Demonstrates the TOCTOU gap can cause a reader to hold a stale
+/// snapshot after a WAL restart (salt change).
+///
+/// Sequence that triggers the bug:
+/// 1. Writer writes frames 1..N
+/// 2. Reader calls maybe_rescan_from_tshm → rescans WAL, sees frames 1..N
+///    with salt_A
+/// 3. Writer does TRUNCATE checkpoint → WAL truncated to 0, DB updated
+/// 4. Writer writes frame 1 with new salt_B
+/// 5. Reader calls inner.begin_read_tx() → snapshots max_frame from
+///    shared state (which rescan populated in step 2 with salt_A's frames)
+/// 6. Reader claims TSHM slot with max_frame=N
+/// 7. Reader calls find_frame(page_X) → finds frame from step 2's
+///    frame_cache, but the WAL file now has different content at that
+///    offset (salt_B frame or zeros)
+///
+/// This test creates the conditions and checks for inconsistency.
+#[test]
+fn test_mp_toctou_stale_salt_after_wal_restart() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+
+    // Write enough data to have multiple pages in the WAL.
+    for i in 1..=100 {
+        exec(
+            &conn_w,
+            &format!("INSERT INTO t VALUES ({i}, '{}')", "x".repeat(100)),
+        );
+    }
+
+    let (_db_r, conn_r) = open_second_process(&dir);
+
+    // Reader sees all 100 rows.
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 100);
+
+    // Now do a TRUNCATE checkpoint → WAL goes to 0, DB has everything.
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Writer writes new data — this starts a fresh WAL with new salt.
+    exec(&conn_w, "UPDATE t SET val = 'updated' WHERE id = 1");
+
+    // The writer's WAL now has frame 1 with a new salt.
+    // The reader's cached state (from the rescan during its last
+    // begin_read_tx) had the old WAL with old salt.
+    //
+    // When the reader does its next begin_read_tx:
+    // - maybe_rescan_from_tshm detects TSHM changed → rescans WAL from disk
+    // - BUT between the rescan and claiming the TSHM slot, the writer could
+    //   do another checkpoint+write cycle, making the rescan stale.
+    //
+    // For a single-threaded test we can't reproduce the exact interleaving,
+    // but we verify the reader sees correct data regardless.
+    let val = query_rows(&conn_r, "SELECT val FROM t WHERE id = 1");
+    match &val[0][0] {
+        Value::Text(s) => assert!(
+            s.as_ref() == "updated" || s.as_ref() == "x".repeat(100),
+            "Reader saw unexpected value after WAL restart: {s}"
+        ),
+        other => panic!("unexpected type: {other:?}"),
+    }
+
+    // Full verification: all rows should be consistent.
+    let count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(count, 100, "Row count mismatch after WAL restart");
+    assert_integrity_ok(&conn_r);
+}
+
+/// Test: Multi-threaded TOCTOU stress test.
+///
+/// Spawns a writer thread doing rapid write→checkpoint→write cycles and
+/// a reader thread doing rapid SELECT queries. The reader must never see
+/// an inconsistent snapshot — every read must return a valid committed
+/// state of the database.
+///
+/// This test has a higher chance of hitting the TOCTOU window because
+/// the writer and reader run concurrently on real OS threads, creating
+/// genuine interleaving at the rescan↔slot-claim boundary.
+#[test]
+fn test_mp_toctou_concurrent_stress() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    let dir = tempfile::tempdir().unwrap().keep();
+    let mut db_path = dir.clone();
+    db_path.push("test.db");
+
+    // Create WAL-mode database.
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.pragma_update(None, "journal_mode", "wal").unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER)", [])
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 0)", []).unwrap();
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Writer thread.
+    let stop_w = stop.clone();
+    let dir_w = dir.clone();
+    let writer = thread::spawn(move || {
+        let (_db, conn) = open_with_mode(&dir_w, LockingMode::SharedWrites);
+        let mut val: i64 = 0;
+        while !stop_w.load(Ordering::Relaxed) {
+            val += 1;
+            exec(&conn, &format!("UPDATE t SET val = {val} WHERE id = 1"));
+
+            // Occasionally checkpoint to trigger WAL restarts.
+            if val % 10 == 0 {
+                let pager = conn.pager.load();
+                let _ = pager.io.block(|| {
+                    pager.checkpoint(
+                        CheckpointMode::Truncate {
+                            upper_bound_inclusive: None,
+                        },
+                        crate::SyncMode::Full,
+                        true,
+                    )
+                });
+            }
+        }
+    });
+
+    // Reader thread.
+    let stop_r = stop.clone();
+    let reader = thread::spawn(move || {
+        let (_db, conn) = open_with_mode(&dir, LockingMode::SharedWrites);
+        let mut reads = 0u64;
+        let mut max_seen: i64 = 0;
+        let mut non_monotonic_errors = 0u64;
+        let mut short_read_errors = 0u64;
+
+        while !stop_r.load(Ordering::Relaxed) {
+            let result = (|| -> crate::Result<i64> {
+                let mut stmt = conn.prepare("SELECT val FROM t WHERE id = 1")?;
+                let mut val: i64 = 0;
+                stmt.run_with_row_callback(|row| {
+                    val = row.get(0)?;
+                    Ok(())
+                })?;
+                Ok(val)
+            })();
+
+            match result {
+                Ok(val) => {
+                    // Monotonic reads: within the same connection, values
+                    // should never decrease. Each begin_read_tx should get
+                    // a snapshot >= the previous one.
+                    if val < max_seen {
+                        // Non-monotonic read = snapshot went backwards.
+                        // This is a real protocol violation.
+                        non_monotonic_errors += 1;
+                    }
+                    if val > max_seen {
+                        max_seen = val;
+                    }
+                    reads += 1;
+                }
+                Err(e) => {
+                    let msg = format!("{e}");
+                    if msg.contains("ShortRead") || msg.contains("Completion") {
+                        short_read_errors += 1;
+                    }
+                    // Other errors (Busy, etc.) are expected under
+                    // contention — just retry.
+                }
+            }
+        }
+
+        (reads, non_monotonic_errors, short_read_errors)
+    });
+
+    // Let it run for a bit.
+    thread::sleep(Duration::from_secs(3));
+    stop.store(true, Ordering::Relaxed);
+
+    writer.join().expect("writer panicked");
+    let (total_reads, non_monotonic, short_reads) = reader.join().expect("reader panicked");
+
+    eprintln!(
+        "TOCTOU concurrent stress: {total_reads} reads, \
+         {non_monotonic} non-monotonic, {short_reads} short-reads"
+    );
+
+    assert!(
+        total_reads > 0,
+        "Reader thread didn't execute any reads — test is vacuous"
+    );
+
+    // Non-monotonic reads must NEVER happen — this would be a real
+    // protocol violation (snapshot went backwards).
+    assert_eq!(
+        non_monotonic, 0,
+        "Non-monotonic reads detected: reader saw an older value \
+         after seeing a newer one ({non_monotonic} occurrences)"
+    );
+
+    // ShortReadWalFrame can occur in same-process multi-thread tests
+    // because TSHM reader slots use PID. Since all threads share the
+    // same PID, the writer's checkpoint ignores the reader's slot
+    // (min_reader_frame_excluding filters by PID). In real multi-process
+    // usage with different PIDs, the reader's slot would prevent the
+    // writer from truncating frames the reader is actively using.
+    if short_reads > 0 {
+        eprintln!(
+            "NOTE: {short_reads} ShortReadWalFrame errors (expected in \
+             same-process multi-thread tests due to shared PID)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Write path: WalIndex sync instead of disk rescan
+// ---------------------------------------------------------------------------
+
+/// Test: when process B writes (bumping TSHM), process A's next begin_write_tx
+/// syncs from the WalIndex mmap instead of rescanning the WAL from disk.
+#[test]
+fn test_mp_write_path_no_disk_rescan() {
+    let (_db_a, conn_a, dir) = open_mp_database();
+
+    exec(&conn_a, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_a, "INSERT INTO t VALUES (1, 'a1')");
+
+    let (_db_b, conn_b) = open_second_process(&dir);
+
+    // Warm up: B reads to settle initial state.
+    assert_eq!(query_i64(&conn_b, "SELECT count(*) FROM t"), 1);
+
+    // B writes — bumps TSHM.
+    exec(&conn_b, "INSERT INTO t VALUES (2, 'b1')");
+
+    // Record A's rescan count before A writes again.
+    let rescan_before = mp_rescan_count(&conn_a);
+
+    // A writes — begin_write_tx detects TSHM change, syncs from WalIndex.
+    exec(&conn_a, "INSERT INTO t VALUES (3, 'a2')");
+
+    let rescan_after = mp_rescan_count(&conn_a);
+    assert_eq!(
+        rescan_after, rescan_before,
+        "begin_write_tx should sync from WalIndex, not rescan_wal_from_disk \
+         (before={rescan_before}, after={rescan_after})"
+    );
+
+    // Verify data integrity.
+    assert_eq!(query_i64(&conn_a, "SELECT count(*) FROM t"), 3);
+    assert_integrity_ok(&conn_a);
+}
+
+// ---------------------------------------------------------------------------
+// TSHM rebuild on missing file + corrupt→delete→reopen recovery
+// ---------------------------------------------------------------------------
+
+/// Test: opening a database without a tshm file rebuilds it automatically.
+#[test]
+fn test_mp_tshm_rebuild_on_missing_file() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'hello')");
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'world')");
+
+    let tshm_path = dir.join("test.db-tshm");
+    assert!(tshm_path.exists(), "tshm file should exist after writes");
+
+    // Drop all connections so the file isn't held open.
+    drop(conn_w);
+    drop(_db_w);
+
+    // Delete the tshm file.
+    std::fs::remove_file(&tshm_path).unwrap();
+    assert!(!tshm_path.exists());
+
+    // Reopen — tshm should be recreated and data fully accessible.
+    let (_db_new, conn_new) = open_with_mode(&dir, LockingMode::SharedWrites);
+    assert_eq!(query_i64(&conn_new, "SELECT count(*) FROM t"), 2);
+
+    assert!(tshm_path.exists(), "tshm file should be recreated on open");
+    assert_integrity_ok(&conn_new);
+}
+
+/// Test: corrupt WalIndex → detect error → delete tshm → reopen recovers.
+#[test]
+fn test_mp_corrupt_tshm_delete_reopen_recovers() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    for i in 1..=10 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'row_{i}')"));
+    }
+
+    let wal_index = db_w
+        .wal_index
+        .as_ref()
+        .expect("SharedWrites should have WalIndex");
+    assert!(wal_index.max_frame() > 0);
+
+    // Corrupt the WalIndex hash tables.
+    wal_index.corrupt_hash_tables();
+
+    // verify_hash_integrity should detect the corruption.
+    let result = wal_index.verify_hash_integrity();
+    assert!(
+        result.is_err(),
+        "verify_hash_integrity should return error on corruption"
+    );
+
+    let tshm_path = dir.join("test.db-tshm");
+
+    // Drop everything so the tshm file isn't held open.
+    drop(conn_w);
+    drop(db_w);
+
+    // Delete the tshm file (user recovery action).
+    std::fs::remove_file(&tshm_path).unwrap();
+
+    // Reopen — tshm is rebuilt, all data accessible.
+    let (db_new, conn_new) = open_with_mode(&dir, LockingMode::SharedWrites);
+    assert_eq!(query_i64(&conn_new, "SELECT count(*) FROM t"), 10);
+
+    // WalIndex should pass integrity check after rebuild.
+    if let Some(wal_index) = &db_new.wal_index {
+        assert!(wal_index.verify_hash_integrity().is_ok());
+    }
+
+    assert!(tshm_path.exists());
+    assert_integrity_ok(&conn_new);
+}
+
+/// Corrupt tshm on disk, then reopen — should fail with Corrupt error.
+/// The user deletes the tshm file and reopens to recover.
+#[test]
+fn test_mp_corrupt_tshm_reopen_returns_corrupt_error() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    for i in 1..=5 {
+        exec(&conn_w, &format!("INSERT INTO t VALUES ({i}, 'row_{i}')"));
+    }
+
+    let wal_index = db_w
+        .wal_index
+        .as_ref()
+        .expect("SharedWrites should have WalIndex");
+    assert!(wal_index.max_frame() > 0);
+
+    // Corrupt the WalIndex hash tables (which corrupts pgno_checksum).
+    wal_index.corrupt_hash_tables();
+
+    // Drop everything so the tshm file is closed.
+    drop(conn_w);
+    drop(db_w);
+
+    // Reopen — open_inner should detect the checksum mismatch and return
+    // a Corrupt error instead of silently rebuilding.
+    let tshm_path = dir.join("test.db-tshm");
+    assert!(tshm_path.exists(), "tshm file should still exist");
+
+    let err_msg = match try_open_with_mode(&dir, LockingMode::SharedWrites) {
+        Ok(_) => panic!("reopen with corrupt tshm should return an error"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        err_msg.contains("corruption") || err_msg.contains("Corrupt"),
+        "error should indicate corruption, got: {err_msg}"
+    );
+}
+
+/// WalIndex corruption detected during begin_read_tx (via verify_hash_integrity)
+/// propagates as an error through mvcc_refresh_if_db_changed.
+#[test]
+fn test_mp_corruption_propagates_through_mvcc_refresh() {
+    let (_db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'initial')");
+
+    // Open a second process and verify it can read.
+    let (db_r, conn_r) = open_second_process(&dir);
+    assert_eq!(query_i64(&conn_r, "SELECT count(*) FROM t"), 1);
+
+    // Write more data from the first process to bump TSHM writer_state.
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'second')");
+
+    // Corrupt the WalIndex hash tables. Since both processes share the
+    // same mmap'd WalIndex, this corruption is visible to the reader.
+    let wal_index = db_r
+        .wal_index
+        .as_ref()
+        .expect("SharedWrites should have WalIndex");
+    wal_index.corrupt_hash_tables();
+
+    // The next begin_read_tx on the reader should detect corruption.
+    // The TSHM writer_state changed (from the write above), so
+    // sync_from_wal_index_for_read will call verify_hash_integrity.
+    let result = conn_r.execute("SELECT count(*) FROM t");
+    assert!(
+        result.is_err(),
+        "read after corruption should fail, not silently return stale data"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// finish_append_frames_commit: WalIndex visibility on first write
+// ---------------------------------------------------------------------------
+
+/// Test: On the very first write to an empty WAL, finish_append_frames_commit
+/// must call commit_max_frame to make WalIndex entries visible. Previously,
+/// the guard `if wal_index.max_frame() > 0` skipped this, leaving frames
+/// appended to the WalIndex but invisible (max_frame stuck at 0).
+#[test]
+fn test_mp_finish_commit_updates_wal_index_on_first_write() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    // Truncate checkpoint to start with a completely empty WAL.
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    let wal_index = db_w
+        .wal_index
+        .as_ref()
+        .expect("SharedWrites should have WalIndex");
+    assert_eq!(
+        wal_index.max_frame(),
+        0,
+        "WalIndex should be empty after truncate"
+    );
+
+    // First write to the empty WAL.
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'first')");
+
+    // WalIndex max_frame must reflect the committed frames.
+    assert!(
+        wal_index.max_frame() > 0,
+        "WalIndex max_frame should be > 0 after first write (was 0)"
+    );
+
+    // A second process must be able to read the data via WalIndex.
+    let (_db_r, conn_r) = open_second_process(&dir);
+    assert_eq!(
+        query_i64(&conn_r, "SELECT count(*) FROM t"),
+        1,
+        "Reader should see the row committed via first write"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// rollback(None): WalIndex cleanup of uncommitted entries
+// ---------------------------------------------------------------------------
+
+/// Test: After rollback(None), uncommitted WalIndex entries (appended by
+/// append_frame but not committed by commit_max_frame) must be cleaned up.
+/// Without cleanup, stale hash entries persist and can cause collisions
+/// when new frames are written at the same positions.
+#[test]
+fn test_mp_rollback_none_cleans_wal_index() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1, 'baseline')");
+
+    let wal_index = db_w
+        .wal_index
+        .as_ref()
+        .expect("SharedWrites should have WalIndex");
+    let max_frame_before = wal_index.max_frame();
+    assert!(max_frame_before > 0);
+
+    // Begin a write transaction, insert data, then rollback.
+    exec(&conn_w, "BEGIN");
+    exec(&conn_w, "INSERT INTO t VALUES (2, 'will_rollback')");
+    exec(&conn_w, "INSERT INTO t VALUES (3, 'will_rollback')");
+    exec(&conn_w, "ROLLBACK");
+
+    // WalIndex max_frame should be unchanged (no commit happened).
+    assert_eq!(
+        wal_index.max_frame(),
+        max_frame_before,
+        "WalIndex max_frame should not change after rollback"
+    );
+
+    // Now write new data at the same frame positions.
+    // Without cleanup_uncommitted, stale hash entries from the rolled-back
+    // frames would pollute the hash table.
+    exec(&conn_w, "INSERT INTO t VALUES (4, 'after_rollback')");
+
+    // Verify data integrity.
+    assert_eq!(
+        query_i64(&conn_w, "SELECT count(*) FROM t"),
+        2,
+        "Writer should see baseline + new row"
+    );
+
+    // Reader must see correct data too.
+    let (_db_r, conn_r) = open_second_process(&dir);
+    assert_eq!(
+        query_i64(&conn_r, "SELECT count(*) FROM t"),
+        2,
+        "Reader should see baseline + new row"
+    );
+    assert_integrity_ok(&conn_r);
+}
+
+/// Regression: verify that begin_read_tx claims the TSHM reader slot BEFORE
+/// acquiring the inner read lock. Without this ordering, a concurrent Truncate
+/// checkpoint could scan TSHM, not see the reader, and truncate the WAL while
+/// the reader still needs its frames.
+#[test]
+fn test_mp_tshm_slot_claimed_before_inner_read_lock() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    // Write some data so the WAL has frames.
+    exec(&conn_w, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    exec(&conn_w, "INSERT INTO t VALUES (1,'hello')");
+
+    // Open a second process.
+    let (db_r, conn_r) = open_second_process(&dir);
+
+    // Start a read transaction in the reader.
+    exec(&conn_r, "BEGIN");
+    let count = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(count, 1);
+
+    // Verify the reader's TSHM slot is visible to the writer process.
+    // The writer's TSHM is the same mmap'd region, so it sees the slot.
+    let tshm_w = db_w.tshm.as_ref().expect("writer DB must have TSHM");
+    let tshm_r = db_r.tshm.as_ref().expect("reader DB must have TSHM");
+
+    // The writer should see at least one active reader (the reader process).
+    // Exclude the writer's own PID to check for external readers.
+    let writer_pid = std::process::id();
+    let external_min = tshm_w.min_reader_frame_excluding(writer_pid);
+    // In test mode, both use the same PID, so check has_active_readers instead.
+    assert!(
+        tshm_r.has_active_readers(),
+        "TSHM should have an active reader slot during read transaction"
+    );
+
+    // The external_min should be Some (since reader has a slot with our PID).
+    // Even though we exclude writer_pid, in tests both are the same PID,
+    // so fall back to checking has_active_readers above.
+    // If they had different PIDs (real multi-process), external_min would
+    // be Some(max_frame).
+    let _ = external_min;
+
+    // End the read transaction and verify the slot is released.
+    exec(&conn_r, "COMMIT");
+    // After commit, the reader's slot should be released. Start another
+    // read tx and immediately check — this just verifies the lifecycle.
+    // The slot is released in end_read_tx, which happens implicitly after COMMIT.
+
+    // Key verification: do a Truncate checkpoint while reader has a slot.
+    // Start a new read tx in the reader.
+    exec(&conn_r, "BEGIN");
+    let count2 = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(count2, 1);
+
+    // Checkpoint as Truncate — the reader's slot should prevent WAL truncation
+    // from causing issues.
+    run_checkpoint(
+        &conn_w,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    // Reader should still be able to read (WAL frames preserved or already
+    // in DB file after checkpoint).
+    let count3 = query_i64(&conn_r, "SELECT count(*) FROM t");
+    assert_eq!(count3, 1);
+    exec(&conn_r, "COMMIT");
+
+    assert_integrity_ok(&conn_w);
+    assert_integrity_ok(&conn_r);
+}
+
+/// Test that cache spilling (append_frames_vectored) works correctly
+/// with MultiProcessWal. When the page cache is full, dirty pages are
+/// spilled to the WAL via append_frames_vectored. The MultiProcessWal
+/// wrapper inserts those frames into the WalIndex but defers committing
+/// max_frame until finish_append_frames_commit (on COMMIT). This test
+/// verifies:
+/// 1. Data is correct after a spill+commit
+/// 2. Cross-process readers see the committed data
+/// 3. WalIndex is consistent after spilling
+#[test]
+fn test_mp_spill_deferred_commit() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    exec(
+        &conn_w,
+        "CREATE TABLE spill_test(id INTEGER PRIMARY KEY, val TEXT)",
+    );
+
+    // Record max_frame after CREATE TABLE (before the spill transaction).
+    let max_frame_before = db_w
+        .wal_index
+        .as_ref()
+        .map(|wi| wi.max_frame())
+        .unwrap_or(0);
+
+    // The minimum page cache is 200 pages (MINIMUM_PAGE_CACHE_SIZE_IN_PAGES).
+    // Spill threshold is 90% = 180 pages. Each ~4000 byte row fills roughly
+    // one page. Insert 250 rows to exceed the 180-page threshold and trigger
+    // cache spilling via append_frames_vectored.
+    exec(&conn_w, "PRAGMA cache_size = 200");
+
+    // Insert enough large rows in a single transaction to trigger spilling.
+    exec(&conn_w, "BEGIN");
+    for i in 0..250 {
+        let val: String = std::iter::repeat_n('x', 3800).collect();
+        conn_w
+            .execute(format!(
+                "INSERT INTO spill_test(id, val) VALUES ({i}, '{val}')"
+            ))
+            .unwrap();
+    }
+
+    // Verify spilling actually occurred BEFORE commit: the WAL file
+    // should have grown from append_frames_vectored writing spilled
+    // pages. WAL header = 32 bytes, each frame = 24 + 4096 = 4120 bytes.
+    // With only the CREATE TABLE frames, size ≈ 8K. If spilling occurred,
+    // size should be much larger.
+    let wal_path = dir.join("test.db-wal");
+    let wal_size_mid_tx = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+    assert!(
+        wal_size_mid_tx > 100_000,
+        "WAL file should have grown mid-transaction from spilling (size={wal_size_mid_tx})"
+    );
+
+    exec(&conn_w, "COMMIT");
+
+    // Verify writer sees all rows.
+    let count = query_i64(&conn_w, "SELECT count(*) FROM spill_test");
+    assert_eq!(
+        count, 250,
+        "writer should see all 250 rows after spill+commit"
+    );
+
+    // Verify WalIndex is consistent and has significantly more frames
+    // than before the spill transaction (indicating spilling occurred).
+    if let Some(wal_index) = &db_w.wal_index {
+        let max_frame_after = wal_index.max_frame();
+        assert!(
+            max_frame_after > max_frame_before + 100,
+            "WalIndex should have many more frames after spill+commit (before={max_frame_before}, after={max_frame_after})"
+        );
+        wal_index.verify_hash_integrity().unwrap();
+    }
+
+    // Cross-process reader should see all 250 rows.
+    let (_db_r, conn_r) = open_second_process(&dir);
+    let count_r = query_i64(&conn_r, "SELECT count(*) FROM spill_test");
+    assert_eq!(
+        count_r, 250,
+        "cross-process reader should see all 250 rows after spill+commit"
+    );
+
+    // Verify individual rows to check data integrity.
+    let rows = query_rows(&conn_r, "SELECT id FROM spill_test ORDER BY id LIMIT 5");
+    let ids: Vec<i64> = rows
+        .iter()
+        .filter_map(|r| match r.first() {
+            Some(Value::Numeric(crate::numeric::Numeric::Integer(v))) => Some(*v),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        ids,
+        vec![0, 1, 2, 3, 4],
+        "first 5 rows should have sequential ids"
+    );
+
+    assert_integrity_ok(&conn_w);
+    assert_integrity_ok(&conn_r);
+}
+
+/// Test that spill + rollback correctly discards spilled frames.
+/// When a transaction spills dirty pages and then rolls back,
+/// the WalIndex entries are cleaned up and cross-process readers
+/// should NOT see the rolled-back data.
+#[test]
+fn test_mp_spill_rollback() {
+    let (db_w, conn_w, dir) = open_mp_database();
+
+    exec(
+        &conn_w,
+        "CREATE TABLE spill_rb(id INTEGER PRIMARY KEY, val TEXT)",
+    );
+
+    // Insert baseline data.
+    exec(&conn_w, "INSERT INTO spill_rb(id) VALUES (1)");
+
+    // Open reader BEFORE the spill transaction.
+    let (db_r, conn_r) = open_second_process(&dir);
+    let count_before = query_i64(&conn_r, "SELECT count(*) FROM spill_rb");
+    assert_eq!(count_before, 1);
+
+    // Set minimum cache and do a large transaction that we'll roll back.
+    // 250 rows × ~4000 bytes each should exceed the 180-page spill threshold.
+    exec(&conn_w, "PRAGMA cache_size = 200");
+    exec(&conn_w, "BEGIN");
+    for i in 100..350 {
+        let val: String = std::iter::repeat_n('y', 3800).collect();
+        conn_w
+            .execute(format!(
+                "INSERT INTO spill_rb(id, val) VALUES ({i}, '{val}')"
+            ))
+            .unwrap();
+    }
+
+    // Verify spilling occurred before rollback.
+    let wal_path = dir.join("test.db-wal");
+    let wal_size_mid_tx = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+    assert!(
+        wal_size_mid_tx > 100_000,
+        "WAL file should have grown mid-transaction from spilling (size={wal_size_mid_tx})"
+    );
+
+    exec(&conn_w, "ROLLBACK");
+
+    // Writer should only see baseline data.
+    let count_w = query_i64(&conn_w, "SELECT count(*) FROM spill_rb");
+    assert_eq!(count_w, 1, "writer should see only baseline after rollback");
+
+    // Verify WalIndex cleanup.
+    if let Some(wal_index) = &db_w.wal_index {
+        wal_index.verify_hash_integrity().unwrap();
+    }
+
+    // Cross-process reader should also see only baseline.
+    let count_r2 = query_i64(&conn_r, "SELECT count(*) FROM spill_rb");
+    assert_eq!(
+        count_r2, 1,
+        "cross-process reader should not see rolled-back spill data"
+    );
+
+    assert_integrity_ok(&conn_w);
+    assert_integrity_ok(&conn_r);
+
+    drop(conn_r);
+    drop(db_r);
+    drop(conn_w);
+    drop(db_w);
+}

--- a/core/storage/multi_process_wal.rs
+++ b/core/storage/multi_process_wal.rs
@@ -1,0 +1,964 @@
+//! Multi-process WAL wrapper.
+//!
+//! Wraps a [`WalFile`] and adds inter-process coordination via:
+//! - **TSHM** reader slots (readers publish their snapshot frame for checkpoint safety)
+//! - **TSHM** writer state (writer publishes max_frame+checkpoint_seq so readers
+//!   can skip expensive WAL rescans when nothing changed)
+//! - **TSHM** write lock (CAS + fcntl byte-range lock for exclusive write access)
+//!
+//! The WAL file format is unchanged — this is purely a coordination layer.
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[allow(dead_code)]
+mod imp {
+    use std::fmt;
+    use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    use crate::io::{File, FileSyncType};
+    use crate::storage::buffer_pool::BufferPool;
+    use crate::storage::database::IOContext;
+    use crate::storage::pager::{PageRef, Pager};
+    use crate::storage::sqlite3_ondisk::PageSize;
+    use crate::storage::tshm::{SlotHandle, Tshm};
+    use crate::storage::wal::{
+        CheckpointMode, CheckpointResult, PreparedFrames, RollbackTo, Wal, WalFile,
+    };
+    use crate::storage::wal_index::WalIndex;
+    use crate::sync::Mutex;
+    use crate::types::IOResult;
+    use crate::{Completion, LimboError};
+
+    /// Multi-process-aware WAL that wraps a [`WalFile`] with inter-process
+    /// coordination via TSHM reader slots and CAS + fcntl write locking.
+    pub struct MultiProcessWal {
+        inner: WalFile,
+        tshm: Arc<Tshm>,
+        locking_mode: crate::LockingMode,
+        /// Slot handle for the current read transaction (if any).
+        reader_slot: Mutex<Option<SlotHandle>>,
+        /// Cached TSHM writer state. Compared against the live TSHM value
+        /// in `begin_read_tx` to decide whether a full WAL rescan is needed.
+        /// Packed as [checkpoint_seq:32][max_frame:32].
+        cached_writer_state: AtomicU64,
+        /// Shared WAL index in mmap'd memory for zero-I/O frame lookups.
+        wal_index: Option<Arc<WalIndex>>,
+        /// WalIndex generation at the time of our read transaction.
+        /// If the WalIndex generation changes (WAL restart/truncate), we fall
+        /// back to inner.find_frame to avoid reading stale entries.
+        cached_wal_index_generation: AtomicU32,
+        /// WalIndex pgno_checksum snapshot from begin_read_tx.
+        /// Used to detect hash table corruption between transactions:
+        /// if pgno_checksum changed without a TSHM bump, corruption is likely.
+        cached_pgno_checksum: AtomicU32,
+        /// Max frame from successful spill (append_frames_vectored) that
+        /// hasn't been committed to WalIndex yet. Set by append_frames_vectored
+        /// on success (no failure), consumed by finish_append_frames_commit.
+        /// 0 means no pending spill. This prevents uncommitted spill frames
+        /// from being visible to cross-process readers via WalIndex.
+        pending_spill_max_frame: AtomicU32,
+        /// Cached per-connection min_frame from begin_read_tx. Avoids
+        /// a cross-struct atomic load in find_frame (called per page read).
+        /// min_frame is stable within a transaction (only changes after
+        /// checkpoint), so caching it in begin_read_tx is safe.
+        /// Note: max_frame is NOT cached because it changes during writes
+        /// (commit_prepared_frames, append_frames_vectored, rollback).
+        cached_reader_min_frame: AtomicU32,
+        /// Cached process ID (avoid syscall on macOS per begin_read_tx).
+        pid: u32,
+    }
+
+    impl fmt::Debug for MultiProcessWal {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("MultiProcessWal")
+                .field("inner", &self.inner)
+                .finish()
+        }
+    }
+
+    impl MultiProcessWal {
+        pub fn new(
+            inner: WalFile,
+            tshm: Arc<Tshm>,
+            locking_mode: crate::LockingMode,
+            wal_index: Option<Arc<WalIndex>>,
+        ) -> Self {
+            Self {
+                inner,
+                tshm,
+                locking_mode,
+                reader_slot: Mutex::new(None),
+                cached_writer_state: AtomicU64::new(0),
+                wal_index,
+                // Sentinel: no generation matches until begin_read_tx validates
+                // the WalIndex state. Prevents stale WalIndex data from being
+                // used during early reads (e.g. page 1 during database open).
+                cached_wal_index_generation: AtomicU32::new(u32::MAX),
+                cached_pgno_checksum: AtomicU32::new(0),
+                pending_spill_max_frame: AtomicU32::new(0),
+                cached_reader_min_frame: AtomicU32::new(0),
+                pid: std::process::id(),
+            }
+        }
+
+        /// Access the inner WalFile (for tests that need to inspect WAL internals).
+        pub fn inner(&self) -> &WalFile {
+            &self.inner
+        }
+
+        /// Publish the current WAL state (checkpoint_seq + max_frame) to the
+        /// TSHM header so other processes can detect changes cheaply.
+        /// Also updates our local cache so we don't trigger a spurious rescan
+        /// on our own next `begin_read_tx`.
+        /// Bump the TSHM writer-state counter so readers in other processes
+        /// detect that the WAL has changed and trigger a rescan.
+        fn publish_writer_state(&self) {
+            let new_state = self.tshm.increment_writer_state();
+            self.cached_writer_state.store(new_state, Ordering::Release);
+        }
+
+        /// Read all header fields from WalIndex and sync the inner WalFile.
+        /// Returns true if WalIndex was populated and sync succeeded,
+        /// false if WalIndex is empty (max_frame == 0).
+        ///
+        /// Does NOT call `verify_hash_integrity` — callers that need integrity
+        /// verification (write path) should call it explicitly. The read path
+        /// relies on the O(1) pgno_checksum comparison in `begin_read_tx`.
+        fn sync_inner_from_wal_index(&self, wal_index: &WalIndex) -> crate::Result<bool> {
+            wal_index.ensure_segments_mapped()?;
+            // Seqlock: snapshot generation before reading header fields.
+            let gen_before = wal_index.generation();
+            let wi_max_frame = wal_index.max_frame();
+            if wi_max_frame == 0 {
+                return Ok(false);
+            }
+            let (wi_s1, wi_s2) = wal_index.salt();
+            let wi_page_size = wal_index.page_size();
+            let wi_last_checksum = wal_index.last_checksum();
+            let wi_checkpoint_seq = wal_index.checkpoint_seq();
+            // If generation changed during our reads, a concurrent
+            // clear/restart occurred and our values may be torn.
+            // Return false to trigger disk fallback.
+            if wal_index.generation() != gen_before {
+                return Ok(false);
+            }
+            self.inner.sync_from_wal_index_header(
+                wi_max_frame as u64,
+                wi_s1,
+                wi_s2,
+                wi_page_size,
+                wi_last_checksum,
+                wi_checkpoint_seq,
+            );
+            Ok(true)
+        }
+
+        /// Fall back to WAL file rescan and invalidate the cached WalIndex
+        /// generation so find_frame uses inner.find_frame.
+        fn rescan_and_invalidate_generation(&self) -> crate::Result<()> {
+            self.inner.rescan_wal_from_disk()?;
+            self.cached_wal_index_generation
+                .store(u32::MAX, Ordering::Release);
+            Ok(())
+        }
+
+        /// Clear the WalIndex, passing the current WAL salt so readers
+        /// don't see a transient zero-salt window.
+        fn clear_wal_index(&self, wal_index: &WalIndex) {
+            let (s1, s2) = self.inner.get_wal_salt();
+            wal_index.clear(s1, s2);
+        }
+
+        /// Clear WalIndex and rescan WAL from disk. Used when WalIndex
+        /// becomes inconsistent (e.g. append_frame I/O failure).
+        /// After a successful rescan, repopulates the WalIndex so readers
+        /// can use it immediately instead of falling back to inner.find_frame.
+        fn recover_wal_index(&self, wal_index: &WalIndex, context: &str) {
+            tracing::warn!("WalIndex {context}, clearing index and rescanning from disk");
+            self.clear_wal_index(wal_index);
+            match self.inner.rescan_wal_from_disk() {
+                Ok(()) => {
+                    if let Err(e) = self.inner.populate_wal_index(wal_index) {
+                        tracing::warn!("WalIndex repopulation after recovery failed: {e}");
+                        // Not fatal — next begin_write_tx will retry.
+                        wal_index.cleanup_uncommitted();
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "rescan_wal_from_disk failed during WalIndex recovery: {e}. \
+                         WalIndex cleared; readers fall back to disk until next rescan."
+                    );
+                    // Force next begin_read_tx to attempt a fresh rescan
+                    // by invalidating cached state.
+                    self.cached_writer_state.store(0, Ordering::Release);
+                    self.cached_wal_index_generation
+                        .store(u32::MAX, Ordering::Release);
+                }
+            }
+        }
+
+        /// After appending frames to WalIndex, handle failure recovery
+        /// or commit. Called by commit_prepared_frames (with commit=true)
+        /// and append_frames_vectored (with commit=false).
+        ///
+        /// When commit=false (spill path), frames are inserted into the hash
+        /// table but max_frame is NOT advanced. This prevents cross-process
+        /// readers from seeing uncommitted spilled data. The max_frame is
+        /// advanced later by finish_append_frames_commit on successful commit,
+        /// or the entries are cleaned up by rollback(None) via
+        /// cleanup_uncommitted.
+        fn finalize_wal_index_append(
+            &self,
+            wal_index: &WalIndex,
+            any_failed: bool,
+            new_max_frame: u32,
+            commit: bool,
+            context: &str,
+        ) {
+            if any_failed {
+                self.recover_wal_index(wal_index, context);
+            } else if commit && new_max_frame > 0 {
+                wal_index.commit_max_frame(new_max_frame);
+            }
+            self.sync_wal_index_metadata(wal_index);
+        }
+
+        /// Compare the current pgno_checksum against our cached value.
+        /// On mismatch, call verify_hash_integrity to detect corruption.
+        /// Updates the cached checksum on success.
+        ///
+        /// The O(max_frame) verify only triggers when pgno_checksum changed,
+        /// which requires a cross-process writer commit. Within a process,
+        /// TSHM state never diverges so checksum stays constant.
+        fn check_pgno_checksum(&self, wal_index: &WalIndex) -> crate::Result<()> {
+            let current_cksum = wal_index.pgno_checksum();
+            let cached_cksum = self.cached_pgno_checksum.load(Ordering::Acquire);
+            if current_cksum != cached_cksum {
+                wal_index.verify_hash_integrity()?;
+                self.cached_pgno_checksum
+                    .store(current_cksum, Ordering::Release);
+            }
+            Ok(())
+        }
+
+        /// Check the TSHM writer state and sync WAL metadata if another
+        /// process has modified it since our last check. Returns whether the
+        /// TSHM state changed (useful for forcing page cache invalidation even
+        /// when the WAL rescan reports no changes, e.g. after Truncate).
+        ///
+        /// Used by the WRITE path (begin_write_tx). When WalIndex is available
+        /// and populated, syncs from mmap instead of reading the WAL file.
+        /// Falls back to disk rescan only when WalIndex is empty/unavailable.
+        fn maybe_rescan_from_tshm(&self) -> crate::Result<bool> {
+            let current_state = self.tshm.writer_state();
+            let cached_state = self.cached_writer_state.load(Ordering::Acquire);
+            if current_state == cached_state {
+                return Ok(false);
+            }
+
+            if let Some(wal_index) = &self.wal_index {
+                // Write path needs integrity verification before trusting
+                // WalIndex header values (max_frame, salt, last_checksum)
+                // that will be used for checksum chaining in prepare_frames.
+                wal_index.verify_hash_integrity()?;
+                if self.sync_inner_from_wal_index(wal_index)? {
+                    // Don't invalidate WalIndex generation — it's still valid.
+                    self.cached_writer_state
+                        .store(current_state, Ordering::Release);
+                    return Ok(true);
+                }
+            }
+
+            // WalIndex empty or unavailable — fall back to disk.
+            self.rescan_and_invalidate_generation()?;
+            self.cached_writer_state
+                .store(current_state, Ordering::Release);
+            Ok(true)
+        }
+
+        /// Sync WAL state for the READ path using the WalIndex (zero I/O).
+        ///
+        /// When the WalIndex is populated (max_frame > 0), updates the inner
+        /// WalFile's shared state from the mmap'd header — no file I/O at all.
+        /// The read path then uses WalIndex for `find_frame` lookups.
+        ///
+        /// When the WalIndex is empty (max_frame == 0), falls back to a WAL
+        /// file rescan. This handles two cases:
+        /// - WAL genuinely empty after a Truncate checkpoint (rescan is cheap)
+        /// - WalIndex cleared due to an error (rescan discovers actual frames)
+        fn sync_from_wal_index_for_read(&self) -> crate::Result<bool> {
+            let current_state = self.tshm.writer_state();
+            let cached_state = self.cached_writer_state.load(Ordering::Acquire);
+            if current_state == cached_state {
+                return Ok(false);
+            }
+
+            if let Some(wal_index) = &self.wal_index {
+                if !self.sync_inner_from_wal_index(wal_index)? {
+                    // WalIndex empty — fall back to WAL rescan.
+                    self.rescan_and_invalidate_generation()?;
+                }
+            } else {
+                self.inner.rescan_wal_from_disk()?;
+            }
+
+            self.cached_writer_state
+                .store(current_state, Ordering::Release);
+            Ok(true)
+        }
+
+        /// Publish external reader constraint from TSHM so that WalFile's
+        /// checkpoint and try_restart_log respect cross-process readers.
+        /// Excludes our own PID (managed by process-local read_locks).
+        fn publish_external_reader_constraint(&self) {
+            let min_frame = self
+                .tshm
+                .min_reader_frame_excluding(self.pid)
+                .map(|f| f as u64)
+                .unwrap_or(0);
+            self.inner.set_external_reader_max_frame(min_frame);
+        }
+
+        /// Sync WAL metadata (salt, page_size, last_checksum) from inner
+        /// WalFile to WalIndex header. Called by the writer after commits
+        /// so that readers can sync from WalIndex without reading the WAL file.
+        fn sync_wal_index_metadata(&self, wal_index: &WalIndex) {
+            let ps = self.inner.get_wal_page_size();
+            if ps > 0 && wal_index.page_size() != ps {
+                wal_index.set_page_size(ps);
+            }
+            let (s1, s2) = self.inner.get_wal_salt();
+            let (wi_s1, wi_s2) = wal_index.salt();
+            if (s1, s2) != (wi_s1, wi_s2) {
+                wal_index.set_salt(s1, s2);
+            }
+            let (c1, c2) = self.inner.get_last_checksum();
+            wal_index.set_last_checksum(c1, c2);
+            let ckpt_seq = self.inner.get_checkpoint_seq();
+            wal_index.set_checkpoint_seq(ckpt_seq);
+        }
+    }
+
+    impl Wal for MultiProcessWal {
+        fn begin_read_tx(&self) -> crate::Result<bool> {
+            let tshm_changed = self.sync_from_wal_index_for_read()?;
+
+            // Claim a TSHM slot BEFORE inner.begin_read_tx() so that
+            // concurrent checkpointers in other processes see our presence.
+            // Without this, a Truncate checkpoint could scan TSHM between
+            // our inner.begin_read_tx() and slot claim, not see us, and
+            // truncate the WAL while we still need its frames.
+            //
+            // Use the shared max_frame as a conservative preliminary value.
+            // The actual per-connection max_frame (set by inner.begin_read_tx)
+            // may differ in either direction, but both cases are safe for
+            // checkpoint bounding (see update comment below).
+            let pid = self.pid;
+            let preliminary_max = self.inner.get_max_frame_in_wal() as u32;
+            let handle = match self.tshm.claim_reader_slot(pid, preliminary_max) {
+                Some(h) => h,
+                None => return Err(LimboError::Busy),
+            };
+
+            let changed = match self.inner.begin_read_tx() {
+                Ok(c) => c,
+                Err(e) => {
+                    self.tshm.release_reader_slot(handle);
+                    return Err(e);
+                }
+            };
+
+            // Update the slot with the actual per-connection max_frame.
+            // May differ from preliminary_max in either direction:
+            // - After WAL restart/truncate: actual < preliminary (slot was
+            //   conservative, blocks checkpoint longer — safe)
+            // - After concurrent writer commit: actual > preliminary (slot
+            //   briefly allows more checkpoint, but inner read_lock provides
+            //   per-process protection — safe)
+            let actual_max = self.inner.get_max_frame() as u32;
+            if actual_max != preliminary_max {
+                self.tshm.update_reader_slot(&handle, pid, actual_max);
+            }
+
+            // Cache min_frame for find_frame so it doesn't need to reach
+            // into inner (separate struct / cache line) on every page read.
+            self.cached_reader_min_frame
+                .store(self.inner.get_min_frame() as u32, Ordering::Relaxed);
+
+            // Snapshot the WalIndex generation and pgno_checksum so find_frame
+            // can detect stale entries and mid-transaction corruption.
+            if let Some(wal_index) = &self.wal_index {
+                let wi_max = wal_index.max_frame();
+                if wi_max > 0 {
+                    // Cache generation so find_frame uses WalIndex.
+                    self.cached_wal_index_generation
+                        .store(wal_index.generation(), Ordering::Release);
+                    // Detect hash table corruption via O(1) pgno_checksum
+                    // comparison. Checked every begin_read_tx because
+                    // corruption can co-occur with legitimate TSHM bumps.
+                    if let Err(e) = self.check_pgno_checksum(wal_index) {
+                        // Reset generation so a retry doesn't accidentally
+                        // match a stale value from this failed attempt.
+                        self.cached_wal_index_generation
+                            .store(u32::MAX, Ordering::Release);
+                        self.tshm.release_reader_slot(handle);
+                        self.inner.end_read_tx();
+                        return Err(e);
+                    }
+                } else {
+                    // WalIndex empty (cleared or fresh) — sentinel forces
+                    // find_frame to fall through to inner.find_frame.
+                    self.cached_wal_index_generation
+                        .store(u32::MAX, Ordering::Release);
+                }
+            }
+
+            // Single mutex acquisition: release any leftover slot (defense-in-depth)
+            // and store the new handle.
+            {
+                let mut slot = self.reader_slot.lock();
+                if let Some(old_handle) = slot.take() {
+                    debug_assert!(false, "begin_read_tx called without end_read_tx");
+                    self.tshm.release_reader_slot(old_handle);
+                }
+                *slot = Some(handle);
+            }
+
+            // If the TSHM writer state changed, always force page cache
+            // invalidation. After a Truncate checkpoint the WAL goes back
+            // to empty — rescan_wal_from_disk may see identical WAL state
+            // (0,0) and skip, but the DB file has been updated by the
+            // checkpoint. The TSHM counter change tells us *something*
+            // happened, so it's always safe (and necessary) to invalidate.
+            Ok(changed || tshm_changed)
+        }
+
+        fn mvcc_refresh_if_db_changed(&self) -> crate::Result<bool> {
+            // MVCC is incompatible with shared locking modes (enforced at
+            // Database::header_validation). This path is unreachable but
+            // required by the Wal trait.
+            debug_assert!(
+                false,
+                "mvcc_refresh_if_db_changed called on MultiProcessWal"
+            );
+            Ok(self.inner.mvcc_refresh_if_db_changed())
+        }
+
+        fn begin_write_tx(&self) -> crate::Result<()> {
+            // Clear any stale pending spill max_frame from a previous
+            // transaction (e.g. if end_write_tx was called without commit
+            // or rollback due to an error path).
+            self.pending_spill_max_frame.store(0, Ordering::Release);
+
+            // Acquire inter-process write lock (may return Busy).
+            // In SharedReads mode, the CAS lock in TSHM provides exclusion:
+            // only one process can hold it at a time. If the previous holder
+            // crashed, dead-owner detection allows another process to take over.
+            self.tshm.write_lock()?;
+
+            // Check if another process modified the WAL since our last rescan.
+            // Critical case: another process did a Restart checkpoint (changing
+            // the salt) and wrote frames with the new salt. Without this rescan,
+            // our WalFileShared still has the old salt, and prepare_frames would
+            // embed the old salt in frame headers — making those frames
+            // invisible on recovery (salt mismatch with the on-disk WAL header).
+            //
+            // begin_read_tx also rescans (TSHM-gated), but that may not have
+            // run if the caller held an explicit transaction open (BEGIN +
+            // SELECT, then INSERT upgrades directly to write without a new
+            // begin_read_tx). This check catches that case.
+            //
+            // TSHM-based detection is safe here because in our implementation
+            // the TSHM writer_state is always bumped (via publish_writer_state
+            // in begin_write_tx) before the WAL header is flushed to disk (via
+            // prepare_wal_start). So any on-disk salt change is always preceded
+            // by a TSHM bump that we can observe.
+            if let Err(e) = self.maybe_rescan_from_tshm() {
+                self.tshm.write_unlock();
+                return Err(e);
+            }
+
+            // Publish external reader info so that try_restart_log_before_write
+            // won't destroy WAL frames that other-process readers still need.
+            self.publish_external_reader_constraint();
+
+            // Save checkpoint_seq before begin_write_tx (which may restart the WAL).
+            let checkpoint_seq_before = self.inner.get_checkpoint_seq();
+
+            match self.inner.begin_write_tx() {
+                Ok(()) => {
+                    // Detect WAL restart/truncate: checkpoint_seq changed or WAL
+                    // is empty but WalIndex still has stale frames.
+                    if let Some(wal_index) = &self.wal_index {
+                        let inner_max = self.inner.get_max_frame();
+                        if self.inner.get_checkpoint_seq() != checkpoint_seq_before
+                            || (inner_max == 0 && wal_index.max_frame() > 0)
+                        {
+                            self.clear_wal_index(wal_index);
+                        }
+                        // Bootstrap: WalIndex is empty but WAL has frames.
+                        // This happens on first write after open, after a
+                        // clear(), or when another process wrote frames that
+                        // the WalIndex doesn't know about yet.
+                        if wal_index.max_frame() == 0 && inner_max > 0 {
+                            if let Err(e) = self.inner.populate_wal_index(wal_index) {
+                                // Clean up partially-inserted hash entries to
+                                // avoid duplicate insertions on retry.
+                                wal_index.cleanup_uncommitted();
+                                self.inner.end_write_tx();
+                                self.inner.set_external_reader_max_frame(0);
+                                self.tshm.write_unlock();
+                                return Err(e);
+                            }
+                        }
+                        self.sync_wal_index_metadata(wal_index);
+                    }
+                    // begin_write_tx may trigger WAL restart (checkpoint_seq
+                    // changes, max_frame → 0). Publish so readers see it.
+                    self.publish_writer_state();
+                    Ok(())
+                }
+                Err(e) => {
+                    // Inner lock failed — release inter-process lock.
+                    self.inner.set_external_reader_max_frame(0);
+                    self.tshm.write_unlock();
+                    Err(e)
+                }
+            }
+        }
+
+        fn end_read_tx(&self) {
+            // Release TSHM slot before inner read lock.
+            if let Some(handle) = self.reader_slot.lock().take() {
+                self.tshm.release_reader_slot(handle);
+            }
+            self.inner.end_read_tx();
+        }
+
+        fn end_write_tx(&self) {
+            // No publish_writer_state() here — commit_prepared_frames,
+            // finish_append_frames_commit, and begin_write_tx already
+            // published the final state. Publishing again causes readers
+            // to spuriously enter the sync slow path for no new data.
+            self.inner.end_write_tx();
+            self.inner.set_external_reader_max_frame(0);
+            // In SharedReads mode, keep the write lock permanently held
+            // (sticky) so no other process can write. Only release if the
+            // refcount is > 1 (header_validation already holds one ref).
+            // When a process takes over after the original holder crashed,
+            // active_writers() == 1, so we skip the unlock — making the
+            // new holder permanent too.
+            if self.locking_mode == crate::LockingMode::SharedReads
+                && self.tshm.active_writers() <= 1
+            {
+                return;
+            }
+            self.tshm.write_unlock();
+        }
+
+        fn holds_read_lock(&self) -> bool {
+            self.inner.holds_read_lock()
+        }
+
+        fn holds_write_lock(&self) -> bool {
+            self.inner.holds_write_lock()
+        }
+
+        fn find_frame(
+            &self,
+            page_id: u64,
+            frame_watermark: Option<u64>,
+        ) -> crate::Result<Option<u64>> {
+            // Use the shared WAL index for zero-I/O lookups when populated
+            // and from the same generation as our read snapshot. The live
+            // generation comparison acts as a safety net: if anything changes
+            // the WalIndex during this read transaction (e.g. WAL restart
+            // after a TRUNCATE checkpoint where our reader_max equals the
+            // WAL max_frame), the mismatch forces fallback to inner.find_frame.
+            if let Some(wal_index) = &self.wal_index {
+                let wi_gen = wal_index.generation();
+                // Relaxed: cached_gen is set by begin_read_tx in the same
+                // thread; no cross-thread synchronization needed.
+                let cached_gen = self.cached_wal_index_generation.load(Ordering::Relaxed);
+                let reader_max = self.inner.get_max_frame() as u32;
+                if wi_gen == cached_gen && reader_max > 0 {
+                    // Use cached min_frame (set in begin_read_tx, stable
+                    // within a transaction) to avoid reaching into inner.
+                    let min_frame = self.cached_reader_min_frame.load(Ordering::Relaxed);
+                    let max_frame = frame_watermark.unwrap_or(u32::MAX as u64) as u32;
+                    let effective_max = max_frame.min(reader_max);
+                    return Ok(wal_index
+                        .find_frame(page_id as u32, min_frame, effective_max)
+                        .map(|f| f as u64));
+                }
+            }
+            // Stale generation or WalIndex unavailable — use inner frame_cache.
+            self.inner.find_frame(page_id, frame_watermark)
+        }
+
+        fn read_frame(
+            &self,
+            frame_id: u64,
+            page: PageRef,
+            buffer_pool: Arc<BufferPool>,
+        ) -> crate::Result<Completion> {
+            self.inner.read_frame(frame_id, page, buffer_pool)
+        }
+
+        fn read_frame_raw(&self, frame_id: u64, frame: &mut [u8]) -> crate::Result<Completion> {
+            self.inner.read_frame_raw(frame_id, frame)
+        }
+
+        fn write_frame_raw(
+            &self,
+            buffer_pool: Arc<BufferPool>,
+            frame_id: u64,
+            page_id: u64,
+            db_size: u64,
+            page: &[u8],
+            sync_type: FileSyncType,
+        ) -> crate::Result<()> {
+            self.inner
+                .write_frame_raw(buffer_pool, frame_id, page_id, db_size, page, sync_type)
+        }
+
+        fn prepare_wal_start(&self, page_sz: PageSize) -> crate::Result<Option<Completion>> {
+            self.inner.prepare_wal_start(page_sz)
+        }
+
+        fn prepare_wal_finish(&self, sync_type: FileSyncType) -> crate::Result<Completion> {
+            self.inner.prepare_wal_finish(sync_type)
+        }
+
+        fn prepare_frames(
+            &self,
+            pages: &[PageRef],
+            page_sz: PageSize,
+            db_size_on_commit: Option<u32>,
+            prev: Option<&PreparedFrames>,
+        ) -> crate::Result<PreparedFrames> {
+            self.inner
+                .prepare_frames(pages, page_sz, db_size_on_commit, prev)
+        }
+
+        fn commit_prepared_frames(&self, prepared: &[PreparedFrames]) {
+            self.inner.commit_prepared_frames(prepared);
+
+            // Append committed frames to the shared WalIndex.
+            if let Some(wal_index) = &self.wal_index {
+                let mut any_failed = false;
+                for batch in prepared {
+                    for (page, frame_id, _checksum) in &batch.metadata {
+                        if wal_index
+                            .append_frame(page.get().id as u32, *frame_id as u32)
+                            .is_err()
+                        {
+                            any_failed = true;
+                            break;
+                        }
+                    }
+                    if any_failed {
+                        break;
+                    }
+                }
+                let new_max = prepared
+                    .last()
+                    .map(|b| b.final_max_frame as u32)
+                    .unwrap_or(0);
+                self.finalize_wal_index_append(
+                    wal_index,
+                    any_failed,
+                    new_max,
+                    true, // commit: frames are committed
+                    "append_frame failed in commit",
+                );
+            }
+
+            // Publish new max_frame so readers in other processes can see
+            // the committed frames without waiting for end_write_tx.
+            self.publish_writer_state();
+        }
+
+        fn finalize_committed_pages(&self, prepared: &[PreparedFrames]) {
+            self.inner.finalize_committed_pages(prepared)
+        }
+
+        fn wal_file(&self) -> crate::Result<Arc<dyn File>> {
+            self.inner.wal_file()
+        }
+
+        fn append_frames_vectored(
+            &self,
+            pages: Vec<PageRef>,
+            page_sz: PageSize,
+        ) -> crate::Result<Completion> {
+            if let Some(wal_index) = &self.wal_index {
+                // Capture page IDs and pre-append max_frame before consuming pages.
+                let pre_max = self.inner.get_max_frame() as u32;
+                let page_ids: Vec<u32> = pages.iter().map(|p| p.get().id as u32).collect();
+                let result = self.inner.append_frames_vectored(pages, page_sz)?;
+                let mut any_failed = false;
+                for (i, &page_id) in page_ids.iter().enumerate() {
+                    let frame_id = match pre_max.checked_add(1 + i as u32) {
+                        Some(id) => id,
+                        None => {
+                            any_failed = true;
+                            break;
+                        }
+                    };
+                    if wal_index.append_frame(page_id, frame_id).is_err() {
+                        any_failed = true;
+                        break;
+                    }
+                }
+                // Do NOT commit max_frame here — spilled frames are
+                // uncommitted. commit_max_frame is deferred to
+                // finish_append_frames_commit so cross-process readers
+                // cannot see uncommitted data. On rollback,
+                // cleanup_uncommitted trims entries above the committed
+                // max_frame.
+                let new_max = self.inner.get_max_frame() as u32;
+                self.finalize_wal_index_append(
+                    wal_index,
+                    any_failed,
+                    new_max,
+                    false, // spill: do not commit max_frame yet
+                    "append_frame failed in vectored spill",
+                );
+                // Record the pending max_frame for finish_append_frames_commit
+                // to commit on successful transaction completion. Reset to 0
+                // on failure (recover_wal_index cleared the WalIndex).
+                if !any_failed {
+                    self.pending_spill_max_frame
+                        .store(new_max, Ordering::Release);
+                } else {
+                    self.pending_spill_max_frame.store(0, Ordering::Release);
+                }
+                Ok(result)
+            } else {
+                self.inner.append_frames_vectored(pages, page_sz)
+            }
+        }
+
+        fn finish_append_frames_commit(&self) -> crate::Result<()> {
+            let result = self.inner.finish_append_frames_commit();
+            if result.is_ok() {
+                // Commit the pending spill max_frame to WalIndex now that the
+                // transaction is committed. Only commits if append_frames_vectored
+                // recorded a pending value (non-zero) without failure.
+                //
+                // Guard: commit_prepared_frames may have already advanced
+                // WalIndex max_frame beyond the spill value (spill frames 1-N,
+                // then commit frames N+1..M calls commit_max_frame(M)).
+                // Only advance when pending exceeds the current committed max.
+                let pending = self.pending_spill_max_frame.swap(0, Ordering::AcqRel);
+                if pending > 0 {
+                    if let Some(wal_index) = &self.wal_index {
+                        if pending > wal_index.max_frame() {
+                            wal_index.commit_max_frame(pending);
+                        }
+                    }
+                }
+                self.publish_writer_state();
+            }
+            result
+        }
+
+        fn should_checkpoint(&self) -> bool {
+            self.inner.should_checkpoint()
+        }
+
+        fn checkpoint(
+            &self,
+            pager: &Pager,
+            mode: CheckpointMode,
+        ) -> crate::Result<IOResult<CheckpointResult>> {
+            // Rescan the WAL from disk so our frame_cache includes frames
+            // written by other processes. Without this, we'd only checkpoint
+            // our own frames, and a subsequent WAL restart would lose the
+            // uncopied frames. Also clear the page cache so checkpoint doesn't
+            // use stale cached pages that don't match the on-disk WAL frames.
+            self.inner.rescan_wal_from_disk()?;
+            pager.clear_page_cache(false);
+
+            // Publish TSHM min_reader_frame so that WalFile's
+            // determine_max_safe_checkpoint_frame() respects cross-process readers.
+            self.publish_external_reader_constraint();
+
+            let result = self.inner.checkpoint(pager, mode);
+
+            // Clear after checkpoint completes.
+            self.inner.set_external_reader_max_frame(0);
+
+            // Only clear WalIndex on successful checkpoint. On failure after
+            // a partial Restart (restart_log succeeded but a later step failed),
+            // max_frame_in_wal may be 0 but the WAL frames are still valid.
+            // Clearing would create a WalIndex/TSHM inconsistency since
+            // publish_writer_state is gated on success below.
+            if let Some(wal_index) = &self.wal_index {
+                if result.is_ok()
+                    && self.inner.get_max_frame_in_wal() == 0
+                    && wal_index.max_frame() > 0
+                {
+                    self.clear_wal_index(wal_index);
+                }
+                // Sync metadata (salt may have changed after Restart checkpoint).
+                self.sync_wal_index_metadata(wal_index);
+            }
+
+            // After a Restart checkpoint the WAL header is updated in memory
+            // (new checkpoint_seq, new salt) but NOT on disk. The new header
+            // is flushed lazily by prepare_wal_start() on the next write,
+            // which happens only after the pager has fully synced the DB file.
+            // Flushing the header eagerly here would risk data loss: a crash
+            // before the DB sync would leave the WAL with a new salt (making
+            // old frames invisible) while the DB pages are not durable.
+            //
+            // Other processes detect the restart via the
+            // TSHM writer_state change (publish_writer_state below) and rescan
+            // from disk: they see the old header + old frames, which contain
+            // data already backfilled to the DB, so reads are correct.
+
+            // Publish so readers in other processes detect the change and
+            // trigger a rescan.
+            if result.is_ok() {
+                self.publish_writer_state();
+            }
+
+            result
+        }
+
+        fn sync(&self, sync_type: FileSyncType) -> crate::Result<Completion> {
+            self.inner.sync(sync_type)
+        }
+
+        fn is_syncing(&self) -> bool {
+            self.inner.is_syncing()
+        }
+
+        fn get_max_frame_in_wal(&self) -> u64 {
+            self.inner.get_max_frame_in_wal()
+        }
+
+        fn get_checkpoint_seq(&self) -> u32 {
+            self.inner.get_checkpoint_seq()
+        }
+
+        fn get_max_frame(&self) -> u64 {
+            self.inner.get_max_frame()
+        }
+
+        fn get_min_frame(&self) -> u64 {
+            self.inner.get_min_frame()
+        }
+
+        fn rollback(&self, rollback_to: Option<RollbackTo>) {
+            if let Some(ref rt) = rollback_to {
+                // Savepoint rollback: trim pending spill max_frame to the
+                // savepoint frame. Spilled frames before the savepoint are
+                // still valid; only post-savepoint spills are discarded.
+                // Use fetch_update to atomically clamp (only decrease).
+                let savepoint_frame = rt.frame as u32;
+                let _ = self.pending_spill_max_frame.fetch_update(
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                    |current| {
+                        if current > savepoint_frame {
+                            Some(savepoint_frame)
+                        } else {
+                            None // already at or below savepoint
+                        }
+                    },
+                );
+                if let Some(wal_index) = &self.wal_index {
+                    // Remove any uncommitted spill entries above WalIndex
+                    // committed max_frame. Without this, stale entries from
+                    // spills that were rolled back accumulate in the hash
+                    // table, wasting slots and lengthening probe chains.
+                    wal_index.cleanup_uncommitted();
+                    wal_index.rollback_to(rt.frame as u32);
+                }
+                // Savepoint rollback changes visible WAL state — notify
+                // cross-process readers so they re-sync.
+                self.publish_writer_state();
+            } else {
+                // Full rollback: discard all pending spill state.
+                self.pending_spill_max_frame.store(0, Ordering::Release);
+                // Clean up any uncommitted WalIndex entries (appended via
+                // append_frame but not committed via commit_max_frame).
+                // Since append_frames_vectored no longer calls commit_max_frame,
+                // spilled entries are above the WalIndex max_frame and
+                // cleanup_uncommitted correctly removes them.
+                if let Some(wal_index) = &self.wal_index {
+                    wal_index.cleanup_uncommitted();
+                }
+                // begin_write_tx published to TSHM. Readers that synced during
+                // this write tx may have stale state. Publish so they re-sync
+                // on their next begin_read_tx.
+                self.publish_writer_state();
+            }
+            self.inner.rollback(rollback_to)
+        }
+
+        fn abort_checkpoint(&self) {
+            self.inner.abort_checkpoint()
+        }
+
+        fn get_last_checksum(&self) -> (u32, u32) {
+            self.inner.get_last_checksum()
+        }
+
+        fn changed_pages_after(&self, frame_watermark: u64) -> crate::Result<Vec<u32>> {
+            self.inner.changed_pages_after(frame_watermark)
+        }
+
+        fn set_io_context(&self, ctx: IOContext) {
+            self.inner.set_io_context(ctx)
+        }
+
+        fn update_max_frame(&self) {
+            self.inner.update_max_frame()
+        }
+
+        fn truncate_wal(
+            &self,
+            result: &mut CheckpointResult,
+            sync_type: FileSyncType,
+        ) -> crate::Result<IOResult<()>> {
+            let r = self.inner.truncate_wal(result, sync_type)?;
+            // WAL file was truncated to 0 — clear the WalIndex.
+            if let Some(wal_index) = &self.wal_index {
+                if wal_index.max_frame() > 0 {
+                    self.clear_wal_index(wal_index);
+                }
+            }
+            // Notify other processes that the WAL was truncated so they
+            // rescan and don't try to read frames from the empty file.
+            self.publish_writer_state();
+            Ok(r)
+        }
+
+        #[cfg(debug_assertions)]
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    impl Drop for MultiProcessWal {
+        fn drop(&mut self) {
+            // Release the TSHM reader slot if one is held, so other processes
+            // can checkpoint past our snapshot frame.
+            if let Some(handle) = self.reader_slot.get_mut().take() {
+                self.tshm.release_reader_slot(handle);
+            }
+            // Clear external reader constraint to prevent a stale value from
+            // blocking checkpoint progress if dropped mid-write-transaction.
+            self.inner.set_external_reader_max_frame(0);
+        }
+    }
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[allow(unused_imports)]
+pub use imp::*;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2520,15 +2520,16 @@ impl Pager {
     }
 
     /// MVCC-only: refresh connection-private WAL change counters without starting a read tx and invalidate cache if needed.
-    pub fn mvcc_refresh_if_db_changed(&self) {
+    pub fn mvcc_refresh_if_db_changed(&self) -> crate::Result<()> {
         let Some(wal) = self.wal.as_ref() else {
-            return;
+            return Ok(());
         };
-        if wal.mvcc_refresh_if_db_changed() {
+        if wal.mvcc_refresh_if_db_changed()? {
             // Prevents stale page cache reads after MVCC checkpoints update the DB file.
             self.clear_page_cache(false);
             self.set_schema_cookie(None);
         }
+        Ok(())
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/storage/shm_sentinel.rs
+++ b/core/storage/shm_sentinel.rs
@@ -1,0 +1,687 @@
+//! SQLite `-shm` sentinel file.
+//!
+//! Prevents SQLite from operating on the same database by exploiting its
+//! WAL-index locking protocol. SQLite uses `fcntl(F_SETLK)` byte-range
+//! locks on bytes 120-127 of the `-shm` file:
+//!
+//! - Byte 120: WAL_WRITE_LOCK   (exclusive for writers)
+//! - Byte 121: WAL_CKPT_LOCK    (exclusive for checkpointers)
+//! - Byte 122: WAL_RECOVER_LOCK (exclusive for recovery)
+//! - Bytes 123-127: WAL_READ_LOCK(0-4) (shared for readers)
+//!
+//! We hold **shared** fcntl locks on bytes 120-122, which blocks SQLite
+//! from acquiring the exclusive locks it needs for writing, checkpointing,
+//! and recovery. Multiple Turso processes can coexist because shared locks
+//! don't conflict with each other.
+//!
+//! We also hold a shared lock on byte 200 (outside SQLite's range) as a
+//! "Turso marker" — used by `F_GETLK` probing to distinguish Turso from
+//! SQLite when detecting existing lock holders.
+//!
+//! Additionally, we invalidate the WAL-index header (bytes 0-95) so that
+//! even an idle SQLite process is forced into recovery mode on its next
+//! operation — which our shared lock on byte 122 blocks.
+
+use std::fs::{File, OpenOptions};
+use std::os::unix::io::AsRawFd;
+
+use crate::LimboError;
+
+/// Start of SQLite's WAL-index lock region.
+const WALINDEX_LOCK_OFFSET: i64 = 120;
+
+/// Number of bytes we lock in the SQLite lock region (120, 121, 122).
+const WALINDEX_LOCK_COUNT: i64 = 3;
+
+/// Byte outside SQLite's range, used as a Turso process marker.
+const TURSO_MARKER_BYTE: i64 = 200;
+
+/// Size of the WAL-index header (two 48-byte copies).
+const WAL_INDEX_HEADER_SIZE: usize = 96;
+
+/// Holds an open `-shm` file with fcntl byte-range locks that prevent
+/// SQLite from using the database. Dropping this struct closes the fd
+/// and releases all locks.
+pub struct ShmSentinel {
+    _file: File,
+}
+
+impl ShmSentinel {
+    /// Open (or create) the `-shm` sentinel file, detect any active SQLite
+    /// process, acquire shared locks, and invalidate the WAL-index header.
+    pub fn open(shm_path: &str) -> crate::Result<Self> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(shm_path)
+            .map_err(|e| LimboError::LockingError(format!("Failed to open {shm_path}: {e}")))?;
+
+        let fd = file.as_raw_fd();
+
+        // Probe for active SQLite: check if any process holds locks on
+        // SQLite's WAL-index bytes (120-127) WITHOUT also holding the
+        // Turso marker (byte 200).
+        if is_byte_range_locked(fd, WALINDEX_LOCK_OFFSET, 8)
+            && !is_byte_range_locked(fd, TURSO_MARKER_BYTE, 1)
+        {
+            return Err(LimboError::LockingError(
+                "Database -shm file is locked by another process (possibly SQLite). \
+                 Cannot open database while SQLite holds WAL-index locks."
+                    .to_string(),
+            ));
+        }
+
+        // Acquire Turso marker FIRST, before WAL-index locks. This prevents
+        // a race where a concurrent ShmSentinel::open() sees our WAL-index
+        // locks (120-122) but not yet the Turso marker (200), falsely
+        // concluding SQLite holds the locks.
+        fcntl_shared_lock(fd, TURSO_MARKER_BYTE, 1).map_err(|e| {
+            LimboError::LockingError(format!(
+                "Failed to lock {shm_path} Turso marker byte {TURSO_MARKER_BYTE}: {e}"
+            ))
+        })?;
+
+        // Acquire shared locks on SQLite's critical exclusive-only bytes.
+        fcntl_shared_lock(fd, WALINDEX_LOCK_OFFSET, WALINDEX_LOCK_COUNT).map_err(|e| {
+            LimboError::LockingError(format!(
+                "Failed to lock {shm_path} bytes {WALINDEX_LOCK_OFFSET}-{}: {e}",
+                WALINDEX_LOCK_OFFSET + WALINDEX_LOCK_COUNT - 1
+            ))
+        })?;
+
+        // Invalidate the WAL-index header so that any SQLite process
+        // (even one that was idle with a valid mmap) is forced into
+        // recovery mode on its next operation.
+        invalidate_wal_index_header(&file, shm_path)?;
+
+        Ok(Self { _file: file })
+    }
+}
+
+/// Check if any process holds a lock (shared or exclusive) on the given
+/// byte range using `fcntl(F_GETLK)`.
+fn is_byte_range_locked(fd: i32, start: i64, len: i64) -> bool {
+    let mut fl = new_flock(libc::F_WRLCK as libc::c_short, start, len);
+    let ret = unsafe { libc::fcntl(fd, libc::F_GETLK, &mut fl) };
+    if ret == -1 {
+        return false; // If F_GETLK fails, assume unlocked.
+    }
+    // F_GETLK sets l_type to F_UNLCK if no conflicting lock exists.
+    fl.l_type != libc::F_UNLCK as libc::c_short
+}
+
+/// Acquire a shared (F_RDLCK) byte-range lock using `fcntl(F_SETLK)`.
+/// Non-blocking: returns an error if the lock cannot be acquired.
+fn fcntl_shared_lock(fd: i32, start: i64, len: i64) -> std::io::Result<()> {
+    let fl = new_flock(libc::F_RDLCK as libc::c_short, start, len);
+    let ret = unsafe { libc::fcntl(fd, libc::F_SETLK, &fl) };
+    if ret == -1 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+/// Zero the WAL-index header region (bytes 0-95) to invalidate it for SQLite.
+fn invalidate_wal_index_header(file: &File, shm_path: &str) -> crate::Result<()> {
+    use std::os::unix::fs::FileExt;
+
+    let len = file
+        .metadata()
+        .map_err(|e| LimboError::LockingError(format!("Failed to stat {shm_path}: {e}")))?
+        .len();
+
+    if len == 0 {
+        // File is empty — SQLite already needs recovery if it tries to use this.
+        return Ok(());
+    }
+
+    let write_len = std::cmp::min(WAL_INDEX_HEADER_SIZE, len as usize);
+    let zeros = [0u8; WAL_INDEX_HEADER_SIZE];
+    file.write_all_at(&zeros[..write_len], 0).map_err(|e| {
+        LimboError::LockingError(format!(
+            "Failed to invalidate WAL-index header in {shm_path}: {e}"
+        ))
+    })?;
+
+    Ok(())
+}
+
+/// Construct a `libc::flock` struct for byte-range locking.
+fn new_flock(l_type: libc::c_short, start: i64, len: i64) -> libc::flock {
+    libc::flock {
+        l_type,
+        l_whence: libc::SEEK_SET as libc::c_short,
+        l_start: start as libc::off_t,
+        l_len: len as libc::off_t,
+        l_pid: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn temp_shm_path() -> (TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db-shm");
+        (dir, path.to_string_lossy().to_string())
+    }
+
+    #[test]
+    fn test_sentinel_creates_file() {
+        let (_dir, path) = temp_shm_path();
+        let _sentinel = ShmSentinel::open(&path).unwrap();
+        assert!(std::path::Path::new(&path).exists());
+    }
+
+    #[test]
+    fn test_multiple_turso_sentinels_same_process() {
+        let (_dir, path) = temp_shm_path();
+        let _s1 = ShmSentinel::open(&path).unwrap();
+        // Second sentinel on same file should succeed (shared locks).
+        let _s2 = ShmSentinel::open(&path).unwrap();
+    }
+
+    // All lock-conflict tests use fork() because fcntl locks are per-process:
+    // F_GETLK doesn't report own-process locks, and F_SETLK upgrades instead
+    // of conflicting within the same process.
+
+    #[test]
+    fn test_turso_coexistence_cross_process() {
+        // Parent opens ShmSentinel, then child opens another — should succeed
+        // because both hold SHARED locks (shared+shared = no conflict).
+        let (_dir, path) = temp_shm_path();
+        let _sentinel = ShmSentinel::open(&path).unwrap();
+
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            let code = match ShmSentinel::open(&path) {
+                Ok(_) => 0,
+                Err(_) => 1,
+            };
+            unsafe { libc::_exit(code) };
+        }
+        assert!(child > 0, "fork failed");
+        let mut status: libc::c_int = 0;
+        unsafe { libc::waitpid(child, &mut status, 0) };
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "Second Turso process should coexist with first via shared locks"
+        );
+    }
+
+    #[test]
+    fn test_sqlite_exclusive_locks_blocked_cross_process() {
+        // Parent holds ShmSentinel (shared locks on 120-122).
+        // Child (simulating SQLite) tries exclusive locks on each byte — all
+        // should be blocked.
+        let (_dir, path) = temp_shm_path();
+        let _sentinel = ShmSentinel::open(&path).unwrap();
+
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+            let fd = file.as_raw_fd();
+
+            for byte in [120i64, 121, 122] {
+                let fl = new_flock(libc::F_WRLCK as libc::c_short, byte, 1);
+                let ret = unsafe { libc::fcntl(fd, libc::F_SETLK, &fl) };
+                if ret != -1 {
+                    unsafe { libc::_exit(1) }; // Lock succeeded — unexpected
+                }
+            }
+            unsafe { libc::_exit(0) }; // All blocked — expected
+        }
+        assert!(child > 0, "fork failed");
+        let mut status: libc::c_int = 0;
+        unsafe { libc::waitpid(child, &mut status, 0) };
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "SQLite exclusive locks on bytes 120-122 should be blocked by Turso sentinel"
+        );
+    }
+
+    #[test]
+    fn test_detect_active_sqlite_process() {
+        // Child (simulating SQLite) holds an exclusive lock on byte 122.
+        // Parent tries ShmSentinel::open — should detect the active SQLite
+        // process and refuse to open.
+        let (_dir, path) = temp_shm_path();
+
+        // Create the file so both processes can open it.
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .unwrap();
+
+        // Pipe for child→parent "lock acquired" synchronization.
+        let mut pipefd = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(pipefd.as_mut_ptr()) }, 0);
+
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            unsafe { libc::close(pipefd[0]) }; // close read end
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+            let fd = file.as_raw_fd();
+            let fl = new_flock(libc::F_WRLCK as libc::c_short, 122, 1);
+            let ret = unsafe { libc::fcntl(fd, libc::F_SETLK, &fl) };
+            if ret == -1 {
+                unsafe { libc::_exit(2) }; // couldn't acquire lock
+            }
+            // Signal parent that lock is held.
+            let sig = [1u8];
+            unsafe { libc::write(pipefd[1], sig.as_ptr() as *const libc::c_void, 1) };
+            // Hold lock until killed.
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            unsafe { libc::_exit(0) };
+        }
+
+        assert!(child > 0, "fork failed");
+        unsafe { libc::close(pipefd[1]) }; // close write end in parent
+
+        // Wait for child to signal that it holds the lock.
+        let mut buf = [0u8; 1];
+        let n = unsafe { libc::read(pipefd[0], buf.as_mut_ptr() as *mut libc::c_void, 1) };
+        assert_eq!(n, 1, "Should receive signal from child");
+
+        // ShmSentinel::open should detect active SQLite and fail.
+        let result = ShmSentinel::open(&path);
+        assert!(
+            result.is_err(),
+            "Should detect active SQLite process holding exclusive lock"
+        );
+
+        // Clean up child.
+        unsafe {
+            libc::kill(child, libc::SIGTERM);
+            let mut status: libc::c_int = 0;
+            libc::waitpid(child, &mut status, 0);
+        }
+    }
+
+    #[test]
+    fn test_concurrent_sentinel_open_cross_process() {
+        // N children all race to ShmSentinel::open() on the same file.
+        // Without the marker-first acquisition order, some children see
+        // WAL-index locks (120-122) before the Turso marker (200) and
+        // falsely detect SQLite.
+        let (_dir, path) = temp_shm_path();
+        let n = 20;
+
+        let mut children = Vec::new();
+        for _ in 0..n {
+            let child = unsafe { libc::fork() };
+            if child == 0 {
+                let code = match ShmSentinel::open(&path) {
+                    Ok(_sentinel) => {
+                        // Hold locks briefly so other processes can observe them.
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        0
+                    }
+                    Err(_) => 1,
+                };
+                unsafe { libc::_exit(code) };
+            }
+            assert!(child > 0, "fork failed");
+            children.push(child);
+        }
+
+        for child in children {
+            let mut status: libc::c_int = 0;
+            unsafe { libc::waitpid(child, &mut status, 0) };
+            assert!(
+                libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+                "All Turso processes should coexist — child {child} failed"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sentinel_cleanup_on_drop() {
+        // After dropping a ShmSentinel, a new process should be able to open
+        // the same file without seeing any stale locks.
+        let (_dir, path) = temp_shm_path();
+
+        // Open and immediately drop.
+        let sentinel = ShmSentinel::open(&path).unwrap();
+        drop(sentinel);
+
+        // Child should see no locks at all.
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+            let fd = file.as_raw_fd();
+            let wal_locked = is_byte_range_locked(fd, WALINDEX_LOCK_OFFSET, 8);
+            let marker_locked = is_byte_range_locked(fd, TURSO_MARKER_BYTE, 1);
+            // Neither should be locked after parent dropped the sentinel.
+            let code = if wal_locked || marker_locked { 1 } else { 0 };
+            unsafe { libc::_exit(code) };
+        }
+        assert!(child > 0, "fork failed");
+        let mut status: libc::c_int = 0;
+        unsafe { libc::waitpid(child, &mut status, 0) };
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "Locks should be fully released after ShmSentinel is dropped"
+        );
+    }
+
+    #[test]
+    fn test_sentinel_survives_child_exit() {
+        // A child opens a ShmSentinel and exits. The parent (which also holds
+        // a ShmSentinel) should still have its locks intact — child exit must
+        // not affect parent's locks.
+        let (_dir, path) = temp_shm_path();
+        let _parent_sentinel = ShmSentinel::open(&path).unwrap();
+
+        // Child opens, holds briefly, exits.
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            let _child_sentinel = ShmSentinel::open(&path).unwrap();
+            unsafe { libc::_exit(0) };
+        }
+        assert!(child > 0, "fork failed");
+        let mut status: libc::c_int = 0;
+        unsafe { libc::waitpid(child, &mut status, 0) };
+        assert!(libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0);
+
+        // Verify parent's locks are still held: a new child should see them.
+        let child2 = unsafe { libc::fork() };
+        if child2 == 0 {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+            let fd = file.as_raw_fd();
+            let wal_locked = is_byte_range_locked(fd, WALINDEX_LOCK_OFFSET, WALINDEX_LOCK_COUNT);
+            let marker_locked = is_byte_range_locked(fd, TURSO_MARKER_BYTE, 1);
+            let code = if wal_locked && marker_locked { 0 } else { 1 };
+            unsafe { libc::_exit(code) };
+        }
+        assert!(child2 > 0, "fork failed");
+        unsafe { libc::waitpid(child2, &mut status, 0) };
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "Parent's ShmSentinel locks should survive child process exit"
+        );
+    }
+
+    #[test]
+    fn test_sqlite_shared_read_locks_not_false_positive() {
+        // SQLite readers hold SHARED locks on bytes 123-127 (WAL_READ_LOCK).
+        // Our probe checks bytes 120-127 with F_WRLCK, which would detect
+        // shared locks too. Verify that reader-only locks (without 120-122
+        // exclusive locks) do NOT trigger a false positive, since our check
+        // requires bytes 120-127 to be locked AND byte 200 to be unlocked.
+        //
+        // In practice, SQLite readers hold shared locks on 123-127 and the
+        // writer holds exclusive on 120. But if ONLY shared read locks exist
+        // (no writer), our probe should still detect them because F_WRLCK
+        // conflicts with F_RDLCK. The key is that byte 200 distinguishes
+        // Turso from SQLite.
+        let (_dir, path) = temp_shm_path();
+
+        // Create the file.
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .unwrap();
+
+        // Pipe for synchronization.
+        let mut pipefd = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(pipefd.as_mut_ptr()) }, 0);
+
+        // Child simulates a SQLite reader: shared lock on byte 123 only.
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            unsafe { libc::close(pipefd[0]) };
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+            let fd = file.as_raw_fd();
+            let fl = new_flock(libc::F_RDLCK as libc::c_short, 123, 1);
+            let ret = unsafe { libc::fcntl(fd, libc::F_SETLK, &fl) };
+            if ret == -1 {
+                unsafe { libc::_exit(2) };
+            }
+            let sig = [1u8];
+            unsafe { libc::write(pipefd[1], sig.as_ptr() as *const libc::c_void, 1) };
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            unsafe { libc::_exit(0) };
+        }
+        assert!(child > 0, "fork failed");
+        unsafe { libc::close(pipefd[1]) };
+
+        let mut buf = [0u8; 1];
+        let n = unsafe { libc::read(pipefd[0], buf.as_mut_ptr() as *mut libc::c_void, 1) };
+        assert_eq!(n, 1);
+
+        // Parent opens ShmSentinel — should detect the SQLite reader lock
+        // on byte 123 (within 120-127 range) without a Turso marker.
+        let result = ShmSentinel::open(&path);
+        assert!(
+            result.is_err(),
+            "Should detect SQLite reader holding shared lock on byte 123"
+        );
+
+        unsafe {
+            libc::kill(child, libc::SIGTERM);
+            let mut status: libc::c_int = 0;
+            libc::waitpid(child, &mut status, 0);
+        }
+    }
+
+    #[test]
+    fn test_walindex_without_marker_detected_as_sqlite() {
+        // A process holding WAL-index locks (120-122) WITHOUT the Turso marker
+        // (byte 200) looks exactly like SQLite. ShmSentinel::open() must reject.
+        // This is the intermediate state that the old (buggy) lock acquisition
+        // order could expose to concurrent observers.
+        let (_dir, path) = temp_shm_path();
+
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .unwrap();
+
+        let mut pipefd = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(pipefd.as_mut_ptr()) }, 0);
+
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            unsafe { libc::close(pipefd[0]) };
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+            let fd = file.as_raw_fd();
+            // Acquire ONLY WAL-index locks — no Turso marker.
+            fcntl_shared_lock(fd, WALINDEX_LOCK_OFFSET, WALINDEX_LOCK_COUNT).unwrap();
+            let sig = [1u8];
+            unsafe { libc::write(pipefd[1], sig.as_ptr() as *const libc::c_void, 1) };
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            unsafe { libc::_exit(0) };
+        }
+        assert!(child > 0, "fork failed");
+        unsafe { libc::close(pipefd[1]) };
+
+        let mut buf = [0u8; 1];
+        let n = unsafe { libc::read(pipefd[0], buf.as_mut_ptr() as *mut libc::c_void, 1) };
+        assert_eq!(n, 1);
+
+        let result = ShmSentinel::open(&path);
+        assert!(
+            result.is_err(),
+            "WAL-index locks without Turso marker must be detected as SQLite"
+        );
+
+        unsafe {
+            libc::kill(child, libc::SIGTERM);
+            let mut status: libc::c_int = 0;
+            libc::waitpid(child, &mut status, 0);
+        }
+    }
+
+    #[test]
+    fn test_marker_without_walindex_not_detected_as_sqlite() {
+        // A process holding ONLY the Turso marker (byte 200) without WAL-index
+        // locks (120-122) must NOT trigger SQLite detection. This is the
+        // intermediate state during the correct (marker-first) acquisition order.
+        let (_dir, path) = temp_shm_path();
+
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .unwrap();
+
+        let mut pipefd = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(pipefd.as_mut_ptr()) }, 0);
+
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            unsafe { libc::close(pipefd[0]) };
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+            let fd = file.as_raw_fd();
+            // Acquire ONLY Turso marker — no WAL-index locks.
+            fcntl_shared_lock(fd, TURSO_MARKER_BYTE, 1).unwrap();
+            let sig = [1u8];
+            unsafe { libc::write(pipefd[1], sig.as_ptr() as *const libc::c_void, 1) };
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            unsafe { libc::_exit(0) };
+        }
+        assert!(child > 0, "fork failed");
+        unsafe { libc::close(pipefd[1]) };
+
+        let mut buf = [0u8; 1];
+        let n = unsafe { libc::read(pipefd[0], buf.as_mut_ptr() as *mut libc::c_void, 1) };
+        assert_eq!(n, 1);
+
+        // Should succeed — marker-only means Turso, not SQLite.
+        let result = ShmSentinel::open(&path);
+        assert!(
+            result.is_ok(),
+            "Turso marker without WAL-index locks must NOT be detected as SQLite"
+        );
+
+        unsafe {
+            libc::kill(child, libc::SIGTERM);
+            let mut status: libc::c_int = 0;
+            libc::waitpid(child, &mut status, 0);
+        }
+    }
+
+    #[test]
+    fn test_both_walindex_and_marker_not_detected_as_sqlite() {
+        // A process holding BOTH WAL-index locks AND the Turso marker must NOT
+        // trigger SQLite detection. This is the steady state for a Turso process.
+        let (_dir, path) = temp_shm_path();
+
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .unwrap();
+
+        let mut pipefd = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(pipefd.as_mut_ptr()) }, 0);
+
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            unsafe { libc::close(pipefd[0]) };
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+            let fd = file.as_raw_fd();
+            // Acquire both — same as a fully-initialized ShmSentinel.
+            fcntl_shared_lock(fd, TURSO_MARKER_BYTE, 1).unwrap();
+            fcntl_shared_lock(fd, WALINDEX_LOCK_OFFSET, WALINDEX_LOCK_COUNT).unwrap();
+            let sig = [1u8];
+            unsafe { libc::write(pipefd[1], sig.as_ptr() as *const libc::c_void, 1) };
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            unsafe { libc::_exit(0) };
+        }
+        assert!(child > 0, "fork failed");
+        unsafe { libc::close(pipefd[1]) };
+
+        let mut buf = [0u8; 1];
+        let n = unsafe { libc::read(pipefd[0], buf.as_mut_ptr() as *mut libc::c_void, 1) };
+        assert_eq!(n, 1);
+
+        let result = ShmSentinel::open(&path);
+        assert!(
+            result.is_ok(),
+            "Both WAL-index and Turso marker must NOT be detected as SQLite"
+        );
+
+        unsafe {
+            libc::kill(child, libc::SIGTERM);
+            let mut status: libc::c_int = 0;
+            libc::waitpid(child, &mut status, 0);
+        }
+    }
+
+    #[test]
+    fn test_rapid_open_close_cycles() {
+        // Stress test: rapidly open and close sentinels across processes.
+        // Tests that lock cleanup is reliable and no stale state accumulates.
+        let (_dir, path) = temp_shm_path();
+
+        for _ in 0..50 {
+            let child = unsafe { libc::fork() };
+            if child == 0 {
+                let code = match ShmSentinel::open(&path) {
+                    Ok(_) => 0,
+                    Err(_) => 1,
+                };
+                unsafe { libc::_exit(code) };
+            }
+            assert!(child > 0, "fork failed");
+            let mut status: libc::c_int = 0;
+            unsafe { libc::waitpid(child, &mut status, 0) };
+            assert!(
+                libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+                "Rapid open/close cycle failed"
+            );
+        }
+    }
+}

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1443,6 +1443,7 @@ pub fn build_shared_wal(
         checkpoint_lock: TursoRwLock::new(),
         initialized: AtomicBool::new(false),
         epoch: AtomicU32::new(0),
+        external_reader_max_frame: AtomicU64::new(0),
     }));
 
     if size < WAL_HEADER_SIZE as u64 {

--- a/core/storage/tshm.rs
+++ b/core/storage/tshm.rs
@@ -1,0 +1,1190 @@
+//! Turso Shared Memory (TSHM) for multi-process coordination.
+//!
+//! The TSHM file (`{db}-tshm`) contains both the coordination page and the
+//! WAL index segments. The first 16384 bytes are the coordination page
+//! (sized to fill a full Apple Silicon page and allow mmap-aligned WalIndex
+//! segments to start immediately after):
+//!
+//! ```text
+//! Offset 0:     writer_state   [monotonic counter]                (AtomicU64)
+//! Offset 8:     locking_mode   [0=unset, 1=SharedReads, 2=SharedWrites]
+//! Offset 16:    write_lock     [pid:32][instance:32]              (AtomicU64)
+//! Offset 24:    reader slot 0  [pid:32][max_frame:32]             (AtomicU64)
+//! Offset 32:    reader slot 1
+//! ...
+//! Offset 16376: reader slot 2044
+//! ```
+//!
+//! **Writer state** (slot 0): Updated by the writer after committing frames
+//! or restarting the WAL. Readers compare this to a cached value to decide
+//! whether a full WAL rescan is needed — skip if unchanged (~10ns per read tx).
+//!
+//! **Write lock** (slot 2): Atomic CAS-based write lock that stores the
+//! owner's identity as `[pid:32][instance:32]`. Provides exclusion both
+//! across separate OS processes AND within the same process (multiple
+//! Database instances). Complemented by an fcntl byte-range lock on the
+//! same 8 bytes for defense-in-depth (kernel-guaranteed exclusion and
+//! automatic cleanup on process crash).
+//!
+//! **Reader slots** (slots 3..511): Each slot is an AtomicU64 packed as
+//! [pid:32][max_frame:32]. Readers claim a slot at transaction start (CAS)
+//! and release it at transaction end (store 0). The writer scans slots at
+//! checkpoint time to determine the safe checkpoint boundary.
+//!
+//! This module is only available on 64-bit Unix platforms where AtomicU64
+//! operations on mmap'd memory are guaranteed to be hardware-atomic across
+//! processes.
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[allow(dead_code)]
+mod imp {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Coordination page size. 16 KB fills one Apple Silicon page and
+    /// ensures WalIndex segments (which start immediately after) are
+    /// mmap-aligned on all platforms (16 KB on aarch64, 4 KB on x86_64).
+    const PAGE_SIZE: usize = 16384;
+    const SLOT_SIZE: usize = std::mem::size_of::<AtomicU64>();
+    const NUM_SLOTS: usize = PAGE_SIZE / SLOT_SIZE; // 2048
+
+    /// Number of slots reserved at the start for header metadata.
+    const HEADER_SLOTS: usize = 3;
+    /// Number of reader slots available for transaction registration.
+    pub const NUM_READER_SLOTS: usize = NUM_SLOTS - HEADER_SLOTS; // 2045
+
+    /// Header slot 0: writer state — monotonic counter incremented on each commit.
+    const HDR_WRITER_STATE: usize = 0;
+    /// Header slot 1: locking mode — 0 = unset, 1 = SharedReads, 2 = SharedWrites.
+    const HDR_LOCKING_MODE: usize = 1;
+    /// Header slot 2: write lock owner — packed [pid:32][instance:32].
+    /// 0 means unlocked. Non-zero identifies the Tshm instance that holds the lock.
+    const HDR_WRITE_LOCK: usize = 2;
+
+    /// Sentinel value for write_lock_refcount while the 0→1 transition is
+    /// acquiring the real inter-process locks. Prevents other threads from
+    /// bumping the refcount before the SHM/fcntl locks are acquired.
+    const LOCK_ACQUIRING: u32 = u32::MAX;
+
+    /// Global counter for generating unique per-Tshm instance IDs within a process.
+    static INSTANCE_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(1);
+
+    /// Pack a PID and max_frame into a single u64 slot value.
+    #[inline]
+    pub fn pack_slot(pid: u32, max_frame: u32) -> u64 {
+        ((pid as u64) << 32) | (max_frame as u64)
+    }
+
+    /// Unpack a slot value into (pid, max_frame).
+    #[inline]
+    pub fn unpack_slot(val: u64) -> (u32, u32) {
+        let pid = (val >> 32) as u32;
+        let max_frame = val as u32;
+        (pid, max_frame)
+    }
+
+    /// Pack checkpoint_seq and max_frame into a single u64 writer state value.
+    #[inline]
+    pub fn pack_writer_state(checkpoint_seq: u32, max_frame: u32) -> u64 {
+        ((checkpoint_seq as u64) << 32) | (max_frame as u64)
+    }
+
+    /// Handle to an acquired reader slot. Stores the absolute slot index
+    /// (including header offset) so it can be released later.
+    pub struct SlotHandle {
+        index: usize,
+    }
+
+    impl SlotHandle {
+        /// Returns the absolute slot index.
+        pub fn index(&self) -> usize {
+            self.index
+        }
+    }
+
+    /// Byte offset of the write lock slot in the tshm file, used for
+    /// fcntl byte-range locking. Matches `HDR_WRITE_LOCK * SLOT_SIZE`.
+    const WRITE_LOCK_BYTE_OFFSET: i64 = (HDR_WRITE_LOCK * SLOT_SIZE) as i64;
+
+    /// Byte length of the write lock slot (one AtomicU64 = 8 bytes).
+    const WRITE_LOCK_BYTE_LEN: i64 = SLOT_SIZE as i64;
+
+    /// Turso Shared Memory file for multi-process coordination.
+    ///
+    /// Handles reader slot management (via mmap'd atomics), writer state
+    /// publishing, and inter-process write locking (via shared-memory CAS
+    /// + fcntl byte-range lock on the write lock slot).
+    pub struct Tshm {
+        /// Pointer to the mmap'd region. The region is PAGE_SIZE bytes,
+        /// interpreted as an array of NUM_SLOTS AtomicU64 values.
+        ptr: *mut u8,
+        /// File descriptor for the tshm file (kept open for the lifetime of the mmap).
+        /// Also used for fcntl byte-range write locking on the HDR_WRITE_LOCK slot.
+        fd: std::os::unix::io::RawFd,
+        /// Write lock refcount. Only the 0→1 transition acquires the real
+        /// locks (shared-memory CAS + fcntl), only the 1→0 transition
+        /// releases them. Used by SharedReads to hold the write lock
+        /// permanently (header_validation holds ref=1, write tx bumps to 2,
+        /// end_write_tx sees <=1 and skips unlock).
+        write_lock_refcount: std::sync::atomic::AtomicU32,
+        /// Unique identity for this Tshm instance, packed as [pid:32][counter:32].
+        /// Used for the shared-memory write lock (HDR_WRITE_LOCK slot).
+        instance_id: u64,
+    }
+
+    // SAFETY: The mmap'd region is shared across processes and accessed only
+    // through atomic operations. The pointer itself is stable for the lifetime
+    // of the Tshm (the mmap is not remapped or resized).
+    unsafe impl Send for Tshm {}
+    unsafe impl Sync for Tshm {}
+
+    impl Tshm {
+        /// Return the raw fd for the tshm file. Used by WalIndex to share
+        /// the same fd (critical: POSIX fcntl locks are per-process-per-inode,
+        /// so opening a second fd and closing it would release our write lock).
+        pub fn fd(&self) -> std::os::unix::io::RawFd {
+            self.fd
+        }
+
+        /// Open or create a TSHM file at the given path and mmap it.
+        pub fn open(path: &str) -> crate::Result<Self> {
+            use std::os::unix::io::AsRawFd;
+
+            fn io_err(path: &str, e: std::io::Error) -> crate::LimboError {
+                crate::LimboError::InternalError(format!("tshm file '{path}': {e}"))
+            }
+
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(path)
+                .map_err(|e| io_err(path, e))?;
+
+            let fd = file.as_raw_fd();
+
+            // Ensure the file is exactly PAGE_SIZE bytes.
+            let metadata = file.metadata().map_err(|e| io_err(path, e))?;
+            if metadata.len() < PAGE_SIZE as u64 {
+                file.set_len(PAGE_SIZE as u64)
+                    .map_err(|e| io_err(path, e))?;
+            }
+
+            // SAFETY: We've ensured the file is at least PAGE_SIZE bytes.
+            // MAP_SHARED ensures changes are visible across processes.
+            let ptr = unsafe {
+                libc::mmap(
+                    std::ptr::null_mut(),
+                    PAGE_SIZE,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_SHARED,
+                    fd,
+                    0,
+                )
+            };
+            if ptr == libc::MAP_FAILED {
+                return Err(crate::LimboError::InternalError(format!(
+                    "mmap failed for tshm file '{path}': {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+
+            // Leak the File so the fd stays open (we manage it via _fd and Drop).
+            let fd = file.into_raw_fd();
+
+            // Generate a unique instance ID: [pid:32][counter:32].
+            // Non-zero by construction (PID is never 0, counter starts at 1).
+            // Skip 0 on wrap to maintain the non-zero invariant.
+            let pid = std::process::id();
+            let counter = INSTANCE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let counter = if counter == 0 {
+                INSTANCE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            } else {
+                counter
+            };
+            let instance_id = ((pid as u64) << 32) | (counter as u64);
+
+            Ok(Self {
+                ptr: ptr as *mut u8,
+                fd,
+                write_lock_refcount: std::sync::atomic::AtomicU32::new(0),
+                instance_id,
+            })
+        }
+
+        /// Get a reference to the entire slot array (header + reader slots).
+        #[inline]
+        fn all_slots(&self) -> &[AtomicU64; NUM_SLOTS] {
+            // SAFETY: The mmap'd region is PAGE_SIZE bytes = NUM_SLOTS * 8 bytes,
+            // properly aligned for AtomicU64 (mmap returns page-aligned memory).
+            unsafe { &*(self.ptr as *const [AtomicU64; NUM_SLOTS]) }
+        }
+
+        /// Get a slice of only the reader slots (excluding header).
+        #[inline]
+        fn reader_slots(&self) -> &[AtomicU64] {
+            &self.all_slots()[HEADER_SLOTS..]
+        }
+
+        // --- Writer state (header slot 0) ---
+
+        /// Load the writer state from shared memory.
+        /// Returns a packed u64: [checkpoint_seq:32][max_frame:32].
+        pub fn writer_state(&self) -> u64 {
+            self.all_slots()[HDR_WRITER_STATE].load(Ordering::Acquire)
+        }
+
+        /// Store the writer state to shared memory.
+        /// `val` should be packed via `pack_writer_state(checkpoint_seq, max_frame)`.
+        pub fn set_writer_state(&self, val: u64) {
+            self.all_slots()[HDR_WRITER_STATE].store(val, Ordering::Release)
+        }
+
+        /// Atomically increment the writer state counter and return the new value.
+        /// Used by MultiProcessWal to signal readers that the WAL has changed.
+        pub fn increment_writer_state(&self) -> u64 {
+            self.all_slots()[HDR_WRITER_STATE].fetch_add(1, Ordering::AcqRel) + 1
+        }
+
+        // --- Locking mode (header slot 1) ---
+
+        /// Load the locking mode from shared memory.
+        /// Returns 0 (unset), 1 (SharedReads), or 2 (SharedWrites).
+        pub fn locking_mode(&self) -> u64 {
+            self.all_slots()[HDR_LOCKING_MODE].load(Ordering::Acquire)
+        }
+
+        /// Try to set the locking mode in shared memory.
+        /// If the slot is unset (0), atomically sets it to `mode` via CAS.
+        /// If the slot is already set, returns the existing value.
+        /// Returns Ok(()) if the mode was set (or already matches),
+        /// or Err(existing_mode) if a different mode is already set.
+        pub fn try_set_locking_mode(&self, mode: u64) -> Result<(), u64> {
+            let slot = &self.all_slots()[HDR_LOCKING_MODE];
+            match slot.compare_exchange(0, mode, Ordering::AcqRel, Ordering::Acquire) {
+                Ok(_) => Ok(()),
+                Err(existing) if existing == mode => Ok(()),
+                Err(existing) => Err(existing),
+            }
+        }
+
+        /// Force-set the locking mode (for when we know TSHM is stale).
+        pub fn set_locking_mode(&self, mode: u64) {
+            self.all_slots()[HDR_LOCKING_MODE].store(mode, Ordering::Release);
+        }
+
+        /// Clear the locking mode (set to 0 / unset).
+        pub fn clear_locking_mode(&self) {
+            self.all_slots()[HDR_LOCKING_MODE].store(0, Ordering::Release);
+        }
+
+        /// Convert a `LockingMode` to the u64 value stored in TSHM slot 1.
+        /// 0 = unset (Exclusive is not stored), 1 = SharedReads, 2 = SharedWrites.
+        pub fn locking_mode_to_value(mode: crate::LockingMode) -> u64 {
+            match mode {
+                crate::LockingMode::Exclusive => 0,
+                crate::LockingMode::SharedReads => 1,
+                crate::LockingMode::SharedWrites => 2,
+            }
+        }
+
+        /// Convert from a TSHM slot 1 value to a `LockingMode`.
+        /// Returns `None` for 0 (unset) or unknown values.
+        pub fn locking_mode_from_value(val: u64) -> Option<crate::LockingMode> {
+            match val {
+                0 => None, // unset
+                1 => Some(crate::LockingMode::SharedReads),
+                2 => Some(crate::LockingMode::SharedWrites),
+                _ => None,
+            }
+        }
+
+        // --- Reader slot management ---
+
+        /// Try to claim a reader slot with the given PID and max_frame.
+        /// Returns a SlotHandle on success, or None if all slots are full.
+        pub fn claim_reader_slot(&self, pid: u32, max_frame: u32) -> Option<SlotHandle> {
+            let val = pack_slot(pid, max_frame);
+            for (i, slot) in self.reader_slots().iter().enumerate() {
+                if slot
+                    .compare_exchange(0, val, Ordering::AcqRel, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    return Some(SlotHandle {
+                        index: i + HEADER_SLOTS,
+                    });
+                }
+            }
+            None
+        }
+
+        /// Release a previously claimed reader slot.
+        pub fn release_reader_slot(&self, handle: SlotHandle) {
+            self.all_slots()[handle.index].store(0, Ordering::Release);
+        }
+
+        /// Update the max_frame in an already-claimed reader slot.
+        /// Used by begin_read_tx after acquiring the actual read snapshot
+        /// (which may differ from the preliminary value used at claim time).
+        pub fn update_reader_slot(&self, handle: &SlotHandle, pid: u32, new_max_frame: u32) {
+            let new_val = pack_slot(pid, new_max_frame);
+            self.all_slots()[handle.index].store(new_val, Ordering::Release);
+        }
+
+        /// Release a reader slot by absolute index.
+        pub fn release_slot_by_index(&self, index: usize) {
+            assert!(
+                (HEADER_SLOTS..NUM_SLOTS).contains(&index),
+                "release_slot_by_index: index {index} out of reader slot range [{HEADER_SLOTS}..{NUM_SLOTS})"
+            );
+            self.all_slots()[index].store(0, Ordering::Release);
+        }
+
+        /// Scan all reader slots and return the minimum max_frame across slots
+        /// with live PIDs. Returns None if no reader slots are occupied.
+        ///
+        /// Also reclaims slots with dead PIDs as a side effect.
+        pub fn min_reader_frame(&self) -> Option<u32> {
+            self.min_reader_frame_excluding(0)
+        }
+
+        /// Return the minimum `max_frame` across all active reader slots,
+        /// excluding any slots owned by `exclude_pid`. When the writer
+        /// process wants to know about *external* readers only (to decide
+        /// whether WAL restart is safe), it passes its own PID here so
+        /// that its own reader slot doesn't block restart.
+        pub fn min_reader_frame_excluding(&self, exclude_pid: u32) -> Option<u32> {
+            let mut min_frame: Option<u32> = None;
+
+            for slot in self.reader_slots().iter() {
+                let val = slot.load(Ordering::Acquire);
+                if val == 0 {
+                    continue;
+                }
+                let (pid, max_frame) = unpack_slot(val);
+                if exclude_pid != 0 && pid == exclude_pid {
+                    continue;
+                }
+                if pid_is_alive(pid) {
+                    min_frame = Some(match min_frame {
+                        Some(current) => current.min(max_frame),
+                        None => max_frame,
+                    });
+                } else {
+                    // Reclaim dead slot. Use CAS to avoid clearing a slot that
+                    // was reclaimed and re-claimed by another process between
+                    // our load and this CAS.
+                    let _ = slot.compare_exchange(val, 0, Ordering::AcqRel, Ordering::Relaxed);
+                }
+            }
+            min_frame
+        }
+
+        /// Reclaim all reader slots belonging to dead PIDs.
+        pub fn reclaim_dead_slots(&self) {
+            for slot in self.reader_slots().iter() {
+                let val = slot.load(Ordering::Acquire);
+                if val == 0 {
+                    continue;
+                }
+                let (pid, _) = unpack_slot(val);
+                if !pid_is_alive(pid) {
+                    let _ = slot.compare_exchange(val, 0, Ordering::AcqRel, Ordering::Relaxed);
+                }
+            }
+        }
+
+        /// Check if any reader slot is occupied (with a live PID).
+        pub fn has_active_readers(&self) -> bool {
+            self.min_reader_frame().is_some()
+        }
+
+        // --- Inter-process write lock (shared-memory CAS + fcntl byte-range) ---
+
+        /// Acquire the inter-process write lock (non-blocking).
+        /// Uses a two-level mechanism:
+        /// 1. Shared-memory CAS on HDR_WRITE_LOCK (works across processes
+        ///    AND within one process on macOS where fcntl is per-process).
+        /// 2. fcntl byte-range lock on the write lock slot for
+        ///    defense-in-depth (kernel-guaranteed exclusion and automatic
+        ///    cleanup on process crash).
+        ///
+        /// Refcount: only the 0→1 transition acquires the lock;
+        /// subsequent callers in the same Tshm instance bump the refcount.
+        /// Used by SharedReads to hold the write lock permanently.
+        pub fn write_lock(&self) -> crate::Result<()> {
+            let mut spin_count: u32 = 0;
+            loop {
+                let prev = self
+                    .write_lock_refcount
+                    .load(std::sync::atomic::Ordering::Acquire);
+                match prev {
+                    0 => {
+                        // Try the 0→ACQUIRING transition. Other threads that
+                        // see ACQUIRING will spin until we resolve to 0 or 1.
+                        if self
+                            .write_lock_refcount
+                            .compare_exchange(
+                                0,
+                                LOCK_ACQUIRING,
+                                std::sync::atomic::Ordering::AcqRel,
+                                std::sync::atomic::Ordering::Acquire,
+                            )
+                            .is_err()
+                        {
+                            continue;
+                        }
+                        // We own the transition — acquire the real locks.
+                        if !self.try_acquire_shm_write_lock() {
+                            self.write_lock_refcount
+                                .store(0, std::sync::atomic::Ordering::Release);
+                            return Err(crate::LimboError::Busy);
+                        }
+                        if !Self::fcntl_write_lock(self.fd) {
+                            self.release_shm_write_lock();
+                            self.write_lock_refcount
+                                .store(0, std::sync::atomic::Ordering::Release);
+                            return Err(crate::LimboError::Busy);
+                        }
+                        // Locks acquired — transition ACQUIRING → 1.
+                        self.write_lock_refcount
+                            .store(1, std::sync::atomic::Ordering::Release);
+                        return Ok(());
+                    }
+                    LOCK_ACQUIRING => {
+                        // Another thread is acquiring the real locks — spin.
+                        // Bounded: if the acquirer panicked, recover after
+                        // enough iterations to avoid permanent livelock.
+                        // Use a large threshold (10M iterations ~ 10-100ms)
+                        // to avoid falsely stealing from a preempted thread.
+                        spin_count += 1;
+                        if spin_count > 10_000_000 {
+                            if self
+                                .write_lock_refcount
+                                .compare_exchange(
+                                    LOCK_ACQUIRING,
+                                    0,
+                                    std::sync::atomic::Ordering::AcqRel,
+                                    std::sync::atomic::Ordering::Acquire,
+                                )
+                                .is_ok()
+                            {
+                                tracing::warn!("write_lock: recovered stuck LOCK_ACQUIRING state");
+                                // Defensively release in case partially acquired.
+                                self.release_shm_write_lock();
+                                Self::fcntl_write_unlock(self.fd);
+                            }
+                            spin_count = 0;
+                        }
+                        std::hint::spin_loop();
+                        continue;
+                    }
+                    _ => {
+                        // Lock already held by this Tshm instance — bump the
+                        // refcount. Used by SharedReads where header_validation
+                        // holds ref=1 permanently and write tx bumps to 2.
+                        // Guard: prevent refcount from reaching LOCK_ACQUIRING
+                        // sentinel, which would trigger spurious recovery.
+                        if prev >= LOCK_ACQUIRING - 1 {
+                            return Err(crate::LimboError::InternalError(
+                                "write_lock refcount overflow".to_string(),
+                            ));
+                        }
+                        if self
+                            .write_lock_refcount
+                            .compare_exchange(
+                                prev,
+                                prev + 1,
+                                std::sync::atomic::Ordering::AcqRel,
+                                std::sync::atomic::Ordering::Acquire,
+                            )
+                            .is_err()
+                        {
+                            continue;
+                        }
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        /// Release the inter-process write lock.
+        /// Only the last holder in this Tshm instance calls the actual release.
+        pub fn write_unlock(&self) {
+            let prev = self
+                .write_lock_refcount
+                .fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
+            assert!(
+                prev > 0 && prev != LOCK_ACQUIRING,
+                "write_unlock called without matching write_lock"
+            );
+            if prev == 1 {
+                self.release_shm_write_lock();
+                Self::fcntl_write_unlock(self.fd);
+            }
+        }
+
+        /// Returns the current write lock refcount for this Tshm instance.
+        pub fn active_writers(&self) -> u32 {
+            self.write_lock_refcount
+                .load(std::sync::atomic::Ordering::Acquire)
+        }
+
+        /// Try to acquire the shared-memory write lock via CAS.
+        /// Returns true if acquired, false if another live instance holds it.
+        fn try_acquire_shm_write_lock(&self) -> bool {
+            let slot = &self.all_slots()[HDR_WRITE_LOCK];
+            let current = slot.load(Ordering::Acquire);
+            if current == 0 {
+                // Unlocked — try to claim it.
+                return slot
+                    .compare_exchange(0, self.instance_id, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok();
+            }
+            if current == self.instance_id {
+                // We already hold it (shouldn't happen with refcount, but safe).
+                return true;
+            }
+            // Someone else holds it. Check if they're still alive.
+            let owner_pid = (current >> 32) as u32;
+            if !pid_is_alive(owner_pid) {
+                // Dead owner — steal the lock.
+                return slot
+                    .compare_exchange(
+                        current,
+                        self.instance_id,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    )
+                    .is_ok();
+            }
+            // Live owner, different instance — lock is held.
+            false
+        }
+
+        /// Release the shared-memory write lock.
+        fn release_shm_write_lock(&self) {
+            let slot = &self.all_slots()[HDR_WRITE_LOCK];
+            // Only clear if we're the owner (CAS to avoid clearing someone else's lock).
+            let _ = slot.compare_exchange(self.instance_id, 0, Ordering::AcqRel, Ordering::Relaxed);
+        }
+
+        /// Acquire an exclusive fcntl byte-range lock on the write lock slot.
+        /// Non-blocking: returns false if the lock cannot be acquired.
+        fn fcntl_write_lock(fd: std::os::unix::io::RawFd) -> bool {
+            let fl = libc::flock {
+                l_type: libc::F_WRLCK as libc::c_short,
+                l_whence: libc::SEEK_SET as libc::c_short,
+                l_start: WRITE_LOCK_BYTE_OFFSET as libc::off_t,
+                l_len: WRITE_LOCK_BYTE_LEN as libc::off_t,
+                l_pid: 0,
+            };
+            let ret = unsafe { libc::fcntl(fd, libc::F_SETLK, &fl) };
+            ret != -1
+        }
+
+        /// Release the fcntl byte-range lock on the write lock slot.
+        fn fcntl_write_unlock(fd: std::os::unix::io::RawFd) {
+            let fl = libc::flock {
+                l_type: libc::F_UNLCK as libc::c_short,
+                l_whence: libc::SEEK_SET as libc::c_short,
+                l_start: WRITE_LOCK_BYTE_OFFSET as libc::off_t,
+                l_len: WRITE_LOCK_BYTE_LEN as libc::off_t,
+                l_pid: 0,
+            };
+            unsafe {
+                libc::fcntl(fd, libc::F_SETLK, &fl);
+            }
+        }
+    }
+
+    impl Drop for Tshm {
+        fn drop(&mut self) {
+            if *self.write_lock_refcount.get_mut() > 0 {
+                // Release shared-memory write lock before closing the fd.
+                self.release_shm_write_lock();
+                Self::fcntl_write_unlock(self.fd);
+            }
+            unsafe {
+                libc::munmap(self.ptr as *mut libc::c_void, PAGE_SIZE);
+                libc::close(self.fd);
+            }
+        }
+    }
+
+    /// Check if a process with the given PID is alive.
+    fn pid_is_alive(pid: u32) -> bool {
+        // Guard against corrupt TSHM data: pid 0 means "our own process group"
+        // in kill(), and pid > i32::MAX wraps to negative when cast to i32,
+        // which kill() interprets as a process group ID — both are dangerous.
+        if pid == 0 || pid > i32::MAX as u32 {
+            return false;
+        }
+        // kill with signal 0 checks if the process exists without sending a signal.
+        // Returns 0 if the process exists (and we have permission to signal it).
+        // Returns -1 with ESRCH if the process does not exist.
+        // Returns -1 with EPERM if we don't have permission (but the process exists).
+        let ret = unsafe { libc::kill(pid as i32, 0) };
+        if ret == 0 {
+            return true;
+        }
+        // EPERM means the process exists but we can't signal it
+        std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    }
+
+    use std::os::unix::io::IntoRawFd;
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn temp_tshm_path() -> (tempfile::TempDir, String) {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("test-tshm");
+            (dir, path.to_str().unwrap().to_string())
+        }
+
+        #[test]
+        fn test_open_creates_file() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+            let metadata = std::fs::metadata(&path).unwrap();
+            assert_eq!(metadata.len(), PAGE_SIZE as u64);
+            drop(tshm);
+        }
+
+        #[test]
+        fn test_claim_and_release_slot() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            let pid = std::process::id();
+            let handle = tshm.claim_reader_slot(pid, 100).unwrap();
+
+            // Verify slot is occupied (at absolute index in the mmap)
+            let val = tshm.all_slots()[handle.index()].load(Ordering::Acquire);
+            assert_eq!(val, pack_slot(pid, 100));
+
+            // Release
+            let idx = handle.index();
+            tshm.release_reader_slot(handle);
+            let val = tshm.all_slots()[idx].load(Ordering::Acquire);
+            assert_eq!(val, 0);
+        }
+
+        #[test]
+        fn test_min_reader_frame() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+            let pid = std::process::id();
+
+            // No readers → None
+            assert_eq!(tshm.min_reader_frame(), None);
+
+            let h1 = tshm.claim_reader_slot(pid, 200).unwrap();
+            let h2 = tshm.claim_reader_slot(pid, 50).unwrap();
+            let h3 = tshm.claim_reader_slot(pid, 150).unwrap();
+
+            // Min should be 50
+            assert_eq!(tshm.min_reader_frame(), Some(50));
+
+            tshm.release_reader_slot(h2);
+            // Min should now be 150
+            assert_eq!(tshm.min_reader_frame(), Some(150));
+
+            tshm.release_reader_slot(h3);
+            assert_eq!(tshm.min_reader_frame(), Some(200));
+
+            tshm.release_reader_slot(h1);
+            assert_eq!(tshm.min_reader_frame(), None);
+        }
+
+        #[test]
+        fn test_claim_all_reader_slots_returns_none() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+            let pid = std::process::id();
+
+            let mut handles = Vec::new();
+            for i in 0..NUM_READER_SLOTS {
+                let h = tshm.claim_reader_slot(pid, i as u32);
+                assert!(h.is_some(), "failed to claim slot {i}");
+                handles.push(h.unwrap());
+            }
+
+            // Next claim should fail — all reader slots are full.
+            assert!(tshm.claim_reader_slot(pid, 999).is_none());
+
+            // Release all
+            for h in handles {
+                tshm.release_reader_slot(h);
+            }
+
+            // Should be claimable again
+            assert!(tshm.claim_reader_slot(pid, 0).is_some());
+        }
+
+        #[test]
+        fn test_reader_slots_dont_touch_header() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+            let pid = std::process::id();
+
+            // Set a writer state in header slot
+            let state = pack_writer_state(5, 42);
+            tshm.set_writer_state(state);
+
+            // Claim and release all reader slots
+            let mut handles = Vec::new();
+            for i in 0..NUM_READER_SLOTS {
+                handles.push(tshm.claim_reader_slot(pid, i as u32).unwrap());
+            }
+            for h in handles {
+                tshm.release_reader_slot(h);
+            }
+
+            // Header should be untouched
+            assert_eq!(tshm.writer_state(), state);
+        }
+
+        #[test]
+        fn test_reclaim_dead_slots() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            // Use a PID that (almost certainly) doesn't exist.
+            // PID 1 is init/launchd and always exists, so use a very high PID.
+            let dead_pid: u32 = 4_000_000;
+            let val = pack_slot(dead_pid, 42);
+            // Write to the first reader slot (absolute index HEADER_SLOTS)
+            tshm.all_slots()[HEADER_SLOTS].store(val, Ordering::Release);
+
+            // Before reclaim, slot is occupied
+            assert_ne!(tshm.all_slots()[HEADER_SLOTS].load(Ordering::Acquire), 0);
+
+            tshm.reclaim_dead_slots();
+
+            // After reclaim, slot should be cleared (assuming PID 4000000 doesn't exist)
+            if !pid_is_alive(dead_pid) {
+                assert_eq!(tshm.all_slots()[HEADER_SLOTS].load(Ordering::Acquire), 0);
+            }
+        }
+
+        #[test]
+        fn test_pid_is_alive_rejects_zero() {
+            // pid 0 would send kill() to our own process group — must be rejected.
+            assert!(!pid_is_alive(0));
+        }
+
+        #[test]
+        fn test_pid_is_alive_rejects_negative_wrap() {
+            // pid > i32::MAX wraps to negative i32, which kill() interprets
+            // as a process group ID — must be rejected.
+            assert!(!pid_is_alive(i32::MAX as u32 + 1));
+            assert!(!pid_is_alive(u32::MAX));
+        }
+
+        #[test]
+        fn test_pid_is_alive_accepts_current_process() {
+            let pid = std::process::id();
+            assert!(pid_is_alive(pid));
+        }
+
+        #[test]
+        fn test_has_active_readers() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+            let pid = std::process::id();
+
+            assert!(!tshm.has_active_readers());
+
+            let h = tshm.claim_reader_slot(pid, 100).unwrap();
+            assert!(tshm.has_active_readers());
+
+            tshm.release_reader_slot(h);
+            assert!(!tshm.has_active_readers());
+        }
+
+        #[test]
+        fn test_concurrent_slot_claims() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = std::sync::Arc::new(Tshm::open(&path).unwrap());
+            let pid = std::process::id();
+            // Barrier ensures all threads finish claiming before any release,
+            // so we get an accurate count with no slot recycling.
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+
+            let mut handles = Vec::new();
+            for t in 0..8 {
+                let tshm = tshm.clone();
+                let barrier = barrier.clone();
+                handles.push(std::thread::spawn(move || {
+                    let mut slot_handles = Vec::new();
+                    for i in 0..64 {
+                        let frame = (t * 64 + i) as u32;
+                        if let Some(h) = tshm.claim_reader_slot(pid, frame) {
+                            slot_handles.push(h);
+                        }
+                    }
+                    let count = slot_handles.len();
+                    // Wait for all threads to finish claiming before releasing.
+                    barrier.wait();
+                    for h in slot_handles {
+                        tshm.release_reader_slot(h);
+                    }
+                    count
+                }));
+            }
+
+            let total: usize = handles.into_iter().map(|h| h.join().unwrap()).sum();
+            // 8 threads * 64 attempts = 512, all should succeed since
+            // NUM_READER_SLOTS (2045) > 512.
+            assert_eq!(total, 512);
+        }
+
+        #[test]
+        fn test_pack_unpack_roundtrip() {
+            let pid = 12345u32;
+            let max_frame = 67890u32;
+            let packed = pack_slot(pid, max_frame);
+            let (unpacked_pid, unpacked_frame) = unpack_slot(packed);
+            assert_eq!(unpacked_pid, pid);
+            assert_eq!(unpacked_frame, max_frame);
+        }
+
+        #[test]
+        fn test_pack_unpack_max_values() {
+            let pid = u32::MAX;
+            let max_frame = u32::MAX;
+            let packed = pack_slot(pid, max_frame);
+            let (unpacked_pid, unpacked_frame) = unpack_slot(packed);
+            assert_eq!(unpacked_pid, pid);
+            assert_eq!(unpacked_frame, max_frame);
+        }
+
+        #[test]
+        fn test_shared_across_opens() {
+            let (_dir, path) = temp_tshm_path();
+            let pid = std::process::id();
+
+            // First open: claim a slot
+            let tshm1 = Tshm::open(&path).unwrap();
+            let _h = tshm1.claim_reader_slot(pid, 42).unwrap();
+
+            // Second open of same file: should see the slot
+            let tshm2 = Tshm::open(&path).unwrap();
+            assert_eq!(tshm2.min_reader_frame(), Some(42));
+        }
+
+        // --- Writer state tests ---
+
+        #[test]
+        fn test_writer_state_set_get() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            // Initially zero
+            assert_eq!(tshm.writer_state(), 0);
+
+            let state = pack_writer_state(3, 100);
+            tshm.set_writer_state(state);
+            assert_eq!(tshm.writer_state(), state);
+
+            // Update
+            let state2 = pack_writer_state(4, 200);
+            tshm.set_writer_state(state2);
+            assert_eq!(tshm.writer_state(), state2);
+        }
+
+        #[test]
+        fn test_writer_state_shared_across_opens() {
+            let (_dir, path) = temp_tshm_path();
+
+            let tshm1 = Tshm::open(&path).unwrap();
+            let state = pack_writer_state(7, 42);
+            tshm1.set_writer_state(state);
+
+            // Second open should see the writer state
+            let tshm2 = Tshm::open(&path).unwrap();
+            assert_eq!(tshm2.writer_state(), state);
+        }
+
+        #[test]
+        fn test_writer_state_pack_roundtrip() {
+            let ckpt = 12345u32;
+            let frame = 67890u32;
+            let packed = pack_writer_state(ckpt, frame);
+            // Upper 32 = checkpoint_seq, lower 32 = max_frame
+            assert_eq!((packed >> 32) as u32, ckpt);
+            assert_eq!(packed as u32, frame);
+        }
+
+        #[test]
+        fn test_increment_writer_state_monotonic() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            assert_eq!(tshm.writer_state(), 0);
+
+            let s1 = tshm.increment_writer_state();
+            assert_eq!(s1, 1);
+            assert_eq!(tshm.writer_state(), 1);
+
+            let s2 = tshm.increment_writer_state();
+            assert_eq!(s2, 2);
+
+            let s3 = tshm.increment_writer_state();
+            assert_eq!(s3, 3);
+
+            // Every call produces a unique value
+            assert_ne!(s1, s2);
+            assert_ne!(s2, s3);
+        }
+
+        /// Regression test for the ABA problem: when a WAL restart resets
+        /// max_frame to 0 and the next write lands at the same max_frame as
+        /// before, the old pack_writer_state(ckpt_seq, max_frame) encoding
+        /// produced an identical value, causing readers to skip the rescan.
+        /// The monotonic counter avoids this.
+        #[test]
+        fn test_increment_writer_state_no_aba() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            // Simulate: initial state after first write tx (some frames committed)
+            let state_before = tshm.increment_writer_state();
+
+            // Simulate: second write tx commits (WAL may restart internally,
+            // but the counter always advances)
+            let state_after = tshm.increment_writer_state();
+
+            // Reader cached state_before. After the second commit, the reader
+            // must see a different value to trigger a WAL rescan.
+            assert_ne!(
+                state_before, state_after,
+                "writer state must differ after every commit to avoid ABA"
+            );
+        }
+
+        #[test]
+        fn test_increment_writer_state_visible_cross_open() {
+            let (_dir, path) = temp_tshm_path();
+
+            let tshm1 = Tshm::open(&path).unwrap();
+            let s1 = tshm1.increment_writer_state();
+
+            // Second open (simulating another process) should see the updated state
+            let tshm2 = Tshm::open(&path).unwrap();
+            assert_eq!(tshm2.writer_state(), s1);
+
+            // Writer bumps again
+            let s2 = tshm1.increment_writer_state();
+            assert_ne!(s1, s2);
+
+            // Reader sees the new value
+            assert_eq!(tshm2.writer_state(), s2);
+        }
+
+        // --- Write lock tests (CAS + fcntl byte-range on tshm fd) ---
+
+        #[test]
+        fn test_write_lock_acquire_release() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            assert_eq!(tshm.active_writers(), 0);
+
+            tshm.write_lock().unwrap();
+            assert_eq!(tshm.active_writers(), 1);
+
+            tshm.write_unlock();
+            assert_eq!(tshm.active_writers(), 0);
+        }
+
+        #[test]
+        fn test_write_lock_refcount() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            // Refcount: multiple write_lock calls bump the counter
+            tshm.write_lock().unwrap();
+            assert_eq!(tshm.active_writers(), 1);
+
+            tshm.write_lock().unwrap();
+            assert_eq!(tshm.active_writers(), 2);
+
+            tshm.write_lock().unwrap();
+            assert_eq!(tshm.active_writers(), 3);
+
+            tshm.write_unlock();
+            assert_eq!(tshm.active_writers(), 2);
+
+            tshm.write_unlock();
+            assert_eq!(tshm.active_writers(), 1);
+
+            tshm.write_unlock();
+            assert_eq!(tshm.active_writers(), 0);
+        }
+
+        #[test]
+        fn test_write_lock_reacquire_after_full_release() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            tshm.write_lock().unwrap();
+            tshm.write_unlock();
+            assert_eq!(tshm.active_writers(), 0);
+
+            // Re-acquire — should call fcntl again
+            tshm.write_lock().unwrap();
+            assert_eq!(tshm.active_writers(), 1);
+            tshm.write_unlock();
+        }
+
+        #[test]
+        fn test_write_lock_cross_process_exclusion() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            tshm.write_lock().unwrap();
+
+            // Fork a child that tries to acquire the same lock
+            let child = unsafe { libc::fork() };
+            if child == 0 {
+                let tshm2 = Tshm::open(&path).unwrap();
+                let result = tshm2.write_lock();
+                let code = if result.is_err() { 0 } else { 1 };
+                unsafe { libc::_exit(code) };
+            }
+
+            assert!(child > 0, "fork failed");
+
+            let mut status: libc::c_int = 0;
+            unsafe { libc::waitpid(child, &mut status, 0) };
+            assert!(
+                libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+                "child should have failed to acquire lock (exit status: {})",
+                libc::WEXITSTATUS(status)
+            );
+
+            tshm.write_unlock();
+        }
+
+        #[test]
+        fn test_write_lock_concurrent_threads() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = std::sync::Arc::new(Tshm::open(&path).unwrap());
+
+            let mut handles = Vec::new();
+            for _ in 0..8 {
+                let tshm = tshm.clone();
+                handles.push(std::thread::spawn(move || {
+                    for _ in 0..100 {
+                        tshm.write_lock().unwrap();
+                        std::thread::yield_now();
+                        tshm.write_unlock();
+                    }
+                }));
+            }
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            assert_eq!(tshm.active_writers(), 0);
+        }
+
+        #[test]
+        fn test_write_lock_drop_releases() {
+            let (_dir, path) = temp_tshm_path();
+
+            {
+                let tshm = Tshm::open(&path).unwrap();
+                tshm.write_lock().unwrap();
+                tshm.write_lock().unwrap();
+                // Drop without explicit unlock
+            }
+
+            // After drop, a new instance should be able to acquire
+            let tshm2 = Tshm::open(&path).unwrap();
+            tshm2.write_lock().unwrap();
+            tshm2.write_unlock();
+        }
+
+        #[test]
+        fn test_locking_mode_slot_default_is_zero() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+            assert_eq!(
+                tshm.locking_mode(),
+                0,
+                "fresh TSHM should have mode 0 (unset)"
+            );
+        }
+
+        #[test]
+        fn test_locking_mode_set_and_read() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            // Set SharedWrites (2).
+            assert!(tshm.try_set_locking_mode(2).is_ok());
+            assert_eq!(tshm.locking_mode(), 2);
+
+            // Second instance sees the same value via mmap.
+            let tshm2 = Tshm::open(&path).unwrap();
+            assert_eq!(tshm2.locking_mode(), 2);
+        }
+
+        #[test]
+        fn test_locking_mode_cas_same_mode_ok() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            // First set succeeds (CAS 0 → 1).
+            assert!(tshm.try_set_locking_mode(1).is_ok());
+
+            // Same mode again succeeds (already 1, requested 1).
+            assert!(tshm.try_set_locking_mode(1).is_ok());
+        }
+
+        #[test]
+        fn test_locking_mode_cas_conflicting_mode_rejected() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            // First set: SharedReads (1).
+            assert!(tshm.try_set_locking_mode(1).is_ok());
+
+            // Conflicting: SharedWrites (2) — should fail with Err(1).
+            let result = tshm.try_set_locking_mode(2);
+            assert_eq!(result, Err(1), "conflicting mode should be rejected");
+
+            // Second instance also rejected.
+            let tshm2 = Tshm::open(&path).unwrap();
+            let result = tshm2.try_set_locking_mode(2);
+            assert_eq!(result, Err(1), "second instance conflicting mode rejected");
+        }
+
+        #[test]
+        fn test_locking_mode_clear_and_reset() {
+            let (_dir, path) = temp_tshm_path();
+            let tshm = Tshm::open(&path).unwrap();
+
+            tshm.try_set_locking_mode(2).unwrap();
+            assert_eq!(tshm.locking_mode(), 2);
+
+            // Clear resets to 0.
+            tshm.clear_locking_mode();
+            assert_eq!(tshm.locking_mode(), 0);
+
+            // Can now set a different mode.
+            assert!(tshm.try_set_locking_mode(1).is_ok());
+            assert_eq!(tshm.locking_mode(), 1);
+        }
+    }
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[allow(unused_imports)]
+pub use imp::*;

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -119,7 +119,7 @@ pub enum CheckpointMode {
 }
 
 impl CheckpointMode {
-    fn should_restart_log(&self) -> bool {
+    pub fn should_restart_log(&self) -> bool {
         matches!(
             self,
             CheckpointMode::Truncate { .. } | CheckpointMode::Restart
@@ -321,7 +321,7 @@ pub trait Wal: Debug + Send + Sync {
     /// Returns whether the database state has changed since the last read transaction.
     fn begin_read_tx(&self) -> Result<bool>;
     /// MVCC helper: check if WAL state changed without starting a read tx.
-    fn mvcc_refresh_if_db_changed(&self) -> bool;
+    fn mvcc_refresh_if_db_changed(&self) -> Result<bool>;
 
     /// Begin a write transaction.
     fn begin_write_tx(&self) -> Result<()>;
@@ -731,6 +731,12 @@ pub struct WalFile {
     checkpoint_guard: RwLock<Option<CheckpointLocks>>,
 
     io_ctx: RwLock<IOContext>,
+
+    /// Counter for how many times `rescan_wal_from_disk` has been called.
+    /// Used by multi-process tests to assert that WAL file reads don't
+    /// happen on the read hot path.
+    #[cfg(test)]
+    rescan_count: AtomicU64,
 }
 
 impl fmt::Debug for WalFile {
@@ -817,8 +823,6 @@ pub struct WalFileShared {
     // Frame cache maps a Page to all the frames it has stored in WAL in ascending order.
     // This is to easily find the frame it must checkpoint each connection if a checkpoint is
     // necessary.
-    // One difference between SQLite and limbo is that we will never support multi process, meaning
-    // we don't need WAL's index file. So we can do stuff like this without shared memory.
     // TODO: this will need refactoring because this is incredible memory inefficient.
     pub frame_cache: Arc<SpinLock<FxHashMap<u64, Vec<u64>>>>,
     pub last_checksum: (u32, u32), // Check of last frame in WAL, this is a cumulative checksum over all frames in the WAL
@@ -841,6 +845,11 @@ pub struct WalFileShared {
     /// Increments on each checkpoint, used to prevent stale cached pages being used for
     /// backfilling.
     pub epoch: AtomicU32,
+
+    /// Maximum frame that external (other-process) readers may still be reading.
+    /// Set by MultiProcessWal from TSHM min_reader_frame() before checkpoint.
+    /// 0 means no external readers are active.
+    pub external_reader_max_frame: AtomicU64,
 }
 
 impl fmt::Debug for WalFileShared {
@@ -1182,8 +1191,8 @@ impl Wal for WalFile {
         }
     }
 
-    fn mvcc_refresh_if_db_changed(&self) -> bool {
-        WalFile::mvcc_refresh_if_db_changed(self)
+    fn mvcc_refresh_if_db_changed(&self) -> crate::Result<bool> {
+        Ok(WalFile::mvcc_refresh_if_db_changed(self))
     }
 
     /// End a read transaction.
@@ -2158,7 +2167,282 @@ impl WalFile {
             last_checksum: RwLock::new(last_checksum),
             checkpoint_guard: RwLock::new(None),
             io_ctx: RwLock::new(IOContext::default()),
+            #[cfg(test)]
+            rescan_count: AtomicU64::new(0),
         }
+    }
+
+    /// Set the external reader max frame (from TSHM) that checkpoint must respect.
+    pub fn set_external_reader_max_frame(&self, frame: u64) {
+        self.with_shared(|shared| {
+            shared
+                .external_reader_max_frame
+                .store(frame, Ordering::Release);
+        });
+    }
+
+    /// Number of times `rescan_wal_from_disk` has been called (test-only).
+    #[cfg(test)]
+    pub fn rescan_count(&self) -> u64 {
+        self.rescan_count.load(Ordering::Relaxed)
+    }
+
+    /// Get the WAL header page_size.
+    pub fn get_wal_page_size(&self) -> u32 {
+        self.with_shared(|shared| shared.wal_header.lock().page_size)
+    }
+
+    /// Set the WAL header page_size (from WalIndex shared state).
+    pub fn set_wal_page_size(&self, page_size: u32) {
+        self.with_shared(|shared| {
+            shared.wal_header.lock().page_size = page_size;
+        });
+    }
+
+    /// Get the WAL header salt values (salt_1, salt_2).
+    pub fn get_wal_salt(&self) -> (u32, u32) {
+        self.with_shared(|shared| {
+            let hdr = shared.wal_header.lock();
+            (hdr.salt_1, hdr.salt_2)
+        })
+    }
+
+    /// Get shared max_frame (for diagnostics / cross-process state inspection).
+    pub fn get_shared_max_frame(&self) -> u64 {
+        self.with_shared(|shared| shared.max_frame.load(Ordering::Acquire))
+    }
+
+    /// Get shared nbackfills (for diagnostics / cross-process state inspection).
+    pub fn get_shared_nbackfills(&self) -> u64 {
+        self.with_shared(|shared| shared.nbackfills.load(Ordering::Acquire))
+    }
+
+    /// Bump shared transaction_count to force db_changed detection.
+    pub fn bump_transaction_count(&self) {
+        self.with_shared(|shared| {
+            shared.transaction_count.fetch_add(1, Ordering::AcqRel);
+        });
+    }
+
+    /// Set shared wal_header checkpoint_seq (for testing).
+    #[cfg(test)]
+    pub fn set_checkpoint_seq(&self, seq: u32) {
+        self.with_shared(|shared| {
+            shared.wal_header.lock().checkpoint_seq = seq;
+        });
+    }
+
+    /// Clear the frame_cache (for testing).
+    #[cfg(test)]
+    pub fn clear_frame_cache(&self) {
+        self.with_shared(|shared| {
+            shared.frame_cache.lock().clear();
+        });
+    }
+
+    /// Sync inner shared state from WalIndex header values (zero file I/O).
+    ///
+    /// Replaces `rescan_wal_from_disk` for the multi-process case where
+    /// a WalIndex is available. Updates max_frame, salt, page_size,
+    /// last_checksum, resets nbackfills to 0, and bumps transaction_count
+    /// to invalidate page caches.
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub fn sync_from_wal_index_header(
+        &self,
+        max_frame: u64,
+        salt_1: u32,
+        salt_2: u32,
+        page_size: u32,
+        last_checksum: (u32, u32),
+        checkpoint_seq: u32,
+    ) {
+        let mut shared = self.shared.write();
+
+        // Detect state changes that require a hard-reset of max_frame:
+        //
+        // 1. Salt changed (WAL restart): the WAL was restarted with a new
+        //    salt — frame numbers are reused with different content.
+        //
+        // 2. max_frame decreased (truncation/checkpoint): the WAL was
+        //    truncated. After a Truncate checkpoint the WalIndex is cleared
+        //    (max_frame = 0, salt = (0,0)). The salt comparison alone won't
+        //    catch this because incoming salt is (0,0) and salt_changed
+        //    requires both sides non-zero.
+        //
+        // In all other cases, use fetch_max so we never decrease max_frame
+        // when the writer committed frames the WalIndex hasn't published yet.
+        let salt_changed = {
+            let hdr = shared.wal_header.lock();
+            let current_non_zero = hdr.salt_1 != 0 || hdr.salt_2 != 0;
+            let incoming_non_zero = salt_1 != 0 || salt_2 != 0;
+            current_non_zero && incoming_non_zero && (hdr.salt_1 != salt_1 || hdr.salt_2 != salt_2)
+        };
+        let current_max = shared.max_frame.load(Ordering::Acquire);
+
+        if salt_changed || max_frame < current_max {
+            // WAL was restarted or truncated — hard-reset.
+            shared.max_frame.store(max_frame, Ordering::Release);
+        } else {
+            // Same WAL generation, monotonically increasing — use fetch_max
+            // so we never decrease max_frame (in same-process mode, the
+            // writer may have committed frames the WalIndex hasn't
+            // published yet).
+            shared.max_frame.fetch_max(max_frame, Ordering::Release);
+        }
+
+        // Always update header fields from WalIndex.
+        {
+            let mut hdr = shared.wal_header.lock();
+            if salt_1 != 0 || salt_2 != 0 {
+                hdr.salt_1 = salt_1;
+                hdr.salt_2 = salt_2;
+            }
+            if page_size > 0 {
+                hdr.page_size = page_size;
+            }
+            hdr.checkpoint_seq = checkpoint_seq;
+        }
+        if last_checksum != (0, 0) {
+            shared.last_checksum = last_checksum;
+        }
+        // Keep per-WalFile last_checksum in sync (needed by prepare_frames
+        // checksum chain).
+        *self.last_checksum.write() = shared.last_checksum;
+
+        // Always reset nbackfills to 0. We cannot know the actual
+        // checkpoint progress from the WalIndex alone, and leaving a
+        // stale nbackfills can cause try_begin_read_tx to take the
+        // "fully checkpointed" path (shared_max == nbackfills) when the
+        // WAL actually has frames that haven't been backfilled to DB.
+        shared.nbackfills.store(0, Ordering::Release);
+
+        // Force page cache invalidation.
+        shared.transaction_count.fetch_add(1, Ordering::AcqRel);
+
+        if max_frame > 0 || (salt_1 != 0 || salt_2 != 0) {
+            shared.initialized.store(true, Ordering::Release);
+        }
+    }
+
+    /// Populate frame_cache from WalIndex entries (zero file I/O).
+    ///
+    /// Replaces the frame_cache rebuild done by `rescan_wal_from_disk`.
+    /// Accepts the output of `WalIndex::iter_latest_frames()` — a list
+    /// of (page_id, frame_id) pairs representing the latest frame per page.
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    /// Populate the given WalIndex from our frame_cache.
+    /// Called to bootstrap the shared WalIndex when a process opens an
+    /// existing WAL that already has frames.
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub fn populate_wal_index(
+        &self,
+        wal_index: &crate::storage::wal_index::WalIndex,
+    ) -> Result<()> {
+        self.with_shared(|shared| {
+            let frame_cache = shared.frame_cache.lock();
+            for (page_id, frames) in frame_cache.iter() {
+                debug_assert!(
+                    *page_id <= u32::MAX as u64,
+                    "page_id {page_id} exceeds u32::MAX"
+                );
+                for &frame_id in frames {
+                    debug_assert!(
+                        frame_id <= u32::MAX as u64,
+                        "frame_id {frame_id} exceeds u32::MAX"
+                    );
+                    wal_index.append_frame(*page_id as u32, frame_id as u32)?;
+                }
+            }
+            let max_frame = shared.max_frame.load(Ordering::Acquire);
+            if max_frame > 0 {
+                debug_assert!(
+                    max_frame <= u32::MAX as u64,
+                    "max_frame {max_frame} exceeds u32::MAX"
+                );
+                wal_index.commit_max_frame(max_frame as u32);
+            }
+            Ok(())
+        })
+    }
+
+    /// Re-read the WAL file from disk and update the shared state.
+    ///
+    /// Used by MultiProcessWal so that a reader process can discover
+    /// frames written by a writer in another process. This rebuilds
+    /// `frame_cache`, `max_frame`, `last_checksum`, and the WAL header
+    /// from the on-disk WAL file. The rebuild is unconditional — the
+    /// caller is responsible for gating calls behind a TSHM writer_state
+    /// check to avoid redundant rescans.
+    pub fn rescan_wal_from_disk(&self) -> Result<()> {
+        #[cfg(test)]
+        self.rescan_count.fetch_add(1, Ordering::Relaxed);
+        let file = self.with_shared(|s| s.file.clone());
+        let file = match file {
+            Some(f) => f,
+            None => return Ok(()), // noop WAL (no file)
+        };
+
+        // Re-read WAL from disk into a fresh temporary WalFileShared.
+        let fresh_shared = crate::storage::sqlite3_ondisk::build_shared_wal(&file, &self.io)?;
+        let fresh = fresh_shared.read();
+
+        // Always apply the fresh state from disk. Even when checkpoint_seq
+        // and max_frame look identical, the frame *contents* may differ
+        // (e.g. after a Truncate checkpoint followed by new writes that
+        // happen to reach the same max_frame count). The frame_cache must
+        // be rebuilt from the actual WAL on disk to stay correct.
+
+        // Copy relevant fields into our shared state.
+        // We deliberately don't touch process-local coordination fields
+        // (read_locks, write_lock, checkpoint_lock, epoch,
+        // external_reader_max_frame).
+        let mut shared = self.shared.write();
+
+        shared
+            .max_frame
+            .store(fresh.max_frame.load(Ordering::Acquire), Ordering::Release);
+        shared.last_checksum = fresh.last_checksum;
+
+        // Reset nbackfills to 0: we don't know the actual checkpoint
+        // progress from just the WAL file, and leaving a stale nbackfills
+        // can cause try_begin_read_tx to take the "fully checkpointed"
+        // path when the WAL actually has uncommitted-to-db frames.
+        shared.nbackfills.store(0, Ordering::Release);
+
+        // Bump transaction_count so db_changed() returns true for any
+        // connection that hasn't seen this rescan yet, forcing page cache
+        // invalidation.
+        shared.transaction_count.fetch_add(1, Ordering::AcqRel);
+
+        {
+            let mut cache = shared.frame_cache.lock();
+            let fresh_cache = fresh.frame_cache.lock();
+            cache.clone_from(&fresh_cache);
+        }
+
+        {
+            let mut hdr = shared.wal_header.lock();
+            let fresh_hdr = fresh.wal_header.lock();
+            let prev_page_size = hdr.page_size;
+            *hdr = *fresh_hdr;
+            // A truncated WAL file has page_size=0 in the default header.
+            // Preserve the known page_size so prepare_frames doesn't panic.
+            if hdr.page_size == 0 {
+                hdr.page_size = prev_page_size;
+            }
+        }
+
+        shared
+            .initialized
+            .store(fresh.initialized.load(Ordering::Acquire), Ordering::Release);
+
+        // Keep per-WalFile last_checksum in sync with shared. Without this,
+        // callers that read get_last_checksum() after a rescan (e.g.
+        // sync_wal_index_metadata in begin_write_tx) see a stale value from
+        // the previous read transaction and propagate it to the WalIndex.
+        *self.last_checksum.write() = shared.last_checksum;
+
+        Ok(())
     }
 
     fn page_size(&self) -> u32 {
@@ -2634,6 +2918,12 @@ impl WalFile {
                     }
                 }
             }
+            // Also respect external (other-process) readers tracked via TSHM.
+            let ext = shared.external_reader_max_frame.load(Ordering::Acquire);
+            if ext > 0 && ext < max_safe_frame {
+                max_safe_frame = ext;
+            }
+
             max_safe_frame
         })
     }
@@ -2667,6 +2957,15 @@ impl WalFile {
         if max_frame != nbackfills {
             tracing::debug!(
                 "try_restart_log_before_write: max_frame={max_frame}, nbackfills={nbackfills}, not everything is backfilled to the DB file - can't restart the log"
+            );
+            return Ok(());
+        }
+        // Don't restart if external (other-process) readers are active.
+        // They may still need to read WAL frames from this generation.
+        let ext = self.with_shared(|s| s.external_reader_max_frame.load(Ordering::Acquire));
+        if ext > 0 {
+            tracing::debug!(
+                "try_restart_log_before_write: external readers active (frame={ext}), can't restart the log"
             );
             return Ok(());
         }
@@ -2961,6 +3260,7 @@ impl WalFileShared {
             loaded: AtomicBool::new(true),
             initialized: AtomicBool::new(false),
             epoch: AtomicU32::new(0),
+            external_reader_max_frame: AtomicU64::new(0),
         };
         Arc::new(RwLock::new(shared))
     }
@@ -2993,6 +3293,7 @@ impl WalFileShared {
             loaded: AtomicBool::new(true),
             initialized: AtomicBool::new(false),
             epoch: AtomicU32::new(0),
+            external_reader_max_frame: AtomicU64::new(0),
         };
         Ok(Arc::new(RwLock::new(shared)))
     }
@@ -3044,6 +3345,8 @@ impl WalFileShared {
 
 #[cfg(test)]
 pub mod test {
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    use crate::numeric::Numeric;
     use crate::sync::{atomic::Ordering, Arc};
     use crate::sync::{Mutex, RwLock};
     use crate::{
@@ -3054,7 +3357,7 @@ pub mod test {
         types::IOResult,
         util::IOExt,
         CheckpointMode, CheckpointResult, Completion, Connection, Database, LimboError, PlatformIO,
-        WalFileShared, IO,
+        Value, WalFileShared, IO,
     };
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
@@ -3659,6 +3962,16 @@ pub mod test {
             let wal_any = _wal.as_any();
             if let Some(wal_file) = wal_any.downcast_ref::<crate::WalFile>() {
                 return wal_file.max_frame_read_lock_index.load(Ordering::Acquire)
+                    == _expected_slot;
+            }
+            #[cfg(all(unix, target_pointer_width = "64"))]
+            if let Some(mp_wal) =
+                wal_any.downcast_ref::<crate::storage::multi_process_wal::MultiProcessWal>()
+            {
+                return mp_wal
+                    .inner()
+                    .max_frame_read_lock_index
+                    .load(Ordering::Acquire)
                     == _expected_slot;
             }
         }
@@ -4344,5 +4657,465 @@ pub mod test {
             result.everything_backfilled(),
             "checkpoint must succeed after rollback, not return Busy"
         );
+    }
+
+    /// Test that rescan_wal_from_disk discovers frames written to the WAL
+    /// file on disk. Simulates a reader process that opened the DB before
+    /// the writer wrote any data.
+    #[test]
+    fn test_rescan_wal_from_disk_discovers_new_frames() {
+        use crate::storage::buffer_pool::BufferPool;
+
+        let (db, _path) = get_database();
+        let conn = db.connect().unwrap();
+
+        // Get the WAL file handle BEFORE writing any data — simulates a
+        // reader process that opened the DB at this point.
+        let wal_file_handle = db.shared_wal.read().file.as_ref().unwrap().clone();
+
+        // Build a "stale" WalFileShared from the (currently empty) WAL.
+        let stale_shared = sqlite3_ondisk::build_shared_wal(&wal_file_handle, &db.io).unwrap();
+        let stale_max = stale_shared.read().max_frame.load(Ordering::Acquire);
+        assert_eq!(stale_max, 0, "WAL should be empty before writes");
+
+        // Now write data through the real connection — creates WAL frames.
+        conn.execute("CREATE TABLE test(id integer primary key, value text)")
+            .unwrap();
+        conn.execute("INSERT INTO test(value) VALUES ('hello'), ('world')")
+            .unwrap();
+
+        // The stale shared still shows max_frame=0.
+        assert_eq!(
+            stale_shared.read().max_frame.load(Ordering::Acquire),
+            0,
+            "stale shared must not see new frames"
+        );
+
+        // Create a WalFile with the stale shared (simulates reader process).
+        let last_cksum = stale_shared.read().last_checksum_and_max_frame();
+        let buffer_pool = BufferPool::begin_init(&db.io, 65536);
+        buffer_pool.finalize_with_page_size(4096).unwrap();
+        let reader_wal =
+            super::WalFile::new(db.io.clone(), stale_shared.clone(), last_cksum, buffer_pool);
+
+        // Before rescan: frame_cache is empty.
+        assert!(
+            stale_shared.read().frame_cache.lock().is_empty(),
+            "frame_cache should be empty before rescan"
+        );
+
+        // Rescan from disk.
+        reader_wal.rescan_wal_from_disk().unwrap();
+
+        // After rescan: max_frame > 0 and frame_cache has entries.
+        let refreshed_max = stale_shared.read().max_frame.load(Ordering::Acquire);
+        assert!(
+            refreshed_max > 0,
+            "rescan must discover WAL frames (max_frame={refreshed_max})"
+        );
+        assert!(
+            !stale_shared.read().frame_cache.lock().is_empty(),
+            "frame_cache must have entries after rescan"
+        );
+    }
+
+    /// Test that try_restart_log_before_write does NOT restart the WAL
+    /// when external_reader_max_frame is set (indicating other-process readers).
+    #[test]
+    fn test_restart_blocked_by_external_readers() {
+        let (db, _path) = get_database();
+        let conn = db.connect().unwrap();
+
+        conn.execute("CREATE TABLE test(id integer primary key, value text)")
+            .unwrap();
+        bulk_inserts(&conn, 3, 5);
+
+        // Checkpoint everything so nbackfills == max_frame (restart precondition).
+        {
+            let pager = conn.pager.load();
+            run_checkpoint_until_done(
+                &pager,
+                CheckpointMode::Passive {
+                    upper_bound_inclusive: None,
+                },
+            );
+        }
+
+        let max_before = db.shared_wal.read().max_frame.load(Ordering::Acquire);
+        let nbackfills = db.shared_wal.read().nbackfills.load(Ordering::Acquire);
+        assert_eq!(
+            max_before, nbackfills,
+            "everything should be backfilled for restart to be possible"
+        );
+        assert!(max_before > 0, "WAL should have frames");
+
+        // Simulate external readers by setting external_reader_max_frame.
+        db.shared_wal
+            .read()
+            .external_reader_max_frame
+            .store(max_before, Ordering::Release);
+
+        // Now start a write transaction — this calls try_restart_log_before_write
+        // internally, which should be blocked by external readers.
+        {
+            let pager = conn.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.begin_read_tx().unwrap();
+            wal.begin_write_tx().unwrap();
+        }
+
+        // Verify the WAL was NOT restarted — max_frame should still be > 0.
+        let max_after = db.shared_wal.read().max_frame.load(Ordering::Acquire);
+        assert_eq!(
+            max_after, max_before,
+            "WAL restart must be blocked when external readers are active \
+             (max_frame went from {max_before} to {max_after})"
+        );
+
+        // Cleanup: end the write/read transactions.
+        {
+            let pager = conn.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.end_write_tx();
+            wal.end_read_tx();
+        }
+
+        // Clear external readers and verify restart CAN now happen.
+        db.shared_wal
+            .read()
+            .external_reader_max_frame
+            .store(0, Ordering::Release);
+
+        {
+            let pager = conn.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.begin_read_tx().unwrap();
+            wal.begin_write_tx().unwrap();
+        }
+
+        // After clearing external readers and starting a new write tx,
+        // try_restart_log_before_write should have restarted the WAL.
+        let max_final = db.shared_wal.read().max_frame.load(Ordering::Acquire);
+        assert_eq!(
+            max_final, 0,
+            "WAL should be restarted when no external readers (max_frame={max_final})"
+        );
+
+        {
+            let pager = conn.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            wal.end_write_tx();
+            wal.end_read_tx();
+        }
+    }
+
+    /// Test that a second process (simulated via a separate Database instance)
+    /// can see data written by the first process after rescan.
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_cross_process_reader_sees_writer_data() {
+        let (db, path) = get_database();
+        let conn = db.connect().unwrap();
+
+        // Writer: create table and insert data.
+        conn.execute("CREATE TABLE test(id integer primary key, value text)")
+            .unwrap();
+        conn.execute("INSERT INTO test(value) VALUES ('alpha'), ('beta'), ('gamma')")
+            .unwrap();
+
+        // Verify writer can see data.
+        let writer_count = count_test_table(&conn);
+        assert_eq!(writer_count, 3, "writer should see 3 rows");
+
+        // Simulate reader process: open a SECOND Database on the same file.
+        let mut db_path = path;
+        db_path.push("test.db");
+        let io2: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db2 = Database::open_file(io2.clone(), db_path.to_str().unwrap()).unwrap();
+        let conn2 = db2.connect().unwrap();
+
+        // Reader should see the data written by writer (via WAL rescan
+        // that happens in MultiProcessWal::begin_read_tx).
+        let reader_count = count_test_table(&conn2);
+        assert_eq!(
+            reader_count, 3,
+            "reader process must see data written by writer (got {reader_count})"
+        );
+
+        // Writer: insert more data.
+        conn.execute("INSERT INTO test(value) VALUES ('delta')")
+            .unwrap();
+        assert_eq!(count_test_table(&conn), 4, "writer should see 4 rows");
+
+        // Reader: should see the new data after a fresh query (which starts
+        // a new read transaction with WAL rescan).
+        let reader_count2 = count_test_table(&conn2);
+        assert_eq!(
+            reader_count2, 4,
+            "reader must see new data after rescan (got {reader_count2})"
+        );
+    }
+
+    /// Test that when process A creates a new table, process B can see the
+    /// new table's schema and query it. This exercises the reprepare path
+    /// where the DB-level schema is stale and must be reparsed from disk.
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_cross_process_schema_change_visible() {
+        let (db, path) = get_database();
+        let conn = db.connect().unwrap();
+
+        // Writer (process A): create initial table.
+        conn.execute("CREATE TABLE t1(id integer primary key, value text)")
+            .unwrap();
+        conn.execute("INSERT INTO t1(value) VALUES ('hello')")
+            .unwrap();
+
+        // Reader (process B): open a second Database on the same file.
+        let mut db_path = path;
+        db_path.push("test.db");
+        let io2: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db2 = Database::open_file(io2.clone(), db_path.to_str().unwrap()).unwrap();
+        let conn2 = db2.connect().unwrap();
+
+        // Reader can see t1.
+        let mut stmt = conn2.prepare("SELECT value FROM t1").unwrap();
+        let rows = stmt.run_collect_rows().unwrap();
+        assert_eq!(rows.len(), 1, "reader should see 1 row in t1");
+
+        // Writer: create a SECOND table (increments schema cookie).
+        conn.execute("CREATE TABLE t2(id integer primary key, name text)")
+            .unwrap();
+        conn.execute("INSERT INTO t2(name) VALUES ('world')")
+            .unwrap();
+
+        // Reader: query the new table. This triggers:
+        // 1. WAL rescan (new frames from writer)
+        // 2. Schema cookie mismatch → SchemaUpdated
+        // 3. reprepare → detects stale DB schema → reparses from disk
+        // 4. Successfully re-translates with the new schema
+        let mut stmt2 = conn2.prepare("SELECT name FROM t2").unwrap();
+        let rows2 = stmt2.run_collect_rows().unwrap();
+        assert_eq!(
+            rows2.len(),
+            1,
+            "reader must see data in table created by another process"
+        );
+
+        // Reader: .schema equivalent — query sqlite_schema to see all tables.
+        let mut schema_stmt = conn2
+            .prepare("SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name")
+            .unwrap();
+        let schema_rows = schema_stmt.run_collect_rows().unwrap();
+        let table_names: Vec<String> = schema_rows
+            .iter()
+            .map(|r| match &r[0] {
+                Value::Text(s) => s.to_string(),
+                _ => panic!("expected text"),
+            })
+            .collect();
+        assert!(
+            table_names.contains(&"t1".to_string()),
+            "schema should contain t1, got: {table_names:?}"
+        );
+        assert!(
+            table_names.contains(&"t2".to_string()),
+            "schema should contain t2, got: {table_names:?}"
+        );
+    }
+
+    /// Test that a reader process sees a table dropped by the writer.
+    /// After DROP TABLE, prepare("SELECT * FROM t") must fail with "no such table".
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_cross_process_drop_table_visible() {
+        let (db, path) = get_database();
+        let conn = db.connect().unwrap();
+
+        // Writer: create table and insert data.
+        conn.execute("CREATE TABLE t1(id integer primary key, value text)")
+            .unwrap();
+        conn.execute("INSERT INTO t1(value) VALUES ('hello')")
+            .unwrap();
+
+        // Reader: open second Database on the same file.
+        let mut db_path = path;
+        db_path.push("test.db");
+        let io2: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db2 = Database::open_file(io2.clone(), db_path.to_str().unwrap()).unwrap();
+        let conn2 = db2.connect().unwrap();
+
+        // Reader can see t1.
+        let mut stmt = conn2.prepare("SELECT value FROM t1").unwrap();
+        let rows = stmt.run_collect_rows().unwrap();
+        assert_eq!(rows.len(), 1);
+
+        // Writer: drop the table.
+        conn.execute("DROP TABLE t1").unwrap();
+
+        // Reader: prepare should fail with "no such table".
+        let result = conn2.prepare("SELECT value FROM t1");
+        assert!(result.is_err(), "prepare should fail after DROP TABLE");
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("no such table"),
+            "error should mention 'no such table', got: {err_msg}"
+        );
+    }
+
+    /// Test that a reader process sees a table dropped and recreated with
+    /// different columns by the writer.
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_cross_process_drop_and_recreate_table() {
+        let (db, path) = get_database();
+        let conn = db.connect().unwrap();
+
+        // Writer: create table v1.
+        conn.execute("CREATE TABLE t1(id integer primary key, value text)")
+            .unwrap();
+        conn.execute("INSERT INTO t1(value) VALUES ('v1')").unwrap();
+
+        // Reader: open second Database, see t1 v1.
+        let mut db_path = path;
+        db_path.push("test.db");
+        let io2: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db2 = Database::open_file(io2.clone(), db_path.to_str().unwrap()).unwrap();
+        let conn2 = db2.connect().unwrap();
+
+        let mut stmt = conn2.prepare("SELECT value FROM t1").unwrap();
+        let rows = stmt.run_collect_rows().unwrap();
+        assert_eq!(rows.len(), 1);
+        match &rows[0][0] {
+            Value::Text(s) => assert_eq!(s.as_str(), "v1"),
+            other => panic!("expected Text, got: {other:?}"),
+        }
+
+        // Writer: drop and recreate with different columns.
+        conn.execute("DROP TABLE t1").unwrap();
+        conn.execute("CREATE TABLE t1(id integer primary key, name text, age integer)")
+            .unwrap();
+        conn.execute("INSERT INTO t1(name, age) VALUES ('alice', 30)")
+            .unwrap();
+
+        // Reader: query new columns. prepare() must detect the schema change,
+        // reparse from disk, and see the new column layout.
+        let mut stmt2 = conn2.prepare("SELECT name, age FROM t1").unwrap();
+        let rows2 = stmt2.run_collect_rows().unwrap();
+        assert_eq!(rows2.len(), 1, "reader should see 1 row in recreated t1");
+        match &rows2[0][0] {
+            Value::Text(s) => assert_eq!(s.as_str(), "alice"),
+            other => panic!("expected Text for name, got: {other:?}"),
+        }
+        match &rows2[0][1] {
+            Value::Numeric(Numeric::Integer(n)) => assert_eq!(*n, 30),
+            other => panic!("expected Integer for age, got: {other:?}"),
+        }
+    }
+
+    /// Test that ALTER TABLE ADD COLUMN by one process is visible to another.
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_cross_process_alter_table_add_column() {
+        let (db, path) = get_database();
+        let conn = db.connect().unwrap();
+
+        // Writer: create table with one column.
+        conn.execute("CREATE TABLE t1(id integer primary key, value text)")
+            .unwrap();
+        conn.execute("INSERT INTO t1(value) VALUES ('hello')")
+            .unwrap();
+
+        // Reader: open second Database and verify existing columns.
+        let mut db_path = path;
+        db_path.push("test.db");
+        let io2: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db2 = Database::open_file(io2.clone(), db_path.to_str().unwrap()).unwrap();
+        let conn2 = db2.connect().unwrap();
+
+        let mut stmt = conn2.prepare("SELECT value FROM t1").unwrap();
+        let rows = stmt.run_collect_rows().unwrap();
+        assert_eq!(rows.len(), 1);
+
+        // Writer: add a new column.
+        conn.execute("ALTER TABLE t1 ADD COLUMN extra text DEFAULT 'default_val'")
+            .unwrap();
+        conn.execute("INSERT INTO t1(value, extra) VALUES ('world', 'custom')")
+            .unwrap();
+
+        // Reader: query the new column. prepare() should detect stale schema
+        // and reparse from disk.
+        let mut stmt2 = conn2
+            .prepare("SELECT value, extra FROM t1 ORDER BY id")
+            .unwrap();
+        let rows2 = stmt2.run_collect_rows().unwrap();
+        assert_eq!(rows2.len(), 2, "reader should see 2 rows after ALTER TABLE");
+        // First row: extra should be the default value (NULL or 'default_val')
+        // Second row: extra should be 'custom'
+        match &rows2[1][1] {
+            Value::Text(s) => assert_eq!(s.as_str(), "custom"),
+            other => panic!("expected Text 'custom' for extra, got: {other:?}"),
+        }
+    }
+
+    /// Test that sqlite_schema queries work correctly after cross-process
+    /// schema changes (the .schema path).
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_cross_process_sqlite_schema_query() {
+        let (db, path) = get_database();
+        let conn = db.connect().unwrap();
+
+        // Writer: create two tables.
+        conn.execute("CREATE TABLE t1(id integer primary key)")
+            .unwrap();
+        conn.execute("CREATE TABLE t2(id integer primary key)")
+            .unwrap();
+
+        // Reader: open second Database, see both tables via sqlite_schema.
+        let mut db_path = path;
+        db_path.push("test.db");
+        let io2: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db2 = Database::open_file(io2.clone(), db_path.to_str().unwrap()).unwrap();
+        let conn2 = db2.connect().unwrap();
+
+        let table_names = query_table_names(&conn2);
+        assert!(table_names.contains(&"t1".to_string()));
+        assert!(table_names.contains(&"t2".to_string()));
+
+        // Writer: create a third table and drop the first.
+        conn.execute("CREATE TABLE t3(id integer primary key)")
+            .unwrap();
+        conn.execute("DROP TABLE t1").unwrap();
+
+        // Reader: sqlite_schema should reflect the changes.
+        let table_names = query_table_names(&conn2);
+        assert!(
+            !table_names.contains(&"t1".to_string()),
+            "t1 should be dropped, got: {table_names:?}"
+        );
+        assert!(
+            table_names.contains(&"t2".to_string()),
+            "t2 should still exist, got: {table_names:?}"
+        );
+        assert!(
+            table_names.contains(&"t3".to_string()),
+            "t3 should be visible, got: {table_names:?}"
+        );
+    }
+
+    /// Helper: query all table names from sqlite_schema.
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    fn query_table_names(conn: &Arc<Connection>) -> Vec<String> {
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name")
+            .unwrap();
+        let rows = stmt.run_collect_rows().unwrap();
+        rows.iter()
+            .map(|r| match &r[0] {
+                Value::Text(s) => s.to_string(),
+                _ => panic!("expected text"),
+            })
+            .collect()
     }
 }

--- a/core/storage/wal_index.rs
+++ b/core/storage/wal_index.rs
@@ -1,0 +1,1692 @@
+//! Shared WAL Index for multi-process coordination.
+//!
+//! The WAL index provides a shared `page_id → frame_id` mapping in mmap'd
+//! shared memory, eliminating file I/O from the reader hot path.
+//!
+//! ## File layout (embedded in `{db}-tshm` starting at byte 16384)
+//!
+//! The WAL index lives in the tshm file immediately after the 16 KB
+//! coordination page. The coordination page is 16 KB to fill one Apple
+//! Silicon page and ensure mmap alignment on all platforms.
+//! Segments are 32 KB each, separately mmap'd:
+//!
+//! ```text
+//! Segment 0 (32768 bytes, file offset 16384):
+//!   [0..128):       WalIndexHeader
+//!   [128..16384):   aPgno[4064]  — u32: frame_offset → page_id
+//!   [16384..32768): aHash[8192]  — u16: hash table for reverse lookup
+//!
+//! Segments 1+ (32768 bytes each, file offset 16384 + N*32768):
+//!   [0..16384):     aPgno[4096]
+//!   [16384..32768): aHash[8192]
+//! ```
+//!
+//! ## Hash table
+//!
+//! Same design as SQLite's WAL index:
+//! - Hash function: `(page_id * 383) % nslot`
+//! - Linear probing with wraparound
+//! - `aHash[i] == 0` → empty slot
+//! - `aHash[i] == k` (k ≥ 1) → `aPgno[k-1]` holds the page_id
+//!
+//! ## Memory ordering
+//!
+//! Writer stores aPgno/aHash with Relaxed, then stores `max_frame` with
+//! Release. Reader loads `max_frame` with Acquire, then reads aPgno/aHash
+//! with Relaxed. The Release/Acquire pair on `max_frame` creates the
+//! happens-before edge.
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+mod imp {
+    #[cfg(test)]
+    use std::os::unix::io::IntoRawFd;
+    use std::os::unix::io::RawFd;
+    use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
+
+    const SEGMENT_SIZE: usize = 32_768;
+    const HEADER_SIZE: usize = 128;
+
+    /// Byte offset where WAL index segments begin within the tshm file.
+    /// Must be a multiple of the system page size for mmap alignment (16 KB on
+    /// Apple Silicon, 4 KB on x86_64). Matches the 16 KB coordination page size,
+    /// so segments start immediately after with no wasted space.
+    const BASE_OFFSET: usize = 16_384;
+
+    /// Number of aPgno entries in segment 0 (after header).
+    const APGNO_COUNT_SEG0: usize = (SEGMENT_SIZE - HEADER_SIZE - AHASH_SIZE) / 4;
+    /// Number of aPgno entries in segments 1+.
+    const APGNO_COUNT: usize = (SEGMENT_SIZE - AHASH_SIZE) / 4;
+    /// Number of hash table slots per segment.
+    const AHASH_NSLOT: usize = 8192;
+    /// Size of hash table in bytes.
+    const AHASH_SIZE: usize = AHASH_NSLOT * 2;
+
+    /// Magic number for the WAL index header ("WALI").
+    const WAL_INDEX_MAGIC: u32 = 0x5741_4C49;
+
+    /// A single mmap'd segment of the WAL index.
+    struct WalIndexSegment {
+        ptr: *mut u8,
+    }
+
+    // SAFETY: mmap'd MAP_SHARED region accessed through atomics only.
+    unsafe impl Send for WalIndexSegment {}
+    unsafe impl Sync for WalIndexSegment {}
+
+    impl WalIndexSegment {
+        /// Get pointer to the aPgno array as a slice of AtomicU32.
+        fn apgno(&self, seg_idx: usize) -> &[AtomicU32] {
+            let offset = if seg_idx == 0 { HEADER_SIZE } else { 0 };
+            let count = if seg_idx == 0 {
+                APGNO_COUNT_SEG0
+            } else {
+                APGNO_COUNT
+            };
+            unsafe {
+                let ptr = self.ptr.add(offset) as *const AtomicU32;
+                std::slice::from_raw_parts(ptr, count)
+            }
+        }
+
+        /// Get pointer to the aHash array as a slice of AtomicU16.
+        fn ahash(&self, seg_idx: usize) -> &[AtomicU16] {
+            let offset = if seg_idx == 0 {
+                HEADER_SIZE + APGNO_COUNT_SEG0 * 4
+            } else {
+                APGNO_COUNT * 4
+            };
+            unsafe {
+                let ptr = self.ptr.add(offset) as *const AtomicU16;
+                std::slice::from_raw_parts(ptr, AHASH_NSLOT)
+            }
+        }
+    }
+
+    /// Compute the base frame number for a segment.
+    /// Frame IDs are 1-based. Segment 0 holds frames 1..=APGNO_COUNT_SEG0,
+    /// segment 1 holds frames (APGNO_COUNT_SEG0+1)..=(APGNO_COUNT_SEG0+APGNO_COUNT), etc.
+    #[inline]
+    fn seg_base_frame(seg_idx: usize) -> u32 {
+        if seg_idx == 0 {
+            0
+        } else {
+            APGNO_COUNT_SEG0 as u32 + (seg_idx as u32 - 1) * APGNO_COUNT as u32
+        }
+    }
+
+    /// How many aPgno entries fit in this segment.
+    #[inline]
+    fn seg_capacity(seg_idx: usize) -> usize {
+        if seg_idx == 0 {
+            APGNO_COUNT_SEG0
+        } else {
+            APGNO_COUNT
+        }
+    }
+
+    /// Which segment and offset within that segment a frame_id maps to.
+    /// frame_id is 1-based.
+    #[inline]
+    fn frame_to_seg_offset(frame_id: u32) -> (usize, usize) {
+        debug_assert!(frame_id > 0, "frame_id must be 1-based");
+        let idx = frame_id as usize - 1; // 0-based index
+        if idx < APGNO_COUNT_SEG0 {
+            (0, idx)
+        } else {
+            let remaining = idx - APGNO_COUNT_SEG0;
+            let seg = 1 + remaining / APGNO_COUNT;
+            let offset = remaining % APGNO_COUNT;
+            (seg, offset)
+        }
+    }
+
+    /// Hash function for the WAL index (same as SQLite).
+    #[inline]
+    fn wal_hash(page_id: u32) -> usize {
+        ((page_id as u64 * 383) % AHASH_NSLOT as u64) as usize
+    }
+
+    /// Search a single segment's hash table for the latest frame of `page_id`
+    /// within `[min_frame, max_frame]`. Extracted to avoid duplicating the
+    /// probe loop between the lock-free segment-0 fast path and the
+    /// multi-segment slow path.
+    #[inline]
+    fn find_in_segment(
+        seg: &WalIndexSegment,
+        seg_idx: usize,
+        page_id: u32,
+        min_frame: u32,
+        max_frame: u32,
+    ) -> Option<u32> {
+        let base = seg_base_frame(seg_idx);
+        let cap = seg_capacity(seg_idx);
+        let apgno = seg.apgno(seg_idx);
+        let ahash = seg.ahash(seg_idx);
+
+        let mut h = wal_hash(page_id);
+        let mut best: Option<u32> = None;
+
+        for _ in 0..AHASH_NSLOT {
+            let slot_val = ahash[h].load(Ordering::Relaxed);
+            if slot_val == 0 {
+                break;
+            }
+            let frame_offset = (slot_val as usize) - 1;
+            if frame_offset < cap {
+                let stored_page = apgno[frame_offset].load(Ordering::Relaxed);
+                if stored_page == page_id {
+                    let global_frame = base + frame_offset as u32 + 1;
+                    if global_frame >= min_frame && global_frame <= max_frame {
+                        best = Some(match best {
+                            Some(b) => b.max(global_frame),
+                            None => global_frame,
+                        });
+                    }
+                }
+            }
+            h = (h + 1) % AHASH_NSLOT;
+        }
+        best
+    }
+
+    /// Insert a page_id → offset mapping into the hash table via linear probing.
+    fn hash_insert(ahash: &[AtomicU16], page_id: u32, offset: usize) -> crate::Result<()> {
+        let nslot = ahash.len();
+        let mut h = wal_hash(page_id) % nslot;
+        for _ in 0..nslot {
+            if ahash[h].load(Ordering::Relaxed) == 0 {
+                ahash[h].store((offset + 1) as u16, Ordering::Relaxed);
+                return Ok(());
+            }
+            h = (h + 1) % nslot;
+        }
+        Err(crate::LimboError::InternalError(
+            "wal_index hash table full or corrupt (no empty slot found)".to_string(),
+        ))
+    }
+
+    /// Ensure file is at least `needed_size` bytes, extending with ftruncate if needed.
+    fn ensure_file_size(fd: RawFd, needed_size: u64) -> crate::Result<()> {
+        let current_size = unsafe {
+            let mut stat: libc::stat = std::mem::zeroed();
+            if libc::fstat(fd, &mut stat) != 0 {
+                return Err(crate::LimboError::InternalError(format!(
+                    "wal_index fstat: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            stat.st_size as u64
+        };
+        if current_size < needed_size {
+            let ret = unsafe { libc::ftruncate(fd, needed_size as libc::off_t) };
+            if ret != 0 {
+                return Err(crate::LimboError::InternalError(format!(
+                    "wal_index ftruncate: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Shared WAL index providing page_id → frame_id lookup via mmap'd shared memory.
+    pub struct WalIndex {
+        fd: RawFd,
+        /// Whether this instance owns the fd and should close it on drop.
+        /// False when borrowing the fd from Tshm (production path).
+        /// True when opened standalone (unit tests).
+        owns_fd: bool,
+        /// RwLock protects the Vec (segment count), not the mmap'd data.
+        segments: crate::sync::RwLock<Vec<WalIndexSegment>>,
+        /// Direct pointer to the header in segment 0's mmap region.
+        /// Valid for the entire lifetime of WalIndex (segment 0 is never unmapped).
+        header_ptr: *const WalIndexHeader,
+        /// Test-only: when true, `append_frame` returns an error to simulate
+        /// disk failures (ftruncate/mmap) during segment growth.
+        #[cfg(test)]
+        inject_failure: std::sync::atomic::AtomicBool,
+    }
+
+    // SAFETY: mmap'd MAP_SHARED, accessed through atomics. header_ptr points
+    // into segment 0 which lives for the lifetime of WalIndex.
+    unsafe impl Send for WalIndex {}
+    unsafe impl Sync for WalIndex {}
+
+    impl WalIndex {
+        /// Open the WAL index using a borrowed fd from Tshm.
+        ///
+        /// The fd is NOT owned — WalIndex will not close it on drop.
+        /// This is critical: POSIX fcntl locks are per-process-per-inode,
+        /// so closing any fd to the same file would release Tshm's write lock.
+        pub fn open(fd: RawFd) -> crate::Result<Self> {
+            Self::open_inner(fd, false)
+        }
+
+        /// Open a standalone WAL index for unit tests.
+        /// Creates its own file (with BASE_OFFSET padding) and owns the fd.
+        #[cfg(test)]
+        pub fn open_standalone(path: &str) -> crate::Result<Self> {
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(path)
+                .map_err(|e| {
+                    crate::LimboError::InternalError(format!("wal_index file '{path}': {e}"))
+                })?;
+            let fd = file.into_raw_fd();
+            Self::open_inner(fd, true)
+        }
+
+        fn open_inner(fd: RawFd, owns_fd: bool) -> crate::Result<Self> {
+            // Ensure file is large enough for BASE_OFFSET + one segment.
+            ensure_file_size(fd, (BASE_OFFSET + SEGMENT_SIZE) as u64)?;
+
+            // mmap segment 0.
+            let seg0 = mmap_segment(fd, 0)?;
+            let header_ptr = seg0.ptr as *const WalIndexHeader;
+
+            let wal_index = Self {
+                fd,
+                owns_fd,
+                segments: crate::sync::RwLock::new(vec![seg0]),
+                header_ptr,
+                #[cfg(test)]
+                inject_failure: std::sync::atomic::AtomicBool::new(false),
+            };
+
+            // Initialize header if fresh file.
+            let header = wal_index.header();
+            if header.magic.load(Ordering::Acquire) != WAL_INDEX_MAGIC {
+                header.magic.store(WAL_INDEX_MAGIC, Ordering::Release);
+                header.max_frame.store(0, Ordering::Release);
+                header.nbackfills.store(0, Ordering::Release);
+                header.num_segments.store(1, Ordering::Release);
+                header.generation.store(0, Ordering::Release);
+                header.salt_1.store(0, Ordering::Release);
+                header.salt_2.store(0, Ordering::Release);
+                header.pgno_checksum.store(0, Ordering::Release);
+            } else {
+                // Existing file — verify hash table integrity.
+                let stored_cksum = header.pgno_checksum.load(Ordering::Acquire);
+                let max_frame = header.max_frame.load(Ordering::Acquire);
+                let num_segments = header.num_segments.load(Ordering::Acquire);
+
+                // Ensure all segments are mapped.
+                if num_segments > 1 {
+                    wal_index.ensure_segments_mapped_inner(num_segments)?;
+                }
+
+                if max_frame > 0 {
+                    let segments = wal_index.segments.read();
+                    let computed = Self::compute_pgno_checksum_with(&segments, max_frame);
+                    if computed != stored_cksum {
+                        return Err(crate::LimboError::Corrupt(format!(
+                            "WalIndex hash table corruption detected at open \
+                             (stored_checksum={stored_cksum:#x}, computed={computed:#x}, \
+                             max_frame={max_frame}). \
+                             Delete the -tshm file and reopen the database to recover."
+                        )));
+                    }
+                    drop(segments);
+                    // Clean up stale hash entries left by a crashed writer
+                    // (appended via append_frame but never committed via
+                    // commit_max_frame). Without this, stale entries
+                    // accumulate across crash cycles, lengthening probe
+                    // chains and eventually exhausting hash slots.
+                    wal_index.cleanup_uncommitted();
+                }
+            }
+
+            Ok(wal_index)
+        }
+
+        /// Get a reference to the header (at the start of segment 0).
+        /// Lock-free: uses a pointer cached at construction time.
+        #[inline]
+        fn header(&self) -> &WalIndexHeader {
+            // SAFETY: segment 0 is always mapped for the lifetime of WalIndex,
+            // and the header is at offset 0, properly aligned (mmap returns
+            // page-aligned memory, all fields are naturally aligned u32).
+            unsafe { &*self.header_ptr }
+        }
+
+        /// Get current max_frame from header.
+        pub fn max_frame(&self) -> u32 {
+            self.header().max_frame.load(Ordering::Acquire)
+        }
+
+        /// Get current generation from header.
+        pub fn generation(&self) -> u32 {
+            self.header().generation.load(Ordering::Acquire)
+        }
+
+        /// Get salt values from header.
+        pub fn salt(&self) -> (u32, u32) {
+            let h = self.header();
+            (
+                h.salt_1.load(Ordering::Acquire),
+                h.salt_2.load(Ordering::Acquire),
+            )
+        }
+
+        /// Set salt values in header (called by writer after WAL restart).
+        pub fn set_salt(&self, salt_1: u32, salt_2: u32) {
+            let h = self.header();
+            h.salt_1.store(salt_1, Ordering::Release);
+            h.salt_2.store(salt_2, Ordering::Release);
+        }
+
+        /// Get the pgno_checksum from header. Used by readers to detect
+        /// hash table corruption mid-transaction.
+        pub fn pgno_checksum(&self) -> u32 {
+            self.header().pgno_checksum.load(Ordering::Acquire)
+        }
+
+        /// Get page_size from header.
+        pub fn page_size(&self) -> u32 {
+            self.header().page_size.load(Ordering::Acquire)
+        }
+
+        /// Set page_size in header (called by writer).
+        pub fn set_page_size(&self, page_size: u32) {
+            self.header().page_size.store(page_size, Ordering::Release);
+        }
+
+        /// Get current nbackfills from header.
+        pub fn nbackfills(&self) -> u32 {
+            self.header().nbackfills.load(Ordering::Acquire)
+        }
+
+        /// Set nbackfills after checkpoint.
+        pub fn set_nbackfills(&self, val: u32) {
+            self.header().nbackfills.store(val, Ordering::Release);
+        }
+
+        /// Get rolling checksum of the last WAL frame.
+        pub fn last_checksum(&self) -> (u32, u32) {
+            let h = self.header();
+            (
+                h.last_checksum_1.load(Ordering::Acquire),
+                h.last_checksum_2.load(Ordering::Acquire),
+            )
+        }
+
+        /// Set rolling checksum of the last WAL frame (called by writer on commit).
+        pub fn set_last_checksum(&self, c1: u32, c2: u32) {
+            let h = self.header();
+            h.last_checksum_1.store(c1, Ordering::Release);
+            h.last_checksum_2.store(c2, Ordering::Release);
+        }
+
+        /// Get checkpoint_seq from header.
+        pub fn checkpoint_seq(&self) -> u32 {
+            self.header().checkpoint_seq.load(Ordering::Acquire)
+        }
+
+        /// Set checkpoint_seq in header (called by writer after checkpoint).
+        pub fn set_checkpoint_seq(&self, seq: u32) {
+            self.header().checkpoint_seq.store(seq, Ordering::Release);
+        }
+
+        /// Look up the latest frame for `page_id` within [min_frame, max_frame].
+        /// Reads only from mmap'd shared memory — zero file I/O.
+        pub fn find_frame(&self, page_id: u32, min_frame: u32, max_frame: u32) -> Option<u32> {
+            if max_frame == 0 || page_id == 0 || max_frame < min_frame {
+                return None;
+            }
+
+            // Fast path: all frames fit in segment 0 (99%+ of workloads).
+            // SAFETY: header_ptr is derived from segment 0's mmap, which
+            // is valid for the entire lifetime of WalIndex.
+            if max_frame <= APGNO_COUNT_SEG0 as u32 {
+                let seg0 = WalIndexSegment {
+                    ptr: self.header_ptr as *mut u8,
+                };
+                return find_in_segment(&seg0, 0, page_id, min_frame, max_frame);
+            }
+
+            // Multi-segment slow path: acquire RwLock.
+            let segments = self.segments.read();
+            for seg_idx in (0..segments.len()).rev() {
+                if let Some(frame) =
+                    find_in_segment(&segments[seg_idx], seg_idx, page_id, min_frame, max_frame)
+                {
+                    return Some(frame);
+                }
+            }
+            None
+        }
+
+        /// Test-only: brute-force scan of aPgno arrays to find ALL frames
+        /// for a page_id, ignoring hash tables. Used to debug hash lookup issues.
+        #[cfg(test)]
+        pub fn brute_force_find(&self, page_id: u32, min_frame: u32, max_frame: u32) -> Vec<u32> {
+            let mut results = Vec::new();
+            let segments = self.segments.read();
+            for (seg_idx, seg) in segments.iter().enumerate() {
+                let base = seg_base_frame(seg_idx);
+                let apgno = seg.apgno(seg_idx);
+                for (offset, entry) in apgno.iter().enumerate() {
+                    let global_frame = base + offset as u32 + 1;
+                    if global_frame < min_frame || global_frame > max_frame {
+                        continue;
+                    }
+                    if entry.load(Ordering::Relaxed) == page_id {
+                        results.push(global_frame);
+                    }
+                }
+            }
+            results
+        }
+
+        /// Test-only: dump hash table probe chain for a page_id.
+        #[cfg(test)]
+        pub fn debug_hash_chain(&self, page_id: u32) -> String {
+            let segments = self.segments.read();
+            let mut out = String::new();
+            for (seg_idx, seg) in segments.iter().enumerate() {
+                let ahash = seg.ahash(seg_idx);
+                let apgno = seg.apgno(seg_idx);
+                let cap = seg_capacity(seg_idx);
+                let base = seg_base_frame(seg_idx);
+                let mut h = wal_hash(page_id);
+                use std::fmt::Write;
+                write!(out, "seg{seg_idx}[hash={h}]: ").unwrap();
+                for i in 0..20 {
+                    let val = ahash[h].load(Ordering::Relaxed);
+                    if val == 0 {
+                        write!(out, "slot[{h}]=0(empty) ").unwrap();
+                        break;
+                    }
+                    let offset = (val as usize) - 1;
+                    let pg = if offset < cap {
+                        apgno[offset].load(Ordering::Relaxed)
+                    } else {
+                        u32::MAX
+                    };
+                    let gf = base + offset as u32 + 1;
+                    write!(out, "slot[{h}]={val}(pg={pg},gf={gf}) ").unwrap();
+                    h = (h + 1) % AHASH_NSLOT;
+                    if i == 19 {
+                        write!(out, "...").unwrap();
+                    }
+                }
+            }
+            out
+        }
+
+        /// Test-only: return the segment 0 mmap pointer for diagnostics.
+        #[cfg(test)]
+        pub fn debug_seg0_ptr(&self) -> usize {
+            let segments = self.segments.read();
+            segments[0].ptr as usize
+        }
+
+        /// Test-only: read a specific ahash slot value.
+        #[cfg(test)]
+        pub fn debug_ahash_slot(&self, slot: usize) -> u16 {
+            let segments = self.segments.read();
+            segments[0].ahash(0)[slot].load(Ordering::SeqCst)
+        }
+
+        /// Test-only: return the fd used by this WalIndex.
+        #[cfg(test)]
+        pub fn debug_fd(&self) -> i32 {
+            self.fd
+        }
+
+        /// Test-only: dump raw memory at the ahash location for a page_id.
+        /// Bypasses AtomicU16::load to check if the issue is in atomic ops.
+        #[cfg(test)]
+        pub fn debug_raw_ahash(&self, page_id: u32) -> String {
+            let segments = self.segments.read();
+            let mut out = String::new();
+            use std::fmt::Write;
+            for (seg_idx, seg) in segments.iter().enumerate() {
+                let h = wal_hash(page_id);
+                let ahash = seg.ahash(seg_idx);
+                let apgno = seg.apgno(seg_idx);
+
+                // Read via AtomicU16::load
+                let atomic_val = ahash[h].load(Ordering::SeqCst);
+
+                // Read via raw pointer (volatile)
+                let raw_val = unsafe {
+                    let ptr = &ahash[h] as *const AtomicU16 as *const u16;
+                    std::ptr::read_volatile(ptr)
+                };
+
+                // Read apgno[0] for comparison
+                let apgno0_atomic = apgno[0].load(Ordering::SeqCst);
+                let apgno0_raw = unsafe {
+                    let ptr = &apgno[0] as *const AtomicU32 as *const u32;
+                    std::ptr::read_volatile(ptr)
+                };
+
+                // Also read a few surrounding ahash slots
+                let mut surrounding = String::new();
+                for i in 0..5 {
+                    let idx = (h + i) % AHASH_NSLOT;
+                    let v = ahash[idx].load(Ordering::SeqCst);
+                    write!(surrounding, "[{idx}]={v} ").unwrap();
+                }
+
+                // Segment pointer info
+                let seg_ptr = seg.ptr as usize;
+                let ahash_offset = if seg_idx == 0 {
+                    HEADER_SIZE + APGNO_COUNT_SEG0 * 4
+                } else {
+                    APGNO_COUNT * 4
+                };
+                let ahash_ptr = seg_ptr + ahash_offset + h * 2;
+
+                write!(
+                    out,
+                    "seg{seg_idx}: ahash[{h}] atomic={atomic_val} raw={raw_val}, \
+                     apgno[0] atomic={apgno0_atomic} raw={apgno0_raw}, \
+                     seg_ptr=0x{seg_ptr:x} ahash_ptr=0x{ahash_ptr:x}, \
+                     nearby: {surrounding}"
+                )
+                .unwrap();
+            }
+            out
+        }
+
+        /// Test-only: make all subsequent `append_frame` calls fail.
+        #[cfg(test)]
+        pub fn inject_append_failure(&self, fail: bool) {
+            self.inject_failure
+                .store(fail, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        /// Test-only: zero all hash tables while keeping aPgno and max_frame
+        /// intact. Simulates hash table corruption — find_frame returns None
+        /// for every page even though the data is in the index.
+        #[cfg(test)]
+        pub fn corrupt_hash_tables(&self) {
+            let segments = self.segments.read();
+            for (seg_idx, seg) in segments.iter().enumerate() {
+                let ahash = seg.ahash(seg_idx);
+                for entry in ahash {
+                    entry.store(0, Ordering::Relaxed);
+                }
+            }
+            // Also corrupt the pgno_checksum so the integrity check detects
+            // the corruption and triggers a rebuild. In a real crash, both
+            // ahash and pgno_checksum would be stale.
+            self.header()
+                .pgno_checksum
+                .store(0xDEAD_BEEF, Ordering::Release);
+        }
+
+        /// Append a frame entry. Called by writer after committing a frame.
+        /// May grow the file and mmap new segments.
+        pub fn append_frame(&self, page_id: u32, frame_id: u32) -> crate::Result<()> {
+            #[cfg(test)]
+            if self.inject_failure.load(Ordering::Relaxed) {
+                return Err(crate::LimboError::InternalError(
+                    "injected append_frame failure".to_string(),
+                ));
+            }
+
+            assert!(page_id > 0, "page_id must be > 0");
+            assert!(frame_id > 0, "frame_id must be 1-based");
+
+            let (seg_idx, offset) = frame_to_seg_offset(frame_id);
+
+            // Grow if needed.
+            self.ensure_segment_exists(seg_idx)?;
+
+            let segments = self.segments.read();
+            let seg = &segments[seg_idx];
+            let apgno = seg.apgno(seg_idx);
+            let ahash = seg.ahash(seg_idx);
+
+            // Store page_id in aPgno (source of truth).
+            apgno[offset].store(page_id, Ordering::Relaxed);
+
+            // Insert into hash table via linear probing.
+            hash_insert(ahash, page_id, offset)?;
+
+            Ok(())
+        }
+
+        /// Make appended frames visible to readers by updating header.max_frame.
+        /// Called after all frames in a commit batch have been appended.
+        /// Incrementally updates pgno_checksum — only processes newly committed
+        /// frames [old_max+1..=frame_id] instead of recomputing from frame 1.
+        pub fn commit_max_frame(&self, frame_id: u32) {
+            let header = self.header();
+            let old_max = header.max_frame.load(Ordering::Acquire);
+            assert!(
+                frame_id >= old_max,
+                "commit_max_frame: frame_id ({frame_id}) must not decrease max_frame ({old_max})"
+            );
+            let old_checksum = header.pgno_checksum.load(Ordering::Acquire);
+
+            // Incrementally extend the checksum from old_max+1 to frame_id.
+            let segments = self.segments.read();
+            let mut checksum = old_checksum;
+            for fid in (old_max + 1)..=frame_id {
+                let (seg_idx, offset) = frame_to_seg_offset(fid);
+                if seg_idx >= segments.len() {
+                    break;
+                }
+                let page_id = segments[seg_idx].apgno(seg_idx)[offset].load(Ordering::Relaxed);
+                checksum = checksum.wrapping_add(page_id).wrapping_mul(17);
+            }
+            drop(segments);
+
+            header.pgno_checksum.store(checksum, Ordering::Relaxed);
+            // Release barrier: ensures all aPgno/aHash stores above are visible
+            // to any reader that loads this max_frame with Acquire.
+            header.max_frame.store(frame_id, Ordering::Release);
+        }
+
+        /// Clear the entire index. Called on WAL restart/truncate.
+        /// Auto-increments the generation counter so readers with stale
+        /// snapshots detect the change and fall back to inner find_frame.
+        pub fn clear(&self, salt_1: u32, salt_2: u32) {
+            #[cfg(test)]
+            {
+                let self_addr = self as *const Self as usize;
+                let bt = std::backtrace::Backtrace::force_capture();
+                eprintln!(
+                    "WalIndex::clear called on 0x{self_addr:x}, max_frame={}\n{bt}",
+                    self.max_frame()
+                );
+            }
+            let header = self.header();
+            // Bump generation and zero max_frame BEFORE zeroing data —
+            // concurrent readers that load the new generation will see
+            // the mismatch against cached_gen and fall back to
+            // inner.find_frame(), avoiding reads from zeroed hash tables.
+            header.bump_generation();
+            header.max_frame.store(0, Ordering::Release);
+
+            let segments = self.segments.read();
+            for (seg_idx, seg) in segments.iter().enumerate() {
+                let apgno = seg.apgno(seg_idx);
+                let ahash = seg.ahash(seg_idx);
+                for entry in apgno {
+                    entry.store(0, Ordering::Relaxed);
+                }
+                for entry in ahash {
+                    entry.store(0, Ordering::Relaxed);
+                }
+            }
+            drop(segments);
+
+            header.nbackfills.store(0, Ordering::Release);
+            header.salt_1.store(salt_1, Ordering::Release);
+            header.salt_2.store(salt_2, Ordering::Release);
+            header.pgno_checksum.store(0, Ordering::Release);
+            // Keep num_segments as-is; segments are reusable.
+        }
+
+        /// Zero aPgno entries beyond `max_frame` and rebuild hash tables
+        /// for affected segments. Does NOT update the header (max_frame,
+        /// pgno_checksum) — callers handle that. Returns true if any
+        /// entries were actually trimmed.
+        fn trim_beyond(segments: &[WalIndexSegment], max_frame: u32) -> bool {
+            let mut any_trimmed = false;
+            for (seg_idx, seg) in segments.iter().enumerate() {
+                let base = seg_base_frame(seg_idx);
+                let apgno = seg.apgno(seg_idx);
+                for (offset, entry) in apgno.iter().enumerate() {
+                    let global_frame = base + offset as u32 + 1;
+                    if global_frame > max_frame && entry.load(Ordering::Relaxed) != 0 {
+                        entry.store(0, Ordering::Relaxed);
+                        any_trimmed = true;
+                    }
+                }
+            }
+            if any_trimmed {
+                for (seg_idx, seg) in segments.iter().enumerate() {
+                    let base = seg_base_frame(seg_idx);
+                    let cap = seg_capacity(seg_idx);
+                    let seg_last_frame = base + cap as u32;
+                    if seg_last_frame > max_frame {
+                        Self::rebuild_segment_hash(seg, seg_idx, max_frame);
+                    }
+                }
+            }
+            any_trimmed
+        }
+
+        /// Clean up any uncommitted entries beyond the committed max_frame.
+        /// Called after rollback(None) to remove hash table entries that
+        /// were added by `append_frame` but never made visible via
+        /// `commit_max_frame`. Without this, stale hash entries pollute
+        /// the table and can cause collisions on subsequent writes.
+        pub fn cleanup_uncommitted(&self) {
+            let header = self.header();
+            let current_max = header.max_frame.load(Ordering::Acquire);
+            let segments = self.segments.read();
+            // Check if there are any uncommitted entries to clean up.
+            let has_uncommitted = segments.iter().enumerate().any(|(seg_idx, seg)| {
+                let base = seg_base_frame(seg_idx);
+                seg.apgno(seg_idx)
+                    .iter()
+                    .enumerate()
+                    .any(|(offset, entry)| {
+                        let global_frame = base + offset as u32 + 1;
+                        global_frame > current_max && entry.load(Ordering::Relaxed) != 0
+                    })
+            });
+            if !has_uncommitted {
+                return;
+            }
+            // Bump generation BEFORE rebuilding hash tables so concurrent
+            // readers detect the mismatch and fall back to inner.find_frame,
+            // avoiding reads from partially-rebuilt hash tables.
+            header.bump_generation();
+            Self::trim_beyond(&segments, current_max);
+        }
+
+        /// Trim frames > max_frame. Called on rollback.
+        /// Rebuilds hash tables for affected segments.
+        pub fn rollback_to(&self, max_frame: u32) {
+            let header = self.header();
+            let current_max = header.max_frame.load(Ordering::Acquire);
+            if max_frame >= current_max {
+                return; // Nothing to trim.
+            }
+
+            // Bump generation BEFORE rebuilding hash tables so concurrent
+            // readers detect the mismatch and fall back to inner.find_frame,
+            // avoiding reads from partially-rebuilt hash tables.
+            header.bump_generation();
+            let segments = self.segments.read();
+            Self::trim_beyond(&segments, max_frame);
+            let checksum = Self::compute_pgno_checksum_with(&segments, max_frame);
+            drop(segments);
+            self.header()
+                .pgno_checksum
+                .store(checksum, Ordering::Relaxed);
+            self.header().max_frame.store(max_frame, Ordering::Release);
+        }
+
+        /// Iterate all (page_id, frame_id) pairs in [min_frame, max_frame].
+        /// Used by checkpoint to determine which pages to back up.
+        /// For each page, returns only the latest frame in the range.
+        pub fn iter_latest_frames(&self, min_frame: u32, max_frame: u32) -> Vec<(u32, u32)> {
+            use rustc_hash::FxHashMap;
+            let mut latest: FxHashMap<u32, u32> = FxHashMap::default();
+            let segments = self.segments.read();
+
+            for (seg_idx, seg) in segments.iter().enumerate() {
+                let base = seg_base_frame(seg_idx);
+                let apgno = seg.apgno(seg_idx);
+
+                for (offset, entry) in apgno.iter().enumerate() {
+                    let global_frame = base + offset as u32 + 1;
+                    if global_frame < min_frame || global_frame > max_frame {
+                        continue;
+                    }
+                    let page_id = entry.load(Ordering::Relaxed);
+                    if page_id != 0 {
+                        latest
+                            .entry(page_id)
+                            .and_modify(|f| *f = (*f).max(global_frame))
+                            .or_insert(global_frame);
+                    }
+                }
+            }
+
+            let mut result: Vec<(u32, u32)> = latest.into_iter().collect();
+            result.sort_unstable_by_key(|&(_, frame)| frame);
+            result
+        }
+
+        /// Verify WalIndex hash table integrity. Returns `Ok(())` if intact,
+        /// or an error if corruption is detected. The caller should fail the
+        /// operation — recovery is done by deleting the tshm file and reopening.
+        ///
+        /// On ARM (Apple Silicon), `commit_max_frame` stores pgno_checksum
+        /// (Relaxed) and max_frame (Release) as two separate atomics. A reader
+        /// can transiently observe the new pgno_checksum with the old max_frame,
+        /// causing a false mismatch. We retry once on mismatch to distinguish
+        /// transient races from real corruption.
+        pub fn verify_hash_integrity(&self) -> crate::Result<()> {
+            let header = self.header();
+            let segments = self.segments.read();
+            let mut last_max = 0u32;
+            let mut last_stored = 0u32;
+            let mut last_computed = 0u32;
+
+            // Retry once: a mismatch on the first attempt may be a transient
+            // race between pgno_checksum and max_frame stores on ARM.
+            for _ in 0..2 {
+                let max_frame = header.max_frame.load(Ordering::Acquire);
+                if max_frame == 0 {
+                    return Ok(());
+                }
+                let stored = header.pgno_checksum.load(Ordering::Acquire);
+                let computed = Self::compute_pgno_checksum_with(&segments, max_frame);
+                if stored == computed {
+                    return Ok(());
+                }
+                last_max = max_frame;
+                last_stored = stored;
+                last_computed = computed;
+            }
+            drop(segments);
+            Err(crate::LimboError::Corrupt(format!(
+                "WalIndex hash table corruption detected \
+                 (stored_checksum={last_stored:#x}, computed={last_computed:#x}, \
+                 max_frame={last_max}). \
+                 Delete the -tshm file and reopen the database to recover."
+            )))
+        }
+
+        /// Ensure all segments up to the current num_segments are mmap'd.
+        /// Called by readers when they detect the writer added segments.
+        pub fn ensure_segments_mapped(&self) -> crate::Result<()> {
+            let num_segments = self.header().num_segments.load(Ordering::Acquire);
+            self.ensure_segments_mapped_inner(num_segments)
+        }
+
+        fn ensure_segments_mapped_inner(&self, num_segments: u32) -> crate::Result<()> {
+            let current_count = self.segments.read().len();
+            if current_count >= num_segments as usize {
+                return Ok(());
+            }
+
+            let mut segments = self.segments.write();
+            // Re-check under write lock.
+            if segments.len() >= num_segments as usize {
+                return Ok(());
+            }
+
+            for i in segments.len()..num_segments as usize {
+                let seg = mmap_segment(self.fd, i)?;
+                segments.push(seg);
+            }
+            Ok(())
+        }
+
+        /// Ensure a specific segment exists (grow file + mmap if needed).
+        fn ensure_segment_exists(&self, seg_idx: usize) -> crate::Result<()> {
+            let current_count = self.segments.read().len();
+            if seg_idx < current_count {
+                return Ok(());
+            }
+
+            let mut segments = self.segments.write();
+            // Re-check under write lock.
+            if seg_idx < segments.len() {
+                return Ok(());
+            }
+
+            // Grow file to accommodate the new segment (after BASE_OFFSET).
+            ensure_file_size(self.fd, (BASE_OFFSET + (seg_idx + 1) * SEGMENT_SIZE) as u64)?;
+
+            // mmap new segments.
+            for i in segments.len()..=seg_idx {
+                let seg = mmap_segment(self.fd, i)?;
+                segments.push(seg);
+            }
+
+            // Update header directly (no lock needed — header_ptr is always valid).
+            self.header()
+                .num_segments
+                .store(segments.len() as u32, Ordering::Release);
+
+            Ok(())
+        }
+
+        /// Compute checksum over aPgno entries [1..=max_frame] using an already-locked segments slice.
+        fn compute_pgno_checksum_with(segments: &[WalIndexSegment], max_frame: u32) -> u32 {
+            let mut checksum: u32 = 0;
+            for frame_id in 1..=max_frame {
+                let (seg_idx, offset) = frame_to_seg_offset(frame_id);
+                if seg_idx >= segments.len() {
+                    break;
+                }
+                let page_id = segments[seg_idx].apgno(seg_idx)[offset].load(Ordering::Relaxed);
+                checksum = checksum.wrapping_add(page_id).wrapping_mul(17);
+            }
+            checksum
+        }
+
+        /// Rebuild the hash table for a single segment from its aPgno.
+        /// Used by `rollback_to` after trimming aPgno entries beyond max_frame.
+        fn rebuild_segment_hash(seg: &WalIndexSegment, seg_idx: usize, max_frame: u32) {
+            let base = seg_base_frame(seg_idx);
+            let apgno = seg.apgno(seg_idx);
+            let ahash = seg.ahash(seg_idx);
+
+            // Clear the entire hash table.
+            for entry in ahash {
+                entry.store(0, Ordering::Relaxed);
+            }
+
+            // Re-insert valid entries.
+            for (offset, entry) in apgno.iter().enumerate() {
+                let global_frame = base + offset as u32 + 1;
+                if global_frame > max_frame {
+                    break;
+                }
+                let page_id = entry.load(Ordering::Relaxed);
+                if page_id == 0 {
+                    continue;
+                }
+
+                // AHASH_NSLOT (8192) > max aPgno entries per segment (4064/4096),
+                // so the hash table should never be full during a rebuild.
+                let result = hash_insert(ahash, page_id, offset);
+                debug_assert!(
+                    result.is_ok(),
+                    "rebuild_segment_hash: hash table overflow at seg={seg_idx} offset={offset}"
+                );
+                if let Err(e) = result {
+                    tracing::error!(
+                        "rebuild_segment_hash: {e} at seg={seg_idx} \
+                         offset={offset} page_id={page_id} max_frame={max_frame}"
+                    );
+                }
+            }
+        }
+    }
+
+    impl Drop for WalIndex {
+        fn drop(&mut self) {
+            let segments = self.segments.get_mut();
+            for seg in segments.drain(..) {
+                unsafe {
+                    libc::munmap(seg.ptr as *mut libc::c_void, SEGMENT_SIZE);
+                }
+            }
+            if self.owns_fd {
+                unsafe {
+                    libc::close(self.fd);
+                }
+            }
+        }
+    }
+
+    /// mmap a single segment at the given index.
+    /// Segments start at BASE_OFFSET within the file (after the tshm coordination page).
+    fn mmap_segment(fd: RawFd, seg_idx: usize) -> crate::Result<WalIndexSegment> {
+        let offset = BASE_OFFSET + seg_idx * SEGMENT_SIZE;
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                SEGMENT_SIZE,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd,
+                offset as libc::off_t,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            return Err(crate::LimboError::InternalError(format!(
+                "wal_index mmap segment {seg_idx}: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        #[cfg(test)]
+        {
+            let inode = unsafe {
+                let mut stat: libc::stat = std::mem::zeroed();
+                libc::fstat(fd, &mut stat);
+                stat.st_ino
+            };
+            // Read ahash[383] immediately after mapping
+            let ahash_val = if seg_idx == 0 {
+                let ahash_offset = HEADER_SIZE + APGNO_COUNT_SEG0 * 4 + 383 * 2;
+                unsafe {
+                    let ahash_ptr = (ptr as *const u8).add(ahash_offset) as *const u16;
+                    std::ptr::read_volatile(ahash_ptr)
+                }
+            } else {
+                0
+            };
+            eprintln!(
+                "MMAP_SEGMENT: seg_idx={seg_idx} fd={fd} inode={inode} offset=0x{offset:x} \
+                 ptr=0x{:x} ahash[383]={ahash_val}",
+                ptr as usize
+            );
+        }
+        Ok(WalIndexSegment {
+            ptr: ptr as *mut u8,
+        })
+    }
+
+    /// WAL index header at the start of segment 0.
+    #[repr(C)]
+    struct WalIndexHeader {
+        /// Number of valid frames (1-based count: frames 1..=max_frame).
+        max_frame: AtomicU32,
+        /// Number of frames checkpointed to DB file.
+        nbackfills: AtomicU32,
+        /// Number of 32KB segments in use.
+        num_segments: AtomicU32,
+        /// WAL generation (matches checkpoint_seq from WalHeader).
+        generation: AtomicU32,
+        /// Salt values from WAL header (for crash detection).
+        salt_1: AtomicU32,
+        salt_2: AtomicU32,
+        /// Checksum over aPgno entries for corruption detection.
+        pgno_checksum: AtomicU32,
+        /// Magic number (WAL_INDEX_MAGIC).
+        magic: AtomicU32,
+        /// Database page size (set by writer, read by reader for frame_offset).
+        page_size: AtomicU32,
+        /// Rolling checksum of the last frame in the WAL (component 1).
+        /// Updated by writer on commit so a new writer can chain checksums
+        /// without reading the WAL file.
+        last_checksum_1: AtomicU32,
+        /// Rolling checksum of the last frame in the WAL (component 2).
+        last_checksum_2: AtomicU32,
+        /// WAL header checkpoint_seq, synced so readers can detect WAL restart
+        /// without reading the WAL file from disk.
+        checkpoint_seq: AtomicU32,
+        // Remaining bytes up to HEADER_SIZE are padding.
+    }
+
+    impl WalIndexHeader {
+        /// Atomically bump the generation counter with Release ordering.
+        /// Skips `u32::MAX` to avoid collision with the sentinel value
+        /// used by `cached_wal_index_generation` in `MultiProcessWal`.
+        fn bump_generation(&self) {
+            let mut new_gen = self.generation.load(Ordering::Relaxed).wrapping_add(1);
+            if new_gen == u32::MAX {
+                new_gen = 0;
+            }
+            self.generation.store(new_gen, Ordering::Release);
+        }
+    }
+
+    // Verify the header fits.
+    const _: () = assert!(std::mem::size_of::<WalIndexHeader>() <= HEADER_SIZE);
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn temp_wal_index() -> (tempfile::TempDir, String) {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("test-twal");
+            (dir, path.to_str().unwrap().to_string())
+        }
+
+        #[test]
+        fn test_open_creates_file() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+            let metadata = std::fs::metadata(&path).unwrap();
+            assert_eq!(metadata.len(), (BASE_OFFSET + SEGMENT_SIZE) as u64);
+            assert_eq!(idx.max_frame(), 0);
+            assert_eq!(idx.generation(), 0);
+            drop(idx);
+        }
+
+        #[test]
+        fn test_basic_append_and_find() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            idx.append_frame(10, 1).unwrap();
+            idx.append_frame(20, 2).unwrap();
+            idx.append_frame(30, 3).unwrap();
+            idx.commit_max_frame(3);
+
+            assert_eq!(idx.find_frame(10, 1, 3), Some(1));
+            assert_eq!(idx.find_frame(20, 1, 3), Some(2));
+            assert_eq!(idx.find_frame(30, 1, 3), Some(3));
+            assert_eq!(idx.find_frame(99, 1, 3), None);
+        }
+
+        #[test]
+        fn test_multiple_frames_per_page() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            idx.append_frame(42, 1).unwrap();
+            idx.append_frame(99, 2).unwrap();
+            idx.append_frame(42, 3).unwrap();
+            idx.append_frame(99, 4).unwrap();
+            idx.append_frame(42, 5).unwrap();
+            idx.commit_max_frame(5);
+
+            assert_eq!(idx.find_frame(42, 1, 5), Some(5));
+            assert_eq!(idx.find_frame(42, 1, 4), Some(3));
+            assert_eq!(idx.find_frame(42, 1, 2), Some(1));
+            assert_eq!(idx.find_frame(42, 2, 4), Some(3));
+            assert_eq!(idx.find_frame(42, 4, 5), Some(5));
+            assert_eq!(idx.find_frame(42, 6, 10), None);
+        }
+
+        #[test]
+        fn test_watermark_respect() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            idx.append_frame(1, 1).unwrap();
+            idx.append_frame(2, 2).unwrap();
+            idx.append_frame(3, 3).unwrap();
+            idx.commit_max_frame(3);
+
+            assert_eq!(idx.find_frame(1, 2, 3), None);
+            assert_eq!(idx.find_frame(3, 1, 2), None);
+            assert_eq!(idx.find_frame(2, 1, 3), Some(2));
+        }
+
+        #[test]
+        fn test_hash_collision_handling() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            let target_hash = wal_hash(1);
+            let mut colliding_pages = vec![1u32];
+            let mut candidate = 2u32;
+            while colliding_pages.len() < 5 {
+                if wal_hash(candidate) == target_hash {
+                    colliding_pages.push(candidate);
+                }
+                candidate += 1;
+            }
+
+            for (i, &page_id) in colliding_pages.iter().enumerate() {
+                idx.append_frame(page_id, (i + 1) as u32).unwrap();
+            }
+            idx.commit_max_frame(colliding_pages.len() as u32);
+
+            for (i, &page_id) in colliding_pages.iter().enumerate() {
+                assert_eq!(
+                    idx.find_frame(page_id, 1, colliding_pages.len() as u32),
+                    Some((i + 1) as u32),
+                    "failed to find page_id {page_id}"
+                );
+            }
+        }
+
+        #[test]
+        fn test_segment_growth() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            let total_frames = APGNO_COUNT_SEG0 as u32 + 100;
+            for frame_id in 1..=total_frames {
+                idx.append_frame(frame_id * 10, frame_id).unwrap();
+            }
+            idx.commit_max_frame(total_frames);
+
+            assert_eq!(idx.find_frame(10, 1, total_frames), Some(1));
+            let last_seg0_frame = APGNO_COUNT_SEG0 as u32;
+            assert_eq!(
+                idx.find_frame(last_seg0_frame * 10, 1, total_frames),
+                Some(last_seg0_frame)
+            );
+            assert_eq!(
+                idx.find_frame((last_seg0_frame + 1) * 10, 1, total_frames),
+                Some(last_seg0_frame + 1)
+            );
+            assert_eq!(
+                idx.find_frame(total_frames * 10, 1, total_frames),
+                Some(total_frames)
+            );
+
+            let metadata = std::fs::metadata(&path).unwrap();
+            assert_eq!(metadata.len(), (BASE_OFFSET + 2 * SEGMENT_SIZE) as u64);
+        }
+
+        #[test]
+        fn test_clear() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            idx.append_frame(42, 1).unwrap();
+            idx.append_frame(43, 2).unwrap();
+            idx.commit_max_frame(2);
+            assert_eq!(idx.find_frame(42, 1, 2), Some(1));
+
+            idx.clear(100, 200);
+
+            assert_eq!(idx.max_frame(), 0);
+            assert_eq!(idx.generation(), 1);
+            assert_eq!(idx.find_frame(42, 1, 2), None);
+            assert_eq!(idx.find_frame(43, 1, 2), None);
+        }
+
+        #[test]
+        fn test_rollback() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            idx.append_frame(10, 1).unwrap();
+            idx.append_frame(20, 2).unwrap();
+            idx.append_frame(30, 3).unwrap();
+            idx.append_frame(40, 4).unwrap();
+            idx.append_frame(50, 5).unwrap();
+            idx.commit_max_frame(5);
+
+            idx.rollback_to(3);
+
+            assert_eq!(idx.max_frame(), 3);
+            assert_eq!(idx.find_frame(10, 1, 3), Some(1));
+            assert_eq!(idx.find_frame(20, 1, 3), Some(2));
+            assert_eq!(idx.find_frame(30, 1, 3), Some(3));
+            assert_eq!(idx.find_frame(40, 1, 5), None);
+            assert_eq!(idx.find_frame(50, 1, 5), None);
+        }
+
+        #[test]
+        fn test_empty_index() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            assert_eq!(idx.find_frame(1, 1, 100), None);
+            assert_eq!(idx.max_frame(), 0);
+        }
+
+        #[test]
+        fn test_crash_recovery_returns_corrupt_error() {
+            let (_dir, path) = temp_wal_index();
+
+            {
+                let idx = WalIndex::open_standalone(&path).unwrap();
+                idx.append_frame(10, 1).unwrap();
+                idx.append_frame(20, 2).unwrap();
+                idx.append_frame(30, 3).unwrap();
+                idx.commit_max_frame(3);
+
+                // Corrupt the pgno_checksum.
+                idx.header().pgno_checksum.store(0xDEAD, Ordering::Release);
+            }
+
+            // Reopen — should detect mismatch and return Corrupt error.
+            let result = WalIndex::open_standalone(&path);
+            assert!(result.is_err(), "open with corrupt checksum should fail");
+            let err = result.err().unwrap();
+            assert!(
+                err.to_string().contains("corruption") || err.to_string().contains("Corrupt"),
+                "error should indicate corruption, got: {err}"
+            );
+
+            // Recovery path: delete the file and reopen (gets a fresh index).
+            std::fs::remove_file(&path).unwrap();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+            assert_eq!(idx.max_frame(), 0);
+        }
+
+        #[test]
+        fn test_iter_latest_frames() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            idx.append_frame(10, 1).unwrap();
+            idx.append_frame(20, 2).unwrap();
+            idx.append_frame(10, 3).unwrap();
+            idx.append_frame(30, 4).unwrap();
+            idx.commit_max_frame(4);
+
+            let frames = idx.iter_latest_frames(1, 4);
+            assert_eq!(frames.len(), 3);
+            assert!(frames.contains(&(20, 2)));
+            assert!(frames.contains(&(10, 3)));
+            assert!(frames.contains(&(30, 4)));
+            assert!(!frames.contains(&(10, 1)));
+        }
+
+        #[test]
+        fn test_segment_boundary_crossing() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            let seg0_cap = APGNO_COUNT_SEG0 as u32;
+            for frame_id in 1..=seg0_cap {
+                idx.append_frame(frame_id, frame_id).unwrap();
+            }
+            idx.commit_max_frame(seg0_cap);
+
+            assert_eq!(idx.find_frame(seg0_cap, 1, seg0_cap), Some(seg0_cap));
+
+            let first_seg1 = seg0_cap + 1;
+            idx.append_frame(first_seg1, first_seg1).unwrap();
+            idx.commit_max_frame(first_seg1);
+
+            assert_eq!(idx.find_frame(seg0_cap, 1, first_seg1), Some(seg0_cap));
+            assert_eq!(idx.find_frame(first_seg1, 1, first_seg1), Some(first_seg1));
+        }
+
+        #[test]
+        fn test_many_segments() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            // Force 5 segments.
+            let target = APGNO_COUNT_SEG0 as u32 + 4 * APGNO_COUNT as u32;
+            for frame_id in 1..=target {
+                idx.append_frame(frame_id, frame_id).unwrap();
+            }
+            idx.commit_max_frame(target);
+
+            assert_eq!(idx.find_frame(1, 1, target), Some(1));
+            assert_eq!(idx.find_frame(target, 1, target), Some(target));
+
+            let metadata = std::fs::metadata(&path).unwrap();
+            assert_eq!(metadata.len(), (BASE_OFFSET + 5 * SEGMENT_SIZE) as u64);
+        }
+
+        #[test]
+        fn test_cross_open_visibility() {
+            let (_dir, path) = temp_wal_index();
+
+            let writer = WalIndex::open_standalone(&path).unwrap();
+            writer.append_frame(42, 1).unwrap();
+            writer.append_frame(43, 2).unwrap();
+            writer.commit_max_frame(2);
+
+            let reader = WalIndex::open_standalone(&path).unwrap();
+            assert_eq!(reader.max_frame(), 2);
+            assert_eq!(reader.find_frame(42, 1, 2), Some(1));
+            assert_eq!(reader.find_frame(43, 1, 2), Some(2));
+        }
+
+        /// Reproduce the clear+rewrite visibility bug.
+        /// Writer writes, clears (checkpoint), writes again.
+        /// Reader (opened early) must see the new hash table entries.
+        #[test]
+        fn test_cross_mmap_clear_rewrite_visibility() {
+            let (_dir, path) = temp_wal_index();
+
+            let writer = WalIndex::open_standalone(&path).unwrap();
+            let reader = WalIndex::open_standalone(&path).unwrap();
+
+            // Phase 1: Writer writes frames 1-3
+            writer.append_frame(1, 1).unwrap(); // page 1 → frame 1
+            writer.append_frame(2, 2).unwrap(); // page 2 → frame 2
+            writer.append_frame(3, 3).unwrap(); // page 3 → frame 3
+            writer.commit_max_frame(3);
+
+            // Reader sees them via hash table
+            assert_eq!(reader.max_frame(), 3);
+            assert_eq!(reader.find_frame(1, 1, 3), Some(1));
+            assert_eq!(reader.find_frame(2, 1, 3), Some(2));
+            assert_eq!(reader.find_frame(3, 1, 3), Some(3));
+
+            // Phase 2: clear (simulates checkpoint + WAL restart)
+            writer.clear(0, 0);
+            assert_eq!(reader.max_frame(), 0);
+
+            // Phase 3: Writer writes again (same page IDs, new frames)
+            writer.append_frame(1, 1).unwrap();
+            writer.append_frame(2, 2).unwrap();
+            writer.append_frame(3, 3).unwrap();
+            writer.append_frame(1, 4).unwrap(); // page 1 updated again
+            writer.commit_max_frame(4);
+
+            // Reader MUST see the new hash table entries
+            assert_eq!(reader.max_frame(), 4);
+
+            // Brute-force confirms aPgno has data
+            let brute1 = reader.brute_force_find(1, 1, 4);
+            assert!(!brute1.is_empty(), "aPgno missing page 1: brute={brute1:?}");
+
+            // Hash table lookup must also work
+            let hash_result = reader.find_frame(1, 1, 4);
+            assert_eq!(
+                hash_result,
+                Some(4),
+                "Hash lookup failed for page 1! brute={brute1:?}, chain={}",
+                reader.debug_hash_chain(1)
+            );
+            assert_eq!(reader.find_frame(2, 1, 4), Some(2));
+            assert_eq!(reader.find_frame(3, 1, 4), Some(3));
+        }
+
+        #[test]
+        fn test_rollback_across_segments() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            let total = APGNO_COUNT_SEG0 as u32 + 50;
+            for frame_id in 1..=total {
+                idx.append_frame(frame_id * 10, frame_id).unwrap();
+            }
+            idx.commit_max_frame(total);
+
+            let rollback_point = APGNO_COUNT_SEG0 as u32 - 10;
+            idx.rollback_to(rollback_point);
+
+            assert_eq!(idx.max_frame(), rollback_point);
+            assert_eq!(
+                idx.find_frame(rollback_point * 10, 1, rollback_point),
+                Some(rollback_point)
+            );
+            assert_eq!(idx.find_frame((rollback_point + 1) * 10, 1, total), None);
+        }
+
+        #[test]
+        fn test_frame_to_seg_offset() {
+            assert_eq!(frame_to_seg_offset(1), (0, 0));
+            let seg0_cap = APGNO_COUNT_SEG0 as u32;
+            assert_eq!(frame_to_seg_offset(seg0_cap), (0, APGNO_COUNT_SEG0 - 1));
+            assert_eq!(frame_to_seg_offset(seg0_cap + 1), (1, 0));
+            assert_eq!(
+                frame_to_seg_offset(seg0_cap + APGNO_COUNT as u32),
+                (1, APGNO_COUNT - 1)
+            );
+            assert_eq!(
+                frame_to_seg_offset(seg0_cap + APGNO_COUNT as u32 + 1),
+                (2, 0)
+            );
+        }
+
+        #[test]
+        fn test_reopen_preserves_state() {
+            let (_dir, path) = temp_wal_index();
+
+            {
+                let idx = WalIndex::open_standalone(&path).unwrap();
+                idx.append_frame(10, 1).unwrap();
+                idx.append_frame(20, 2).unwrap();
+                idx.commit_max_frame(2);
+            }
+
+            let idx = WalIndex::open_standalone(&path).unwrap();
+            assert_eq!(idx.max_frame(), 2);
+            assert_eq!(idx.find_frame(10, 1, 2), Some(1));
+            assert_eq!(idx.find_frame(20, 1, 2), Some(2));
+        }
+
+        #[test]
+        fn test_clear_then_reuse() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            idx.append_frame(10, 1).unwrap();
+            idx.commit_max_frame(1);
+            assert_eq!(idx.find_frame(10, 1, 1), Some(1));
+
+            idx.clear(0, 0);
+
+            idx.append_frame(20, 1).unwrap();
+            idx.append_frame(30, 2).unwrap();
+            idx.commit_max_frame(2);
+
+            assert_eq!(idx.find_frame(10, 1, 2), None);
+            assert_eq!(idx.find_frame(20, 1, 2), Some(1));
+            assert_eq!(idx.find_frame(30, 1, 2), Some(2));
+        }
+
+        #[test]
+        fn test_rollback_noop_when_at_or_beyond_max() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            idx.append_frame(10, 1).unwrap();
+            idx.append_frame(20, 2).unwrap();
+            idx.commit_max_frame(2);
+
+            idx.rollback_to(2);
+            assert_eq!(idx.max_frame(), 2);
+            assert_eq!(idx.find_frame(10, 1, 2), Some(1));
+            assert_eq!(idx.find_frame(20, 1, 2), Some(2));
+
+            idx.rollback_to(5);
+            assert_eq!(idx.max_frame(), 2);
+        }
+
+        /// Stress test: writer thread appends frames while reader thread
+        /// probes for known pages. Validates Release/Acquire ordering on
+        /// max_frame ensures aPgno/aHash stores are visible to readers.
+        #[test]
+        fn test_concurrent_append_and_find() {
+            let (_dir, path) = temp_wal_index();
+            let idx = std::sync::Arc::new(WalIndex::open_standalone(&path).unwrap());
+
+            let total_frames = 2000u32;
+
+            // Writer thread: append frames and commit in batches.
+            let writer_idx = idx.clone();
+            let writer = std::thread::spawn(move || {
+                let batch_size = 10;
+                for frame_id in 1..=total_frames {
+                    // Use page_id = frame_id * 7 to avoid trivial patterns.
+                    writer_idx.append_frame(frame_id * 7, frame_id).unwrap();
+                    if frame_id % batch_size == 0 {
+                        writer_idx.commit_max_frame(frame_id);
+                    }
+                }
+                writer_idx.commit_max_frame(total_frames);
+            });
+
+            // Reader thread: continuously probe for pages that should exist.
+            let reader_idx = idx.clone();
+            let reader = std::thread::spawn(move || {
+                let mut found_count = 0u64;
+                for _ in 0..50_000 {
+                    let max = reader_idx.max_frame();
+                    if max == 0 {
+                        std::thread::yield_now();
+                        continue;
+                    }
+                    // Pick a frame we know should be committed.
+                    let target_frame = 1 + (found_count as u32 % max);
+                    let target_page = target_frame * 7;
+                    if let Some(frame) = reader_idx.find_frame(target_page, 1, max) {
+                        assert_eq!(
+                            frame, target_frame,
+                            "find_frame returned wrong frame for page {target_page}"
+                        );
+                        found_count += 1;
+                    }
+                }
+                assert!(
+                    found_count > 0,
+                    "reader never found any frames during concurrent test"
+                );
+            });
+
+            writer.join().unwrap();
+            reader.join().unwrap();
+
+            // Final verification: all frames findable.
+            for frame_id in 1..=total_frames {
+                assert_eq!(
+                    idx.find_frame(frame_id * 7, 1, total_frames),
+                    Some(frame_id),
+                    "missing frame {frame_id} after concurrent test"
+                );
+            }
+        }
+
+        /// Fill segment 0 to maximum capacity (APGNO_COUNT_SEG0 entries)
+        /// and verify every page is findable. Stresses long probe chains
+        /// at high load factor (~49.6% of 8192 hash slots).
+        #[test]
+        fn test_near_full_hash_table() {
+            let (_dir, path) = temp_wal_index();
+            let idx = WalIndex::open_standalone(&path).unwrap();
+
+            let cap = APGNO_COUNT_SEG0 as u32;
+            // Use distinct page IDs that will create hash collisions.
+            for frame_id in 1..=cap {
+                idx.append_frame(frame_id * 3, frame_id).unwrap();
+            }
+            idx.commit_max_frame(cap);
+
+            // Verify every single page is findable.
+            for frame_id in 1..=cap {
+                assert_eq!(
+                    idx.find_frame(frame_id * 3, 1, cap),
+                    Some(frame_id),
+                    "missing page_id {} at frame {frame_id} in near-full table",
+                    frame_id * 3
+                );
+            }
+
+            // Verify a page not in the table returns None (must traverse
+            // long probe chains to determine this).
+            assert_eq!(idx.find_frame(999_999, 1, cap), None);
+        }
+
+        /// Simulate crash between append_frame and commit_max_frame.
+        /// On reopen, frames beyond max_frame should be invisible and
+        /// the aPgno slots should be safely overwritable.
+        #[test]
+        fn test_crash_after_append_before_commit() {
+            let (_dir, path) = temp_wal_index();
+
+            // Phase 1: append and commit 3 frames.
+            {
+                let idx = WalIndex::open_standalone(&path).unwrap();
+                idx.append_frame(10, 1).unwrap();
+                idx.append_frame(20, 2).unwrap();
+                idx.append_frame(30, 3).unwrap();
+                idx.commit_max_frame(3);
+            }
+
+            // Phase 2: append 2 more frames but DON'T commit (simulate crash).
+            {
+                let idx = WalIndex::open_standalone(&path).unwrap();
+                idx.append_frame(40, 4).unwrap();
+                idx.append_frame(50, 5).unwrap();
+                // Crash! No commit_max_frame called.
+                // max_frame stays at 3.
+            }
+
+            // Phase 3: reopen and verify.
+            {
+                let idx = WalIndex::open_standalone(&path).unwrap();
+                assert_eq!(
+                    idx.max_frame(),
+                    3,
+                    "max_frame should still be 3 after crash"
+                );
+
+                // Committed frames should be visible.
+                assert_eq!(idx.find_frame(10, 1, 3), Some(1));
+                assert_eq!(idx.find_frame(20, 1, 3), Some(2));
+                assert_eq!(idx.find_frame(30, 1, 3), Some(3));
+
+                // Uncommitted frames should NOT be visible when using committed max_frame.
+                // Hash entries for frames 4,5 still exist but find_frame respects the
+                // max_frame bound, so they are invisible.
+                let committed_max = idx.max_frame();
+                assert_eq!(idx.find_frame(40, 1, committed_max), None);
+                assert_eq!(idx.find_frame(50, 1, committed_max), None);
+
+                // New writes should overwrite the stale aPgno entries.
+                idx.append_frame(60, 4).unwrap();
+                idx.append_frame(70, 5).unwrap();
+                idx.commit_max_frame(5);
+
+                assert_eq!(idx.find_frame(60, 1, 5), Some(4));
+                assert_eq!(idx.find_frame(70, 1, 5), Some(5));
+                // Old uncommitted pages should not be findable.
+                assert_eq!(idx.find_frame(40, 1, 5), None);
+                assert_eq!(idx.find_frame(50, 1, 5), None);
+            }
+        }
+    }
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+pub use imp::*;

--- a/core/sync.rs
+++ b/core/sync.rs
@@ -42,6 +42,10 @@ mod shuttle_adapter {
             self.0.try_lock().ok().map(MutexGuard)
         }
 
+        pub fn get_mut(&mut self) -> &mut T {
+            self.0.get_mut().unwrap()
+        }
+
         /// Lock the mutex through an Arc, returning an owned guard that can be stored
         pub fn lock_arc(self: &Arc<Self>) -> ArcMutexGuard<T>
         where

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -538,6 +538,37 @@ fn update_pragma(
             connection.set_temp_store(temp_store);
             Ok(TransactionMode::None)
         }
+        PragmaName::LockingMode => {
+            let name_bytes = match &value {
+                Expr::Literal(Literal::Keyword(name)) => name.as_bytes(),
+                Expr::Name(name) | Expr::Id(name) => name.as_str().as_bytes(),
+                Expr::Literal(Literal::String(s)) => s.as_bytes(),
+                _ => bail_parse_error!(
+                    "locking_mode must be EXCLUSIVE, SHARED_READS, SHARED_WRITES, or NORMAL"
+                ),
+            };
+            let mode = match_ignore_ascii_case!(match name_bytes {
+                b"EXCLUSIVE" => crate::LockingMode::Exclusive,
+                b"SHARED_READS" => crate::LockingMode::SharedReads,
+                b"SHARED_WRITES" | b"NORMAL" => crate::LockingMode::SharedWrites,
+                _ => bail_parse_error!(
+                    "locking_mode must be EXCLUSIVE, SHARED_READS, SHARED_WRITES, or NORMAL"
+                ),
+            });
+            let current = connection.db.locking_mode;
+            if mode != current {
+                return Err(crate::LimboError::InternalError(format!(
+                    "cannot change locking_mode from {current} to {mode} on an open database. \
+                     Set before opening with: file:database.db?locking={mode}"
+                )));
+            }
+            // Mode matches — return it as confirmation.
+            let register = program.alloc_register();
+            program.emit_string8(mode.to_string(), register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
         PragmaName::FunctionList => query_pragma(
             PragmaName::FunctionList,
             resolver,
@@ -673,6 +704,14 @@ fn query_pragma(
                 program.emit_result_row(register, 1);
             }
 
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::LockingMode => {
+            let mode = connection.db.locking_mode;
+            let register = program.alloc_register();
+            program.emit_string8(mode.to_string(), register);
+            program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)
         }

--- a/core/util.rs
+++ b/core/util.rs
@@ -161,7 +161,7 @@ pub fn parse_schema_rows(
 
     // TODO: How do we ensure that the I/O we submitted to
     // read the schema is actually complete?
-    rows.run_with_row_callback(|row| {
+    rows.run_with_row_callback_no_reprepare(|row| {
         let ty = row.get::<&str>(0)?;
         let name = row.get::<&str>(1)?;
         let table_name = row.get::<&str>(2)?;
@@ -908,6 +908,8 @@ pub struct OpenOptions<'a> {
     pub cipher: Option<String>,
     // The encryption key in hex format
     pub hexkey: Option<String>,
+    /// Multi-process locking mode: exclusive, shared_reads, or shared_writes
+    pub locking: Option<crate::LockingMode>,
 }
 
 pub const MEMORY_PATH: &str = ":memory:";
@@ -1061,6 +1063,14 @@ fn parse_query_params(query: &str, opts: &mut OpenOptions) -> Result<()> {
                 "vfs" => opts.vfs = Some(decoded_value),
                 "cipher" => opts.cipher = Some(decoded_value),
                 "hexkey" => opts.hexkey = Some(decoded_value),
+                "locking" => {
+                    opts.locking = Some(decoded_value.parse().map_err(|_| {
+                        crate::LimboError::InvalidArgument(format!(
+                                "Invalid locking mode: '{decoded_value}'. \
+                                 Expected 'exclusive', 'shared_reads', 'shared_writes', or 'normal'"
+                            ))
+                    })?)
+                }
                 _ => {}
             }
         }
@@ -2433,6 +2443,68 @@ pub mod tests {
         let opts = OpenOptions::parse(uri).unwrap();
         assert_eq!(opts.path, "/home/user/db.sqlite");
         assert_eq!(opts.vfs, None);
+    }
+
+    #[test]
+    fn test_uri_with_locking_shared_reads() {
+        let uri = "file:/home/user/db.sqlite?locking=shared_reads";
+        let opts = OpenOptions::parse(uri).unwrap();
+        assert_eq!(opts.path, "/home/user/db.sqlite");
+        assert_eq!(opts.locking, Some(crate::LockingMode::SharedReads));
+    }
+
+    #[test]
+    fn test_uri_with_locking_shared_writes() {
+        let uri = "file:/home/user/db.sqlite?locking=shared_writes";
+        let opts = OpenOptions::parse(uri).unwrap();
+        assert_eq!(opts.locking, Some(crate::LockingMode::SharedWrites));
+    }
+
+    #[test]
+    fn test_uri_with_locking_exclusive() {
+        let uri = "file:/home/user/db.sqlite?locking=exclusive";
+        let opts = OpenOptions::parse(uri).unwrap();
+        assert_eq!(opts.locking, Some(crate::LockingMode::Exclusive));
+    }
+
+    #[test]
+    fn test_uri_with_locking_normal() {
+        let uri = "file:/home/user/db.sqlite?locking=normal";
+        let opts = OpenOptions::parse(uri).unwrap();
+        assert_eq!(opts.locking, Some(crate::LockingMode::SharedWrites));
+    }
+
+    #[test]
+    fn test_uri_with_invalid_locking() {
+        let uri = "file:/home/user/db.sqlite?locking=bogus";
+        assert!(OpenOptions::parse(uri).is_err());
+    }
+
+    #[test]
+    fn test_uri_with_locking_and_other_params() {
+        let uri = "file:/home/user/db.sqlite?mode=rw&locking=shared_writes&cache=shared";
+        let opts = OpenOptions::parse(uri).unwrap();
+        assert_eq!(opts.mode, OpenMode::ReadWrite);
+        assert_eq!(opts.locking, Some(crate::LockingMode::SharedWrites));
+        assert_eq!(opts.cache, CacheMode::Shared);
+    }
+
+    #[test]
+    fn test_uri_without_locking_defaults_to_none() {
+        let uri = "file:/home/user/db.sqlite?mode=rw";
+        let opts = OpenOptions::parse(uri).unwrap();
+        assert_eq!(opts.locking, None);
+    }
+
+    #[test]
+    fn test_no_file_prefix_ignores_query_params() {
+        // Without file: prefix, the entire string becomes the path.
+        // Query parameters are NOT parsed. This prevents silently
+        // creating a different file when the user forgets the prefix.
+        let uri = "test.db?locking=shared_reads";
+        let opts = OpenOptions::parse(uri).unwrap();
+        assert_eq!(opts.path, "test.db?locking=shared_reads");
+        assert_eq!(opts.locking, None);
     }
 
     #[test]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2473,7 +2473,7 @@ pub fn op_transaction_inner(
                         if !pager.holds_read_lock() {
                             pager.begin_read_tx()?;
                         }
-                        pager.mvcc_refresh_if_db_changed();
+                        pager.mvcc_refresh_if_db_changed()?;
 
                         let current_mv_tx = conn.get_mv_tx_for_db(*db);
                         if current_mv_tx.is_none() {
@@ -2535,7 +2535,7 @@ pub fn op_transaction_inner(
                             state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
                         }
                         // MVCC reads must refresh WAL change counters to avoid stale page-cache reads.
-                        pager.mvcc_refresh_if_db_changed();
+                        pager.mvcc_refresh_if_db_changed()?;
                         // In MVCC we don't have write exclusivity, therefore we just need to start a transaction if needed.
                         // Programs can run Transaction twice, first with read flag and then with write flag. So a single txid is enough
                         // for both.
@@ -3050,31 +3050,37 @@ pub fn op_savepoint(
             // After rolling back pages, the in-memory schema cache may be stale
             // if DDL was executed within the savepoint. Invalidate the pager's
             // cached schema cookie and check if a schema reparse is needed.
-            pager.set_schema_cookie(None);
-            let in_memory_version = conn.schema.read().schema_version;
-            let pager_ref = conn.pager.load().clone();
-            match pager_ref
-                .io
-                .block(|| pager.with_header(|h| h.schema_cookie.get()))
-            {
-                Ok(on_disk_cookie) if in_memory_version != on_disk_cookie => {
-                    // Schema was modified during the savepoint. Try to reparse
-                    // from the restored database pages. If that fails (e.g. the
-                    // database was empty at the savepoint), use an empty schema.
-                    if conn.reparse_schema().is_err() {
+            //
+            // In MVCC mode, schema is tracked through MvStore which already
+            // handled the rollback above, so skip the pager-based check
+            // (page 1's schema_cookie may not reflect MVCC state).
+            if mv_store.is_none() {
+                pager.set_schema_cookie(None);
+                let in_memory_version = conn.schema.read().schema_version;
+                let pager_ref = conn.pager.load().clone();
+                match pager_ref
+                    .io
+                    .block(|| pager.with_header(|h| h.schema_cookie.get()))
+                {
+                    Ok(on_disk_cookie) if in_memory_version != on_disk_cookie => {
+                        // Schema was modified during the savepoint. Try to reparse
+                        // from the restored database pages. If that fails (e.g. the
+                        // database was empty at the savepoint), use an empty schema.
+                        if conn.reparse_schema().is_err() {
+                            conn.with_schema_mut(|schema| {
+                                *schema = Schema::new();
+                            });
+                        }
+                    }
+                    Err(_) => {
+                        // Header page is not readable (database empty after rollback).
+                        // Reset to an empty schema.
                         conn.with_schema_mut(|schema| {
                             *schema = Schema::new();
                         });
                     }
+                    _ => {} // Schema unchanged, nothing to do.
                 }
-                Err(_) => {
-                    // Header page is not readable (database empty after rollback).
-                    // Reset to an empty schema.
-                    conn.with_schema_mut(|schema| {
-                        *schema = Schema::new();
-                    });
-                }
-                _ => {} // Schema unchanged, nothing to do.
             }
 
             state.pc += 1;
@@ -9738,11 +9744,19 @@ pub fn op_set_cookie(
                     if *db == crate::MAIN_DB_ID {
                         match program.connection.get_tx_state() {
                             TransactionState::Write { .. } => {
-                                program.connection.set_tx_state(TransactionState::Write { schema_did_change: true });
-                            },
-                            TransactionState::Read => unreachable!("invalid transaction state for SetCookie: TransactionState::Read, should be write"),
-                            TransactionState::None => unreachable!("invalid transaction state for SetCookie: TransactionState::None, should be write"),
-                            TransactionState::PendingUpgrade { .. } => unreachable!("invalid transaction state for SetCookie: TransactionState::PendingUpgrade, should be write"),
+                                program.connection.set_tx_state(TransactionState::Write {
+                                    schema_did_change: true,
+                                });
+                            }
+                            TransactionState::Read => unreachable!(
+                                "invalid transaction state for SetCookie: TransactionState::Read, should be write"
+                            ),
+                            TransactionState::None => unreachable!(
+                                "invalid transaction state for SetCookie: TransactionState::None, should be write"
+                            ),
+                            TransactionState::PendingUpgrade { .. } => unreachable!(
+                                "invalid transaction state for SetCookie: TransactionState::PendingUpgrade, should be write"
+                            ),
                         }
                     }
                     program.connection.with_database_schema_mut(*db, |schema| {
@@ -12213,6 +12227,11 @@ fn op_journal_mode_inner(
 
                 // Setup new mode
                 if matches!(new_mode, journal_mode::JournalMode::Mvcc) {
+                    if program.connection.db.locking_mode.is_shared() {
+                        return Err(LimboError::InternalError(
+                            "cannot enable MVCC in shared locking mode (SharedReads or SharedWrites). MVCC and multi-process WAL coordination are incompatible.".to_string(),
+                        ));
+                    }
                     if program.connection.get_capture_data_changes_info().is_some() {
                         return Err(LimboError::InternalError(
                             "cannot enable MVCC while CDC is active".to_string(),

--- a/docs/agent-guides/transaction-correctness.md
+++ b/docs/agent-guides/transaction-correctness.md
@@ -34,7 +34,7 @@ Checkpoint types:
 - **TRUNCATE**: Like RESTART, also truncates WAL file to zero length
 
 ### WAL-Index
-SQLite uses a shared memory file (`-shm`) for WAL index. **Turso does not** - it uses in-memory data structures (`frame_cache` hashmap, atomic read marks) since multi-process access is not supported.
+In exclusive mode (the default), Turso uses in-memory data structures (`frame_cache` hashmap, atomic read marks) instead of SQLite's shared memory file (`-shm`). In shared locking modes (`shared_reads`, `shared_writes`), Turso uses its own shared memory file (`-tshm`) that embeds both a coordination page and the WAL index segments for cross-process frame lookup.
 
 ## Concurrency Rules
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -40,6 +40,7 @@ Welcome to Turso database manual!
     - [WAL manipulation](#wal-manipulation)
       - [`libsql_wal_frame_count`](#libsql_wal_frame_count)
   - [Journal Mode](#journal-mode)
+  - [Multi-Process Access](#multi-process-access)
   - [Encryption](#encryption)
   - [Vector search](#vector-search)
   - [Full-Text Search](#full-text-search-experimental)
@@ -96,13 +97,14 @@ hello, world
 Turso aims towards full SQLite compatibility but has the following limitations:
 
 * Query result ordering is not guaranteed to be the same (see [#2964](https://github.com/tursodatabase/turso/issues/2964) for more discussion)
-* No multi-process access
 * No multi-threading
 * No savepoints
 * No triggers
 * No views
 * No vacuum
 * UTF-8 is the only supported character encoding
+
+Multi-process access is supported via `PRAGMA locking_mode` or the `?locking=` URI parameter. See [Multi-Process Access](#multi-process-access) for details.
 
 For more detailed list of SQLite compatibility, please refer to [COMPAT.md](../COMPAT.md).
 
@@ -635,6 +637,35 @@ turso> PRAGMA journal_mode = mvcc;
 - Switching journal modes triggers a checkpoint to ensure all pending changes are persisted before the mode change.
 - When switching from MVCC to WAL mode, the MVCC log file is cleared after checkpointing.
 - Legacy SQLite databases are automatically converted to WAL mode when opened.
+
+## Multi-Process Access
+
+By default, Turso opens databases in exclusive mode where only a single process can access the database. To allow multiple processes to read from or write to the same database, use `PRAGMA locking_mode` or the `?locking=` URI parameter.
+
+### Locking Modes
+
+| Mode | Description |
+|------|-------------|
+| `exclusive` | Single-process exclusive access (default). No shared memory overhead. |
+| `shared_reads` | Multiple processes can read, but only one process writes. The writing process acquires a permanent write lock at startup. |
+| `shared_writes` | Full multi-process read and write access. Write locks are acquired and released per transaction. |
+| `normal` | Alias for `shared_writes`, provided for SQLite compatibility. |
+
+### Usage
+
+**Set via PRAGMA:**
+
+```sql
+PRAGMA locking_mode = shared_writes;
+```
+
+**Set via URI parameter:**
+
+```bash
+tursodb "file:database.db?locking=shared_writes"
+```
+
+All processes accessing the same database must use the same locking mode. When a shared locking mode is active, Turso creates a shared memory file (`database.db-tshm`) alongside the database to coordinate reader slots and writer state across processes.
 
 ## Encryption
 

--- a/docs/sql-reference/compatibility.mdx
+++ b/docs/sql-reference/compatibility.mdx
@@ -21,6 +21,7 @@ These features extend Turso beyond SQLite compatibility:
 | [BEGIN CONCURRENT](/docs/sql-reference/statements/transactions#begin-concurrent) | Optimistic concurrent write transactions (MVCC) |
 | [Vector functions](/docs/sql-reference/functions/vector) | Vector storage, distance calculations, similarity search |
 | [Full-text search](/docs/sql-reference/functions/fts) | Tantivy-powered FTS with BM25 scoring |
+| [Multi-Process Access](/docs/sql-reference/pragmas#multi-process-access) | Multi-process database access via PRAGMA locking_mode or URI parameter |
 | [CDC](/docs/sql-reference/pragmas#change-data-capture) | Change Data Capture via PRAGMA |
 | [Encryption](/docs/sql-reference/pragmas#encryption) | At-rest database encryption |
 | [Custom index methods](/docs/sql-reference/statements/create-index#using-method) | CREATE INDEX ... USING for FTS and custom access methods |

--- a/docs/sql-reference/experimental-features.mdx
+++ b/docs/sql-reference/experimental-features.mdx
@@ -18,6 +18,7 @@ Some Turso features are still experimental and must be explicitly enabled before
 | Encryption | `encryption` | At-rest encryption via [PRAGMA cipher / hexkey](/docs/sql-reference/pragmas#encryption) |
 | Index Methods | `index_method` | [CREATE INDEX ... USING](/docs/sql-reference/statements/create-index#using-clause) for FTS and custom index types |
 | Autovacuum | `autovacuum` | Automatic database file compaction |
+| Shared Access | `shared_access` | [Multi-process database access](/docs/sql-reference/pragmas#multi-process-access) via PRAGMA locking_mode or `?locking=` URI parameter |
 | Attach | `attach` | [ATTACH DATABASE](/docs/sql-reference/statements/attach-database) and [DETACH DATABASE](/docs/sql-reference/statements/detach-database) |
 
 ## CLI

--- a/docs/sql-reference/pragmas.mdx
+++ b/docs/sql-reference/pragmas.mdx
@@ -318,6 +318,67 @@ PRAGMA ignore_check_constraints = 1;   -- disable CHECK constraints
 PRAGMA ignore_check_constraints = 0;   -- enable CHECK constraints
 ```
 
+## Multi-Process Access
+
+<Info>
+**Turso Extension**: Multi-process database access is a Turso-specific feature that allows multiple processes to safely read from and write to the same database file.
+</Info>
+
+### locking_mode
+
+Returns or sets the locking mode, which controls how multiple processes coordinate access to the database file.
+
+```sql
+PRAGMA locking_mode;
+PRAGMA locking_mode = shared_writes;
+```
+
+| Mode | Description |
+|------|-------------|
+| `exclusive` | Single-process exclusive access (default). No shared memory overhead. Only one process can open the database. |
+| `shared_reads` | Multiple processes can read, but only one process can write. The writing process acquires a permanent write lock at startup. |
+| `shared_writes` | Full multi-process read and write access. Write locks are acquired and released per transaction. |
+| `normal` | Alias for `shared_writes`, provided for SQLite compatibility. |
+
+All processes accessing the same database must use the same locking mode. Attempting to open a database with a different locking mode than the one already in use returns an error.
+
+When a shared locking mode is active, Turso creates a shared memory file (`database.db-tshm`) alongside the database. This file coordinates reader slots and writer state across processes.
+
+#### URI Parameter
+
+The locking mode can also be set via a URI parameter when opening the database:
+
+```sql
+.open file:database.db?locking=shared_writes
+```
+
+```bash
+tursodb "file:database.db?locking=shared_reads"
+```
+
+Valid values: `exclusive`, `shared_reads`, `shared_writes`, `normal`.
+
+#### Example
+
+```sql
+-- Process 1: Open with shared writes
+PRAGMA locking_mode = shared_writes;
+
+CREATE TABLE t(x);
+INSERT INTO t VALUES (1), (2), (3);
+
+-- Process 2: Open same database with shared writes
+PRAGMA locking_mode = shared_writes;
+
+SELECT * FROM t;
+-- Returns rows written by Process 1
+```
+
+#### SharedReads vs SharedWrites
+
+- **`shared_reads`**: Best when you have one writer and multiple readers. The writer holds a permanent lock, so there is no lock acquisition overhead per transaction. Other processes can read concurrently but cannot write.
+- **`shared_writes`**: Best when multiple processes need to write. Each write transaction acquires and releases the lock, so there is per-transaction lock overhead, but any process can write.
+
 ## Integrity Checks
 
 ### integrity_check

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1602,6 +1602,8 @@ pub enum PragmaName {
     IntegrityCheck,
     /// `journal_mode` pragma
     JournalMode,
+    /// `locking_mode` pragma — controls multi-process locking behavior
+    LockingMode,
     /// Run a quick integrity check (skips expensive index consistency validation)
     QuickCheck,
     /// encryption key for encrypted databases, specified as hexadecimal string.

--- a/verification/tla/.gitignore
+++ b/verification/tla/.gitignore
@@ -1,0 +1,7 @@
+# TLA+ tooling (download from https://github.com/tlaplus/tlaplus/releases)
+tla2tools.jar
+
+# TLC model-checker output
+states/
+*_TTrace_*.tla
+*_TTrace_*.bin

--- a/verification/tla/README.md
+++ b/verification/tla/README.md
@@ -1,0 +1,107 @@
+# TLA+ Formal Verification of WAL Checkpoint Protocol
+
+This directory contains a TLA+ model of the Turso multi-process WAL checkpoint
+protocol with WalIndex shared mmap and TSHM seqlock-style reader validation.
+The model verifies that no committed data is lost after any combination of
+process or power crashes, that readers always see consistent snapshots, and
+that the WalIndex shared memory structure remains coherent.
+
+## What it models
+
+- Write transactions with WAL frame writes and commits
+- Read transactions with snapshot isolation (reader holds max_frame at start)
+- **WalIndex shared mmap**: zero-I/O frame lookup structure with generation
+  counter, salt tracking, and max_frame commit
+- **TSHM writer_state seqlock**: readers load S1, sync from WalIndex, claim
+  TSHM slot, re-validate S2; retry if S1 != S2 (closes TOCTOU gap)
+- **sync_shared_from_wal_index**: reader zero-I/O sync from WalIndex mmap
+  (only increases max_frame, syncs salt)
+- WalIndex clear/populate lifecycle: clear on WAL restart, populate on
+  bootstrap, rebuild after partial checkpoint
+- Checkpoint (Restart and Truncate modes): backfill, salt change, DB sync,
+  optional WAL truncation, header flush
+- Reader-aware checkpoint: safe backfill boundary respects active readers
+- Partial checkpoint: if readers block full backfill, checkpoint finalizes
+  without restarting the WAL log and rebuilds the WalIndex
+- Process crashes (per-process volatile state lost, shared mmap survives)
+- Power crashes (all non-durable state lost, including shared mmap)
+- Recovery from durable state
+
+Source files modeled:
+- `core/storage/multi_process_wal.rs`
+- `core/storage/wal.rs`
+- `core/storage/pager.rs`
+- `core/storage/tshm.rs`
+- `core/storage/wal_index.rs`
+
+## Running the model checker
+
+### 1. Download TLC
+
+Download `tla2tools.jar` from https://github.com/tlaplus/tlaplus/releases
+and place it in this directory.
+
+### 2. Verify the protocol (all invariants pass)
+
+```bash
+java -jar tla2tools.jar -config WALCheckpoint.cfg WALCheckpoint.tla
+```
+
+Expected: all 6 invariants pass (`NoCrashDataLoss`, `WriterExclusion`,
+`NoStaleReads`, `WalIndexCoherence`, `SeqlockSafety`, `TypeOK`).
+
+State space: ~54,000,000 distinct states, depth 75, completes in ~13 minutes
+with 8 workers (2 processes, 2 writes).
+
+## Invariants
+
+- `NoCrashDataLoss`: every committed write ID is recoverable from durable
+  storage (DB file + visible WAL frames). "Visible" means the frame's salt
+  matches the durable WAL header salt.
+
+- `WriterExclusion`: at most one process is in a writer phase at a time.
+
+- `NoStaleReads`: every active reader's snapshot is consistent — all committed
+  writes within the reader's snapshot boundary are recoverable. This verifies
+  that checkpoint backfill respects active reader boundaries, and that the
+  seqlock-based begin_read_tx doesn't expose stale snapshots.
+
+- `WalIndexCoherence`: when the WalIndex has frames (max_frame > 0), every
+  visible entry corresponds to a durable WAL frame. Ensures WalIndex lookups
+  never return frame IDs pointing to non-existent or stale WAL data.
+
+- `SeqlockSafety`: a reader in "reading" phase with a validated WalIndex
+  generation has a generation <= the current WalIndex generation. Validates
+  that the seqlock mechanism prevents readers from using invalidated WalIndex
+  state.
+
+- `TypeOK`: type invariant including `nbackfills <= shared_max_frame`,
+  `wal_hdr_durable.salt` bounds, and WalIndex/TSHM counter bounds.
+
+## Key safety properties
+
+### Salt-based frame visibility
+
+The WAL header flush (which changes the durable salt, making old frames
+invisible) is deferred to `prepare_wal_start()` on the next write. This
+ensures it only runs AFTER the pager has synced the DB file via `CkptSyncDb`.
+Flushing the header before the DB sync would cause data loss on power crash
+(old frames become invisible while DB pages are only buffered).
+
+Similarly, WAL file truncation (Truncate checkpoint mode) only runs in the
+`TruncateWalFile` phase AFTER `SyncDbFile`, ensuring all backfilled data is
+durable before the WAL frames are destroyed.
+
+### WalIndex lifecycle
+
+The WalIndex is cleared (with the new salt and bumped generation) at WAL
+restart. It is repopulated from the durable WAL during `begin_write_tx` when
+the writer detects a stale or empty WalIndex. Readers cache the WalIndex
+generation at `begin_read_tx` and assert it hasn't changed during `find_frame`.
+
+### TOCTOU prevention via seqlock
+
+The seqlock in `begin_read_tx` prevents the TOCTOU race where a writer could
+checkpoint+truncate the WAL between a reader's sync and TSHM slot claim.
+By re-validating `writer_state` after the slot claim, any concurrent writer
+activity is detected and the reader retries with fresh state.

--- a/verification/tla/WALCheckpoint.cfg
+++ b/verification/tla/WALCheckpoint.cfg
@@ -1,0 +1,21 @@
+\* TLC configuration for the WAL checkpoint protocol.
+\* All invariants should PASS.
+
+CONSTANTS
+    p1 = p1
+    p2 = p2
+    Procs = {p1, p2}
+    MaxWrites = 2
+
+INIT Init
+NEXT Next
+
+INVARIANTS
+    NoCrashDataLoss
+    WriterExclusion
+    NoStaleReads
+    WalIndexCoherence
+    SeqlockSafety
+    TypeOK
+
+CHECK_DEADLOCK FALSE

--- a/verification/tla/WALCheckpoint.tla
+++ b/verification/tla/WALCheckpoint.tla
@@ -1,0 +1,859 @@
+--------------------------- MODULE WALCheckpoint ---------------------------
+(*
+ * TLA+ formal verification of the Turso multi-process WAL checkpoint protocol
+ * with WalIndex shared mmap and TSHM seqlock-style reader validation.
+ *
+ * Models the ordering of durability operations (write, fsync) across multiple
+ * processes coordinated via an exclusive write lock. Verifies that no
+ * committed data is lost after any combination of process or power crashes,
+ * and that readers always see a consistent snapshot.
+ *
+ * Key mechanisms:
+ *
+ * 1. Salt-based frame visibility. After restart_log generates a new salt,
+ *    old WAL frames become invisible during recovery (salt mismatch with the
+ *    durable WAL header). The critical invariant is that the new salt must
+ *    NOT be flushed to disk before the DB file is synced.
+ *
+ * 2. WalIndex shared mmap. A zero-I/O frame lookup structure stored in
+ *    shared memory. Writers append page->frame mappings and commit max_frame
+ *    atomically. Readers trust the WalIndex for frame lookups — no fallback
+ *    to WAL file scanning. The WalIndex has a generation counter that is
+ *    bumped on clear(); readers cache this generation at begin_read_tx and
+ *    assert it hasn't changed during find_frame.
+ *
+ * 3. TSHM writer_state + seqlock. Readers load the TSHM writer_state counter
+ *    (S1), sync from WalIndex, acquire read locks, claim a TSHM reader slot,
+ *    then re-load writer_state (S2). If S1 != S2, a writer modified the WAL
+ *    concurrently — the reader releases everything and retries. This closes
+ *    the TOCTOU gap between sync and slot claim.
+ *
+ * Source files modeled:
+ *   core/storage/multi_process_wal.rs  -- MultiProcessWal coordination
+ *   core/storage/wal.rs               -- WalFile, restart_log, checkpoint
+ *   core/storage/pager.rs             -- Pager checkpoint state machine
+ *   core/storage/tshm.rs              -- TSHM reader slots, writer_state
+ *   core/storage/wal_index.rs          -- WalIndex shared mmap
+ *
+ * Abstraction choices:
+ *   - WalIndex frame mappings are modeled as a set of [wid, salt] records.
+ *     find_frame queries this set. Hash collisions, bucket layout, and the
+ *     append-only log are abstracted away.
+ *   - WalIndex generation is a monotonic counter bumped on clear().
+ *   - TSHM writer_state is a monotonic counter bumped by the writer after
+ *     committing frames or checkpointing. Readers use it as a seqlock.
+ *   - sync_shared_from_wal_index is modeled as reading wi_max_frame and
+ *     wi_salt from shared state (zero I/O).
+ *   - The "never decrease max_frame" heuristic in sync_shared_from_wal_index
+ *     is modeled.
+ *   - WAL frames are modeled as a set of [wid, salt] records, not sequences.
+ *   - Write + sync are combined into one atomic step (WriteFrame).
+ *   - Backfill copies all safe-to-backfill writes in one step.
+ *)
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS
+    Procs,          \* Set of process IDs, e.g. {p1, p2}
+    MaxWrites       \* Maximum write transactions to model
+
+ASSUME Procs # {}
+ASSUME MaxWrites \in Nat \ {0}
+
+None == "none"
+WriteIds == 1..MaxWrites
+
+\* Bound on salt values. With MaxWrites writes, we need at most MaxWrites
+\* checkpoint restarts. Add headroom for crash recovery cycles.
+MaxSalt == MaxWrites + 3
+
+\* Bound on WalIndex generation and TSHM writer_state counters.
+\* Each write commit bumps writer_state, and each checkpoint clear bumps
+\* generation. Checkpoint actions now also bump writer_state BEFORE
+\* modifying the WalIndex (seqlock protocol fix). Bound to keep state
+\* space finite.
+\* With MaxWrites=2: one full write+checkpoint cycle needs ~8 tshm bumps
+\* (begin_write+1, commit+1, ckpt_restart+1, ckpt_truncwal+1, ckpt_finalize+1,
+\* end_write+1, plus checkpoint rebuild bump). Two processes need ~16.
+\* wi_generation needs ~4 per cycle. MaxWrites * 4 + 6 gives enough headroom.
+MaxCounter == MaxWrites * 4 + 6
+
+\* Process phases
+Phases == {
+    "idle",
+    "read_sync",        \* begin_read_tx: synced from WalIndex, before slot claim
+    "reading",          \* Active read transaction
+    "writing",          \* Holds write lock, can write frames or start checkpoint
+    "committing",       \* Writing frame, about to commit
+    "ckpt_backfill",    \* Checkpoint: copying WAL to DB (buffered)
+    "ckpt_restart",     \* Checkpoint: new salt in memory
+    "ckpt_dbsync",      \* Checkpoint: DB fsync in progress
+    "ckpt_truncwal",    \* Checkpoint (Truncate mode): truncating WAL file to 0
+    "wal_hdr_flushing", \* Flushing WAL header (lazy, on next write after restart)
+    "crashed"
+}
+
+\* All phases where the process holds the write lock.
+WriterPhases == {
+    "writing", "committing", "wal_hdr_flushing",
+    "ckpt_backfill", "ckpt_restart", "ckpt_dbsync", "ckpt_truncwal"
+}
+
+VARIABLES
+    (* === Durable storage (survives all crashes) === *)
+    db_durable,         \* SUBSET WriteIds: pages synced to DB file
+    wal_durable,        \* Set of [wid: Nat, salt: Nat]: synced WAL frames
+    wal_hdr_durable,    \* [salt: Nat]: synced WAL header
+
+    (* === Buffered storage (page cache, lost on power crash) === *)
+    db_buffered,        \* SUBSET WriteIds: pages written to DB, not synced
+
+    (* === Write lock (survives process crash via dead-owner detection) === *)
+    wlock,              \* Procs \cup {None}: write lock holder
+
+    (* === Per-process volatile state === *)
+    pc,                 \* [Procs -> Phases]: current phase
+    mem_salt,           \* [Procs -> Nat]: in-memory active salt
+    wal_init,           \* [Procs -> BOOLEAN]: WAL header on disk matches memory
+    read_snap,          \* [Procs -> Nat]: reader snapshot (max_frame at read start)
+
+    (* === WalIndex: shared mmap state (survives process crash, lost on power crash) === *)
+    wi_frames,          \* Set of [wid: Nat, salt: Nat]: frame entries in WalIndex
+    wi_max_frame,       \* Nat: committed max_frame visible to readers
+    wi_salt,            \* Nat: salt stored in WalIndex header
+    wi_generation,      \* Nat: generation counter (bumped on clear)
+
+    (* === Per-process cached WalIndex generation === *)
+    cached_wi_gen,      \* [Procs -> Nat \cup {MaxCounter+1}]: cached generation
+                        \*   MaxCounter+1 is the sentinel (u32::MAX equivalent)
+
+    (* === TSHM writer_state: shared counter (survives process crash, lost on power crash) === *)
+    tshm_writer_state,  \* Nat: writer state counter
+    cached_tshm_state,  \* [Procs -> Nat]: per-process cached writer_state
+
+    (* === Seqlock: per-process S1 snapshot for begin_read_tx === *)
+    read_s1,            \* [Procs -> Nat]: writer_state at start of begin_read_tx
+
+    (* === Global shared in-memory state (per WalFileShared) === *)
+    shared_max_frame,   \* Nat: committed frame count (shared.max_frame)
+    nbackfills,         \* Nat: frames checkpointed to DB
+
+    (* === Bookkeeping === *)
+    committed,          \* SUBSET WriteIds: acknowledged writes
+    next_wid,           \* Nat: next write ID counter
+    next_salt,          \* Nat: next salt counter
+    ckpt_mode           \* [Procs -> {"restart", "truncate", "none"}]: checkpoint mode
+
+vars == <<db_durable, wal_durable, wal_hdr_durable,
+          db_buffered, wlock,
+          pc, mem_salt, wal_init, read_snap,
+          wi_frames, wi_max_frame, wi_salt, wi_generation,
+          cached_wi_gen, tshm_writer_state, cached_tshm_state, read_s1,
+          shared_max_frame, nbackfills,
+          committed, next_wid, next_salt, ckpt_mode>>
+
+(* ================================================================== *)
+(* Constants                                                          *)
+(* ================================================================== *)
+
+\* Sentinel value for "no generation cached yet" (u32::MAX equivalent).
+SentinelGen == MaxCounter + 1
+
+(* ================================================================== *)
+(* Helpers                                                            *)
+(* ================================================================== *)
+
+\* Write IDs visible through the durable WAL: frames whose salt matches
+\* the durable WAL header. After restart_log changes the salt, old frames
+\* become invisible during recovery.
+VisibleWalWrites ==
+    {f.wid : f \in {x \in wal_durable : x.salt = wal_hdr_durable.salt}}
+
+\* Set of write IDs recoverable from durable state after any crash.
+RecoverableWrites == db_durable \cup VisibleWalWrites
+
+\* WalIndex-visible writes: entries in the WalIndex whose salt matches
+\* the WalIndex header salt AND whose wid <= wi_max_frame.
+WalIndexVisibleWrites ==
+    {f.wid : f \in {x \in wi_frames : x.salt = wi_salt /\ x.wid <= wi_max_frame}}
+
+\* Minimum reader snapshot across all active readers (0 if no readers).
+\* Models TSHM min_reader_frame_excluding() and determine_max_safe_checkpoint_frame().
+\* The checkpointer must not backfill past this boundary.
+MinReaderSnapshot ==
+    LET active_readers == {p \in Procs : pc[p] = "reading" /\ read_snap[p] > 0}
+    IN IF active_readers = {} THEN 0
+       ELSE CHOOSE m \in {read_snap[p] : p \in active_readers} :
+            \A p \in active_readers : m <= read_snap[p]
+
+\* Safe checkpoint frame: min of shared_max_frame and MinReaderSnapshot.
+\* If no readers, checkpoint can go up to shared_max_frame.
+SafeCheckpointFrame ==
+    LET min_reader == MinReaderSnapshot
+    IN IF min_reader = 0 THEN shared_max_frame
+       ELSE IF min_reader < shared_max_frame THEN min_reader
+       ELSE shared_max_frame
+
+\* WAL writes that are safe to backfill (respecting reader snapshots).
+\* Only frames up to SafeCheckpointFrame can be copied to the DB file.
+SafeBackfillWrites ==
+    LET safe == SafeCheckpointFrame
+        visible == {x \in wal_durable : x.salt = wal_hdr_durable.salt}
+    IN {f.wid : f \in {x \in visible : x.wid <= safe}}
+
+(* ================================================================== *)
+(* Init                                                               *)
+(* ================================================================== *)
+
+Init ==
+    /\ db_durable = {}
+    /\ wal_durable = {}
+    /\ wal_hdr_durable = [salt |-> 1]
+    /\ db_buffered = {}
+    /\ wlock = None
+    /\ pc = [p \in Procs |-> "idle"]
+    /\ mem_salt = [p \in Procs |-> 1]
+    /\ wal_init = [p \in Procs |-> TRUE]
+    /\ read_snap = [p \in Procs |-> 0]
+    /\ wi_frames = {}
+    /\ wi_max_frame = 0
+    /\ wi_salt = 1
+    /\ wi_generation = 0
+    /\ cached_wi_gen = [p \in Procs |-> SentinelGen]
+    /\ tshm_writer_state = 0
+    /\ cached_tshm_state = [p \in Procs |-> 0]
+    /\ read_s1 = [p \in Procs |-> 0]
+    /\ shared_max_frame = 0
+    /\ nbackfills = 0
+    /\ committed = {}
+    /\ next_wid = 1
+    /\ next_salt = 2
+    /\ ckpt_mode = [p \in Procs |-> "none"]
+
+(* ================================================================== *)
+(* Read Transaction (seqlock-style)                                   *)
+(* ================================================================== *)
+
+\* Phase 1 of begin_read_tx: load writer_state (S1) and sync from WalIndex.
+\*
+\* Models the first half of the seqlock loop in begin_read_tx():
+\*   1. Load S1 = tshm.writer_state()
+\*   2. If S1 != cached, call sync_shared_from_wal_index()
+\*   3. Call inner.begin_read_tx() (acquire inner read lock)
+\*   4. Cache WalIndex generation
+\*
+\* sync_shared_from_wal_index() updates shared_max_frame from WalIndex
+\* (only increasing, never decreasing) and syncs the salt. This is the
+\* zero-I/O fast path — no WAL file reads.
+\*
+\* After this step, the process has synced state from the WalIndex mmap
+\* and acquired the inner read lock, but has NOT yet claimed a TSHM reader
+\* slot. A writer could still interleave.
+BeginReadSync(p) ==
+    /\ pc[p] = "idle"
+    /\ LET s1 == tshm_writer_state
+       IN
+       \* sync_shared_from_wal_index: update shared_max_frame from WalIndex
+       \* (only increase, never decrease — modeling the heuristic in the code).
+       /\ shared_max_frame' = IF wi_max_frame > shared_max_frame
+                              THEN wi_max_frame
+                              ELSE shared_max_frame
+       \* Sync salt from WalIndex: if WalIndex has a non-zero salt, adopt it.
+       \* This models set_wal_salt() in sync_shared_from_wal_index.
+       /\ mem_salt' = [mem_salt EXCEPT ![p] = IF wi_salt > 0
+                                              THEN wi_salt
+                                              ELSE mem_salt[p]]
+       \* Snapshot WalIndex generation so find_frame can validate it.
+       /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = wi_generation]
+       \* Snapshot max_frame for the read transaction.
+       \* Uses the post-sync value (max of wi_max_frame, shared_max_frame).
+       /\ read_snap' = [read_snap EXCEPT ![p] =
+                            IF wi_max_frame > shared_max_frame
+                            THEN wi_max_frame
+                            ELSE shared_max_frame]
+       \* Remember S1 for the seqlock check in BeginReadValidate.
+       /\ read_s1' = [read_s1 EXCEPT ![p] = s1]
+       /\ cached_tshm_state' = [cached_tshm_state EXCEPT ![p] = s1]
+    /\ pc' = [pc EXCEPT ![p] = "read_sync"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   wlock, wal_init,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   tshm_writer_state,
+                   nbackfills,
+                   committed, next_wid, next_salt, ckpt_mode>>
+
+\* Phase 2 of begin_read_tx: claim TSHM slot and validate seqlock.
+\*
+\* Models the second half of the seqlock loop:
+\*   5. Claim TSHM reader slot with [pid, max_frame]
+\*   6. Re-load S2 = tshm.writer_state()
+\*   7. If S2 != S1: release slot, release inner lock, retry (go back to idle)
+\*   8. If S2 == S1: commit — transition to "reading"
+\*
+\* The TSHM slot claim is modeled implicitly by the read_snap[p] value.
+\* The slot claim publishes max_frame so that checkpoint respects this reader.
+BeginReadValidate(p) ==
+    /\ pc[p] = "read_sync"
+    /\ LET s2 == tshm_writer_state
+       IN IF s2 = read_s1[p]
+          THEN
+            \* Seqlock valid: writer_state didn't change during our sync.
+            \* Commit to reading phase.
+            /\ pc' = [pc EXCEPT ![p] = "reading"]
+            /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                           wlock, mem_salt, wal_init, read_snap,
+                           wi_frames, wi_max_frame, wi_salt, wi_generation,
+                           cached_wi_gen, tshm_writer_state, cached_tshm_state,
+                           read_s1,
+                           shared_max_frame, nbackfills,
+                           committed, next_wid, next_salt, ckpt_mode>>
+          ELSE
+            \* Seqlock INVALID: writer modified WAL concurrently.
+            \* Release everything and go back to idle for retry.
+            /\ read_snap' = [read_snap EXCEPT ![p] = 0]
+            /\ pc' = [pc EXCEPT ![p] = "idle"]
+            /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                           wlock, mem_salt, wal_init,
+                           wi_frames, wi_max_frame, wi_salt, wi_generation,
+                           cached_wi_gen, tshm_writer_state, cached_tshm_state,
+                           read_s1,
+                           shared_max_frame, nbackfills,
+                           committed, next_wid, next_salt, ckpt_mode>>
+
+\* End read: release snapshot and TSHM slot.
+\* Models end_read_tx() releasing the read lock and TSHM reader slot.
+EndRead(p) ==
+    /\ pc[p] = "reading"
+    /\ read_snap' = [read_snap EXCEPT ![p] = 0]
+    /\ pc' = [pc EXCEPT ![p] = "idle"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   wlock, mem_salt, wal_init,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   cached_wi_gen, tshm_writer_state, cached_tshm_state,
+                   read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt, ckpt_mode>>
+
+(* ================================================================== *)
+(* Write Transaction                                                  *)
+(* ================================================================== *)
+
+\* Acquire write lock, rescan from disk, manage WalIndex, publish state.
+\*
+\* CRITICAL: We MUST read the durable header unconditionally here, not rely
+\* on TSHM change detection. The reason: another process may have flushed a
+\* new WAL header (changing the salt via prepare_wal_start after a checkpoint
+\* restart) and then crashed before bumping the TSHM writer state counter.
+\* The TSHM bump and header flush are NOT atomic.
+\*
+\* After acquiring the write lock, the writer also:
+\*   1. Rescans WAL from disk (getting current salt)
+\*   2. Detects WAL restart (salt mismatch) and clears WalIndex
+\*   3. Repopulates WalIndex from durable WAL if WalIndex is empty
+\*   4. Publishes writer_state so readers detect the change
+\*
+\* In the implementation (multi_process_wal.rs), this corresponds to
+\* begin_write_tx() calling maybe_rescan_from_tshm() + inner.begin_write_tx()
+\* + clear_wal_index/populate_wal_index + publish_writer_state().
+BeginWrite(p) ==
+    /\ pc[p] = "reading"
+    /\ wlock = None
+    /\ wlock' = p
+    \* Always read the durable WAL header to get the current salt.
+    /\ mem_salt' = [mem_salt EXCEPT ![p] = wal_hdr_durable.salt]
+    /\ wal_init' = [wal_init EXCEPT ![p] = TRUE]
+    \* Detect WAL restart: if WalIndex salt doesn't match the durable
+    \* header salt, clear it and repopulate from durable WAL.
+    /\ IF wi_salt # wal_hdr_durable.salt
+       THEN
+         \* Clear WalIndex with current salt and bump generation.
+         \* Then repopulate from durable visible WAL frames.
+         /\ LET new_gen == IF wi_generation < MaxCounter
+                           THEN wi_generation + 1
+                           ELSE wi_generation
+                visible == {x \in wal_durable : x.salt = wal_hdr_durable.salt}
+            IN
+            /\ wi_frames' = visible
+            /\ wi_max_frame' = Cardinality({f.wid : f \in visible})
+            /\ wi_salt' = wal_hdr_durable.salt
+            /\ wi_generation' = new_gen
+            /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = new_gen]
+       ELSE IF wi_max_frame = 0 /\ shared_max_frame > 0
+       THEN
+         \* WalIndex empty but WAL has frames: populate (bootstrap).
+         /\ LET new_gen == IF wi_generation < MaxCounter
+                           THEN wi_generation + 1
+                           ELSE wi_generation
+                visible == {x \in wal_durable : x.salt = wal_hdr_durable.salt}
+            IN
+            /\ wi_frames' = visible
+            /\ wi_max_frame' = Cardinality({f.wid : f \in visible})
+            /\ wi_salt' = wi_salt
+            /\ wi_generation' = new_gen
+            /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = new_gen]
+       ELSE
+         \* WalIndex is up-to-date.
+         /\ wi_frames' = wi_frames
+         /\ wi_max_frame' = wi_max_frame
+         /\ wi_salt' = wi_salt
+         /\ wi_generation' = wi_generation
+         /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = wi_generation]
+    \* Publish writer_state so readers detect this write-lock acquisition.
+    /\ tshm_writer_state' = IF tshm_writer_state < MaxCounter
+                            THEN tshm_writer_state + 1
+                            ELSE tshm_writer_state
+    /\ cached_tshm_state' = [cached_tshm_state EXCEPT ![p] =
+                                IF tshm_writer_state < MaxCounter
+                                THEN tshm_writer_state + 1
+                                ELSE tshm_writer_state]
+    /\ pc' = [pc EXCEPT ![p] = "writing"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   read_snap, read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt, ckpt_mode>>
+
+\* Write a frame to the WAL (durable) and to the WalIndex (shared mmap).
+\* WAL header must be on disk first (wal_init = TRUE).
+WriteFrame(p) ==
+    /\ pc[p] = "writing"
+    /\ next_wid <= MaxWrites
+    /\ wal_init[p] = TRUE
+    /\ LET frame == [wid |-> next_wid, salt |-> mem_salt[p]]
+       IN
+       /\ wal_durable' = wal_durable \cup {frame}
+       \* Append to WalIndex (writer only). The frame is written but
+       \* wi_max_frame is not updated yet — that happens at Commit.
+       /\ wi_frames' = wi_frames \cup {frame}
+       /\ next_wid' = next_wid + 1
+    /\ pc' = [pc EXCEPT ![p] = "committing"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_hdr_durable,
+                   wlock, mem_salt, wal_init, read_snap,
+                   wi_max_frame, wi_salt, wi_generation,
+                   cached_wi_gen, tshm_writer_state, cached_tshm_state,
+                   read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_salt, ckpt_mode>>
+
+\* Commit: update shared_max_frame, WalIndex max_frame, and bump
+\* TSHM writer_state so readers detect the commit.
+\* Process stays in "writing" (still holds lock).
+Commit(p) ==
+    /\ pc[p] = "committing"
+    /\ committed' = committed \cup {next_wid - 1}
+    /\ shared_max_frame' = shared_max_frame + 1
+    \* Commit WalIndex max_frame atomically so readers see the new frame.
+    /\ wi_max_frame' = shared_max_frame + 1
+    \* Bump TSHM writer_state so readers detect the commit.
+    /\ tshm_writer_state' = IF tshm_writer_state < MaxCounter
+                            THEN tshm_writer_state + 1
+                            ELSE tshm_writer_state
+    /\ cached_tshm_state' = [cached_tshm_state EXCEPT ![p] =
+                                IF tshm_writer_state < MaxCounter
+                                THEN tshm_writer_state + 1
+                                ELSE tshm_writer_state]
+    /\ pc' = [pc EXCEPT ![p] = "writing"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   wlock, mem_salt, wal_init, read_snap,
+                   wi_frames, wi_salt, wi_generation,
+                   cached_wi_gen, read_s1,
+                   nbackfills,
+                   next_wid, next_salt, ckpt_mode>>
+
+\* Release write lock and return to reading.
+\* Publish writer_state one final time before releasing lock.
+EndWrite(p) ==
+    /\ pc[p] = "writing"
+    /\ wlock' = None
+    /\ tshm_writer_state' = IF tshm_writer_state < MaxCounter
+                            THEN tshm_writer_state + 1
+                            ELSE tshm_writer_state
+    /\ cached_tshm_state' = [cached_tshm_state EXCEPT ![p] =
+                                IF tshm_writer_state < MaxCounter
+                                THEN tshm_writer_state + 1
+                                ELSE tshm_writer_state]
+    /\ pc' = [pc EXCEPT ![p] = "reading"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   mem_salt, wal_init, read_snap,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   cached_wi_gen, read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt, ckpt_mode>>
+
+(* ================================================================== *)
+(* Checkpoint                                                         *)
+(* ================================================================== *)
+
+\* Backfill WAL frames to DB (buffered, not durable yet).
+\* Copies ALL safe-to-backfill writes respecting active reader snapshots.
+\* Before backfill, invalidate cached WalIndex generation (sentinel)
+\* so find_frame falls through to inner during the checkpoint operation.
+\*
+\* The checkpoint mode (Restart or Truncate) is chosen non-deterministically.
+CkptBackfill(p) ==
+    /\ pc[p] = "writing"
+    /\ nbackfills < shared_max_frame
+    /\ LET safe == SafeBackfillWrites
+       IN /\ safe # {}
+          /\ db_buffered' = db_buffered \cup safe
+    \* Non-deterministically choose Restart or Truncate mode.
+    /\ \E mode \in {"restart", "truncate"}:
+         ckpt_mode' = [ckpt_mode EXCEPT ![p] = mode]
+    \* Invalidate WalIndex generation — bypass WalIndex during checkpoint.
+    \* Models: cached_wal_index_generation.store(u32::MAX) in checkpoint().
+    /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = SentinelGen]
+    /\ pc' = [pc EXCEPT ![p] = "ckpt_backfill"]
+    /\ UNCHANGED <<db_durable, wal_durable, wal_hdr_durable,
+                   wlock, mem_salt, wal_init, read_snap,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   tshm_writer_state, cached_tshm_state, read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt>>
+
+\* Restart the WAL log: new salt in memory, reset shared_max_frame
+\* and nbackfills, clear WalIndex with the new salt and bump generation.
+\* CRITICAL: does NOT flush WAL header to disk.
+\*
+\* Guard: VisibleWalWrites must all be in db_buffered (all frames backfilled).
+\* If readers blocked full backfill, CkptFinalizePartial fires instead.
+CkptRestart(p) ==
+    /\ pc[p] = "ckpt_backfill"
+    /\ VisibleWalWrites \subseteq db_buffered    \* All frames were backfilled
+    /\ next_salt <= MaxSalt
+    /\ nbackfills' = 0
+    /\ LET new_salt == next_salt
+           new_gen == IF wi_generation < MaxCounter
+                      THEN wi_generation + 1
+                      ELSE wi_generation
+       IN
+       /\ next_salt' = next_salt + 1
+       /\ mem_salt' = [mem_salt EXCEPT ![p] = new_salt]
+       /\ wal_init' = [wal_init EXCEPT ![p] = FALSE]
+       \* Clear WalIndex with new salt and bump generation.
+       /\ wi_frames' = {}
+       /\ wi_max_frame' = 0
+       /\ wi_salt' = new_salt
+       /\ wi_generation' = new_gen
+       /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = new_gen]
+    /\ shared_max_frame' = 0
+    \* Bump tshm_writer_state BEFORE WalIndex modification so readers
+    \* detect the change via the seqlock. Without this, a reader could
+    \* cache the new WalIndex generation between its sync and seqlock
+    \* check without detecting the interleaving.
+    /\ tshm_writer_state' = IF tshm_writer_state < MaxCounter
+                            THEN tshm_writer_state + 1
+                            ELSE tshm_writer_state
+    /\ cached_tshm_state' = [cached_tshm_state EXCEPT ![p] =
+                                IF tshm_writer_state < MaxCounter
+                                THEN tshm_writer_state + 1
+                                ELSE tshm_writer_state]
+    /\ pc' = [pc EXCEPT ![p] = "ckpt_restart"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   wlock, read_snap, read_s1,
+                   committed, next_wid, ckpt_mode>>
+
+\* Finalize a partial checkpoint: readers blocked full backfill.
+\* Rebuild WalIndex from the remaining WAL frames.
+\* The WalIndex was invalidated (sentinel gen) at CkptBackfill start;
+\* now re-clear and repopulate with current WAL state.
+CkptFinalizePartial(p) ==
+    /\ pc[p] = "ckpt_backfill"
+    /\ ~(VisibleWalWrites \subseteq db_buffered)    \* NOT all frames backfilled
+    /\ ckpt_mode' = [ckpt_mode EXCEPT ![p] = "none"]
+    \* Rebuild WalIndex after partial checkpoint.
+    /\ LET new_gen == IF wi_generation < MaxCounter
+                      THEN wi_generation + 1
+                      ELSE wi_generation
+           current_salt == mem_salt[p]
+           remaining == {x \in wal_durable : x.salt = wal_hdr_durable.salt}
+       IN
+       /\ wi_frames' = remaining
+       /\ wi_max_frame' = shared_max_frame
+       /\ wi_salt' = current_salt
+       /\ wi_generation' = new_gen
+       /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = new_gen]
+    \* Bump tshm_writer_state BEFORE WalIndex modification (seqlock protocol).
+    /\ tshm_writer_state' = IF tshm_writer_state < MaxCounter
+                            THEN tshm_writer_state + 1
+                            ELSE tshm_writer_state
+    /\ cached_tshm_state' = [cached_tshm_state EXCEPT ![p] =
+                                IF tshm_writer_state < MaxCounter
+                                THEN tshm_writer_state + 1
+                                ELSE tshm_writer_state]
+    /\ pc' = [pc EXCEPT ![p] = "writing"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   wlock, mem_salt, wal_init, read_snap, read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt>>
+
+\* Fsync DB file: buffered DB pages become durable.
+CkptSyncDb(p) ==
+    /\ pc[p] = "ckpt_restart"
+    /\ db_durable' = db_durable \cup db_buffered
+    \* Truncate mode continues to ckpt_truncwal; Restart mode goes to ckpt_dbsync.
+    /\ pc' = [pc EXCEPT ![p] = IF ckpt_mode[p] = "truncate"
+                                THEN "ckpt_truncwal"
+                                ELSE "ckpt_dbsync"]
+    /\ UNCHANGED <<db_buffered, wal_durable, wal_hdr_durable,
+                   wlock, mem_salt, wal_init, read_snap,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   cached_wi_gen, tshm_writer_state, cached_tshm_state,
+                   read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt, ckpt_mode>>
+
+\* Truncate WAL file to zero bytes (Truncate mode only).
+\* This happens AFTER CkptSyncDb has made the DB durable, so all backfilled
+\* data is safe on disk. Also clear WalIndex since all frames are destroyed.
+CkptTruncateWal(p) ==
+    /\ pc[p] = "ckpt_truncwal"
+    /\ wal_durable' = {}
+    \* Clear WalIndex (frames destroyed by truncation).
+    /\ LET new_gen == IF wi_generation < MaxCounter
+                      THEN wi_generation + 1
+                      ELSE wi_generation
+       IN
+       /\ wi_frames' = {}
+       /\ wi_max_frame' = 0
+       /\ wi_generation' = new_gen
+       /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = new_gen]
+    \* Bump tshm_writer_state BEFORE WalIndex modification (seqlock protocol).
+    /\ tshm_writer_state' = IF tshm_writer_state < MaxCounter
+                            THEN tshm_writer_state + 1
+                            ELSE tshm_writer_state
+    /\ cached_tshm_state' = [cached_tshm_state EXCEPT ![p] =
+                                IF tshm_writer_state < MaxCounter
+                                THEN tshm_writer_state + 1
+                                ELSE tshm_writer_state]
+    /\ pc' = [pc EXCEPT ![p] = "ckpt_dbsync"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_hdr_durable,
+                   wlock, mem_salt, wal_init, read_snap,
+                   wi_salt, read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt, ckpt_mode>>
+
+\* Finalize checkpoint: publish writer_state and return to writing.
+CkptFinalize(p) ==
+    /\ pc[p] = "ckpt_dbsync"
+    /\ ckpt_mode' = [ckpt_mode EXCEPT ![p] = "none"]
+    \* Publish writer_state so readers detect the checkpoint.
+    /\ tshm_writer_state' = IF tshm_writer_state < MaxCounter
+                            THEN tshm_writer_state + 1
+                            ELSE tshm_writer_state
+    /\ cached_tshm_state' = [cached_tshm_state EXCEPT ![p] =
+                                IF tshm_writer_state < MaxCounter
+                                THEN tshm_writer_state + 1
+                                ELSE tshm_writer_state]
+    /\ pc' = [pc EXCEPT ![p] = "writing"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   wlock, mem_salt, wal_init, read_snap,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   cached_wi_gen, read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt>>
+
+(* ================================================================== *)
+(* Lazy WAL Header Flush (prepare_wal_start on next write)            *)
+(* ================================================================== *)
+
+\* Write + sync new WAL header to disk. Called when wal_init is FALSE
+\* (after restart_log changed the salt). This happens AFTER CkptSyncDb
+\* has made the DB durable, so it is safe for the writing process.
+\* Other processes pick up the new salt via BeginWrite's unconditional
+\* header read.
+FlushWalHeader(p) ==
+    /\ pc[p] = "writing"
+    /\ wal_init[p] = FALSE
+    /\ wal_hdr_durable' = [salt |-> mem_salt[p]]
+    /\ wal_init' = [wal_init EXCEPT ![p] = TRUE]
+    /\ pc' = [pc EXCEPT ![p] = "wal_hdr_flushing"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable,
+                   wlock, mem_salt, read_snap,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   cached_wi_gen, tshm_writer_state, cached_tshm_state,
+                   read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt, ckpt_mode>>
+
+\* After header flush, return to writing to write frames.
+FlushWalHeaderDone(p) ==
+    /\ pc[p] = "wal_hdr_flushing"
+    /\ pc' = [pc EXCEPT ![p] = "writing"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   wlock, mem_salt, wal_init, read_snap,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   cached_wi_gen, tshm_writer_state, cached_tshm_state,
+                   read_s1,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt, ckpt_mode>>
+
+(* ================================================================== *)
+(* Crash and Recovery                                                 *)
+(* ================================================================== *)
+
+\* Process crash: per-process volatile state lost, write lock released.
+\* WalIndex (shared mmap) and TSHM writer_state survive process crash.
+\* db_buffered is NOT cleared because the OS page cache survives a process
+\* crash — only a power crash (PowerCrash) destroys buffered DB pages.
+ProcessCrash(p) ==
+    /\ pc[p] # "crashed"
+    /\ pc' = [pc EXCEPT ![p] = "crashed"]
+    /\ wlock' = IF wlock = p THEN None ELSE wlock
+    /\ mem_salt' = [mem_salt EXCEPT ![p] = 0]
+    /\ wal_init' = [wal_init EXCEPT ![p] = FALSE]
+    /\ read_snap' = [read_snap EXCEPT ![p] = 0]
+    /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = SentinelGen]
+    /\ cached_tshm_state' = [cached_tshm_state EXCEPT ![p] = 0]
+    /\ read_s1' = [read_s1 EXCEPT ![p] = 0]
+    /\ ckpt_mode' = [ckpt_mode EXCEPT ![p] = "none"]
+    \* Shared mmap state survives: wi_*, tshm_writer_state unchanged.
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   tshm_writer_state,
+                   shared_max_frame, nbackfills,
+                   committed, next_wid, next_salt>>
+
+\* Power crash: ALL non-durable state is lost — including shared mmap.
+\* Only db_durable, wal_durable, and wal_hdr_durable survive.
+PowerCrash ==
+    /\ \E p \in Procs: pc[p] # "crashed"
+    /\ db_buffered' = db_durable
+    /\ wlock' = None
+    /\ pc' = [p \in Procs |-> "crashed"]
+    /\ mem_salt' = [p \in Procs |-> 0]
+    /\ wal_init' = [p \in Procs |-> FALSE]
+    /\ read_snap' = [p \in Procs |-> 0]
+    \* WalIndex lost (mmap backed by tmpfs / not durable).
+    /\ wi_frames' = {}
+    /\ wi_max_frame' = 0
+    /\ wi_salt' = 0
+    /\ wi_generation' = 0
+    /\ cached_wi_gen' = [p \in Procs |-> SentinelGen]
+    /\ tshm_writer_state' = 0
+    /\ cached_tshm_state' = [p \in Procs |-> 0]
+    /\ read_s1' = [p \in Procs |-> 0]
+    /\ shared_max_frame' = 0
+    /\ nbackfills' = 0
+    /\ ckpt_mode' = [p \in Procs |-> "none"]
+    /\ UNCHANGED <<db_durable, wal_durable, wal_hdr_durable,
+                   committed, next_wid, next_salt>>
+
+\* Recovery: rebuild from durable state.
+\* shared_max_frame rebuilt from visible WAL frames. WalIndex populated
+\* during the first writer's begin_write_tx (modeled by BeginWrite's
+\* populate logic). For recovery, we set cached_wi_gen to sentinel —
+\* the first BeginWrite will detect the stale WalIndex and repopulate.
+Recover(p) ==
+    /\ pc[p] = "crashed"
+    /\ mem_salt' = [mem_salt EXCEPT ![p] = wal_hdr_durable.salt]
+    /\ wal_init' = [wal_init EXCEPT ![p] = TRUE]
+    /\ shared_max_frame' = Cardinality(VisibleWalWrites)
+    /\ nbackfills' = 0
+    /\ cached_wi_gen' = [cached_wi_gen EXCEPT ![p] = SentinelGen]
+    /\ pc' = [pc EXCEPT ![p] = "idle"]
+    /\ UNCHANGED <<db_durable, db_buffered, wal_durable, wal_hdr_durable,
+                   wlock, read_snap,
+                   wi_frames, wi_max_frame, wi_salt, wi_generation,
+                   tshm_writer_state, cached_tshm_state, read_s1,
+                   committed, next_wid, next_salt, ckpt_mode>>
+
+(* ================================================================== *)
+(* Next-state relation                                                *)
+(* ================================================================== *)
+
+Next ==
+    \/ \E p \in Procs:
+        \/ BeginReadSync(p)
+        \/ BeginReadValidate(p)
+        \/ EndRead(p)
+        \/ BeginWrite(p)
+        \/ WriteFrame(p)
+        \/ Commit(p)
+        \/ EndWrite(p)
+        \/ CkptBackfill(p)
+        \/ CkptRestart(p)
+        \/ CkptFinalizePartial(p)
+        \/ CkptSyncDb(p)
+        \/ CkptTruncateWal(p)
+        \/ CkptFinalize(p)
+        \/ FlushWalHeader(p)
+        \/ FlushWalHeaderDone(p)
+        \/ ProcessCrash(p)
+        \/ Recover(p)
+    \/ PowerCrash
+
+Spec == Init /\ [][Next]_vars
+
+(* ================================================================== *)
+(* Safety Properties                                                  *)
+(* ================================================================== *)
+
+\* PRIMARY INVARIANT: No committed data is ever lost.
+\* Every committed write must be recoverable from durable storage
+\* (DB file + visible WAL frames) at all times.
+NoCrashDataLoss ==
+    committed \subseteq RecoverableWrites
+
+\* At most one process in a writer phase at a time.
+WriterExclusion ==
+    \A p, q \in Procs:
+        (p # q) => ~(pc[p] \in WriterPhases /\ pc[q] \in WriterPhases)
+
+\* No reader observes a torn snapshot: every frame in a reader's snapshot
+\* range must be recoverable. If a reader holds a snapshot at frame S,
+\* all committed writes with wid <= S must be in RecoverableWrites.
+\* This ensures that checkpoint backfill does not overwrite DB pages that
+\* a reader is still accessing via the WAL.
+\*
+\* Extended for WalIndex: if a reader synced from WalIndex (via
+\* sync_shared_from_wal_index), its snapshot must still be valid even
+\* though the reader used the zero-I/O WalIndex path instead of reading
+\* the WAL file directly. The seqlock guarantees this: if a writer
+\* interleaved, the reader retries.
+NoStaleReads ==
+    \A p \in Procs:
+        pc[p] = "reading" /\ read_snap[p] > 0 =>
+            \A wid \in committed:
+                wid <= read_snap[p] => wid \in RecoverableWrites
+
+\* WalIndex coherence: when the WalIndex has frames (max_frame > 0),
+\* every entry visible through the WalIndex must correspond to a durable
+\* WAL frame. This ensures that WalIndex lookups never return frame IDs
+\* pointing to non-existent or stale WAL data.
+\*
+\* Specifically: for every committed wid in the WalIndex (wid <= wi_max_frame
+\* and matching salt), there must be a corresponding durable WAL frame.
+WalIndexCoherence ==
+    wi_max_frame > 0 =>
+        \A wid \in WalIndexVisibleWrites:
+            wid \in committed =>
+                \E f \in wal_durable: f.wid = wid /\ f.salt = wi_salt
+
+\* Seqlock safety: a reader in "reading" phase with a validated generation
+\* (cached_wi_gen != SentinelGen) must have a generation <= the current
+\* WalIndex generation. The cached generation can be < wi_generation if
+\* a writer cleared+repopulated after the reader's begin_read_tx, but
+\* the reader's snapshot (read_snap) is still valid because checkpoint
+\* respects TSHM reader slots (MinReaderSnapshot boundary).
+SeqlockSafety ==
+    \A p \in Procs:
+        (pc[p] = "reading" /\ cached_wi_gen[p] # SentinelGen) =>
+            cached_wi_gen[p] <= wi_generation
+
+\* Type invariant
+TypeOK ==
+    /\ db_durable \subseteq WriteIds
+    /\ db_buffered \subseteq WriteIds
+    /\ committed \subseteq WriteIds
+    /\ wlock \in Procs \cup {None}
+    /\ \A p \in Procs: pc[p] \in Phases
+    /\ \A p \in Procs: read_snap[p] \in Nat
+    /\ \A p \in Procs: ckpt_mode[p] \in {"restart", "truncate", "none"}
+    /\ next_wid \in 1..(MaxWrites + 1)
+    /\ shared_max_frame \in Nat
+    /\ nbackfills \in Nat
+    /\ nbackfills <= shared_max_frame
+    /\ wal_hdr_durable.salt \in 1..MaxSalt
+    /\ wi_max_frame \in Nat
+    /\ wi_generation \in 0..MaxCounter
+    /\ tshm_writer_state \in 0..MaxCounter
+
+=============================================================================


### PR DESCRIPTION
Motivation: while using Turso to build local tools like cachebro,
codemogger and memelord, lack of multi-process proved to be a major
pain.

## Why not SQLite's .shm protocol?

This draws from our experience at Scylla, where after deliberation we
decided *not* to support the Cassandra protocol for inter-node
communication, afraid that should a bug occur, in practice no one
would know who to blame. This proved to be a very wise decision.
Shared memory requires careful coordination, and subtle bugs in a
protocol we don't fully own can lead to data corruption that is very
hard to detect. By using our own protocol (tshm -- turso shared memory)
we can iterate on it freely and debug it end-to-end.

We could also exclusively-lock a .shm file to prevent SQLite from
opening a database that is currently opened with Turso (not done in
this commit).

## Protocol overview

The tshm file is a single mmap'd page (4096 bytes) of AtomicU64 slots:

    +--------------------------------------------------+
    | Slot 0: writer_state  [monotonic counter]        | <- header
    | Slot 1: locking_mode  [0|1=SharedReads|2=Shared] |
    | Slot 2: write_lock    [pid:32 | instance_id:32]  |
    +--------------------------------------------------+
    | Slot 3:   reader 0    [pid:32 | max_frame:32]    |
    | Slot 4:   reader 1    [pid:32 | max_frame:32]    | <- 509 reader
    | ...                                              |    slots
    | Slot 511: reader 508  [pid:32 | max_frame:32]    |
    +--------------------------------------------------+

### Reader path (zero lock syscalls)

Readers never call flock or fcntl. To begin a read transaction:

  1. Load writer_state (atomic load from mmap, ~10ns).
     If unchanged since last read, skip WAL rescan entirely.
     If changed, re-read the WAL header from disk to pick up
     new frames or a restarted WAL.
  2. CAS an empty reader slot from 0 -> [pid | max_frame].
     This tells the writer which WAL frame is our read horizon
     so checkpoint won't recycle frames we still need.

To end a read transaction: store 0 into the slot (no CAS needed --
only the owner releases).

The PID is stored so that if a reader crashes, the writer can detect
the dead process (kill(pid, 0)) and reclaim the slot. This limits
concurrent readers to 509, which seems reasonable; we can extend the
shared memory area later if needed.

### Writer path

Writers acquire an exclusive lock through two layers:

  1. CAS on tshm slot 2 (shared-memory lock): provides exclusion
     both across processes AND within the same process. This is
     critical on macOS where flock is per-inode, not per-fd, so
     two file descriptors in the same process share the same flock.
  2. flock on the tshm fd: defense-in-depth for cross-process
     exclusion, and handles stale mmap state after crashes.

Dead-owner detection: if the CAS slot is held by a dead PID
(verified via kill(pid, 0) -> ESRCH), the new writer steals the
lock via CAS.

### Locking modes

We default to exclusive (single-process, no tshm overhead).
Two shared modes are available:

  * shared_reads: one writer, many readers. The writer acquires
    flock once at startup and holds it permanently -- zero lock
    syscalls on the write path after initialization.
  * shared_writes (aka normal): any process can write. flock
    is acquired and released per write transaction.

For MVCC, a refcount coalesces the lock: only the 0->1 transition
acquires flock+CAS, subsequent concurrent MVCC writers in the
same Database just bump the counter. Only the 1->0 transition
releases.

## Verification

The protocol is specified and verified in TLA+
(verification/tla/WALCheckpoint.tla) with four invariants:
NoCrashDataLoss, WriterExclusion, NoStaleReads, TypeOK.
TLC explores 112,409 states with all invariants passing.

A seeded generative fuzzer (mp_generative_tests) exercises
multi-process coordination with random interleavings of readers,
writers, checkpoints, crashes, and restarts.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

