### PR TITLE
Stabilize self-reading WHERE subqueries

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1016,6 +1016,22 @@ fn update_write_set_reason(
             }
         }
 
+        // Any subquery in the WHERE clause is evaluated row-by-row during the
+        // UPDATE scan. If the subquery reads a table that the UPDATE could
+        // mutate (directly via the target table, or transitively via triggers
+        // / FKs), it may observe rows already modified by earlier iterations
+        // and produce incorrect results. Detecting all such mutation paths
+        // precisely is expensive, so we conservatively materialize target
+        // rowids whenever the UPDATE has any WHERE-clause subquery.
+        // (See issue #5806.)
+        if plan
+            .non_from_clause_subqueries
+            .iter()
+            .any(|sq| sq.origin == SubqueryOrigin::DmlWhere)
+        {
+            break 'requires Some(DmlSafetyReason::SubqueryInWhere);
+        }
+
         // REPLACE mode requires ephemeral table because REPLACE deletes conflicting rows,
         // which can corrupt the iteration order when iterating via an index.
         if matches!(

--- a/testing/sqltests/tests/snapshot_tests/modifications/modifications.sqltest
+++ b/testing/sqltests/tests/snapshot_tests/modifications/modifications.sqltest
@@ -102,6 +102,33 @@ snapshot update-simple {
     WHERE category = 'Electronics';
 }
 
+# Any WHERE-clause subquery in UPDATE forces the optimizer to materialize
+# target rowids into an ephemeral table first, so the row-by-row predicate
+# evaluation cannot observe rows already modified by earlier iterations.
+# (See issue #5806.)
+@setup schema
+snapshot update-where-unrelated-subquery {
+    UPDATE products
+    SET quantity = quantity + 1
+    WHERE EXISTS (
+        SELECT 1
+        FROM users
+        WHERE users.id = products.id
+    );
+}
+
+@setup schema
+snapshot update-where-self-subquery {
+    UPDATE products
+    SET quantity = quantity + 1
+    WHERE EXISTS (
+        SELECT 1
+        FROM products AS p2
+        WHERE p2.id = products.id - 1
+          AND p2.quantity < 5
+    );
+}
+
 # TODO: Uncomment when subquery in UPDATE SET is supported
 # # UPDATE with subquery - computed update value
 # @setup schema

--- a/testing/sqltests/tests/snapshot_tests/modifications/snapshots/modifications__update-where-self-subquery.snap
+++ b/testing/sqltests/tests/snapshot_tests/modifications/snapshots/modifications__update-where-self-subquery.snap
@@ -1,0 +1,66 @@
+---
+source: modifications.sqltest
+expression: |-
+  UPDATE products
+      SET quantity = quantity + 1
+      WHERE EXISTS (
+          SELECT 1
+          FROM products AS p2
+          WHERE p2.id = products.id - 1
+            AND p2.quantity < 5
+      );
+info:
+  statement_type: UPDATE
+  tables:
+  - products
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN products
+`--SEARCH p2 USING INTEGER PRIMARY KEY (rowid=?)
+
+BYTECODE
+addr  opcode           p1  p2  p3  p4                 p5  comment
+   0    Init            0  36   0                      0  Start at 36
+   1    OpenEphemeral   0   1   0                      0  cursor=0 is_table=true
+   2    OpenRead        1   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+   3    Rewind          1  19   0                      0  Rewind table products
+   4      BeginSubrtn   3   0   0                      0  r[3]=NULL
+   5      Integer       0   1   0                      0  r[1]=0
+   6      OpenRead      2   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+   7      RowId         1   6   0                      0  r[6]=products.rowid
+   8      Subtract      6   7   5                      0  r[5]=r[6]-r[7]
+   9      SeekRowid     2   5  13                      0  if (r[5]!=cursor 2 for table products.rowid) goto 13
+  10      Column        2   3   9  0                   0  r[9]=products.quantity
+  11      Ge            9  10  13  Binary              0  if r[9]>=r[10] goto 13
+  12      Integer       1   1   0                      0  r[1]=1
+  13    Return          3   0   1                      0
+  14    IfNot           1  18   1                      0  if !r[1] goto 18
+  15    RowId           1   2   0                      0  r[2]=products.rowid
+  16    MakeRecord      2   1  11                      0  r[11]=mkrec(r[2..2]); for ephemeral_scratch
+  17    Insert          0  11   2  ephemeral_scratch   6  intkey=r[2] data=r[11]
+  18  Next              1   4   0                      0
+  19  OpenWrite         1   2   0                      0  root=2; iDb=0
+  20  Rewind            0  35   0                      0  Rewind table ephemeral(ephemeral_scratch)
+  21    RowId           0  12   0                      0  r[12]=ephemeral(ephemeral_scratch).rowid
+  22    NotExists       1  34  12                      0
+  23    Null            0  13   0                      0  r[13]=NULL
+  24    Column          1   1  14                      0  r[14]=products.name
+  25    Column          1   2  15                      0  r[15]=products.price
+  26    Column          1   3  18  0                   0  r[18]=products.quantity
+  27    Add            18  19  16                      0  r[16]=r[18]+r[19]
+  28    Column          1   4  17                      0  r[17]=products.category
+  29    Affinity       13   5   0                      0  r[13..18] = D, B, E, D, B
+  30    MakeRecord     13   5  20                      0  r[20]=mkrec(r[13..17])
+  31    NotExists       1  34  12                      0
+  32    Delete          1   0   0  products            0
+  33    Insert          1  20  12  products           11  intkey=r[12] data=r[20]
+  34  Next              0  21   0                      0
+  35  Halt              0   0   0                      0
+  36  Transaction       0   2  10                      0  iDb=0 tx_mode=Write
+  37  Integer           1   7   0                      0  r[7]=1
+  38  Integer           5  10   0                      0  r[10]=5
+  39  Integer           1  19   0                      0  r[19]=1
+  40  Goto              0   1   0                      0

--- a/testing/sqltests/tests/snapshot_tests/modifications/snapshots/modifications__update-where-unrelated-subquery.snap
+++ b/testing/sqltests/tests/snapshot_tests/modifications/snapshots/modifications__update-where-unrelated-subquery.snap
@@ -1,0 +1,61 @@
+---
+source: modifications.sqltest
+expression: |-
+  UPDATE products
+      SET quantity = quantity + 1
+      WHERE EXISTS (
+          SELECT 1
+          FROM users
+          WHERE users.id = products.id
+      );
+info:
+  statement_type: UPDATE
+  tables:
+  - products
+  - users
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN products
+`--SEARCH users USING INTEGER PRIMARY KEY (rowid=?)
+
+BYTECODE
+addr  opcode           p1  p2  p3  p4                 p5  comment
+   0    Init            0  33   0                      0  Start at 33
+   1    OpenEphemeral   0   1   0                      0  cursor=0 is_table=true
+   2    OpenRead        1   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+   3    Rewind          1  16   0                      0  Rewind table products
+   4      BeginSubrtn   3   0   0                      0  r[3]=NULL
+   5      Integer       0   1   0                      0  r[1]=0
+   6      OpenRead      2   3   0  k(4,B,B,B,B)        0  table=users, root=3, iDb=0
+   7      RowId         1   5   0                      0  r[5]=products.rowid
+   8      SeekRowid     2   5  10                      0  if (r[5]!=cursor 2 for table users.rowid) goto 10
+   9      Integer       1   1   0                      0  r[1]=1
+  10    Return          3   0   1                      0
+  11    IfNot           1  15   1                      0  if !r[1] goto 15
+  12    RowId           1   2   0                      0  r[2]=products.rowid
+  13    MakeRecord      2   1   6                      0  r[6]=mkrec(r[2..2]); for ephemeral_scratch
+  14    Insert          0   6   2  ephemeral_scratch   6  intkey=r[2] data=r[6]
+  15  Next              1   4   0                      0
+  16  OpenWrite         1   2   0                      0  root=2; iDb=0
+  17  Rewind            0  32   0                      0  Rewind table ephemeral(ephemeral_scratch)
+  18    RowId           0   7   0                      0  r[7]=ephemeral(ephemeral_scratch).rowid
+  19    NotExists       1  31   7                      0
+  20    Null            0   8   0                      0  r[8]=NULL
+  21    Column          1   1   9                      0  r[9]=products.name
+  22    Column          1   2  10                      0  r[10]=products.price
+  23    Column          1   3  13  0                   0  r[13]=products.quantity
+  24    Add            13  14  11                      0  r[11]=r[13]+r[14]
+  25    Column          1   4  12                      0  r[12]=products.category
+  26    Affinity        8   5   0                      0  r[8..13] = D, B, E, D, B
+  27    MakeRecord      8   5  15                      0  r[15]=mkrec(r[8..12])
+  28    NotExists       1  31   7                      0
+  29    Delete          1   0   0  products            0
+  30    Insert          1  15   7  products           11  intkey=r[7] data=r[15]
+  31  Next              0  18   0                      0
+  32  Halt              0   0   0                      0
+  33  Transaction       0   2  10                      0  iDb=0 tx_mode=Write
+  34  Integer           1  14   0                      0  r[14]=1
+  35  Goto              0   1   0                      0

--- a/testing/sqltests/tests/update.sqltest
+++ b/testing/sqltests/tests/update.sqltest
@@ -939,6 +939,138 @@ expect {
     3|has_items
 }
 
+# Regression for #5806: a correlated EXISTS subquery on the target table
+# was evaluated row-by-row against a partially-updated image of the table,
+# causing later predicate checks to observe rows already incremented by
+# earlier iterations and miss matches that depended on the pre-update value.
+@cross-check-integrity
+test update-correlated-self-exists-where {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+    INSERT INTO t VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+
+    UPDATE t
+    SET v = v + 10
+    WHERE EXISTS (
+        SELECT 1 FROM t AS t2
+        WHERE t2.id = t.id - 1 AND t2.v < 3
+    );
+
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|1
+    2|12
+    3|13
+    4|4
+    5|5
+}
+
+# Same shape but using IN instead of EXISTS, to cover the other subquery
+# expression flavor that lands in non_from_clause_subqueries.
+@cross-check-integrity
+test update-correlated-self-in-where {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+    INSERT INTO t VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+
+    UPDATE t
+    SET v = v + 10
+    WHERE id IN (SELECT id + 1 FROM t WHERE v < 3);
+
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|1
+    2|12
+    3|13
+    4|4
+    5|5
+}
+
+# NOT IN against the target — must observe the pre-update image of t.
+@cross-check-integrity
+test update-correlated-self-not-in-where {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+    INSERT INTO t VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+
+    UPDATE t
+    SET v = v + 10
+    WHERE id NOT IN (SELECT id FROM t WHERE v >= 3);
+
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|11
+    2|12
+    3|3
+    4|4
+    5|5
+}
+
+# NOT EXISTS — parsed as NOT (EXISTS ...). The Exists subquery still lands
+# in non_from_clause_subqueries with origin DmlWhere.
+@cross-check-integrity
+test update-correlated-self-not-exists-where {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+    INSERT INTO t VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+
+    UPDATE t
+    SET v = v + 10
+    WHERE NOT EXISTS (
+        SELECT 1 FROM t AS t2
+        WHERE t2.id = t.id - 1 AND t2.v < 3
+    );
+
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|11
+    2|2
+    3|3
+    4|14
+    5|15
+}
+
+# Scalar comparison subquery — `x op (SELECT ...)` goes through Expr::Subquery.
+@cross-check-integrity
+test update-correlated-self-scalar-cmp-where {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+    INSERT INTO t VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+
+    UPDATE t
+    SET v = v + 10
+    WHERE v < (SELECT MAX(v) FROM t);
+
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|11
+    2|12
+    3|13
+    4|14
+    5|5
+}
+
+# Row-value subquery — `(a, b) = (SELECT a, b FROM ...)` also goes through
+# Expr::Subquery and must trigger the stable write set.
+@cross-check-integrity
+test update-correlated-self-rowvalue-where {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+    INSERT INTO t VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+
+    UPDATE t
+    SET v = v + 10
+    WHERE (id, v) = (SELECT id, v FROM t WHERE v = 2);
+
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|1
+    2|12
+    3|3
+    4|4
+    5|5
+}
+
 # Test UPDATE with NOT EXISTS subquery
 
 @cross-check-integrity


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

Fix UPDATE planning for correlated WHERE subqueries that read from the target table.

Previously, UPDATE ... WHERE EXISTS (SELECT ... FROM same_table ...) could under-update rows because Turso evaluated and wrote in a single pass, so later predicate checks could observe rows already modified by earlier iterations. 

The fix moves the safety decision to the optimizer and enables the existing stable write set path only when a planned DmlWhere subquery actually reads the target table. In that case, rowids are collected first and writes happen in a second pass.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Issue #5806: correlated self-subqueries in UPDATE WHERE could produce incorrect results compared with SQLite.

  Example:

```SQL
  UPDATE t
  SET v = v + 10
  WHERE EXISTS (
      SELECT 1
      FROM t AS t2
      WHERE t2.id = t.id - 1
        AND t2.v < 3
  );
```

SQLite updates rows 2 and 3. Turso only updated row 2 because the predicate for later rows was evaluated against a partially updated table image.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5806


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
