### PR TITLE
core/json: Fix json_array_length(NULL) returns 0 instead of NULL

### DIFF
--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -284,6 +284,10 @@ pub fn json_array_length(
     path: Option<&Value>,
     json_cache: &JsonCacheCell,
 ) -> crate::Result<Value> {
+    if let Value::Null = value {
+        return Ok(Value::Null);
+    }
+
     let make_jsonb_fn = curry_convert_dbtype_to_jsonb(Conv::Strict);
     let mut json = json_cache.get_or_insert_with(value, make_jsonb_fn)?;
 
@@ -1131,6 +1135,14 @@ mod tests {
         } else {
             panic!("Expected Value::Numeric(Numeric::Integer)");
         }
+    }
+
+    #[test]
+    fn test_json_array_length_null() {
+        let input = Value::Null;
+        let json_cache = JsonCacheCell::new();
+        let result = json_array_length(&input, None, &json_cache).unwrap();
+        assert_eq!(result, Value::Null);
     }
 
     #[test]

--- a/testing/runner/tests/json/default.sqltest
+++ b/testing/runner/tests/json/default.sqltest
@@ -1015,6 +1015,12 @@ expect {
     3
 }
 
+test json_array_length_NULL {
+    SELECT json_array_length(NULL);
+}
+expect {
+}
+
 test json_type_no_path {
     select json_type('{"a":[2,3.5,true,false,null,"x"]}')
 }


### PR DESCRIPTION
## Description

Fixes #5901
`json_array_length(NULL)` returns 0 because SQL NULL gets silently converted to a JSONB null element before `array_len()` runs. Added an early NULL check to propagate SQL NULL, matching SQLite behavior and the pattern used by other JSON functions in the codebase.

