### PR TITLE
truncate logical log in `maybe_complete_interrupted_checkpoint` after wal backfill

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4325,6 +4325,16 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         pager
             .io
             .block(|| wal.truncate_wal(&mut checkpoint_result, pager.get_sync_type()))?;
+
+        // Truncate the logical log to 0 — all data has been checkpointed into the DB file.
+        // This mirrors the TruncateLogicalLog step in the MVCC checkpoint state machine.
+        let c = self.storage.truncate()?;
+        pager.io.wait_for_completion(c)?;
+        if connection.get_sync_mode() != SyncMode::Off {
+            let c = self.storage.sync(pager.get_sync_type())?;
+            pager.io.wait_for_completion(c)?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Description
Still need to see if this is actually allowed in the current mvcc recovery model

## Motivation and context
So that after a `Pragma journal_mode = "mvcc"` we have an empty log file. I think we had a stale LOG_HEADER there from a potential recovery attempt.

