### PR TITLE
fix(#5549): update in-memory trigger AST cache after ALTER TABLE RENA…

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1357,6 +1357,10 @@ pub fn translate_alter_table(
             });
 
             // Update trigger SQL for renamed columns
+            // Clone before the loop since `for` takes ownership of the Vec.
+            // The clone is passed into AlterColumn so op_alter_column can
+            // update the in-memory schema triggers cache.
+            let triggers_for_insn = triggers_to_rewrite.clone();
             for (trigger_name, new_sql) in triggers_to_rewrite {
                 let escaped_sql = new_sql.replace('\'', "''");
                 let update_stmt = format!(
@@ -1399,6 +1403,7 @@ pub fn translate_alter_table(
                 db: database_id,
                 table: table_name.to_owned(),
                 column_index,
+                triggers_to_rewrite: triggers_for_insn,
                 definition: Box::new(definition),
                 rename,
             });

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10591,6 +10591,7 @@ pub fn op_alter_column(
             db,
             table: table_name,
             column_index,
+            triggers_to_rewrite,
             definition,
             rename,
         },
@@ -10616,7 +10617,7 @@ pub fn op_alter_column(
     let new_column = crate::schema::Column::try_from(definition.as_ref())?;
     let new_name = definition.col_name.as_str().to_owned();
 
-    conn.with_database_schema_mut(*db, |schema| {
+    conn.with_database_schema_mut(*db, |schema| -> crate::Result<()> {
         let table_arc = schema
             .tables
             .get_mut(&normalized_table_name)
@@ -10718,7 +10719,47 @@ pub fn op_alter_column(
                 }
             }
         }
-    });
+
+        // Reparse each trigger with updated SQL and refresh the in-memory schema cache.
+        // The disk (sqlite_master) was already updated by the bytecode emitted in alter.rs.
+        for (trigger_name, new_sql) in triggers_to_rewrite.iter() {
+            use crate::schema::Trigger;
+            use turso_parser::ast::{Cmd, Stmt};
+            let mut parser = Parser::new(new_sql.as_bytes());
+            let Ok(Some(Cmd::Stmt(Stmt::CreateTrigger {
+                temporary,
+                if_not_exists: _,
+                trigger_name: _,
+                time,
+                event,
+                tbl_name,
+                for_each_row,
+                when_clause,
+                commands,
+            }))) = parser.next_cmd()
+            else {
+                return Err(crate::LimboError::ParseError(format!(
+                    "invalid trigger sql: {new_sql}"
+                )));
+            };
+            schema.remove_trigger(trigger_name)?;
+            schema.add_trigger(
+                Trigger::new(
+                    trigger_name.clone(),
+                    new_sql.to_string(),
+                    tbl_name.name.to_string(),
+                    time,
+                    event,
+                    for_each_row,
+                    when_clause.map(|e| *e),
+                    commands,
+                    temporary,
+                ),
+                tbl_name.name.as_str(),
+            )?;
+        }
+        Ok(())
+    })?;
 
     if *rename {
         conn.with_schema(*db, |schema| -> crate::Result<()> {

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1934,7 +1934,7 @@ pub fn insn_to_row(
                 0,
                 format!("add_column({table}, {column:?})"),
             ),
-            Insn::AlterColumn { db: _, table, column_index, definition: column, rename } => (
+            Insn::AlterColumn { db: _, table, column_index, definition: column, rename, triggers_to_rewrite: _ } => (
                 "AlterColumn",
                 0,
                 0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1338,6 +1338,7 @@ pub enum Insn {
     AlterColumn {
         db: usize,
         table: String,
+        triggers_to_rewrite: Vec<(String, String)>,
         column_index: usize,
         definition: Box<turso_parser::ast::ColumnDefinition>,
         rename: bool,

--- a/testing/runner/tests/issue_5549.sqltest
+++ b/testing/runner/tests/issue_5549.sqltest
@@ -1,0 +1,18 @@
+@database :memory:
+
+test trigger_cache_after_rename_column {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr AFTER INSERT ON t
+    BEGIN
+      INSERT INTO log VALUES('name=' || NEW.name);
+    END;
+    INSERT INTO t VALUES(1, 'test');
+    ALTER TABLE t RENAME COLUMN name TO full_name;
+    INSERT INTO t VALUES(2, 'hello');
+    SELECT msg FROM log ORDER BY msg;
+}
+expect {
+    name=hello
+    name=test
+}


### PR DESCRIPTION
ixes: #5549

Root cause: ALTER TABLE RENAME COLUMN correctly rewrote the trigger SQL text in sqlite_master on disk, but the in-memory schema.triggers cache still held the stale parsed AST. When the trigger fired post-rename, it resolved column references against the old AST and failed with no such column in NEW: name.

Fix: Extended the AlterColumn VDBE instruction to carry triggers_to_rewrite: Vec<(String, String)>. In 

op_alter_column
, after updating the table schema, each affected trigger is re-parsed from its updated SQL and atomically swapped into schema.triggers using remove_trigger + add_trigger

Files changed: insn.rs,  alter.rs, explain.rs, execute.rs, + new test.
