### PR TITLE
Add DEFAULT keyword support in INSERT VALUES expressions

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -872,6 +872,9 @@ pub fn translate_condition_expr(
             translate_expr(program, Some(referenced_tables), expr, expr_reg, resolver)?;
             emit_cond_jump(program, condition_metadata, expr_reg);
         }
+        ast::Expr::Default => {
+            crate::bail_parse_error!("DEFAULT is only valid in INSERT VALUES");
+        }
         ast::Expr::Array { .. } | ast::Expr::Subscript { .. } => {
             unreachable!("Array and Subscript are desugared into function calls by the parser")
         }
@@ -3689,6 +3692,9 @@ pub fn translate_expr(
             });
             Ok(target_register)
         }
+        ast::Expr::Default => {
+            crate::bail_parse_error!("DEFAULT is only valid in INSERT VALUES");
+        }
         ast::Expr::Array { .. } | ast::Expr::Subscript { .. } => {
             unreachable!("Array and Subscript are desugared into function calls by the parser")
         }
@@ -5346,7 +5352,8 @@ where
                 | ast::Expr::Name(_)
                 | ast::Expr::Qualified(..)
                 | ast::Expr::Variable(_)
-                | ast::Expr::Register(_) => {
+                | ast::Expr::Register(_)
+                | ast::Expr::Default => {
                     // No nested expressions
                 }
             }
@@ -5959,7 +5966,8 @@ where
                 | ast::Expr::Name(_)
                 | ast::Expr::Qualified(..)
                 | ast::Expr::Variable(_)
-                | ast::Expr::Register(_) => {
+                | ast::Expr::Register(_)
+                | ast::Expr::Default => {
                     // No nested expressions
                 }
             }
@@ -6696,6 +6704,7 @@ pub fn expr_vector_size(expr: &Expr) -> Result<usize> {
             SubqueryType::In { .. } => 1,
             SubqueryType::RowValue { num_regs, .. } => *num_regs,
         },
