### PR TITLE
Fix case-insensitive behaviour for tables and views

### DIFF
--- a/cli/commands/import.rs
+++ b/cli/commands/import.rs
@@ -273,5 +273,7 @@ pub fn normalize_ident(identifier: &str) -> String {
     } else {
         identifier
     }
+    // SQLite identifiers are case-insensitive only for ASCII characters
+    // (see: https://www.sqlite.org/datatype3.html#collation)
     .to_ascii_lowercase()
 }

--- a/cli/commands/import.rs
+++ b/cli/commands/import.rs
@@ -273,5 +273,5 @@ pub fn normalize_ident(identifier: &str) -> String {
     } else {
         identifier
     }
-    .to_lowercase()
+    .to_ascii_lowercase()
 }

--- a/core/util.rs
+++ b/core/util.rs
@@ -3851,7 +3851,7 @@ pub mod tests {
     fn test_normalize_ident() {
         assert_eq!(normalize_ident("foo"), "foo");
         assert_eq!(normalize_ident("FOO"), "foo");
-        assert_eq!(normalize_ident("ὈΔΥΣΣΕΎΣ"), "ὀδυσσεύς");
+        assert_eq!(normalize_ident("ὈΔΥΣΣΕΎΣ"), "ὈΔΥΣΣΕΎΣ");
     }
 
     fn schema_with_tables(create_table_sqls: &[&str]) -> Schema {

--- a/core/util.rs
+++ b/core/util.rs
@@ -124,7 +124,7 @@ const QUOTE_PAIRS: &[(char, char)] = &[
 pub fn normalize_ident(identifier: &str) -> String {
     // quotes normalization already happened in the parser layer (see Name ast node implementation)
     // so, we only need to convert identifier string to lowercase
-    identifier.to_lowercase()
+    identifier.to_ascii_lowercase()
 }
 
 /// Escape a SQL string literal payload for safe interpolation inside single quotes.

--- a/core/util.rs
+++ b/core/util.rs
@@ -124,6 +124,8 @@ const QUOTE_PAIRS: &[(char, char)] = &[
 pub fn normalize_ident(identifier: &str) -> String {
     // quotes normalization already happened in the parser layer (see Name ast node implementation)
     // so, we only need to convert identifier string to lowercase
+    // SQLite identifiers are case-insensitive only for ASCII characters
+    // (see: https://www.sqlite.org/datatype3.html#collation)
     identifier.to_ascii_lowercase()
 }
 

--- a/testing/runner/tests/create_table.sqltest
+++ b/testing/runner/tests/create_table.sqltest
@@ -15,6 +15,14 @@ expect {
 }
 
 @cross-check-integrity
+test create_table_non_ascii_case {
+    CREATE TABLE é(a);
+    CREATE TABLE É(a);
+}
+expect {
+}
+
+@cross-check-integrity
 test create_table_unique_contained_in_primary_keys {
     CREATE TABLE t4 (a,b, primary key(a,b), unique(a));
 }


### PR DESCRIPTION
## Description
I replaced `to_lowercase()` with `to_ascii_lowercase()` to improve SQLite compatibility
Closes #5730 

## Motivation and context
I want to contribute more to this project and be part of this great community.

## Description of AI Usage
AI was only used to help locate the source of the issue in the codebase.