### PR TITLE
Add support for Decimal Extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,6 +3031,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "limbo_decimal"
+version = "0.5.0-pre.15"
+dependencies = [
+ "mimalloc",
+ "turso_ext",
+]
+
+[[package]]
 name = "limbo_fuzzy"
 version = "0.5.0-pre.16"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_decimal"
-version = "0.5.0-pre.15"
+version = "0.5.0-pre.16"
 dependencies = [
  "mimalloc",
  "turso_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,14 +3031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "limbo_decimal"
-version = "0.5.0-pre.16"
-dependencies = [
- "mimalloc",
- "turso_ext",
-]
-
-[[package]]
 name = "limbo_fuzzy"
 version = "0.5.0-pre.16"
 dependencies = [
@@ -6358,6 +6350,14 @@ dependencies = [
  "uncased",
  "uuid",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "turso_decimal"
+version = "0.5.0-pre.16"
+dependencies = [
+ "mimalloc",
+ "turso_ext",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "extensions/regexp",
     "extensions/tests",
     "extensions/fuzzy",
+    "extensions/decimal",
     "macros",
     "testing/simulator",
     "sqlite3",

--- a/extensions/decimal/Cargo.toml
+++ b/extensions/decimal/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "limbo_decimal"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Limbo Decimal extension"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+static = ["turso_ext/static"]
+
+[dependencies]
+turso_ext = { workspace = true, features = ["static"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mimalloc = { version = "0.1", default-features = false }

--- a/extensions/decimal/Cargo.toml
+++ b/extensions/decimal/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "limbo_decimal"
+name = "turso_decimal"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Limbo Decimal extension"
+description = "Turso Decimal extension"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/extensions/decimal/build.rs
+++ b/extensions/decimal/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}

--- a/extensions/decimal/src/lib.rs
+++ b/extensions/decimal/src/lib.rs
@@ -1,0 +1,393 @@
+// Adapted from https://github.com/sqlite/sqlite/blob/master/ext/misc/decimal.c
+use turso_ext::{register_extension, scalar, Value, ValueType};
+
+#[derive(Clone)]
+struct Decimal {
+    sign: bool,
+    is_null: bool,
+    n_digit: usize,
+    n_frac: usize,
+    a: Vec<u8>,
+}
+
+register_extension! {
+    scalars: {decimal_func, decimal_func_exp}
+}
+
+#[scalar(name = "decimal")]
+fn decimal_func(args: &[Value]) -> Value {
+    let mut d = match Decimal::decimal_new(&args[0], false) {
+        Some(d) => d,
+        None => return Value::null(),
+    };
+
+    let n = if args.len() == 2 {
+        args[1].to_integer().unwrap_or(0).max(0) as usize
+    } else {
+        0
+    };
+
+    if n > 0 {
+        d.decimal_round(n);
+    }
+
+    let result = d.decimal_result();
+    match result {
+        Some(s) => Value::from_text(s),
+        None => Value::null(),
+    }
+}
+
+#[scalar(name = "decimal_exp")]
+fn decimal_func_exp(args: &[Value]) -> Value {
+    let mut d = match Decimal::decimal_new(&args[0], false) {
+        Some(d) => d,
+        None => return Value::null(),
+    };
+
+    let n = if args.len() == 2 {
+        args[1].to_integer().unwrap_or(0).max(0) as usize
+    } else {
+        0
+    };
+
+    if n > 0 {
+        d.decimal_round(n);
+    }
+
+    let result = d.decimal_result_sci(n);
+
+    match result {
+        Some(s) => Value::from_text(s),
+        None => Value::null(),
+    }
+}
+
+impl Decimal {
+    //create a decimal object from &str
+    fn from_text(z_in: &str) -> Option<Self> {
+        let chars: Vec<char> = z_in.chars().collect();
+        let n = chars.len();
+        let mut i = 0;
+        let mut i_exp: i64 = 0;
+
+        let mut p = Decimal {
+            sign: false,
+            is_null: false,
+            n_digit: 0,
+            n_frac: 0,
+            a: Vec::with_capacity(n + 1),
+        };
+
+        while i < n && chars[i].is_ascii_whitespace() {
+            i += 1;
+        }
+
+        if i < n && chars[i] == '-' {
+            p.sign = true;
+            i += 1;
+        } else if i < n && chars[i] == '+' {
+            i += 1;
+        }
+
+        while i < n && chars[i] == '0' {
+            i += 1;
+        }
+
+        while i < n {
+            let c = chars[i];
+
+            if c.is_ascii_digit() {
+                p.a.push((c as u8) - b'0');
+                p.n_digit += 1;
+            } else if c == '.' {
+                p.n_frac = p.n_digit + 1;
+            } else if c == 'e' || c == 'E' {
+                let mut j = i + 1;
+                let mut neg = false;
+
+                if j >= n {
+                    break;
+                }
+
+                if chars[j] == '-' {
+                    neg = true;
+                    j += 1;
+                } else if chars[j] == '+' {
+                    j += 1;
+                }
+
+                while j < n && i_exp < 1_000_000 {
+                    if chars[j].is_ascii_digit() {
+                        i_exp = i_exp * 10 + (chars[j] as i64) - ('0' as i64);
+                    }
+                    j += 1;
+                }
+
+                if neg {
+                    i_exp = -i_exp;
+                }
+                break;
+            }
+
+            i += 1;
+        }
+
+        // right after .
+        if p.n_frac > 0 {
+            p.n_frac = p.n_digit - (p.n_frac - 1);
+        }
+
+        //exponent
+        if i_exp > 0 {
+            let i_exp = i_exp as usize;
+
+            // move dot to the right
+            if p.n_frac > 0 {
+                if i_exp <= p.n_frac {
+                    p.n_frac -= i_exp;
+                } else {
+                    let remaining = i_exp - p.n_frac;
+                    p.n_frac = 0;
+                    p.a.resize(p.n_digit + remaining, 0);
+                    p.n_digit += remaining;
+                }
+            } else {
+                p.a.resize(p.n_digit + i_exp, 0);
+                p.n_digit += i_exp;
+            }
+        } else if i_exp < 0 {
+            // move dot to the left
+            let i_exp = (-i_exp) as usize;
+            let n_extra = if p.n_digit > p.n_frac {
+                p.n_digit - p.n_frac - 1
+            } else {
+                0
+            };
+
+            let mut remaining_exp = i_exp;
+
+            if n_extra > 0 {
+                if n_extra >= remaining_exp {
+                    p.n_frac += remaining_exp;
+                    remaining_exp = 0;
+                } else {
+                    remaining_exp -= n_extra;
+                    p.n_frac = p.n_digit - 1;
+                }
+            }
+
+            if remaining_exp > 0 {
+                //add leading zeros
+                let old_digits = p.a.clone();
+                p.a = vec![0u8; remaining_exp]; // leading zeros
+                p.a.extend_from_slice(&old_digits[..p.n_digit]);
+                p.n_digit += remaining_exp;
+                p.n_frac += remaining_exp;
+            }
+        }
+
+        // "-0" to "0"
+        if p.sign {
+            let all_zero = p.a[..p.n_digit].iter().all(|&d| d == 0);
+            if all_zero {
+                p.sign = false;
+            }
+        }
+
+        Some(p)
+    }
+
+    fn decimal_result(&self) -> Option<String> {
+        if self.is_null {
+            return None;
+        }
+
+        let mut z = String::with_capacity(self.n_digit + 4);
+
+        let is_zero = self.n_digit == 0 || (self.n_digit == 1 && self.a[0] == 0);
+        let sign = self.sign && !is_zero;
+
+        if sign {
+            z.push('-');
+        }
+
+        let n_integer = self.n_digit as isize - self.n_frac as isize;
+
+        if n_integer <= 0 {
+            z.push('0');
+        }
+
+        // skip leading zeros (at least one digit stil written)
+        let mut j = 0usize;
+        let mut n = n_integer;
+
+        while n > 1 && j < self.n_digit && self.a[j] == 0 {
+            j += 1;
+            n -= 1;
+        }
+
+        while n > 0 {
+            if j < self.n_digit {
+                z.push((b'0' + self.a[j]) as char);
+                j += 1;
+            }
+            n -= 1;
+        }
+
+        if self.n_frac > 0 {
+            z.push('.');
+            while j < self.n_digit {
+                z.push((b'0' + self.a[j]) as char);
+                j += 1;
+            }
+        }
+
+        Some(z)
+    }
+
+    fn decimal_new(arg: &Value, b_text_only: bool) -> Option<Decimal> {
+        match arg.value_type() {
+            ValueType::Text | ValueType::Integer => Decimal::from_text(arg.to_text()?),
+            ValueType::Float if b_text_only => Decimal::from_text(arg.to_text()?),
+            ValueType::Blob if b_text_only => Decimal::from_text(arg.to_text()?),
+            _ => None,
+        }
+    }
+    fn decimal_round(&mut self, n: usize) {
+        if n < 1 {
+            return;
+        }
+        let n_zero = self.a[..self.n_digit]
+            .iter()
+            .take_while(|&&d| d == 0)
+            .count();
+
+        let n = n + n_zero;
+
+        if self.n_digit <= n {
+            return;
+        }
+
+        if self.a[n] > 4 {
+            self.a[n - 1] += 1;
+
+            let mut i = n - 1;
+            while i > 0 && self.a[i] > 9 {
+                self.a[i] = 0;
+                self.a[i - 1] += 1;
+                i -= 1;
+            }
+
+            if self.a[0] > 9 {
+                self.a[0] = 0;
+                self.a.insert(0, 1);
+                self.n_digit += 1;
+                if self.n_frac > 0 {
+                    self.n_frac -= 1;
+                }
+            }
+        }
+
+        for d in &mut self.a[n..self.n_digit] {
+            *d = 0;
+        }
+    }
+    fn decimal_result_sci(&self, n: usize) -> Option<String> {
+        if self.is_null {
+            return None;
+        }
+
+        let n = if n < 1 { 0 } else { n };
+
+        let mut n_digit = self.n_digit;
+        while n_digit > n && n_digit > 0 && self.a[n_digit - 1] == 0 {
+            n_digit -= 1;
+        }
+
+        let n_zero = self.a[..n_digit].iter().take_while(|&&d| d == 0).count();
+
+        let n_frac = self.n_frac as isize + (n_digit as isize - self.n_digit as isize);
+
+        let n_digit = n_digit - n_zero;
+
+        let (a, n_digit, n_frac): (&[u8], usize, isize) = if n_digit == 0 {
+            (&[0u8][..], 1, 0)
+        } else {
+            (&self.a[n_zero..self.n_digit], n_digit, n_frac)
+        };
+
+        let mut z = String::with_capacity(n_digit + 20);
+        if self.sign && n_digit > 0 && !(n_digit == 1 && a[0] == 0) {
+            z.push('-');
+        } else {
+            z.push('+');
+        }
+
+        z.push((b'0' + a[0]) as char);
+        z.push('.');
+
+        if n_digit == 1 {
+            z.push('0');
+        } else {
+            for digit in a.iter().take(n_digit).skip(1) {
+                z.push((b'0' + *digit) as char);
+            }
+        }
+
+        // exp = position of the decimal point relative to the first digit
+        //"314.15" → a=[3,1,4,1,5], nFrac=2
+        //   exp = 5 - 2 - 1 = 2  → "+3.1415e+02"
+        //
+        //"0.00123" → a=[1,2,3], nFrac=5
+        //   exp = 3 - 5 - 1 = -3 → "+1.23e-03" ✓=
+        // This implementation return +1.23e+06 instead of +1.23e+006 in https://github.com/sqlite/sqlite/blob/master/test/decimal.test
+        let exp = n_digit as isize - n_frac - 1;
+        if exp >= 0 {
+            z.push_str(&format!("e+{exp:02}"));
+        } else {
+            z.push_str(&format!("e-{:02}", -exp));
+        }
+
+        Some(z)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_text_and_result() {
+        let d = Decimal::from_text("-123.45e2").expect("must be not None");
+        assert!(d.sign);
+        assert_eq!(d.n_digit, 5);
+        assert_eq!(d.n_frac, 0);
+        assert_eq!(d.a, vec![1, 2, 3, 4, 5]);
+        assert_eq!(d.decimal_result(), Some("-12345".to_string()));
+
+        let dd = Decimal::from_text("0.00123").unwrap();
+        assert!(!dd.sign);
+        assert_eq!(dd.n_digit, 5);
+        assert_eq!(dd.n_frac, 5);
+        assert_eq!(dd.a, vec![0, 0, 1, 2, 3]);
+        assert_eq!(dd.decimal_result(), Some("0.00123".to_string()));
+    }
+
+    #[test]
+    fn test_decimal_round() {
+        let mut d = Decimal::from_text("999").expect("must be not None");
+        assert_eq!(d.n_frac, 0);
+        d.decimal_round(1);
+        assert_eq!(d.decimal_result(), Some("1000".to_string()));
+    }
+
+    #[test]
+
+    fn test_result_sci_n_param() {
+        let d = Decimal::from_text("3.14000").expect("'3.14000' is valid decimal string");
+        assert_eq!(d.decimal_result_sci(0), Some("+3.14e+00".to_string()));
+
+        let d2 = Decimal::from_text("3.14000").expect("'3.14000' is valid decimal string");
+        assert_eq!(d2.decimal_result_sci(5), Some("+3.1400e+00".to_string()));
+    }
+}

--- a/extensions/decimal/src/lib.rs
+++ b/extensions/decimal/src/lib.rs
@@ -374,6 +374,119 @@ mod tests {
     }
 
     #[test]
+    fn test_decimal() {
+        // 1000
+        assert_eq!(
+            Decimal::from_text("1")
+                .expect("'1' is a valid decimal")
+                .decimal_result(),
+            Some("1".to_string())
+        );
+
+        // 1001
+        assert_eq!(
+            Decimal::from_text("+0")
+                .expect("'+0' is a valid decimal")
+                .decimal_result(),
+            Some("0".to_string())
+        );
+        assert_eq!(
+            Decimal::from_text("-0")
+                .expect("'-0' is a valid decimal")
+                .decimal_result(),
+            Some("0".to_string())
+        );
+
+        // 1010
+        assert_eq!(
+            Decimal::from_text("1.0")
+                .expect("'1.0' is a valid decimal")
+                .decimal_result(),
+            Some("1.0".to_string())
+        );
+
+        // 1020
+        assert_eq!(
+            Decimal::from_text("0001.0")
+                .expect("'0001.0' is a valid decimal")
+                .decimal_result(),
+            Some("1.0".to_string())
+        );
+
+        // 1030
+        assert_eq!(
+            Decimal::from_text("+0001.0")
+                .expect("'+0001.0' is a valid decimal")
+                .decimal_result(),
+            Some("1.0".to_string())
+        );
+
+        // 1040
+        assert_eq!(
+            Decimal::from_text("-0001.0")
+                .expect("'-0001.0' is a valid decimal")
+                .decimal_result(),
+            Some("-1.0".to_string())
+        );
+
+        // 1041
+        assert_eq!(
+            Decimal::from_text("-0000.0")
+                .expect("'-0000.0' is a valid decimal")
+                .decimal_result(),
+            Some("0.0".to_string())
+        );
+
+        // 1042 not yet
+
+        // 1050
+        assert_eq!(
+            Decimal::from_text("1.0e72")
+                .expect("'1.0e72' is a valid decimal")
+                .decimal_result(),
+            Some(
+                "1000000000000000000000000000000000000000000000000000000000000000000000000"
+                    .to_string()
+            )
+        );
+
+        // 1060
+        assert_eq!(
+            Decimal::from_text("1.0e-72")
+                .expect("'1.0e-72' is a valid decimal")
+                .decimal_result(),
+            Some(
+                "0.0000000000000000000000000000000000000000000000000000000000000000000000010"
+                    .to_string()
+            )
+        );
+
+        // 1070
+        assert_eq!(
+            Decimal::from_text("-123e-4")
+                .expect("'-123e-4' is a valid decimal")
+                .decimal_result(),
+            Some("-0.0123".to_string())
+        );
+
+        // 1080
+        assert_eq!(
+            Decimal::from_text("+123e+4")
+                .expect("'+123e+4' is a valid decimal")
+                .decimal_result(),
+            Some("1230000".to_string())
+        );
+
+        // 1081
+        assert_eq!(
+            Decimal::from_text("+123e+4")
+                .expect("'+123e+4' is a valid decimal")
+                .decimal_result_sci(0),
+            Some("+1.23e+06".to_string())
+        );
+    }
+
+    #[test]
     fn test_decimal_round() {
         let mut d = Decimal::from_text("999").expect("must be not None");
         assert_eq!(d.n_frac, 0);

--- a/extensions/decimal/src/lib.rs
+++ b/extensions/decimal/src/lib.rs
@@ -11,7 +11,7 @@ struct Decimal {
 }
 
 register_extension! {
-    scalars: {decimal_func, decimal_func_exp, decimal_func_add, decimal_func_sub, decimal_func_mul, decimal_func_pow2}
+    scalars: {decimal_func, decimal_func_exp, decimal_func_add, decimal_func_sub, decimal_func_mul, decimal_func_pow2, decimal_func_cmp}
 }
 
 #[scalar(name = "decimal")]
@@ -178,6 +178,38 @@ fn decimal_func_pow2(args: &[Value]) -> Value {
         Some(res) => Value::from_text(res),
         None => Value::null(),
     }
+}
+
+//The decimal_cmp(A,B) function compares two decimal values A and B. The result will be negative, zero, or positive if A is less than, equal to, or greater than B, respectively
+#[scalar(name = "decimal_cmp")]
+fn decimal_func_cmp(args: &[Value]) -> Value {
+    if args.len() != 2 {
+        return Value::error(ResultCode::InvalidArgs);
+    }
+
+    let mut pa = match Decimal::decimal_new(&args[0], true) {
+        Some(a) => a,
+        None => return Value::null(),
+    };
+
+    let mut pb = match Decimal::decimal_new(&args[1], true) {
+        Some(b) => b,
+        None => return Value::null(),
+    };
+
+    if pa.is_null || pb.is_null {
+        return Value::null();
+    }
+
+    let res = pa.cmp(&mut pb);
+    let res = if res < 0 {
+        -1
+    } else if res > 0 {
+        1
+    } else {
+        0
+    };
+    Value::from_integer(res as i64)
 }
 
 impl Decimal {
@@ -706,6 +738,46 @@ impl Decimal {
                     borrow = 0;
                 }
             }
+        }
+    }
+
+    //
+    // Compare to Decimal objects.  Return negative, 0, or positive if the
+    // first object is less than, equal to, or greater than the second.
+    //
+    fn cmp(&mut self, p_b: &mut Decimal) -> i32 {
+        while self.n_frac > 0 && self.n_digit > 0 && self.a[self.n_digit - 1] == 0 {
+            self.n_digit -= 1;
+            self.n_frac -= 1;
+        }
+        while p_b.n_frac > 0 && p_b.n_digit > 0 && p_b.a[p_b.n_digit - 1] == 0 {
+            p_b.n_digit -= 1;
+            p_b.n_frac -= 1;
+        }
+
+        if self.sign != p_b.sign {
+            return if self.sign { -1 } else { 1 };
+        }
+
+        let (a, b) = if self.sign {
+            (p_b as &Decimal, self as &Decimal)
+        } else {
+            (self as &Decimal, p_b as &Decimal)
+        };
+
+        let n_a_sig = a.n_digit as i32 - a.n_frac as i32;
+        let n_b_sig = b.n_digit as i32 - b.n_frac as i32;
+        if n_a_sig != n_b_sig {
+            return n_a_sig - n_b_sig;
+        }
+
+        let n = a.n_digit.min(b.n_digit);
+        let rc = a.a[..n].cmp(&b.a[..n]);
+
+        match rc {
+            std::cmp::Ordering::Equal => a.n_digit as i32 - b.n_digit as i32,
+            std::cmp::Ordering::Less => -1,
+            std::cmp::Ordering::Greater => 1,
         }
     }
 }

--- a/extensions/decimal/src/lib.rs
+++ b/extensions/decimal/src/lib.rs
@@ -1,5 +1,7 @@
 // Adapted from https://github.com/sqlite/sqlite/blob/master/ext/misc/decimal.c
-use turso_ext::{register_extension, scalar, ResultCode, Value, ValueType};
+use turso_ext::{
+    register_extension, scalar, AggFunc, AggregateDerive, ResultCode, Value, ValueType,
+};
 
 #[derive(Clone)]
 struct Decimal {
@@ -11,7 +13,8 @@ struct Decimal {
 }
 
 register_extension! {
-    scalars: {decimal_func, decimal_func_exp, decimal_func_add, decimal_func_sub, decimal_func_mul, decimal_func_pow2, decimal_func_cmp}
+    scalars: {decimal_func, decimal_func_exp, decimal_func_add, decimal_func_sub, decimal_func_mul, decimal_func_pow2, decimal_func_cmp},
+    aggregates: {DecimalSum},
 }
 
 #[scalar(name = "decimal")]
@@ -210,6 +213,48 @@ fn decimal_func_cmp(args: &[Value]) -> Value {
         0
     };
     Value::from_integer(res as i64)
+}
+
+#[derive(AggregateDerive)]
+struct DecimalSum;
+
+impl AggFunc for DecimalSum {
+    type State = Option<Decimal>;
+    type Error = &'static str;
+    const NAME: &'static str = "decimal_sum";
+    const ARGS: i32 = 1;
+
+    fn step(state: &mut Self::State, args: &[Value]) {
+        let arg = match args.first() {
+            Some(v) => v,
+            None => return,
+        };
+        if arg.value_type() == ValueType::Null {
+            return;
+        }
+
+        let mut val = match Decimal::decimal_new(arg, true) {
+            Some(v) => v,
+            None => return,
+        };
+
+        match state {
+            Some(acc) => acc.add(&mut val),
+            None => {
+                *state = Some(val);
+            }
+        }
+    }
+
+    fn finalize(state: Self::State) -> Result<Value, Self::Error> {
+        match state {
+            Some(acc) => match acc.decimal_result() {
+                Some(res) => Ok(Value::from_text(res)),
+                None => Ok(Value::null()),
+            },
+            None => Ok(Value::null()),
+        }
+    }
 }
 
 impl Decimal {

--- a/extensions/decimal/src/lib.rs
+++ b/extensions/decimal/src/lib.rs
@@ -11,7 +11,7 @@ struct Decimal {
 }
 
 register_extension! {
-    scalars: {decimal_func, decimal_func_exp, decimal_func_add, decimal_func_sub}
+    scalars: {decimal_func, decimal_func_exp, decimal_func_add, decimal_func_sub, decimal_func_mul, decimal_func_pow2}
 }
 
 #[scalar(name = "decimal")]
@@ -122,6 +122,61 @@ fn decimal_func_sub(args: &[Value]) -> Value {
             None => Value::null(),
         },
         _ => Value::null(),
+    }
+}
+
+#[scalar(name = "decimal_mul")]
+fn decimal_func_mul(args: &[Value]) -> Value {
+    if args.len() != 2 {
+        return Value::error(ResultCode::InvalidArgs);
+    }
+
+    let mut pa = match Decimal::decimal_new(&args[0], true) {
+        Some(a) => a,
+        None => return Value::null(),
+    };
+
+    let pb = match Decimal::decimal_new(&args[1], true) {
+        Some(b) => b,
+        None => return Value::null(),
+    };
+
+    if pa.is_null || pb.is_null {
+        return Value::null();
+    }
+
+    pa.mul(&pb);
+
+    match pa.decimal_result() {
+        Some(res) => Value::from_text(res),
+        None => Value::null(),
+    }
+}
+
+//Return the N-th power of 2.  N must be an integer.
+#[scalar(name = "decimal_pow2")]
+fn decimal_func_pow2(args: &[Value]) -> Value {
+    if args.len() != 1 {
+        return Value::error(ResultCode::InvalidArgs);
+    }
+
+    if args[0].value_type() != ValueType::Integer {
+        return Value::null();
+    }
+
+    let n = match args[0].to_integer() {
+        Some(n) => n as i32,
+        None => return Value::null(),
+    };
+
+    let pa = match Decimal::pow2(n) {
+        Some(d) => d,
+        None => return Value::null(),
+    };
+
+    match pa.decimal_result_sci(0) {
+        Some(res) => Value::from_text(res),
+        None => Value::null(),
     }
 }
 

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -721,7 +721,7 @@ def test_fuzzy():
 
 
 def test_decimal():
-    turso = TestTursoShell()
+    turso = TestTursoShell(init_commands="")
     ext_path = "./target/debug/liblimbo_decimal"
     turso.run_test_fn(
         "SELECT decimal('0.1');",
@@ -744,7 +744,27 @@ def test_decimal():
         lambda res: "+1.23e+06" == res,
         "decimal_exp('+123e+4') function return correctly",
     )
-    
+    turso.run_test_fn(
+        "SELECT decimal_exp(0.99);",
+        lambda res: "+9.899999999999999911182158029987476766109466552734375e-01"== res,
+        "decimal_exp(0.99) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal(0.55);",
+        lambda res: "0.5500000000000000444089209850062616169452667236328125"== res,
+        "decimal(0.55) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal(X'3FE0000000000000');",
+        lambda res: "0.5"== res,
+        "decimal(X'3FE0000000000000') function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal(X'DEADBEEF');",
+        lambda res: "" == res,
+        "decimal(X'DEADBEEF') function return correctly",
+    )
+
 def test_vfs():
     turso = TestTursoShell()
     ext_path = "target/debug/libturso_ext_tests"

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -776,13 +776,28 @@ def test_decimal():
     )
     turso.run_test_fn(
         "SELECT decimal_add(X'3FE0000000000000', 2.2);",
-        lambda res: "2.7" == res,
+        lambda res: "2.2" == res,
         "decimal_add(X'3FE0000000000000', 2.2) function return correctly",
     )
     turso.run_test_fn(
         "SELECT decimal_add('2.5', '1.1');",
         lambda res: "3.6" == res,
         "decimal_add('2.5', '1.1') function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_sub('2.5', '1.1');",
+        lambda res: "1.4" == res,
+        "decimal_sub('2.5', '1.1') function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_sub(3.1, 2);",
+        lambda res: "1.1" == res,
+        "decimal_sub(3.1, 2) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_sub(X'3FE0000000000000', 2.2);",
+        lambda res: "-2.2" == res,
+        "decimal_sub(X'3FE0000000000000', 2.2) function return correctly",
     )
 
 def test_vfs():

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -720,6 +720,31 @@ def test_fuzzy():
     )
 
 
+def test_decimal():
+    turso = TestTursoShell()
+    ext_path = "./target/debug/liblimbo_decimal"
+    turso.run_test_fn(
+        "SELECT decimal('0.1');",
+        lambda res: "error: no such function: " in res,
+        "decimal function returns null when ext not loaded",
+    )
+    turso.execute_dot(f".load {ext_path}")
+    turso.run_test_fn(
+        "SELECT decimal('0.1');",
+        lambda res: "0.1" == res,
+        "decimal(0.1) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal('1.0e72');",
+        lambda res: "1000000000000000000000000000000000000000000000000000000000000000000000000"== res,
+        "decimal('1.0e72') function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_exp('+123e+4');",
+        lambda res: "+1.23e+06" == res,
+        "decimal_exp('+123e+4') function return correctly",
+    )
+    
 def test_vfs():
     turso = TestTursoShell()
     ext_path = "target/debug/libturso_ext_tests"
@@ -977,6 +1002,7 @@ def main():
         test_csv()
         test_tablestats()
         test_fuzzy()
+        test_decimal()
     except Exception as e:
         console.error(f"Test FAILED: {e}")
         cleanup()

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -764,6 +764,26 @@ def test_decimal():
         lambda res: "" == res,
         "decimal(X'DEADBEEF') function return correctly",
     )