+        Expr::Default => 1,
         Expr::Array { .. } | Expr::Subscript { .. } => {
             unreachable!("Array and Subscript are desugared into function calls by the parser")
         }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -314,6 +314,7 @@ pub fn translate_insert(
         program,
         resolver,
         &table,
+        &columns,
         &mut body,
         on_conflict.unwrap_or(ResolveType::Abort),
         database_id,
@@ -1731,10 +1732,48 @@ fn expr_contains_subquery(expr: &Expr) -> bool {
     found_subquery
 }
 
+/// Resolve `Expr::Default` in a VALUES row by replacing it with the column's
+/// default expression from the schema.
+fn resolve_defaults_in_row(
+    row: &mut [Box<Expr>],
+    table: &Table,
+    columns: &[ast::Name],
+    resolver: &Resolver,
+) {
+    let is_strict = table.is_strict();
+    for (i, expr) in row.iter_mut().enumerate() {
+        if !matches!(expr.as_ref(), Expr::Default) {
+            continue;
+        }
+        let col = if columns.is_empty() {
+            // No column list — position maps to non-hidden columns in order
+            table.columns().iter().filter(|c| !c.hidden()).nth(i)
+        } else {
+            // Column list — map by name
+            columns.get(i).and_then(|name| {
+                let name = crate::util::normalize_ident(name.as_str());
+                table.get_column_by_name(&name).map(|(_, col)| col)
+            })
+        };
+        *expr = match col {
+            Some(col) => col.default.clone().unwrap_or_else(|| {
+                if let Some(type_def) = resolver.schema().get_type_def(&col.ty_str, is_strict) {
+                    if let Some(ref default_expr) = type_def.default {
+                        return default_expr.clone();
+                    }
+                }
+                Box::new(ast::Expr::Literal(ast::Literal::Null))
+            }),
+            None => Box::new(ast::Expr::Literal(ast::Literal::Null)),
+        };
+    }
+}
+
 fn bind_insert(
     program: &mut ProgramBuilder,
     resolver: &Resolver,
     table: &Table,
+    columns: &[ast::Name],
     body: &mut InsertBody,
     on_conflict: ResolveType,
     database_id: usize,
@@ -1766,6 +1805,19 @@ fn bind_insert(
                 .collect();
         }
         InsertBody::Select(select, upsert_opt) => {
+            // Resolve Expr::Default in all VALUES rows before any compilation.
+            if let OneSelect::Values(values_expr) = &mut select.body.select {
+                for row in values_expr.iter_mut() {
+                    resolve_defaults_in_row(row, table, columns, resolver);
+                }
+            }
+            for compound in select.body.compounds.iter_mut() {
+                if let OneSelect::Values(values_expr) = &mut compound.select {
+                    for row in values_expr.iter_mut() {
+                        resolve_defaults_in_row(row, table, columns, resolver);
+                    }
+                }
+            }
             if select.body.compounds.is_empty() {
                 match &mut select.body.select {
                     // TODO see how to avoid clone

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -2681,6 +2681,7 @@ impl Optimizable for ast::Expr {
             Expr::Unary(_, expr) => expr.is_nonnull(tables),
             Expr::Variable(..) => false,
             Expr::Register(..) => false, // Register values can be null
+            Expr::Default => false,
             Expr::Array { .. } | Expr::Subscript { .. } => {
                 unreachable!("Array and Subscript are desugared into function calls by the parser")
             }
@@ -2769,6 +2770,7 @@ impl Optimizable for ast::Expr {
             Expr::Unary(_, expr) => expr.is_constant(resolver),
             Expr::Variable(_) => true,
             Expr::Register(_) => false,
+            Expr::Default => true,
             Expr::Array { .. } | Expr::Subscript { .. } => {
                 unreachable!("Array and Subscript are desugared into function calls by the parser")
             }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1097,7 +1097,8 @@ fn expr_contains_subquery(expr: &Expr) -> bool {
             | Expr::Qualified(_, _)
             | Expr::Register(_)
             | Expr::RowId { .. }
-            | Expr::Variable(_) => {}
+            | Expr::Variable(_)
+            | Expr::Default => {}
         }
     }
     false

--- a/docs/sql-reference/compatibility.mdx
+++ b/docs/sql-reference/compatibility.mdx
@@ -25,6 +25,7 @@ These features extend Turso beyond SQLite compatibility:
 | [Encryption](/docs/sql-reference/pragmas#encryption) | At-rest database encryption |
 | [Custom index methods](/docs/sql-reference/statements/create-index#using-method) | CREATE INDEX ... USING for FTS and custom access methods |
 | stddev() | Standard deviation aggregate function |
+| [DEFAULT in VALUES](/docs/sql-reference/statements/insert#default-keyword-in-values) | SQL-standard DEFAULT keyword in INSERT VALUES lists |
 
 ## See Also
 

--- a/docs/sql-reference/statements/insert.mdx
+++ b/docs/sql-reference/statements/insert.mdx
@@ -31,7 +31,7 @@ INSERT [OR conflict_action] INTO table_name [(column_name [, ...])]
 | `conflict_action` | keyword | One of REPLACE, IGNORE, ABORT, ROLLBACK, or FAIL. Controls behavior on constraint violations |
 | `table_name` | identifier | The table to insert rows into |
 | `column_name` | identifier | Column to assign a value to. Unlisted columns receive their default value or NULL |
-| `expression` | expression | A value to insert. Must match the position or name of the target column |
+| `expression` | expression | A value to insert, or the keyword `DEFAULT` to use the column's default value. Must match the position or name of the target column |
 | `select_statement` | SELECT query | A query whose result rows are inserted into the table |
 | `result_column` | expression | Column or expression to return for each inserted row |
 
@@ -125,6 +125,37 @@ CREATE TABLE tasks (
 -- status, priority, and created_at use their defaults
 INSERT INTO tasks (title) VALUES ('Review pull request');
 ```
+
+## DEFAULT Keyword in VALUES
+
+<Info>
+**Turso extension** -- This feature follows the SQL standard (SQL:2016) but is not supported by SQLite.
+</Info>
+
+The `DEFAULT` keyword can be used in place of any value expression in a VALUES list. It resolves to the column's default value as defined in the CREATE TABLE statement, or NULL if no default is defined. This is particularly useful when inserting multiple rows where different rows need defaults for different columns -- something that cannot be achieved by simply omitting columns from the column list.
+
+```sql
+CREATE TABLE tasks (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  status TEXT DEFAULT 'pending',
+  priority INTEGER DEFAULT 0
+);
+
+-- Use DEFAULT for specific columns
+INSERT INTO tasks (id, title, status, priority)
+VALUES (1, 'Fix bug', DEFAULT, 5);
+-- Inserts: (1, 'Fix bug', 'pending', 5)
+
+-- Different columns use DEFAULT in different rows
+INSERT INTO tasks (id, title, status, priority) VALUES
+  (2, 'Write docs', DEFAULT, 3),
+  (3, 'Code review', 'in_progress', DEFAULT);
+-- Inserts: (2, 'Write docs', 'pending', 3)
+--          (3, 'Code review', 'in_progress', 0)
+```
+
+The `DEFAULT` keyword is only valid inside INSERT VALUES lists. Using it in other contexts (SELECT, WHERE, UPDATE) produces an error.
 
 ## Conflict Handling
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -518,6 +518,8 @@ pub enum Expr {
         /// The type of subquery.
         query_type: SubqueryType,
     },
+    /// `DEFAULT` keyword in INSERT VALUES
+    Default,
     /// `ARRAY[expr, ...]` array literal
     Array {
         /// elements of the array

--- a/parser/src/ast/fmt.rs
+++ b/parser/src/ast/fmt.rs
@@ -1009,6 +1009,7 @@ impl ToTokens for Expr {
                 let indexed = format!("?{}", var.index.get());
                 s.append(TK_VARIABLE, Some(indexed.as_str()))
             }
+            Self::Default => s.append(TK_DEFAULT, None),
             Self::Array { elements } => {
                 s.append(TK_ID, Some("ARRAY"))?;
                 s.append(TK_LBRACKET, None)?;

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1409,9 +1409,14 @@ impl<'a> Parser<'a> {
             TK_EXISTS,
             TK_CASE,
             TK_LBRACKET,
+            TK_DEFAULT,
         );
 
         match tok.token_type {
+            TK_DEFAULT => {
+                eat_assert!(self, TK_DEFAULT);
+                Ok(Box::new(Expr::Default))
+            }
             TK_LP => {
                 eat_assert!(self, TK_LP);
                 match self.peek_no_eof()?.token_type {

--- a/testing/sqltests/turso-tests/insert-default.sqltest
+++ b/testing/sqltests/turso-tests/insert-default.sqltest
@@ -1,0 +1,75 @@
+@database :memory:
+
+test single-row-all-default {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER DEFAULT 10, b TEXT DEFAULT 'hello', c INTEGER);
+    INSERT INTO t (id, a, b, c) VALUES (1, DEFAULT, DEFAULT, DEFAULT);
+    SELECT * FROM t;
+}
+expect {
+    1|10|hello|
+}
+
+test single-row-mixed-default-and-values {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER DEFAULT 10, b TEXT DEFAULT 'hello', c INTEGER);
+    INSERT INTO t (id, a, b, c) VALUES (2, DEFAULT, 'world', 42);
+    SELECT * FROM t;
+}
+expect {
+    2|10|world|42
+}
+
+test multi-row-different-defaults {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER DEFAULT 10, b TEXT DEFAULT 'hello', c INTEGER);
+    INSERT INTO t (id, a, b, c) VALUES (3, DEFAULT, 'foo', 1), (4, 99, DEFAULT, 2);
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    3|10|foo|1
+    4|99|hello|2
+}
+
+test no-default-resolves-to-null {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER DEFAULT 10, b TEXT DEFAULT 'hello', c INTEGER);
+    INSERT INTO t (id, a, b, c) VALUES (5, DEFAULT, DEFAULT, DEFAULT);
+    SELECT id, a, b, c IS NULL FROM t;
+}
+expect {
+    5|10|hello|1
+}
+
+test default-with-returning {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER DEFAULT 10, b TEXT DEFAULT 'hello', c INTEGER);
+    INSERT INTO t (id, a, b, c) VALUES (6, DEFAULT, DEFAULT, DEFAULT) RETURNING id, a, b;
+}
+expect {
+    6|10|hello
+}
+
+test default-without-column-list {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER DEFAULT 10, b TEXT DEFAULT 'hello');
+    INSERT INTO t VALUES (1, DEFAULT, DEFAULT);
+    SELECT * FROM t;
+}
+expect {
+    1|10|hello
+}
+
+test default-on-not-null-column-without-default-errors {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+    INSERT INTO t (id, name) VALUES (1, DEFAULT);
+}
+expect error {
+}
+
+test default-in-select-errors {
+    SELECT DEFAULT;
+}
+expect error {
+}
+
+test default-in-where-errors {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER DEFAULT 10);
+    SELECT * FROM t WHERE a = DEFAULT;
+}
+expect error {
+}


### PR DESCRIPTION
Implement the SQL-standard (SQL:2016 §14.11) DEFAULT keyword inside INSERT VALUES lists, allowing explicit use of column defaults on a per-value basis:

  INSERT INTO t (a, b) VALUES (1, DEFAULT), (DEFAULT, 2);

This feature does not exist in SQLite — it is a Turso extension as part of our effort to make Turso behave more like Postgres, which has supported this syntax for a long time. The motivation is that omitting columns from the INSERT column list applies defaults uniformly across all rows, but DEFAULT in VALUES lets different rows use defaults for different columns within the same statement.

Expr::Default is resolved to the actual column default expression (or NULL) in the AST before bytecode compilation, so both single-row and multi-row INSERT paths work without special-casing.