### PR TITLE
core/vdbe: Fix SUBSTR() with negative offsets for multi-byte UTF-8 strings

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -487,8 +487,10 @@ impl Value {
             }
             (value, Value::Numeric(Numeric::Integer(start))) => {
                 if let Some(text) = value.cast_text() {
+                    // Use character count to accurately resolve negative offsets in UTF-8 strings
+                    let char_count = text.chars().count();
                     let (mut start, mut end) =
-                        calculate_postions(start, text.len(), length_value.as_ref());
+                        calculate_postions(start, char_count, length_value.as_ref());
 
                     // https://github.com/sqlite/sqlite/blob/a248d84f/src/func.c#L417
                     let s = text.as_str();

--- a/testing/runner/tests/scalar-functions.sqltest
+++ b/testing/runner/tests/scalar-functions.sqltest
@@ -1099,6 +1099,35 @@ expect {
     mbo
 }
 
+test substr-utf8 {
+    SELECT substr('café', -2, 3);
+    SELECT substr('café', -1, 2);
+    SELECT substr('café', -4, 5);
+    SELECT substr('日本語', -1, 1);
+    SELECT substr('日本語', -2, 2);
+    SELECT substr('日本語', -3, 3);
+    SELECT substr('café', 1, 3);
+    SELECT substr('café', 4, 1);
+    SELECT substr('日本語', 1, 1);
+    SELECT substr('日本語', 2, 2);
+    SELECT substr('café', -2);
+    SELECT substr('日本語', -1);
+}
+expect {
+    fé
+    é
+    café
+    語
+    本語
+    日本語
+    caf
+    é
+    日
+    本語
+    fé
+    語
+}
+
 test substr-large-float-clamp {
     SELECT substr('abcdefghijklmnopqrstuvwxyz', 18446744073709551488);
 }


### PR DESCRIPTION
Use character count instead of byte length when calculating start positions from the end of a string. This ensures indices refer to Unicode characters as expected.

Fixes https://github.com/tursodatabase/turso/issues/5749