### PR TITLE
core/mvcc: Fix immediate tx gets WriteWrite conflict against concurrent speculative write

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3988,9 +3988,17 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     fn release_exclusive_tx(&self, tx_id: &TxID) {
         tracing::trace!("release_exclusive_tx(tx_id={})", tx_id);
         let prev = self.exclusive_tx.swap(NO_EXCLUSIVE_TX, Ordering::Release);
-        self.can_override_speculative_write_lock
-            .store(NO_EXCLUSIVE_TX, Ordering::Release);
         turso_assert_eq!(prev, *tx_id, "exclusive lock released by wrong tx", { "expected_tx_id": *tx_id, "actual_tx_id": prev });
+        self.clear_speculative_write_override_for_released_tx(tx_id);
+    }
+
+    fn clear_speculative_write_override_for_released_tx(&self, tx_id: &TxID) {
+        let _ = self.can_override_speculative_write_lock.compare_exchange(
+            *tx_id,
+            NO_EXCLUSIVE_TX,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
     }
 
     /// Generates next unique transaction id

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2844,7 +2844,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
                             continue;
                         }
-                        if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv) {
+                        if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
+                            && !self.is_exclusive_tx(&tx.tx_id)
+                        {
                             turso_assert_reachable!("write-write conflict on delete");
                             drop(row_versions);
                             drop(row_versions_opt);
@@ -2881,7 +2883,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
                             continue;
                         }
-                        if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv) {
+                        if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
+                            && !self.is_exclusive_tx(&tx.tx_id)
+                        {
                             turso_assert_reachable!("write-write conflict on delete");
                             drop(row_versions);
                             drop(row_versions_opt);

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2279,6 +2279,20 @@ pub struct MvStore<Clock: LogicalClock> {
     /// to exclusive, it will abort if another transaction committed after its begin timestamp.
     last_committed_tx_ts: AtomicU64,
     table_id_to_last_rowid: RwLock<HashMap<MVTableId, Arc<RowidAllocator>>>,
+    /// Tx id allowed to override speculative write locks.
+    ///
+    /// `NO_EXCLUSIVE_TX` means "no override-eligible tx".
+    ///
+    /// This is intentionally separate from `exclusive_tx`:
+    /// - `exclusive_tx` = who currently holds exclusive lock
+    /// - this field = who is allowed to bypass a delete/update write-write conflict
+    ///
+    /// We only set this for fresh exclusive starts (IMMEDIATE-like path), not for
+    /// deferred/read transactions that later upgrade to exclusive. That preserves
+    /// `BEGIN IMMEDIATE` behavior while preventing upgraded deferred writers from
+    /// stealing speculative deletes and causing row-visibility anomalies.
+    /// See https://github.com/tursodatabase/turso/issues/5954
+    can_override_speculative_write_lock: AtomicU64,
 }
 
 impl<Clock: LogicalClock> MvStore<Clock> {
@@ -2353,6 +2367,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             last_committed_schema_change_ts: AtomicU64::new(0),
             last_committed_tx_ts: AtomicU64::new(0),
             table_id_to_last_rowid: RwLock::new(HashMap::default()),
+            can_override_speculative_write_lock: AtomicU64::new(NO_EXCLUSIVE_TX),
         }
     }
 
@@ -2844,9 +2859,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
                             continue;
                         }
-                        if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
-                            && !self.can_exclusive_preempt_write_lock(tx, rv)
-                        {
+                        if self.is_delete_conflict(tx, rv) {
                             turso_assert_reachable!("write-write conflict on delete");
                             drop(row_versions);
                             drop(row_versions_opt);
@@ -2883,9 +2896,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
                             continue;
                         }
-                        if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
-                            && !self.can_exclusive_preempt_write_lock(tx, rv)
-                        {
+                        if self.is_delete_conflict(tx, rv) {
                             turso_assert_reachable!("write-write conflict on delete");
                             drop(row_versions);
                             drop(row_versions_opt);
@@ -3289,6 +3300,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         &self,
         pager: Arc<Pager>,
         maybe_existing_tx_id: Option<TxID>,
+        allow_speculative_override: bool,
     ) -> Result<TxID> {
         // Existing transactions already hold one blocking-checkpoint read guard
         // from begin_tx(). When upgrading read->write, do not acquire another one.
@@ -3367,6 +3379,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         );
         tracing::debug!("begin_exclusive_tx: tx_id={} succeeded", tx_id);
         self.txs.insert(tx_id, tx);
+        // Fresh exclusive tx: mark as override-eligible only when not a deferred upgrade.
+        if allow_speculative_override {
+            self.can_override_speculative_write_lock
+                .store(tx_id, Ordering::Release);
+        }
         Ok(tx_id)
     }
 
@@ -3889,18 +3906,32 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
     }
 
