### PR TITLE
fix: BEFORE UPDATE trigger does not fire when OR IGNORE suppresses violation

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -400,6 +400,7 @@ fn emit_update_column_values<'a>(
     t_ctx: &mut TranslateCtx<'a>,
     skip_set_clauses: bool,
     skip_row_label: BranchOffset,
+    skip_notnull_checks: bool,
 ) -> crate::Result<()> {
     let or_conflict = program.resolve_type;
     if has_direct_rowid_update {
@@ -476,7 +477,7 @@ fn emit_update_column_values<'a>(
                             &t_ctx.resolver,
                         )?;
                     }
-                    if table_column.notnull() {
+                    if table_column.notnull() && !skip_notnull_checks {
                         let notnull_conflict = if program.has_statement_conflict {
                             or_conflict
                         } else {
@@ -618,6 +619,89 @@ fn emit_update_column_values<'a>(
                 program.mark_last_insn_constant();
                 program.emit_null(value_reg, None);
                 program.mark_last_insn_constant();
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Emit NOT NULL constraint checks for SET clause columns after BEFORE triggers have fired.
+/// This is deferred from the first `emit_update_column_values` call so that triggers
+/// run before constraint checks, matching SQLite's behavior.
+#[allow(clippy::too_many_arguments)]
+fn emit_deferred_notnull_checks<'a>(
+    program: &mut ProgramBuilder,
+    table_references: &mut TableReferences,
+    target_table: &Arc<JoinedTable>,
+    set_clauses: &[(usize, Box<ast::Expr>)],
+    start: usize,
+    table_name: &str,
+    skip_row_label: BranchOffset,
+    t_ctx: &mut TranslateCtx<'a>,
+) -> crate::Result<()> {
+    let or_conflict = program.resolve_type;
+    for (idx, table_column) in target_table.table.columns().iter().enumerate() {
+        if !table_column.notnull() {
+            continue;
+        }
+        // Only check columns that are in SET clauses
+        if !set_clauses.iter().any(|(i, _)| *i == idx) {
+            continue;
+        }
+        let target_reg = start + idx;
+        match or_conflict {
+            ResolveType::Ignore => {
+                program.emit_insn(Insn::IsNull {
+                    reg: target_reg,
+                    target_pc: skip_row_label,
+                });
+            }
+            ResolveType::Replace => {
+                if let Some(default_expr) = table_column.default.as_ref() {
+                    let continue_label = program.allocate_label();
+                    program.emit_insn(Insn::NotNull {
+                        reg: target_reg,
+                        target_pc: continue_label,
+                    });
+                    translate_expr_no_constant_opt(
+                        program,
+                        Some(table_references),
+                        default_expr,
+                        target_reg,
+                        &t_ctx.resolver,
+                        NoConstantOptReason::RegisterReuse,
+                    )?;
+                    program.preassign_label_to_next_insn(continue_label);
+                } else {
+                    use crate::error::SQLITE_CONSTRAINT_NOTNULL;
+                    program.emit_insn(Insn::HaltIfNull {
+                        target_reg,
+                        err_code: SQLITE_CONSTRAINT_NOTNULL,
+                        description: format!(
+                            "{}.{}",
+                            table_name,
+                            table_column
+                                .name
+                                .as_ref()
+                                .expect("Column name must be present")
+                        ),
+                    });
+                }
+            }
+            _ => {
+                use crate::error::SQLITE_CONSTRAINT_NOTNULL;
+                program.emit_insn(Insn::HaltIfNull {
+                    target_reg,
+                    err_code: SQLITE_CONSTRAINT_NOTNULL,
+                    description: format!(
+                        "{}.{}",
+                        table_name,
+                        table_column
+                            .name
+                            .as_ref()
+                            .expect("Column name must be present")
+                    ),
+                });
             }
         }
     }
@@ -824,6 +908,27 @@ fn emit_update_insns<'a>(
 
     let skip_set_clauses = false;
 
+    // Check early whether BEFORE UPDATE triggers exist, so we can defer NOT NULL
+    // constraint checks until after the triggers fire (matching SQLite behavior).
+    let update_database_id = target_table.database_id;
+    let has_before_triggers_early = if let Some(btree_table) = target_table.table.btree() {
+        let updated_column_indices: HashSet<usize> =
+            set_clauses.iter().map(|(col_idx, _)| *col_idx).collect();
+        t_ctx.resolver.with_schema(update_database_id, |s| {
+            get_relevant_triggers_type_and_time(
+                s,
+                TriggerEvent::Update,
+                TriggerTime::Before,
+                Some(updated_column_indices),
+                &btree_table,
+            )
+            .next()
+            .is_some()
+        })
+    } else {
+        false
+    };
+
     emit_update_column_values(
         program,
         table_references,
@@ -843,6 +948,7 @@ fn emit_update_insns<'a>(
         t_ctx,
         skip_set_clauses,
         skip_row_label,
+        has_before_triggers_early,
     )?;
 
     // For non-STRICT tables, apply column affinity to the NEW values early.
@@ -866,7 +972,6 @@ fn emit_update_insns<'a>(
     }
 
     // Fire BEFORE UPDATE triggers and preserve old_registers for AFTER triggers
-    let update_database_id = target_table.database_id;
     let mut has_before_triggers = false;
     let preserved_old_registers: Option<Vec<usize>> = if let Some(btree_table) =
         target_table.table.btree()
@@ -1011,6 +1116,8 @@ fn emit_update_insns<'a>(
     // 2|666|666
     if target_table.table.btree().is_some() && has_before_triggers {
         let skip_set_clauses = true;
+        // Re-read non-SET columns (triggers may have changed them).
+        // NOT NULL checks are NOT skipped here — they cover non-SET columns.
         emit_update_column_values(
             program,
             table_references,
@@ -1030,6 +1137,21 @@ fn emit_update_insns<'a>(
             t_ctx,
             skip_set_clauses,
             skip_row_label,
+            false,
+        )?;
+
+        // Now emit NOT NULL checks for SET clause columns that were deferred
+        // from the first emit_update_column_values call. In SQLite, NOT NULL
+        // constraint checks happen after BEFORE triggers fire.
+        emit_deferred_notnull_checks(
+            program,
+            table_references,
+            &target_table,
+            set_clauses,
+            start,
+            table_name,
+            skip_row_label,
+            t_ctx,
         )?;
     }
 

--- a/testing/runner/tests/trigger_on_conflict.sqltest
+++ b/testing/runner/tests/trigger_on_conflict.sqltest
@@ -318,6 +318,108 @@ expect {
     1|150
 }
 
+# =============================================================================
+# UPDATE OR IGNORE with BEFORE triggers
+# In SQLite, BEFORE UPDATE triggers fire before constraint checks. With
+# UPDATE OR IGNORE, the trigger fires first, then the constraint violation
+# is silently ignored. https://github.com/tursodatabase/turso/issues/5873
+# =============================================================================
+
+# Test: Basic reproducer from issue #5873 - BEFORE UPDATE trigger fires
+# even when OR IGNORE suppresses NOT NULL violation
+@cross-check-integrity
+test update-or-ignore-notnull-fires-before-trigger {
+    CREATE TABLE t(a, b NOT NULL);
+    CREATE TABLE log(msg);
+    CREATE TRIGGER tr BEFORE UPDATE ON t BEGIN
+        INSERT INTO log VALUES('trigger ran');
+    END;
+    INSERT INTO t VALUES(1, 'hello');
+    UPDATE OR IGNORE t SET b = NULL WHERE a = 1;
+    SELECT * FROM log;
+    SELECT * FROM t;
+}
+expect {
+    trigger ran
+    1|hello
+}
+
+# Test: UPDATE OR IGNORE with BEFORE trigger - no constraint violation
+@cross-check-integrity
+test update-or-ignore-notnull-no-violation {
+    CREATE TABLE t(a, b NOT NULL);
+    CREATE TABLE log(msg);
+    CREATE TRIGGER tr BEFORE UPDATE ON t BEGIN
+        INSERT INTO log VALUES('trigger ran');
+    END;
+    INSERT INTO t VALUES(1, 'hello');
+    UPDATE OR IGNORE t SET b = 'world' WHERE a = 1;
+    SELECT * FROM log;
+    SELECT * FROM t;
+}
+expect {
+    trigger ran
+    1|world
+}
+
+# Test: UPDATE OR IGNORE with multiple rows - trigger fires for each row
+@cross-check-integrity
+test update-or-ignore-notnull-multiple-rows {
+    CREATE TABLE t(a, b NOT NULL);
+    CREATE TABLE log(msg);
+    CREATE TRIGGER tr BEFORE UPDATE ON t BEGIN
+        INSERT INTO log VALUES('trigger for a=' || OLD.a);
+    END;
+    INSERT INTO t VALUES(1, 'x');
+    INSERT INTO t VALUES(2, 'y');
+    INSERT INTO t VALUES(3, 'z');
+    UPDATE OR IGNORE t SET b = NULL;
+    SELECT * FROM log ORDER BY rowid;
+    SELECT * FROM t ORDER BY a;
+}
+expect {
+    trigger for a=1
+    trigger for a=2
+    trigger for a=3
+    1|x
+    2|y
+    3|z
+}
+
+# Test: UPDATE OR IGNORE with BEFORE trigger and UNIQUE constraint
+@cross-check-integrity
+test update-or-ignore-unique-fires-before-trigger {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT UNIQUE);
+    CREATE TABLE log(msg);
+    CREATE TRIGGER tr BEFORE UPDATE ON t BEGIN
+        INSERT INTO log VALUES('trigger ran');
+    END;
+    INSERT INTO t VALUES(1, 'hello');
+    INSERT INTO t VALUES(2, 'world');
+    UPDATE OR IGNORE t SET b = 'hello' WHERE a = 2;
+    SELECT * FROM log;
+    SELECT * FROM t ORDER BY a;
+}
+expect {
+    trigger ran
+    1|hello
+    2|world
+}
+
+# Test: Plain UPDATE (ABORT) with NOT NULL violation still errors after trigger
+@cross-check-integrity
+test update-abort-notnull-trigger-fires-then-errors {
+    CREATE TABLE t(a, b NOT NULL);
+    CREATE TABLE log(msg);
+    CREATE TRIGGER tr BEFORE UPDATE ON t BEGIN
+        INSERT INTO log VALUES('trigger ran');
+    END;
+    INSERT INTO t VALUES(1, 'hello');
+    UPDATE t SET b = NULL WHERE a = 1;
+}
+expect error {
+}
+
 # NEW.column in UPSERT where delta is negative and WHERE filters it out
 @cross-check-integrity
 test trigger-upsert-new-in-where-no-update {


### PR DESCRIPTION
In SQLite, BEFORE UPDATE triggers fire before constraint checks. With UPDATE OR IGNORE, the trigger fires first, then the constraint violation is silently ignored. In Turso, the NOT NULL constraint check was emitted before the trigger Program instruction, so the trigger never fired.

The fix defers NOT NULL constraint checks for SET clause columns until after BEFORE triggers have fired, matching SQLite's bytecode order.

Closes #5873

## Description of AI Usage
generated by _turso auto fixer_ :tm: :robot: 