### PR TITLE
Preserve non-UTF8 TEXT bytes end-to-end and match SQLite text semantics

### DIFF
--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -638,6 +638,7 @@ fn convert_value_to_core(value: &Value) -> CoreValue {
         Value::Float { value } => CoreValue::from_f64(*value),
         Value::Text { value } => CoreValue::Text(turso_core::types::Text {
             value: std::borrow::Cow::Owned(value.clone()),
+            raw_bytes: None,
             subtype: turso_core::types::TextSubtype::Text,
         }),
         Value::Blob { value } => CoreValue::Blob(value.to_vec()),

--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -196,6 +196,26 @@ fn coerce_to_string(value: &Value) -> String {
     }
 }
 
+fn coerce_printf_string_bytes(value: &Value) -> Vec<u8> {
+    match value {
+        Value::Null => Vec::new(),
+        Value::Numeric(Numeric::Integer(i)) => i.to_string().into_bytes(),
+        Value::Numeric(Numeric::Float(f)) => format_float(f64::from(*f)).into_bytes(),
+        Value::Text(t) => {
+            let bytes = t.as_bytes();
+            let end = bytes
+                .iter()
+                .position(|&byte| byte == 0)
+                .unwrap_or(bytes.len());
+            bytes[..end].to_vec()
+        }
+        Value::Blob(b) => {
+            let end = b.iter().position(|&byte| byte == 0).unwrap_or(b.len());
+            b[..end].to_vec()
+        }
+    }
+}
+
 // ── Formatting helpers ──────────────────────────────────────────
 
 /// Insert comma separators into a digit string (e.g. "1234567" → "1,234,567").
@@ -1042,32 +1062,42 @@ fn format_general_inner(output: &mut String, f: f64, spec: &FormatSpec, uppercas
     apply_width(output, prefix, &content, spec.width, &spec.flags, false);
 }
 
-fn format_string(output: &mut String, value: &Value, spec: &FormatSpec) {
-    // For blobs, truncate at first NUL byte (SQLite behavior)
-    let s = match value {
-        Value::Blob(b) => {
-            let end = b.iter().position(|&byte| byte == 0).unwrap_or(b.len());
-            String::from_utf8_lossy(&b[..end]).to_string()
-        }
-        _ => coerce_to_string(value),
-    };
-    let truncated = if let Some(prec) = spec.precision {
-        // Truncate by character count (not bytes). SQLite uses bytes by default
-        // and chars with !, but since blobs are already lossy-converted to UTF-8,
-        // character-based truncation avoids mid-char splits.
-        if let Some((byte_idx, _)) = s.char_indices().nth(prec) {
-            &s[..byte_idx]
-        } else {
-            &s
-        }
-    } else {
-        &s
-    };
+fn truncate_bytes_to_precision(bytes: &[u8], precision: Option<usize>) -> Vec<u8> {
+    precision
+        .map(|precision| bytes[..bytes.len().min(precision)].to_vec())
+        .unwrap_or_else(|| bytes.to_vec())
+}
 
-    // Zero-pad flag is ignored for string specifiers
+fn apply_width_bytes(
+    output: &mut Vec<u8>,
+    content: &[u8],
+    width: Option<usize>,
+    flags: &FormatFlags,
+) {
+    let width = width.unwrap_or(0);
+    if width <= content.len() {
+        output.extend_from_slice(content);
+        return;
+    }
+
+    let pad_len = width - content.len();
+    if flags.left_justify {
+        output.extend_from_slice(content);
+        output.extend(repeat_n(b' ', pad_len));
+    } else {
+        output.extend(repeat_n(b' ', pad_len));
+        output.extend_from_slice(content);
+    }
+}
+
+fn format_string(output: &mut Vec<u8>, value: &Value, spec: &FormatSpec) {
+    let s = coerce_printf_string_bytes(value);
+    let truncated = truncate_bytes_to_precision(&s, spec.precision);
+
+    // Zero-pad flag is ignored for string specifiers.
     let mut flags = spec.flags.clone();
     flags.zero_pad = false;
-    apply_width(output, "", truncated, spec.width, &flags, false);
+    apply_width_bytes(output, &truncated, spec.width, &flags);
 }
 
 fn format_char(output: &mut String, value: &Value, spec: &FormatSpec) {
@@ -1271,7 +1301,7 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
         }
     };
 
-    let mut result = String::new();
+    let mut result = Vec::new();
     let mut args_index = 1;
     let mut chars = format_str.chars().peekable();
     // Track whether any output or specifier processing happened. SQLite's
@@ -1284,7 +1314,8 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
     while let Some(c) = chars.next() {
         if c != '%' {
             touched = true;
-            result.push(c);
+            let mut buf = [0u8; 4];
+            result.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
             continue;
         }
 
@@ -1292,13 +1323,13 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
         if chars.peek() == Some(&'%') {
             touched = true;
             chars.next();
-            result.push('%');
+            result.push(b'%');
             continue;
         }
 
         // Trailing '%' at end of format string is preserved
         if chars.peek().is_none() {
-            result.push('%');
+            result.push(b'%');
             break;
         }
 
@@ -1320,25 +1351,26 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
             &null_val
         };
 
+        let mut formatted = String::new();
         match spec.spec_type {
-            'd' | 'i' => format_signed_int(&mut result, arg, &spec),
-            'u' => format_unsigned_int(&mut result, arg, &spec),
-            'f' => format_float_decimal(&mut result, arg, &spec),
-            'e' => format_exponential(&mut result, arg, &spec, false),
-            'E' => format_exponential(&mut result, arg, &spec, true),
-            'g' => format_general(&mut result, arg, &spec, false),
-            'G' => format_general(&mut result, arg, &spec, true),
-            'x' => format_hex(&mut result, arg, &spec, false),
-            'X' => format_hex(&mut result, arg, &spec, true),
-            'o' => format_octal(&mut result, arg, &spec),
-            'p' => format_hex(&mut result, arg, &spec, true),
+            'd' | 'i' => format_signed_int(&mut formatted, arg, &spec),
+            'u' => format_unsigned_int(&mut formatted, arg, &spec),
+            'f' => format_float_decimal(&mut formatted, arg, &spec),
+            'e' => format_exponential(&mut formatted, arg, &spec, false),
+            'E' => format_exponential(&mut formatted, arg, &spec, true),
+            'g' => format_general(&mut formatted, arg, &spec, false),
+            'G' => format_general(&mut formatted, arg, &spec, true),
+            'x' => format_hex(&mut formatted, arg, &spec, false),
+            'X' => format_hex(&mut formatted, arg, &spec, true),
+            'o' => format_octal(&mut formatted, arg, &spec),
+            'p' => format_hex(&mut formatted, arg, &spec, true),
             's' | 'z' => format_string(&mut result, arg, &spec),
-            'c' => format_char(&mut result, arg, &spec),
-            'q' => format_sql_quote(&mut result, arg, &spec),
-            'Q' => format_sql_quote_wrap(&mut result, arg, &spec),
-            'w' => format_sql_identifier(&mut result, arg, &spec),
-            'r' => format_ordinal(&mut result, arg, &spec),
-            'n' => { /* silently ignored, no arg consumed */ }
+            'c' => format_char(&mut formatted, arg, &spec),
+            'q' => format_sql_quote(&mut formatted, arg, &spec),
+            'Q' => format_sql_quote_wrap(&mut formatted, arg, &spec),
+            'w' => format_sql_identifier(&mut formatted, arg, &spec),
+            'r' => format_ordinal(&mut formatted, arg, &spec),
+            'n' => {}
             _ => {
                 // Unknown specifier: return NULL if nothing was processed
                 // before this point, otherwise return accumulated text.
@@ -1350,10 +1382,14 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
                 break;
             }
         }
+
+        if !formatted.is_empty() {
+            result.extend_from_slice(formatted.as_bytes());
+        }
         touched = true;
     }
 
-    Ok(Value::build_text(result))
+    Ok(Value::build_text_from_bytes(result))
 }
 
 #[cfg(test)]
@@ -1898,6 +1934,35 @@ mod tests {
             exec_printf(&[text("%s"), blob_hello]).unwrap(),
             *text("Hello").get_value()
         );