+    turso.run_test_fn(
+        "SELECT decimal_add(0.69, 2.2222222);",
+        lambda res: "2.9122222" == res,
+        "decimal_add(0.69, 2.2222222) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_add(X'3EEEEE', 2.2);",
+        lambda res: "2.2" == res,
+        "decimal_add(X'3EEEEE', 2.2) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_add(X'3FE0000000000000', 2.2);",
+        lambda res: "2.7" == res,
+        "decimal_add(X'3FE0000000000000', 2.2) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_add('2.5', '1.1');",
+        lambda res: "3.6" == res,
+        "decimal_add('2.5', '1.1') function return correctly",
+    )
 
 def test_vfs():
     turso = TestTursoShell()

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -824,7 +824,27 @@ def test_decimal():
         lambda res: "+4.0e+00" == res,
         "decimal_pow2(2) function return correctly",
     )
-    
+    turso.run_test_fn(
+        "SELECT decimal_cmp(2.22222, 0.222);",
+        lambda res: "1" == res,
+        "decimal_cmp(2.22222, 0.222) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_cmp(0.2, 0.3);",
+        lambda res: "-1" == res,
+        "decimal_cmp(0.2, 0.3) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_cmp(0.4, '0.4');",
+        lambda res: "0" == res,
+        "decimal_cmp(0.4, '0.4')  function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_cmp('+4.0e+00', 0.4);",
+        lambda res: "1" == res,
+        "decimal_cmp('+4.0e+00', 0.4)  function return correctly",
+    )
+     
 
 def test_vfs():
     turso = TestTursoShell()

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -722,7 +722,7 @@ def test_fuzzy():
 
 def test_decimal():
     turso = TestTursoShell(init_commands="")
