### PR TITLE
feat: add opt-in wasm-fts feature for FTS in WASM builds

### DIFF
--- a/bindings/javascript/Cargo.toml
+++ b/bindings/javascript/Cargo.toml
@@ -25,5 +25,6 @@ chrono = { workspace = true, default-features = false, features = ["clock"] }
 [features]
 browser = []
 tracing_release = ["turso_core/tracing_release"]
+wasm-fts = ["turso_core/wasm-fts"]
 [build-dependencies]
 napi-build = "2.2.3"

--- a/bindings/javascript/packages/wasm/fts.test.ts
+++ b/bindings/javascript/packages/wasm/fts.test.ts
@@ -1,0 +1,196 @@
+import { expect, test, afterAll, beforeEach, afterEach, describe } from 'vitest'
+import { connect } from './promise-default.js'
+import { MainWorker } from './index-default.js'
+
+beforeEach((ctx) => {
+    console.log(`[test:start] ${ctx.task.name}`);
+})
+
+afterEach((ctx) => {
+    console.log(`[test:end] ${ctx.task.name} (${ctx.task.result?.state})`);
+})
+
+afterAll(() => {
+    console.log('[afterAll] terminating MainWorker');
+    MainWorker?.terminate();
+    console.log('[afterAll] MainWorker terminated');
+})
+
+// FTS tests - these require the wasm-fts feature to be enabled during build
+// Skip these tests if FTS is not available
+
+describe('FTS (Full-Text Search)', () => {
+    test('fts-basic-create-and-query', async () => {
+        const db = await connect(":memory:");
+
+        // Create table and FTS index
+        await db.exec("CREATE TABLE documents (id INTEGER PRIMARY KEY, content TEXT)");
+        await db.exec("CREATE INDEX docs_fts ON documents USING fts (content)");
+
+        // Insert test documents
+        await db.exec("INSERT INTO documents VALUES (1, 'The quick brown fox jumps over the lazy dog')");
+        await db.exec("INSERT INTO documents VALUES (2, 'A fast red fox runs through the forest')");
+        await db.exec("INSERT INTO documents VALUES (3, 'The lazy cat sleeps all day')");
+
+        // Query using fts_match
+        const results = await db.prepare("SELECT id, content FROM documents WHERE fts_match(content, 'fox') ORDER BY id").all();
+
+        expect(results).toEqual([
+            { id: 1, content: 'The quick brown fox jumps over the lazy dog' },
+            { id: 2, content: 'A fast red fox runs through the forest' }
+        ]);
+
+        await db.close();
+    })
+
+    test('fts-no-match', async () => {
+        const db = await connect(":memory:");
+
+        await db.exec("CREATE TABLE articles (id INTEGER PRIMARY KEY, title TEXT)");
+        await db.exec("CREATE INDEX articles_fts ON articles USING fts (title)");
+
+        await db.exec("INSERT INTO articles VALUES (1, 'Introduction to Rust programming')");
+        await db.exec("INSERT INTO articles VALUES (2, 'Advanced TypeScript patterns')");
+
+        // Search for a term that doesn't exist
+        const results = await db.prepare("SELECT id FROM articles WHERE fts_match(title, 'python')").all();
+
+        expect(results).toEqual([]);
+
+        await db.close();
+    })
+
+    test('fts-delete-with-match', async () => {
+        const db = await connect(":memory:");
+
+        await db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT)");
+        await db.exec("CREATE INDEX t_idx ON t USING fts (x)");
+
+        await db.exec("INSERT INTO t VALUES (1, 'hello world')");
+        await db.exec("INSERT INTO t VALUES (2, 'goodbye world')");
+        await db.exec("INSERT INTO t VALUES (3, 'hello there')");
+
+        // Delete rows matching 'hello'
+        await db.exec("DELETE FROM t WHERE fts_match(x, 'hello')");
+
+        const results = await db.prepare("SELECT id, x FROM t ORDER BY id").all();
+
+        expect(results).toEqual([
+            { id: 2, x: 'goodbye world' }
+        ]);
+
+        await db.close();
+    })
+
+    test('fts-update-with-match', async () => {
+        const db = await connect(":memory:");
+
+        await db.exec("CREATE TABLE notes (id INTEGER PRIMARY KEY, content TEXT)");
+        await db.exec("CREATE INDEX notes_fts ON notes USING fts (content)");
+
+        await db.exec("INSERT INTO notes VALUES (1, 'urgent task one')");
+        await db.exec("INSERT INTO notes VALUES (2, 'normal task two')");
+        await db.exec("INSERT INTO notes VALUES (3, 'urgent task three')");
+
+        // Update rows matching 'urgent'
+        await db.exec("UPDATE notes SET content = 'completed' WHERE fts_match(content, 'urgent')");
+
+        const results = await db.prepare("SELECT id, content FROM notes ORDER BY id").all();
+
+        expect(results).toEqual([
+            { id: 1, content: 'completed' },
+            { id: 2, content: 'normal task two' },
+            { id: 3, content: 'completed' }
+        ]);
+
+        await db.close();
+    })
+
+    test('fts-insert-then-search', async () => {
+        const db = await connect(":memory:");
+
+        await db.exec("CREATE TABLE blog (id INTEGER PRIMARY KEY, body TEXT)");
+        await db.exec("CREATE INDEX blog_fts ON blog USING fts (body)");
+
+        // Insert multiple rows
+        const insert = db.prepare("INSERT INTO blog (body) VALUES (?)");
+        await insert.run("Learning Rust from scratch");
+        await insert.run("Database internals explained");
+        await insert.run("Building a Rust compiler");
+        await insert.run("Web development with JavaScript");
+
+        // Search for 'Rust'
+        const rustResults = await db.prepare("SELECT id, body FROM blog WHERE fts_match(body, 'Rust') ORDER BY id").all();
+        expect(rustResults.length).toBe(2);
+        expect(rustResults[0].body).toContain('Rust');
+        expect(rustResults[1].body).toContain('Rust');
+
+        await db.close();
+    })
+
+    test('fts-multiple-columns', async () => {
+        const db = await connect(":memory:");
+
+        // Create table with multiple text columns
+        await db.exec("CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, description TEXT)");
+        await db.exec("CREATE INDEX products_fts ON products USING fts (name, description)");
+
+        await db.exec("INSERT INTO products VALUES (1, 'Laptop Computer', 'Powerful laptop for work')");
+        await db.exec("INSERT INTO products VALUES (2, 'Desktop Computer', 'High performance desktop')");
+        await db.exec("INSERT INTO products VALUES (3, 'Wireless Mouse', 'Ergonomic mouse for comfort')");
+
+        // Search across both columns - 'laptop' appears in name for id=1
+        const results = await db.prepare("SELECT id, name FROM products WHERE fts_match(name, 'laptop')").all();
+
+        expect(results).toEqual([
+            { id: 1, name: 'Laptop Computer' }
+        ]);
+
+        await db.close();
+    })
+
+    test('fts-with-transaction', async () => {
+        const db = await connect(":memory:");
+
+        await db.exec("CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT)");
+        await db.exec("CREATE INDEX logs_fts ON logs USING fts (message)");
+
+        // Start transaction
+        await db.exec("BEGIN");
+        await db.exec("INSERT INTO logs VALUES (1, 'error occurred in module A')");
+        await db.exec("INSERT INTO logs VALUES (2, 'warning from module B')");
+        await db.exec("INSERT INTO logs VALUES (3, 'error in database connection')");
+        await db.exec("COMMIT");
+
+        // Search for errors
+        const errors = await db.prepare("SELECT id FROM logs WHERE fts_match(message, 'error') ORDER BY id").all();
+
+        expect(errors).toEqual([{ id: 1 }, { id: 3 }]);
+
+        await db.close();
+    })
+
+    test('fts-rollback', async () => {
+        const db = await connect(":memory:");
+
+        await db.exec("CREATE TABLE data (id INTEGER PRIMARY KEY, text TEXT)");
+        await db.exec("CREATE INDEX data_fts ON data USING fts (text)");
+
+        await db.exec("INSERT INTO data VALUES (1, 'initial data')");
+
+        // Start transaction and insert, then rollback
+        await db.exec("BEGIN");
+        await db.exec("INSERT INTO data VALUES (2, 'temporary data')");
+        await db.exec("ROLLBACK");
+
+        // Only initial data should exist
+        const all = await db.prepare("SELECT id FROM data").all();
+        expect(all).toEqual([{ id: 1 }]);
+
+        // FTS should also not find the rolled back data
+        const search = await db.prepare("SELECT id FROM data WHERE fts_match(text, 'temporary')").all();
+        expect(search).toEqual([]);
+
+        await db.close();
+    })
+})

