### PR TITLE
mvcc: fix autoincrement handling

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -272,6 +272,7 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static> {
     btree_advance_state: Option<AdvanceBtreeState>,
     /// Dual-cursor peek state for proper iteration
     dual_peek: DualCursorPeek,
+    suppress_rowid_allocator_update_once: bool,
 }
 
 pub enum NextRowidResult {
@@ -315,6 +316,7 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
             count_state: None,
             btree_advance_state: None,
             dual_peek: DualCursorPeek::default(),
+            suppress_rowid_allocator_update_once: false,
         })
     }
 
@@ -429,6 +431,31 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
             allocator.unlock();
             self.creating_new_rowid = false;
         }
+    }
+
+    /// Marks this cursor's table-id as `sqlite_sequence` in the MV store so
+    /// sqlite_sequence-specific MVCC rules can be applied.
+    pub fn register_sqlite_sequence_table_id(&self) {
+        self.db.register_sqlite_sequence_table_id(self.table_id);
+    }
+
+    /// Suppresses a single allocator bump on the next table insert through
+    /// this cursor.
+    ///
+    /// Used for UPDATE rowid rewrite paths (`DELETE` + `INSERT`) so those
+    /// inserts do not advance AUTOINCREMENT allocator state as if they were
+    /// fresh auto-generated rowids.
+    pub fn suppress_next_rowid_allocator_update(&mut self) {
+        self.suppress_rowid_allocator_update_once = true;
+    }
+
+    /// Raises the rowid allocator floor to at least `rowid`.
+    ///
+    /// This is used by `NewRowid` when a caller provides a `prev_largest_reg`
+    /// floor (e.g. AUTOINCREMENT floor derived from sequence/table max).
+    pub fn bump_rowid_floor(&self, rowid: i64) {
+        let allocator = self.db.get_rowid_allocator(&self.table_id);
+        allocator.insert_row_id_maybe_update(rowid);
     }
 
     fn get_immutable_record_or_create(&mut self) -> Option<&mut ImmutableRecord> {
@@ -1236,6 +1263,9 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
     /// Insert a row into the table or index.
     /// Sets the cursor to the inserted row.
     fn insert(&mut self, key: &BTreeKey) -> Result<IOResult<()>> {
+        let suppress_allocator_update = self.suppress_rowid_allocator_update_once;
+        self.suppress_rowid_allocator_update_once = false;
+
         let row_id = match key {
             BTreeKey::TableRowId((rowid, _)) => RowID::new(self.table_id, RowKey::Int(*rowid)),
             BTreeKey::IndexKey(record) => {
@@ -1292,7 +1322,12 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
             .is_some()
         {
             self.db
-                .update_to_table_or_index(self.tx_id, row, maybe_index_id)
+                .update_to_table_or_index_with_allocator_update(
+                    self.tx_id,
+                    row,
+                    maybe_index_id,
+                    !suppress_allocator_update,
+                )
                 .inspect_err(|_| {
                     self.current_pos = CursorPosition::BeforeFirst;
                 })?;
@@ -1306,7 +1341,12 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                 })?;
         } else {
             self.db
-                .insert_to_table_or_index(self.tx_id, row, maybe_index_id)
+                .insert_to_table_or_index_with_allocator_update(
+                    self.tx_id,
+                    row,
+                    maybe_index_id,
+                    !suppress_allocator_update,
+                )
                 .inspect_err(|_| {
                     self.current_pos = CursorPosition::BeforeFirst;
                 })?;

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -272,6 +272,11 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static> {
     btree_advance_state: Option<AdvanceBtreeState>,
     /// Dual-cursor peek state for proper iteration
     dual_peek: DualCursorPeek,
+    /// One-shot flag that prevents the next `insert()` from bumping the MVCC
+    /// rowid allocator. SQLite implements `UPDATE ... SET rowid = <new>` as
+    /// DELETE + INSERT; without this flag the re-insert would feed the
+    /// user-chosen rowid into the monotonic allocator, advancing it as though
+    /// a fresh auto-generated rowid was consumed.
     suppress_rowid_allocator_update_once: bool,
 }
 

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -454,7 +454,9 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             }
                         } else if type_str.as_str() == "table" {
                             // This is a table schema change (existing logic)
-                            tracing::trace!("table schema change with root page {root_page}, is_delete={is_delete}");
+                            tracing::trace!(
+                                "table schema change with root page {root_page}, is_delete={is_delete}"
+                            );
                             if is_delete {
                                 if root_page < 0 {
                                     // Table was never checkpointed - derive table_id directly from root_page.

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -981,6 +981,11 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         tx: &Transaction,
         mvcc_store: &Arc<MvStore<Clock>>,
     ) -> Result<()> {
+        if mvcc_store.is_sqlite_sequence_table_id(rowid.table_id) {
+            // sqlite_sequence uses monotonic sequence metadata updates; concurrent
+            // AUTOINCREMENT writers must not fail due to row-level WW conflicts on this table.
+            return Ok(());
+        }
         let row_versions = mvcc_store.rows.get(rowid);
         if row_versions.is_none() {
             return Ok(());
@@ -2027,6 +2032,7 @@ pub struct MvStore<Clock: LogicalClock> {
     /// to exclusive, it will abort if another transaction committed after its begin timestamp.
     last_committed_tx_ts: AtomicU64,
     table_id_to_last_rowid: RwLock<HashMap<MVTableId, Arc<RowidAllocator>>>,
+    sqlite_sequence_table_ids: RwLock<HashSet<MVTableId>>,
 }
 
 impl<Clock: LogicalClock> MvStore<Clock> {
@@ -2101,6 +2107,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             last_committed_schema_change_ts: AtomicU64::new(0),
             last_committed_tx_ts: AtomicU64::new(0),
             table_id_to_last_rowid: RwLock::new(HashMap::default()),
+            sqlite_sequence_table_ids: RwLock::new(HashSet::default()),
         }
     }
 
@@ -2169,7 +2176,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             Err(err) => {
                 return Err(LimboError::Corrupt(format!(
                     "Failed to read MVCC metadata table: {err}"
-                )))
+                )));
             }
         };
         let mut value: Option<i64> = None;
@@ -2340,6 +2347,22 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         row: Row,
         maybe_index_id: Option<MVTableId>,
     ) -> Result<()> {
+        self.insert_to_table_or_index_with_allocator_update(tx_id, row, maybe_index_id, true)
+    }
+
+    /// Same as [`Self::insert_to_table_or_index`], but allows callers to
+    /// suppress rowid allocator updates for table inserts.
+    ///
+    /// This is used for UPDATE rowid rewrite paths (`DELETE` + `INSERT`) where
+    /// the inserted rowid should not be treated as advancing the allocator's
+    /// AUTOINCREMENT floor.
+    pub fn insert_to_table_or_index_with_allocator_update(
+        &self,
+        tx_id: TxID,
+        row: Row,
+        maybe_index_id: Option<MVTableId>,
+        update_rowid_allocator: bool,
+    ) -> Result<()> {
         tracing::trace!("insert(tx_id={}, row.id={:?})", tx_id, row.id);
         let tx = self
             .txs
@@ -2382,8 +2405,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 };
                 tx.insert_to_write_set(id.clone());
                 tx.record_created_table_version(id.clone(), version_id);
-                let allocator = self.get_rowid_allocator(&id.table_id);
-                allocator.insert_row_id_maybe_update(id.row_id.to_int_or_panic());
+                if update_rowid_allocator {
+                    let allocator = self.get_rowid_allocator(&id.table_id);
+                    allocator.insert_row_id_maybe_update(id.row_id.to_int_or_panic());
+                }
                 self.insert_version(id, row_version);
             }
         }
@@ -2518,11 +2543,31 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         row: Row,
         maybe_index_id: Option<MVTableId>,
     ) -> Result<bool> {
+        self.update_to_table_or_index_with_allocator_update(tx_id, row, maybe_index_id, true)
+    }
+
+    /// Same as [`Self::update_to_table_or_index`], but allows callers to
+    /// control whether the inserted replacement row updates the rowid allocator.
+    ///
+    /// The update is implemented as delete-then-insert; the flag is forwarded
+    /// to the insert step.
+    pub fn update_to_table_or_index_with_allocator_update(
+        &self,
+        tx_id: TxID,
+        row: Row,
+        maybe_index_id: Option<MVTableId>,
+        update_rowid_allocator: bool,
+    ) -> Result<bool> {
         tracing::trace!("update(tx_id={}, row.id={:?})", tx_id, row.id);
         if !self.delete_from_table_or_index(tx_id, row.id.clone(), maybe_index_id)? {
             return Ok(false);
         }
-        self.insert_to_table_or_index(tx_id, row, maybe_index_id)?;
+        self.insert_to_table_or_index_with_allocator_update(
+            tx_id,
+            row,
+            maybe_index_id,
+            update_rowid_allocator,
+        )?;
         Ok(true)
     }
 
