### PR TITLE
core/translate/perf: GROUP BY - deduplicate column reads and shrink sorter size

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -234,32 +234,18 @@ pub fn handle_distinct(
     });
 }
 
-/// Enum representing the source of the aggregate function arguments
+/// Source of aggregate function arguments during bytecode emission.
 ///
-/// Aggregate arguments can come from different sources, depending on how the aggregation
-/// is evaluated:
-/// * In the common grouped case, the aggregate function arguments are  first inserted
-///   into a sorter in the main loop, and in the group by aggregation phase we read
-///   the data from the sorter.
-/// * In grouped cases where no sorting is required, arguments are retrieved  directly
-///   from registers allocated in the main loop.
-/// * In ungrouped cases, arguments are computed directly from the `args` expressions.
+/// * `Register`: arguments were pre-computed into contiguous registers
+///   (used for GROUP BY without a sorter, where the main loop is already sorted).
+/// * `Expression`: arguments are evaluated on-the-fly from the original AST
+///   (used for ungrouped aggregates, window functions, and for the GROUP BY sorter
+///   path where leaf columns are cached in `expr_to_reg_cache` before evaluation).
 pub enum AggArgumentSource<'a> {
-    /// The aggregate function arguments are retrieved from a pseudo cursor
-    /// which reads from the GROUP BY sorter.
-    PseudoCursor {
-        cursor_id: usize,
-        col_start: usize,
-        dest_reg_start: usize,
-        aggregate: &'a Aggregate,
-    },
-    /// The aggregate function arguments are retrieved from a contiguous block of registers
-    /// allocated in the main loop for that given aggregate function.
     Register {
         src_reg_start: usize,
         aggregate: &'a Aggregate,
     },