+    }
+
+    #[test]
+    fn test_text_nul_truncation() {
+        let text_val = Register::Value(Value::build_text("A\0B"));
+        let result = exec_printf(&[text("%s"), text_val]).unwrap();
+        assert_eq!(result.exec_hex(), Value::build_text("41"));
+    }
+
+    #[test]
+    fn test_string_precision_is_byte_based() {
+        let result = exec_printf(&[text("%.1s"), text("\u{00E9}")]).unwrap();
+        assert_eq!(result.exec_hex(), Value::build_text("C3"));
+    }
+
+    #[test]
+    fn test_blob_invalid_utf8_preserves_raw_bytes() {
+        let blob_val = Register::Value(Value::Blob(vec![0xAB]));
+        let result = exec_printf(&[text("%s"), blob_val]).unwrap();
+        assert_eq!(result.exec_typeof(), Value::build_text("text"));
+        assert_eq!(result.exec_hex(), Value::build_text("AB"));
+    }
+
+    #[test]
+    fn test_blob_invalid_utf8_preserved_with_literal_prefix() {
+        let blob_val = Register::Value(Value::Blob(vec![0xAB]));
+        let result = exec_printf(&[text("x%s"), blob_val]).unwrap();
+        assert_eq!(result.exec_typeof(), Value::build_text("text"));
+        assert_eq!(result.exec_hex(), Value::build_text("78AB"));
     }
 
     #[test]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -957,6 +957,18 @@ pub fn validate_serial_type(value: u64) -> Result<()> {
     Ok(())
 }
 
+#[inline(always)]
+fn decode_text_ref(data: &[u8]) -> TextRef<'_> {
+    match std::str::from_utf8(data) {
+        Ok(value) => TextRef::new(value, TextSubtype::Text),
+        Err(_) => {
+            // TextRef is a borrowed view; preserve authoritative bytes in `raw_bytes`.
+            // Callers that need an owned value reconstruct a lossy string in ValueRef::to_owned.
+            TextRef::new_with_raw("", data, TextSubtype::Text)
+        }
+    }
+}
+
 /// Reads a value that might reference the buffer it is reading from. Be sure to store RefValue with the buffer
 /// always.
 #[inline(always)]
@@ -1078,12 +1090,7 @@ pub fn read_value<'a>(buf: &'a [u8], serial_type: SerialType) -> Result<(ValueRe
                     content_size
                 ))
             })?;
-            // SAFETY: SerialTypeKind is Text so this buffer is a valid string
-            let val = unsafe { std::str::from_utf8_unchecked(data) };
-            Ok((
-                ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
-                content_size,
-            ))
+            Ok((ValueRef::Text(decode_text_ref(data)), content_size))
         }
     }
 }
@@ -1206,12 +1213,7 @@ pub fn read_value_serial_type<'a>(
                         content_size
                     ))
                 })?;
-                // SAFETY: SerialTypeKind is Text so this buffer is a valid string
-                let val = unsafe { std::str::from_utf8_unchecked(data) };
-                Ok((
-                    ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
-                    content_size,
-                ))
+                Ok((ValueRef::Text(decode_text_ref(data)), content_size))
             }
             _ => unreachable!(),
         },
@@ -2058,6 +2060,7 @@ mod tests {
     #[case(&[1, 2, 3], SerialType::blob(3), Value::Blob(vec![1, 2, 3]))]
     #[case(&[], SerialType::blob(0), Value::Blob(vec![]))] // empty blob
     #[case(&[65, 66, 67], SerialType::text(3), Value::build_text("ABC"))]
+    #[case(&[0xAB], SerialType::text(1), Value::build_text_from_bytes(vec![0xAB]))]
     #[case(&[0x80], SerialType::i8(), Value::from_i64(-128))]
     #[case(&[0x80, 0], SerialType::i16(), Value::from_i64(-32768))]
     #[case(&[0x80, 0, 0], SerialType::i24(), Value::from_i64(-8388608))]
@@ -2077,6 +2080,13 @@ mod tests {
     ) {
         let result = read_value(buf, serial_type).unwrap();
         assert_eq!(result.0.to_owned(), expected);
+    }
+
+    #[test]
+    fn test_read_value_serial_type_invalid_utf8_text() {
+        let (value, consumed) = read_value_serial_type(&[0xAB], 15).unwrap();
+        assert_eq!(consumed, 1);
+        assert_eq!(value.to_owned(), Value::build_text_from_bytes(vec![0xAB]));
     }
 
     #[test]

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -54,20 +54,58 @@ impl CollationSeq {
     }
 
     #[inline(always)]
+    pub fn compare_bytes(&self, lhs: &[u8], rhs: &[u8]) -> Ordering {
+        match self {
+            CollationSeq::Unset | CollationSeq::Binary => lhs.cmp(rhs),
+            CollationSeq::NoCase => Self::nocase_cmp_bytes(lhs, rhs),
+            CollationSeq::Rtrim => {
+                let lhs = Self::rtrim_bytes(lhs);
+                let rhs = Self::rtrim_bytes(rhs);
+                lhs.cmp(rhs)
+            }
+        }
+    }
+
+    #[inline(always)]
     fn binary_cmp(lhs: &str, rhs: &str) -> Ordering {
         lhs.cmp(rhs)
     }
 
     #[inline(always)]
     fn nocase_cmp(lhs: &str, rhs: &str) -> Ordering {
-        let nocase_lhs = uncased::UncasedStr::new(lhs);
-        let nocase_rhs = uncased::UncasedStr::new(rhs);
-        nocase_lhs.cmp(nocase_rhs)
+        Self::nocase_cmp_bytes(lhs.as_bytes(), rhs.as_bytes())
     }
 
     #[inline(always)]
     fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
         lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' '))
+    }
+
+    #[inline(always)]
+    fn nocase_cmp_bytes(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        let min_len = lhs.len().min(rhs.len());
+        for i in 0..min_len {
+            let left = lhs[i].to_ascii_lowercase();
+            let right = rhs[i].to_ascii_lowercase();
+
+            if left == 0 && right == 0 {
+                return lhs.len().cmp(&rhs.len());
+            }
+
+            if left != right {
+                return left.cmp(&right);
+            }
+        }
+        lhs.len().cmp(&rhs.len())
+    }
+
+    #[inline(always)]
+    fn rtrim_bytes(bytes: &[u8]) -> &[u8] {
+        let end = bytes
+            .iter()
+            .rposition(|&byte| byte != b' ')
+            .map_or(0, |idx| idx + 1);
+        &bytes[..end]
     }
 }
 
@@ -187,6 +225,24 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_nocase_embedded_nul_len_tiebreak() {
+        // SQLite NOCASE compares bytes case-insensitively up to NUL, then uses
+        // original byte length as a tie-breaker.
+        assert_eq!(
+            CollationSeq::NoCase.compare_bytes(b"A\0B", b"A\0C"),
+            Ordering::Equal
+        );
+        assert_eq!(
+            CollationSeq::NoCase.compare_bytes(b"A\0B", b"A"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            CollationSeq::NoCase.compare_bytes(b"A\0", b"A\0B"),
+            Ordering::Less
+        );
+    }
 
     #[test]
     fn test_get_collseq_from_expr_single_table_single_column() {

--- a/core/types.rs
+++ b/core/types.rs
@@ -69,6 +69,7 @@ pub enum TextSubtype {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Text {
     pub value: Cow<'static, str>,
+    pub raw_bytes: Option<Cow<'static, [u8]>>,
     pub subtype: TextSubtype,
 }
 
@@ -82,13 +83,39 @@ impl Text {
     pub fn new(value: impl Into<Cow<'static, str>>) -> Self {
         Self {
             value: value.into(),
+            raw_bytes: None,
             subtype: TextSubtype::Text,
         }
     }
+
+    pub fn from_bytes_with_subtype(bytes: Vec<u8>, subtype: TextSubtype) -> Self {
+        match String::from_utf8(bytes) {
+            Ok(value) => Self {
+                value: value.into(),
+                raw_bytes: None,
+                subtype,
+            },
+            Err(err) => {
+                let bytes = err.into_bytes();
+                let value = String::from_utf8_lossy(&bytes).into_owned();
+                Self {
+                    value: value.into(),
+                    raw_bytes: Some(bytes.into()),
+                    subtype,
+                }
+            }
+        }
+    }
+
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self::from_bytes_with_subtype(bytes, TextSubtype::Text)
+    }
+
     #[cfg(feature = "json")]
     pub fn json(value: String) -> Self {
         Self {
             value: value.into(),
+            raw_bytes: None,
             subtype: TextSubtype::Json,
         }
     }
@@ -96,22 +123,46 @@ impl Text {
     pub fn as_str(&self) -> &str {
         &self.value
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.raw_bytes
+            .as_deref()
+            .unwrap_or_else(|| self.value.as_bytes())
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct TextRef<'a> {
     pub value: &'a str,
+    pub raw_bytes: Option<&'a [u8]>,
     pub subtype: TextSubtype,
 }
 
 impl<'a> TextRef<'a> {
     pub fn new(value: &'a str, subtype: TextSubtype) -> Self {
-        Self { value, subtype }
+        Self {
+            value,
+            raw_bytes: None,
+            subtype,
+        }
+    }
+
+    pub fn new_with_raw(value: &'a str, raw_bytes: &'a [u8], subtype: TextSubtype) -> Self {
+        Self {
+            value,
+            raw_bytes: Some(raw_bytes),
+            subtype,
+        }
     }
 
     #[inline]
     pub fn as_str(&self) -> &'a str {
         self.value
+    }
+
+    #[inline]
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.raw_bytes.unwrap_or(self.value.as_bytes())
     }
 }
 
@@ -161,6 +212,7 @@ impl<T: AnyText> Extendable<T> for Text {
                 self.value = Cow::Owned(other_str.to_owned());
             }
         }
+        self.raw_bytes = None;
         self.subtype = other.subtype();
     }
 }
