### PR TITLE
Reject unreferenced CTE qualified columns without panic

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5104,6 +5104,25 @@ pub fn bind_and_rewrite_expr<'a>(
                     let matching_tbl = referenced_tables
                         .find_table_and_internal_id_by_identifier(&normalized_table_name);
                     if matching_tbl.is_none() {
+                        // CTEs preplanned for subquery FROM visibility are kept as
+                        // definition-only outer refs. They are not valid column sources
+                        // unless explicitly referenced in this scope's FROM clause.
+                        // Restrict this branch to actual CTE definition refs so other
+                        // definition-only uses (if added later) still report "no such table".
+                        if referenced_tables
+                            .find_outer_query_ref_by_identifier(&normalized_table_name)
+                            .is_some_and(|outer_ref| {
+                                outer_ref.cte_definition_only
+                                    && (outer_ref.cte_id.is_some()
+                                        || outer_ref.cte_select.is_some())
+                            })
+                        {
+                            crate::bail_parse_error!(
+                                "no such column: {}.{}",
+                                tbl.as_str(),
+                                id.as_str()
+                            );
+                        }
                         crate::bail_parse_error!("no such table: {}", normalized_table_name);
                     }
                     let (tbl_id, tbl) = matching_tbl.unwrap();

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1273,7 +1273,10 @@ pub fn parse_from(
                     cte_select: Some(cte_def.select.clone()),
                     cte_explicit_columns: cte_def.explicit_columns.clone(),
                     cte_id: Some(cte_def.cte_id),
-                    cte_definition_only: false,
+                    // Preplanned CTE refs are for subquery FROM lookup only. They are not
+                    // visible as column sources unless the CTE is explicitly referenced in
+                    // this scope's FROM/JOIN clause.
+                    cte_definition_only: true,
                     rowid_referenced: false,
                 });
             }

--- a/testing/runner/tests/cte.sqltest
+++ b/testing/runner/tests/cte.sqltest
@@ -350,7 +350,7 @@ expect {
 # =============================================================================
 
 # Direct CTE column reference in SET clause is invalid SQL (issue #5224).
-# SQLite rejects with "no such column: c.v", we reject with "no such table: c".
+# SQLite rejects with "no such column: c.v", we match with "no such column: c.v".
 @cross-check-integrity
 test cte-update-direct-ref-keyed {
     CREATE TABLE t(a INTEGER PRIMARY KEY, b);
@@ -1021,6 +1021,17 @@ test cte-duplicate-name {
 }
 expect error {
     duplicate WITH table name
+}
+
+@cross-check-integrity
+test cte-unreferenced-qualified-column-orderby-exists {
+    CREATE TABLE t(a);
+    WITH cte AS (SELECT 1 y)
+    SELECT cte.y FROM t
+    ORDER BY EXISTS (SELECT 1);
+}
+expect error {
+    no such column: cte\.y
 }
 
 @cross-check-integrity


### PR DESCRIPTION
## Description

Prevent invalid `cte.col` references from binding through preplanned CTE outer refs when the CTE is not present in the current FROM/JOIN scope.

  - mark preplanned WITH CTE outer refs as `cte_definition_only`
  - in `Expr::Qualified` binding, return `no such column: tbl.col` only for actual
    definition-only CTE refs, otherwise keep `no such table` behavior

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

The issue #5766 allowed an invalid SQL reference (cte.y without cte in FROM/JOIN) to pass binding and fail later in codegen with a panic.

The failing pattern was:

 ```sql
  CREATE TABLE t(a);
  WITH cte AS (SELECT 1 y)
  SELECT cte.y FROM t
  ORDER BY EXISTS (SELECT 1);
```

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


Closes #5766
## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
