### PR TITLE
core/mvcc: experimental_group_commit_delay_us

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2162,6 +2162,23 @@ impl Connection {
             None => Err(LimboError::InternalError("MVCC not enabled".into())),
         }
     }
+
+    pub(crate) fn set_group_commit_delay_us(&self, delay_us: u64) -> Result<()> {
+        match self.db.get_mv_store().as_ref() {
+            Some(mv_store) => {
+                mv_store.set_group_commit_delay_us(delay_us);
+                Ok(())
+            }
+            None => Err(LimboError::InternalError("MVCC not enabled".into())),
+        }
+    }
+
+    pub(crate) fn group_commit_delay_us(&self) -> Result<u64> {
+        match self.db.get_mv_store().as_ref() {
+            Some(mv_store) => Ok(mv_store.group_commit_delay_us()),
+            None => Err(LimboError::InternalError("MVCC not enabled".into())),
+        }
+    }
 }
 
 pub type Row = vdbe::Row;

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1,3 +1,4 @@
+use crate::io::clock::MonotonicInstant;
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::cursor::{static_iterator_hack, MvccIterator};
 use crate::mvcc::persistent_storage::Storage;
@@ -43,6 +44,7 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Bound;
+use std::time::Duration;
 use tracing::instrument;
 use tracing::Level;
 
@@ -854,6 +856,14 @@ pub enum CommitState<Clock: LogicalClock> {
         end_ts: u64,
         log_record: LogRecord,
     },
+    /// Wait for a batched fsync in group commit mode. Multiple transactions
+    /// join a SyncGroup after writing their log records. The first transaction
+    /// to observe the group window expired becomes the leader and issues fsync.
+    WaitForGroupSync {
+        end_ts: u64,
+        /// True if this transaction is the leader that issued the fsync.
+        is_leader: bool,
+    },
     EndCommitLogicalLog {
         end_ts: u64,
     },
@@ -879,15 +889,98 @@ pub enum WriteRowState {
     Next,
 }
 
