### PR TITLE
Implement SQLite-compatible bare-column behavior for single MIN/MAX aggregates

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -173,12 +173,13 @@ fn emit_collseq_if_needed(
     program: &mut ProgramBuilder,
     referenced_tables: &TableReferences,
     expr: &ast::Expr,
+    reg_minmax_not_updated: Option<usize>,
 ) {
     // Check if this is a column expression with explicit COLLATE clause
     if let ast::Expr::Collate(_, collation_name) = expr {
         if let Ok(collation) = CollationSeq::new(collation_name.as_str()) {
             program.emit_insn(Insn::CollSeq {
-                reg: None,
+                reg: reg_minmax_not_updated,
                 collation,
             });
         }
@@ -191,7 +192,7 @@ fn emit_collseq_if_needed(
             if let Some(table_column) = table_ref.get_column_at(*column) {
                 if let Some(c) = table_column.collation_opt() {
                     program.emit_insn(Insn::CollSeq {
-                        reg: None,
+                        reg: reg_minmax_not_updated,
                         collation: c,
                     });
                     return;
@@ -203,7 +204,7 @@ fn emit_collseq_if_needed(
     // Always emit a CollSeq to reset to BINARY default, preventing collation
     // from a previous aggregate leaking into this one.
     program.emit_insn(Insn::CollSeq {
-        reg: None,
+        reg: reg_minmax_not_updated,
         collation: CollationSeq::Binary,
     });
 }
@@ -391,6 +392,7 @@ pub fn translate_aggregation_step(
     agg_arg_source: AggArgumentSource,
     target_register: usize,
     resolver: &Resolver,
+    reg_minmax_not_updated: Option<usize>,
 ) -> Result<usize> {
     let num_args = agg_arg_source.num_args();
     let func = agg_arg_source.agg_func();
@@ -471,7 +473,7 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             let expr = &agg_arg_source.arg_at(0);
-            emit_collseq_if_needed(program, referenced_tables, expr);
+            emit_collseq_if_needed(program, referenced_tables, expr, reg_minmax_not_updated);
             let comparator_func_name =
                 super::order_by::custom_type_lt_func(expr, referenced_tables, resolver.schema());
             program.emit_insn(Insn::AggStep {
@@ -490,7 +492,7 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             let expr = &agg_arg_source.arg_at(0);
-            emit_collseq_if_needed(program, referenced_tables, expr);
+            emit_collseq_if_needed(program, referenced_tables, expr, reg_minmax_not_updated);
             let comparator_func_name =
                 super::order_by::custom_type_lt_func(expr, referenced_tables, resolver.schema());
             program.emit_insn(Insn::AggStep {

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -508,6 +508,8 @@ pub fn group_by_process_single_group(
         .as_ref()
         .expect("group by metadata not found");
     program.preassign_label_to_next_insn(labels.label_sort_loop_start);
+    let minmax_agg_idx = plan.single_minmax_for_bare_result_columns();
+    let reg_minmax_not_updated = minmax_agg_idx.map(|_| program.alloc_register());
     let groups_start_reg = match &row_source {
         GroupByRowSource::Sorter {
             sort_cursor,
@@ -629,6 +631,11 @@ pub fn group_by_process_single_group(
             agg_arg_source,
             agg_result_reg,
             &t_ctx.resolver,
+            if Some(i) == minmax_agg_idx {
+                reg_minmax_not_updated
+            } else {
+                None
+            },
         )?;
         if let Distinctness::Distinct { ctx } = &agg.distinctness {
             let ctx = ctx
@@ -645,11 +652,29 @@ pub fn group_by_process_single_group(
         program.offset(),
         "don't emit group columns if continuing existing group",
     );
-    program.emit_insn(Insn::If {
-        target_pc: labels.label_acc_indicator_set_flag_true,
-        reg: registers.reg_data_in_acc_flag,
-        jump_if_null: false,
-    });
+    if let Some(reg) = reg_minmax_not_updated {
+        let label_emit_nonagg = program.allocate_label();
+        // First row in group always captures non-aggregate expressions.
+        program.emit_insn(Insn::IfNot {
+            target_pc: label_emit_nonagg,
+            reg: registers.reg_data_in_acc_flag,
+            jump_if_null: false,
+        });
+        // For subsequent rows, only refresh non-aggregate expressions when
+        // MIN/MAX accumulator changed in this row.
+        program.emit_insn(Insn::If {
+            target_pc: labels.label_acc_indicator_set_flag_true,
+            reg,
+            jump_if_null: false,
+        });
+        program.resolve_label(label_emit_nonagg, program.offset());
+    } else {
+        program.emit_insn(Insn::If {
+            target_pc: labels.label_acc_indicator_set_flag_true,
+            reg: registers.reg_data_in_acc_flag,
+            jump_if_null: false,
+        });
+    }
 
     // Read non-aggregate columns from the current row
     match row_source {

--- a/core/translate/main_loop.rs
+++ b/core/translate/main_loop.rs
@@ -2336,6 +2336,8 @@ fn emit_loop_source<'a>(
             let start_reg = t_ctx
                 .reg_agg_start
                 .expect("aggregate registers must be initialized");
+            let minmax_agg_idx = plan.single_minmax_for_bare_result_columns();
+            let reg_minmax_not_updated = minmax_agg_idx.map(|_| program.alloc_register());
 
             // In planner.rs, we have collected all aggregates from the SELECT clause, including ones where the aggregate is embedded inside
             // a more complex expression. Some examples: length(sum(x)), sum(x) + avg(y), sum(x) + 1, etc.
@@ -2349,6 +2351,11 @@ fn emit_loop_source<'a>(
                     AggArgumentSource::new_from_expression(&agg.func, &agg.args, &agg.distinctness),
                     reg,
                     &t_ctx.resolver,
+                    if Some(i) == minmax_agg_idx {
+                        reg_minmax_not_updated
+                    } else {
+                        None
+                    },
                 )?;
                 if let Distinctness::Distinct { ctx } = &agg.distinctness {
                     let ctx = ctx
@@ -2360,11 +2367,28 @@ fn emit_loop_source<'a>(
 
             let label_emit_nonagg_only_once = if let Some(flag) = t_ctx.reg_nonagg_emit_once_flag {
                 let if_label = program.allocate_label();
-                program.emit_insn(Insn::If {
-                    reg: flag,
-                    target_pc: if_label,
-                    jump_if_null: false,
-                });
+                if let Some(reg) = reg_minmax_not_updated {
+                    let label_eval = program.allocate_label();
+                    // First row always evaluates non-aggregate columns (flag == 0).
+                    program.emit_insn(Insn::IfNot {
+                        reg: flag,
+                        target_pc: label_eval,
+                        jump_if_null: false,
+                    });
+                    // For subsequent rows, skip unless MIN/MAX accumulator changed this row.
+                    program.emit_insn(Insn::If {
+                        reg,
+                        target_pc: if_label,
+                        jump_if_null: false,
+                    });
+                    program.resolve_label(label_eval, program.offset());
+                } else {
+                    program.emit_insn(Insn::If {
+                        reg: flag,
+                        target_pc: if_label,
+                        jump_if_null: false,
+                    });
+                }
                 Some(if_label)
             } else {
                 None
@@ -2395,18 +2419,26 @@ fn emit_loop_source<'a>(
                 )?;
             }
 
-            // For result columns that contain aggregates but also reference
-            // non-aggregate columns (e.g. CASE WHEN SUM(1) THEN a ELSE b END),
-            // pre-read those column references while the cursor is still valid.
-            // They are cached in expr_to_reg_cache so that when the full
-            // expression is evaluated after AggFinal, translate_expr finds
-            // the cached values instead of reading from the exhausted cursor.
-            for rc in plan
-                .result_columns
-                .iter()
-                .filter(|rc| rc.contains_aggregates)
-            {
-                walk_expr(&rc.expr, &mut |expr: &'a Expr| -> Result<WalkControl> {
+            // For post-aggregation expressions that may reference row data
+            // (e.g. CASE WHEN SUM(1) THEN a ELSE b END), pre-read those column
+            // references while the cursor is still valid. They are cached in
+            // expr_to_reg_cache so that when expressions are evaluated after
+            // AggFinal, translate_expr finds cached values instead of reading
+            // from an exhausted cursor.
+            let minmax_cache_skip_label = if let Some(reg) = reg_minmax_not_updated {
+                let label_skip = program.allocate_label();
+                program.emit_insn(Insn::If {
+                    reg,
+                    target_pc: label_skip,
+                    jump_if_null: false,
+                });
+                Some(label_skip)
+            } else {
+                None
+            };
+
+            let mut cache_row_refs_from_expr = |root_expr: &'a Expr| -> Result<()> {
+                walk_expr(root_expr, &mut |expr: &'a Expr| -> Result<WalkControl> {
                     match expr {
                         Expr::Column { .. } | Expr::RowId { .. } => {
                             let reg = program.alloc_register();
@@ -2432,6 +2464,35 @@ fn emit_loop_source<'a>(
                         }
                     }
                 })?;
+                Ok(())
+            };
+
+            // Result expressions containing aggregates are always evaluated
+            // after AggFinal and may require row-data cache entries.
+            for rc in plan
+                .result_columns
+                .iter()
+                .filter(|rc| rc.contains_aggregates)
+            {
+                cache_row_refs_from_expr(&rc.expr)?;
+            }
+
+            // HAVING (without GROUP BY expressions) is also evaluated after
+            // aggregation. For the MIN/MAX bare-column special case, it must
+            // observe row values from the chosen MIN/MAX row.
+            if reg_minmax_not_updated.is_some() {
+                if let Some(group_by) = &plan.group_by {
+                    if group_by.exprs.is_empty() {
+                        if let Some(having) = &group_by.having {
+                            for expr in having {
+                                cache_row_refs_from_expr(expr)?;
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(label_skip) = minmax_cache_skip_label {
+                program.resolve_label(label_skip, program.offset());
             }
 
             if let Some(label) = label_emit_nonagg_only_once {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -11,7 +11,7 @@ use crate::{
     translate::{
         collate::{get_collseq_from_expr, CollationSeq},
         emitter::UpdateRowSource,
-        expr::{as_binary_components, get_expr_affinity},
+        expr::{as_binary_components, get_expr_affinity, walk_expr, WalkControl},
         expression_index::{normalize_expr_for_index_matching, single_table_column_usage},
         optimizer::constraints::{BinaryExprSide, SeekRangeConstraint},
         planner::determine_where_to_eval_term,
@@ -503,6 +503,78 @@ impl SelectPlan {
 
     pub fn agg_args_count(&self) -> usize {
         self.aggregates.iter().map(|agg| agg.args.len()).sum()
+    }
+
+    fn has_row_dependent_post_agg_expr_outside_aggregates(&self) -> bool {
+        let expr_depends_on_row = |root_expr: &ast::Expr| {
+            let mut depends_on_input_row = false;
+            walk_expr(root_expr, &mut |expr| -> Result<WalkControl> {
+                match expr {
+                    ast::Expr::Column { table, .. } | ast::Expr::RowId { table, .. } => {
+                        if self
+                            .table_references
+                            .find_joined_table_by_internal_id(*table)
+                            .is_some()
+                        {
+                            depends_on_input_row = true;
+                        }
+                        Ok(WalkControl::SkipChildren)
+                    }
+                    _ => {
+                        if self.aggregates.iter().any(|a| a.original_expr == *expr) {
+                            return Ok(WalkControl::SkipChildren);
+                        }
+                        Ok(WalkControl::Continue)
+                    }
+                }
+            })
+            .expect("walking post-aggregate expression should be infallible");
+            depends_on_input_row
+        };
+
+        if self
+            .result_columns
+            .iter()
+            .any(|rc| expr_depends_on_row(&rc.expr))
+        {
+            return true;
+        }
+        if self
+            .order_by
+            .iter()
+            .any(|(expr, _)| expr_depends_on_row(expr.as_ref()))
+        {
+            return true;
+        }
+        if let Some(group_by) = &self.group_by {
+            if let Some(having) = &group_by.having {
+                return having.iter().any(expr_depends_on_row);
+            }
+        }
+        false
+    }
+
+    /// Returns the aggregate index when this SELECT qualifies for SQLite's
+    /// bare-column MIN/MAX row-selection behavior.
+    ///
+    /// For a query with exactly one MIN() or MAX() aggregate and at least one
+    /// post-aggregation expression that depends on the input row (outside
+    /// aggregate arguments), SQLite takes that expression's source row from the
+    /// same input row that provides the MIN/MAX value.
+    pub fn single_minmax_for_bare_result_columns(&self) -> Option<usize> {
+        if !self.has_row_dependent_post_agg_expr_outside_aggregates() {
+            return None;
+        }
+        let mut minmax_idx = None;
+        for (idx, agg) in self.aggregates.iter().enumerate() {
+            if matches!(agg.func, AggFunc::Min | AggFunc::Max) {
+                if minmax_idx.is_some() {
+                    return None;
+                }
+                minmax_idx = Some(idx);
+            }
+        }
+        minmax_idx
     }
 
     /// Whether this query or any of its subqueries reference columns from the outer query.

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -960,6 +960,7 @@ fn emit_aggregation_step(
             AggArgumentSource::new_from_expression(&func.func, &args, &Distinctness::NonDistinct),
             reg_acc_start,
             resolver,
+            None,
         )?;
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4453,7 +4453,7 @@ fn update_agg_payload(
     payload: &mut [Value],
     collation: CollationSeq,
     comparator: &Option<crate::vdbe::sorter::SortComparator>,
-) -> Result<()> {
+) -> Result<bool> {
     match func {
         AggFunc::Count => {
             // COUNT(column) increments only when arg is not NULL. Empty args treated as non-NULL
@@ -4481,7 +4481,7 @@ fn update_agg_payload(
         }
         AggFunc::Avg => {
             if matches!(arg, Value::Null) {
-                return Ok(());
+                return Ok(false);
             }
             // invariant as per init_agg_payload: payload[0] is Float (sum), payload[1] is Float (r_err), payload[2] is Integer (count)
             let [sum_val, r_err_val, count_val, ..] = payload else {
@@ -4611,11 +4611,14 @@ fn update_agg_payload(
         }
         AggFunc::Min | AggFunc::Max => {
             if matches!(arg, Value::Null) {
-                return Ok(());
+                // Match SQLite behavior for all-NULL groups: when the accumulator
+                // is still NULL, treat this as selecting the current row so bare
+                // columns follow the last row visited.
+                return Ok(matches!(payload[0], Value::Null));
             }
             if matches!(payload[0], Value::Null) {
                 payload[0] = arg;
-                return Ok(());
+                return Ok(true);
             }
             use std::cmp::Ordering;
             // Use custom type comparator if available, otherwise fall back to collation
@@ -4633,11 +4636,13 @@ fn update_agg_payload(
             };
             if should_update {
                 payload[0] = arg;
+                return Ok(true);
             }
+            return Ok(false);
         }
         AggFunc::GroupConcat | AggFunc::StringAgg => {
             if matches!(arg, Value::Null) {
-                return Ok(());
+                return Ok(false);
             }
             let delimiter = maybe_arg2.unwrap_or_else(|| Value::build_text(","));
             let acc = &mut payload[0];
@@ -4695,7 +4700,7 @@ fn update_agg_payload(
             vec.append(&mut data);
         }
     }
-    Ok(())
+    Ok(false)
 }
 
 /// Convert the intermediate aggregate state in `payload` into the final result value.
@@ -4883,6 +4888,7 @@ pub fn op_agg_step(
                 _ => None,
             };
             let collation = state.current_collation.unwrap_or(CollationSeq::Binary);
+            let minmax_not_updated_reg = state.minmax_not_updated_reg;
 
             // Now get mutable borrow on payload
             let Register::Aggregate(agg) = &mut state.registers[*acc_reg] else {
@@ -4892,7 +4898,13 @@ pub fn op_agg_step(
                 );
             };
             let payload = agg.payload_mut();
-            update_agg_payload(func, arg, maybe_arg2, payload, collation, &comparator)?;
+            let minmax_updated =
+                update_agg_payload(func, arg, maybe_arg2, payload, collation, &comparator)?;
+            if matches!(func, AggFunc::Min | AggFunc::Max) && !minmax_updated {
+                if let Some(reg_idx) = minmax_not_updated_reg {
+                    state.registers[reg_idx] = Register::Value(Value::from_i64(1));
+                }
+            }
         }
     };
 
@@ -9278,6 +9290,7 @@ pub fn op_coll_seq(
 
     // Set the current collation sequence for use by subsequent functions
     state.current_collation = Some(*collation);
+    state.minmax_not_updated_reg = *reg;
 
     // If P1 is not zero, initialize that register to 0
     if let Some(reg_idx) = reg {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -369,6 +369,9 @@ pub struct ProgramState {
     seek_state: OpSeekState,
     /// Current collation sequence set by OP_CollSeq instruction
     current_collation: Option<CollationSeq>,
+    /// Optional register used by MIN/MAX aggregate stepping to indicate that
+    /// the current row did not replace the accumulator value.
+    minmax_not_updated_reg: Option<usize>,
     op_column_state: OpColumnState,
     op_row_id_state: OpRowIdState,
     op_transaction_state: OpTransactionState,
@@ -473,6 +476,7 @@ impl ProgramState {
             distinct_key_values: Vec::new(),
             seek_state: OpSeekState::Start,
             current_collation: None,
+            minmax_not_updated_reg: None,
             op_column_state: OpColumnState::Start,
             op_row_id_state: OpRowIdState::Start,
             op_transaction_state: OpTransactionState::Start,
@@ -578,6 +582,7 @@ impl ProgramState {
         self.op_no_conflict_state = OpNoConflictState::Start;
         self.seek_state = OpSeekState::Start;
         self.current_collation = None;
+        self.minmax_not_updated_reg = None;
         self.op_column_state = OpColumnState::Start;
         self.op_row_id_state = OpRowIdState::Start;
         self.commit_state = CommitState::Ready;

--- a/testing/runner/tests/agg-functions/minmax-bare-columns.sqltest
+++ b/testing/runner/tests/agg-functions/minmax-bare-columns.sqltest
@@ -1,0 +1,180 @@
+@database :memory:
+
+@cross-check-integrity
+test bare_columns_follow_max_row_ungrouped {
+    CREATE TABLE t(id INT, val INT, name TEXT);
+    INSERT INTO t VALUES
+        (1,10,'first'),
+        (2,30,'second'),
+        (3,20,'third');
+    SELECT id, name, MAX(val) FROM t;
+}
+expect {
+    2|second|30
+}
+
+@cross-check-integrity
+test bare_columns_follow_min_row_ungrouped {
+    CREATE TABLE t(id INT, val INT, name TEXT);
+    INSERT INTO t VALUES
+        (1,10,'first'),
+        (2,30,'second'),
+        (3,20,'third');
+    SELECT id, name, MIN(val) FROM t;
+}
+expect {
+    1|first|10
+}
+
+@cross-check-integrity
+test row_dependent_expression_follows_max_row {
+    CREATE TABLE t(id INT, val INT);
+    INSERT INTO t VALUES
+        (1,10),
+        (2,30),
+        (3,20);
+    SELECT id + 1, MAX(val) FROM t;
+}
+expect {
+    3|30
+}
+
+@cross-check-integrity
+test mixed_expression_with_aggregate_uses_max_row {
+    CREATE TABLE t(id INT, val INT);
+    INSERT INTO t VALUES
+        (1,10),
+        (2,30),
+        (3,20);
+    SELECT id + MAX(val) FROM t;
+}
+expect {
+    32
+}
+
+@cross-check-integrity
+test mixed_expression_with_aggregate_uses_max_row_per_group {
+    CREATE TABLE t(g TEXT, id INT, val INT);
+    INSERT INTO t VALUES
+        ('a', 1, 10),
+        ('a', 2, 30),
+        ('a', 3, 20),
+        ('b', 4,  5),
+        ('b', 5, 40);
+    SELECT g, id + MAX(val) FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    a|32
+    b|45
+}
+
+@cross-check-integrity
+test bare_columns_follow_max_row_grouped {
+    CREATE TABLE t(g TEXT, id INT, val INT, name TEXT);
+    INSERT INTO t VALUES
+        ('a', 1, 10, 'a10'),
+        ('a', 2, 30, 'a30'),
+        ('a', 3, 20, 'a20'),
+        ('b', 4,  5, 'b5'),
+        ('b', 5, 40, 'b40');
+    SELECT g, id, name, MAX(val) FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    a|2|a30|30
+    b|5|b40|40
+}
+
+@cross-check-integrity
+test bare_columns_follow_single_max_even_with_other_aggregates {
+    CREATE TABLE t(id INT, val INT);
+    INSERT INTO t VALUES
+        (1,10),
+        (2,30),
+        (3,20);
+    SELECT id, MAX(val), COUNT(*) FROM t;
+}
+expect {
+    2|30|3
+}
+
+@cross-check-integrity
+test grouped_bare_columns_follow_single_max_even_with_other_aggregates {
+    CREATE TABLE t(g TEXT, id INT, val INT);
+    INSERT INTO t VALUES
+        ('a', 1, 10),
+        ('a', 2, 30),
+        ('a', 3, 20),
+        ('b', 9,  1),
+        ('b', 7,  5);
+    SELECT g, id, MAX(val), SUM(val) FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    a|2|30|60
+    b|7|5|6
+}
+
+@cross-check-integrity
+test order_by_bare_column_follows_max_row_even_if_not_selected {
+    CREATE TABLE t(g TEXT, id INT, val INT);
+    INSERT INTO t VALUES
+        ('a', 1, 10),
+        ('a', 9, 30),
+        ('b', 2,  5),
+        ('b', 3, 40);
+    SELECT MAX(val) FROM t GROUP BY g ORDER BY id;
+}
+expect {
+    40
+    30
+}
+
+@cross-check-integrity
+test having_bare_column_follows_max_row_even_if_not_selected {
+    CREATE TABLE t(id INT, val INT);
+    INSERT INTO t VALUES
+        (-1, 10),
+        ( 2, 30);
+    SELECT MAX(val) FROM t HAVING id > 0;
+}
+expect {
+    30
+}
+
+@cross-check-integrity
+test having_bare_column_filters_by_max_row_even_if_first_row_matches {
+    CREATE TABLE t(id INT, val INT);
+    INSERT INTO t VALUES
+        ( 2, 10),
+        (-1, 30);
+    SELECT MAX(val) FROM t HAVING id > 0;
+}
+expect {
+}
+
+@cross-check-integrity
+test bare_columns_all_null_max_choose_last_row {
+    CREATE TABLE t(id INT, val INT, name TEXT);
+    INSERT INTO t VALUES
+        (1, NULL, 'first'),
+        (2, NULL, 'second'),
+        (3, NULL, 'third');
+    SELECT id, name, MAX(val) FROM t;
+}
+expect {
+    3|third|
+}
+
+@cross-check-integrity
+test bare_columns_all_null_min_grouped_choose_last_row_per_group {
+    CREATE TABLE t(g TEXT, id INT, val INT, name TEXT);
+    INSERT INTO t VALUES
+        ('a', 1, NULL, 'a1'),
+        ('a', 2, NULL, 'a2'),
+        ('b', 3, NULL, 'b3'),
+        ('b', 4, NULL, 'b4');
+    SELECT g, id, name, MIN(val) FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    a|2|a2|
+    b|4|b4|
+}


### PR DESCRIPTION

## Description

Fixes bare-column row selection for aggregate queries with a single `MIN()` or `MAX()` to match SQLite semantics.

Previously, Turso could return bare (non-aggregate) values from the first row encountered, even when `MIN/MAX` came from a different row. This now follows SQLite behavior by taking row-dependent bare values from the row that produced the `MIN/MAX` value.

  Changes:
  - Updated planner detection to enable this path when there is exactly one `MIN/MAX` aggregate (even if other aggregates are also present).
  - Expanded trigger detection to include row-dependent post-aggregation expressions in:
    - `SELECT`
    - `ORDER BY`
    - `HAVING`
  - Updated aggregation/main-loop handling so row-dependent cached values are only refreshed when the tracked `MIN/MAX` accumulator is replaced.
  - Added/extended SQL regression tests
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

SQLite documents that when an aggregate query has a single `MIN()` or `MAX()`, all bare columns come from the same input row that contains that `MIN/MAX` value.

  Issue #5545 reported Turso diverging from this behavior:
  - Example: `SELECT id, name, MAX(val) FROM t`
  - Expected (SQLite): bare columns from max-row
  - Actual (before): bare columns from first row

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5545

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
