### PR TITLE
fix: Outer statement conflict resolution not propagated to trigger body

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -924,13 +924,23 @@ fn emit_update_insns<'a>(
                 .chain(std::iter::once(new_rowid_reg))
                 .collect();
 
-            // If the program has a trigger_conflict_override, propagate it to the trigger context.
+            // Propagate conflict resolution to trigger context:
+            // 1. UPSERT DO UPDATE override takes precedence
+            // 2. Outer UPDATE's explicit ON CONFLICT overrides trigger body
+            // 3. Otherwise, use trigger's own conflict resolution
             let trigger_ctx = if let Some(override_conflict) = program.trigger_conflict_override {
                 TriggerContext::new_with_override_conflict(
                     btree_table,
                     Some(new_registers),
                     Some(old_registers.clone()), // Clone for AFTER trigger
                     override_conflict,
+                )
+            } else if !matches!(or_conflict, ResolveType::Abort) {
+                TriggerContext::new_with_override_conflict(
+                    btree_table,
+                    Some(new_registers),
+                    Some(old_registers.clone()),
+                    or_conflict,
                 )
             } else {
                 TriggerContext::new(
@@ -2093,7 +2103,7 @@ fn emit_update_insns<'a>(
                 // Use preserved OLD registers from BEFORE trigger
                 let old_registers_after = preserved_old_registers;
 
-                // If the program has a trigger_conflict_override, propagate it to the trigger context.
+                // Propagate conflict resolution to AFTER trigger context (same logic as BEFORE)
                 let trigger_ctx_after =
                     if let Some(override_conflict) = program.trigger_conflict_override {
                         TriggerContext::new_after_with_override_conflict(
@@ -2101,6 +2111,13 @@ fn emit_update_insns<'a>(
                             Some(new_registers_after),
                             old_registers_after, // OLD values preserved from BEFORE trigger
                             override_conflict,
+                        )
+                    } else if !matches!(or_conflict, ResolveType::Abort) {
+                        TriggerContext::new_after_with_override_conflict(
+                            btree_table,
+                            Some(new_registers_after),
+                            old_registers_after,
+                            or_conflict,
                         )
                     } else {
                         TriggerContext::new_after(

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -481,8 +481,9 @@ pub fn translate_insert(
             .collect();
         // Determine the conflict resolution to propagate to triggers:
         // 1. If there's already an override from UPSERT DO UPDATE context, use it (forces ABORT)
-        // 2. If the INSERT uses OR IGNORE, propagate IGNORE to trigger statements
-        //    (per SQLite semantics, OR IGNORE should apply to all statements in the trigger)
+        // 2. If the INSERT uses an explicit ON CONFLICT clause (not default ABORT),
+        //    propagate it to trigger statements (per SQLite semantics, the outer
+        //    statement's conflict resolution overrides the trigger body's)
         // 3. Otherwise, don't override (use statement's own conflict resolution)
         let trigger_ctx = if let Some(override_conflict) = program.trigger_conflict_override {
             TriggerContext::new_with_override_conflict(
@@ -491,13 +492,12 @@ pub fn translate_insert(
                 None, // No OLD for INSERT
                 override_conflict,
             )
-        } else if matches!(ctx.on_conflict, ResolveType::Ignore) {
-            // Propagate OR IGNORE to trigger statements
+        } else if !matches!(ctx.on_conflict, ResolveType::Abort) {
             TriggerContext::new_with_override_conflict(
                 btree_table.clone(),
                 Some(new_registers),
                 None, // No OLD for INSERT
-                ResolveType::Ignore,
+                ctx.on_conflict,
             )
         } else {
             TriggerContext::new(
@@ -819,12 +819,12 @@ pub fn translate_insert(
                 None,
                 override_conflict,
             )
-        } else if matches!(ctx.on_conflict, ResolveType::Ignore) {
+        } else if !matches!(ctx.on_conflict, ResolveType::Abort) {
             TriggerContext::new_after_with_override_conflict(
                 btree_table.clone(),
                 Some(new_registers_after),
                 None,
-                ResolveType::Ignore,
+                ctx.on_conflict,
             )
         } else {
             TriggerContext::new_after(btree_table.clone(), Some(new_registers_after), None)

--- a/testing/runner/tests/trigger_on_conflict.sqltest
+++ b/testing/runner/tests/trigger_on_conflict.sqltest
@@ -335,3 +335,108 @@ test trigger-upsert-new-in-where-no-update {
 expect {
     1|100
 }
+
+# =============================================================================
+# Outer statement ON CONFLICT propagation to trigger body
+# Per SQLite docs: "if an ON CONFLICT clause is specified as part of the
+# statement causing the trigger to fire, then conflict handling policy of
+# the outer statement is used instead."
+# =============================================================================
+
+# Test: INSERT OR REPLACE on outer statement overrides INSERT OR IGNORE in trigger
+@cross-check-integrity
+test outer-replace-overrides-trigger-ignore {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE t2(b INTEGER PRIMARY KEY, c TEXT);
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN
+      INSERT OR IGNORE INTO t2 VALUES(NEW.a, NEW.val);
+    END;
+    INSERT INTO t1 VALUES(1, 'first');
+    INSERT OR REPLACE INTO t1 VALUES(1, 'second');
+    SELECT * FROM t2;
+}
+expect {
+    1|second
+}
+
+# Test: INSERT OR IGNORE on outer statement overrides INSERT OR REPLACE in trigger
+@cross-check-integrity
+test outer-ignore-overrides-trigger-replace {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE t2(b INTEGER PRIMARY KEY, c TEXT);
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN
+      INSERT OR REPLACE INTO t2 VALUES(NEW.a, NEW.val);
+    END;
+    INSERT INTO t1 VALUES(1, 'first');
+    INSERT OR IGNORE INTO t1 VALUES(1, 'duplicate');
+    SELECT * FROM t2;
+}
+expect {
+    1|first
+}
+
+# Test: INSERT OR REPLACE on outer propagates through BEFORE trigger too
+@cross-check-integrity
+test outer-replace-propagates-before-trigger {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE t2(b INTEGER PRIMARY KEY, c TEXT);
+    CREATE TRIGGER tr BEFORE INSERT ON t1 BEGIN
+      INSERT OR IGNORE INTO t2 VALUES(NEW.a, NEW.val);
+    END;
+    INSERT INTO t1 VALUES(1, 'first');
+    INSERT OR REPLACE INTO t1 VALUES(1, 'second');
+    SELECT * FROM t2;
+}
+expect {
+    1|second
+}
+
+# Test: Plain INSERT (default ABORT) does NOT override trigger body's conflict clause
+@cross-check-integrity
+test default-abort-does-not-override-trigger {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE t2(b INTEGER PRIMARY KEY, c TEXT);
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN
+      INSERT OR IGNORE INTO t2 VALUES(NEW.a, NEW.val);
+    END;
+    INSERT INTO t1 VALUES(1, 'first');
+    INSERT INTO t1 VALUES(2, 'second');
+    SELECT * FROM t2 ORDER BY b;
+}
+expect {
+    1|first
+    2|second
+}
+
+# Test: INSERT OR FAIL on outer statement propagates to trigger body,
+# causing the trigger's INSERT OR IGNORE to behave as INSERT OR FAIL
+@cross-check-integrity
+test outer-fail-overrides-trigger-ignore {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY);
+    CREATE TABLE t2(b INTEGER PRIMARY KEY);
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN
+      INSERT OR IGNORE INTO t2 VALUES(NEW.a);
+    END;
+    INSERT INTO t1 VALUES(1);
+    INSERT INTO t2 VALUES(2);
+    INSERT OR FAIL INTO t1 VALUES(2);
+}
+expect error {
+}
+
+# Test: UPDATE OR REPLACE on outer statement overrides trigger body's conflict clause
+@cross-check-integrity
+test outer-update-replace-overrides-trigger-ignore {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE t2(b INTEGER PRIMARY KEY, c TEXT);
+    CREATE TRIGGER tr AFTER UPDATE ON t1 BEGIN
+      INSERT OR IGNORE INTO t2 VALUES(NEW.a, NEW.val);
+    END;
+    INSERT INTO t1 VALUES(1, 'first');
+    INSERT INTO t2 VALUES(1, 'old');
+    UPDATE OR REPLACE t1 SET val = 'updated' WHERE a = 1;
+    SELECT * FROM t2;
+}
+expect {
+    1|updated
+}


### PR DESCRIPTION
Per SQLite docs, when an ON CONFLICT clause is specified on the outer statement causing a trigger to fire, the outer conflict resolution should override the trigger body's own conflict clauses. Previously, only OR IGNORE was propagated; now all explicit conflict resolutions (REPLACE, IGNORE, FAIL, ROLLBACK) are propagated to trigger body statements for both INSERT and UPDATE outer statements.

Closes #5874

## Description of AI Usage
Generated with _turso auto fixer_ :tm: :robot: