### PR TITLE
MATCH operator on non-FTS tables should error

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -861,6 +861,16 @@ impl Schema {
             .filter(|i| !i.is_backing_btree_index())
     }
 
+    #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+    pub fn has_fts_index(&self, table_name: &str) -> bool {
+        use crate::index_method::fts::FTS_INDEX_METHOD_NAME;
+        self.get_indices(table_name).any(|idx| {
+            idx.index_method
+                .as_ref()
+                .is_some_and(|m| m.definition().method_name == FTS_INDEX_METHOD_NAME)
+        })
+    }
+
     pub fn get_index(&self, table_name: &str, index_name: &str) -> Option<&Arc<Index>> {
         let name = normalize_ident(table_name);
         self.indexes

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -448,10 +448,40 @@ pub fn optimize_plan(
 
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
 /// Transform MATCH expressions to fts_match() function calls.
-fn transform_match_to_fts_match(where_clause: &mut [WhereTerm]) {
-    use super::ast::{FunctionTail, LikeOperator, Name};
+fn transform_match_to_fts_match(
+    where_clause: &mut [WhereTerm],
+    schema: &Schema,
+    table_references: &TableReferences,
+) -> Result<()> {
+    use super::ast::{FunctionTail, LikeOperator, Name, TableInternalId};
     use super::expr::{walk_expr_mut, WalkControl};
 
+    // Helper to extract table ID from a column expression
+    fn get_table_id_from_expr(expr: &Expr) -> Option<TableInternalId> {
+        match expr {
+            Expr::Column { table, .. } => Some(*table),
+            Expr::Parenthesized(exprs) if !exprs.is_empty() => get_table_id_from_expr(&exprs[0]),
+            _ => None,
+        }
+    }
+
+    // Helper to check if a table has an FTS index by its internal ID
+    let table_has_fts_index = |table_id: TableInternalId| -> bool {
+        table_references
+            .joined_tables()
+            .iter()
+            .find(|t| t.internal_id == table_id)
+            .and_then(|t| {
+                if let Table::BTree(btree) = &t.table {
+                    Some(schema.has_fts_index(&btree.name))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(false)
+    };
+
+    let mut match_without_fts = false;
     for term in where_clause.iter_mut() {
         let _ = walk_expr_mut(&mut term.expr, &mut |e: &mut Expr| -> Result<WalkControl> {
             match e {
@@ -462,6 +492,15 @@ fn transform_match_to_fts_match(where_clause: &mut [WhereTerm]) {
                     rhs,
                     escape: _,
                 } => {
+                    // Check if the specific table referenced by this MATCH has an FTS index
+                    let has_fts = get_table_id_from_expr(lhs).is_some_and(table_has_fts_index);
+
+                    if !has_fts {
+                        match_without_fts = true;
+                        // Don't transform, we'll error after the walk
+                        return Ok(WalkControl::SkipChildren);
+                    }
+
                     // Transform MATCH to fts_match():
                     // - `col MATCH 'query'` -> `fts_match(col, 'query')`
                     // - `(col1, col2) MATCH 'query'` -> `fts_match(col1, col2, 'query')`
@@ -493,6 +532,14 @@ fn transform_match_to_fts_match(where_clause: &mut [WhereTerm]) {
             }
         });
     }
+
+    if match_without_fts {
+        return Err(LimboError::ParseError(
+            "unable to use function MATCH in the requested context".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Detect whether this plan qualifies for the simple-aggregate fast path.
@@ -574,7 +621,7 @@ struct OptimizeTableAccessResult {
 pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
     // Transform MATCH expressions to fts_match() for FTS optimizer recognition
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause);
+    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
 
     unnest::unnest_exists_subqueries(plan)?;
     // EXISTS only needs 1 row. Add LIMIT 1 to surviving (non-unnested) EXISTS
@@ -663,7 +710,7 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
 
 fn optimize_delete_plan(plan: &mut DeletePlan, schema: &Schema) -> Result<()> {
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause);
+    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
 
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
@@ -702,7 +749,7 @@ fn optimize_update_plan(
 ) -> Result<()> {
     let schema = resolver.schema();
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause);
+    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?

--- a/testing/runner/turso-tests/fts.sqltest
+++ b/testing/runner/turso-tests/fts.sqltest
@@ -873,3 +873,90 @@ expect {
     leave me|2
     change me|99
 }
+
+# -------------------------------------------------------------------
+# MATCH operator error tests - MATCH on non-FTS tables should error
+# -------------------------------------------------------------------
+
+@backend cli
+test match-operator-non-fts-table-select-error {
+    CREATE TABLE t (a TEXT, b TEXT, c TEXT);
+    INSERT INTO t VALUES ('hello', 'world', 'test');
+    SELECT * FROM t WHERE a MATCH 'hello';
+}
+expect error {
+    Parse error: unable to use function MATCH in the requested context
+}
+
+@backend cli
+test match-operator-non-fts-table-delete-error {
+    CREATE TABLE t (a TEXT, b TEXT);
+    INSERT INTO t VALUES ('hello', 'world');
+    DELETE FROM t WHERE a MATCH 'hello';
+}
+expect error {
+    Parse error: unable to use function MATCH in the requested context
+}
+
+@backend cli
+test match-operator-non-fts-table-update-error {
+    CREATE TABLE t (a TEXT, b TEXT);
+    INSERT INTO t VALUES ('hello', 'world');
+    UPDATE t SET b = 'updated' WHERE a MATCH 'hello';
+}
+expect error {
+    Parse error: unable to use function MATCH in the requested context
+}
+
+@backend cli
+test match-operator-with-fts-index-works {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT);
+    CREATE INDEX t_idx ON t USING fts (x);
+    INSERT INTO t VALUES (1, 'hello world');
+    INSERT INTO t VALUES (2, 'goodbye world');
+    SELECT id, x FROM t WHERE x MATCH 'hello';
+}
+expect {
+    1|hello world
+}
+
+@backend cli
+test not-match-operator-non-fts-table-error {
+    CREATE TABLE t (a TEXT, b TEXT);
+    INSERT INTO t VALUES ('hello', 'world');
+    SELECT * FROM t WHERE a NOT MATCH 'hello';
+}
+expect error {
+    Parse error: unable to use function MATCH in the requested context
+}
+
+@backend cli
+test match-operator-multi-table-join-wrong-table-error {
+    -- documents has FTS, users does not
+    CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE documents (id INTEGER PRIMARY KEY, content TEXT);
+    CREATE INDEX docs_fts ON documents USING fts (content);
+    INSERT INTO users VALUES (1, 'alice');
+    INSERT INTO documents VALUES (1, 'hello world');
+    -- MATCH on users.name should error even though documents has FTS
+    SELECT * FROM users, documents WHERE users.name MATCH 'alice';
+}
+expect error {
+    Parse error: unable to use function MATCH in the requested context
+}
+
+@backend cli
+test match-operator-multi-table-join-correct-table-works {
+    -- documents has FTS, users does not
+    CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE documents (id INTEGER PRIMARY KEY, content TEXT);
+    CREATE INDEX docs_fts ON documents USING fts (content);
+    INSERT INTO users VALUES (1, 'alice');
+    INSERT INTO documents VALUES (1, 'hello world');
+    -- MATCH on documents.content should work
+    SELECT users.name, documents.content FROM users, documents WHERE documents.content MATCH 'hello';
+}
+expect {
+    alice|hello world
+}
+


### PR DESCRIPTION

## Description

Using the MATCH operator on a regular (non-FTS) table silently returns an empty result set instead of raising an error, which is inconsistent with SQLite's behavior.

### Solution
Added validation in the optimizer to check if any table in the query has an FTS index when MATCH is used. If not, return the error: "unable to use function MATCH in the requested context".

#### Multi-Table MATCH Problem
Before the fix: The code checked if any table in the query had an FTS index. This was wrong for multi-table joins.

Example:

If documents had an FTS index but users did not, the old code would allow this query (because some table has FTS), but it should error because the MATCH is on users.name, not a documents column.

The fix: Extract the `TableInternalId` from the column in the MATCH expression `lhs` look up that specific table, and check if that table has an FTS index.


## Motivation and context
https://github.com/tursodatabase/turso/issues/5902
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

Using AI to understand the relationship between FTS indices and btree tables
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
