### PR TITLE
github/release: Add retry logic to network-dependent install steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,13 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install dist
-        # we specify bash to get pipefail; it guards against the `curl` command
-        # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.2/cargo-dist-installer.sh | sh"
+        run: |
+          for i in 1 2 3; do
+            curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.2/cargo-dist-installer.sh | sh && break
+            echo "Attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -126,13 +129,25 @@ jobs:
           submodules: recursive
       - name: Install Rust non-interactively if not already installed
         if: ${{ matrix.container }}
+        shell: bash
         run: |
-          if ! command -v cargo > /dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          fi
+          for i in 1 2 3; do
+            if command -v cargo > /dev/null 2>&1; then
+              break
+            fi
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && break
+            echo "Attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install dist
-        run: ${{ matrix.install_dist.run }}
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            ${{ matrix.install_dist.run }} && break
+            echo "Attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@v4

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,3 +21,5 @@ install-updater = true
 dist = false
 # Whether to enable GitHub Attestations
 github-attestations = true
+# Allow manual edits to CI scripts (e.g. retry logic for network resilience)
+allow-dirty = ["ci"]


### PR DESCRIPTION
Transient network failures (e.g. GitHub connectivity timeouts) can cause the release workflow to fail when downloading cargo-dist or rustup. Wrap all curl-based install steps with a bash retry loop (3 attempts, 15s delay) to handle these gracefully without adding third-party actions.