### PR TITLE
fix/mvcc: NullRow in MVCC cursors

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -320,6 +320,9 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
 
     /// Returns the current row as an immutable record.
     pub fn current_row(&mut self) -> Result<IOResult<Option<&crate::types::ImmutableRecord>>> {
+        if self.get_null_flag() {
+            return Ok(IOResult::Done(None));
+        }
         let current_pos = &self.current_pos;
         tracing::trace!("current_row({:?})", current_pos);
         match current_pos {
@@ -1027,6 +1030,9 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
     }
 
     fn rowid(&mut self) -> Result<IOResult<Option<i64>>> {
+        if self.get_null_flag() {
+            return Ok(IOResult::Done(None));
+        }
         let rowid = match self.get_current_pos() {
             CursorPosition::Loaded {
                 row_id,

--- a/testing/runner/tests/join/memory.sqltest
+++ b/testing/runner/tests/join/memory.sqltest
@@ -211,6 +211,24 @@ expect {
 }
 
 @cross-check-integrity
+test left-join-indexed-equality-no-match-nulls-right-side {
+    CREATE TABLE l(id INTEGER PRIMARY KEY);
+    CREATE TABLE r(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE INDEX r_val ON r(val);
+    INSERT INTO l VALUES (1), (2);
+    INSERT INTO r VALUES (10, 3), (11, 4);
+
+    SELECT l.id, IFNULL(r.id, -1), IFNULL(r.val, -1)
+    FROM l
+    LEFT JOIN r ON r.val = l.id
+    ORDER BY l.id;
+}
+expect {
+    1|-1|-1
+    2|-1|-1
+}
+
+@cross-check-integrity
 test three-way-left-chain-null {
     create table t(a, b);
     create table u(a, b);


### PR DESCRIPTION
LEFT JOINs were broken again