+/// A batch of transactions sharing a single fsync of the logical log.
+///
+/// Transactions write their log records sequentially under the commit lock,
+/// then join a SyncGroup to wait for a batched fsync. The first transaction
+/// to observe the group window has expired becomes the leader, seals the group,
+/// and issues the fsync. All members wait on the shared completion.
+struct SyncGroup {
+    /// Monotonic timestamp when this group was created.
+    created_at: MonotonicInstant,
+    /// True once sealed — no more members accepted.
+    sealed: AtomicBool,
+    /// True once a leader has been claimed via CAS.
+    leader_claimed: AtomicBool,
+    /// Set by leader after issuing fsync. Polled by followers.
+    sync_done: AtomicBool,
+    /// Set if fsync failed — all members propagate this error.
+    sync_error: Mutex<Option<String>>,
+}
+
+impl SyncGroup {
+    fn new() -> Self {
+        Self {
+            created_at: MonotonicInstant::now(),
+            sealed: AtomicBool::new(false),
+            leader_claimed: AtomicBool::new(false),
+            sync_done: AtomicBool::new(false),
+            sync_error: Mutex::new(None),
+        }
+    }
+}
+
+impl Debug for SyncGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyncGroup")
+            .field("sealed", &self.sealed.load(Ordering::Relaxed))
+            .field("sync_done", &self.sync_done.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
 #[derive(Debug)]
 struct CommitCoordinator {
+    /// Serializes logical log writes. In group commit mode, held only during
+    /// the write phase (not during fsync).
     pager_commit_lock: Arc<TursoRwLock>,
+    /// Active sync group that transactions join after writing their log record.
+    /// None when group commit is disabled or no group is currently active.
+    current_group: Mutex<Option<Arc<SyncGroup>>>,
+    /// Group commit window in microseconds. 0 = disabled (legacy per-tx fsync).
+    group_commit_delay_us: AtomicU64,
 }
 
 impl CommitCoordinator {
     fn new() -> Self {
         Self {
             pager_commit_lock: Arc::new(TursoRwLock::new()),
+            current_group: Mutex::new(None),
+            group_commit_delay_us: AtomicU64::new(0),
+        }
+    }
+
+    fn is_group_commit_enabled(&self) -> bool {
+        self.group_commit_delay_us.load(Ordering::Relaxed) > 0
+    }
+
+    fn group_commit_window(&self) -> Duration {
+        Duration::from_micros(self.group_commit_delay_us.load(Ordering::Relaxed))
+    }
+
+    /// Join an existing sync group or create a new one.
+    /// Returns the group arc.
+    fn join_or_create_group(&self) -> Arc<SyncGroup> {
+        let mut current = self.current_group.lock();
+        if let Some(ref group) = *current {
+            if !group.sealed.load(Ordering::Acquire) {
+                return group.clone();
+            }
+        }
+        let group = Arc::new(SyncGroup::new());
+        *current = Some(group.clone());
+        group
+    }
+
+    /// Seal the current group and clear it so the next joiner creates a new one.
+    fn seal_and_rotate(&self, group: &SyncGroup) {
+        group.sealed.store(true, Ordering::Release);
+        let mut current = self.current_group.lock();
+        // Only clear if this is still the current group (pointer comparison via sealed flag).
+        if let Some(ref g) = *current {
+            if g.sealed.load(Ordering::Acquire) {
+                *current = None;
+            }
         }
     }
 }
@@ -904,9 +997,13 @@ pub struct CommitStateMachine<Clock: LogicalClock> {
     header: Arc<RwLock<Option<DatabaseHeader>>>,
     pager: Arc<Pager>,
     /// Bytes appended to the logical log for this commit; applied to writer offset only after durability and before lock release.
+    /// Only used in legacy (non-group-commit) mode.
     pending_log_append_bytes: Option<u64>,
     /// The synchronous mode for fsync operations. When set to Off, fsync is skipped.
     sync_mode: SyncMode,
+    /// Sync group this transaction joined. Set when group commit is enabled and
+    /// the transaction has written its log record. None in legacy mode.
+    sync_group: Option<Arc<SyncGroup>>,
     _phantom: PhantomData<Clock>,
 }
 
@@ -967,6 +1064,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             header,
             pending_log_append_bytes: None,
             sync_mode,
+            sync_group: None,
             _phantom: PhantomData,
         }
     }
