### PR TITLE
Fix simple_count optimization not triggering case-insensitively

### DIFF
--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -227,8 +227,7 @@ pub fn emit_query<'a>(
         &mut plan.non_from_clause_subqueries,
     )?;
 
-    if plan.is_simple_count() {
-        emit_simple_count(program, t_ctx, plan)?;
+    if plan.is_simple_count() && emit_simple_count(program, t_ctx, plan)? {
         // Keep LIMIT's early-exit jump target valid even on the simple_count fast path.
         // init_limit may emit an IfNot to after_main_loop_label (e.g. scalar subquery injects LIMIT 1).
         // Without resolving this label before the early return, bytecode assembly fails

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -544,33 +544,16 @@ impl SelectPlan {
         if !matches!(table_ref.table, crate::schema::Table::BTree(..)) {
             return false;
         }
-        let agg = self.aggregates.first().unwrap();
-        if !matches!(agg.func, AggFunc::Count0) {
-            return false;
-        }
-
-        let count = ast::Expr::FunctionCall {
-            name: ast::Name::exact("count".to_string()),
-            distinctness: None,
-            args: vec![],
-            order_by: vec![],
-            filter_over: ast::FunctionTail {
-                filter_clause: None,
-                over_clause: None,
-            },
-        };
-        let count_star = ast::Expr::FunctionCallStar {
-            name: ast::Name::exact("count".to_string()),
-            filter_over: ast::FunctionTail {
-                filter_clause: None,
-                over_clause: None,
-            },
-        };
-        let result_col_expr = &self.result_columns.first().unwrap().expr;
-        if *result_col_expr != count && *result_col_expr != count_star {
-            return false;
-        }
-        true
+        let agg = self
+            .aggregates
+            .first()
+            .expect("we already checked aggregates.len() == 1");
+        let result_expr = &self
+            .result_columns
+            .first()
+            .expect("we already checked result_columns.len() == 1")
+            .expr;
+        matches!(agg.func, AggFunc::Count0) && exprs_are_equivalent(result_expr, &agg.original_expr)
     }
 }
 

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1187,7 +1187,7 @@ pub fn emit_simple_count(
     program: &mut ProgramBuilder,
     _t_ctx: &mut TranslateCtx,
     plan: &SelectPlan,
-) -> Result<()> {
+) -> Result<bool> {
     let cursors = plan
         .joined_tables()
         .first()
@@ -1197,9 +1197,15 @@ pub fn emit_simple_count(
     let cursor_id = {
         match cursors {
             (_, Some(cursor_id)) | (Some(cursor_id), None) => cursor_id,
-            _ => panic!("cursor for table should have been opened"),
+            _ => return Ok(false),
         }
     };
+
+    // Count opcode only works on BTree cursors. Materialized view trigger
+    // queries may have pseudo cursors — fall back to normal aggregation.
+    if !program.cursor_is_btree(cursor_id) {
+        return Ok(false);
+    }
 
     // TODO: I think this allocation can be avoided if we are smart with the `TranslateCtx`
     let target_reg = program.alloc_register();
@@ -1218,7 +1224,7 @@ pub fn emit_simple_count(
         extra_amount: 0,
     });
     program.emit_result_row(output_reg, 1);
-    Ok(())
+    Ok(true)
 }
 
 fn process_having_clause(

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1463,6 +1463,11 @@ impl ProgramBuilder {
         self.table_references.contains_table(table)
     }
 
+    /// Returns true if the cursor is a BTreeTable cursor.
+    pub fn cursor_is_btree(&self, cursor_id: CursorID) -> bool {
+        matches!(self.cursor_ref[cursor_id].1, CursorType::BTreeTable(_))
+    }
+
     #[inline]
     pub fn cursor_loop(&mut self, cursor_id: CursorID, f: impl Fn(&mut ProgramBuilder, usize)) {
         let loop_start = self.allocate_label();

--- a/testing/runner/tests/simple-count-optimization.sqltest
+++ b/testing/runner/tests/simple-count-optimization.sqltest
@@ -1,0 +1,28 @@
+@database :memory:
+
+# Regression tests for the simple count (Count opcode) optimization.
+
+test simple-count {
+    CREATE TABLE t1(x);
+    INSERT INTO t1 VALUES(1),(NULL),(3);
+    SELECT count(*) FROM t1;
+    SELECT count() FROM t1;
+    SELECT COUNT(*) FROM t1;
+    SELECT Count(*) FROM t1;
+    SELECT cOuNt(*) FROM t1;
+    -- count(col) skips NULLs, must NOT use the Count opcode
+    SELECT count(x) FROM t1;
+    -- expressions wrapping count must NOT use the Count opcode
+    SELECT count(*) + 1 FROM t1;
+    SELECT count(*) * 2 FROM t1;
+}
+expect {
+    3
+    3
+    3
+    3
+    3
+    2
+    4
+    6
+}

--- a/testing/runner/tests/snapshot_tests/aggregation/aggregation.sqltest
+++ b/testing/runner/tests/snapshot_tests/aggregation/aggregation.sqltest
@@ -219,3 +219,38 @@ snapshot distinct-count-with-join {
     ORDER BY
         unique_customers DESC;
 }
+
+# Simple count optimization: count(*) and count() should use the Count opcode
+# instead of a full table scan with AggStep.
+
+setup simple_table {
+    CREATE TABLE t1(x);
+}
+
+@setup simple_table
+snapshot simple-count-star {
+    SELECT count(*) FROM t1;
+}
+
+@setup simple_table
+snapshot simple-count-no-args {
+    SELECT count() FROM t1;
+}
+
+# count(col) must NOT use the Count opcode because it skips NULLs
+@setup simple_table
+snapshot count-column {
+    SELECT count(x) FROM t1;
+}
+
+# Mixed case must also use the Count opcode
+@setup simple_table
+snapshot simple-count-mixed-case {
+    SELECT CoUnT(*) FROM t1;
+}
+
+# Expression wrapping count must NOT use the Count opcode
+@setup simple_table
+snapshot count-star-plus-expr {
+    SELECT count(*) + 1 FROM t1;
+}

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__count-column.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__count-column.snap
@@ -1,0 +1,29 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(x) FROM t1;
+info:
+  statement_type: SELECT
+  tables:
+  - t1
+  setup_blocks:
+  - simple_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t1
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0  11   0           0  Start at 11
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   2   0  k(2,B)   0  table=t1, root=2, iDb=0
+   3  Rewind        0   7   0           0  Rewind table t1
+   4    Column      0   0   3           0  r[3]=t1.x
+   5    AggStep     0   3   2  count    0  accum=r[2] step(r[3])
+   6  Next          0   4   0           0
+   7  AggFinal      0   2   0  count    0  accum=r[2]
+   8  Copy          2   1   0           0  r[1]=r[2]
+   9  ResultRow     1   1   0           0  output=r[1]
+  10  Halt          0   0   0           0
+  11  Transaction   0   1   1           0  iDb=0 tx_mode=Read
+  12  Goto          0   1   0           0

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__count-star-plus-expr.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__count-star-plus-expr.snap
@@ -1,0 +1,31 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) + 1 FROM t1;
+info:
+  statement_type: SELECT
+  tables:
+  - t1
+  setup_blocks:
+  - simple_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t1
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0  11   0           0  Start at 11
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   2   0  k(2,B)   0  table=t1, root=2, iDb=0
+   3  Rewind        0   6   0           0  Rewind table t1
+   4    AggStep     0   3   2  count    0  accum=r[2] step(r[3])
+   5  Next          0   4   0           0
+   6  AggFinal      0   2   0  count    0  accum=r[2]
+   7  Copy          2   4   0           0  r[4]=r[2]
+   8  Add           4   5   1           0  r[1]=r[4]+r[5]
+   9  ResultRow     1   1   0           0  output=r[1]
+  10  Halt          0   0   0           0
+  11  Transaction   0   1   1           0  iDb=0 tx_mode=Read
+  12  Integer       1   3   0           0  r[3]=1
+  13  Integer       1   5   0           0  r[5]=1
+  14  Goto          0   1   0           0

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-mixed-case.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-mixed-case.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT CoUnT(*) FROM t1;
+info:
+  statement_type: SELECT
+  tables:
+  - t1
+  setup_blocks:
+  - simple_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t1
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0   8   0           0  Start at 8
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   2   0  k(2,B)   0  table=t1, root=2, iDb=0
+   3  Count         0   3   0           0
+   4  Close         0   0   0           0
+   5  Copy          3   4   0           0  r[4]=r[3]
+   6  ResultRow     4   1   0           0  output=r[4]
+   7  Halt          0   0   0           0
+   8  Transaction   0   1   1           0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0           0

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-no-args.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-no-args.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT count() FROM t1;
+info:
+  statement_type: SELECT
+  tables:
+  - t1
+  setup_blocks:
+  - simple_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t1
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0   8   0           0  Start at 8
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   2   0  k(2,B)   0  table=t1, root=2, iDb=0
+   3  Count         0   3   0           0
+   4  Close         0   0   0           0
+   5  Copy          3   4   0           0  r[4]=r[3]
+   6  ResultRow     4   1   0           0  output=r[4]
+   7  Halt          0   0   0           0
+   8  Transaction   0   1   1           0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0           0

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-star.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__simple-count-star.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) FROM t1;
+info:
+  statement_type: SELECT
+  tables:
+  - t1
+  setup_blocks:
+  - simple_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t1
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0   8   0           0  Start at 8
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   2   0  k(2,B)   0  table=t1, root=2, iDb=0
+   3  Count         0   3   0           0
+   4  Close         0   0   0           0
+   5  Copy          3   4   0           0  r[4]=r[3]
+   6  ResultRow     4   1   0           0  output=r[4]
+   7  Halt          0   0   0           0
+   8  Transaction   0   1   1           0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0           0


### PR DESCRIPTION
is_simple_count() had redundant code that reconstructed an AST node corresponding to a count(*)/count() expression but then compared case-insensitively to the select list expression.this resulted in the count() optimization not triggering for mixed case result list expressions like COUNT() or cOuNt().

fix: remove the manual AST node construction and compare with exprs_are_equivalent().

also guard emit_simple_count() so it only attempts the optimization for btree cursors.

Adapted from #5794 
Closes #5794