### PR TITLE
perf/core/vdbe: add #[inline(always)] to hot VDBE micro-operation hel…

### DIFF
--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -47,6 +47,7 @@ pub enum Numeric {
 }
 
 impl Numeric {
+    #[inline(always)]
     pub fn from_value<T: AsValueRef>(value: T) -> Option<Self> {
         let value = value.as_value_ref();
 
@@ -183,6 +184,7 @@ impl From<Numeric> for Value {
 }
 
 impl From<Option<Numeric>> for Value {
+    #[inline(always)]
     fn from(value: Option<Numeric>) -> Self {
         value.map_or_else(|| Value::Null, Value::from)
     }

--- a/core/numeric/nonnan.rs
+++ b/core/numeric/nonnan.rs
@@ -4,6 +4,7 @@
 pub struct NonNan(f64);
 
 impl NonNan {
+    #[inline(always)]
     pub fn new(value: f64) -> Option<Self> {
         if value.is_nan() {
             return None;
@@ -38,12 +39,14 @@ impl PartialOrd<NonNan> for f64 {
 }
 
 impl From<i64> for NonNan {
+    #[inline(always)]
     fn from(value: i64) -> Self {
         NonNan(value as f64)
     }
 }
 
 impl From<NonNan> for f64 {
+    #[inline(always)]
     fn from(value: NonNan) -> Self {
         value.0
     }
@@ -52,6 +55,7 @@ impl From<NonNan> for f64 {
 impl std::ops::Deref for NonNan {
     type Target = f64;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -60,6 +64,7 @@ impl std::ops::Deref for NonNan {
 impl std::ops::Add for NonNan {
     type Output = Option<NonNan>;
 
+    #[inline(always)]
     fn add(self, rhs: Self) -> Self::Output {
         Self::new(self.0 + rhs.0)
     }
@@ -68,6 +73,7 @@ impl std::ops::Add for NonNan {
 impl std::ops::Sub for NonNan {
     type Output = Option<NonNan>;
 
+    #[inline(always)]
     fn sub(self, rhs: Self) -> Self::Output {
         Self::new(self.0 - rhs.0)
     }
@@ -76,6 +82,7 @@ impl std::ops::Sub for NonNan {
 impl std::ops::Mul for NonNan {
     type Output = Option<NonNan>;
 
+    #[inline(always)]
     fn mul(self, rhs: Self) -> Self::Output {
         Self::new(self.0 * rhs.0)
     }
@@ -84,6 +91,7 @@ impl std::ops::Mul for NonNan {
 impl std::ops::Div for NonNan {
     type Output = Option<NonNan>;
 
+    #[inline(always)]
     fn div(self, rhs: Self) -> Self::Output {
         Self::new(self.0 / rhs.0)
     }
@@ -92,6 +100,7 @@ impl std::ops::Div for NonNan {
 impl std::ops::Rem for NonNan {
     type Output = Option<NonNan>;
 
+    #[inline(always)]
     fn rem(self, rhs: Self) -> Self::Output {
         Self::new(self.0 % rhs.0)
     }
@@ -106,6 +115,7 @@ impl std::fmt::Display for NonNan {
 impl std::ops::Neg for NonNan {
     type Output = Self;
 
+    #[inline(always)]
     fn neg(self) -> Self::Output {
         Self(-self.0)
     }

--- a/core/types.rs
+++ b/core/types.rs
@@ -1918,6 +1918,7 @@ where
     Ok(std::cmp::Ordering::Equal)
 }
 
+#[inline(always)]
 pub fn compare_immutable_single<V1, V2>(l: V1, r: V2, collation: CollationSeq) -> std::cmp::Ordering
 where
     V1: AsValueRef,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -292,6 +292,7 @@ fn make_sort_comparator(func_name: &str) -> Option<crate::vdbe::sorter::SortComp
 
 /// Compare two values using the specified collation for text values.
 /// Non-text values are compared using their natural ordering.
+#[inline(always)]
 fn compare_with_collation(
     lhs: &Value,
     rhs: &Value,
@@ -12702,6 +12703,7 @@ fn advance_unmatched_scan(
     }
 }
 
+#[inline]
 fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
     if let Register::Value(value) = target {
         if matches!(value, Value::Blob(_)) {
@@ -12817,6 +12819,7 @@ fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
     true
 }
 
+#[inline]
 fn try_float_to_integer_affinity(value: &mut Value, fl: f64) -> bool {
     // Check if the float can be exactly represented as an integer
     if let Ok(int_val) = cast_real_to_integer(fl) {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -314,6 +314,7 @@ impl Register {
 
     // Set the value of the register to NULL,
     // reusing the existing Register::Value(Value::Null) if possible.
+    #[inline(always)]
     pub fn set_null(&mut self) {
         match self {
             Register::Value(Value::Null) => {}
@@ -327,6 +328,7 @@ impl Register {
     }
 
     /// Set the register to a generic Value, attempting to reuse backing allocation if compatible.
+    #[inline(always)]
     pub fn set_value(&mut self, val: Value) {
         match self {
             Register::Value(v) => {
@@ -946,6 +948,7 @@ pub enum EndStatement {
 }
 
 impl Register {
+    #[inline(always)]
     pub fn get_value(&self) -> &Value {
         match self {
             Register::Value(v) => v,

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -123,6 +123,7 @@ pub(super) enum ComparisonOp {
 }
 
 impl ComparisonOp {
+    #[inline(always)]
     pub(super) fn compare<V1: AsValueRef, V2: AsValueRef>(
         &self,
         lhs: V1,
@@ -140,6 +141,7 @@ impl ComparisonOp {
         }
     }
 
+    #[inline(always)]
     pub(super) fn compare_nulls<V1: AsValueRef, V2: AsValueRef>(
         &self,
         lhs: V1,
@@ -715,6 +717,7 @@ impl Value {
     }
 
     // exec_if returns whether you should jump
+    #[inline(always)]
     pub fn exec_if(&self, jump_if_null: bool, not: bool) -> bool {
         Numeric::from_value(self)
             .map(|v| v.to_bool())
@@ -931,30 +934,37 @@ impl Value {
         Value::from_f64(result)
     }
 
+    #[inline(always)]
     pub fn exec_add(&self, rhs: &Value) -> Value {
         (|| Numeric::from_value(self)?.checked_add(Numeric::from_value(rhs)?))().into()
     }
 
+    #[inline(always)]
     pub fn exec_subtract(&self, rhs: &Value) -> Value {
         (|| Numeric::from_value(self)?.checked_sub(Numeric::from_value(rhs)?))().into()
     }
 
+    #[inline(always)]
     pub fn exec_multiply(&self, rhs: &Value) -> Value {
         (|| Numeric::from_value(self)?.checked_mul(Numeric::from_value(rhs)?))().into()
     }
 
+    #[inline(always)]
     pub fn exec_divide(&self, rhs: &Value) -> Value {
         (|| Numeric::from_value(self)?.checked_div(Numeric::from_value(rhs)?))().into()
     }
 
+    #[inline(always)]
     pub fn exec_bit_and(&self, rhs: &Value) -> Value {
         (NullableInteger::from(self) & NullableInteger::from(rhs)).into()
     }
 
+    #[inline(always)]
     pub fn exec_bit_or(&self, rhs: &Value) -> Value {
         (NullableInteger::from(self) | NullableInteger::from(rhs)).into()
     }
 
+    #[inline(always)]
     pub fn exec_remainder(&self, rhs: &Value) -> Value {
         let convert_to_float = matches!(Numeric::from_value(self), Some(Numeric::Float(_)))
             || matches!(Numeric::from_value(rhs), Some(Numeric::Float(_)));
@@ -971,18 +981,22 @@ impl Value {
         }
     }
 
+    #[inline(always)]
     pub fn exec_bit_not(&self) -> Value {
         (!NullableInteger::from(self)).into()
     }
 
+    #[inline(always)]
     pub fn exec_shift_left(&self, rhs: &Value) -> Value {
         (NullableInteger::from(self) << NullableInteger::from(rhs)).into()
     }
 
+    #[inline(always)]
     pub fn exec_shift_right(&self, rhs: &Value) -> Value {
         (NullableInteger::from(self) >> NullableInteger::from(rhs)).into()
     }
 
+    #[inline(always)]
     pub fn exec_boolean_not(&self) -> Value {
         match Numeric::from_value(self).map(|v| v.to_bool()) {
             None => Value::Null,
@@ -990,6 +1004,7 @@ impl Value {
         }
     }
 
+    #[inline(always)]
     pub fn exec_concat(&self, rhs: &Value) -> Value {
         if let (Value::Blob(lhs), Value::Blob(rhs)) = (self, rhs) {
             return Value::Blob([lhs.as_slice(), rhs.as_slice()].concat().to_vec());
@@ -1006,6 +1021,7 @@ impl Value {
         Value::build_text(lhs + &rhs)
     }
 
+    #[inline(always)]
     pub fn exec_and(&self, rhs: &Value) -> Value {
         match (
             Numeric::from_value(self).map(|v| v.to_bool()),
@@ -1017,6 +1033,7 @@ impl Value {
         }
     }
 
+    #[inline(always)]
     pub fn exec_or(&self, rhs: &Value) -> Value {
         match (
             Numeric::from_value(self).map(|v| v.to_bool()),


### PR DESCRIPTION
…pers

Handler functions called through the instruction vtable (fn pointers) cannot be inlined by the compiler. Add #[inline(always)] to the small helpers they call so the optimizer can fold them into tight instruction bodies. Annotated functions:

- Value arithmetic: exec_add/subtract/multiply/divide/bit_*/shift_*/concat/and/or/boolean_not/exec_if
- Register accessors: get_value, set_value, set_null
- Comparison: ComparisonOp::compare/compare_nulls, compare_immutable_single, compare_with_collation
- Numeric: Numeric::from_value, From<Option<Numeric>>, NonNan ops/conversions
- Affinity: apply_affinity_char (#[inline]), try_float_to_integer_affinity (#[inline])

TPC-H benchmarks show 2-8% improvement on computation-heavy queries (Q5 -7.6%, Q7 -6.1%, Q14 -8.5%). I/O-dominated queries unaffected.

# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
