### PR TITLE
Natural joins fallback to cross join if no common columns

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1783,7 +1783,7 @@ fn parse_join(
             }
         }
         if distinct_names.is_empty() {
-            crate::bail_parse_error!("No columns found to NATURAL join on");
+            None // No common columns = cross join
         } else {
             Some(ast::JoinConstraint::Using(distinct_names))
         }

--- a/testing/runner/tests/join/natural_join_no_common.sqltest
+++ b/testing/runner/tests/join/natural_join_no_common.sqltest
@@ -1,0 +1,39 @@
+@database :memory:
+
+# NATURAL JOIN with no common columns should produce a cross join
+# Per SQLite docs: "A NATURAL join automatically uses all common column names for the join condition"
+# When there are no common columns, this degenerates to a cross join
+test natural-join-no-common-columns {
+    create table t1 (a int, b int);
+    create table t2 (c int, d int);
+    insert into t1 values (1, 2), (3, 4);
+    insert into t2 values (5, 6), (7, 8);
+    select * from t1 natural join t2;
+}
+expect {
+    1|2|5|6
+    1|2|7|8
+    3|4|5|6
+    3|4|7|8
+}
+
+# NATURAL JOIN with no common columns and empty tables
+test natural-join-no-common-columns-empty {
+    create table t3 (x int);
+    create table t4 (y int);
+    select * from t3 natural join t4;
+}
+expect {
+}
+
+# NATURAL JOIN with no common columns - single row each
+test natural-join-no-common-columns-single {
+    create table t5 (p text);
+    create table t6 (q text);
+    insert into t5 values ('hello');
+    insert into t6 values ('world');
+    select * from t5 natural join t6;
+}
+expect {
+    hello|world
+}


### PR DESCRIPTION


## Description

NATURAL JOIN with no common columns now produces a cross join instead of an error

When a NATURAL JOIN is performed between two tables that share no common column names, the behavior has been changed from throwing an error to producing a cross join (Cartesian product).

### Why returning None produces a cross join
In the join parsing logic, the `constraint` variable determines what join condition to apply. When processing an ON clause, equality predicates are added to filter the join. When processing a USING clause, equality predicates are built for the named columns.

When `constraint` is `None`, the entire constraint-handling block is skipped and no predicates are added to the WHERE clause. A join with no filtering condition is by definition a cross join as it produces every combination of rows from both tables. 

Changes
Modified the natural join handling to return no constraint instead of an error when no common columns are found
Added three new tests covering the cross join behavior: a standard case with multiple rows, an empty table case, and a single-row case


## Motivation and context
https://github.com/tursodatabase/turso/issues/5900

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

Created the required tests via AI and to examine any other missing use cases.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
