### PR TITLE
do not clone db schema if inside a write transaction that changed the  schema

### DIFF
--- a/core/statement.rs
+++ b/core/statement.rs
@@ -2,18 +2,20 @@ use std::{
     borrow::Cow,
     num::NonZero,
     ops::Deref,
-    sync::{atomic::Ordering, Arc},
+    sync::{Arc, atomic::Ordering},
     task::Waker,
     time::Duration,
 };
 
-use tracing::{instrument, Level};
+use tracing::{Level, instrument};
 use turso_parser::{
-    ast::{fmt::ToTokens, Cmd},
+    ast::{Cmd, fmt::ToTokens},
     parser::Parser,
 };
 
 use crate::{
+    EXPLAIN_COLUMNS, EXPLAIN_QUERY_PLAN_COLUMNS, LimboError, MvStore, Pager, QueryMode, Result,
+    TransactionState, Value,
     busy::BusyHandlerState,
     parameters,
     schema::Trigger,
@@ -23,8 +25,6 @@ use crate::{
         self,
         explain::{EXPLAIN_COLUMNS_TYPE, EXPLAIN_QUERY_PLAN_COLUMNS_TYPE},
     },
-    LimboError, MvStore, Pager, QueryMode, Result, Value, EXPLAIN_COLUMNS,
-    EXPLAIN_QUERY_PLAN_COLUMNS,
 };
 
 type ProgramExecutionState = vdbe::ProgramExecutionState;
@@ -421,7 +421,7 @@ impl Statement {
                 vdbe::StepResult::IO => self.pager.io.step()?,
                 vdbe::StepResult::Row => continue,
                 vdbe::StepResult::Interrupt | vdbe::StepResult::Busy => {
-                    return Err(LimboError::Busy)
+                    return Err(LimboError::Busy);
                 }
             }
         }
@@ -438,7 +438,7 @@ impl Statement {
                     continue;
                 }
                 vdbe::StepResult::Interrupt | vdbe::StepResult::Busy => {
-                    return Err(LimboError::Busy)
+                    return Err(LimboError::Busy);
                 }
             }
         }
@@ -515,11 +515,23 @@ impl Statement {
             }
         }
 
+        // When this connection has performed DDL within a write transaction
+        // (schema_did_change == true), the connection's schema is more up-to-date
+        // than the shared DB schema (which won't be updated until COMMIT).
+        // Overwriting it here would revert the schema cookie and cause an
+        // infinite reprepare loop. In all other cases, refresh from the shared DB.
         // if current connection is within a transaction which changed schema - we must use its schema version instead of DB schema version
         // see test_prepared_stmt_reprepare_ddl_change_txn (plus test_sync_pull_after_local_ddl_and_remote_writes)
         {
             let mut conn_schema = conn.schema.write();
-            if conn_schema.schema_version < conn.db.schema.lock().schema_version {
+            if conn_schema.schema_version < conn.db.schema.lock().schema_version
+                && !matches!(
+                    conn.get_tx_state(),
+                    TransactionState::Write {
+                        schema_did_change: true
+                    }
+                )
+            {
                 *conn_schema = conn.db.clone_schema();
             }
         }
@@ -998,7 +1010,7 @@ impl Drop for Statement {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Database, DatabaseOpts, MemoryIO, OpenFlags, IO};
+    use crate::{Database, DatabaseOpts, IO, MemoryIO, OpenFlags};
 
     fn open_test_connection() -> crate::Result<Arc<crate::Connection>> {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());

--- a/tests/integration/statement_reset.rs
+++ b/tests/integration/statement_reset.rs
@@ -92,6 +92,28 @@ fn returning_delete_drop_after_partial_read_commits(tmp_db: TempDatabase) -> any
     Ok(())
 }
 
+/// Reproduces https://github.com/tursodatabase/turso/issues/5930
+/// When a prepared statement is stepped after DDL runs inside an explicit
+/// BEGIN...COMMIT transaction, reprepare() overwrites the connection schema
+/// with the stale shared DB schema, causing an infinite SchemaUpdated loop.
+#[turso_macros::test(init_sql = "CREATE TABLE t0 (c0 TEXT);")]
+fn reprepare_loop_during_explicit_txn(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    // Pre-prepare INSERT (caches schema cookie from before the DDL)
+    let mut insert_stmt = conn.prepare("INSERT INTO t0 VALUES ('hello')")?;
+
+    // Explicit transaction with DDL that advances the schema cookie
+    conn.execute("BEGIN")?;
+    conn.execute("CREATE TABLE t1 (c0 TEXT)")?;
+
+    // Step the stale prepared statement — triggers SchemaUpdated → reprepare
+    insert_stmt.run_ignore_rows()?;
+
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
 /// Plain INSERT (no RETURNING): runs to completion via step(), then drop.
 /// This is the normal case — Halt commits the transaction.
 #[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);")]


### PR DESCRIPTION
## Motivation and context
Fixes https://github.com/tursodatabase/turso/issues/5930


## Description of AI Usage
Just confirmed with Claude that issue is reproduced by the test and applied the fix. 