### PR TITLE
core/pager: open ephemeral tables lazily on first actual write

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -128,6 +128,114 @@ pub trait File: Send + Sync {
     }
 }
 
+/// A file that defers actual filesystem creation until the first write.
+/// Used for ephemeral tables so that small tables (e.g. IN lists) never
+/// touch the filesystem — all pages stay in the page cache.
+/// When dropped, the temp directory (and file inside it) is automatically removed.
+#[cfg(not(target_family = "wasm"))]
+pub(crate) struct LazyFile {
+    io: Arc<dyn IO>,
+    inner: crate::sync::Mutex<Option<OpenedLazyFile>>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+struct OpenedLazyFile {
+    /// Dropping this removes the temp directory and the file inside it.
+    _temp_dir: tempfile::TempDir,
+    file: Arc<dyn File>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl LazyFile {
+    pub fn new(io: Arc<dyn IO>) -> Self {
+        Self {
+            io,
+            inner: crate::sync::Mutex::new(None),
+        }
+    }
+
+    fn ensure_open(&self) -> Result<Arc<dyn File>> {
+        let mut inner = self.inner.lock();
+        if let Some(ref opened) = *inner {
+            return Ok(opened.file.clone());
+        }
+        let temp_dir =
+            tempfile::tempdir().map_err(|e| crate::error::io_error(e, "ephemeral tempdir"))?;
+        let path = temp_dir.as_ref().join("tursodb_ephemeral");
+        let path_str = path.to_str().ok_or_else(|| {
+            crate::LimboError::InternalError(
+                "Failed to convert ephemeral path to string".to_string(),
+            )
+        })?;
+        let file = self.io.open_file(path_str, OpenFlags::Create, false)?;
+        *inner = Some(OpenedLazyFile {
+            _temp_dir: temp_dir,
+            file: file.clone(),
+        });
+        Ok(file)
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl File for LazyFile {
+    fn lock_file(&self, _exclusive: bool) -> Result<()> {
+        Ok(())
+    }
+
+    fn unlock_file(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
+        let inner = self.inner.lock();
+        if let Some(ref opened) = *inner {
+            return opened.file.pread(pos, c);
+        }
+        drop(inner);
+        // No file yet — complete with 0 bytes read (no data on disk)
+        c.complete(0);
+        Ok(c)
+    }
+
+    fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
+        let file = self.ensure_open()?;
+        file.pwrite(pos, buffer, c)
+    }
+
+    fn pwritev(&self, pos: u64, buffers: Vec<Arc<Buffer>>, c: Completion) -> Result<Completion> {
+        let file = self.ensure_open()?;
+        file.pwritev(pos, buffers, c)
+    }
+
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> Result<Completion> {
+        let inner = self.inner.lock();
+        if let Some(ref opened) = *inner {
+            return opened.file.sync(c, sync_type);
+        }
+        drop(inner);
+        c.complete(0);
+        Ok(c)
+    }
+
+    fn size(&self) -> Result<u64> {
+        let inner = self.inner.lock();
+        if let Some(ref opened) = *inner {
+            return opened.file.size();
+        }
+        Ok(0)
+    }
+
+    fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+        let inner = self.inner.lock();
+        if let Some(ref opened) = *inner {
+            return opened.file.truncate(len, c);
+        }
+        drop(inner);
+        c.complete(0);
+        Ok(c)
+    }
+}
+
 pub struct TempFile {
     /// When temp_dir is dropped the folder is deleted
     /// set to None if tempfile allocated in memory (for example, in case of WASM target)

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1341,6 +1341,9 @@ pub struct Pager {
     /// Only stored on Apple platforms; on others, always returns Fsync.
     #[cfg(target_vendor = "apple")]
     sync_type: AtomicFileSyncType,
+    /// True for ephemeral pagers. Skips disk I/O in allocate_page1() so that
+    /// small ephemeral tables never touch the filesystem.
+    temp_file: AtomicBool,
 }
 
 assert_send_sync!(Pager);
@@ -1509,6 +1512,7 @@ impl Pager {
             init_page_1,
             #[cfg(target_vendor = "apple")]
             sync_type: AtomicFileSyncType::new(FileSyncType::Fsync),
+            temp_file: AtomicBool::new(false),
         })
     }
 
@@ -1538,6 +1542,10 @@ impl Pager {
     #[cfg(not(target_vendor = "apple"))]
     pub fn set_sync_type(&self, _value: FileSyncType) {
         // No-op: FullFsync only has effect on Apple platforms
+    }
+
+    pub fn set_temp_file(&self, value: bool) {
+        self.temp_file.store(value, Ordering::SeqCst);
     }
 
     pub fn init_page_1(&self) -> Arc<ArcSwapOption<Page>> {
@@ -4376,6 +4384,27 @@ impl Pager {
                     (default_header.page_size.get() - default_header.reserved_space as u32)
                         as usize,
                 );
+
+                if self.temp_file.load(Ordering::SeqCst) {
+                    // Ephemeral pager: skip disk write, insert page 1 directly
+                    // into cache as dirty. The LazyFile will create the actual
+                    // file only if the cache spills to disk later.
+                    let page_key = PageCacheKey::new(page1.get().id);
+                    self.page_cache
+                        .write()
+                        .insert(page_key, page1.clone())
+                        .map_err(|e| {
+                            LimboError::InternalError(format!(
+                                "Failed to insert page 1 into cache: {e:?}"
+                            ))
+                        })?;
+                    page1.set_dirty();
+                    self.dirty_pages.write().insert(1);
+                    self.init_page_1.store(None);
+                    *self.allocate_page1_state.write() = AllocatePage1State::Done;
+                    return Ok(IOResult::Done(page1));
+                }
+
                 let c = begin_write_btree_page(self, &page1)?;
 
                 // Pin page1 to prevent eviction while stored in state machine

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -69,7 +69,6 @@ use branches::{mark_unlikely, unlikely};
 use either::Either;
 use smallvec::SmallVec;
 use std::any::Any;
-use std::env::temp_dir;
 use std::str::FromStr;
 use std::{
     borrow::BorrowMut,
@@ -10816,9 +10815,10 @@ pub fn op_open_ephemeral(
             ));
             let conn = program.connection.clone();
             let io = conn.pager.load().io.clone();
-            let rand_num = io.generate_random_number();
             let db_file: Arc<dyn DatabaseStorage>;
             let db_file_io: Arc<dyn crate::IO>;
+            #[allow(unused_mut, unused_assignments)]
+            let mut is_temp_file = false;
 
             // we support OPFS in WASM - but it require files to be pre-opened in the browser before use
             // we can fix this if we will make open_file interface async
@@ -10841,17 +10841,14 @@ pub fn op_open_ephemeral(
                     let file = db_file_io.open_file("temp-file", OpenFlags::Create, false)?;
                     db_file = Arc::new(DatabaseFile::new(file));
                 } else {
-                    let temp_dir = temp_dir();
-                    let rand_path = std::path::Path::new(&temp_dir)
-                        .join(format!("tursodb-ephemeral-{rand_num}"));
-                    let Some(rand_path_str) = rand_path.to_str() else {
-                        return Err(LimboError::InternalError(
-                            "Failed to convert path to string".to_string(),
-                        ));
-                    };
-                    let file = io.open_file(rand_path_str, OpenFlags::Create, false)?;
-                    db_file = Arc::new(DatabaseFile::new(file));
+                    // Use LazyFile so that small ephemeral tables (IN lists, etc.)
+                    // never touch the filesystem. The file is only created on first
+                    // cache spill.
+                    use crate::io::LazyFile;
+                    let lazy_file: Arc<dyn crate::io::File> = Arc::new(LazyFile::new(io.clone()));
+                    db_file = Arc::new(DatabaseFile::new(lazy_file));
                     db_file_io = io;
+                    is_temp_file = true;
                 }
             }
 
@@ -10872,6 +10869,9 @@ pub fn op_open_ephemeral(
             )?);
 
             pager.set_page_size(page_size);
+            if is_temp_file {
+                pager.set_temp_file(true);
+            }
 
             state.op_open_ephemeral_state = OpOpenEphemeralState::StartingTxn { pager };
         }