--- a/bindings/javascript/packages/wasm/package.json
+++ b/bindings/javascript/packages/wasm/package.json
@@ -39,10 +39,13 @@
   },
   "scripts": {
     "napi-build": "napi build --features browser --profile release-official --platform --target wasm32-wasip1-threads --no-js --manifest-path ../../Cargo.toml --output-dir . && rm index.d.ts turso.wasi* wasi* browser.js",
+    "napi-build-fts": "napi build --features browser,wasm-fts --profile release-official --platform --target wasm32-wasip1-threads --no-js --manifest-path ../../Cargo.toml --output-dir . && rm index.d.ts turso.wasi* wasi* browser.js",
     "tsc-build": "npm exec tsc && cp turso.wasm32-wasi.wasm ./dist/turso.wasm32-wasi.wasm && WASM_FILE=turso.wasm32-wasi.wasm JS_FILE=./dist/wasm-inline.js node ../../scripts/inline-wasm-base64.js && npm run bundle",
     "bundle": "vite build",
     "build": "npm run napi-build && npm run tsc-build",
-    "test": "CI=1 vitest --browser=chromium --run && CI=1 vitest --browser=firefox --run"
+    "build-fts": "npm run napi-build-fts && npm run tsc-build",
+    "test": "CI=1 vitest --browser=chromium --run && CI=1 vitest --browser=firefox --run",
+    "test-fts": "CI=1 vitest --browser=chromium --run fts.test.ts && CI=1 vitest --browser=firefox --run fts.test.ts"
   },
   "napi": {
     "binaryName": "turso",

--- a/bindings/javascript/sync/Cargo.toml
+++ b/bindings/javascript/sync/Cargo.toml
@@ -27,3 +27,4 @@ napi-build = "2.2.3"
 
 [features]
 browser = ["turso_node/browser"]
+wasm-fts = ["turso_core/wasm-fts", "turso_node/wasm-fts"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,7 @@ test_helper = []
 bench = []
 nanosecond-bench = ["bench"]
 fts = ["dep:tantivy"]
+wasm-fts = ["dep:tantivy"]
 codspeed = ["bench"]
 optimizer_params = ["serde", "dep:serde_json"]
 
@@ -60,7 +61,8 @@ libc = { version = "0.2.172" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 libloading = "0.8.6"
-tantivy = { version = "0.25.0", optional = true }
+# Enable mmap features for tantivy on non-WASM platforms (fts feature)
+tantivy = { version = "0.25.0", optional = true, features = ["mmap"] }
 
 [dependencies]
 turso_ext = { workspace = true, features = ["core_only"] }
@@ -89,6 +91,7 @@ serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 paste = "1.0.15"
 uuid = { version = "1.11.0", features = ["v4", "v5", "v7"], optional = true }
+tantivy = { version = "0.25.0", optional = true, default-features = false }
 tempfile = { workspace = true }
 pack1 = { version = "1.0.0", features = ["bytemuck"] }
 bytemuck = "1.23.1"

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -2,7 +2,10 @@
 mod dynamic;
 mod vtab_xconnect;
 use crate::index_method::backing_btree::BackingBtreeIndexMethod;
-#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[cfg(any(
+    all(feature = "fts", not(target_family = "wasm")),
+    feature = "wasm-fts"
+))]
 use crate::index_method::fts::{FtsIndexMethod, FTS_INDEX_METHOD_NAME};
 use crate::index_method::toy_vector_sparse_ivf::VectorSparseInvertedIndexMethod;
 use crate::index_method::{
@@ -195,7 +198,10 @@ impl Database {
                 BACKING_BTREE_INDEX_METHOD_NAME.to_string(),
                 Arc::new(BackingBtreeIndexMethod),
             );
-            #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+            #[cfg(any(
+                all(feature = "fts", not(target_family = "wasm")),
+                feature = "wasm-fts"
+            ))]
             syms.index_methods
                 .insert(FTS_INDEX_METHOD_NAME.to_string(), Arc::new(FtsIndexMethod));
         }

