### PR TITLE
sqlite3: Add Diesel-required C API functions (phase 2: value lifecycle)

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -520,7 +520,7 @@ Modifiers:
 | sqlite3_column_blob      | ✅ Yes     |         |
 | sqlite3_column_bytes     | ✅ Yes     |         |
 | sqlite3_column_bytes16   | ❌ No      |         |
-| sqlite3_column_value     | ❌ No      |         |
+| sqlite3_column_value     | ✅ Yes     |         |
 | sqlite3_column_table_name| ✅ Yes     |         |
 | sqlite3_column_database_name | ❌ No  |         |
 | sqlite3_column_origin_name | ❌ No    |         |
@@ -539,8 +539,8 @@ Modifiers:
 | sqlite3_value_blob     | ✅ Yes     |         |
 | sqlite3_value_bytes    | ✅ Yes     |         |
 | sqlite3_value_bytes16  | ❌ No      |         |
-| sqlite3_value_dup      | ❌ No      |         |
-| sqlite3_value_free     | ❌ No      |         |
+| sqlite3_value_dup      | ✅ Yes     |         |
+| sqlite3_value_free     | ✅ Yes     |         |
 | sqlite3_value_nochange | ❌ No      |         |
 | sqlite3_value_frombind | ❌ No      |         |
 | sqlite3_value_subtype  | ❌ No      |         |
@@ -614,7 +614,7 @@ Modifiers:
 | sqlite3_create_window_function | ❌ No    | Stub    |
 | sqlite3_aggregate_context    | ❌ No      | Stub    |
 | sqlite3_user_data            | ❌ No      | Stub    |
-| sqlite3_context_db_handle    | ❌ No      | Stub    |
+| sqlite3_context_db_handle    | ✅ Yes     |         |
 | sqlite3_get_auxdata          | ❌ No      |         |
 | sqlite3_set_auxdata          | ❌ No      |         |
 | sqlite3_result_null          | ❌ No      | Stub    |

--- a/sqlite3/include/sqlite3.h
+++ b/sqlite3/include/sqlite3.h
@@ -195,6 +195,8 @@ const void *sqlite3_column_blob(sqlite3_stmt *_stmt, int _idx);
 
 int sqlite3_column_bytes(sqlite3_stmt *_stmt, int _idx);
 
+void *sqlite3_column_value(sqlite3_stmt *_stmt, int _idx);
+
 int sqlite3_value_type(void *value);
 
 int64_t sqlite3_value_int64(void *value);
@@ -208,6 +210,10 @@ const unsigned char *sqlite3_value_text(void *value);
 const void *sqlite3_value_blob(void *value);
 
 int sqlite3_value_bytes(void *value);
+
+void *sqlite3_value_dup(void *value);
+
+void sqlite3_value_free(void *value);
 
 const unsigned char *sqlite3_column_text(sqlite3_stmt *stmt, int idx);
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -118,6 +118,9 @@ pub struct sqlite3_stmt {
     )>,
     pub(crate) next: *mut sqlite3_stmt,
     pub(crate) text_cache: Vec<Vec<u8>>,
+    /// Cached ExtValue instances for sqlite3_column_value().
+    /// Populated lazily per column; cleared on each step/reset.
+    pub(crate) value_cache: Vec<Option<ExtValue>>,
 }
 
 impl sqlite3_stmt {
@@ -129,6 +132,7 @@ impl sqlite3_stmt {
             destructors: Vec::new(),
             next: std::ptr::null_mut(),
             text_cache: vec![vec![]; n_cols],
+            value_cache: (0..n_cols).map(|_| None).collect(),
         }
     }
     #[inline]
@@ -136,6 +140,10 @@ impl sqlite3_stmt {
         // Drop per-column buffers for the previous row
         for r in &mut self.text_cache {
             r.clear();
+        }
+        // Drop cached ExtValues for the previous row
+        for v in &mut self.value_cache {
+            *v = None;
         }
     }
 }
