### PR TITLE
fix: RAISE() rejects non-literal string expressions for error message

### DIFF
--- a/core/incremental/expr_compiler.rs
+++ b/core/incremental/expr_compiler.rs
@@ -351,6 +351,7 @@ impl CompiledExpression {
             err_code: 0,
             description: String::new(),
             on_error: None,
+            description_reg: None,
         });
 
         // Build the program from the compiled expression bytecode

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -316,6 +316,7 @@ fn emit_add_column_default_type_validation(
         err_code: 1,
         description: "type mismatch on DEFAULT".to_string(),
         on_error: None,
+        description_reg: None,
     });
 
     program.resolve_label(skip_check_label, program.offset());
@@ -433,6 +434,7 @@ fn emit_add_column_check_validation(
             err_code: SQLITE_CONSTRAINT_CHECK,
             description: name,
             on_error: None,
+            description_reg: None,
         });
 
         program.preassign_label_to_next_insn(check_passed_label);
@@ -1032,6 +1034,7 @@ pub fn translate_alter_table(
                     err_code: 1,
                     description: error_message.to_string(),
                     on_error: None,
+                    description_reg: None,
                 });
 
                 program.resolve_label(skip_error_label, program.offset());

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1410,6 +1410,7 @@ fn emit_check_constraint_bytecode(
                     err_code: SQLITE_CONSTRAINT_CHECK,
                     description: constraint_name.to_string(),
                     on_error: None,
+                    description_reg: None,
                 });
             }
         }

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1194,6 +1194,7 @@ fn emit_update_insns<'a>(
                         err_code: SQLITE_CONSTRAINT_UNIQUE,
                         description: column_names,
                         on_error: None,
+                        description_reg: None,
                     });
                 }
                 _ => unreachable!(
@@ -1253,6 +1254,7 @@ fn emit_update_insns<'a>(
                         err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
                         description,
                         on_error: None,
+                        description_reg: None,
                     });
                 }
                 _ => unreachable!(
@@ -1820,6 +1822,7 @@ fn emit_update_insns<'a>(
                         err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
                         description: column_names,
                         on_error: None,
+                        description_reg: None,
                     });
                 }
             }
@@ -1941,6 +1944,7 @@ fn emit_update_insns<'a>(
                         err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
                         description,
                         on_error: None,
+                        description_reg: None,
                     });
                 }
             }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -3389,6 +3389,7 @@ pub fn translate_expr(
                         err_code: 0,
                         description: String::new(),
                         on_error: Some(ResolveType::Ignore),
+                        description_reg: None,
                     });
                 }
                 ResolveType::Fail | ResolveType::Abort | ResolveType::Rollback => {
@@ -3397,29 +3398,37 @@ pub fn translate_expr(
                             "RAISE() may only be used within a trigger-program"
                         );
                     }
-                    let msg = match msg_expr {
+                    let err_code = if in_trigger {
+                        SQLITE_CONSTRAINT_TRIGGER
+                    } else {
+                        SQLITE_ERROR
+                    };
+                    match msg_expr {
                         Some(e) => match e.as_ref() {
-                            ast::Expr::Literal(ast::Literal::String(s)) => sanitize_string(s),
+                            ast::Expr::Literal(ast::Literal::String(s)) => {
+                                program.emit_insn(Insn::Halt {
+                                    err_code,
+                                    description: sanitize_string(s),
+                                    on_error: Some(*resolve_type),
+                                    description_reg: None,
+                                });
+                            }
                             _ => {
-                                crate::bail_parse_error!(
-                                    "RAISE error message must be a string literal"
-                                );
+                                // Expression-based error message: evaluate at runtime
+                                let reg = program.alloc_register();
+                                translate_expr(program, referenced_tables, e, reg, resolver)?;
+                                program.emit_insn(Insn::Halt {
+                                    err_code,
+                                    description: String::new(),
+                                    on_error: Some(*resolve_type),
+                                    description_reg: Some(reg),
+                                });
                             }
                         },
                         None => {
                             crate::bail_parse_error!("RAISE requires an error message");
                         }
                     };
-                    let err_code = if in_trigger {
-                        SQLITE_CONSTRAINT_TRIGGER
-                    } else {
-                        SQLITE_ERROR
-                    };
-                    program.emit_insn(Insn::Halt {
-                        err_code,
-                        description: msg,
-                        on_error: Some(*resolve_type),
-                    });
                 }
                 ResolveType::Replace => {
                     crate::bail_parse_error!("REPLACE is not valid for RAISE");
@@ -7142,6 +7151,7 @@ fn emit_array_element_loop(
             "array exceeds maximum element count for custom type transform ({MAX_ARRAY_LOOP_ELEMENTS})"
         ),
         on_error: None,
+        description_reg: None,
     });
     program.preassign_label_to_next_insn(ok_label);
     // reg_idx is the 1-based array index for ArrayElement (PG convention)

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -240,6 +240,7 @@ pub fn emit_fk_restrict_halt(program: &mut ProgramBuilder) -> Result<()> {
         err_code: SQLITE_CONSTRAINT_FOREIGNKEY,
         description: "FOREIGN KEY constraint failed".to_string(),
         on_error: None,
+        description_reg: None,
     });
     Ok(())
 }

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -492,6 +492,7 @@ pub fn translate_create_index(
                 err_code: SQLITE_CONSTRAINT_UNIQUE,
                 description: format_unique_violation_desc(tbl_name.as_str(), &idx),
                 on_error: None,
+                description_reg: None,
             });
             program.preassign_label_to_next_insn(label_after_sorter_compare);
         } else {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1227,6 +1227,7 @@ fn emit_rowid_generation(
             err_code: crate::error::SQLITE_FULL,
             description: "database or disk is full".to_string(),
             on_error: None,
+            description_reg: None,
         });
 
         program.preassign_label_to_next_insn(no_overflow_label);
