### PR TITLE
Add graph query benchmark with complex multijoins

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -42,6 +42,12 @@ jobs:
         with:
           tool: cargo-codspeed
 
+      - name: Generate graph-queries DBs
+        run: |
+          python3 perf/graph-queries/generate_seed.py | sqlite3 perf/graph-queries/graph-queries.db
+          cp perf/graph-queries/graph-queries.db perf/graph-queries/graph-queries-analyzed.db
+          sqlite3 perf/graph-queries/graph-queries-analyzed.db "ANALYZE;"
+
       - name: Build benchmarks (excluding TPC-H)
         run: make codspeed-build-bench-exclude-tpc-h
 

--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -28,6 +28,12 @@ jobs:
       # - name: Install dependencies
       #   run: npm install && npm run build
 
+      - name: Generate graph-queries DB
+        run: |
+          python3 perf/graph-queries/generate_seed.py | sqlite3 perf/graph-queries/graph-queries.db
+          cp perf/graph-queries/graph-queries.db perf/graph-queries/graph-queries-analyzed.db
+          sqlite3 perf/graph-queries/graph-queries-analyzed.db "ANALYZE;"
+
       - name: Bench
         run: make bench-exclude-tpc-h  2>&1 | tee output.txt
       - name: Analyze benchmark result with Nyrkiö
@@ -170,4 +176,5 @@ jobs:
           # Smaller p-value = less change points found. Larger p-value = more, but also more false positives.
           nyrkio-settings-pvalue: 0.00001
           nyrkio-settings-threshold: 0%
+
 

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -36,6 +36,8 @@ jobs:
             features: "--features bench"
           - bench: parser_benchmark
             features: ""
+          - bench: graph_queries_benchmark
+            features: "--features bench"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -43,6 +45,12 @@ jobs:
         with:
           prefix-key: "v1-rust"
           cache-on-failure: true
+      - name: Generate graph-queries DB
+        if: matrix.bench == 'graph_queries_benchmark'
+        run: |
+          python3 perf/graph-queries/generate_seed.py | sqlite3 perf/graph-queries/graph-queries.db
+          cp perf/graph-queries/graph-queries.db perf/graph-queries/graph-queries-analyzed.db
+          sqlite3 perf/graph-queries/graph-queries-analyzed.db "ANALYZE;"
       - name: Bench ${{ matrix.bench }}
         run: cargo bench --bench ${{ matrix.bench }} ${{ matrix.features }} 2>&1 | tee output.txt
       - uses: actions/upload-artifact@v4

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -197,3 +197,7 @@ harness = false
 name = "fts_benchmark"
 harness = false
 required-features = ["fts"]
+
+[[bench]]
+name = "graph_queries_benchmark"
+harness = false

