### PR TITLE
core/io: chunk huge >=2GB pwrites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ reset-db:
 .PHONY: reset-db
 
 test-fuzz:
-	RUST_LOG=$(RUST_LOG) cargo test -p core_tester --release -- fuzz
+	RUST_LOG=$(RUST_LOG) SEED=$(or $(SEED), $$(date +%s)) cargo test -p core_tester --release -- fuzz
 	RUST_LOG=$(RUST_LOG) cargo run -p differential-fuzzer --bin custom_types_fuzzer -- --seed $(or $(SEED), $$(date +%s)) -n $(or $(N),200) -t $(or $(TABLES),2)
 .PHONY: test-fuzz
 

--- a/bindings/javascript/src/browser.rs
+++ b/bindings/javascript/src/browser.rs
@@ -64,7 +64,7 @@ impl Opfs {
             let mut completions = self.inner.completions.borrow_mut();
             completions.remove(&completion_no).unwrap()
         };
-        completion.complete(result);
+        completion.complete(result as i64);
     }
 
     fn register_completion(&self, c: Completion) -> u32 {
@@ -184,7 +184,7 @@ impl File for OpfsFile {
         let buffer = buffer.as_mut_slice();
         if web_worker {
             let result = unsafe { read(handle, buffer.as_mut_ptr(), buffer.len(), pos as i32) };
-            c.complete(result as i32);
+            c.complete(result as i64);
         } else {
             let completion_no = self.opfs.register_completion(c.clone());
             unsafe {
@@ -220,7 +220,7 @@ impl File for OpfsFile {
         let buffer = buffer.as_slice();
         if web_worker {
             let result = unsafe { write(handle, buffer.as_ptr(), buffer.len(), pos as i32) };
-            c.complete(result as i32);
+            c.complete(result as i64);
         } else {
             let completion_no = self.opfs.register_completion(c.clone());
             unsafe {
@@ -246,7 +246,7 @@ impl File for OpfsFile {
         let handle = self.handle;
         if web_worker {
             let result = unsafe { sync(handle) };
-            c.complete(result as i32);
+            c.complete(result as i64);
         } else {
             let completion_no = self.opfs.register_completion(c.clone());
             unsafe { sync_async(handle, completion_no) };
@@ -269,7 +269,7 @@ impl File for OpfsFile {
         let handle = self.handle;
         if web_worker {
             let result = unsafe { truncate(handle, len as usize) };
-            c.complete(result as i32);
+            c.complete(result as i64);
         } else {
             let completion_no = self.opfs.register_completion(c.clone());
             unsafe { truncate_async(handle, len as usize, completion_no) };

--- a/core/io/completions.rs
+++ b/core/io/completions.rs
@@ -16,10 +16,10 @@ use crate::{Buffer, CompletionError};
 /// Callback for read completions. Returns `Some(error)` if the callback detects an error
 /// (e.g., short read), which will be stored in the completion and propagated to VDBE.
 pub type ReadComplete =
-    dyn Fn(Result<(Arc<Buffer>, i32), CompletionError>) -> Option<CompletionError> + Send + Sync;
-pub type WriteComplete = dyn Fn(Result<i32, CompletionError>) + Send + Sync;
-pub type SyncComplete = dyn Fn(Result<i32, CompletionError>) + Send + Sync;
-pub type TruncateComplete = dyn Fn(Result<i32, CompletionError>) + Send + Sync;
+    dyn Fn(Result<(Arc<Buffer>, i64), CompletionError>) -> Option<CompletionError> + Send + Sync;
+pub type WriteComplete = dyn Fn(Result<i64, CompletionError>) + Send + Sync;
+pub type SyncComplete = dyn Fn(Result<i64, CompletionError>) + Send + Sync;
+pub type TruncateComplete = dyn Fn(Result<i64, CompletionError>) + Send + Sync;
 
 #[must_use]
 #[derive(Debug, Clone)]
@@ -125,13 +125,13 @@ impl fmt::Debug for CompletionInner {
 
 pub struct CompletionGroup {
     completions: Vec<Completion>,
-    callback: Box<dyn Fn(Result<i32, CompletionError>) + Send + Sync>,
+    callback: Box<dyn Fn(Result<i64, CompletionError>) + Send + Sync>,
 }
 
 impl CompletionGroup {
     pub fn new<F>(callback: F) -> Self
     where
-        F: Fn(Result<i32, CompletionError>) + Send + Sync + 'static,
+        F: Fn(Result<i64, CompletionError>) + Send + Sync + 'static,
     {
         Self {
             completions: Vec::new(),
@@ -216,7 +216,7 @@ struct GroupCompletionInner {
     /// Number of completions that need to finish
     outstanding: AtomicUsize,
     /// Callback to invoke when all completions finish
-    complete: Box<dyn Fn(Result<i32, CompletionError>) + Send + Sync>,
+    complete: Box<dyn Fn(Result<i64, CompletionError>) + Send + Sync>,
     /// Cached result after all completions finish
     result: OnceLock<Option<CompletionError>>,
     /// Reference to the group's own Completion for notifying parents
@@ -226,7 +226,7 @@ struct GroupCompletionInner {
 impl GroupCompletion {
     pub fn new<F>(complete: F, outstanding: usize) -> Self
     where
-        F: Fn(Result<i32, CompletionError>) + Send + Sync + 'static,
+        F: Fn(Result<i64, CompletionError>) + Send + Sync + 'static,
     {
         Self {
             inner: Arc::new(GroupCompletionInner {
@@ -238,7 +238,7 @@ impl GroupCompletion {
         }
     }
 
-    pub fn callback(&self, result: Result<i32, CompletionError>) {
+    pub fn callback(&self, result: Result<i64, CompletionError>) {
         turso_assert_eq!(
             self.inner.outstanding.load(Ordering::SeqCst),
             0,
@@ -307,7 +307,7 @@ impl Completion {
 
     pub fn new_write<F>(complete: F) -> Self
     where
-        F: Fn(Result<i32, CompletionError>) + Send + Sync + 'static,
+        F: Fn(Result<i64, CompletionError>) + Send + Sync + 'static,
     {
         Self::new(CompletionType::Write(WriteCompletion::new(Box::new(
             complete,
@@ -316,7 +316,7 @@ impl Completion {
 
     pub fn new_read<F>(buf: Arc<Buffer>, complete: F) -> Self
     where
-        F: Fn(Result<(Arc<Buffer>, i32), CompletionError>) -> Option<CompletionError>
+        F: Fn(Result<(Arc<Buffer>, i64), CompletionError>) -> Option<CompletionError>
             + Send
             + Sync
             + 'static,
@@ -328,7 +328,7 @@ impl Completion {
     }
     pub fn new_sync<F>(complete: F) -> Self
     where
-        F: Fn(Result<i32, CompletionError>) + Send + Sync + 'static,
+        F: Fn(Result<i64, CompletionError>) + Send + Sync + 'static,
     {
         Self::new(CompletionType::Sync(SyncCompletion::new(Box::new(
             complete,
@@ -337,7 +337,7 @@ impl Completion {
 
     pub fn new_trunc<F>(complete: F) -> Self
     where
-        F: Fn(Result<i32, CompletionError>) + Send + Sync + 'static,
+        F: Fn(Result<i64, CompletionError>) + Send + Sync + 'static,
     {
         Self::new(CompletionType::Truncate(TruncateCompletion::new(Box::new(
             complete,
@@ -419,7 +419,7 @@ impl Completion {
         self.inner.is_none()
     }
 
-    pub fn complete(&self, result: i32) {
+    pub fn complete(&self, result: i64) {
         let result = Ok(result);
         self.callback(result);
     }
@@ -433,7 +433,7 @@ impl Completion {
         self.error(CompletionError::Aborted);
     }
 
-    fn callback(&self, result: Result<i32, CompletionError>) {
+    fn callback(&self, result: Result<i64, CompletionError>) {
         let inner = self.get_inner();
         inner.result.get_or_init(|| {
             // Run the type-specific callback. For ReadCompletion, this returns
@@ -531,7 +531,7 @@ impl ReadCompletion {
         &self.buf
     }
 
-    pub fn callback(&self, bytes_read: Result<i32, CompletionError>) -> Option<CompletionError> {
+    pub fn callback(&self, bytes_read: Result<i64, CompletionError>) -> Option<CompletionError> {
         (self.complete)(bytes_read.map(|b| (self.buf.clone(), b)))
     }
 
@@ -549,7 +549,7 @@ impl WriteCompletion {
         Self { complete }
     }
 
-    pub fn callback(&self, bytes_written: Result<i32, CompletionError>) {
+    pub fn callback(&self, bytes_written: Result<i64, CompletionError>) {
         (self.complete)(bytes_written);
     }
 }
@@ -563,7 +563,7 @@ impl SyncCompletion {
         Self { complete }
     }
 
-    pub fn callback(&self, res: Result<i32, CompletionError>) {
+    pub fn callback(&self, res: Result<i64, CompletionError>) {
         (self.complete)(res);
     }
 }
@@ -577,7 +577,7 @@ impl TruncateCompletion {
         Self { complete }
     }
 
-    pub fn callback(&self, res: Result<i32, CompletionError>) {
+    pub fn callback(&self, res: Result<i64, CompletionError>) {
         (self.complete)(res);
     }
 }
@@ -1210,9 +1210,9 @@ mod tests {
 
     #[test]
     fn test_completion_callback_receives_success_result() {
-        use crate::sync::atomic::{AtomicI32, Ordering};
+        use crate::sync::atomic::{AtomicI64, Ordering};
 
-        let result_value = Arc::new(AtomicI32::new(-1));
+        let result_value = Arc::new(AtomicI64::new(-1));
         let result_value_clone = result_value.clone();
 
         let c = Completion::new_write(move |res| {

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -78,7 +78,7 @@ impl File for GenericFile {
             let r = c.as_read();
             let buf = r.buf();
             let buf = buf.as_mut_slice();
-            file.read(buf).map_err(|e| io_error(e, "pread"))? as i32
+            file.read(buf).map_err(|e| io_error(e, "pread"))? as i64
         };
         c.complete(nr);
         Ok(c)
@@ -90,7 +90,7 @@ impl File for GenericFile {
         file.seek(std::io::SeekFrom::Start(pos)).map_err(|e| io_error(e, "pwrite"))?;
         let buf = buffer.as_slice();
         file.write_all(buf).map_err(|e| io_error(e, "pwrite"))?;
-        c.complete(buffer.len() as i32);
+        c.complete(buffer.len() as i64);
         Ok(c)
     }
 

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -468,7 +468,7 @@ impl WrappedIOUring {
                 );
                 // write complete, return iovec to pool
                 state.free_last_iov(&mut self.iov_pool);
-                completion_from_key(user_data).complete(state.total_written as i32);
+                completion_from_key(user_data).complete(state.total_written as i64);
             }
             remaining => {
                 tracing::trace!(
@@ -563,7 +563,7 @@ impl IO for UringIO {
                     let err = std::io::Error::from_raw_os_error(errno);
                     completion_from_key(user_data).error(CompletionError::IOError(err.kind(), "io_uring_cqe"));
                 } else {
-                    completion_from_key(user_data).complete(result)
+                    completion_from_key(user_data).complete(result as i64)
                 }
             }
         }
@@ -617,7 +617,7 @@ impl IO for UringIO {
                 let err = std::io::Error::from_raw_os_error(errno);
                 completion_from_key(user_data).error(CompletionError::IOError(err.kind(), "io_uring_cqe"));
             } else {
-                completion_from_key(user_data).complete(result)
+                completion_from_key(user_data).complete(result as i64)
             }
         }
     }

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -134,7 +134,7 @@ impl File for MemoryFile {
                 remaining -= bytes_to_read;
             }
         }
-        c.complete(read_len as i32);
+        c.complete(read_len as i64);
         Ok(c)
     }
 
@@ -175,7 +175,7 @@ impl File for MemoryFile {
         self.size
             .set(core::cmp::max(pos + buf_len as u64, self.size.get()));
 
-        c.complete(buf_len as i32);
+        c.complete(buf_len as i64);
         Ok(c)
     }
 
@@ -237,7 +237,7 @@ impl File for MemoryFile {
             }
             total_written += buf_len;
         }
-        c.complete(total_written as i32);
+        c.complete(total_written as i64);
         self.size
             .set(core::cmp::max(pos + total_written as u64, self.size.get()));
         Ok(c)

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -95,7 +95,7 @@ pub trait File: Send + Sync {
                         total_written.fetch_add(n as usize, Ordering::SeqCst);
                         if outstanding.fetch_sub(1, Ordering::AcqRel) == 1 {
                             // last one finished
-                            c_main.complete(total_written.load(Ordering::Acquire) as i32);
+                            c_main.complete(total_written.load(Ordering::Acquire) as i64);
                         }
                     }
                 })
@@ -324,7 +324,7 @@ impl<'a> WriteBatch<'a> {
     pub fn submit(self) -> Result<Vec<Completion>> {
         let mut completions = Vec::with_capacity(self.ops.len());
         for WriteOp { pos, bufs } in self.ops {
-            let total_len = bufs.iter().map(|b| b.len()).sum::<usize>() as i32;
+            let total_len = bufs.iter().map(|b| b.len()).sum::<usize>() as i64;
             let c = Completion::new_write(move |res| {
                 let Ok(bytes_written) = res else {
                     return;

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -218,7 +218,7 @@ impl File for UnixFile {
         } else {
             trace!("pread n: {}", result);
             // Read succeeded immediately
-            c.complete(result as i32);
+            c.complete(result as i64);
             Ok(c)
         }
     }
@@ -265,7 +265,7 @@ impl File for UnixFile {
             trace!("pwrite iteration: wrote {written}, total {total_written}/{total_size}");
         }
         trace!("pwrite complete: wrote {total_written} bytes");
-        c.complete(total_written as i32);
+        c.complete(total_written as i64);
         Ok(c)
     }
 
@@ -340,7 +340,7 @@ impl File for UnixFile {
             }
         }
         trace!("pwritev complete: wrote {total_written} bytes");
-        c.complete(total_written as i32);
+        c.complete(total_written as i64);
         Ok(c)
     }
 

--- a/core/io/vfs.rs
+++ b/core/io/vfs.rs
@@ -88,7 +88,7 @@ unsafe extern "C" fn callback_fn(result: i32, ctx: SendPtr) {
     let completion = Completion {
         inner: (Some(Arc::from_raw(ctx.inner().as_ptr() as *mut CompletionInner))),
     };
-    completion.complete(result);
+    completion.complete(result as i64);
 }
 
 fn to_callback(c: Completion) -> IOCallback {

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -79,7 +79,7 @@ impl File for WindowsFile {
             let r = c.as_read();
             let buf = r.buf();
             let buf = buf.as_mut_slice();
-            file.read(buf).map_err(|e| io_error(e, "pread"))? as i32
+            file.read(buf).map_err(|e| io_error(e, "pread"))? as i64
         };
         c.complete(nr);
         Ok(c)
@@ -91,7 +91,7 @@ impl File for WindowsFile {
         file.seek(std::io::SeekFrom::Start(pos)).map_err(|e| io_error(e, "pwrite"))?;
         let buf = buffer.as_slice();
         file.write_all(buf).map_err(|e| io_error(e, "pwrite"))?;
-        c.complete(buffer.len() as i32);
+        c.complete(buffer.len() as i64);
         Ok(c)
     }
 

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -373,12 +373,12 @@ impl LogicalLog {
         let buffer = Arc::new(Buffer::new(self.write_buf.clone()));
         let c = Completion::new_write({
             let buffer_len = buffer.len();
-            move |res: Result<i32, CompletionError>| {
+            move |res: Result<i64, CompletionError>| {
                 let Ok(bytes_written) = res else {
                     return;
                 };
                 turso_assert!(
-                    bytes_written == buffer_len as i32,
+                    bytes_written == buffer_len as i64,
                     "wrote({bytes_written}) != expected({buffer_len})"
                 );
             }
@@ -456,12 +456,12 @@ impl LogicalLog {
         let buffer = Arc::new(Buffer::new(header_bytes.to_vec()));
         let c = Completion::new_write({
             let buffer_len = buffer.len();
-            move |res: Result<i32, CompletionError>| {
+            move |res: Result<i64, CompletionError>| {
                 let Ok(bytes_written) = res else {
                     return;
                 };
                 turso_assert!(
-                    bytes_written == buffer_len as i32,
+                    bytes_written == buffer_len as i64,
                     "wrote({bytes_written}) != expected({buffer_len})"
                 );
             }

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -123,7 +123,7 @@ impl DatabaseStorage for DatabaseFile {
                 let read_buffer = r.buf_arc();
                 let original_c = c.clone();
                 let decrypt_complete =
-                    Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                    Box::new(move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
                         let (buf, bytes_read) = match res {
                             Ok((buf, bytes_read)) => (buf, bytes_read),
                             Err(err) => {
@@ -166,7 +166,7 @@ impl DatabaseStorage for DatabaseFile {
                 let original_c = c.clone();
 
                 let verify_complete =
-                    Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                    Box::new(move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
                         let (buf, bytes_read) = match res {
                             Ok((buf, bytes_read)) => (buf, bytes_read),
                             Err(err) => {
@@ -303,7 +303,7 @@ mod tests {
     use crate::{File, MemoryIO, IO};
 
     struct MockFile {
-        read_result: std::result::Result<i32, CompletionError>,
+        read_result: std::result::Result<i64, CompletionError>,
     }
 
     impl File for MockFile {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1663,7 +1663,7 @@ impl Pager {
 
         let write_complete = {
             let buf_copy = buffer.clone();
-            Box::new(move |res: Result<i32, CompletionError>| {
+            Box::new(move |res: Result<i64, CompletionError>| {
                 let Ok(bytes_written) = res else {
                     return;
                 };
@@ -1671,7 +1671,7 @@ impl Pager {
                 let buf_len = buf_copy.len();
 
                 turso_assert!(
-                    bytes_written == buf_len as i32,
+                    bytes_written == buf_len as i64,
                     "wrote({bytes_written}) != expected({buf_len})"
                 );
 

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -552,7 +552,7 @@ pub fn begin_read_page(
     let buf = buffer_pool.get_page();
     #[allow(clippy::arc_with_non_send_sync)]
     let buf = Arc::new(buf);
-    let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+    let complete = Box::new(move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
         let Ok((buf, bytes_read)) = res else {
             page.clear_locked();
             return None; // IO error already captured in completion
@@ -570,7 +570,7 @@ pub fn begin_read_page(
                     actual: 0,
                 });
             }
-        } else if bytes_read != buf_len as i32 {
+        } else if bytes_read != buf_len as i64 {
             tracing::error!(
                 "short read on page {page_idx}: expected {buf_len} bytes, got {bytes_read}"
             );
@@ -621,7 +621,7 @@ pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completio
     let buf_len = buffer.len();
 
     let write_complete = {
-        Box::new(move |res: Result<i32, CompletionError>| {
+        Box::new(move |res: Result<i64, CompletionError>| {
             let Ok(bytes_written) = res else {
                 return;
             };
@@ -629,7 +629,7 @@ pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completio
 
             page_finish.clear_dirty();
             turso_assert!(
-                bytes_written == buf_len as i32,
+                bytes_written == buf_len as i64,
                 "wrote({bytes_written}) != expected({buf_len})"
             );
         })
@@ -700,7 +700,7 @@ pub fn write_pages_vectored(
         let done_cl = done_flag.clone();
         let err_cl = err.clone();
 
-        let expected_bytes = (page_sz * run_bufs.len()) as i32;
+        let expected_bytes = (page_sz * run_bufs.len()) as i64;
 
         let cmp = Completion::new_write(move |res| {
             // Record error/mismatch, but always resolve the batch progress.
@@ -1583,12 +1583,12 @@ impl StreamingWalReader {
         Ok((read_size, guard))
     }
 
-    fn handle_header_read(self: Arc<Self>, res: Result<(Arc<Buffer>, i32), CompletionError>) {
+    fn handle_header_read(self: Arc<Self>, res: Result<(Arc<Buffer>, i64), CompletionError>) {
         let Ok((buf, bytes_read)) = res else {
             self.finalize_loading();
             return;
         };
-        if bytes_read != WAL_HEADER_SIZE as i32 {
+        if bytes_read != WAL_HEADER_SIZE as i64 {
             self.finalize_loading();
             return;
         }
@@ -1633,7 +1633,7 @@ impl StreamingWalReader {
         self.page_atomic.store(page_sz as u64, Ordering::Release);
     }
 
-    fn handle_chunk_read(self: Arc<Self>, res: Result<(Arc<Buffer>, i32), CompletionError>) {
+    fn handle_chunk_read(self: Arc<Self>, res: Result<(Arc<Buffer>, i64), CompletionError>) {
         let Ok((buf, bytes_read)) = res else {
             self.finalize_loading();
             return;
@@ -1800,7 +1800,7 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
             let original_complete = complete;
 
             let decrypt_complete =
-                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                Box::new(move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
                     let Ok((encrypted_buf, bytes_read)) = res else {
                         return original_complete(res);
                     };
@@ -1834,7 +1834,7 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
             let checksum_ctx = ctx.clone();
             let original_c = complete;
             let verify_complete =
-                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                Box::new(move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
                     let Ok((buf, bytes_read)) = res else {
                         return original_c(res);
                     };
@@ -1938,12 +1938,12 @@ pub fn begin_write_wal_header<F: File + ?Sized>(io: &F, header: &WalHeader) -> R
         Arc::new(buffer)
     };
 
-    let write_complete = move |res: Result<i32, CompletionError>| {
+    let write_complete = move |res: Result<i64, CompletionError>| {
         let Ok(bytes_written) = res else {
             return;
         };
         turso_assert!(
-            bytes_written == WAL_HEADER_SIZE as i32,
+            bytes_written == WAL_HEADER_SIZE as i64,
             "wal header wrote({bytes_written}) != expected({WAL_HEADER_SIZE})"
         );
     };

--- a/core/storage/subjournal.rs
+++ b/core/storage/subjournal.rs
@@ -69,12 +69,12 @@ impl Subjournal {
         );
         let c = Completion::new_read(
             page_id_buffer,
-            move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+            move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
                 let Ok((buf, bytes_read)) = res else {
                     return None;
                 };
                 let expected = buf.len();
-                if bytes_read != expected as i32 {
+                if bytes_read != expected as i64 {
                     tracing::error!(
                         "subjournal short read: expected {expected} bytes, got {bytes_read}"
                     );
@@ -101,12 +101,12 @@ impl Subjournal {
         turso_assert_eq!(buffer.len(), page_size, "buffer length should be page_size");
         let c = Completion::new_read(
             buffer,
-            move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+            move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
                 let Ok((buf, bytes_read)) = res else {
                     return None;
                 };
                 let page_idx = page.get().id;
-                if bytes_read != page_size as i32 {
+                if bytes_read != page_size as i64 {
                     tracing::error!(
                         "subjournal short read on page {page_idx}: expected {page_size} bytes, got {bytes_read}"
                     );
@@ -125,7 +125,7 @@ impl Subjournal {
     }
 
     pub fn truncate(&self, offset: u64) -> Result<Completion> {
-        let c = Completion::new_trunc(move |res: Result<i32, CompletionError>| {
+        let c = Completion::new_trunc(move |res: Result<i64, CompletionError>| {
             let Ok(_) = res else {
                 return;
             };

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1377,7 +1377,7 @@ impl Wal for WalFile {
         let frame = page.clone();
         let page_idx = page.get().id;
         let shared_file = self.shared.clone();
-        let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+        let complete = Box::new(move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 tracing::debug!(err = ?res.unwrap_err());
                 page.clear_locked();
@@ -1385,7 +1385,7 @@ impl Wal for WalFile {
                 return None; // IO error already captured in completion
             };
             let buf_len = buf.len();
-            if bytes_read != buf_len as i32 {
+            if bytes_read != buf_len as i64 {
                 tracing::debug!(
                     "WAL short read at offset {offset}, page {page_idx}, frame_id={frame_id}: expected {buf_len} bytes, got {bytes_read}"
                 );
@@ -1446,12 +1446,12 @@ impl Wal for WalFile {
             let io_ctx = self.io_ctx.read();
             io_ctx.encryption_context().cloned()
         };
-        let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+        let complete = Box::new(move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 return None; // IO error already captured in completion
             };
             let buf_len = buf.len();
-            if bytes_read != buf_len as i32 {
+            if bytes_read != buf_len as i64 {
                 tracing::debug!(
                     "short read on WAL frame {frame_id} at offset {offset}: expected {buf_len} bytes, got {bytes_read}"
                 );
@@ -1546,12 +1546,12 @@ impl Wal for WalFile {
 
             let complete = Box::new({
                 let conflict = conflict.clone();
-                move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
                     let Ok((buf, bytes_read)) = res else {
                         return None; // IO error already captured in completion
                     };
                     let buf_len = buf.len();
-                    if bytes_read != buf_len as i32 {
+                    if bytes_read != buf_len as i64 {
                         tracing::debug!(
                             "short read on WAL frame validation at offset {offset}, page_id={page_id}: expected {buf_len} bytes, got {bytes_read}"
                         );
@@ -2060,9 +2060,9 @@ impl Wal for WalFile {
         let start_off = self.frame_offset(first_frame_id);
 
         // single completion for the whole batch
-        let total_len: i32 = iovecs.iter().map(|b| b.len() as i32).sum();
+        let total_len: i64 = iovecs.iter().map(|b| b.len() as i64).sum();
         let page_frame_for_cb = page_frame_and_checksum.clone();
-        let cmp = move |res: Result<i32, CompletionError>| {
+        let cmp = move |res: Result<i64, CompletionError>| {
             let Ok(bytes_written) = res else {
                 return;
             };
@@ -2816,13 +2816,13 @@ impl WalFile {
 
         let complete = {
             let buf_slot = buf_slot.clone();
-            Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+            Box::new(move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
                 let Ok((buf, read)) = res else {
                     return None;
                 };
                 let buf_len = buf.len();
                 turso_assert!(
-                    read == buf_len as i32,
+                    read == buf_len as i64,
                     "read bytes does not match expected buffer length",
                     { "read": read, "expected": buf_len, "frame_id": frame_id }
                 );

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -1368,7 +1368,7 @@ impl HashTable {
         io_state.set(SpillIOState::WaitingForWrite);
 
         let buffer_ref = Arc::new(buffer);
-        let write_complete = Box::new(move |res: Result<i32, crate::CompletionError>| match res {
+        let write_complete = Box::new(move |res: Result<i64, crate::CompletionError>| match res {
             Ok(_) => {
                 tracing::trace!("Successfully wrote spilled partition to disk");
                 io_state.set(SpillIOState::WriteComplete);
@@ -1522,7 +1522,7 @@ impl HashTable {
         // Submit single I/O write
         let buffer_ref = Arc::new(buffer);
         let _buffer_ref_clone = buffer_ref.clone();
-        let write_complete = Box::new(move |res: Result<i32, crate::CompletionError>| match res {
+        let write_complete = Box::new(move |res: Result<i64, crate::CompletionError>| match res {
             Ok(_) => {
                 let _buf = _buffer_ref_clone.clone();
                 tracing::trace!(
@@ -2123,7 +2123,7 @@ impl HashTable {
                 } => {
                     let read_buffer = Arc::new(Buffer::new_temporary(read_size));
                     let read_complete = Box::new(
-                        move |res: Result<(Arc<Buffer>, i32), CompletionError>| match res {
+                        move |res: Result<(Arc<Buffer>, i64), CompletionError>| match res {
                             Ok((buf, bytes_read)) => {
                                 tracing::trace!(
                                     "Completed read of spilled partition chunk: bytes_read={}",

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -659,7 +659,7 @@ impl SortedChunk {
         let stored_buffer_copy = self.buffer.clone();
         let stored_buffer_len_copy = self.buffer_len.clone();
         let total_bytes_read_copy = self.total_bytes_read.clone();
-        let read_complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+        let read_complete = Box::new(move |res: Result<(Arc<Buffer>, i64), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 return None;
             };
@@ -722,13 +722,13 @@ impl SortedChunk {
 
         let buffer_ref_copy = buffer_ref.clone();
         let chunk_io_state_copy = self.io_state.clone();
-        let write_complete = Box::new(move |res: Result<i32, CompletionError>| {
+        let write_complete = Box::new(move |res: Result<i64, CompletionError>| {
             let Ok(bytes_written) = res else {
                 *chunk_io_state_copy.write() = SortedChunkIOState::WriteError;
                 return;
             };
             let buf_len = buffer_ref_copy.len();
-            if bytes_written < buf_len as i32 {
+            if bytes_written < buf_len as i64 {
                 tracing::error!("wrote({bytes_written}) less than expected({buf_len})");
                 *chunk_io_state_copy.write() = SortedChunkIOState::WriteError;
             } else {

--- a/sync/engine/src/database_sync_lazy_storage.rs
+++ b/sync/engine/src/database_sync_lazy_storage.rs
@@ -453,7 +453,7 @@ async fn read_page<Ctx, IO: SyncEngineIo>(
 
     tracing::info!("read_page(page={page}): page loaded");
     read_buf.copy_from_slice(&buffer.as_slice()[0..read_buf_len]);
-    c.complete(read_buf_len as i32);
+    c.complete(read_buf_len as i64);
     Ok(())
 }
 

--- a/sync/engine/src/sparse_io.rs
+++ b/sync/engine/src/sparse_io.rs
@@ -82,7 +82,7 @@ impl File for SparseLinuxFile {
             let buf = buf.as_mut_slice();
             file.read_exact_at(buf, pos)
                 .map_err(|e| io_error(e, "pread"))?;
-            buf.len() as i32
+            buf.len() as i64
         };
         c.complete(nr);
         Ok(c)
@@ -94,7 +94,7 @@ impl File for SparseLinuxFile {
         let buf = buffer.as_slice();
         file.write_all_at(buf, pos)
             .map_err(|e| io_error(e, "pwrite"))?;
-        c.complete(buffer.len() as i32);
+        c.complete(buffer.len() as i64);
         Ok(c)
     }
 

--- a/testing/concurrent-simulator/io.rs
+++ b/testing/concurrent-simulator/io.rs
@@ -216,7 +216,7 @@ impl IO for SimulatorIO {
 
 struct PendingCompletion {
     completion: Completion,
-    result: i32,
+    result: i64,
 }
 type PendingQueue = Arc<Mutex<Vec<PendingCompletion>>>;
 
@@ -289,7 +289,7 @@ impl File for SimulatorFile {
         let result = if pos + len <= MAX_FILE_SIZE {
             let mmap = self.mmap.lock().unwrap();
             buffer.as_mut_slice().copy_from_slice(&mmap[pos..pos + len]);
-            len as i32
+            len as i64
         } else {
             0
         };
@@ -320,7 +320,7 @@ impl File for SimulatorFile {
                     sizes.insert(self.path.clone(), *size as u64);
                 }
             }
-            len as i32
+            len as i64
         } else {
             0
         };
@@ -369,7 +369,7 @@ impl File for SimulatorFile {
 
         self.pending.lock().unwrap().push(PendingCompletion {
             completion: c.clone(),
-            result: total_written as i32,
+            result: total_written as i64,
         });
         Ok(c)
     }

--- a/testing/differential-oracle/fuzzer/memory/file.rs
+++ b/testing/differential-oracle/fuzzer/memory/file.rs
@@ -66,7 +66,7 @@ impl File for MemorySimFile {
             if read_len > 0 {
                 buf[..read_len].copy_from_slice(&file_buf[offset..][..read_len]);
             }
-            read_len as i32
+            read_len as i64
         };
         c.complete(buf_size);
         Ok(c)
@@ -79,7 +79,7 @@ impl File for MemorySimFile {
         c: Completion,
     ) -> Result<Completion> {
         let written = self.write_buf(buffer.as_slice(), pos as usize);
-        c.complete(written as i32);
+        c.complete(written as i64);
         Ok(c)
     }
 
@@ -103,7 +103,7 @@ impl File for MemorySimFile {
             total_written += written;
         }
 
-        c.complete(total_written as i32);
+        c.complete(total_written as i64);
         Ok(c)
     }
 

--- a/testing/simulator/runner/memory/io.rs
+++ b/testing/simulator/runner/memory/io.rs
@@ -79,7 +79,7 @@ impl Operation {
                             // Keep deterministic behavior for unread tail bytes.
                             buf[to_copy..].fill(0);
                         }
-                        to_copy as i32
+                        to_copy as i64
                     }
                 };
                 completion.complete(bytes_read);
@@ -91,7 +91,7 @@ impl Operation {
             } => {
                 let file = files.get(fd.as_str()).unwrap();
                 let buf_size = file.write_buf(buffer.as_slice(), offset);
-                completion.complete(buf_size as i32);
+                completion.complete(buf_size as i64);
             }
             OperationType::WriteV {
                 buffers,
@@ -108,7 +108,7 @@ impl Operation {
                     pos += buf_size;
                     written + buf_size
                 });
-                completion.complete(written as i32);
+                completion.complete(written as i64);
             }
             OperationType::Sync { completion, .. } => {
                 // There is no Sync for in memory


### PR DESCRIPTION
at least on Mac, trying to pwrite over i32::MAX bytes results in an EINVAL error.

this can happen if a massive single INSERT is done in MVCC mode, causing a >=2GB write to the logical log.

fix by looping in max i32::MAX byte chunks

Closes #5665


TODO: good point here
https://github.com/tursodatabase/turso/pull/5666#pullrequestreview-3867100588 