### PR TITLE
Use updated rowid in BEFORE UPDATE trigger NEW context

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -908,9 +908,10 @@ fn emit_update_insns<'a>(
             let old_registers =
                 old_registers.expect("old_registers allocated when has_before_triggers");
             // NEW row values are already in 'start' registers
+            let new_rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
             let new_registers = (0..col_len)
                 .map(|i| start + i)
-                .chain(std::iter::once(beg))
+                .chain(std::iter::once(new_rowid_reg))
                 .collect();
 
             // If the program has a trigger_conflict_override, propagate it to the trigger context.

--- a/testing/runner/tests/trigger.sqltest
+++ b/testing/runner/tests/trigger.sqltest
@@ -1353,6 +1353,67 @@ expect {
     triggered for id 1
 }
 
+# https://github.com/tursodatabase/turso/issues/5844
+# BEFORE UPDATE trigger WHEN should see the updated rowid alias value
+@cross-check-integrity
+test trigger-before-update-rowid-change-when-sees-new-rowid {
+    CREATE TABLE t_5844_when(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO t_5844_when VALUES(1, 'hello');
+    CREATE TRIGGER tr_5844_when BEFORE UPDATE ON t_5844_when WHEN NEW.id = 5 BEGIN
+      SELECT RAISE(ABORT, 'blocked');
+    END;
+    UPDATE t_5844_when SET id = 5 WHERE id = 1;
+}
+expect error {
+    blocked
+}
+
+# BEFORE UPDATE trigger body should see the updated rowid alias value
+@cross-check-integrity
+test trigger-before-update-rowid-change-body-sees-new-rowid {
+    CREATE TABLE t_5844_body(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE log_5844_body(val INTEGER);
+    INSERT INTO t_5844_body VALUES(1, 'hello');
+    CREATE TRIGGER tr_5844_body BEFORE UPDATE ON t_5844_body BEGIN
+      INSERT INTO log_5844_body VALUES(NEW.id);
+    END;
+    UPDATE t_5844_body SET id = 5 WHERE id = 1;
+    SELECT * FROM log_5844_body;
+}
+expect {
+    5
+}
+
+# BEFORE UPDATE trigger WHEN should see the updated bare rowid value
+@cross-check-integrity
+test trigger-before-update-bare-rowid-change-when-sees-new-rowid {
+    CREATE TABLE t_5844_rowid_when(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO t_5844_rowid_when VALUES(1, 'hello');
+    CREATE TRIGGER tr_5844_rowid_when BEFORE UPDATE ON t_5844_rowid_when WHEN NEW.rowid = 5 BEGIN
+      SELECT RAISE(ABORT, 'blocked');
+    END;
+    UPDATE t_5844_rowid_when SET rowid = 5 WHERE id = 1;
+}
+expect error {
+    blocked
+}
+
+# BEFORE UPDATE trigger body should see the updated bare rowid value
+@cross-check-integrity
+test trigger-before-update-bare-rowid-change-body-sees-new-rowid {
+    CREATE TABLE t_5844_rowid_body(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE log_5844_rowid_body(val INTEGER);
+    INSERT INTO t_5844_rowid_body VALUES(1, 'hello');
+    CREATE TRIGGER tr_5844_rowid_body BEFORE UPDATE ON t_5844_rowid_body BEGIN
+      INSERT INTO log_5844_rowid_body VALUES(NEW.rowid);
+    END;
+    UPDATE t_5844_rowid_body SET rowid = 5 WHERE id = 1;
+    SELECT * FROM log_5844_rowid_body;
+}
+expect {
+    5
+}
+
 # https://github.com/tursodatabase/turso/issues/5175
 # Subquery in trigger body UPDATE SET clause
 @cross-check-integrity


### PR DESCRIPTION
## Description

Use the updated rowid register when building the `NEW` pseudo-row for `BEFORE UPDATE`.

This fixes cases where an `UPDATE` changes the rowid, either through an `INTEGER PRIMARY KEY` alias or through bare `rowid`, and `BEFORE UPDATE` triggers were still seeing the old rowid via `NEW.id` / `NEW.rowid`

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Issue #5844 showed that `BEFORE UPDATE` triggers were wired to the old rowid register when the updated row changed its rowid. As a result:
  - `WHEN` clauses that depended on `NEW.id` or `NEW.rowid` did not fire
  - trigger bodies observed the old rowid instead of the new one

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5844


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
