### PR TITLE
Avoid panic on unresolved qualified column in DO UPDATE

### DIFF
--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -1423,6 +1423,8 @@ fn rewrite_expr_to_registers(
                         if ns.eq_ignore_ascii_case(tn) {
                             if let Some(r) = col_reg_from_row_image(&c) {
                                 *expr = Expr::Register(r);
+                            } else {
+                                bail_parse_error!("no such column: {}.{}", ns, c);
                             }
                             return Ok(WalkControl::Continue);
                         }

--- a/testing/runner/tests/upsert.sqltest
+++ b/testing/runner/tests/upsert.sqltest
@@ -253,6 +253,22 @@ expect error {
 }
 
 @cross-check-integrity
+test upsert-unknown-qualified-column-do-update {
+    CREATE TABLE accounts(
+      id INTEGER PRIMARY KEY,
+      owner TEXT,
+      version INTEGER
+    );
+    INSERT INTO accounts(id, owner, version) VALUES (1, 'a', 1);
+    INSERT INTO accounts(id, owner) VALUES (1, 'b')
+      ON CONFLICT(id) DO UPDATE
+      SET version = accounts.versABS + 1;
+}
+expect error {
+    no such column: accounts\.versabs
+}
+
+@cross-check-integrity
 test upsert-values-returning-mixed {
     CREATE TABLE mix (k UNIQUE, v);
     INSERT INTO mix VALUES (1,'one');


### PR DESCRIPTION
## Description

Fixes a panic in UPSERT translation when `ON CONFLICT ... DO UPDATE` contains an unresolved qualified identifier (for example, `accounts.versABS`)

The `rewrite_expr_to_registers` now throws a parse error when the namespace matches the target table but the column  lookup fails, instead of leaving the expression unresolved.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Issue #5692 reported a panic at `core/translate/expr.rs` (`unreachable!: Qualified should be resolved to a Column before translation`) for UPSERT with an unknown qualified column


Cause:
  - UPSERT-specific expression rewriting only replaced qualified target-table
    references when column resolution succeeded.
  - Missing columns in the same namespace were not rejected and were forwarded
    unresolved to the expression translator, triggering the panic.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5692

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
