### PR TITLE
core: Adapt null handling in json_string_to_db_type

### DIFF
--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -581,7 +581,7 @@ where
 ///
 /// - `jsonb` – the value to convert
 /// - `element_type` – the element type of the jsonb
-/// - `flag` – how the result should be formatted.
+/// - `flag` – how the result should be formatted (null values will stay null).
 ///   - If the flag is `OutputVariant::Binary`, the result is a `Value::Blob`.
 ///   - If it is `OutputVariant::ElementType` and the `element_type` is text, the result has a subtype of `TestSubtype::Text`, with the outer quotes removed.
 ///   - If it is `OutputVariant::String` and the `element_type` is text, the result has a subtype of `TextSubtype::Text`.
@@ -591,6 +591,9 @@ pub fn json_string_to_db_type(
     element_type: ElementType,
     flag: OutputVariant,
 ) -> crate::Result<Value> {
+    if element_type == ElementType::NULL {
+        return Ok(Value::Null);
+    }
     if matches!(flag, OutputVariant::Binary) {
         return Ok(Value::Blob(json.data()));
     }
@@ -640,7 +643,6 @@ pub fn json_string_to_db_type(
         }
         ElementType::TRUE => Ok(Value::from_i64(1)),
         ElementType::FALSE => Ok(Value::from_i64(0)),
-        ElementType::NULL => Ok(Value::Null),
         _ => unreachable!(),
     }
 }

--- a/core/json/ops.rs
+++ b/core/json/ops.rs
@@ -5,7 +5,7 @@ use super::{
     Conv, JsonCacheCell, OutputVariant,
 };
 use crate::{
-    types::{AsValueRef, Value},
+    types::{AsValueRef, Text, Value},
     ValueRef,
 };
 
@@ -24,6 +24,13 @@ pub fn json_patch(
         (ValueRef::Null, _) | (_, ValueRef::Null) => return Ok(Value::Null),
         (ValueRef::Blob(_), _) | (_, ValueRef::Blob(_)) => {
             crate::bail_constraint_error!("blob is not supported!");
+        }
+        // Explicit handling for the case json_path('{}', 'null') case. If the patch value is
+        // the text null, the result will also be the text null. No extra parsing required.
+        (_, ValueRef::Text(t)) => {
+            if t.value == "null" {
+                return Ok(Value::Text(Text::new("null")));
+            }
         }
         _ => (),
     }

--- a/testing/sqltests/tests/json/default.sqltest
+++ b/testing/sqltests/tests/json/default.sqltest
@@ -3255,3 +3255,24 @@ expect {
     tab	here
 newline	tab
 }
+
+test json-set-field-null {
+    SELECT typeof(json_set(null, '$.field', 'value'));
+}
+expect {
+  null
+}
+
+test json-insert-null {
+    SELECT typeof(json_insert(NULL, '$.a', 1));
+}
+expect {
+  null
+}
+
+test json-remove-null {
+    SELECT typeof(json_remove(NULL, '$.a'));
+}
+expect {
+  null
+}


### PR DESCRIPTION
## Description

Various JSON related functions call json_string_to_db_type with a specify OutputVariant. Before this change, null was also transformed into the specified OutputVariant, which caused a few issues down the line. For example `json_set(NULL, '$.a', 1)` would return the SQL string null and not the type null.

The function has been adapted to not touch null values, no matter the specified OutputVariant.

Fixes #5750

## Motivation and context

Fix for issue #5750

## Description of AI Usage

No AI has been used. 
