### PR TITLE
docs: Removed unsupported macOS mold linker instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,6 @@ sudo dnf install mold
 
 # Ubuntu/Debian
 sudo apt install mold
-
-# macOS
-brew install mold
 ```
 
 Then configure Cargo to use mold by creating `.cargo/config.toml`:
@@ -80,18 +77,6 @@ Then configure Cargo to use mold by creating `.cargo/config.toml`:
 
 ```toml
 [target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
-```
-
-**For macOS:**
-
-```toml
-[target.x86_64-apple-darwin]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
-
-[target.aarch64-apple-darwin]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 ```


### PR DESCRIPTION
# NOTICE:

Following `CONTRIBUTING.md` on macOS ARM (Apple Silicon) fails when mold is configured as linker. Mold explicitly does not support macOS. According to mold when running `mold --help`. No mention of MacOS:

```
mold: supported targets: elf32-i386 elf64-x86-64 elf32-littlearm elf64-littleaarch64 elf64-bigaarch64 elf32-littleriscv elf32-bigriscv elf64-littleriscv elf64-bigriscv elf32-powerpc elf64-powerpc elf64-powerpc elf64-powerpcle elf64-s390 elf64-sparc elf32-m68k elf32-sh-linux elf64-loongarch elf32-loongarch
mold: supported emulations: elf_i386 elf_x86_64 armelf_linux_eabi aarch64elf aarch64linux aarch64elfb aarch64linuxb elf32lriscv elf32briscv elf64lriscv elf64briscv elf32ppc elf32ppclinux elf64ppc elf64lppc elf64_s390 elf64_sparc m68kelf shlelf_linux shelf_linux elf64loongarch elf32loongarch
```


## Description

I removed mention on MacOS mold linker support from the contributing documentation.

## Motivation and context

Fixes #5609