### PR TITLE
fix: Allow virtual table functions in trigger bodies

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -106,7 +106,9 @@ fn plan_first_virtual_table_name(plan: &Plan) -> Option<String> {
 fn select_plan_first_virtual_table_name(select_plan: &SelectPlan) -> Option<String> {
     for joined_table in select_plan.joined_tables() {
         match &joined_table.table {
-            Table::Virtual(virtual_table) => return Some(virtual_table.name.clone()),
+            Table::Virtual(virtual_table) if !virtual_table.innocuous => {
+                return Some(virtual_table.name.clone())
+            }
             Table::FromClauseSubquery(from_clause_subquery) => {
                 if let Some(name) = plan_first_virtual_table_name(&from_clause_subquery.plan) {
                     return Some(name);

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -24,6 +24,9 @@ pub struct VirtualTable {
     vtab_type: VirtualTableType,
     // identifier to tie a cursor to a specific instantiated virtual table instance
     vtab_id: u64,
+    // Whether this virtual table is safe to use from within triggers and views.
+    // Corresponds to SQLite's SQLITE_VTAB_INNOCUOUS flag.
+    pub(crate) innocuous: bool,
 }
 
 impl VirtualTable {
@@ -48,6 +51,7 @@ impl VirtualTable {
             kind: VTabKind::TableValuedFunction,
             vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(dbpage_table))),
             vtab_id: 0,
+            innocuous: true,
         };
         Arc::new(dbpage_vtab)
     }
@@ -62,6 +66,7 @@ impl VirtualTable {
             kind: VTabKind::TableValuedFunction,
             vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(btree_dump_table))),
             vtab_id: 0,
+            innocuous: true,
         };
         Arc::new(vtab)
     }
@@ -75,6 +80,7 @@ impl VirtualTable {
             kind: VTabKind::TableValuedFunction,
             vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(table))),
             vtab_id: 0,
+            innocuous: true,
         };
         Arc::new(vtab)
     }
@@ -90,6 +96,7 @@ impl VirtualTable {
                     kind: VTabKind::TableValuedFunction,
                     vtab_type: VirtualTableType::Pragma(tab),
                     vtab_id: 0,
+                    innocuous: true,
                 };
                 Arc::new(vtab)
             })
@@ -124,6 +131,7 @@ impl VirtualTable {
             kind: VTabKind::TableValuedFunction,
             vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(json_each))),
             vtab_id: 0,
+            innocuous: true,
         };
 
         let json_tree = JsonVirtualTable::json_tree();
@@ -135,6 +143,7 @@ impl VirtualTable {
             kind: VTabKind::TableValuedFunction,
             vtab_type: VirtualTableType::Internal(Arc::new(RwLock::new(json_tree))),
             vtab_id: 0,
+            innocuous: true,
         };
 
         vec![
@@ -160,6 +169,7 @@ impl VirtualTable {
             kind: VTabKind::TableValuedFunction,
             vtab_type,
             vtab_id: 0,
+            innocuous: false,
         };
         Ok(Arc::new(vtab))
     }
@@ -179,6 +189,7 @@ impl VirtualTable {
             kind: VTabKind::VirtualTable,
             vtab_type: VirtualTableType::External(table),
             vtab_id: VTAB_ID_COUNTER.fetch_add(1, Ordering::Acquire),
+            innocuous: false,
         };
         Ok(Arc::new(vtab))
     }

--- a/testing/runner/tests/trigger-virtual-table-innocuous.sqltest
+++ b/testing/runner/tests/trigger-virtual-table-innocuous.sqltest
@@ -1,0 +1,96 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t(a TEXT);
+    CREATE TABLE log(msg TEXT);
+}
+
+@setup schema
+test json-each-in-trigger {
+    CREATE TRIGGER tr AFTER INSERT ON t BEGIN
+      INSERT INTO log SELECT value FROM json_each(NEW.a);
+    END;
+    INSERT INTO t VALUES('[1,2,3]');
+    SELECT msg FROM log ORDER BY msg;
+}
+expect {
+    1
+    2
+    3
+}
+
+setup schema2 {
+    CREATE TABLE t2(a TEXT);
+    CREATE TABLE log2(key_name TEXT, val TEXT);
+}
+
+@setup schema2
+test json-tree-in-trigger {
+    CREATE TRIGGER tr2 AFTER INSERT ON t2 BEGIN
+      INSERT INTO log2 SELECT key, value FROM json_tree(NEW.a) WHERE type != 'object';
+    END;
+    INSERT INTO t2 VALUES('{"x":10,"y":20}');
+    SELECT key_name, val FROM log2 ORDER BY key_name;
+}
+expect {
+    x|10
+    y|20
+}
+
+setup schema3 {
+    CREATE TABLE items(data TEXT);
+    CREATE TABLE flat(val TEXT);
+}
+
+@setup schema3
+test json-each-nested-array-in-trigger {
+    CREATE TRIGGER tr3 AFTER INSERT ON items BEGIN
+      INSERT INTO flat SELECT value FROM json_each(NEW.data);
+    END;
+    INSERT INTO items VALUES('[]');
+    INSERT INTO items VALUES('[42]');
+    INSERT INTO items VALUES('[10,20,30]');
+    SELECT val FROM flat ORDER BY rowid;
+}
+expect {
+    42
+    10
+    20
+    30
+}
+
+setup schema4 {
+    CREATE TABLE src(payload TEXT);
+    CREATE TABLE dest(k TEXT, v TEXT);
+}
+
+@setup schema4
+test json-each-with-subquery-in-trigger {
+    CREATE TRIGGER tr4 AFTER INSERT ON src BEGIN
+      INSERT INTO dest SELECT je.key, je.value FROM json_each(NEW.payload) AS je WHERE je.type = 'integer';
+    END;
+    INSERT INTO src VALUES('{"a":1,"b":"hello","c":3}');
+    SELECT k, v FROM dest ORDER BY k;
+}
+expect {
+    a|1
+    c|3
+}
+
+setup schema5 {
+    CREATE TABLE input(data TEXT);
+    CREATE TABLE output(msg TEXT);
+}
+
+@setup schema5
+test json-each-before-trigger {
+    CREATE TRIGGER tr5 BEFORE INSERT ON input BEGIN
+      INSERT INTO output SELECT value FROM json_each(NEW.data);
+    END;
+    INSERT INTO input VALUES('[100,200]');
+    SELECT msg FROM output ORDER BY msg;
+}
+expect {
+    100
+    200
+}


### PR DESCRIPTION
Add an `innocuous` flag to VirtualTable (matching SQLite's SQLITE_VTAB_INNOCUOUS). Built-in table-valued functions (json_each, json_tree, pragma, etc.) are marked innocuous and allowed in trigger bodies. External virtual tables remain blocked.

Closes #5876


## Description of AI Usage
Generated with _turso auto-fixer_ :tm: :robot: 