### PR TITLE
Fix GROUP BY COLLATE sort-elision with implicit BINARY indexes

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -2156,8 +2156,8 @@ fn eliminate_constant_conditions(
     Ok(ConstantConditionEliminationResult::Continue)
 }
 
-/// Check if the order by collation matches the index columns collations.
-/// Only remove the index if sort was eliminated.
+/// Check if the order target collation matches index column collations.
+/// Only remove the index when sort elimination selected this plan.
 fn maybe_remove_index_candidate(
     index: &mut Option<Arc<Index>>,
     table_reference: &JoinedTable,
@@ -2188,12 +2188,9 @@ fn maybe_remove_index_candidate(
             };
 
             if let Some(idx_col) = matching_idx_col {
-                let idx_collation = idx_col.collation;
-
-                // If ORDER BY collation doesn't match index collation, this index can't satisfy the ordering
-                if idx_collation.is_some_and(|idx_collation| col_order.collation != idx_collation)
-                    && sort_eliminated
-                {
+                // Index columns without explicit COLLATE use BINARY.
+                // Treat them as BINARY for ordering compatibility checks.
+                if col_order.collation != idx_col.collation.unwrap_or_default() {
                     *index = None;
                     return;
                 }

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -273,11 +273,9 @@ pub fn plan_satisfies_order_target(
                             }
                         }
 
-                        // If ORDER BY collation doesn't match index collation, this index can't satisfy the ordering
-                        if idx_col
-                            .collation
-                            .is_some_and(|idx_collation| target_col.collation != idx_collation)
-                        {
+                        // Index columns without explicit COLLATE use BINARY.
+                        // Treat them as BINARY for ordering compatibility checks.
+                        if target_col.collation != idx_col.collation.unwrap_or_default() {
                             break;
                         }
 

--- a/testing/runner/tests/collate.sqltest
+++ b/testing/runner/tests/collate.sqltest
@@ -425,6 +425,22 @@ expect {
 }
 
 @cross-check-integrity
+test collate_group_by_explicit_override_binary_index {
+    CREATE TABLE t(a TEXT, b INT);
+    CREATE INDEX i_a ON t(a);
+    INSERT INTO t VALUES
+      ('a',1),('A',2),('b',3),('B',4),('a',5);
+    SELECT sum(b)
+    FROM t
+    GROUP BY a COLLATE NOCASE
+    ORDER BY 1;
+}
+expect {
+    7
+    8
+}
+
+@cross-check-integrity
 test collate_group_by_mixed_columns {
     CREATE TABLE t(a TEXT COLLATE NOCASE, b TEXT COLLATE RTRIM);
     INSERT INTO t VALUES ('A', 'x'), ('a', 'x '), ('B', 'y'), ('b', 'y  ');


### PR DESCRIPTION
## Description

When checking whether an index scan can satisfy GROUP BY/ORDER BY ordering, treat index columns without an explicit collation as BINARY (the SQLite default), instead of "no collation restriction".

This prevents incorrect GROUP BY sorter elimination for queries like: GROUP BY a COLLATE NOCASE with an index on a that has implicit BINARY collation.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Issue #5728 reported a SQLite-compatibility bug:

  - Query: `SELECT a COLLATE NOCASE, sum(b) FROM t GROUP BY a COLLATE NOCASE;`
  - Schema includes `CREATE INDEX i_a ON t(a);` (implicit `BINARY` collation)

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5728

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