@@ -2619,6 +2664,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             None => {
                 let row_versions_opt = self.rows.get(&id);
                 if let Some(ref row_versions) = row_versions_opt {
+                    let ignore_conflicts = self.is_sqlite_sequence_table_id(id.table_id);
                     let mut row_versions = row_versions.value().write();
                     for rv in row_versions.iter_mut().rev() {
                         let tx = self
@@ -2632,7 +2678,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
                             continue;
                         }
-                        if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv) {
+                        if !ignore_conflicts
+                            && is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
+                        {
                             turso_assert_reachable!("write-write conflict on delete");
                             drop(row_versions);
                             drop(row_versions_opt);
@@ -2714,11 +2762,45 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             None => {
                 if let Some(row_versions) = self.rows.get(id) {
                     let row_versions = row_versions.value().read();
-                    if let Some(rv) = row_versions
-                        .iter()
-                        .rev()
-                        .find(|rv| rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
-                    {
+                    let selected = if self.is_sqlite_sequence_table_id(id.table_id) {
+                        // sqlite_sequence is monotonic metadata, not regular user data.
+                        //
+                        // Under MVCC we can have multiple visible versions/rows for the same
+                        // logical sequence entry (same table name) from concurrent writers.
+                        // If we just returned the latest visible version by MVCC order, we can
+                        // pick a stale/lower sequence value and regress AUTOINCREMENT behavior.
+                        //
+                        // To preserve SQLite semantics ("never reuse a lower AUTOINCREMENT id"),
+                        // prefer the visible row with the highest seq value. If seq parsing fails
+                        // for all visible rows, fall back to latest_visible to preserve read
+                        // behavior instead of returning no row.
+                        let mut latest_visible: Option<&RowVersion> = None;
+                        let mut max_seq_visible: Option<(i64, &RowVersion)> = None;
+                        for rv in row_versions.iter().rev() {
+                            if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
+                                continue;
+                            }
+                            if latest_visible.is_none() {
+                                latest_visible = Some(rv);
+                            }
+                            if let Some(seq) = sqlite_sequence_seq_from_row(&rv.row) {
+                                let should_replace = match max_seq_visible {
+                                    Some((max_seq, _)) => seq > max_seq,
+                                    None => true,
+                                };
+                                if should_replace {
+                                    max_seq_visible = Some((seq, rv));
+                                }
+                            }
+                        }
+                        max_seq_visible.map(|(_, rv)| rv).or(latest_visible)
+                    } else {
+                        row_versions
+                            .iter()
+                            .rev()
+                            .find(|rv| rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
+                    };
+                    if let Some(rv) = selected {
                         tx.insert_to_read_set(id.clone());
                         return Ok(Some(rv.row.clone()));
                     }
@@ -4128,12 +4210,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             HeaderReadResult::NoLog => {
                 return Err(LimboError::Corrupt(
                     "WAL has committed frames but logical log header is missing".to_string(),
-                ))
+                ));
             }
             HeaderReadResult::Invalid => {
                 return Err(LimboError::Corrupt(
                     "WAL has committed frames but logical log header is invalid".to_string(),
-                ))
+                ));
             }
         };
         self.storage.set_header(header);
@@ -4213,7 +4295,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             HeaderReadResult::Invalid => {
                 return Err(LimboError::Corrupt(
                     "Logical log header corrupt and no WAL recovery available".to_string(),
-                ))
+                ));
             }
         };
 
@@ -4228,7 +4310,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 None => {
                     return Err(LimboError::Corrupt(
                         "Missing MVCC metadata table".to_string(),
-                    ))
+                    ));
                 }
             }
         } else {
@@ -4298,7 +4380,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         _ => {
                             return Err(LimboError::Corrupt(
                                 "sqlite_schema type must be text".to_string(),
-                            ))
+                            ));
                         }
                     };
                     let name = match record.get_value_opt(1) {
@@ -4306,7 +4388,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         _ => {
                             return Err(LimboError::Corrupt(
                                 "sqlite_schema name must be text".to_string(),
-                            ))
+                            ));
                         }
                     };
                     let table_name = match record.get_value_opt(2) {
@@ -4314,7 +4396,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         _ => {
                             return Err(LimboError::Corrupt(
                                 "sqlite_schema tbl_name must be text".to_string(),
-                            ))
+                            ));
                         }
                     };
                     let root_page = match record.get_value_opt(3) {
@@ -4322,7 +4404,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         _ => {
                             return Err(LimboError::Corrupt(
                                 "sqlite_schema root_page must be integer".to_string(),
-                            ))
+                            ));
                         }
                     };
                     let sql = match record.get_value_opt(4) {
@@ -4465,17 +4547,23 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                 let table_id = self.get_table_id_from_root_page(root_page);
                                 if let Some(entry) = self.table_id_to_rootpage.get(&table_id) {
                                     if let Some(value) = *entry.value() {
-                                        panic!("Logical log contains an insertion of a sqlite_schema record that has both a negative root page and a positive root page: {root_page} & {value}");
+                                        panic!(
+                                            "Logical log contains an insertion of a sqlite_schema record that has both a negative root page and a positive root page: {root_page} & {value}"
+                                        );
                                     }
                                 }
                                 self.insert_table_id_to_rootpage(table_id, None);
                             } else {
                                 let table_id = self.get_table_id_from_root_page(root_page);
                                 let Some(entry) = self.table_id_to_rootpage.get(&table_id) else {
-                                    panic!("Logical log contains root page reference {root_page} that does not exist in the table_id_to_rootpage map");
+                                    panic!(
+                                        "Logical log contains root page reference {root_page} that does not exist in the table_id_to_rootpage map"
+                                    );
                                 };
                                 let Some(value) = *entry.value() else {
-                                    panic!("Logical log contains root page reference {root_page} that does not have a root page in the table_id_to_rootpage map");
+                                    panic!(
+                                        "Logical log contains root page reference {root_page} that does not have a root page in the table_id_to_rootpage map"
+                                    );
                                 };
                                 turso_assert_eq!(value, root_page as u64, "logical log root page does not match table_id_to_rootpage map", { "root_page": root_page, "map_value": value });
                             }
@@ -4738,6 +4826,17 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
     }
 
+    /// Records a table-id as `sqlite_sequence` so MVCC can apply its special
+    /// conflict/read rules for AUTOINCREMENT metadata rows.
+    pub fn register_sqlite_sequence_table_id(&self, table_id: MVTableId) {
+        self.sqlite_sequence_table_ids.write().insert(table_id);
+    }
+
+    /// Returns true if `table_id` is known to be the `sqlite_sequence` table.
+    pub fn is_sqlite_sequence_table_id(&self, table_id: MVTableId) -> bool {
+        self.sqlite_sequence_table_ids.read().contains(&table_id)
+    }
+
     pub fn is_btree_allocated(&self, table_id: &MVTableId) -> bool {
         let maybe_root_page = self.table_id_to_rootpage.get(table_id);
         maybe_root_page.is_some_and(|entry| entry.value().is_some())
@@ -4876,6 +4975,15 @@ fn is_write_write_conflict(
         Some(TxTimestampOrID::Timestamp(_)) => true,
         None => false,
     }
+}
+
+fn sqlite_sequence_seq_from_row(row: &Row) -> Option<i64> {
+    let record = ImmutableRecord::from_bin_record(row.payload().to_vec());
+    let val = record.get_value_opt(1)?;
+    let ValueRef::Numeric(Numeric::Integer(seq)) = val else {
+        return None;
+    };
+    Some(seq)
 }
 
 impl RowVersion {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6463,6 +6463,48 @@ fn test_mvcc_same_primary_key_concurrent() {
         .expect_err("duplicate key - first committer wins");
 }
 
+/// What this test checks: AUTOINCREMENT inserts in concurrent MVCC transactions can proceed
+/// without failing due to sqlite_sequence write-write conflicts.
+/// Why this matters: sqlite_sequence is shared metadata for a table and should not serialize
+/// otherwise-disjoint row inserts in optimistic concurrent write mode.
+#[test]
+fn test_mvcc_autoincrement_concurrent_inserts_do_not_conflict_on_sqlite_sequence() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn1 = db.connect();
+    let conn2 = db.connect();
+
+    conn1
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, payload TEXT)")
+        .unwrap();
+
+    // Seed sqlite_sequence so concurrent writers both perform updates to the
+    // same sqlite_sequence row.
+    conn1
+        .execute("INSERT INTO t(payload) VALUES ('seed')")
+        .unwrap();
+
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+    conn2.execute("BEGIN CONCURRENT").unwrap();
+
+    conn1
+        .execute("INSERT INTO t(payload) VALUES ('c1')")
+        .unwrap();
+    conn2
+        .execute("INSERT INTO t(payload) VALUES ('c2')")
+        .unwrap();
+
+    conn1.execute("COMMIT").unwrap();
+    conn2
+        .execute("COMMIT")
+        .expect("AUTOINCREMENT concurrent commit should not fail on sqlite_sequence conflict");
+
+    let rows = get_rows(&conn1, "SELECT id, payload FROM t ORDER BY id");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0][1].to_string(), "seed");
+    assert_eq!(rows[1][1].to_string(), "c1");
+    assert_eq!(rows[2][1].to_string(), "c2");
+}
+
 // ─── End-to-end GC + dual cursor tests ───────────────────────────────────
 
 /// After checkpoint + GC, checkpointed current versions are removed from
