### PR TITLE
concurrent-simulator: Fix DDL inside BEGIN CONCURRENT transactions

### DIFF
--- a/testing/concurrent-simulator/chaotic_elle.rs
+++ b/testing/concurrent-simulator/chaotic_elle.rs
@@ -29,7 +29,7 @@ use rand::Rng;
 use rand_chacha::ChaCha8Rng;
 
 use crate::elle::{ELLE_LIST_APPEND_KEY_COUNT, ELLE_RW_REGISTER_KEY_COUNT, elle_key_name};
-use crate::operations::{OpResult, Operation};
+use crate::operations::{OpResult, Operation, TxMode};
 
 /// A chaotic workload instance (one per fiber, drives a single transaction).
 ///
@@ -90,9 +90,9 @@ impl ChaoticElleWorkload {
         match planned {
             PlannedOp::Begin => Operation::Begin {
                 mode: if self.enable_mvcc {
-                    "BEGIN CONCURRENT".into()
+                    TxMode::Concurrent
                 } else {
-                    "BEGIN".into()
+                    TxMode::Default
                 },
             },
             PlannedOp::Read { key } => match self.model {

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -32,7 +32,7 @@ use crate::{
     workloads::{Workload, WorkloadContext},
 };
 pub use io::{IOFaultConfig, SimulatorIO};
-pub use operations::{FiberState, OpContext, OpResult, Operation};
+pub use operations::{FiberState, OpContext, OpResult, Operation, TxMode};
 
 /// A bounded container for sampling values with reservoir sampling.
 #[derive(Debug, Clone)]
@@ -678,8 +678,14 @@ impl Whopper {
             let _enter = span.enter();
             debug!("result={step_result:?}, rows.len()={}", rows.len());
 
-            if matches!(completed_op, Operation::Begin { .. }) && step_result.is_ok() {
-                ctx.fiber.state = FiberState::InTx;
+            if let Operation::Begin { mode } = completed_op {
+                if step_result.is_ok() {
+                    ctx.fiber.state = if mode == TxMode::Concurrent {
+                        FiberState::InConcurrentTx
+                    } else {
+                        FiberState::InTx
+                    };
+                }
             }
 
             let txn_id = ctx.fiber.txn_id;
@@ -726,9 +732,7 @@ impl Whopper {
                     | turso_core::LimboError::BusySnapshot
                     | turso_core::LimboError::WriteWriteConflict
                     | turso_core::LimboError::InvalidArgument(..) => {
-                        if matches!(ctx.fiber.state, FiberState::InTx)
-                            && !ctx.fiber.connection.get_auto_commit()
-                        {
+                        if ctx.fiber.state.is_in_tx() && !ctx.fiber.connection.get_auto_commit() {
                             ctx.fiber.current_op = Some(Operation::Rollback);
                         } else {
                             ctx.fiber.txn_id = None;

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -13,6 +13,37 @@ const MAX_SAMPLE_KEYS_PER_TABLE: usize = 1000;
 pub enum FiberState {
     Idle,
     InTx,
+    InConcurrentTx,
+}
+
+impl FiberState {
+    pub fn is_in_tx(self) -> bool {
+        matches!(self, FiberState::InTx | FiberState::InConcurrentTx)
+    }
+}
+
+/// Transaction begin mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TxMode {
+    Default,
+    Deferred,
+    Immediate,
+    Concurrent,
+}
+
+impl TxMode {
+    pub fn as_sql(self) -> &'static str {
+        match self {
+            TxMode::Default => "BEGIN",
+            TxMode::Deferred => "BEGIN DEFERRED",
+            TxMode::Immediate => "BEGIN IMMEDIATE",
+            TxMode::Concurrent => "BEGIN CONCURRENT",
+        }
+    }
+
+    pub fn is_deferred(self) -> bool {
+        matches!(self, TxMode::Default | TxMode::Deferred)
+    }
 }
 
 /// An operation that can be executed on the database.
@@ -20,7 +51,7 @@ pub enum FiberState {
 #[derive(Debug, Clone)]
 pub enum Operation {
     /// Begin a transaction
-    Begin { mode: String },
+    Begin { mode: TxMode },
     /// Commit current transaction
     Commit,
     /// Rollback current transaction
@@ -87,7 +118,7 @@ impl Operation {
     /// Get the SQL string for this operation
     pub fn sql(&self) -> String {
         match self {
-            Operation::Begin { mode } => mode.clone(),
+            Operation::Begin { mode } => mode.as_sql().to_string(),
             Operation::Commit => "COMMIT".to_string(),
             Operation::Rollback => "ROLLBACK".to_string(),
             Operation::IntegrityCheck => "PRAGMA integrity_check".to_string(),

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -418,7 +418,7 @@ impl Property for ElleHistoryRecorder {
             Operation::Begin { mode } => {
                 // For BEGIN and BEGIN DEFERRED, defer index reservation until first operation
                 // For BEGIN IMMEDIATE/EXCLUSIVE, reserve index now since they acquire locks immediately
-                let is_deferred = mode == "BEGIN" || mode.to_uppercase().contains("DEFERRED");
+                let is_deferred = mode.is_deferred();
                 let (invoke_index, invoke_time) = if is_deferred {
                     (None, None)
                 } else {

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -14,7 +14,7 @@ use sql_generation::{
 };
 
 use crate::elle::{ELLE_LIST_APPEND_KEY_COUNT, ELLE_RW_REGISTER_KEY_COUNT, elle_key_name};
-use crate::operations::Operation;
+use crate::operations::{Operation, TxMode};
 use crate::{FiberState, SimulatorState};
 
 /// Context passed to workloads for generating operations.
@@ -59,15 +59,13 @@ impl Workload for BeginWorkload {
             return None;
         }
         let mode = if ctx.enable_mvcc {
-            ["BEGIN DEFERRED", "BEGIN IMMEDIATE", "BEGIN CONCURRENT"]
+            *[TxMode::Deferred, TxMode::Immediate, TxMode::Concurrent]
                 .choose(rng)
                 .expect("array is not empty")
         } else {
-            "BEGIN"
+            TxMode::Default
         };
-        Some(Operation::Begin {
-            mode: mode.to_string(),
-        })
+        Some(Operation::Begin { mode })
     }
 }
 
@@ -197,6 +195,10 @@ pub struct CreateIndexWorkload;
 
 impl Workload for CreateIndexWorkload {
     fn generate(&self, ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        // DDL is not allowed inside concurrent transactions
+        if *ctx.fiber_state == FiberState::InConcurrentTx {
+            return None;
+        }
         let create_index = CreateIndex::arbitrary(rng, ctx);
         let sql = create_index.to_string();
         Some(Operation::CreateIndex {
@@ -212,6 +214,10 @@ pub struct DropIndexWorkload;
 
 impl Workload for DropIndexWorkload {
     fn generate(&self, ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        // DDL is not allowed inside concurrent transactions
+        if *ctx.fiber_state == FiberState::InConcurrentTx {
+            return None;
+        }
         if ctx.sim_state.indexes.is_empty() {
             return None;
         }
@@ -251,7 +257,7 @@ pub struct CommitWorkload;
 
 impl Workload for CommitWorkload {
     fn generate(&self, ctx: &WorkloadContext, _rng: &mut ChaCha8Rng) -> Option<Operation> {
-        if *ctx.fiber_state != FiberState::InTx {
+        if !ctx.fiber_state.is_in_tx() {
             return None;
         }
         Some(Operation::Commit)
@@ -263,7 +269,7 @@ pub struct RollbackWorkload;
 
 impl Workload for RollbackWorkload {
     fn generate(&self, ctx: &WorkloadContext, _rng: &mut ChaCha8Rng) -> Option<Operation> {
-        if *ctx.fiber_state != FiberState::InTx {
+        if !ctx.fiber_state.is_in_tx() {
             return None;
         }
         Some(Operation::Rollback)


### PR DESCRIPTION
DDL statements (CREATE INDEX, DROP INDEX) were being generated inside BEGIN CONCURRENT transactions, which is not allowed.