-    fn can_exclusive_preempt_write_lock(&self, tx: &Transaction, rv: &RowVersion) -> bool {
+    fn is_delete_conflict(&self, tx: &Transaction, rv: &RowVersion) -> bool {
+        is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
+            && !self.can_exclusive_override_speculative_write_lock(tx, rv)
+    }
+
+    fn can_exclusive_override_speculative_write_lock(
+        &self,
+        tx: &Transaction,
+        rv: &RowVersion,
+    ) -> bool {
         if !self.is_exclusive_tx(&tx.tx_id) {
             return false;
         }
-
+        if self
+            .can_override_speculative_write_lock
+            .load(Ordering::Acquire)
+            != tx.tx_id
+        {
+            return false;
+        }
         let Some(TxTimestampOrID::TxID(owner_tx_id)) = rv.end else {
             return false;
         };
         if owner_tx_id == tx.tx_id {
             return false;
         }
-
         let Some(owner_tx_entry) = self.txs.get(&owner_tx_id) else {
             return false;
         };
@@ -3957,6 +3988,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     fn release_exclusive_tx(&self, tx_id: &TxID) {
         tracing::trace!("release_exclusive_tx(tx_id={})", tx_id);
         let prev = self.exclusive_tx.swap(NO_EXCLUSIVE_TX, Ordering::Release);
+        self.can_override_speculative_write_lock
+            .store(NO_EXCLUSIVE_TX, Ordering::Release);
         turso_assert_eq!(prev, *tx_id, "exclusive lock released by wrong tx", { "expected_tx_id": *tx_id, "actual_tx_id": prev });
     }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2845,7 +2845,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             continue;
                         }
                         if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
-                            && !self.is_exclusive_tx(&tx.tx_id)
+                            && !self.can_exclusive_preempt_write_lock(tx, rv)
                         {
                             turso_assert_reachable!("write-write conflict on delete");
                             drop(row_versions);
@@ -2884,7 +2884,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             continue;
                         }
                         if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv)
-                            && !self.is_exclusive_tx(&tx.tx_id)
+                            && !self.can_exclusive_preempt_write_lock(tx, rv)
                         {
                             turso_assert_reachable!("write-write conflict on delete");
                             drop(row_versions);
@@ -3886,6 +3886,30 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 continue;
             }
             tx.write_set.remove(&rowid);
+        }
+    }
+
+    fn can_exclusive_preempt_write_lock(&self, tx: &Transaction, rv: &RowVersion) -> bool {
+        if !self.is_exclusive_tx(&tx.tx_id) {
+            return false;
+        }
+
+        let Some(TxTimestampOrID::TxID(owner_tx_id)) = rv.end else {
+            return false;
+        };
+        if owner_tx_id == tx.tx_id {
+            return false;
+        }
+
+        let Some(owner_tx_entry) = self.txs.get(&owner_tx_id) else {
+            return false;
+        };
+        let owner_tx = owner_tx_entry.value();
+        match owner_tx.state.load() {
+            TransactionState::Active | TransactionState::Preparing(_) => {
+                tx.begin_ts < owner_tx.begin_ts
+            }
+            _ => false,
         }
     }
 

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9483,3 +9483,73 @@ fn test_immediate_not_blocked_by_concurrent_speculative_write() {
     let rows = get_rows(&conn3, "SELECT val FROM t1 WHERE id = 1");
     assert_eq!(rows[0][0].to_string(), "immediate_val");
 }
