### PR TITLE
Reject unusable hidden-arg constraints in json_each/json_tree

### DIFF
--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -93,15 +93,37 @@ impl InternalVirtualTable for JsonVirtualTable {
 
         let mut json_idx: Option<usize> = None;
         let mut path_idx: Option<usize> = None;
+        let mut has_json_eq_constraint = false;
+        let mut has_root_eq_constraint = false;
         for (i, c) in constraints.iter().enumerate() {
-            if !c.usable || c.op != ConstraintOp::Eq {
+            if c.op != ConstraintOp::Eq {
                 continue;
             }
             match c.column_index as usize {
-                COL_JSON => json_idx = Some(i),
-                COL_ROOT => path_idx = Some(i),
+                COL_JSON => {
+                    has_json_eq_constraint = true;
+                    if c.usable {
+                        json_idx = Some(i);
+                    }
+                }
+                COL_ROOT => {
+                    has_root_eq_constraint = true;
+                    if c.usable {
+                        path_idx = Some(i);
+                    }
+                }
                 _ => {}
             }
+        }
+
+        // Hidden arguments supplied in SQL must be usable in the chosen loop.
+        // If they are present but unusable, reject this access shape so the
+        // optimizer can pick a join order where argument registers are available.
+        if has_json_eq_constraint && json_idx.is_none() {
+            return Err(ResultCode::ConstraintViolation);
+        }
+        if has_root_eq_constraint && path_idx.is_none() {
+            return Err(ResultCode::ConstraintViolation);
         }
 
         let argc = match (json_idx, path_idx) {

--- a/testing/runner/tests/json/default.sqltest
+++ b/testing/runner/tests/json/default.sqltest
@@ -2608,6 +2608,49 @@ test json-each-no-arguments {
 expect {
 }
 
+test json-each-join-table-column-order-by-issue-5904 {
+    WITH t1(id, a) AS (
+        VALUES (1, '[1,2]'), (2, '[3,4]')
+    )
+    SELECT t1.id, j.value
+    FROM t1, json_each(t1.a) AS j
+    ORDER BY t1.id, CAST(j.key AS INTEGER);
+}
+expect {
+    1|1
+    1|2
+    2|3
+    2|4
+}
+
+test json-each-join-table-column-two-arg-issue-5904 {
+    WITH t2(data) AS (
+        VALUES ('{"items":[1,2,3]}')
+    )
+    SELECT j.value
+    FROM t2, json_each(t2.data, '$.items') AS j
+    ORDER BY CAST(j.key AS INTEGER);
+}
+expect {
+    1
+    2
+    3
+}
+
+test json-each-join-complex-expression-where-issue-5904 {
+    WITH t3(id, data) AS (
+        VALUES (1, '{"items":[{"name":"a"},{"name":"b"},{"name":"c"}]}')
+    )
+    SELECT j.value
+    FROM t3, json_each(json_extract(t3.data, '$.items')) AS j
+    WHERE j.key > 0
+    ORDER BY CAST(j.key AS INTEGER);
+}
+expect {
+    {"name":"b"}
+    {"name":"c"}
+}
+
 test json_each_3_arguments {
     SELECT * FROM json_each(1, 2, 3);
 }


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

In JsonVirtualTable::best_index, if an equality constraint is present for a hidden arg (`json` or `root`) but marked unusable for the current join order,return ConstraintViolation. This forces the optimizer to pick a valid loop order where argument registers are available, instead of producing empty results.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Issue #5904 shows SQLite/Turso mismatch:

  - ORDER BY over parent table column with json_each(table_col) returned no rows.
  - Two-argument json_each(table_col, '$.path') returned no rows.
  - json_each(json_extract(table_col,...)) with WHERE returned no rows.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5904


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
