### PR TITLE
Align PRAGMA auto_vacuum transaction behavior with SQLite

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -314,20 +314,6 @@ fn update_pragma(
                 ));
             }
 
-            let is_empty = is_database_empty(resolver.schema(), &pager)?;
-            tracing::debug!(
-                "Checking if database is empty for auto_vacuum pragma: {}",
-                is_empty
-            );
-
-            if !is_empty {
-                // SQLite's behavior is to silently ignore this pragma if the database is not empty.
-                tracing::debug!(
-                    "Attempted to set auto_vacuum, database is not empty so we are ignoring pragma."
-                );
-                return Ok(TransactionMode::None);
-            }
-
             let auto_vacuum_mode = match value {
                 Expr::Name(name) => {
                     let name = name.as_str().as_bytes();
@@ -348,41 +334,64 @@ fn update_pragma(
                     ));
                 }
             };
-            match auto_vacuum_mode {
-                0 => update_auto_vacuum_mode(AutoVacuumMode::None, 0, pager)?,
-                1 => update_auto_vacuum_mode(AutoVacuumMode::Full, 1, pager)?,
-                2 => update_auto_vacuum_mode(AutoVacuumMode::Incremental, 1, pager)?,
-                _ => {
-                    return Err(LimboError::InvalidArgument(
-                        "invalid auto vacuum mode".to_string(),
-                    ));
-                }
+
+            let is_empty = is_database_empty(resolver.schema());
+            tracing::debug!(
+                "Checking if database is empty for auto_vacuum pragma: {}",
+                is_empty
+            );
+            if !is_empty {
+                // Match SQLite behavior: ignore mode changes for non-empty databases.
+                tracing::debug!(
+                    "Attempted to set auto_vacuum, database is not empty so we are ignoring pragma."
+                );
+                return Ok(TransactionMode::None);
             }
-            let largest_root_page_number_reg = program.alloc_register();
-            program.emit_insn(Insn::ReadCookie {
-                db: database_id,
-                dest: largest_root_page_number_reg,
-                cookie: Cookie::LargestRootPageNumber,
-            });
-            let set_cookie_label = program.allocate_label();
-            program.emit_insn(Insn::If {
-                reg: largest_root_page_number_reg,
-                target_pc: set_cookie_label,
-                jump_if_null: false,
-            });
-            program.emit_insn(Insn::Halt {
-                err_code: 0,
-                description: "Early halt because auto vacuum mode is not enabled".to_string(),
-                on_error: None,
-            });
-            program.resolve_label(set_cookie_label, program.offset());
-            program.emit_insn(Insn::SetCookie {
-                db: database_id,
-                cookie: Cookie::IncrementalVacuum,
-                value: auto_vacuum_mode - 1,
-                p5: 0,
-            });
-            Ok(TransactionMode::None)
+
+            let (auto_vacuum_mode, largest_root_page_number, set_incremental_vacuum_cookie) =
+                match auto_vacuum_mode {
+                    0 => (AutoVacuumMode::None, 0, None),
+                    1 => (AutoVacuumMode::Full, 1, Some(0)),
+                    2 => (AutoVacuumMode::Incremental, 1, Some(1)),
+                    _ => {
+                        return Err(LimboError::InvalidArgument(
+                            "invalid auto vacuum mode".to_string(),
+                        ));
+                    }
+                };
+
+            update_auto_vacuum_mode(auto_vacuum_mode, largest_root_page_number, pager)?;
+
+            if let Some(incr_vacuum_cookie_value) = set_incremental_vacuum_cookie {
+                let largest_root_page_number_reg = program.alloc_register();
+                program.emit_insn(Insn::ReadCookie {
+                    db: database_id,
+                    dest: largest_root_page_number_reg,
+                    cookie: Cookie::LargestRootPageNumber,
+                });
+                let set_cookie_label = program.allocate_label();
+                program.emit_insn(Insn::If {
+                    reg: largest_root_page_number_reg,
+                    target_pc: set_cookie_label,
+                    jump_if_null: false,
+                });
+                program.emit_insn(Insn::Halt {
+                    err_code: 0,
+                    description: "Early halt because database is not auto-vacuum capable"
+                        .to_string(),
+                    on_error: None,
+                });
+                program.resolve_label(set_cookie_label, program.offset());
+                program.emit_insn(Insn::SetCookie {
+                    db: database_id,
+                    cookie: Cookie::IncrementalVacuum,
+                    value: incr_vacuum_cookie_value,
+                    p5: 0,
+                });
+                Ok(TransactionMode::Write)
+            } else {
+                Ok(TransactionMode::None)
+            }
         }
         PragmaName::IntegrityCheck => unreachable!("integrity_check cannot be set"),
         PragmaName::QuickCheck => unreachable!("quick_check cannot be set"),
@@ -1458,29 +1467,14 @@ fn update_page_size(connection: Arc<crate::Connection>, page_size: u32) -> crate
     Ok(())
 }
 
