### PR TITLE
bindings/react-native: Fix Database.close() not finalizing statements

### DIFF
--- a/bindings/react-native/cpp/TursoStatementHostObject.cpp
+++ b/bindings/react-native/cpp/TursoStatementHostObject.cpp
@@ -17,9 +17,21 @@ void TursoStatementHostObject::throwError(jsi::Runtime &rt, const char *error) {
     throw jsi::JSError(rt, error ? error : "Unknown error");
 }
 
+void TursoStatementHostObject::checkStatement(jsi::Runtime &rt) {
+    if (!stmt_) {
+        throw jsi::JSError(rt, "statement has been finalized");
+    }
+}
+
 jsi::Value TursoStatementHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
     auto propName = name.utf8(rt);
 
+    if (propName == "dispose") {
+        return jsi::Function::createFromHostFunction(rt, name, 0,
+            [this](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *, size_t) -> jsi::Value {
+                return this->dispose(rt);
+            });
+    }
     if (propName == "bindPositionalNull") {
         return jsi::Function::createFromHostFunction(rt, name, 1,
             [this](jsi::Runtime &rt, const jsi::Value &, const jsi::Value *args, size_t count) -> jsi::Value {
@@ -162,6 +174,7 @@ void TursoStatementHostObject::set(jsi::Runtime &rt, const jsi::PropNameID &name
 
 std::vector<jsi::PropNameID> TursoStatementHostObject::getPropertyNames(jsi::Runtime &rt) {
     std::vector<jsi::PropNameID> props;
+    props.emplace_back(jsi::PropNameID::forAscii(rt, "dispose"));
     props.emplace_back(jsi::PropNameID::forAscii(rt, "bindPositionalNull"));
     props.emplace_back(jsi::PropNameID::forAscii(rt, "bindPositionalInt"));
     props.emplace_back(jsi::PropNameID::forAscii(rt, "bindPositionalDouble"));
@@ -189,7 +202,16 @@ std::vector<jsi::PropNameID> TursoStatementHostObject::getPropertyNames(jsi::Run
 
 // 1:1 C API mapping - NO logic, just calls through to C API
 
+jsi::Value TursoStatementHostObject::dispose(jsi::Runtime &rt) {
+    if (stmt_) {
+        turso_statement_deinit(stmt_);
+        stmt_ = nullptr;
+    }
+    return jsi::Value::undefined();
+}
+
 jsi::Value TursoStatementHostObject::bindPositionalNull(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 1 || !args[0].isNumber()) {
         throw jsi::JSError(rt, "bindPositionalNull: expected number argument (position)");
     }
@@ -199,6 +221,7 @@ jsi::Value TursoStatementHostObject::bindPositionalNull(jsi::Runtime &rt, const 
 }
 
 jsi::Value TursoStatementHostObject::bindPositionalInt(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 2 || !args[0].isNumber() || !args[1].isNumber()) {
         throw jsi::JSError(rt, "bindPositionalInt: expected two number arguments (position, value)");
     }
@@ -209,6 +232,7 @@ jsi::Value TursoStatementHostObject::bindPositionalInt(jsi::Runtime &rt, const j
 }
 
 jsi::Value TursoStatementHostObject::bindPositionalDouble(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 2 || !args[0].isNumber() || !args[1].isNumber()) {
         throw jsi::JSError(rt, "bindPositionalDouble: expected two number arguments (position, value)");
     }
@@ -219,6 +243,7 @@ jsi::Value TursoStatementHostObject::bindPositionalDouble(jsi::Runtime &rt, cons
 }
 
 jsi::Value TursoStatementHostObject::bindPositionalBlob(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 2 || !args[0].isNumber() || !args[1].isObject()) {
         throw jsi::JSError(rt, "bindPositionalBlob: expected number and ArrayBuffer arguments");
     }
@@ -234,6 +259,7 @@ jsi::Value TursoStatementHostObject::bindPositionalBlob(jsi::Runtime &rt, const 
 }
 
 jsi::Value TursoStatementHostObject::bindPositionalText(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 2 || !args[0].isNumber() || !args[1].isString()) {
         throw jsi::JSError(rt, "bindPositionalText: expected number and string arguments");
     }
@@ -244,6 +270,7 @@ jsi::Value TursoStatementHostObject::bindPositionalText(jsi::Runtime &rt, const 
 }
 
 jsi::Value TursoStatementHostObject::execute(jsi::Runtime &rt) {
+    checkStatement(rt);
     uint64_t rows_changed = 0;
     const char* error = nullptr;
     turso_status_code_t status = turso_statement_execute(stmt_, &rows_changed, &error);
@@ -260,6 +287,7 @@ jsi::Value TursoStatementHostObject::execute(jsi::Runtime &rt) {
 }
 
 jsi::Value TursoStatementHostObject::step(jsi::Runtime &rt) {
+    checkStatement(rt);
     const char* error = nullptr;
     turso_status_code_t status = turso_statement_step(stmt_, &error);
 
@@ -271,6 +299,7 @@ jsi::Value TursoStatementHostObject::step(jsi::Runtime &rt) {
 }
 
 jsi::Value TursoStatementHostObject::runIo(jsi::Runtime &rt) {
+    checkStatement(rt);
     const char* error = nullptr;
     turso_status_code_t status = turso_statement_run_io(stmt_, &error);
 
@@ -282,6 +311,7 @@ jsi::Value TursoStatementHostObject::runIo(jsi::Runtime &rt) {
 }
 
 jsi::Value TursoStatementHostObject::reset(jsi::Runtime &rt) {
+    checkStatement(rt);
     const char* error = nullptr;
     turso_status_code_t status = turso_statement_reset(stmt_, &error);
 
@@ -312,16 +342,19 @@ jsi::Value TursoStatementHostObject::finalize(jsi::Runtime &rt) {
 }
 
 jsi::Value TursoStatementHostObject::nChange(jsi::Runtime &rt) {
+    checkStatement(rt);
     int64_t n = turso_statement_n_change(stmt_);
     return jsi::Value(static_cast<double>(n));
 }
 
 jsi::Value TursoStatementHostObject::columnCount(jsi::Runtime &rt) {
+    checkStatement(rt);
     int64_t count = turso_statement_column_count(stmt_);
     return jsi::Value(static_cast<double>(count));
 }
 
 jsi::Value TursoStatementHostObject::columnName(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 1 || !args[0].isNumber()) {
         throw jsi::JSError(rt, "columnName: expected number argument (index)");
     }
@@ -339,6 +372,7 @@ jsi::Value TursoStatementHostObject::columnName(jsi::Runtime &rt, const jsi::Val
 }
 
 jsi::Value TursoStatementHostObject::rowValueKind(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 1 || !args[0].isNumber()) {
         throw jsi::JSError(rt, "rowValueKind: expected number argument (index)");
     }
@@ -348,6 +382,7 @@ jsi::Value TursoStatementHostObject::rowValueKind(jsi::Runtime &rt, const jsi::V
 }
 
 jsi::Value TursoStatementHostObject::rowValueBytesCount(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 1 || !args[0].isNumber()) {
         throw jsi::JSError(rt, "rowValueBytesCount: expected number argument (index)");
     }
@@ -357,6 +392,7 @@ jsi::Value TursoStatementHostObject::rowValueBytesCount(jsi::Runtime &rt, const 
 }
 
 jsi::Value TursoStatementHostObject::rowValueBytesPtr(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 1 || !args[0].isNumber()) {
         throw jsi::JSError(rt, "rowValueBytesPtr: expected number argument (index)");
     }
@@ -378,6 +414,7 @@ jsi::Value TursoStatementHostObject::rowValueBytesPtr(jsi::Runtime &rt, const js
 }
 
 jsi::Value TursoStatementHostObject::rowValueText(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 1 || !args[0].isNumber()) {
         throw jsi::JSError(rt, "rowValueText: expected number argument (index)");
     }
@@ -395,6 +432,7 @@ jsi::Value TursoStatementHostObject::rowValueText(jsi::Runtime &rt, const jsi::V
 }
 
 jsi::Value TursoStatementHostObject::rowValueInt(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 1 || !args[0].isNumber()) {
         throw jsi::JSError(rt, "rowValueInt: expected number argument (index)");
     }
@@ -404,6 +442,7 @@ jsi::Value TursoStatementHostObject::rowValueInt(jsi::Runtime &rt, const jsi::Va
 }
 
 jsi::Value TursoStatementHostObject::rowValueDouble(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 1 || !args[0].isNumber()) {
         throw jsi::JSError(rt, "rowValueDouble: expected number argument (index)");
     }
@@ -413,6 +452,7 @@ jsi::Value TursoStatementHostObject::rowValueDouble(jsi::Runtime &rt, const jsi:
 }
 
 jsi::Value TursoStatementHostObject::namedPosition(jsi::Runtime &rt, const jsi::Value *args, size_t count) {
+    checkStatement(rt);
     if (count < 1 || !args[0].isString()) {
         throw jsi::JSError(rt, "namedPosition: expected string argument (name)");
     }
@@ -422,11 +462,13 @@ jsi::Value TursoStatementHostObject::namedPosition(jsi::Runtime &rt, const jsi::
 }
 
 jsi::Value TursoStatementHostObject::parametersCount(jsi::Runtime &rt) {
+    checkStatement(rt);
     int64_t count = turso_statement_parameters_count(stmt_);
     return jsi::Value(static_cast<double>(count));
 }
 
 jsi::Value TursoStatementHostObject::getAllRows(jsi::Runtime &rt) {
+    checkStatement(rt);
     int64_t colCount = turso_statement_column_count(stmt_);
     if (colCount < 0) {
         // defensive fallback to 0 to not allocate a vector with a negative size

--- a/bindings/react-native/cpp/TursoStatementHostObject.h
+++ b/bindings/react-native/cpp/TursoStatementHostObject.h
@@ -38,7 +38,11 @@ private:
     // Helper to throw JS errors
     void throwError(jsi::Runtime &rt, const char *error);
 
+    // Throws if stmt_ is null (statement was finalized or disposed)
+    void checkStatement(jsi::Runtime &rt);
+
     // 1:1 C API mapping methods (NO logic - just calls through to C API)
+    jsi::Value dispose(jsi::Runtime &rt);
     jsi::Value bindPositionalNull(jsi::Runtime &rt, const jsi::Value *args, size_t count);
     jsi::Value bindPositionalInt(jsi::Runtime &rt, const jsi::Value *args, size_t count);
     jsi::Value bindPositionalDouble(jsi::Runtime &rt, const jsi::Value *args, size_t count);

--- a/bindings/react-native/src/Database.ts
+++ b/bindings/react-native/src/Database.ts
@@ -77,6 +77,7 @@ export class Database {
   private _isSync = false;
   private _connected = false;
   private _closed = false;
+  private _statements: Set<Statement> = new Set();
   private _execLock: AsyncLock;
   private _extraIo?: () => Promise<void>;
   private _ioContext?: {
@@ -226,7 +227,7 @@ export class Database {
     }
 
     const nativeStmt = this._connection.prepareSingle(sql);
-    return new Statement(nativeStmt, this._connection!, this._execLock, this._extraIo);
+    return new Statement(nativeStmt, this._connection!, this._execLock, this._extraIo, this._statements);
   }
 
   /**
@@ -408,6 +409,15 @@ export class Database {
     if (this._closed) {
       return;
     }
+
+    // Dispose all outstanding statements. Each turso_statement holds an
+    // Arc<Connection> -> Arc<Database> chain; if we don't release them the
+    // Weak in DATABASE_MANAGER can still be upgraded after a file rename,
+    // causing a stale Database to be returned on the next open().
+    for (const stmt of this._statements) {
+      stmt._dispose();
+    }
+    this._statements.clear();
 
     if (this._connection) {
       this._connection.close();

--- a/bindings/react-native/src/Statement.ts
+++ b/bindings/react-native/src/Statement.ts
@@ -25,12 +25,17 @@ export class Statement {
   private _execLock: AsyncLock | null;
   private _finalized = false;
   private _extraIo?: () => Promise<void>;
+  private _stmtTracker?: Set<Statement>;
 
-  constructor(statement: NativeStatement, connection: NativeConnection, execLock: AsyncLock | null, extraIo?: () => Promise<void>) {
+  constructor(statement: NativeStatement, connection: NativeConnection, execLock: AsyncLock | null, extraIo?: () => Promise<void>, stmtTracker?: Set<Statement>) {
     this._statement = statement;
     this._connection = connection;
     this._execLock = execLock;
     this._extraIo = extraIo;
+    this._stmtTracker = stmtTracker;
+    if (stmtTracker) {
+      stmtTracker.add(this);
+    }
   }
 
   /**
@@ -425,10 +430,33 @@ export class Statement {
         break;
       }
       this._finalized = true;
+      this._removeFromTracker();
     } finally {
       if (this._execLock) {
         this._execLock.release();
       }
+    }
+  }
+
+  /**
+   * Synchronously dispose the native statement. Called by Database.close() to
+   * break the reference chain (Statement -> Connection -> Database) that would
+   * otherwise keep the database alive in DATABASE_MANAGER.
+   * @internal
+   */
+  _dispose(): void {
+    if (this._finalized) {
+      return;
+    }
+    this._statement.dispose();
+    this._finalized = true;
+    this._removeFromTracker();
+  }
+
+  private _removeFromTracker(): void {
+    if (this._stmtTracker) {
+      this._stmtTracker.delete(this);
+      this._stmtTracker = undefined;
     }
   }
 

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -50,6 +50,7 @@ export interface NativeStatement {
   runIo(): number;
   reset(): void;
   finalize(): number;
+  dispose(): void;
 
   // Query methods
   nChange(): number;

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -68,3 +68,91 @@ fn test_database_rename_registry_stale() {
          DATABASE_MANAGER returned stale Database after rename"
     );
 }
+
+/// Regression test: a leaked (un-finalized) Statement keeps the Database alive
+/// in DATABASE_MANAGER via the Arc chain Statement -> Program -> Arc<Connection>
+/// -> Arc<Database>.
+///
+/// This is the core-level scenario that the React Native (and JavaScript)
+/// bindings must guard against: if Database.close() does not dispose outstanding
+/// statements, reopening the same path after a rename returns the stale database.
+///
+/// Steps:
+///   1. Open database "A.db", create a table and insert data
+///   2. Prepare a statement but keep it alive (simulating un-GC'd JS Statement)
+///   3. Drop the Connection and Database handles
+///   4. Rename A.db -> B.db on disk
+///   5. Open a new database at path "A.db"
+///   6. The new A.db must be stale because the leaked statement kept the old
+///      database alive — demonstrating the bug the bindings fix prevents
+#[test]
+fn test_leaked_statement_keeps_database_alive() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let path_a = tmp_dir.path().join("A.db");
+    let path_b = tmp_dir.path().join("B.db");
+
+    let io: Arc<dyn turso_core::IO + Send> = Arc::new(turso_core::PlatformIO::new().unwrap());
+
+    // 1. Open database A and populate it.
+    let db_a = Database::open_file_with_flags(
+        io.clone(),
+        path_a.to_str().unwrap(),
+        OpenFlags::Create,
+        turso_core::DatabaseOpts::new(),
+        None,
+    )
+    .unwrap();
+
+    let conn_a = db_a.connect().unwrap();
+    conn_a.execute("CREATE TABLE t(x INTEGER)").unwrap();
+    conn_a.execute("INSERT INTO t VALUES (42)").unwrap();
+
+    // 2. Prepare a statement and keep it alive — this simulates an un-GC'd
+    //    JS/RN Statement object that has not been finalized.
+    let leaked_stmt = conn_a.prepare("SELECT x FROM t").unwrap();
+
+    // 3. Drop the connection and database handles. The leaked statement still
+    //    holds Arc<Connection> -> Arc<Database>, so DATABASE_MANAGER's Weak
+    //    remains upgradeable.
+    drop(conn_a);
+    drop(db_a);
+
+    // 4. Rename A.db -> B.db on disk.
+    std::fs::rename(&path_a, &path_b).unwrap();
+    let wal_a = tmp_dir.path().join("A.db-wal");
+    let wal_b = tmp_dir.path().join("B.db-wal");
+    if wal_a.exists() {
+        std::fs::rename(&wal_a, &wal_b).unwrap();
+    }
+    let shm_a = tmp_dir.path().join("A.db-shm");
+    let shm_b = tmp_dir.path().join("B.db-shm");
+    if shm_a.exists() {
+        std::fs::rename(&shm_a, &shm_b).unwrap();
+    }
+
+    // 5. Open a new database at the original path A.db.
+    let db_a2 = Database::open_file_with_flags(
+        io.clone(),
+        path_a.to_str().unwrap(),
+        OpenFlags::Create,
+        turso_core::DatabaseOpts::new(),
+        None,
+    )
+    .unwrap();
+
+    // 6. Because the leaked statement kept the old Database alive in the
+    //    registry, DATABASE_MANAGER returns the stale instance — table 't'
+    //    is visible even though the file was renamed away.  This demonstrates
+    //    the bug that the bindings-level fix (disposing statements on close)
+    //    prevents.
+    let conn_a2 = db_a2.connect().unwrap();
+    let result = conn_a2.execute("SELECT x FROM t");
+    assert!(
+        result.is_ok(),
+        "Leaked statement should keep old Database alive in registry — \
+         table 't' should still be visible via the stale Database"
+    );
+
+    // Cleanup: drop the leaked statement so the old database can be freed.
+    drop(leaked_stmt);
+}


### PR DESCRIPTION
Database.close() dropped the native database but left outstanding turso_statement_t objects alive (held by un-GC'd JS Statement objects). Each statement holds Arc<Connection> -> Arc<Database>, keeping the Weak in DATABASE_MANAGER upgradeable. After a file rename, reopening the same path returned the stale Database.

Fix by tracking every Statement in a Set on Database and calling dispose() on each when close() is called. The C++ dispose() method calls turso_statement_deinit() to unconditionally drop the Rust statement, breaking the reference chain.

Also add null guards (checkStatement) to all native statement methods so that using a disposed statement throws "statement has been finalized" instead of crashing.