### PR TITLE
Fix/real float comparison issue

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -298,6 +298,29 @@ fn make_sort_comparator(cmp_type: &SortComparatorType) -> crate::vdbe::sorter::S
     }
 }
 
+/// Apply affinity conversion for comparison purposes.
+///
+/// Unlike storage affinity, comparison affinity for REAL must NOT convert
+/// Integer operands to Float. Converting Integer(i) to Float(i as f64) loses
+/// precision for large integers (beyond 2^53), causing incorrect equality
+/// results. Instead, leave integers as-is — `Numeric::cmp` uses
+/// `sqlite_int_float_cmp` which handles Float-vs-Integer without precision loss.
+///
+/// Only TEXT values need conversion (e.g. "3.14" → Float for REAL affinity).
+fn convert_for_comparison<'a>(
+    affinity: Affinity,
+    val: &'a impl AsValueRef,
+) -> Option<either::Either<ValueRef<'a>, crate::Value>> {
+    // For REAL affinity: if the value is already an integer, skip conversion.
+    // Numeric::cmp handles Float-vs-Integer correctly via sqlite_int_float_cmp.
+    if matches!(affinity, Affinity::Real)
+        && matches!(val.as_value_ref(), ValueRef::Numeric(Numeric::Integer(_)))
+    {
+        return None;
+    }
+    affinity.convert(val)
+}
+
 /// Compare two values using the specified collation for text values.
 /// Non-text values are compared using their natural ordering.
 fn compare_with_collation(
@@ -977,8 +1000,8 @@ pub fn op_comparison(
     }
 
     let (new_lhs, new_rhs) = (
-        affinity.convert_for_compare(lhs_value),
-        affinity.convert_for_compare(rhs_value),
+        convert_for_comparison(affinity, lhs_value),
+        convert_for_comparison(affinity, rhs_value),
     );
 
     let should_jump = op.compare(

--- a/testing/sqltests/tests/real_integer_comparison.sqltest
+++ b/testing/sqltests/tests/real_integer_comparison.sqltest
@@ -1,0 +1,75 @@
+@database :memory:
+
+test direct-comparison {
+    SELECT 3036093696168066048.0 = 3036093696168066000;
+}
+expect {
+    0
+}
+
+test through-cast {
+    SELECT CAST(3036093696168066048.0 AS REAL) = 3036093696168066000;
+}
+expect {
+    0
+}
+
+test through-table-column {
+    CREATE TABLE t1 (val REAL);
+    INSERT INTO t1 VALUES (3036093696168066048.0);
+    SELECT val = 3036093696168066000 FROM t1;
+}
+expect {
+    0
+}
+
+test all-six-operators {
+    CREATE TABLE t2 (val REAL);
+    INSERT INTO t2 VALUES (3036093696168066048.0);
+    SELECT val = 3036093696168066000,
+           val != 3036093696168066000,
+           val < 3036093696168066000,
+           val > 3036093696168066000,
+           val <= 3036093696168066000,
+           val >= 3036093696168066000
+    FROM t2;
+}
+expect {
+    0|1|0|1|0|1
+}
+
+test precision-boundary-2pow53 {
+    CREATE TABLE t9 (val REAL);
+    INSERT INTO t9 VALUES (9007199254740992.0);
+    SELECT val = 9007199254740993 FROM t9;
+}
+expect {
+    0
+}
+
+test negative-values-equality {
+    CREATE TABLE t11 (val REAL);
+    INSERT INTO t11 VALUES (-3036093696168066048.0);
+    SELECT val = -3036093696168066000 FROM t11;
+}
+expect {
+    0
+}
+
+test negative-values-less-than {
+    CREATE TABLE t12 (val REAL);
+    INSERT INTO t12 VALUES (-3036093696168066048.0);
+    SELECT val < -3036093696168066000 FROM t12;
+}
+expect {
+    1
+}
+
+test i64max-real {
+    CREATE TABLE t_pavan (id INTEGER PRIMARY KEY, x1 REAL, x2 REAL);
+    INSERT INTO t_pavan VALUES(1, 0, 9223372036854775807);
+    SELECT count(*) FROM t_pavan WHERE x2 <= 9223372036854775807;
+}
+expect {
+    0
+}


### PR DESCRIPTION
## Description
When comparing a REAL column value (or CAST-to-REAL) against a large
INTEGER literal, the REAL affinity conversion was coercing the integer
operand to f64 before comparison. This caused precision loss for integers
beyond 2^53, making values like 3036093696168066048.0 and
3036093696168066000 appear equal.

The fix skips the Integer-to-Float conversion in the comparison path,
letting Numeric::cmp route through sqlite_int_float_cmp which compares
Float-vs-Integer without precision loss.

## Motivation and context
Fixes: https://github.com/tursodatabase/turso/issues/6056


## Description of AI Usage
I used AI to navigate the codebase and understand concepts and implementations I was not familiar with.