### PR TITLE
core/mvcc: Fix speculative delete conflict

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1117,11 +1117,15 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
 
             match version.end {
-                Some(TxTimestampOrID::Timestamp(_)) => {
+                Some(TxTimestampOrID::Timestamp(end_ts)) => {
                     // Committed deletion. If end_ts > our begin_ts, the conflict
                     // would have been already caught earlier when we iterate through
-                    // the row versions in reverse. If end_ts <= our
+                    // the row versions in reverse. If end_ts < our
                     // begin_ts, the deletion predates our snapshot — no conflict.
+                    turso_assert!(
+                        end_ts < tx.begin_ts,
+                        "row version's end_ts cannot be greater than txns begin_ts"
+                    );
                     continue;
                 }
                 Some(TxTimestampOrID::TxID(end_tx_id)) => {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7666,9 +7666,9 @@ fn test_committed_delete_tombstone_conflict() {
 /// transaction (T2) that also writes to the same row detects the conflict —
 /// even though T1's version has end=TxID(Td) with Td committed.
 ///
-/// This tests the `Committed(_) => continue` branch in our fix: skipping T1's
-/// version is safe because Td's NEW version (begin=TxID(Td)) catches the conflict.
-/// (regression test: test_speculative_delete_hides_committed_version_sql)
+/// This tests the `Committed(_) => continue` branch in `check_version_conflicts`:
+/// skipping T1's version is safe because Td's NEW version (begin=TxID(Td)) catches
+/// the conflict.
 ///
 /// Timeline:
 ///   T1: insert row 1, commit


### PR DESCRIPTION
## Description

  Probable fix for:
  - https://github.com/tursodatabase/turso/actions/runs/22897613476/job/66435626641?pr=5714
  - https://github.com/tursodatabase/turso/actions/runs/22855976911/job/66296309873?pr=5819
  - https://github.com/tursodatabase/turso/actions/runs/22902909999/job/66453807514?pr=5836

  This is the first bug found by Elle 🥳

It is a lost-write / speculative-delete bug that only becomes visible when you analyze what 
transactions observed during the run. The final database state at the end of the workload is 
correct, but Elle still catches the violation because snapshot isolation bugs can appear in 
intermediate states observed by concurrent transactions, not just in the final state.

  ## Motivation and Context

We have an Elle `list-append` workload in the concurrent simulator. Each key is treated as 
an append-only list. Transactions append values to one or more keys, and later readers 
observe those lists.

Under snapshot isolation, a committed transaction’s effects must appear consistently: if 
later transactions can observe some of its appends, they must not lose other appends 
from the same committed transaction.

  ### The Bug

  In the failing run, MVCC transaction `21084` committed these appends:

  - `k7 += 18368`
  - `k9 += 18369`
  - `k6 += 18370`

  Later reads showed:

  - `k7` contained `18368`
  - `k9` contained `18369`
  - `k6` did not contain `18370`

  `18370` never appeared in later reads, which means that write was permanently lost even though the transaction committed.

  The conflicting row had already been committed, but was temporarily marked with a 
speculative delete by another in-flight transaction. That speculative delete hid the 
 committed version from commit-time conflict validation, which allowed an invalid commit to go through.

  ### Fix

  `check_version_conflicts()` missed a conflict case for versions whose `end` field 
   was set to an in-flight transaction ID.

  More specifically, a committed current version with:

  - `begin = Timestamp(...)`
  - `end = TxID(...)`

  was skipped even when that `end` only represented a speculative delete from another 
  active transaction.

  The fix keeps treating that row as a conflict candidate unless the deleting transaction has 
actually committed. This prevents speculative deletes from hiding a committed current version during 
first-committer-wins validation.

  This patch also adds regression tests modeled after the Elle workload:

```
mvcc::database::tests::test_elle_lost_update_exclusive_concurrent
mvcc::database::tests::test_speculative_delete_hides_committed_version
mvcc::database::tests::test_speculative_delete_hides_committed_version_sql
```

  ## Description of AI Usage

  I used AI to help debug the issue.

  It helped with:
  - writing scripts to validate that the Elle report was a real bug and not a false positive
  - tracing the failing history back to the offending transaction
  - checking the relevant execution paths once the bad transaction was isolated
  - i was sus on the `check_version_conflicts()` and AI validated it
  - It also produced a regression test for the missed conflict case