@@ -1538,7 +1636,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 return Ok(TransitionResult::Continue);
             }
             CommitState::BeginCommitLogicalLog { end_ts, log_record } => {
-                if !mvcc_store.is_exclusive_tx(&self.tx_id) {
+                let is_exclusive = mvcc_store.is_exclusive_tx(&self.tx_id);
+                if !is_exclusive {
                     // logical log needs to be serialized
                     let locked = self.commit_coordinator.pager_commit_lock.write();
                     if !locked {
@@ -1554,18 +1653,118 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         .pager_commit_lock_held
                         .store(true, Ordering::Release);
                 }
-                let (c, append_bytes) = mvcc_store.storage.log_tx(log_record)?;
-                self.pending_log_append_bytes = Some(append_bytes);
-                self.state = CommitState::SyncLogicalLog { end_ts: *end_ts };
-                // if Completion Completed without errors we can continue
-                if c.succeeded() {
-                    Ok(TransitionResult::Continue)
+
+                let use_group_commit =
+                    !is_exclusive && self.commit_coordinator.is_group_commit_enabled();
+
+                if use_group_commit {
+                    // Group commit: write + immediately advance offset, then release lock.
+                    let c = mvcc_store.storage.log_tx_and_advance(log_record)?;
+                    // Release commit lock immediately — fsync will be batched.
+                    let tx = mvcc_store
+                        .txs
+                        .get(&self.tx_id)
+                        .ok_or_else(|| LimboError::NoSuchTransactionID(self.tx_id.to_string()))?;
+                    mvcc_store.unlock_commit_lock_if_held(tx.value());
+                    self.state = CommitState::WaitForGroupSync {
+                        end_ts: *end_ts,
+                        is_leader: false,
+                    };
+                    if c.succeeded() {
+                        Ok(TransitionResult::Continue)
+                    } else {
+                        Ok(TransitionResult::Io(IOCompletions::Single(c)))
+                    }
                 } else {
-                    Ok(TransitionResult::Io(IOCompletions::Single(c)))
+                    // Legacy: deferred offset, lock held through fsync.
+                    let (c, append_bytes) = mvcc_store.storage.log_tx(log_record)?;
+                    self.pending_log_append_bytes = Some(append_bytes);
+                    self.state = CommitState::SyncLogicalLog { end_ts: *end_ts };
+                    if c.succeeded() {
+                        Ok(TransitionResult::Continue)
+                    } else {
+                        Ok(TransitionResult::Io(IOCompletions::Single(c)))
+                    }
                 }
             }
 
+            CommitState::WaitForGroupSync { end_ts, is_leader } => {
+                // Skip fsync when synchronous mode is not FULL — same as legacy path.
+                if self.sync_mode != SyncMode::Full {
+                    tracing::debug!("Skipping group fsync of logical log (synchronous!=full)");
+                    self.state = CommitState::EndCommitLogicalLog { end_ts: *end_ts };
+                    return Ok(TransitionResult::Continue);
+                }
+
+                // First entry: join or create a sync group.
+                if self.sync_group.is_none() {
+                    let group = self.commit_coordinator.join_or_create_group();
+                    self.sync_group = Some(group);
+                }
+                let group = self.sync_group.as_ref().unwrap();
+
+                // Leader re-entry: we issued the fsync on a previous step and the IO
+                // completion brought us back. The fsync succeeded (errors are handled
+                // at the point of issuance). Mark the group done for followers.
+                if *is_leader {
+                    group.sync_done.store(true, Ordering::Release);
+                    self.state = CommitState::EndCommitLogicalLog { end_ts: *end_ts };
+                    return Ok(TransitionResult::Continue);
+                }
+
+                // Check if fsync already completed (by the leader).
+                if group.sync_done.load(Ordering::Acquire) {
+                    if let Some(ref err_msg) = *group.sync_error.lock() {
+                        return Err(LimboError::InternalError(err_msg.clone()));
+                    }
+                    self.state = CommitState::EndCommitLogicalLog { end_ts: *end_ts };
+                    return Ok(TransitionResult::Continue);
+                }
+
+                // Try to become leader once the group window has expired.
+                let elapsed = group.created_at.elapsed();
+                let window = self.commit_coordinator.group_commit_window();
+
+                if elapsed >= window
+                    && group
+                        .leader_claimed
+                        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+                        .is_ok()
+                {
+                    // Leader: seal group so new arrivals create a fresh group,
+                    // then issue fsync covering all writes up to this point.
+                    self.commit_coordinator.seal_and_rotate(group);
+                    match mvcc_store.storage.sync(self.pager.get_sync_type()) {
+                        Ok(c) => {
+                            if c.succeeded() {
+                                group.sync_done.store(true, Ordering::Release);
+                                self.state = CommitState::EndCommitLogicalLog { end_ts: *end_ts };
+                                return Ok(TransitionResult::Continue);
+                            }
+                            // Fsync in flight — mark ourselves as leader so on re-entry
+                            // we take the leader path above.
+                            self.state = CommitState::WaitForGroupSync {
+                                end_ts: *end_ts,
+                                is_leader: true,
+                            };
+                            return Ok(TransitionResult::Io(IOCompletions::Single(c)));
+                        }
+                        Err(e) => {
+                            // Fsync failed — propagate to all group members.
+                            *group.sync_error.lock() = Some(e.to_string());
+                            group.sync_done.store(true, Ordering::Release);
+                            return Err(e);
+                        }
+                    }
+                }
+
+                // Follower or window not yet expired — yield and re-check.
+                Ok(TransitionResult::Io(IOCompletions::Single(
+                    Completion::new_yield(),
+                )))
+            }
             CommitState::SyncLogicalLog { end_ts } => {
+                // Legacy (non-group-commit) fsync path.
                 // Skip fsync when synchronous mode is not FULL.
                 // NORMAL mode skips fsync on commit (but still fsyncs on checkpoint).
                 if self.sync_mode != SyncMode::Full {
@@ -1600,7 +1799,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 return Ok(TransitionResult::Continue);
             }
             CommitState::CommitEnd { end_ts } => {
-                // Order of operations matters here:
+                // Order of operations matters here (legacy / non-group-commit path):
                 // 1. Advance logical log writer offset (makes the written bytes "owned")
                 // 2. Mark transaction Committed (publishes versions to readers)
                 // 3. Release commit lock (allows next committer)
@@ -1619,6 +1818,12 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 // writes to disk. If the commit fails before reaching here (e.g. during
                 // sync), the bytes are never consumed and the in-memory writer offset
                 // stays behind — the next write overwrites the uncommitted bytes.
+                //
+                // In group commit mode, (1) and (3) are already done in
+                // BeginCommitLogicalLog: offset is advanced immediately under the lock,
+                // and the lock is released before joining the sync group.
+                // pending_log_append_bytes is None, and pager_commit_lock_held is
+                // false, so the corresponding code below is naturally skipped.
                 let tx = mvcc_store
                     .txs
                     .get(&self.tx_id)
@@ -4700,6 +4905,18 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         self.storage.checkpoint_threshold()
     }
 
+    pub fn set_group_commit_delay_us(&self, delay_us: u64) {
+        self.commit_coordinator
+            .group_commit_delay_us
+            .store(delay_us, Ordering::Relaxed);
+    }
+
+    pub fn group_commit_delay_us(&self) -> u64 {
+        self.commit_coordinator
+            .group_commit_delay_us
+            .load(Ordering::Relaxed)
+    }
+
     pub fn get_real_table_id(&self, table_id: i64) -> i64 {
         let entry = self.table_id_to_rootpage.get(&MVTableId::from(table_id));
         if let Some(entry) = entry {
@@ -5185,6 +5402,11 @@ impl<Clock: LogicalClock> Debug for CommitState<Clock> {
             Self::EndCommitLogicalLog { end_ts } => f
                 .debug_struct("EndCommitLogicalLog")
                 .field("end_ts", end_ts)
+                .finish(),
+            Self::WaitForGroupSync { end_ts, is_leader } => f
+                .debug_struct("WaitForGroupSync")
+                .field("end_ts", end_ts)
+                .field("is_leader", is_leader)
                 .finish(),
             Self::SyncLogicalLog { end_ts } => f
                 .debug_struct("SyncLogicalLog")

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7115,3 +7115,141 @@ fn test_double_delete_btree_resident_row_with_unique_index() {
         "Index corruption after concurrent double-delete of B-tree-resident row"
     );
 }
+
+// -- Group commit tests --
+
+/// What this test checks: Single transaction commits correctly with group commit enabled.
+/// Why this matters: The group commit code path must handle the degenerate case of a
+/// single member in the sync group (which also becomes the leader).
+#[test]
+fn test_group_commit_single_transaction() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    let mv_store = db.get_mvcc_store();
+    mv_store.set_group_commit_delay_us(0);
+    // Enable with a minimal window — single tx should still commit fine.
+    mv_store.set_group_commit_delay_us(1);
+
+    conn.execute("CREATE TABLE t(x)").unwrap();
+    conn.execute("INSERT INTO t VALUES (42)").unwrap();
+
+    let rows = get_rows(&conn, "SELECT * FROM t");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].to_string(), "42");
+}
+
+/// What this test checks: Existing commit behavior is unchanged when group commit is disabled.
+/// Why this matters: Regression test — the default (group_commit_delay_us=0) must use the
+/// legacy per-tx fsync path.
+#[test]
+fn test_group_commit_disabled_regression() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    let mv_store = db.get_mvcc_store();
+    assert_eq!(mv_store.group_commit_delay_us(), 0);
+    assert!(!mv_store.commit_coordinator.is_group_commit_enabled());
+
+    conn.execute("CREATE TABLE t(x)").unwrap();
+    conn.execute("INSERT INTO t VALUES (1)").unwrap();
+    conn.execute("INSERT INTO t VALUES (2)").unwrap();
+
+    let rows = get_rows(&conn, "SELECT * FROM t ORDER BY x");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].to_string(), "1");
+    assert_eq!(rows[1][0].to_string(), "2");
+}
+
+/// What this test checks: The group_commit_delay_us PRAGMA reads and writes correctly.
+/// Why this matters: The PRAGMA is the user-facing configuration surface.
+#[test]
+fn test_group_commit_pragma() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+
+    // Default is 0 (disabled).
+    let rows = get_rows(&conn, "PRAGMA group_commit_delay_us");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].to_string(), "0");
+
+    // Set to 5000 (5ms).
+    conn.execute("PRAGMA group_commit_delay_us = 5000").unwrap();
+    let rows = get_rows(&conn, "PRAGMA group_commit_delay_us");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].to_string(), "5000");
+
+    // Set back to 0.
+    conn.execute("PRAGMA group_commit_delay_us = 0").unwrap();
+    let rows = get_rows(&conn, "PRAGMA group_commit_delay_us");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].to_string(), "0");
+}
+
+/// What this test checks: Group commit works with auto-checkpoint.
+/// Why this matters: Checkpoint is triggered in CommitEnd after the group sync completes.
+/// The offset must be correctly advanced for should_checkpoint() to trigger.
+#[test]
+fn test_group_commit_with_checkpoint() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    let mv_store = db.get_mvcc_store();
+
+    // Enable group commit with minimal window.
+    mv_store.set_group_commit_delay_us(1);
+    // Force checkpoint on every commit.
+    mv_store.set_checkpoint_threshold(0);
+
+    conn.execute("CREATE TABLE t(x)").unwrap();
+    conn.execute("INSERT INTO t VALUES (1)").unwrap();
+    conn.execute("INSERT INTO t VALUES (2)").unwrap();
+
+    let rows = get_rows(&conn, "SELECT * FROM t ORDER BY x");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].to_string(), "1");
+    assert_eq!(rows[1][0].to_string(), "2");
+}
+
+/// What this test checks: Multiple sequential transactions commit correctly with group commit.
+/// Why this matters: Each transaction creates/joins a sync group. Sequential transactions
+/// should each get their own group (window expired by the time the next one commits).
+#[test]
+fn test_group_commit_multiple_sequential_transactions() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    let mv_store = db.get_mvcc_store();
+
+    // Enable group commit with 1us window — effectively immediate for sequential txns.
+    mv_store.set_group_commit_delay_us(1);
+
+    conn.execute("CREATE TABLE t(x)").unwrap();
+    for i in 0..10 {
+        conn.execute(format!("INSERT INTO t VALUES ({i})"))
+            .unwrap();
+    }
+
+    let rows = get_rows(&conn, "SELECT count(*) FROM t");
+    assert_eq!(rows[0][0].to_string(), "10");
+}
+
+/// What this test checks: Group commit with restart (recovery) preserves data.
+/// Why this matters: After a restart, the logical log is replayed. Group-committed
+/// transactions that were fsynced must be recovered correctly.
+#[test]
+fn test_group_commit_restart_recovery() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        let mv_store = db.get_mvcc_store();
+        mv_store.set_group_commit_delay_us(1);
+
+        conn.execute("CREATE TABLE t(x)").unwrap();
+        conn.execute("INSERT INTO t VALUES (100)").unwrap();
+        conn.execute("INSERT INTO t VALUES (200)").unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    let rows = get_rows(&conn, "SELECT * FROM t ORDER BY x");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].to_string(), "100");
+    assert_eq!(rows[1][0].to_string(), "200");
+}

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -396,6 +396,13 @@ impl LogicalLog {
         Ok(c)
     }
 