@@ -147,6 +155,7 @@ impl sqlite3_stmt {
 pub struct SqliteContext {
     pub(crate) result: ExtValue,
     pub(crate) p_app: *mut ffi::c_void,
+    pub(crate) db: *mut sqlite3,
 }
 
 // SAFETY: SqliteContext is only used single-threaded within a function call.
@@ -157,6 +166,7 @@ struct FuncSlot {
     p_app: usize,   // *mut c_void stored as usize for Send
     destroy: usize, // Option<unsafe extern "C" fn(*mut c_void)> stored as usize for Send
     name: String,
+    db: usize, // *mut sqlite3 stored as usize for Send
 }
 
 // SAFETY: p_app lifetime is the caller's responsibility (same as SQLite C API).
@@ -171,10 +181,10 @@ fn func_slots() -> &'static Mutex<[Option<FuncSlot>; MAX_CUSTOM_FUNCS]> {
 }
 
 unsafe fn dispatch_func_bridge(slot_id: usize, argc: i32, argv: *const ExtValue) -> ExtValue {
-    let (x_func, p_app) = {
+    let (x_func, p_app, db) = {
         let slots = func_slots().lock().unwrap();
         match slots[slot_id].as_ref() {
-            Some(s) => (s.x_func, s.p_app),
+            Some(s) => (s.x_func, s.p_app, s.db),
             None => return ExtValue::null(),
         }
     };
@@ -188,6 +198,7 @@ unsafe fn dispatch_func_bridge(slot_id: usize, argc: i32, argv: *const ExtValue)
     let mut ctx = SqliteContext {
         result: ExtValue::null(),
         p_app: p_app as *mut ffi::c_void,
+        db: db as *mut sqlite3,
     };
 
     x_func(
@@ -695,8 +706,12 @@ pub unsafe extern "C" fn sqlite3_set_authorizer(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sqlite3_context_db_handle(_context: *mut ffi::c_void) -> *mut ffi::c_void {
-    stub!();
+pub unsafe extern "C" fn sqlite3_context_db_handle(context: *mut ffi::c_void) -> *mut ffi::c_void {
+    if context.is_null() {
+        return std::ptr::null_mut();
+    }
+    let ctx = &*(context as *const SqliteContext);
+    ctx.db as *mut ffi::c_void
 }
 
 #[no_mangle]
@@ -1800,6 +1815,40 @@ pub unsafe extern "C" fn sqlite3_value_bytes(value: *mut ffi::c_void) -> ffi::c_
     }
 }
 
+/// Deep-copies an `sqlite3_value`.  Returns a heap-allocated copy that must
+/// be freed with `sqlite3_value_free`.  Diesel uses this to create
+/// `OwnedSqliteValue` instances.
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_value_dup(value: *mut ffi::c_void) -> *mut ffi::c_void {
+    if value.is_null() {
+        return std::ptr::null_mut();
+    }
+    let v = &*(value as *const ExtValue);
+    let copy = match v.value_type() {
+        turso_ext::ValueType::Integer => ExtValue::from_integer(v.to_integer().unwrap_or(0)),
+        turso_ext::ValueType::Float => ExtValue::from_float(v.to_float().unwrap_or(0.0)),
+        turso_ext::ValueType::Text => {
+            let s = v.to_text().unwrap_or("");
+            ExtValue::from_text(s.to_owned())
+        }
+        turso_ext::ValueType::Blob => {
+            let b = v.to_blob().unwrap_or_default();
+            ExtValue::from_blob(b.to_vec())
+        }
+        _ => ExtValue::null(),
+    };
+    Box::into_raw(Box::new(copy)) as *mut ffi::c_void
+}
+
+/// Frees a value previously allocated by `sqlite3_value_dup`.
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_value_free(value: *mut ffi::c_void) {
+    if value.is_null() {
+        return;
+    }
+    let _ = Box::from_raw(value as *mut ExtValue);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_column_text(
     stmt: *mut sqlite3_stmt,
@@ -1831,6 +1880,47 @@ pub unsafe extern "C" fn sqlite3_column_text(
         }
         _ => std::ptr::null(),
     }
+}
+
+/// Returns an `sqlite3_value*` (ExtValue pointer) for a column in the current
+/// result row.  The pointer remains valid until the next `sqlite3_step()`,
+/// `sqlite3_reset()`, or `sqlite3_finalize()`.  Diesel uses this via
+/// `sqlite3_column_value` → `sqlite3_value_dup` to read all column types.
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_column_value(
+    stmt: *mut sqlite3_stmt,
+    idx: ffi::c_int,
+) -> *mut ffi::c_void {
+    if stmt.is_null() || idx < 0 {
+        return std::ptr::null_mut();
+    }
+    let stmt = &mut *stmt;
+    let i = idx as usize;
+    if i >= stmt.value_cache.len() {
+        return std::ptr::null_mut();
+    }
+    // Return cached value if we already built one for this column.
+    if stmt.value_cache[i].is_some() {
+        return stmt.value_cache[i].as_mut().unwrap() as *mut ExtValue as *mut ffi::c_void;
+    }
+    let binding = stmt.stmt.row();
+    let row = match binding.as_ref() {
+        Some(row) => row,
+        None => return std::ptr::null_mut(),
+    };
+    let ext = match row.get::<&Value>(i) {
+        Ok(turso_core::Value::Numeric(turso_core::Numeric::Integer(n))) => {
+            ExtValue::from_integer(*n)
+        }
+        Ok(turso_core::Value::Numeric(turso_core::Numeric::Float(f))) => {
+            ExtValue::from_float(f64::from(*f))
+        }
+        Ok(turso_core::Value::Text(t)) => ExtValue::from_text(t.value.to_string()),
+        Ok(turso_core::Value::Blob(b)) => ExtValue::from_blob(b.clone()),
+        _ => ExtValue::null(),
+    };
+    stmt.value_cache[i] = Some(ext);
+    stmt.value_cache[i].as_mut().unwrap() as *mut ExtValue as *mut ffi::c_void
 }
 
 pub struct TabResult {
@@ -2231,6 +2321,7 @@ pub unsafe extern "C" fn sqlite3_create_function_v2(
         p_app: context as usize,
         destroy: destroy_fn.map_or(0, |f| f as usize),
         name: func_name.clone(),
+        db: db as usize,
     });
     drop(slots);
 
@@ -2749,6 +2840,7 @@ fn limbo_err_code(err: &LimboError) -> i32 {
         LimboError::TableLocked => SQLITE_LOCKED,
         LimboError::ReadOnly => SQLITE_READONLY,
         LimboError::Busy => SQLITE_BUSY,
+        LimboError::SchemaUpdated | LimboError::SchemaConflict => SQLITE_SCHEMA,
         _ => SQLITE_ERROR,
     }
 }

--- a/sqlite3/tests/compat/mod.rs
+++ b/sqlite3/tests/compat/mod.rs
@@ -162,6 +162,13 @@ extern "C" {
         flags: i32,
         z_vfs: *const libc::c_char,
     ) -> i32;
+    fn sqlite3_column_value(stmt: *mut sqlite3_stmt, idx: i32) -> *mut libc::c_void;
+    fn sqlite3_value_int64(value: *mut libc::c_void) -> i64;
+    fn sqlite3_value_double(value: *mut libc::c_void) -> f64;
+    fn sqlite3_value_text(value: *mut libc::c_void) -> *const libc::c_char;
+    fn sqlite3_value_dup(value: *mut libc::c_void) -> *mut libc::c_void;
+    fn sqlite3_value_free(value: *mut libc::c_void);
+    fn sqlite3_context_db_handle(context: *mut libc::c_void) -> *mut libc::c_void;
 }
 
 const SQLITE_OK: i32 = 0;
@@ -3324,6 +3331,159 @@ mod tests {
 
             assert_eq!(sqlite3_close(db2), SQLITE_OK);
             assert_eq!(sqlite3_close(db1), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    #[cfg(not(feature = "sqlite3"))]
+    fn test_sqlite3_column_value_and_value_dup_free() {
+        unsafe {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("test.db");
+            let path_cstr = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(path_cstr.as_ptr(), &mut db), SQLITE_OK);
+
+            let mut errmsg: *mut libc::c_char = ptr::null_mut();
+            assert_eq!(
+                sqlite3_exec(
+                    db,
+                    c"CREATE TABLE t2 (i INTEGER, f REAL, t TEXT, b BLOB);".as_ptr(),
+                    None,
+                    ptr::null_mut(),
+                    &mut errmsg,
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(
+                sqlite3_exec(
+                    db,
+                    c"INSERT INTO t2 VALUES (42, 1.5, 'hello', X'DEADBEEF');".as_ptr(),
+                    None,
+                    ptr::null_mut(),
+                    &mut errmsg,
+                ),
+                SQLITE_OK
+            );
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT i, f, t, b FROM t2".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+
+            let val0 = sqlite3_column_value(stmt, 0);
+            assert!(!val0.is_null());
+            assert_eq!(sqlite3_value_type(val0), SQLITE_INTEGER);
+            assert_eq!(sqlite3_value_int64(val0), 42);
+
+            let val1 = sqlite3_column_value(stmt, 1);
+            assert!(!val1.is_null());
+            assert_eq!(sqlite3_value_type(val1), SQLITE_FLOAT);
+            assert!((sqlite3_value_double(val1) - 1.5).abs() < 0.001);
+
+            let val2 = sqlite3_column_value(stmt, 2);
+            assert!(!val2.is_null());
+            assert_eq!(sqlite3_value_type(val2), SQLITE_TEXT);
+            let text_ptr = sqlite3_value_text(val2);
+            assert!(!text_ptr.is_null());
+            let text_len = sqlite3_value_bytes(val2) as usize;
+            let text =
+                std::str::from_utf8(std::slice::from_raw_parts(text_ptr as *const u8, text_len))
+                    .unwrap();
+            assert_eq!(text, "hello");
+
+            let val3 = sqlite3_column_value(stmt, 3);
+            assert!(!val3.is_null());
+            assert_eq!(sqlite3_value_type(val3), SQLITE_BLOB);
+            assert_eq!(sqlite3_value_bytes(val3), 4);
+
+            let dup = sqlite3_value_dup(val0);
+            assert!(!dup.is_null());
+            assert_eq!(sqlite3_value_type(dup), SQLITE_INTEGER);
+            assert_eq!(sqlite3_value_int64(dup), 42);
+
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_value_int64(dup), 42);
+
+            sqlite3_value_free(dup);
+
+            sqlite3_value_free(ptr::null_mut());
+            let null_dup = sqlite3_value_dup(ptr::null_mut());
+            assert!(null_dup.is_null());
+
+            let null_val = sqlite3_column_value(ptr::null_mut(), 0);
+            assert!(null_val.is_null());
+
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    #[cfg(not(feature = "sqlite3"))]
+    fn test_sqlite3_context_db_handle() {
+        unsafe {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("test.db");
+            let path_cstr = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(path_cstr.as_ptr(), &mut db), SQLITE_OK);
+
+            use std::sync::atomic::{AtomicPtr, Ordering};
+            static CAPTURED_DB: AtomicPtr<libc::c_void> = AtomicPtr::new(ptr::null_mut());
+
+            unsafe extern "C" fn test_func(
+                ctx: *mut libc::c_void,
+                _argc: i32,
+                _argv: *mut *mut libc::c_void,
+            ) {
+                CAPTURED_DB.store(sqlite3_context_db_handle(ctx), Ordering::SeqCst);
+                sqlite3_result_int(ctx, 1);
+            }
+
+            assert_eq!(
+                sqlite3_create_function_v2(
+                    db,
+                    c"test_db_handle".as_ptr(),
+                    0,
+                    SQLITE_UTF8,
+                    ptr::null_mut(),
+                    Some(test_func),
+                    None,
+                    None,
+                    None,
+                ),
+                SQLITE_OK
+            );
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT test_db_handle()".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+
+            assert_eq!(CAPTURED_DB.load(Ordering::SeqCst), db as *mut libc::c_void);
+
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+
+            let null_handle = sqlite3_context_db_handle(ptr::null_mut());
+            assert!(null_handle.is_null());
+
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
         }
     }
 }


### PR DESCRIPTION
~~Need to wait to phase1 be merged first (this contain the commit of phase 1 too, because is dependent).~~ Edit: done

## Description

Implements 4 missing sqlite3 C API functions that Diesel ORM requires for column value reading and custom function support:

- `sqlite3_column_value` — returns an `sqlite3_value*` (ExtValue) for a column in the current result row, with a per-statement cache that is cleared on step/reset/finalize
- `sqlite3_value_dup` — deep-copies an `sqlite3_value` to a heap allocation (used by Diesel's `OwnedSqliteValue`)
- `sqlite3_value_free` — frees a value previously created by `sqlite3_value_dup`
- `sqlite3_context_db_handle` — returns the parent `sqlite3*` from a custom function context (was a `stub!()`); threads the `db` pointer through `FuncSlot` → `dispatch_func_bridge` → `SqliteContext`

### Structural changes

- Added `value_cache: Vec<Option<ExtValue>>` field to `sqlite3_stmt`, cleared alongside `text_cache` on each step/reset
- Added `db: *mut sqlite3` field to `SqliteContext`
- Added `db: usize` field to `FuncSlot`, populated in `sqlite3_create_function_v2`

## Motivation and context

This is phase 2 of the effort to enable Diesel ORM as a consumer of Turso's sqlite3 C API. Phase 1 (https://github.com/tursodatabase/turso/pull/5927) added statement preparation functions; this phase completes the value lifecycle that Diesel uses to read all column types.

## Description of AI Usage

AI (Claude) was used to assist with:
- Analyzing the ExtValue/turso_core::Value type system to design the column_value cache
- Drafting implementations and tests
- Code review of the changes (Reviwerd by myself and also coderabbitai)

All code was reviewed, validated, and committed by the contributor.

## Test plan

- [x] `cargo check -p turso_sqlite3` passes
- [x] `cargo fmt --all -- --check` passes
- [x] All 4 new symbols verified exported via `nm -D`
- [x] Added `test_sqlite3_column_value_and_value_dup_free` — tests all column types (integer, float, text, blob), value duplication surviving finalize, and null safety
- [x] Added `test_sqlite3_context_db_handle` — registers a custom function, verifies the db handle pointer identity, and null safety
- [x] Updated COMPAT.md for all 4 functions