### PR TITLE
core: Optimize prepared statement recompilation check

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -49,30 +49,9 @@ pub(crate) enum TransactionState {
 
 /// Database connection handle.
 ///
-/// # Compile-Affecting Fields
-///
-/// The following fields affect SQL statement compilation and are tracked by `PrepareContext`
-/// in `vdbe/mod.rs`. If you add a new field that affects how statements are compiled or
-/// executed, you MUST also update `PrepareContext::from_connection()` to include it
-/// in core/vdbe/mod.rs.
-/// Failure to do so will cause stale cached statements to be used incorrectly.
-///
-/// Currently tracked fields:
-/// - `db` (via database pointer identity)
-/// - `fk_pragma` (foreign_keys)
-/// - `query_only`
-/// - `capture_data_changes`
-/// - `syms` / `syms_generation` (registered functions, virtual tables, etc.)
-/// - `attached_databases` (via fingerprint)
-/// - `busy_handler` (timeout affects retry behavior)
-/// - `cache_size`
-/// - `page_size`
-/// - `sync_mode`
-/// - `data_sync_retry`
-/// - `encryption_key` (whether set)
-/// - `encryption_cipher_mode`
-/// - Pager's `spill_enabled` setting
-/// - MVCC checkpoint threshold (when MVCC enabled)
+/// If you add a setting that affects SQL compilation or execution, call
+/// `bump_prepare_context_generation()` in its setter so cached prepared
+/// statements know they need to be reprepared.
 pub struct Connection {
     pub(crate) db: Arc<Database>,
     pub(crate) pager: ArcSwap<Pager>,
@@ -87,7 +66,6 @@ pub struct Connection {
     pub(crate) last_change: AtomicI64,
     pub(crate) total_changes: AtomicI64,
     pub(crate) syms: parking_lot::RwLock<SymbolTable>,
-    pub(crate) syms_generation: AtomicU64,
     pub(super) _shared_cache: bool,
     pub(super) cache_size: AtomicI32,
     /// page size used for an uninitialized database or the next vacuum command.
@@ -144,13 +122,13 @@ pub struct Connection {
     pub(super) check_constraints_pragma: AtomicBool,
     /// Track when each virtual table instance is currently in transaction.
     pub(crate) vtab_txn_states: RwLock<HashSet<u64>>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct AttachedDatabasesFingerprint {
-    pub(crate) count: usize,
-    pub(crate) hash1: u64,
-    pub(crate) hash2: u64,
+    /// Generation counter bumped whenever any setting that affects PrepareContext
+    /// changes. Allows prepared statements to cheaply detect when they need to be
+    /// reprepared (single u64 comparison instead of rebuilding the full context).
+    /// IMPORTANT: this is a bit of a regression landmine because the generation
+    /// MUST be incremented whenever any setting that affects PrepareContext changes,
+    /// and this is not currently centralized; each setter bumps the generation individually.
+    pub(crate) prepare_context_generation: AtomicU64,
 }
 
 // SAFETY: This needs to be audited for thread safety.
@@ -211,6 +189,20 @@ impl Drop for Connection {
 }
 
 impl Connection {
+    /// Bump the prepare context generation counter. Must be called whenever any
+    /// connection setting that is tracked in `PrepareContext` changes, so that
+    /// prepared statements know they need to be reprepared.
+    #[inline]
+    pub(crate) fn bump_prepare_context_generation(&self) {
+        self.prepare_context_generation
+            .fetch_add(1, Ordering::Release);
+    }
+
+    #[inline]
+    pub(crate) fn prepare_context_generation(&self) -> u64 {
+        self.prepare_context_generation.load(Ordering::Acquire)
+    }
+
     /// check if connection executes nested program (so it must not do any "finalization" work as parent program will handle it)
     pub fn is_nested_stmt(&self) -> bool {
         self.nestedness.load(Ordering::SeqCst) > 0
@@ -753,6 +745,7 @@ impl Connection {
 
     pub fn set_foreign_keys_enabled(&self, enable: bool) {
         self.fk_pragma.store(enable, Ordering::Release);
+        self.bump_prepare_context_generation();
     }
 
     pub fn foreign_keys_enabled(&self) -> bool {
@@ -1146,6 +1139,7 @@ impl Connection {
     }
     pub fn set_cache_size(&self, size: i32) {
         self.cache_size.store(size, Ordering::SeqCst);
+        self.bump_prepare_context_generation();
     }
 
     pub fn get_capture_data_changes_info(
@@ -1155,6 +1149,7 @@ impl Connection {
     }
     pub fn set_capture_data_changes_info(&self, opts: Option<CaptureDataChangesInfo>) {
         *self.capture_data_changes.write() = opts;
+        self.bump_prepare_context_generation();
     }
     pub fn get_cdc_transaction_id(&self) -> i64 {
         self.cdc_transaction_id.load(Ordering::SeqCst)
@@ -1215,6 +1210,7 @@ impl Connection {
 
         self.page_size.store(size.get_raw(), Ordering::SeqCst);
         self.pager.load().set_initial_page_size(size)?;
+        self.bump_prepare_context_generation();
 
         Ok(())
     }
@@ -1585,6 +1581,7 @@ impl Connection {
             }
         }
         self.attached_databases.write().insert(alias, (db, pager));
+        self.bump_prepare_context_generation();
 
         Ok(())
     }
@@ -1643,6 +1640,7 @@ impl Connection {
         // Invalidate the cached schema for this database index so that a future
         // ATTACH reusing the same index won't see stale schema entries.
         self.database_schemas.write().remove(&database_id);
+        self.bump_prepare_context_generation();
 
         Ok(())
     }
@@ -1744,58 +1742,6 @@ impl Connection {
         }
     }
 
-    pub(crate) fn attached_databases_fingerprint(&self) -> AttachedDatabasesFingerprint {
-        const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
-        const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-
-        fn hash_bytes(mut hash: u64, bytes: &[u8]) -> u64 {
-            for &byte in bytes {
-                hash ^= byte as u64;
-                hash = hash.wrapping_mul(FNV_PRIME);
-            }
-            hash
-        }
-
-        fn hash_u64(hash: u64, value: u64) -> u64 {
-            hash_bytes(hash, &value.to_le_bytes())
-        }
-
-        fn hash_entry(index: usize, alias: &str, db_ptr: usize) -> u64 {
-            let mut hash = FNV_OFFSET_BASIS;
-            hash = hash_u64(hash, index as u64);
-            hash = hash_bytes(hash, alias.as_bytes());
-            hash_u64(hash, db_ptr as u64)
-        }
-
-        let attached = self.attached_databases.read();
-        if attached.name_to_index.is_empty() {
-            return AttachedDatabasesFingerprint {
-                count: 0,
-                hash1: 0,
-                hash2: 0,
-            };
-        }
-
-        let mut hash1 = 0u64;
-        let mut hash2 = 0u64;
-        for (alias, &index) in attached.name_to_index.iter() {
-            let db_ptr = attached
-                .index_to_data
-                .get(&index)
-                .map(|(db, _pager)| Arc::as_ptr(db) as usize)
-                .unwrap_or(0);
-            let entry_hash = hash_entry(index, alias.as_str(), db_ptr);
-            hash1 = hash1.wrapping_add(entry_hash);
-            hash2 ^= entry_hash.rotate_left(17);
-        }
-
-        AttachedDatabasesFingerprint {
-            count: attached.name_to_index.len(),
-            hash1,
-            hash2,
-        }
-    }
-
     /// List all databases (main + attached) with their sequence numbers, names, and file paths
     /// Returns a vector of tuples: (seq_number, name, file_path)
     pub fn list_all_databases(&self) -> Vec<(usize, String, String)> {
@@ -1832,6 +1778,7 @@ impl Connection {
 
     pub fn set_query_only(&self, value: bool) {
         self.query_only.store(value, Ordering::SeqCst);
+        self.bump_prepare_context_generation();
     }
 
     pub fn get_sync_mode(&self) -> SyncMode {
@@ -1840,6 +1787,7 @@ impl Connection {
 
     pub fn set_sync_mode(&self, mode: SyncMode) {
         self.sync_mode.set(mode);
+        self.bump_prepare_context_generation();
     }
 
     pub fn get_temp_store(&self) -> crate::TempStore {
@@ -1858,6 +1806,7 @@ impl Connection {
     pub fn set_data_sync_retry(&self, value: bool) {
         self.data_sync_retry
             .store(value, crate::sync::atomic::Ordering::SeqCst);
+        self.bump_prepare_context_generation();
     }
 
     /// Get the sync type setting.
@@ -1892,10 +1841,6 @@ impl Connection {
             .collect()
     }
 
-    pub(crate) fn syms_generation(&self) -> u64 {
-        self.syms_generation.load(Ordering::SeqCst)
-    }
-
     pub(crate) fn database_ptr(&self) -> usize {
         Arc::as_ptr(&self.db) as usize
     }
@@ -1903,12 +1848,14 @@ impl Connection {
     pub fn set_encryption_key(&self, key: EncryptionKey) -> Result<()> {
         tracing::trace!("setting encryption key for connection");
         *self.encryption_key.write() = Some(key);
+        self.bump_prepare_context_generation();
         self.set_encryption_context()
     }
 
     pub fn set_encryption_cipher(&self, cipher_mode: CipherMode) -> Result<()> {
         tracing::trace!("setting encryption cipher for connection");
         self.encryption_cipher_mode.set(cipher_mode);
+        self.bump_prepare_context_generation();
         self.set_encryption_context()
     }
 
@@ -1958,6 +1905,7 @@ impl Connection {
             Some(callback) => BusyHandler::Custom { callback },
             None => BusyHandler::None,
         };
+        self.bump_prepare_context_generation();
     }
 
     /// Sets maximum total accumulated timeout. If the duration is Zero, we unset the busy handler.
@@ -1967,6 +1915,7 @@ impl Connection {
         } else {
             BusyHandler::Timeout(duration)
         };
+        self.bump_prepare_context_generation();
     }
 
     /// Get the busy timeout duration.
@@ -2137,6 +2086,7 @@ impl Connection {
         match self.db.get_mv_store().as_ref() {
             Some(mv_store) => {
                 mv_store.set_checkpoint_threshold(threshold);
+                self.bump_prepare_context_generation();
                 Ok(())
             }
             None => Err(LimboError::InternalError("MVCC not enabled".into())),

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -38,8 +38,9 @@ pub use vtab_xconnect::{execute, prepare_stmt};
 pub struct ExtensionCtx {
     syms: *mut SymbolTable,
     schema: *mut c_void,
-    /// We must update this generation counter when we modify the symbol table
-    syms_generation: *const AtomicU64,
+    /// We must bump the prepare context generation so prepared statements
+    /// know they need to be reprepared after extension registration.
+    prepare_context_generation: *const AtomicU64,
 }
 
 pub(crate) unsafe extern "C" fn register_vtab_module(
@@ -68,9 +69,8 @@ pub(crate) unsafe extern "C" fn register_vtab_module(
     unsafe {
         let syms = &mut *ext_ctx.syms;
         syms.vtab_modules.insert(name_str.clone(), vmodule.into());
-        if !ext_ctx.syms_generation.is_null() {
-            let syms_generation = &*ext_ctx.syms_generation;
-            syms_generation.fetch_add(1, Ordering::SeqCst);
+        if !ext_ctx.prepare_context_generation.is_null() {
+            (*ext_ctx.prepare_context_generation).fetch_add(1, Ordering::Release);
         }
 
         if kind == VTabKind::TableValuedFunction {
@@ -113,9 +113,8 @@ pub(crate) unsafe extern "C" fn register_scalar_function(
             name_str.clone(),
             Arc::new(ExternalFunc::new_scalar(name_str, func)),
         );
-        if !ext_ctx.syms_generation.is_null() {
-            let syms_generation = &*ext_ctx.syms_generation;
-            syms_generation.fetch_add(1, Ordering::SeqCst);
+        if !ext_ctx.prepare_context_generation.is_null() {
+            (*ext_ctx.prepare_context_generation).fetch_add(1, Ordering::Release);
         }
     }
     ResultCode::OK
@@ -147,9 +146,8 @@ pub(crate) unsafe extern "C" fn register_aggregate_function(
                 (init_func, step_func, finalize_func),
             )),
         );
-        if !ext_ctx.syms_generation.is_null() {
-            let syms_generation = &*ext_ctx.syms_generation;
-            syms_generation.fetch_add(1, Ordering::SeqCst);
+        if !ext_ctx.prepare_context_generation.is_null() {
+            (*ext_ctx.prepare_context_generation).fetch_add(1, Ordering::Release);
         }
     }
     ResultCode::OK
@@ -208,7 +206,7 @@ impl Database {
         let ctx = Box::into_raw(Box::new(ExtensionCtx {
             syms,
             schema: schema_mutex_ptr as *mut c_void,
-            syms_generation: std::ptr::null(),
+            prepare_context_generation: std::ptr::null(),
         }));
         #[allow(unused)]
         let mut ext_api = ExtensionApi {
@@ -267,7 +265,7 @@ impl Connection {
         let ctx = ExtensionCtx {
             syms: self.syms.data_ptr(),
             schema: schema_mutex_ptr as *mut c_void,
-            syms_generation: &self.syms_generation as *const _,
+            prepare_context_generation: &self.prepare_context_generation as *const _,
         };
         let ctx = Box::into_raw(Box::new(ctx)) as *mut c_void;
         ExtensionApi {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1263,7 +1263,6 @@ impl Database {
             last_change: AtomicI64::new(0),
             total_changes: AtomicI64::new(0),
             syms: parking_lot::RwLock::new(SymbolTable::new()),
-            syms_generation: AtomicU64::new(0),
             _shared_cache: false,
             cache_size: AtomicI32::new(default_cache_size),
             page_size: AtomicU16::new(page_size.get_raw()),
@@ -1291,6 +1290,7 @@ impl Database {
             fk_deferred_violations: AtomicIsize::new(0),
             check_constraints_pragma: AtomicBool::new(false),
             vtab_txn_states: RwLock::new(HashSet::default()),
+            prepare_context_generation: AtomicU64::new(0),
         });
         self.n_connections
             .fetch_add(1, crate::sync::atomic::Ordering::SeqCst);

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -200,6 +200,7 @@ fn update_pragma(
         PragmaName::CacheSpill => {
             let enabled = parse_pragma_enabled(&value);
             connection.get_pager().set_spill_enabled(enabled);
+            connection.bump_prepare_context_generation();
             Ok(TransactionMode::None)
         }
         PragmaName::Encoding => {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -52,21 +52,19 @@ use crate::{
         hash_table::HashTable,
         metrics::StatementMetrics,
     },
-    CipherMode, ValueRef,
+    ValueRef,
 };
 use smallvec::SmallVec;
 
+#[cfg(feature = "json")]
+use crate::json::JsonCacheCell;
+use crate::sync::RwLock;
 use crate::{
     storage::pager::Pager,
     translate::plan::ResultSetColumn,
     types::{AggContext, Cursor, ImmutableRecord, Value},
     vdbe::{builder::CursorType, insn::Insn},
 };
-
-use crate::connection::AttachedDatabasesFingerprint;
-#[cfg(feature = "json")]
-use crate::json::JsonCacheCell;
-use crate::sync::RwLock;
 use crate::{
     AtomicBool, CaptureDataChangesInfo, Connection, MvStore, Result, SyncMode, TransactionState,
 };
@@ -899,61 +897,32 @@ pub struct Program {
 /// # Adding New Fields
 ///
 /// If you add a new setting to `Connection` that affects statement compilation or execution,
-/// you MUST add a corresponding field here and update `from_connection()`. See the doc
-/// comment on `Connection` in `connection.rs` for the authoritative list of tracked fields.
-///
-/// Fields that affect compilation include (but are not limited to):
-/// - PRAGMA settings that change query semantics (foreign_keys, query_only, etc.)
-/// - Registered functions/virtual tables (tracked via syms_generation)
-/// - Attached databases (tracked via fingerprint)
-/// - Storage settings (page_size, cache_size, encryption, sync_mode, etc.)
+/// When adding a new connection setting that affects query compilation, you MUST call
+/// `bump_prepare_context_generation()` in its setter so that prepared statements know
+/// they need to be reprepared.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrepareContext {
+    /// Identity check: the prepared statement must belong to the same database.
     database_ptr: usize,
-    foreign_keys: bool,
-    query_only: bool,
-    capture_data_changes: Option<CaptureDataChangesInfo>,
-    syms_generation: u64,
-    attached_databases_fingerprint: AttachedDatabasesFingerprint,
-    busy_timeout_ms: u64,
-    cache_size: i32,
-    spill_enabled: bool,
-    page_size: u32,
-    sync_mode: SyncMode,
-    data_sync_retry: bool,
-    encryption_key_set: bool,
-    encryption_cipher: CipherMode,
-    mvcc_checkpoint_threshold: Option<i64>,
+    /// Generation counter snapshot taken at prepare time. Compared against the
+    /// connection's current generation to detect setting changes (pragmas,
+    /// attach/detach, extension registration, etc.) without rebuilding the full
+    /// context on every step.
+    generation: u64,
 }
 
 impl PrepareContext {
     pub fn from_connection(connection: &Connection) -> Self {
-        let pager = connection.get_pager();
         Self {
             database_ptr: connection.database_ptr(),
-            foreign_keys: connection.foreign_keys_enabled(),
-            query_only: connection.get_query_only(),
-            capture_data_changes: connection.get_capture_data_changes_info().clone(),
-            syms_generation: connection.syms_generation(),
-            attached_databases_fingerprint: connection.attached_databases_fingerprint(),
-            busy_timeout_ms: connection.get_busy_timeout().as_millis() as u64,
-            cache_size: connection.get_cache_size(),
-            spill_enabled: pager.get_spill_enabled(),
-            page_size: connection.get_page_size().get(),
-            sync_mode: connection.get_sync_mode(),
-            data_sync_retry: connection.get_data_sync_retry(),
-            encryption_key_set: connection.encryption_key.read().is_some(),
-            encryption_cipher: connection.encryption_cipher_mode.get(),
-            mvcc_checkpoint_threshold: connection
-                .db
-                .mvcc_enabled()
-                .then(|| connection.mvcc_checkpoint_threshold())
-                .and_then(|res| res.ok()),
+            generation: connection.prepare_context_generation(),
         }
     }
 
+    #[inline]
     pub fn matches_connection(&self, connection: &Connection) -> bool {
-        self == &Self::from_connection(connection)
+        self.database_ptr == connection.database_ptr()
+            && self.generation == connection.prepare_context_generation()
     }
 }
 


### PR DESCRIPTION
## Background

PrepareContext::matches_connection() is used to detect when a prepared statement needs recompilation.

## Problem

It used to reconstruct the entire context struct — 14 fields, multiple lock acquisitions, an FNV fingerprint over attached databases — and compare it field-by-field on every step(). This is wasteful: the context rarely changes. On one particular benchmark, 7 percent (!) of `step()` time was used on `matches_connection()`.

## Fix

Replace it with a monotonic u64 generation counter on Connection. Each setter that affects query compilation bumps the counter; prepared statements just compare two integers. The old AttachedDatabasesFingerprint, the per-field struct, and the syms_generation accessor are all removed.