### PR TITLE
fix: CREATE INDEX corrupting materialized views with sqlite_master data

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7729,13 +7729,14 @@ pub fn op_insert(
                 {
                     state.op_insert_state.sub_state = OpInsertSubState::UpdateLastRowid;
                 } else {
-                    let schema = program.connection.schema.read();
-                    let dependent_views = schema.get_dependent_materialized_views(table_name);
-                    if !dependent_views.is_empty() {
-                        state.op_insert_state.sub_state = OpInsertSubState::ApplyViewChange;
-                    } else {
-                        break;
-                    }
+                    // Schema table writes (sqlite_master, sqlite_sequence, ephemeral)
+                    // must not produce view deltas. The p4 table_name on these inserts
+                    // refers to the *target* table (for the update hook), not the table
+                    // actually being written to. Tracking deltas here would feed the
+                    // sqlite_master record into the DBSP circuit as if it were data
+                    // from the named table, corrupting the materialized view.
+                    state.op_insert_state.old_record = None;
+                    break;
                 }
             }
             OpInsertSubState::UpdateLastRowid => {

--- a/testing/runner/tests/matview-create-index.sqltest
+++ b/testing/runner/tests/matview-create-index.sqltest
@@ -1,0 +1,22 @@
+@database :memory:
+@skip-file-if mvcc "materialized views not supported in MVCC mode"
+@skip-file-if sqlite "materialized views are a turso-specific feature"
+@requires materialized_views "requires materialized view support"
+
+test create-index-does-not-corrupt-matview {
+    CREATE TABLE t (id INTEGER, val TEXT, score REAL);
+    INSERT INTO t VALUES (1, 'hello', 3.14);
+    INSERT INTO t VALUES (2, 'world', 2.72);
+    CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
+    SELECT COUNT(*) FROM mv;
+
+    CREATE INDEX idx ON t (id DESC);
+    SELECT COUNT(*) FROM mv;
+    SELECT * FROM mv ORDER BY id;
+}
+expect {
+    2
+    2
+    1|hello|3.14
+    2|world|2.72
+}


### PR DESCRIPTION
## Description

CREATE INDEX on a table with a materialized view silently injects the `sqlite_master` schema record as a phantom data row into the matview.

The `Insert` opcode for CREATE INDEX writes to `sqlite_master` (root_page=1) but its p4 parameter contains the target table name (e.g. `t`). The `else` branch for schema table writes was checking `get_dependent_materialized_views(table_name)`, finding the matview, and feeding the sqlite_master record (`type|name|tbl_name|rootpage|sql`) as a data delta into the DBSP circuit.

Fix: skip view delta tracking entirely for schema table writes (root_page==1, sqlite_sequence, ephemeral), since these should never produce data deltas.

### Before

```
sqlite> SELECT * FROM mv;
1|hello|3.14
2|world|2.72
sqlite> CREATE INDEX idx ON t (id DESC);
sqlite> SELECT * FROM mv;
1|hello|3.14
2|world|2.72
index|idx|t          <-- phantom row from sqlite_master
```

### After

```
sqlite> SELECT * FROM mv;
1|hello|3.14
2|world|2.72
sqlite> CREATE INDEX idx ON t (id DESC);
sqlite> SELECT * FROM mv;
1|hello|3.14
2|world|2.72
```

## Motivation and context

Found while testing materialized views under page cache pressure with the simulator. CREATE INDEX on a table backing a matview would either silently corrupt the view (when column counts happened to match) or crash with a register mismatch assertion (when they didn't).

## Description of AI Usage

Claude Code was used to trace the bytecode execution path from CREATE INDEX through the Insert opcode handler, identify the root cause (p4 table name mismatch for sqlite_master writes), and implement the fix. I directed the investigation strategy and reviewed the fix.