### PR TITLE
Case sensitive table, schema and view creation

### DIFF
--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -70,8 +70,8 @@ pub fn translate_create_index(
 
     let original_idx_name = idx_name;
     let database_id = resolver.resolve_database_id(&original_idx_name)?;
-    let idx_name = normalize_ident(original_idx_name.name.as_str());
-    let tbl_name = normalize_ident(tbl_name.as_str());
+    let idx_name = original_idx_name.name.as_str().to_string();
+    let tbl_name = tbl_name.as_str().to_string();
 
     if tbl_name.eq_ignore_ascii_case("sqlite_sequence") {
         crate::bail_parse_error!("table sqlite_sequence may not be indexed");

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -850,7 +850,7 @@ pub fn translate_create_table(
         let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
         program.begin_write_on_database(database_id, schema_cookie);
     }
-    let normalized_tbl_name = normalize_ident(tbl_name.name.as_str());
+    let normalized_tbl_name = tbl_name.name.as_str().to_string();
     if temporary {
         bail_parse_error!("TEMPORARY table not supported yet");
     }

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -267,7 +267,7 @@ pub fn translate_create_view(
         let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
         program.begin_write_on_database(database_id, schema_cookie);
     }
-    let normalized_view_name = normalize_ident(view_name.name.as_str());
+    let normalized_view_name = view_name.name.as_str().to_string();
 
     // Check for name conflicts with existing schema objects
     if let Some(object_type) =

--- a/testing/runner/tests/column_name_case.sqltest
+++ b/testing/runner/tests/column_name_case.sqltest
@@ -127,3 +127,35 @@ test quoted_identifiers {
 expect {
     MixedCase
 }
+
+# Table and view names should preserve their original case in sqlite_schema
+
+@cross-check-integrity
+test table_name_case_in_sqlite_schema {
+    CREATE TABLE tTt(aAa);
+    SELECT name, tbl_name FROM sqlite_schema WHERE type = 'table';
+}
+expect {
+    tTt|tTt
+}
+
+@cross-check-integrity
+test view_name_case_in_sqlite_schema {
+    CREATE TABLE t(x);
+    CREATE VIEW vVv AS SELECT * FROM t;
+    SELECT name, tbl_name FROM sqlite_schema WHERE type = 'view';
+}
+expect {
+    vVv|vVv
+}
+
+@cross-check-integrity
+test mixed_case_table_and_index_names {
+    CREATE TABLE MyTable(Col1 INT);
+    CREATE INDEX MyIndex ON MyTable(Col1);
+    SELECT type, name, tbl_name FROM sqlite_schema ORDER BY type, name;
+}
+expect {
+    index|MyIndex|MyTable
+    table|MyTable|MyTable
+}


### PR DESCRIPTION
## Description

Table, view, and index names are being incorrectly lowercased when stored in sqlite_schema. When a user creates CREATE TABLE tTt(aAa), the `name` and `tbl_name` columns in sqlite_schema show `ttt` instead of preserving the original case `tTt`. This differs from SQLite's behavior, which preserves the original case of identifiers.

Root Cause
The `normalize_ident` function converts identifiers to lowercase for case-insensitive lookups. However, this normalized (lowercased) name is also being used when writing entries to sqlite_schema, rather than preserving the original name for storage.
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

https://github.com/tursodatabase/turso/issues/5781
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage
Use AI to generate tests.
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
