### PR TITLE
bindings/rust: Use the proper Column decl_type

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -458,10 +458,8 @@ impl Statement {
                 .column_name(i)
                 .expect("column index must be within valid range")
                 .into_owned();
-            cols.push(Column {
-                name,
-                decl_type: None, // TODO
-            });
+            let decl_type = stmt.column_decltype(i);
+            cols.push(Column { name, decl_type });
         }
 
         cols


### PR DESCRIPTION
## Description
Ran into this as part of starting to add turso support to `sqlx`