-    /// The aggregate function arguments are retrieved by evaluating expressions.
     Expression {
         func: &'a AggFunc,
         args: &'a Vec<ast::Expr>,
@@ -268,23 +254,6 @@ pub enum AggArgumentSource<'a> {
 }
 
 impl<'a> AggArgumentSource<'a> {
-    /// Create a new [AggArgumentSource] that retrieves the values from a GROUP BY sorter.
-    pub fn new_from_cursor(
-        program: &mut ProgramBuilder,
-        cursor_id: usize,
-        col_start: usize,
-        aggregate: &'a Aggregate,
-    ) -> Self {
-        let dest_reg_start = program.alloc_registers(aggregate.args.len());
-        Self::PseudoCursor {
-            cursor_id,
-            col_start,
-            dest_reg_start,
-            aggregate,
-        }
-    }
-    /// Create a new [AggArgumentSource] that retrieves the values directly from an already
-    /// populated register or registers.
     pub fn new_from_registers(src_reg_start: usize, aggregate: &'a Aggregate) -> Self {
         Self::Register {
             src_reg_start,
@@ -292,7 +261,6 @@ impl<'a> AggArgumentSource<'a> {
         }
     }
 
-    /// Create a new [AggArgumentSource] that retrieves the values by evaluating `args` expressions.
     pub fn new_from_expression(
         func: &'a AggFunc,
         args: &'a Vec<ast::Expr>,
@@ -307,7 +275,6 @@ impl<'a> AggArgumentSource<'a> {
 
     pub fn distinctness(&self) -> &Distinctness {
         match self {
-            AggArgumentSource::PseudoCursor { aggregate, .. } => &aggregate.distinctness,
             AggArgumentSource::Register { aggregate, .. } => &aggregate.distinctness,
             AggArgumentSource::Expression { distinctness, .. } => distinctness,
         }
@@ -315,26 +282,26 @@ impl<'a> AggArgumentSource<'a> {
 
     pub fn agg_func(&self) -> &AggFunc {
         match self {
-            AggArgumentSource::PseudoCursor { aggregate, .. } => &aggregate.func,
             AggArgumentSource::Register { aggregate, .. } => &aggregate.func,
             AggArgumentSource::Expression { func, .. } => func,
         }
     }
+
     pub fn arg_at(&self, idx: usize) -> &ast::Expr {
         match self {
-            AggArgumentSource::PseudoCursor { aggregate, .. } => &aggregate.args[idx],
             AggArgumentSource::Register { aggregate, .. } => &aggregate.args[idx],
             AggArgumentSource::Expression { args, .. } => &args[idx],
         }
     }
+
     pub fn num_args(&self) -> usize {
         match self {
-            AggArgumentSource::PseudoCursor { aggregate, .. } => aggregate.args.len(),
             AggArgumentSource::Register { aggregate, .. } => aggregate.args.len(),
             AggArgumentSource::Expression { args, .. } => args.len(),
         }
     }
-    /// Read the value of an aggregate function argument
+
+    /// Emit bytecode to read an aggregate function argument into a register.
     pub fn translate(
         &self,
         program: &mut ProgramBuilder,
@@ -343,19 +310,6 @@ impl<'a> AggArgumentSource<'a> {
         arg_idx: usize,
     ) -> Result<usize> {
         match self {
-            AggArgumentSource::PseudoCursor {
-                cursor_id,
-                col_start,
-                dest_reg_start,
-                ..
-            } => {
-                program.emit_column_or_rowid(
-                    *cursor_id,
-                    *col_start + arg_idx,
-                    dest_reg_start + arg_idx,
-                );
-                Ok(dest_reg_start + arg_idx)
-            }
             AggArgumentSource::Register {
                 src_reg_start: start_reg,
                 ..

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -459,6 +459,11 @@ pub struct TranslateCtx<'a> {
     /// - First: all `GROUP BY` expressions, in the order they appear in the `GROUP BY` clause.
     /// - Then: remaining non-aggregate expressions that are not part of `GROUP BY`.
     pub non_aggregate_expressions: Vec<(&'a Expr, bool)>,
+    /// Unique leaf column expressions extracted from aggregate function arguments.
+    /// Only populated when GROUP BY uses a sorter, enabling deferred expression
+    /// evaluation: the sorter stores raw columns instead of pre-computed expressions,
+    /// and full expressions are re-evaluated from the pseudo cursor during aggregation.
+    pub agg_leaf_columns: Vec<Expr>,
     /// Cursor id for cdc table (if capture_data_changes PRAGMA is set and query can modify the data)
     pub cdc_cursor_id: Option<usize>,
     pub meta_window: Option<WindowMetadata<'a>>,
@@ -499,6 +504,7 @@ impl<'a> TranslateCtx<'a> {
             materialized_build_inputs: HashMap::default(),
             resolver,
             non_aggregate_expressions: Vec::new(),
+            agg_leaf_columns: Vec::new(),
             cdc_cursor_id: None,
             meta_window: None,
             meta_in_seeks: (0..table_count).map(|_| None).collect(),

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -132,7 +132,14 @@ impl EmitGroupBy {
         // END BLOCK
 
         let reg_sorter_key = program.alloc_register();
-        let column_count = plan.agg_args_count() + t_ctx.non_aggregate_expressions.len();
+        let column_count = if !group_by.sort_elided {
+            // Sorter path: store only unique leaf columns from aggregate args
+            // instead of pre-computed expression results.
+            t_ctx.agg_leaf_columns = collect_agg_leaf_columns(&plan.aggregates, plan)?;
+            t_ctx.non_aggregate_expressions.len() + t_ctx.agg_leaf_columns.len()
+        } else {
+            plan.agg_args_count() + t_ctx.non_aggregate_expressions.len()
+        };
         let reg_group_by_source_cols_start = program.alloc_registers(column_count);
 
         let row_source = if !group_by.sort_elided {
@@ -304,6 +311,35 @@ pub fn compute_group_by_sort_order(
         }
     }
     result
+}
+
+/// Extracts unique leaf column references from all aggregate function arguments.
+/// These are the base table columns that aggregate expressions depend on.
+/// By storing only these in the GROUP BY sorter (instead of pre-computed expression
+/// results), we reduce sorter record size and avoid redundant B-tree column reads.
+fn collect_agg_leaf_columns(aggregates: &[Aggregate], plan: &SelectPlan) -> Result<Vec<ast::Expr>> {
+    let mut leaf_columns: Vec<ast::Expr> = Vec::new();
+    for agg in aggregates {
+        for arg in &agg.args {
+            walk_expr(arg, &mut |expr: &ast::Expr| -> Result<WalkControl> {
+                match expr {
+                    ast::Expr::Column { table, .. } | ast::Expr::RowId { table, .. } => {
+                        if plan
+                            .table_references
+                            .find_joined_table_by_internal_id(*table)
+                            .is_some()
+                            && !leaf_columns.iter().any(|e| exprs_are_equivalent(e, expr))
+                        {
+                            leaf_columns.push(expr.clone());
+                        }
+                        Ok(WalkControl::SkipChildren)
+                    }
+                    _ => Ok(WalkControl::Continue),
+                }
+            })?;
+        }
+    }
+    Ok(leaf_columns)
 }
 
 fn collect_non_aggregate_expressions<'a>(
@@ -617,40 +653,79 @@ pub fn group_by_process_single_group(
 
     // Process each aggregate function for the current row
     program.preassign_label_to_next_insn(labels.label_grouping_agg_step);
-    let cursor_index = t_ctx.non_aggregate_expressions.len(); // Skipping all columns in sorter that not an aggregation arguments
-    let mut offset = 0;
-    for (i, agg) in plan.aggregates.iter().enumerate() {
-        let start_reg = t_ctx
-            .reg_agg_start
-            .expect("aggregate registers must be initialized");
-        let agg_result_reg = start_reg + i;
-        let agg_arg_source = match &row_source {
-            GroupByRowSource::Sorter { pseudo_cursor, .. } => AggArgumentSource::new_from_cursor(
-                program,
-                *pseudo_cursor,
-                cursor_index + offset,
-                agg,
-            ),
-            GroupByRowSource::MainLoop { start_reg_src, .. } => {
-                // Aggregation arguments are always placed in the registers that follow any scalars.
-                let start_reg_aggs = start_reg_src + t_ctx.non_aggregate_expressions.len();
-                AggArgumentSource::new_from_registers(start_reg_aggs + offset, agg)
+
+    match &row_source {
+        GroupByRowSource::Sorter { pseudo_cursor, .. } => {
+            // Read leaf columns from the pseudo cursor and cache them so that
+            // translate_expr can resolve column references during expression evaluation.
+            let leaf_start_idx = t_ctx.non_aggregate_expressions.len();
+            let leaf_regs = program.alloc_registers(t_ctx.agg_leaf_columns.len());
+            for i in 0..t_ctx.agg_leaf_columns.len() {
+                program.emit_column_or_rowid(*pseudo_cursor, leaf_start_idx + i, leaf_regs + i);
             }
-        };
-        translate_aggregation_step(
-            program,
-            &plan.table_references,
-            agg_arg_source,
-            agg_result_reg,
-            &t_ctx.resolver,
-        )?;
-        if let Distinctness::Distinct { ctx } = &agg.distinctness {
-            let ctx = ctx
-                .as_ref()
-                .expect("distinct aggregate context not populated");
-            program.preassign_label_to_next_insn(ctx.label_on_conflict);
+
+            let cache_len = t_ctx.resolver.expr_to_reg_cache.len();
+            let cache_was_enabled = t_ctx.resolver.expr_to_reg_cache_enabled;
+            for (i, leaf_expr) in t_ctx.agg_leaf_columns.drain(..).enumerate() {
+                t_ctx.resolver.expr_to_reg_cache.push((
+                    std::borrow::Cow::Owned(leaf_expr),
+                    leaf_regs + i,
+                    false,
+                ));
+            }
+            t_ctx.resolver.enable_expr_to_reg_cache();
+
+            for (i, agg) in plan.aggregates.iter().enumerate() {
+                let agg_start_reg = t_ctx
+                    .reg_agg_start
+                    .expect("aggregate registers must be initialized");
+                let agg_result_reg = agg_start_reg + i;
+                let agg_arg_source =
+                    AggArgumentSource::new_from_expression(&agg.func, &agg.args, &agg.distinctness);
+                translate_aggregation_step(
+                    program,
+                    &plan.table_references,
+                    agg_arg_source,
+                    agg_result_reg,
+                    &t_ctx.resolver,
+                )?;
+                if let Distinctness::Distinct { ctx } = &agg.distinctness {
+                    let ctx = ctx
+                        .as_ref()
+                        .expect("distinct aggregate context not populated");
+                    program.preassign_label_to_next_insn(ctx.label_on_conflict);
+                }
+            }
+
+            t_ctx.resolver.expr_to_reg_cache.truncate(cache_len);
+            t_ctx.resolver.expr_to_reg_cache_enabled = cache_was_enabled;
         }
-        offset += agg.args.len();
+        GroupByRowSource::MainLoop { start_reg_src, .. } => {
+            let mut offset = 0;
+            for (i, agg) in plan.aggregates.iter().enumerate() {
+                let agg_start_reg = t_ctx
+                    .reg_agg_start
+                    .expect("aggregate registers must be initialized");
+                let agg_result_reg = agg_start_reg + i;
+                let start_reg_aggs = start_reg_src + t_ctx.non_aggregate_expressions.len();
+                let agg_arg_source =
+                    AggArgumentSource::new_from_registers(start_reg_aggs + offset, agg);
+                translate_aggregation_step(
+                    program,
+                    &plan.table_references,
+                    agg_arg_source,
+                    agg_result_reg,
+                    &t_ctx.resolver,
+                )?;
+                if let Distinctness::Distinct { ctx } = &agg.distinctness {
+                    let ctx = ctx
+                        .as_ref()
+                        .expect("distinct aggregate context not populated");
+                    program.preassign_label_to_next_insn(ctx.label_on_conflict);
+                }
+                offset += agg.args.len();
+            }
+        }
     }
 
     // We only need to store non-aggregate columns once per group

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -135,15 +135,6 @@ fn emit_loop_source<'a>(
 ) -> Result<()> {
     match emit_target {
         LoopEmitTarget::GroupBy => {
-            // This function either:
-            // - creates a sorter for GROUP BY operations by allocating registers and translating expressions for three types of columns:
-            // 1) GROUP BY columns (used as sorting keys)
-            // 2) non-aggregate, non-GROUP BY columns
-            // 3) aggregate function arguments
-            // - or if the rows produced by the loop are already sorted in the order required by the GROUP BY keys,
-            // the group by comparisons are done directly inside the main loop.
-            let aggregates = &plan.aggregates;
-
             let GroupByMetadata {
                 row_source,
                 registers,
@@ -173,25 +164,6 @@ fn emit_loop_source<'a>(
                 )?;
             }
 
-            // Step 2: Process arguments for all aggregate functions
-            // For each aggregate, translate all its argument expressions
-            for agg in aggregates.iter() {
-                // For a query like: SELECT group_col, SUM(val1), AVG(val2) FROM table GROUP BY group_col
-                // we'll process val1 and val2 here, storing them in the sorter so they're available
-                // when computing the aggregates after sorting by group_col
-                for expr in agg.args.iter() {
-                    let agg_reg = cur_reg;
-                    cur_reg += 1;
-                    translate_expr(
-                        program,
-                        Some(&plan.table_references),
-                        expr,
-                        agg_reg,
-                        &t_ctx.resolver,
-                    )?;
-                }
-            }
-
             match row_source {
                 GroupByRowSource::Sorter {
                     sort_cursor,
@@ -199,6 +171,19 @@ fn emit_loop_source<'a>(
                     reg_sorter_key,
                     ..
                 } => {
+                    // Sorter path: store only unique leaf columns from aggregate args.
+                    // Full expressions are re-evaluated from the pseudo cursor during aggregation.
+                    for leaf_expr in t_ctx.agg_leaf_columns.iter() {
+                        let reg = cur_reg;
+                        cur_reg += 1;
+                        translate_expr(
+                            program,
+                            Some(&plan.table_references),
+                            leaf_expr,
+                            reg,
+                            &t_ctx.resolver,
+                        )?;
+                    }
                     sorter_insert(
                         program,
                         start_reg,
@@ -207,7 +192,22 @@ fn emit_loop_source<'a>(
                         *reg_sorter_key,
                     );
                 }
-                GroupByRowSource::MainLoop { .. } => group_by_agg_phase(program, t_ctx, plan)?,
+                GroupByRowSource::MainLoop { .. } => {
+                    for agg in plan.aggregates.iter() {
+                        for expr in agg.args.iter() {
+                            let agg_reg = cur_reg;
+                            cur_reg += 1;
+                            translate_expr(
+                                program,
+                                Some(&plan.table_references),
+                                expr,
+                                agg_reg,
+                                &t_ctx.resolver,
+                            )?;
+                        }
+                    }
+                    group_by_agg_phase(program, t_ctx, plan)?;
+                }
             }
 
             Ok(())

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1340,6 +1340,7 @@ pub fn emit_from_clause_subquery(
                 reg_limit_offset_sum: None,
                 resolver: t_ctx.resolver.fork(),
                 non_aggregate_expressions: Vec::new(),
+                agg_leaf_columns: Vec::new(),
                 cdc_cursor_id: None,
                 meta_window: None,
                 meta_in_seeks: (0..select_plan.joined_tables().len())
@@ -1425,6 +1426,7 @@ fn emit_indexed_materialized_subquery(
                 reg_limit_offset_sum: None,
                 resolver: t_ctx.resolver.fork(),
                 non_aggregate_expressions: Vec::new(),
+                agg_leaf_columns: Vec::new(),
                 cdc_cursor_id: None,
                 meta_window: None,
                 meta_in_seeks: (0..select_plan.joined_tables().len())
@@ -1519,6 +1521,7 @@ fn emit_materialized_subquery_table(
                 reg_limit_offset_sum: None,
                 resolver: t_ctx.resolver.fork(),
                 non_aggregate_expressions: Vec::new(),
+                agg_leaf_columns: Vec::new(),
                 cdc_cursor_id: None,
                 meta_window: None,
                 meta_in_seeks: (0..select_plan.joined_tables().len())

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__aggregation-with-join.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__aggregation-with-join.snap
@@ -31,13 +31,13 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4                p5  comment
-   0          Init               0  78   0                     0  Start at 78
+   0          Init               0  81   0                     0  Start at 81
    1          SorterOpen         0   1   0  k(1,-B)            0  cursor=0
    2          Null               0  11  13                     0  r[11..13]=NULL
    3          SorterOpen         1   4   0  k(1,-B)            0  cursor=1
    4          Integer            0   8   0                     0  r[8]=0; clear group by abort flag
    5          Null               0   9   0                     0  r[9]=NULL; initialize group by comparison registers to NULL
-   6          Gosub             19  65   0                     0  ; go to clear accumulator subroutine
+   6          Gosub             19  68   0                     0  ; go to clear accumulator subroutine
    7          OpenRead           3   6   0  k(4,B,B,B,B)       0  table=products, root=6, iDb=0
    8          OpenRead           4   7   0  k(6,B,B,B,B,B,B)   0  table=orders, root=7, iDb=0
    9          OpenRead           5   9   0  k(2,B)             0  index=idx_orders_product, root=9, iDb=0
@@ -61,53 +61,56 @@ addr  opcode                    p1  p2  p3  p4                p5  comment
   27            Goto             0  16   0                     0
   28          Next               3  11   0                     0
   29          OpenPseudo         2  14   4                     0  4 columns in r[14]
-  30          SorterSort         1  49   0                     0
+  30          SorterSort         1  52   0                     0
   31            SorterData       1  14   2                     0  r[14]=data
   32            Column           2   0  22                     0  r[22]=pseudo.column 0
   33            Compare          9  22   1  k(1, Binary)       0  r[9..9]==r[22..22]
   34            Jump            35  39  35                     0  ; start new group if comparison is not equal
-  35            Gosub            6  53   0                     0  ; check if ended group had data, and output if so
+  35            Gosub            6  56   0                     0  ; check if ended group had data, and output if so
   36            Move            22   9   1                     0  r[9..9]=r[22..22]
-  37            IfPos            8  68   0                     0  r[8]>0 -> r[8]-=0, goto 68; check abort flag
-  38            Gosub           19  65   0                     0  ; goto clear accumulator subroutine
+  37            IfPos            8  71   0                     0  r[8]>0 -> r[8]-=0, goto 71; check abort flag
+  38            Gosub           19  68   0                     0  ; goto clear accumulator subroutine
   39            Column           2   1  23                     0  r[23]=pseudo.column 1
-  40            AggStep          0  23  11  count              0  accum=r[11] step(r[23])
-  41            Column           2   2  24                     0  r[24]=pseudo.column 2
-  42            AggStep          0  24  12  sum                0  accum=r[12] step(r[24])
-  43            Column           2   3  25                     0  r[25]=pseudo.column 3
-  44            AggStep          0  25  13  avg                0  accum=r[13] step(r[25])
-  45            If               7  47   0                     0  if r[7] goto 47; don't emit group columns if continuing existing group
-  46            Column           2   0  10                     0  r[10]=pseudo.column 0
-  47            Integer          1   7   0                     0  r[7]=1; indicate data in accumulator
-  48          SorterNext         1  31   0                     0
-  49          Gosub              6  53   0                     0  ; emit row for final group
-  50          Goto               0  68   0                     0  ; group by finished
-  51          Integer            1   8   0                     0  r[8]=1
-  52        Return               6   0   0                     0
-  53        IfPos                7  55   0                     0  r[7]>0 -> r[7]-=0, goto 55; output group by row subroutine start
-  54      Return                 6   0   0                     0
-  55      AggFinal               0  11   0  count              0  accum=r[11]
-  56      AggFinal               0  12   0  sum                0  accum=r[12]
-  57      AggFinal               0  13   0  avg                0  accum=r[13]
-  58      Copy                  12  26   0                     0  r[26]=r[12]
-  59      Copy                  10  27   0                     0  r[27]=r[10]
-  60      Copy                  11  28   0                     0  r[28]=r[11]
-  61      Copy                  13  29   0                     0  r[29]=r[13]
-  62      MakeRecord            26   4   5                     0  r[5]=mkrec(r[26..29])
-  63      SorterInsert           0   5   0  0                  0  key=r[5]
-  64    Return                   6   0   0                     0
-  65    Null                     0  10  13                     0  r[10..13]=NULL; clear accumulator subroutine start
-  66    Integer                  0   7   0                     0  r[7]=0
-  67  Return                    19   0   0                     0
-  68  OpenPseudo                 6   5   4                     0  4 columns in r[5]
-  69  SorterSort                 0  77   0                     0
-  70    SorterData               0   5   6                     0  r[5]=data
-  71    Column                   6   1   1                     0  r[1]=pseudo.column 1
-  72    Column                   6   2   2                     0  r[2]=pseudo.column 2
-  73    Column                   6   0   3                     0  r[3]=pseudo.column 0
-  74    Column                   6   3   4                     0  r[4]=pseudo.column 3
-  75    ResultRow                1   4   0                     0  output=r[1..4]
-  76  SorterNext                 0  70   0                     0
-  77  Halt                       0   0   0                     0
-  78  Transaction                0   1   8                     0  iDb=0 tx_mode=Read
-  79  Goto                       0   1   0                     0
+  40            Column           2   2  24                     0  r[24]=pseudo.column 2
+  41            Column           2   3  25                     0  r[25]=pseudo.column 3
+  42            Copy            23  26   0                     0  r[26]=r[23]
+  43            AggStep          0  26  11  count              0  accum=r[11] step(r[26])
+  44            Copy            24  27   0                     0  r[27]=r[24]
+  45            AggStep          0  27  12  sum                0  accum=r[12] step(r[27])
+  46            Copy            25  28   0                     0  r[28]=r[25]
+  47            AggStep          0  28  13  avg                0  accum=r[13] step(r[28])
+  48            If               7  50   0                     0  if r[7] goto 50; don't emit group columns if continuing existing group
+  49            Column           2   0  10                     0  r[10]=pseudo.column 0
+  50            Integer          1   7   0                     0  r[7]=1; indicate data in accumulator
+  51          SorterNext         1  31   0                     0
+  52          Gosub              6  56   0                     0  ; emit row for final group
+  53          Goto               0  71   0                     0  ; group by finished
+  54          Integer            1   8   0                     0  r[8]=1
+  55        Return               6   0   0                     0
+  56        IfPos                7  58   0                     0  r[7]>0 -> r[7]-=0, goto 58; output group by row subroutine start
+  57      Return                 6   0   0                     0
+  58      AggFinal               0  11   0  count              0  accum=r[11]
+  59      AggFinal               0  12   0  sum                0  accum=r[12]
+  60      AggFinal               0  13   0  avg                0  accum=r[13]
+  61      Copy                  12  29   0                     0  r[29]=r[12]
+  62      Copy                  10  30   0                     0  r[30]=r[10]
+  63      Copy                  11  31   0                     0  r[31]=r[11]
+  64      Copy                  13  32   0                     0  r[32]=r[13]
+  65      MakeRecord            29   4   5                     0  r[5]=mkrec(r[29..32])
+  66      SorterInsert           0   5   0  0                  0  key=r[5]
+  67    Return                   6   0   0                     0
+  68    Null                     0  10  13                     0  r[10..13]=NULL; clear accumulator subroutine start
+  69    Integer                  0   7   0                     0  r[7]=0
+  70  Return                    19   0   0                     0
+  71  OpenPseudo                 6   5   4                     0  4 columns in r[5]
+  72  SorterSort                 0  80   0                     0
+  73    SorterData               0   5   6                     0  r[5]=data
+  74    Column                   6   1   1                     0  r[1]=pseudo.column 1
+  75    Column                   6   2   2                     0  r[2]=pseudo.column 2
+  76    Column                   6   0   3                     0  r[3]=pseudo.column 0
+  77    Column                   6   3   4                     0  r[4]=pseudo.column 3
+  78    ResultRow                1   4   0                     0  output=r[1..4]
+  79  SorterNext                 0  73   0                     0
+  80  Halt                       0   0   0                     0
+  81  Transaction                0   1   8                     0  iDb=0 tx_mode=Read
+  82  Goto                       0   1   0                     0

--- a/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__distinct-count-with-join.snap
+++ b/testing/runner/tests/snapshot_tests/aggregation/snapshots/aggregation__distinct-count-with-join.snap
@@ -32,13 +32,13 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                          p1  p2  p3  p4                p5  comment
-   0          Init                     0  66   0                     0  Start at 66
+   0          Init                     0  68   0                     0  Start at 68
    1          SorterOpen               0   1   0  k(1,-B)            0  cursor=0
    2          Null                     0  10  11                     0  r[10..11]=NULL
    3          SorterOpen               1   3   0  k(1,-B)            0  cursor=1
    4          Integer                  0   7   0                     0  r[7]=0; clear group by abort flag
    5          Null                     0   8   0                     0  r[8]=NULL; initialize group by comparison registers to NULL
-   6          Gosub                   16  52   0                     0  ; go to clear accumulator subroutine
+   6          Gosub                   16  54   0                     0  ; go to clear accumulator subroutine
    7          OpenRead                 3   6   0  k(4,B,B,B,B)       0  table=products, root=6, iDb=0
    8          OpenRead                 4   7   0  k(6,B,B,B,B,B,B)   0  table=orders, root=7, iDb=0
    9          Rewind                   4  18   0                     0  Rewind table orders
@@ -51,52 +51,54 @@ addr  opcode                          p1  p2  p3  p4                p5  comment
   16            SorterInsert           1  12   0  0                  0  key=r[12]
   17          Next                     4  10   0                     0
   18          OpenPseudo               2  12   3                     0  3 columns in r[12]
-  19          SorterSort               1  38   0                     0
+  19          SorterSort               1  40   0                     0
   20            SorterData             1  12   2                     0  r[12]=data
   21            Column                 2   0  18                     0  r[18]=pseudo.column 0
   22            Compare                8  18   1  k(1, Binary)       0  r[8..8]==r[18..18]
   23            Jump                  24  28  24                     0  ; start new group if comparison is not equal
-  24            Gosub                  5  42   0                     0  ; check if ended group had data, and output if so
+  24            Gosub                  5  44   0                     0  ; check if ended group had data, and output if so
   25            Move                  18   8   1                     0  r[8..8]=r[18..18]
-  26            IfPos                  7  57   0                     0  r[7]>0 -> r[7]-=0, goto 57; check abort flag
-  27            Gosub                 16  52   0                     0  ; goto clear accumulator subroutine
+  26            IfPos                  7  59   0                     0  r[7]>0 -> r[7]-=0, goto 59; check abort flag
+  27            Gosub                 16  54   0                     0  ; goto clear accumulator subroutine
   28            Column                 2   1  19                     0  r[19]=pseudo.column 1
-  29            HashDistinct  1073741824  19   1  jmp=31             0
-  30            AggStep                0  19  10  count              0  accum=r[10] step(r[19])
-  31            Column                 2   2  20                     0  r[20]=pseudo.column 2
-  32            HashDistinct  1073741825  20   1  jmp=34             0
-  33            AggStep                0  20  11  count              0  accum=r[11] step(r[20])
-  34            If                     6  36   0                     0  if r[6] goto 36; don't emit group columns if continuing existing group
-  35            Column                 2   0   9                     0  r[9]=pseudo.column 0
-  36            Integer                1   6   0                     0  r[6]=1; indicate data in accumulator
-  37          SorterNext               1  20   0                     0
-  38          Gosub                    5  42   0                     0  ; emit row for final group
-  39          Goto                     0  57   0                     0  ; group by finished
-  40          Integer                  1   7   0                     0  r[7]=1
-  41        Return                     5   0   0                     0
-  42        IfPos                      6  44   0                     0  r[6]>0 -> r[6]-=0, goto 44; output group by row subroutine start
-  43      Return                       5   0   0                     0
-  44      AggFinal                     0  10   0  count              0  accum=r[10]
-  45      AggFinal                     0  11   0  count              0  accum=r[11]
-  46      Copy                        10  21   0                     0  r[21]=r[10]
-  47      Copy                         9  22   0                     0  r[22]=r[9]
-  48      Copy                        11  23   0                     0  r[23]=r[11]
-  49      MakeRecord                  21   3   4                     0  r[4]=mkrec(r[21..23])
-  50      SorterInsert                 0   4   0  0                  0  key=r[4]
-  51    Return                         5   0   0                     0
-  52    Null                           0   9  11                     0  r[9..11]=NULL; clear accumulator subroutine start
-  53    HashClear             1073741824   0   0                     0
-  54    HashClear             1073741825   0   0                     0
-  55    Integer                        0   6   0                     0  r[6]=0
-  56  Return                          16   0   0                     0
-  57  OpenPseudo                       5   4   3                     0  3 columns in r[4]
-  58  SorterSort                       0  65   0                     0
-  59    SorterData                     0   4   5                     0  r[4]=data
-  60    Column                         5   1   1                     0  r[1]=pseudo.column 1
-  61    Column                         5   0   2                     0  r[2]=pseudo.column 0
-  62    Column                         5   2   3                     0  r[3]=pseudo.column 2
-  63    ResultRow                      1   3   0                     0  output=r[1..3]
-  64  SorterNext                       0  59   0                     0
-  65  Halt                             0   0   0                     0
-  66  Transaction                      0   1   8                     0  iDb=0 tx_mode=Read
-  67  Goto                             0   1   0                     0
+  29            Column                 2   2  20                     0  r[20]=pseudo.column 2
+  30            Copy                  19  21   0                     0  r[21]=r[19]
+  31            HashDistinct  1073741824  21   1  jmp=33             0
+  32            AggStep                0  21  10  count              0  accum=r[10] step(r[21])
+  33            Copy                  20  22   0                     0  r[22]=r[20]
+  34            HashDistinct  1073741825  22   1  jmp=36             0
+  35            AggStep                0  22  11  count              0  accum=r[11] step(r[22])
+  36            If                     6  38   0                     0  if r[6] goto 38; don't emit group columns if continuing existing group
+  37            Column                 2   0   9                     0  r[9]=pseudo.column 0
+  38            Integer                1   6   0                     0  r[6]=1; indicate data in accumulator
+  39          SorterNext               1  20   0                     0
+  40          Gosub                    5  44   0                     0  ; emit row for final group
+  41          Goto                     0  59   0                     0  ; group by finished
+  42          Integer                  1   7   0                     0  r[7]=1
+  43        Return                     5   0   0                     0
+  44        IfPos                      6  46   0                     0  r[6]>0 -> r[6]-=0, goto 46; output group by row subroutine start
+  45      Return                       5   0   0                     0
+  46      AggFinal                     0  10   0  count              0  accum=r[10]
+  47      AggFinal                     0  11   0  count              0  accum=r[11]
+  48      Copy                        10  23   0                     0  r[23]=r[10]
+  49      Copy                         9  24   0                     0  r[24]=r[9]
+  50      Copy                        11  25   0                     0  r[25]=r[11]
+  51      MakeRecord                  23   3   4                     0  r[4]=mkrec(r[23..25])
+  52      SorterInsert                 0   4   0  0                  0  key=r[4]
+  53    Return                         5   0   0                     0
+  54    Null                           0   9  11                     0  r[9..11]=NULL; clear accumulator subroutine start
+  55    HashClear             1073741824   0   0                     0
+  56    HashClear             1073741825   0   0                     0
+  57    Integer                        0   6   0                     0  r[6]=0
+  58  Return                          16   0   0                     0
+  59  OpenPseudo                       5   4   3                     0  3 columns in r[4]
+  60  SorterSort                       0  67   0                     0
+  61    SorterData                     0   4   5                     0  r[4]=data
+  62    Column                         5   1   1                     0  r[1]=pseudo.column 1
+  63    Column                         5   0   2                     0  r[2]=pseudo.column 0
+  64    Column                         5   2   3                     0  r[3]=pseudo.column 2
+  65    ResultRow                      1   3   0                     0  output=r[1..3]
+  66  SorterNext                       0  61   0                     0
+  67  Halt                             0   0   0                     0
+  68  Transaction                      0   1   8                     0  iDb=0 tx_mode=Read
+  69  Goto                             0   1   0                     0

--- a/testing/runner/tests/snapshot_tests/analyze/snapshots/analyze__aggregate-after-analyze.snap
+++ b/testing/runner/tests/snapshot_tests/analyze/snapshots/analyze__aggregate-after-analyze.snap
@@ -18,12 +18,12 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                p5  comment
-   0          Init             0  48   0                     0  Start at 48
+   0          Init             0  49   0                     0  Start at 49
    1          Null             0   9  10                     0  r[9..10]=NULL
    2          SorterOpen       0   2   0  k(1,B)             0  cursor=0
    3          Integer          0   6   0                     0  r[6]=0; clear group by abort flag
    4          Null             0   7   0                     0  r[7]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           14  44   0                     0  ; go to clear accumulator subroutine
+   5          Gosub           14  45   0                     0  ; go to clear accumulator subroutine
    6          OpenRead         2   2   0  k(6,B,B,B,B,B,B)   0  table=products, root=2, iDb=0
    7          Rewind           2  14   0                     0  Rewind table products
    8            Column         2   3  12                     0  r[12]=products.category
@@ -33,39 +33,40 @@ addr  opcode                  p1  p2  p3  p4                p5  comment
   12            SorterInsert   0  11   0  0                  0  key=r[11]
   13          Next             2   8   0                     0
   14          OpenPseudo       1  11   2                     0  2 columns in r[11]
-  15          SorterSort       0  31   0                     0
+  15          SorterSort       0  32   0                     0
   16            SorterData     0  11   1                     0  r[11]=data
   17            Column         1   0  15                     0  r[15]=pseudo.column 0
   18            Compare        7  15   1  k(1, Binary)       0  r[7..7]==r[15..15]
   19            Jump          20  24  20                     0  ; start new group if comparison is not equal
-  20            Gosub          4  35   0                     0  ; check if ended group had data, and output if so
+  20            Gosub          4  36   0                     0  ; check if ended group had data, and output if so
   21            Move          15   7   1                     0  r[7..7]=r[15..15]
-  22            IfPos          6  47   0                     0  r[6]>0 -> r[6]-=0, goto 47; check abort flag
-  23            Gosub         14  44   0                     0  ; goto clear accumulator subroutine
-  24            AggStep        0  16   9  count              0  accum=r[9] step(r[16])
-  25            Column         1   1  17                     0  r[17]=pseudo.column 1
-  26            AggStep        0  17  10  avg                0  accum=r[10] step(r[17])
-  27            If             5  29   0                     0  if r[5] goto 29; don't emit group columns if continuing existing group
-  28            Column         1   0   8                     0  r[8]=pseudo.column 0
-  29            Integer        1   5   0                     0  r[5]=1; indicate data in accumulator
-  30          SorterNext       0  16   0                     0
-  31          Gosub            4  35   0                     0  ; emit row for final group
-  32          Goto             0  47   0                     0  ; group by finished
-  33          Integer          1   6   0                     0  r[6]=1
-  34        Return             4   0   0                     0
-  35        IfPos              5  37   0                     0  r[5]>0 -> r[5]-=0, goto 37; output group by row subroutine start
-  36      Return               4   0   0                     0
-  37      AggFinal             0   9   0  count              0  accum=r[9]
-  38      AggFinal             0  10   0  avg                0  accum=r[10]
-  39      Copy                 8   1   0                     0  r[1]=r[8]
-  40      Copy                 9   2   0                     0  r[2]=r[9]
-  41      Copy                10   3   0                     0  r[3]=r[10]
-  42      ResultRow            1   3   0                     0  output=r[1..3]
-  43    Return                 4   0   0                     0
-  44    Null                   0   8  10                     0  r[8..10]=NULL; clear accumulator subroutine start
-  45    Integer                0   5   0                     0  r[5]=0
-  46  Return                  14   0   0                     0
-  47  Halt                     0   0   0                     0
-  48  Transaction              0   1   5                     0  iDb=0 tx_mode=Read
-  49  Integer                  1  16   0                     0  r[16]=1
-  50  Goto                     0   1   0                     0
+  22            IfPos          6  48   0                     0  r[6]>0 -> r[6]-=0, goto 48; check abort flag
+  23            Gosub         14  45   0                     0  ; goto clear accumulator subroutine
+  24            Column         1   1  16                     0  r[16]=pseudo.column 1
+  25            AggStep        0  17   9  count              0  accum=r[9] step(r[17])
+  26            Copy          16  18   0                     0  r[18]=r[16]
+  27            AggStep        0  18  10  avg                0  accum=r[10] step(r[18])
+  28            If             5  30   0                     0  if r[5] goto 30; don't emit group columns if continuing existing group
+  29            Column         1   0   8                     0  r[8]=pseudo.column 0
+  30            Integer        1   5   0                     0  r[5]=1; indicate data in accumulator
+  31          SorterNext       0  16   0                     0
+  32          Gosub            4  36   0                     0  ; emit row for final group
+  33          Goto             0  48   0                     0  ; group by finished
+  34          Integer          1   6   0                     0  r[6]=1
+  35        Return             4   0   0                     0
+  36        IfPos              5  38   0                     0  r[5]>0 -> r[5]-=0, goto 38; output group by row subroutine start
+  37      Return               4   0   0                     0
+  38      AggFinal             0   9   0  count              0  accum=r[9]
+  39      AggFinal             0  10   0  avg                0  accum=r[10]
+  40      Copy                 8   1   0                     0  r[1]=r[8]
+  41      Copy                 9   2   0                     0  r[2]=r[9]
+  42      Copy                10   3   0                     0  r[3]=r[10]
+  43      ResultRow            1   3   0                     0  output=r[1..3]
+  44    Return                 4   0   0                     0
+  45    Null                   0   8  10                     0  r[8..10]=NULL; clear accumulator subroutine start
+  46    Integer                0   5   0                     0  r[5]=0
+  47  Return                  14   0   0                     0
+  48  Halt                     0   0   0                     0
+  49  Transaction              0   1   5                     0  iDb=0 tx_mode=Read
+  50  Integer                  1  17   0                     0  r[17]=1
+  51  Goto                     0   1   0                     0

--- a/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
+++ b/testing/runner/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
@@ -31,13 +31,13 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4                    p5  comment
-   0          Init               0  80   0                         0  Start at 80
+   0          Init               0  82   0                         0  Start at 82
    1          SorterOpen         0   2   0  k(2,-B,Binary)         0  cursor=0
    2          Null               0  13  14                         0  r[13..14]=NULL
    3          SorterOpen         1   4   0  k(2,B,B)               0  cursor=1
    4          Integer            0   8   0                         0  r[8]=0; clear group by abort flag
    5          Null               0   9  10                         0  r[9..10]=NULL; initialize group by comparison registers to NULL
-   6          Gosub             20  67   0                         0  ; go to clear accumulator subroutine
+   6          Gosub             20  69   0                         0  ; go to clear accumulator subroutine
    7          OpenRead           3   2   0  k(5,B,B,B,B,B)         0  table=customers, root=2, iDb=0
    8          OpenRead           4   4   0  k(5,B,B,B,B,B)         0  table=orders, root=4, iDb=0
    9          OpenRead           5   8   0  k(2,B)                 0  index=idx_orders_customer_id, root=8, iDb=0
@@ -61,55 +61,57 @@ addr  opcode                    p1  p2  p3  p4                    p5  comment
   27            Goto             0  16   0                         0
   28          Next               3  11   0                         0
   29          OpenPseudo         2  15   4                         0  4 columns in r[15]
-  30          SorterSort         1  49   0                         0
+  30          SorterSort         1  51   0                         0
   31            SorterData       1  15   2                         0  r[15]=data
   32            Column           2   0  23                         0  r[23]=pseudo.column 0
   33            Column           2   1  24                         0  r[24]=pseudo.column 1
   34            Compare          9  23   2  k(2, Binary, Binary)   0  r[9..10]==r[23..24]
   35            Jump            36  40  36                         0  ; start new group if comparison is not equal
-  36            Gosub            6  53   0                         0  ; check if ended group had data, and output if so
+  36            Gosub            6  55   0                         0  ; check if ended group had data, and output if so
   37            Move            23   9   2                         0  r[9..10]=r[23..24]
-  38            IfPos            8  70   0                         0  r[8]>0 -> r[8]-=0, goto 70; check abort flag
-  39            Gosub           20  67   0                         0  ; goto clear accumulator subroutine
+  38            IfPos            8  72   0                         0  r[8]>0 -> r[8]-=0, goto 72; check abort flag
+  39            Gosub           20  69   0                         0  ; goto clear accumulator subroutine
   40            Column           2   2  25                         0  r[25]=pseudo.column 2
-  41            AggStep          0  25  13  count                  0  accum=r[13] step(r[25])
-  42            Column           2   3  26                         0  r[26]=pseudo.column 3
-  43            AggStep          0  26  14  sum                    0  accum=r[14] step(r[26])
-  44            If               7  47   0                         0  if r[7] goto 47; don't emit group columns if continuing existing group
-  45            Column           2   0  11                         0  r[11]=pseudo.column 0
-  46            Column           2   1  12                         0  r[12]=pseudo.column 1
-  47            Integer          1   7   0                         0  r[7]=1; indicate data in accumulator
-  48          SorterNext         1  31   0                         0
-  49          Gosub              6  53   0                         0  ; emit row for final group
-  50          Goto               0  70   0                         0  ; group by finished
-  51          Integer            1   8   0                         0  r[8]=1
-  52        Return               6   0   0                         0
-  53        IfPos                7  55   0                         0  r[7]>0 -> r[7]-=0, goto 55; output group by row subroutine start
-  54      Return                 6   0   0                         0
-  55      AggFinal               0  13   0  count                  0  accum=r[13]
-  56      AggFinal               0  14   0  sum                    0  accum=r[14]
-  57      Copy                  14  27   0                         0  r[27]=r[14]
-  58      NotNull               27  60   0                         0  r[27]!=NULL -> goto 60
-  59      Integer                0  27   0                         0  r[27]=0
-  60      Sequence               0  28   0                         0
-  61      Copy                  11  29   0                         0  r[29]=r[11]
-  62      Copy                  12  30   0                         0  r[30]=r[12]
-  63      Copy                  13  31   0                         0  r[31]=r[13]
-  64      MakeRecord            27   5   5                         0  r[5]=mkrec(r[27..31])
-  65      SorterInsert           0   5   0  0                      0  key=r[5]
-  66    Return                   6   0   0                         0
-  67    Null                     0  11  14                         0  r[11..14]=NULL; clear accumulator subroutine start
-  68    Integer                  0   7   0                         0  r[7]=0
-  69  Return                    20   0   0                         0
-  70  OpenPseudo                 6   5   5                         0  5 columns in r[5]
-  71  SorterSort                 0  79   0                         0
-  72    SorterData               0   5   6                         0  r[5]=data
-  73    Column                   6   2   1                         0  r[1]=pseudo.column 2
-  74    Column                   6   3   2                         0  r[2]=pseudo.column 3
-  75    Column                   6   4   3                         0  r[3]=pseudo.column 4
-  76    Column                   6   0   4                         0  r[4]=pseudo.column 0
-  77    ResultRow                1   4   0                         0  output=r[1..4]
-  78  SorterNext                 0  72   0                         0
-  79  Halt                       0   0   0                         0
-  80  Transaction                0   1  10                         0  iDb=0 tx_mode=Read
-  81  Goto                       0   1   0                         0
+  41            Column           2   3  26                         0  r[26]=pseudo.column 3
+  42            Copy            25  27   0                         0  r[27]=r[25]
+  43            AggStep          0  27  13  count                  0  accum=r[13] step(r[27])
+  44            Copy            26  28   0                         0  r[28]=r[26]
+  45            AggStep          0  28  14  sum                    0  accum=r[14] step(r[28])
+  46            If               7  49   0                         0  if r[7] goto 49; don't emit group columns if continuing existing group
+  47            Column           2   0  11                         0  r[11]=pseudo.column 0
+  48            Column           2   1  12                         0  r[12]=pseudo.column 1
+  49            Integer          1   7   0                         0  r[7]=1; indicate data in accumulator
+  50          SorterNext         1  31   0                         0
+  51          Gosub              6  55   0                         0  ; emit row for final group
+  52          Goto               0  72   0                         0  ; group by finished
+  53          Integer            1   8   0                         0  r[8]=1
+  54        Return               6   0   0                         0
+  55        IfPos                7  57   0                         0  r[7]>0 -> r[7]-=0, goto 57; output group by row subroutine start
+  56      Return                 6   0   0                         0
+  57      AggFinal               0  13   0  count                  0  accum=r[13]
+  58      AggFinal               0  14   0  sum                    0  accum=r[14]
+  59      Copy                  14  29   0                         0  r[29]=r[14]
+  60      NotNull               29  62   0                         0  r[29]!=NULL -> goto 62
+  61      Integer                0  29   0                         0  r[29]=0
+  62      Sequence               0  30   0                         0
+  63      Copy                  11  31   0                         0  r[31]=r[11]
+  64      Copy                  12  32   0                         0  r[32]=r[12]
+  65      Copy                  13  33   0                         0  r[33]=r[13]
+  66      MakeRecord            29   5   5                         0  r[5]=mkrec(r[29..33])
+  67      SorterInsert           0   5   0  0                      0  key=r[5]
+  68    Return                   6   0   0                         0
+  69    Null                     0  11  14                         0  r[11..14]=NULL; clear accumulator subroutine start
+  70    Integer                  0   7   0                         0  r[7]=0
+  71  Return                    20   0   0                         0
+  72  OpenPseudo                 6   5   5                         0  5 columns in r[5]
+  73  SorterSort                 0  81   0                         0
+  74    SorterData               0   5   6                         0  r[5]=data
+  75    Column                   6   2   1                         0  r[1]=pseudo.column 2
+  76    Column                   6   3   2                         0  r[2]=pseudo.column 3
+  77    Column                   6   4   3                         0  r[3]=pseudo.column 4
+  78    Column                   6   0   4                         0  r[4]=pseudo.column 0
+  79    ResultRow                1   4   0                         0  output=r[1..4]
+  80  SorterNext                 0  74   0                         0
+  81  Halt                       0   0   0                         0
+  82  Transaction                0   1  10                         0  iDb=0 tx_mode=Read
+  83  Goto                       0   1   0                         0

--- a/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
+++ b/testing/runner/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
@@ -31,9 +31,9 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                      p1  p2  p3  p4              p5  comment
-   0            Init               0  77   0                   0  Start at 77
+   0            Init               0  78   0                   0  Start at 78
    1            OpenRead           0   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   2            Rewind             0  76   0                   0  Rewind table employees
+   2            Rewind             0  77   0                   0  Rewind table employees
    3              BeginSubrtn      5   0   0                   0  r[5]=NULL
    4              Null             0   1   0                   0  r[1]=NULL
    5              OpenEphemeral    1   0   0                   0  cursor=1 is_table=false
@@ -41,7 +41,7 @@ addr  opcode                      p1  p2  p3  p4              p5  comment
    7              SorterOpen       2   2   0  k(1,B)           0  cursor=2
    8              Integer          0  12   0                   0  r[12]=0; clear group by abort flag
    9              Null             0  13   0                   0  r[13]=NULL; initialize group by comparison registers to NULL
-  10              Gosub           19  49   0                   0  ; go to clear accumulator subroutine
+  10              Gosub           19  50   0                   0  ; go to clear accumulator subroutine
   11              OpenRead         4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
   12              Rewind           4  19   0                   0  Rewind table employees
   13                Column         4   3  17                   0  r[17]=employees.department
@@ -51,62 +51,63 @@ addr  opcode                      p1  p2  p3  p4              p5  comment
   17                SorterInsert   2  16   0  0                0  key=r[16]
   18              Next             4  13   0                   0
   19              OpenPseudo       3  16   2                   0  2 columns in r[16]
-  20              SorterSort       2  35   0                   0
+  20              SorterSort       2  36   0                   0
   21                SorterData     2  16   3                   0  r[16]=data
   22                Column         3   0  20                   0  r[20]=pseudo.column 0
   23                Compare       13  20   1  k(1, Binary)     0  r[13..13]==r[20..20]
   24                Jump          25  29  25                   0  ; start new group if comparison is not equal
-  25                Gosub         10  39   0                   0  ; check if ended group had data, and output if so
+  25                Gosub         10  40   0                   0  ; check if ended group had data, and output if so
   26                Move          20  13   1                   0  r[13..13]=r[20..20]
-  27                IfPos         12  52   0                   0  r[12]>0 -> r[12]-=0, goto 52; check abort flag
-  28                Gosub         19  49   0                   0  ; goto clear accumulator subroutine
+  27                IfPos         12  53   0                   0  r[12]>0 -> r[12]-=0, goto 53; check abort flag
+  28                Gosub         19  50   0                   0  ; goto clear accumulator subroutine
   29                Column         3   1  21                   0  r[21]=pseudo.column 1
-  30                AggStep        0  21  15  avg              0  accum=r[15] step(r[21])
-  31                If            11  33   0                   0  if r[11] goto 33; don't emit group columns if continuing existing group
-  32                Column         3   0  14                   0  r[14]=pseudo.column 0
-  33                Integer        1  11   0                   0  r[11]=1; indicate data in accumulator
-  34              SorterNext       2  21   0                   0
-  35              Gosub           10  39   0                   0  ; emit row for final group
-  36              Goto             0  52   0                   0  ; group by finished
-  37              Integer          1  12   0                   0  r[12]=1
-  38            Return            10   0   0                   0
-  39            IfPos             11  41   0                   0  r[11]>0 -> r[11]-=0, goto 41; output group by row subroutine start
-  40          Return              10   0   0                   0
-  41          AggFinal             0  15   0  avg              0  accum=r[15]
-  42          Copy                14   8   0                   0  r[8]=r[14]
-  43          Copy                15   9   0                   0  r[9]=r[15]
-  44          Copy                 8  23   1                   0  r[23]=r[8]
-  45          Sequence             1  25   0                   0
-  46          MakeRecord          23   3  22                   0  r[22]=mkrec(r[23..25]); for ephemeral_subquery_t6
-  47          IdxInsert            1  22   0                   8  key=r[22]
-  48        Return                10   0   0                   0
-  49        Null                   0  14  15                   0  r[14..15]=NULL; clear accumulator subroutine start
-  50        Integer                0  11   0                   0  r[11]=0
-  51      Return                  19   0   0                   0
-  52      Integer                  1  27   0                   0  r[27]=1; LIMIT counter
-  53      IfNot                   27  65   0                   0  if !r[27] goto 65
-  54      Column                   0   3  28                   0  r[28]=employees.department
-  55      IsNull                  28  65   0                   0  if (r[28]==NULL) goto 65
-  56      Affinity                28   1   0                   0  r[28..29] = B
-  57      SeekGE                   1  65  28                   0  key=[28..28]
-  58        IdxGT                  1  65  28                   0  key=[28..28]
-  59        Column                 1   0   6                   0  r[6]=ephemeral(ephemeral_subquery_t6).department
-  60        Column                 1   1   7                   0  r[7]=ephemeral(ephemeral_subquery_t6).avg_salary
-  61        Column                 1   1  26                   0  r[26]=ephemeral(ephemeral_subquery_t6).avg_salary
-  62        Copy                  26   1   0                   0  r[1]=r[26]
-  63        DecrJumpZero          27  65   0                   0  if (--r[27]==0) goto 65
-  64      Next                     1  58   0                   0
-  65    Return                     5   0   1                   0
-  66    Column                     0   4  30                   0  r[30]=employees.salary
-  67    RealAffinity              30   0   0                   0
-  68    Copy                       1  31   0                   0  r[31]=r[1]
-  69    Le                        30  31  75  Binary           0  if r[30]<=r[31] goto 75
-  70    Column                     0   1   2                   0  r[2]=employees.name
-  71    Column                     0   3   3                   0  r[3]=employees.department
-  72    Column                     0   4   4                   0  r[4]=employees.salary
-  73    RealAffinity               4   0   0                   0
-  74    ResultRow                  2   3   0                   0  output=r[2..4]
-  75  Next                         0   3   0                   0
-  76  Halt                         0   0   0                   0
-  77  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
-  78  Goto                         0   1   0                   0
+  30                Copy          21  22   0                   0  r[22]=r[21]
+  31                AggStep        0  22  15  avg              0  accum=r[15] step(r[22])
+  32                If            11  34   0                   0  if r[11] goto 34; don't emit group columns if continuing existing group
+  33                Column         3   0  14                   0  r[14]=pseudo.column 0
+  34                Integer        1  11   0                   0  r[11]=1; indicate data in accumulator
+  35              SorterNext       2  21   0                   0
+  36              Gosub           10  40   0                   0  ; emit row for final group
+  37              Goto             0  53   0                   0  ; group by finished
+  38              Integer          1  12   0                   0  r[12]=1
+  39            Return            10   0   0                   0
+  40            IfPos             11  42   0                   0  r[11]>0 -> r[11]-=0, goto 42; output group by row subroutine start
+  41          Return              10   0   0                   0
+  42          AggFinal             0  15   0  avg              0  accum=r[15]
+  43          Copy                14   8   0                   0  r[8]=r[14]
+  44          Copy                15   9   0                   0  r[9]=r[15]
+  45          Copy                 8  24   1                   0  r[24]=r[8]
+  46          Sequence             1  26   0                   0
+  47          MakeRecord          24   3  23                   0  r[23]=mkrec(r[24..26]); for ephemeral_subquery_t6
+  48          IdxInsert            1  23   0                   8  key=r[23]
+  49        Return                10   0   0                   0
+  50        Null                   0  14  15                   0  r[14..15]=NULL; clear accumulator subroutine start
+  51        Integer                0  11   0                   0  r[11]=0
+  52      Return                  19   0   0                   0
+  53      Integer                  1  28   0                   0  r[28]=1; LIMIT counter
+  54      IfNot                   28  66   0                   0  if !r[28] goto 66
+  55      Column                   0   3  29                   0  r[29]=employees.department
+  56      IsNull                  29  66   0                   0  if (r[29]==NULL) goto 66
+  57      Affinity                29   1   0                   0  r[29..30] = B
+  58      SeekGE                   1  66  29                   0  key=[29..29]
+  59        IdxGT                  1  66  29                   0  key=[29..29]
+  60        Column                 1   0   6                   0  r[6]=ephemeral(ephemeral_subquery_t6).department
+  61        Column                 1   1   7                   0  r[7]=ephemeral(ephemeral_subquery_t6).avg_salary
+  62        Column                 1   1  27                   0  r[27]=ephemeral(ephemeral_subquery_t6).avg_salary
+  63        Copy                  27   1   0                   0  r[1]=r[27]
+  64        DecrJumpZero          28  66   0                   0  if (--r[28]==0) goto 66
+  65      Next                     1  59   0                   0
+  66    Return                     5   0   1                   0
+  67    Column                     0   4  31                   0  r[31]=employees.salary
+  68    RealAffinity              31   0   0                   0
+  69    Copy                       1  32   0                   0  r[32]=r[1]
+  70    Le                        31  32  76  Binary           0  if r[31]<=r[32] goto 76
+  71    Column                     0   1   2                   0  r[2]=employees.name
+  72    Column                     0   3   3                   0  r[3]=employees.department
+  73    Column                     0   4   4                   0  r[4]=employees.salary
+  74    RealAffinity               4   0   0                   0
+  75    ResultRow                  2   3   0                   0  output=r[2..4]
+  76  Next                         0   3   0                   0
+  77  Halt                         0   0   0                   0
+  78  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
+  79  Goto                         0   1   0                   0

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q1-pricing-summary.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q1-pricing-summary.snap
@@ -36,102 +36,103 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                                     p5  comment
-   0          Init             0  92   0                                          0  Start at 92
+   0          Init             0  93   0                                          0  Start at 93
    1          Null             0  18  25                                          0  r[18..25]=NULL
-   2          SorterOpen       0   9   0  k(2,B,B)                                0  cursor=0
+   2          SorterOpen       0   6   0  k(2,B,B)                                0  cursor=0
    3          Integer          0  13   0                                          0  r[13]=0; clear group by abort flag
    4          Null             0  14  15                                          0  r[14..15]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           36  88   0                                          0  ; go to clear accumulator subroutine
+   5          Gosub           33  89   0                                          0  ; go to clear accumulator subroutine
    6          OpenRead         2  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   7          Rewind           2  31   0                                          0  Rewind table lineitem
-   8            Column         2  10  38                                          0  r[38]=lineitem.L_SHIPDATE
-   9            Gt            38  39  30  Binary                                  0  if r[38]>r[39] goto 30
+   7          Rewind           2  19   0                                          0  Rewind table lineitem
+   8            Column         2  10  35                                          0  r[35]=lineitem.L_SHIPDATE
+   9            Gt            35  36  18  Binary                                  0  if r[35]>r[36] goto 18
   10            Column         2   8  27                                          0  r[27]=lineitem.L_RETURNFLAG
   11            Column         2   9  28                                          0  r[28]=lineitem.L_LINESTATUS
   12            Column         2   4  29                                          0  r[29]=lineitem.L_QUANTITY
   13            Column         2   5  30                                          0  r[30]=lineitem.L_EXTENDEDPRICE
-  14            Column         2   5  40                                          0  r[40]=lineitem.L_EXTENDEDPRICE
-  15            Column         2   6  43                                          0  r[43]=lineitem.L_DISCOUNT
-  16            Subtract      42  43  41                                          0  r[41]=r[42]-r[43]
-  17            Multiply      40  41  31                                          0  r[31]=r[40]*r[41]
-  18            Column         2   5  46                                          0  r[46]=lineitem.L_EXTENDEDPRICE
-  19            Column         2   6  49                                          0  r[49]=lineitem.L_DISCOUNT
-  20            Subtract      48  49  47                                          0  r[47]=r[48]-r[49]
-  21            Multiply      46  47  44                                          0  r[44]=r[46]*r[47]
-  22            Column         2   7  51                                          0  r[51]=lineitem.L_TAX
-  23            Add           50  51  45                                          0  r[45]=r[50]+r[51]
-  24            Multiply      44  45  32                                          0  r[32]=r[44]*r[45]
-  25            Column         2   4  33                                          0  r[33]=lineitem.L_QUANTITY
-  26            Column         2   5  34                                          0  r[34]=lineitem.L_EXTENDEDPRICE
-  27            Column         2   6  35                                          0  r[35]=lineitem.L_DISCOUNT
-  28            MakeRecord    27   9  26                                          0  r[26]=mkrec(r[27..35])
-  29            SorterInsert   0  26   0  0                                       0  key=r[26]
-  30          Next             2   8   0                                          0
-  31          OpenPseudo       1  26   9                                          0  9 columns in r[26]
-  32          SorterSort       0  62   0                                          0
-  33            SorterData     0  26   1                                          0  r[26]=data
-  34            Column         1   0  52                                          0  r[52]=pseudo.column 0
-  35            Column         1   1  53                                          0  r[53]=pseudo.column 1
-  36            Compare       14  52   2  k(2, Binary, Binary)                    0  r[14..15]==r[52..53]
-  37            Jump          38  42  38                                          0  ; start new group if comparison is not equal
-  38            Gosub         11  66   0                                          0  ; check if ended group had data, and output if so
-  39            Move          52  14   2                                          0  r[14..15]=r[52..53]
-  40            IfPos         13  91   0                                          0  r[13]>0 -> r[13]-=0, goto 91; check abort flag
-  41            Gosub         36  88   0                                          0  ; goto clear accumulator subroutine
-  42            Column         1   2  54                                          0  r[54]=pseudo.column 2
-  43            AggStep        0  54  18  sum                                     0  accum=r[18] step(r[54])
-  44            Column         1   3  55                                          0  r[55]=pseudo.column 3
-  45            AggStep        0  55  19  sum                                     0  accum=r[19] step(r[55])
-  46            Column         1   4  56                                          0  r[56]=pseudo.column 4
-  47            AggStep        0  56  20  sum                                     0  accum=r[20] step(r[56])
-  48            Column         1   5  57                                          0  r[57]=pseudo.column 5
-  49            AggStep        0  57  21  sum                                     0  accum=r[21] step(r[57])
-  50            Column         1   6  58                                          0  r[58]=pseudo.column 6
-  51            AggStep        0  58  22  avg                                     0  accum=r[22] step(r[58])
-  52            Column         1   7  59                                          0  r[59]=pseudo.column 7
-  53            AggStep        0  59  23  avg                                     0  accum=r[23] step(r[59])
-  54            Column         1   8  60                                          0  r[60]=pseudo.column 8
-  55            AggStep        0  60  24  avg                                     0  accum=r[24] step(r[60])
-  56            AggStep        0  61  25  count                                   0  accum=r[25] step(r[61])
-  57            If            12  60   0                                          0  if r[12] goto 60; don't emit group columns if continuing existing group
-  58            Column         1   0  16                                          0  r[16]=pseudo.column 0
-  59            Column         1   1  17                                          0  r[17]=pseudo.column 1
-  60            Integer        1  12   0                                          0  r[12]=1; indicate data in accumulator
-  61          SorterNext       0  33   0                                          0
-  62          Gosub           11  66   0                                          0  ; emit row for final group
-  63          Goto             0  91   0                                          0  ; group by finished
-  64          Integer          1  13   0                                          0  r[13]=1
-  65        Return            11   0   0                                          0
-  66        IfPos             12  68   0                                          0  r[12]>0 -> r[12]-=0, goto 68; output group by row subroutine start
-  67      Return              11   0   0                                          0
-  68      AggFinal             0  18   0  sum                                     0  accum=r[18]
-  69      AggFinal             0  19   0  sum                                     0  accum=r[19]
-  70      AggFinal             0  20   0  sum                                     0  accum=r[20]
-  71      AggFinal             0  21   0  sum                                     0  accum=r[21]
-  72      AggFinal             0  22   0  avg                                     0  accum=r[22]
-  73      AggFinal             0  23   0  avg                                     0  accum=r[23]
-  74      AggFinal             0  24   0  avg                                     0  accum=r[24]
-  75      AggFinal             0  25   0  count                                   0  accum=r[25]
-  76      Copy                16   1   0                                          0  r[1]=r[16]
-  77      Copy                17   2   0                                          0  r[2]=r[17]
-  78      Copy                18   3   0                                          0  r[3]=r[18]
-  79      Copy                19   4   0                                          0  r[4]=r[19]
-  80      Copy                20   5   0                                          0  r[5]=r[20]
-  81      Copy                21   6   0                                          0  r[6]=r[21]
-  82      Copy                22   7   0                                          0  r[7]=r[22]
-  83      Copy                23   8   0                                          0  r[8]=r[23]
-  84      Copy                24   9   0                                          0  r[9]=r[24]
-  85      Copy                25  10   0                                          0  r[10]=r[25]
-  86      ResultRow            1  10   0                                          0  output=r[1..10]
-  87    Return                11   0   0                                          0
-  88    Null                   0  16  25                                          0  r[16..25]=NULL; clear accumulator subroutine start
-  89    Integer                0  12   0                                          0  r[12]=0
-  90  Return                  36   0   0                                          0
-  91  Halt                     0   0   0                                          0
-  92  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
-  93  String8                  0  39   0  1998-12-01                              0  r[39]='1998-12-01'
-  94  Integer                  1  42   0                                          0  r[42]=1
+  14            Column         2   6  31                                          0  r[31]=lineitem.L_DISCOUNT
+  15            Column         2   7  32                                          0  r[32]=lineitem.L_TAX
+  16            MakeRecord    27   6  26                                          0  r[26]=mkrec(r[27..32])
+  17            SorterInsert   0  26   0  0                                       0  key=r[26]
+  18          Next             2   8   0                                          0
+  19          OpenPseudo       1  26   6                                          0  6 columns in r[26]
+  20          SorterSort       0  63   0                                          0
+  21            SorterData     0  26   1                                          0  r[26]=data
+  22            Column         1   0  37                                          0  r[37]=pseudo.column 0
+  23            Column         1   1  38                                          0  r[38]=pseudo.column 1
+  24            Compare       14  37   2  k(2, Binary, Binary)                    0  r[14..15]==r[37..38]
+  25            Jump          26  30  26                                          0  ; start new group if comparison is not equal
+  26            Gosub         11  67   0                                          0  ; check if ended group had data, and output if so
+  27            Move          37  14   2                                          0  r[14..15]=r[37..38]
+  28            IfPos         13  92   0                                          0  r[13]>0 -> r[13]-=0, goto 92; check abort flag
+  29            Gosub         33  89   0                                          0  ; goto clear accumulator subroutine
+  30            Column         1   2  39                                          0  r[39]=pseudo.column 2
+  31            Column         1   3  40                                          0  r[40]=pseudo.column 3
+  32            Column         1   4  41                                          0  r[41]=pseudo.column 4
+  33            Column         1   5  42                                          0  r[42]=pseudo.column 5
+  34            Copy          39  43   0                                          0  r[43]=r[39]
+  35            AggStep        0  43  18  sum                                     0  accum=r[18] step(r[43])
+  36            Copy          40  44   0                                          0  r[44]=r[40]
+  37            AggStep        0  44  19  sum                                     0  accum=r[19] step(r[44])
+  38            Copy          40  46   0                                          0  r[46]=r[40]
+  39            Copy          41  49   0                                          0  r[49]=r[41]
+  40            Subtract      48  49  47                                          0  r[47]=r[48]-r[49]
+  41            Multiply      46  47  45                                          0  r[45]=r[46]*r[47]
+  42            AggStep        0  45  20  sum                                     0  accum=r[20] step(r[45])
+  43            Copy          40  53   0                                          0  r[53]=r[40]
+  44            Copy          41  56   0                                          0  r[56]=r[41]
+  45            Subtract      55  56  54                                          0  r[54]=r[55]-r[56]
+  46            Multiply      53  54  51                                          0  r[51]=r[53]*r[54]
+  47            Copy          42  58   0                                          0  r[58]=r[42]
+  48            Add           57  58  52                                          0  r[52]=r[57]+r[58]
+  49            Multiply      51  52  50                                          0  r[50]=r[51]*r[52]
+  50            AggStep        0  50  21  sum                                     0  accum=r[21] step(r[50])
+  51            Copy          39  59   0                                          0  r[59]=r[39]
+  52            AggStep        0  59  22  avg                                     0  accum=r[22] step(r[59])
+  53            Copy          40  60   0                                          0  r[60]=r[40]
+  54            AggStep        0  60  23  avg                                     0  accum=r[23] step(r[60])
+  55            Copy          41  61   0                                          0  r[61]=r[41]
+  56            AggStep        0  61  24  avg                                     0  accum=r[24] step(r[61])
+  57            AggStep        0  62  25  count                                   0  accum=r[25] step(r[62])
+  58            If            12  61   0                                          0  if r[12] goto 61; don't emit group columns if continuing existing group
+  59            Column         1   0  16                                          0  r[16]=pseudo.column 0
+  60            Column         1   1  17                                          0  r[17]=pseudo.column 1
+  61            Integer        1  12   0                                          0  r[12]=1; indicate data in accumulator
+  62          SorterNext       0  21   0                                          0
+  63          Gosub           11  67   0                                          0  ; emit row for final group
+  64          Goto             0  92   0                                          0  ; group by finished
+  65          Integer          1  13   0                                          0  r[13]=1
+  66        Return            11   0   0                                          0
+  67        IfPos             12  69   0                                          0  r[12]>0 -> r[12]-=0, goto 69; output group by row subroutine start
+  68      Return              11   0   0                                          0
+  69      AggFinal             0  18   0  sum                                     0  accum=r[18]
+  70      AggFinal             0  19   0  sum                                     0  accum=r[19]
+  71      AggFinal             0  20   0  sum                                     0  accum=r[20]
+  72      AggFinal             0  21   0  sum                                     0  accum=r[21]
+  73      AggFinal             0  22   0  avg                                     0  accum=r[22]
+  74      AggFinal             0  23   0  avg                                     0  accum=r[23]
+  75      AggFinal             0  24   0  avg                                     0  accum=r[24]
+  76      AggFinal             0  25   0  count                                   0  accum=r[25]
+  77      Copy                16   1   0                                          0  r[1]=r[16]
+  78      Copy                17   2   0                                          0  r[2]=r[17]
+  79      Copy                18   3   0                                          0  r[3]=r[18]
+  80      Copy                19   4   0                                          0  r[4]=r[19]
+  81      Copy                20   5   0                                          0  r[5]=r[20]
+  82      Copy                21   6   0                                          0  r[6]=r[21]
+  83      Copy                22   7   0                                          0  r[7]=r[22]
+  84      Copy                23   8   0                                          0  r[8]=r[23]
+  85      Copy                24   9   0                                          0  r[9]=r[24]
+  86      Copy                25  10   0                                          0  r[10]=r[25]
+  87      ResultRow            1  10   0                                          0  output=r[1..10]
+  88    Return                11   0   0                                          0
+  89    Null                   0  16  25                                          0  r[16..25]=NULL; clear accumulator subroutine start
+  90    Integer                0  12   0                                          0  r[12]=0
+  91  Return                  33   0   0                                          0
+  92  Halt                     0   0   0                                          0
+  93  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
+  94  String8                  0  36   0  1998-12-01                              0  r[36]='1998-12-01'
   95  Integer                  1  48   0                                          0  r[48]=1
-  96  Integer                  1  50   0                                          0  r[50]=1
-  97  Integer                  1  61   0                                          0  r[61]=1
-  98  Goto                     0   1   0                                          0
+  96  Integer                  1  55   0                                          0  r[55]=1
+  97  Integer                  1  57   0                                          0  r[57]=1
+  98  Integer                  1  62   0                                          0  r[62]=1
+  99  Goto                     0   1   0                                          0

--- a/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
+++ b/testing/runner/tests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
@@ -46,80 +46,80 @@ BYTECODE
 addr  opcode                  p1  p2  p3  p4                                     p5  comment
    0          Init             0  93   0                                          0  Start at 93
    1          Null             0   9  10                                          0  r[9..10]=NULL
-   2          SorterOpen       0   3   0  k(1,B)                                  0  cursor=0
+   2          SorterOpen       0   2   0  k(1,B)                                  0  cursor=0
    3          Integer          0   6   0                                          0  r[6]=0; clear group by abort flag
    4          Null             0   7   0                                          0  r[7]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           15  89   0                                          0  ; go to clear accumulator subroutine
+   5          Gosub           14  89   0                                          0  ; go to clear accumulator subroutine
    6          OpenRead         2   9   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=orders, root=9, iDb=0
    7          OpenRead         3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   8          Rewind           3  58   0                                          0  Rewind table lineitem
-   9            Column         3  14  16                                          0  r[16]=lineitem.L_SHIPMODE
-  10            Eq            16  17  12  Binary                                  0  if r[16]==r[17] goto 12
-  11            Ne            16  18  57  Binary                                  0  if r[16]!=r[18] goto 57
-  12            Column         3  11  20                                          0  r[20]=lineitem.L_COMMITDATE
-  13            Column         3  12  21                                          0  r[21]=lineitem.L_RECEIPTDATE
-  14            Ge            20  21  57  Binary                                  0  if r[20]>=r[21] goto 57
-  15            Column         3  10  23                                          0  r[23]=lineitem.L_SHIPDATE
-  16            Column         3  11  24                                          0  r[24]=lineitem.L_COMMITDATE
-  17            Ge            23  24  57  Binary                                  0  if r[23]>=r[24] goto 57
-  18            Column         3  12  26                                          0  r[26]=lineitem.L_RECEIPTDATE
-  19            Lt            26  27  57  Binary                                  0  if r[26]<r[27] goto 57
-  20            Column         3  12  29                                          0  r[29]=lineitem.L_RECEIPTDATE
-  21            Ge            29  30  57  Binary                                  0  if r[29]>=r[30] goto 57
-  22            Column         3   0  31                                          0  r[31]=lineitem.L_ORDERKEY
-  23            SeekRowid      2  31  57                                          0  if (r[31]!=cursor 2 for table orders.rowid) goto 57
+   8          Rewind           3  29   0                                          0  Rewind table lineitem
+   9            Column         3  14  15                                          0  r[15]=lineitem.L_SHIPMODE
+  10            Eq            15  16  12  Binary                                  0  if r[15]==r[16] goto 12
+  11            Ne            15  17  28  Binary                                  0  if r[15]!=r[17] goto 28
+  12            Column         3  11  19                                          0  r[19]=lineitem.L_COMMITDATE
+  13            Column         3  12  20                                          0  r[20]=lineitem.L_RECEIPTDATE
+  14            Ge            19  20  28  Binary                                  0  if r[19]>=r[20] goto 28
+  15            Column         3  10  22                                          0  r[22]=lineitem.L_SHIPDATE
+  16            Column         3  11  23                                          0  r[23]=lineitem.L_COMMITDATE
+  17            Ge            22  23  28  Binary                                  0  if r[22]>=r[23] goto 28
+  18            Column         3  12  25                                          0  r[25]=lineitem.L_RECEIPTDATE
+  19            Lt            25  26  28  Binary                                  0  if r[25]<r[26] goto 28
+  20            Column         3  12  28                                          0  r[28]=lineitem.L_RECEIPTDATE
+  21            Ge            28  29  28  Binary                                  0  if r[28]>=r[29] goto 28
+  22            Column         3   0  30                                          0  r[30]=lineitem.L_ORDERKEY
+  23            SeekRowid      2  30  28                                          0  if (r[30]!=cursor 2 for table orders.rowid) goto 28
   24            Column         3  14  12                                          0  r[12]=lineitem.L_SHIPMODE
-  25            Column         2   5  35                                          0  r[35]=orders.O_ORDERPRIORITY
-  26            String8        0  36   0  1-URGENT                                0  r[36]='1-URGENT'
-  27            Integer        1  33   0                                          0  r[33]=1
-  28            Eq            35  36  30  Binary                                  0  if r[35]==r[36] goto 30
-  29            ZeroOrNull    35  33  36                                          0  ((r[35]=NULL)|(r[36]=NULL)) ? r[33]=NULL : r[33]=0
-  30            Column         2   5  37                                          0  r[37]=orders.O_ORDERPRIORITY
-  31            String8        0  38   0  2-HIGH                                  0  r[38]='2-HIGH'
-  32            Integer        1  34   0                                          0  r[34]=1
-  33            Eq            37  38  35  Binary                                  0  if r[37]==r[38] goto 35
-  34            ZeroOrNull    37  34  38                                          0  ((r[37]=NULL)|(r[38]=NULL)) ? r[34]=NULL : r[34]=0
-  35            Or            34  33  32                                          0  r[32]=(r[33] || r[34])
-  36            IfNot         32  39   1                                          0  if !r[32] goto 39
-  37            Integer        1  13   0                                          0  r[13]=1
-  38            Goto           0  40   0                                          0
-  39            Integer        0  13   0                                          0  r[13]=0
-  40            Column         2   5  42                                          0  r[42]=orders.O_ORDERPRIORITY
-  41            String8        0  43   0  1-URGENT                                0  r[43]='1-URGENT'
-  42            Integer        1  40   0                                          0  r[40]=1
-  43            Ne            42  43  45  Binary                                  0  if r[42]!=r[43] goto 45
-  44            ZeroOrNull    42  40  43                                          0  ((r[42]=NULL)|(r[43]=NULL)) ? r[40]=NULL : r[40]=0
-  45            Column         2   5  44                                          0  r[44]=orders.O_ORDERPRIORITY
-  46            String8        0  45   0  2-HIGH                                  0  r[45]='2-HIGH'
-  47            Integer        1  41   0                                          0  r[41]=1
-  48            Ne            44  45  50  Binary                                  0  if r[44]!=r[45] goto 50
-  49            ZeroOrNull    44  41  45                                          0  ((r[44]=NULL)|(r[45]=NULL)) ? r[41]=NULL : r[41]=0
-  50            And           41  40  39                                          0  r[39]=(r[40] && r[41])
-  51            IfNot         39  54   1                                          0  if !r[39] goto 54
-  52            Integer        1  14   0                                          0  r[14]=1
+  25            Column         2   5  13                                          0  r[13]=orders.O_ORDERPRIORITY
+  26            MakeRecord    12   2  11                                          0  r[11]=mkrec(r[12..13])
+  27            SorterInsert   0  11   0  0                                       0  key=r[11]
+  28          Next             3   9   0                                          0
+  29          OpenPseudo       1  11   2                                          0  2 columns in r[11]
+  30          SorterSort       0  76   0                                          0
+  31            SorterData     0  11   1                                          0  r[11]=data
+  32            Column         1   0  31                                          0  r[31]=pseudo.column 0
+  33            Compare        7  31   1  k(1, Binary)                            0  r[7..7]==r[31..31]
+  34            Jump          35  39  35                                          0  ; start new group if comparison is not equal
+  35            Gosub          4  80   0                                          0  ; check if ended group had data, and output if so
+  36            Move          31   7   1                                          0  r[7..7]=r[31..31]
+  37            IfPos          6  92   0                                          0  r[6]>0 -> r[6]-=0, goto 92; check abort flag
+  38            Gosub         14  89   0                                          0  ; goto clear accumulator subroutine
+  39            Column         1   1  32                                          0  r[32]=pseudo.column 1
+  40            Copy          32  37   0                                          0  r[37]=r[32]
+  41            String8        0  38   0  1-URGENT                                0  r[38]='1-URGENT'
+  42            Integer        1  35   0                                          0  r[35]=1
+  43            Eq            37  38  45  Binary                                  0  if r[37]==r[38] goto 45
+  44            ZeroOrNull    37  35  38                                          0  ((r[37]=NULL)|(r[38]=NULL)) ? r[35]=NULL : r[35]=0
+  45            Copy          32  39   0                                          0  r[39]=r[32]
+  46            String8        0  40   0  2-HIGH                                  0  r[40]='2-HIGH'
+  47            Integer        1  36   0                                          0  r[36]=1
+  48            Eq            39  40  50                                          0  if r[39]==r[40] goto 50
+  49            ZeroOrNull    39  36  40                                          0  ((r[39]=NULL)|(r[40]=NULL)) ? r[36]=NULL : r[36]=0
+  50            Or            36  35  34                                          0  r[34]=(r[35] || r[36])
+  51            IfNot         34  54   1                                          0  if !r[34] goto 54
+  52            Integer        1  33   0                                          0  r[33]=1
   53            Goto           0  55   0                                          0
-  54            Integer        0  14   0                                          0  r[14]=0
-  55            MakeRecord    12   3  11                                          0  r[11]=mkrec(r[12..14])
-  56            SorterInsert   0  11   0  0                                       0  key=r[11]
-  57          Next             3   9   0                                          0
-  58          OpenPseudo       1  11   3                                          0  3 columns in r[11]
-  59          SorterSort       0  76   0                                          0
-  60            SorterData     0  11   1                                          0  r[11]=data
-  61            Column         1   0  46                                          0  r[46]=pseudo.column 0
-  62            Compare        7  46   1  k(1, Binary)                            0  r[7..7]==r[46..46]
-  63            Jump          64  68  64                                          0  ; start new group if comparison is not equal
-  64            Gosub          4  80   0                                          0  ; check if ended group had data, and output if so
-  65            Move          46   7   1                                          0  r[7..7]=r[46..46]
-  66            IfPos          6  92   0                                          0  r[6]>0 -> r[6]-=0, goto 92; check abort flag
-  67            Gosub         15  89   0                                          0  ; goto clear accumulator subroutine
-  68            Column         1   1  47                                          0  r[47]=pseudo.column 1
-  69            AggStep        0  47   9  sum                                     0  accum=r[9] step(r[47])
-  70            Column         1   2  48                                          0  r[48]=pseudo.column 2
-  71            AggStep        0  48  10  sum                                     0  accum=r[10] step(r[48])
+  54            Integer        0  33   0                                          0  r[33]=0
+  55            AggStep        0  33   9  sum                                     0  accum=r[9] step(r[33])
+  56            Copy          32  45   0                                          0  r[45]=r[32]
+  57            String8        0  46   0  1-URGENT                                0  r[46]='1-URGENT'
+  58            Integer        1  43   0                                          0  r[43]=1
+  59            Ne            45  46  61                                          0  if r[45]!=r[46] goto 61
+  60            ZeroOrNull    45  43  46                                          0  ((r[45]=NULL)|(r[46]=NULL)) ? r[43]=NULL : r[43]=0
+  61            Copy          32  47   0                                          0  r[47]=r[32]
+  62            String8        0  48   0  2-HIGH                                  0  r[48]='2-HIGH'
+  63            Integer        1  44   0                                          0  r[44]=1
+  64            Ne            47  48  66                                          0  if r[47]!=r[48] goto 66
+  65            ZeroOrNull    47  44  48                                          0  ((r[47]=NULL)|(r[48]=NULL)) ? r[44]=NULL : r[44]=0
+  66            And           44  43  42                                          0  r[42]=(r[43] && r[44])
+  67            IfNot         42  70   1                                          0  if !r[42] goto 70
+  68            Integer        1  41   0                                          0  r[41]=1
+  69            Goto           0  71   0                                          0
+  70            Integer        0  41   0                                          0  r[41]=0
+  71            AggStep        0  41  10  sum                                     0  accum=r[10] step(r[41])
   72            If             5  74   0                                          0  if r[5] goto 74; don't emit group columns if continuing existing group
   73            Column         1   0   8                                          0  r[8]=pseudo.column 0
   74            Integer        1   5   0                                          0  r[5]=1; indicate data in accumulator
-  75          SorterNext       0  60   0                                          0
+  75          SorterNext       0  31   0                                          0
   76          Gosub            4  80   0                                          0  ; emit row for final group
   77          Goto             0  92   0                                          0  ; group by finished
   78          Integer          1   6   0                                          0  r[6]=1
@@ -135,11 +135,11 @@ addr  opcode                  p1  p2  p3  p4                                    
   88    Return                 4   0   0                                          0
   89    Null                   0   8  10                                          0  r[8..10]=NULL; clear accumulator subroutine start
   90    Integer                0   5   0                                          0  r[5]=0
-  91  Return                  15   0   0                                          0
+  91  Return                  14   0   0                                          0
   92  Halt                     0   0   0                                          0
   93  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
-  94  String8                  0  17   0  FOB                                     0  r[17]='FOB'
-  95  String8                  0  18   0  SHIP                                    0  r[18]='SHIP'
-  96  String8                  0  27   0  1994-01-01                              0  r[27]='1994-01-01'
-  97  String8                  0  30   0  1995-01-01                              0  r[30]='1995-01-01'
+  94  String8                  0  16   0  FOB                                     0  r[16]='FOB'
+  95  String8                  0  17   0  SHIP                                    0  r[17]='SHIP'
+  96  String8                  0  26   0  1994-01-01                              0  r[26]='1994-01-01'
+  97  String8                  0  29   0  1995-01-01                              0  r[29]='1995-01-01'
   98  Goto                     0   1   0                                          0


### PR DESCRIPTION
## Problem

Previously, `GROUP BY` queries pre-computed all aggregate argument expressions in the scan loop and stored the results in the sorter. When multiple aggregates shared column references e.g. TPC-H Q1's:

`sum(l_extendedprice * (1 - l_discount))`
and
`sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)))`
(plus many others),

each column was read from the B-tree redundantly — 13 reads per row instead of 7. Also, since all the complex expressions were stuffed in the sorter, the sorter's size was larger than it needs to be, making the sort-for-group phase slower as well.

## Fix

Now we store only the unique leaf columns in the sorter and defer expression evaluation to the grouping phase, where values are read from the sorter cursor instead.

For Q1:

- 13 vs 7 `Column` instructions per row of `lineitem`
- 9 vs 6 columns in the `GROUP BY` sorter

## Perf

On my machine roughly a 20% drop in Q1 latency.