### PR TITLE
Fix INSERT failing on non-INTEGER PRIMARY KEY when column is omitted

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -2307,7 +2307,7 @@ fn translate_column(
             });
         }
     } else {
-        let nullable = !column.notnull() && !column.primary_key();
+        let nullable = !column.notnull() && !column.is_rowid_alias();
         if !nullable {
             crate::bail_parse_error!(
                 "column {} is not nullable",

--- a/testing/runner/tests/insert.sqltest
+++ b/testing/runner/tests/insert.sqltest
@@ -2111,3 +2111,43 @@ test insert-ipk-index-explicit-value {
 expect {
     ok
 }
+
+@cross-check-integrity
+test serial-pk-omit-column {
+    CREATE TABLE t_serial (id SERIAL PRIMARY KEY, name TEXT NOT NULL);
+    INSERT INTO t_serial (name) VALUES ('alice');
+    SELECT typeof(id), id, name FROM t_serial;
+}
+expect {
+    null||alice
+}
+
+@cross-check-integrity
+test serial-pk-explicit-null {
+    CREATE TABLE t_serial (id SERIAL PRIMARY KEY, name TEXT NOT NULL);
+    INSERT INTO t_serial (id, name) VALUES (NULL, 'bob');
+    SELECT typeof(id), id, name FROM t_serial;
+}
+expect {
+    null||bob
+}
+
+@cross-check-integrity
+test text-pk-omit-column {
+    CREATE TABLE t_text (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+    INSERT INTO t_text (name) VALUES ('alice');
+    SELECT typeof(id), id, name FROM t_text;
+}
+expect {
+    null||alice
+}
+
+@cross-check-integrity
+test integer-pk-omit-column {
+    CREATE TABLE t_int (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+    INSERT INTO t_int (name) VALUES ('alice');
+    SELECT typeof(id), id, name FROM t_int;
+}
+expect {
+    integer|1|alice
+}


### PR DESCRIPTION
In SQLite, only INTEGER PRIMARY KEY (rowid alias) columns are implicitly NOT NULL. Other PRIMARY KEY types (TEXT, SERIAL, REAL, etc.) can hold NULLs per documented SQLite behavior. The nullable check was using primary_key() which rejected all PK columns; changed to is_rowid_alias() to match SQLite semantics.

Fixes https://github.com/tursodatabase/turso/issues/5716

## Description of AI Usage

clauded