+
+#[test]
+fn test_immediate_and_concurrent_non_conflicting_updates_both_commit() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn0 = db.connect();
+    conn0
+        .execute("CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)")
+        .unwrap();
+    conn0
+        .execute("INSERT INTO t1 VALUES(1, 'row1'), (2, 'row2')")
+        .unwrap();
+    conn0.close().unwrap();
+
+    let conn1 = db.connect();
+    let conn2 = db.connect();
+
+    conn1.execute("BEGIN IMMEDIATE").unwrap();
+    conn2.execute("BEGIN CONCURRENT").unwrap();
+    conn2
+        .execute("UPDATE t1 SET val = 'concurrent_val' WHERE id = 1")
+        .unwrap();
+    conn1
+        .execute("UPDATE t1 SET val = 'immediate_val' WHERE id = 2")
+        .unwrap();
+    conn1.execute("COMMIT").unwrap();
+    conn2.execute("COMMIT").unwrap();
+
+    let conn3 = db.connect();
+    let rows = get_rows(&conn3, "SELECT id, val FROM t1 ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "concurrent_val");
+    assert_eq!(rows[1][0].as_int().unwrap(), 2);
+    assert_eq!(rows[1][1].to_string(), "immediate_val");
+}
+
+#[test]
+fn test_concurrent_commit_survives_immediate_rollback_on_disjoint_rows() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn0 = db.connect();
+    conn0
+        .execute("CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)")
+        .unwrap();
+    conn0
+        .execute("INSERT INTO t1 VALUES(1, 'row1'), (2, 'row2')")
+        .unwrap();
+    conn0.close().unwrap();
+
+    let conn1 = db.connect();
+    let conn2 = db.connect();
+
+    conn1.execute("BEGIN IMMEDIATE").unwrap();
+    conn2.execute("BEGIN CONCURRENT").unwrap();
+    conn2
+        .execute("UPDATE t1 SET val = 'concurrent_val' WHERE id = 1")
+        .unwrap();
+    conn1
+        .execute("UPDATE t1 SET val = 'immediate_val' WHERE id = 2")
+        .unwrap();
+    conn1.execute("ROLLBACK").unwrap();
+    conn2.execute("COMMIT").unwrap();
+
+    let conn3 = db.connect();
+    let rows = get_rows(&conn3, "SELECT id, val FROM t1 ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "concurrent_val");
+    assert_eq!(rows[1][0].as_int().unwrap(), 2);
+    assert_eq!(rows[1][1].to_string(), "row2");
+}

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9485,6 +9485,93 @@ fn test_immediate_not_blocked_by_concurrent_speculative_write() {
 }
 
 #[test]
