### PR TITLE
add mvcc repl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ limbo/
 | Deterministic tests | `testing/simulator/` | Fault injection, differential testing |
 | New SQL tests | `testing/runner/tests/` | `.sqltest` format preferred |
 | Quick sqlite3 diff | `scripts/diff.sh` | Compare sqlite3 vs tursodb output for a query |
+| MVCC testing REPL | `cli/mvcc_repl.rs` | Multi-conn concurrent txn testing REPL        |
 
 ## Guides
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,6 +71,7 @@ experimental_win_iocp = ["turso_core/experimental_win_iocp"]
 tracing_release = ["turso_core/tracing_release"]
 mimalloc = ["dep:mimalloc"]
 fts = ["turso_core/fts"]
+mvcc_repl = []
 
 [build-dependencies]
 syntect = { git = "https://github.com/trishume/syntect.git", rev = "64644ffe064457265cbcee12a0c1baf9485ba6ee", default-features = false, features = ["default-fancy"] }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -90,6 +90,9 @@ pub struct Opts {
     pub experimental_autovacuum: bool,
     #[clap(long, help = "Enable experimental attach feature")]
     pub experimental_attach: bool,
+    #[cfg(feature = "mvcc_repl")]
+    #[clap(long, help = "Start MVCC concurrent transaction harness")]
+    pub mvcc: bool,
     #[clap(
         long,
         help = "Enable unsafe testing features (e.g. sqlite_dbpage writes)"

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -10,6 +10,9 @@ mod opcodes_dictionary;
 mod read_state_machine;
 mod sync_server;
 
+#[cfg(feature = "mvcc_repl")]
+mod mvcc_repl;
+
 use config::CONFIG_DIR;
 use mcp_server::TursoMcpServer;
 use rustyline::{error::ReadlineError, Config, Editor};
@@ -54,6 +57,21 @@ fn run_sync_server(app: app::Limbo) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
+    #[cfg(feature = "mvcc_repl")]
+    {
+        use clap::Parser as _;
+        let opts = app::Opts::parse();
+        if opts.mvcc {
+            let path = opts
+                .database
+                .as_ref()
+                .and_then(|p| p.to_str())
+                .unwrap_or(":memory:")
+                .to_owned();
+            return mvcc_repl::run(&path);
+        }
+    }
+
     let (mut app, _guard) = app::Limbo::new()?;
 
     if app.is_mcp_mode() {

--- a/cli/mvcc_repl.rs
+++ b/cli/mvcc_repl.rs
@@ -1,0 +1,162 @@
+//! MVCC Concurrent Transaction REPL
+//!
+//! Utility for interactive testing of concurrent MVCC transactions.
+//!
+//! # Overview
+//!
+//! This provides an interactive REPL where you can drive multiple in-process database
+//! connections and test concurrent transaction behavior, conflict detection, and isolation
+//! semantics. Connections are created lazily, when they are first used.
+//!
+//! # Invocation
+//!
+//! ```bash
+//! cargo run --bin tursodb --features mvcc_repl -- --mvcc [path]
+//! ```
+//!
+//! # Usage Examples
+//!
+//! Once started, you'll see a prompt where you can run SQL on specific connections:
+//!
+//! ```text
+//! mvcc> conn1 CREATE TABLE t(x INT)
+//! [conn1] OK
+//!
+//! mvcc> conn1 BEGIN CONCURRENT
+//! [conn1] OK
+//!
+//! mvcc> conn2 BEGIN CONCURRENT
+//! [conn2] OK
+//!
+//! mvcc> conn1 INSERT INTO t VALUES (42)
+//! [conn1] OK
+//!
+//! mvcc> conn2 INSERT INTO t VALUES (42)
+//! [conn2] ERROR: write-write conflict (transaction rolled back)
+//! ```
+use anyhow::Context as _;
+use rustyline::DefaultEditor;
+use std::{collections::HashMap, sync::Arc};
+use turso_core::{Connection, Database, DatabaseOpts, LimboError, OpenFlags, Value};
+
+pub fn run(path: &str) -> anyhow::Result<()> {
+    let interactive_stdin = std::io::IsTerminal::is_terminal(&std::io::stdin());
+    if interactive_stdin {
+        println!("MVCC REPL");
+        println!("Type `connN SQL` to run SQL on connection N (e.g. `conn1 BEGIN CONCURRENT;`)");
+        println!("Connections are auto-created on first use");
+        println!();
+    }
+
+    let db = open_mvcc_db(path)?;
+    let mut connections: HashMap<String, Arc<Connection>> = HashMap::new();
+    let mut rl = DefaultEditor::new()?;
+
+    loop {
+        match rl.readline("mvcc> ") {
+            Ok(line) => {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                if line == ".quit" {
+                    break;
+                }
+
+                if let Some((conn_name, sql)) = parse_conn_input(line) {
+                    let conn = connections
+                        .entry(conn_name.clone())
+                        .or_insert_with(|| db.connect().expect("failed to create connection"));
+
+                    match execute_and_display(conn, sql, &conn_name) {
+                        Ok(()) => {}
+                        Err(e) => {
+                            eprintln!("[{conn_name}] ERROR: {e}");
+                        }
+                    }
+                } else {
+                    eprintln!("Error: format is `connN SQL` (e.g. `conn1 SELECT * FROM t`)");
+                }
+            }
+            Err(rustyline::error::ReadlineError::Eof) => break,
+            Err(rustyline::error::ReadlineError::Interrupted) => {
+                println!();
+                continue;
+            }
+            Err(e) => anyhow::bail!(e),
+        }
+    }
+
+    Ok(())
+}
+
+fn open_mvcc_db(path: &str) -> anyhow::Result<Arc<Database>> {
+    let (_, db) = Database::open_new::<&str>(
+        path,
+        None,
+        OpenFlags::default(),
+        DatabaseOpts::default(),
+        None,
+    )
+    .context("failed to open database")?;
+
+    let boot = db.connect()?;
+    boot.execute("PRAGMA journal_mode = 'mvcc'")?;
+    boot.close()?;
+
+    Ok(db)
+}
+
+fn parse_conn_input(line: &str) -> Option<(String, &str)> {
+    let (first, rest) = line.split_once(char::is_whitespace)?;
+
+    if !first.starts_with("conn") {
+        return None;
+    }
+
+    let num_part = &first[4..];
+    num_part.parse::<u32>().ok()?;
+
+    Some((first.to_string(), rest.trim()))
+}
+
+fn execute_and_display(conn: &Arc<Connection>, sql: &str, conn_name: &str) -> anyhow::Result<()> {
+    let mut stmt = conn.prepare(sql).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    match stmt.run_collect_rows() {
+        Ok(rows) => {
+            if rows.is_empty() {
+                println!("[{conn_name}] OK");
+            } else {
+                for row in rows {
+                    let formatted: Vec<String> = row.iter().map(fmt_value).collect();
+                    println!("[{conn_name}] {}", formatted.join(" | "));
+                }
+            }
+            Ok(())
+        }
+        Err(LimboError::WriteWriteConflict) => Err(anyhow::anyhow!(
+            "write-write conflict (transaction rolled back)"
+        )),
+        Err(e) => Err(anyhow::anyhow!("{e}")),
+    }
+}
+
+fn fmt_value(v: &Value) -> String {
+    use turso_core::Numeric;
+    match v {
+        Value::Null => "NULL".to_string(),
+        Value::Numeric(Numeric::Integer(i)) => i.to_string(),
+        Value::Numeric(Numeric::Float(f)) => {
+            let fval: f64 = (*f).into();
+            // Format floats without trailing zeros for cleaner display
+            if fval.fract() == 0.0 && fval.abs() < 1e10 {
+                format!("{fval:.1}")
+            } else {
+                format!("{fval}")
+            }
+        }
+        Value::Text(s) => s.to_string(),
+        Value::Blob(b) => format!("<blob {} bytes>", b.len()),
+    }
+}


### PR DESCRIPTION
## Description

This adds a MVCC REPL mode to the CLI. It's very minimalistic, but it's enough to test things manually. It has already allowed me to find 7 MVCC bugs in the last 2 days by giving the CLI to Claude Code and letting it do its thing.

<img width="639" height="606" alt="image" src="https://github.com/user-attachments/assets/9e91eafa-b6fd-4cc5-95fd-7ad51cbf13b4" />

It also works well in non-interactive mode:

<img width="976" height="579" alt="image" src="https://github.com/user-attachments/assets/f8c95a3e-585e-4c64-a9ba-17c5337bd1d2" />

## Description of AI Usage

Claude wrote, I revised (mostly deleting comments).