### PR TITLE
core/mvcc: Keep MVCC schema version immutable

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -6,6 +6,7 @@ use crossbeam_skiplist::SkipMap;
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
     create_seek_range, MVTableId, MvStore, Row, RowID, RowKey, RowVersion, SortableIndexKey,
+    SQLITE_SCHEMA_MVCC_TABLE_ID,
 };
 use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
 use crate::sync::Arc;
@@ -16,7 +17,8 @@ use crate::types::{
 };
 use crate::vdbe::make_record;
 use crate::vdbe::Register;
-use crate::{return_if_io, Completion, LimboError, Pager, Result};
+use crate::Numeric;
+use crate::{return_if_io, Completion, LimboError, Pager, Result, ValueRef};
 use std::any::Any;
 use std::fmt::Debug;
 use std::ops::Bound;
@@ -33,6 +35,11 @@ enum CursorPosition {
     },
     /// We have reached the end of the table.
     End,
+}
+
+enum ProjectedPayload<'a> {
+    Borrowed(&'a [u8]),
+    Owned(ImmutableRecord),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -336,6 +343,11 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                     let Some(row) = self.read_mvcc_current_row()? else {
                         return Ok(IOResult::Done(None));
                     };
+                    let payload = self.project_sqlite_schema_payload(&row)?;
+                    let payload = match &payload {
+                        ProjectedPayload::Borrowed(payload) => *payload,
+                        ProjectedPayload::Owned(record) => record.as_blob(),
+                    };
                     {
                         let mut record = self.get_immutable_record_or_create();
                         let record = record.as_mut().ok_or_else(|| {
@@ -344,7 +356,7 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                             )
                         })?;
                         record.invalidate();
-                        record.start_serialization(row.payload());
+                        record.start_serialization(payload);
                     }
 
                     let record_ref = self.reusable_immutable_record.as_ref().ok_or_else(|| {
@@ -372,6 +384,38 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
         };
         self.db
             .read_from_table_or_index(self.tx_id, row_id, maybe_index_id)
+    }
+
+    fn project_sqlite_schema_payload<'a>(&self, row: &'a Row) -> Result<ProjectedPayload<'a>> {
+        if !matches!(self.mv_cursor_type, MvccCursorType::Table)
+            || row.id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID
+            || row.is_index_row()
+        {
+            return Ok(ProjectedPayload::Borrowed(row.payload()));
+        }
+
+        let record = ImmutableRecord::from_bin_record(row.payload().to_vec());
+        let Ok((ValueRef::Text(row_type), ValueRef::Numeric(Numeric::Integer(root_page)))) =
+            record.get_two_values(0, 3)
+        else {
+            return Ok(ProjectedPayload::Borrowed(row.payload()));
+        };
+        if row_type.as_str() != "table" && row_type.as_str() != "index" {
+            return Ok(ProjectedPayload::Borrowed(row.payload()));
+        }
+        if root_page >= 0 {
+            return Ok(ProjectedPayload::Borrowed(row.payload()));
+        }
+
+        let physical_root_page = self.db.get_real_table_id(root_page);
+        if physical_root_page == root_page {
+            return Ok(ProjectedPayload::Borrowed(row.payload()));
+        }
+
+        let mut values = record.get_values_owned()?;
+        values[3] = Value::from_i64(physical_root_page);
+        let record = ImmutableRecord::from_values(&values, values.len());
+        Ok(ProjectedPayload::Owned(record))
     }
 
     pub fn close(self) -> Result<()> {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -106,9 +106,9 @@ pub struct CheckpointStateMachine<Clock: LogicalClock> {
     delete_row_state_machine: Option<StateMachine<DeleteRowStateMachine>>,
     /// Cursors for the B-trees
     cursors: HashMap<u64, Arc<RwLock<BTreeCursor>>>,
-    /// Tables or indexes that were created in this checkpoint
-    /// key is the rowid in the sqlite_schema table
-    created_btrees: HashMap<i64, (MVTableId, RowVersion)>,
+    /// Tables or indexes that were created in this checkpoint.
+    /// Key is the rowid in sqlite_schema; value is the stable MVCC table/index id.
+    created_btrees: HashMap<i64, MVTableId>,
     /// Tables that were destroyed in this checkpoint
     destroyed_tables: HashSet<MVTableId>,
     /// Indexes that were destroyed in this checkpoint
@@ -941,8 +941,10 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     })
                 };
 
