### PR TITLE
Preserve UNION ALL duplicates for same-source branches

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -1542,6 +1542,12 @@ impl DbspCompiler {
         // Extract source identifiers from each input (for UNION ALL)
         let left_source = Self::extract_source_identifier(&union.inputs[0]);
         let right_source = Self::extract_source_identifier(&union.inputs[1]);
+        // Compiler currently lowers UNION as a binary tree. We attach an explicit branch key
+        // per input arm so same-source UNION ALL branches preserve duplicates.
+        // If compilation ever moves to n-ary merge nodes, each input arm must provide its own
+        // unique branch key.
+        let left_source_key = format!("{left_source}#branch:0");
+        let right_source_key = format!("{right_source}#branch:1");
 
         // Compile left and right inputs
         let left_id = self.compile_plan(&union.inputs[0])?;
@@ -1552,10 +1558,10 @@ impl DbspCompiler {
         // Create a merge operator that handles the rowid transformation
         let operator_id = self.circuit.next_id;
         let mode = if union.all {
-            // For UNION ALL, pass the source identifiers
+            // For UNION ALL, pass source+branch keys.
             UnionMode::All {
-                left_table: left_source,
-                right_table: right_source,
+                left_source_key,
+                right_source_key,
             }
         } else {
             UnionMode::Distinct

--- a/core/incremental/merge_operator.rs
+++ b/core/incremental/merge_operator.rs
@@ -18,10 +18,11 @@ use std::hash::{Hash, Hasher};
 pub enum UnionMode {
     /// For UNION (distinct) - hash values only to merge duplicates
     Distinct,
-    /// For UNION ALL - include source table name in hash to keep duplicates separate
+    /// For UNION ALL - include a compiler-provided source+branch key in hash
+    /// to keep duplicates from different branches separate.
     All {
-        left_table: String,
-        right_table: String,
+        left_source_key: String,
+        right_source_key: String,
     },
 }
 
@@ -32,7 +33,7 @@ pub struct MergeOperator {
     operator_id: i64,
     union_mode: UnionMode,
     /// For UNION: tracks seen value hashes with their assigned rowids
-    /// For UNION ALL: tracks (source_id, original_rowid) -> assigned_rowid mappings
+    /// For UNION ALL: tracks (source_branch_id, original_rowid) -> assigned_rowid mappings
     seen_rows: HashMap<u64, i64>, // hash -> assigned_rowid
     /// Next rowid to assign for new rows
     next_rowid: i64,
@@ -80,27 +81,33 @@ impl MergeOperator {
                 output
             }
             UnionMode::All {
-                left_table,
-                right_table,
+                left_source_key,
+                right_source_key,
             } => {
-                // For UNION ALL, maintain consistent rowid mapping per source
-                let table = if is_left { left_table } else { right_table };
+                // For UNION ALL, maintain consistent rowid mapping per source/branch.
+                // The same base table can appear on both sides; branch side must be part
+                // of the identity so overlapping rowids do not collapse.
+                let source_key = if is_left {
+                    left_source_key
+                } else {
+                    right_source_key
+                };
                 let mut source_hasher = DefaultHasher::new();
-                table.hash(&mut source_hasher);
+                source_key.hash(&mut source_hasher);
                 let source_id = source_hasher.finish();
 
                 let mut output = Delta::new();
                 for (row, weight) in delta.changes {
-                    // Create a unique key for this (source, rowid) pair
+                    // Create a unique key for this (source-branch, rowid) pair.
                     let mut key_hasher = DefaultHasher::new();
                     source_id.hash(&mut key_hasher);
                     row.rowid.hash(&mut key_hasher);
                     let key_hash = key_hasher.finish();
 
-                    // Check if we've seen this (source, rowid) before
+                    // Check if we've seen this (source-branch, rowid) before.
                     let assigned_rowid =
                         if let Some(&existing_rowid) = self.seen_rows.get(&key_hash) {
-                            // Use existing rowid for this (source, rowid) pair
+                            // Use existing rowid for this (source-branch, rowid) pair.
                             existing_rowid
                         } else {
                             // New row - assign new rowid

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -3716,8 +3716,8 @@ mod tests {
         let mut merge_op = MergeOperator::new(
             1,
             UnionMode::All {
-                left_table: "table1".to_string(),
-                right_table: "table2".to_string(),
+                left_source_key: "table1#branch:0".to_string(),
+                right_source_key: "table2#branch:1".to_string(),
             },
         );
 
@@ -3760,6 +3760,68 @@ mod tests {
             assert!(values.contains(&2));
             assert!(values.contains(&3));
             assert!(values.contains(&4));
+        } else {
+            panic!("Expected Done result");
+        }
+    }
+
+    #[test]
+    fn test_merge_operator_union_all_same_source_keeps_branch_duplicates() {
+        let (_pager, table_root_page_id, index_root_page_id) = create_test_pager();
+        let table_cursor = BTreeCursor::new_table(_pager.clone(), table_root_page_id, 5);
+        let index_def = create_dbsp_state_index(index_root_page_id);
+        let index_cursor = BTreeCursor::new_index(_pager, index_root_page_id, &index_def, 4);
+        let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
+
+        // Reproducer: UNION ALL where both branches read the same table and rowid.
+        let mut merge_op = MergeOperator::new(
+            11,
+            UnionMode::All {
+                left_source_key: "t#branch:0".to_string(),
+                right_source_key: "t#branch:1".to_string(),
+            },
+        );
+
+        let mut left_delta = Delta::new();
+        left_delta.insert(1, vec![Value::from_i64(42)]);
+        let mut right_delta = Delta::new();
+        right_delta.insert(1, vec![Value::from_i64(42)]);
+
+        let result1 = merge_op
+            .commit(DeltaPair::new(left_delta, right_delta), &mut cursors)
+            .unwrap();
+
+        let first_rowids = if let IOResult::Done(merged) = result1 {
+            assert_eq!(
+                merged.len(),
+                2,
+                "UNION ALL should preserve both branch rows"
+            );
+            let rowids: Vec<i64> = merged.changes.iter().map(|(row, _)| row.rowid).collect();
+            assert_ne!(
+                rowids[0], rowids[1],
+                "same-source UNION ALL branches must map to distinct storage rowids"
+            );
+            rowids
+        } else {
+            panic!("Expected Done result");
+        };
+
+        // Rowid mapping should remain stable per branch across commits.
+        let mut left_delta2 = Delta::new();
+        left_delta2.insert(1, vec![Value::from_i64(100)]);
+        let mut right_delta2 = Delta::new();
+        right_delta2.insert(1, vec![Value::from_i64(200)]);
+        let result2 = merge_op
+            .commit(DeltaPair::new(left_delta2, right_delta2), &mut cursors)
+            .unwrap();
+
+        if let IOResult::Done(merged) = result2 {
+            let rowids: Vec<i64> = merged.changes.iter().map(|(row, _)| row.rowid).collect();
+            assert_eq!(
+                rowids, first_rowids,
+                "same branch/source rowid should keep stable mapped rowid"
+            );
         } else {
             panic!("Expected Done result");
         }
@@ -3850,8 +3912,8 @@ mod tests {
         let mut merge_op = MergeOperator::new(
             10,
             UnionMode::All {
-                left_table: "orders".to_string(),
-                right_table: "archived_orders".to_string(),
+                left_source_key: "orders#branch:0".to_string(),
+                right_source_key: "archived_orders#branch:1".to_string(),
             },
         );
 
@@ -3969,8 +4031,8 @@ mod tests {
         let mut merge_op = MergeOperator::new(
             12,
             UnionMode::All {
-                left_table: "t1".to_string(),
-                right_table: "t2".to_string(),
+                left_source_key: "t1#branch:0".to_string(),
+                right_source_key: "t2#branch:1".to_string(),
             },
         );
 

--- a/testing/runner/turso-tests/materialized_views.sqltest
+++ b/testing/runner/turso-tests/materialized_views.sqltest
@@ -1363,6 +1363,70 @@ expect {
     2|20
 }
 
+test matview-union-all-same-table-overlap-maintenance {
+    CREATE TABLE t(a);
+    CREATE MATERIALIZED VIEW mv AS
+    SELECT * FROM t
+    UNION ALL
+    SELECT * FROM t;
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT a FROM mv ORDER BY a;
+}
+expect {
+    1
+    1
+    2
+    2
+    3
+    3
+}
+
+test matview-union-all-same-table-overlap-delete-maintenance {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER);
+    INSERT INTO t VALUES (1, 1), (2, 2), (3, 3);
+    CREATE MATERIALIZED VIEW mv AS
+    SELECT a FROM t
+    UNION ALL
+    SELECT a FROM t;
+    SELECT a FROM mv ORDER BY a;
+    DELETE FROM t WHERE id = 2;
+    SELECT a FROM mv ORDER BY a;
+}
+expect {
+    1
+    1
+    2
+    2
+    3
+    3
+    1
+    1
+    3
+    3
+}
+
+test matview-union-all-same-table-overlap-update-maintenance {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER);
+    INSERT INTO t VALUES (1, 1), (2, 2);
+    CREATE MATERIALIZED VIEW mv AS
+    SELECT a FROM t
+    UNION ALL
+    SELECT a FROM t;
+    SELECT a FROM mv ORDER BY a;
+    UPDATE t SET a = 5 WHERE id = 2;
+    SELECT a FROM mv ORDER BY a;
+}
+expect {
+    1
+    1
+    2
+    2
+    1
+    1
+    5
+    5
+}
+
 # Test UNION ALL preserves all rows in count
 test matview-union-all-row-count {
     CREATE TABLE data(id INTEGER PRIMARY KEY, num INTEGER);
@@ -2499,4 +2563,3 @@ expect {
     3|40
     4|60
 }
-


### PR DESCRIPTION
## Description

Fix materialized views built from `UNION ALL` when multiple branches read from the same base table.

UNION ALL row mapping in the incremental merge operator used source+rowid.When both UNION ALL branches referenced the same table, overlapping rowids collided and one branch’s row overwrote the other in materialized view state.


Switch UNION ALL identity to explicit compiler-provided source-branch keys,and map rows by (source-branch key, rowid). This preserves duplicates while keeping rowid assignment stable across incremental maintenance. Also updated docs.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Repro:
  ```sql
  CREATE TABLE t(a);
  CREATE MATERIALIZED VIEW mv AS
  SELECT * FROM t
  UNION ALL
  SELECT * FROM t;
  INSERT INTO t VALUES (1), (2), (3);
  SELECT * FROM mv;
```
  Expected: 6 rows (1,1,2,2,3,3)
  Actual before fix: 3 rows (1,2,3)

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5734

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
