### PR TITLE
Fix UPDATE not honoring table-level ON CONFLICT ROLLBACK for rowid-alias PKs

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1390,18 +1390,15 @@ fn emit_update_insns<'a>(
 
             // Conflict found - handle based on conflict resolution mode.
             // Use per-constraint ON CONFLICT when no statement-level OR clause.
+            // Use pk_conflict_clause from BTreeTable, which is preserved
+            // even for rowid-alias PKs (whose UniqueSet is removed from unique_sets).
             let pk_conflict = if program.has_statement_conflict {
                 or_conflict
             } else {
                 target_table
                     .table
                     .btree()
-                    .and_then(|bt| {
-                        bt.unique_sets
-                            .iter()
-                            .find(|us| us.is_primary_key)
-                            .and_then(|us| us.conflict_clause)
-                    })
+                    .and_then(|bt| bt.pk_conflict_clause)
                     .unwrap_or(ResolveType::Abort)
             };
             match pk_conflict {
@@ -2105,19 +2102,15 @@ fn emit_update_insns<'a>(
             });
 
             // Handle conflict resolution for rowid/primary key conflict.
-            // Use per-constraint ON CONFLICT when no statement-level OR clause.
+            // Use pk_conflict_clause from BTreeTable, which is preserved
+            // even for rowid-alias PKs (whose UniqueSet is removed from unique_sets).
             let pk_conflict = if program.has_statement_conflict {
                 or_conflict
             } else {
                 target_table
                     .table
                     .btree()
-                    .and_then(|bt| {
-                        bt.unique_sets
-                            .iter()
-                            .find(|us| us.is_primary_key)
-                            .and_then(|us| us.conflict_clause)
-                    })
+                    .and_then(|bt| bt.pk_conflict_clause)
                     .unwrap_or(ResolveType::Abort)
             };
             match pk_conflict {


### PR DESCRIPTION
### Problem
When a table is defined with `INTEGER PRIMARY KEY ON CONFLICT ROLLBACK` (a rowid alias), UPDATE statements that cause a PK violation would not auto-rollback the transaction. Instead, turso treated it as `ON CONFLICT ABORT` (the default), leaving the transaction active when it should have been rolled back.

SQLite correctly rolls back the entire transaction on such a violation, allowing a subsequent `BEGIN` to succeed. Turso rejected the `BEGIN` with `"cannot start a transaction within a transaction"`.

### Root cause

During schema construction, rowid-alias PK `UniqueSet` entries are removed from `BTreeTable::unique_sets` (since they don't need an automatic index). The PK's conflict clause is preserved in `BTreeTable::pk_conflict_clause` for exactly this reason.

The UPDATE emitter was searching `unique_sets` for `is_primary_key` to find the conflict clause, which fails for rowid-alias PKs because the entry was already removed. It then fell back to `ResolveType::Abort`.