-                // If a table was created, it now has a real root page allocated for it, but the 'root_page' field in the sqlite_schema record is still the table id.
-                // So we need to rewrite the row version to use the real root page.
+                // If a table was created, it now has a real root page allocated for it, but the
+                // sqlite_schema payload queued for pager write still holds the negative MV table
+                // id. Patch the checkpoint-local write-set copy only; the MVCC version chain
+                // remains immutable and is projected through table_id_to_rootpage on reads.
                 if let Some(SpecialWrite::BTreeCreate {
                     table_id,
                     sqlite_schema_rowid,
@@ -958,25 +960,23 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             .value()
                             .expect("Table ID does not have a root page")
                     };
-                    let row_version = {
-                        let (row_version, _) = self
-                            .get_current_row_version_mut(write_set_index)
-                            .ok_or_else(|| {
-                                LimboError::InternalError(
-                                    "row version not found in write set".to_string(),
-                                )
-                            })?;
-                        let record =
-                            ImmutableRecord::from_bin_record(row_version.row.payload().to_vec());
 
-                        let mut values = record.get_values_owned()?;
-                        values[3] = Value::from_i64(root_page as i64);
-                        let record = ImmutableRecord::from_values(&values, values.len());
-                        row_version.row.data = Some(record.get_payload().to_owned());
-                        row_version.clone()
-                    };
-                    self.created_btrees
-                        .insert(sqlite_schema_rowid, (table_id, row_version));
+                    let (row_version, _) = self
+                        .get_current_row_version_mut(write_set_index)
+                        .ok_or_else(|| {
+                            LimboError::InternalError(
+                                "row version not found in write set".to_string(),
+                            )
+                        })?;
+                    let record =
+                        ImmutableRecord::from_bin_record(row_version.row.payload().to_vec());
+
+                    let mut values = record.get_values_owned()?;
+                    values[3] = Value::from_i64(root_page as i64);
+                    let record = ImmutableRecord::from_values(&values, values.len());
+                    row_version.row.data = Some(record.get_payload().to_owned());
+
+                    self.created_btrees.insert(sqlite_schema_rowid, table_id);
                 } else if let Some(SpecialWrite::BTreeCreateIndex {
                     index_id,
                     sqlite_schema_rowid,
@@ -993,25 +993,22 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             .value()
                             .expect("Index ID does not have a root page")
                     };
-                    let row_version = {
-                        let (row_version, _) = self
-                            .get_current_row_version_mut(write_set_index)
-                            .ok_or_else(|| {
-                                LimboError::InternalError(
-                                    "row version not found in write set".to_string(),
-                                )
-                            })?;
-                        let record =
-                            ImmutableRecord::from_bin_record(row_version.row.payload().to_vec());
-                        let mut values = record.get_values_owned()?;
-                        values[3] = Value::from_i64(root_page as i64);
-                        let record = ImmutableRecord::from_values(&values, values.len());
-                        row_version.row.data = Some(record.get_payload().to_owned());
-                        row_version.clone()
-                    };
 
-                    self.created_btrees
-                        .insert(sqlite_schema_rowid, (index_id, row_version));
+                    let (row_version, _) = self
+                        .get_current_row_version_mut(write_set_index)
+                        .ok_or_else(|| {
+                            LimboError::InternalError(
+                                "row version not found in write set".to_string(),
+                            )
+                        })?;
+                    let record =
+                        ImmutableRecord::from_bin_record(row_version.row.payload().to_vec());
+                    let mut values = record.get_values_owned()?;
+                    values[3] = Value::from_i64(root_page as i64);
+                    let record = ImmutableRecord::from_values(&values, values.len());
+                    row_version.row.data = Some(record.get_payload().to_owned());
+
+                    self.created_btrees.insert(sqlite_schema_rowid, index_id);
                 }
 
                 // Get or create cursor for this table
@@ -1041,7 +1038,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     if self
                         .created_btrees
                         .values()
