### PR TITLE
bindings/js: add prepared statement type inference

### DIFF
--- a/bindings/javascript/packages/common/compat.ts
+++ b/bindings/javascript/packages/common/compat.ts
@@ -1,4 +1,5 @@
 import { bindParams } from "./bind.js";
+import { BindParams } from "./sql-params.js";
 import { SqliteError } from "./sqlite-error.js";
 import { NativeDatabase, NativeStatement, STEP_IO, STEP_ROW, STEP_DONE } from "./types.js";
 
@@ -66,7 +67,7 @@ class Database {
    *
    * @param {string} sql - The SQL statement string to prepare.
    */
-  prepare(sql) {
+  prepare<S extends string>(sql: S): Statement<S> {
     if (!this.open) {
       throw new TypeError("The database connection is not open");
     }
@@ -75,7 +76,7 @@ class Database {
     }
 
     try {
-      return new Statement(this.db.prepare(sql), this.db);
+      return new Statement<S>(this.db.prepare(sql), this.db);
     } catch (err) {
       throw convertError(err);
     }
@@ -227,7 +228,7 @@ class Database {
 /**
  * Statement represents a prepared SQL statement that can be executed.
  */
-class Statement {
+class Statement<SQL extends string = string> {
   stmt: NativeStatement;
   db: NativeDatabase;
 
@@ -290,7 +291,7 @@ class Statement {
   /**
    * Executes the SQL statement and returns an info object.
    */
-  run(...bindParameters) {
+  run(...bindParameters: BindParams<SQL>) {
     const totalChangesBefore = this.db.totalChanges();
 
     this.stmt.reset();
@@ -321,7 +322,7 @@ class Statement {
    *
    * @param bindParameters - The bind parameters for executing the statement.
    */
-  get(...bindParameters) {
+  get(...bindParameters: BindParams<SQL>) {
     this.stmt.reset();
     bindParams(this.stmt, bindParameters);
     let row = undefined;
@@ -346,7 +347,7 @@ class Statement {
    *
    * @param bindParameters - The bind parameters for executing the statement.
    */
-  *iterate(...bindParameters) {
+  *iterate(...bindParameters: BindParams<SQL>) {
     this.stmt.reset();
     bindParams(this.stmt, bindParameters);
 
@@ -370,7 +371,7 @@ class Statement {
    *
    * @param bindParameters - The bind parameters for executing the statement.
    */
-  all(...bindParameters) {
+  all(...bindParameters: BindParams<SQL>) {
     this.stmt.reset();
     bindParams(this.stmt, bindParameters);
     const rows: any[] = [];
@@ -404,7 +405,7 @@ class Statement {
    * @param bindParameters - The bind parameters for binding the statement.
    * @returns this - Statement with binded parameters
    */
-  bind(...bindParameters) {
+  bind(...bindParameters: BindParams<SQL>) {
     try {
       bindParams(this.stmt, bindParameters);
       return this;

--- a/bindings/javascript/packages/common/index.ts
+++ b/bindings/javascript/packages/common/index.ts
@@ -3,6 +3,7 @@ import { Database as DatabaseCompat, Statement as StatementCompat } from "./comp
 import { Database as DatabasePromise, Statement as StatementPromise } from "./promise.js";
 import { SqliteError } from "./sqlite-error.js";
 import { AsyncLock } from "./async-lock.js";
+import type { BindParams, SqlValue } from "./sql-params.js";
 
 export {
     DatabaseOpts,
@@ -14,3 +15,4 @@ export {
     SqliteError,
     AsyncLock
 }
+export type { BindParams, SqlValue }

--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -1,5 +1,6 @@
 import { AsyncLock } from "./async-lock.js";
 import { bindParams } from "./bind.js";
+import { BindParams } from "./sql-params.js";
 import { SqliteError } from "./sqlite-error.js";
 import { NativeDatabase, NativeStatement, STEP_IO, STEP_ROW, STEP_DONE, DatabaseOpts } from "./types.js";
 
@@ -69,7 +70,7 @@ class Database {
    *
    * @param {string} sql - The SQL statement string to prepare.
    */
-  prepare(sql) {
+  prepare<S extends string>(sql: S): Statement<S> {
     // Only throw if we connected before but now the database is closed
     // Allow implicit connection if not connected yet
     if (this.connected && !this.open) {
@@ -81,9 +82,9 @@ class Database {
 
     try {
       if (this.connected) {
-        return new Statement(maybeValue(this.db.prepare(sql)), this.db, this.execLock, this.ioStep);
+        return new Statement<S>(maybeValue(this.db.prepare(sql)), this.db, this.execLock, this.ioStep);
       } else {
-        return new Statement(maybePromise(() => this.connect().then(() => this.db.prepare(sql))), this.db, this.execLock, this.ioStep)
+        return new Statement<S>(maybePromise(() => this.connect().then(() => this.db.prepare(sql))), this.db, this.execLock, this.ioStep)
       }
     } catch (err) {
       throw convertError(err);
@@ -293,7 +294,7 @@ function maybeValue<T>(value: T): MaybeLazy<T> {
 /**
  * Statement represents a prepared SQL statement that can be executed.
  */
-class Statement {
+class Statement<SQL extends string = string> {
   private stmt: MaybeLazy<NativeStatement>;
   private db: NativeDatabase;
   private execLock: AsyncLock;
@@ -360,7 +361,7 @@ class Statement {
   /**
    * Executes the SQL statement and returns an info object.
    */
-  async run(...bindParameters) {
+  async run(...bindParameters: BindParams<SQL>) {
     let stmt = await this.stmt.resolve();
 
     bindParams(stmt, bindParameters);
@@ -398,7 +399,7 @@ class Statement {
    *
    * @param bindParameters - The bind parameters for executing the statement.
    */
-  async get(...bindParameters) {
+  async get(...bindParameters: BindParams<SQL>) {
     let stmt = await this.stmt.resolve();
 
     bindParams(stmt, bindParameters);
@@ -432,7 +433,7 @@ class Statement {
    *
    * @param bindParameters - The bind parameters for executing the statement.
    */
-  async *iterate(...bindParameters) {
+  async *iterate(...bindParameters: BindParams<SQL>) {
     let stmt = await this.stmt.resolve();
 
     bindParams(stmt, bindParameters);
@@ -463,7 +464,7 @@ class Statement {
    *
    * @param bindParameters - The bind parameters for executing the statement.
    */
-  async all(...bindParameters) {
+  async all(...bindParameters: BindParams<SQL>) {
     let stmt = await this.stmt.resolve();
 
     bindParams(stmt, bindParameters);
@@ -510,7 +511,7 @@ class Statement {
    * @param bindParameters - The bind parameters for binding the statement.
    * @returns this - Statement with binded parameters
    */
-  bind(...bindParameters) {
+  bind(...bindParameters: BindParams<SQL>) {
     try {
       bindParams(this.stmt, bindParameters);
       return this;

--- a/bindings/javascript/packages/common/sql-params.test.ts
+++ b/bindings/javascript/packages/common/sql-params.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Type-level tests for SQL named parameter extraction.
+ *
+ * Uses vitest's built-in expectTypeOf (powered by expect-type) for real
+ * type assertions. Tests go end-to-end through Database.prepare() →
+ * Statement method signatures.
+ *
+ * Run: cd bindings/javascript/packages/common && npx vitest --run
+ */
+
+import { describe, it, expectTypeOf } from "vitest";
+import type { BindParams, SqlValue } from "./sql-params.js";
+import type { Database as CompatDatabase, Statement as CompatStatement } from "./compat.js";
+import type { Database as PromiseDatabase, Statement as PromiseStatement } from "./promise.js";
+
+// ─── BindParams utility type ─────────────────────────────────────────────────
+
+describe("BindParams: single named parameter", () => {
+  it("extracts $-prefixed param", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $name">>()
+      .toEqualTypeOf<[params: { name: SqlValue }]>();
+  });
+
+  it("extracts :-prefixed param", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = :name">>()
+      .toEqualTypeOf<[params: { name: SqlValue }]>();
+  });
+
+  it("extracts @-prefixed param", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = @name">>()
+      .toEqualTypeOf<[params: { name: SqlValue }]>();
+  });
+
+  it("extracts param with underscores", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $first_name">>()
+      .toEqualTypeOf<[params: { first_name: SqlValue }]>();
+  });
+
+  it("extracts param with digits", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $param1">>()
+      .toEqualTypeOf<[params: { param1: SqlValue }]>();
+  });
+
+  it("extracts param starting with digit", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $1abc">>()
+      .toEqualTypeOf<[params: { "1abc": SqlValue }]>();
+  });
+});
+
+describe("BindParams: multiple named parameters", () => {
+  it("extracts two params with different prefixes", () => {
+    expectTypeOf<BindParams<"SELECT * FROM users WHERE name = $name AND age = :age">>()
+      .toEqualTypeOf<[params: { name: SqlValue; age: SqlValue }]>();
+  });
+
+  it("extracts three params with mixed prefixes", () => {
+    expectTypeOf<BindParams<"INSERT INTO t VALUES ($a, :b, @c)">>()
+      .toEqualTypeOf<[params: { a: SqlValue; b: SqlValue; c: SqlValue }]>();
+  });
+
+  it("deduplicates repeated param name", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $name OR y = $name">>()
+      .toEqualTypeOf<[params: { name: SqlValue }]>();
+  });
+
+  it("handles five params", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE a=$a AND b=$b AND c=$c AND d=$d AND e=$e">>()
+      .toEqualTypeOf<[params: { a: SqlValue; b: SqlValue; c: SqlValue; d: SqlValue; e: SqlValue }]>();
+  });
+});
+
+describe("BindParams: param terminators", () => {
+  it("param followed by comma", () => {
+    expectTypeOf<BindParams<"INSERT INTO t VALUES ($a, $b)">>()
+      .toEqualTypeOf<[params: { a: SqlValue; b: SqlValue }]>();
+  });
+
+  it("param followed by closing paren", () => {
+    expectTypeOf<BindParams<"INSERT INTO t VALUES ($val)">>()
+      .toEqualTypeOf<[params: { val: SqlValue }]>();
+  });
+
+  it("param followed by semicolon", () => {
+    expectTypeOf<BindParams<"UPDATE t SET x = $val;">>()
+      .toEqualTypeOf<[params: { val: SqlValue }]>();
+  });
+
+  it("param followed by newline", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $name\nAND y = :age">>()
+      .toEqualTypeOf<[params: { name: SqlValue; age: SqlValue }]>();
+  });
+});
+
+describe("BindParams: complex SQL", () => {
+  it("param in subquery", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x IN (SELECT id FROM s WHERE y = $val)">>()
+      .toEqualTypeOf<[params: { val: SqlValue }]>();
+  });
+
+  it("param in JOIN condition", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t JOIN s ON t.id = s.id WHERE t.x = :val">>()
+      .toEqualTypeOf<[params: { val: SqlValue }]>();
+  });
+
+  it("named params mixed with positional ?", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $name AND y = ?">>()
+      .toEqualTypeOf<[params: { name: SqlValue }]>();
+  });
+});
+
+describe("BindParams: positional parameters", () => {
+  it("single ? gives spread SqlValue[]", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = ?">>()
+      .toEqualTypeOf<[...params: (SqlValue | SqlValue[])[]]>();
+  });
+
+  it("multiple ? gives spread SqlValue[]", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = ? AND y = ?">>()
+      .toEqualTypeOf<[...params: (SqlValue | SqlValue[])[]]>();
+  });
+
+  it("accepts an array as a single argument for positional params", () => {
+    type Stmt = CompatStatement<"SELECT * FROM t WHERE x = ?">;
+    // stmt.all([1]) — passing an array instead of spreading
+    expectTypeOf<Stmt["all"]>()
+      .toBeCallableWith([1]);
+  });
+
+  it("accepts spread args for positional params", () => {
+    type Stmt = CompatStatement<"SELECT * FROM t WHERE x = ? AND y = ?">;
+    // stmt.all(1, 2) — spreading individual values
+    expectTypeOf<Stmt["all"]>()
+      .toBeCallableWith(1, 2);
+  });
+});
+
+describe("BindParams: no parameters", () => {
+  it("no params gives empty tuple (no args allowed)", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t">>()
+      .toEqualTypeOf<[]>();
+  });
+
+  it("empty string gives empty tuple", () => {
+    expectTypeOf<BindParams<"">>()
+      .toEqualTypeOf<[]>();
+  });
+});
+
+describe("BindParams: non-literal string fallback", () => {
+  it("plain string type gives permissive any[]", () => {
+    expectTypeOf<BindParams<string>>()
+      .toEqualTypeOf<[...params: any[]]>();
+  });
+});
+
+describe("BindParams: edge cases", () => {
+  it("$$ (prefix not followed by alphanum) gives empty tuple", () => {
+    expectTypeOf<BindParams<"SELECT $$ FROM t">>()
+      .toEqualTypeOf<[]>();
+  });
+});
+
+describe("BindParams: rejects incorrect types", () => {
+  it("named params do not match positional spread", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $name">>()
+      .not.toEqualTypeOf<[...params: (SqlValue | SqlValue[])[]]>();
+  });
+
+  it("named params reject wrong keys", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $name">>()
+      .not.toEqualTypeOf<[params: { wrong: SqlValue }]>();
+  });
+
+  it("named params reject empty object", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $name">>()
+      .not.toEqualTypeOf<[params: {}]>();
+  });
+
+  it("positional does not match named object", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = ?">>()
+      .not.toEqualTypeOf<[params: { x: SqlValue }]>();
+  });
+
+  it("non-literal string does not match specific named params", () => {
+    expectTypeOf<BindParams<string>>()
+      .not.toEqualTypeOf<[params: { name: SqlValue }]>();
+  });
+
+  it("named params are not permissive any[]", () => {
+    expectTypeOf<BindParams<"SELECT * FROM t WHERE x = $name">>()
+      .not.toEqualTypeOf<[...params: any[]]>();
+  });
+});
+
+// ─── End-to-end: Database.prepare() → Statement methods ─────────────────────
+
+describe("compat: Database.prepare() returns typed Statement", () => {
+  it("prepare with named params returns Statement<SQL>", () => {
+    expectTypeOf<CompatDatabase["prepare"]>()
+      .returns.toMatchTypeOf<CompatStatement<any>>();
+  });
+
+  it("Statement.all() requires named params object for named SQL", () => {
+    type Stmt = CompatStatement<"SELECT * FROM t WHERE x = $name AND y = :age">;
+    expectTypeOf<Stmt["all"]>()
+      .parameters.toEqualTypeOf<[params: { name: SqlValue; age: SqlValue }]>();
+  });
+
+  it("Statement.get() requires named params object for named SQL", () => {
+    type Stmt = CompatStatement<"SELECT * FROM t WHERE x = $name">;
+    expectTypeOf<Stmt["get"]>()
+      .parameters.toEqualTypeOf<[params: { name: SqlValue }]>();
+  });
+
+  it("Statement.run() requires named params object for named SQL", () => {
+    type Stmt = CompatStatement<"INSERT INTO t VALUES ($a, $b)">;
+    expectTypeOf<Stmt["run"]>()
+      .parameters.toEqualTypeOf<[params: { a: SqlValue; b: SqlValue }]>();
+  });
+
+  it("Statement.iterate() requires named params object for named SQL", () => {
+    type Stmt = CompatStatement<"SELECT * FROM t WHERE id = :id">;
+    expectTypeOf<Stmt["iterate"]>()
+      .parameters.toEqualTypeOf<[params: { id: SqlValue }]>();
+  });
+
+  it("Statement.bind() requires named params object for named SQL", () => {
+    type Stmt = CompatStatement<"SELECT * FROM t WHERE x = @val">;
+    expectTypeOf<Stmt["bind"]>()
+      .parameters.toEqualTypeOf<[params: { val: SqlValue }]>();
+  });
+
+  it("Statement.all() accepts positional args for ? SQL", () => {
+    type Stmt = CompatStatement<"SELECT * FROM t WHERE x = ?">;
+    expectTypeOf<Stmt["all"]>()
+      .parameters.toEqualTypeOf<[...params: (SqlValue | SqlValue[])[]]>();
+  });
+
+  it("Statement.all() accepts no args for parameterless SQL", () => {
+    type Stmt = CompatStatement<"SELECT * FROM t">;
+    expectTypeOf<Stmt["all"]>()
+      .parameters.toEqualTypeOf<[]>();
+  });
+
+  it("Statement.run() accepts no args for parameterless SQL", () => {
+    type Stmt = CompatStatement<"CREATE TABLE t (id INTEGER)">;
+    expectTypeOf<Stmt["run"]>()
+      .parameters.toEqualTypeOf<[]>();
+  });
+
+  it("Statement methods are permissive for non-literal string", () => {
+    type Stmt = CompatStatement<string>;
+    expectTypeOf<Stmt["all"]>()
+      .parameters.toEqualTypeOf<[...params: any[]]>();
+  });
+});
+
+describe("promise: Database.prepare() returns typed Statement", () => {
+  it("Statement.all() requires named params object for named SQL", () => {
+    type Stmt = PromiseStatement<"SELECT * FROM t WHERE x = $name AND y = :age">;
+    expectTypeOf<Stmt["all"]>()
+      .parameters.toEqualTypeOf<[params: { name: SqlValue; age: SqlValue }]>();
+  });
+
+  it("Statement.get() requires named params object for named SQL", () => {
+    type Stmt = PromiseStatement<"SELECT * FROM t WHERE x = $name">;
+    expectTypeOf<Stmt["get"]>()
+      .parameters.toEqualTypeOf<[params: { name: SqlValue }]>();
+  });
+
+  it("Statement.run() requires named params object for named SQL", () => {
+    type Stmt = PromiseStatement<"INSERT INTO t VALUES ($a, $b)">;
+    expectTypeOf<Stmt["run"]>()
+      .parameters.toEqualTypeOf<[params: { a: SqlValue; b: SqlValue }]>();
+  });
+
+  it("Statement.iterate() requires named params for named SQL", () => {
+    type Stmt = PromiseStatement<"SELECT * FROM t WHERE id = :id">;
+    expectTypeOf<Stmt["iterate"]>()
+      .parameters.toEqualTypeOf<[params: { id: SqlValue }]>();
+  });
+
+  it("Statement.bind() requires named params for named SQL", () => {
+    type Stmt = PromiseStatement<"SELECT * FROM t WHERE x = @val">;
+    expectTypeOf<Stmt["bind"]>()
+      .parameters.toEqualTypeOf<[params: { val: SqlValue }]>();
+  });
+
+  it("Statement.all() accepts positional args for ? SQL", () => {
+    type Stmt = PromiseStatement<"SELECT * FROM t WHERE x = ?">;
+    expectTypeOf<Stmt["all"]>()
+      .parameters.toEqualTypeOf<[...params: (SqlValue | SqlValue[])[]]>();
+  });
+
+  it("Statement.all() accepts no args for parameterless SQL", () => {
+    type Stmt = PromiseStatement<"SELECT * FROM t">;
+    expectTypeOf<Stmt["all"]>()
+      .parameters.toEqualTypeOf<[]>();
+  });
+
+  it("Statement.run() accepts no args for parameterless SQL", () => {
+    type Stmt = PromiseStatement<"CREATE TABLE t (id INTEGER)">;
+    expectTypeOf<Stmt["run"]>()
+      .parameters.toEqualTypeOf<[]>();
+  });
+
+  it("Statement methods are permissive for non-literal string", () => {
+    type Stmt = PromiseStatement<string>;
+    expectTypeOf<Stmt["all"]>()
+      .parameters.toEqualTypeOf<[...params: any[]]>();
+  });
+});

--- a/bindings/javascript/packages/common/sql-params.ts
+++ b/bindings/javascript/packages/common/sql-params.ts
@@ -1,0 +1,54 @@
+/** Valid SQLite bind parameter value types. */
+export type SqlValue = string | number | bigint | Buffer | Uint8Array | null;
+
+// Extract named parameter names ($foo, :bar, @baz) from a SQL string literal at the type level.
+
+type ParamPrefix = '$' | ':' | '@';
+
+type AlphaNum =
+  | 'a'|'b'|'c'|'d'|'e'|'f'|'g'|'h'|'i'|'j'|'k'|'l'|'m'|'n'|'o'|'p'|'q'|'r'|'s'|'t'|'u'|'v'|'w'|'x'|'y'|'z'
+  | 'A'|'B'|'C'|'D'|'E'|'F'|'G'|'H'|'I'|'J'|'K'|'L'|'M'|'N'|'O'|'P'|'Q'|'R'|'S'|'T'|'U'|'V'|'W'|'X'|'Y'|'Z'
+  | '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'|'_';
+
+// Take consecutive alphanumeric chars from the start of S to form a parameter name.
+type TakeParamName<S extends string, Acc extends string = ''> =
+  S extends `${infer C}${infer Rest}`
+    ? C extends AlphaNum
+      ? TakeParamName<Rest, `${Acc}${C}`>
+      : Acc extends '' ? never : Acc
+    : Acc extends '' ? never : Acc;
+
+// Skip consecutive alphanumeric chars, return the remainder.
+type SkipParamName<S extends string> =
+  S extends `${infer C}${infer Rest}`
+    ? C extends AlphaNum ? SkipParamName<Rest> : S
+    : '';
+
+// Recurse through SQL, collecting parameter names that follow a prefix character.
+type ExtractParams<SQL extends string> =
+  SQL extends `${string}${ParamPrefix}${infer Rest}`
+    ? TakeParamName<Rest> | ExtractParams<SkipParamName<Rest>>
+    : never;
+
+type HasNamedParams<SQL extends string> = ExtractParams<SQL> extends never ? false : true;
+
+// Detect whether the SQL contains any positional `?` parameter.
+type HasPositionalParams<SQL extends string> =
+  SQL extends `${string}?${infer _}` ? true : false;
+
+/**
+ * Derive the bind-parameter signature from a SQL string literal.
+ *
+ * - Non-literal `string`: permissive `...any[]` (backwards compatible)
+ * - Literal with named params (`$foo`, `:bar`, `@baz`): require `{ foo: unknown, bar: unknown, baz: unknown }`
+ * - Literal with positional `?` params (no named): `...unknown[]`
+ * - Literal with no params at all: `[]` (no arguments accepted)
+ */
+export type BindParams<SQL extends string> =
+  string extends SQL
+    ? [...params: any[]]
+    : HasNamedParams<SQL> extends true
+      ? [params: { [K in ExtractParams<SQL>]: SqlValue }]
+      : HasPositionalParams<SQL> extends true
+        ? [...params: (SqlValue | SqlValue[])[]]
+        : [];

--- a/bindings/javascript/packages/native/compat.test.ts
+++ b/bindings/javascript/packages/native/compat.test.ts
@@ -95,7 +95,7 @@ test('attach', () => {
 
         const stmt = db1.prepare("SELECT * FROM t UNION ALL SELECT * FROM secondary.q");
         expect(stmt.columns()).toEqual([{ name: "x", column: null, database: null, table: null, type: null }]);
-        const rows = stmt.all([1]);
+        const rows = stmt.all();
         expect(rows).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }, { x: 5 }, { x: 6 }]);
     } finally {
         unlinkSync(path1);
@@ -103,6 +103,42 @@ test('attach', () => {
         unlinkSync(path2);
         unlinkSync(`${path2}-wal`);
     }
+})
+
+test('named parameters with $', () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE users(name TEXT, age INTEGER)");
+    db.exec("INSERT INTO users VALUES ('Alice', 30), ('Bob', 25), ('Carol', 35)");
+    const stmt = db.prepare("SELECT * FROM users WHERE name = $name AND age = $age");
+    const row = stmt.get({ name: 'Alice', age: 30 });
+    expect(row).toEqual({ name: 'Alice', age: 30 });
+})
+
+test('named parameters with :', () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t(x, y)");
+    db.exec("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+    const stmt = db.prepare("SELECT * FROM t WHERE x = :x");
+    const rows = stmt.all({ x: 2 });
+    expect(rows).toEqual([{ x: 2, y: 'b' }]);
+})
+
+test('named parameters with @', () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t(x)");
+    db.exec("INSERT INTO t VALUES (10), (20), (30)");
+    const stmt = db.prepare("SELECT * FROM t WHERE x = @val");
+    const row = stmt.get({ val: 20 });
+    expect(row).toEqual({ x: 20 });
+})
+
+test('named parameters with mixed prefixes', () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t(a, b, c)");
+    db.exec("INSERT INTO t VALUES (1, 2, 3)");
+    const stmt = db.prepare("SELECT * FROM t WHERE a = $a AND b = :b AND c = @c");
+    const row = stmt.get({ a: 1, b: 2, c: 3 });
+    expect(row).toEqual({ a: 1, b: 2, c: 3 });
 })
 
 test('blobs', () => {

--- a/bindings/javascript/packages/native/promise.test.ts
+++ b/bindings/javascript/packages/native/promise.test.ts
@@ -218,7 +218,7 @@ test('attach', async () => {
 
         const stmt = db1.prepare("SELECT * FROM t UNION ALL SELECT * FROM secondary.q");
         expect(stmt.columns()).toEqual([{ name: "x", column: null, database: null, table: null, type: null }]);
-        const rows = await stmt.all([1]);
+        const rows = await stmt.all();
         expect(rows).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }, { x: 5 }, { x: 6 }]);
     } finally {
         unlinkSync(path1);
@@ -262,6 +262,42 @@ test('fts', async () => {
         "SELECT * FROM documents WHERE fts_match(title, body, 'nonexistentterm')"
     ).all();
     expect(noResults.length).toBe(0);
+})
+
+test('named parameters with $', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE users(name TEXT, age INTEGER)");
+    await db.exec("INSERT INTO users VALUES ('Alice', 30), ('Bob', 25), ('Carol', 35)");
+    const stmt = db.prepare("SELECT * FROM users WHERE name = $name AND age = $age");
+    const row = await stmt.get({ name: 'Alice', age: 30 });
+    expect(row).toEqual({ name: 'Alice', age: 30 });
+})
+
+test('named parameters with :', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t(x, y)");
+    await db.exec("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+    const stmt = db.prepare("SELECT * FROM t WHERE x = :x");
+    const rows = await stmt.all({ x: 2 });
+    expect(rows).toEqual([{ x: 2, y: 'b' }]);
+})
+
+test('named parameters with @', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t(x)");
+    await db.exec("INSERT INTO t VALUES (10), (20), (30)");
+    const stmt = db.prepare("SELECT * FROM t WHERE x = @val");
+    const row = await stmt.get({ val: 20 });
+    expect(row).toEqual({ x: 20 });
+})
+
+test('named parameters with mixed prefixes', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t(a, b, c)");
+    await db.exec("INSERT INTO t VALUES (1, 2, 3)");
+    const stmt = db.prepare("SELECT * FROM t WHERE a = $a AND b = :b AND c = @c");
+    const row = await stmt.get({ a: 1, b: 2, c: 3 });
+    expect(row).toEqual({ a: 1, b: 2, c: 3 });
 })
 
 test('blobs', async () => {

--- a/bindings/javascript/packages/wasm/promise.test.ts
+++ b/bindings/javascript/packages/wasm/promise.test.ts
@@ -204,6 +204,46 @@ test('on-disk db', async () => {
 //     expect(rows).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }, { x: 5 }, { x: 6 }]);
 // })
 
+test('named parameters with $', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE users(name TEXT, age INTEGER)");
+    await db.exec("INSERT INTO users VALUES ('Alice', 30), ('Bob', 25), ('Carol', 35)");
+    const stmt = db.prepare("SELECT * FROM users WHERE name = $name AND age = $age");
+    const row = await stmt.get({ name: 'Alice', age: 30 });
+    expect(row).toEqual({ name: 'Alice', age: 30 });
+    await db.close();
+})
+
+test('named parameters with :', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t(x, y)");
+    await db.exec("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+    const stmt = db.prepare("SELECT * FROM t WHERE x = :x");
+    const rows = await stmt.all({ x: 2 });
+    expect(rows).toEqual([{ x: 2, y: 'b' }]);
+    await db.close();
+})
+
+test('named parameters with @', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t(x)");
+    await db.exec("INSERT INTO t VALUES (10), (20), (30)");
+    const stmt = db.prepare("SELECT * FROM t WHERE x = @val");
+    const row = await stmt.get({ val: 20 });
+    expect(row).toEqual({ x: 20 });
+    await db.close();
+})
+
+test('named parameters with mixed prefixes', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t(a, b, c)");
+    await db.exec("INSERT INTO t VALUES (1, 2, 3)");
+    const stmt = db.prepare("SELECT * FROM t WHERE a = $a AND b = :b AND c = @c");
+    const row = await stmt.get({ a: 1, b: 2, c: 3 });
+    expect(row).toEqual({ a: 1, b: 2, c: 3 });
+    await db.close();
+})
+
 test('blobs', async () => {
     const db = await connect(":memory:");
     const rows = await db.prepare("SELECT x'1020' as x").all();

--- a/bindings/javascript/sync/packages/native/promise.test.ts
+++ b/bindings/javascript/sync/packages/native/promise.test.ts
@@ -267,6 +267,42 @@ test('concurrent-actions-consistency', async () => {
     await Promise.all([pull(100), push(100), run(200)]);
 })
 
+test('named parameters with $', async () => {
+    const db = new Database({ path: ':memory:' });
+    await db.exec("CREATE TABLE users(name TEXT, age INTEGER)");
+    await db.exec("INSERT INTO users VALUES ('Alice', 30), ('Bob', 25), ('Carol', 35)");
+    const stmt = db.prepare("SELECT * FROM users WHERE name = $name AND age = $age");
+    const row = await stmt.get({ name: 'Alice', age: 30 });
+    expect(row).toEqual({ name: 'Alice', age: 30 });
+})
+
+test('named parameters with :', async () => {
+    const db = new Database({ path: ':memory:' });
+    await db.exec("CREATE TABLE t(x, y)");
+    await db.exec("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+    const stmt = db.prepare("SELECT * FROM t WHERE x = :x");
+    const rows = await stmt.all({ x: 2 });
+    expect(rows).toEqual([{ x: 2, y: 'b' }]);
+})
+
+test('named parameters with @', async () => {
+    const db = new Database({ path: ':memory:' });
+    await db.exec("CREATE TABLE t(x)");
+    await db.exec("INSERT INTO t VALUES (10), (20), (30)");
+    const stmt = db.prepare("SELECT * FROM t WHERE x = @val");
+    const row = await stmt.get({ val: 20 });
+    expect(row).toEqual({ x: 20 });
+})
+
+test('named parameters with mixed prefixes', async () => {
+    const db = new Database({ path: ':memory:' });
+    await db.exec("CREATE TABLE t(a, b, c)");
+    await db.exec("INSERT INTO t VALUES (1, 2, 3)");
+    const stmt = db.prepare("SELECT * FROM t WHERE a = $a AND b = :b AND c = @c");
+    const row = await stmt.get({ a: 1, b: 2, c: 3 });
+    expect(row).toEqual({ a: 1, b: 2, c: 3 });
+})
+
 test('simple-db', async () => {
     const db = new Database({ path: ':memory:' });
     expect(await db.prepare("SELECT 1 as x").all()).toEqual([{ x: 1 }])

--- a/bindings/javascript/sync/packages/native/promise.ts
+++ b/bindings/javascript/sync/packages/native/promise.ts
@@ -228,7 +228,7 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
+    override prepare<S extends string>(sql: S) {
         const localStmt = super.prepare(sql);
 
         if (!this.#remoteWriter) {

--- a/bindings/javascript/sync/packages/wasm/promise-bundle.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-bundle.ts
@@ -248,7 +248,7 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
+    override prepare<S extends string>(sql: S) {
         const localStmt = super.prepare(sql);
 
         if (!this.#remoteWriter) {

--- a/bindings/javascript/sync/packages/wasm/promise-default.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-default.ts
@@ -248,7 +248,7 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
+    override prepare<S extends string>(sql: S) {
         const localStmt = super.prepare(sql);
 
         if (!this.#remoteWriter) {

--- a/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
@@ -248,7 +248,7 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
+    override prepare<S extends string>(sql: S) {
         const localStmt = super.prepare(sql);
 
         if (!this.#remoteWriter) {

--- a/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
@@ -248,7 +248,7 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
+    override prepare<S extends string>(sql: S) {
         const localStmt = super.prepare(sql);
 
         if (!this.#remoteWriter) {


### PR DESCRIPTION
<img width="589" height="128" alt="Screenshot 2026-03-09 at 23 17 51" src="https://github.com/user-attachments/assets/ae222883-34dd-4ba5-8764-50c9a2a5c372" />

`db.prepare("SELECT * FROM t WHERE a = $first and b = $second");`

now returns a type where the arguments are strongly typed:

`{ first: SqlValue, second: SqlValue }`

where `type SqlValue = string | number | bigint | Buffer | Uint8Array | null`

This applies to positional parameters too, and even statements with no arguments, so that args can't be erroneously passed to statements that don't accept them.