### PR TITLE
testing/stress: Allow --seed parameter for non-deterministic runs

### DIFF
--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -584,11 +584,6 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .build()?;
 
     let opts = Opts::parse();
-    if opts.seed.is_some() {
-        eprintln!("seed is only supporte when building with --cfg shuttle");
-        std::process::exit(1);
-    }
-
     rt.block_on(Box::pin(async_main(opts)))
 }
 


### PR DESCRIPTION
Not allowing `--seed` for non-deterministic runs is silly because many hangs, for example, are sensitive to the seed, even if the runs are not deterministic.