### PR TITLE
enable triggers in differential fuzzer

### DIFF
--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -55,8 +55,6 @@ impl SqlGenBackend {
         let ctx = sql_gen::Context::new_with_seed(seed);
         let mut policy = Policy::default()
             .with_stmt_weights(sql_gen::StmtWeights {
-                create_trigger: 0,
-                drop_trigger: 0,
                 ..sql_gen::StmtWeights::default()
             })
             .with_function_config(


### PR DESCRIPTION
## Description
Just lets them be generated with their default weight. 