@@ -230,6 +282,7 @@ impl From<&str> for Text {
     fn from(value: &str) -> Self {
         Text {
             value: value.to_owned().into(),
+            raw_bytes: None,
             subtype: TextSubtype::Text,
         }
     }
@@ -239,6 +292,7 @@ impl From<String> for Text {
     fn from(value: String) -> Self {
         Text {
             value: Cow::from(value),
+            raw_bytes: None,
             subtype: TextSubtype::Text,
         }
     }
@@ -362,6 +416,7 @@ impl Value {
             Value::Numeric(n) => ValueRef::Numeric(*n),
             Value::Text(v) => ValueRef::Text(TextRef {
                 value: &v.value,
+                raw_bytes: v.raw_bytes.as_deref(),
                 subtype: v.subtype,
             }),
             Value::Blob(v) => ValueRef::Blob(v.as_slice()),
@@ -371,6 +426,10 @@ impl Value {
     // A helper function that makes building a text Value easier.
     pub fn build_text(text: impl Into<Cow<'static, str>>) -> Self {
         Self::Text(Text::new(text))
+    }
+
+    pub fn build_text_from_bytes(bytes: Vec<u8>) -> Self {
+        Self::Text(Text::from_bytes(bytes))
     }
 
     pub fn to_blob(&self) -> Option<&[u8]> {
@@ -458,7 +517,7 @@ impl Value {
                 let fval: f64 = (*f).into();
                 out.extend_from_slice(&fval.to_be_bytes());
             }
-            Value::Text(t) => out.extend_from_slice(t.value.as_bytes()),
+            Value::Text(t) => out.extend_from_slice(t.as_bytes()),
             Value::Blob(b) => out.extend_from_slice(b),
         };
     }
@@ -802,26 +861,32 @@ impl std::ops::AddAssign for Value {
                 *self = sum.into();
             }
             (Self::Text(string_left), Self::Text(string_right)) => {
-                string_left.value.to_mut().push_str(&string_right.value);
-                string_left.subtype = TextSubtype::Text;
+                let mut bytes = Vec::with_capacity(
+                    string_left.as_bytes().len() + string_right.as_bytes().len(),
+                );
+                bytes.extend_from_slice(string_left.as_bytes());
+                bytes.extend_from_slice(string_right.as_bytes());
+                *string_left = Text::from_bytes_with_subtype(bytes, TextSubtype::Text);
             }
             (Self::Text(string_left), Self::Numeric(Numeric::Integer(int_right))) => {
-                let string_right = int_right.to_string();
-                string_left.value.to_mut().push_str(&string_right);
-                string_left.subtype = TextSubtype::Text;
+                let mut bytes = string_left.as_bytes().to_vec();
+                bytes.extend_from_slice(int_right.to_string().as_bytes());
+                *string_left = Text::from_bytes_with_subtype(bytes, TextSubtype::Text);
             }
             (Self::Numeric(Numeric::Integer(int_left)), Self::Text(string_right)) => {
-                let string_left = int_left.to_string();
-                *self = Self::build_text(string_left + string_right.as_str());
+                let mut bytes = int_left.to_string().into_bytes();
+                bytes.extend_from_slice(string_right.as_bytes());
+                *self = Self::build_text_from_bytes(bytes);
             }
             (Self::Text(string_left), Self::Numeric(Numeric::Float(_))) => {
-                let string_right = rhs.to_string();
-                string_left.value.to_mut().push_str(&string_right);
-                string_left.subtype = TextSubtype::Text;
+                let mut bytes = string_left.as_bytes().to_vec();
+                bytes.extend_from_slice(rhs.to_string().as_bytes());
+                *string_left = Text::from_bytes_with_subtype(bytes, TextSubtype::Text);
             }
             (Self::Numeric(Numeric::Float(_)), Self::Text(string_right)) => {
-                let string_left = self.to_string();
-                *self = Self::build_text(string_left + string_right.as_str());
+                let mut bytes = self.to_string().into_bytes();
+                bytes.extend_from_slice(string_right.as_bytes());
+                *self = Self::build_text_from_bytes(bytes);
             }
             (_, Self::Null) => {}
             (Self::Null, _) => *self = rhs,
@@ -898,7 +963,7 @@ impl<'a> TryFrom<ValueRef<'a>> for &'a str {
     #[inline]
     fn try_from(value: ValueRef<'a>) -> Result<Self, Self::Error> {
         match value {
-            ValueRef::Text(s) => Ok(s.as_str()),
+            ValueRef::Text(s) if s.raw_bytes.is_none() => Ok(s.as_str()),
             _ => Err(LimboError::ConversionError("Expected text value".into())),
         }
     }
@@ -1238,7 +1303,7 @@ impl ImmutableRecord {
                     writer.extend_from_slice(&fval.to_be_bytes());
                 }
                 ValueRef::Text(t) => {
-                    writer.extend_from_slice(t.value.as_bytes());
+                    writer.extend_from_slice(t.as_bytes());
                 }
                 ValueRef::Blob(b) => {
                     writer.extend_from_slice(b);
@@ -1686,7 +1751,12 @@ impl<'a> ValueRef<'a> {
             ValueRef::Null => Value::Null,
             ValueRef::Numeric(n) => Value::from(*n),
             ValueRef::Text(text) => Value::Text(Text {
-                value: text.value.to_string().into(),
+                value: text
+                    .raw_bytes
+                    .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+                    .unwrap_or_else(|| text.value.to_string())
+                    .into(),
+                raw_bytes: text.raw_bytes.map(|bytes| bytes.to_vec().into()),
                 subtype: text.subtype,
             }),
             ValueRef::Blob(b) => Value::Blob(b.to_vec()),
@@ -1725,7 +1795,7 @@ impl<'a> PartialEq<ValueRef<'a>> for ValueRef<'a> {
             (Self::Null, Self::Null) => true,
             (Self::Numeric(a), Self::Numeric(b)) => a == b,
             (Self::Text(text_left), Self::Text(text_right)) => {
-                text_left.value.as_bytes() == text_right.value.as_bytes()
+                text_left.as_bytes() == text_right.as_bytes()
             }
             (Self::Blob(blob_left), Self::Blob(blob_right)) => blob_left.eq(blob_right),
             _ => false,
@@ -1762,7 +1832,7 @@ impl<'a> Ord for ValueRef<'a> {
             (_, Self::Numeric(_)) => std::cmp::Ordering::Greater,
 
             (Self::Text(text_left), Self::Text(text_right)) => {
-                text_left.value.as_bytes().cmp(text_right.value.as_bytes())
+                text_left.as_bytes().cmp(text_right.as_bytes())
             }
             (Self::Text(_), Self::Blob(_)) => std::cmp::Ordering::Less,
             (Self::Blob(_), Self::Text(_)) => std::cmp::Ordering::Greater,
@@ -1914,8 +1984,21 @@ where
     let l = l.as_value_ref();
     let r = r.as_value_ref();
     match (l, r) {
-        (ValueRef::Text(left), ValueRef::Text(right)) => collation.compare_strings(&left, &right),
+        (ValueRef::Text(left), ValueRef::Text(right)) => compare_text_refs(left, right, collation),
         _ => l.cmp(&r),
+    }
+}
+
+#[inline]
+pub fn compare_text_refs(
+    lhs: TextRef<'_>,
+    rhs: TextRef<'_>,
+    collation: CollationSeq,
+) -> std::cmp::Ordering {
+    if lhs.raw_bytes.is_some() || rhs.raw_bytes.is_some() {
+        collation.compare_bytes(lhs.as_bytes(), rhs.as_bytes())
+    } else {
+        collation.compare_strings(lhs.as_str(), rhs.as_str())
     }
 }
 
@@ -2178,7 +2261,7 @@ where
     };
 
     let collation = index_info.key_info[0].collation;
-    let comparison = collation.compare_strings(&lhs_text, &rhs_text);
+    let comparison = compare_text_refs(lhs_text, rhs_text, collation);
 
     let final_comparison = match index_info.key_info[0].sort_order {
         SortOrder::Asc => comparison,
@@ -2187,7 +2270,7 @@ where
 
     match final_comparison {
         std::cmp::Ordering::Equal => {
-            let len_cmp = lhs_text.len().cmp(&rhs_text.len());
+            let len_cmp = lhs_text.as_bytes().len().cmp(&rhs_text.as_bytes().len());
             if len_cmp != std::cmp::Ordering::Equal {
                 let adjusted = match index_info.key_info[0].sort_order {
                     SortOrder::Asc => len_cmp,
@@ -2303,9 +2386,11 @@ where
         };
 
         let comparison = match (&lhs_value, rhs_value) {
-            (ValueRef::Text(lhs_text), ValueRef::Text(rhs_text)) => index_info.key_info[field_idx]
-                .collation
-                .compare_strings(lhs_text, rhs_text),
+            (ValueRef::Text(lhs_text), ValueRef::Text(rhs_text)) => compare_text_refs(
+                *lhs_text,
+                *rhs_text,
+                index_info.key_info[field_idx].collation,
+            ),
 
             _ => lhs_value.cmp(rhs_value),
         };
@@ -2512,7 +2597,7 @@ impl<T: AsValueRef> From<T> for SerialType {
                 _ => SerialType::i64(),
             },
             ValueRef::Numeric(Numeric::Float(_)) => SerialType::f64(),
-            ValueRef::Text(t) => SerialType::text(t.value.len() as u64),
+            ValueRef::Text(t) => SerialType::text(t.as_bytes().len() as u64),
             ValueRef::Blob(b) => SerialType::blob(b.len() as u64),
         }
     }
@@ -2610,7 +2695,7 @@ impl Record {
                 Value::Numeric(Numeric::Float(f)) => {
                     buf.extend_from_slice(&f64::from(*f).to_be_bytes())
                 }
-                Value::Text(t) => buf.extend_from_slice(t.value.as_bytes()),
+                Value::Text(t) => buf.extend_from_slice(t.as_bytes()),
                 Value::Blob(b) => buf.extend_from_slice(b),
             };
         }
@@ -3113,7 +3198,7 @@ mod tests {
 
             let cmp = match (&l[i], &r[i]) {
                 (ValueRef::Text(left), ValueRef::Text(right)) => {
-                    collation.compare_strings(left, right)
+                    compare_text_refs(*left, *right, collation)
                 }
                 _ => l[i].partial_cmp(&r[i]).unwrap_or(std::cmp::Ordering::Equal),
             };
@@ -3985,5 +4070,33 @@ mod tests {
                 "column_count should be {num_values}, not {cnt}"
             );
         }
+    }
+
+    #[test]
+    fn test_text_built_from_invalid_bytes_preserves_storage_bytes() {
+        let value = Value::build_text_from_bytes(vec![0xAB, 0xCD]);
+
+        assert_eq!(value.value_type(), ValueType::Text);
+        if let Value::Text(text) = &value {
+            assert_eq!(text.as_bytes(), &[0xAB, 0xCD]);
+        } else {
+            panic!("expected text value");
+        }
+
+        let serial = SerialType::from(&value);
+        assert_eq!(serial.kind(), SerialTypeKind::Text);
+        assert_eq!(serial.size(), 2);
+
+        let mut out = Vec::new();
+        value.serialize_serial(&mut out);
+        assert_eq!(out, vec![0xAB, 0xCD]);
+    }
+
+    #[test]
+    fn test_valueref_to_str_fails_for_invalid_utf8_text() {
+        let raw = [0xAB];
+        let value = ValueRef::Text(TextRef::new_with_raw("", &raw, TextSubtype::Text));
+        let as_str = <&str>::try_from(value);
+        assert!(as_str.is_err());
     }
 }

--- a/core/vdbe/bloom_filter.rs
+++ b/core/vdbe/bloom_filter.rs
@@ -161,7 +161,7 @@ fn hash_value<H: Hasher>(hasher: &mut H, value: &ValueRef) {
         }
         ValueRef::Text(s) => {
             3u8.hash(hasher);
-            s.as_str().hash(hasher);
+            s.as_bytes().hash(hasher);
         }
         ValueRef::Blob(b) => {
             4u8.hash(hasher);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -260,7 +260,19 @@ fn compare_with_collation(
     match (lhs, rhs) {
         (Value::Text(lhs_text), Value::Text(rhs_text)) => {
             if let Some(coll) = collation {
-                coll.compare_strings(lhs_text.as_str(), rhs_text.as_str())
+                crate::types::compare_text_refs(
+                    crate::types::TextRef {
+                        value: lhs_text.as_str(),
+                        raw_bytes: lhs_text.raw_bytes.as_deref(),
+                        subtype: lhs_text.subtype,
+                    },
+                    crate::types::TextRef {
+                        value: rhs_text.as_str(),
+                        raw_bytes: rhs_text.raw_bytes.as_deref(),
+                        subtype: rhs_text.subtype,
+                    },
+                    coll,
+                )
             } else {
                 lhs.cmp(rhs)
             }
@@ -4643,7 +4655,11 @@ fn update_agg_payload(
             let acc = &mut payload[0];
             if matches!(acc, Value::Null) {
                 // First non-null value: convert to Text
-                *acc = Value::build_text(arg.to_string());
+                *acc = match &arg {
+                    Value::Text(text) => Value::build_text_from_bytes(text.as_bytes().to_vec()),
+                    Value::Blob(blob) => Value::build_text_from_bytes(blob.clone()),
+                    _ => Value::build_text(arg.to_string()),
+                };
             } else {
                 acc.exec_group_concat(&delimiter);
                 acc.exec_group_concat(&arg);

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -9,7 +9,7 @@ use crate::{
         Arc, RwLock,
     },
     translate::collate::CollationSeq,
-    types::{IOCompletions, IOResult, Value, ValueRef},
+    types::{compare_text_refs, IOCompletions, IOResult, Value, ValueRef},
     vdbe::metrics::HashJoinMetrics,
     CompletionError, Numeric, Result,
 };
@@ -44,10 +44,14 @@ const BLOB_HASH: u8 = 4;
 #[inline]
 /// Hash text case-insensitively without allocation (ASCII-only for SQLite NOCASE).
 /// SQLite's NOCASE collation only considers ASCII case, so to_ascii_lowercase() is correct.
-fn hash_text_nocase(hasher: &mut impl Hasher, text: &str) {
-    for byte in text.bytes() {
+fn hash_text_nocase(hasher: &mut impl Hasher, text: &[u8]) {
+    for &byte in text {
+        if byte == 0 {
+            break;
+        }
         hasher.write_u8(byte.to_ascii_lowercase());
     }
+    hasher.write_usize(text.len());
 }
 
 /// Hash function for join keys using rapidhash
@@ -83,11 +87,15 @@ fn hash_join_key(key_values: &[ValueRef], collations: &[CollationSeq]) -> u64 {
                 hasher.write_u8(TEXT_HASH);
                 match collation {
                     CollationSeq::NoCase => {
-                        hash_text_nocase(&mut hasher, text.as_str());
+                        hash_text_nocase(&mut hasher, text.as_bytes());
                     }
                     CollationSeq::Rtrim => {
-                        let trimmed = text.as_str().trim_end();
-                        hasher.write(trimmed.as_bytes());
+                        let trimmed_len = text
+                            .as_bytes()
+                            .iter()
+                            .rposition(|&byte| byte != b' ')
+                            .map_or(0, |idx| idx + 1);
+                        hasher.write(&text.as_bytes()[..trimmed_len]);
                     }
                     CollationSeq::Binary | CollationSeq::Unset => {
                         hasher.write(text.as_bytes());
@@ -150,7 +158,7 @@ fn values_equal(v1: ValueRef, v2: ValueRef, collation: CollationSeq) -> bool {
         (ValueRef::Blob(b1), ValueRef::Blob(b2)) => b1 == b2,
         (ValueRef::Text(t1), ValueRef::Text(t2)) => {
             // Use collation for text comparison
-            collation.compare_strings(t1.as_str(), t2.as_str()) == Ordering::Equal
+            compare_text_refs(t1, t2, collation) == Ordering::Equal
         }
         _ => false,
     }
@@ -244,7 +252,7 @@ impl HashEntry {
         let value_size = |v: &Value| match v {
             Value::Null => 1,
             Value::Numeric(_) => 8,
-            Value::Text(t) => t.as_str().len(),
+            Value::Text(t) => t.as_bytes().len(),
             Value::Blob(b) => b.len(),
         };
         let key_size: usize = key_values.iter().map(value_size).sum();
@@ -259,7 +267,7 @@ impl HashEntry {
             Value::Null => 0,
             Value::Numeric(_) => 8,
             Value::Text(t) => {
-                let len = t.as_str().len();
+                let len = t.as_bytes().len();
                 varint_len(len as u64) + len
             }
             Value::Blob(b) => varint_len(b.len() as u64) + b.len(),
@@ -325,7 +333,7 @@ impl HashEntry {
             Value::Text(t) => {
                 buf[offset] = TEXT_HASH;
                 offset += 1;
-                let bytes = t.as_str().as_bytes();
+                let bytes = t.as_bytes();
                 offset += write_varint(&mut buf[offset..], bytes.len() as u64);
                 buf[offset..offset + bytes.len()].copy_from_slice(bytes);
                 offset += bytes.len();
@@ -380,7 +388,7 @@ impl HashEntry {
             }
             Value::Text(t) => {
                 buf.push(TEXT_HASH);
-                let bytes = t.as_str().as_bytes();
+                let bytes = t.as_bytes();
                 let len = write_varint(varint_buf, bytes.len() as u64);
                 buf.extend_from_slice(&varint_buf[..len]);
                 buf.extend_from_slice(bytes);
@@ -483,14 +491,9 @@ impl HashEntry {
                         "HashEntry: buffer too small for text".to_string(),
                     ));
                 }
-                // SAFETY: We serialized this data ourselves, so it should be valid UTF-8.
-                // Skipping validation here for performance in the spill/reload path.
-                // Doing checked utf8 construction here is a massive performance hit.
-                let s = unsafe {
-                    String::from_utf8_unchecked(buf[offset..offset + str_len as usize].to_vec())
-                };
+                let bytes = buf[offset..offset + str_len as usize].to_vec();
                 offset += str_len as usize;
-                Value::Text(s.into())
+                Value::build_text_from_bytes(bytes)
             }
             BLOB_HASH => {
                 let (blob_len, varint_len) = read_varint(&buf[offset..])?;
@@ -2993,6 +2996,32 @@ mod hashtests {
     }
 
     #[test]
+    fn test_hash_nocase_embedded_nul_matches_collation_equality() {
+        use crate::types::{TextRef, TextSubtype};
+
+        let keys1 = vec![ValueRef::Text(TextRef::new("A\0B", TextSubtype::Text))];
+        let keys2 = vec![ValueRef::Text(TextRef::new("A\0C", TextSubtype::Text))];
+        let keys3 = vec![ValueRef::Text(TextRef::new("A", TextSubtype::Text))];
+
+        let nocase_coll = vec![CollationSeq::NoCase];
+
+        // Under SQLite NOCASE semantics, bytes after embedded NUL are ignored
+        // when lengths are equal.
+        assert!(values_equal(keys1[0], keys2[0], CollationSeq::NoCase));
+        assert_eq!(
+            hash_join_key(&keys1, &nocase_coll),
+            hash_join_key(&keys2, &nocase_coll)
+        );
+
+        // Length remains a tie-breaker, so "A\0B" and "A" are not equal.
+        assert!(!values_equal(keys1[0], keys3[0], CollationSeq::NoCase));
+        assert_ne!(
+            hash_join_key(&keys1, &nocase_coll),
+            hash_join_key(&keys3, &nocase_coll)
+        );
+    }
+
+    #[test]
     fn test_values_equal_with_collations() {
         use crate::types::{TextRef, TextSubtype};
 
@@ -3477,6 +3506,35 @@ mod hashtests {
             deserialized.payload_values[4],
             Value::Blob(vec![1, 2, 3, 4])
         );
+    }
+
+    #[test]
+    fn test_hash_entry_invalid_utf8_text_serialization() {
+        let entry = HashEntry::new_with_payload(
+            12345,
+            vec![Value::build_text_from_bytes(vec![0xAB])],
+            100,
+            vec![Value::build_text_from_bytes(vec![0x80, 0x81])],
+        );
+
+        let mut buf = Vec::new();
+        entry.serialize(&mut buf);
+
+        let (deserialized, bytes_consumed) = HashEntry::deserialize(&buf).unwrap();
+        assert_eq!(bytes_consumed, buf.len());
+
+        assert_eq!(deserialized.hash, entry.hash);
+        assert_eq!(deserialized.rowid, entry.rowid);
+
+        match &deserialized.key_values[0] {
+            Value::Text(text) => assert_eq!(text.as_bytes(), &[0xAB]),
+            other => panic!("expected text key, got {other:?}"),
+        }
+
+        match &deserialized.payload_values[0] {
+            Value::Text(text) => assert_eq!(text.as_bytes(), &[0x80, 0x81]),
+            other => panic!("expected text payload, got {other:?}"),
+        }
     }
 
     #[test]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2104,7 +2104,7 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
     #[inline(always)]
     fn nth_into_register(&mut self, n: usize, dest: &mut Register) -> Option<Result<()>> {
         use crate::storage::sqlite3_ondisk::read_varint;
-        use crate::types::{get_serial_type_size, Extendable, Text};
+        use crate::types::{get_serial_type_size, Extendable, Text, TextSubtype};
 
         let mut header = self.header_section_ref();
         let mut data = self.data_section_ref();
@@ -2282,25 +2282,22 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 }
                 self.set_data_section(&data[content_size..]);
                 let text_data = &data[..content_size];
-                // SAFETY: TEXT serial type contains valid UTF-8
-                let text_str = if cfg!(debug_assertions) {
-                    match std::str::from_utf8(text_data) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            return Some(Err(LimboError::InternalError(format!(
-                                "Invalid UTF-8 in TEXT serial type: {e}"
-                            ))));
-                        }
-                    }
-                } else {
-                    unsafe { std::str::from_utf8_unchecked(text_data) }
-                };
                 match dest {
                     Register::Value(Value::Text(existing_text)) => {
-                        existing_text.do_extend(&text_str);
+                        if let Ok(text_str) = std::str::from_utf8(text_data) {
+                            existing_text.do_extend(&text_str);
+                        } else {
+                            *existing_text = Text::from_bytes_with_subtype(
+                                text_data.to_vec(),
+                                TextSubtype::Text,
+                            );
+                        }
                     }
                     _ => {
-                        *dest = Register::Value(Value::Text(Text::new(text_str.to_string())));
+                        *dest = Register::Value(Value::Text(Text::from_bytes_with_subtype(
+                            text_data.to_vec(),
+                            TextSubtype::Text,
+                        )));
                     }
                 }
             }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -11,7 +11,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 
 use crate::io::TempFile;
-use crate::types::{IOCompletions, ValueIterator};
+use crate::types::{compare_text_refs, IOCompletions, ValueIterator};
 use crate::{
     error::LimboError,
     io::{Buffer, Completion, CompletionGroup, File, IO},
@@ -830,7 +830,7 @@ impl Ord for ArenaSortableRecord {
             } else {
                 match (self_val, other_val) {
                     (ValueRef::Text(left), ValueRef::Text(right)) => {
-                        key_info.collation.compare_strings(&left, &right)
+                        compare_text_refs(left, right, key_info.collation)
                     }
                     _ => self_val.partial_cmp(&other_val).unwrap_or(Ordering::Equal),
                 }
@@ -932,7 +932,7 @@ impl Ord for BoxedSortableRecord {
             } else {
                 match (self_val, other_val) {
                     (ValueRef::Text(left), ValueRef::Text(right)) => {
-                        key_info.collation.compare_strings(&left, &right)
+                        compare_text_refs(left, right, key_info.collation)
                     }
                     _ => self_val.partial_cmp(&other_val).unwrap_or(Ordering::Equal),
                 }

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -232,6 +232,20 @@ impl Value {
         }))
     }
 
+    fn string_context_bytes(&self) -> Option<std::borrow::Cow<'_, [u8]>> {
+        match self {
+            Value::Null => None,
+            Value::Text(text) => Some(std::borrow::Cow::Borrowed(text.as_bytes())),
+            Value::Blob(blob) => Some(std::borrow::Cow::Borrowed(blob)),
+            Value::Numeric(Numeric::Integer(i)) => {
+                Some(std::borrow::Cow::Owned(i.to_string().into_bytes()))
+            }
+            Value::Numeric(Numeric::Float(f)) => Some(std::borrow::Cow::Owned(
+                format_float(f64::from(*f)).into_bytes(),
+            )),
+        }
+    }
+
     /// Generates the Soundex code for a given word
     pub fn exec_soundex(&self) -> Value {
         let s = match self {
@@ -569,10 +583,8 @@ impl Value {
 
     pub fn exec_hex(&self) -> Value {
         match self {
-            Value::Text(_) | Value::Numeric(_) => {
-                let text = self.to_string();
-                Value::build_text(hex::encode_upper(text))
-            }
+            Value::Text(text) => Value::build_text(hex::encode_upper(text.as_bytes())),
+            Value::Numeric(_) => Value::build_text(hex::encode_upper(self.to_string())),
             Value::Blob(blob_bytes) => Value::build_text(hex::encode_upper(blob_bytes)),
             Value::Null => Value::build_text(""),
         }
@@ -727,19 +739,18 @@ impl Value {
         match Affinity::affinity(datatype) {
             // NONE	Casting a value to a type-name with no affinity causes the value to be converted into a BLOB. Casting to a BLOB consists of first casting the value to TEXT in the encoding of the database connection, then interpreting the resulting byte sequence as a BLOB instead of as TEXT.
             // Historically called NONE, but it's the same as BLOB
-            Affinity::Blob => {
-                // Convert to TEXT first, then interpret as BLOB
-                // TODO: handle encoding
-                let text = self.to_string();
-                Value::Blob(text.into_bytes())
-            }
+            Affinity::Blob => match self {
+                Value::Blob(blob) => Value::Blob(blob.clone()),
+                Value::Text(text) => Value::Blob(text.as_bytes().to_vec()),
+                _ => Value::Blob(self.to_string().into_bytes()),
+            },
             // TEXT To cast a BLOB value to TEXT, the sequence of bytes that make up the BLOB is interpreted as text encoded using the database encoding.
             // Casting an INTEGER or REAL value into TEXT renders the value as if via sqlite3_snprintf() except that the resulting TEXT uses the encoding of the database connection.
-            Affinity::Text => {
-                // Convert everything to text representation
-                // TODO: handle encoding and whatever sqlite3_snprintf does
-                Value::build_text(self.to_string())
-            }
+            Affinity::Text => match self {
+                Value::Text(text) => Value::Text(text.clone()),
+                Value::Blob(blob) => Value::build_text_from_bytes(blob.clone()),
+                _ => Value::build_text(self.to_string()),
+            },
             Affinity::Real => match self {
                 Value::Blob(b) => {
                     let text = String::from_utf8_lossy(b);
@@ -800,24 +811,39 @@ impl Value {
             return Value::Null;
         }
 
-        let source = source.exec_cast("TEXT");
-        let pattern = pattern.exec_cast("TEXT");
-        let replacement = replacement.exec_cast("TEXT");
+        let source_bytes = source
+            .string_context_bytes()
+            .expect("NULL case returned early");
+        let pattern_bytes = pattern
+            .string_context_bytes()
+            .expect("NULL case returned early");
+        let replacement_bytes = replacement
+            .string_context_bytes()
+            .expect("NULL case returned early");
 
-        // If any of the casts failed, panic as text casting is not expected to fail.
-        match (&source, &pattern, &replacement) {
-            (Value::Text(source), Value::Text(pattern), Value::Text(replacement)) => {
-                if pattern.as_str().is_empty() || pattern.as_str().starts_with('\0') {
-                    return Value::Text(source.clone());
-                }
+        let source_bytes = source_bytes.as_ref();
+        let pattern_bytes = pattern_bytes.as_ref();
+        let replacement_bytes = replacement_bytes.as_ref();
 
-                let result = source
-                    .as_str()
-                    .replace(pattern.as_str(), replacement.as_str());
-                Value::build_text(result)
-            }
-            _ => unreachable!("text cast should never fail"),
+        if pattern_bytes.is_empty() || pattern_bytes[0] == b'\0' {
+            return Value::build_text_from_bytes(source_bytes.to_vec());
         }
+
+        let mut result = Vec::with_capacity(source_bytes.len());
+        let mut idx = 0;
+
+        while idx + pattern_bytes.len() <= source_bytes.len() {
+            if &source_bytes[idx..idx + pattern_bytes.len()] == pattern_bytes {
+                result.extend_from_slice(replacement_bytes);
+                idx += pattern_bytes.len();
+            } else {
+                result.push(source_bytes[idx]);
+                idx += 1;
+            }
+        }
+        result.extend_from_slice(&source_bytes[idx..]);
+
+        Value::build_text_from_bytes(result)
     }
 
     pub fn exec_math_unary(&self, function: &MathFunc) -> Value {
@@ -989,19 +1015,18 @@ impl Value {
     }
 
     pub fn exec_concat(&self, rhs: &Value) -> Value {
-        if let (Value::Blob(lhs), Value::Blob(rhs)) = (self, rhs) {
-            return Value::Blob([lhs.as_slice(), rhs.as_slice()].concat().to_vec());
-        }
-
-        let Some(lhs) = self.cast_text() else {
+        let Some(lhs) = self.string_context_bytes() else {
             return Value::Null;
         };
 
-        let Some(rhs) = rhs.cast_text() else {
+        let Some(rhs) = rhs.string_context_bytes() else {
             return Value::Null;
         };
 
-        Value::build_text(lhs + &rhs)
+        let mut concatenated = Vec::with_capacity(lhs.len() + rhs.len());
+        concatenated.extend_from_slice(lhs.as_ref());
+        concatenated.extend_from_slice(rhs.as_ref());
+        Value::build_text_from_bytes(concatenated)
     }
 
     pub fn exec_and(&self, rhs: &Value) -> Value {
@@ -1142,21 +1167,23 @@ impl Value {
         let Value::Text(text) = self else {
             panic!("concat_to_text must be called only on Value::Text");
         };
-        text.value.to_mut().push_str(&other.to_string());
+
+        let mut concatenated = Vec::with_capacity(text.as_bytes().len());
+        concatenated.extend_from_slice(text.as_bytes());
+        if let Some(other_bytes) = other.string_context_bytes() {
+            concatenated.extend_from_slice(other_bytes.as_ref());
+        }
+        *self = Value::build_text_from_bytes(concatenated);
     }
 
     pub fn exec_concat_strings<'a, T: Iterator<Item = &'a Self>>(registers: T) -> Self {
-        let mut result = String::new();
+        let mut result = Vec::new();
         for val in registers {
-            match val {
-                Value::Null => continue,
-                Value::Text(s) => result.push_str(s.as_str()),
-                Value::Blob(b) => result.push_str(&String::from_utf8_lossy(b)),
-                Value::Numeric(Numeric::Integer(i)) => result.push_str(&i.to_string()),
-                Value::Numeric(Numeric::Float(f)) => result.push_str(&format_float(f64::from(*f))),
+            if let Some(bytes) = val.string_context_bytes() {
+                result.extend_from_slice(bytes.as_ref());
             }
         }
-        Value::build_text(result)
+        Value::build_text_from_bytes(result)
     }
 
     pub fn exec_concat_ws<'a, T: ExactSizeIterator<Item = &'a Self>>(mut registers: T) -> Self {
@@ -2767,5 +2794,32 @@ mod tests {
             Value::exec_replace(&input_str, &pattern_str, &replace_str),
             expected_str
         );
+    }
+
+    #[test]
+    fn test_concat_preserves_blob_bytes_in_text_context() {
+        let lhs = Value::Blob(vec![0xAB]);
+        let rhs = Value::build_text("text");
+        let result = lhs.exec_concat(&rhs);
+        assert_eq!(result.exec_typeof(), Value::build_text("text"));
+        assert_eq!(result.exec_hex(), Value::build_text("AB74657874"));
+
+        let reverse_result = rhs.exec_concat(&lhs);
+        assert_eq!(reverse_result.exec_typeof(), Value::build_text("text"));
+        assert_eq!(reverse_result.exec_hex(), Value::build_text("74657874AB"));
+
+        let both_blobs = Value::Blob(vec![0xAA]).exec_concat(&Value::Blob(vec![0xBB]));
+        assert_eq!(both_blobs.exec_typeof(), Value::build_text("text"));
+        assert_eq!(both_blobs.exec_hex(), Value::build_text("AABB"));
+    }
+
+    #[test]
+    fn test_replace_preserves_blob_bytes_in_text_context() {
+        let source = Value::Blob(vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x03]);
+        let pattern = Value::Blob(vec![0x03]);
+        let replacement = Value::Blob(vec![0xFF]);
+        let result = Value::exec_replace(&source, &pattern, &replacement);
+        assert_eq!(result.exec_typeof(), Value::build_text("text"));
+        assert_eq!(result.exec_hex(), Value::build_text("0102FF0405FF"));
     }
 }

--- a/testing/runner/tests/agg-functions/group-concat-types.sqltest
+++ b/testing/runner/tests/agg-functions/group-concat-types.sqltest
@@ -441,4 +441,19 @@ expect {
     �,��
 }
 
+@cross-check-integrity
+test group-concat-blob-invalid-bytes-preserves-bytes {
+    SELECT hex(GROUP_CONCAT(v, '')) FROM (SELECT x'AB' AS v UNION ALL SELECT 'text');
+}
+expect {
+    AB74657874
+}
+
+@cross-check-integrity
+test group-concat-blob-invalid-bytes-type {
+    SELECT typeof(GROUP_CONCAT(v, '')) FROM (SELECT x'AB' AS v UNION ALL SELECT 'text');
+}
+expect {
+    text
+}
 

--- a/testing/runner/tests/collate.sqltest
+++ b/testing/runner/tests/collate.sqltest
@@ -790,3 +790,338 @@ test agg_collate_no_leak_with_count {
 expect {
     a|a|2
 }
+
+@cross-check-integrity
+test collate-invalid-bytes-storage-roundtrip {
+    CREATE TABLE t_blob_text_roundtrip(x);
+    INSERT INTO t_blob_text_roundtrip VALUES(CAST(x'AB' AS TEXT));
+    SELECT hex(x), typeof(x) FROM t_blob_text_roundtrip;
+}
+expect {
+    AB|text
+}
+
+test collate-invalid-bytes-binary-comparison {
+    SELECT CAST(x'80' AS TEXT)=CAST(x'81' AS TEXT), CAST(x'80' AS TEXT)<CAST(x'81' AS TEXT);
+}
+expect {
+    0|1
+}
+
+test collate-invalid-bytes-nocase-compare {
+    SELECT CAST(X'8041' AS TEXT)=CAST(X'8061' AS TEXT) COLLATE NOCASE,
+           CAST(X'8041' AS TEXT)=CAST(X'8061' AS TEXT) COLLATE BINARY;
+}
+expect {
+    1|0
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-nocase-order {
+    CREATE TABLE t_collate_nocase_invalid(x);
+    INSERT INTO t_collate_nocase_invalid VALUES
+      (CAST(X'8042' AS TEXT)),
+      (CAST(X'8061' AS TEXT)),
+      (CAST(X'8041' AS TEXT)),
+      (CAST(X'7A' AS TEXT));
+    SELECT hex(x) FROM t_collate_nocase_invalid ORDER BY x COLLATE NOCASE, hex(x);
+}
+expect {
+    7A
+    8041
+    8061
+    8042
+}
+
+test collate-invalid-bytes-rtrim-compare {
+    SELECT CAST(X'AB20' AS TEXT)=CAST(X'AB2020' AS TEXT) COLLATE RTRIM,
+           CAST(X'AB20' AS TEXT)=CAST(X'AB2020' AS TEXT) COLLATE BINARY;
+}
+expect {
+    1|0
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-rtrim-order {
+    CREATE TABLE t_collate_rtrim_invalid(x);
+    INSERT INTO t_collate_rtrim_invalid VALUES
+      (CAST(X'AB2020' AS TEXT)),
+      (CAST(X'AB21' AS TEXT)),
+      (CAST(X'AB20' AS TEXT));
+    SELECT hex(x) FROM t_collate_rtrim_invalid ORDER BY x COLLATE RTRIM, hex(x);
+}
+expect {
+    AB20
+    AB2020
+    AB21
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-index-binary-seek {
+    CREATE TABLE t_idx_binary_invalid(x TEXT);
+    CREATE INDEX t_idx_binary_invalid_x ON t_idx_binary_invalid(x);
+    INSERT INTO t_idx_binary_invalid VALUES
+      (CAST(X'80' AS TEXT)),
+      (CAST(X'81' AS TEXT)),
+      (CAST(X'80' AS TEXT));
+    SELECT hex(x)
+    FROM t_idx_binary_invalid
+    WHERE x = CAST(X'80' AS TEXT)
+    ORDER BY rowid;
+    SELECT hex(x)
+    FROM t_idx_binary_invalid
+    WHERE x >= CAST(X'80' AS TEXT)
+    ORDER BY x, rowid;
+}
+expect {
+    80
+    80
+    80
+    80
+    81
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-index-nocase-seek-order {
+    CREATE TABLE t_idx_nocase_invalid(x TEXT COLLATE NOCASE);
+    CREATE INDEX t_idx_nocase_invalid_x ON t_idx_nocase_invalid(x COLLATE NOCASE);
+    INSERT INTO t_idx_nocase_invalid VALUES
+      (CAST(X'8041' AS TEXT)),
+      (CAST(X'8061' AS TEXT)),
+      (CAST(X'8042' AS TEXT));
+    SELECT count(*)
+    FROM t_idx_nocase_invalid
+    WHERE x = CAST(X'8041' AS TEXT);
+    SELECT hex(x)
+    FROM t_idx_nocase_invalid
+    WHERE x >= CAST(X'8041' AS TEXT)
+    ORDER BY x COLLATE NOCASE, hex(x);
+}
+expect {
+    2
+    8041
+    8061
+    8042
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-index-rtrim-seek-order {
+    CREATE TABLE t_idx_rtrim_invalid(x TEXT COLLATE RTRIM);
+    CREATE INDEX t_idx_rtrim_invalid_x ON t_idx_rtrim_invalid(x COLLATE RTRIM);
+    INSERT INTO t_idx_rtrim_invalid VALUES
+      (CAST(X'AB20' AS TEXT)),
+      (CAST(X'AB2020' AS TEXT)),
+      (CAST(X'AB21' AS TEXT));
+    SELECT count(*)
+    FROM t_idx_rtrim_invalid
+    WHERE x = CAST(X'AB20' AS TEXT);
+    SELECT hex(x)
+    FROM t_idx_rtrim_invalid
+    WHERE x >= CAST(X'AB20' AS TEXT)
+    ORDER BY x COLLATE RTRIM, hex(x);
+}
+expect {
+    2
+    AB20
+    AB2020
+    AB21
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-distinct-binary {
+    CREATE TABLE t_distinct_group_invalid(x);
+    INSERT INTO t_distinct_group_invalid VALUES
+      ('A'),
+      (CAST(X'80' AS TEXT)),
+      (CAST(X'80' AS TEXT)),
+      (CAST(X'81' AS TEXT));
+    SELECT hex(x) FROM (SELECT DISTINCT x FROM t_distinct_group_invalid) ORDER BY x;
+}
+expect {
+    41
+    80
+    81
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-group-by-binary {
+    CREATE TABLE t_distinct_group_invalid_2(x);
+    INSERT INTO t_distinct_group_invalid_2 VALUES
+      ('A'),
+      (CAST(X'80' AS TEXT)),
+      (CAST(X'80' AS TEXT)),
+      (CAST(X'81' AS TEXT));
+    SELECT hex(x), count(*) FROM t_distinct_group_invalid_2 GROUP BY x ORDER BY x;
+}
+expect {
+    41|1
+    80|2
+    81|1
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-distinct-group-by-nocase {
+    CREATE TABLE t_distinct_group_nocase_invalid(x);
+    INSERT INTO t_distinct_group_nocase_invalid VALUES
+      (CAST(X'8041' AS TEXT)),
+      (CAST(X'8061' AS TEXT)),
+      (CAST(X'8042' AS TEXT)),
+      (CAST(X'7A' AS TEXT));
+    SELECT count(*) FROM (SELECT DISTINCT x COLLATE NOCASE FROM t_distinct_group_nocase_invalid);
+    SELECT min(c), max(c), count(*)
+    FROM (
+        SELECT count(*) AS c
+        FROM t_distinct_group_nocase_invalid
+        GROUP BY x COLLATE NOCASE
+    );
+}
+expect {
+    3
+    1|2|3
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-join-binary {
+    CREATE TABLE t_join_left_invalid(x);
+    CREATE TABLE t_join_right_invalid(x);
+    INSERT INTO t_join_left_invalid VALUES
+      (CAST(X'80' AS TEXT)),
+      (CAST(X'81' AS TEXT)),
+      (CAST(X'8041' AS TEXT));
+    INSERT INTO t_join_right_invalid VALUES
+      (CAST(X'81' AS TEXT)),
+      (CAST(X'80' AS TEXT)),
+      (CAST(X'8061' AS TEXT));
+    SELECT hex(l.x), hex(r.x)
+    FROM t_join_left_invalid l
+    JOIN t_join_right_invalid r ON l.x = r.x
+    ORDER BY l.x, r.x;
+}
+expect {
+    80|80
+    81|81
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-join-nocase {
+    CREATE TABLE t_join_left_invalid_2(x);
+    CREATE TABLE t_join_right_invalid_2(x);
+    INSERT INTO t_join_left_invalid_2 VALUES
+      (CAST(X'80' AS TEXT)),
+      (CAST(X'81' AS TEXT)),
+      (CAST(X'8041' AS TEXT));
+    INSERT INTO t_join_right_invalid_2 VALUES
+      (CAST(X'81' AS TEXT)),
+      (CAST(X'80' AS TEXT)),
+      (CAST(X'8061' AS TEXT));
+    SELECT hex(l.x), hex(r.x)
+    FROM t_join_left_invalid_2 l
+    JOIN t_join_right_invalid_2 r ON l.x COLLATE NOCASE = r.x
+    ORDER BY l.x COLLATE NOCASE, r.x COLLATE NOCASE, hex(l.x), hex(r.x);
+}
+expect {
+    80|80
+    8041|8061
+    81|81
+}
+
+@cross-check-integrity
+test collate-invalid-bytes-join-nocase-cross-product {
+    CREATE TABLE t_join_left_invalid_3(x);
+    CREATE TABLE t_join_right_invalid_3(x);
+    INSERT INTO t_join_left_invalid_3 VALUES
+      (CAST(X'8041' AS TEXT)),
+      (CAST(X'8061' AS TEXT)),
+      (CAST(X'8042' AS TEXT));
+    INSERT INTO t_join_right_invalid_3 VALUES
+      (CAST(X'8041' AS TEXT)),
+      (CAST(X'8061' AS TEXT)),
+      (CAST(X'8042' AS TEXT));
+    SELECT count(*)
+    FROM t_join_left_invalid_3 l
+    JOIN t_join_right_invalid_3 r ON l.x COLLATE NOCASE = r.x;
+    SELECT hex(l.x), hex(r.x)
+    FROM t_join_left_invalid_3 l
+    JOIN t_join_right_invalid_3 r ON l.x COLLATE NOCASE = r.x
+    ORDER BY l.x COLLATE NOCASE, r.x COLLATE NOCASE, hex(l.x), hex(r.x);
+}
+expect {
+    5
+    8041|8041
+    8041|8061
+    8061|8041
+    8061|8061
+    8042|8042
+}
+
+test collate-embedded-nul-boundaries {
+    SELECT ('A'||char(0)||'B') = ('A'||char(0)||'C') COLLATE NOCASE,
+           ('A'||char(0)||'B') = ('A'||char(0)||'C') COLLATE BINARY,
+           ('A'||char(0)||'B') < ('A'||char(0)||'C') COLLATE BINARY;
+    SELECT ('A'||char(0)||'B') > 'A' COLLATE NOCASE,
+           ('A'||char(0)||'B') = 'A' COLLATE NOCASE;
+    SELECT ('A'||char(0)||'B ') = ('A'||char(0)||'B  ') COLLATE RTRIM,
+           ('A'||char(0)||'B ') = ('A'||char(0)||'B  ') COLLATE BINARY;
+}
+expect {
+    1|0|1
+    1|0
+    1|0
+}
+
+@cross-check-integrity
+test collate-embedded-nul-order-by-boundaries {
+    CREATE TABLE t_nul_order_boundaries(x);
+    INSERT INTO t_nul_order_boundaries VALUES
+      ('A'||char(0)||'C'),
+      ('A'||char(0)||'B'),
+      ('A '),
+      ('A');
+    SELECT hex(x) FROM t_nul_order_boundaries ORDER BY x COLLATE BINARY;
+    SELECT hex(x) FROM t_nul_order_boundaries ORDER BY x COLLATE RTRIM, hex(x);
+}
+expect {
+    41
+    410042
+    410043
+    4120
+    41
+    4120
+    410042
+    410043
+}
+
+@cross-check-integrity
+test collate-embedded-nul-order-by-nocase {
+    CREATE TABLE t_nul_nocase_order(x);
+    INSERT INTO t_nul_nocase_order VALUES
+      ('A'||char(0)||'b'),
+      ('a'||char(0)||'B'),
+      ('A'||char(0)||'C');
+    SELECT hex(x) FROM t_nul_nocase_order ORDER BY x COLLATE NOCASE, hex(x);
+}
+expect {
+    410043
+    410062
+    610042
+}
+
+@cross-check-integrity
+test collate-embedded-nul-distinct-group-by-nocase {
+    CREATE TABLE t_nul_group(x);
+    INSERT INTO t_nul_group VALUES
+      ('A'||char(0)||'B'),
+      ('a'||char(0)||'C'),
+      ('A'||char(0)||'D');
+    SELECT count(*) FROM (SELECT DISTINCT x COLLATE NOCASE FROM t_nul_group);
+    SELECT min(c), max(c), count(*)
+    FROM (
+        SELECT count(*) AS c
+        FROM t_nul_group
+        GROUP BY x COLLATE NOCASE
+    );
+}
+expect {
+    1
+    3|3|1
+}

--- a/testing/runner/tests/concat.sqltest
+++ b/testing/runner/tests/concat.sqltest
@@ -40,3 +40,31 @@ test concat-blob {
 expect {
     0102
 }
+
+test concat-blob-text-invalid-bytes-left {
+    SELECT hex(x'AB' || 'text');
+}
+expect {
+    AB74657874
+}
+
+test concat-blob-text-invalid-bytes-left-type {
+    SELECT typeof(x'AB' || 'text');
+}
+expect {
+    text
+}
+
+test concat-blob-text-invalid-bytes-right {
+    SELECT hex('text' || x'AB');
+}
+expect {
+    74657874AB
+}
+
+test concat-blob-text-invalid-bytes-right-type {
+    SELECT typeof('text' || x'AB');
+}
+expect {
+    text
+}

--- a/testing/runner/tests/scalar-functions-printf.sqltest
+++ b/testing/runner/tests/scalar-functions-printf.sqltest
@@ -1374,3 +1374,45 @@ test printf-blob-s-nul {
 expect {
     1
 }
+
+test printf-blob-invalid-utf8-preserves-bytes {
+    SELECT hex(printf('%s', x'AB'));
+}
+expect {
+    AB
+}
+
+test printf-blob-invalid-utf8-preserves-bytes-type {
+    SELECT typeof(printf('%s', x'AB'));
+}
+expect {
+    text
+}
+
+test printf-blob-invalid-utf8-with-prefix {
+    SELECT hex(printf('x%s', x'AB'));
+}
+expect {
+    78AB
+}
+
+test printf-blob-invalid-utf8-with-prefix-type {
+    SELECT typeof(printf('x%s', x'AB'));
+}
+expect {
+    text
+}
+
+test printf-text-s-truncates-at-first-nul {
+    SELECT hex(printf('%s', 'A'||char(0)||'B'));
+}
+expect {
+    41
+}
+
+test printf-string-precision-is-byte-based-invalid-utf8 {
+    SELECT hex(printf('%.1s', char(233)));
+}
+expect {
+    C3
+}

--- a/testing/runner/tests/scalar-functions.sqltest
+++ b/testing/runner/tests/scalar-functions.sqltest
@@ -328,6 +328,20 @@ expect {
     hello
 }
 
+test replace-blob-invalid-bytes-preserves-bytes {
+    select hex(replace(x'010203040503', x'03', x'ff'));
+}
+expect {
+    0102FF0405FF
+}
+
+test replace-blob-invalid-bytes-type {
+    select typeof(replace(x'010203040503', x'03', x'ff'));
+}
+expect {
+    text
+}
+
 test hex {
     select hex('limbo')
 }


### PR DESCRIPTION
## Description

This PR fixes TEXT byte-semantics to match SQLite when values contain invalid UTF-8 bytes. TEXT values are now preserved end-to-end as raw bytes (including storage decode, expression evaluation, comparison, hashing, sorting, and formatting paths), instead of being lossy-converted through UTF-8 replacement behavior.

It also fixes %s behavior in printf to match SQLite:

  - DISTINCT/GROUP BY/joins with mixed valid and invalid text bytes
  - embedded-NUL collation/grouping/ordering boundaries

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Issue #5757 exposed multiple SQLite-compatibility breaks caused by treating TEXT as always-valid UTF-8 in Rust string paths. That produced lossy byte replacement (U+FFFD), failed round-trips, and incorrect equality/ordering semantics in collation and hash/sort paths.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5757

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
