### PR TITLE
fix: raising immediate constraint on UPDATE of parent table with ON CONFLICT REPLACE

### DIFF
--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -577,17 +577,24 @@ fn emit_fk_parent_key_probe(
                 }
             }
 
-            // NEW key referenced by a child (cancel one deferred violation)
-            // Note: for RESTRICT, we already halted on OLD pass if child exists,
-            // so this branch only applies to NO ACTION deferred FKs
-            (true, ParentProbePass::New) => {
-                // Guard to avoid underflow if OLD pass didn't increment.
-                let skip = p.allocate_label();
-                emit_guarded_fk_decrement(p, skip, fk_ref.fk.deferred);
-                p.preassign_label_to_next_insn(skip);
+            // NEW key referenced by a child: cancel one violation from the OLD pass
+            // or from a REPLACE delete that removed the previous row with this key.
+            // For RESTRICT, we already halted on OLD pass if child exists,
+            // so this only applies to NO ACTION FKs.
+            //
+            // We emit the decrement WITHOUT the FkIfZero guard because ON CONFLICT
+            // REPLACE may fire AFTER this point, adding violations that this
+            // decrement must cancel. With a guard the counter would be zero here
+            // and the decrement would be skipped, leaving REPLACE violations
+            // unresolved. Allowing the counter to go temporarily negative is safe:
+            // the REPLACE increment restores it, matching SQLite's behaviour where
+            // the REPLACE fires first and the resolution fires second.
+            (_, ParentProbePass::New) => {
+                p.emit_insn(Insn::FkCounter {
+                    increment_value: -1,
+                    deferred: is_deferred,
+                });
             }
-            // Immediate FK on NEW pass: nothing to cancel; do nothing.
-            (false, ParentProbePass::New) => {}
         }
         Ok(())
     };

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -3808,110 +3808,134 @@ pub fn emit_parent_side_fk_decrement_on_insert(
         }
         let (new_pk_start, n_cols) =
             build_parent_key_image_for_insert(program, parent_table, &pref, insertion)?;
+        emit_fk_child_scan_and_decrement(
+            program,
+            &pref,
+            new_pk_start,
+            n_cols,
+            resolver,
+            database_id,
+        )?;
+    }
+    Ok(())
+}
 
