### PR TITLE
Add test to ensure compaction after vaccum into

### DIFF
--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -2154,7 +2154,7 @@ fn test_vacuum_into_compacts_fragmented_database(tmp_db: TempDatabase) -> anyhow
     let dest_path = dest_dir.path().join("vacuumed.db");
     let dest_path_str = dest_path.to_str().unwrap();
 
-    conn.execute(format!("VACUUM INTO '{}'", dest_path_str))?;
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
 
     let dest_db = TempDatabase::new_with_existent(&dest_path);
     let dest_conn = dest_db.connect_limbo();
@@ -2189,9 +2189,7 @@ fn test_vacuum_into_compacts_fragmented_database(tmp_db: TempDatabase) -> anyhow
     let dest_size = std::fs::metadata(&dest_path)?.len();
     assert!(
         dest_size < source_size,
-        "VACUUM INTO should reduce file size. Source: {} bytes, Destination: {} bytes",
-        source_size,
-        dest_size
+        "VACUUM INTO should reduce file size. Source: {source_size} bytes, Destination: {dest_size} bytes"
     );
 
     Ok(())


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->

## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

Add new test to ensure that after a database is vacuumed using `VACUUM INTO`  the size of the new database is reduced.

These are the steps for the test:
1. Create a table containing blob field
2. Insert 100 rows with 4KB blobs
3. Delete 60 rows
4. Update the remaining rows with a random blob of 4KB and then another blob with 8KB
5. Call `VACUUM INTO`

The assertions in the test are:
1. Ensure the deleted rows were really deleted
2. Run the integrity check for the vacuumed db. (I'm not sure it's really needed)
3. Ensure both database has the same hash
4. Ensure that the `page_count` of the vacuumed database is lower than the source
5. Ensure the table in the vacuumed db has just 40 rows
6. Ensure the size of the vacuumed.db file is lower than the source file.

Closes #6044 

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->
I was looking for easy issues that I could work on, then I created this pr that is intended to close the #6044 


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

I used AI to help me to understand some concepts like pages and the overflow pages. As I'm new to Rust I  used to guide me on my approach, for example I asked multiple times what I could improve in the test and the AI suggested me some things that I found interesting like using a larger blob to force the page overflow and also update blobs with different sizes. AI also suggested me to use `conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;` in order to update the main db after the delete and udpates.