### PR TITLE
fix: preserve full column type string including size params in PRAGMA table_info

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2540,7 +2540,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     .unwrap_or_default();
                 let declared_type = col_type
                     .as_ref()
-                    .map(|t| ast_type_to_str(t))
+                    .map(ast_type_to_str)
                     .unwrap_or_default();
 
                 let ty_params: Vec<Box<Expr>> = match col_type {
@@ -3251,7 +3251,7 @@ impl TryFrom<&ColumnDefinition> for Column {
         let declared_type = value
             .col_type
             .as_ref()
-            .map(|t| ast_type_to_str(t))
+            .map(ast_type_to_str)
             .unwrap_or_default();
 
         let ty_params: Vec<Box<turso_parser::ast::Expr>> = match &value.col_type {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -157,6 +157,8 @@ pub const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
 /// Format an `ast::Type` as the declared type string, preserving parenthesized
 /// size parameters exactly as written (e.g. `VARCHAR(100)`, `DECIMAL(10,2)`).
 /// SQLite stores and reports the full declared type including parameters.
+/// Note: only the base `name` part (without size) is used for type registry
+/// lookups and affinity determination; the full string is for display only.
 fn ast_type_to_str(t: &ast::Type) -> String {
     match &t.size {
         None => t.name.clone(),
@@ -2139,9 +2141,9 @@ impl BTreeTable {
                 sql.push_str(column_name);
             }
 
-            if !column.ty_str.is_empty() {
+            if !column.declared_type.is_empty() {
                 sql.push(' ');
-                sql.push_str(&column.ty_str);
+                sql.push_str(&column.declared_type);
             }
             if column.notnull() {
                 sql.push_str(" NOT NULL");
@@ -2534,6 +2536,10 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 // https://www.sqlite.org/lang_createtable.html#rowids_and_the_integer_primary_key
                 let ty_str = col_type
                     .as_ref()
+                    .map(|t| t.name.clone())
+                    .unwrap_or_default();
+                let declared_type = col_type
+                    .as_ref()
                     .map(|t| ast_type_to_str(t))
                     .unwrap_or_default();
 
@@ -2728,6 +2734,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     },
                 );
                 col.ty_params = ty_params;
+                col.declared_type = declared_type;
                 cols.push(col);
             }
 
@@ -2961,7 +2968,11 @@ impl ResolvedFkRef {
 #[derive(Debug, Clone)]
 pub struct Column {
     pub name: Option<String>,
+    /// Base type name used for type registry lookup, affinity, and internal logic (e.g. "numeric").
     pub ty_str: String,
+    /// Full declared type string as written in CREATE TABLE, including size params (e.g. "numeric(10,2)").
+    /// Used only for PRAGMA table_info display. Equals ty_str when no size params are present.
+    pub declared_type: String,
     pub ty_params: Vec<Box<Expr>>,
     pub default: Option<Box<Expr>>,
     pub generated: Option<Box<Expr>>,
@@ -3094,7 +3105,8 @@ impl Column {
         }
         Self {
             name,
-            ty_str,
+            ty_str: ty_str.clone(),
+            declared_type: ty_str,
             ty_params: Vec::new(),
             default,
             generated,
@@ -3234,6 +3246,11 @@ impl TryFrom<&ColumnDefinition> for Column {
         let ty_str = value
             .col_type
             .as_ref()
+            .map(|t| t.name.clone())
+            .unwrap_or_default();
+        let declared_type = value
+            .col_type
+            .as_ref()
             .map(|t| ast_type_to_str(t))
             .unwrap_or_default();
 
@@ -3267,6 +3284,7 @@ impl TryFrom<&ColumnDefinition> for Column {
             },
         );
         col.ty_params = ty_params;
+        col.declared_type = declared_type;
         Ok(col)
     }
 }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -154,6 +154,17 @@ pub const TURSO_TYPES_TABLE_NAME: &str = "__turso_internal_types";
 pub const DBSP_TABLE_PREFIX: &str = "__turso_internal_dbsp_state_v";
 pub const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
 
+/// Format an `ast::Type` as the declared type string, preserving parenthesized
+/// size parameters exactly as written (e.g. `VARCHAR(100)`, `DECIMAL(10,2)`).
+/// SQLite stores and reports the full declared type including parameters.
+fn ast_type_to_str(t: &ast::Type) -> String {
+    match &t.size {
+        None => t.name.clone(),
+        Some(ast::TypeSize::MaxSize(expr)) => format!("{}({})", t.name, expr),
+        Some(ast::TypeSize::TypeSize(e1, e2)) => format!("{}({},{})", t.name, e1, e2),
+    }
+}
+
 /// Quote a SQL identifier with double quotes if it needs quoting.
 /// Quotes when the name contains non-alphanumeric characters (except underscore),
 /// starts with a digit, or is empty. Simple names like "test_uint" are left unquoted.
@@ -2523,8 +2534,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 // https://www.sqlite.org/lang_createtable.html#rowids_and_the_integer_primary_key
                 let ty_str = col_type
                     .as_ref()
-                    .cloned()
-                    .map(|ast::Type { name, .. }| name)
+                    .map(|t| ast_type_to_str(t))
                     .unwrap_or_default();
 
                 let ty_params: Vec<Box<Expr>> = match col_type {
@@ -3224,7 +3234,7 @@ impl TryFrom<&ColumnDefinition> for Column {
         let ty_str = value
             .col_type
             .as_ref()
-            .map(|t| t.name.to_string())
+            .map(|t| ast_type_to_str(t))
             .unwrap_or_default();
 
         let ty_params: Vec<Box<turso_parser::ast::Expr>> = match &value.col_type {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1105,7 +1105,13 @@ impl Schema {
             let mut pk_index_added = false;
             for unique_set in &table.unique_sets {
                 if unique_set.is_primary_key {
-                    assert!(table.primary_key_columns.len() == unique_set.columns.len(), "trying to add a {}-column primary key index for table {}, but the table has {} primary key columns", unique_set.columns.len(), table.name, table.primary_key_columns.len());
+                    assert!(
+                        table.primary_key_columns.len() == unique_set.columns.len(),
+                        "trying to add a {}-column primary key index for table {}, but the table has {} primary key columns",
+                        unique_set.columns.len(),
+                        table.name,
+                        table.primary_key_columns.len()
+                    );
                     // Add composite primary key index
                     assert!(
                         !pk_index_added,
@@ -1179,7 +1185,11 @@ impl Schema {
             // In MVCC mode during recovery, not all automatic index schema rows might be visible yet
             // during incremental schema reparsing, so we may have extra entries
             if !mvcc_enabled {
-                assert!(automatic_indexes.is_empty(), "all automatic indexes parsed from sqlite_schema should have been consumed, but {} remain", automatic_indexes.len());
+                assert!(
+                    automatic_indexes.is_empty(),
+                    "all automatic indexes parsed from sqlite_schema should have been consumed, but {} remain",
+                    automatic_indexes.len()
+                );
             }
         }
         Ok(())
@@ -1325,7 +1335,9 @@ impl Schema {
                                     // This will cause populate_materialized_views to skip this view
                                     tracing::warn!(
                                         "Skipping materialized view '{}' - has version {} but current version is {}. DROP and recreate the view to use it.",
-                                        view_name, stored_version, DBSP_CIRCUIT_VERSION
+                                        view_name,
+                                        stored_version,
+                                        DBSP_CIRCUIT_VERSION
                                     );
                                     // We can't track incompatible views here since we're in handle_schema_row
                                     // which doesn't have mutable access to self
@@ -2538,10 +2550,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     .as_ref()
                     .map(|t| t.name.clone())
                     .unwrap_or_default();
-                let declared_type = col_type
-                    .as_ref()
-                    .map(ast_type_to_str)
-                    .unwrap_or_default();
+                let declared_type = col_type.as_ref().map(ast_type_to_str).unwrap_or_default();
 
                 let ty_params: Vec<Box<Expr>> = match col_type {
                     Some(ast::Type {

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1354,7 +1354,7 @@ fn emit_columns_for_table_info(
         program.emit_string8(column.name.clone().unwrap_or_default(), base_reg + 1);
 
         // type
-        program.emit_string8(column.ty_str.clone(), base_reg + 2);
+        program.emit_string8(column.declared_type.clone(), base_reg + 2);
 
         // notnull
         program.emit_bool(column.notnull(), base_reg + 3);

--- a/testing/runner/tests/pragma/table_info.sqltest
+++ b/testing/runner/tests/pragma/table_info.sqltest
@@ -1,0 +1,46 @@
+@database :memory:
+
+# ============================================================================
+# Issue #5762: PRAGMA table_info should preserve full type strings including
+# parenthesized parameters (e.g. VARCHAR(100), DECIMAL(10,2)).
+# Per SQLite docs: the "type" column reports the declared type of the column.
+# ============================================================================
+
+test pragma-table-info-type-with-single-param {
+    CREATE TABLE t_type_param (a VARCHAR(100), b CHAR(50), c FLOAT(24));
+    PRAGMA table_info(t_type_param)
+}
+expect {
+    0|a|VARCHAR(100)|0||0
+    1|b|CHAR(50)|0||0
+    2|c|FLOAT(24)|0||0
+}
+
+test pragma-table-info-type-with-two-params {
+    CREATE TABLE t_type_param2 (a DECIMAL(10,2), b NUMERIC(5,3));
+    PRAGMA table_info(t_type_param2)
+}
+expect {
+    0|a|DECIMAL(10,2)|0||0
+    1|b|NUMERIC(5,3)|0||0
+}
+
+test pragma-table-info-type-nvarchar {
+    CREATE TABLE t_nvarchar (a NVARCHAR(200));
+    PRAGMA table_info(t_nvarchar)
+}
+expect {
+    0|a|NVARCHAR(200)|0||0
+}
+
+test pragma-table-info-type-no-params-unchanged {
+    CREATE TABLE t_no_params (a INTEGER, b TEXT, c REAL, d BLOB);
+    PRAGMA table_info(t_no_params)
+}
+expect {
+    0|a|INTEGER|0||0
+    1|b|TEXT|0||0
+    2|c|REAL|0||0
+    3|d|BLOB|0||0
+}
+


### PR DESCRIPTION


## Description
For issue #5762 
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

I am new to this repository so I ran copilot on it to understand the structure and some main flows.
Then I reproduced the issue first then made the fix and created the SQL test using Copilot ( using Claude sonnet 4.6 )
Then finally tested it manually 

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
