### PR TITLE
core/mvcc: Fix pager read lock panics after BEGIN DEFERRED then BEGIN CONCURRENT

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9445,3 +9445,24 @@ fn test_snapshot_stability_full() {
     }
     assert!(rs > 0, "reader made no progress");
 }
+
+#[test]
+fn test_read_lock_leak_deferred_then_concurrent() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn0 = db.connect();
+    conn0
+        .execute("CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)")
+        .unwrap();
+    conn0.execute("INSERT INTO t1 VALUES(1, 'v1')").unwrap();
+    conn0.close().unwrap();
+
+    let conn1 = db.connect();
+    conn1.execute("BEGIN DEFERRED").unwrap();
+    // BEGIN CONCURRENT after BEGIN DEFERRED should error but not leak state
+    let result = conn1.execute("BEGIN CONCURRENT");
+    assert!(result.is_err());
+
+    // After the error, SELECT should work without panicking
+    let rows = get_rows(&conn1, "SELECT * FROM t1");
+    assert_eq!(rows.len(), 1);
+}

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3494,6 +3494,9 @@ pub fn op_transaction_inner(
                             && *tx_mode == TransactionMode::Concurrent
                         {
                             mark_unlikely();
+                            pager.end_read_tx();
+                            conn.set_tx_state(TransactionState::None);
+                            state.auto_txn_cleanup = TxnCleanup::None;
                             return Err(LimboError::TxError(
                                 "Cannot start CONCURRENT transaction after BEGIN DEFERRED"
                                     .to_string(),


### PR DESCRIPTION
## Description
Close the read transaction before returning `TxError` when attempting to start concurrent transaction from deferred to avoid `cannot start a new read tx without ending an existing one` panic. Using the same cleanup pattern as rest of the codebase.

## Motivation and context

Fixes: #5953

## Description of AI Usage
Asked codex for review of the changes