--- a/core/function.rs
+++ b/core/function.rs
@@ -244,7 +244,10 @@ impl VectorFunc {
 }
 
 /// Full-text search functions
-#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[cfg(any(
+    all(feature = "fts", not(target_family = "wasm")),
+    feature = "wasm-fts"
+))]
 #[derive(Debug, Clone, PartialEq, strum::EnumIter)]
 pub enum FtsFunc {
     /// fts_score(col1, col2, ..., query): computes FTS relevance score
@@ -258,7 +261,10 @@ pub enum FtsFunc {
     Highlight,
 }
 
-#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[cfg(any(
+    all(feature = "fts", not(target_family = "wasm")),
+    feature = "wasm-fts"
+))]
 impl FtsFunc {
     pub fn is_deterministic(&self) -> bool {
         true
@@ -273,7 +279,10 @@ impl FtsFunc {
     }
 }
 
-#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[cfg(any(
+    all(feature = "fts", not(target_family = "wasm")),
+    feature = "wasm-fts"
+))]
 impl Display for FtsFunc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str = match self {
@@ -1040,7 +1049,10 @@ pub enum Func {
     Scalar(ScalarFunc),
     Math(MathFunc),
     Vector(VectorFunc),
-    #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+    #[cfg(any(
+        all(feature = "fts", not(target_family = "wasm")),
+        feature = "wasm-fts"
+    ))]
     Fts(FtsFunc),
     #[cfg(feature = "json")]
     Json(JsonFunc),