@@ -2411,6 +2412,7 @@ fn emit_pk_uniqueness_check(
             err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
             description,
             on_error: None,
+            description_reg: None,
         });
     }
     program.preassign_label_to_next_insn(make_record_label);
@@ -2574,6 +2576,7 @@ fn emit_unique_index_check(
             err_code: SQLITE_CONSTRAINT_UNIQUE,
             description: format_unique_violation_desc(ctx.table.name.as_str(), index),
             on_error: None,
+            description_reg: None,
         });
 
         // continue preflight with next constraint
@@ -2607,6 +2610,7 @@ fn emit_unique_index_check(
                 err_code: SQLITE_CONSTRAINT_UNIQUE,
                 description: format_unique_violation_desc(ctx.table.name.as_str(), index),
                 on_error: None,
+                description_reg: None,
             });
         }
         program.preassign_label_to_next_insn(ok);

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -73,6 +73,7 @@ fn emit_integrity_result_row(
     program.emit_insn(Insn::Halt {
         err_code: 0,
         on_error: None,
+        description_reg: None,
         description: String::new(),
     });
     program.preassign_label_to_next_insn(continue_label);

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -376,6 +376,7 @@ fn update_pragma(
                 err_code: 0,
                 description: "Early halt because auto vacuum mode is not enabled".to_string(),
                 on_error: None,
+                description_reg: None,
             });
             program.resolve_label(set_cookie_label, program.offset());
             program.emit_insn(Insn::SetCookie {

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -996,6 +996,7 @@ pub fn emit_upsert(
                     err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
                     description,
                     on_error: None,
+                    description_reg: None,
                 });
                 program.preassign_label_to_next_insn(ok);
             }
@@ -1062,6 +1063,7 @@ pub fn emit_upsert(
                     .unwrap_or("rowid")
             ),
             on_error: None,
+            description_reg: None,
         });
         program.preassign_label_to_next_insn(ok);
 

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -814,6 +814,7 @@ impl ProgramBuilder {
                 String::new()
             },
             on_error: None,
+            description_reg: None,
         });
     }
 
@@ -826,6 +827,7 @@ impl ProgramBuilder {
             err_code,
             description,
             on_error: None,
+            description_reg: None,
         });
     }
 
@@ -1419,6 +1421,7 @@ impl ProgramBuilder {
                 err_code: 0,
                 description: description.to_string(),
                 on_error: None,
+                description_reg: None,
             });
             return;
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2855,10 +2855,18 @@ pub fn op_halt(
             err_code,
             description,
             on_error,
+            description_reg,
         },
         insn
     );
