### PR TITLE
fix: block cross-database view definitions

### DIFF
--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -257,6 +257,7 @@ pub fn translate_create_view(
         let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
         program.begin_write_on_database(database_id, schema_cookie);
     }
+    ensure_no_cross_db_view_references(select_stmt, database_id, resolver)?;
     let normalized_view_name = normalize_ident(view_name.name.as_str());
 
     // Check for name conflicts with existing schema objects
@@ -343,6 +344,69 @@ fn create_view_to_str(
         return format!("CREATE VIEW {view_name} ({columns_str}) AS {select_stmt}");
     }
     format!("CREATE VIEW {view_name} AS {select_stmt}")
+}
+
+fn ensure_no_cross_db_view_references(
+    select_stmt: &ast::Select,
+    view_database_id: usize,
+    resolver: &Resolver,
+) -> Result<()> {
+    let view_db_name = resolver
+        .get_database_name_by_index(view_database_id)
+        .unwrap_or_else(|| "main".to_string());
+
+    fn check_qualified_name(name: &ast::QualifiedName, view_db_name: &str) -> Result<()> {
+        if let Some(db_name) = &name.db_name {
+            let referenced_db = crate::util::normalize_ident(db_name.as_str());
+            if referenced_db != view_db_name {
+                crate::bail_parse_error!("cross-database views are not supported");
+            }
+        }
+        Ok(())
+    }
+
+    fn check_table(table: &ast::SelectTable, view_db_name: &str) -> Result<()> {
+        match table {
+            ast::SelectTable::Table(name, _, _) | ast::SelectTable::TableCall(name, _, _) => {
+                check_qualified_name(name, view_db_name)
+            }
+            ast::SelectTable::Select(select, _) => check_select(select, view_db_name),
+            ast::SelectTable::Sub(from, _) => check_from_clause(from, view_db_name),
+        }
+    }
+
+    fn check_from_clause(from: &ast::FromClause, view_db_name: &str) -> Result<()> {
+        check_table(&from.select, view_db_name)?;
+        for join in &from.joins {
+            check_table(&join.table, view_db_name)?;
+        }
+        Ok(())
+    }
+
+    fn check_one_select(one_select: &ast::OneSelect, view_db_name: &str) -> Result<()> {
+        if let ast::OneSelect::Select { from, .. } = one_select {
+            if let Some(from_clause) = from {
+                check_from_clause(from_clause, view_db_name)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn check_select(select: &ast::Select, view_db_name: &str) -> Result<()> {
+        if let Some(with) = &select.with {
+            for cte in &with.ctes {
+                check_select(&cte.select, view_db_name)?;
+            }
+        }
+
+        check_one_select(&select.body.select, view_db_name)?;
+        for compound in &select.body.compounds {
+            check_one_select(&compound.select, view_db_name)?;
+        }
+        Ok(())
+    }
+
+    check_select(select_stmt, &view_db_name)
 }
 
 pub fn translate_drop_view(

--- a/tests/integration/query_processing/test_ddl.rs
+++ b/tests/integration/query_processing/test_ddl.rs
@@ -1,5 +1,32 @@
 use crate::common::TempDatabase;
 
+#[turso_macros::test]
+fn test_reject_cross_db_view_definition(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    let aux_path = tmp_db
+        .path
+        .parent()
+        .unwrap()
+        .join("aux_cross_db_view.db")
+        .to_string_lossy()
+        .to_string();
+
+    conn.execute(format!("ATTACH '{aux_path}' AS aux"))?;
+    conn.execute("CREATE TABLE aux.t1 (x INTEGER)")?;
+
+    let err = conn
+        .execute("CREATE VIEW v AS SELECT x FROM aux.t1")
+        .expect_err("cross-db view should be rejected");
+    assert!(
+        err.to_string()
+            .contains("cross-database views are not supported"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b);")]
 fn test_fail_drop_indexed_column(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let _ = env_logger::try_init();


### PR DESCRIPTION
## Description
- reject `CREATE VIEW` statements when the view definition references tables from a different database alias
- recursively validate `SELECT` sources in the view query (including joins, compounds, and CTEs)
- add an integration regression test covering `ATTACH` + cross-db `CREATE VIEW`
- Fixes #5784

## Motivation and context
Cross-database views are currently accepted, but they can produce schema states that SQLite later rejects as malformed. This change enforces the intended restriction so attached-database references cannot be persisted in view definitions.

## Description of AI Usage
I used AI assistance to speed up code navigation and draft the initial implementation approach, then manually reviewed and adjusted the resulting Rust changes and test coverage before submitting.