-fn is_database_empty(schema: &Schema, pager: &Arc<Pager>) -> crate::Result<bool> {
-    if schema.tables.len() > 1 {
-        return Ok(false);
-    }
-    if let Some(table_arc) = schema.tables.values().next() {
-        let table_name = match table_arc.as_ref() {
-            crate::schema::Table::BTree(tbl) => &tbl.name,
-            crate::schema::Table::Virtual(tbl) => &tbl.name,
-            crate::schema::Table::FromClauseSubquery(tbl) => &tbl.name,
+fn is_database_empty(schema: &Schema) -> bool {
+    for table_arc in schema.tables.values() {
+        let crate::schema::Table::BTree(tbl) = table_arc.as_ref() else {
+            continue;
         };
-
-        if table_name != "sqlite_schema" {
-            return Ok(false);
+        if tbl.name != "sqlite_schema" {
+            return false;
         }
     }
-
-    let db_size_result = pager
-        .io
-        .block(|| pager.with_header(|header| header.database_size.get()));
-
-    match db_size_result {
-        Err(_) => Ok(true),
-        Ok(0 | 1) => Ok(true),
-        Ok(_) => Ok(false),
-    }
+    true
 }

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -2,7 +2,7 @@ use crate::common::{limbo_exec_rows, TempDatabase};
 use rusqlite::types::Value as RValue;
 #[cfg(not(target_vendor = "apple"))]
 use turso_core::LimboError;
-use turso_core::{Numeric, StepResult, Value};
+use turso_core::{DatabaseOpts, Numeric, StepResult, Value};
 
 #[turso_macros::test(mvcc)]
 fn test_pragma_module_list_returns_list(db: TempDatabase) {
@@ -389,6 +389,90 @@ fn test_pragma_cache_size_min_value(db: TempDatabase) {
         panic!("expected integer value");
     };
     assert_eq!(*value, 200);
+}
+
+#[turso_macros::test]
+fn test_pragma_auto_vacuum_explain_uses_transaction(_db: TempDatabase) {
+    let db = TempDatabase::builder()
+        .with_opts(DatabaseOpts::new().with_autovacuum(true))
+        .build();
+    let conn = db.connect_limbo();
+
+    let rows = limbo_exec_rows(&conn, "EXPLAIN PRAGMA auto_vacuum=full");
+    let opcodes: Vec<String> = rows
+        .iter()
+        .map(|row| {
+            let RValue::Text(opcode) = &row[1] else {
+                panic!("expected opcode text in column 1, got {:?}", row[1]);
+            };
+            opcode.clone()
+        })
+        .collect();
+
+    assert!(
+        opcodes.iter().any(|opcode| opcode == "Transaction"),
+        "expected EXPLAIN output to include Transaction opcode for PRAGMA auto_vacuum=full, got {opcodes:?}"
+    );
+    assert!(
+        opcodes.iter().any(|opcode| opcode == "ReadCookie"),
+        "expected EXPLAIN output to include ReadCookie opcode for PRAGMA auto_vacuum=full, got {opcodes:?}"
+    );
+    assert!(
+        opcodes.iter().any(|opcode| opcode == "SetCookie"),
+        "expected EXPLAIN output to include SetCookie opcode for PRAGMA auto_vacuum=full, got {opcodes:?}"
+    );
+}
+
+#[turso_macros::test]
+fn test_pragma_auto_vacuum_non_empty_is_ignored(_db: TempDatabase) {
+    let db = TempDatabase::builder()
+        .with_opts(DatabaseOpts::new().with_autovacuum(true))
+        .build();
+    let conn = db.connect_limbo();
+
+    conn.execute("PRAGMA auto_vacuum=none").unwrap();
+    conn.execute("CREATE TABLE t(x)").unwrap();
+    conn.execute("PRAGMA auto_vacuum=full").unwrap();
+
+    let mut rows = conn.query("PRAGMA auto_vacuum").unwrap().unwrap();
+    let StepResult::Row = rows.step().unwrap() else {
+        panic!("expected row");
+    };
+    let row = rows.row().unwrap();
+    let Value::Numeric(Numeric::Integer(value)) = row.get_value(0) else {
+        panic!("expected integer value");
+    };
+    assert_eq!(
+        *value, 0,
+        "auto_vacuum=full must be ignored for non-empty databases"
+    );
+}
+
+#[turso_macros::test]
+fn test_pragma_auto_vacuum_explain_non_empty_omits_transaction(_db: TempDatabase) {
+    let db = TempDatabase::builder()
+        .with_opts(DatabaseOpts::new().with_autovacuum(true))
+        .build();
+    let conn = db.connect_limbo();
+
+    conn.execute("PRAGMA auto_vacuum=none").unwrap();
+    conn.execute("CREATE TABLE t(x)").unwrap();
+
+    let rows = limbo_exec_rows(&conn, "EXPLAIN PRAGMA auto_vacuum=full");
+    let opcodes: Vec<String> = rows
+        .iter()
+        .map(|row| {
+            let RValue::Text(opcode) = &row[1] else {
+                panic!("expected opcode text in column 1, got {:?}", row[1]);
+            };
+            opcode.clone()
+        })
+        .collect();
+
+    assert!(
+        !opcodes.iter().any(|opcode| opcode == "Transaction"),
+        "non-empty database should not emit Transaction for PRAGMA auto_vacuum=full, got {opcodes:?}"
+    );
 }
 
 #[turso_macros::test]


### PR DESCRIPTION
## Description

Fixes `PRAGMA auto_vacuum` setter behavior to match SQLite for both bytecode shape and runtime semantics:

  - For empty databases:
    - mode changes are ignored (no transaction path), consistent with SQLite.

  Add integration tests covering:
  1. Empty DB explain path includes `Transaction` + cookie ops.
  2. Non-empty DB mode change is ignored.
  3. Non-empty DB explain path omits `Transaction`.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

`PRAGMA auto_vacuum=full` was not consistently using a transaction path in Turso, and a prior attempt introduced a semantic regression where non-empty DBs could still flip mode.

  SQLite behavior is:
  - empty DB + `full/incremental` => transaction + cookie update path,
  - non-empty DB => pragma is effectively ignored.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #3133

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
