### PR TITLE
docs: add CLI reference (getting started, options, shell commands)

### DIFF
--- a/docs/sql-reference/README.md
+++ b/docs/sql-reference/README.md
@@ -1,6 +1,6 @@
-# SQL Language Reference
+# Turso Reference
 
-This directory contains the Turso SQL language reference documentation. The files are `.mdx` (Markdown + JSX components) and render as readable markdown on GitHub.
+This directory contains the Turso reference documentation — both the SQL language reference and the CLI reference. The files are `.mdx` (Markdown + JSX components) and render as readable markdown on GitHub.
 
 ## Structure
 
@@ -25,7 +25,11 @@ sql-reference/
 │   └── ...
 ├── pragmas.mdx                 # All supported PRAGMAs (includes CDC, encryption)
 ├── extensions.mdx              # UUID, regexp, vector, time, CSV, percentile
-└── compatibility.mdx           # SQLite compatibility notes and known differences
+├── compatibility.mdx           # SQLite compatibility notes and known differences
+└── cli/                        # CLI reference
+    ├── getting-started.mdx     # Installation, usage patterns, output modes
+    ├── command-line-options.mdx # CLI flags and arguments
+    └── shell-commands.mdx      # Dot commands (.tables, .schema, etc.)
 ```
 
 ## Editing guidelines

--- a/docs/sql-reference/book.toml
+++ b/docs/sql-reference/book.toml
@@ -1,5 +1,5 @@
 [book]
-title = "Turso SQL Reference"
+title = "Turso Reference"
 authors = ["Turso"]
 src = "src"
 

--- a/docs/sql-reference/cli/command-line-options.mdx
+++ b/docs/sql-reference/cli/command-line-options.mdx
@@ -1,0 +1,163 @@
+---
+title: Command-Line Options
+description: CLI flags, arguments, and server modes for the tursodb command
+sidebarTitle: Command-Line Options
+---
+
+# Command-Line Options
+
+```bash
+tursodb [OPTIONS] [DATABASE] [SQL]
+```
+
+## Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `DATABASE` | `:memory:` | Path to a SQLite database file. If omitted, an in-memory database is created |
+| `SQL` | — | SQL statement to execute. If provided, the shell runs the query and exits |
+
+### Examples
+
+```bash
+# In-memory database
+tursodb
+
+# Open an existing file
+tursodb customers.db
+
+# Run a query and exit
+tursodb customers.db "SELECT count(*) FROM orders;"
+
+# Pipe SQL from stdin
+echo "SELECT 1 + 1;" | tursodb -q
+```
+
+## Options
+
+### `-m, --output-mode <MODE>`
+
+Set the output display format.
+
+| Mode | Description |
+|------|-------------|
+| `pretty` | Table with borders (default) |
+| `list` | Pipe-delimited values |
+| `line` | One column per line with column names |
+
+```bash
+tursodb -m list mydata.db "SELECT * FROM users;"
+```
+
+### `-o, --output <PATH>`
+
+Redirect query output to a file instead of stdout.
+
+```bash
+tursodb -o results.txt mydata.db "SELECT * FROM users;"
+```
+
+### `-q, --quiet`
+
+Suppress the startup banner and version information.
+
+```bash
+tursodb -q mydata.db
+```
+
+### `-e, --echo`
+
+Print each SQL statement before executing it. Useful for debugging scripts.
+
+```bash
+echo "SELECT 42;" | tursodb -q -e
+```
+
+```
+SELECT 42;
+42
+```
+
+### `-v, --vfs <VFS>`
+
+Select the Virtual File System backend.
+
+| VFS | Description |
+|-----|-------------|
+| `syscall` | Standard OS file I/O (default) |
+| `memory` | In-memory storage |
+| `io_uring` | Linux io_uring (requires feature flag) |
+
+```bash
+tursodb -v memory
+```
+
+### `-t, --tracing-output <PATH>`
+
+Write internal log traces to a file. Useful for debugging and performance analysis.
+
+```bash
+tursodb -t trace.log mydata.db
+```
+
+### `--readonly`
+
+Open the database in read-only mode. Write operations will return an error.
+
+```bash
+tursodb --readonly production.db "SELECT count(*) FROM users;"
+```
+
+Attempting to write in read-only mode:
+
+```bash
+tursodb --readonly production.db "INSERT INTO users VALUES (1, 'test');"
+# Error: Resource is read-only
+```
+
+### `--mcp`
+
+Start a Model Context Protocol server instead of the interactive shell. This allows AI assistants and other MCP clients to interact with the database via JSON-RPC.
+
+```bash
+tursodb --mcp mydata.db
+```
+
+### `--sync-server <ADDRESS>`
+
+Start a sync server for database replication, listening at the given address.
+
+```bash
+tursodb --sync-server 0.0.0.0:8080 mydata.db
+```
+
+## Experimental Feature Flags
+
+These flags enable features that are still under development. They may change or be removed in future releases.
+
+<Warning>
+Experimental features may have incomplete implementations or known limitations. Use them for testing and development only.
+</Warning>
+
+| Flag | Description |
+|------|-------------|
+| `--experimental-views` | Enable views (`CREATE VIEW` / `DROP VIEW`) |
+| `--experimental-custom-types` | Enable custom types (`CREATE TYPE` / `DROP TYPE`) |
+| `--experimental-encryption` | Enable at-rest database encryption |
+| `--experimental-index-method` | Enable custom index methods. Necessary for FTS and Sparse Vector indexes |
+| `--experimental-autovacuum` | Enable automatic database vacuuming |
+| `--experimental-triggers` | Enable triggers (`CREATE TRIGGER` / `DROP TRIGGER`) |
+| `--experimental-attach` | Enable `ATTACH DATABASE` / `DETACH DATABASE` |
+
+```bash
+# Enable views and triggers
+tursodb --experimental-views --experimental-triggers mydata.db
+```
+
+## Other Flags
+
+| Flag | Description |
+|------|-------------|
+| `--unsafe-testing` | Enable unsafe testing features (e.g., `sqlite_dbpage` writes) |
+| `-h, --help` | Print usage help |
+| `-V, --version` | Print version information |

--- a/docs/sql-reference/cli/getting-started.mdx
+++ b/docs/sql-reference/cli/getting-started.mdx
@@ -1,0 +1,144 @@
+---
+title: Getting Started
+description: Install and use the Turso interactive SQL shell
+sidebarTitle: Getting Started
+---
+
+# Getting Started
+
+The Turso CLI (`tursodb`) is an interactive SQL shell for working with Turso databases. It supports in-memory and file-based databases, multiple output modes, CSV import, database cloning, and built-in documentation.
+
+## Quick Start
+
+### In-Memory Database
+
+Launch the shell with a transient in-memory database:
+
+```bash
+tursodb
+```
+
+### Open a Database File
+
+```bash
+tursodb mydata.db
+```
+
+### Run a Query Directly
+
+Pass SQL as a command-line argument to run it and exit:
+
+```bash
+tursodb mydata.db "SELECT * FROM users;"
+```
+
+### Pipe SQL from stdin
+
+```bash
+echo "SELECT sqlite_version();" | tursodb -q
+```
+
+## Interactive Shell
+
+When launched without a SQL argument, the shell provides an interactive REPL with command history and syntax highlighting.
+
+### Multi-line Input
+
+Unfinished statements (missing semicolons, unbalanced parentheses) automatically continue on the next line. The prompt indicates nesting depth:
+
+```
+tursodb> SELECT *
+   ...>   FROM employees
+   ...>   WHERE department = 'Engineering';
+```
+
+### Command History
+
+Command history is saved automatically to `~/.limbo_history` and accessible with up/down arrow keys.
+
+### Exiting
+
+Use `.quit` or `.exit` to leave the shell. Pressing Ctrl+C twice also exits.
+
+## Output Modes
+
+Turso supports three output modes, selectable with the `-m` flag or the `.mode` dot command.
+
+### Pretty (Default)
+
+Human-readable table with borders:
+
+```bash
+tursodb -q -m pretty
+```
+
+```
+┌────┬─────────┬─────────────┬─────────┐
+│ id │ name    │ department  │ salary  │
+├────┼─────────┼─────────────┼─────────┤
+│  1 │ Alice   │ Engineering │ 95000.0 │
+├────┼─────────┼─────────────┼─────────┤
+│  2 │ Bob     │ Marketing   │ 72000.0 │
+└────┴─────────┴─────────────┴─────────┘
+```
+
+### List
+
+Pipe-delimited values suitable for scripting:
+
+```bash
+tursodb -q -m list
+```
+
+```
+1|Alice|Engineering|95000.0
+2|Bob|Marketing|72000.0
+```
+
+### Line
+
+One column per line, with column names:
+
+```bash
+tursodb -q -m line
+```
+
+```
+        id = 1
+      name = Alice
+department = Engineering
+    salary = 95000.0
+```
+
+## Non-Interactive Mode
+
+When input is piped (not a terminal), the shell runs in non-interactive mode:
+
+- Output defaults to `list` mode (override with `-m`)
+- No startup banner, history, or syntax highlighting
+- Exits with code 1 on query errors
+
+```bash
+echo "SELECT 1 + 2;" | tursodb -q
+```
+
+## Server Modes
+
+The CLI can also run as a server instead of an interactive shell.
+
+### MCP Server
+
+Start a [Model Context Protocol](https://modelcontextprotocol.io/) server, allowing AI assistants to interact with the database:
+
+```bash
+tursodb --mcp mydata.db
+```
+
+### Sync Server
+
+Start a sync server for database replication:
+
+```bash
+tursodb --sync-server 0.0.0.0:8080 mydata.db
+```
+

--- a/docs/sql-reference/cli/shell-commands.mdx
+++ b/docs/sql-reference/cli/shell-commands.mdx
@@ -1,0 +1,490 @@
+---
+title: Shell Commands
+description: Dot commands available in the Turso interactive SQL shell
+sidebarTitle: Shell Commands
+---
+
+# Shell Commands
+
+Dot commands are special commands available in the interactive shell. They start with a period (`.`) and do not require a trailing semicolon.
+
+```
+tursodb> .help
+```
+
+## Database & Navigation
+
+### .open
+
+Open a database file, optionally specifying a VFS backend.
+
+```
+.open <PATH> [VFS]
+```
+
+```
+tursodb> .open mydata.db
+tursodb> .open mydata.db memory
+```
+
+### .quit
+
+Exit the shell. Aliases: `.q`, `.qu`, `.qui`.
+
+```
+tursodb> .quit
+```
+
+### .exit
+
+Exit the shell with an optional return code. Aliases: `.ex`, `.exi`.
+
+```
+.exit [CODE]
+```
+
+```
+tursodb> .exit
+tursodb> .exit 1
+```
+
+### .cd
+
+Change the current working directory.
+
+```
+.cd <DIRECTORY>
+```
+
+```
+tursodb> .cd /tmp
+```
+
+## Schema Inspection
+
+### .tables
+
+List all tables in the database, optionally filtered by a pattern.
+
+```
+.tables [PATTERN]
+```
+
+```sql
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
+CREATE TABLE departments (id INTEGER PRIMARY KEY, name TEXT);
+```
+
+```
+tursodb> .tables
+employees
+departments
+
+tursodb> .tables emp%
+employees
+```
+
+### .schema
+
+Display the CREATE statement for a table, or all tables if no argument is given.
+
+```
+.schema [TABLE]
+```
+
+```
+tursodb> .schema employees
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
+
+tursodb> .schema
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
+CREATE TABLE departments (id INTEGER PRIMARY KEY, name TEXT);
+```
+
+### .indexes
+
+Show index names, optionally filtered by table.
+
+```
+.indexes [TABLE]
+```
+
+```sql
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT, department TEXT);
+CREATE INDEX idx_dept ON employees(department);
+CREATE INDEX idx_name ON employees(name);
+```
+
+```
+tursodb> .indexes
+idx_dept
+idx_name
+
+tursodb> .indexes employees
+idx_dept
+idx_name
+```
+
+### .databases
+
+List all attached databases.
+
+```
+tursodb> .databases
+main: /path/to/mydata.db r/w
+```
+
+## Output Control
+
+### .mode
+
+Set the output display mode.
+
+```
+.mode <MODE>
+```
+
+| Mode | Description |
+|------|-------------|
+| `pretty` | Table with borders (default) |
+| `list` | Pipe-delimited values |
+| `line` | One column per line with column names |
+
+```
+tursodb> .mode list
+tursodb> SELECT 1 AS a, 2 AS b;
+1|2
+
+tursodb> .mode line
+tursodb> SELECT 1 AS a, 2 AS b;
+a = 1
+b = 2
+
+tursodb> .mode pretty
+tursodb> SELECT 1 AS a, 2 AS b;
+┌───┬───┐
+│ a │ b │
+├───┼───┤
+│ 1 │ 2 │
+└───┴───┘
+```
+
+### .headers
+
+Toggle column headers on or off in `list` mode.
+
+```
+.headers <on|off>
+```
+
+```
+tursodb> .mode list
+tursodb> .headers on
+tursodb> SELECT 1 AS x, 2 AS y;
+x|y
+1|2
+
+tursodb> .headers off
+tursodb> SELECT 1 AS x, 2 AS y;
+1|2
+```
+
+### .nullvalue
+
+Set the string displayed for NULL values in `list` mode.
+
+```
+.nullvalue <STRING>
+```
+
+```
+tursodb> .mode list
+tursodb> .nullvalue [NULL]
+tursodb> SELECT 1 AS a, NULL AS b;
+1|[NULL]
+```
+
+### .output
+
+Redirect query output to a file. Call with no argument or `stdout` to restore output to the terminal.
+
+```
+.output [PATH]
+```
+
+```
+tursodb> .output results.txt
+tursodb> SELECT * FROM employees;
+tursodb> .output
+tursodb> -- Output is back to the terminal
+```
+
+### .echo
+
+Toggle echo mode. When on, each SQL statement is printed before execution.
+
+```
+.echo <on|off>
+```
+
+```
+tursodb> .echo on
+tursodb> SELECT 42;
+SELECT 42;
+┌────┐
+│ 42 │
+├────┤
+│ 42 │
+└────┘
+```
+
+### .show
+
+Display current shell settings.
+
+```
+tursodb> .show
+Settings:
+Output mode: pretty
+DB: mydata.db
+Output: STDOUT
+Null value:
+CWD: /home/user
+Echo: off
+Headers: off
+```
+
+## Performance & Diagnostics
+
+### .timer
+
+Toggle query timing. When on, shows execution time and I/O statistics after each query.
+
+```
+.timer <on|off>
+```
+
+```
+tursodb> .timer on
+tursodb> SELECT 42;
+42
+Command stats:
+----------------------------
+total: 442 us (this includes parsing/coloring of cli app)
+
+query execution stats:
+----------------------------
+Execution: avg=4 us, total=8 us
+I/O: No samples available
+```
+
+### .stats
+
+Display database statistics. Use `on`/`off` to toggle automatic display after every query, or `--reset` to clear counters.
+
+```
+.stats [on|off] [--reset]
+```
+
+```
+tursodb> .stats
+Connection Metrics:
+  Total statements:     3
+  High-water marks:
+    Max VM steps:       19
+    Max rows read:      1
+
+Aggregate Statistics:
+Statement Metrics:
+  Row Operations:
+    Rows read:        1
+    Rows written:     2
+  Execution:
+    VM steps:         48
+    Instructions:     47
+  ...
+```
+
+### .opcodes
+
+Show VDBE (Virtual Database Engine) opcodes with descriptions. Optionally filter by opcode name.
+
+```
+.opcodes [OPCODE]
+```
+
+```
+tursodb> .opcodes Integer
+Integer
+-------
+The 64-bit integer value P1 is written into register P2. This is different
+from SQLite, where this opcode is used for 32-bit integers
+```
+
+### .vfslist
+
+List available Virtual File System modules.
+
+```
+tursodb> .vfslist
+Available VFS modules:
+memory
+syscall
+```
+
+## Data Import & Export
+
+### .dump
+
+Output the entire database as SQL statements that can recreate it.
+
+```
+tursodb> .dump
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
+INSERT INTO "employees" VALUES(1,'Alice');
+INSERT INTO "employees" VALUES(2,'Bob');
+COMMIT;
+```
+
+<Info>
+The output of `.dump` can be piped into another Turso instance to recreate the database:
+
+```bash
+tursodb original.db ".dump" | tursodb -q clone.db
+```
+</Info>
+
+### .import
+
+Import data from a file into a table.
+
+```
+.import [--csv] [--skip N] [--verbose] <FILE> <TABLE>
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--csv` | on | Use comma as field separator and newline as record separator |
+| `--skip N` | 0 | Skip the first N rows (useful for skipping a header row) |
+| `--verbose` | off | Print progress information during import |
+
+```
+tursodb> CREATE TABLE people (name TEXT, age INTEGER);
+tursodb> .import --csv --skip 1 data.csv people
+tursodb> SELECT * FROM people;
+┌─────────┬─────┐
+│ name    │ age │
+├─────────┼─────┤
+│ Alice   │  30 │
+├─────────┼─────┤
+│ Bob     │  25 │
+├─────────┼─────┤
+│ Charlie │  35 │
+└─────────┴─────┘
+```
+
+Given a CSV file `data.csv`:
+
+```csv
+name,age
+Alice,30
+Bob,25
+Charlie,35
+```
+
+### .clone
+
+Clone the current database to a new file.
+
+```
+.clone <OUTPUT_FILE>
+```
+
+```
+tursodb> .clone backup.db
+employees... done
+```
+
+### .read
+
+Execute SQL statements from a file.
+
+```
+.read <PATH>
+```
+
+```
+tursodb> .read setup.sql
+```
+
+### .load
+
+Load an extension library.
+
+```
+.load <PATH>
+```
+
+```
+tursodb> .load ./liblimbo_regexp
+```
+
+<Info>
+Only Turso-native extensions can be loaded. SQLite `.so`/`.dll` loadable extensions are not supported. See the [Extensions](/docs/sql-reference/extensions) documentation for available extensions.
+</Info>
+
+## Debugging
+
+### .dbtotxt
+
+Display raw database page contents in hex format. Useful for debugging storage-level issues.
+
+```
+.dbtotxt [--page PAGE_NO]
+```
+
+```
+tursodb> .dbtotxt --page 1
+| size 8192 pagesize 4096 filename :memory:
+| page 1 offset 0
+|      0: 53 51 4c 69 74 65 20 66 6f 72 6d 61 74 20 33 00   SQLite format 3.
+|     16: 10 00 02 02 00 40 20 20 00 00 00 01 00 00 00 02   .....@  ........
+...
+```
+
+### .dbconfig
+
+Print or set database configuration flags. Currently a no-op in Turso.
+
+```
+.dbconfig [CONFIG] [on|off]
+```
+
+## Documentation
+
+### .manual
+
+Display built-in manual pages for Turso features. Call with no argument to list all available manuals.
+
+```
+.manual [PAGE]
+```
+
+Aliases: `.man`.
+
+```
+tursodb> .manual
+# Turso Manual Pages
+
+Available manuals:
+  custom-types    Custom Types for STRICT Tables
+  cdc             Change Data Capture
+  encryption      At-Rest Database Encryption
+  vector          Vector Search
+  materialized-views  Live Materialized Views
+  mcp             Model Context Protocol server
+
+tursodb> .manual vector
+```

--- a/docs/sql-reference/preview.sh
+++ b/docs/sql-reference/preview.sh
@@ -12,7 +12,7 @@ fi
 
 # Clean and create src directory for mdbook
 rm -rf src
-mkdir -p src/statements src/functions
+mkdir -p src/statements src/functions src/cli
 
 # Convert .mdx files to .md:
 #  - Strip YAML frontmatter
@@ -23,7 +23,7 @@ convert() {
   # Determine depth: files in subdirs need ../ prefix for top-level pages
   local depth=""
   case "$in" in
-    statements/*|functions/*) depth="../" ;;
+    statements/*|functions/*|cli/*) depth="../" ;;
   esac
   sed -E \
     -e 's/^<Info>$/> **Note**/g' \
@@ -44,10 +44,21 @@ done
 for f in functions/*.mdx; do
   convert "$f" "src/${f%.mdx}.md"
 done
+for f in cli/*.mdx; do
+  convert "$f" "src/${f%.mdx}.md"
+done
 
 # Generate SUMMARY.md
 cat > src/SUMMARY.md << 'EOF'
 # Summary
+
+# CLI
+
+- [Getting Started](cli/getting-started.md)
+- [Command-Line Options](cli/command-line-options.md)
+- [Shell Commands](cli/shell-commands.md)
+
+# SQL Language
 
 - [Data Types](data-types.md)
 - [Expressions](expressions.md)


### PR DESCRIPTION
Add documentation for the tursodb CLI as a new top-level section in the existing reference book. Covers command-line flags, all dot commands with tested examples, output modes, and server modes.


## Motivation and context

We have an in-tree reference for the language constructs, but the CLI is also our own, and needs its own reference