@@ -1055,7 +1067,10 @@ impl Display for Func {
             Self::Scalar(scalar_func) => write!(f, "{scalar_func}"),
             Self::Math(math_func) => write!(f, "{math_func}"),
             Self::Vector(vector_func) => write!(f, "{vector_func}"),
-            #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+            #[cfg(any(
+                all(feature = "fts", not(target_family = "wasm")),
+                feature = "wasm-fts"
+            ))]
             Self::Fts(fts_func) => write!(f, "{fts_func}"),
             #[cfg(feature = "json")]
             Self::Json(json_func) => write!(f, "{json_func}"),
@@ -1078,7 +1093,10 @@ impl Deterministic for Func {
             Self::Scalar(scalar_func) => scalar_func.is_deterministic(),
             Self::Math(math_func) => math_func.is_deterministic(),
             Self::Vector(vector_func) => vector_func.is_deterministic(),
-            #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+            #[cfg(any(
+                all(feature = "fts", not(target_family = "wasm")),
+                feature = "wasm-fts"
+            ))]
             Self::Fts(fts_func) => fts_func.is_deterministic(),
             #[cfg(feature = "json")]
             Self::Json(json_func) => json_func.is_deterministic(),
@@ -1359,11 +1377,20 @@ impl Func {
             "vector_concat" => Ok(Self::Vector(VectorFunc::VectorConcat)),
             "vector_slice" => Ok(Self::Vector(VectorFunc::VectorSlice)),
             // FTS functions
-            #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+            #[cfg(any(
+                all(feature = "fts", not(target_family = "wasm")),
+                feature = "wasm-fts"
+            ))]
             "fts_score" => Ok(Self::Fts(FtsFunc::Score)),
-            #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+            #[cfg(any(
+                all(feature = "fts", not(target_family = "wasm")),
+                feature = "wasm-fts"
+            ))]
             "fts_match" => Ok(Self::Fts(FtsFunc::Match)),
-            #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+            #[cfg(any(
+                all(feature = "fts", not(target_family = "wasm")),
+                feature = "wasm-fts"
+            ))]
             "fts_highlight" => Ok(Self::Fts(FtsFunc::Highlight)),
             // Test type functions (for custom type system testing)
             "test_uint_encode" => Ok(Self::Scalar(ScalarFunc::TestUintEncode)),
@@ -1461,7 +1488,10 @@ impl Func {
         }
 
         // FTS functions (feature-gated)
-        #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+        #[cfg(any(
+            all(feature = "fts", not(target_family = "wasm")),
+            feature = "wasm-fts"
+        ))]
         for f in FtsFunc::iter() {
             push(f.to_string(), "s", f.arities(), f.is_deterministic());
         }

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1887,12 +1887,17 @@ impl FtsCursor {
                 Index::open(hybrid_dir.clone())
                     .map_err(|e| LimboError::InternalError(e.to_string()))?
             } else {
-                Index::create(
-                    hybrid_dir.clone(),
-                    self.schema.clone(),
-                    IndexSettings::default(),
-                )
-                .map_err(|e| LimboError::InternalError(e.to_string()))?
+                // On WASM, disable the dedicated compression thread to avoid Atomics.wait errors
+                #[cfg(target_family = "wasm")]
+                let settings = IndexSettings {
+                    docstore_compress_dedicated_thread: false,
+                    ..IndexSettings::default()
+                };
+                #[cfg(not(target_family = "wasm"))]
+                let settings = IndexSettings::default();
+
+                Index::create(hybrid_dir.clone(), self.schema.clone(), settings)
+                    .map_err(|e| LimboError::InternalError(e.to_string()))?
             };
 
             // Register custom tokenizers

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -12,7 +12,10 @@ use crate::{
 };
 
 pub mod backing_btree;
