### PR TITLE
Update sqlite_sequence on ALTER TABLE ... RENAME TO

### DIFF
--- a/testing/runner/tests/autoincr.sqltest
+++ b/testing/runner/tests/autoincr.sqltest
@@ -168,6 +168,21 @@ test autoinc-drop-last-table-empties-sequence {
 expect {
 }
 
+# Test: Renaming an AUTOINCREMENT table updates sqlite_sequence in place.
+@cross-check-integrity
+test autoinc-rename-table-updates-sequence-entry {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY AUTOINCREMENT, val TEXT);
+    INSERT INTO t1(val) VALUES ('a');
+    ALTER TABLE t1 RENAME TO t2;
+    SELECT name, seq FROM sqlite_sequence ORDER BY name;
+    INSERT INTO t2(val) VALUES ('b');
+    SELECT name, seq FROM sqlite_sequence ORDER BY name;
+}
+expect {
+    t2|1
+    t2|2
+}
+
 # Test: AUTOINCREMENT fails if the maximum rowid is reached. (Assumes 64-bit rowid)
 @cross-check-integrity
 test autoinc-fail-on-max-rowid {


### PR DESCRIPTION
## Description

Fixes `ALTER TABLE ... RENAME TO` for AUTOINCREMENT tables so that `sqlite_sequence` is updated in place during rename.

  Changes:
  - Update the ALTER TABLE rename translation path to rewrite
    `sqlite_sequence.name` from old table name to new table name.
  - Keep behavior consistent with existing MVCC update patterns.
  - Add regression test `autoinc-rename-table-updates-sequence-entry` in
    `testing/runner/tests/autoincr.sqltest`.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

  Issue #5129 reported that after:

  1. creating an AUTOINCREMENT table,
  2. renaming it via `ALTER TABLE ... RENAME TO`,
  3. querying `sqlite_sequence`,

  the old table name remained, and later inserts created a second row for the new table name.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5129

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
