### PR TITLE
core: Rewrite IN() lists to OR chains for index seek utilization

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -487,12 +487,56 @@ fn transform_match_to_fts_match(where_clause: &mut [WhereTerm]) {
     }
 }
 
+/// Rewrite `col IN (v1, v2, ..., vN)` to `col = v1 OR col = v2 OR ... OR col = vN`
+/// so that the existing MULTI-INDEX OR infrastructure can generate index seeks.
+/// Limited to 200 values — beyond that, the expression tree and N separate index seeks
+/// start to rival a full table scan. The optimizer's cost model decides whether
+/// MULTI-INDEX OR is actually cheaper than a scan for the given table size.
+fn transform_in_list_to_or_chain(where_clause: &mut [WhereTerm]) {
+    use super::expr::{walk_expr_mut, WalkControl};
+
+    const MAX_IN_LIST_REWRITE: usize = 200;
+
+    for term in where_clause.iter_mut() {
+        let _ = walk_expr_mut(&mut term.expr, &mut |e: &mut Expr| -> Result<WalkControl> {
+            match e {
+                Expr::InList { lhs, not, rhs }
+                    if !rhs.is_empty() && rhs.len() <= MAX_IN_LIST_REWRITE =>
+                {
+                    // Build: (lhs = v1) OR (lhs = v2) OR ... OR (lhs = vN)
+                    let mut or_chain: Option<Expr> = None;
+                    for val in rhs.drain(..) {
+                        let eq = Expr::Binary(lhs.clone(), ast::Operator::Equals, val);
+                        or_chain = Some(match or_chain {
+                            None => eq,
+                            Some(prev) => {
+                                Expr::Binary(Box::new(prev), ast::Operator::Or, Box::new(eq))
+                            }
+                        });
+                    }
+                    let or_expr = or_chain.unwrap();
+                    if *not {
+                        *e = Expr::Unary(ast::UnaryOperator::Not, Box::new(or_expr));
+                    } else {
+                        *e = or_expr;
+                    }
+                    Ok(WalkControl::Continue)
+                }
+                _ => Ok(WalkControl::Continue),
+            }
+        });
+    }
+}
+
 /**
  * Make a few passes over the plan to optimize it.
  * TODO: these could probably be done in less passes,
  * but having them separate makes them easier to understand
  */
 pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
+    // Rewrite small IN lists to OR chains before other optimizations
+    transform_in_list_to_or_chain(&mut plan.where_clause);
+
     // Transform MATCH expressions to fts_match() for FTS optimizer recognition
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
     transform_match_to_fts_match(&mut plan.where_clause);