-        let child_tbl = &pref.child_table;
-        let child_cols = &pref.fk.child_columns;
-        let indices: Vec<_> = resolver.with_schema(database_id, |s| {
-            s.get_indices(&child_tbl.name).cloned().collect()
-        });
-        let idx = indices.iter().find(|ix| {
-            ix.columns.len() == child_cols.len()
-                && ix
-                    .columns
-                    .iter()
-                    .zip(child_cols.iter())
-                    .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
-        });
+/// Parent-side: after a row is written to the parent table (via INSERT or
+/// UPDATE REPLACE), scan the child table for rows referencing the NEW parent
+/// key and emit a guarded FkCounter decrement for each match.
+///
+/// Shared logic: scan child table for rows referencing `new_pk_start` and
+/// emit guarded FkCounter decrements.
+fn emit_fk_child_scan_and_decrement(
+    program: &mut ProgramBuilder,
+    pref: &ResolvedFkRef,
+    new_pk_start: usize,
+    n_cols: usize,
+    resolver: &Resolver,
+    database_id: usize,
+) -> crate::Result<()> {
+    let child_tbl = &pref.child_table;
+    let child_cols = &pref.fk.child_columns;
+    let indices: Vec<_> = resolver.with_schema(database_id, |s| {
+        s.get_indices(&child_tbl.name).cloned().collect()
+    });
+    let idx = indices.iter().find(|ix| {
+        ix.columns.len() == child_cols.len()
+            && ix
+                .columns
+                .iter()
+                .zip(child_cols.iter())
+                .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
+    });
 
-        if let Some(ix) = idx {
-            let icur = open_read_index(program, ix, database_id);
-            // Copy key into probe regs and apply child-index affinities
-            let probe_start = program.alloc_registers(n_cols);
-            for i in 0..n_cols {
-                program.emit_insn(Insn::Copy {
-                    src_reg: new_pk_start + i,
-                    dst_reg: probe_start + i,
-                    extra_amount: 0,
-                });
-            }
-            if let Some(count) = NonZeroUsize::new(n_cols) {
-                program.emit_insn(Insn::Affinity {
-                    start_reg: probe_start,
-                    count,
-                    affinities: build_index_affinity_string(ix, child_tbl),
-                });
-            }
-
-            let found = program.allocate_label();
-            program.emit_insn(Insn::Found {
-                cursor_id: icur,
-                target_pc: found,
-                record_reg: probe_start,
-                num_regs: n_cols,
+    if let Some(ix) = idx {
+        let icur = open_read_index(program, ix, database_id);
+        // Copy key into probe regs and apply child-index affinities
+        let probe_start = program.alloc_registers(n_cols);
+        for i in 0..n_cols {
+            program.emit_insn(Insn::Copy {
+                src_reg: new_pk_start + i,
+                dst_reg: probe_start + i,
+                extra_amount: 0,
             });
-
-            // Not found, nothing to decrement
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            let skip = program.allocate_label();
-            program.emit_insn(Insn::Goto { target_pc: skip });
-
-            // Found: guarded counter decrement
-            program.resolve_label(found, program.offset());
-            program.emit_insn(Insn::Close { cursor_id: icur });
-            emit_guarded_fk_decrement(program, skip, pref.fk.deferred);
-            program.resolve_label(skip, program.offset());
-        } else {
-            // fallback scan :(
-            let ccur = open_read_table(program, child_tbl, database_id);
-            let done = program.allocate_label();
-            program.emit_insn(Insn::Rewind {
-                cursor_id: ccur,
-                pc_if_empty: done,
-            });
-            let loop_top = program.allocate_label();
-            let next_row = program.allocate_label();
-            program.resolve_label(loop_top, program.offset());
-
-            for (i, child_name) in child_cols.iter().enumerate() {
-                let (pos, _) = child_tbl.get_column(child_name).ok_or_else(|| {
-                    crate::LimboError::InternalError(format!("child col {child_name} missing"))
-                })?;
-                let tmp = program.alloc_register();
-                program.emit_insn(Insn::Column {
-                    cursor_id: ccur,
-                    column: pos,
-                    dest: tmp,
-                    default: None,
-                });
-
-                program.emit_insn(Insn::IsNull {
-                    reg: tmp,
-                    target_pc: next_row,
-                });
-
-                let cont = program.allocate_label();
-                program.emit_insn(Insn::Eq {
-                    lhs: tmp,
-                    rhs: new_pk_start + i,
-                    target_pc: cont,
-                    flags: CmpInsFlags::default().jump_if_null(),
-                    collation: Some(super::collate::CollationSeq::Binary),
-                });
-                program.emit_insn(Insn::Goto {
-                    target_pc: next_row,
-                });
-                program.resolve_label(cont, program.offset());
-            }
-            // Matched one child row: guarded decrement of counter
-            emit_guarded_fk_decrement(program, next_row, pref.fk.deferred);
-            program.resolve_label(next_row, program.offset());
-            program.emit_insn(Insn::Next {
-                cursor_id: ccur,
-                pc_if_next: loop_top,
-            });
-            program.resolve_label(done, program.offset());
-            program.emit_insn(Insn::Close { cursor_id: ccur });
         }
+        if let Some(count) = NonZeroUsize::new(n_cols) {
+            program.emit_insn(Insn::Affinity {
+                start_reg: probe_start,
+                count,
+                affinities: build_index_affinity_string(ix, child_tbl),
+            });
+        }
+
+        let found = program.allocate_label();
+        program.emit_insn(Insn::Found {
+            cursor_id: icur,
+            target_pc: found,
+            record_reg: probe_start,
+            num_regs: n_cols,
+        });
+
+        // Not found, nothing to decrement
+        program.emit_insn(Insn::Close { cursor_id: icur });
+        let skip = program.allocate_label();
+        program.emit_insn(Insn::Goto { target_pc: skip });
+
+        // Found: guarded counter decrement
+        program.resolve_label(found, program.offset());
+        program.emit_insn(Insn::Close { cursor_id: icur });
+        emit_guarded_fk_decrement(program, skip, pref.fk.deferred);
+        program.resolve_label(skip, program.offset());
+    } else {
+        // fallback scan :(
+        let ccur = open_read_table(program, child_tbl, database_id);
+        let done = program.allocate_label();
+        program.emit_insn(Insn::Rewind {
+            cursor_id: ccur,
+            pc_if_empty: done,
+        });
+        let loop_top = program.allocate_label();
+        let next_row = program.allocate_label();
+        program.resolve_label(loop_top, program.offset());
+
+        for (i, child_name) in child_cols.iter().enumerate() {
+            let (pos, _) = child_tbl.get_column(child_name).ok_or_else(|| {
+                crate::LimboError::InternalError(format!("child col {child_name} missing"))
+            })?;
+            let tmp = program.alloc_register();
+            program.emit_insn(Insn::Column {
+                cursor_id: ccur,
+                column: pos,
+                dest: tmp,
+                default: None,
+            });
+
+            program.emit_insn(Insn::IsNull {
+                reg: tmp,
+                target_pc: next_row,
+            });
+
+            let cont = program.allocate_label();
+            program.emit_insn(Insn::Eq {
+                lhs: tmp,
+                rhs: new_pk_start + i,
+                target_pc: cont,
+                flags: CmpInsFlags::default().jump_if_null(),
+                collation: Some(super::collate::CollationSeq::Binary),
+            });
+            program.emit_insn(Insn::Goto {
+                target_pc: next_row,
+            });
+            program.resolve_label(cont, program.offset());
+        }
+        // Matched one child row: guarded decrement of counter
+        emit_guarded_fk_decrement(program, next_row, pref.fk.deferred);
+        program.resolve_label(next_row, program.offset());
+        program.emit_insn(Insn::Next {
+            cursor_id: ccur,
+            pc_if_next: loop_top,
+        });
+        program.resolve_label(done, program.offset());
+        program.emit_insn(Insn::Close { cursor_id: ccur });
     }
     Ok(())
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3411,6 +3411,9 @@ pub fn op_auto_commit(
             conn.set_tx_state(TransactionState::None);
             conn.auto_commit.store(true, Ordering::SeqCst);
             conn.set_cdc_transaction_id(-1);
+            // ROLLBACK undoes all changes, so all deferred FK violations are moot.
+            // Matches SQLite's OP_AutoCommit which clears nDeferredCons on rollback.
+            conn.clear_deferred_foreign_key_violations();
         } else {
             // BEGIN (true->false) or COMMIT (false->true)
             if is_commit_req {


### PR DESCRIPTION
Closes https://github.com/tursodatabase/turso/issues/5984


Includes a smol refactor to the INSERT fk path