### PR TITLE
Validate ADD COLUMN CHECK against existing rows

### DIFF
--- a/testing/runner/tests/check_constraint.sqltest
+++ b/testing/runner/tests/check_constraint.sqltest
@@ -982,6 +982,26 @@ expect {
 }
 
 @cross-check-integrity
+test check_constraint_alter_add_column_existing_column_violation {
+    CREATE TABLE t(a INTEGER);
+    INSERT INTO t VALUES(-1);
+    ALTER TABLE t ADD COLUMN b INT CHECK (a > 0);
+}
+expect error {
+}
+
+@cross-check-integrity
+test check_constraint_alter_add_column_existing_column_satisfied {
+    CREATE TABLE t(a INTEGER);
+    INSERT INTO t VALUES(1);
+    ALTER TABLE t ADD COLUMN b INT CHECK (a > 0);
+    SELECT a, b FROM t;
+}
+expect {
+    1|
+}
+
+@cross-check-integrity
 test check_constraint_alter_add_column_with_data_enforced {
     CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT);
     INSERT INTO products VALUES (1, 'Widget A');


### PR DESCRIPTION
## Description

This PR fixes a SQLite compatibility mismatch in `ALTER TABLE ... ADD COLUMN ... CHECK`. Before this change, ADD COLUMN CHECK validation idid not correctly validate constraints that reference pre-existing columns. 

Example:

  ```sql
  CREATE TABLE t(a);
  INSERT INTO t VALUES(-1);
  ALTER TABLE t ADD COLUMN b INT CHECK (a > 0);
 ```
  
SQLite rejects this with CHECK constraint failed, while Turso previously accepted it.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

The previous implementation validated only default-substituted expressions and could miss constraints that depend on existing columns. That creates behavior divergence from SQLite and risks accepting invalid schema transitions on non-empty tables.

This fix aligns ALTER TABLE semantics with SQLite by enforcing CHECK constraints against actual pre-existing row values at ALTER time.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5655

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
