### PR TITLE
fix(sqlite3): prevent sqlite3_initialize abort when tracing subscriber exists

### DIFF
--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -284,7 +284,11 @@ static INIT_DONE: std::sync::Once = std::sync::Once::new();
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_initialize() -> ffi::c_int {
     INIT_DONE.call_once(|| {
-        tracing_subscriber::fmt::init();
+        // Use try_init() instead of init() to avoid panicking if a global
+        // subscriber is already installed (e.g., by the embedding application
+        // or test harness). A panic here poisons the Once, causing all
+        // subsequent sqlite3_initialize calls to abort (panic in extern "C").
+        let _ = tracing_subscriber::fmt::try_init();
     });
     SQLITE_OK
 }

--- a/sqlite3/tests/compat/mod.rs
+++ b/sqlite3/tests/compat/mod.rs
@@ -144,6 +144,7 @@ extern "C" {
         final_: Option<unsafe extern "C" fn()>,
         destroy: Option<unsafe extern "C" fn(*mut libc::c_void)>,
     ) -> i32;
+    fn sqlite3_initialize() -> i32;
 }
 
 const SQLITE_OK: i32 = 0;
@@ -2763,6 +2764,21 @@ mod tests {
 
             assert_eq!(sqlite3_finalize(stmt2), SQLITE_OK);
             assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    /// Test: sqlite3_initialize must not panic when a global tracing subscriber
+    /// is already installed.
+    #[test]
+    fn test_sqlite3_initialize_no_panic_with_existing_subscriber() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        unsafe {
+            let rc = sqlite3_initialize();
+            assert_eq!(rc, SQLITE_OK);
+
+            let rc2 = sqlite3_initialize();
+            assert_eq!(rc2, SQLITE_OK);
         }
     }
 }


### PR DESCRIPTION
## Description

`sqlite3_initialize()` calls `tracing_subscriber::fmt::init()` inside a `std::sync::Once`. If a global tracing subscriber is already installed (by the embedding application or test harness), `init()` panics with `SetLoggerError`. This poisons the `Once`, causing **all subsequent** `sqlite3_initialize()` calls to panic with `"Once instance has previously been poisoned"`. Since `sqlite3_initialize` is `extern "C"`, the panic triggers `panic_cannot_unwind` → **SIGABRT**.

```
thread 'r2d2-worker-0' panicked at tracing-subscriber/src/fmt/mod.rs:1263:16:
Unable to install global subscriber: SetLoggerError(())

thread 'r2d2-worker-1' panicked at sqlite3/src/lib.rs:297:15:
Once instance has previously been poisoned

thread 'r2d2-worker-1' panicked at library/core/src/panicking.rs:225:5:
panic in a function that cannot unwind
// → SIGABRT
```

**Fix**: Replace `init()` with `try_init()`, which returns `Err` instead of panicking when a subscriber already exists.

```rust
// BEFORE (panics)
INIT_DONE.call_once(|| {
    tracing_subscriber::fmt::init();
});

// AFTER (safe)
INIT_DONE.call_once(|| {
    let _ = tracing_subscriber::fmt::try_init();
});
```

A regression test is included that installs a subscriber first, then calls `sqlite3_initialize()` twice — verifying both calls return `SQLITE_OK` without panicking.

## Motivation and context

This crashes any application that sets up its own tracing subscriber before opening a database. Common scenarios:

- **Diesel + r2d2** connection pools — r2d2 spawns worker threads that each call `sqlite3_open_v2` → `sqlite3_initialize`. If the first worker races with the app's tracing setup, the pool aborts.
- **Test harnesses** — test frameworks often install a global subscriber; any test using Turso's SQLite C API will SIGABRT.
- **Any Rust application** that uses `tracing` (very common) and Turso together.

As a general principle, library crates should not install global subscribers — only application binaries should do that. `try_init()` is the minimal fix that preserves the current behavior (tracing works if no subscriber exists) while not crashing when one does.

## Description of AI Usage

This PR was created with assistance from Claude Code (Anthropic's CLI). AI was used to trace the root cause from CI logs (SIGABRT in e2e tests), identify the `init()` vs `try_init()` issue, implement the fix, and write the regression test. The committer reviewed and verified all changes.