### PR TITLE
fix(core): handle ON CONFLICT ROLLBACK for rowid alias primary keys

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1396,12 +1396,7 @@ fn emit_update_insns<'a>(
                 target_table
                     .table
                     .btree()
-                    .and_then(|bt| {
-                        bt.unique_sets
-                            .iter()
-                            .find(|us| us.is_primary_key)
-                            .and_then(|us| us.conflict_clause)
-                    })
+                    .and_then(|bt| bt.pk_conflict_clause)
                     .unwrap_or(ResolveType::Abort)
             };
             match pk_conflict {
@@ -2112,12 +2107,7 @@ fn emit_update_insns<'a>(
                 target_table
                     .table
                     .btree()
-                    .and_then(|bt| {
-                        bt.unique_sets
-                            .iter()
-                            .find(|us| us.is_primary_key)
-                            .and_then(|us| us.conflict_clause)
-                    })
+                    .and_then(|bt| bt.pk_conflict_clause)
                     .unwrap_or(ResolveType::Abort)
             };
             match pk_conflict {

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1794,3 +1794,42 @@ fn test_attached_read_lock_released_after_main_write(tmp_db: TempDatabase) -> an
 
     Ok(())
 }
+
+#[turso_macros::test]
+fn test_update_on_conflict_rollback_rowid_alias(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY ON CONFLICT ROLLBACK, b TEXT);")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES(1, 'one');").unwrap();
+    conn.execute("INSERT INTO t VALUES(2, 'two');").unwrap();
+
+    // Start a transaction and insert a canary row
+    conn.execute("BEGIN;").unwrap();
+    conn.execute("INSERT INTO t VALUES(3, 'three');").unwrap();
+
+    // This UPDATE should fail and cause a ROLLBACK of the whole transaction
+    let res = conn.execute("UPDATE t SET a = 1 WHERE b = 'two';");
+    assert!(res.is_err());
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .contains("UNIQUE constraint failed"));
+
+    // If it correctly ROLLED BACK, the transaction should no longer be active.
+    // Committing should fail.
+    let res_commit = conn.execute("COMMIT;");
+    assert!(res_commit.is_err());
+    assert!(res_commit
+        .unwrap_err()
+        .to_string()
+        .contains("no transaction is active"));
+
+    // Verify the final state of the table: row 3 should be gone.
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT a FROM t ORDER BY a");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].0, 1);
+    assert_eq!(rows[1].0, 2);
+
+    Ok(())
+}


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

This PR fixes a bug in the UPDATE statement code generation where ON CONFLICT ROLLBACK clause was ignored for tables using INTEGER PRIMARY KEY (rowid alias).

The fix involves updating the translation logic in `core/translate/emitter/update.rs ` to retrieve the conflict resolution strategy from the **pk_conflict_clause** field of the BTreeTable schema. Previously, the
code searched through unique_sets, which is explicitly empty for rowid-alias primary keys in Limbo's schema representation. This change ensures the correct conflict strategy is chosen for Primary Key types.

## Motivation and context

Fixes #5982.

 The issue was discovered via a fuzz test (fk_deferred_constraints_and_triggers_fuzz). When a constraint violation occurred on a rowid-alias PK with ON CONFLICT ROLLBACK, Limbo incorrectly defaulted to ABORT.
  This left the transaction active instead of rolling it back, causing subsequent BEGIN statements to fail with "cannot start a transaction within a transaction".