--- a/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__in-clause-multiple-values.snap
+++ b/testing/runner/tests/snapshot_tests/indexes/snapshots/indexes__in-clause-multiple-values.snap
@@ -13,4 +13,4 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SCAN events
+`--MULTI-INDEX OR events (idx_events_type, idx_events_type, idx_events_type)

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
@@ -44,102 +44,103 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                                     p5  comment
-   0          Init             0  93   0                                          0  Start at 93
+   0          Init             0  94   0                                          0  Start at 94
    1          Null             0   9  10                                          0  r[9..10]=NULL
    2          SorterOpen       0   3   0  k(1,B)                                  0  cursor=0
    3          Integer          0   6   0                                          0  r[6]=0; clear group by abort flag
    4          Null             0   7   0                                          0  r[7]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           15  89   0                                          0  ; go to clear accumulator subroutine
+   5          Gosub           15  90   0                                          0  ; go to clear accumulator subroutine
    6          OpenRead         2   9   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=orders, root=9, iDb=0
    7          OpenRead         3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   8          Rewind           3  58   0                                          0  Rewind table lineitem
-   9            Column         3  14  16                                          0  r[16]=lineitem.l_shipmode
-  10            Eq            16  17  12  Binary                                  0  if r[16]==r[17] goto 12
-  11            Ne            16  18  57  Binary                                  0  if r[16]!=r[18] goto 57
-  12            Column         3  11  20                                          0  r[20]=lineitem.l_commitdate
-  13            Column         3  12  21                                          0  r[21]=lineitem.l_receiptdate
-  14            Ge            20  21  57  Binary                                  0  if r[20]>=r[21] goto 57
-  15            Column         3  10  23                                          0  r[23]=lineitem.l_shipdate
-  16            Column         3  11  24                                          0  r[24]=lineitem.l_commitdate
-  17            Ge            23  24  57  Binary                                  0  if r[23]>=r[24] goto 57
-  18            Column         3  12  26                                          0  r[26]=lineitem.l_receiptdate
-  19            Lt            26  27  57  Binary                                  0  if r[26]<r[27] goto 57
-  20            Column         3  12  29                                          0  r[29]=lineitem.l_receiptdate
-  21            Ge            29  30  57  Binary                                  0  if r[29]>=r[30] goto 57
-  22            Column         3   0  31                                          0  r[31]=lineitem.l_orderkey
-  23            SeekRowid      2  31  57                                          0  if (r[31]!=cursor 2 for table orders.rowid) goto 57
-  24            Column         3  14  12                                          0  r[12]=lineitem.l_shipmode
-  25            Column         2   5  35                                          0  r[35]=orders.o_orderpriority
-  26            String8        0  36   0  1-URGENT                                0  r[36]='1-URGENT'
-  27            Integer        1  33   0                                          0  r[33]=1
-  28            Eq            35  36  30  Binary                                  0  if r[35]==r[36] goto 30
-  29            ZeroOrNull    35  33  36                                          0  ((r[35]=NULL)|(r[36]=NULL)) ? r[33]=NULL : r[33]=0
-  30            Column         2   5  37                                          0  r[37]=orders.o_orderpriority
-  31            String8        0  38   0  2-HIGH                                  0  r[38]='2-HIGH'
-  32            Integer        1  34   0                                          0  r[34]=1
-  33            Eq            37  38  35  Binary                                  0  if r[37]==r[38] goto 35
-  34            ZeroOrNull    37  34  38                                          0  ((r[37]=NULL)|(r[38]=NULL)) ? r[34]=NULL : r[34]=0
-  35            Or            34  33  32                                          0  r[32]=(r[33] || r[34])
-  36            IfNot         32  39   1                                          0  if !r[32] goto 39
-  37            Integer        1  13   0                                          0  r[13]=1
-  38            Goto           0  40   0                                          0
-  39            Integer        0  13   0                                          0  r[13]=0
-  40            Column         2   5  42                                          0  r[42]=orders.o_orderpriority
-  41            String8        0  43   0  1-URGENT                                0  r[43]='1-URGENT'
-  42            Integer        1  40   0                                          0  r[40]=1
-  43            Ne            42  43  45  Binary                                  0  if r[42]!=r[43] goto 45
-  44            ZeroOrNull    42  40  43                                          0  ((r[42]=NULL)|(r[43]=NULL)) ? r[40]=NULL : r[40]=0
-  45            Column         2   5  44                                          0  r[44]=orders.o_orderpriority
-  46            String8        0  45   0  2-HIGH                                  0  r[45]='2-HIGH'
-  47            Integer        1  41   0                                          0  r[41]=1
-  48            Ne            44  45  50  Binary                                  0  if r[44]!=r[45] goto 50
-  49            ZeroOrNull    44  41  45                                          0  ((r[44]=NULL)|(r[45]=NULL)) ? r[41]=NULL : r[41]=0
-  50            And           41  40  39                                          0  r[39]=(r[40] && r[41])
-  51            IfNot         39  54   1                                          0  if !r[39] goto 54
-  52            Integer        1  14   0                                          0  r[14]=1
-  53            Goto           0  55   0                                          0
-  54            Integer        0  14   0                                          0  r[14]=0
-  55            MakeRecord    12   3  11                                          0  r[11]=mkrec(r[12..14])
-  56            SorterInsert   0  11   0  0                                       0  key=r[11]
-  57          Next             3   9   0                                          0
-  58          OpenPseudo       1  11   3                                          0  3 columns in r[11]
-  59          SorterSort       0  76   0                                          0
-  60            SorterData     0  11   1                                          0  r[11]=data
-  61            Column         1   0  46                                          0  r[46]=pseudo.column 0
-  62            Compare        7  46   1  k(1, Binary)                            0  r[7..7]==r[46..46]
-  63            Jump          64  68  64                                          0  ; start new group if comparison is not equal
-  64            Gosub          4  80   0                                          0  ; check if ended group had data, and output if so
-  65            Move          46   7   1                                          0  r[7..7]=r[46..46]
-  66            IfPos          6  92   0                                          0  r[6]>0 -> r[6]-=0, goto 92; check abort flag
-  67            Gosub         15  89   0                                          0  ; goto clear accumulator subroutine
-  68            Column         1   1  47                                          0  r[47]=pseudo.column 1
-  69            AggStep        0  47   9  sum                                     0  accum=r[9] step(r[47])
-  70            Column         1   2  48                                          0  r[48]=pseudo.column 2
-  71            AggStep        0  48  10  sum                                     0  accum=r[10] step(r[48])
-  72            If             5  74   0                                          0  if r[5] goto 74; don't emit group columns if continuing existing group
-  73            Column         1   0   8                                          0  r[8]=pseudo.column 0
-  74            Integer        1   5   0                                          0  r[5]=1; indicate data in accumulator
-  75          SorterNext       0  60   0                                          0
-  76          Gosub            4  80   0                                          0  ; emit row for final group
-  77          Goto             0  92   0                                          0  ; group by finished
-  78          Integer          1   6   0                                          0  r[6]=1
-  79        Return             4   0   0                                          0
-  80        IfPos              5  82   0                                          0  r[5]>0 -> r[5]-=0, goto 82; output group by row subroutine start
-  81      Return               4   0   0                                          0
-  82      AggFinal             0   9   0  sum                                     0  accum=r[9]
-  83      AggFinal             0  10   0  sum                                     0  accum=r[10]
-  84      Copy                 8   1   0                                          0  r[1]=r[8]
-  85      Copy                 9   2   0                                          0  r[2]=r[9]
-  86      Copy                10   3   0                                          0  r[3]=r[10]
-  87      ResultRow            1   3   0                                          0  output=r[1..3]
-  88    Return                 4   0   0                                          0
-  89    Null                   0   8  10                                          0  r[8..10]=NULL; clear accumulator subroutine start
-  90    Integer                0   5   0                                          0  r[5]=0
-  91  Return                  15   0   0                                          0
-  92  Halt                     0   0   0                                          0
-  93  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
-  94  String8                  0  17   0  FOB                                     0  r[17]='FOB'
-  95  String8                  0  18   0  SHIP                                    0  r[18]='SHIP'
-  96  String8                  0  27   0  1994-01-01                              0  r[27]='1994-01-01'
-  97  String8                  0  30   0  1995-01-01                              0  r[30]='1995-01-01'
-  98  Goto                     0   1   0                                          0
+   8          Rewind           3  59   0                                          0  Rewind table lineitem
+   9            Column         3  14  17                                          0  r[17]=lineitem.l_shipmode
+  10            Eq            17  18  13  Binary                                  0  if r[17]==r[18] goto 13
+  11            Column         3  14  20                                          0  r[20]=lineitem.l_shipmode
+  12            Ne            20  21  58  Binary                                  0  if r[20]!=r[21] goto 58
+  13            Column         3  11  23                                          0  r[23]=lineitem.l_commitdate
+  14            Column         3  12  24                                          0  r[24]=lineitem.l_receiptdate
+  15            Ge            23  24  58  Binary                                  0  if r[23]>=r[24] goto 58
+  16            Column         3  10  26                                          0  r[26]=lineitem.l_shipdate
+  17            Column         3  11  27                                          0  r[27]=lineitem.l_commitdate
+  18            Ge            26  27  58  Binary                                  0  if r[26]>=r[27] goto 58
+  19            Column         3  12  29                                          0  r[29]=lineitem.l_receiptdate
+  20            Lt            29  30  58  Binary                                  0  if r[29]<r[30] goto 58
+  21            Column         3  12  32                                          0  r[32]=lineitem.l_receiptdate
+  22            Ge            32  33  58  Binary                                  0  if r[32]>=r[33] goto 58
+  23            Column         3   0  34                                          0  r[34]=lineitem.l_orderkey
+  24            SeekRowid      2  34  58                                          0  if (r[34]!=cursor 2 for table orders.rowid) goto 58
+  25            Column         3  14  12                                          0  r[12]=lineitem.l_shipmode
+  26            Column         2   5  38                                          0  r[38]=orders.o_orderpriority
+  27            String8        0  39   0  1-URGENT                                0  r[39]='1-URGENT'
+  28            Integer        1  36   0                                          0  r[36]=1
+  29            Eq            38  39  31  Binary                                  0  if r[38]==r[39] goto 31
+  30            ZeroOrNull    38  36  39                                          0  ((r[38]=NULL)|(r[39]=NULL)) ? r[36]=NULL : r[36]=0
+  31            Column         2   5  40                                          0  r[40]=orders.o_orderpriority
+  32            String8        0  41   0  2-HIGH                                  0  r[41]='2-HIGH'
+  33            Integer        1  37   0                                          0  r[37]=1
+  34            Eq            40  41  36  Binary                                  0  if r[40]==r[41] goto 36
+  35            ZeroOrNull    40  37  41                                          0  ((r[40]=NULL)|(r[41]=NULL)) ? r[37]=NULL : r[37]=0
+  36            Or            37  36  35                                          0  r[35]=(r[36] || r[37])
+  37            IfNot         35  40   1                                          0  if !r[35] goto 40
+  38            Integer        1  13   0                                          0  r[13]=1
+  39            Goto           0  41   0                                          0
+  40            Integer        0  13   0                                          0  r[13]=0
+  41            Column         2   5  45                                          0  r[45]=orders.o_orderpriority
+  42            String8        0  46   0  1-URGENT                                0  r[46]='1-URGENT'
+  43            Integer        1  43   0                                          0  r[43]=1
+  44            Ne            45  46  46  Binary                                  0  if r[45]!=r[46] goto 46
+  45            ZeroOrNull    45  43  46                                          0  ((r[45]=NULL)|(r[46]=NULL)) ? r[43]=NULL : r[43]=0
+  46            Column         2   5  47                                          0  r[47]=orders.o_orderpriority
+  47            String8        0  48   0  2-HIGH                                  0  r[48]='2-HIGH'
+  48            Integer        1  44   0                                          0  r[44]=1
+  49            Ne            47  48  51  Binary                                  0  if r[47]!=r[48] goto 51
+  50            ZeroOrNull    47  44  48                                          0  ((r[47]=NULL)|(r[48]=NULL)) ? r[44]=NULL : r[44]=0
+  51            And           44  43  42                                          0  r[42]=(r[43] && r[44])
+  52            IfNot         42  55   1                                          0  if !r[42] goto 55
+  53            Integer        1  14   0                                          0  r[14]=1
+  54            Goto           0  56   0                                          0
+  55            Integer        0  14   0                                          0  r[14]=0
+  56            MakeRecord    12   3  11                                          0  r[11]=mkrec(r[12..14])
+  57            SorterInsert   0  11   0  0                                       0  key=r[11]
+  58          Next             3   9   0                                          0
+  59          OpenPseudo       1  11   3                                          0  3 columns in r[11]
+  60          SorterSort       0  77   0                                          0
+  61            SorterData     0  11   1                                          0  r[11]=data
+  62            Column         1   0  49                                          0  r[49]=pseudo.column 0
+  63            Compare        7  49   1  k(1, Binary)                            0  r[7..7]==r[49..49]
+  64            Jump          65  69  65                                          0  ; start new group if comparison is not equal
+  65            Gosub          4  81   0                                          0  ; check if ended group had data, and output if so
+  66            Move          49   7   1                                          0  r[7..7]=r[49..49]
+  67            IfPos          6  93   0                                          0  r[6]>0 -> r[6]-=0, goto 93; check abort flag
+  68            Gosub         15  90   0                                          0  ; goto clear accumulator subroutine
+  69            Column         1   1  50                                          0  r[50]=pseudo.column 1
+  70            AggStep        0  50   9  sum                                     0  accum=r[9] step(r[50])
+  71            Column         1   2  51                                          0  r[51]=pseudo.column 2
+  72            AggStep        0  51  10  sum                                     0  accum=r[10] step(r[51])
+  73            If             5  75   0                                          0  if r[5] goto 75; don't emit group columns if continuing existing group
+  74            Column         1   0   8                                          0  r[8]=pseudo.column 0
+  75            Integer        1   5   0                                          0  r[5]=1; indicate data in accumulator
+  76          SorterNext       0  61   0                                          0
+  77          Gosub            4  81   0                                          0  ; emit row for final group
+  78          Goto             0  93   0                                          0  ; group by finished
+  79          Integer          1   6   0                                          0  r[6]=1
+  80        Return             4   0   0                                          0
+  81        IfPos              5  83   0                                          0  r[5]>0 -> r[5]-=0, goto 83; output group by row subroutine start
+  82      Return               4   0   0                                          0
+  83      AggFinal             0   9   0  sum                                     0  accum=r[9]
+  84      AggFinal             0  10   0  sum                                     0  accum=r[10]
+  85      Copy                 8   1   0                                          0  r[1]=r[8]
+  86      Copy                 9   2   0                                          0  r[2]=r[9]
+  87      Copy                10   3   0                                          0  r[3]=r[10]
+  88      ResultRow            1   3   0                                          0  output=r[1..3]
+  89    Return                 4   0   0                                          0
+  90    Null                   0   8  10                                          0  r[8..10]=NULL; clear accumulator subroutine start
+  91    Integer                0   5   0                                          0  r[5]=0
+  92  Return                  15   0   0                                          0
+  93  Halt                     0   0   0                                          0
+  94  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
+  95  String8                  0  18   0  FOB                                     0  r[18]='FOB'
+  96  String8                  0  21   0  SHIP                                    0  r[21]='SHIP'
+  97  String8                  0  30   0  1994-01-01                              0  r[30]='1994-01-01'
+  98  String8                  0  33   0  1995-01-01                              0  r[33]='1995-01-01'
+  99  Goto                     0   1   0                                          0

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q16-parts-supplier.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q16-parts-supplier.snap
@@ -43,8 +43,8 @@ info:
 QUERY PLAN
 |--LIST SUBQUERY 1
 |  `--SCAN supplier