+fn test_tx_a_rollback_does_not_clear_tx_b_immediate_override() {
+    let db = MvccTestDb::new();
+    let mvcc_store = db.mvcc_store.clone();
+
+    // TX A starts as a BEGIN IMMEDIATE-style transaction and owns both the
+    // exclusive lock and the speculative-write override marker.
+    let tx_a_conn = db.conn.clone();
+    let tx_a_id = mvcc_store
+        .begin_exclusive_tx(tx_a_conn.pager.load().clone(), None, true)
+        .unwrap();
+
+    let tx_a_released_exclusive = Arc::new(std::sync::Barrier::new(2));
+    let tx_b_started_immediate = Arc::new(std::sync::Barrier::new(2));
+    let rollback_store = mvcc_store.clone();
+    let rollback_thread = {
+        let tx_a_released_exclusive = tx_a_released_exclusive.clone();
+        let tx_b_started_immediate = tx_b_started_immediate.clone();
+        std::thread::spawn(move || {
+            // First half of TX A rollback: it is aborted and no longer blocks
+            // another BEGIN IMMEDIATE from taking the exclusive lock.
+            {
+                let tx_a = rollback_store.txs.get(&tx_a_id).unwrap();
+                tx_a.value().state.store(TransactionState::Aborted);
+                rollback_store.unlock_commit_lock_if_held(tx_a.value());
+            }
+
+            let released_tx_id = rollback_store
+                .exclusive_tx
+                .swap(NO_EXCLUSIVE_TX, Ordering::Release);
+            assert_eq!(released_tx_id, tx_a_id);
+
+            tx_a_released_exclusive.wait();
+            tx_b_started_immediate.wait();
+
+            // Second half of TX A rollback. This must not clear the override
+            // marker if TX B acquired it while TX A was between the two steps.
+            rollback_store.clear_speculative_write_override_for_released_tx(&tx_a_id);
+            if let Some(tx_a) = rollback_store.txs.get(&tx_a_id) {
+                tx_a.value().state.store(TransactionState::Terminated);
+            }
+            rollback_store.remove_tx(tx_a_id);
+        })
+    };
+
+    tx_a_released_exclusive.wait();
+    assert_eq!(
+        mvcc_store.exclusive_tx.load(Ordering::Acquire),
+        NO_EXCLUSIVE_TX
+    );
+
+    // TX B starts while TX A rollback is paused after releasing exclusive_tx
+    // but before clearing can_override_speculative_write_lock.
+    let tx_b_conn = db.db.connect().unwrap();
+    let tx_b_result = mvcc_store.begin_exclusive_tx(tx_b_conn.pager.load().clone(), None, true);
+    let override_tx_id = mvcc_store
+        .can_override_speculative_write_lock
+        .load(Ordering::Acquire);
+    // TX A is still rolling back here: released exclusive_tx, but not removed.
+    let tx_a = mvcc_store.txs.get(&tx_a_id).unwrap();
+    assert_eq!(tx_a.value().state.load(), TransactionState::Aborted);
+
+    tx_b_started_immediate.wait();
+    let tx_b_id = tx_b_result.unwrap();
+    assert_eq!(
+        override_tx_id, tx_b_id,
+        "TX B BEGIN IMMEDIATE should set speculative-write override"
+    );
+
+    rollback_thread.join().unwrap();
+    // TX A has finished rollback after TX B began. TX B must still own the
+    // override marker, otherwise it can spuriously hit WriteWriteConflict.
+    assert_eq!(
+        mvcc_store
+            .can_override_speculative_write_lock
+            .load(Ordering::Acquire),
+        tx_b_id
+    );
+
+    mvcc_store.rollback_tx(
+        tx_b_id,
+        tx_b_conn.pager.load().clone(),
+        &tx_b_conn,
+        crate::MAIN_DB_ID,
+    );
+}
+
+#[test]
 fn test_immediate_and_concurrent_non_conflicting_updates_both_commit() {
     let db = MvccTestDbNoConn::new_with_random_db();
     let conn0 = db.connect();

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9445,3 +9445,41 @@ fn test_snapshot_stability_full() {
     }
     assert!(rs > 0, "reader made no progress");
 }
+
+#[test]
+fn test_immediate_not_blocked_by_concurrent_speculative_write() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn0 = db.connect();
+    conn0
+        .execute("CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)")
+        .unwrap();
+    conn0
+        .execute("INSERT INTO t1 VALUES(1, 'original')")
+        .unwrap();
+    conn0.close().unwrap();
+
+    let conn1 = db.connect();
+    let conn2 = db.connect();
+
+    conn1.execute("BEGIN IMMEDIATE").unwrap();
+    conn2.execute("BEGIN CONCURRENT").unwrap();
+    conn2
+        .execute("UPDATE t1 SET val = 'concurrent_val' WHERE id = 1")
+        .unwrap();
+    // IMMEDIATE tx holds the exclusive lock — this should succeed
+    conn1
+        .execute("UPDATE t1 SET val = 'immediate_val' WHERE id = 1")
+        .unwrap();
+    conn1.execute("COMMIT").unwrap();
+
+    // CONCURRENT should fail with write-write conflict
+    let result = conn2.execute("COMMIT");
+    assert!(
+        matches!(&result, Err(LimboError::WriteWriteConflict)),
+        "CONCURRENT commit should fail: {result:?}",
+    );
+
+    let conn3 = db.connect();
+    let rows = get_rows(&conn3, "SELECT val FROM t1 WHERE id = 1");
+    assert_eq!(rows[0][0].to_string(), "immediate_val");
+}

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3177,12 +3177,15 @@ fn begin_mvcc_tx(
     pager: &Arc<Pager>,
     mode: &TransactionMode,
     existing_tx_id: Option<u64>,
+    allow_speculative_override: bool,
 ) -> Result<u64> {
     match mode {
         TransactionMode::None | TransactionMode::Read | TransactionMode::Concurrent => {
             mv_store.begin_tx(pager.clone())
         }
-        TransactionMode::Write => mv_store.begin_exclusive_tx(pager.clone(), existing_tx_id),
+        TransactionMode::Write => {
+            mv_store.begin_exclusive_tx(pager.clone(), existing_tx_id, allow_speculative_override)
+        }
     }
 }
 
