### PR TITLE
core: Don't clone StatementMetrics on every statement completion

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -529,31 +529,30 @@ impl Limbo {
         let conn = self.conn.clone();
         let runner = conn.query_runner(input.as_bytes());
         let had_error_before = self.had_query_error;
-        for output in runner {
+        let capture_stats = self.opts.stats;
+        let mut last_stmt_metrics = None;
+        for mut output in runner {
             if self
-                .print_query_result(input, output, stats.as_mut())
+                .print_query_result(input, &mut output, stats.as_mut())
                 .is_err()
                 || self.had_query_error != had_error_before
             {
                 self.had_query_error = true;
                 break;
             }
+            // Capture metrics after stepping, before the Statement is dropped
+            if capture_stats {
+                if let Ok(Some(ref stmt)) = output {
+                    last_stmt_metrics = Some(stmt.metrics().clone());
+                }
+            }
         }
 
         self.print_query_performance_stats(start, stats.as_ref());
 
         // Display stats if enabled
-        if self.opts.stats {
-            let stats_output = {
-                let metrics = self.conn.metrics.read();
-                metrics
-                    .last_statement
-                    .as_ref()
-                    .map(|last| format!("\n{last}"))
-            };
-            if let Some(output) = stats_output {
-                let _ = self.writeln(output);
-            }
+        if let Some(ref last) = last_stmt_metrics {
+            let _ = self.writeln(format!("\n{last}"));
         }
     }
 
@@ -828,7 +827,7 @@ impl Limbo {
     fn print_query_result(
         &mut self,
         sql: &str,
-        mut output: Result<Option<Statement>, LimboError>,
+        output: &mut Result<Option<Statement>, LimboError>,
         statistics: Option<&mut QueryStatistics>,
     ) -> anyhow::Result<()> {
         match output {
@@ -856,12 +855,13 @@ impl Limbo {
             }
             Ok(None) => {}
 
-            Err(err) => {
+            Err(ref err) => {
                 match err {
                     LimboError::Busy => {}
                     LimboError::Interrupt => {}
                     _ => {
-                        let report = miette::Error::from(err).with_source_code(sql.to_owned());
+                        let report =
+                            miette::Error::from(err.clone()).with_source_code(sql.to_owned());
                         let _ = self.writeln_fmt(format_args!("{report:?}"));
                     }
                 }

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -128,6 +128,11 @@ impl Statement {
         self.state.execution_state
     }
 
+    /// Current statement-level metrics (rows read, VM steps, etc.).
+    pub fn metrics(&self) -> &vdbe::metrics::StatementMetrics {
+        &self.state.metrics
+    }
+
     pub fn mv_store(&self) -> impl Deref<Target = Option<Arc<MvStore>>> {
         self.program.connection.mv_store()
     }
@@ -177,11 +182,13 @@ impl Statement {
 
         // Aggregate metrics when statement completes
         if matches!(res, Ok(StepResult::Done)) {
-            let mut conn_metrics = self.program.connection.metrics.write();
-            conn_metrics.record_statement(self.state.metrics.clone());
+            self.program
+                .connection
+                .metrics
+                .write()
+                .record_statement(&self.state.metrics);
             self.busy = false;
             self.busy_handler_state = None; // Reset busy state on completion
-            drop(conn_metrics);
 
             // After ANALYZE completes, refresh in-memory stats so planners can use them.
             let sql = self.program.sql.trim_start();

--- a/core/vdbe/metrics.rs
+++ b/core/vdbe/metrics.rs
@@ -192,9 +192,6 @@ pub struct ConnectionMetrics {
     /// Aggregate metrics from all statements
     pub aggregate: StatementMetrics,
 
-    /// Metrics from the last executed statement
-    pub last_statement: Option<StatementMetrics>,
-
     /// High-water marks for monitoring
     pub max_vm_steps_per_statement: u64,
     pub max_rows_read_per_statement: u64,
@@ -205,8 +202,8 @@ impl ConnectionMetrics {
         Self::default()
     }
 
-    /// Record a completed statement's metrics
-    pub fn record_statement(&mut self, metrics: StatementMetrics) {
+    /// Record a completed statement's metrics (borrows, no clone).
+    pub fn record_statement(&mut self, metrics: &StatementMetrics) {
         self.total_statements = self.total_statements.saturating_add(1);
 
         // Update high-water marks
@@ -214,10 +211,7 @@ impl ConnectionMetrics {
         self.max_rows_read_per_statement = self.max_rows_read_per_statement.max(metrics.rows_read);
 
         // Aggregate into total
-        self.aggregate.merge(&metrics);
-
-        // Keep last statement for debugging
-        self.last_statement = Some(metrics);
+        self.aggregate.merge(metrics);
     }
 
     /// Reset connection metrics
@@ -244,13 +238,6 @@ impl fmt::Display for ConnectionMetrics {
         writeln!(f)?;
         writeln!(f, "Aggregate Statistics:")?;
         write!(f, "{}", self.aggregate)?;
-
-        if let Some(ref last) = self.last_statement {
-            writeln!(f)?;
-            writeln!(f, "Last Statement:")?;
-            write!(f, "{last}")?;
-        }
-
         Ok(())
     }
 }
@@ -286,12 +273,12 @@ mod tests {
         let mut stmt1 = StatementMetrics::new();
         stmt1.vm_steps = 100;
         stmt1.rows_read = 50;
-        conn_metrics.record_statement(stmt1);
+        conn_metrics.record_statement(&stmt1);
 
         let mut stmt2 = StatementMetrics::new();
         stmt2.vm_steps = 75;
         stmt2.rows_read = 100;
-        conn_metrics.record_statement(stmt2);
+        conn_metrics.record_statement(&stmt2);
 
         assert_eq!(conn_metrics.max_vm_steps_per_statement, 100);
         assert_eq!(conn_metrics.max_rows_read_per_statement, 100);


### PR DESCRIPTION
Pass metrics by reference to record_statement() instead of cloning 184 bytes per statement. Remove last_statement storage from ConnectionMetrics; CLI captures metrics directly from Statement.