--- a/testing/simulator/runner/memory/statement_abandon.rs
+++ b/testing/simulator/runner/memory/statement_abandon.rs
@@ -80,9 +80,17 @@ fn query_rows(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<Vec<(i64, Stri
 #[test]
 fn sim_abandon_during_dml_rolls_back() -> Result<()> {
     let (conn, io) = make_conn(1)?;
-    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v BLOB)")?;
+    // Minimum page cache is 200 pages; large blobs exceed that, forcing
+    // cache spills which produce async IO.
+    conn.execute("PRAGMA cache_size=2")?;
 
-    let mut stmt = conn.prepare("INSERT INTO t VALUES (1, 'a'), (2, 'b') RETURNING id")?;
+    let values = (1..=250)
+        .map(|id| format!("({id}, zeroblob(4000))"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!("INSERT INTO t VALUES {values} RETURNING id");
+    let mut stmt = conn.prepare(&sql)?;
     let first = stmt.step()?;
     assert!(
         matches!(first, StepResult::IO),
@@ -100,10 +108,16 @@ fn sim_abandon_during_dml_rolls_back() -> Result<()> {
 #[test]
 fn sim_abandon_after_first_returning_row_commits() -> Result<()> {
     let (conn, io) = make_conn(2)?;
-    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v BLOB)")?;
+    conn.execute("PRAGMA cache_size=2")?;
 
-    let mut stmt =
-        conn.prepare("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c') RETURNING id")?;
+    let n_rows: i64 = 250;
+    let values = (1..=n_rows)
+        .map(|id| format!("({id}, zeroblob(4000))"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!("INSERT INTO t VALUES {values} RETURNING id");
+    let mut stmt = conn.prepare(&sql)?;
     let mut saw_io = false;
     loop {
         match stmt.step()? {
@@ -124,7 +138,7 @@ fn sim_abandon_after_first_returning_row_commits() -> Result<()> {
     // Abandon after scan-back has started; DML is already complete.
     drop(stmt);
 
-    assert_eq!(query_count(&conn, io.as_ref())?, 3);
+    assert_eq!(query_count(&conn, io.as_ref())?, n_rows);
     Ok(())
 }
 


### PR DESCRIPTION
it's quite a big overhead to always open files for every ephemeral table, especially since they rarely spill to disk anyway