-#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[cfg(any(
+    all(feature = "fts", not(target_family = "wasm")),
+    feature = "wasm-fts"
+))]
 pub mod fts;
 pub mod toy_vector_sparse_ivf;
 

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -8,7 +8,10 @@ use turso_parser::ast::{self, Expr, ResolveType, SubqueryType, TableInternalId, 
 use super::emitter::Resolver;
 use super::optimizer::Optimizable;
 use super::plan::TableReferences;
-#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[cfg(any(
+    all(feature = "fts", not(target_family = "wasm")),
+    feature = "wasm-fts"
+))]
 use crate::function::FtsFunc;
 #[cfg(feature = "json")]
 use crate::function::JsonFunc;
@@ -2671,7 +2674,10 @@ pub fn translate_expr(
                         Ok(target_register)
                     }
                 },
-                #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+                #[cfg(any(
+                    all(feature = "fts", not(target_family = "wasm")),
+                    feature = "wasm-fts"
+                ))]
                 Func::Fts(_) => {
                     // FTS functions are handled via index method pattern matching.
                     // If we reach here, no index matched, so translate as a regular function call.
@@ -4815,7 +4821,10 @@ fn translate_like_base(
                 },
             });
         }
-        #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+        #[cfg(any(
+            all(feature = "fts", not(target_family = "wasm")),
+            feature = "wasm-fts"
+        ))]
         ast::LikeOperator::Match => {
             // Transform MATCH to fts_match():
             // - `col MATCH 'query'` -> `fts_match(col, 'query')`
@@ -4848,9 +4857,12 @@ fn translate_like_base(
                 },
             });
         }
-        #[cfg(any(not(feature = "fts"), target_family = "wasm"))]
+        #[cfg(not(any(
+            all(feature = "fts", not(target_family = "wasm")),
+            feature = "wasm-fts"
+        )))]
         ast::LikeOperator::Match => {
-            crate::bail_parse_error!("MATCH requires the 'fts' feature to be enabled")
+            crate::bail_parse_error!("MATCH requires the 'fts' or 'wasm-fts' feature to be enabled")
         }
         ast::LikeOperator::Regexp => {
             if escape.is_some() {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -445,7 +445,10 @@ pub fn optimize_plan(
     Ok(())
 }
 
-#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[cfg(any(
+    all(feature = "fts", not(target_family = "wasm")),
+    feature = "wasm-fts"
+))]
 /// Transform MATCH expressions to fts_match() function calls.
 fn transform_match_to_fts_match(where_clause: &mut [WhereTerm]) {
     use super::ast::{FunctionTail, LikeOperator, Name};
@@ -572,7 +575,10 @@ struct OptimizeTableAccessResult {
  */
 pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
     // Transform MATCH expressions to fts_match() for FTS optimizer recognition
-    #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+    #[cfg(any(
+        all(feature = "fts", not(target_family = "wasm")),
+        feature = "wasm-fts"
+    ))]
     transform_match_to_fts_match(&mut plan.where_clause);
 
     unnest::unnest_exists_subqueries(plan)?;
@@ -661,7 +667,10 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
 }
 
 fn optimize_delete_plan(plan: &mut DeletePlan, schema: &Schema) -> Result<()> {
-    #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+    #[cfg(any(
+        all(feature = "fts", not(target_family = "wasm")),
+        feature = "wasm-fts"
+    ))]
     transform_match_to_fts_match(&mut plan.where_clause);
 
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
@@ -700,7 +709,10 @@ fn optimize_update_plan(
     resolver: &Resolver,
 ) -> Result<()> {
     let schema = resolver.schema();
-    #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+    #[cfg(any(
+        all(feature = "fts", not(target_family = "wasm")),
+        feature = "wasm-fts"
+    ))]
     transform_match_to_fts_match(&mut plan.where_clause);
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8057,7 +8057,10 @@ pub fn op_function(
                 state.registers[*dest + 4] = Register::Value(sql.clone());
             }
         }
-        #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+        #[cfg(any(
+            all(feature = "fts", not(target_family = "wasm")),
+            feature = "wasm-fts"
+        ))]
         crate::function::Func::Fts(fts_func) => {
             // FTS functions are typically handled via index method pattern matching.
             // If we reach here, just return a fallback since no FTS index matched.


### PR DESCRIPTION
Add a new `wasm-fts` feature flag that enables FTS (full-text search) support in WASM builds while keeping the default WASM bundle size unchanged.

Closes #5817

Generated with [Claude Code](https://claude.ai/claude-code)

## Note

Clanker-generated scaffolding from #5817 - I haven't validated this works at all.