### PR TITLE
core/vdbe: finalize MVCC commit state machine on abort

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -945,6 +945,22 @@ pub struct DeleteRowStateMachine {
     cursor: Arc<RwLock<BTreeCursor>>,
 }
 
+impl<Clock: LogicalClock> Drop for CommitStateMachine<Clock> {
+    fn drop(&mut self) {
+        // Dropping a CommitStateMachine that progressed past Initial without
+        // finalizing leaks the transaction in Preparing state, holds commit
+        // locks, and poisons dependent transactions. Crash rather than corrupt.
+        if !matches!(self.state, CommitState::Initial) {
+            assert!(
+                self.is_finalized,
+                "CommitStateMachine dropped without being finalized (state={:?}). \
+                 This leaks locks and leaves the transaction in a broken state.",
+                self.state
+            );
+        }
+    }
+}
+
 impl<Clock: LogicalClock> CommitStateMachine<Clock> {
     fn new(
         state: CommitState<Clock>,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1935,6 +1935,26 @@ impl Program {
                 }
             }
         }
+        // If a MVCC commit was in progress, rollback_current_txn already cleaned
+        // up the store-level state. Mark the state machine as finalized so it
+        // doesn't panic on drop (its Drop impl asserts finalization).
+        match std::mem::replace(&mut state.commit_state, CommitState::Ready) {
+            CommitState::CommittingMvcc { mut state_machine } => {
+                if let Some(mv_store) = self.connection.mv_store().as_ref() {
+                    let _ = state_machine.finalize(mv_store);
+                }
+            }
+            CommitState::CommittingAttachedMvcc {
+                mut state_machine,
+                mv_store,
+                ..
+            } => {
+                let _ = state_machine.finalize(&mv_store);
+            }
+            other => {
+                state.commit_state = other;
+            }
+        }
         if state.uses_subjournal {
             pager.stop_use_subjournal();
             state.uses_subjournal = false;


### PR DESCRIPTION
When a statement is aborted while an MVCC commit is in progress, rollback_current_txn cleans up the store-level state but the CommitStateMachine inside ProgramState.commit_state is left unfinalized. When ProgramState::reset later overwrites commit_state, the Drop impl panics.

Fix by taking the commit state in abort() and explicitly finalizing the state machine after the rollback completes.