### PR TITLE
core/mvcc: fix MAX() on non-rowid PK after delete

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -845,10 +845,11 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                     self.dual_peek.mvcc_peek = CursorPeek::Exhausted;
                 }
             },
-            MvccCursorType::Index(_) => match self
-                .db
-                .get_last_index_rowid(self.table_id, &mut self.index_iterator)
-            {
+            MvccCursorType::Index(_) => match self.db.get_last_index_rowid(
+                self.table_id,
+                &mut self.index_iterator,
+                self.tx_id,
+            ) {
                 Some(k) => {
                     self.dual_peek.mvcc_peek = CursorPeek::Row(k);
                 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4058,7 +4058,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         &self,
         index_id: MVTableId,
         index_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
+        tx_id: TxID,
     ) -> Option<RowKey> {
+        let tx = self.txs.get(&tx_id).expect("transaction should exist");
+        let tx = tx.value();
         let index = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
         let index = index.value();
         let iter_box = Box::new(index.iter().rev());
@@ -4066,8 +4069,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let iter = index_iterator
             .as_mut()
             .expect("index_iterator was assigned above");
-        iter.next()
-            .map(|entry| RowKey::Record((**entry.key()).clone()))
+        loop {
+            let entry = iter.next()?;
+            if let Some(visible_row) = self.find_last_visible_index_version(tx, entry) {
+                return Some(visible_row.row_id);
+            }
+        }
     }
 
     pub fn get_logical_log_file(&self) -> Arc<dyn File> {

--- a/testing/runner/tests/mvcc-max-bug.sqltest
+++ b/testing/runner/tests/mvcc-max-bug.sqltest
@@ -1,0 +1,60 @@
+@database :temp:
+@skip-file-if sqlite "MVCC is not supported in SQLite"
+
+# Regression test: MAX() on non-rowid PK after delete should return the next max value, not NULL.
+
+test mvcc-max-after-delete {
+    CREATE TABLE t(id INT PRIMARY KEY, v INT);
+    PRAGMA journal_mode='MVCC';
+    INSERT INTO t VALUES (1, 10);
+    INSERT INTO t VALUES (2, 20);
+    INSERT INTO t VALUES (3, 30);
+    DELETE FROM t WHERE id = 3;
+    SELECT MAX(id) FROM t;
+}
+expect {
+    mvcc
+    2
+}
+
+test mvcc-min-after-delete {
+    CREATE TABLE t(id INT PRIMARY KEY, v INT);
+    PRAGMA journal_mode='MVCC';
+    INSERT INTO t VALUES (1, 10);
+    INSERT INTO t VALUES (2, 20);
+    INSERT INTO t VALUES (3, 30);
+    DELETE FROM t WHERE id = 1;
+    SELECT MIN(id) FROM t;
+}
+expect {
+    mvcc
+    2
+}
+
+test mvcc-count-after-delete {
+    CREATE TABLE t(id INT PRIMARY KEY, v INT);
+    PRAGMA journal_mode='MVCC';
+    INSERT INTO t VALUES (1, 10);
+    INSERT INTO t VALUES (2, 20);
+    INSERT INTO t VALUES (3, 30);
+    DELETE FROM t WHERE id = 3;
+    SELECT COUNT(*) FROM t;
+}
+expect {
+    mvcc
+    2
+}
+
+test mvcc-max-all-deleted {
+    CREATE TABLE t(id INT PRIMARY KEY, v INT);
+    PRAGMA journal_mode='MVCC';
+    INSERT INTO t VALUES (1, 10);
+    INSERT INTO t VALUES (2, 20);
+    DELETE FROM t WHERE id = 1;
+    DELETE FROM t WHERE id = 2;
+    SELECT MAX(id) FROM t;
+}
+expect {
+    mvcc
+
+}


### PR DESCRIPTION
## Description

Fixes a bug in the MVCC where MAX() would incorrectly return NULL when operating on a non-rowid-alias INT PRIMARY KEY column if the row containing the maximum value had been deleted.

`get_last_index_rowid` now make sure to get the last visible index before returning.

## Motivation and context

Closes #5938


## Description of AI Usage

Used to generate tests