### PR TITLE
Drop support for Python 3.9 and add Python 3.14

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - id: gen-matrix
         run: |
-          echo "python-versions=[\"3.9\",\"3.13\"]" >> $GITHUB_OUTPUT
+          echo "python-versions=[\"3.10\",\"3.14\"]" >> $GITHUB_OUTPUT
 
   test:
     needs: configure-strategy

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -5,17 +5,17 @@ build-backend = 'maturin'
 [project]
 name = 'pyturso'
 description = "Turso is a work-in-progress, in-process OLTP database management system, compatible with SQLite."
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 classifiers = [
     'Development Status :: 3 - Alpha',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Rust',
     'License :: OSI Approved :: MIT License',
     'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
## Description

Fixes https://github.com/tursodatabase/turso/issues/4349

(Edit: Just saw after this PR has been merged that wheels for Python 3.14 were already being built because maturin is being run with the `--find-interpreter` flag and there is no upper bound for `requires-python` in `pyproject.toml`)

This PR changes the supported Python versions in the Python bindings for turso. It drops support for Python 3.9 and adds support for Python 3.14.

## Motivation and context

[Python 3.9 is EOL since October 2025](https://devguide.python.org/versions) so I'd argue it's fair to drop support for it. Support for Python 3.14 can also be added because the currently used [PyO3 version 0.27.0 supports Python 3.14](https://github.com/PyO3/pyo3/releases/tag/v0.27.0).


## Description of AI Usage

I used Claude Code with Opus 4.6 to verify the minimal changes I did. I also used it to search through the issues on GitHub to gather more context.