+    /// Writes a transaction to the log, immediately advances the writer offset,
+    /// and returns `(completion, bytes_written)`. Used by group commit where the
+    /// caller needs the byte count for shadow offset tracking.
+    pub fn log_tx_with_byte_count(&mut self, tx: &LogRecord) -> Result<(Completion, u64)> {
+        self.serialize_and_pwrite_tx(tx, true)
+    }
+
     /// Writes a transaction to the log but does NOT advance the writer offset.
     /// Returns `(completion, bytes_written)`. The caller must call
     /// `advance_offset_after_success(bytes)` after confirming the commit succeeded.

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -43,6 +43,17 @@ impl Storage {
         self.logical_log.write().log_tx_deferred_offset(m)
     }
 
+    /// Write log record AND immediately advance offset and CRC chain.
+    /// Used by group commit where the caller holds the commit lock to serialize
+    /// writes, and durability is guaranteed by a later batched fsync.
+    pub fn log_tx_and_advance(&self, m: &LogRecord) -> Result<Completion> {
+        let mut log = self.logical_log.write();
+        let (c, bytes) = log.log_tx_with_byte_count(m)?;
+        drop(log);
+        self.shadow_offset_advance(bytes);
+        Ok(c)
+    }
+
     pub fn read_tx_log(&self) -> Result<Vec<LogRecord>> {
         todo!()
     }

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -167,6 +167,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["mvcc_checkpoint_threshold"],
         ),