@@ -7393,4 +7435,59 @@ fn test_autoincrement_no_reuse_after_delete_and_restart() {
          sqlite_sequence had {seq_count} duplicate rows; \
          init_autoincrement picked the stale one (seq=1 instead of seq=2)."
     );
+}
+
+/// UPDATE on a rowid alias must not advance AUTOINCREMENT state.
+/// Only INSERTs (implicit or explicit rowid) should move sqlite_sequence.
+#[test]
+#[ignore = "AUTOINCREMENT not yet supported in MVCC mode"]
+fn test_autoincrement_update_rowid_does_not_advance_sequence() {
+    let _ = tracing_subscriber::fmt().try_init();
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, b TEXT)")
+        .unwrap();
+
+    conn.execute("INSERT INTO t(b) VALUES ('seed')").unwrap();
+    conn.execute("UPDATE OR IGNORE t SET a = 30 WHERE a = 1")
+        .unwrap();
+    conn.execute("DELETE FROM t WHERE a = 30").unwrap();
+    conn.execute("INSERT INTO t(b) VALUES ('after_delete')")
+        .unwrap();
+
+    let rows = get_rows(&conn, "SELECT a FROM t ORDER BY a");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+
+    let seq_rows = get_rows(&conn, "SELECT seq FROM sqlite_sequence WHERE name = 't'");
+    assert_eq!(seq_rows.len(), 1);
+    assert_eq!(seq_rows[0][0].as_int().unwrap(), 2);
+}
+
+/// AUTOINCREMENT must still account for the current table max rowid after UPDATE.
+#[test]
+#[ignore = "AUTOINCREMENT not yet supported in MVCC mode"]
+fn test_autoincrement_uses_current_max_rowid_after_update() {
+    let _ = tracing_subscriber::fmt().try_init();
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, b TEXT)")
+        .unwrap();
+
+    conn.execute("INSERT INTO t(b) VALUES ('seed')").unwrap();
+    conn.execute("UPDATE OR IGNORE t SET a = 30 WHERE a = 1")
+        .unwrap();
+    conn.execute("INSERT INTO t(b) VALUES ('after_update')")
+        .unwrap();
+
+    let rows = get_rows(&conn, "SELECT a FROM t ORDER BY a");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].as_int().unwrap(), 30);
+    assert_eq!(rows[1][0].as_int().unwrap(), 31);
+
+    let seq_rows = get_rows(&conn, "SELECT seq FROM sqlite_sequence WHERE name = 't'");
+    assert_eq!(seq_rows.len(), 1);
+    assert_eq!(seq_rows[0][0].as_int().unwrap(), 31);
 }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -3210,6 +3210,7 @@ fn build_constraints_to_check(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emit_update_sqlite_sequence(
     program: &mut ProgramBuilder,
     resolver: &Resolver,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -90,11 +90,6 @@ fn validate(
     if table.btree().is_some_and(|t| !t.has_rowid) {
         crate::bail_parse_error!("INSERT into WITHOUT ROWID table is not supported");
     }
-    if table.btree().is_some_and(|t| t.has_autoincrement) && conn.mvcc_enabled() {
-        crate::bail_parse_error!(
-            "AUTOINCREMENT is not supported in MVCC mode (journal_mode=experimental_mvcc)"
-        );
-    }
 
     Ok(())
 }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1474,7 +1474,7 @@ fn init_autoincrement(
 
     let seq_col_reg = program.alloc_register();
     program.emit_column_or_rowid(seq_cursor_id, 1, seq_col_reg);
-    program.emit_insn(Insn::Le {
+    program.emit_insn(Insn::Lt {
         lhs: seq_col_reg,
         rhs: r_seq,
         target_pc: skip_update_label,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -280,6 +280,7 @@ pub fn translate_insert(
     validate(table_name.as_str(), resolver, &table, connection)?;
 
     let fk_enabled = connection.foreign_keys_enabled();
+    let use_fixed_rowid_for_sequence = connection.mvcc_enabled();
     if let Some(virtual_table) = &table.virtual_table() {
         translate_virtual_table_insert(
             program,
@@ -311,7 +312,13 @@ pub fn translate_insert(
     )?;
 
     if inserting_multiple_rows && btree_table.has_autoincrement {
-        ensure_sequence_initialized(program, resolver, &btree_table, database_id)?;
+        ensure_sequence_initialized(
+            program,
+            resolver,
+            &btree_table,
+            database_id,
+            use_fixed_rowid_for_sequence,
+        )?;
     }
 
     let cdc_table = prepare_cdc_if_necessary(program, resolver.schema(), table.get_name())?;
@@ -448,7 +455,7 @@ pub fn translate_insert(
     let has_user_provided_rowid = insertion.key.is_provided_by_user();
 
     if ctx.table.has_autoincrement {
-        init_autoincrement(program, &mut ctx, resolver)?;
+        init_autoincrement(program, &mut ctx, resolver, use_fixed_rowid_for_sequence)?;
     }
 
     // Fire BEFORE INSERT triggers
@@ -606,6 +613,8 @@ pub fn translate_insert(
             r_seq,
             r_seq_rowid,
             table_name_reg,
+            fallback_rowid_reg,
+            use_fixed_rowid_for_sequence,
         }) = ctx.autoincrement_meta
         {
             turso_assert!(ctx.table.has_autoincrement);
@@ -633,6 +642,8 @@ pub fn translate_insert(
                 seq_cursor_id,
                 r_seq_rowid,
                 table_name_reg,
+                fallback_rowid_reg,
+                use_fixed_rowid_for_sequence,
                 insertion.key_register(),
             )?;
             program.emit_insn(Insn::Goto {
@@ -863,6 +874,8 @@ pub fn translate_insert(
         r_seq,
         r_seq_rowid,
         table_name_reg,
+        fallback_rowid_reg,
+        use_fixed_rowid_for_sequence,
     }) = ctx.autoincrement_meta
     {
         let no_update_needed_label = program.allocate_label();
@@ -881,6 +894,8 @@ pub fn translate_insert(
             seq_cursor_id,
             r_seq_rowid,
             table_name_reg,
+            fallback_rowid_reg,
+            use_fixed_rowid_for_sequence,
             insertion.key_register(),
         )?;
 
@@ -1183,55 +1198,119 @@ fn emit_rowid_generation(
         seq_cursor_id,
         r_seq_rowid,
         table_name_reg,
-        ..
+        fallback_rowid_reg,
+        use_fixed_rowid_for_sequence,
     }) = ctx.autoincrement_meta
     {
-        let r_max = program.alloc_register();
+        if use_fixed_rowid_for_sequence {
+            // In MVCC mode, compute the current table max rowid and use it as a floor
+            // for allocator-based rowid generation. This keeps concurrent allocations
+            // unique while matching SQLite behavior for UPDATE rowid + DELETE patterns.
+            let r_table_max = program.alloc_register();
+            let table_empty_label = program.allocate_label();
+            let table_max_ready_label = program.allocate_label();
+            program.emit_insn(Insn::Last {
+                cursor_id: ctx.cursor_id,
+                pc_if_empty: table_empty_label,
+            });
+            program.emit_insn(Insn::RowId {
+                cursor_id: ctx.cursor_id,
+                dest: r_table_max,
+            });
+            program.emit_insn(Insn::Goto {
+                target_pc: table_max_ready_label,
+            });
+            program.preassign_label_to_next_insn(table_empty_label);
+            program.emit_insn(Insn::Integer {
+                dest: r_table_max,
+                value: 0,
+            });
+            program.preassign_label_to_next_insn(table_max_ready_label);
 
-        let dummy_reg = program.alloc_register();
+            let r_floor = program.alloc_register();
+            program.emit_insn(Insn::Copy {
+                src_reg: r_seq,
+                dst_reg: r_floor,
+                extra_amount: 0,
+            });
+            program.emit_insn(Insn::MemMax {
+                dest_reg: r_floor,
+                src_reg: r_table_max,
+            });
 
-        program.emit_insn(Insn::NewRowid {
-            cursor: ctx.cursor_id,
-            rowid_reg: dummy_reg,
-            prev_largest_reg: r_max,
-        });
+            let no_overflow_label = program.allocate_label();
+            let max_i64_reg = program.alloc_register();
+            program.emit_insn(Insn::Integer {
+                dest: max_i64_reg,
+                value: i64::MAX,
+            });
+            program.emit_insn(Insn::Ne {
+                lhs: r_floor,
+                rhs: max_i64_reg,
+                target_pc: no_overflow_label,
+                flags: Default::default(),
+                collation: None,
+            });
 
-        program.emit_insn(Insn::Copy {
-            src_reg: r_seq,
-            dst_reg: insertion.key_register(),
-            extra_amount: 0,
-        });
-        program.emit_insn(Insn::MemMax {
-            dest_reg: insertion.key_register(),
-            src_reg: r_max,
-        });
+            program.emit_insn(Insn::Halt {
+                err_code: crate::error::SQLITE_FULL,
+                description: "database or disk is full".to_string(),
+                on_error: None,
+            });
 
-        let no_overflow_label = program.allocate_label();
-        let max_i64_reg = program.alloc_register();
-        program.emit_insn(Insn::Integer {
-            dest: max_i64_reg,
-            value: i64::MAX,
-        });
-        program.emit_insn(Insn::Ne {
-            lhs: insertion.key_register(),
-            rhs: max_i64_reg,
-            target_pc: no_overflow_label,
-            flags: Default::default(),
-            collation: None,
-        });
+            program.preassign_label_to_next_insn(no_overflow_label);
 
-        program.emit_insn(Insn::Halt {
-            err_code: crate::error::SQLITE_FULL,
-            description: "database or disk is full".to_string(),
-            on_error: None,
-        });
+            program.emit_insn(Insn::NewRowid {
+                cursor: ctx.cursor_id,
+                rowid_reg: insertion.key_register(),
+                prev_largest_reg: r_floor,
+            });
+        } else {
+            let r_max = program.alloc_register();
+            let dummy_reg = program.alloc_register();
+            program.emit_insn(Insn::NewRowid {
+                cursor: ctx.cursor_id,
+                rowid_reg: dummy_reg,
+                prev_largest_reg: r_max,
+            });
 
-        program.preassign_label_to_next_insn(no_overflow_label);
+            program.emit_insn(Insn::Copy {
+                src_reg: r_seq,
+                dst_reg: insertion.key_register(),
+                extra_amount: 0,
+            });
+            program.emit_insn(Insn::MemMax {
+                dest_reg: insertion.key_register(),
+                src_reg: r_max,
+            });
 
-        program.emit_insn(Insn::AddImm {
-            register: insertion.key_register(),
-            value: 1,
-        });
+            let no_overflow_label = program.allocate_label();
+            let max_i64_reg = program.alloc_register();
+            program.emit_insn(Insn::Integer {
+                dest: max_i64_reg,
+                value: i64::MAX,
+            });
+            program.emit_insn(Insn::Ne {
+                lhs: insertion.key_register(),
+                rhs: max_i64_reg,
+                target_pc: no_overflow_label,
+                flags: Default::default(),
+                collation: None,
+            });
+
+            program.emit_insn(Insn::Halt {
+                err_code: crate::error::SQLITE_FULL,
+                description: "database or disk is full".to_string(),
+                on_error: None,
+            });
+
+            program.preassign_label_to_next_insn(no_overflow_label);
+
+            program.emit_insn(Insn::AddImm {
+                register: insertion.key_register(),
+                value: 1,
+            });
+        }
 
         emit_update_sqlite_sequence(
             program,
@@ -1240,6 +1319,8 @@ fn emit_rowid_generation(
             seq_cursor_id,
             r_seq_rowid,
             table_name_reg,
+            fallback_rowid_reg,
+            use_fixed_rowid_for_sequence,
             insertion.key_register(),
         )?;
     } else {
@@ -1333,6 +1414,7 @@ fn init_autoincrement(
     program: &mut ProgramBuilder,
     ctx: &mut InsertEmitCtx,
     resolver: &Resolver,
+    use_fixed_rowid_for_sequence: bool,
 ) -> Result<()> {
     let seq_table = get_valid_sqlite_sequence_table(resolver, ctx.database_id)?;
     let seq_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(seq_table.clone()));
@@ -1345,12 +1427,15 @@ fn init_autoincrement(
     let table_name_reg = program.emit_string8_new_reg(ctx.table.name.clone());
     let r_seq = program.alloc_register();
     let r_seq_rowid = program.alloc_register();
+    let fallback_rowid_reg = program.alloc_register();
 
     ctx.autoincrement_meta = Some(AutoincMeta {
         seq_cursor_id,
         r_seq,
         r_seq_rowid,
         table_name_reg,
+        fallback_rowid_reg,
+        use_fixed_rowid_for_sequence,
     });
 
     program.emit_insn(Insn::Integer {
@@ -1361,10 +1446,15 @@ fn init_autoincrement(
         dest: r_seq_rowid,
         dest_end: None,
     });
+    program.emit_insn(Insn::Integer {
+        dest: fallback_rowid_reg,
+        value: ctx.table.root_page,
+    });
 
     let loop_start_label = program.allocate_label();
     let loop_end_label = program.allocate_label();
-    let found_label = program.allocate_label();
+    let next_row_label = program.allocate_label();
+    let skip_update_label = program.allocate_label();
 
     program.emit_insn(Insn::Rewind {
         cursor_id: seq_cursor_id,
@@ -1377,21 +1467,32 @@ fn init_autoincrement(
     program.emit_insn(Insn::Ne {
         lhs: table_name_reg,
         rhs: name_col_reg,
-        target_pc: found_label,
+        target_pc: next_row_label,
         flags: Default::default(),
         collation: None,
     });
 
-    program.emit_column_or_rowid(seq_cursor_id, 1, r_seq);
+    let seq_col_reg = program.alloc_register();
+    program.emit_column_or_rowid(seq_cursor_id, 1, seq_col_reg);
+    program.emit_insn(Insn::Le {
+        lhs: seq_col_reg,
+        rhs: r_seq,
+        target_pc: skip_update_label,
+        flags: Default::default(),
+        collation: None,
+    });
+    program.emit_insn(Insn::Copy {
+        src_reg: seq_col_reg,
+        dst_reg: r_seq,
+        extra_amount: 0,
+    });
     program.emit_insn(Insn::RowId {
         cursor_id: seq_cursor_id,
         dest: r_seq_rowid,
     });
-    program.emit_insn(Insn::Goto {
-        target_pc: loop_end_label,
-    });
 
-    program.preassign_label_to_next_insn(found_label);
+    program.preassign_label_to_next_insn(skip_update_label);
+    program.preassign_label_to_next_insn(next_row_label);
     program.emit_insn(Insn::Next {
         cursor_id: seq_cursor_id,
         pc_if_next: loop_start_label,
@@ -1926,6 +2027,8 @@ pub struct AutoincMeta {
     r_seq: usize,
     r_seq_rowid: usize,
     table_name_reg: usize,
+    fallback_rowid_reg: usize,
+    use_fixed_rowid_for_sequence: bool,
 }
 
 pub static ROWID_COLUMN: std::sync::LazyLock<Column> = std::sync::LazyLock::new(|| {
@@ -2759,6 +2862,7 @@ fn ensure_sequence_initialized(
     resolver: &Resolver,
     table: &schema::BTreeTable,
     database_id: usize,
+    use_fixed_rowid_for_sequence: bool,
 ) -> Result<()> {
     let seq_table = get_valid_sqlite_sequence_table(resolver, database_id)?;
 
@@ -2838,11 +2942,18 @@ fn ensure_sequence_initialized(
     });
 
     let new_rowid_reg = program.alloc_register();
-    program.emit_insn(Insn::NewRowid {
-        cursor: seq_cursor_id,
-        rowid_reg: new_rowid_reg,
-        prev_largest_reg: 0,
-    });
+    if use_fixed_rowid_for_sequence {
+        program.emit_insn(Insn::Integer {
+            dest: new_rowid_reg,
+            value: table.root_page,
+        });
+    } else {
+        program.emit_insn(Insn::NewRowid {
+            cursor: seq_cursor_id,
+            rowid_reg: new_rowid_reg,
+            prev_largest_reg: 0,
+        });
+    }
     program.emit_insn(Insn::Insert {
         cursor: seq_cursor_id,
         key_reg: new_rowid_reg,
@@ -3106,6 +3217,8 @@ fn emit_update_sqlite_sequence(
     seq_cursor_id: usize,
     r_seq_rowid: usize,
     table_name_reg: usize,
+    fallback_rowid_reg: usize,
+    use_fixed_rowid_for_sequence: bool,
     new_key_reg: usize,
 ) -> Result<()> {
     let record_reg = program.alloc_register();
@@ -3142,11 +3255,19 @@ fn emit_update_sqlite_sequence(
         target_pc: update_existing_label,
     });
 
-    program.emit_insn(Insn::NewRowid {
-        cursor: seq_cursor_id,
-        rowid_reg: r_seq_rowid,
-        prev_largest_reg: 0,
-    });
+    if use_fixed_rowid_for_sequence {
+        program.emit_insn(Insn::Copy {
+            src_reg: fallback_rowid_reg,
+            dst_reg: r_seq_rowid,
+            extra_amount: 0,
+        });
+    } else {
+        program.emit_insn(Insn::NewRowid {
+            cursor: seq_cursor_id,
+            rowid_reg: r_seq_rowid,
+            prev_largest_reg: 0,
+        });
+    }
     program.emit_insn(Insn::Insert {
         cursor: seq_cursor_id,
         key_reg: r_seq_rowid,
@@ -3163,7 +3284,9 @@ fn emit_update_sqlite_sequence(
         cursor: seq_cursor_id,
         key_reg: r_seq_rowid,
         record_reg,
-        flag: InsertFlags(turso_parser::ast::ResolveType::Replace.bit_value() as u8),
+        flag: InsertFlags(
+            (turso_parser::ast::ResolveType::Replace.bit_value() as u8) | InsertFlags::REQUIRE_SEEK,
+        ),
         table_name: SQLITE_SEQUENCE_TABLE_NAME.to_string(),
     });
 

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -671,6 +671,8 @@ pub fn translate_insert(
                 seq_cursor_id,
                 r_seq_rowid,
                 table_name_reg,
+                fallback_rowid_reg,
+                use_fixed_rowid_for_sequence,
                 seq_to_write_reg,
             )?;
             program.preassign_label_to_next_insn(explicit_done_label);

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -953,12 +953,6 @@ pub fn translate_create_table(
         }
     }
 
-    if has_autoincrement && connection.mvcc_enabled() {
-        bail_parse_error!(
-            "AUTOINCREMENT is not supported in MVCC mode (journal_mode=experimental_mvcc)"
-        );
-    }
-
     let schema_master_table = resolver.schema().get_btree_table(SQLITE_TABLEID).unwrap();
     let sqlite_schema_cursor_id =
         program.alloc_cursor_id(CursorType::BTreeTable(schema_master_table));

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8968,9 +8968,17 @@ pub enum OpNewRowidState {
     Start,
     SeekingToLast {
         mvcc_already_initialized: bool,
+        /// The AUTOINCREMENT floor: `max(sqlite_sequence.seq, table_max_rowid)`,
+        /// read from `prev_largest_reg` at `Start`. Threaded through each state
+        /// so `bump_rowid_floor()` can be called wherever the allocator is
+        /// initialized or consulted, ensuring the allocator never hands out a
+        /// rowid at or below the sequence high-water mark — even when the B-tree
+        /// has not yet been checkpointed with the latest MVCC writes.
+        /// Zero means no floor (non-AUTOINCREMENT path).
         requested_prev_largest: i64,
     },
     ReadingMaxRowid {
+        /// See `SeekingToLast::requested_prev_largest`.
         requested_prev_largest: i64,
     },
     GeneratingRandom {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8405,6 +8405,27 @@ pub fn op_insert(
                         Value::Numeric(Numeric::Integer(i)) => *i,
                         _ => unreachable!("expected integer key"),
                     };
+
+                    if table_name == SQLITE_SEQUENCE_TABLE_NAME
+                        && program.connection.mv_store().is_some()
+                    {
+                        let cursor = state.get_cursor(*cursor_id);
+                        let cursor = cursor.as_btree_mut() as &mut dyn Any;
+                        if let Some(mvcc_cursor) = cursor.downcast_mut::<MvCursor>() {
+                            mvcc_cursor.register_sqlite_sequence_table_id();
+                        }
+                    }
+
+                    if flag.has(InsertFlags::UPDATE_ROWID_CHANGE)
+                        && program.connection.mv_store().is_some()
+                    {
+                        let cursor = state.get_cursor(*cursor_id);
+                        let cursor = cursor.as_btree_mut() as &mut dyn Any;
+                        if let Some(mvcc_cursor) = cursor.downcast_mut::<MvCursor>() {
+                            mvcc_cursor.suppress_next_rowid_allocator_update();
+                        }
+                    }
+
                     let record = match &state.registers[*record_reg] {
                         Register::Record(r) => std::borrow::Cow::Borrowed(r),
                         Register::Value(value) => {
@@ -8416,6 +8437,7 @@ pub fn op_insert(
                             unreachable!("Cannot insert an aggregate value.")
                         }
                     };
+
                     let cursor = get_cursor!(state, *cursor_id);
                     let cursor = cursor.as_btree_mut();
                     return_if_io!(cursor.insert(&BTreeKey::new_table_rowid(key, Some(&record))));
@@ -8946,8 +8968,11 @@ pub enum OpNewRowidState {
     Start,
     SeekingToLast {
         mvcc_already_initialized: bool,
+        requested_prev_largest: i64,
     },
-    ReadingMaxRowid,
+    ReadingMaxRowid {
+        requested_prev_largest: i64,
+    },
     GeneratingRandom {
         attempts: u32,
     },
@@ -9009,6 +9034,14 @@ fn new_rowid_inner(
     loop {
         match state.op_new_rowid_state {
             OpNewRowidState::Start => {
+                let requested_prev_largest = if *prev_largest_reg > 0 {
+                    match state.registers[*prev_largest_reg].get_value() {
+                        Value::Numeric(Numeric::Integer(v)) if *v > 0 => *v,
+                        _ => 0,
+                    }
+                } else {
+                    0
+                };
                 if mv_store.is_some() {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut() as &mut dyn Any;
@@ -9017,12 +9050,32 @@ fn new_rowid_inner(
                             NextRowidResult::Uninitialized => {
                                 state.op_new_rowid_state = OpNewRowidState::SeekingToLast {
                                     mvcc_already_initialized: false,
+                                    requested_prev_largest,
                                 };
                             }
                             NextRowidResult::Next {
-                                new_rowid,
-                                prev_rowid,
+                                mut new_rowid,
+                                mut prev_rowid,
                             } => {
+                                if requested_prev_largest > 0 {
+                                    mvcc_cursor.bump_rowid_floor(requested_prev_largest);
+                                    if new_rowid <= requested_prev_largest {
+                                        match mvcc_cursor.allocate_next_rowid() {
+                                            Some((next_rowid, next_prev_rowid)) => {
+                                                new_rowid = next_rowid;
+                                                prev_rowid = next_prev_rowid;
+                                            }
+                                            None => {
+                                                mvcc_cursor.end_new_rowid();
+                                                state.op_new_rowid_state =
+                                                    OpNewRowidState::GeneratingRandom {
+                                                        attempts: 0,
+                                                    };
+                                                continue;
+                                            }
+                                        }
+                                    }
+                                }
                                 // Allocator already initialized — release lock immediately
                                 mvcc_cursor.end_new_rowid();
                                 state.registers[*rowid_reg] =
@@ -9033,6 +9086,7 @@ fn new_rowid_inner(
                                 }
                                 state.op_new_rowid_state = OpNewRowidState::SeekingToLast {
                                     mvcc_already_initialized: true,
+                                    requested_prev_largest,
                                 };
                             }
                             NextRowidResult::FindRandom => {
@@ -9051,17 +9105,20 @@ fn new_rowid_inner(
                         );
                         state.op_new_rowid_state = OpNewRowidState::SeekingToLast {
                             mvcc_already_initialized: false,
+                            requested_prev_largest: 0,
                         };
                     }
                 } else {
                     state.op_new_rowid_state = OpNewRowidState::SeekingToLast {
                         mvcc_already_initialized: false,
+                        requested_prev_largest: 0,
                     };
                 }
             }
 
             OpNewRowidState::SeekingToLast {
                 mvcc_already_initialized,
+                requested_prev_largest,
             } => {
                 {
                     let cursor = state.get_cursor(*cursor);
@@ -9075,16 +9132,21 @@ fn new_rowid_inner(
                 if mvcc_already_initialized {
                     state.op_new_rowid_state = OpNewRowidState::GoNext;
                 } else {
-                    state.op_new_rowid_state = OpNewRowidState::ReadingMaxRowid;
+                    state.op_new_rowid_state = OpNewRowidState::ReadingMaxRowid {
+                        requested_prev_largest,
+                    };
                 }
             }
 
-            OpNewRowidState::ReadingMaxRowid => {
+            OpNewRowidState::ReadingMaxRowid {
+                requested_prev_largest,
+            } => {
                 let current_max = {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut();
                     return_if_io!(cursor.rowid())
                 };
+                let current_max_for_newrowid = current_max.map(|v| v.max(0));
 
                 if mv_store.is_some() {
                     let cursor = state.get_cursor(*cursor);
@@ -9093,7 +9155,10 @@ fn new_rowid_inner(
                         // Initialize the monotonic counter from the btree max.
                         // The allocator lock is held, so no other thread can
                         // race between this read and initialize.
-                        mvcc_cursor.initialize_max_rowid(current_max)?;
+                        mvcc_cursor.initialize_max_rowid(current_max_for_newrowid)?;
+                        if requested_prev_largest > 0 {
+                            mvcc_cursor.bump_rowid_floor(requested_prev_largest);
+                        }
                         // Allocate the first rowid from the freshly initialized counter.
                         match mvcc_cursor.allocate_next_rowid() {
                             Some((new_rowid, prev_rowid)) => {
@@ -9120,10 +9185,10 @@ fn new_rowid_inner(
                 // Non-MVCC path (or ephemeral cursor in MVCC mode)
                 if *prev_largest_reg > 0 {
                     state.registers[*prev_largest_reg] =
-                        Register::Value(Value::from_i64(current_max.unwrap_or(0)));
+                        Register::Value(Value::from_i64(current_max_for_newrowid.unwrap_or(0)));
                 }
-                match current_max {
-                    Some(rowid) if rowid < MAX_ROWID => {
+                match current_max_for_newrowid {
+                    Some(rowid) if rowid > 0 && rowid < MAX_ROWID => {
                         state.registers[*rowid_reg] = Register::Value(Value::from_i64(rowid + 1));
                         tracing::trace!("new_rowid={}", rowid + 1);
                         state.op_new_rowid_state = OpNewRowidState::GoNext;

--- a/testing/runner/tests/autoincr.sqltest
+++ b/testing/runner/tests/autoincr.sqltest
@@ -126,6 +126,17 @@ expect {
     1235|2
 }
 
+# First explicit insert with a non-positive rowid still initializes sqlite_sequence.
+@cross-check-integrity
+test autoinc-explicit-negative-initializes-sequence-zero {
+    CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y);
+    INSERT OR IGNORE INTO t1(x, y) VALUES(-43, 'neg');
+    SELECT name, seq FROM sqlite_sequence WHERE name='t1';
+}
+expect {
+    t1|0
+}
+
 # Test: AUTOINCREMENT works for multiple tables independently.
 @cross-check-integrity
 test autoinc-multiple-tables {

--- a/tests/fuzz/autoincrement.rs
+++ b/tests/fuzz/autoincrement.rs
@@ -1,10 +1,14 @@
 #[cfg(test)]
 mod autoincrement_fuzz_tests {
     use crate::helpers;
-    use core_tester::common::{limbo_exec_rows, sqlite_exec_rows, TempDatabase};
+    use core_tester::common::{
+        limbo_exec_rows, limbo_exec_rows_fallible, sqlite_exec_rows, TempDatabase,
+    };
     use rand::seq::IndexedRandom;
     use rand::Rng;
+    use rusqlite::params;
     use rusqlite::types::Value;
+    use std::sync::Arc;
 
     fn single_int(rows: &[Vec<Value>], label: &str) -> i64 {
         assert_eq!(rows.len(), 1, "{label}: expected 1 row, got {}", rows.len());
@@ -56,6 +60,44 @@ mod autoincrement_fuzz_tests {
     ) -> Option<i64> {
         let ids = fetch_limbo_ids(conn);
         ids.choose(rng).copied()
+    }
+
+    fn sequence_max(rows: &[Vec<Value>], label: &str) -> i64 {
+        let mut max_seq = 0;
+        for row in rows {
+            assert_eq!(
+                row.len(),
+                2,
+                "{label}: expected 2 columns (name, seq), got {}",
+                row.len()
+            );
+            let seq = match row[1] {
+                Value::Integer(v) => v,
+                ref v => panic!("{label}: expected integer seq, got {v:?}"),
+            };
+            max_seq = max_seq.max(seq);
+        }
+        max_seq
+    }
+
+    fn execute_outcome_parity(
+        db: &TempDatabase,
+        limbo_conn: &Arc<turso_core::Connection>,
+        sqlite_conn: &rusqlite::Connection,
+        stmt: &str,
+        ctx: &str,
+    ) -> bool {
+        let sqlite_res = sqlite_conn.execute(stmt, params![]);
+        let limbo_res = limbo_exec_rows_fallible(db, limbo_conn, stmt);
+        match (sqlite_res, limbo_res) {
+            (Ok(_), Ok(_)) => true,
+            (Err(_), Err(_)) => false,
+            (sqlite_outcome, limbo_outcome) => {
+                panic!(
+                    "statement outcome mismatch\n{ctx}\nstmt={stmt}\nsqlite={sqlite_outcome:?}\nlimbo={limbo_outcome:?}"
+                );
+            }
+        }
     }
 
     #[turso_macros::test(mvcc)]
@@ -158,6 +200,190 @@ mod autoincrement_fuzz_tests {
                 "SELECT id, payload FROM t ORDER BY id",
                 &ctx,
             );
+        }
+
+        helpers::assert_differential(
+            &limbo_conn,
+            &sqlite_conn,
+            "PRAGMA integrity_check",
+            &format!("seed={seed} final"),
+        );
+    }
+
+    #[turso_macros::test(mvcc)]
+    fn autoincrement_transactional_differential_fuzz(db: TempDatabase) {
+        let (mut rng, seed) =
+            helpers::init_fuzz_test("autoincrement_transactional_differential_fuzz");
+
+        let limbo_conn = db.connect_limbo();
+        let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+        helpers::execute_on_both(
+            &limbo_conn,
+            &sqlite_conn,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, payload TEXT)",
+            "create table",
+        );
+
+        let iterations = std::env::var("FUZZ_ITERATIONS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| helpers::fuzz_iterations(300));
+
+        let mut history: Vec<String> = Vec::with_capacity(iterations + 16);
+        let mut in_tx = false;
+        let mut tx_start_seq: Option<i64> = None;
+        let mut last_committed_seq: i64 = 0;
+
+        for step in 0..iterations {
+            helpers::log_progress(
+                "autoincrement_transactional_differential_fuzz",
+                step,
+                iterations,
+                8,
+            );
+
+            let action = rng.random_range(0..100);
+            let stmt = if in_tx {
+                if action < 18 {
+                    "COMMIT".to_string()
+                } else if action < 36 {
+                    "ROLLBACK".to_string()
+                } else if action < 60 {
+                    match maybe_random_existing_id(&mut rng, &limbo_conn) {
+                        Some(id) => format!("DELETE FROM t WHERE id = {id}"),
+                        None => continue,
+                    }
+                } else if action < 85 {
+                    match maybe_random_existing_id(&mut rng, &limbo_conn) {
+                        Some(id) => {
+                            let delta = rng.random_range(-5..=20);
+                            let new_id = id.saturating_add(delta);
+                            format!("UPDATE OR IGNORE t SET id = {new_id} WHERE id = {id}")
+                        }
+                        None => continue,
+                    }
+                } else {
+                    match maybe_random_existing_id(&mut rng, &limbo_conn) {
+                        Some(id) => {
+                            if rng.random_bool(0.5) {
+                                format!(
+                                    "INSERT OR ABORT INTO t(id, payload) VALUES ({id}, 'dup_{step}')"
+                                )
+                            } else {
+                                format!(
+                                    "INSERT OR ROLLBACK INTO t(id, payload) VALUES ({id}, 'dup_rb_{step}')"
+                                )
+                            }
+                        }
+                        None => continue,
+                    }
+                }
+            } else if action < 10 {
+                "BEGIN".to_string()
+            } else if action < 56 {
+                format!("INSERT INTO t(payload) VALUES ('tx_auto_{step}')")
+            } else if action < 74 {
+                let explicit_id = match rng.random_range(0..4) {
+                    0 => rng.random_range(1..=(last_committed_seq + 1).max(1)),
+                    1 => last_committed_seq + rng.random_range(1..=32),
+                    2 => rng.random_range(-50..=50),
+                    _ => rng.random_range(1..=200),
+                };
+                format!(
+                    "INSERT OR IGNORE INTO t(id, payload) VALUES ({explicit_id}, 'tx_explicit_{step}')"
+                )
+            } else if action < 86 {
+                match maybe_random_existing_id(&mut rng, &limbo_conn) {
+                    Some(id) => format!("DELETE FROM t WHERE id = {id}"),
+                    None => continue,
+                }
+            } else if action < 96 {
+                match maybe_random_existing_id(&mut rng, &limbo_conn) {
+                    Some(id) => {
+                        let delta = rng.random_range(-5..=20);
+                        let new_id = id.saturating_add(delta);
+                        format!("UPDATE OR IGNORE t SET id = {new_id} WHERE id = {id}")
+                    }
+                    None => continue,
+                }
+            } else {
+                match maybe_random_existing_id(&mut rng, &limbo_conn) {
+                    Some(id) => {
+                        format!("INSERT OR ABORT INTO t(id, payload) VALUES ({id}, 'dup_{step}')")
+                    }
+                    None => continue,
+                }
+            };
+
+            history.push(stmt.clone());
+            let ctx = format!(
+                "seed={seed} step={step} in_tx_before={in_tx}\nstmt={stmt}\nhistory:\n{}",
+                helpers::history_tail(&history, 40)
+            );
+
+            let success = execute_outcome_parity(&db, &limbo_conn, &sqlite_conn, &stmt, &ctx);
+
+            if success {
+                if stmt == "BEGIN" {
+                    in_tx = true;
+                } else if stmt == "COMMIT" || stmt == "ROLLBACK" {
+                    in_tx = false;
+                    tx_start_seq = None;
+                }
+            } else if in_tx && stmt.contains("OR ROLLBACK") {
+                in_tx = false;
+                tx_start_seq = None;
+            }
+
+            helpers::assert_differential(
+                &limbo_conn,
+                &sqlite_conn,
+                "SELECT id, payload FROM t ORDER BY id",
+                &ctx,
+            );
+            helpers::assert_differential(
+                &limbo_conn,
+                &sqlite_conn,
+                "SELECT name, seq FROM sqlite_sequence WHERE name='t' ORDER BY seq",
+                &ctx,
+            );
+
+            let seq_rows = limbo_exec_rows(
+                &limbo_conn,
+                "SELECT name, seq FROM sqlite_sequence WHERE name='t' ORDER BY seq",
+            );
+            let seq = sequence_max(&seq_rows, "sqlite_sequence rows");
+
+            if stmt == "BEGIN" && success {
+                tx_start_seq = Some(seq);
+            }
+            if stmt == "ROLLBACK" && success {
+                if let Some(start_seq) = tx_start_seq {
+                    assert_eq!(
+                        seq, start_seq,
+                        "ROLLBACK did not restore sqlite_sequence start value\nstart_seq={start_seq} end_seq={seq}\n{ctx}"
+                    );
+                }
+                tx_start_seq = None;
+            }
+            if !success && stmt.contains("OR ROLLBACK") {
+                if let Some(start_seq) = tx_start_seq {
+                    assert_eq!(
+                        seq, start_seq,
+                        "OR ROLLBACK conflict did not restore sqlite_sequence start value\nstart_seq={start_seq} end_seq={seq}\n{ctx}"
+                    );
+                }
+                tx_start_seq = None;
+            }
+
+            if !in_tx {
+                assert!(
+                    seq >= last_committed_seq,
+                    "committed sqlite_sequence decreased: prev={last_committed_seq} new={seq}\n{ctx}"
+                );
+                last_committed_seq = seq;
+            }
         }
 
         helpers::assert_differential(

--- a/tests/fuzz/autoincrement.rs
+++ b/tests/fuzz/autoincrement.rs
@@ -1,0 +1,302 @@
+#[cfg(test)]
+mod autoincrement_fuzz_tests {
+    use crate::helpers;
+    use core_tester::common::{limbo_exec_rows, sqlite_exec_rows, TempDatabase};
+    use rand::seq::IndexedRandom;
+    use rand::Rng;
+    use rusqlite::types::Value;
+
+    fn single_int(rows: &[Vec<Value>], label: &str) -> i64 {
+        assert_eq!(rows.len(), 1, "{label}: expected 1 row, got {}", rows.len());
+        assert_eq!(
+            rows[0].len(),
+            1,
+            "{label}: expected 1 column, got {}",
+            rows[0].len()
+        );
+        match rows[0][0] {
+            Value::Integer(v) => v,
+            ref v => panic!("{label}: expected integer, got {v:?}"),
+        }
+    }
+
+    fn read_limbo_seq(conn: &std::sync::Arc<turso_core::Connection>) -> i64 {
+        single_int(
+            &limbo_exec_rows(
+                conn,
+                "SELECT COALESCE(MAX(seq), 0) FROM sqlite_sequence WHERE name='t'",
+            ),
+            "limbo sqlite_sequence max(seq)",
+        )
+    }
+
+    fn read_sqlite_seq(conn: &rusqlite::Connection) -> i64 {
+        single_int(
+            &sqlite_exec_rows(
+                conn,
+                "SELECT COALESCE(MAX(seq), 0) FROM sqlite_sequence WHERE name='t'",
+            ),
+            "sqlite sqlite_sequence max(seq)",
+        )
+    }
+
+    fn fetch_limbo_ids(conn: &std::sync::Arc<turso_core::Connection>) -> Vec<i64> {
+        let rows = limbo_exec_rows(conn, "SELECT id FROM t ORDER BY id");
+        rows.iter()
+            .map(|row| match row[0] {
+                Value::Integer(v) => v,
+                ref v => panic!("expected integer id, got {v:?}"),
+            })
+            .collect()
+    }
+
+    fn maybe_random_existing_id(
+        rng: &mut impl rand::Rng,
+        conn: &std::sync::Arc<turso_core::Connection>,
+    ) -> Option<i64> {
+        let ids = fetch_limbo_ids(conn);
+        ids.choose(rng).copied()
+    }
+
+    #[turso_macros::test(mvcc)]
+    fn autoincrement_monotonic_differential_fuzz(db: TempDatabase) {
+        let (mut rng, seed) = helpers::init_fuzz_test("autoincrement_monotonic_differential_fuzz");
+
+        let limbo_conn = db.connect_limbo();
+        let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+        let create_sql = "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, payload TEXT)";
+        helpers::execute_on_both(&limbo_conn, &sqlite_conn, create_sql, "create table");
+
+        let iterations = std::env::var("FUZZ_ITERATIONS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| helpers::fuzz_iterations(250));
+
+        let mut last_auto_id: i64 = 0;
+        let mut last_seq: i64 = 0;
+        let mut history: Vec<String> = Vec::with_capacity(iterations + 16);
+
+        for step in 0..iterations {
+            helpers::log_progress(
+                "autoincrement_monotonic_differential_fuzz",
+                step,
+                iterations,
+                8,
+            );
+            let action = rng.random_range(0..100);
+            let stmt = if action < 55 {
+                // Auto-assigned id path (main invariant target).
+                format!("INSERT INTO t(payload) VALUES ('auto_{step}') RETURNING id")
+            } else if action < 75 {
+                // Explicit id insert can move sqlite_sequence forward if id is larger.
+                let explicit_id = match rng.random_range(0..4) {
+                    0 => rng.random_range(1..=(last_seq + 1).max(1)),
+                    1 => last_seq + rng.random_range(1..=32),
+                    2 => rng.random_range(-50..=50),
+                    _ => rng.random_range(1..=200),
+                };
+                format!("INSERT OR IGNORE INTO t(id, payload) VALUES ({explicit_id}, 'explicit_{step}')")
+            } else if action < 88 {
+                match maybe_random_existing_id(&mut rng, &limbo_conn) {
+                    Some(id) => format!("DELETE FROM t WHERE id = {id}"),
+                    None => continue,
+                }
+            } else {
+                match maybe_random_existing_id(&mut rng, &limbo_conn) {
+                    Some(id) => {
+                        let delta = rng.random_range(-5..=20);
+                        let new_id = id.saturating_add(delta);
+                        format!("UPDATE OR IGNORE t SET id = {new_id} WHERE id = {id}")
+                    }
+                    None => continue,
+                }
+            };
+
+            history.push(stmt.clone());
+            let ctx = format!(
+                "seed={seed} step={step}\nstmt={stmt}\nhistory:\n{}",
+                helpers::history_tail(&history, 24)
+            );
+
+            if stmt.contains("RETURNING id") {
+                let limbo_rows = limbo_exec_rows(&limbo_conn, &stmt);
+                let sqlite_rows = sqlite_exec_rows(&sqlite_conn, &stmt);
+                assert_eq!(
+                    limbo_rows, sqlite_rows,
+                    "RETURNING mismatch\n{}\nlimbo={:?}\nsqlite={:?}",
+                    ctx, limbo_rows, sqlite_rows
+                );
+                let inserted_id = single_int(&limbo_rows, "RETURNING id");
+                assert!(
+                    inserted_id > last_auto_id,
+                    "auto rowid regressed: prev={} new={}\n{}",
+                    last_auto_id,
+                    inserted_id,
+                    ctx
+                );
+                last_auto_id = inserted_id;
+            } else {
+                helpers::execute_on_both(&limbo_conn, &sqlite_conn, &stmt, &ctx);
+            }
+
+            let limbo_seq = read_limbo_seq(&limbo_conn);
+            let sqlite_seq = read_sqlite_seq(&sqlite_conn);
+            assert_eq!(
+                limbo_seq, sqlite_seq,
+                "sqlite_sequence parity mismatch\n{}\nlimbo_seq={}\nsqlite_seq={}",
+                ctx, limbo_seq, sqlite_seq
+            );
+            assert!(
+                limbo_seq >= last_seq,
+                "sqlite_sequence decreased: prev={} new={}\n{}",
+                last_seq,
+                limbo_seq,
+                ctx
+            );
+            assert!(
+                limbo_seq >= last_auto_id,
+                "sqlite_sequence below last auto id: seq={} last_auto={}\n{}",
+                limbo_seq,
+                last_auto_id,
+                ctx
+            );
+            last_seq = limbo_seq;
+
+            helpers::assert_differential(
+                &limbo_conn,
+                &sqlite_conn,
+                "SELECT id, payload FROM t ORDER BY id",
+                &ctx,
+            );
+        }
+
+        helpers::assert_differential(
+            &limbo_conn,
+            &sqlite_conn,
+            "PRAGMA integrity_check",
+            &format!("seed={seed} final"),
+        );
+    }
+
+    #[turso_macros::test(mvcc)]
+    fn autoincrement_concurrent_commit_fuzz(db: TempDatabase) {
+        if !db.enable_mvcc {
+            return;
+        }
+        let (mut rng, seed) = helpers::init_fuzz_test("autoincrement_concurrent_commit_fuzz");
+        let admin = db.connect_limbo();
+        let conn1 = db.connect_limbo();
+        let conn2 = db.connect_limbo();
+
+        admin
+            .execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, payload TEXT)")
+            .unwrap();
+
+        let rounds = std::env::var("FUZZ_ITERATIONS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| helpers::fuzz_iterations(150));
+
+        let mut last_seq: i64 = 0;
+        let mut generated_ids: Vec<i64> = Vec::with_capacity(rounds * 4);
+
+        for round in 0..rounds {
+            helpers::log_progress("autoincrement_concurrent_commit_fuzz", round, rounds, 8);
+
+            conn1.execute("BEGIN CONCURRENT").unwrap();
+            conn2.execute("BEGIN CONCURRENT").unwrap();
+
+            let n1 = rng.random_range(1..=3);
+            let n2 = rng.random_range(1..=3);
+            for i in 0..n1 {
+                let rows = limbo_exec_rows(
+                    &conn1,
+                    &format!("INSERT INTO t(payload) VALUES ('c1_{round}_{i}') RETURNING id"),
+                );
+                generated_ids.push(single_int(&rows, "conn1 returning id"));
+            }
+            for i in 0..n2 {
+                let rows = limbo_exec_rows(
+                    &conn2,
+                    &format!("INSERT INTO t(payload) VALUES ('c2_{round}_{i}') RETURNING id"),
+                );
+                generated_ids.push(single_int(&rows, "conn2 returning id"));
+            }
+
+            let commit_order_conn1_first = rng.random_bool(0.5);
+            let first = if commit_order_conn1_first {
+                (&conn1, "conn1")
+            } else {
+                (&conn2, "conn2")
+            };
+            let second = if commit_order_conn1_first {
+                (&conn2, "conn2")
+            } else {
+                (&conn1, "conn1")
+            };
+
+            first.0.execute("COMMIT").unwrap_or_else(|e| {
+                panic!(
+                    "{} commit failed (seed={seed}, round={round}): {e:?}",
+                    first.1
+                )
+            });
+            second.0.execute("COMMIT").unwrap_or_else(|e| {
+                panic!(
+                    "{} commit failed (seed={seed}, round={round}): {e:?}",
+                    second.1
+                )
+            });
+
+            if rng.random_bool(0.30) {
+                let explicit = last_seq + rng.random_range(1..=16);
+                admin
+                    .execute(format!(
+                        "INSERT OR IGNORE INTO t(id, payload) VALUES ({explicit}, 'admin_{round}')"
+                    ))
+                    .unwrap();
+            }
+            if rng.random_bool(0.25) {
+                if let Some(id) = maybe_random_existing_id(&mut rng, &admin) {
+                    admin
+                        .execute(format!("DELETE FROM t WHERE id = {id}"))
+                        .unwrap();
+                }
+            }
+
+            let seq = read_limbo_seq(&admin);
+            assert!(
+                seq >= last_seq,
+                "sqlite_sequence decreased (seed={seed}, round={round}): {} -> {}",
+                last_seq,
+                seq
+            );
+            last_seq = seq;
+        }
+
+        for pair in generated_ids.windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "auto rowid allocation regressed (seed={seed}): {:?}",
+                pair
+            );
+        }
+
+        let max_generated = generated_ids.iter().copied().max().unwrap_or(0);
+        let final_seq = read_limbo_seq(&admin);
+        assert!(
+            final_seq >= max_generated,
+            "final sqlite_sequence below max generated id (seed={seed}): seq={} max_generated={}",
+            final_seq,
+            max_generated
+        );
+
+        let integrity = limbo_exec_rows(&admin, "PRAGMA integrity_check");
+        assert_eq!(
+            integrity,
+            vec![vec![Value::Text("ok".to_string())]],
+            "integrity_check failed (seed={seed})"
+        );
+    }
+}

--- a/tests/fuzz/autoincrement.rs
+++ b/tests/fuzz/autoincrement.rs
@@ -124,16 +124,12 @@ mod autoincrement_fuzz_tests {
                 let sqlite_rows = sqlite_exec_rows(&sqlite_conn, &stmt);
                 assert_eq!(
                     limbo_rows, sqlite_rows,
-                    "RETURNING mismatch\n{}\nlimbo={:?}\nsqlite={:?}",
-                    ctx, limbo_rows, sqlite_rows
+                    "RETURNING mismatch\n{ctx}\nlimbo={limbo_rows:?}\nsqlite={sqlite_rows:?}"
                 );
                 let inserted_id = single_int(&limbo_rows, "RETURNING id");
                 assert!(
                     inserted_id > last_auto_id,
-                    "auto rowid regressed: prev={} new={}\n{}",
-                    last_auto_id,
-                    inserted_id,
-                    ctx
+                    "auto rowid regressed: prev={last_auto_id} new={inserted_id}\n{ctx}"
                 );
                 last_auto_id = inserted_id;
             } else {
@@ -144,22 +140,15 @@ mod autoincrement_fuzz_tests {
             let sqlite_seq = read_sqlite_seq(&sqlite_conn);
             assert_eq!(
                 limbo_seq, sqlite_seq,
-                "sqlite_sequence parity mismatch\n{}\nlimbo_seq={}\nsqlite_seq={}",
-                ctx, limbo_seq, sqlite_seq
+                "sqlite_sequence parity mismatch\n{ctx}\nlimbo_seq={limbo_seq}\nsqlite_seq={sqlite_seq}"
             );
             assert!(
                 limbo_seq >= last_seq,
-                "sqlite_sequence decreased: prev={} new={}\n{}",
-                last_seq,
-                limbo_seq,
-                ctx
+                "sqlite_sequence decreased: prev={last_seq} new={limbo_seq}\n{ctx}"
             );
             assert!(
                 limbo_seq >= last_auto_id,
-                "sqlite_sequence below last auto id: seq={} last_auto={}\n{}",
-                limbo_seq,
-                last_auto_id,
-                ctx
+                "sqlite_sequence below last auto id: seq={limbo_seq} last_auto={last_auto_id}\n{ctx}"
             );
             last_seq = limbo_seq;
 
@@ -268,9 +257,7 @@ mod autoincrement_fuzz_tests {
             let seq = read_limbo_seq(&admin);
             assert!(
                 seq >= last_seq,
-                "sqlite_sequence decreased (seed={seed}, round={round}): {} -> {}",
-                last_seq,
-                seq
+                "sqlite_sequence decreased (seed={seed}, round={round}): {last_seq} -> {seq}"
             );
             last_seq = seq;
         }
@@ -278,8 +265,7 @@ mod autoincrement_fuzz_tests {
         for pair in generated_ids.windows(2) {
             assert!(
                 pair[1] > pair[0],
-                "auto rowid allocation regressed (seed={seed}): {:?}",
-                pair
+                "auto rowid allocation regressed (seed={seed}): {pair:?}"
             );
         }
 
@@ -287,9 +273,7 @@ mod autoincrement_fuzz_tests {
         let final_seq = read_limbo_seq(&admin);
         assert!(
             final_seq >= max_generated,
-            "final sqlite_sequence below max generated id (seed={seed}): seq={} max_generated={}",
-            final_seq,
-            max_generated
+            "final sqlite_sequence below max generated id (seed={seed}): seq={final_seq} max_generated={max_generated}"
         );
 
         let integrity = limbo_exec_rows(&admin, "PRAGMA integrity_check");

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -1,3 +1,4 @@
+pub mod autoincrement;
 pub mod cte;
 pub mod custom_types;
 pub mod expression_index;


### PR DESCRIPTION
## Description
Addressing #5687 and adds some of the tests added in that PR.


## Problem
`AUTOINCREMENT` in MVCC had two correctness issues:

1. Concurrent writers could fail with `WriteWriteConflict` on `sqlite_sequence`.
2. In mixed `INSERT` / `UPDATE rowid` / `DELETE` workloads, auto-assigned rowids could diverge from SQLite semantics (including monotonicity failures in fuzzed cases).

## Solution
*At a high level:*
MVCC now treats `sqlite_sequence` specially for conflict/read semantics:
  - ignore row-level WW conflicts on `sqlite_sequence` at delete/commit time
  - when reading `sqlite_sequence`, prefer the visible version with the highest `seq`

Insert translation was tightened so sequence-row updates are stable and deterministic in MVCC:
  - MVCC uses fixed sequence-row identity strategy where appropriate
  - update path uses `REQUIRE_SEEK` to avoid duplicate sequence-row artifacts
- AUTOINCREMENT allocation now uses a floor in MVCC:
  - floor = `max(sqlite_sequence.seq, current table max rowid)`
  - that floor is passed into `NewRowid` so concurrent allocation remains allocator-driven but never falls behind sequence/table state
- Rowid-update paths no longer poison allocator state:
  - `UPDATE ... SET rowid=...` writes are marked and applied without bumping the allocator as if they were normal autogen inserts
- Negative rowid edge handling in `NewRowid` initialization is normalized to SQLite-compatible behavior for autogen allocation.