-    halt(program, state, pager, *err_code, description, *on_error)
+    // If description_reg is set, read the error message from that register at runtime
+    // (used by RAISE with expression-based error messages).
+    let desc = if let Some(reg) = description_reg {
+        state.registers[*reg].get_value().to_string()
+    } else {
+        description.to_string()
+    };
+    halt(program, state, pager, *err_code, &desc, *on_error)
 }
 
 pub fn op_halt_if_null(

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -800,6 +800,7 @@ pub fn insn_to_row(
                 err_code,
                 description,
                 on_error,
+                description_reg,
             } => {
                 let p2 = match on_error {
                     Some(ResolveType::Rollback) => 1,
@@ -809,11 +810,12 @@ pub fn insn_to_row(
                     Some(ResolveType::Replace) => 5,
                     None => 0,
                 };
+                let p3 = description_reg.unwrap_or(0) as i64;
                 (
                     "Halt",
                     *err_code as i64,
                     p2,
-                    0,
+                    p3,
                     Value::build_text(description.clone()),
                     0,
                     "".to_string(),

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -662,6 +662,9 @@ pub enum Insn {
         description: String,
         /// Override the program's resolve_type for error handling (used by RAISE).
         on_error: Option<ResolveType>,
+        /// If set, read the error description from this register instead of
+        /// the static `description` field (used by RAISE with expression messages).
+        description_reg: Option<usize>,
     },
 
     /// Halt the program if P3 is null.

--- a/testing/runner/tests/trigger.sqltest
+++ b/testing/runner/tests/trigger.sqltest
@@ -1897,6 +1897,67 @@ expect error {
     delete fail
 }
 
+# RAISE(ABORT, expr) with concatenation expression (issue #5875)
+test trigger-raise-expr-concat {
+    CREATE TABLE raise_expr_t1 (a INTEGER);
+    CREATE TRIGGER raise_expr_tr1 BEFORE INSERT ON raise_expr_t1 WHEN NEW.a < 0 BEGIN
+        SELECT RAISE(ABORT, 'bad: ' || NEW.a);
+    END;
+    INSERT INTO raise_expr_t1 VALUES(-5);
+}
+expect error {
+    bad: -5
+}
+
+# RAISE(ABORT, expr) with concatenation - allowed value passes
+test trigger-raise-expr-concat-pass {
+    CREATE TABLE raise_expr_t1b (a INTEGER);
+    CREATE TRIGGER raise_expr_tr1b BEFORE INSERT ON raise_expr_t1b WHEN NEW.a < 0 BEGIN
+        SELECT RAISE(ABORT, 'bad: ' || NEW.a);
+    END;
+    INSERT INTO raise_expr_t1b VALUES(5);
+    SELECT * FROM raise_expr_t1b;
+}
+expect {
+    5
+}
+
+# RAISE(FAIL, expr) with expression error message
+test trigger-raise-fail-expr {
+    CREATE TABLE raise_expr_t2 (a INTEGER);
+    CREATE TRIGGER raise_expr_tr2 BEFORE INSERT ON raise_expr_t2 WHEN NEW.a < 0 BEGIN
+        SELECT RAISE(FAIL, 'invalid value: ' || NEW.a);
+    END;
+    INSERT INTO raise_expr_t2 VALUES(-10);
+}
+expect error {
+    invalid value: -10
+}
+
+# RAISE(ROLLBACK, expr) with expression error message
+test trigger-raise-rollback-expr {
+    CREATE TABLE raise_expr_t3 (a INTEGER);
+    CREATE TRIGGER raise_expr_tr3 BEFORE INSERT ON raise_expr_t3 WHEN NEW.a < 0 BEGIN
+        SELECT RAISE(ROLLBACK, 'rollback: ' || NEW.a);
+    END;
+    INSERT INTO raise_expr_t3 VALUES(-1);
+}
+expect error {
+    rollback: -1
+}
+
+# RAISE with expression using CASE
+test trigger-raise-expr-case {
+    CREATE TABLE raise_expr_t4 (a INTEGER);
+    CREATE TRIGGER raise_expr_tr4 BEFORE INSERT ON raise_expr_t4 WHEN NEW.a < 0 BEGIN
+        SELECT RAISE(ABORT, CASE WHEN NEW.a < -10 THEN 'very bad' ELSE 'bad' END);
+    END;
+    INSERT INTO raise_expr_t4 VALUES(-5);
+}
+expect error {
+    bad
+}
+
 # Bare column reference in trigger WHEN clause should error
 # SQLite rejects bare column names in WHEN clauses; they must be
 # qualified with NEW or OLD.


### PR DESCRIPTION
Allow RAISE(ABORT/FAIL/ROLLBACK, expr) to accept arbitrary expressions as the error message, not just string literals. This matches SQLite 3.47.0+ behavior where the error-message can be any SQL expression.

The fix adds an optional description_reg field to the Halt instruction. When set, the error message is read from the register at runtime instead of the static description string, enabling expression-based messages like RAISE(ABORT, 'bad: ' || NEW.a) to be evaluated dynamically.

Closes #5875


## Description of AI Usage
Generated by _turso auto fixer_ :tm:  :robot: 