### PR TITLE
test: fix failing test on Windows due to reserved 'aux' filename

### DIFF
--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1692,7 +1692,7 @@ fn test_update_pk_on_attached_table_with_unique_index(tmp_db: TempDatabase) -> a
         .path
         .parent()
         .unwrap()
-        .join("aux.db")
+        .join("aux_update.db")
         .to_string_lossy()
         .to_string();
     conn.execute(format!("ATTACH '{aux_path}' AS aux1"))?;


### PR DESCRIPTION
Windows FS does not allow a file to be named 'aux'. Changing the secondary DB name to 'aux_update.db' resolves the failure.

## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->
Changed the Attached DB entry name to aux_update.db instead of aux.db.
to resolve an issue on Windows where aux filenames are reserved and can't be used.

## Motivation and context
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->
While trying to run cargo test on Windows I got

```
failures:

---- query_processing::test_write_path::test_update_pk_on_attached_table_with_unique_index stdout ----

thread 'query_processing::test_write_path::test_update_pk_on_attached_table_with_unique_index' (21376) panicked at tests\integration\query_processing\test_write_path.rs:1687:1:
called `Result::unwrap()` on an `Err` value: I/O error (open): entity not found


failures:
    query_processing::test_write_path::test_update_pk_on_attached_table_with_unique_index
```
This test was introduced here #5509 
It turns out that the filenames 'aux.*' are reserved on Windows and cannot be created.
[Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file)
Changing the attached entry to `join("aux_update.db")` resolved the issue.

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

I Copy/Paste the failing test along with the failure error message to Gemini, that suggested this fix.
Made sure before changing that this is actually a reserved filename, and that modifying the name will solve this.