-    ext_path = "./target/debug/liblimbo_decimal"
+    ext_path = "./target/debug/libturso_decimal"
     turso.run_test_fn(
         "SELECT decimal('0.1');",
         lambda res: "error: no such function: " in res,

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -844,7 +844,15 @@ def test_decimal():
         lambda res: "1" == res,
         "decimal_cmp('+4.0e+00', 0.4)  function return correctly",
     )
-     
+    turso.run_test_fn(
+        """CREATE TABLE fin (val TEXT);
+        INSERT INTO fin VALUES ('123456789012345678.99');
+        INSERT INTO fin VALUES ('0.01');
+        SELECT decimal_sum(val) FROM fin;""",
+        lambda res: "123456789012345679.00" == res,
+        "decimal_sum preserves full precision",
+    )
+
 
 def test_vfs():
     turso = TestTursoShell()

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -799,6 +799,32 @@ def test_decimal():
         lambda res: "-2.2" == res,
         "decimal_sub(X'3FE0000000000000', 2.2) function return correctly",
     )
+    turso.run_test_fn(
+        "SELECT decimal_mul(3.1, 2);",
+        lambda res: "6.2" == res,
+        "decimal_mul(3.1, 2) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_mul(X'3FE0000000000000', 2.2);",
+        lambda res: "0" == res,
+        "decimal_mul(X'3FE0000000000000', 2.2) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_mul('2222', 0.2);",
+        lambda res: "444.4" == res,
+        "decimal_mul('2222', 0.2) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_pow2(3.3);",
+        lambda res: "" == res,
+        "decimal_pow2(3.3) function return correctly",
+    )
+    turso.run_test_fn(
+        "SELECT decimal_pow2(2);",
+        lambda res: "+4.0e+00" == res,
+        "decimal_pow2(2) function return correctly",
+    )
+    
 
 def test_vfs():
     turso = TestTursoShell()


### PR DESCRIPTION
## Description
This Draft PR adds support for decimal extension that adapted from sqlite decimal loadable extension
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
Closes #5515
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage
I use claude to help understand the original sqlite C implementation, IEEE-754,  and generate a test. However the code itself is written by my hand.
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
