### PR TITLE
fix: Duplicate trigger names accepted instead of being rejected

### DIFF
--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -117,8 +117,7 @@ pub fn translate_create_trigger(
 
     // Check if trigger already exists
     if resolver.with_schema(database_id, |s| {
-        s.get_trigger_for_table(&normalized_table_name, &normalized_trigger_name)
-            .is_some()
+        s.get_trigger(&normalized_trigger_name).is_some()
     }) {
         if if_not_exists {
             return Ok(());

--- a/testing/runner/tests/duplicate-trigger-names.sqltest
+++ b/testing/runner/tests/duplicate-trigger-names.sqltest
@@ -1,0 +1,55 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t1(a);
+    CREATE TABLE t2(a);
+    CREATE TABLE log(msg);
+}
+
+@setup schema
+test duplicate-trigger-name-different-tables {
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('t1'); END;
+    CREATE TRIGGER tr AFTER INSERT ON t2 BEGIN INSERT INTO log VALUES('t2'); END;
+}
+expect error {
+    trigger tr already exists
+}
+
+@setup schema
+test duplicate-trigger-name-same-table {
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('first'); END;
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('second'); END;
+}
+expect error {
+    trigger tr already exists
+}
+
+@setup schema
+test duplicate-trigger-if-not-exists {
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('t1'); END;
+    CREATE TRIGGER IF NOT EXISTS tr AFTER INSERT ON t2 BEGIN INSERT INTO log VALUES('t2'); END;
+    INSERT INTO t1 VALUES(1);
+    SELECT * FROM log;
+}
+expect {
+    t1
+}
+
+@setup schema
+test trigger-name-case-insensitive {
+    CREATE TRIGGER TR AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('t1'); END;
+    CREATE TRIGGER tr AFTER INSERT ON t2 BEGIN INSERT INTO log VALUES('t2'); END;
+}
+expect error {
+    trigger tr already exists
+}
+
+@setup schema
+test correct-trigger-fires-after-failed-duplicate {
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('from_t1'); END;
+    INSERT INTO t1 VALUES(1);
+    SELECT * FROM log;
+}
+expect {
+    from_t1
+}


### PR DESCRIPTION
The duplicate trigger check used `get_trigger_for_table` which only looked for triggers with the same name on the same table. Changed to `get_trigger` which checks across all tables in the schema, matching SQLite's behavior where trigger names must be unique per database.

Closes #5866

## Description of AI Usage
Generated by _turso auto fixer_ :tm: :robot: 