-                        .any(|(table_id, _)| *table_id == row_version.row.id.table_id)
+                        .any(|table_id| *table_id == row_version.row.id.table_id)
                     {
                         self.state = CheckpointState::WriteRow {
                             write_set_index: write_set_index + 1,
@@ -1172,7 +1169,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     if self
                         .created_btrees
                         .values()
-                        .any(|(table_id, _)| *table_id == row_version.row.id.table_id)
+                        .any(|table_id| *table_id == row_version.row.id.table_id)
                     {
                         self.state = CheckpointState::WriteIndexRow {
                             index_write_set_index: index_write_set_index + 1,
@@ -1408,36 +1405,6 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
             CheckpointState::Finalize => {
                 tracing::debug!("Releasing blocking checkpoint lock");
-                // Patch sqlite_schema in MV Store to contain positive rootpages instead of negative ones
-                // for tables and indexes that were flushed to the physical database
-                for (sqlite_schema_rowid, (_, row_version)) in self.created_btrees.drain() {
-                    let key = RowID {
-                        table_id: SQLITE_SCHEMA_MVCC_TABLE_ID,
-                        row_id: RowKey::Int(sqlite_schema_rowid),
-                    };
-                    let sqlite_schema_row = self
-                        .mvstore
-                        .rows
-                        .get(&key)
-                        .expect("sqlite_schema row not found");
-                    let mut row_versions = sqlite_schema_row.value().write();
-                    // row_version is a clone of the original with only the root
-                    // page column patched, so it shares the same version id. We
-                    // must replace the original in-place rather than append,
-                    // otherwise the version chain ends up with two entries that
-                    // have identical (id, begin, end). A later DELETE only marks
-                    // one of them as ended (it returns after the first match),
-                    // leaving the other as a phantom current version that causes
-                    // spurious write-write conflicts at commit time.
-                    let vid = row_version.id;
-                    if let Some(existing) = row_versions.iter_mut().find(|rv| rv.id == vid) {
-                        *existing = row_version;
-                    } else {
-                        self.mvstore
-                            .insert_version_raw(&mut row_versions, row_version);
-                    }
-                }
-
                 // Patch in-memory schema to do the same
                 self.connection.db.with_schema_mut(|schema| {
                     for table in schema.tables.values_mut() {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6450,6 +6450,83 @@ fn test_checkpoint_root_page_mismatch_with_index() {
     println!("Test passed - row found correctly after checkpoint");
 }
 
+/// What this test checks: checkpoint does not rewrite committed sqlite_schema MVCC versions in place.
+/// Why this matters: Hekaton-style versions are immutable in the version chain; only Begin/End change.
+/// The physical root page must be projected from table_id_to_rootpage at read time instead.
+#[test]
+fn test_checkpoint_preserves_sqlite_schema_version_immutability() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    let mvcc_store = db.get_mvcc_store();
+
+    let pinned_reader_tx_id = 1_000_000;
+    let header = *mvcc_store
+        .global_header
+        .read()
+        .as_ref()
+        .expect("global_header should be initialized");
+    mvcc_store.txs.insert(
+        pinned_reader_tx_id,
+        Transaction::new(pinned_reader_tx_id, 0, header),
+    );
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT rowid, rootpage FROM sqlite_schema WHERE type = 'table' AND name = 't'",
+    );
+    assert_eq!(rows.len(), 1);
+    let sqlite_schema_rowid = rows[0][0].as_int().unwrap();
+    let root_before_checkpoint = rows[0][1].as_int().unwrap();
+    assert!(
+        root_before_checkpoint < 0,
+        "new MVCC table should expose a negative rootpage before checkpoint"
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let visible_root_after_checkpoint = get_rows(
+        &conn,
+        "SELECT rootpage FROM sqlite_schema WHERE type = 'table' AND name = 't'",
+    )[0][0]
+        .as_int()
+        .unwrap();
+    assert!(
+        visible_root_after_checkpoint > 0,
+        "sqlite_schema reads should surface the physical rootpage after checkpoint"
+    );
+
+    let key = RowID::new(
+        SQLITE_SCHEMA_MVCC_TABLE_ID,
+        RowKey::Int(sqlite_schema_rowid),
+    );
+    let sqlite_schema_versions = mvcc_store
+        .rows
+        .get(&key)
+        .expect("sqlite_schema row should exist in MV store");
+    let sqlite_schema_versions = sqlite_schema_versions.value().read();
+    let current_version = sqlite_schema_versions
+        .iter()
+        .rev()
+        .find(|rv| rv.end.is_none())
+        .expect("sqlite_schema row should have a current version");
+    let record = ImmutableRecord::from_bin_record(current_version.row.payload().to_vec());
+    let Some(ValueRef::Numeric(Numeric::Integer(raw_root_after_checkpoint))) =
+        record.get_value_opt(3)
+    else {
+        panic!("sqlite_schema.rootpage should remain an INTEGER");
+    };
+
+    assert_eq!(
+        raw_root_after_checkpoint, root_before_checkpoint,
+        "checkpoint must not mutate the committed sqlite_schema row version in place"
+    );
+
+    mvcc_store.txs.remove(&pinned_reader_tx_id);
+}
+
 /// What this test checks: Checkpoint transitions preserve DB/WAL/log ordering and watermark updates for the tested edge case.
 /// Why this matters: Incorrect ordering breaks crash safety, replay boundaries, or durability guarantees.
 #[test]


### PR DESCRIPTION
## Description

During checkpoint, we patched committed `sqlite_schema` row-version payloads in place after assigning physical root pages. That is not a good fit for a Hekaton-style MVCC model, where logical updates create new versions and postprocessing mutates version metadata (`Begin`/`End`), not arbitrary committed payload.

This PR removes that post-checkpoint payload rewrite. Instead, it keeps the committed MVCC `sqlite_schema` version logical and projects `sqlite_schema.rootpage` at the MVCC cursor layer when materializing SQL-visible rows.

## Motivation and context

I hit this while working on #3499. The in-place payload rewrite was a blocker because the concurrent data structure can't perform/perform very inefficient with arbitrary payload mutation.

## Description of AI Usage

- Brainstormed approaches that best fit the existing MVCC design and Hekaton-style version handling
- Helped draft the test