### PR TITLE
Fix unresolved IfNot label in scalar count(*) subqueries

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -528,14 +528,13 @@ impl SelectPlan {
     pub fn is_simple_count(&self) -> bool {
         if !self.where_clause.is_empty()
             || self.aggregates.len() != 1
-            || matches!(
-                self.query_destination,
-                QueryDestination::CoroutineYield { .. }
-            )
+            || !matches!(self.query_destination, QueryDestination::ResultRows)
             || self.table_references.joined_tables().len() != 1
             || !self.table_references.outer_query_refs().is_empty()
             || self.result_columns.len() != 1
             || self.group_by.is_some()
+            || self.limit.is_some()
+            || self.offset.is_some()
             || self.contains_constant_false_condition
         // TODO: (pedrocarlo) maybe can optimize to use the count optmization with more columns
         {

--- a/testing/runner/tests/subquery/expressions.sqltest
+++ b/testing/runner/tests/subquery/expressions.sqltest
@@ -364,6 +364,17 @@ expect {
     0
 }
 
+test subquery-scalar-count-fast-path {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY);
+    INSERT INTO t1 VALUES(1), (2);
+    SELECT (SELECT count(*) FROM t1);
+    SELECT (SELECT count(*) FROM sqlite_schema);
+}
+expect {
+    2
+    1
+}
+
 test subquery-empty-in-coalesce {
     SELECT COALESCE((SELECT 1 WHERE FALSE), 'default');
 }

--- a/testing/runner/tests/trigger.sqltest
+++ b/testing/runner/tests/trigger.sqltest
@@ -1152,6 +1152,26 @@ expect {
     2
 }
 
+# https://github.com/tursodatabase/turso/issues/5115
+# Scalar count(*) subquery in trigger body
+@cross-check-integrity
+test trigger-after-insert-scalar-count-subquery {
+    CREATE TABLE t5115(id INTEGER PRIMARY KEY, data TEXT);
+    CREATE TABLE log5115(msg TEXT);
+    CREATE TRIGGER tr5115 AFTER INSERT ON t5115
+    BEGIN
+        INSERT INTO log5115 VALUES('count=' || (SELECT count(*) FROM t5115));
+    END;
+
+    INSERT INTO t5115 VALUES(1, 'a');
+    INSERT INTO t5115 VALUES(2, 'b');
+    SELECT * FROM log5115 ORDER BY rowid;
+}
+expect {
+    count=1
+    count=2
+}
+
 # RAISE(ABORT) in BEFORE INSERT trigger prevents insertion
 test trigger-raise-abort-before-insert {
     CREATE TABLE raise_t1 (x INTEGER, y TEXT);
@@ -1654,4 +1674,3 @@ test trigger-raise-fail-delete {
 expect error {
     delete fail
 }
-


### PR DESCRIPTION
## Description

This PR fixes a bug where scalar subqueries using `count(*)` could fail with:

  `Corrupt database: Reference to undefined or unresolved label in IfNot: <n>`

The fix does two things:

  1. Resolves `after_main_loop_label` before returning from the simple-count fast path in `emit_query()`, so jumps emitted by `init_limit()` always have a valid target.
  2. Narrows `is_simple_count()` applicability to `ResultRows` queries without `LIMIT/OFFSET`, so the optimization is not applied in subquery/trigger destinations where it is unsafe.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

  Scalar subqueries are planned as row-value subqueries with an implicit `LIMIT 1`. That causes `init_limit()` to emit an `IfNot` jump to the main-loop-end label. When the plan also matched the simple-count optimization, code generation returned early before that label was resolved, leaving an unresolved jump target and causing runtime corruption errors.

  This was user-visible in both direct scalar subqueries and trigger bodies, e.g.:

  - `SELECT (SELECT count(*) FROM t1);`
  - `SELECT (SELECT count(*) FROM sqlite_schema);`
  - Trigger body:
    `INSERT INTO log VALUES('count=' || (SELECT count(*) FROM t));

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5115 

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