-|--SCAN part
-|--SEARCH partsupp USING INDEX sqlite_autoindex_partsupp_1 (ps_partkey=?)
+|--SCAN partsupp USING COVERING INDEX sqlite_autoindex_partsupp_1
+|--SEARCH part USING INTEGER PRIMARY KEY (rowid=?)
 |--USE SORTER FOR GROUP BY
 |--USE HASH TABLE FOR count(DISTINCT)
 `--USE SORTER FOR ORDER BY

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
@@ -50,102 +50,112 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4                                     p5  comment
-   0  Init          0  63   0                                          0  Start at 63
+   0  Init          0  73   0                                          0  Start at 73
    1  Null          0   2   0                                          0  r[2]=NULL
    2  OpenRead      0  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
    3  OpenRead      1   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
-   4  Rewind        0  59   0                                          0  Rewind table lineitem
-   5    Column      0  14   3                                          0  r[3]=lineitem.l_shipmode
-   6    Eq          3   4   8  Binary                                  0  if r[3]==r[4] goto 8
-   7    Ne          3   5  58  Binary                                  0  if r[3]!=r[5] goto 58
-   8    Column      0  13   7                                          0  r[7]=lineitem.l_shipinstruct
-   9    Ne          7   8  58  Binary                                  0  if r[7]!=r[8] goto 58
-  10    Column      0   1   9                                          0  r[9]=lineitem.l_partkey
-  11    SeekRowid   1   9  58                                          0  if (r[9]!=cursor 1 for table part.rowid) goto 58
-  12    Column      1   3  11                                          0  r[11]=part.p_brand
-  13    Ne         11  12  25  Binary                                  0  if r[11]!=r[12] goto 25
-  14    Column      1   6  13                                          0  r[13]=part.p_container
-  15    Eq         13  14  19  Binary                                  0  if r[13]==r[14] goto 19
-  16    Eq         13  15  19  Binary                                  0  if r[13]==r[15] goto 19
-  17    Eq         13  16  19  Binary                                  0  if r[13]==r[16] goto 19
-  18    Ne         13  17  25  Binary                                  0  if r[13]!=r[17] goto 25
-  19    Column      0   4  19                                          0  r[19]=lineitem.l_quantity
-  20    Lt         19  20  25  Binary                                  0  if r[19]<r[20] goto 25
-  21    Column      0   4  22                                          0  r[22]=lineitem.l_quantity
-  22    Gt         22  23  25  Binary                                  0  if r[22]>r[23] goto 25
-  23    Column      1   5  27                                          0  r[27]=part.p_size
-  24    Le         27  28  51  Binary                                  0  if r[27]<=r[28] goto 51
-  25    Column      1   3  30                                          0  r[30]=part.p_brand
-  26    Ne         30  31  38  Binary                                  0  if r[30]!=r[31] goto 38
-  27    Column      1   6  32                                          0  r[32]=part.p_container
-  28    Eq         32  33  32  Binary                                  0  if r[32]==r[33] goto 32
-  29    Eq         32  34  32  Binary                                  0  if r[32]==r[34] goto 32
-  30    Eq         32  35  32  Binary                                  0  if r[32]==r[35] goto 32
-  31    Ne         32  36  38  Binary                                  0  if r[32]!=r[36] goto 38
-  32    Column      0   4  38                                          0  r[38]=lineitem.l_quantity
-  33    Lt         38  39  38  Binary                                  0  if r[38]<r[39] goto 38
-  34    Column      0   4  41                                          0  r[41]=lineitem.l_quantity
-  35    Gt         41  42  38  Binary                                  0  if r[41]>r[42] goto 38
-  36    Column      1   5  45                                          0  r[45]=part.p_size
-  37    Le         45  46  51  Binary                                  0  if r[45]<=r[46] goto 51
-  38    Column      1   3  48                                          0  r[48]=part.p_brand
-  39    Ne         48  49  58  Binary                                  0  if r[48]!=r[49] goto 58
-  40    Column      1   6  50                                          0  r[50]=part.p_container
-  41    Eq         50  51  45  Binary                                  0  if r[50]==r[51] goto 45
-  42    Eq         50  52  45  Binary                                  0  if r[50]==r[52] goto 45
-  43    Eq         50  53  45  Binary                                  0  if r[50]==r[53] goto 45
-  44    Ne         50  54  58  Binary                                  0  if r[50]!=r[54] goto 58
-  45    Column      0   4  56                                          0  r[56]=lineitem.l_quantity
-  46    Lt         56  57  58  Binary                                  0  if r[56]<r[57] goto 58
-  47    Column      0   4  59                                          0  r[59]=lineitem.l_quantity
-  48    Gt         59  60  58  Binary                                  0  if r[59]>r[60] goto 58
-  49    Column      1   5  64                                          0  r[64]=part.p_size
-  50    Gt         64  65  58  Binary                                  0  if r[64]>r[65] goto 58
-  51    Column      1   5  68                                          0  r[68]=part.p_size
-  52    Gt         67  68  58  Binary                                  0  if r[67]>r[68] goto 58
-  53    Column      0   5  70                                          0  r[70]=lineitem.l_extendedprice
-  54    Column      0   6  73                                          0  r[73]=lineitem.l_discount
-  55    Subtract   72  73  71                                          0  r[71]=r[72]-r[73]
-  56    Multiply   70  71  69                                          0  r[69]=r[70]*r[71]
-  57    AggStep     0  69   2  sum                                     0  accum=r[2] step(r[69])
-  58  Next          0   5   0                                          0
-  59  AggFinal      0   2   0  sum                                     0  accum=r[2]
-  60  Copy          2   1   0                                          0  r[1]=r[2]
-  61  ResultRow     1   1   0                                          0  output=r[1]
-  62  Halt          0   0   0                                          0
-  63  Transaction   0   1   8                                          0  iDb=0 tx_mode=Read
-  64  String8       0   4   0  AIR                                     0  r[4]='AIR'
-  65  String8       0   5   0  AIR REG                                 0  r[5]='AIR REG'
-  66  String8       0   8   0  DELIVER IN PERSON                       0  r[8]='DELIVER IN PERSON'
-  67  String8       0  12   0  Brand#22                                0  r[12]='Brand#22'
-  68  String8       0  14   0  SM CASE                                 0  r[14]='SM CASE'
-  69  String8       0  15   0  SM BOX                                  0  r[15]='SM BOX'
-  70  String8       0  16   0  SM PACK                                 0  r[16]='SM PACK'
-  71  String8       0  17   0  SM PKG                                  0  r[17]='SM PKG'
-  72  Integer       8  20   0                                          0  r[20]=8
-  73  Integer       8  24   0                                          0  r[24]=8
-  74  Integer      10  25   0                                          0  r[25]=10
-  75  Add          24  25  23                                          0  r[23]=r[24]+r[25]
-  76  Integer       5  28   0                                          0  r[28]=5
-  77  String8       0  31   0  Brand#23                                0  r[31]='Brand#23'
-  78  String8       0  33   0  MED BAG                                 0  r[33]='MED BAG'
-  79  String8       0  34   0  MED BOX                                 0  r[34]='MED BOX'
-  80  String8       0  35   0  MED PKG                                 0  r[35]='MED PKG'
-  81  String8       0  36   0  MED PACK                                0  r[36]='MED PACK'
-  82  Integer      10  39   0                                          0  r[39]=10
-  83  Integer      10  43   0                                          0  r[43]=10
-  84  Add          43  43  42                                          0  r[42]=r[43]+r[43]
-  85  Integer      10  46   0                                          0  r[46]=10
-  86  String8       0  49   0  Brand#12                                0  r[49]='Brand#12'
-  87  String8       0  51   0  LG CASE                                 0  r[51]='LG CASE'
-  88  String8       0  52   0  LG BOX                                  0  r[52]='LG BOX'
-  89  String8       0  53   0  LG PACK                                 0  r[53]='LG PACK'
-  90  String8       0  54   0  LG PKG                                  0  r[54]='LG PKG'
-  91  Integer      24  57   0                                          0  r[57]=24
-  92  Integer      24  61   0                                          0  r[61]=24
-  93  Integer      10  62   0                                          0  r[62]=10
-  94  Add          61  62  60                                          0  r[60]=r[61]+r[62]
-  95  Integer      15  65   0                                          0  r[65]=15
-  96  Integer       1  67   0                                          0  r[67]=1
-  97  Integer       1  72   0                                          0  r[72]=1
-  98  Goto          0   1   0                                          0
+   4  Rewind        0  69   0                                          0  Rewind table lineitem
+   5    Column      0  14   4                                          0  r[4]=lineitem.l_shipmode
+   6    Eq          4   5   9  Binary                                  0  if r[4]==r[5] goto 9
+   7    Column      0  14   7                                          0  r[7]=lineitem.l_shipmode
+   8    Ne          7   8  68  Binary                                  0  if r[7]!=r[8] goto 68
+   9    Column      0  13  10                                          0  r[10]=lineitem.l_shipinstruct
+  10    Ne         10  11  68  Binary                                  0  if r[10]!=r[11] goto 68
+  11    Column      0   1  12                                          0  r[12]=lineitem.l_partkey
+  12    SeekRowid   1  12  68                                          0  if (r[12]!=cursor 1 for table part.rowid) goto 68
+  13    Column      1   3  14                                          0  r[14]=part.p_brand
+  14    Ne         14  15  29  Binary                                  0  if r[14]!=r[15] goto 29
+  15    Column      1   6  17                                          0  r[17]=part.p_container
+  16    Eq         17  18  23  Binary                                  0  if r[17]==r[18] goto 23
+  17    Column      1   6  20                                          0  r[20]=part.p_container
+  18    Eq         20  21  23  Binary                                  0  if r[20]==r[21] goto 23
+  19    Column      1   6  23                                          0  r[23]=part.p_container
+  20    Eq         23  24  23  Binary                                  0  if r[23]==r[24] goto 23
+  21    Column      1   6  26                                          0  r[26]=part.p_container
+  22    Ne         26  27  29  Binary                                  0  if r[26]!=r[27] goto 29
+  23    Column      0   4  29                                          0  r[29]=lineitem.l_quantity
+  24    Lt         29  30  29  Binary                                  0  if r[29]<r[30] goto 29
+  25    Column      0   4  32                                          0  r[32]=lineitem.l_quantity
+  26    Gt         32  33  29  Binary                                  0  if r[32]>r[33] goto 29
+  27    Column      1   5  37                                          0  r[37]=part.p_size
+  28    Le         37  38  61  Binary                                  0  if r[37]<=r[38] goto 61
+  29    Column      1   3  40                                          0  r[40]=part.p_brand
+  30    Ne         40  41  45  Binary                                  0  if r[40]!=r[41] goto 45
+  31    Column      1   6  43                                          0  r[43]=part.p_container
+  32    Eq         43  44  39  Binary                                  0  if r[43]==r[44] goto 39
+  33    Column      1   6  46                                          0  r[46]=part.p_container
+  34    Eq         46  47  39  Binary                                  0  if r[46]==r[47] goto 39
+  35    Column      1   6  49                                          0  r[49]=part.p_container
+  36    Eq         49  50  39  Binary                                  0  if r[49]==r[50] goto 39
+  37    Column      1   6  52                                          0  r[52]=part.p_container
+  38    Ne         52  53  45  Binary                                  0  if r[52]!=r[53] goto 45
+  39    Column      0   4  55                                          0  r[55]=lineitem.l_quantity
+  40    Lt         55  56  45  Binary                                  0  if r[55]<r[56] goto 45
+  41    Column      0   4  58                                          0  r[58]=lineitem.l_quantity
+  42    Gt         58  59  45  Binary                                  0  if r[58]>r[59] goto 45
+  43    Column      1   5  62                                          0  r[62]=part.p_size
+  44    Le         62  63  61  Binary                                  0  if r[62]<=r[63] goto 61
+  45    Column      1   3  65                                          0  r[65]=part.p_brand
+  46    Ne         65  66  68  Binary                                  0  if r[65]!=r[66] goto 68
+  47    Column      1   6  68                                          0  r[68]=part.p_container
+  48    Eq         68  69  55  Binary                                  0  if r[68]==r[69] goto 55
+  49    Column      1   6  71                                          0  r[71]=part.p_container
+  50    Eq         71  72  55  Binary                                  0  if r[71]==r[72] goto 55
+  51    Column      1   6  74                                          0  r[74]=part.p_container
+  52    Eq         74  75  55  Binary                                  0  if r[74]==r[75] goto 55
+  53    Column      1   6  77                                          0  r[77]=part.p_container
+  54    Ne         77  78  68  Binary                                  0  if r[77]!=r[78] goto 68
+  55    Column      0   4  80                                          0  r[80]=lineitem.l_quantity
+  56    Lt         80  81  68  Binary                                  0  if r[80]<r[81] goto 68
+  57    Column      0   4  83                                          0  r[83]=lineitem.l_quantity
+  58    Gt         83  84  68  Binary                                  0  if r[83]>r[84] goto 68
+  59    Column      1   5  88                                          0  r[88]=part.p_size
+  60    Gt         88  89  68  Binary                                  0  if r[88]>r[89] goto 68
+  61    Column      1   5  92                                          0  r[92]=part.p_size
+  62    Gt         91  92  68  Binary                                  0  if r[91]>r[92] goto 68
+  63    Column      0   5  94                                          0  r[94]=lineitem.l_extendedprice
+  64    Column      0   6  97                                          0  r[97]=lineitem.l_discount
+  65    Subtract   96  97  95                                          0  r[95]=r[96]-r[97]
+  66    Multiply   94  95  93                                          0  r[93]=r[94]*r[95]
+  67    AggStep     0  93   2  sum                                     0  accum=r[2] step(r[93])
+  68  Next          0   5   0                                          0
+  69  AggFinal      0   2   0  sum                                     0  accum=r[2]
+  70  Copy          2   1   0                                          0  r[1]=r[2]
+  71  ResultRow     1   1   0                                          0  output=r[1]
+  72  Halt          0   0   0                                          0
+  73  Transaction   0   1   8                                          0  iDb=0 tx_mode=Read
+  74  String8       0   5   0  AIR                                     0  r[5]='AIR'
+  75  String8       0   8   0  AIR REG                                 0  r[8]='AIR REG'
+  76  String8       0  11   0  DELIVER IN PERSON                       0  r[11]='DELIVER IN PERSON'
+  77  String8       0  15   0  Brand#22                                0  r[15]='Brand#22'
+  78  String8       0  18   0  SM CASE                                 0  r[18]='SM CASE'
+  79  String8       0  21   0  SM BOX                                  0  r[21]='SM BOX'
+  80  String8       0  24   0  SM PACK                                 0  r[24]='SM PACK'
+  81  String8       0  27   0  SM PKG                                  0  r[27]='SM PKG'
+  82  Integer       8  30   0                                          0  r[30]=8
+  83  Integer       8  34   0                                          0  r[34]=8
+  84  Integer      10  35   0                                          0  r[35]=10
+  85  Add          34  35  33                                          0  r[33]=r[34]+r[35]
+  86  Integer       5  38   0                                          0  r[38]=5
+  87  String8       0  41   0  Brand#23                                0  r[41]='Brand#23'
+  88  String8       0  44   0  MED BAG                                 0  r[44]='MED BAG'
+  89  String8       0  47   0  MED BOX                                 0  r[47]='MED BOX'
+  90  String8       0  50   0  MED PKG                                 0  r[50]='MED PKG'
+  91  String8       0  53   0  MED PACK                                0  r[53]='MED PACK'
+  92  Integer      10  56   0                                          0  r[56]=10
+  93  Integer      10  60   0                                          0  r[60]=10
+  94  Add          60  60  59                                          0  r[59]=r[60]+r[60]
+  95  Integer      10  63   0                                          0  r[63]=10
+  96  String8       0  66   0  Brand#12                                0  r[66]='Brand#12'
+  97  String8       0  69   0  LG CASE                                 0  r[69]='LG CASE'
+  98  String8       0  72   0  LG BOX                                  0  r[72]='LG BOX'
+  99  String8       0  75   0  LG PACK                                 0  r[75]='LG PACK'
+ 100  String8       0  78   0  LG PKG                                  0  r[78]='LG PKG'
+ 101  Integer      24  81   0                                          0  r[81]=24
+ 102  Integer      24  85   0                                          0  r[85]=24
+ 103  Integer      10  86   0                                          0  r[86]=10
+ 104  Add          85  86  84                                          0  r[84]=r[85]+r[86]
+ 105  Integer      15  89   0                                          0  r[89]=15
+ 106  Integer       1  91   0                                          0  r[91]=1
+ 107  Integer       1  96   0                                          0  r[96]=1
+ 108  Goto          0   1   0                                          0

--- a/testing/runner/tests/snapshots/graph_traversal_text_pk__cte-neighbor-traversal-text-pk.snap
+++ b/testing/runner/tests/snapshots/graph_traversal_text_pk__cte-neighbor-traversal-text-pk.snap
@@ -27,6 +27,6 @@ info:
 ---
 QUERY PLAN
 |--SCAN seed_articles AS s
-|  `--SCAN article AS a USING COVERING INDEX sqlite_autoindex_article_1
+|  `--MULTI-INDEX OR a (sqlite_autoindex_article_1, sqlite_autoindex_article_1, sqlite_autoindex_article_1)
 |--MULTI-INDEX OR l (idx_link_source, idx_link_target)
 `--MULTI-INDEX OR a (sqlite_autoindex_article_1, sqlite_autoindex_article_1)


