### PR TITLE
simulator: gracefully rollback when a dependent txn aborts

### DIFF
--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -731,6 +731,7 @@ impl Whopper {
                     | turso_core::LimboError::Busy
                     | turso_core::LimboError::BusySnapshot
                     | turso_core::LimboError::WriteWriteConflict
+                    | turso_core::LimboError::CommitDependencyAborted
                     | turso_core::LimboError::InvalidArgument(..) => {
                         if ctx.fiber.state.is_in_tx() && !ctx.fiber.connection.get_auto_commit() {
                             ctx.fiber.current_op = Some(Operation::Rollback);


### PR DESCRIPTION
## Description

Right now we aren't handling `CommitDependencyAborted` error in whopper, which exits with non zero and shows as failed in CI. This patch fixes the issue i.e. if a dependent txn aborts, then we just rollback and continue with the workload.

example failure run (now passes with this patch) - https://github.com/tursodatabase/turso/actions/runs/23186916306/job/67372651722