### PR TITLE
Fix trigger namespace collisions with tables, indexes, and views

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -723,7 +723,7 @@ impl Schema {
     }
 
     pub fn add_trigger(&mut self, trigger: Trigger, table_name: &str) -> Result<()> {
-        self.check_object_name_conflict(&trigger.name)?;
+        self.check_trigger_name_conflict(&trigger.name)?;
         let table_name = normalize_ident(table_name);
 
         // See [Schema::add_index] for why we push to the front of the deque.
@@ -1748,6 +1748,16 @@ impl Schema {
             };
             return Err(crate::LimboError::ParseError(format!(
                 "{type_str} \"{name}\" already exists"
+            )));
+        }
+        Ok(())
+    }
+
+    fn check_trigger_name_conflict(&self, name: &str) -> Result<()> {
+        let normalized_name = normalize_ident(name);
+        if self.get_trigger(&normalized_name).is_some() {
+            return Err(crate::LimboError::ParseError(format!(
+                "trigger {normalized_name} already exists"
             )));
         }
         Ok(())

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -122,7 +122,7 @@ pub fn translate_create_trigger(
         if if_not_exists {
             return Ok(());
         }
-        bail_parse_error!("Trigger {} already exists", normalized_trigger_name);
+        bail_parse_error!("trigger {} already exists", normalized_trigger_name);
     }
 
     // Verify the table exists
@@ -187,7 +187,9 @@ pub fn translate_create_trigger(
     let escaped_trigger_name = escape_sql_string_literal(&normalized_trigger_name);
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
-        where_clause: Some(format!("name = '{escaped_trigger_name}'")),
+        where_clause: Some(format!(
+            "type = 'trigger' AND name = '{escaped_trigger_name}'"
+        )),
     });
 
     Ok(())

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -238,7 +238,9 @@ pub fn translate_create_materialized_view(
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
         where_clause: Some(format!(
-            "name = '{escaped_view_name}' OR name = '{escaped_dbsp_table_name}' OR name = '{escaped_dbsp_index_name}'"
+            "(type = 'view' AND name = '{escaped_view_name}') \
+             OR (type = 'table' AND name = '{escaped_dbsp_table_name}') \
+             OR (type = 'index' AND name = '{escaped_dbsp_index_name}')"
         )),
     });
 
@@ -345,7 +347,7 @@ pub fn translate_create_view(
     let escaped_view_name = escape_sql_string_literal(&normalized_view_name);
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
-        where_clause: Some(format!("name = '{escaped_view_name}'")),
+        where_clause: Some(format!("type = 'view' AND name = '{escaped_view_name}'")),
     });
 
     let schema_version = resolver.with_schema(database_id, |s| s.schema_version);

--- a/testing/runner/tests/duplicate-trigger-names.sqltest
+++ b/testing/runner/tests/duplicate-trigger-names.sqltest
@@ -53,3 +53,69 @@ test correct-trigger-fires-after-failed-duplicate {
 expect {
     from_t1
 }
+
+@setup schema
+test trigger-name-can-match-table-name {
+    CREATE TABLE tr(a);
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('table'); END;
+    INSERT INTO t1 VALUES(1);
+    SELECT * FROM log;
+}
+expect {
+    table
+}
+
+@setup schema
+test trigger-name-can-match-index-name {
+    CREATE INDEX tr ON t1(a);
+    CREATE TRIGGER tr AFTER INSERT ON t2 BEGIN INSERT INTO log VALUES('index'); END;
+    INSERT INTO t2 VALUES(1);
+    SELECT * FROM log;
+}
+expect {
+    index
+}
+
+@setup schema
+test trigger-name-can-match-view-name {
+    CREATE VIEW tr AS SELECT a FROM t1;
+    CREATE TRIGGER tr AFTER INSERT ON t2 BEGIN INSERT INTO log VALUES('view'); END;
+    INSERT INTO t2 VALUES(1);
+    SELECT * FROM log;
+}
+expect {
+    view
+}
+
+@setup schema
+test table-name-can-match-trigger-name {
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('table'); END;
+    CREATE TABLE tr(a);
+    SELECT type, name FROM sqlite_schema WHERE name = 'tr' ORDER BY type;
+}
+expect {
+    table|tr
+    trigger|tr
+}
+
+@setup schema
+test index-name-can-match-trigger-name {
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('index'); END;
+    CREATE INDEX tr ON t2(a);
+    SELECT type, name FROM sqlite_schema WHERE name = 'tr' ORDER BY type;
+}
+expect {
+    index|tr
+    trigger|tr
+}
+
+@setup schema
+test view-name-can-match-trigger-name {
+    CREATE TRIGGER tr AFTER INSERT ON t1 BEGIN INSERT INTO log VALUES('view'); END;
+    CREATE VIEW tr AS SELECT a FROM t2;
+    SELECT type, name FROM sqlite_schema WHERE name = 'tr' ORDER BY type;
+}
+expect {
+    trigger|tr
+    view|tr
+}


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

Fix trigger name handling so triggers use their own namespace instead of sharing the table/view/index namespace.

  Changes:

  - stop using the generic schema object conflict check when loading or adding triggers in memory
  - keep duplicate-trigger detection case-insensitive and trigger-specific
  - narrow ParseSchema reloads for CREATE TRIGGER to type = 'trigger'
  - narrow ParseSchema reloads for CREATE VIEW and materialized view creation to type-qualified filters, so same-named triggers are not reparsed as conflicting objects
  - add regression coverage for both directions of the namespace rule:
      - trigger name matches existing table/index/view
      - table/index/view name matches existing trigger

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

SQLite keeps triggers in a separate namespace from tables, indexes, and views. Turso incorrectly treated trigger names as part of the shared schema object namespace, so statements
  like:

  CREATE TABLE t(x);
  CREATE TRIGGER t AFTER INSERT ON t ...

  failed even though SQLite accepts them.

  The bug had two parts:

  - in-memory schema loading used the generic object conflict path for triggers
  - some schema reload paths filtered sqlite_schema only by name, which caused same-named objects of other types to be reparsed and rejected

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #5867
## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