+        PragmaName::ExperimentalGroupCommitDelayUs => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["experimental_group_commit_delay_us"],
+        ),
         ForeignKeys => Pragma::new(
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["foreign_keys"],

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -481,6 +481,15 @@ fn update_pragma(
             connection.set_mvcc_checkpoint_threshold(threshold)?;
             Ok(TransactionMode::None)
         }
+        PragmaName::ExperimentalGroupCommitDelayUs => {
+            let delay = match parse_signed_number(&value)? {
+                Value::Numeric(Numeric::Integer(size)) if size >= 0 => size as u64,
+                _ => bail_parse_error!("experimental_group_commit_delay_us must be 0 or a positive integer"),
+            };
+
+            connection.set_group_commit_delay_us(delay)?;
+            Ok(TransactionMode::None)
+        }
         PragmaName::ForeignKeys => {
             let enabled = parse_pragma_enabled(&value);
             connection.set_foreign_keys_enabled(enabled);
@@ -1191,6 +1200,14 @@ fn query_pragma(
             let threshold = connection.mvcc_checkpoint_threshold()?;
             let register = program.alloc_register();
             program.emit_int(threshold, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::ExperimentalGroupCommitDelayUs => {
+            let delay = connection.group_commit_delay_us()?;
+            let register = program.alloc_register();
+            program.emit_int(delay as i64, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1654,6 +1654,10 @@ pub enum PragmaName {
     WalCheckpoint,
     /// Sets or queries the threshold (in bytes) at which MVCC triggers an automatic checkpoint.
     MvccCheckpointThreshold,
+    /// Sets or queries the group commit delay in microseconds for MVCC.
+    /// When > 0, transactions batch their fsync calls within this window
+    /// to trade latency for throughput.
+    ExperimentalGroupCommitDelayUs,
     /// List all available types (built-in and custom)
     ListTypes,
 }

--- a/perf/throughput/plot/plot-compute-impact.py
+++ b/perf/throughput/plot/plot-compute-impact.py
@@ -1,15 +1,11 @@
+import os
 import sys
 
 import matplotlib.pyplot as plt
 import pandas as pd
 import scienceplots  # noqa: F401
 
-plt.style.use(["science"])
-plt.rcParams.update({
-  "text.usetex": True,
-  "font.family": "serif",
-  "font.serif": ["Times"],
-})
+plt.style.use(["science", "no-latex"])
 
 # Get CSV filenames from command line arguments
 if len(sys.argv) < 2:
@@ -21,8 +17,13 @@ csv_filenames = sys.argv[1:]
 # Output filename
 output_filename = "compute-impact.pdf"
 
-# Read data from all CSV files and concatenate
-dfs = [pd.read_csv(filename) for filename in csv_filenames]
+# Read data from all CSV files, using the filename stem as the system name.
+dfs = []
+for filename in csv_filenames:
+    frame = pd.read_csv(filename)
+    stem = os.path.splitext(os.path.basename(filename))[0]
+    frame["system"] = stem
+    dfs.append(frame)
 df = pd.concat(dfs, ignore_index=True)
 
 # Create figure and axis
@@ -55,7 +56,7 @@ for sys_idx, system in enumerate(systems):
             plot_idx += 1
 
 # Customize the plot
-ax.set_xlabel(r"Compute Time (microseconds)", fontsize=14, fontweight="bold")
+ax.set_xlabel("Compute Time (microseconds)", fontsize=14, fontweight="bold")
 ax.set_ylabel("Throughput (rows/second)", fontsize=14, fontweight="bold")
 
 # Set y-axis to start from 0 with dynamic upper limit

--- a/perf/throughput/plot/plot-thread-scaling.py
+++ b/perf/throughput/plot/plot-thread-scaling.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import matplotlib.pyplot as plt
@@ -5,7 +6,7 @@ import numpy as np
 import pandas as pd
 import scienceplots  # noqa: F401
 
-plt.style.use(["science"])
+plt.style.use(["science", "no-latex"])
 
 # Get CSV filenames from command line arguments
 if len(sys.argv) < 2:
@@ -17,8 +18,17 @@ csv_filenames = sys.argv[1:]
 # Output filename
 output_filename = "thread-scaling.pdf"
 
-# Read data from all CSV files and concatenate
-dfs = [pd.read_csv(filename) for filename in csv_filenames]
+# Read data from all CSV files, using the filename stem as the system name
+# when multiple files share the same system column value.
+dfs = []
+for filename in csv_filenames:
+    frame = pd.read_csv(filename)
+    # Use filename stem (e.g. "turso-mvcc-group") as the system label
+    # so that multiple CSVs with "Turso" in the system column are
+    # distinguishable on the plot.
+    stem = os.path.splitext(os.path.basename(filename))[0]
+    frame["system"] = stem
+    dfs.append(frame)
 df = pd.concat(dfs, ignore_index=True)
 
 # Filter for compute time = 0
@@ -35,21 +45,23 @@ fig, ax = plt.subplots(figsize=(10, 6))
 x_pos = np.arange(len(threads))
 bar_width = 0.35
 
-# Colors and hatching patterns matching TPC-H plot
-system_colors = {"Turso": "#2E7D32", "SQLite": "#1976D2"}
-system_hatches = {"Turso": "//", "SQLite": "///"}
+# Colors and hatching patterns — one per CSV / system label
+palette = ["#2E7D32", "#1976D2", "#D32F2F", "#F57C00", "#7B1FA2"]
+hatch_pool = ["//", "///", "\\\\", "xx", ""]
 
 # Plot bars for each system
+n_systems = len(systems)
+bar_width = 0.8 / max(n_systems, 1)
 for i, system in enumerate(systems):
     system_data = df_filtered[df_filtered["system"] == system].sort_values("threads")
     throughput = system_data["throughput"].tolist()
 
-    offset = (i - len(systems)/2 + 0.5) * bar_width
+    offset = (i - n_systems / 2 + 0.5) * bar_width
     bars = ax.bar(x_pos + offset, throughput, bar_width,
                    label=system,
-                   color=system_colors.get(system, "#888888"),
+                   color=palette[i % len(palette)],
                    edgecolor="black", linewidth=0.5,
-                   hatch=system_hatches.get(system, ""),
+                   hatch=hatch_pool[i % len(hatch_pool)],
                    rasterized=True)
 
 # Customize the plot

--- a/perf/throughput/turso/bench.sh
+++ b/perf/throughput/turso/bench.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RUNS=${1:-10}
-CMD="cargo run --release --bin write-throughput -- -t 6 --mode legacy -i 1000"
+CMD="cargo run --release --bin write-throughput -- -t 6 --mode concurrent -i 1000"
 
 echo "Running benchmark $RUNS times..."
 echo "Command: $CMD"

--- a/perf/throughput/turso/src/main.rs
+++ b/perf/throughput/turso/src/main.rs
@@ -52,6 +52,13 @@ struct Args {
 
     #[arg(long = "io", help = "IO backend")]
     io: Option<IoOption>,
+
+    #[arg(
+        long = "group-commit-delay",
+        default_value = "0",
+        help = "Group commit delay in microseconds (0 = disabled)"
+    )]
+    group_commit_delay: u64,
 }
 
 fn main() -> Result<()> {
@@ -87,7 +94,7 @@ async fn async_main(args: Args) -> Result<()> {
         std::fs::remove_file(wal_path).expect("Failed to remove existing database");
     }
 
-    let db = setup_database(db_path, args.mode, args.io).await?;
+    let db = setup_database(db_path, args.mode, args.io, args.group_commit_delay).await?;
 
     let start_barrier = Arc::new(Barrier::new(args.threads));
     let mut handles = Vec::new();
@@ -144,6 +151,7 @@ async fn setup_database(
     db_path: &str,
     mode: TransactionMode,
     io: Option<IoOption>,
+    group_commit_delay: u64,
 ) -> Result<Database> {
     let builder = Builder::new_local(db_path);
 
@@ -163,6 +171,11 @@ async fn setup_database(
         TransactionMode::Mvcc | TransactionMode::Concurrent | TransactionMode::LogicalLog
     ) {
         conn.pragma_update("journal_mode", "'mvcc'").await?;
+    }
+
+    if group_commit_delay > 0 {
+        conn.pragma_update("experimental_group_commit_delay_us", group_commit_delay)
+            .await?;
     }
 
     conn.execute(


### PR DESCRIPTION
- Implement group commit for MVCC: multiple concurrent transactions batch their fsync calls into a single fsync, trading commit latency for throughput
- Add `PRAGMA experimental_group_commit_delay_us` to configure the batch window (0 = disabled, default)
- Add `--group-commit-delay` flag to the write-throughput benchmark

Currently each MVCC commit holds the `pager_commit_lock` for the entire duration of: log write → fsync → offset advance. The fsync dominates (~milliseconds on SSD), serializing all concurrent commits.

Group commit splits this: transactions write their log record and advance the offset under the lock (microseconds), then release the lock and join a **SyncGroup** to wait for a batched fsync. The first transaction to observe the batch window expired becomes the **leader** via CAS on `leader_claimed`, seals the group, and issues a single fsync covering all pending writes. Followers poll `sync_done` and proceed once set.

New state machine flow (group commit enabled):
```
BeginCommitLogicalLog  →  WaitForGroupSync [NEW]  →  EndCommitLogicalLog  →  CommitEnd
   (write + advance         (join group, leader       (schema updates,        (mark Committed,
    offset, release lock)    election, batched fsync)   header copy)            notify deps)