### PR TITLE
fix: last_insert_rowid() corrupted by INSERTs inside trigger bodies

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3739,6 +3739,9 @@ pub enum OpProgramState {
     Step {
         is_trigger: bool,
         statement: Box<Statement>,
+        /// Saved last_insert_rowid to restore after trigger subprogram completes.
+        /// Per SQLite docs, trigger-body INSERTs must not overwrite the top-level rowid.
+        saved_last_insert_rowid: Option<i64>,
     },
 }
 
@@ -3770,12 +3773,14 @@ pub fn op_program(
                 statement.reset()?;
 
                 // Check if this is a trigger subprogram - if so, track execution
-                let is_trigger = if let Some(ref trigger) = statement.get_trigger() {
-                    program.connection.start_trigger_execution(trigger.clone());
-                    true
-                } else {
-                    false
-                };
+                // and save last_insert_rowid so it can be restored after the trigger finishes.
+                let (is_trigger, saved_last_insert_rowid) =
+                    if let Some(ref trigger) = statement.get_trigger() {
+                        program.connection.start_trigger_execution(trigger.clone());
+                        (true, Some(program.connection.last_insert_rowid()))
+                    } else {
+                        (false, None)
+                    };
 
                 // Extract register values from params (which contain register indices encoded as negative integers)
                 // and bind them to the subprogram's parameters
@@ -3805,13 +3810,16 @@ pub fn op_program(
                 state.op_program_state = OpProgramState::Step {
                     is_trigger,
                     statement: Box::new(statement),
+                    saved_last_insert_rowid,
                 };
             }
             OpProgramState::Step {
                 is_trigger,
                 statement,
+                saved_last_insert_rowid,
             } => {
                 let is_trigger = *is_trigger;
+                let saved_last_insert_rowid = *saved_last_insert_rowid;
                 let mut raise_ignore = false;
                 // Track whether the subprogram aborted with an error. When abort()
                 // runs inside the subprogram, it already calls end_trigger_execution(),
@@ -3854,6 +3862,12 @@ pub fn op_program(
                 // already called end_trigger_execution() via abort() in the subprogram.
                 if is_trigger && !subprogram_aborted {
                     program.connection.end_trigger_execution();
+                }
+
+                // Restore last_insert_rowid after trigger execution, per SQLite semantics:
+                // trigger-body INSERTs must not overwrite the top-level rowid.
+                if let Some(rowid) = saved_last_insert_rowid {
+                    program.connection.update_last_rowid(rowid);
                 }
 
                 state.op_program_state = OpProgramState::Start;

--- a/testing/runner/tests/trigger-last-insert-rowid.sqltest
+++ b/testing/runner/tests/trigger-last-insert-rowid.sqltest
@@ -1,0 +1,93 @@
+@database :memory:
+@requires-file trigger "trigger tests require trigger support"
+
+test trigger-last-insert-rowid-basic {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(x INTEGER PRIMARY KEY, y TEXT);
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN
+        INSERT INTO t2 VALUES(NEW.a + 1000, 'from trigger');
+    END;
+    INSERT INTO t1 VALUES(1, 'hello');
+    SELECT last_insert_rowid();
+}
+expect {
+    1
+}
+
+test trigger-last-insert-rowid-multiple {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(x INTEGER PRIMARY KEY, y TEXT);
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN
+        INSERT INTO t2 VALUES(NEW.a + 1000, 'from trigger');
+    END;
+    INSERT INTO t1 VALUES(2, 'world');
+    INSERT INTO t1 VALUES(3, 'foo');
+    SELECT last_insert_rowid();
+}
+expect {
+    3
+}
+
+test trigger-last-insert-rowid-side-effect {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(x INTEGER PRIMARY KEY, y TEXT);
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN
+        INSERT INTO t2 VALUES(NEW.a + 1000, 'from trigger');
+    END;
+    INSERT INTO t1 VALUES(42, 'check');
+    SELECT last_insert_rowid();
+    SELECT x, y FROM t2;
+}
+expect {
+    42
+    1042|from trigger
+}
+
+test trigger-last-insert-rowid-autoincrement {
+    CREATE TABLE t3(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t4(x INTEGER PRIMARY KEY, y TEXT);
+    CREATE TRIGGER tr2 AFTER INSERT ON t3 BEGIN
+        INSERT INTO t4 VALUES(NEW.a * 100, 'triggered');
+    END;
+    INSERT INTO t3(b) VALUES('auto1');
+    SELECT last_insert_rowid();
+}
+expect {
+    1
+}
+
+test trigger-last-insert-rowid-before-insert {
+    CREATE TABLE t5(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t6(x INTEGER PRIMARY KEY, y TEXT);
+    CREATE TRIGGER tr_before BEFORE INSERT ON t5 BEGIN
+        INSERT INTO t6 VALUES(NEW.a + 500, 'before trigger');
+    END;
+    INSERT INTO t5 VALUES(10, 'before test');
+    SELECT last_insert_rowid();
+    SELECT x, y FROM t6;
+}
+expect {
+    10
+    510|before trigger
+}
+
+test trigger-last-insert-rowid-nested {
+    CREATE TABLE outer_t(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE mid_t(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE inner_t(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TRIGGER tr_outer AFTER INSERT ON outer_t BEGIN
+        INSERT INTO mid_t VALUES(NEW.id + 100, 'mid');
+    END;
+    CREATE TRIGGER tr_mid AFTER INSERT ON mid_t BEGIN
+        INSERT INTO inner_t VALUES(NEW.id + 1000, 'inner');
+    END;
+    INSERT INTO outer_t VALUES(5, 'start');
+    SELECT last_insert_rowid();
+    SELECT * FROM mid_t;
+    SELECT * FROM inner_t;
+}
+expect {
+    5
+    105|mid
+    1105|inner
+}


### PR DESCRIPTION
Save and restore last_insert_rowid around trigger subprogram execution in op_program, matching SQLite semantics where trigger-body INSERTs must not overwrite the top-level rowid.

Closes #5870

_generated by *turso auto-fixer*_ :tm: :robot: