### PR TITLE
core/vdbe: Fix `unicode(char(0))` to return NULL

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -615,6 +615,9 @@ impl Value {
             Value::Text(_) | Value::Numeric(_) | Value::Blob(_) => {
                 let text = self.to_string();
                 if let Some(first_char) = text.chars().next() {
+                    if first_char == '\0' {
+                        return Value::Null;
+                    }
                     Value::from_i64(first_char as u32 as i64)
                 } else {
                     Value::Null
@@ -1883,6 +1886,7 @@ mod tests {
             Value::from_i64(128522)
         );
         assert_eq!(Value::build_text("").exec_unicode(), Value::Null);
+        assert_eq!(Value::build_text("\0").exec_unicode(), Value::Null);
         assert_eq!(Value::from_i64(23).exec_unicode(), Value::from_i64(50));
         assert_eq!(Value::from_i64(0).exec_unicode(), Value::from_i64(48));
         assert_eq!(Value::from_f64(0.0).exec_unicode(), Value::from_i64(48));

--- a/testing/runner/tests/scalar-functions.sqltest
+++ b/testing/runner/tests/scalar-functions.sqltest
@@ -1384,6 +1384,12 @@ test unicode-null {
 expect {
 }
 
+test unicode-char0 {
+    SELECT unicode(char(0));
+}
+expect {
+}
+
 test quote-string-embedded-nul {
     SELECT quote(concat('abc', char(0), 'def'))
 }


### PR DESCRIPTION
## Description
Closes https://github.com/tursodatabase/turso/issues/5907
`unicode(char(0))` returns 0 instead of NULL. SQLite uses NUL-terminated C strings internally, so a string starting with NUL is effectively empty, and `unicode()` of an empty string returns NULL. In Rust, strings can contain NUL bytes, so `exec_unicode()` was finding '\0' as a valid first character and returning its codepoint. The fix adds a check in `exec_unicode()` to treat '\0' as if the string were empty and return NULL, matching SQLite's behavior.
