### PR TITLE
core/vector: Avoid simsimd on Windows AArch64

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -98,7 +98,6 @@ turso_parser = { workspace = true }
 twox-hash = "2.1.1"
 intrusive-collections = "0.9.7"
 roaring = "0.11.2"
-simsimd = "6.5.3"
 arc-swap = "1.7"
 rustc-hash = "2.0"
 either = { workspace = true }
@@ -112,6 +111,9 @@ crc32c = "0.6.8"
 bigdecimal = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
+
+[target.'cfg(not(any(target_family = "wasm", all(target_os = "windows", target_arch = "aarch64"))))'.dependencies]
+simsimd = "6.5.3"
 
 [target.'cfg(antithesis)'.dependencies]
 antithesis_sdk = { workspace = true, features = ["full"] }

--- a/core/vector/operations/distance_cos.rs
+++ b/core/vector/operations/distance_cos.rs
@@ -2,6 +2,10 @@ use crate::{
     vector::vector_types::{Vector, VectorSparse, VectorType},
     LimboError, Result,
 };
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+)))]
 use simsimd::SpatialSimilarity;
 
 pub fn vector_distance_cos(v1: &Vector, v2: &Vector) -> Result<f64> {
@@ -16,23 +20,11 @@ pub fn vector_distance_cos(v1: &Vector, v2: &Vector) -> Result<f64> {
         ));
     }
     match v1.vector_type {
-        #[cfg(not(target_family = "wasm"))]
         VectorType::Float32Dense => Ok(vector_f32_distance_cos_simsimd(
             v1.as_f32_slice(),
             v2.as_f32_slice(),
         )),
-        #[cfg(target_family = "wasm")]
-        VectorType::Float32Dense => Ok(vector_f32_distance_cos_rust(
-            v1.as_f32_slice(),
-            v2.as_f32_slice(),
-        )),
-        #[cfg(not(target_family = "wasm"))]
         VectorType::Float64Dense => Ok(vector_f64_distance_cos_simsimd(
-            v1.as_f64_slice(),
-            v2.as_f64_slice(),
-        )),
-        #[cfg(target_family = "wasm")]
-        VectorType::Float64Dense => Ok(vector_f64_distance_cos_rust(
             v1.as_f64_slice(),
             v2.as_f64_slice(),
         )),
@@ -86,11 +78,15 @@ fn vector_f8_distance_cos(v1: &Vector, v2: &Vector) -> f64 {
 }
 
 #[allow(dead_code)]
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+)))]
 fn vector_f32_distance_cos_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
     f32::cosine(v1, v2).unwrap_or(f64::NAN)
 }
 
-// SimSIMD do not support WASM for now, so we have alternative implementation: https://github.com/ashvardanian/SimSIMD/issues/189
+// SimSIMD does not support WASM, and Windows AArch64 has linker issues with simsimd.lib.
 #[allow(dead_code)]
 fn vector_f32_distance_cos_rust(v1: &[f32], v2: &[f32]) -> f64 {
     let (mut dot, mut norm1, mut norm2) = (0.0, 0.0, 0.0);
@@ -106,11 +102,24 @@ fn vector_f32_distance_cos_rust(v1: &[f32], v2: &[f32]) -> f64 {
 }
 
 #[allow(dead_code)]
+#[cfg(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+))]
+fn vector_f32_distance_cos_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
+    vector_f32_distance_cos_rust(v1, v2)
+}
+
+#[allow(dead_code)]
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+)))]
 fn vector_f64_distance_cos_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
     f64::cosine(v1, v2).unwrap_or(f64::NAN)
 }
 
