### PR TITLE
properly scope table references when binding

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -12,7 +12,7 @@ use crate::{
     translate::{
         emitter::Resolver,
         expr::{rewrite_between_expr, translate_expr, walk_expr, walk_expr_mut, WalkControl},
-        plan::{ColumnUsedMask, OuterQueryReference, TableReferences},
+        plan::{ColumnUsedMask, OuterQueryReference, TableReference, TableReferences},
     },
     util::{check_expr_references_column, normalize_ident, parse_numeric_literal},
     vdbe::{
@@ -582,7 +582,10 @@ pub fn translate_alter_table(
                     let mut table_references = TableReferences::new(
                         vec![],
                         vec![OuterQueryReference {
-                            identifier: table_name.to_string(),
+                            reference: TableReference::unaliased(
+                                table_name.to_string(),
+                                database_id,
+                            ),
                             internal_id: TableInternalId::from(0),
                             table: Table::BTree(Arc::new(btree.clone())),
                             col_used_mask: ColumnUsedMask::default(),

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -183,7 +183,9 @@ mod tests {
 
     use crate::{
         schema::{BTreeTable, ColDef, Column, Table, Type},
-        translate::plan::{ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan},
+        translate::plan::{
+            ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReference,
+        },
     };
 
     use super::*;
@@ -488,8 +490,7 @@ mod tests {
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
-            identifier: "foo".to_string(),
+            reference: TableReference::unaliased("foo", 0),
             internal_id: TableInternalId::from(1),
             join_info: None,
             table,
@@ -512,8 +513,7 @@ mod tests {
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
-            identifier: "t1".to_string(),
+            reference: TableReference::unaliased("t1", 0),
             internal_id: TableInternalId::from(1),
             join_info: None,
             table: Table::BTree(Arc::new(BTreeTable {
@@ -546,8 +546,7 @@ mod tests {
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
-            identifier: "t2".to_string(),
+            reference: TableReference::unaliased("t2", 0),
             internal_id: TableInternalId::from(2),
             join_info: None,
             table: Table::BTree(Arc::new(BTreeTable {
@@ -587,8 +586,7 @@ mod tests {
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
-            identifier: "bar".to_string(),
+            reference: TableReference::unaliased("bar", 0),
             internal_id: TableInternalId::from(1),
             join_info: None,
             table: Table::BTree(Arc::new(BTreeTable {

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -195,7 +195,6 @@ pub fn prepare_delete_plan(
     parse_where(
         where_clause.as_deref(),
         &mut table_references,
-        None,
         &mut where_predicates,
         resolver,
     )?;

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -18,7 +18,7 @@ use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
 use crate::Result;
 use turso_parser::ast::{Expr, Limit, QualifiedName, ResultColumn, TriggerEvent, With};
 
-use super::plan::{ColumnUsedMask, JoinedTable, TableReferences, WhereTerm};
+use super::plan::{ColumnUsedMask, JoinedTable, TableReference, TableReferences, WhereTerm};
 
 #[allow(clippy::too_many_arguments)]
 pub fn translate_delete(
@@ -177,13 +177,12 @@ pub fn prepare_delete_plan(
     let joined_tables = vec![JoinedTable {
         op: Operation::default_scan_for(&table),
         table,
-        identifier: tbl_name,
+        reference: TableReference::unaliased(tbl_name, database_id),
         internal_id: program.table_reference_counter.next(),
         join_info: None,
         col_used_mask: ColumnUsedMask::default(),
         column_use_counts: Vec::new(),
         expression_index_usages: Vec::new(),
-        database_id,
     }];
     let mut table_references = TableReferences::new(joined_tables, vec![]);
 

--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -94,11 +94,7 @@ impl Display for SelectPlan {
 
             match &reference.op {
                 Operation::Scan(scan) => {
-                    let table_name = if reference.table.get_name() == reference.identifier {
-                        reference.identifier.clone()
-                    } else {
-                        format!("{} AS {}", reference.table.get_name(), reference.identifier)
-                    };
+                    let table_name = reference.reference.display_name();
 
                     match scan {
                         Scan::BTreeTable { index, .. } => {
@@ -130,7 +126,8 @@ impl Display for SelectPlan {
                         writeln!(
                             f,
                             "{}SEARCH {} USING INTEGER PRIMARY KEY (rowid=?)",
-                            indent, reference.identifier
+                            indent,
+                            reference.reference.lookup_name()
                         )?;
                     }
                     Search::Seek {
@@ -139,7 +136,9 @@ impl Display for SelectPlan {
                         writeln!(
                             f,
                             "{}SEARCH {} USING INDEX {}",
-                            indent, reference.identifier, index.name
+                            indent,
+                            reference.reference.lookup_name(),
+                            index.name
                         )?;
                     }
                 },
@@ -173,7 +172,7 @@ impl Display for SelectPlan {
                     writeln!(
                         f,
                         "{indent}{op_name} {} ({}) ",
-                        reference.identifier,
+                        reference.reference.lookup_name(),
                         index_names.join(", ")
                     )?;
                 }
@@ -193,11 +192,7 @@ impl Display for DeletePlan {
 
             match &reference.op {
                 Operation::Scan(scan) => {
-                    let table_name = if reference.table.get_name() == reference.identifier {
-                        reference.identifier.clone()
-                    } else {
-                        format!("{} AS {}", reference.table.get_name(), reference.identifier)
-                    };
+                    let table_name = reference.reference.display_name();
 
                     match scan {
                         Scan::BTreeTable { index, .. } => {
@@ -229,7 +224,8 @@ impl Display for DeletePlan {
                         writeln!(
                             f,
                             "{}SEARCH {} USING INTEGER PRIMARY KEY (rowid=?)",
-                            indent, reference.identifier
+                            indent,
+                            reference.reference.lookup_name()
                         )?;
                     }
                     Search::Seek {
@@ -238,7 +234,9 @@ impl Display for DeletePlan {
                         writeln!(
                             f,
                             "{}SEARCH {} USING INDEX {}",
-                            indent, reference.identifier, index.name
+                            indent,
+                            reference.reference.lookup_name(),
+                            index.name
                         )?;
                     }
                 },
@@ -272,7 +270,7 @@ impl Display for DeletePlan {
                     writeln!(
                         f,
                         "{indent}{op_name} {} ({})",
-                        reference.identifier,
+                        reference.reference.lookup_name(),
                         index_names.join(", ")
                     )?;
                 }
@@ -300,11 +298,7 @@ impl fmt::Display for UpdatePlan {
 
             match &reference.op {
                 Operation::Scan(scan) => {
-                    let table_name = if reference.table.get_name() == reference.identifier {
-                        reference.identifier.clone()
-                    } else {
-                        format!("{} AS {}", reference.table.get_name(), reference.identifier)
-                    };
+                    let table_name = reference.reference.display_name();
 
                     match scan {
                         Scan::BTreeTable { index, .. } => {
@@ -341,7 +335,8 @@ impl fmt::Display for UpdatePlan {
                         writeln!(
                             f,
                             "{}SEARCH {} USING INTEGER PRIMARY KEY (rowid=?)",
-                            indent, reference.identifier
+                            indent,
+                            reference.reference.lookup_name()
                         )?;
                     }
                     Search::Seek {
@@ -350,7 +345,9 @@ impl fmt::Display for UpdatePlan {
                         writeln!(
                             f,
                             "{}SEARCH {} USING INDEX {}",
-                            indent, reference.identifier, index.name
+                            indent,
+                            reference.reference.lookup_name(),
+                            index.name
                         )?;
                     }
                 },
@@ -422,9 +419,9 @@ impl ToSqlContext for PlanContext<'_> {
         let joined_table = table_ref.find_joined_table_by_internal_id(id);
         let outer_query = table_ref.find_outer_query_ref_by_internal_id(id);
         match (joined_table, outer_query) {
-            (Some(table), None) => Some(&table.identifier),
-            (None, Some(table)) => Some(&table.identifier),
-            (Some(table), Some(_)) => Some(&table.identifier),
+            (Some(table), None) => Some(table.reference.lookup_name()),
+            (None, Some(table)) => Some(table.reference.lookup_name()),
+            (Some(table), Some(_)) => Some(table.reference.lookup_name()),
             (None, None) => unreachable!(),
         }
     }
@@ -507,11 +504,11 @@ impl ToTokens for JoinedTable {
     ) -> Result<(), S::Error> {
         match &self.table {
             Table::BTree(..) | Table::Virtual(..) => {
-                let name = self.table.get_name();
+                let name = self.reference.table_name.as_ref();
                 s.append(TokenType::TK_ID, Some(name))?;
-                if self.identifier != name {
+                if let Some(alias) = &self.reference.alias {
                     s.append(TokenType::TK_AS, None)?;
-                    s.append(TokenType::TK_ID, Some(&self.identifier))?;
+                    s.append(TokenType::TK_ID, Some(alias.as_ref()))?;
                 }
             }
             Table::FromClauseSubquery(from_clause_subquery) => {
@@ -521,7 +518,7 @@ impl ToTokens for JoinedTable {
                 s.append(TokenType::TK_RP, None)?;
 
                 s.append(TokenType::TK_AS, None)?;
-                s.append(TokenType::TK_ID, Some(&self.identifier))?;
+                s.append(TokenType::TK_ID, Some(self.reference.lookup_name()))?;
             }
         };
 

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -49,7 +49,7 @@ use crate::translate::fkeys::{
 };
 use crate::translate::plan::{
     DeletePlan, EphemeralRowidMode, EvalAt, IndexMethodQuery, JoinedTable, NonFromClauseSubquery,
-    Plan, QueryDestination, ResultSetColumn, Search,
+    Plan, QueryDestination, ResultSetColumn, Search, TableReference,
 };
 use crate::translate::planner::ROWID_STRS;
 use crate::translate::planner::{table_mask_from_expr, TableMask};
@@ -712,15 +712,7 @@ fn emit_materialized_build_inputs(
     // Now we emit each of the materialization subplans into an ephemeral table.
     for spec in materializations.iter() {
         let build_table = &plan.table_references.joined_tables()[spec.build_table_idx];
-        let build_table_name = if build_table.table.get_name() == build_table.identifier {
-            build_table.identifier.clone()
-        } else {
-            format!(
-                "{} AS {}",
-                build_table.table.get_name(),
-                build_table.identifier
-            )
-        };
+        let build_table_name = build_table.reference.display_name();
         let internal_id = program.table_reference_counter.next();
         let columns = match &spec.mode {
             MaterializedBuildInputMode::RowidOnly => vec![build_rowid_column()],
@@ -1605,13 +1597,14 @@ fn emit_program_for_delete(
             program.emit_insn(Insn::OpenWrite {
                 cursor_id: table_cursor_id,
                 root_page: RegisterOrLiteral::Literal(btree_table.root_page),
-                db: table_ref.database_id,
+                db: table_ref.reference.database_id,
             });
 
             // Open all indexes for writing (needed for DELETE)
-            let write_indices: Vec<_> = resolver.with_schema(table_ref.database_id, |s| {
-                s.get_indices(table_ref.table.get_name()).cloned().collect()
-            });
+            let write_indices: Vec<_> = resolver
+                .with_schema(table_ref.reference.database_id, |s| {
+                    s.get_indices(table_ref.table.get_name()).cloned().collect()
+                });
             for index in &write_indices {
                 let index_cursor_id = program.alloc_cursor_index(
                     Some(CursorKey::index(table_ref.internal_id, index.clone())),
@@ -1620,7 +1613,7 @@ fn emit_program_for_delete(
                 program.emit_insn(Insn::OpenWrite {
                     cursor_id: index_cursor_id,
                     root_page: RegisterOrLiteral::Literal(index.root_page),
-                    db: table_ref.database_id,
+                    db: table_ref.reference.database_id,
                 });
             }
         }
@@ -1899,7 +1892,7 @@ fn emit_delete_insns<'a>(
         }
     };
     let btree_table = unsafe { &*table_reference }.btree();
-    let database_id = unsafe { (*table_reference).database_id };
+    let database_id = unsafe { (*table_reference).reference.database_id };
     let main_table_cursor_id = program.resolve_cursor_id(&CursorKey::table(internal_id));
     let has_returning = !result_columns.is_empty();
     let has_delete_triggers = if let Some(btree_table) = btree_table {
@@ -2049,7 +2042,7 @@ fn emit_delete_row_common(
     // Phase 1: Before Delete - build parent key registers and handle NoAction/Restrict.
     // CASCADE/SetNull/SetDefault actions are prepared but deferred until after Delete.
     let prepared_fk_actions = if connection.foreign_keys_enabled() {
-        let delete_db_id = unsafe { (*table_reference).database_id };
+        let delete_db_id = unsafe { (*table_reference).reference.database_id };
         if let Some(table) = unsafe { &*table_reference }.btree() {
             let prepared = if t_ctx
                 .resolver
@@ -2100,7 +2093,7 @@ fn emit_delete_row_common(
         });
     } else {
         // Delete from all indexes before deleting from the main table.
-        let db_id = unsafe { (*table_reference).database_id };
+        let db_id = unsafe { (*table_reference).reference.database_id };
         let all_indices: Vec<_> = t_ctx
             .resolver
             .with_schema(db_id, |s| s.get_indices(table_name).cloned().collect());
@@ -2230,7 +2223,7 @@ fn emit_delete_row_common(
     // Per SQLite docs, the parent row must be deleted before FK cascade actions fire,
     // so triggers during cascade see the parent row as already deleted.
     {
-        let delete_db_id = unsafe { (*table_reference).database_id };
+        let delete_db_id = unsafe { (*table_reference).reference.database_id };
         prepared_fk_actions.fire_prepared_fk_delete_actions(
             program,
             &mut t_ctx.resolver,
@@ -2274,7 +2267,7 @@ fn emit_delete_insns_when_triggers_present(
         return Err(crate::LimboError::ReadOnly);
     }
     let btree_table = unsafe { &*table_reference }.btree();
-    let database_id = unsafe { (*table_reference).database_id };
+    let database_id = unsafe { (*table_reference).reference.database_id };
     let has_returning = !result_columns.is_empty();
     let has_delete_triggers = if let Some(btree_table) = btree_table {
         t_ctx.resolver.with_schema(database_id, |s| {
@@ -2593,10 +2586,10 @@ fn emit_program_for_update(
     )?;
 
     // Prepare index cursors
-    // Use target_table.database_id because in the PrebuiltEphemeralTable case,
+    // Use target_table.reference.database_id because in the PrebuiltEphemeralTable case,
     // plan.table_references contains the ephemeral table (database_id=0),
     // not the actual target table.
-    let target_database_id = target_table.database_id;
+    let target_database_id = target_table.reference.database_id;
     let mut index_cursors = Vec::with_capacity(plan.indexes_to_update.len());
     for index in &plan.indexes_to_update {
         let index_cursor = if let Some(cursor) = program.resolve_cursor_id_safe(&CursorKey::index(
@@ -3229,7 +3222,7 @@ fn emit_update_insns<'a>(
     }
 
     // Fire BEFORE UPDATE triggers and preserve old_registers for AFTER triggers
-    let update_database_id = target_table.database_id;
+    let update_database_id = target_table.reference.database_id;
     let preserved_old_registers: Option<Vec<usize>> = if let Some(btree_table) =
         target_table.table.btree()
     {
@@ -4365,7 +4358,7 @@ fn emit_update_insns<'a>(
             } else {
                 InsertFlags::new().skip_last_rowid()
             },
-            table_name: target_table.identifier.clone(),
+            table_name: target_table.reference.lookup_name().to_string(),
         });
 
         // Fire FK CASCADE/SET NULL actions AFTER the parent row is updated
@@ -5368,7 +5361,10 @@ fn emit_check_constraint_bytecode(
             if let Some(joined_table) = binding_tables.joined_tables_mut().first_mut() {
                 // CHECK expressions come from schema SQL and may use the base table name
                 // even when the query references the table through an alias.
-                joined_table.identifier = table_name.to_string();
+                joined_table.reference = TableReference::unaliased(
+                    table_name.to_string(),
+                    joined_table.reference.database_id,
+                );
             }
             let mut scope = FullTableScope::new(&mut binding_tables);
             bind_and_rewrite_expr(&mut rewritten_expr, &mut scope, resolver, false)?;

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -39,7 +39,7 @@ use crate::schema::{
 use crate::translate::compound_select::emit_program_for_compound_select;
 use crate::translate::expr::{
     bind_and_rewrite_expr, emit_returning_results, emit_returning_scan_back, rewrite_between_expr,
-    translate_expr_no_constant_opt, walk_expr, walk_expr_mut, BindingBehavior, NoConstantOptReason,
+    translate_expr_no_constant_opt, walk_expr, walk_expr_mut, NoConstantOptReason,
     ReturningBufferCtx, WalkControl,
 };
 use crate::translate::fkeys::{
@@ -53,6 +53,7 @@ use crate::translate::plan::{
 };
 use crate::translate::planner::ROWID_STRS;
 use crate::translate::planner::{table_mask_from_expr, TableMask};
+use crate::translate::scope::FullTableScope;
 use crate::translate::subquery::emit_non_from_clause_subquery;
 use crate::translate::trigger_exec::{
     fire_trigger, get_relevant_triggers_type_and_time, has_relevant_triggers_type_only,
@@ -5272,13 +5273,8 @@ fn emit_index_column_value_old_image(
 ) -> Result<()> {
     if let Some(expr) = &idx_col.expr {
         let mut expr = expr.as_ref().clone();
-        bind_and_rewrite_expr(
-            &mut expr,
-            Some(table_references),
-            None,
-            resolver,
-            BindingBehavior::ResultColumnsNotAllowed,
-        )?;
+        let mut scope = FullTableScope::new(table_references);
+        bind_and_rewrite_expr(&mut expr, &mut scope, resolver, false)?;
         translate_expr_no_constant_opt(
             program,
             Some(table_references),
@@ -5374,13 +5370,8 @@ fn emit_check_constraint_bytecode(
                 // even when the query references the table through an alias.
                 joined_table.identifier = table_name.to_string();
             }
-            bind_and_rewrite_expr(
-                &mut rewritten_expr,
-                Some(&mut binding_tables),
-                None,
-                resolver,
-                BindingBehavior::ResultColumnsNotAllowed,
-            )?;
+            let mut scope = FullTableScope::new(&mut binding_tables);
+            bind_and_rewrite_expr(&mut rewritten_expr, &mut scope, resolver, false)?;
         }
 
         translate_expr_no_constant_opt(

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5620,8 +5620,8 @@ pub fn process_returning_clause(
     let mut result_columns = Vec::with_capacity(returning.len());
 
     let alias_to_string = |alias: &ast::As| match alias {
-        ast::As::Elided(alias) => alias.as_str().to_string(),
-        ast::As::As(alias) => alias.as_str().to_string(),
+        ast::As::Elided(alias) => alias.as_str().into(),
+        ast::As::As(alias) => alias.as_str().into(),
     };
 
     for rc in returning.iter_mut() {
@@ -5663,7 +5663,7 @@ pub fn process_returning_clause(
 
                     result_columns.push(ResultSetColumn {
                         expr: column_expr,
-                        alias: column.name.clone(),
+                        alias: column.name.clone().map(Into::into),
                         contains_aggregates: false,
                     });
                 }

--- a/core/translate/expression_index.rs
+++ b/core/translate/expression_index.rs
@@ -96,7 +96,8 @@ pub fn expression_index_column_usage(
     let mut bound_expr = expr.clone();
     let mut binding_table = table_reference.clone();
     if let Some(btree_table) = binding_table.table.btree() {
-        binding_table.identifier.clone_from(&btree_table.name);
+        binding_table.reference.table_name = btree_table.name.clone().into();
+        binding_table.reference.alias = None;
     }
     let mut binding_tables = TableReferences::new(vec![binding_table], vec![]);
     let mut scope = FullTableScope::new(&mut binding_tables);

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -17,7 +17,8 @@ use crate::translate::expr::{
 };
 use crate::translate::insert::format_unique_violation_desc;
 use crate::translate::plan::{
-    ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReferences,
+    ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReference,
+    TableReferences,
 };
 use crate::translate::scope::FullTableScope;
 use crate::vdbe::builder::{CursorKey, ProgramBuilderOpts};
@@ -217,13 +218,12 @@ pub fn translate_create_index(
                 index: None,
             }),
             table: Table::BTree(tbl.clone()),
-            identifier: tbl_name.clone(),
+            reference: TableReference::unaliased(tbl_name.clone(), 0),
             internal_id: table_ref,
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
         }],
         vec![],
     );

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         plan::{
             ColumnUsedMask, EvalAt, JoinedTable, Operation, QueryDestination, ResultSetColumn,
-            TableReferences,
+            TableReference, TableReferences,
         },
         planner::{plan_ctes_as_outer_refs, ROWID_STRS},
         scope::{EmptyScope, FullTableScope},
@@ -320,14 +320,13 @@ pub fn translate_insert(
                     .btree()
                     .expect("we shouldn't have got here without a BTree table"),
             ),
-            identifier: table_name.to_string(),
+            reference: TableReference::unaliased(normalize_ident(table_name.as_str()), database_id),
             internal_id: program.table_reference_counter.next(),
             op: Operation::default_scan_for(&table),
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id,
         }],
         vec![],
     );

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -4,9 +4,10 @@ use crate::{
         emitter::Resolver,
         expr::{
             bind_and_rewrite_expr, translate_condition_expr, translate_expr_no_constant_opt,
-            BindingBehavior, ConditionMetadata, NoConstantOptReason,
+            ConditionMetadata, NoConstantOptReason,
         },
         plan::{ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReferences},
+        scope::FullTableScope,
     },
     vdbe::{
         builder::{CursorKey, CursorType, ProgramBuilder},
@@ -114,13 +115,8 @@ fn bind_expr_for_table(
     resolver: &Resolver,
 ) -> crate::Result<ast::Expr> {
     let mut out = expr.clone();
-    bind_and_rewrite_expr(
-        &mut out,
-        Some(table_references),
-        None,
-        resolver,
-        BindingBehavior::ResultColumnsNotAllowed,
-    )?;
+    let mut scope = FullTableScope::new(table_references);
+    bind_and_rewrite_expr(&mut out, &mut scope, resolver, false)?;
     Ok(out)
 }
 

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -6,7 +6,10 @@ use crate::{
             bind_and_rewrite_expr, translate_condition_expr, translate_expr_no_constant_opt,
             ConditionMetadata, NoConstantOptReason,
         },
-        plan::{ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReferences},
+        plan::{
+            ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan, TableReference,
+            TableReferences,
+        },
         scope::FullTableScope,
     },
     vdbe::{
@@ -216,13 +219,12 @@ fn translate_integrity_check_impl(
                     index: None,
                 }),
                 table: Table::BTree(btree_table.clone()),
-                identifier: btree_table.name.clone(),
+                reference: TableReference::unaliased(btree_table.name.clone(), database_id),
                 internal_id: table_ref_id,
                 join_info: None,
                 col_used_mask: ColumnUsedMask::default(),
                 column_use_counts: Vec::new(),
                 expression_index_usages: Vec::new(),
-                database_id,
             }],
             vec![],
         );

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -210,11 +210,11 @@ pub fn init_loop(
             continue;
         }
         // Ensure attached databases have a Transaction instruction for read access
-        if crate::is_attached_db(table.database_id) {
+        if crate::is_attached_db(table.reference.database_id) {
             let schema_cookie = t_ctx
                 .resolver
-                .with_schema(table.database_id, |s| s.schema_version);
-            program.begin_read_on_database(table.database_id, schema_cookie);
+                .with_schema(table.reference.database_id, |s| s.schema_version);
+            program.begin_read_on_database(table.reference.database_id, schema_cookie);
         }
         // Initialize bookkeeping for OUTER JOIN
         if let Some(join_info) = table.join_info.as_ref() {
@@ -256,14 +256,14 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenRead {
                             cursor_id,
                             root_page,
-                            db: table.database_id,
+                            db: table.reference.database_id,
                         });
                     }
                     if let Some(index_cursor_id) = index_cursor_id {
                         program.emit_insn(Insn::OpenRead {
                             cursor_id: index_cursor_id,
                             root_page: index.as_ref().unwrap().root_page,
-                            db: table.database_id,
+                            db: table.reference.database_id,
                         });
                     }
                 }
@@ -273,19 +273,21 @@ pub fn init_loop(
                         cursor_id: table_cursor_id
                             .expect("table cursor is always opened in OperationMode::DELETE"),
                         root_page: root_page.into(),
-                        db: table.database_id,
+                        db: table.reference.database_id,
                     });
                     if let Some(index_cursor_id) = index_cursor_id {
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id: index_cursor_id,
                             root_page: index.as_ref().unwrap().root_page.into(),
-                            db: table.database_id,
+                            db: table.reference.database_id,
                         });
                     }
                     // For delete, we need to open all the other indexes too for writing
-                    let indices: Vec<_> = t_ctx.resolver.with_schema(table.database_id, |s| {
-                        s.get_indices(table.table.get_name()).cloned().collect()
-                    });
+                    let indices: Vec<_> = t_ctx
+                        .resolver
+                        .with_schema(table.reference.database_id, |s| {
+                            s.get_indices(table.table.get_name()).cloned().collect()
+                        });
                     for index in &indices {
                         if table
                             .op
@@ -301,7 +303,7 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id,
                             root_page: index.root_page.into(),
-                            db: table.database_id,
+                            db: table.reference.database_id,
                         });
                     }
                 }
@@ -314,7 +316,7 @@ pub fn init_loop(
                                     "table cursor is always opened in OperationMode::UPDATE",
                                 ),
                                 root_page: root_page.into(),
-                                db: table.database_id,
+                                db: table.reference.database_id,
                             });
                         }
                         UpdateRowSource::PrebuiltEphemeralTable { target_table, .. } => {
@@ -323,15 +325,15 @@ pub fn init_loop(
                             program.emit_insn(Insn::OpenWrite {
                                 cursor_id: target_table_cursor_id,
                                 root_page: target_table.btree().unwrap().root_page.into(),
-                                db: target_table.database_id,
+                                db: target_table.reference.database_id,
                             });
                         }
                     }
                     let write_db_id = match &update_mode {
                         UpdateRowSource::PrebuiltEphemeralTable { target_table, .. } => {
-                            target_table.database_id
+                            target_table.reference.database_id
                         }
-                        _ => table.database_id,
+                        _ => table.reference.database_id,
                     };
                     if let Some(index_cursor_id) = index_cursor_id {
                         program.emit_insn(Insn::OpenWrite {
@@ -380,7 +382,7 @@ pub fn init_loop(
                             program.emit_insn(Insn::OpenRead {
                                 cursor_id: table_cursor_id,
                                 root_page: table.table.get_root_page()?,
-                                db: table.database_id,
+                                db: table.reference.database_id,
                             });
                         }
                     }
@@ -392,14 +394,15 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id: table_cursor_id,
                             root_page: table.table.get_root_page()?.into(),
-                            db: table.database_id,
+                            db: table.reference.database_id,
                         });
 
                         // For DELETE, we need to open all the indexes for writing
                         // UPDATE opens these in emit_program_for_update() separately
                         if matches!(mode, OperationMode::DELETE) {
-                            let indices: Vec<_> =
-                                t_ctx.resolver.with_schema(table.database_id, |s| {
+                            let indices: Vec<_> = t_ctx
+                                .resolver
+                                .with_schema(table.reference.database_id, |s| {
                                     s.get_indices(table.table.get_name()).cloned().collect()
                                 });
                             for index in &indices {
@@ -417,7 +420,7 @@ pub fn init_loop(
                                 program.emit_insn(Insn::OpenWrite {
                                     cursor_id,
                                     root_page: index.root_page.into(),
-                                    db: table.database_id,
+                                    db: table.reference.database_id,
                                 });
                             }
                         }
@@ -441,7 +444,7 @@ pub fn init_loop(
                                     cursor_id: index_cursor_id
                                         .expect("index cursor is always opened in Seek with index"),
                                     root_page: index.root_page,
-                                    db: table.database_id,
+                                    db: table.reference.database_id,
                                 });
                             }
                             OperationMode::UPDATE { .. } | OperationMode::DELETE => {
@@ -449,7 +452,7 @@ pub fn init_loop(
                                     cursor_id: index_cursor_id
                                         .expect("index cursor is always opened in Seek with index"),
                                     root_page: index.root_page.into(),
-                                    db: table.database_id,
+                                    db: table.reference.database_id,
                                 });
                             }
                             _ => {
@@ -468,14 +471,14 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenRead {
                             cursor_id: table_cursor_id,
                             root_page: table.table.get_root_page()?,
-                            db: table.database_id,
+                            db: table.reference.database_id,
                         });
                     }
                     let index_cursor_id = index_cursor_id.unwrap();
                     program.emit_insn(Insn::OpenRead {
                         cursor_id: index_cursor_id,
                         root_page: table.op.index().unwrap().root_page,
-                        db: table.database_id,
+                        db: table.reference.database_id,
                     });
                 }
                 OperationMode::DELETE => {
@@ -483,18 +486,20 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id: table_cursor_id,
                             root_page: table.table.get_root_page()?.into(),
-                            db: table.database_id,
+                            db: table.reference.database_id,
                         });
                     }
                     let index_cursor_id = index_cursor_id.expect("index cursor is always opened in OperationMode::DELETE for IndexMethodQuery");
                     program.emit_insn(Insn::OpenWrite {
                         cursor_id: index_cursor_id,
                         root_page: table.op.index().expect("index to exist").root_page.into(),
-                        db: table.database_id,
+                        db: table.reference.database_id,
                     });
-                    let indices: Vec<_> = t_ctx.resolver.with_schema(table.database_id, |s| {
-                        s.get_indices(table.table.get_name()).cloned().collect()
-                    });
+                    let indices: Vec<_> = t_ctx
+                        .resolver
+                        .with_schema(table.reference.database_id, |s| {
+                            s.get_indices(table.table.get_name()).cloned().collect()
+                        });
                     for index in &indices {
                         if table
                             .op
@@ -510,7 +515,7 @@ pub fn init_loop(
                         program.emit_insn(Insn::OpenWrite {
                             cursor_id,
                             root_page: index.root_page.into(),
-                            db: table.database_id,
+                            db: table.reference.database_id,
                         });
                     }
                 }
@@ -521,13 +526,13 @@ pub fn init_loop(
                     program.emit_insn(Insn::OpenWrite {
                         cursor_id: table_cursor_id,
                         root_page: table.table.get_root_page()?.into(),
-                        db: table.database_id,
+                        db: table.reference.database_id,
                     });
                     let index_cursor_id = index_cursor_id.unwrap();
                     program.emit_insn(Insn::OpenWrite {
                         cursor_id: index_cursor_id,
                         root_page: table.op.index().expect("index to exist").root_page.into(),
-                        db: table.database_id,
+                        db: table.reference.database_id,
                     });
                 }
                 _ => panic!("Unsupported operation mode for index method"),
@@ -543,7 +548,7 @@ pub fn init_loop(
                             program.emit_insn(Insn::OpenRead {
                                 cursor_id: table_cursor_id,
                                 root_page: btree.root_page,
-                                db: table.database_id,
+                                db: table.reference.database_id,
                             });
                         }
                     }
@@ -561,7 +566,7 @@ pub fn init_loop(
                             program.emit_insn(Insn::OpenRead {
                                 cursor_id: table_cursor_id,
                                 root_page: btree.root_page,
-                                db: table.database_id,
+                                db: table.reference.database_id,
                             });
                         }
                         // Open cursors for each index branch
@@ -574,7 +579,7 @@ pub fn init_loop(
                                 program.emit_insn(Insn::OpenRead {
                                     cursor_id: branch_cursor_id,
                                     root_page: index.root_page,
-                                    db: table.database_id,
+                                    db: table.reference.database_id,
                                 });
                             }
                         }
@@ -836,7 +841,7 @@ fn emit_hash_build_phase(
         program.emit_insn(Insn::OpenRead {
             cursor_id: hash_build_cursor_id,
             root_page: btree.root_page,
-            db: build_table.database_id,
+            db: build_table.reference.database_id,
         });
     }
 
@@ -1618,7 +1623,7 @@ pub fn open_loop(
                     program.emit_insn(Insn::OpenRead {
                         cursor_id,
                         root_page: btree.root_page,
-                        db: build_table.database_id,
+                        db: build_table.reference.database_id,
                     });
                     cursor_id
                 };

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod pragma;
 pub(crate) mod result_row;
 pub(crate) mod rollback;
 pub(crate) mod schema;
+pub(crate) mod scope;
 pub(crate) mod select;
 pub(crate) mod subquery;
 pub(crate) mod transaction;

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -15,6 +15,8 @@ use super::{
     order::OrderTarget,
     IndexMethodCandidate,
 };
+#[cfg(test)]
+use crate::translate::plan::TableReference;
 use crate::{
     schema::{Index, Schema},
     stats::AnalyzeStats,
@@ -2831,12 +2833,11 @@ mod tests {
             op: Operation::default_scan_for(&table),
             table,
             internal_id: table_id_counter.next(),
-            identifier: "t1".to_string(),
+            reference: TableReference::unaliased("t1", 0),
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
         });
 
         // Create where clause that only references second column
@@ -2946,12 +2947,11 @@ mod tests {
             op: Operation::default_scan_for(&table),
             table,
             internal_id: table_id_counter.next(),
-            identifier: "t1".to_string(),
+            reference: TableReference::unaliased("t1", 0),
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
         });
 
         // Create where clause that references first and third columns
@@ -3081,12 +3081,11 @@ mod tests {
             op: Operation::default_scan_for(&table),
             table,
             internal_id: table_id_counter.next(),
-            identifier: "t1".to_string(),
+            reference: TableReference::unaliased("t1", 0),
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
         });
 
         // Create where clause: c1 = 5 AND c2 > 10 AND c3 = 7
@@ -3246,13 +3245,12 @@ mod tests {
         JoinedTable {
             op: Operation::default_scan_for(&table),
             table,
-            identifier: name,
+            reference: TableReference::unaliased(name, 0),
             internal_id,
             join_info,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
         }
     }
 

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         plan::{
             ColumnUsedMask, DmlSafetyReason, EphemeralRowidMode, HashJoinOp, IndexMethodQuery,
             NonFromClauseSubquery, OuterQueryReference, QueryDestination, ResultSetColumn, Scan,
-            SeekKeyComponent, SubqueryState,
+            SeekKeyComponent, SubqueryState, TableReference,
         },
         trigger_exec::has_relevant_triggers_type_only,
     },
@@ -667,7 +667,7 @@ fn first_update_safety_reason(
 
         // Check if there are UPDATE triggers
         let updated_cols: HashSet<usize> = plan.set_clauses.iter().map(|(i, _)| *i).collect();
-        let database_id = table_ref.database_id;
+        let database_id = table_ref.reference.database_id;
         if resolver.with_schema(database_id, |s| {
             has_relevant_triggers_type_only(
                 s,
@@ -791,7 +791,7 @@ fn add_ephemeral_table_to_update_plan(
     let table_references_update = TableReferences::new(
         vec![JoinedTable {
             table: Table::BTree(ephemeral_table.clone()),
-            identifier: "ephemeral_scratch".to_string(),
+            reference: TableReference::unaliased("ephemeral_scratch", 0),
             internal_id,
             op: Operation::Scan(Scan::BTreeTable {
                 iter_dir: IterationDirection::Forwards,
@@ -801,7 +801,6 @@ fn add_ephemeral_table_to_update_plan(
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
         }],
         vec![],
     );
@@ -815,7 +814,7 @@ fn add_ephemeral_table_to_update_plan(
         // The update loop needs to reference columns from the original source table, so we add it as an outer query reference.
         plan.table_references
             .add_outer_query_reference(OuterQueryReference {
-                identifier: table.identifier.clone(),
+                reference: table.reference.clone(),
                 internal_id: table.internal_id,
                 table: table.table.clone(),
                 col_used_mask: table.col_used_mask.clone(),

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -56,7 +56,7 @@ fn infer_type_from_expr(
 #[derive(Debug, Clone)]
 pub struct ResultSetColumn {
     pub expr: ast::Expr,
-    pub alias: Option<String>,
+    pub alias: Option<Arc<str>>,
     // TODO: encode which aggregates (e.g. index bitmask of plan.aggregates) are present in this column
     pub contains_aggregates: bool,
 }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -777,6 +777,70 @@ impl JoinInfo {
     }
 }
 
+/// Identifies a table reference in a query, separating base table identity
+/// from the optional alias visible to name resolution.
+#[derive(Debug, Clone)]
+pub struct TableReference {
+    /// Original normalized table name, or synthetic/CTE name for subqueries.
+    pub table_name: Arc<str>,
+    /// Normalized alias from AS/implicit alias clauses.
+    pub alias: Option<Arc<str>>,
+    /// Database index. 0 = main, 1 = temp, 2+ = attached.
+    pub database_id: usize,
+}
+
+impl TableReference {
+    pub fn new(
+        table_name: impl Into<Arc<str>>,
+        alias: Option<Arc<str>>,
+        database_id: usize,
+    ) -> Self {
+        Self {
+            table_name: table_name.into(),
+            alias,
+            database_id,
+        }
+    }
+
+    pub fn unaliased(table_name: impl Into<Arc<str>>, database_id: usize) -> Self {
+        Self::new(table_name, None, database_id)
+    }
+
+    pub fn aliased(
+        table_name: impl Into<Arc<str>>,
+        alias: impl Into<Arc<str>>,
+        database_id: usize,
+    ) -> Self {
+        Self::new(table_name, Some(alias.into()), database_id)
+    }
+
+    /// Name used by single-qualifier lookups (`alias.col` or `table.col`).
+    pub fn lookup_name(&self) -> &str {
+        self.alias
+            .as_deref()
+            .unwrap_or_else(|| self.table_name.as_ref())
+    }
+
+    pub fn is_aliased(&self) -> bool {
+        self.alias.is_some()
+    }
+
+    pub fn matches_table_name(&self, name: &str) -> bool {
+        self.table_name.as_ref() == name
+    }
+
+    pub fn matches_lookup_name(&self, name: &str) -> bool {
+        self.lookup_name() == name
+    }
+
+    pub fn display_name(&self) -> String {
+        match &self.alias {
+            Some(alias) => format!("{} AS {}", self.table_name, alias),
+            None => self.table_name.to_string(),
+        }
+    }
+}
+
 /// A joined table in the query plan.
 /// For example,
 /// ```sql
@@ -793,8 +857,8 @@ pub struct JoinedTable {
     pub op: Operation,
     /// Table object, which contains metadata about the table, e.g. columns.
     pub table: Table,
-    /// The name of the table as referred to in the query, either the literal name or an alias e.g. "users" or "u"
-    pub identifier: String,
+    /// Base table identity and optional alias visible in this scope.
+    pub reference: TableReference,
     /// Internal ID of the table reference, used in e.g. [Expr::Column] to refer to this table.
     pub internal_id: TableInternalId,
     /// The join info for this table reference, if it is the right side of a join (which all except the first table reference have)
@@ -816,14 +880,12 @@ pub struct JoinedTable {
     /// expression? If yes, all columns that *only* feed this expression can be
     /// removed from the required-column set.
     pub expression_index_usages: Vec<ExpressionIndexUsage>,
-    /// The index of the database. "main" is always zero.
-    pub database_id: usize,
 }
 
 #[derive(Debug, Clone)]
 pub struct OuterQueryReference {
-    /// The name of the table as referred to in the query, either the literal name or an alias e.g. "users" or "u"
-    pub identifier: String,
+    /// Base table identity and optional alias visible in this scope.
+    pub reference: TableReference,
     /// Internal ID of the table reference, used in e.g. [Expr::Column] to refer to this table.
     pub internal_id: TableInternalId,
     /// Table object, which contains metadata about the table, e.g. columns.
@@ -1037,12 +1099,12 @@ impl TableReferences {
     pub fn find_table_by_identifier(&self, identifier: &str) -> Option<&Table> {
         self.joined_tables
             .iter()
-            .find(|t| t.identifier == identifier)
+            .find(|t| t.reference.matches_lookup_name(identifier))
             .map(|t| &t.table)
             .or_else(|| {
                 self.outer_query_refs
                     .iter()
-                    .find(|t| t.identifier == identifier)
+                    .find(|t| t.reference.matches_lookup_name(identifier))
                     .map(|t| &t.table)
             })
     }
@@ -1056,12 +1118,12 @@ impl TableReferences {
     pub fn find_table_by_table_name(&self, name: &str) -> Option<&Table> {
         self.joined_tables
             .iter()
-            .find(|t| t.table.get_name() == name)
+            .find(|t| t.reference.matches_table_name(name))
             .map(|t| &t.table)
             .or_else(|| {
                 self.outer_query_refs
                     .iter()
-                    .find(|t| t.table.get_name() == name)
+                    .find(|t| t.reference.matches_table_name(name))
                     .map(|t| &t.table)
             })
     }
@@ -1074,7 +1136,7 @@ impl TableReferences {
     ) -> Option<&OuterQueryReference> {
         self.outer_query_refs
             .iter()
-            .find(|t| t.identifier == identifier)
+            .find(|t| t.reference.matches_lookup_name(identifier))
     }
 
     /// Marks the pre-planned [OuterQueryReference] with the given identifier as
@@ -1086,7 +1148,7 @@ impl TableReferences {
         if let Some(outer_ref) = self
             .outer_query_refs
             .iter_mut()
-            .find(|t| t.identifier == identifier)
+            .find(|t| t.reference.matches_lookup_name(identifier))
         {
             outer_ref.cte_definition_only = true;
         }
@@ -1099,12 +1161,12 @@ impl TableReferences {
     ) -> Option<(TableInternalId, &Table)> {
         self.joined_tables
             .iter()
-            .find(|t| t.identifier == identifier)
+            .find(|t| t.reference.matches_lookup_name(identifier))
             .map(|t| (t.internal_id, &t.table))
             .or_else(|| {
                 self.outer_query_refs
                     .iter()
-                    .find(|t| t.identifier == identifier && !t.cte_definition_only)
+                    .find(|t| t.reference.matches_lookup_name(identifier) && !t.cte_definition_only)
                     .map(|t| (t.internal_id, &t.table))
             })
     }
@@ -1515,7 +1577,7 @@ impl JoinedTable {
 
     /// Creates a new TableReference for a subquery from a SelectPlan.
     pub fn new_subquery(
-        identifier: String,
+        reference: TableReference,
         plan: SelectPlan,
         join_info: Option<JoinInfo>,
         internal_id: TableInternalId,
@@ -1546,7 +1608,7 @@ impl JoinedTable {
         }
 
         let table = Table::FromClauseSubquery(Arc::new(FromClauseSubquery {
-            name: identifier.clone(),
+            name: reference.table_name.to_string(),
             plan: Box::new(Plan::Select(plan)),
             columns,
             result_columns_start_reg: None,
@@ -1556,13 +1618,12 @@ impl JoinedTable {
         Ok(Self {
             op: Operation::default_scan_for(&table),
             table,
-            identifier,
+            reference,
             internal_id,
             join_info,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
         })
     }
 
@@ -1572,7 +1633,7 @@ impl JoinedTable {
     /// If `materialize_hint` is true, the CTE was declared with AS MATERIALIZED and should always
     /// be materialized regardless of reference count.
     pub fn new_subquery_from_plan(
-        identifier: String,
+        reference: TableReference,
         plan: Plan,
         join_info: Option<JoinInfo>,
         internal_id: TableInternalId,
@@ -1638,7 +1699,7 @@ impl JoinedTable {
         // Multi-reference CTEs are also detected at emission time via reference counting,
         // and they may be materialized regardless of explicit keyword usage.
         let table = Table::FromClauseSubquery(Arc::new(FromClauseSubquery {
-            name: identifier.clone(),
+            name: reference.table_name.to_string(),
             plan: Box::new(plan),
             columns,
             result_columns_start_reg: None,
@@ -1648,13 +1709,12 @@ impl JoinedTable {
         Ok(Self {
             op: Operation::default_scan_for(&table),
             table,
-            identifier,
+            reference,
             internal_id,
             join_info,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id: 0,
         })
     }
 

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -13,8 +13,9 @@ use super::{
 };
 use crate::translate::{
     emitter::Resolver,
-    expr::{unwrap_parens, BindingBehavior, WalkControl},
+    expr::{unwrap_parens, WalkControl},
     plan::{NonFromClauseSubquery, SubqueryState},
+    scope::{AliasScope, ChainedScope, EmptyScope, FullTableScope},
 };
 use crate::{
     ast::Limit,
@@ -1322,13 +1323,16 @@ pub fn parse_where(
         let start_idx = out_where_clause.len();
         break_predicate_at_and_boundaries(where_expr, out_where_clause);
         for expr in out_where_clause[start_idx..].iter_mut() {
-            bind_and_rewrite_expr(
-                &mut expr.expr,
-                Some(table_references),
-                result_columns,
-                resolver,
-                BindingBehavior::TryCanonicalColumnsFirst,
-            )?;
+            if let Some(result_columns) = result_columns {
+                let mut scope = ChainedScope {
+                    inner: FullTableScope::new(table_references),
+                    outer: AliasScope::new(result_columns),
+                };
+                bind_and_rewrite_expr(&mut expr.expr, &mut scope, resolver, false)?;
+            } else {
+                let mut scope = FullTableScope::new(table_references);
+                bind_and_rewrite_expr(&mut expr.expr, &mut scope, resolver, false)?;
+            }
         }
         // BETWEEN is rewritten to (lhs >= start) AND (lhs <= end) by bind_and_rewrite_expr.
         // Re-break any ANDs that were created so they become separate WhereTerms for
@@ -1800,13 +1804,8 @@ fn parse_join(
                     } else {
                         None
                     };
-                    bind_and_rewrite_expr(
-                        &mut predicate.expr,
-                        Some(table_references),
-                        None,
-                        resolver,
-                        BindingBehavior::TryResultColumnsFirst,
-                    )?;
+                    let mut scope = FullTableScope::new(table_references);
+                    bind_and_rewrite_expr(&mut predicate.expr, &mut scope, resolver, false)?;
                 }
             }
             ast::JoinConstraint::Using(distinct_names) => {
@@ -1964,21 +1963,10 @@ pub fn parse_limit(
     mut limit: Limit,
     resolver: &Resolver,
 ) -> Result<(Option<Box<Expr>>, Option<Box<Expr>>)> {
-    bind_and_rewrite_expr(
-        &mut limit.expr,
-        None,
-        None,
-        resolver,
-        BindingBehavior::TryResultColumnsFirst,
-    )?;
+    let mut scope = EmptyScope;
+    bind_and_rewrite_expr(&mut limit.expr, &mut scope, resolver, false)?;
     if let Some(ref mut off_expr) = limit.offset {
-        bind_and_rewrite_expr(
-            off_expr,
-            None,
-            None,
-            resolver,
-            BindingBehavior::TryResultColumnsFirst,
-        )?;
+        bind_and_rewrite_expr(off_expr, &mut scope, resolver, false)?;
     }
     Ok((Some(limit.expr), limit.offset))
 }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -7,7 +7,7 @@ use super::{
     plan::{
         Aggregate, ColumnUsedMask, Distinctness, EvalAt, IterationDirection, JoinInfo,
         JoinOrderMember, JoinType as PlanJoinType, JoinedTable, Operation, OuterQueryReference,
-        Plan, QueryDestination, ResultSetColumn, Scan, TableReferences, WhereTerm,
+        Plan, QueryDestination, ResultSetColumn, Scan, TableReference, TableReferences, WhereTerm,
     },
     select::prepare_select_plan,
 };
@@ -456,7 +456,7 @@ fn plan_cte(
         // This avoids exponential re-planning when CTEs have transitive dependencies.
         if outer_query_refs
             .iter()
-            .any(|r| &r.identifier == ref_cte_name)
+            .any(|r| r.reference.matches_lookup_name(ref_cte_name))
         {
             continue;
         }
@@ -474,7 +474,7 @@ fn plan_cte(
             false,
         )?;
         outer_query_refs.push(OuterQueryReference {
-            identifier: referenced_table.identifier.clone(),
+            reference: referenced_table.reference.clone(),
             internal_id: referenced_table.internal_id,
             table: referenced_table.table.clone(),
             col_used_mask: ColumnUsedMask::default(),
@@ -537,7 +537,7 @@ fn plan_cte(
 
     match cte_plan {
         Plan::Select(_) | Plan::CompoundSelect { .. } => JoinedTable::new_subquery_from_plan(
-            cte_def.name.clone(),
+            TableReference::unaliased(cte_def.name.clone(), 0),
             cte_plan,
             None,
             program.table_reference_counter.next(),
@@ -583,7 +583,7 @@ pub fn plan_ctes_as_outer_refs(
         if table_references
             .outer_query_refs()
             .iter()
-            .any(|r| r.identifier == cte_name)
+            .any(|r| r.reference.matches_lookup_name(&cte_name))
         {
             crate::bail_parse_error!("duplicate WITH table name: {}", cte.tbl_name.as_str());
         }
@@ -617,7 +617,7 @@ pub fn plan_ctes_as_outer_refs(
         };
         let joined_table = match cte_plan {
             Plan::Select(_) | Plan::CompoundSelect { .. } => JoinedTable::new_subquery_from_plan(
-                cte_name.clone(),
+                TableReference::unaliased(cte_name.clone(), 0),
                 cte_plan,
                 None,
                 program.table_reference_counter.next(),
@@ -636,7 +636,7 @@ pub fn plan_ctes_as_outer_refs(
         // resolution (e.g. UPDATE t SET b = c.v which SQLite rejects as
         // "no such column").
         table_references.add_outer_query_reference(OuterQueryReference {
-            identifier: cte_name,
+            reference: TableReference::unaliased(cte_name, 0),
             internal_id: joined_table.internal_id,
             table: joined_table.table,
             col_used_mask: ColumnUsedMask::default(),
@@ -692,7 +692,7 @@ fn parse_from_clause_table(
                 // This avoids exponential re-planning when CTEs have transitive dependencies.
                 if outer_query_refs_for_subquery
                     .iter()
-                    .any(|r| r.identifier == cte_def.name)
+                    .any(|r| r.reference.matches_lookup_name(&cte_def.name))
                 {
                     continue;
                 }
@@ -711,7 +711,7 @@ fn parse_from_clause_table(
                     false,
                 )?;
                 outer_query_refs_for_subquery.push(OuterQueryReference {
-                    identifier: cte_def.name.clone(),
+                    reference: TableReference::unaliased(cte_def.name.clone(), 0),
                     internal_id: cte_table.internal_id,
                     table: cte_table.table,
                     col_used_mask: ColumnUsedMask::default(),
@@ -740,15 +740,16 @@ fn parse_from_clause_table(
                 }
             }
             let cur_table_index = table_references.joined_tables().len();
-            let identifier = maybe_alias
+            let table_name = format!("subquery_{cur_table_index}");
+            let alias = maybe_alias
                 .map(|a| match a {
                     ast::As::As(id) => id,
                     ast::As::Elided(id) => id,
                 })
                 .map(|id| normalize_ident(id.as_str()))
-                .unwrap_or_else(|| format!("subquery_{cur_table_index}"));
+                .map(Into::into);
             table_references.add_joined_table(JoinedTable::new_subquery_from_plan(
-                identifier,
+                TableReference::new(table_name, alias, 0),
                 subplan,
                 None,
                 program.table_reference_counter.next(),
@@ -816,7 +817,7 @@ fn parse_table(
                 ast::As::As(id) => id,
                 ast::As::Elided(id) => id,
             };
-            cte_table.identifier = normalize_ident(alias.as_str());
+            cte_table.reference.alias = Some(normalize_ident(alias.as_str()).into());
         }
 
         // Mark the pre-planned outer_query_ref as "CTE definition only" so it is
@@ -899,7 +900,7 @@ fn parse_table(
             // Use the CTE name for the subquery name so query plans show
             // "SCAN cte_name AS alias" instead of just "SCAN alias".
             let mut jt = JoinedTable::new_subquery_from_plan(
-                normalized_qualified_name.clone(),
+                TableReference::unaliased(normalized_qualified_name.clone(), database_id),
                 cte_plan,
                 None,
                 program.table_reference_counter.next(),
@@ -908,22 +909,25 @@ fn parse_table(
                 materialize_hint,
             )?;
             if let Some(alias) = alias {
-                jt.identifier = alias;
+                jt.reference.alias = Some(alias.into());
             }
-            jt.database_id = database_id;
+            jt.reference.database_id = database_id;
             table_references.add_joined_table(jt);
         } else {
             let internal_id = program.table_reference_counter.next();
             table_references.add_joined_table(JoinedTable {
                 op: Operation::default_scan_for(&outer_table),
                 table: outer_table,
-                identifier: alias.unwrap_or(normalized_qualified_name),
+                reference: TableReference::new(
+                    normalized_qualified_name,
+                    alias.map(Into::into),
+                    database_id,
+                ),
                 internal_id,
                 join_info: None,
                 col_used_mask: ColumnUsedMask::default(),
                 column_use_counts: Vec::new(),
                 expression_index_usages: Vec::new(),
-                database_id,
             });
         }
         return Ok(());
@@ -953,13 +957,16 @@ fn parse_table(
         table_references.add_joined_table(JoinedTable {
             op: Operation::default_scan_for(&tbl_ref),
             table: tbl_ref,
-            identifier: alias.unwrap_or(normalized_qualified_name),
+            reference: TableReference::new(
+                normalized_qualified_name,
+                alias.map(Into::into),
+                database_id,
+            ),
             internal_id,
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id,
         });
         return Ok(());
     };
@@ -1068,13 +1075,16 @@ fn parse_table(
                 index: None,
             }),
             table: Table::BTree(btree_table),
-            identifier: alias.unwrap_or(normalized_qualified_name),
+            reference: TableReference::new(
+                normalized_qualified_name,
+                alias.map(Into::into),
+                database_id,
+            ),
             internal_id: program.table_reference_counter.next(),
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
             column_use_counts: Vec::new(),
             expression_index_usages: Vec::new(),
-            database_id,
         });
         return Ok(());
     }
@@ -1093,13 +1103,16 @@ fn parse_table(
             table_references.add_joined_table(JoinedTable {
                 op: Operation::default_scan_for(&outer_ref.table),
                 table: outer_ref.table.clone(),
-                identifier: outer_ref.identifier.clone(),
+                reference: TableReference::new(
+                    outer_ref.reference.table_name.clone(),
+                    outer_ref.reference.alias.clone(),
+                    database_id,
+                ),
                 internal_id: program.table_reference_counter.next(),
                 join_info: None,
                 col_used_mask: ColumnUsedMask::default(),
                 column_use_counts: Vec::new(),
                 expression_index_usages: Vec::new(),
-                database_id,
             });
             return Ok(());
         }
@@ -1178,7 +1191,11 @@ fn base_outer_refs_for_cte_planning(
     cte_definitions: &[CteDefinition],
 ) -> Vec<OuterQueryReference> {
     refs.iter()
-        .filter(|r| !cte_definitions.iter().any(|cte| cte.name == r.identifier))
+        .filter(|r| {
+            !cte_definitions
+                .iter()
+                .any(|cte| r.reference.matches_lookup_name(&cte.name))
+        })
         .cloned()
         .map(|mut r| {
             if matches!(r.table, Table::FromClauseSubquery(_)) {
@@ -1267,7 +1284,7 @@ pub fn parse_from(
                     false,
                 )?;
                 table_references.add_outer_query_reference(OuterQueryReference {
-                    identifier: cte_def.name.clone(),
+                    reference: TableReference::unaliased(cte_def.name.clone(), 0),
                     internal_id: cte_table.internal_id,
                     table: cte_table.table,
                     col_used_mask: ColumnUsedMask::default(),
@@ -1741,7 +1758,7 @@ fn parse_join(
         .joined_tables()
         .iter()
         .take(table_references.joined_tables().len() - 1)
-        .any(|t| t.identifier == rightmost_table.identifier);
+        .any(|t| t.reference.lookup_name() == rightmost_table.reference.lookup_name());
 
     if has_duplicate
         && !natural
@@ -1752,7 +1769,7 @@ fn parse_join(
         // Duplicate table names are only allowed for NATURAL or USING joins
         crate::bail_parse_error!(
             "table name {} specified more than once - use an alias to disambiguate",
-            rightmost_table.identifier
+            rightmost_table.reference.lookup_name()
         );
     }
     let constraint = if natural {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -7,7 +7,7 @@ use super::{
     plan::{
         Aggregate, ColumnUsedMask, Distinctness, EvalAt, IterationDirection, JoinInfo,
         JoinOrderMember, JoinType as PlanJoinType, JoinedTable, Operation, OuterQueryReference,
-        Plan, QueryDestination, ResultSetColumn, Scan, TableReference, TableReferences, WhereTerm,
+        Plan, QueryDestination, Scan, TableReference, TableReferences, WhereTerm,
     },
     select::prepare_select_plan,
 };
@@ -15,7 +15,7 @@ use crate::translate::{
     emitter::Resolver,
     expr::{unwrap_parens, WalkControl},
     plan::{NonFromClauseSubquery, SubqueryState},
-    scope::{AliasScope, ChainedScope, EmptyScope, FullTableScope},
+    scope::{EmptyScope, FullTableScope},
 };
 use crate::{
     ast::Limit,
@@ -1332,7 +1332,6 @@ pub fn parse_from(
 pub fn parse_where(
     where_clause: Option<&Expr>,
     table_references: &mut TableReferences,
-    result_columns: Option<&[ResultSetColumn]>,
     out_where_clause: &mut Vec<WhereTerm>,
     resolver: &Resolver,
 ) -> Result<()> {
@@ -1340,16 +1339,8 @@ pub fn parse_where(
         let start_idx = out_where_clause.len();
         break_predicate_at_and_boundaries(where_expr, out_where_clause);
         for expr in out_where_clause[start_idx..].iter_mut() {
-            if let Some(result_columns) = result_columns {
-                let mut scope = ChainedScope {
-                    inner: FullTableScope::new(table_references),
-                    outer: AliasScope::new(result_columns),
-                };
-                bind_and_rewrite_expr(&mut expr.expr, &mut scope, resolver, false)?;
-            } else {
-                let mut scope = FullTableScope::new(table_references);
-                bind_and_rewrite_expr(&mut expr.expr, &mut scope, resolver, false)?;
-            }
+            let mut scope = FullTableScope::new(table_references);
+            bind_and_rewrite_expr(&mut expr.expr, &mut scope, resolver, false)?;
         }
         // BETWEEN is rewritten to (lhs >= start) AND (lhs <= end) by bind_and_rewrite_expr.
         // Re-break any ANDs that were created so they become separate WhereTerms for

--- a/core/translate/scope.rs
+++ b/core/translate/scope.rs
@@ -1,0 +1,470 @@
+use crate::schema::Table;
+use crate::translate::plan::{ResultSetColumn, TableReferences};
+use crate::translate::planner::parse_row_id;
+use crate::util::normalize_ident;
+use crate::Result;
+use turso_parser::ast::{self, TableInternalId};
+
+/// Canonical output of name resolution. The binder turns this into concrete AST nodes.
+#[derive(Debug, Clone)]
+pub enum ResolvedColumn {
+    Column {
+        database: Option<usize>,
+        table: TableInternalId,
+        column: usize,
+        is_rowid_alias: bool,
+    },
+    RowId {
+        database: Option<usize>,
+        table: TableInternalId,
+    },
+    AliasExpansion {
+        expr: Box<ast::Expr>,
+    },
+}
+
+/// Tri-state lookup result used by composable scopes.
+///
+/// We keep ambiguity as data so callers can decide whether to short-circuit
+/// or continue fallback resolution.
+#[derive(Debug, Clone)]
+pub enum LookupResult {
+    Found(ResolvedColumn),
+    NotFound,
+    Ambiguous(String),
+}
+
+/// A clause-local name-resolution context.
+///
+/// Different SQL clauses compose different scope chains to reproduce SQLite
+/// name-resolution precedence without global behavior flags.
+pub trait Scope {
+    fn resolve_column(&mut self, name: &str) -> Result<LookupResult>;
+    fn resolve_qualified(&mut self, table: &str, col: &str) -> Result<LookupResult>;
+    fn table_references_mut(&mut self) -> Option<&mut TableReferences> {
+        None
+    }
+}
+
+fn resolve_column_in_joined_tables(refs: &TableReferences, name: &str) -> Result<LookupResult> {
+    let normalized_name = normalize_ident(name);
+    let mut match_result = None;
+
+    for joined_table in refs.joined_tables() {
+        let database = Some(joined_table.database_id);
+
+        let col_idx = joined_table.table.columns().iter().position(|c| {
+            c.name
+                .as_ref()
+                .is_some_and(|col_name| col_name.eq_ignore_ascii_case(&normalized_name))
+        });
+
+        if let Some(col_idx) = col_idx {
+            if match_result.is_some() {
+                let mut ok = false;
+                // Column name ambiguity is ok if it is in the USING clause because then it
+                // is deduplicated and the left table is used.
+                if let Some(join_info) = &joined_table.join_info {
+                    if join_info
+                        .using
+                        .iter()
+                        .any(|using_col| using_col.as_str().eq_ignore_ascii_case(&normalized_name))
+                    {
+                        ok = true;
+                    }
+                }
+                if !ok {
+                    return Ok(LookupResult::Ambiguous(format!(
+                        "Column {name} is ambiguous"
+                    )));
+                }
+            } else {
+                let col = &joined_table.table.columns()[col_idx];
+
+                match_result = Some(ResolvedColumn::Column {
+                    database,
+                    table: joined_table.internal_id,
+                    column: col_idx,
+                    is_rowid_alias: col.is_rowid_alias(),
+                });
+            }
+        // only if we haven't found a match, check for explicit rowid reference
+        } else if let Table::BTree(btree) = &joined_table.table {
+            if parse_row_id(
+                &normalized_name,
+                refs.joined_tables()[0].internal_id,
+                || refs.joined_tables().len() != 1,
+            )?
+            .is_some()
+            {
+                if !btree.has_rowid {
+                    crate::bail_parse_error!("no such column: {}", name);
+                }
+                return Ok(LookupResult::Found(ResolvedColumn::RowId {
+                    database,
+                    table: refs.joined_tables()[0].internal_id,
+                }));
+            }
+        }
+    }
+
+    Ok(match match_result {
+        Some(found) => LookupResult::Found(found),
+        None => LookupResult::NotFound,
+    })
+}
+
+fn resolve_column_in_outer_refs(refs: &TableReferences, name: &str) -> LookupResult {
+    let normalized_name = normalize_ident(name);
+    let mut match_result = None;
+
+    for outer_ref in refs.outer_query_refs() {
+        // CTEs (FromClauseSubquery) in outer_query_refs are only for table
+        // lookup (e.g., FROM cte1), not for column resolution. Columns from
+        // CTEs should only be accessible when the CTE is explicitly in the
+        // FROM clause, not as implicit outer references.
+        if matches!(outer_ref.table, Table::FromClauseSubquery(_)) {
+            continue;
+        }
+
+        let col_idx = outer_ref.table.columns().iter().position(|c| {
+            c.name
+                .as_ref()
+                .is_some_and(|col_name| col_name.eq_ignore_ascii_case(&normalized_name))
+        });
+
+        if let Some(col_idx) = col_idx {
+            if match_result.is_some() {
+                return LookupResult::Ambiguous(format!("Column {name} is ambiguous"));
+            }
+
+            let col = &outer_ref.table.columns()[col_idx];
+            match_result = Some(ResolvedColumn::Column {
+                database: None, // TODO: support different databases
+                table: outer_ref.internal_id,
+                column: col_idx,
+                is_rowid_alias: col.is_rowid_alias(),
+            });
+        }
+    }
+
+    match match_result {
+        Some(found) => LookupResult::Found(found),
+        None => LookupResult::NotFound,
+    }
+}
+
+fn resolve_qualified_in_joined_tables(
+    refs: &TableReferences,
+    table: &str,
+    col: &str,
+) -> Result<LookupResult> {
+    let normalized_table = normalize_ident(table);
+    let Some(joined_table) = refs
+        .joined_tables()
+        .iter()
+        .find(|t| t.identifier == normalized_table)
+    else {
+        return Ok(LookupResult::NotFound);
+    };
+
+    let normalized_col = normalize_ident(col);
+    let col_idx = joined_table.table.columns().iter().position(|c| {
+        c.name
+            .as_ref()
+            .is_some_and(|col_name| col_name.eq_ignore_ascii_case(&normalized_col))
+    });
+
+    if let Some(col_idx) = col_idx {
+        let col = &joined_table.table.columns()[col_idx];
+        let database = Some(joined_table.database_id);
+        return Ok(LookupResult::Found(ResolvedColumn::Column {
+            database,
+            table: joined_table.internal_id,
+            column: col_idx,
+            is_rowid_alias: col.is_rowid_alias(),
+        }));
+    }
+
+    // User-defined columns take precedence over rowid aliases (oid, rowid,
+    // _rowid_). Only fall back to parse_row_id() when no matching user
+    // column exists.
+    //
+    // Note: Only BTree tables have rowid; derived tables
+    // (FromClauseSubquery) don't have a rowid.
+    if let Table::BTree(btree) = &joined_table.table {
+        if parse_row_id(&normalized_col, joined_table.internal_id, || false)?.is_some() {
+            if !btree.has_rowid {
+                crate::bail_parse_error!("no such column: {}", normalized_col);
+            }
+            let database = Some(joined_table.database_id);
+            return Ok(LookupResult::Found(ResolvedColumn::RowId {
+                database,
+                table: joined_table.internal_id,
+            }));
+        }
+    }
+
+    Ok(LookupResult::NotFound)
+}
+
+fn resolve_qualified_in_outer_refs(
+    refs: &TableReferences,
+    table: &str,
+    col: &str,
+) -> Result<LookupResult> {
+    let normalized_table = normalize_ident(table);
+    let Some(outer_ref) = refs
+        .outer_query_refs()
+        .iter()
+        .find(|t| t.identifier == normalized_table && !t.cte_definition_only)
+    else {
+        return Ok(LookupResult::NotFound);
+    };
+
+    let normalized_col = normalize_ident(col);
+    let col_idx = outer_ref.table.columns().iter().position(|c| {
+        c.name
+            .as_ref()
+            .is_some_and(|col_name| col_name.eq_ignore_ascii_case(&normalized_col))
+    });
+
+    if let Some(col_idx) = col_idx {
+        let col = &outer_ref.table.columns()[col_idx];
+        return Ok(LookupResult::Found(ResolvedColumn::Column {
+            database: None, // TODO: support different databases
+            table: outer_ref.internal_id,
+            column: col_idx,
+            is_rowid_alias: col.is_rowid_alias(),
+        }));
+    }
+
+    if let Table::BTree(btree) = &outer_ref.table {
+        if parse_row_id(&normalized_col, outer_ref.internal_id, || false)?.is_some() {
+            if !btree.has_rowid {
+                crate::bail_parse_error!("no such column: {}", normalized_col);
+            }
+            return Ok(LookupResult::Found(ResolvedColumn::RowId {
+                database: None, // TODO: support different databases
+                table: outer_ref.internal_id,
+            }));
+        }
+    }
+
+    Ok(LookupResult::NotFound)
+}
+
+/// Default column scope: resolve against current FROM tables first, then outer refs.
+///
+/// This is used by most expression contexts where correlation is allowed.
+pub struct FullTableScope<'a> {
+    refs: &'a mut TableReferences,
+}
+
+impl<'a> FullTableScope<'a> {
+    pub fn new(refs: &'a mut TableReferences) -> Self {
+        Self { refs }
+    }
+}
+
+impl Scope for FullTableScope<'_> {
+    fn resolve_column(&mut self, name: &str) -> Result<LookupResult> {
+        match resolve_column_in_joined_tables(self.refs, name)? {
+            LookupResult::Found(found @ ResolvedColumn::Column { table, column, .. }) => {
+                self.refs.mark_column_used(table, column);
+                return Ok(LookupResult::Found(found));
+            }
+            LookupResult::Found(found) => return Ok(LookupResult::Found(found)),
+            LookupResult::Ambiguous(msg) => return Ok(LookupResult::Ambiguous(msg)),
+            LookupResult::NotFound => {}
+        }
+
+        match resolve_column_in_outer_refs(self.refs, name) {
+            LookupResult::Found(found @ ResolvedColumn::Column { table, column, .. }) => {
+                self.refs.mark_column_used(table, column);
+                Ok(LookupResult::Found(found))
+            }
+            other => Ok(other),
+        }
+    }
+
+    fn resolve_qualified(&mut self, table: &str, col: &str) -> Result<LookupResult> {
+        let normalized_table = normalize_ident(table);
+        let table_exists = self
+            .refs
+            .joined_tables()
+            .iter()
+            .any(|t| t.identifier == normalized_table)
+            || self
+                .refs
+                .outer_query_refs()
+                .iter()
+                .any(|t| t.identifier == normalized_table && !t.cte_definition_only);
+        if !table_exists {
+            return Ok(LookupResult::Ambiguous(format!(
+                "no such table: {normalized_table}",
+            )));
+        }
+
+        match resolve_qualified_in_joined_tables(self.refs, table, col)? {
+            LookupResult::Found(found @ ResolvedColumn::Column { table, column, .. }) => {
+                self.refs.mark_column_used(table, column);
+                return Ok(LookupResult::Found(found));
+            }
+            LookupResult::Found(found) => return Ok(LookupResult::Found(found)),
+            LookupResult::Ambiguous(msg) => return Ok(LookupResult::Ambiguous(msg)),
+            LookupResult::NotFound => {}
+        }
+
+        match resolve_qualified_in_outer_refs(self.refs, table, col)? {
+            LookupResult::Found(found @ ResolvedColumn::Column { table, column, .. }) => {
+                self.refs.mark_column_used(table, column);
+                Ok(LookupResult::Found(found))
+            }
+            LookupResult::Found(found @ ResolvedColumn::RowId { table, .. }) => {
+                self.refs.mark_rowid_referenced(table);
+                Ok(LookupResult::Found(found))
+            }
+            other => Ok(other),
+        }
+    }
+
+    fn table_references_mut(&mut self) -> Option<&mut TableReferences> {
+        Some(self.refs)
+    }
+}
+
+/// Isolated table scope: resolve only against current FROM tables.
+///
+/// This is used for clause contexts that must not capture outer references
+/// (for example GROUP BY / HAVING / ORDER BY name resolution layers).
+pub struct LocalTableScope<'a> {
+    refs: &'a mut TableReferences,
+}
+
+impl<'a> LocalTableScope<'a> {
+    pub fn new(refs: &'a mut TableReferences) -> Self {
+        Self { refs }
+    }
+}
+
+impl Scope for LocalTableScope<'_> {
+    fn resolve_column(&mut self, name: &str) -> Result<LookupResult> {
+        match resolve_column_in_joined_tables(self.refs, name)? {
+            LookupResult::Found(found @ ResolvedColumn::Column { table, column, .. }) => {
+                self.refs.mark_column_used(table, column);
+                Ok(LookupResult::Found(found))
+            }
+            other => Ok(other),
+        }
+    }
+
+    fn resolve_qualified(&mut self, table: &str, col: &str) -> Result<LookupResult> {
+        let normalized_table = normalize_ident(table);
+        let table_exists = self
+            .refs
+            .joined_tables()
+            .iter()
+            .any(|t| t.identifier == normalized_table);
+        if !table_exists {
+            return Ok(LookupResult::Ambiguous(format!(
+                "no such table: {normalized_table}",
+            )));
+        }
+
+        match resolve_qualified_in_joined_tables(self.refs, table, col)? {
+            LookupResult::Found(found @ ResolvedColumn::Column { table, column, .. }) => {
+                self.refs.mark_column_used(table, column);
+                Ok(LookupResult::Found(found))
+            }
+            other => Ok(other),
+        }
+    }
+
+    fn table_references_mut(&mut self) -> Option<&mut TableReferences> {
+        Some(self.refs)
+    }
+}
+
+/// Result-column alias scope (e.g. SELECT x AS y ... ORDER BY y).
+///
+/// This scope only handles unqualified names and rewrites them to the aliased
+/// expression tree.
+pub struct AliasScope<'a> {
+    result_columns: &'a [ResultSetColumn],
+}
+
+impl<'a> AliasScope<'a> {
+    pub fn new(result_columns: &'a [ResultSetColumn]) -> Self {
+        Self { result_columns }
+    }
+}
+
+impl Scope for AliasScope<'_> {
+    fn resolve_column(&mut self, name: &str) -> Result<LookupResult> {
+        let normalized_name = normalize_ident(name);
+        for result_column in self.result_columns {
+            if let Some(alias) = &result_column.alias {
+                if alias.eq_ignore_ascii_case(&normalized_name) {
+                    return Ok(LookupResult::Found(ResolvedColumn::AliasExpansion {
+                        expr: Box::new(result_column.expr.clone()),
+                    }));
+                }
+            }
+        }
+
+        Ok(LookupResult::NotFound)
+    }
+
+    fn resolve_qualified(&mut self, _table: &str, _col: &str) -> Result<LookupResult> {
+        Ok(LookupResult::NotFound)
+    }
+}
+
+/// Scope that resolves nothing.
+///
+/// Used for contexts like LIMIT/OFFSET or INSERT VALUES where column binding
+/// should not succeed.
+pub struct EmptyScope;
+
+impl Scope for EmptyScope {
+    fn resolve_column(&mut self, _name: &str) -> Result<LookupResult> {
+        Ok(LookupResult::NotFound)
+    }
+
+    fn resolve_qualified(&mut self, _table: &str, _col: &str) -> Result<LookupResult> {
+        Ok(LookupResult::NotFound)
+    }
+}
+
+/// Generic fallback composition: try `inner`, then `outer` on NotFound.
+///
+/// Clause call sites build concrete chains to encode precedence explicitly
+/// (for example Alias -> LocalTable, or Table -> Alias).
+pub struct ChainedScope<I: Scope, O: Scope> {
+    pub inner: I,
+    pub outer: O,
+}
+
+impl<I: Scope, O: Scope> Scope for ChainedScope<I, O> {
+    fn resolve_column(&mut self, name: &str) -> Result<LookupResult> {
+        match self.inner.resolve_column(name)? {
+            LookupResult::NotFound => self.outer.resolve_column(name),
+            other => Ok(other),
+        }
+    }
+
+    fn resolve_qualified(&mut self, table: &str, col: &str) -> Result<LookupResult> {
+        match self.inner.resolve_qualified(table, col)? {
+            LookupResult::NotFound => self.outer.resolve_qualified(table, col),
+            other => Ok(other),
+        }
+    }
+
+    fn table_references_mut(&mut self) -> Option<&mut TableReferences> {
+        if let Some(table_references) = self.inner.table_references_mut() {
+            return Some(table_references);
+        }
+        self.outer.table_references_mut()
+    }
+}

--- a/core/translate/scope.rs
+++ b/core/translate/scope.rs
@@ -417,17 +417,26 @@ impl<'a> AliasScope<'a> {
 impl Scope for AliasScope<'_> {
     fn resolve_column(&mut self, name: &str) -> Result<LookupResult> {
         let normalized_name = normalize_ident(name);
+        let mut found: Option<&ResultSetColumn> = None;
         for result_column in self.result_columns {
             if let Some(alias) = &result_column.alias {
                 if alias.eq_ignore_ascii_case(&normalized_name) {
-                    return Ok(LookupResult::Found(ResolvedColumn::AliasExpansion {
-                        expr: Box::new(result_column.expr.clone()),
-                    }));
+                    if found.is_some() {
+                        return Ok(LookupResult::Ambiguous(format!(
+                            "ambiguous column alias: {name}"
+                        )));
+                    }
+                    found = Some(result_column);
                 }
             }
         }
 
-        Ok(LookupResult::NotFound)
+        match found {
+            Some(result_column) => Ok(LookupResult::Found(ResolvedColumn::AliasExpansion {
+                expr: Box::new(result_column.expr.clone()),
+            })),
+            None => Ok(LookupResult::NotFound),
+        }
     }
 
     fn resolve_qualified(&mut self, _table: &str, _col: &str) -> Result<LookupResult> {

--- a/core/translate/scope.rs
+++ b/core/translate/scope.rs
@@ -161,7 +161,7 @@ fn resolve_qualified_in_joined_tables(
     let Some(joined_table) = refs
         .joined_tables()
         .iter()
-        .find(|t| t.identifier == normalized_table)
+        .find(|t| t.reference.matches_lookup_name(&normalized_table))
     else {
         return Ok(LookupResult::NotFound);
     };
@@ -213,7 +213,7 @@ fn resolve_qualified_in_outer_refs(
     let Some(outer_ref) = refs
         .outer_query_refs()
         .iter()
-        .find(|t| t.identifier == normalized_table && !t.cte_definition_only)
+        .find(|t| t.reference.matches_lookup_name(&normalized_table) && !t.cte_definition_only)
     else {
         return Ok(LookupResult::NotFound);
     };
@@ -298,12 +298,11 @@ impl Scope for FullTableScope<'_> {
             .refs
             .joined_tables()
             .iter()
-            .any(|t| t.identifier == normalized_table);
-        let outer_table_exists = self
-            .refs
-            .outer_query_refs()
-            .iter()
-            .any(|t| t.identifier == normalized_table && !t.cte_definition_only);
+            .any(|t| t.reference.matches_lookup_name(&normalized_table));
+        let outer_table_exists =
+            self.refs.outer_query_refs().iter().any(|t| {
+                t.reference.matches_lookup_name(&normalized_table) && !t.cte_definition_only
+            });
 
         if !local_table_exists && !outer_table_exists {
             return Ok(LookupResult::Ambiguous(format!(
@@ -380,7 +379,7 @@ impl Scope for LocalTableScope<'_> {
             .refs
             .joined_tables()
             .iter()
-            .any(|t| t.identifier == normalized_table);
+            .any(|t| t.reference.matches_lookup_name(&normalized_table));
         if !table_exists {
             return Ok(LookupResult::Ambiguous(format!(
                 "no such table: {normalized_table}",

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -297,7 +297,7 @@ fn prepare_one_select_plan(
                         ResultColumn::TableStar(n) => table_references
                             .joined_tables()
                             .iter()
-                            .find(|t| t.identifier == n.as_str())
+                            .find(|t| t.reference.matches_lookup_name(n.as_str()))
                             .map(|t| t.columns().iter().filter(|col| !col.hidden()).count())
                             .unwrap_or(5),
                         // Otherwise allocate space for 1 column
@@ -375,7 +375,7 @@ fn prepare_one_select_plan(
                             .table_references
                             .joined_tables_mut()
                             .iter_mut()
-                            .find(|t| t.identifier == name_normalized);
+                            .find(|t| t.reference.matches_lookup_name(&name_normalized));
 
                         if referenced_table.is_none() {
                             crate::bail_parse_error!("no such table: {}", name.as_str());

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -411,8 +411,8 @@ fn prepare_one_select_plan(
                         )?;
                         plan.result_columns.push(ResultSetColumn {
                             alias: maybe_alias.as_ref().map(|alias| match alias {
-                                ast::As::Elided(alias) => alias.as_str().to_string(),
-                                ast::As::As(alias) => alias.as_str().to_string(),
+                                ast::As::Elided(alias) => alias.as_str().into(),
+                                ast::As::As(alias) => alias.as_str().into(),
                             }),
                             expr: *expr,
                             contains_aggregates,
@@ -434,7 +434,6 @@ fn prepare_one_select_plan(
             parse_where(
                 where_clause.as_deref(),
                 &mut plan.table_references,
-                Some(&plan.result_columns),
                 &mut plan.where_clause,
                 resolver,
             )?;
@@ -608,7 +607,7 @@ fn prepare_one_select_plan(
                 result_columns.push(ResultSetColumn {
                     // these result_columns work as placeholders for the values, so the expr doesn't matter
                     expr: ast::Expr::Literal(ast::Literal::Numeric(i.to_string())),
-                    alias: Some(format!("column{}", i + 1)),
+                    alias: Some(format!("column{}", i + 1).into()),
                     contains_aggregates: false,
                 });
             }
@@ -753,10 +752,7 @@ fn add_vtab_predicates_to_where_clause(
     resolver: &Resolver,
 ) -> Result<()> {
     for expr in vtab_predicates.iter_mut() {
-        let mut scope = ChainedScope {
-            inner: FullTableScope::new(&mut plan.table_references),
-            outer: AliasScope::new(&plan.result_columns),
-        };
+        let mut scope = FullTableScope::new(&mut plan.table_references);
         bind_and_rewrite_expr(expr, &mut scope, resolver, false)?;
     }
     for expr in vtab_predicates.drain(..) {

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -291,7 +291,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                 };
                 OuterQueryReference {
                     table: t.table.clone(),
-                    identifier: t.identifier.clone(),
+                    reference: t.reference.clone(),
                     internal_id: t.internal_id,
                     col_used_mask: ColumnUsedMask::default(),
                     cte_select: None,
@@ -307,7 +307,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                     .iter()
                     .map(|t| OuterQueryReference {
                         table: t.table.clone(),
-                        identifier: t.identifier.clone(),
+                        reference: t.reference.clone(),
                         internal_id: t.internal_id,
                         col_used_mask: ColumnUsedMask::default(),
                         cte_select: t.cte_select.clone(),
@@ -895,16 +895,7 @@ pub fn emit_from_clause_subqueries(
             true,
             match &table_reference.op {
                 Operation::Scan(scan) => {
-                    let table_name =
-                        if table_reference.table.get_name() == table_reference.identifier {
-                            table_reference.identifier.clone()
-                        } else {
-                            format!(
-                                "{} AS {}",
-                                table_reference.table.get_name(),
-                                table_reference.identifier
-                            )
-                        };
+                    let table_name = table_reference.reference.display_name();
 
                     match scan {
                         Scan::BTreeTable { index, .. } => {
@@ -927,7 +918,7 @@ pub fn emit_from_clause_subqueries(
                     Search::RowidEq { .. } | Search::Seek { index: None, .. } => {
                         format!(
                             "SEARCH {} USING INTEGER PRIMARY KEY (rowid=?)",
-                            table_reference.identifier
+                            table_reference.reference.lookup_name()
                         )
                     }
                     Search::Seek {
@@ -935,7 +926,8 @@ pub fn emit_from_clause_subqueries(
                     } => {
                         format!(
                             "SEARCH {} USING INDEX {}",
-                            table_reference.identifier, index.name
+                            table_reference.reference.lookup_name(),
+                            index.name
                         )
                     }
                 },
@@ -947,16 +939,7 @@ pub fn emit_from_clause_subqueries(
                     )
                 }
                 Operation::HashJoin(_) => {
-                    let table_name =
-                        if table_reference.table.get_name() == table_reference.identifier {
-                            table_reference.identifier.clone()
-                        } else {
-                            format!(
-                                "{} AS {}",
-                                table_reference.table.get_name(),
-                                table_reference.identifier
-                            )
-                        };
+                    let table_name = table_reference.reference.display_name();
                     format!("HASH JOIN {table_name}")
                 }
                 Operation::MultiIndexScan(multi_idx) => {
@@ -976,7 +959,7 @@ pub fn emit_from_clause_subqueries(
                             SetOperation::Union => "OR",
                             SetOperation::Intersection => "AND",
                         },
-                        table_reference.identifier,
+                        table_reference.reference.lookup_name(),
                         index_names.join(", ")
                     )
                 }

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -382,7 +382,6 @@ pub fn prepare_update_plan(
     parse_where(
         body.where_clause.as_deref(),
         &mut table_references,
-        Some(&result_columns),
         &mut where_clause,
         resolver,
     )?;

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -21,7 +21,8 @@ use super::emitter::emit_program;
 use super::expr::process_returning_clause;
 use super::optimizer::optimize_plan;
 use super::plan::{
-    ColumnUsedMask, DmlSafety, IterationDirection, JoinedTable, Plan, TableReferences, UpdatePlan,
+    ColumnUsedMask, DmlSafety, IterationDirection, JoinedTable, Plan, TableReference,
+    TableReferences, UpdatePlan,
 };
 use super::planner::{parse_where, plan_ctes_as_outer_refs};
 use super::subquery::{
@@ -257,9 +258,13 @@ pub fn prepare_update_plan(
             Table::BTree(btree_table) => Table::BTree(btree_table.clone()),
             _ => unreachable!(),
         },
-        identifier: body.tbl_name.alias.as_ref().map_or_else(
-            || table_name.to_string(),
-            |alias| alias.as_str().to_string(),
+        reference: TableReference::new(
+            table_name.to_string(),
+            body.tbl_name
+                .alias
+                .as_ref()
+                .map(|alias| normalize_ident(alias.as_str()).into()),
+            database_id,
         ),
         internal_id: program.table_reference_counter.next(),
         op: build_scan_op(&table, iter_dir),
@@ -267,7 +272,6 @@ pub fn prepare_update_plan(
         col_used_mask: ColumnUsedMask::default(),
         column_use_counts: Vec::new(),
         expression_index_usages: Vec::new(),
-        database_id,
     }];
     let mut table_references = TableReferences::new(joined_tables, vec![]);
 

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -7,7 +7,7 @@ use crate::translate::expr::{walk_expr, walk_expr_mut, WalkControl};
 use crate::translate::order_by::order_by_sorter_insert;
 use crate::translate::plan::{
     Aggregate, Distinctness, JoinOrderMember, JoinedTable, QueryDestination, ResultSetColumn,
-    SelectPlan, TableReferences, Window,
+    SelectPlan, TableReference, TableReferences, Window,
 };
 use crate::translate::planner::resolve_window_and_aggregate_functions;
 use crate::translate::result_row::emit_select_result;
@@ -227,7 +227,10 @@ fn prepare_window_subquery(
     )?;
 
     let subquery = JoinedTable::new_subquery(
-        format!("window_subquery_{processed_window_count}"),
+        TableReference::unaliased(
+            format!("window_subquery_{processed_window_count}"),
+            SUBQUERY_DATABASE_ID,
+        ),
         inner_plan,
         None,
         subquery_id,
@@ -236,7 +239,7 @@ fn prepare_window_subquery(
     // Verify that the subquery has the expected database ID.
     // This is required to ensure that assumptions in `rewrite_terminal_expr` are valid.
     turso_assert_eq!(
-        subquery.database_id,
+        subquery.reference.database_id,
         SUBQUERY_DATABASE_ID,
         "subquery database id must be SUBQUERY_DATABASE_ID",
         {"SUBQUERY_DATABASE_ID": SUBQUERY_DATABASE_ID}

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -733,7 +733,7 @@ impl ProgramBuilder {
         let expr = ast::Expr::Id(ast::Name::exact("".to_string()));
         self.result_columns.push(ResultSetColumn {
             expr,
-            alias: Some(col_name),
+            alias: Some(col_name.into()),
             contains_aggregates: false,
         });
     }

--- a/testing/runner/tests/alias-scoping-rules.sqltest
+++ b/testing/runner/tests/alias-scoping-rules.sqltest
@@ -30,7 +30,6 @@ expect {
     3
 }
 
-@skip "known deviation: column aliases are currently visible in WHERE in turso"
 test col-alias-not-visible-where {
     CREATE TABLE t_where(x INT);
     INSERT INTO t_where VALUES (10), (20);

--- a/testing/runner/tests/alias-scoping-rules.sqltest
+++ b/testing/runner/tests/alias-scoping-rules.sqltest
@@ -1,0 +1,262 @@
+@database :memory:
+
+test col-alias-visible-order-by {
+    CREATE TABLE t_order(x INT);
+    INSERT INTO t_order VALUES (2), (1);
+    SELECT x + 1 AS y FROM t_order ORDER BY y;
+}
+expect {
+    2
+    3
+}
+
+test col-alias-visible-group-by {
+    CREATE TABLE t_group(category TEXT);
+    INSERT INTO t_group VALUES ('a'), ('a'), ('b');
+    SELECT category AS cat, COUNT(*) FROM t_group GROUP BY cat ORDER BY cat;
+}
+expect {
+    a|2
+    b|1
+}
+
+test col-alias-visible-having {
+    CREATE TABLE t_having(x INT);
+    INSERT INTO t_having VALUES (1), (1), (1), (2), (2), (2);
+    SELECT COUNT(*) AS cnt FROM t_having GROUP BY x HAVING cnt > 2 ORDER BY cnt;
+}
+expect {
+    3
+    3
+}
+
+@skip "known deviation: column aliases are currently visible in WHERE in turso"
+test col-alias-not-visible-where {
+    CREATE TABLE t_where(x INT);
+    INSERT INTO t_where VALUES (10), (20);
+    SELECT x + 1 AS y FROM t_where WHERE y > 10;
+}
+expect error {
+}
+
+test col-alias-not-visible-same-select-item {
+    CREATE TABLE t_same_select(x INT, y INT);
+    INSERT INTO t_same_select VALUES (1, 10);
+    SELECT x AS y, y + 1 AS z FROM t_same_select;
+}
+expect {
+    1|11
+}
+
+test alias-wins-over-column-order-by {
+    CREATE TABLE t_amb_order(a INT, b INT);
+    INSERT INTO t_amb_order VALUES (1, 100), (2, 0);
+    SELECT b AS a FROM t_amb_order ORDER BY a;
+}
+expect {
+    0
+    100
+}
+
+test alias-wins-over-column-group-by {
+    CREATE TABLE t_amb_group(a INT, b INT);
+    INSERT INTO t_amb_group VALUES (1, 10), (1, 20), (2, 30);
+    SELECT COUNT(*) FROM (SELECT b AS a FROM t_amb_group GROUP BY a);
+}
+expect {
+    3
+}
+
+test table-alias-shadows-base-name {
+    CREATE TABLE t_shadow(x INT);
+    INSERT INTO t_shadow VALUES (1);
+    SELECT t_shadow.x FROM t_shadow AS u;
+}
+expect error {
+}
+
+test table-alias-works-across-clauses {
+    CREATE TABLE t_scope(x INT);
+    INSERT INTO t_scope VALUES (6), (2), (7);
+    SELECT u.x FROM t_scope AS u WHERE u.x > 5 GROUP BY u.x HAVING u.x > 5 ORDER BY u.x;
+}
+expect {
+    6
+    7
+}
+
+test table-alias-in-join-on {
+    CREATE TABLE t1_join(id INT);
+    CREATE TABLE t2_join(id INT);
+    INSERT INTO t1_join VALUES (1), (2);
+    INSERT INTO t2_join VALUES (2), (3);
+    SELECT a.id, b.id FROM t1_join AS a JOIN t2_join AS b ON a.id = b.id;
+}
+expect {
+    2|2
+}
+
+test from-subquery-correlation-not-supported {
+    CREATE TABLE t1_from(id INT);
+    CREATE TABLE t2_from(id INT);
+    INSERT INTO t1_from VALUES (1);
+    INSERT INTO t2_from VALUES (1);
+    SELECT * FROM t1_from AS a, (SELECT * FROM t2_from WHERE t2_from.id = a.id);
+}
+expect error {
+}
+
+test subquery-alias-basic {
+    SELECT sub.x FROM (SELECT 1 AS x) AS sub;
+}
+expect {
+    1
+}
+
+test subquery-without-alias-allowed {
+    SELECT x FROM (SELECT 1 AS x);
+}
+expect {
+    1
+}
+
+test subquery-alias-table-scope {
+    SELECT sub.x FROM (SELECT 1 AS x) AS sub WHERE sub.x = 1;
+}
+expect {
+    1
+}
+
+test subquery-output-column-alias-visible {
+    CREATE TABLE t_subcol(x INT);
+    INSERT INTO t_subcol VALUES (1);
+    SELECT sub.y FROM (SELECT x + 1 AS y FROM t_subcol) AS sub;
+}
+expect {
+    2
+}
+
+test subquery-output-base-column-not-visible {
+    CREATE TABLE t_subcol2(x INT);
+    INSERT INTO t_subcol2 VALUES (1);
+    SELECT sub.x FROM (SELECT x + 1 AS y FROM t_subcol2) AS sub;
+}
+expect error {
+}
+
+test cte-basic-scope {
+    WITH cte AS (SELECT 1 AS val)
+    SELECT cte.val FROM cte;
+}
+expect {
+    1
+}
+
+test cte-visible-in-subsequent-cte {
+    WITH
+      a AS (SELECT 1 AS x),
+      b AS (SELECT x + 1 AS y FROM a)
+    SELECT y FROM b;
+}
+expect {
+    2
+}
+
+test cte-not-visible-before-definition {
+    WITH
+      a AS (SELECT y FROM b),
+      b AS (SELECT 1 AS y)
+    SELECT * FROM a;
+}
+expect error {
+}
+
+test cte-shadows-table {
+    CREATE TABLE t_cte_shadow(x INT);
+    INSERT INTO t_cte_shadow VALUES (10);
+    WITH t_cte_shadow AS (SELECT 1 AS x)
+    SELECT x FROM t_cte_shadow;
+}
+expect {
+    1
+}
+
+test cte-not-visible-outside-statement {
+    SELECT * FROM cte_missing;
+}
+expect error {
+}
+
+test self-join-aliases {
+    CREATE TABLE t_self(id INT, parent_id INT, x INT);
+    INSERT INTO t_self VALUES (1, NULL, 10), (2, 1, 20);
+    SELECT a.x, b.x FROM t_self AS a JOIN t_self AS b ON a.id = b.parent_id ORDER BY a.x, b.x;
+}
+expect {
+    10|20
+}
+
+test join-using-with-alias {
+    CREATE TABLE t1_using(id INT, x INT);
+    CREATE TABLE t2_using(id INT, y INT);
+    INSERT INTO t1_using VALUES (1, 10), (2, 20);
+    INSERT INTO t2_using VALUES (2, 200), (3, 300);
+    SELECT id, a.id FROM t1_using AS a JOIN t2_using AS b USING(id);
+}
+expect {
+    2|2
+}
+
+@skip "compound SELECT ORDER BY is not supported yet in turso"
+test compound-first-select-alias-used-in-order-by {
+    CREATE TABLE t1_cmp(x INT, y INT);
+    CREATE TABLE t2_cmp(p INT, q INT);
+    INSERT INTO t1_cmp VALUES (2, 20), (1, 10);
+    INSERT INTO t2_cmp VALUES (3, 30);
+    SELECT x AS a, y AS b FROM t1_cmp
+    UNION ALL
+    SELECT p, q FROM t2_cmp
+    ORDER BY a;
+}
+expect {
+    1|10
+    2|20
+    3|30
+}
+
+test compound-later-select-alias-ignored {
+    CREATE TABLE t1_cmp2(x INT);
+    CREATE TABLE t2_cmp2(p INT);
+    INSERT INTO t1_cmp2 VALUES (1);
+    INSERT INTO t2_cmp2 VALUES (2);
+    SELECT x AS a FROM t1_cmp2
+    UNION ALL
+    SELECT p AS z FROM t2_cmp2
+    ORDER BY z;
+}
+expect error {
+}
+
+test col-alias-not-visible-in-window-order-by {
+    CREATE TABLE t_win(x INT);
+    INSERT INTO t_win VALUES (1), (2);
+    SELECT x + 1 AS y, SUM(x) OVER (ORDER BY y) FROM t_win;
+}
+expect error {
+}
+
+test update-table-alias-not-supported {
+    CREATE TABLE t_up_alias(x INT);
+    INSERT INTO t_up_alias VALUES (3);
+    UPDATE t_up_alias AS u SET u.x = 5 WHERE u.x = 3;
+}
+expect error {
+}
+
+test delete-table-alias-not-supported {
+    CREATE TABLE t_del_alias(x INT);
+    INSERT INTO t_del_alias VALUES (3);
+    DELETE FROM t_del_alias AS u WHERE u.x = 3;
+}
+expect error {
+}

--- a/testing/runner/tests/alias-scoping.sqltest
+++ b/testing/runner/tests/alias-scoping.sqltest
@@ -1,0 +1,26 @@
+@database :memory:
+
+test where-cannot-see-column-aliases {
+    CREATE TABLE t1(x INT, y INT);
+    INSERT INTO t1 VALUES (1, 2);
+    SELECT x AS z FROM t1 WHERE z = 1;
+}
+expect error {
+}
+
+test duplicate-aliases-ambiguous-in-order-by {
+    CREATE TABLE t2(x INT, y INT);
+    INSERT INTO t2 VALUES (1, 2);
+    SELECT x AS a, y AS a FROM t2 ORDER BY a;
+}
+expect error {
+}
+
+test aliases-work-in-group-by-and-order-by {
+    CREATE TABLE t3(x INT, y INT);
+    INSERT INTO t3 VALUES (1, 2);
+    SELECT x AS val FROM t3 GROUP BY val ORDER BY val;
+}
+expect {
+    1
+}

--- a/testing/runner/tests/subquery/correlated-group-by-scope.sqltest
+++ b/testing/runner/tests/subquery/correlated-group-by-scope.sqltest
@@ -1,0 +1,27 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t1(a, b);
+    CREATE TABLE t2(x, y);
+    CREATE TABLE t3(a, x);
+
+    INSERT INTO t1 VALUES(1, 2);
+    INSERT INTO t2 VALUES(10, 20);
+    INSERT INTO t3 VALUES(7, 70);
+}
+
+@setup schema
+test correlated-subquery-group-by-must-not-capture-outer-column {
+    SELECT a FROM t1 WHERE EXISTS (SELECT x FROM t2 GROUP BY a);
+}
+expect error {
+    no such column: a
+}
+
+@setup schema
+test correlated-subquery-group-by-prefers-inner-column {
+    SELECT a FROM t1 WHERE EXISTS (SELECT x FROM t3 GROUP BY a);
+}
+expect {
+    1
+}

--- a/testing/runner/tests/table-alias-shadowing.sqltest
+++ b/testing/runner/tests/table-alias-shadowing.sqltest
@@ -1,0 +1,19 @@
+@database :memory:
+
+test alias-qualified-column-resolves {
+    CREATE TABLE t(x INT);
+    INSERT INTO t VALUES(1);
+    SELECT u.x FROM t AS u;
+}
+expect {
+    1
+}
+
+test base-name-hidden-when-aliased {
+    CREATE TABLE t(x INT);
+    INSERT INTO t VALUES(1);
+    SELECT t.x FROM t AS u;
+}
+expect error {
+    no such table: t
+}


### PR DESCRIPTION
## Description
This PR replaces ad-hoc column name binding in `core/translate/expr.rs` with a composable trait-based scope system.

The previous binder used flat behavior flags and direct iteration over `joined_tables + outer_query_refs`, which made clause-specific scoping fragile. This refactor introduces explicit scope composition at each call site so each SQL clause can define its own name-resolution precedence and visibility.

## Design
### New module
- Added `core/translate/scope.rs` with:
  - `Scope` trait
  - `ResolvedColumn` and `LookupResult`
  - Scope implementations:
    - `FullTableScope` (joined tables, then outer refs)
    - `LocalTableScope` (joined tables only)
    - `AliasScope` (result-column alias expansion)
    - `EmptyScope` (resolves nothing)
  - `ChainedScope<I, O>` combinator for precedence layering
  - Extracted lookup helpers for joined/outer + qualified/unqualified resolution

### Binder API change
- `bind_and_rewrite_expr` signature changed to:

```rust
pub fn bind_and_rewrite_expr(
    expr: &mut ast::Expr,
    scope: &mut impl Scope,
    resolver: &Resolver<'_>,
    tolerate_unbound: bool,
) -> Result<()>
```

- Removed `BindingBehavior`.
- `Expr::Id` and `Expr::Qualified` now delegate to `Scope`.
- Kept `Expr::DoublyQualified` and `Expr::FunctionCallStar` as binder special-cases (using `scope.table_references_mut()` when needed).


## Scoping behavior changes
- `GROUP BY` / `HAVING` / `ORDER BY` alias chains now use `AliasScope -> LocalTableScope` where appropriate, preventing accidental outer-reference capture.
- `WHERE` and general expression contexts continue to use full table visibility via `FullTableScope` (with optional alias fallback depending on clause semantics).

## Motivation and context
I caught some scoping issues with differential fuzzer where a `GROUP BY` in an inner query was resolving a column from an outer query that had the same name but was from a different table. So I wanted to try and solve this once and for all. Look at the `.sqltest` for an example

## Description of AI Usage
Planned with Claude and executed by Codex
