### PR TITLE
optimizer: rewrite LIKE 'prefix%' to range constraints to make it seekable

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -69,6 +69,7 @@ pub(crate) mod join;
 pub(crate) mod lift_common_subexpressions;
 pub(crate) mod multi_index;
 pub(crate) mod order;
+mod rewrite_rules;
 pub(crate) mod unnest;
 
 /// A candidate index method that could be used for table access in a join query.
@@ -592,6 +593,7 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
         }
     }
     optimize_subqueries(plan, schema)?;
+    rewrite_rules::rewrite_like_prefix_to_range(&mut plan.where_clause, &plan.table_references);
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?
@@ -665,6 +667,7 @@ fn optimize_delete_plan(plan: &mut DeletePlan, schema: &Schema) -> Result<()> {
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
     transform_match_to_fts_match(&mut plan.where_clause);
 
+    rewrite_rules::rewrite_like_prefix_to_range(&mut plan.where_clause, &plan.table_references);
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?
@@ -703,6 +706,7 @@ fn optimize_update_plan(
     let schema = resolver.schema();
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
     transform_match_to_fts_match(&mut plan.where_clause);
+    rewrite_rules::rewrite_like_prefix_to_range(&mut plan.where_clause, &plan.table_references);
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?

--- a/core/translate/optimizer/rewrite_rules/like_prefix.rs
+++ b/core/translate/optimizer/rewrite_rules/like_prefix.rs
@@ -1,0 +1,396 @@
+use crate::translate::collate::CollationSeq;
+use crate::translate::plan::{TableReferences, WhereTerm};
+use crate::vdbe::affinity::Affinity;
+use turso_parser::ast;
+
+/// Rewrite `col LIKE 'prefix%'` patterns to add range constraints that enable
+/// index seeks.
+///
+/// For each WHERE term of the form `col LIKE '<prefix>...'` where `<prefix>`
+/// is the literal characters before the first wildcard (`%` or `_`), this pass
+/// adds two new WHERE terms:
+///
+///   col >= UPPER(prefix)   AND   col < increment(LOWER(prefix))
+///
+/// Since LIKE is case-insensitive for ASCII, the range must cover all case
+/// variants. In BINARY collation uppercase sorts before lowercase, so
+/// UPPER(prefix) is the lowest match and increment(LOWER(prefix)) is one
+/// past the highest. This range is intentionally wider than the LIKE — the
+/// original LIKE term is kept as a residual filter for exact correctness.
+///
+/// Restrictions (we bail out and leave the LIKE untouched when any apply):
+/// - NOT LIKE
+/// - GLOB / MATCH / REGEXP
+/// - ESCAPE clause present
+/// - Pattern is not a string literal
+/// - Prefix is empty (pattern starts with `%` or `_`)
+/// - Prefix contains non-ASCII bytes
+/// - Prefix contains escaped single quotes (`''`)
+/// - Column does not have TEXT affinity (non-text values use native type
+///   ordering which differs from the text ordering assumed by the range bounds)
+pub fn rewrite_like_prefix_to_range(
+    where_clause: &mut Vec<WhereTerm>,
+    table_references: &TableReferences,
+) {
+    let original_len = where_clause.len();
+    for i in 0..original_len {
+        if where_clause[i].consumed {
+            continue;
+        }
+        let Some((col_expr, prefix, suffix_is_just_percent)) =
+            extract_like_prefix(&where_clause[i].expr)
+        else {
+            continue;
+        };
+
+        if !column_has_text_affinity(col_expr, table_references) {
+            continue;
+        }
+
+        // Note: this is the *table column* collation. The index may use a
+        // different collation (e.g. CREATE INDEX idx ON t(col COLLATE NOCASE)).
+        // This is safe because the constraint system (constraints.rs) rejects
+        // index seeks when the index collation disagrees with the table column,
+        // so the range terms will only be evaluated under matching collation.
+        let collation = column_collation(col_expr, table_references);
+        let col_owned = col_expr.clone();
+        let (ge_bound, lt_bound) = compute_quoted_bounds(prefix);
+        let from_outer_join = where_clause[i].from_outer_join;
+
+        // When the range bounds are provably exact (no false positives),
+        // mark the original LIKE as consumed to eliminate the residual filter.
+        // This is safe when the suffix is exactly '%' AND:
+        //
+        // NOCASE: The upper bound's last byte must not be an ASCII uppercase
+        //   letter. Only the last byte matters because only it is incremented;
+        //   earlier bytes are just lowercased, which cannot overflow.
+        //   If the incremented byte is uppercase (e.g. '@'+1 = 'A'), NOCASE
+        //   folds it to lowercase ('a' = 97), making the range much wider
+        //   than intended and capturing false positives like '[' (91).
+        //   For letter prefixes this is fine: 'c'+1 = 'd' (lowercase, no folding).
+        //
+        // BINARY: The prefix must have no ASCII letters, so
+        //   UPPER(prefix) == LOWER(prefix) and the bounds collapse to a
+        //   single exact range.
+        //
+        // RTRIM: Never consume. RTRIM trims trailing spaces before comparison,
+        //   so `col >= ' '` under RTRIM matches `''` (empty), widening the
+        //   range beyond what LIKE matches.
+        //
+        // prefix is guaranteed non-empty by extract_like_prefix
+        let incremented_last = prefix.as_bytes().last().unwrap().to_ascii_lowercase() + 1;
+        let can_consume = suffix_is_just_percent
+            && match collation {
+                CollationSeq::NoCase => !incremented_last.is_ascii_uppercase(),
+                CollationSeq::Rtrim => false,
+                _ => prefix.bytes().all(|b| !b.is_ascii_alphabetic()),
+            };
+        if can_consume {
+            where_clause[i].consumed = true;
+        }
+
+        // col >= UPPER(prefix)
+        where_clause.push(WhereTerm {
+            expr: ast::Expr::Binary(
+                Box::new(col_owned.clone()),
+                ast::Operator::GreaterEquals,
+                Box::new(ast::Expr::Literal(ast::Literal::String(ge_bound))),
+            ),
+            from_outer_join,
+            consumed: false,
+        });
+
+        // col < increment(LOWER(prefix))
+        where_clause.push(WhereTerm {
+            expr: ast::Expr::Binary(
+                Box::new(col_owned),
+                ast::Operator::Less,
+                Box::new(ast::Expr::Literal(ast::Literal::String(lt_bound))),
+            ),
+            from_outer_join,
+            consumed: false,
+        });
+    }
+}
+
+/// If `expr` is `col LIKE '<literal>'` (no ESCAPE, not NOT, LIKE operator only),
+/// extract the column expression, the literal prefix up to the first wildcard,
+/// and whether the suffix after the prefix is exactly `%` (meaning the range
+/// bounds are tight and no residual filter is needed).
+/// Returns None if any precondition fails.
+fn extract_like_prefix(expr: &ast::Expr) -> Option<(&ast::Expr, &str, bool)> {
+    let ast::Expr::Like {
+        lhs,
+        not,
+        op,
+        rhs,
+        escape,
+    } = expr
+    else {
+        return None;
+    };
+
+    if *not || *op != ast::LikeOperator::Like || escape.is_some() {
+        return None;
+    }
+
+    let ast::Expr::Literal(ast::Literal::String(pattern)) = rhs.as_ref() else {
+        return None;
+    };
+
+    let (prefix, suffix) = extract_prefix_from_quoted(pattern)?;
+    if prefix.is_empty() || !prefix.is_ascii() {
+        return None;
+    }
+
+    let suffix_is_just_percent = suffix == "%";
+    Some((lhs.as_ref(), prefix, suffix_is_just_percent))
+}
+
+/// Given a SQL quoted string like `'abc%'`, extract the literal prefix
+/// (before the first wildcard) and the suffix (everything after the prefix,
+/// still within the quotes) as `&str` slices of the original string.
+/// Returns None if the string is malformed or the prefix region contains
+/// escaped quotes (`''`), avoiding allocation in the common case.
+fn extract_prefix_from_quoted(s: &str) -> Option<(&str, &str)> {
+    let inner = s.strip_prefix('\'')?.strip_suffix('\'')?;
+    let end = inner
+        .bytes()
+        .position(|b| b == b'%' || b == b'_' || b == b'\'')
+        .unwrap_or(inner.len());
+    // If we stopped at a quote, the prefix contains an escaped quote —
+    // bail out rather than allocate for this rare case.
+    if end < inner.len() && inner.as_bytes()[end] == b'\'' {
+        return None;
+    }
+    Some((&inner[..end], &inner[end..]))
+}
+
+/// Returns true if `expr` is a Column with TEXT affinity.
+/// Non-TEXT columns can store integer/real values whose native type ordering
+/// differs from text ordering, making the range bounds unsound.
+fn column_has_text_affinity(expr: &ast::Expr, table_references: &TableReferences) -> bool {
+    let ast::Expr::Column { table, column, .. } = expr else {
+        return false;
+    };
+    let Some((_, table_ref)) = table_references.find_table_by_internal_id(*table) else {
+        return false;
+    };
+    let Some(col) = table_ref.get_column_at(*column) else {
+        return false;
+    };
+    col.affinity() == Affinity::Text
+}
+
+/// Returns the collation sequence for a Column expression.
+/// Defaults to Binary when the column has no explicit collation or when
+/// the expression is not a Column.
+fn column_collation(expr: &ast::Expr, table_references: &TableReferences) -> CollationSeq {
+    let ast::Expr::Column { table, column, .. } = expr else {
+        return CollationSeq::Binary;
+    };
+    let Some((_, table_ref)) = table_references.find_table_by_internal_id(*table) else {
+        return CollationSeq::Binary;
+    };
+    let Some(col) = table_ref.get_column_at(*column) else {
+        return CollationSeq::Binary;
+    };
+    col.collation()
+}
+
+/// Build the quoted `>=` and `<` bound strings from the prefix.
+///
+/// Returns `(ge_bound, lt_bound)` where:
+/// - `ge_bound` = `'UPPER(prefix)'`  (the `>=` bound)
+/// - `lt_bound` = `'increment(LOWER(prefix))'`  (the `<` bound)
+///
+/// Since the prefix is guaranteed ASCII, increment simply adds 1 to the last
+/// byte's lowercase form (no carry possible for ASCII bytes < 0x80).
+fn compute_quoted_bounds(prefix: &str) -> (String, String) {
+    let bytes = prefix.as_bytes();
+    let len = bytes.len();
+
+    let mut ge = String::with_capacity(len + 2);
+    ge.push('\'');
+    for &b in bytes {
+        ge.push(b.to_ascii_uppercase() as char);
+    }
+    ge.push('\'');
+
+    let mut lt = String::with_capacity(len + 2);
+    lt.push('\'');
+    for &b in &bytes[..len - 1] {
+        lt.push(b.to_ascii_lowercase() as char);
+    }
+    lt.push((bytes[len - 1].to_ascii_lowercase() + 1) as char);
+    lt.push('\'');
+
+    (ge, lt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_prefix_from_quoted() {
+        assert_eq!(extract_prefix_from_quoted("'abc%'"), Some(("abc", "%")));
+        assert_eq!(
+            extract_prefix_from_quoted("'abc_def'"),
+            Some(("abc", "_def"))
+        );
+        assert_eq!(extract_prefix_from_quoted("'%abc'"), Some(("", "%abc")));
+        assert_eq!(extract_prefix_from_quoted("'_abc'"), Some(("", "_abc")));
+        assert_eq!(extract_prefix_from_quoted("'abc'"), Some(("abc", "")));
+        assert_eq!(extract_prefix_from_quoted("''"), Some(("", "")));
+        assert_eq!(extract_prefix_from_quoted("'a%b%c'"), Some(("a", "%b%c")));
+        assert_eq!(
+            extract_prefix_from_quoted("'hello world%'"),
+            Some(("hello world", "%"))
+        );
+        // Escaped quote in prefix region — returns None
+        assert_eq!(extract_prefix_from_quoted("'it''s%'"), None);
+        // Malformed
+        assert_eq!(extract_prefix_from_quoted("abc"), None);
+        assert_eq!(extract_prefix_from_quoted("'abc"), None);
+        assert_eq!(extract_prefix_from_quoted("abc'"), None);
+    }
+
+    #[test]
+    fn test_compute_quoted_bounds() {
+        assert_eq!(
+            compute_quoted_bounds("abc"),
+            ("'ABC'".to_string(), "'abd'".to_string())
+        );
+        assert_eq!(
+            compute_quoted_bounds("AbC"),
+            ("'ABC'".to_string(), "'abd'".to_string())
+        );
+        assert_eq!(
+            compute_quoted_bounds("a"),
+            ("'A'".to_string(), "'b'".to_string())
+        );
+        assert_eq!(
+            compute_quoted_bounds("123"),
+            ("'123'".to_string(), "'124'".to_string())
+        );
+        assert_eq!(
+            compute_quoted_bounds("az"),
+            ("'AZ'".to_string(), "'a{'".to_string())
+        );
+        assert_eq!(
+            compute_quoted_bounds("abc123"),
+            ("'ABC123'".to_string(), "'abc124'".to_string())
+        );
+        assert_eq!(
+            compute_quoted_bounds("z"),
+            ("'Z'".to_string(), "'{'".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_like_prefix_valid() {
+        let col = ast::Expr::Column {
+            database: None,
+            table: 0.into(),
+            column: 0,
+            is_rowid_alias: false,
+        };
+        let expr = ast::Expr::Like {
+            lhs: Box::new(col),
+            not: false,
+            op: ast::LikeOperator::Like,
+            rhs: Box::new(ast::Expr::Literal(ast::Literal::String(
+                "'abc%'".to_string(),
+            ))),
+            escape: None,
+        };
+        let result = extract_like_prefix(&expr);
+        assert!(result.is_some());
+        let (_, prefix, suffix_is_just_percent) = result.unwrap();
+        assert_eq!(prefix, "abc");
+        assert!(suffix_is_just_percent);
+    }
+
+    #[test]
+    fn test_extract_like_prefix_not_like() {
+        let col = ast::Expr::Column {
+            database: None,
+            table: 0.into(),
+            column: 0,
+            is_rowid_alias: false,
+        };
+        let expr = ast::Expr::Like {
+            lhs: Box::new(col),
+            not: true,
+            op: ast::LikeOperator::Like,
+            rhs: Box::new(ast::Expr::Literal(ast::Literal::String(
+                "'abc%'".to_string(),
+            ))),
+            escape: None,
+        };
+        assert!(extract_like_prefix(&expr).is_none());
+    }
+
+    #[test]
+    fn test_extract_like_prefix_with_escape() {
+        let col = ast::Expr::Column {
+            database: None,
+            table: 0.into(),
+            column: 0,
+            is_rowid_alias: false,
+        };
+        let expr = ast::Expr::Like {
+            lhs: Box::new(col),
+            not: false,
+            op: ast::LikeOperator::Like,
+            rhs: Box::new(ast::Expr::Literal(ast::Literal::String(
+                "'abc%'".to_string(),
+            ))),
+            escape: Some(Box::new(ast::Expr::Literal(ast::Literal::String(
+                "'\\''".to_string(),
+            )))),
+        };
+        assert!(extract_like_prefix(&expr).is_none());
+    }
+
+    #[test]
+    fn test_extract_like_prefix_glob() {
+        let col = ast::Expr::Column {
+            database: None,
+            table: 0.into(),
+            column: 0,
+            is_rowid_alias: false,
+        };
+        let expr = ast::Expr::Like {
+            lhs: Box::new(col),
+            not: false,
+            op: ast::LikeOperator::Glob,
+            rhs: Box::new(ast::Expr::Literal(ast::Literal::String(
+                "'abc*'".to_string(),
+            ))),
+            escape: None,
+        };
+        assert!(extract_like_prefix(&expr).is_none());
+    }
+
+    #[test]
+    fn test_extract_like_prefix_leading_wildcard() {
+        let col = ast::Expr::Column {
+            database: None,
+            table: 0.into(),
+            column: 0,
+            is_rowid_alias: false,
+        };
+        let expr = ast::Expr::Like {
+            lhs: Box::new(col),
+            not: false,
+            op: ast::LikeOperator::Like,
+            rhs: Box::new(ast::Expr::Literal(ast::Literal::String(
+                "'%abc'".to_string(),
+            ))),
+            escape: None,
+        };
+        assert!(extract_like_prefix(&expr).is_none());
+    }
+}

--- a/core/translate/optimizer/rewrite_rules/mod.rs
+++ b/core/translate/optimizer/rewrite_rules/mod.rs
@@ -1,0 +1,3 @@
+mod like_prefix;
+
+pub use like_prefix::rewrite_like_prefix_to_range;

--- a/testing/runner/tests/like_prefix_optimization.sqltest
+++ b/testing/runner/tests/like_prefix_optimization.sqltest
@@ -385,12 +385,14 @@ expect {
 # positives, the LIKE filter must remain as a residual.
 
 # NOCASE column + prefix%: LIKE consumed (no Function/like in bytecode)
+@skip-if mvcc "bytecode snapshot has OpenRead with rootpage that differs in MVCC"
 @setup like_prefix_nocase_schema
 snapshot like-prefix-nocase-consumed {
     SELECT * FROM t_nocase WHERE name LIKE 'abc%';
 }
 
 # BINARY column + letters + prefix%: LIKE NOT consumed (Function/like present)
+@skip-if mvcc "bytecode snapshot has OpenRead with rootpage that differs in MVCC"
 @setup like_prefix_schema
 snapshot like-prefix-binary-letters-residual {
     SELECT * FROM t WHERE name LIKE 'abc%';
@@ -405,12 +407,14 @@ setup like_prefix_digits_schema {
     INSERT INTO t_digits VALUES (3, '13000');
 }
 
+@skip-if mvcc "bytecode snapshot has OpenRead with rootpage that differs in MVCC"
 @setup like_prefix_digits_schema
 snapshot like-prefix-digits-consumed {
     SELECT * FROM t_digits WHERE code LIKE '12%';
 }
 
 # Underscore in suffix: LIKE NOT consumed even on NOCASE
+@skip-if mvcc "bytecode snapshot has OpenRead with rootpage that differs in MVCC"
 @setup like_prefix_nocase_schema
 snapshot like-prefix-nocase-underscore-residual {
     SELECT * FROM t_nocase WHERE name LIKE 'abc_%';

--- a/testing/runner/tests/like_prefix_optimization.sqltest
+++ b/testing/runner/tests/like_prefix_optimization.sqltest
@@ -1,0 +1,629 @@
+@database :memory:
+
+setup like_prefix_schema {
+    CREATE TABLE t (
+        id INTEGER PRIMARY KEY,
+        name TEXT
+    );
+    CREATE INDEX idx_name ON t(name);
+
+    INSERT INTO t VALUES (1, 'alice');
+    INSERT INTO t VALUES (2, 'bob');
+    INSERT INTO t VALUES (3, 'abcdef');
+    INSERT INTO t VALUES (4, 'ABCDEF');
+    INSERT INTO t VALUES (5, 'ABCxyz');
+    INSERT INTO t VALUES (6, 'abd');
+    INSERT INTO t VALUES (7, 'abb');
+    INSERT INTO t VALUES (8, 'ABC');
+    INSERT INTO t VALUES (9, 'abc');
+}
+
+setup like_prefix_nocase_schema {
+    CREATE TABLE t_nocase (
+        id INTEGER PRIMARY KEY,
+        name TEXT COLLATE NOCASE
+    );
+    CREATE INDEX idx_name_nocase ON t_nocase(name);
+
+    INSERT INTO t_nocase VALUES (1, 'alice');
+    INSERT INTO t_nocase VALUES (2, 'abcdef');
+    INSERT INTO t_nocase VALUES (3, 'ABCDEF');
+    INSERT INTO t_nocase VALUES (4, 'ABCxyz');
+    INSERT INTO t_nocase VALUES (5, 'abd');
+    INSERT INTO t_nocase VALUES (6, 'abc');
+}
+
+# --- Snapshot tests: verify index is used ---
+
+@setup like_prefix_schema
+snapshot-eqp like-prefix-uses-index {
+    SELECT * FROM t WHERE name LIKE 'abc%';
+}
+
+@setup like_prefix_schema
+snapshot-eqp like-prefix-single-char-uses-index {
+    SELECT * FROM t WHERE name LIKE 'a%';
+}
+
+# NOT LIKE should not use the prefix optimization seek
+@setup like_prefix_schema
+snapshot-eqp not-like-no-index-seek {
+    SELECT * FROM t WHERE name NOT LIKE 'abc%';
+}
+
+# Leading wildcard should not use the prefix optimization seek
+@setup like_prefix_schema
+snapshot-eqp leading-wildcard-no-index-seek {
+    SELECT * FROM t WHERE name LIKE '%abc';
+}
+
+# NOCASE column uses index for LIKE prefix
+@setup like_prefix_nocase_schema
+snapshot-eqp like-prefix-nocase-uses-index {
+    SELECT * FROM t_nocase WHERE name LIKE 'abc%';
+}
+
+# --- Correctness tests ---
+
+@setup like_prefix_schema
+test like-prefix-with-index {
+    SELECT id FROM t WHERE name LIKE 'abc%' ORDER BY id;
+}
+expect {
+    3
+    4
+    5
+    8
+    9
+}
+
+@setup like_prefix_schema
+test like-prefix-single-char {
+    SELECT id FROM t WHERE name LIKE 'a%' ORDER BY id;
+}
+expect {
+    1
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+}
+
+@setup like_prefix_schema
+test like-prefix-exact-match {
+    SELECT id FROM t WHERE name LIKE 'abc' ORDER BY id;
+}
+expect {
+    8
+    9
+}
+
+@setup like_prefix_schema
+test like-prefix-case-insensitive {
+    SELECT id FROM t WHERE name LIKE 'ABC%' ORDER BY id;
+}
+expect {
+    3
+    4
+    5
+    8
+    9
+}
+
+@setup like_prefix_schema
+test like-prefix-no-match {
+    SELECT id FROM t WHERE name LIKE 'xyz%' ORDER BY id;
+}
+expect {
+}
+
+@setup like_prefix_schema
+test like-prefix-with-underscore {
+    SELECT id FROM t WHERE name LIKE 'ab_%' ORDER BY id;
+}
+expect {
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+}
+
+@setup like_prefix_schema
+test like-not-prefix-leading-wildcard {
+    SELECT id FROM t WHERE name LIKE '%def' ORDER BY id;
+}
+expect {
+    3
+    4
+}
+
+@setup like_prefix_schema
+test like-prefix-and-other-conditions {
+    SELECT id FROM t WHERE name LIKE 'abc%' AND id > 4 ORDER BY id;
+}
+expect {
+    5
+    8
+    9
+}
+
+# NOCASE collation correctness
+@setup like_prefix_nocase_schema
+test like-prefix-nocase-correctness {
+    SELECT id FROM t_nocase WHERE name LIKE 'abc%' ORDER BY id;
+}
+expect {
+    2
+    3
+    4
+    6
+}
+
+# Verify digits-only prefix works
+@setup like_prefix_schema
+test like-prefix-digits {
+    CREATE TABLE t_nums (id INTEGER PRIMARY KEY, code TEXT);
+    CREATE INDEX idx_code ON t_nums(code);
+    INSERT INTO t_nums VALUES (1, '12345');
+    INSERT INTO t_nums VALUES (2, '12999');
+    INSERT INTO t_nums VALUES (3, '13000');
+    INSERT INTO t_nums VALUES (4, '11999');
+    SELECT id FROM t_nums WHERE code LIKE '12%' ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+# Verify ESCAPE clause prevents optimization (correctness)
+@setup like_prefix_schema
+test like-with-escape-no-optimization {
+    CREATE TABLE t_esc (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t_esc VALUES (1, 'abc%def');
+    INSERT INTO t_esc VALUES (2, 'abcXdef');
+    INSERT INTO t_esc VALUES (3, 'abcdef');
+    SELECT id FROM t_esc WHERE val LIKE 'abc!%%' ESCAPE '!' ORDER BY id;
+}
+expect {
+    1
+}
+
+# --- Edge case tests ---
+
+# Prefix 'z' — upper bound becomes '{' (0x7B), the char after 'z'.
+# Verify values starting with z/Z are found and 'za...' through 'zz...' all match.
+@setup like_prefix_schema
+test like-prefix-z-boundary {
+    CREATE TABLE t_z (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX idx_z ON t_z(name);
+    INSERT INTO t_z VALUES (1, 'zebra');
+    INSERT INTO t_z VALUES (2, 'ZEBRA');
+    INSERT INTO t_z VALUES (3, 'zoo');
+    INSERT INTO t_z VALUES (4, 'zzz');
+    INSERT INTO t_z VALUES (5, 'yak');
+    INSERT INTO t_z VALUES (6, 'Zap');
+    INSERT INTO t_z VALUES (7, 'z');
+    INSERT INTO t_z VALUES (8, 'Z');
+    SELECT id FROM t_z WHERE name LIKE 'z%' ORDER BY id;
+}
+expect {
+    1
+    2
+    3
+    4
+    6
+    7
+    8
+}
+
+# Prefix 'Z' — same boundary, just different case in pattern
+@setup like_prefix_schema
+test like-prefix-Z-boundary {
+    CREATE TABLE t_z2 (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX idx_z2 ON t_z2(name);
+    INSERT INTO t_z2 VALUES (1, 'zebra');
+    INSERT INTO t_z2 VALUES (2, 'ZEBRA');
+    INSERT INTO t_z2 VALUES (3, 'zzz');
+    INSERT INTO t_z2 VALUES (4, 'ZZZ');
+    INSERT INTO t_z2 VALUES (5, 'yak');
+    SELECT id FROM t_z2 WHERE name LIKE 'Z%' ORDER BY id;
+}
+expect {
+    1
+    2
+    3
+    4
+}
+
+# Values exactly at the range bounds.
+# For prefix 'abc': lower bound = 'ABC', upper bound = 'abd'.
+# 'ABC' should match, 'abd' should NOT match.
+@setup like_prefix_schema
+test like-prefix-exact-bounds {
+    CREATE TABLE t_bounds (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX idx_bounds ON t_bounds(name);
+    INSERT INTO t_bounds VALUES (1, 'ABC');
+    INSERT INTO t_bounds VALUES (2, 'abd');
+    INSERT INTO t_bounds VALUES (3, 'ABD');
+    INSERT INTO t_bounds VALUES (4, 'abc');
+    INSERT INTO t_bounds VALUES (5, 'abczzz');
+    INSERT INTO t_bounds VALUES (6, 'ABCzzz');
+    INSERT INTO t_bounds VALUES (7, 'abb');
+    INSERT INTO t_bounds VALUES (8, 'ABB');
+    SELECT id FROM t_bounds WHERE name LIKE 'abc%' ORDER BY id;
+}
+expect {
+    1
+    4
+    5
+    6
+}
+
+# NULL values must not appear in results
+@setup like_prefix_schema
+test like-prefix-null-values {
+    CREATE TABLE t_null (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX idx_null ON t_null(name);
+    INSERT INTO t_null VALUES (1, NULL);
+    INSERT INTO t_null VALUES (2, 'abc');
+    INSERT INTO t_null VALUES (3, NULL);
+    INSERT INTO t_null VALUES (4, 'abcdef');
+    SELECT id FROM t_null WHERE name LIKE 'abc%' ORDER BY id;
+}
+expect {
+    2
+    4
+}
+
+# Embedded single quote in prefix — optimization is skipped (no allocation
+# for the rare escaped-quote case), but LIKE still produces correct results.
+@setup like_prefix_schema
+test like-prefix-embedded-quote {
+    CREATE TABLE t_quote (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX idx_quote ON t_quote(name);
+    INSERT INTO t_quote VALUES (1, 'it''s fine');
+    INSERT INTO t_quote VALUES (2, 'it''s broken');
+    INSERT INTO t_quote VALUES (3, 'item');
+    INSERT INTO t_quote VALUES (4, 'IT''S FINE');
+    SELECT id FROM t_quote WHERE name LIKE 'it''s%' ORDER BY id;
+}
+expect {
+    1
+    2
+    4
+}
+
+# Multiple LIKE conditions in the same WHERE clause
+@setup like_prefix_schema
+test like-prefix-multiple-likes {
+    CREATE TABLE t_multi (id INTEGER PRIMARY KEY, name TEXT, city TEXT);
+    CREATE INDEX idx_multi_name ON t_multi(name);
+    CREATE INDEX idx_multi_city ON t_multi(city);
+    INSERT INTO t_multi VALUES (1, 'alice', 'amsterdam');
+    INSERT INTO t_multi VALUES (2, 'alice', 'berlin');
+    INSERT INTO t_multi VALUES (3, 'bob', 'amsterdam');
+    INSERT INTO t_multi VALUES (4, 'alice', 'athens');
+    SELECT id FROM t_multi WHERE name LIKE 'ali%' AND city LIKE 'a%' ORDER BY id;
+}
+expect {
+    1
+    4
+}
+
+# Non-indexed column — range terms added but no index seek; must still be correct
+@setup like_prefix_schema
+test like-prefix-no-index {
+    CREATE TABLE t_noidx (id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO t_noidx VALUES (1, 'abc');
+    INSERT INTO t_noidx VALUES (2, 'abcdef');
+    INSERT INTO t_noidx VALUES (3, 'xyz');
+    INSERT INTO t_noidx VALUES (4, 'ABC');
+    SELECT id FROM t_noidx WHERE name LIKE 'abc%' ORDER BY id;
+}
+expect {
+    1
+    2
+    4
+}
+
+# Special ASCII prefix (non-letter, non-digit) — case folding is identity
+@setup like_prefix_schema
+test like-prefix-special-ascii {
+    CREATE TABLE t_special (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX idx_special ON t_special(name);
+    INSERT INTO t_special VALUES (1, '#hashtag');
+    INSERT INTO t_special VALUES (2, '#help');
+    INSERT INTO t_special VALUES (3, '@mention');
+    INSERT INTO t_special VALUES (4, '#100');
+    SELECT id FROM t_special WHERE name LIKE '#h%' ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+# Empty table should return nothing
+@setup like_prefix_schema
+test like-prefix-empty-table {
+    CREATE TABLE t_empty (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX idx_empty ON t_empty(name);
+    SELECT id FROM t_empty WHERE name LIKE 'abc%' ORDER BY id;
+}
+expect {
+}
+
+# Mixed types in column — integers stored in a TEXT column via implicit conversion.
+# LIKE converts values to text, but range comparison uses native type ordering
+# (integers sort before text in SQLite). Verify correctness.
+@setup like_prefix_schema
+test like-prefix-mixed-types {
+    CREATE TABLE t_mixed (id INTEGER PRIMARY KEY, val);
+    CREATE INDEX idx_mixed ON t_mixed(val);
+    INSERT INTO t_mixed VALUES (1, '100abc');
+    INSERT INTO t_mixed VALUES (2, '100xyz');
+    INSERT INTO t_mixed VALUES (3, '200abc');
+    INSERT INTO t_mixed VALUES (4, 100);
+    INSERT INTO t_mixed VALUES (5, '100');
+    SELECT id FROM t_mixed WHERE val LIKE '100%' ORDER BY id;
+}
+expect {
+    1
+    2
+    4
+    5
+}
+
+# --- Residual LIKE consumption tests ---
+# When bounds are provably exact, the LIKE filter should be consumed
+# (no Function/like opcode in bytecode). When bounds may have false
+# positives, the LIKE filter must remain as a residual.
+
+# NOCASE column + prefix%: LIKE consumed (no Function/like in bytecode)
+@setup like_prefix_nocase_schema
+snapshot like-prefix-nocase-consumed {
+    SELECT * FROM t_nocase WHERE name LIKE 'abc%';
+}
+
+# BINARY column + letters + prefix%: LIKE NOT consumed (Function/like present)
+@setup like_prefix_schema
+snapshot like-prefix-binary-letters-residual {
+    SELECT * FROM t WHERE name LIKE 'abc%';
+}
+
+# Digits-only prefix on BINARY column: LIKE consumed (UPPER==LOWER for digits)
+setup like_prefix_digits_schema {
+    CREATE TABLE t_digits (id INTEGER PRIMARY KEY, code TEXT);
+    CREATE INDEX idx_digits ON t_digits(code);
+    INSERT INTO t_digits VALUES (1, '12345');
+    INSERT INTO t_digits VALUES (2, '12999');
+    INSERT INTO t_digits VALUES (3, '13000');
+}
+
+@setup like_prefix_digits_schema
+snapshot like-prefix-digits-consumed {
+    SELECT * FROM t_digits WHERE code LIKE '12%';
+}
+
+# Underscore in suffix: LIKE NOT consumed even on NOCASE
+@setup like_prefix_nocase_schema
+snapshot like-prefix-nocase-underscore-residual {
+    SELECT * FROM t_nocase WHERE name LIKE 'abc_%';
+}
+
+# --- Correctness tests for consumed LIKE ---
+
+# NOCASE consumed correctness — verify results match even without residual
+@setup like_prefix_nocase_schema
+test like-prefix-nocase-consumed-correctness {
+    SELECT id FROM t_nocase WHERE name LIKE 'ABC%' ORDER BY id;
+}
+expect {
+    2
+    3
+    4
+    6
+}
+
+# Digits consumed correctness
+@setup like_prefix_digits_schema
+test like-prefix-digits-consumed-correctness {
+    SELECT id FROM t_digits WHERE code LIKE '12%' ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+# BINARY with letters keeps residual — correctness
+@setup like_prefix_schema
+test like-prefix-binary-with-letters-correctness {
+    SELECT id FROM t WHERE name LIKE 'ABC%' ORDER BY id;
+}
+expect {
+    3
+    4
+    5
+    8
+    9
+}
+
+# Mixed: underscore pattern on NOCASE keeps residual — correctness
+@setup like_prefix_nocase_schema
+test like-prefix-nocase-underscore-correctness {
+    SELECT id FROM t_nocase WHERE name LIKE 'abc_%' ORDER BY id;
+}
+expect {
+    2
+    3
+    4
+}
+
+# Special chars (non-letter, non-digit) prefix on BINARY — consumed
+@setup like_prefix_schema
+test like-prefix-special-chars-consumed {
+    CREATE TABLE t_sp (id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX idx_sp ON t_sp(val);
+    INSERT INTO t_sp VALUES (1, '#hello');
+    INSERT INTO t_sp VALUES (2, '#help');
+    INSERT INTO t_sp VALUES (3, '#world');
+    INSERT INTO t_sp VALUES (4, '@hello');
+    SELECT id FROM t_sp WHERE val LIKE '#he%' ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+# --- Regression tests ---
+
+# Regression: LIKE '@%' on NOCASE must NOT match '[' (ASCII 91).
+# The upper bound increment('@') = 'A', but in NOCASE 'A' folds to 'a' (97),
+# widening the range to include '[' (91) through '`' (96). The residual LIKE
+# must be kept for this case.
+@setup like_prefix_schema
+test like-prefix-nocase-at-sign-regression {
+    CREATE TABLE t_at (id INTEGER PRIMARY KEY, val TEXT COLLATE NOCASE);
+    CREATE INDEX idx_at ON t_at(val);
+    INSERT INTO t_at VALUES (1, '@abc');
+    INSERT INTO t_at VALUES (2, '@def');
+    INSERT INTO t_at VALUES (3, '[');
+    INSERT INTO t_at VALUES (4, '\');
+    INSERT INTO t_at VALUES (5, ']');
+    INSERT INTO t_at VALUES (6, '^');
+    INSERT INTO t_at VALUES (7, '_');
+    INSERT INTO t_at VALUES (8, '`');
+    INSERT INTO t_at VALUES (9, 'Abc');
+    INSERT INTO t_at VALUES (10, 'abc');
+    SELECT id FROM t_at WHERE val LIKE '@%' ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+# RTRIM collation: LIKE prefix must work correctly.
+# RTRIM trims trailing spaces for comparison but LIKE still matches them.
+@setup like_prefix_schema
+test like-prefix-rtrim-collation {
+    CREATE TABLE t_rtrim (id INTEGER PRIMARY KEY, val TEXT COLLATE RTRIM);
+    CREATE INDEX idx_rtrim ON t_rtrim(val);
+    INSERT INTO t_rtrim VALUES (1, 'abc');
+    INSERT INTO t_rtrim VALUES (2, 'abc   ');
+    INSERT INTO t_rtrim VALUES (3, 'abcdef');
+    INSERT INTO t_rtrim VALUES (4, 'ABC');
+    INSERT INTO t_rtrim VALUES (5, 'ABC   ');
+    INSERT INTO t_rtrim VALUES (6, 'abd');
+    INSERT INTO t_rtrim VALUES (7, 'abb');
+    SELECT id FROM t_rtrim WHERE val LIKE 'abc%' ORDER BY id;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+}
+
+# Index collation differs from table column collation (BINARY table + NOCASE index).
+# The LIKE rewrite uses the table column's collation for consumption decisions.
+# The constraint system should reject the mismatched index for seeks, falling
+# back to a scan where the residual LIKE ensures correctness.
+@setup like_prefix_schema
+test like-prefix-collation-mismatch-binary-nocase {
+    CREATE TABLE t_mismatch (id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX idx_mismatch ON t_mismatch(val COLLATE NOCASE);
+    INSERT INTO t_mismatch VALUES (1, 'abc');
+    INSERT INTO t_mismatch VALUES (2, 'ABC');
+    INSERT INTO t_mismatch VALUES (3, 'Abc');
+    INSERT INTO t_mismatch VALUES (4, 'abd');
+    INSERT INTO t_mismatch VALUES (5, 'ABD');
+    INSERT INTO t_mismatch VALUES (6, 'abb');
+    INSERT INTO t_mismatch VALUES (7, '[');
+    INSERT INTO t_mismatch VALUES (8, '@abc');
+    SELECT id FROM t_mismatch WHERE val LIKE 'abc%' ORDER BY id;
+}
+expect {
+    1
+    2
+    3
+}
+
+# Reverse mismatch: NOCASE table + BINARY index.
+@setup like_prefix_schema
+test like-prefix-collation-mismatch-nocase-binary {
+    CREATE TABLE t_mismatch2 (id INTEGER PRIMARY KEY, val TEXT COLLATE NOCASE);
+    CREATE INDEX idx_mismatch2 ON t_mismatch2(val COLLATE BINARY);
+    INSERT INTO t_mismatch2 VALUES (1, 'abc');
+    INSERT INTO t_mismatch2 VALUES (2, 'ABC');
+    INSERT INTO t_mismatch2 VALUES (3, 'Abc');
+    INSERT INTO t_mismatch2 VALUES (4, 'abd');
+    INSERT INTO t_mismatch2 VALUES (5, '@abc');
+    INSERT INTO t_mismatch2 VALUES (6, '[');
+    SELECT id FROM t_mismatch2 WHERE val LIKE 'abc%' ORDER BY id;
+}
+expect {
+    1
+    2
+    3
+}
+
+# Tilde (~, 0x7E) prefix: increment produces DEL (0x7F).
+# DEL is a valid ASCII byte but not printable. The upper bound 0x7F is
+# higher than all printable ASCII, so the range is correct.
+@setup like_prefix_schema
+test like-prefix-tilde-boundary {
+    CREATE TABLE t_tilde (id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX idx_tilde ON t_tilde(val);
+    INSERT INTO t_tilde VALUES (1, '~hello');
+    INSERT INTO t_tilde VALUES (2, '~');
+    INSERT INTO t_tilde VALUES (3, 'abc');
+    INSERT INTO t_tilde VALUES (4, '~world');
+    SELECT id FROM t_tilde WHERE val LIKE '~%' ORDER BY id;
+}
+expect {
+    1
+    2
+    4
+}
+
+# Digits-only prefix on RTRIM column: consumed (no letters, RTRIM is like BINARY for case)
+@setup like_prefix_schema
+test like-prefix-rtrim-digits {
+    CREATE TABLE t_rtrim_d (id INTEGER PRIMARY KEY, code TEXT COLLATE RTRIM);
+    CREATE INDEX idx_rtrim_d ON t_rtrim_d(code);
+    INSERT INTO t_rtrim_d VALUES (1, '12345');
+    INSERT INTO t_rtrim_d VALUES (2, '12   ');
+    INSERT INTO t_rtrim_d VALUES (3, '13000');
+    SELECT id FROM t_rtrim_d WHERE code LIKE '12%' ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+# Regression: LIKE ' %' on RTRIM must NOT match empty strings.
+# Under RTRIM, ' ' (space) compares equal to '' (empty) because trailing
+# spaces are trimmed. So `col >= ' '` under RTRIM includes '', but
+# LIKE ' %' requires the value to actually start with a space.
+@setup like_prefix_schema
+test like-prefix-rtrim-space-regression {
+    CREATE TABLE t_rtrim_sp (id INTEGER PRIMARY KEY, val TEXT COLLATE RTRIM);
+    CREATE INDEX idx_rtrim_sp ON t_rtrim_sp(val);
+    INSERT INTO t_rtrim_sp VALUES (1, '');
+    INSERT INTO t_rtrim_sp VALUES (2, ' hello');
+    INSERT INTO t_rtrim_sp VALUES (3, ' ');
+    INSERT INTO t_rtrim_sp VALUES (4, '  ');
+    INSERT INTO t_rtrim_sp VALUES (5, 'hello');
+    SELECT id FROM t_rtrim_sp WHERE val LIKE ' %' ORDER BY id;
+}
+expect {
+    2
+    3
+    4
+}

--- a/testing/runner/tests/like_prefix_optimization.sqltest
+++ b/testing/runner/tests/like_prefix_optimization.sqltest
@@ -631,3 +631,52 @@ expect {
     3
     4
 }
+
+# Non-ASCII (unicode) prefix: the optimization must be skipped entirely
+# (is_ascii check bails out), but LIKE must still produce correct results.
+@setup like_prefix_schema
+test like-prefix-unicode-no-optimization {
+    CREATE TABLE t_uni (id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX idx_uni ON t_uni(val);
+    INSERT INTO t_uni VALUES (1, 'café');
+    INSERT INTO t_uni VALUES (2, 'caféine');
+    INSERT INTO t_uni VALUES (3, 'cat');
+    INSERT INTO t_uni VALUES (4, '日本語');
+    INSERT INTO t_uni VALUES (5, '日本語テスト');
+    INSERT INTO t_uni VALUES (6, 'über');
+    INSERT INTO t_uni VALUES (7, 'übermut');
+    SELECT id FROM t_uni WHERE val LIKE 'café%' ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+@setup like_prefix_schema
+test like-prefix-unicode-cjk {
+    CREATE TABLE t_cjk (id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX idx_cjk ON t_cjk(val);
+    INSERT INTO t_cjk VALUES (1, '日本語');
+    INSERT INTO t_cjk VALUES (2, '日本語テスト');
+    INSERT INTO t_cjk VALUES (3, '日本');
+    INSERT INTO t_cjk VALUES (4, '中文');
+    SELECT id FROM t_cjk WHERE val LIKE '日本語%' ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+@setup like_prefix_schema
+test like-prefix-unicode-umlaut {
+    CREATE TABLE t_uml (id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX idx_uml ON t_uml(val);
+    INSERT INTO t_uml VALUES (1, 'über');
+    INSERT INTO t_uml VALUES (2, 'übermut');
+    INSERT INTO t_uml VALUES (3, 'uber');
+    SELECT id FROM t_uml WHERE val LIKE 'über%' ORDER BY id;
+}
+expect {
+    1
+    2
+}

--- a/testing/runner/tests/snapshots/like_prefix_optimization__leading-wildcard-no-index-seek.snap
+++ b/testing/runner/tests/snapshots/like_prefix_optimization__leading-wildcard-no-index-seek.snap
@@ -1,0 +1,13 @@
+---
+source: like_prefix_optimization.sqltest
+expression: SELECT * FROM t WHERE name LIKE '%abc';
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - like_prefix_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t

--- a/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-binary-letters-residual.snap
+++ b/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-binary-letters-residual.snap
@@ -1,0 +1,33 @@
+---
+source: like_prefix_optimization.sqltest
+expression: SELECT * FROM t WHERE name LIKE 'abc%';
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - like_prefix_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH t USING INDEX idx_name (name>=? AND name<?)
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4       p5  comment
+   0  Init          0  14   0            0  Start at 14
+   1  OpenRead      0   3   0  k(2,B)    0  index=idx_name, root=3, iDb=0
+   2  String8       0   3   0  ABC       0  r[3]='ABC'
+   3  SeekGE        0  13   3            0  key=[3..3]
+   4  String8       0   3   0  abd       0  r[3]='abd'
+   5    IdxGE       0  13   3            0  key=[3..3]
+   6    Column      0   0   6            0  r[6]=idx_name.name
+   7    Function    1   5   4  like(2)   0  r[4]=func(r[5..6])
+   8    IfNot       4  12   1            0  if !r[4] goto 12
+   9    IdxRowId    0   1   0            0  r[1]=cursor 0 for index idx_name.rowid
+  10    Column      0   0   2            0  r[2]=idx_name.name
+  11    ResultRow   1   2   0            0  output=r[1..2]
+  12  Next          0   5   0            0
+  13  Halt          0   0   0            0
+  14  Transaction   0   1   2            0  iDb=0 tx_mode=Read
+  15  String8       0   5   0  abc%      0  r[5]='abc%'
+  16  Goto          0   1   0            0

--- a/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-digits-consumed.snap
+++ b/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-digits-consumed.snap
@@ -1,0 +1,29 @@
+---
+source: like_prefix_optimization.sqltest
+expression: SELECT * FROM t_digits WHERE code LIKE '12%';
+info:
+  statement_type: SELECT
+  tables:
+  - t_digits
+  setup_blocks:
+  - like_prefix_digits_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH t_digits USING INDEX idx_digits (code>=? AND code<?)
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0  11   0           0  Start at 11
+   1  OpenRead      0   3   0  k(2,B)   0  index=idx_digits, root=3, iDb=0
+   2  String8       0   3   0  12       0  r[3]='12'
+   3  SeekGE        0  10   3           0  key=[3..3]
+   4  String8       0   3   0  13       0  r[3]='13'
+   5    IdxGE       0  10   3           0  key=[3..3]
+   6    IdxRowId    0   1   0           0  r[1]=cursor 0 for index idx_digits.rowid
+   7    Column      0   0   2           0  r[2]=idx_digits.code
+   8    ResultRow   1   2   0           0  output=r[1..2]
+   9  Next          0   5   0           0
+  10  Halt          0   0   0           0
+  11  Transaction   0   1   2           0  iDb=0 tx_mode=Read
+  12  Goto          0   1   0           0

--- a/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-nocase-consumed.snap
+++ b/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-nocase-consumed.snap
@@ -1,0 +1,29 @@
+---
+source: like_prefix_optimization.sqltest
+expression: SELECT * FROM t_nocase WHERE name LIKE 'abc%';
+info:
+  statement_type: SELECT
+  tables:
+  - t_nocase
+  setup_blocks:
+  - like_prefix_nocase_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH t_nocase USING INDEX idx_name_nocase (name>=? AND name<?)
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4           p5  comment
+   0  Init          0  11   0                0  Start at 11
+   1  OpenRead      0   3   0  k(2,NoCase)   0  index=idx_name_nocase, root=3, iDb=0
+   2  String8       0   3   0  ABC           0  r[3]='ABC'
+   3  SeekGE        0  10   3                0  key=[3..3]
+   4  String8       0   3   0  abd           0  r[3]='abd'
+   5    IdxGE       0  10   3                0  key=[3..3]
+   6    IdxRowId    0   1   0                0  r[1]=cursor 0 for index idx_name_nocase.rowid
+   7    Column      0   0   2                0  r[2]=idx_name_nocase.name
+   8    ResultRow   1   2   0                0  output=r[1..2]
+   9  Next          0   5   0                0
+  10  Halt          0   0   0                0
+  11  Transaction   0   1   2                0  iDb=0 tx_mode=Read
+  12  Goto          0   1   0                0

--- a/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-nocase-underscore-residual.snap
+++ b/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-nocase-underscore-residual.snap
@@ -1,0 +1,33 @@
+---
+source: like_prefix_optimization.sqltest
+expression: SELECT * FROM t_nocase WHERE name LIKE 'abc_%';
+info:
+  statement_type: SELECT
+  tables:
+  - t_nocase
+  setup_blocks:
+  - like_prefix_nocase_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH t_nocase USING INDEX idx_name_nocase (name>=? AND name<?)
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4           p5  comment
+   0  Init          0  14   0                0  Start at 14
+   1  OpenRead      0   3   0  k(2,NoCase)   0  index=idx_name_nocase, root=3, iDb=0
+   2  String8       0   3   0  ABC           0  r[3]='ABC'
+   3  SeekGE        0  13   3                0  key=[3..3]
+   4  String8       0   3   0  abd           0  r[3]='abd'
+   5    IdxGE       0  13   3                0  key=[3..3]
+   6    Column      0   0   6                0  r[6]=idx_name_nocase.name
+   7    Function    1   5   4  like(2)       0  r[4]=func(r[5..6])
+   8    IfNot       4  12   1                0  if !r[4] goto 12
+   9    IdxRowId    0   1   0                0  r[1]=cursor 0 for index idx_name_nocase.rowid
+  10    Column      0   0   2                0  r[2]=idx_name_nocase.name
+  11    ResultRow   1   2   0                0  output=r[1..2]
+  12  Next          0   5   0                0
+  13  Halt          0   0   0                0
+  14  Transaction   0   1   2                0  iDb=0 tx_mode=Read
+  15  String8       0   5   0  abc_%         0  r[5]='abc_%'
+  16  Goto          0   1   0                0

--- a/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-nocase-uses-index.snap
+++ b/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-nocase-uses-index.snap
@@ -1,0 +1,13 @@
+---
+source: like_prefix_optimization.sqltest
+expression: SELECT * FROM t_nocase WHERE name LIKE 'abc%';
+info:
+  statement_type: SELECT
+  tables:
+  - t_nocase
+  setup_blocks:
+  - like_prefix_nocase_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH t_nocase USING INDEX idx_name_nocase (name>=? AND name<?)

--- a/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-single-char-uses-index.snap
+++ b/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-single-char-uses-index.snap
@@ -1,0 +1,13 @@
+---
+source: like_prefix_optimization.sqltest
+expression: SELECT * FROM t WHERE name LIKE 'a%';
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - like_prefix_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH t USING INDEX idx_name (name>=? AND name<?)

--- a/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-uses-index.snap
+++ b/testing/runner/tests/snapshots/like_prefix_optimization__like-prefix-uses-index.snap
@@ -1,0 +1,13 @@
+---
+source: like_prefix_optimization.sqltest
+expression: SELECT * FROM t WHERE name LIKE 'abc%';
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - like_prefix_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH t USING INDEX idx_name (name>=? AND name<?)

--- a/testing/runner/tests/snapshots/like_prefix_optimization__not-like-no-index-seek.snap
+++ b/testing/runner/tests/snapshots/like_prefix_optimization__not-like-no-index-seek.snap
@@ -1,0 +1,13 @@
+---
+source: like_prefix_optimization.sqltest
+expression: SELECT * FROM t WHERE name NOT LIKE 'abc%';
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - like_prefix_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t

--- a/tests/fuzz/like_prefix.rs
+++ b/tests/fuzz/like_prefix.rs
@@ -1,0 +1,170 @@
+//! Differential fuzzer for LIKE prefix optimization.
+//!
+//! Tests that the LIKE prefix → range rewrite (including residual consumption)
+//! produces identical results to SQLite across varied collations, prefix
+//! patterns, and data distributions.
+
+#[cfg(test)]
+mod tests {
+    use crate::helpers;
+    use core_tester::common::{limbo_exec_rows, sqlite_exec_rows, TempDatabase};
+    use rand::Rng;
+
+    const COLLATIONS: [&str; 3] = ["BINARY", "NOCASE", "RTRIM"];
+
+    /// ASCII byte pool covering the interesting ranges for LIKE/collation:
+    /// letters (both cases), digits, boundary/special characters, DEL (0x7F),
+    /// and space (relevant for RTRIM).
+    const BYTE_POOL: &[u8] =
+        b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#[{\\]^_`~ \x7F";
+
+    /// Generate a random ASCII string of length 0..=max_len from BYTE_POOL.
+    fn random_string(rng: &mut impl Rng, max_len: usize) -> String {
+        let len = rng.random_range(0..=max_len);
+        (0..len)
+            .map(|_| BYTE_POOL[rng.random_range(0..BYTE_POOL.len())] as char)
+            .collect()
+    }
+
+    /// Generate a random LIKE pattern from a random prefix string plus a
+    /// random wildcard suffix.
+    fn random_like_pattern(rng: &mut impl Rng) -> String {
+        let prefix = random_string(rng, 4);
+        let suffix = match rng.random_range(0..5) {
+            0 => "%".to_string(),
+            1 => "_%".to_string(),
+            2 => format!("{}%", random_string(rng, 2)),
+            3 => String::new(), // exact match, no wildcard
+            _ => format!("%{}", random_string(rng, 2)),
+        };
+        format!("{prefix}{suffix}")
+    }
+
+    #[turso_macros::test(mvcc)]
+    pub fn like_prefix_differential_fuzz(db: TempDatabase) {
+        let (mut rng, seed) = helpers::init_fuzz_test_tracing("like_prefix_differential_fuzz");
+        let builder = helpers::builder_from_db(&db);
+
+        let iters = helpers::fuzz_iterations(200);
+
+        for iter in 0..iters {
+            helpers::log_progress("like_prefix_differential_fuzz", iter, iters, 10);
+
+            let collation = COLLATIONS[rng.random_range(0..COLLATIONS.len())];
+            let has_index = rng.random_bool(0.8);
+
+            let table_ddl =
+                format!("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT COLLATE {collation})");
+            let index_ddl = "CREATE INDEX idx_val ON t(val)";
+
+            let limbo_db = builder.clone().with_init_sql(&table_ddl).build();
+            let limbo_conn = limbo_db.connect_limbo();
+            let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+            sqlite_conn.execute(&table_ddl, ()).unwrap();
+
+            if has_index {
+                limbo_conn.execute(index_ddl).unwrap();
+                sqlite_conn.execute(index_ddl, ()).unwrap();
+            }
+
+            // Insert random data including NULLs
+            let num_rows = rng.random_range(20..=80);
+            for i in 0..num_rows {
+                let insert = if rng.random_bool(0.05) {
+                    format!("INSERT INTO t VALUES ({i}, NULL)")
+                } else {
+                    let val = random_string(&mut rng, 8);
+                    format!("INSERT INTO t VALUES ({i}, '{}')", val.replace('\'', "''"))
+                };
+                sqlite_conn.execute(&insert, ()).unwrap();
+                limbo_conn.execute(&insert).unwrap();
+            }
+
+            // Test random LIKE patterns
+            let num_queries = rng.random_range(3..=8);
+            for _ in 0..num_queries {
+                let pattern = random_like_pattern(&mut rng);
+                let query = format!(
+                    "SELECT id, val FROM t WHERE val LIKE '{}' ORDER BY id",
+                    pattern.replace('\'', "''")
+                );
+
+                let sqlite_rows = sqlite_exec_rows(&sqlite_conn, &query);
+                let limbo_rows = limbo_exec_rows(&limbo_conn, &query);
+
+                similar_asserts::assert_eq!(
+                    Turso: limbo_rows,
+                    Sqlite: sqlite_rows,
+                    "MISMATCH!\nQuery: {query}\nCollation: {collation}\nHas index: {has_index}\nSeed: {seed}\nIteration: {iter}",
+                );
+            }
+        }
+    }
+
+    /// Targeted test for the boundary between consumed and non-consumed LIKE.
+    /// Generates random data and patterns that specifically exercise the
+    /// BINARY collation range where false positives could leak through
+    /// between uppercase and lowercase ASCII ranges.
+    #[turso_macros::test(mvcc)]
+    pub fn like_prefix_binary_boundary_fuzz(db: TempDatabase) {
+        let (mut rng, seed) = helpers::init_fuzz_test_tracing("like_prefix_binary_boundary_fuzz");
+        let builder = helpers::builder_from_db(&db);
+
+        /// Byte pool biased toward boundary characters between uppercase and
+        /// lowercase ASCII ranges: 'Z'=90, '['=91 .. '`'=96, 'a'=97.
+        const BOUNDARY_BYTES: &[u8] = b"abcABCxyzXYZ@Z[\\]^_`{z";
+
+        let iters = helpers::fuzz_iterations(100);
+
+        for iter in 0..iters {
+            helpers::log_progress("like_prefix_binary_boundary_fuzz", iter, iters, 10);
+
+            // Always BINARY collation — this is where false positives can occur
+            let table_ddl = "CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)";
+            let index_ddl = "CREATE INDEX idx_val ON t(val)";
+
+            let limbo_db = builder.clone().with_init_sql(table_ddl).build();
+            let limbo_conn = limbo_db.connect_limbo();
+            limbo_conn.execute(index_ddl).unwrap();
+
+            let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+            sqlite_conn.execute(table_ddl, ()).unwrap();
+            sqlite_conn.execute(index_ddl, ()).unwrap();
+
+            // Insert random boundary-biased data
+            let num_rows = rng.random_range(30..=60);
+            for i in 0..num_rows {
+                let len = rng.random_range(1..=6);
+                let val: String = (0..len)
+                    .map(|_| BOUNDARY_BYTES[rng.random_range(0..BOUNDARY_BYTES.len())] as char)
+                    .collect();
+                let insert = format!("INSERT INTO t VALUES ({i}, '{}')", val.replace('\'', "''"));
+                sqlite_conn.execute(&insert, ()).unwrap();
+                limbo_conn.execute(&insert).unwrap();
+            }
+
+            // Generate random prefix patterns from boundary bytes
+            let num_queries = rng.random_range(4..=10);
+            for _ in 0..num_queries {
+                let prefix_len = rng.random_range(1..=3);
+                let prefix: String = (0..prefix_len)
+                    .map(|_| BOUNDARY_BYTES[rng.random_range(0..BOUNDARY_BYTES.len())] as char)
+                    .collect();
+                let pattern = format!("{}%", prefix);
+                let query = format!(
+                    "SELECT id, val FROM t WHERE val LIKE '{}' ORDER BY id",
+                    pattern.replace('\'', "''")
+                );
+
+                let sqlite_rows = sqlite_exec_rows(&sqlite_conn, &query);
+                let limbo_rows = limbo_exec_rows(&limbo_conn, &query);
+
+                similar_asserts::assert_eq!(
+                    Turso: limbo_rows,
+                    Sqlite: sqlite_rows,
+                    "MISMATCH!\nQuery: {query}\nSeed: {seed}\nIteration: {iter}",
+                );
+            }
+        }
+    }
+}

--- a/tests/fuzz/like_prefix.rs
+++ b/tests/fuzz/like_prefix.rs
@@ -150,7 +150,7 @@ mod tests {
                 let prefix: String = (0..prefix_len)
                     .map(|_| BOUNDARY_BYTES[rng.random_range(0..BOUNDARY_BYTES.len())] as char)
                     .collect();
-                let pattern = format!("{}%", prefix);
+                let pattern = format!("{prefix}%");
                 let query = format!(
                     "SELECT id, val FROM t WHERE val LIKE '{}' ORDER BY id",
                     pattern.replace('\'', "''")

--- a/tests/fuzz/like_prefix.rs
+++ b/tests/fuzz/like_prefix.rs
@@ -18,8 +18,25 @@ mod tests {
     const BYTE_POOL: &[u8] =
         b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#[{\\]^_`~ \x7F";
 
-    /// Generate a random ASCII string of length 0..=max_len from BYTE_POOL.
+    /// Unicode strings mixed in occasionally to ensure the optimization
+    /// correctly bails out for non-ASCII without panicking or corrupting.
+    const UNICODE_POOL: [&str; 8] = [
+        "café",
+        "über",
+        "日本語",
+        "中文",
+        "Ñoño",
+        "résumé",
+        "naïve",
+        "🦀",
+    ];
+
+    /// Generate a random string of length 0..=max_len. Mostly ASCII from
+    /// BYTE_POOL, but ~10% of the time picks a unicode string instead.
     fn random_string(rng: &mut impl Rng, max_len: usize) -> String {
+        if rng.random_bool(0.1) {
+            return UNICODE_POOL[rng.random_range(0..UNICODE_POOL.len())].to_string();
+        }
         let len = rng.random_range(0..=max_len);
         (0..len)
             .map(|_| BYTE_POOL[rng.random_range(0..BYTE_POOL.len())] as char)

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -5,6 +5,7 @@ pub mod grammar_generator;
 pub mod helpers;
 pub mod join;
 pub mod journal_mode;
+pub mod like_prefix;
 pub mod orderby_collation;
 pub mod raise;
 pub mod rowid_alias;


### PR DESCRIPTION
- Rewrite col LIKE 'prefix%' to col >= UPPER(prefix) AND col < increment(LOWER(prefix)) enabling index seeks for LIKE queries. SQLite's `case_sensitive_like` PRAGMA is deprecated and we do not
  support it or plan to support it.
- When the range bounds are provably exact (no false positives), mark the original LIKE as consumed to eliminate the redundant residual filter evaluation on every row. Otherwise, the original LIKE is evaluated as a post-seek filter.

Removing the original LIKE is safe for:
  - NOCASE: prefix% where increment(last char) is not uppercase
  - BINARY: non-letter prefixes only (123%, #he%)

Removing is NOT safe for:
  - BINARY + letter prefixes (case gap between Z and a)
  - RTRIM (space-trimming widens bounds)
  - NOCASE + prefix ending with @ (increment produces A, folds to a)
  - patterns with non-% suffixes (abc_%)