--- a/core/benches/graph_queries_benchmark.rs
+++ b/core/benches/graph_queries_benchmark.rs
@@ -1,0 +1,159 @@
+use std::sync::Arc;
+
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode};
+#[cfg(not(feature = "codspeed"))]
+use pprof::criterion::{Output, PProfProfiler};
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode,
+};
+
+use turso_core::{Database, PlatformIO};
+
+const DB_PATH: &str = "../perf/graph-queries/graph-queries.db";
+const DB_PATH_ANALYZED: &str = "../perf/graph-queries/graph-queries-analyzed.db";
+
+macro_rules! gq_query {
+    ($name:literal) => {
+        (
+            $name,
+            include_str!(concat!("../../perf/graph-queries/queries/", $name, ".sql")),
+        )
+    };
+}
+
+fn rusqlite_open(path: &str) -> rusqlite::Connection {
+    let conn = rusqlite::Connection::open(path).unwrap();
+    conn.pragma_update(None, "locking_mode", "EXCLUSIVE")
+        .unwrap();
+    conn
+}
+
+fn bench_graph_queries(criterion: &mut Criterion) {
+    let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
+
+    #[allow(clippy::arc_with_non_send_sync)]
+    let io = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io.clone(), DB_PATH).unwrap();
+    let limbo_conn = db.connect().unwrap();
+
+    let db_analyzed = Database::open_file(io, DB_PATH_ANALYZED).unwrap();
+    let limbo_conn_analyzed = db_analyzed.connect().unwrap();
+
+    let queries = [
+        gq_query!("a_cooccurrence"),
+        gq_query!("b_or_join"),
+        gq_query!("c_edge_counts"),
+        gq_query!("d_inlist_union"),
+        gq_query!("e_activity_agg"),
+        gq_query!("f1_streak_current"),
+        gq_query!("f2_streak_longest"),
+        gq_query!("3_aggregate_or_in"),
+    ];
+
+    for (name, query) in queries.iter() {
+        let mut group = criterion.benchmark_group(format!("GraphQuery `{name}`"));
+        group.sampling_mode(SamplingMode::Flat);
+        group.sample_size(10);
+
+        group.bench_with_input(BenchmarkId::new("limbo", name), query, |b, query| {
+            let mut stmt = limbo_conn.prepare(query).unwrap();
+            b.iter(|| {
+                loop {
+                    match stmt.step().unwrap() {
+                        turso_core::StepResult::Row => {
+                            black_box(stmt.row());
+                        }
+                        turso_core::StepResult::IO => {
+                            db.io.step().unwrap();
+                        }
+                        turso_core::StepResult::Done => {
+                            break;
+                        }
+                        turso_core::StepResult::Interrupt | turso_core::StepResult::Busy => {
+                            unreachable!();
+                        }
+                    }
+                }
+                stmt.reset().unwrap();
+            });
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("limbo_analyzed", name),
+            query,
+            |b, query| {
+                let mut stmt = limbo_conn_analyzed.prepare(query).unwrap();
+                b.iter(|| {
+                    loop {
+                        match stmt.step().unwrap() {
+                            turso_core::StepResult::Row => {
+                                black_box(stmt.row());
+                            }
+                            turso_core::StepResult::IO => {
+                                db_analyzed.io.step().unwrap();
+                            }
+                            turso_core::StepResult::Done => {
+                                break;
+                            }
+                            turso_core::StepResult::Interrupt | turso_core::StepResult::Busy => {
+                                unreachable!();
+                            }
+                        }
+                    }
+                    stmt.reset().unwrap();
+                });
+            },
+        );
+
+        if enable_rusqlite {
+            let sqlite_conn = rusqlite_open(DB_PATH);
+
+            group.bench_with_input(BenchmarkId::new("sqlite", name), query, |b, query| {
+                let mut stmt = sqlite_conn.prepare(query).unwrap();
+                b.iter(|| {
+                    let mut rows = stmt.raw_query();
+                    while let Some(row) = rows.next().unwrap() {
+                        black_box(row);
+                    }
+                });
+            });
+
+            let sqlite_conn_analyzed = rusqlite_open(DB_PATH_ANALYZED);
+
+            group.bench_with_input(
+                BenchmarkId::new("sqlite_analyzed", name),
+                query,
+                |b, query| {
+                    let mut stmt = sqlite_conn_analyzed.prepare(query).unwrap();
+                    b.iter(|| {
+                        let mut rows = stmt.raw_query();
+                        while let Some(row) = rows.next().unwrap() {
+                            black_box(row);
+                        }
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
+}
+
+#[cfg(not(feature = "codspeed"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_graph_queries
+}
+
+#[cfg(feature = "codspeed")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = bench_graph_queries
+}
+
+criterion_main!(benches);

--- a/perf/graph-queries/.gitignore
+++ b/perf/graph-queries/.gitignore
@@ -1,0 +1,2 @@
+graph-queries.db*
+graph-queries-analyzed.db*

--- a/perf/graph-queries/generate_seed.py
+++ b/perf/graph-queries/generate_seed.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Generate synthetic seed data for the graph-queries performance benchmark.
+
+The data models a university course catalog / enrollment graph:
+  - node:         courses, lectures, exams, departments, professors, etc.
+  - edge:         directed relationships (requires, equivalent, offered_in, ...)
+  - message:      student/advisor messages within enrollment threads
+  - conversation: enrollment / advising sessions
+  - journal:      semester review notes
+
+Usage:
+    python3 generate_seed.py | sqlite3 graph-queries.db
+"""
+
+import json
+import random
+import sys
+
+random.seed(42)
+
+# ── Row counts (original proportions) ────────────────────────────────────────
+NUM_NODES = 2286
+NUM_EDGES = 2787
+NUM_MESSAGES = 6087
+NUM_CONVERSATIONS = 827
+NUM_JOURNALS = 44
+
+# ── Fixed IDs referenced by benchmark queries ───────────────────────────────
+CENTRAL_NODE_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+IN_LIST_IDS = [
+    "6ba7b810-9dad-41d8-80b4-00c04fd430c8",
+    "6ba7b811-9dad-41d8-80b4-00c04fd430c9",
+    "6ba7b812-9dad-41d8-80b4-00c04fd430ca",
+    "6ba7b813-9dad-41d8-80b4-00c04fd430cb",
+    "6ba7b814-9dad-41d8-80b4-00c04fd430cc",
+    "6ba7b815-9dad-41d8-80b4-00c04fd430cd",
+    "6ba7b816-9dad-41d8-80b4-00c04fd430ce",
+    "6ba7b817-9dad-41d8-80b4-00c04fd430cf",
+    "6ba7b818-9dad-41d8-80b4-00c04fd430d0",
+    "6ba7b819-9dad-41d8-80b4-00c04fd430d1",
+]
+
+# ── Timestamp range: Jan 2025 → Mar 2026 (epoch milliseconds) ──────────────
+TS_START = 1735689600000  # 2025-01-01 00:00 UTC
+TS_END = 1773532800000  # ~2026-03-13 00:00 UTC
+# Query-E window (one specific day)
+TS_DAY_START = 1772582400000
+TS_DAY_END = 1772668799999
+
+# ── Node type distribution (must sum to NUM_NODES) ─────────────────────────
+NODE_TYPE_COUNTS = {
+    "lecture": 350,
+    "course": 800,
+    "exam": 200,
+    "assignment": 180,
+    "semester": 80,
+    "term": 60,
+    "department": 50,
+    "building": 50,
+    "professor": 80,
+    "instructor": 40,
+    "program": 30,
+    "major": 30,
+    "credit": 40,
+    "room": 30,
+    "lab": 30,
+    "tutorial": 60,
+    "grade": 60,
+    "enrollment": 40,
+    "unknown": 36,
+    "system": 40,
+}
+assert sum(NODE_TYPE_COUNTS.values()) == NUM_NODES
+
+# ── Edge label distribution (must sum to NUM_EDGES) ────────────────────────
+EDGE_LABEL_COUNTS = {
+    "requires": 1500,
+    "equivalent": 100,
+    "precedes": 150,
+    "follows": 150,
+    "offered_in": 120,
+    "taught_by": 100,
+    "enrolled": 100,
+    "graded": 100,
+    "references": 100,
+    "merges": 67,
+    "covers": 100,
+    "evaluates": 50,
+    "fall_ref": 75,
+    "spring_ref": 75,
+}
+assert sum(EDGE_LABEL_COUNTS.values()) == NUM_EDGES
+
+# ── Level distribution for course nodes ────────────────────────────────────
+LEVEL_COUNTS = {
+    "introductory": 60,
+    "intermediate": 120,
+    "advanced": 200,
+    "graduate": 100,
+    "seminar": 200,
+    "workshop": 80,
+    "independent": 40,
+}
+assert sum(LEVEL_COUNTS.values()) == NODE_TYPE_COUNTS["course"]
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def uuid4():
+    return (
+        f"{random.getrandbits(32):08x}-"
+        f"{random.getrandbits(16):04x}-"
+        f"4{random.getrandbits(12):03x}-"
+        f"{random.choice('89ab')}{random.getrandbits(12):03x}-"
+        f"{random.getrandbits(48):012x}"
+    )
+
+
+def ts(start=TS_START, end=TS_END):
+    return random.uniform(start, end)
+
+
+def sql(s):
+    if s is None:
+        return "NULL"
+    return "'" + str(s).replace("'", "''") + "'"
+
+
+SUBJECTS = [
+    "algebra",
+    "biology",
+    "calculus",
+    "dynamics",
+    "economics",
+    "finance",
+    "geometry",
+    "history",
+    "informatics",
+    "jurisprudence",
+    "kinetics",
+    "linguistics",
+    "mechanics",
+    "neuroscience",
+    "optics",
+    "philosophy",
+    "quantitative",
+    "rhetoric",
+    "statistics",
+    "topology",
+    "urban",
+    "virology",
+    "wavelets",
+    "xenobiology",
+    "yearbook",
+    "zoology",
+]
+
+
+def display_label(ntype, idx):
+    return f"{ntype.upper()[:3]}-{idx:04d}"
+
+
+out = sys.stdout.write
+
+# ── Schema (only columns referenced by benchmark queries) ────────────────
+
+out("PRAGMA journal_mode=WAL;\n")
+out("BEGIN TRANSACTION;\n\n")
+
+out("""CREATE TABLE node (
+  id varchar(36) PRIMARY KEY NOT NULL,
+  displayLabel varchar NOT NULL DEFAULT '',
+  createdAt real,
+  type varchar DEFAULT 'node',
+  entity text DEFAULT '{}'
+);
+
+CREATE TABLE edge (
+  id varchar(36) PRIMARY KEY NOT NULL,
+  fromId varchar(36) NOT NULL DEFAULT '',
+  toId varchar(36) NOT NULL DEFAULT '',
+  label varchar NOT NULL DEFAULT ''
+);
+
+CREATE TABLE message (
+  id varchar NOT NULL PRIMARY KEY,
+  createdAt real,
+  author text
+);
+
+CREATE TABLE conversation (
+  id varchar(36) PRIMARY KEY NOT NULL,
+  startDate real
+);
+
+CREATE TABLE journal (
+  id varchar(36) PRIMARY KEY NOT NULL,
+  createdAt real NOT NULL
+);
+
+""")
+
+# ── Generate nodes ──────────────────────────────────────────────────────────
+
+course_levels = []
+for lvl, cnt in LEVEL_COUNTS.items():
+    course_levels.extend([lvl] * cnt)
+random.shuffle(course_levels)
+lvl_iter = iter(course_levels)
+
+nodes_by_type: dict[str, list[str]] = {t: [] for t in NODE_TYPE_COUNTS}
+all_node_ids: list[str] = []
+
+node_counter = 0
+
+for ntype, count in NODE_TYPE_COUNTS.items():
+    for i in range(count):
+        if ntype == "course" and i == 0:
+            nid = CENTRAL_NODE_ID
+        elif ntype == "lecture" and i < len(IN_LIST_IDS):
+            nid = IN_LIST_IDS[i]
+        else:
+            nid = uuid4()
+
+        nodes_by_type[ntype].append(nid)
+        all_node_ids.append(nid)
+
+        created = ts()
+        dlbl = display_label(ntype, node_counter)
+
+        if ntype == "course":
+            level = next(lvl_iter)
+            entity_json = json.dumps({"level": level})
+        else:
+            entity_json = "{}"
+
+        out(f"INSERT INTO node VALUES({sql(nid)},{sql(dlbl)},{created},{sql(ntype)},{sql(entity_json)});\n")
+        node_counter += 1
+
+# Shift ~200 random nodes into the query-E time window
+for nid in random.sample(all_node_ids, 50):
+    out(f"UPDATE node SET createdAt={ts(TS_DAY_START, TS_DAY_END)} WHERE id={sql(nid)};\n")
+
+out("\n")
+
+# ── Generate edges ──────────────────────────────────────────────────────────
+
+lecture_ids = nodes_by_type["lecture"]
+course_ids = nodes_by_type["course"]
+non_excluded_types = {"semester", "term", "lecture"}
+course_and_other_ids = [nid for ntype, ids in nodes_by_type.items() if ntype not in non_excluded_types for nid in ids]
+
+for elabel, count in EDGE_LABEL_COUNTS.items():
+    for i in range(count):
+        eid = uuid4()
+
+        if elabel == "requires":
+            from_id = random.choice(lecture_ids)
+            to_id = random.choice(course_and_other_ids)
+            # Central course gets ~30 inbound requires edges
+            if i < 30:
+                to_id = CENTRAL_NODE_ID
+            # IN_LIST lectures each get ~5 outbound requires edges
+            if i < 50:
+                from_id = IN_LIST_IDS[i % len(IN_LIST_IDS)]
+            # ~20 edges from central course to other courses (for query B)
+            if 50 <= i < 70:
+                from_id = CENTRAL_NODE_ID
+                to_id = random.choice([c for c in course_ids if c != CENTRAL_NODE_ID])
+
+        elif elabel == "equivalent":
+            from_id = random.choice(course_ids)
+            to_id = random.choice(course_ids)
+            while to_id == from_id:
+                to_id = random.choice(course_ids)
+        else:
+            from_id = random.choice(all_node_ids)
+            to_id = random.choice(all_node_ids)
+            while to_id == from_id:
+                to_id = random.choice(all_node_ids)
+
+        out(f"INSERT INTO edge VALUES({sql(eid)},{sql(from_id)},{sql(to_id)},{sql(elabel)});\n")
+
+out("\n")
+
+# ── Generate conversations ──────────────────────────────────────────────────
+
+conv_ids: list[str] = []
+
+for i in range(NUM_CONVERSATIONS):
+    cid = uuid4()
+    conv_ids.append(cid)
+    start = ts()
+
+    out(f"INSERT INTO conversation VALUES({sql(cid)},{start});\n")
+
+for cid in random.sample(conv_ids, 20):
+    out(f"UPDATE conversation SET startDate={ts(TS_DAY_START, TS_DAY_END)} WHERE id={sql(cid)};\n")
+
+out("\n")
+
+# ── Generate messages ───────────────────────────────────────────────────────
+
+for i in range(NUM_MESSAGES):
+    mid = uuid4()
+    created = ts()
+    author = "student" if random.random() < 0.6 else "advisor"
+
+    out(f"INSERT INTO message VALUES({sql(mid)},{created},{sql(author)});\n")
+
+# Extra student messages in query-E window
+for i in range(30):
+    mid = uuid4()
+    created = ts(TS_DAY_START, TS_DAY_END)
+    out(f"INSERT INTO message VALUES({sql(mid)},{created},'student');\n")
+
+out("\n")
+
+# ── Generate journals ───────────────────────────────────────────────────────
+
+journal_ids_list: list[str] = []
+for i in range(NUM_JOURNALS):
+    jid = uuid4()
+    journal_ids_list.append(jid)
+    created = ts()
+
+    out(f"INSERT INTO journal VALUES({sql(jid)},{created});\n")
+
+for jid in random.sample(journal_ids_list, 5):
+    out(f"UPDATE journal SET createdAt={ts(TS_DAY_START, TS_DAY_END)} WHERE id={sql(jid)};\n")
+
+out("\n")
+
+# ── Indexes ─────────────────────────────────────────────────────────────────
+
+out("""CREATE INDEX idx_edge_label ON edge (label);
+CREATE INDEX idx_edge_toId ON edge (toId);
+CREATE INDEX idx_edge_fromId ON edge (fromId);
+CREATE INDEX idx_conversations_start_date ON conversation (startDate DESC);
+CREATE INDEX idx_journals_createdAt_date ON journal (createdAt DESC);
+""")
+
+out("\nCOMMIT;\n")

--- a/perf/graph-queries/queries/3_aggregate_or_in.sql
+++ b/perf/graph-queries/queries/3_aggregate_or_in.sql
@@ -1,0 +1,19 @@
+SELECT course_id, MIN(created_date) AS firstCreated,
+       MAX(created_date) AS lastCreated, COUNT(*) AS totalCount
+FROM (
+  SELECT n.id as course_id, n.createdAt AS created_date
+  FROM node n
+  WHERE (n.type = 'lecture')
+    AND (
+      n.id IN (
+        SELECT e.fromId FROM edge e
+        WHERE e.label = 'requires'
+          AND e.toId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+      )
+      OR n.id IN (
+        SELECT e.toId FROM edge e
+        WHERE e.label = 'requires'
+          AND e.fromId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+      )
+    )
+) AS combined

--- a/perf/graph-queries/queries/a_cooccurrence.sql
+++ b/perf/graph-queries/queries/a_cooccurrence.sql
@@ -1,0 +1,26 @@
+SELECT DISTINCT
+  c1.displayLabel AS "from",
+  c1.id AS "fromId",
+  c1.type AS "fromType",
+  json_extract(c1.entity, '$.level') AS "fromLevel",
+  c2.displayLabel AS "to",
+  c2.id AS "toId",
+  c2.type AS "toType",
+  json_extract(c2.entity, '$.level') AS "toLevel",
+  '' AS "type"
+FROM edge e1
+JOIN edge e2 ON e1.fromId = e2.fromId
+JOIN node c1 ON e1.toId = c1.id
+JOIN node c2 ON e2.toId = c2.id
+JOIN node lec ON e1.fromId = lec.id
+LEFT JOIN edge eq1 ON c1.id = eq1.toId AND eq1.label = 'equivalent'
+LEFT JOIN edge eq2 ON c2.id = eq2.toId AND eq2.label = 'equivalent'
+WHERE e1.label = 'requires'
+  AND e2.label = 'requires'
+  AND e1.toId != e2.toId
+  AND e1.toId < e2.toId
+  AND lec.type = 'lecture'
+  AND c1.type NOT IN ('semester', 'term', 'lecture')
+  AND c2.type NOT IN ('semester', 'term', 'lecture')
+  AND eq1.id IS NULL
+  AND eq2.id IS NULL

--- a/perf/graph-queries/queries/b_or_join.sql
+++ b/perf/graph-queries/queries/b_or_join.sql
@@ -1,0 +1,7 @@
+SELECT DISTINCT n.id
+FROM node n
+JOIN edge e ON (
+    (e.fromId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479' AND e.toId = n.id AND e.label = 'requires')
+    OR (e.toId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479' AND e.fromId = n.id AND e.label = 'requires')
+)
+WHERE n.type = 'course'

--- a/perf/graph-queries/queries/c_edge_counts.sql
+++ b/perf/graph-queries/queries/c_edge_counts.sql
@@ -1,0 +1,17 @@
+SELECT n.id, n.displayLabel, n.type, n.createdAt, n.entity,
+  (IFNULL(edge_from.edge_count_from, 0) + IFNULL(edge_to.edge_count_to, 0)) AS total_edges,
+  e_eq.fromId as equivalentOf
+FROM node as n
+LEFT JOIN edge e_eq_ex ON n.id = e_eq_ex.toId AND e_eq_ex.label = 'equivalent'
+LEFT JOIN (
+  SELECT fromId, COUNT(*) AS edge_count_from FROM edge GROUP BY fromId
+) AS edge_from ON n.id = edge_from.fromId
+LEFT JOIN (
+  SELECT toId, COUNT(*) AS edge_count_to FROM edge GROUP BY toId
+) AS edge_to ON n.id = edge_to.toId
+LEFT JOIN edge e_eq ON n.id = e_eq.toId AND e_eq.label = 'equivalent'
+WHERE json_extract(n.entity, '$.level') = 'introductory'
+  AND n.type = 'course'
+  AND e_eq_ex.id IS NULL
+ORDER BY total_edges DESC, n.createdAt DESC
+LIMIT 5

--- a/perf/graph-queries/queries/d_inlist_union.sql
+++ b/perf/graph-queries/queries/d_inlist_union.sql
@@ -1,0 +1,39 @@
+SELECT e.toId AS course_id, e.fromId AS lecture_id
+FROM edge e
+JOIN node n_from ON e.fromId = n_from.id
+JOIN node n_to ON e.toId = n_to.id
+WHERE n_from.type = 'lecture'
+  AND n_from.id IN (
+    '6ba7b810-9dad-41d8-80b4-00c04fd430c8',
+    '6ba7b811-9dad-41d8-80b4-00c04fd430c9',
+    '6ba7b812-9dad-41d8-80b4-00c04fd430ca',
+    '6ba7b813-9dad-41d8-80b4-00c04fd430cb',
+    '6ba7b814-9dad-41d8-80b4-00c04fd430cc',
+    '6ba7b815-9dad-41d8-80b4-00c04fd430cd',
+    '6ba7b816-9dad-41d8-80b4-00c04fd430ce',
+    '6ba7b817-9dad-41d8-80b4-00c04fd430cf',
+    '6ba7b818-9dad-41d8-80b4-00c04fd430d0',
+    '6ba7b819-9dad-41d8-80b4-00c04fd430d1'
+  )
+  AND n_to.type = 'course'
+  AND n_to.id NOT IN ('f47ac10b-58cc-4372-a567-0e02b2c3d479')
+UNION ALL
+SELECT e.fromId AS course_id, e.toId AS lecture_id
+FROM edge e
+JOIN node n_from ON e.fromId = n_from.id
+JOIN node n_to ON e.toId = n_to.id
+WHERE n_to.type = 'lecture'
+  AND n_to.id IN (
+    '6ba7b810-9dad-41d8-80b4-00c04fd430c8',
+    '6ba7b811-9dad-41d8-80b4-00c04fd430c9',
+    '6ba7b812-9dad-41d8-80b4-00c04fd430ca',
+    '6ba7b813-9dad-41d8-80b4-00c04fd430cb',
+    '6ba7b814-9dad-41d8-80b4-00c04fd430cc',
+    '6ba7b815-9dad-41d8-80b4-00c04fd430cd',
+    '6ba7b816-9dad-41d8-80b4-00c04fd430ce',
+    '6ba7b817-9dad-41d8-80b4-00c04fd430cf',
+    '6ba7b818-9dad-41d8-80b4-00c04fd430d0',
+    '6ba7b819-9dad-41d8-80b4-00c04fd430d1'
+  )
+  AND n_from.type = 'course'
+  AND n_from.id NOT IN ('f47ac10b-58cc-4372-a567-0e02b2c3d479')

--- a/perf/graph-queries/queries/e_activity_agg.sql
+++ b/perf/graph-queries/queries/e_activity_agg.sql
@@ -1,0 +1,44 @@
+SELECT a.date, a.category, SUM(a.total) AS total
+FROM (
+  SELECT id, date(datetime(createdAt / 1000, 'unixepoch', '+60 minutes')) AS date,
+    'messages' AS category, COUNT(*) AS total
+  FROM message
+  WHERE createdAt >= 1772582400000 AND createdAt <= 1772668799999
+    AND author='student'
+  GROUP BY date
+  UNION ALL
+  SELECT id, date(datetime(startDate / 1000, 'unixepoch', '+60 minutes')) AS date,
+    'sessions' AS category, COUNT(*) AS total
+  FROM conversation
+  WHERE startDate >= 1772582400000 AND startDate <= 1772668799999
+  GROUP BY date
+  UNION ALL
+  SELECT id, date(datetime(createdAt / 1000, 'unixepoch', '+60 minutes')) AS date,
+    'assessments' AS category, COUNT(*) AS total
+  FROM node
+  WHERE createdAt >= 1772582400000 AND createdAt <= 1772668799999
+    AND (type='exam' OR type='assignment')
+  GROUP BY date
+  UNION ALL
+  SELECT id, date(datetime(createdAt / 1000, 'unixepoch', '+60 minutes')) AS date,
+    'assignments' AS category, COUNT(*) AS total
+  FROM node
+  WHERE createdAt >= 1772582400000 AND createdAt <= 1772668799999
+    AND type='assignment'
+  GROUP BY date
+  UNION ALL
+  SELECT id, date(datetime(createdAt / 1000, 'unixepoch', '+60 minutes')) AS date,
+    'exams' AS category, COUNT(*) AS total
+  FROM node
+  WHERE createdAt >= 1772582400000 AND createdAt <= 1772668799999
+    AND type='exam'
+  GROUP BY date
+  UNION ALL
+  SELECT id, date(datetime(createdAt / 1000, 'unixepoch', '+60 minutes')) AS date,
+    'reviews' AS category, COUNT(*) AS total
+  FROM journal
+  WHERE createdAt >= 1772582400000 AND createdAt <= 1772668799999
+  GROUP BY date
+) AS a
+GROUP BY date, category
+ORDER BY date, category

--- a/perf/graph-queries/queries/f1_streak_current.sql
+++ b/perf/graph-queries/queries/f1_streak_current.sql
@@ -1,0 +1,48 @@
+WITH enrollment_dates AS (
+  SELECT DISTINCT date(datetime(stamp / 1000, 'unixepoch', '+60 minutes')) AS enroll_date
+  FROM (
+    SELECT id, createdAt AS stamp FROM message WHERE 1=1 AND author='student'
+    UNION ALL
+    SELECT id, startDate AS stamp FROM conversation WHERE 1=1
+    UNION ALL
+    SELECT id, createdAt AS stamp FROM node WHERE 1=1 AND (type='exam' OR type='assignment')
+    UNION ALL
+    SELECT id, createdAt AS stamp FROM node WHERE 1=1 AND type='assignment'
+    UNION ALL
+    SELECT id, createdAt AS stamp FROM node WHERE 1=1 AND type='exam'
+    UNION ALL
+    SELECT id, createdAt AS stamp FROM journal WHERE 1=1
+  )
+  ORDER BY enroll_date
+),
+date_gaps AS (
+  SELECT enroll_date,
+    (
+      SELECT MAX(d2.enroll_date)
+      FROM enrollment_dates d2
+      WHERE d2.enroll_date < d1.enroll_date
+    ) AS prev_date
+  FROM enrollment_dates d1
+),
+streaks AS (
+  SELECT enroll_date, prev_date, JULIANDAY(enroll_date) - JULIANDAY(prev_date) AS diff,
+    CASE WHEN JULIANDAY(enroll_date) - JULIANDAY(prev_date) = 1 THEN 0 ELSE 1 END AS streak_start
+  FROM date_gaps
+),
+streak_ids AS (
+  SELECT enroll_date, SUM(streak_start) OVER (ORDER BY enroll_date) AS streak_id
+  FROM streaks
+),
+streak_lengths AS (
+  SELECT streak_id, MIN(enroll_date) AS start_date, MAX(enroll_date) AS end_date,
+         COUNT(*) AS streak_length
+  FROM streak_ids
+  GROUP BY streak_id
+)
+SELECT start_date, end_date, streak_length
+FROM streak_lengths
+WHERE streak_id = (
+  SELECT streak_id
+  FROM streak_ids
+  WHERE enroll_date = (SELECT MAX(enroll_date) FROM enrollment_dates)
+)

--- a/perf/graph-queries/queries/f2_streak_longest.sql
+++ b/perf/graph-queries/queries/f2_streak_longest.sql
@@ -1,0 +1,45 @@
+WITH enrollment_dates AS (
+  SELECT DISTINCT date(datetime(stamp / 1000, 'unixepoch', '+60 minutes')) AS enroll_date
+  FROM (
+    SELECT id, createdAt AS stamp FROM message WHERE 1=1 AND author='student'
+    UNION ALL
+    SELECT id, startDate AS stamp FROM conversation WHERE 1=1
+    UNION ALL
+    SELECT id, createdAt AS stamp FROM node WHERE 1=1 AND (type='exam' OR type='assignment')
+    UNION ALL
+    SELECT id, createdAt AS stamp FROM node WHERE 1=1 AND type='assignment'
+    UNION ALL
+    SELECT id, createdAt AS stamp FROM node WHERE 1=1 AND type='exam'
+    UNION ALL
+    SELECT id, createdAt AS stamp FROM journal WHERE 1=1
+  )
+  ORDER BY enroll_date
+),
+date_gaps AS (
+  SELECT enroll_date,
+    (
+      SELECT MAX(d2.enroll_date)
+      FROM enrollment_dates d2
+      WHERE d2.enroll_date < d1.enroll_date
+    ) AS prev_date
+  FROM enrollment_dates d1
+),
+streaks AS (
+  SELECT enroll_date, prev_date, JULIANDAY(enroll_date) - JULIANDAY(prev_date) AS diff,
+    CASE WHEN JULIANDAY(enroll_date) - JULIANDAY(prev_date) = 1 THEN 0 ELSE 1 END AS streak_start
+  FROM date_gaps
+),
+streak_ids AS (
+  SELECT enroll_date, SUM(streak_start) OVER (ORDER BY enroll_date) AS streak_id
+  FROM streaks
+),
+streak_lengths AS (
+  SELECT streak_id, MIN(enroll_date) AS start_date, MAX(enroll_date) AS end_date,
+         COUNT(*) AS streak_length
+  FROM streak_ids
+  GROUP BY streak_id
+)
+SELECT start_date, end_date, streak_length
+FROM streak_lengths
+ORDER BY streak_length DESC
+LIMIT 1


### PR DESCRIPTION
This is used to stress our join optimizer in addition to TPC-H; there are many multiway joins, many CTEs and multiple indexes per table. Also contains paths that benefit from MULTI-INDEX access paths + range scans.