### PR DESCRIPTION
## Description

`WHERE col IN (v1, v2, ..., vN)` always performed a full table scan because IN constraints were marked as unusable for index seeks in the optimizer (`usable: false` in `constraints.rs`).

This patch rewrites small IN lists (up to 200 values) into equivalent OR chains (`col = v1 OR col = v2 OR ... OR col = vN`) before optimization, so the existing MULTI-INDEX OR infrastructure can generate index seeks instead of scanning the entire table.

Benchmark on 100K rows (Criterion, release):

| Query | Before | After | SQLite | Improvement |
|-------|--------|-------|--------|-------------|
| IN(2) | 13.2 ms | 13.7 µs | 7.2 µs | **960x** |
| IN(10) | 28.1 ms | 39.7 µs | 12.0 µs | **707x** |
| IN(50) | 88.3 ms | 167.1 µs | 29.7 µs | **528x** |

## Known limitations

This is a pragmatic quick-fix, not the ideal long-term solution:

- **LHS cloning**: the left-hand side expression is cloned once per IN value. Cheap for column references, potentially costly for complex expressions.
- **Arbitrary limit (200)**: the cutoff doesn't consider table size — IN(50) on a 100-row table may be worse than a scan.
- **NOT IN**: rewritten to `NOT (v1 = col OR v2 = col OR ...)`, which won't produce efficient anti-join plans.
- **AST blowup**: a large IN list creates a deep binary expression tree.

A proper follow-up would mark IN constraints as `usable: true` in the optimizer and add a dedicated codegen path (ephemeral table + seek loop, similar to SQLite's approach) — avoiding the AST rewrite entirely. I (Opus) plan to explore this as a follow-up.

## Motivation and context

`WHERE id IN (1, 2)` on a 100K row table took 25ms (vs 37µs in SQLite) — a 678x regression that made batch lookups (common N+1 pattern) unusable.

## Description of AI Usage

Performance regression was discovered while testing Turso as a bun:sqlite replacement — page render times were ~9x slower. Claude (Opus) benchmarked individual query types, identified root causes by analyzing the source code and comparing `EXPLAIN` output with SQLite, implemented the fix, and confirmed the improvement via benchmarks.