-// SimSIMD do not support WASM for now, so we have alternative implementation: https://github.com/ashvardanian/SimSIMD/issues/189
+// SimSIMD does not support WASM, and Windows AArch64 has linker issues with simsimd.lib.
 #[allow(dead_code)]
 fn vector_f64_distance_cos_rust(v1: &[f64], v2: &[f64]) -> f64 {
     let (mut dot, mut norm1, mut norm2) = (0.0, 0.0, 0.0);
@@ -123,6 +132,15 @@ fn vector_f64_distance_cos_rust(v1: &[f64], v2: &[f64]) -> f64 {
         return 0.0;
     }
     1.0 - dot / (norm1 * norm2).sqrt()
+}
+
+#[allow(dead_code)]
+#[cfg(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+))]
+fn vector_f64_distance_cos_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
+    vector_f64_distance_cos_rust(v1, v2)
 }
 
 fn vector_f32_sparse_distance_cos(v1: VectorSparse<f32>, v2: VectorSparse<f32>) -> f64 {

--- a/core/vector/operations/distance_dot.rs
+++ b/core/vector/operations/distance_dot.rs
@@ -2,6 +2,10 @@ use crate::{
     vector::vector_types::{Vector, VectorSparse, VectorType},
     LimboError, Result,
 };
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+)))]
 use simsimd::SpatialSimilarity;
 
 pub fn vector_distance_dot(v1: &Vector, v2: &Vector) -> Result<f64> {
@@ -16,23 +20,11 @@ pub fn vector_distance_dot(v1: &Vector, v2: &Vector) -> Result<f64> {
         ));
     }
     match v1.vector_type {
-        #[cfg(not(target_family = "wasm"))]
         VectorType::Float32Dense => Ok(vector_f32_distance_dot_simsimd(
             v1.as_f32_slice(),
             v2.as_f32_slice(),
         )),
-        #[cfg(target_family = "wasm")]
-        VectorType::Float32Dense => Ok(vector_f32_distance_dot_rust(
-            v1.as_f32_slice(),
-            v2.as_f32_slice(),
-        )),
-        #[cfg(not(target_family = "wasm"))]
         VectorType::Float64Dense => Ok(vector_f64_distance_dot_simsimd(
-            v1.as_f64_slice(),
-            v2.as_f64_slice(),
-        )),
-        #[cfg(target_family = "wasm")]
-        VectorType::Float64Dense => Ok(vector_f64_distance_dot_rust(
             v1.as_f64_slice(),
             v2.as_f64_slice(),
         )),
@@ -84,11 +76,15 @@ fn vector_f8_distance_dot(v1: &Vector, v2: &Vector) -> f64 {
 }
 
 #[allow(dead_code)]
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+)))]
 fn vector_f32_distance_dot_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
     -f32::dot(v1, v2).unwrap_or(f64::NAN)
 }
 
-// SimSIMD do not support WASM for now, so we have alternative implementation: https://github.com/ashvardanian/SimSIMD/issues/189
+// SimSIMD does not support WASM, and Windows AArch64 has linker issues with simsimd.lib.
 #[allow(dead_code)]
 fn vector_f32_distance_dot_rust(v1: &[f32], v2: &[f32]) -> f64 {
     let mut dot = 0.0;
@@ -99,11 +95,24 @@ fn vector_f32_distance_dot_rust(v1: &[f32], v2: &[f32]) -> f64 {
 }
 
 #[allow(dead_code)]
+#[cfg(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+))]
+fn vector_f32_distance_dot_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
+    vector_f32_distance_dot_rust(v1, v2)
+}
+
+#[allow(dead_code)]
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+)))]
 fn vector_f64_distance_dot_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
     -f64::dot(v1, v2).unwrap_or(f64::NAN)
 }
 
