### PR TITLE
Fix unsound schema access when loading extensions

### DIFF
--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -75,12 +75,11 @@ pub(crate) unsafe extern "C" fn register_vtab_module(
 
         if kind == VTabKind::TableValuedFunction {
             if let Ok(vtab) = VirtualTable::function(&name_str, syms) {
-                // Use the schema handler to insert the table
                 let table = Arc::new(Table::Virtual(vtab));
                 let mutex = &*(ext_ctx.schema as *mut Mutex<Arc<Schema>>);
-                let guard = mutex.lock();
-                let schema_ptr = Arc::as_ptr(&*guard) as *mut Schema;
-                (*schema_ptr).tables.insert(name_str, table);
+                let mut guard = mutex.lock();
+                let schema = Arc::make_mut(&mut *guard);
+                schema.tables.insert(name_str, table);
             } else {
                 return ResultCode::Error;
             }


### PR DESCRIPTION
## Description
Closes #2261 

We use `Arc::make_mut` in all other areas when mutating the schema, so we should also use it here. 