### PR TITLE
Apply column affinity in WHEN register comparisons

### DIFF
--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -667,75 +667,81 @@ pub fn fire_trigger(
     let affinity_ctx = apply_new_column_affinity(program, &decoded_ctx)?;
     let ctx = &affinity_ctx;
 
-    // Evaluate WHEN clause if present
-    if let Some(mut when_expr) = trigger.when_clause.clone() {
-        // Rewrite BETWEEN expressions to AND/OR form before translation,
-        // since translate_expr expects this rewrite to have already happened.
-        rewrite_between_expr(&mut when_expr);
-        // Rewrite NEW/OLD references in WHEN clause to use registers
-        rewrite_trigger_expr_for_when_clause(&mut when_expr, &ctx.table, ctx)?;
+    let saved_register_affinities = std::mem::take(&mut resolver.register_affinities);
+    populate_trigger_register_affinities(resolver, ctx);
+    let result = (|| -> Result<()> {
+        // Evaluate WHEN clause if present
+        if let Some(mut when_expr) = trigger.when_clause.clone() {
+            // Rewrite BETWEEN expressions to AND/OR form before translation,
+            // since translate_expr expects this rewrite to have already happened.
+            rewrite_between_expr(&mut when_expr);
+            // Rewrite NEW/OLD references in WHEN clause to use registers
+            rewrite_trigger_expr_for_when_clause(&mut when_expr, &ctx.table, ctx)?;
 
-        // Plan and emit any subqueries in the WHEN clause (e.g. IN (SELECT ...), EXISTS, scalar subqueries).
-        // This transforms InSelect/Exists/Subquery nodes into SubqueryResult nodes that translate_expr can handle.
-        let mut subqueries = Vec::new();
-        plan_subqueries_from_trigger_when_clause(
-            program,
-            &mut subqueries,
-            &mut when_expr,
-            resolver,
-            connection,
-        )?;
-        // Emit the planned subqueries so their results are available when we evaluate the WHEN expression.
-        // Always treat these as correlated (no `Once` caching) because the WHEN clause is evaluated
-        // per-row, and trigger bodies may modify the tables referenced by the subquery between evaluations.
-        for subquery in &mut subqueries {
-            let plan = subquery.consume_plan(crate::translate::plan::EvalAt::BeforeLoop);
-            emit_non_from_clause_subquery(
+            // Plan and emit any subqueries in the WHEN clause (e.g. IN (SELECT ...), EXISTS, scalar subqueries).
+            // This transforms InSelect/Exists/Subquery nodes into SubqueryResult nodes that translate_expr can handle.
+            let mut subqueries = Vec::new();
+            plan_subqueries_from_trigger_when_clause(
+                program,
+                &mut subqueries,
+                &mut when_expr,
+                resolver,
+                connection,
+            )?;
+            // Emit the planned subqueries so their results are available when we evaluate the WHEN expression.
+            // Always treat these as correlated (no `Once` caching) because the WHEN clause is evaluated
+            // per-row, and trigger bodies may modify the tables referenced by the subquery between evaluations.
+            for subquery in &mut subqueries {
+                let plan = subquery.consume_plan(crate::translate::plan::EvalAt::BeforeLoop);
+                emit_non_from_clause_subquery(
+                    program,
+                    resolver,
+                    *plan,
+                    &subquery.query_type,
+                    true, // always re-evaluate: trigger WHEN is checked per-row
+                    false,
+                )?;
+            }
+
+            let when_reg = program.alloc_register();
+            translate_expr(program, None, &when_expr, when_reg, resolver)?;
+
+            let skip_label = program.allocate_label();
+            program.emit_insn(Insn::IfNot {
+                reg: when_reg,
+                jump_if_null: true,
+                target_pc: skip_label,
+            });
+
+            // Execute trigger commands if WHEN clause is true
+            execute_trigger_commands(
                 program,
                 resolver,
-                *plan,
-                &subquery.query_type,
-                true, // always re-evaluate: trigger WHEN is checked per-row
-                false,
+                &trigger,
+                ctx,
+                connection,
+                database_id,
+                ignore_jump_target,
+            )?;
+
+            program.preassign_label_to_next_insn(skip_label);
+        } else {
+            // No WHEN clause - always execute
+            execute_trigger_commands(
+                program,
+                resolver,
+                &trigger,
+                ctx,
+                connection,
+                database_id,
+                ignore_jump_target,
             )?;
         }
 
-        let when_reg = program.alloc_register();
-        translate_expr(program, None, &when_expr, when_reg, resolver)?;
-
-        let skip_label = program.allocate_label();
-        program.emit_insn(Insn::IfNot {
-            reg: when_reg,
-            jump_if_null: true,
-            target_pc: skip_label,
-        });
-
-        // Execute trigger commands if WHEN clause is true
-        execute_trigger_commands(
-            program,
-            resolver,
-            &trigger,
-            ctx,
-            connection,
-            database_id,
-            ignore_jump_target,
-        )?;
-
-        program.preassign_label_to_next_insn(skip_label);
-    } else {
-        // No WHEN clause - always execute
-        execute_trigger_commands(
-            program,
-            resolver,
-            &trigger,
-            ctx,
-            connection,
-            database_id,
-            ignore_jump_target,
-        )?;
-    }
-
-    Ok(())
+        Ok(())
+    })();
+    resolver.register_affinities = saved_register_affinities;
+    result
 }
 
 /// Decode encoded custom type registers in a TriggerContext.
@@ -854,6 +860,38 @@ fn apply_new_column_affinity(
         override_conflict: ctx.override_conflict,
         new_encoded: ctx.new_encoded,
     })
+}
+
+fn populate_trigger_register_affinities(resolver: &mut Resolver, ctx: &TriggerContext) {
+    populate_trigger_row_register_affinities(resolver, &ctx.table, ctx.new_registers.as_deref());
+    populate_trigger_row_register_affinities(resolver, &ctx.table, ctx.old_registers.as_deref());
+}
+
+fn populate_trigger_row_register_affinities(
+    resolver: &mut Resolver,
+    table: &BTreeTable,
+    row_registers: Option<&[usize]>,
+) {
+    let Some(registers) = row_registers else {
+        return;
+    };
+
+    for (idx, column) in table.columns.iter().enumerate() {
+        let affinity = if column.is_rowid_alias() {
+            Affinity::Integer
+        } else {
+            column.affinity_with_strict(table.is_strict)
+        };
+        if let Some(&register) = registers.get(idx) {
+            resolver.register_affinities.insert(register, affinity);
+        }
+    }
+
+    if let Some(&rowid_register) = registers.last() {
+        resolver
+            .register_affinities
+            .insert(rowid_register, Affinity::Integer);
+    }
 }
 
 /// Rewrite NEW/OLD references in WHEN clause expressions (uses Register expressions, not Variable)