-// SimSIMD do not support WASM for now, so we have alternative implementation: https://github.com/ashvardanian/SimSIMD/issues/189
+// SimSIMD does not support WASM, and Windows AArch64 has linker issues with simsimd.lib.
 #[allow(dead_code)]
 fn vector_f64_distance_dot_rust(v1: &[f64], v2: &[f64]) -> f64 {
     let mut dot = 0.0;
@@ -111,6 +120,15 @@ fn vector_f64_distance_dot_rust(v1: &[f64], v2: &[f64]) -> f64 {
         dot += *a * *b;
     }
     -dot
+}
+
+#[allow(dead_code)]
+#[cfg(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+))]
+fn vector_f64_distance_dot_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
+    vector_f64_distance_dot_rust(v1, v2)
 }
 
 fn vector_f32_sparse_distance_dot(v1: VectorSparse<f32>, v2: VectorSparse<f32>) -> f64 {

--- a/core/vector/operations/distance_l2.rs
+++ b/core/vector/operations/distance_l2.rs
@@ -2,6 +2,10 @@ use crate::{
     vector::vector_types::{Vector, VectorSparse, VectorType},
     LimboError, Result,
 };
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+)))]
 use simsimd::SpatialSimilarity;
 
 pub fn vector_distance_l2(v1: &Vector, v2: &Vector) -> Result<f64> {
@@ -16,23 +20,11 @@ pub fn vector_distance_l2(v1: &Vector, v2: &Vector) -> Result<f64> {
         ));
     }
     match v1.vector_type {
-        #[cfg(not(target_family = "wasm"))]
         VectorType::Float32Dense => Ok(vector_f32_distance_l2_simsimd(
             v1.as_f32_slice(),
             v2.as_f32_slice(),
         )),
-        #[cfg(target_family = "wasm")]
-        VectorType::Float32Dense => Ok(vector_f32_distance_l2_rust(
-            v1.as_f32_slice(),
-            v2.as_f32_slice(),
-        )),
-        #[cfg(not(target_family = "wasm"))]
         VectorType::Float64Dense => Ok(vector_f64_distance_l2_simsimd(
-            v1.as_f64_slice(),
-            v2.as_f64_slice(),
-        )),
-        #[cfg(target_family = "wasm")]
-        VectorType::Float64Dense => Ok(vector_f64_distance_l2_rust(
             v1.as_f64_slice(),
             v2.as_f64_slice(),
         )),
@@ -61,11 +53,15 @@ fn vector_f8_distance_l2(v1: &Vector, v2: &Vector) -> f64 {
 }
 
 #[allow(dead_code)]
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+)))]
 fn vector_f32_distance_l2_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
     f32::euclidean(v1, v2).unwrap_or(f64::NAN)
 }
 
-// SimSIMD do not support WASM for now, so we have alternative implementation: https://github.com/ashvardanian/SimSIMD/issues/189
+// SimSIMD does not support WASM, and Windows AArch64 has linker issues with simsimd.lib.
 #[allow(dead_code)]
 fn vector_f32_distance_l2_rust(v1: &[f32], v2: &[f32]) -> f64 {
     let sum = v1
@@ -77,11 +73,24 @@ fn vector_f32_distance_l2_rust(v1: &[f32], v2: &[f32]) -> f64 {
 }
 
 #[allow(dead_code)]
+#[cfg(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+))]
+fn vector_f32_distance_l2_simsimd(v1: &[f32], v2: &[f32]) -> f64 {
+    vector_f32_distance_l2_rust(v1, v2)
+}
+
+#[allow(dead_code)]
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+)))]
 fn vector_f64_distance_l2_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
     f64::euclidean(v1, v2).unwrap_or(f64::NAN)
 }
 
-// SimSIMD do not support WASM for now, so we have alternative implementation: https://github.com/ashvardanian/SimSIMD/issues/189
+// SimSIMD does not support WASM, and Windows AArch64 has linker issues with simsimd.lib.
 #[allow(dead_code)]
 fn vector_f64_distance_l2_rust(v1: &[f64], v2: &[f64]) -> f64 {
     let sum = v1
@@ -90,6 +99,15 @@ fn vector_f64_distance_l2_rust(v1: &[f64], v2: &[f64]) -> f64 {
         .map(|(a, b)| (a - b).powi(2))
         .sum::<f64>();
     sum.sqrt()
+}
+
+#[allow(dead_code)]
+#[cfg(any(
+    target_family = "wasm",
+    all(target_os = "windows", target_arch = "aarch64")
+))]
+fn vector_f64_distance_l2_simsimd(v1: &[f64], v2: &[f64]) -> f64 {
+    vector_f64_distance_l2_rust(v1, v2)
 }
 
 fn vector_f32_sparse_distance_l2(v1: VectorSparse<f32>, v2: VectorSparse<f32>) -> f64 {


### PR DESCRIPTION
## Summary
- gate `simsimd` dependency out for `aarch64-pc-windows-msvc` and wasm
- keep dense vector distance entry points unchanged while routing to Rust fallback implementations when simsimd is unavailable
- apply same fallback behavior for cosine, dot, and l2 distance operations

## Validation
- cargo fmt
- cargo test -p turso_core vector_distance_ --lib
- cargo check -p turso_core --target aarch64-pc-windows-msvc
- cargo check -p turso_sdk_kit --target aarch64-pc-windows-msvc

Fixes #4981