@@ -3436,12 +3439,21 @@ pub fn op_transaction_inner(
                                         .to_string(),
                                 ));
                             }
+                            let allow_speculative_override =
+                                matches!(tx_mode, TransactionMode::Write)
+                                    && !conn_has_executed_begin_deferred;
                             // Use the same tx_mode as the main DB's active
                             // transaction when available, so BEGIN CONCURRENT
                             // applies to all databases uniformly.
                             let effective_mode =
                                 conn.get_mv_tx().map(|(_, mode)| mode).unwrap_or(*tx_mode);
-                            match begin_mvcc_tx(mv_store, &pager, &effective_mode, None) {
+                            match begin_mvcc_tx(
+                                mv_store,
+                                &pager,
+                                &effective_mode,
+                                None,
+                                allow_speculative_override,
+                            ) {
                                 Ok(tx_id) => {
                                     conn.set_mv_tx_for_db(*db, Some((tx_id, effective_mode)));
                                     started_secondary_tx = true;
@@ -3460,7 +3472,7 @@ pub fn op_transaction_inner(
                                 && matches!(tx_mode, TransactionMode::Write)
                             {
                                 if let Err(err) =
-                                    begin_mvcc_tx(mv_store, &pager, tx_mode, Some(tx_id))
+                                    begin_mvcc_tx(mv_store, &pager, tx_mode, Some(tx_id), false)
                                 {
                                     pager.end_read_tx();
                                     return Err(err);
@@ -3501,7 +3513,16 @@ pub fn op_transaction_inner(
                         }
 
                         if !has_existing_mv_tx {
-                            match begin_mvcc_tx(mv_store, &pager, tx_mode, None) {
+                            let allow_speculative_override =
+                                matches!(tx_mode, TransactionMode::Write)
+                                    && !conn_has_executed_begin_deferred;
+                            match begin_mvcc_tx(
+                                mv_store,
+                                &pager,
+                                tx_mode,
+                                None,
+                                allow_speculative_override,
+                            ) {
                                 Ok(tx_id) => {
                                     program
                                         .connection
@@ -3531,9 +3552,13 @@ pub fn op_transaction_inner(
                             if matches!(new_transaction_state, TransactionState::Write { .. })
                                 && matches!(actual_tx_mode, TransactionMode::Write)
                             {
-                                if let Err(err) =
-                                    begin_mvcc_tx(mv_store, &pager, &actual_tx_mode, Some(tx_id))
-                                {
+                                if let Err(err) = begin_mvcc_tx(
+                                    mv_store,
+                                    &pager,
+                                    &actual_tx_mode,
+                                    Some(tx_id),
+                                    false,
+                                ) {
                                     if started_read_tx {
                                         pager.end_read_tx();
                                         conn.set_tx_state(TransactionState::None);


### PR DESCRIPTION
## Description
Fixes #5954
The root problem was that the MVCC store had no way to distinguish a transaction that started as BEGIN IMMEDIATE from a BEGIN (deferred) transaction that later upgraded to exclusive on its first write. Both end up holding the exclusive lock, so `is_exclusive_tx()` alone could not tell them apart at conflict check time.

The fix adds a new `can_override_speculative_write_lock: AtomicU64` field to `MvStore` that tracks which transaction is allowed to bypass write-write conflict checks on delete. This is set only when a fresh exclusive transaction is created (`begin_exclusive_tx` with no existing tx id), and explicitly not set on the upgrade path. The flag is computed at the VDBE layer in `execute.rs` where the original transaction mode is known (`conn_has_executed_begin_deferred`), and passed down into `begin_exclusive_tx` as `allow_speculative_override`.

## Description of AI Usage
Used Claude Code to navigate around the MVCC internals, asking various questions about how and where transactions are implemented