### PR TITLE
Preserve explicit LIMIT 0 in scalar subqueries instead of forcin…

### DIFF
--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -20,13 +20,15 @@ use crate::{
         },
         select::prepare_select_plan,
     },
+    types::Value,
+    util::parse_signed_number,
     vdbe::{
         affinity,
         builder::{CursorType, MaterializedCteInfo, ProgramBuilder},
         insn::Insn,
         CursorID,
     },
-    Connection, Result,
+    Connection, Numeric, Result,
 };
 
 use super::{
@@ -440,11 +442,23 @@ fn get_subquery_parser<'a>(
                     result_reg_start: reg_start,
                     num_regs: reg_count,
                 };
-                // RowValue subqueries are satisfied after at most 1 row has been returned,
-                // as they are used in comparisons with a scalar or a tuple of scalars like (x,y) = (SELECT ...) or x = (SELECT ...).
-                plan.limit = Some(Box::new(ast::Expr::Literal(ast::Literal::Numeric(
-                    "1".to_string(),
-                ))));
+
+                // Only inject LIMIT 1 if there's no existing limit, or the existing limit is > 1,
+                // If LIMIT 0, subquery should return no rows (NULL).
+                let limit = match &plan.limit {
+                    Some(expr) => match parse_signed_number(expr) {
+                        Ok(Value::Numeric(Numeric::Integer(v))) => !(0..=1).contains(&v),
+                        _ => true,
+                    },
+                    None => true,
+                };
+                if limit {
+                    // RowValue subqueries are satisfied after at most 1 row has been returned,
+                    // as they are used in comparisons with a scalar or a tuple of scalars like (x,y) = (SELECT ...) or x = (SELECT ...).
+                    plan.limit = Some(Box::new(ast::Expr::Literal(ast::Literal::Numeric(
+                        "1".to_string(),
+                    ))));
+                }
 
                 let ast::Expr::SubqueryResult {
                     subquery_id,

--- a/testing/runner/tests/subquery/expressions.sqltest
+++ b/testing/runner/tests/subquery/expressions.sqltest
@@ -417,6 +417,24 @@ expect {
     3
 }
 
+test subquery-scalar-limit-zero {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT 'row', (SELECT * FROM t LIMIT 0);
+}
+expect {
+    row|
+}
+
+test subquery-scalar-limit-negative {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT 'row', (SELECT * FROM t LIMIT -1);
+}
+expect {
+    row|1
+}
+
 # =============================================================================
 # Joins between subqueries
 # =============================================================================


### PR DESCRIPTION
## Description

`Scalar subqueries` used to automatically add `LIMIT 1`, which replaced any `LIMIT` explicitly set by the user
This patch fixes that by adding a check: if user wrote `LIMIT 0` or `LIMIT 1`, we leave it alone, anything else (larger or negative values) still gets capped to 1. Added tests for both cases

Closes #5694 