### PR TITLE
core/translate: Handle list_types=1 pragma with error instead of panic

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -508,7 +508,7 @@ fn update_pragma(
             connection.set_sync_type(sync_type);
             Ok(TransactionMode::None)
         }
-        PragmaName::ListTypes => unreachable!("list_types cannot be set"),
+        PragmaName::ListTypes => bail_parse_error!("list_types cannot be set"),
         PragmaName::TempStore => {
             use crate::TempStore;
             // Try to parse as a string first (default, file, memory)


### PR DESCRIPTION
Return a parse error when list_types is set, instead of unreachable!.

## Description
Replacing `unreachable!` with `bail_parse_error` if `pragma list_types` had a value, to prevent shell crashing.
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
Prevent crashing when trying to set `pragma list_types`, replacing with an error.
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->
closes #5810 
## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
None
