### PR TITLE
fix: unescape JSON string escape sequences in JSON_EXTRACT and ->> operator

### DIFF
--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -15,7 +15,10 @@ use crate::numeric::Numeric;
 use crate::types::{AsValueRef, Text, TextSubtype, Value, ValueType};
 use crate::{bail_constraint_error, bail_parse_error, LimboError, ValueRef};
 pub use cache::JsonCacheCell;
-use jsonb::{ElementType, Jsonb, JsonbHeader, PathOperationMode, SearchOperation, SetOperation};
+use jsonb::{
+    unescape_string, ElementType, Jsonb, JsonbHeader, PathOperationMode, SearchOperation,
+    SetOperation,
+};
 use std::borrow::Cow;
 use std::str::FromStr;
 
@@ -597,7 +600,7 @@ pub fn json_string_to_db_type(
             if matches!(flag, OutputVariant::ElementType) {
                 json_string.remove(json_string.len() - 1);
                 json_string.remove(0);
-                Ok(Value::Text(Text::new(json_string)))
+                Ok(Value::Text(Text::new(unescape_string(&json_string))))
             } else {
                 Ok(Value::Text(Text::new(json_string)))
             }

--- a/testing/runner/tests/json/default.sqltest
+++ b/testing/runner/tests/json/default.sqltest
@@ -3105,3 +3105,104 @@ test json107-1-8 {
 expect {
 		{"a":123,"b":456}
 }
+
+test json_extract-unescape-double-quote {
+    SELECT JSON_EXTRACT('{"key":"value with \"quotes\""}', '$.key');
+}
+expect {
+    value with "quotes"
+}
+
+test json_extract-unescape-backslash {
+    SELECT JSON_EXTRACT('{"a":"back\\\\slash"}', '$.a');
+}
+expect {
+    back\slash
+}
+
+test json_extract-unescape-forward-slash {
+    SELECT JSON_EXTRACT('{"a":"for\\/ward"}', '$.a');
+}
+expect {
+    for/ward
+}
+
+test json_extract-unescape-newline {
+    SELECT JSON_EXTRACT('{"a":"line1\nline2"}', '$.a');
+}
+expect {
+    line1
+line2
+}
+
+test json_extract-unescape-tab {
+    SELECT JSON_EXTRACT('{"a":"col1\tcol2"}', '$.a');
+}
+expect {
+    col1	col2
+}
+
+test json_extract-unescape-carriage-return-length {
+    SELECT LENGTH(JSON_EXTRACT('{"a":"hello\rworld"}', '$.a'));
+}
+expect {
+    11
+}
+
+test json_extract-unescape-backspace-length {
+    SELECT LENGTH(JSON_EXTRACT('{"a":"hello\bworld"}', '$.a'));
+}
+expect {
+    11
+}
+
+test json_extract-unescape-formfeed-length {
+    SELECT LENGTH(JSON_EXTRACT('{"a":"hello\fworld"}', '$.a'));
+}
+expect {
+    11
+}
+
+test json_extract-unescape-unicode {
+    SELECT JSON_EXTRACT('{"a":"hello\\u0020world"}', '$.a');
+}
+expect {
+    hello world
+}
+
+test json_extract-unescape-unicode-emoji {
+    SELECT JSON_EXTRACT('{"a":"\\u263A"}', '$.a');
+}
+expect {
+    ☺
+}
+
+test json_extract-unescape-newline-length {
+    SELECT LENGTH(JSON_EXTRACT('{"a":"hello\nworld"}', '$.a'));
+}
+expect {
+    11
+}
+
+test json_extract-arrow-unescape-double-quote {
+    SELECT '{"key":"value with \"quotes\""}' ->> '$.key';
+}
+expect {
+    value with "quotes"
+}
+
+test json_extract-arrow-unescape-newline {
+    SELECT '{"a":"line1\nline2"}' ->> '$.a';
+}
+expect {
+    line1
+line2
+}
+
+test json_extract-combined-escapes {
+    SELECT JSON_EXTRACT('{"a":"tab\there\nnewline\ttab"}', '$.a');
+}
+expect {
+    tab	here
+newline	tab
+}


### PR DESCRIPTION
## Summary

- Fix JSON_EXTRACT and ->> operator to properly unescape JSON string escape sequences
- Call unescape_string() in json_string_to_db_type() after removing outer quotes
- Add 14 tests covering all RFC 7159 escape sequences

Closes #5751

🤖 Generated with [Claude Code](https://claude.ai/code)