### PR TITLE
fix: CDC panic on DELETE/UPDATE with constant false WHERE clause

### DIFF
--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -261,8 +261,10 @@ pub fn emit_program_for_delete(
         )?;
     }
     program.preassign_label_to_next_insn(after_main_loop_label);
-    if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
-        emit_cdc_autocommit_commit(program, resolver, cdc_cursor_id)?;
+    if !plan.contains_constant_false_condition {
+        if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
+            emit_cdc_autocommit_commit(program, resolver, cdc_cursor_id)?;
+        }
     }
     // Emit scan-back loop for buffered RETURNING results.
     // All DML is complete at this point; now yield the buffered rows to the caller.

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -463,8 +463,10 @@ pub fn emit_program_for_update(
     )?;
 
     program.preassign_label_to_next_insn(after_main_loop_label);
-    if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
-        emit_cdc_autocommit_commit(program, resolver, cdc_cursor_id)?;
+    if !plan.contains_constant_false_condition {
+        if let Some(cdc_cursor_id) = t_ctx.cdc_cursor_id {
+            emit_cdc_autocommit_commit(program, resolver, cdc_cursor_id)?;
+        }
     }
     // Emit scan-back loop for buffered RETURNING results.
     // All DML is complete at this point; now yield the buffered rows to the caller.

--- a/testing/runner/tests/cdc-dml-constant-false.sqltest
+++ b/testing/runner/tests/cdc-dml-constant-false.sqltest
@@ -1,0 +1,76 @@
+@database :memory:
+@skip-file-if mvcc "CDC is not supported in MVCC mode"
+@skip-file-if sqlite "CDC is a turso-specific feature"
+
+# CDC + DML with constant false WHERE clause should not crash.
+# Bug: when WHERE clause is constant false (e.g. WHERE 0), the optimizer skips
+# the main loop including OpenWrite for the CDC cursor, but the CDC autocommit
+# epilogue still tries to use that cursor via NewRowid, causing a panic.
+
+test cdc-delete-where-false {
+    CREATE TABLE t(id INTEGER, val TEXT);
+    INSERT INTO t VALUES (1, 'a');
+    INSERT INTO t VALUES (2, 'b');
+    PRAGMA unstable_capture_data_changes_conn('full');
+    DELETE FROM t WHERE 0;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|a
+    2|b
+}
+
+test cdc-delete-where-not-1 {
+    CREATE TABLE t2(id INTEGER);
+    INSERT INTO t2 VALUES (1);
+    PRAGMA unstable_capture_data_changes_conn('full');
+    DELETE FROM t2 WHERE NOT 1;
+    SELECT * FROM t2;
+}
+expect {
+    1
+}
+
+test cdc-delete-empty-table-where-false {
+    CREATE TABLE t3(id INTEGER);
+    PRAGMA unstable_capture_data_changes_conn('full');
+    DELETE FROM t3 WHERE 0;
+    SELECT count(*) FROM t3;
+}
+expect {
+    0
+}
+
+test cdc-update-where-false {
+    CREATE TABLE t4(id INTEGER, val TEXT);
+    INSERT INTO t4 VALUES (1, 'a');
+    INSERT INTO t4 VALUES (2, 'b');
+    PRAGMA unstable_capture_data_changes_conn('full');
+    UPDATE t4 SET val = 'x' WHERE 0;
+    SELECT * FROM t4 ORDER BY id;
+}
+expect {
+    1|a
+    2|b
+}
+
+test cdc-update-where-not-1 {
+    CREATE TABLE t5(id INTEGER, val TEXT);
+    INSERT INTO t5 VALUES (1, 'a');
+    PRAGMA unstable_capture_data_changes_conn('full');
+    UPDATE t5 SET val = 'x' WHERE NOT 1;
+    SELECT * FROM t5;
+}
+expect {
+    1|a
+}
+
+test cdc-update-empty-table-where-false {
+    CREATE TABLE t6(id INTEGER, val TEXT);
+    PRAGMA unstable_capture_data_changes_conn('full');
+    UPDATE t6 SET val = 'x' WHERE 0;
+    SELECT count(*) FROM t6;
+}
+expect {
+    0
+}


### PR DESCRIPTION
## Description

When CDC (Change Data Capture) is enabled via `PRAGMA unstable_capture_data_changes_conn('full')`, executing a DELETE or UPDATE with a constant false WHERE clause (e.g. `WHERE 0`, `WHERE NOT 1`) causes a panic: `cursor id 0 is None`.

The optimizer detects the impossible condition and emits a `Goto` that skips the main loop — including `init_loop()` which emits `OpenWrite` for the CDC cursor. But the CDC autocommit epilogue after the loop still tries to use that cursor via `NewRowid`, hitting an uninitialized cursor at runtime.

The fix guards the CDC epilogue emission with `!plan.contains_constant_false_condition` in both the DELETE and UPDATE emitters.

## Motivation and context

Pre-existing bug on main, not introduced by recent commits. Found while writing CDC tests.

## Description of AI Usage

Claude Code was used to bisect the bug across recent commits, explore the translation pipeline to find the root cause, and write the fix + tests. The human drove the investigation direction and reviewed all changes.