### PR TITLE
Assert that no two transaction timestamps are ever same

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1053,7 +1053,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
     /// Validates a single version chain against the current transaction's commit timestamp.
     ///
     /// This enforces snapshot-isolation conflict checks for both:
-    /// 1. versions ended by concurrent commits (`end >= tx.begin_ts`), and
+    /// 1. versions ended by concurrent commits (`end > tx.begin_ts`), and
     /// 2. live versions owned by concurrent transactions (state/ts tie-breaking).
     fn check_version_conflicts(
         &self,
@@ -1068,7 +1068,11 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             // committed transaction after our begin timestamp. Even if that
             // version is now "ended", this is still a write-write conflict.
             if let Some(TxTimestampOrID::Timestamp(end_ts)) = version.end {
-                if end_ts >= tx.begin_ts {
+                turso_assert!(
+                    end_ts != tx.begin_ts,
+                    "committed end_ts and begin_ts cannot be equal: txn timestamps are strictly monotonic"
+                );
+                if end_ts > tx.begin_ts {
                     return Err(LimboError::WriteWriteConflict);
                 }
             }
@@ -4843,8 +4847,12 @@ impl RowVersion {
         // Check if this version represents a deletion/update that affects us
         match self.end {
             Some(TxTimestampOrID::Timestamp(end_ts)) => {
-                // Row was deleted at end_ts. If we started at or after end_ts, we shouldn't see it
-                tx.begin_ts >= end_ts
+                // Row was deleted at end_ts. If we started after end_ts, we shouldn't see it
+                turso_assert!(
+                    tx.begin_ts != end_ts,
+                    "begin_ts and committed end_ts cannot be equal: txn timestamps are strictly monotonic"
+                );
+                tx.begin_ts > end_ts
             }
             Some(TxTimestampOrID::TxID(end_tx_id)) => {
                 // Row is being deleted/updated by another transaction
@@ -4954,7 +4962,13 @@ fn is_begin_visible(
     rv: &RowVersion,
 ) -> bool {
     match rv.begin {
-        Some(TxTimestampOrID::Timestamp(rv_begin_ts)) => tx.begin_ts >= rv_begin_ts,
+        Some(TxTimestampOrID::Timestamp(rv_begin_ts)) => {
+            turso_assert!(
+                tx.begin_ts != rv_begin_ts,
+                "begin_ts and committed rv_begin_ts cannot be equal: txn timestamps are strictly monotonic"
+            );
+            tx.begin_ts > rv_begin_ts
+        }
         Some(TxTimestampOrID::TxID(rv_begin)) => {
             let visible = match txs.get(&rv_begin) {
                 Some(tb_entry) => {
@@ -4963,21 +4977,31 @@ fn is_begin_visible(
                         TransactionState::Active => tx.tx_id == tb.tx_id && rv.end.is_none(),
                         TransactionState::Preparing(end_ts) => {
                             // Hekaton Table 1 / Section 2.5: speculative read of TB.
-                            // If begin_ts >= end_ts, the version would be visible once TB
+                            // If begin_ts > end_ts, the version would be visible once TB
                             // commits. Speculatively return true and register a dependency.
                             // Fixes partial commit visibility (Bug #8).
                             turso_assert!(
                                 tx.tx_id != tb.tx_id,
                                 "a txn cannot read its own row versions during prepare"
                             );
-                            if tx.begin_ts >= end_ts {
+                            turso_assert!(
+                                tx.begin_ts != end_ts,
+                                "begin_ts and preparing end_ts cannot be equal: txn timestamps are strictly monotonic"
+                            );
+                            if tx.begin_ts > end_ts {
                                 register_commit_dependency(txs, tx, rv_begin);
                                 true
                             } else {
                                 false
                             }
                         }
-                        TransactionState::Committed(committed_ts) => tx.begin_ts >= committed_ts,
+                        TransactionState::Committed(committed_ts) => {
+                            turso_assert!(
+                                tx.begin_ts != committed_ts,
+                                "begin_ts and committed_ts cannot be equal: txn timestamps are strictly monotonic"
+                            );
+                            tx.begin_ts > committed_ts
+                        }
                         TransactionState::Aborted => false,
                         TransactionState::Terminated => {
                             tracing::debug!(
@@ -4994,7 +5018,13 @@ fn is_begin_visible(
                     visible
                 }
                 None => match lookup_finalized_tx_state(finalized_tx_states, rv_begin) {
-                    Some(TransactionState::Committed(committed_ts)) => tx.begin_ts >= committed_ts,
+                    Some(TransactionState::Committed(committed_ts)) => {
+                        turso_assert!(
+                            tx.begin_ts != committed_ts,
+                            "begin_ts and committed_ts cannot be equal: txn timestamps are strictly monotonic"
+                        );
+                        tx.begin_ts > committed_ts
+                    }
                     Some(TransactionState::Aborted) | Some(TransactionState::Terminated) => false,
                     Some(TransactionState::Active) | Some(TransactionState::Preparing(_)) => {
                         unreachable!(
@@ -5033,7 +5063,7 @@ fn is_end_visible(
                         // transaction can see a row version if the end is a TXId only if it isn't the same transaction.
                         // Source: https://avi.im/blag/2023/hekaton-paper-typo/
                         TransactionState::Active => current_tx.tx_id != other_tx.tx_id,
-                        // Hekaton Table 2: speculative ignore of TE. If end_ts <= begin_ts,
+                        // Hekaton Table 2: speculative ignore of TE. If end_ts < begin_ts,
                         // we speculatively ignore V (treat deletion as committed). Register a
                         // dependency in case TE aborts (then V should have been visible).
                         TransactionState::Preparing(end_ts) => {


### PR DESCRIPTION
## Description

For txn operations, we use monotonic clock. So no two transactions can ever have same timestamp. 

This patch:

1. Updates all the existing conditions, to strictly do greater than/lesser than comparisons. This is a bugfix.
2. Assert that they are not same in all the call sites

Following are going to be always different: txn's `begin_ts`, txn's `end_ts` with each other and everyone else
 