--- a/testing/runner/tests/trigger.sqltest
+++ b/testing/runner/tests/trigger.sqltest
@@ -1353,6 +1353,38 @@ expect {
     triggered for id 1
 }
 
+# Trigger WHEN comparisons must preserve rowid-alias affinity after NEW.* is
+# rewritten to registers, so string literals coerce numerically like SQLite.
+@cross-check-integrity
+test trigger-when-rowid-alias-string-literal-affinity {
+    CREATE TABLE t_5864(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE log_5864(msg TEXT);
+    CREATE TRIGGER t_5864_ai AFTER INSERT ON t_5864
+    WHEN NEW.a = '3' BEGIN
+      INSERT INTO log_5864 VALUES('match');
+    END;
+    INSERT INTO t_5864 VALUES(3, 'z');
+    SELECT * FROM log_5864;
+}
+expect {
+    match
+}
+
+# STRICT ANY must preserve no-affinity comparison semantics in trigger WHEN.
+@cross-check-integrity
+test trigger-when-strict-any-no-affinity {
+    CREATE TABLE t_5864_any(a ANY) STRICT;
+    CREATE TABLE log_5864_any(msg TEXT);
+    CREATE TRIGGER t_5864_any_ai AFTER INSERT ON t_5864_any
+    WHEN NEW.a = '3' BEGIN
+      INSERT INTO log_5864_any VALUES('match');
+    END;
+    INSERT INTO t_5864_any VALUES(3);
+    SELECT * FROM log_5864_any;
+}
+expect {
+}
+
 # https://github.com/tursodatabase/turso/issues/5175
 # Subquery in trigger body UPDATE SET clause
 @cross-check-integrity


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

Fix trigger `WHEN` clause comparisons so `NEW`/`OLD` references rewritten to registers still use the source column's comparison affinity.

  The change populates trigger row-image register affinities before translating the `WHEN` expression, using STRICT-aware affinity resolution for normal columns and `INTEGER` for rowid aliases. This restores SQLite-compatible coercion for cases like `NEW.a = '3'` when `a` is an `INTEGER PRIMARY KEY`, while preserving no-affinity behavior for STRICT `ANY`
  columns.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Turso was evaluating some trigger `WHEN` comparisons differently from SQLite after `NEW`/`OLD` column references were rewritten to `Expr::Register`.

  Because the rewritten registers did not carry the original column affinity metadata, comparisons such as:

  ```sql
  WHEN NEW.a = '3'
```


  could be evaluated without applying numeric affinity, causing triggers not to fire for INTEGER PRIMARY KEY values where SQLite does fire them.

  While fixing that, I also found and covered the STRICT ANY edge case, where SQLite must preserve no-affinity semantics and must not coerce '3' to numeric during the trigger
  comparison.


<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5864

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
