### PR TITLE
Make ROUND(x, d>0) match SQLite tie-breaking semantics

### DIFF
--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write;
 use std::iter::{repeat_n, Peekable};
+use std::num::NonZeroUsize;
 use std::str;
 use std::str::Chars;
 
@@ -547,6 +548,33 @@ fn format_fixed_from_digits(abs_f: f64, precision: usize, max_sig: usize) -> Str
     }
 
     result
+}
+
+/// SQLite's round(X,Y) for Y>0 formats with `%!.*f` and parses back to float.
+/// Reuse the same `%f` decimal path here so round() matches SQLite tie-breaking.
+pub(crate) fn round_half_away_from_zero(value: f64, precision: NonZeroUsize) -> f64 {
+    let precision = precision.get();
+    assert!(
+        precision <= 30,
+        "ROUND precision should be clamped to <= 30"
+    );
+
+    let mut formatted =
+        ensure_decimal_strip_zeros(&format_fixed_from_digits(value.abs(), precision, 26));
+
+    if value.is_sign_negative() {
+        formatted.insert(0, '-');
+    }
+
+    let rounded: f64 = crate::numeric::str_to_f64(formatted)
+        .expect("formatted float should always parse successfully")
+        .into();
+
+    if rounded == 0.0 {
+        0.0
+    } else {
+        rounded
+    }
 }
 
 /// Limit a formatted numeric string to `max_sig` significant digits, rounding

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1,12 +1,14 @@
 use crate::turso_assert;
 use crate::{
     function::MathFunc,
+    functions::printf::round_half_away_from_zero,
     numeric::{format_float, format_float_for_quote, NullableInteger, Numeric},
     translate::collate::CollationSeq,
     types::{compare_immutable_single, AsValueRef, SeekOp},
     vdbe::affinity::{real_to_i64, Affinity},
     LimboError, Result, Value, ValueRef,
 };
+use std::num::NonZeroUsize;
 
 // we use math functions from Rust stdlib in order to be as portable as possible for the production version of the tursodb
 #[cfg(not(test))]
@@ -644,9 +646,10 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        let f: f64 = crate::numeric::str_to_f64(format!("{f:.precision$}"))
-            .expect("formatted float should always parse successfully")
-            .into();
+        let f = round_half_away_from_zero(
+            f,
+            NonZeroUsize::new(precision).expect("precision should be non-zero"),
+        );
 
         Value::from_f64(f)
     }
@@ -2346,6 +2349,33 @@ mod tests {
         let input_val = Value::from_f64(100.123);
         let expected_val = Value::Null;
         assert_eq!(input_val.exec_round(Some(&Value::Null)), expected_val);
+
+        let input_val = Value::from_f64(2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(2.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(-2.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-0.04);
+        let precision_val = Value::from_i64(1);
+        let result = input_val.exec_round(Some(&precision_val));
+        match result {
+            Value::Numeric(Numeric::Float(f)) => {
+                let f = f64::from(f);
+                assert_eq!(f, 0.0);
+                assert!(!f.is_sign_negative());
+            }
+            _ => panic!("exec_round did not return a Float variant"),
+        }
+
+        let input_val = Value::from_f64(123.456);
+        let precision_val = Value::from_i64(4294967297);
+        let expected_val = Value::from_f64(123.456);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
     }
 
     #[test]

--- a/testing/runner/tests/scalar-functions.sqltest
+++ b/testing/runner/tests/scalar-functions.sqltest
@@ -774,6 +774,37 @@ expect {
     123.46
 }
 
+test round-half-away-from-zero-positive-tie {
+    SELECT round(2.25, 1);
+}
+expect {
+    2.3
+}
+
+test round-half-away-from-zero-negative-tie {
+    SELECT round(-2.25, 1);
+}
+expect {
+    -2.3
+}
+
+test round-negative-small-value-rounds-to-positive-zero {
+    SELECT round(-0.04, 1);
+}
+expect {
+    0.0
+}
+expect @js {
+    0
+}
+
+test round-large-precision-is-clamped {
+    SELECT round(123.456, 4294967297);
+}
+expect {
+    123.456
+}
+
 test round-float-with-text-precision {
     SELECT round(123.5, '1');
 }


### PR DESCRIPTION
## Description

ROUND(x, d) for d>0 was using Rust formatting, which rounds ties-to-even(banker's rounding). SQLite uses round-half-away-from-zero behavior via its printf path, so values like ROUND(2.25, 1) diverged (2.2 vs 2.3).

  - Reuse SQLite-compatible decimal rounding path from printf for ROUND d>0
  - Tighten helper contract with NonZeroUsize and assert precision invariant
  - Normalize negative zero outputs to +0.0 for ROUND results
  - Add regression tests

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Issue #5748 reported that `ROUND(x, d)` used banker's rounding for exact tie boundaries (e.g. `2.25` at precision `1`), while SQLite rounds half away from zero.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5748

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
