### PR TITLE
core: implement ORDER BY for compound SELECT statements

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -1,8 +1,9 @@
-use crate::schema::{Index, IndexColumn};
+use crate::schema::{Index, IndexColumn, PseudoCursorType};
 use crate::sync::Arc;
 use crate::translate::collate::get_collseq_from_expr;
 use crate::translate::emitter::{select::emit_query, LimitCtx, Resolver, TranslateCtx};
 use crate::translate::expr::translate_expr;
+use crate::translate::order_by::{custom_type_comparator, sorter_insert};
 use crate::translate::plan::{Plan, QueryDestination, SelectPlan};
 use crate::translate::result_row::emit_columns_to_destination;
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
@@ -22,102 +23,137 @@ pub fn emit_program_for_compound_select(
     resolver: &Resolver,
     plan: Plan,
 ) -> crate::Result<Option<usize>> {
-    let Plan::CompoundSelect {
-        left,
-        right_most,
-        limit,
-        offset,
-        ..
-    } = &plan
-    else {
-        crate::bail_parse_error!("expected compound select plan");
+    // Extract fields we need before plan is consumed by emit_compound_select.
+    let (has_order_by, order_by_owned, limit_owned, offset_owned, right_plan) = {
+        let Plan::CompoundSelect {
+            left: _,
+            right_most,
+            limit,
+            offset,
+            order_by,
+        } = &plan
+        else {
+            crate::bail_parse_error!("expected compound select plan");
+        };
+        (
+            order_by.is_some(),
+            order_by.clone(),
+            limit.clone(),
+            offset.clone(),
+            right_most.clone(),
+        )
     };
-
-    let right_plan = right_most.clone();
+    let Plan::CompoundSelect { ref left, .. } = plan else {
+        unreachable!()
+    };
     let right_most_ctx = TranslateCtx::new(
         program,
         resolver.fork(),
-        right_most.table_references.joined_tables().len(),
+        right_plan.table_references.joined_tables().len(),
         false,
     );
 
     // Each subselect shares the same limit_ctx and offset, because the LIMIT, OFFSET applies to
     // the entire compound select, not just a single subselect.
-    let limit_ctx = limit
-        .as_ref()
-        .map(|limit| {
-            let reg = program.alloc_register();
-            match limit.as_ref() {
-                Expr::Literal(Literal::Numeric(n)) => {
-                    if let Ok(value) = n.parse::<i64>() {
-                        program.add_comment(program.offset(), "LIMIT counter");
-                        program.emit_insn(Insn::Integer { value, dest: reg });
-                    } else {
-                        let value = n
-                            .parse::<f64>()
-                            .map_err(|_| LimboError::ParseError("invalid limit".to_string()))?;
-                        program.emit_insn(Insn::Real { value, dest: reg });
+    // When ORDER BY is present, LIMIT/OFFSET apply to the final sorted output, not intermediate results.
+    let limit_ctx = if has_order_by {
+        None
+    } else {
+        limit_owned
+            .as_ref()
+            .map(|limit| {
+                let reg = program.alloc_register();
+                match limit.as_ref() {
+                    Expr::Literal(Literal::Numeric(n)) => {
+                        if let Ok(value) = n.parse::<i64>() {
+                            program.add_comment(program.offset(), "LIMIT counter");
+                            program.emit_insn(Insn::Integer { value, dest: reg });
+                        } else {
+                            let value = n
+                                .parse::<f64>()
+                                .map_err(|_| LimboError::ParseError("invalid limit".to_string()))?;
+                            program.emit_insn(Insn::Real { value, dest: reg });
+                            program.add_comment(program.offset(), "LIMIT counter");
+                            program.emit_insn(Insn::MustBeInt { reg });
+                        }
+                    }
+                    _ => {
+                        _ = translate_expr(program, None, limit, reg, &right_most_ctx.resolver);
                         program.add_comment(program.offset(), "LIMIT counter");
                         program.emit_insn(Insn::MustBeInt { reg });
                     }
                 }
-                _ => {
-                    _ = translate_expr(program, None, limit, reg, &right_most_ctx.resolver);
-                    program.add_comment(program.offset(), "LIMIT counter");
-                    program.emit_insn(Insn::MustBeInt { reg });
-                }
-            }
-            Ok::<_, LimboError>(LimitCtx::new_shared(reg))
-        })
-        .transpose()?;
-    let offset_reg = offset
-        .as_ref()
-        .map(|offset_expr| {
-            let reg = program.alloc_register();
-            match offset_expr.as_ref() {
-                Expr::Literal(Literal::Numeric(n)) => {
-                    // Compile-time constant offset
-                    if let Ok(value) = n.parse::<i64>() {
-                        program.emit_insn(Insn::Integer { value, dest: reg });
-                    } else {
-                        let value = n
-                            .parse::<f64>()
-                            .map_err(|_| LimboError::ParseError("invalid offset".to_string()))?;
-                        program.emit_insn(Insn::Real { value, dest: reg });
+                Ok::<_, LimboError>(LimitCtx::new_shared(reg))
+            })
+            .transpose()?
+    };
+    let offset_reg = if has_order_by {
+        None
+    } else {
+        offset_owned
+            .as_ref()
+            .map(|offset_expr| {
+                let reg = program.alloc_register();
+                match offset_expr.as_ref() {
+                    Expr::Literal(Literal::Numeric(n)) => {
+                        // Compile-time constant offset
+                        if let Ok(value) = n.parse::<i64>() {
+                            program.emit_insn(Insn::Integer { value, dest: reg });
+                        } else {
+                            let value = n.parse::<f64>().map_err(|_| {
+                                LimboError::ParseError("invalid offset".to_string())
+                            })?;
+                            program.emit_insn(Insn::Real { value, dest: reg });
+                        }
+                    }
+                    _ => {
+                        _ = translate_expr(
+                            program,
+                            None,
+                            offset_expr,
+                            reg,
+                            &right_most_ctx.resolver,
+                        );
                     }
                 }
-                _ => {
-                    _ = translate_expr(program, None, offset_expr, reg, &right_most_ctx.resolver);
-                }
-            }
-            program.add_comment(program.offset(), "OFFSET counter");
-            program.emit_insn(Insn::MustBeInt { reg });
-            let combined_reg = program.alloc_register();
-            program.add_comment(program.offset(), "OFFSET + LIMIT");
-            program.emit_insn(Insn::OffsetLimit {
-                offset_reg: reg,
-                combined_reg,
-                limit_reg: limit_ctx.as_ref().unwrap().reg_limit,
-            });
+                program.add_comment(program.offset(), "OFFSET counter");
+                program.emit_insn(Insn::MustBeInt { reg });
+                let combined_reg = program.alloc_register();
+                program.add_comment(program.offset(), "OFFSET + LIMIT");
+                program.emit_insn(Insn::OffsetLimit {
+                    offset_reg: reg,
+                    combined_reg,
+                    limit_reg: limit_ctx.as_ref().unwrap().reg_limit,
+                });
 
-            Ok::<_, LimboError>(reg)
-        })
-        .transpose()?;
+                Ok::<_, LimboError>(reg)
+            })
+            .transpose()?
+    };
 
-    // When a compound SELECT is part of a query that yields results to a coroutine (e.g. within an INSERT clause),
-    // we must allocate registers for the result columns to be yielded. Each subselect will then yield to
-    // the coroutine using the same set of registers.
-    // When the destination is an EphemeralTable or EphemeralIndex (for CTE materialization), we need to
-    // insert into that table/index.
-    // For top-level queries (ResultRows), we emit ResultRow instructions directly.
+    let real_query_destination = right_plan.query_destination.clone();
+    let num_result_cols = right_plan.result_columns.len();
+
+    // When ORDER BY is present, redirect compound output to a collection index,
+    // then sort and emit to the real destination afterwards.
+    let (query_destination, collection_cursor, collection_index) = if has_order_by {
+        let (cursor_id, index) = create_collection_index(program, &left[0].0, &right_plan)?;
+        let dest = QueryDestination::EphemeralIndex {
+            cursor_id,
+            index: index.clone(),
+            affinity_str: None,
+            is_delete: false,
+        };
+        (dest, Some(cursor_id), Some(index))
+    } else {
+        (real_query_destination.clone(), None, None)
+    };
+
     // Allocate registers for result columns when we need to hold values before emitting.
-    // For ResultRows we allocate fresh registers per-row in read_deduplicated_*.
-    let reg_result_cols_start = match &right_most.query_destination {
+    let reg_result_cols_start = match &query_destination {
         QueryDestination::CoroutineYield { .. }
         | QueryDestination::EphemeralTable { .. }
-        | QueryDestination::EphemeralIndex { .. } => {
-            Some(program.alloc_registers(right_most.result_columns.len()))
-        }
+        | QueryDestination::EphemeralIndex { .. } => Some(program.alloc_registers(num_result_cols)),
         QueryDestination::ResultRows => None,
         other => {
             return Err(LimboError::InternalError(format!(
@@ -125,8 +161,6 @@ pub fn emit_program_for_compound_select(
             )));
         }
     };
-    // Clone the destination for passing to emit_compound_select
-    let query_destination = right_most.query_destination.clone();
 
     emit_explain!(program, true, "COMPOUND QUERY".to_owned());
 
@@ -146,6 +180,13 @@ pub fn emit_program_for_compound_select(
     }
     program.table_references.extend(right_plan.table_references);
 
+    // When ORDER BY is present, update all subselect destinations in the Plan
+    // to write to the collection index instead of ResultRows.
+    let mut plan = plan;
+    if has_order_by {
+        set_compound_plan_destinations(&mut plan, &query_destination);
+    }
+
     program.with_scoped_result_cols_start(|program| {
         emit_compound_select(
             program,
@@ -158,9 +199,28 @@ pub fn emit_program_for_compound_select(
         )
     })?;
     program.pop_current_parent_explain();
-    program.reg_result_cols_start = reg_result_cols_start;
 
-    Ok(reg_result_cols_start)
+    // When ORDER BY is present, sort the collected results and emit to the real destination.
+    if let (Some(order_by), Some(collection_cursor_id), Some(collection_idx)) =
+        (order_by_owned, collection_cursor, collection_index)
+    {
+        let result_reg = emit_compound_order_by(
+            program,
+            &order_by,
+            collection_cursor_id,
+            &collection_idx,
+            num_result_cols,
+            limit_owned.as_deref(),
+            offset_owned.as_deref(),
+            &real_query_destination,
+            &right_most_ctx,
+        )?;
+        program.reg_result_cols_start = result_reg;
+    } else {
+        program.reg_result_cols_start = reg_result_cols_start;
+    }
+
+    Ok(program.reg_result_cols_start)
 }
 
 // Emits bytecode for a compound SELECT statement. This function processes the rightmost part of
@@ -251,10 +311,10 @@ fn emit_compound_select(
             }
             CompoundOperator::Union => {
                 let mut new_dedupe_index = false;
-                let dedupe_index = match right_most.query_destination {
+                let dedupe_index = match &right_most.query_destination {
                     QueryDestination::EphemeralIndex {
                         cursor_id, index, ..
-                    } => (cursor_id, index),
+                    } if !index.has_rowid => (*cursor_id, index.clone()),
                     _ => {
                         new_dedupe_index = true;
                         create_dedupe_index(program, &plan, &right_most)?
@@ -362,10 +422,10 @@ fn emit_compound_select(
             }
             CompoundOperator::Except => {
                 let mut new_index = false;
-                let (cursor_id, index) = match right_most.query_destination {
+                let (cursor_id, index) = match &right_most.query_destination {
                     QueryDestination::EphemeralIndex {
                         cursor_id, index, ..
-                    } => (cursor_id, index),
+                    } if !index.has_rowid => (*cursor_id, index.clone()),
                     _ => {
                         new_index = true;
                         create_dedupe_index(program, &plan, &right_most)?
@@ -634,4 +694,383 @@ fn read_intersect_rows(
         cursor_id: left_cursor_id,
     });
     Ok(())
+}
+
+/// Recursively sets the query_destination of all SelectPlans within a CompoundSelect.
+/// This ensures UNION ALL subselects write to the collection index instead of ResultRows.
+fn set_compound_plan_destinations(plan: &mut Plan, dest: &QueryDestination) {
+    match plan {
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => {
+            for (subplan, _) in left.iter_mut() {
+                subplan.query_destination = dest.clone();
+            }
+            right_most.query_destination = dest.clone();
+        }
+        Plan::Select(select_plan) => {
+            select_plan.query_destination = dest.clone();
+        }
+        _ => {}
+    }
+}
+
+/// Creates an ephemeral index for collecting all compound select results.
+/// Uses `has_rowid=true` to allow duplicate entries (needed for UNION ALL).
+fn create_collection_index(
+    program: &mut ProgramBuilder,
+    left_select: &SelectPlan,
+    right_select: &SelectPlan,
+) -> crate::Result<(usize, Arc<Index>)> {
+    let mut columns = right_select
+        .result_columns
+        .iter()
+        .enumerate()
+        .map(|(i, c)| IndexColumn {
+            name: c
+                .name(&right_select.table_references)
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
+            order: SortOrder::Asc,
+            pos_in_table: i,
+            default: None,
+            collation: None,
+            expr: None,
+        })
+        .collect::<Vec<_>>();
+    for (i, column) in columns.iter_mut().enumerate() {
+        let left_collation = get_collseq_from_expr(
+            &left_select.result_columns[i].expr,
+            &left_select.table_references,
+        )?;
+        let right_collation = get_collseq_from_expr(
+            &right_select.result_columns[i].expr,
+            &right_select.table_references,
+        )?;
+        let collation = match (left_collation, right_collation) {
+            (None, None) => None,
+            (Some(coll), None) | (None, Some(coll)) => Some(coll),
+            (Some(coll), Some(_)) => Some(coll),
+        };
+        column.collation = collation;
+    }
+
+    let index = Arc::new(Index {
+        columns,
+        name: "compound_collection".to_string(),
+        root_page: 0,
+        ephemeral: true,
+        table_name: String::new(),
+        unique: false,
+        has_rowid: true, // Allow duplicates for UNION ALL
+        where_clause: None,
+        index_method: None,
+        on_conflict: None,
+    });
+    let cursor_id = program.alloc_cursor_id(CursorType::BTreeIndex(index.clone()));
+    program.emit_insn(Insn::OpenEphemeral {
+        cursor_id,
+        is_table: false,
+    });
+    Ok((cursor_id, index))
+}
+
+/// Emits bytecode for sorting compound select results and outputting them.
+/// Reads from the collection index, inserts into a Sorter with ORDER BY keys,
+/// then reads sorted rows and emits to the real destination with LIMIT/OFFSET.
+#[allow(clippy::too_many_arguments)]
+fn emit_compound_order_by(
+    program: &mut ProgramBuilder,
+    order_by: &[(usize, SortOrder)],
+    collection_cursor_id: usize,
+    collection_index: &Index,
+    num_result_cols: usize,
+    limit: Option<&Expr>,
+    offset: Option<&Expr>,
+    real_destination: &QueryDestination,
+    right_most_ctx: &TranslateCtx,
+) -> crate::Result<Option<usize>> {
+    // Open a Sorter with ORDER BY specifications.
+    // Sorter layout: [sort_key_0, sort_key_1, ..., result_col_0, result_col_1, ...]
+    // Sort keys that match result columns are deduplicated.
+
+    // Build sort key collations and orders.
+    // We append a sequence number as an extra sort key after the ORDER BY columns
+    // to break ties by insertion order, matching SQLite's merge-based compound SELECT
+    // which naturally outputs left-arm rows before right-arm rows for equal keys.
+    let mut order_and_collations: Vec<(
+        SortOrder,
+        Option<crate::translate::collate::CollationSeq>,
+    )> = order_by
+        .iter()
+        .map(|(col_idx, order)| {
+            let collation = collection_index
+                .columns
+                .get(*col_idx)
+                .and_then(|c| c.collation);
+            (*order, collation)
+        })
+        .collect();
+    // Sequence tie-breaker: preserves insertion order for rows with equal ORDER BY keys
+    order_and_collations.push((SortOrder::Asc, None));
+
+    // Compute deduplication remappings: which result columns share a sort key slot.
+    // The sorter layout is: [order_by_keys..., sequence, non-dedup data cols...]
+    let seq_slot = order_by.len();
+    let data_start = order_by.len() + 1; // data columns start after ORDER BY keys + sequence
+    let mut remappings: Vec<(usize, bool)> = Vec::with_capacity(num_result_cols);
+    let mut non_dedup_count = 0;
+    for col_idx in 0..num_result_cols {
+        if let Some((sort_key_idx, _)) = order_by
+            .iter()
+            .enumerate()
+            .find(|(_, (ob_col, _))| *ob_col == col_idx)
+        {
+            // This result column is also a sort key - deduplicate
+            remappings.push((sort_key_idx, true));
+        } else {
+            remappings.push((data_start + non_dedup_count, false));
+            non_dedup_count += 1;
+        }
+    }
+    let sorter_column_count = order_by.len() + 1 + non_dedup_count;
+
+    let sort_cursor = program.alloc_cursor_id(CursorType::Sorter);
+    // Resolve custom type comparators for ORDER BY columns (e.g. numeric(10,2) needs
+    // NumericLt to sort correctly instead of default blob/text comparison).
+    let mut comparators: Vec<Option<crate::vdbe::insn::SortComparatorType>> = order_by
+        .iter()
+        .map(|(col_idx, _)| {
+            program.result_columns.get(*col_idx).and_then(|rc| {
+                custom_type_comparator(
+                    &rc.expr,
+                    &program.table_references,
+                    right_most_ctx.resolver.schema(),
+                )
+            })
+        })
+        .collect();
+    // No comparator needed for the sequence tie-breaker column
+    comparators.push(None);
+    program.emit_insn(Insn::SorterOpen {
+        cursor_id: sort_cursor,
+        columns: order_and_collations.len(),
+        order_and_collations,
+        comparators,
+    });
+
+    // Read from collection index and insert into Sorter
+    let label_sorter_done = program.allocate_label();
+    let label_sorter_loop = program.allocate_label();
+    // Allocate registers for result columns + the sequence column from the collection
+    let read_regs = program.alloc_registers(num_result_cols + 1);
+    let seq_reg = read_regs + num_result_cols;
+
+    program.emit_insn(Insn::Rewind {
+        cursor_id: collection_cursor_id,
+        pc_if_empty: label_sorter_done,
+    });
+    program.preassign_label_to_next_insn(label_sorter_loop);
+
+    // Read all result columns from collection index
+    for col_idx in 0..num_result_cols {
+        program.emit_insn(Insn::Column {
+            cursor_id: collection_cursor_id,
+            column: col_idx,
+            dest: read_regs + col_idx,
+            default: None,
+        });
+    }
+    // Read the sequence column (appended after result columns in the collection index)
+    program.emit_insn(Insn::Column {
+        cursor_id: collection_cursor_id,
+        column: num_result_cols,
+        dest: seq_reg,
+        default: None,
+    });
+
+    // Build sorter record: [sort_keys..., sequence, non-dedup result cols...]
+    let sorter_regs = program.alloc_registers(sorter_column_count);
+    // First emit sort keys
+    for (sort_key_idx, (col_idx, _)) in order_by.iter().enumerate() {
+        program.emit_insn(Insn::Copy {
+            src_reg: read_regs + col_idx,
+            dst_reg: sorter_regs + sort_key_idx,
+            extra_amount: 0,
+        });
+    }
+    // Then emit sequence number for tie-breaking
+    program.emit_insn(Insn::Copy {
+        src_reg: seq_reg,
+        dst_reg: sorter_regs + seq_slot,
+        extra_amount: 0,
+    });
+    // Then emit non-deduplicated result columns
+    let mut sorter_data_idx = data_start;
+    for (col_idx, &(_sorter_idx, deduplicated)) in
+        remappings.iter().enumerate().take(num_result_cols)
+    {
+        if !deduplicated {
+            program.emit_insn(Insn::Copy {
+                src_reg: read_regs + col_idx,
+                dst_reg: sorter_regs + sorter_data_idx,
+                extra_amount: 0,
+            });
+            sorter_data_idx += 1;
+        }
+    }
+
+    let reg_sorter_data = program.alloc_register();
+    sorter_insert(
+        program,
+        sorter_regs,
+        sorter_column_count,
+        sort_cursor,
+        reg_sorter_data,
+    );
+
+    program.emit_insn(Insn::Next {
+        cursor_id: collection_cursor_id,
+        pc_if_next: label_sorter_loop,
+    });
+    program.preassign_label_to_next_insn(label_sorter_done);
+    program.emit_insn(Insn::Close {
+        cursor_id: collection_cursor_id,
+    });
+
+    // Now emit LIMIT/OFFSET for the sorted output
+    let limit_ctx = limit
+        .map(|limit_expr| {
+            let reg = program.alloc_register();
+            match limit_expr {
+                Expr::Literal(Literal::Numeric(n)) => {
+                    if let Ok(value) = n.parse::<i64>() {
+                        program.add_comment(program.offset(), "LIMIT counter");
+                        program.emit_insn(Insn::Integer { value, dest: reg });
+                    } else {
+                        let value = n
+                            .parse::<f64>()
+                            .map_err(|_| LimboError::ParseError("invalid limit".to_string()))?;
+                        program.emit_insn(Insn::Real { value, dest: reg });
+                        program.add_comment(program.offset(), "LIMIT counter");
+                        program.emit_insn(Insn::MustBeInt { reg });
+                    }
+                }
+                _ => {
+                    _ = translate_expr(program, None, limit_expr, reg, &right_most_ctx.resolver);
+                    program.add_comment(program.offset(), "LIMIT counter");
+                    program.emit_insn(Insn::MustBeInt { reg });
+                }
+            }
+            Ok::<_, LimboError>(reg)
+        })
+        .transpose()?;
+
+    let offset_reg = offset
+        .map(|offset_expr| {
+            let reg = program.alloc_register();
+            match offset_expr {
+                Expr::Literal(Literal::Numeric(n)) => {
+                    if let Ok(value) = n.parse::<i64>() {
+                        program.emit_insn(Insn::Integer { value, dest: reg });
+                    } else {
+                        let value = n
+                            .parse::<f64>()
+                            .map_err(|_| LimboError::ParseError("invalid offset".to_string()))?;
+                        program.emit_insn(Insn::Real { value, dest: reg });
+                    }
+                }
+                _ => {
+                    _ = translate_expr(program, None, offset_expr, reg, &right_most_ctx.resolver);
+                }
+            }
+            program.add_comment(program.offset(), "OFFSET counter");
+            program.emit_insn(Insn::MustBeInt { reg });
+            if let Some(limit_reg) = limit_ctx {
+                let combined_reg = program.alloc_register();
+                program.add_comment(program.offset(), "OFFSET + LIMIT");
+                program.emit_insn(Insn::OffsetLimit {
+                    offset_reg: reg,
+                    combined_reg,
+                    limit_reg,
+                });
+            }
+            Ok::<_, LimboError>(reg)
+        })
+        .transpose()?;
+
+    // Sort and emit results
+    emit_explain!(program, false, "USE SORTER FOR ORDER BY".to_owned());
+
+    let pseudo_cursor = program.alloc_cursor_id(CursorType::Pseudo(PseudoCursorType {
+        column_count: sorter_column_count,
+    }));
+    program.emit_insn(Insn::OpenPseudo {
+        cursor_id: pseudo_cursor,
+        content_reg: reg_sorter_data,
+        num_fields: sorter_column_count,
+    });
+
+    let sort_loop_start = program.allocate_label();
+    let sort_loop_next = program.allocate_label();
+    let sort_loop_end = program.allocate_label();
+
+    // Skip output entirely if LIMIT is 0
+    if let Some(limit_reg) = limit_ctx {
+        program.emit_insn(Insn::IfNot {
+            reg: limit_reg,
+            target_pc: sort_loop_end,
+            jump_if_null: false,
+        });
+    }
+
+    program.emit_insn(Insn::SorterSort {
+        cursor_id: sort_cursor,
+        pc_if_empty: sort_loop_end,
+    });
+
+    program.preassign_label_to_next_insn(sort_loop_start);
+
+    // Apply OFFSET
+    if let Some(offset_r) = offset_reg {
+        program.emit_insn(Insn::IfPos {
+            reg: offset_r,
+            target_pc: sort_loop_next,
+            decrement_by: 1,
+        });
+    }
+
+    program.emit_insn(Insn::SorterData {
+        cursor_id: sort_cursor,
+        dest_reg: reg_sorter_data,
+        pseudo_cursor,
+    });
+
+    // Read result columns from the pseudo cursor, remapping from sorter order to SELECT order
+    let result_start_reg = program.alloc_registers(num_result_cols);
+    for (col_idx, &(sorter_idx, _deduplicated)) in
+        remappings.iter().enumerate().take(num_result_cols)
+    {
+        program.emit_column_or_rowid(pseudo_cursor, sorter_idx, result_start_reg + col_idx);
+    }
+
+    // Emit to real destination
+    emit_columns_to_destination(program, real_destination, result_start_reg, num_result_cols)?;
+
+    // Apply LIMIT
+    if let Some(limit_reg) = limit_ctx {
+        program.emit_insn(Insn::DecrJumpZero {
+            reg: limit_reg,
+            target_pc: sort_loop_end,
+        });
+    }
+
+    program.resolve_label(sort_loop_next, program.offset());
+    program.emit_insn(Insn::SorterNext {
+        cursor_id: sort_cursor,
+        pc_if_next: sort_loop_start,
+    });
+    program.preassign_label_to_next_insn(sort_loop_end);
+
+    Ok(Some(result_start_reg))
 }

--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -672,8 +672,10 @@ impl ToTokens for Plan {
                     s.append(TokenType::TK_BY, None)?;
 
                     s.comma(
-                        order_by.iter().map(|(expr, order)| ast::SortedColumn {
-                            expr: expr.clone().into(),
+                        order_by.iter().map(|(col_idx, order)| ast::SortedColumn {
+                            expr: Box::new(ast::Expr::Literal(ast::Literal::Numeric(
+                                (col_idx + 1).to_string(),
+                            ))),
                             order: Some(*order),
                             nulls: None,
                         }),

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -300,7 +300,9 @@ pub enum Plan {
         right_most: SelectPlan,
         limit: Option<Box<Expr>>,
         offset: Option<Box<Expr>>,
-        order_by: Option<Vec<(ast::Expr, SortOrder)>>,
+        /// ORDER BY for compound selects. Each entry is (result_column_index, sort_order).
+        /// The column index is 0-based into the result set.
+        order_by: Option<Vec<(usize, SortOrder)>>,
     },
     Delete(DeletePlan),
     Update(UpdatePlan),

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -202,16 +202,41 @@ pub fn prepare_select_plan(
                 .limit
                 .map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
 
-            // FIXME: handle ORDER BY for compound selects
-            if !select.order_by.is_empty() {
-                crate::bail_parse_error!("ORDER BY is not supported for compound SELECTs yet");
-            }
+            // Parse ORDER BY for compound selects.
+            // ORDER BY can reference columns by number (1-based) or by name/alias
+            // from the leftmost SELECT's result columns.
+            let leftmost_plan = &left[0].0;
+            let leftmost_result_columns = &leftmost_plan.result_columns;
+            let leftmost_table_refs = &leftmost_plan.table_references;
+            let order_by = if select.order_by.is_empty() {
+                None
+            } else {
+                if select
+                    .order_by
+                    .iter()
+                    .filter_map(|o| o.nulls)
+                    .any(|n| n == ast::NullsOrder::Last)
+                {
+                    crate::bail_parse_error!("NULLS LAST is not supported yet in ORDER BY");
+                }
+                let mut key = Vec::with_capacity(select.order_by.len());
+                for o in &select.order_by {
+                    let col_idx = resolve_compound_order_by_expr(
+                        &o.expr,
+                        leftmost_result_columns,
+                        leftmost_table_refs,
+                    )?;
+                    key.push((col_idx, o.order.unwrap_or(ast::SortOrder::Asc)));
+                }
+                Some(key)
+            };
+
             Ok(Plan::CompoundSelect {
                 left,
                 right_most: last,
                 limit,
                 offset,
-                order_by: None,
+                order_by,
             })
         }
     }
@@ -864,6 +889,65 @@ fn replace_column_number_with_copy_of_column_expr(
         // Otherwise, leave the expression as-is (constant expression, case 3 per SQLite docs)
     }
     Ok(())
+}
+
+/// Resolves a compound SELECT ORDER BY expression to a 0-based column index.
+/// ORDER BY in compound selects can reference columns by:
+/// 1. Numeric position (1-based): ORDER BY 1
+/// 2. Column name or alias from the leftmost SELECT: ORDER BY name
+fn resolve_compound_order_by_expr(
+    expr: &ast::Expr,
+    result_columns: &[ResultSetColumn],
+    table_references: &TableReferences,
+) -> Result<usize> {
+    match expr {
+        // Case 1: Numeric column reference (e.g., ORDER BY 1)
+        ast::Expr::Literal(ast::Literal::Numeric(num)) => {
+            if let Ok(column_number) = num.parse::<usize>() {
+                if column_number == 0 || column_number > result_columns.len() {
+                    crate::bail_parse_error!(
+                        "{} ORDER BY term out of range - should be between 1 and {}",
+                        column_number,
+                        result_columns.len()
+                    );
+                }
+                Ok(column_number - 1)
+            } else {
+                crate::bail_parse_error!(
+                    "ORDER BY expression in compound SELECT must be a column number or name"
+                );
+            }
+        }
+        // Case 2: Name reference (e.g., ORDER BY name or ORDER BY alias)
+        ast::Expr::Id(name) => {
+            let name_normalized = normalize_ident(name.as_str());
+            // First try matching against aliases
+            for (i, rc) in result_columns.iter().enumerate() {
+                if let Some(alias) = &rc.alias {
+                    if normalize_ident(alias) == name_normalized {
+                        return Ok(i);
+                    }
+                }
+            }
+            // Then try matching against column names from the table references
+            for (i, rc) in result_columns.iter().enumerate() {
+                if let Some(col_name) = rc.name(table_references) {
+                    if normalize_ident(col_name) == name_normalized {
+                        return Ok(i);
+                    }
+                }
+            }
+            crate::bail_parse_error!(
+                "ORDER BY term \"{}\" does not match any result column",
+                name.as_str()
+            );
+        }
+        _ => {
+            crate::bail_parse_error!(
+                "ORDER BY expression in compound SELECT must be a column number or name"
+            );
+        }
+    }
 }
 
 /// Count required cursors for a Plan (either Select or CompoundSelect)

--- a/testing/differential-oracle/sql_gen/src/ast.rs
+++ b/testing/differential-oracle/sql_gen/src/ast.rs
@@ -192,6 +192,19 @@ impl SelectStmt {
                 }
             }
         }
+        // Check compound arms' subquery expressions
+        for arm in &self.compounds {
+            for col in &arm.columns {
+                if let Some(reason) = col.expr.unordered_limit_reason() {
+                    return Some(reason);
+                }
+            }
+            if let Some(w) = &arm.where_clause {
+                if let Some(reason) = w.unordered_limit_reason() {
+                    return Some(reason);
+                }
+            }
+        }
         // Check ORDER BY expressions
         for item in &self.order_by {
             if let Some(reason) = item.expr.unordered_limit_reason() {
@@ -205,6 +218,12 @@ impl SelectStmt {
     /// with `ORDER BY` that doesn't include a unique column, meaning tie-breaking
     /// is engine-dependent.
     pub fn non_unique_order_by_reason(&self, schema: &Schema) -> Option<&'static str> {
+        // Compound SELECTs with LIMIT always flag as non-unique: ORDER BY uses
+        // positional indices so unique-column checking doesn't apply.
+        if self.limit.is_some() && !self.compounds.is_empty() {
+            return Some("compound_limit_non_unique_order_by");
+        }
+
         // Check THIS select: LIMIT + ORDER BY without a unique tiebreaker
         if self.limit.is_some()
             && !self.order_by.is_empty()
@@ -663,6 +682,61 @@ pub enum JoinConstraint {
     On(Expr),
 }
 
+/// A compound operator connecting two SELECT arms.
+#[derive(Debug, Clone, Copy)]
+pub enum CompoundOperator {
+    Union,
+    UnionAll,
+    Intersect,
+    Except,
+}
+
+impl fmt::Display for CompoundOperator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompoundOperator::Union => write!(f, "UNION"),
+            CompoundOperator::UnionAll => write!(f, "UNION ALL"),
+            CompoundOperator::Intersect => write!(f, "INTERSECT"),
+            CompoundOperator::Except => write!(f, "EXCEPT"),
+        }
+    }
+}
+
+/// A compound SELECT arm (e.g. `UNION SELECT ...`).
+#[derive(Debug, Clone)]
+pub struct CompoundSelectArm {
+    pub operator: CompoundOperator,
+    pub distinct: bool,
+    pub columns: Vec<SelectColumn>,
+    pub from: Option<FromClause>,
+    pub where_clause: Option<Expr>,
+}
+
+impl fmt::Display for CompoundSelectArm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, " {} SELECT ", self.operator)?;
+        if self.distinct {
+            write!(f, "DISTINCT ")?;
+        }
+        for (i, col) in self.columns.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{col}")?;
+        }
+        if let Some(from) = &self.from {
+            write!(f, " FROM {}", from.table)?;
+            if let Some(alias) = &from.alias {
+                write!(f, " AS {alias}")?;
+            }
+        }
+        if let Some(where_clause) = &self.where_clause {
+            write!(f, " WHERE {where_clause}")?;
+        }
+        Ok(())
+    }
+}
+
 /// A SELECT statement.
 #[derive(Debug, Clone)]
 pub struct SelectStmt {
@@ -674,6 +748,8 @@ pub struct SelectStmt {
     pub joins: Vec<JoinClause>,
     pub where_clause: Option<Expr>,
     pub group_by: Option<GroupByClause>,
+    /// Compound arms (UNION/INTERSECT/EXCEPT) following the first SELECT core.
+    pub compounds: Vec<CompoundSelectArm>,
     pub order_by: Vec<OrderByItem>,
     pub limit: Option<u64>,
     pub offset: Option<u64>,
@@ -744,6 +820,10 @@ impl fmt::Display for SelectStmt {
             if let Some(having) = &group_by.having {
                 write!(f, " HAVING {having}")?;
             }
+        }
+
+        for arm in &self.compounds {
+            write!(f, "{arm}")?;
         }
 
         if !self.order_by.is_empty() {
@@ -1246,7 +1326,7 @@ pub enum TriggerStmt {
     Insert(InsertStmt),
     Update(UpdateStmt),
     Delete(DeleteStmt),
-    Select(SelectStmt),
+    Select(Box<SelectStmt>),
 }
 
 impl fmt::Display for TriggerStmt {
@@ -1942,6 +2022,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![],
             limit: Some(10),
             offset: None,
@@ -1969,6 +2050,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![],
             limit: None,
             offset: None,
@@ -1998,6 +2080,7 @@ mod tests {
             }],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![],
             limit: None,
             offset: None,
@@ -2071,6 +2154,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![OrderByItem {
                 expr: Expr::Literal(Literal::Integer(1)),
                 direction: OrderDirection::Asc,
@@ -2102,6 +2186,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![OrderByItem {
                 expr: Expr::ColumnRef(ColumnRef {
                     table: None,
@@ -2136,6 +2221,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![OrderByItem {
                 expr: Expr::BinaryOp(Box::new(BinaryOpExpr {
                     left: Expr::ColumnRef(ColumnRef {
@@ -2154,6 +2240,7 @@ mod tests {
                         joins: vec![],
                         where_clause: None,
                         group_by: None,
+                        compounds: vec![],
                         order_by: vec![],
                         limit: Some(1),
                         offset: None,
@@ -2192,6 +2279,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![OrderByItem {
                 expr: Expr::Literal(Literal::Integer(1)),
                 direction: OrderDirection::Asc,
@@ -2224,6 +2312,7 @@ mod tests {
                 joins: vec![],
                 where_clause: None,
                 group_by: None,
+                compounds: vec![],
                 order_by: vec![],
                 limit: None,
                 offset: None,
@@ -2252,6 +2341,7 @@ mod tests {
                         joins: vec![],
                         where_clause: None,
                         group_by: None,
+                        compounds: vec![],
                         order_by: vec![],
                         limit: None,
                         offset: None,
@@ -2272,6 +2362,7 @@ mod tests {
                         joins: vec![],
                         where_clause: None,
                         group_by: None,
+                        compounds: vec![],
                         order_by: vec![],
                         limit: None,
                         offset: None,
@@ -2305,6 +2396,7 @@ mod tests {
                         joins: vec![],
                         where_clause: None,
                         group_by: None,
+                        compounds: vec![],
                         order_by: vec![],
                         limit: None,
                         offset: None,
@@ -2320,6 +2412,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![],
             limit: None,
             offset: None,
@@ -2351,6 +2444,7 @@ mod tests {
                         joins: vec![],
                         where_clause: None,
                         group_by: None,
+                        compounds: vec![],
                         order_by: vec![],
                         limit: None,
                         offset: None,
@@ -2402,6 +2496,7 @@ mod tests {
                         joins: vec![],
                         where_clause: None,
                         group_by: None,
+                        compounds: vec![],
                         order_by: vec![],
                         limit: Some(5),
                         offset: None,
@@ -2417,6 +2512,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![],
             limit: None,
             offset: None,
@@ -2459,6 +2555,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![OrderByItem {
                 expr: Expr::ColumnRef(ColumnRef {
                     table: None,
@@ -2506,6 +2603,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![OrderByItem {
                 expr: Expr::ColumnRef(ColumnRef {
                     table: None,
@@ -2556,6 +2654,7 @@ mod tests {
             joins: vec![],
             where_clause: None,
             group_by: None,
+            compounds: vec![],
             order_by: vec![OrderByItem {
                 expr: Expr::ColumnRef(ColumnRef {
                     table: None,
@@ -2580,6 +2679,7 @@ mod tests {
             joins: vec![],
             where_clause: Some(Expr::Subquery(Box::new(inner))),
             group_by: None,
+            compounds: vec![],
             order_by: vec![],
             limit: None,
             offset: None,

--- a/testing/differential-oracle/sql_gen/src/generate/select.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/select.rs
@@ -2,9 +2,9 @@
 
 use crate::SqlGen;
 use crate::ast::{
-    BinOp, CteDefinition, CteMaterialization, Expr, FromClause, GroupByClause, JoinClause,
-    JoinConstraint, JoinType, NullsOrder, OrderByItem, OrderDirection, SelectColumn, SelectStmt,
-    WithClause,
+    BinOp, CompoundOperator, CompoundSelectArm, CteDefinition, CteMaterialization, Expr,
+    FromClause, GroupByClause, JoinClause, JoinConstraint, JoinType, Literal, NullsOrder,
+    OrderByItem, OrderDirection, SelectColumn, SelectStmt, WithClause,
 };
 use crate::capabilities::Capabilities;
 use crate::context::Context;
@@ -13,6 +13,7 @@ use crate::functions::{AGGREGATE_FUNCTIONS, FunctionCategory};
 use crate::generate::expr::generate_condition;
 use crate::generate::expr::generate_expr;
 use crate::generate::literal::generate_literal;
+use crate::policy::SelectConfig;
 use crate::schema::{ColumnDef, DataType, Table};
 use crate::trace::Origin;
 use sql_gen_macros::trace_gen;
@@ -62,6 +63,7 @@ pub fn generate_tableless_select<C: Capabilities>(
         joins: vec![],
         where_clause: None,
         group_by: None,
+        compounds: vec![],
         order_by: vec![],
         limit: None,
         offset: None,
@@ -251,17 +253,6 @@ fn generate_select_impl_inner<C: Capabilities>(
         None
     };
 
-    // --- ORDER BY ---
-    let mut order_by = if ctx.gen_bool_with_prob(order_by_prob) {
-        if let Some(gb) = &group_by {
-            generate_grouped_order_by(generator, ctx, &gb.exprs)?
-        } else {
-            generate_order_by(generator, ctx)?
-        }
-    } else {
-        vec![]
-    };
-
     // --- DISTINCT ---
     let distinct = match mode {
         SelectMode::Full => ctx.gen_bool_with_prob(select_config.distinct_probability),
@@ -271,21 +262,6 @@ fn generate_select_impl_inner<C: Capabilities>(
                 && ctx.gen_bool_with_prob(select_config.subquery_distinct_probability)
         }
     };
-
-    // --- LIMIT / OFFSET ---
-    let (limit, offset) = match mode {
-        SelectMode::Full => generate_limit_offset(generator, ctx),
-        SelectMode::Scalar => (Some(1), None),
-    };
-
-    // Enforce deterministic LIMIT semantics when configured.
-    if limit.is_some() && order_by.is_empty() && select_config.require_order_by_with_limit {
-        order_by = if let Some(gb) = &group_by {
-            generate_grouped_order_by(generator, ctx, &gb.exprs)?
-        } else {
-            generate_order_by(generator, ctx)?
-        };
-    }
 
     let from = {
         let primary_qualified = ctx.tables_in_scope()[0].table.qualified_name();
@@ -308,23 +284,96 @@ fn generate_select_impl_inner<C: Capabilities>(
         let _ = generate_derived_table(generator, ctx);
     }
 
-    // --- Compound (not yet implemented) ---
-    if ctx.gen_bool_with_prob(select_config.compound_probability) {
-        let _ = generate_compound_union(generator, ctx);
-    }
+    // --- Compound SELECT decision ---
+    // Only at top level (not inside subqueries) since Turso doesn't support
+    // compound SELECTs in subquery positions yet.
+    let is_compound = mode == SelectMode::Full
+        && ctx.subquery_depth() == 0
+        && joins.is_empty()
+        && group_by.is_none()
+        && ctx.gen_bool_with_prob(select_config.compound_probability);
 
-    Ok(SelectStmt {
-        with_clause: None,
-        distinct,
-        columns,
-        from,
-        joins,
-        where_clause,
-        group_by,
-        order_by,
-        limit,
-        offset,
-    })
+    if is_compound {
+        let num_result_cols = if columns.is_empty() {
+            // SELECT * — count columns from primary table
+            ctx.tables_in_scope()[0].table.columns.len()
+        } else {
+            columns.len()
+        };
+        let compounds = generate_compound_arms(generator, ctx, num_result_cols)?;
+
+        // ORDER BY for compounds uses positional indices (1..N)
+        let mut order_by = if ctx.gen_bool_with_prob(select_config.compound_order_by_probability) {
+            generate_compound_order_by(ctx, num_result_cols, select_config)?
+        } else {
+            vec![]
+        };
+
+        let (limit, offset) = if ctx.gen_bool_with_prob(select_config.compound_limit_probability) {
+            generate_limit_offset(generator, ctx)
+        } else {
+            (None, None)
+        };
+
+        // Enforce deterministic LIMIT semantics when configured.
+        if limit.is_some() && order_by.is_empty() && select_config.require_order_by_with_limit {
+            order_by = generate_compound_order_by(ctx, num_result_cols, select_config)?;
+        }
+
+        Ok(SelectStmt {
+            with_clause: None,
+            distinct,
+            columns,
+            from,
+            joins,
+            where_clause,
+            group_by,
+            compounds,
+            order_by,
+            limit,
+            offset,
+        })
+    } else {
+        // --- ORDER BY ---
+        let mut order_by = if ctx.gen_bool_with_prob(order_by_prob) {
+            if let Some(gb) = &group_by {
+                generate_grouped_order_by(generator, ctx, &gb.exprs)?
+            } else {
+                generate_order_by(generator, ctx)?
+            }
+        } else {
+            vec![]
+        };
+
+        // --- LIMIT / OFFSET ---
+        let (limit, offset) = match mode {
+            SelectMode::Full => generate_limit_offset(generator, ctx),
+            SelectMode::Scalar => (Some(1), None),
+        };
+
+        // Enforce deterministic LIMIT semantics when configured.
+        if limit.is_some() && order_by.is_empty() && select_config.require_order_by_with_limit {
+            order_by = if let Some(gb) = &group_by {
+                generate_grouped_order_by(generator, ctx, &gb.exprs)?
+            } else {
+                generate_order_by(generator, ctx)?
+            };
+        }
+
+        Ok(SelectStmt {
+            with_clause: None,
+            distinct,
+            columns,
+            from,
+            joins,
+            where_clause,
+            group_by,
+            compounds: vec![],
+            order_by,
+            limit,
+            offset,
+        })
+    }
 }
 
 /// Generate a GROUP BY clause with optional HAVING.
@@ -940,36 +989,117 @@ fn generate_join_on_condition<C: Capabilities>(
     Ok(Expr::binary_op(ctx, col_expr, op, lit_expr))
 }
 
-#[trace_gen(Origin::CompoundUnion)]
-fn generate_compound_union<C: Capabilities>(
-    _generator: &SqlGen<C>,
-    _ctx: &mut Context,
-) -> Result<SelectStmt, GenError> {
-    todo!("UNION generation")
+/// Generate compound arms for a compound SELECT.
+///
+/// Each arm picks a table, generates columns matching `num_cols`, and optionally
+/// generates a WHERE clause. The compound operator is chosen by weighted random.
+fn generate_compound_arms<C: Capabilities>(
+    generator: &SqlGen<C>,
+    ctx: &mut Context,
+    num_cols: usize,
+) -> Result<Vec<CompoundSelectArm>, GenError> {
+    let select_config = &generator.policy().select_config;
+    let weights = &select_config.compound_operator_weights;
+    let max_arms = select_config.compound_max_arms.max(1);
+    let num_arms = ctx.gen_range_inclusive(1, max_arms);
+
+    let mut arms = Vec::with_capacity(num_arms);
+    for _ in 0..num_arms {
+        // Pick operator
+        let op_weights = [
+            weights.union,
+            weights.union_all,
+            weights.intersect,
+            weights.except,
+        ];
+        let operator = match ctx.weighted_index(&op_weights) {
+            Some(0) => CompoundOperator::Union,
+            Some(1) => CompoundOperator::UnionAll,
+            Some(2) => CompoundOperator::Intersect,
+            Some(3) => CompoundOperator::Except,
+            _ => CompoundOperator::UnionAll,
+        };
+
+        // Record coverage for the specific compound operator
+        let origin = match operator {
+            CompoundOperator::Union => Origin::CompoundUnion,
+            CompoundOperator::UnionAll => Origin::CompoundUnionAll,
+            CompoundOperator::Intersect => Origin::CompoundIntersect,
+            CompoundOperator::Except => Origin::CompoundExcept,
+        };
+
+        let arm = ctx.scope(origin, |ctx| {
+            // Pick a table for this arm
+            let table = ctx
+                .choose(&generator.schema().tables)
+                .ok_or_else(|| GenError::schema_empty("tables"))?;
+            let table = table.clone();
+            let table_name = table.qualified_name();
+
+            // Generate columns in a temporary table scope for this arm's table
+            let (columns, where_clause) = ctx.with_table_scope(vec![(table, None)], |ctx| {
+                // Generate columns matching the required count
+                let mut cols = Vec::with_capacity(num_cols);
+                for _ in 0..num_cols {
+                    let expr = pick_scoped_column_ref(ctx)?;
+                    cols.push(SelectColumn { expr, alias: None });
+                }
+
+                // Optionally generate WHERE
+                let where_clause =
+                    if ctx.gen_bool_with_prob(select_config.compound_where_probability) {
+                        Some(generate_condition(generator, ctx)?)
+                    } else {
+                        None
+                    };
+
+                Ok::<_, GenError>((cols, where_clause))
+            })?;
+
+            Ok(CompoundSelectArm {
+                operator,
+                distinct: false,
+                columns,
+                from: Some(FromClause {
+                    table: table_name,
+                    alias: None,
+                }),
+                where_clause,
+            })
+        })?;
+
+        arms.push(arm);
+    }
+
+    Ok(arms)
 }
 
-#[trace_gen(Origin::CompoundUnionAll)]
-fn generate_compound_union_all<C: Capabilities>(
-    _generator: &SqlGen<C>,
-    _ctx: &mut Context,
-) -> Result<SelectStmt, GenError> {
-    todo!("UNION ALL generation")
-}
+/// Generate ORDER BY for compound SELECTs using positional column indices.
+///
+/// Compound SELECTs require ORDER BY to use integer positions (e.g. `ORDER BY 1`)
+/// since column names from the first SELECT may not be valid across arms.
+fn generate_compound_order_by(
+    ctx: &mut Context,
+    num_result_cols: usize,
+    select_config: &SelectConfig,
+) -> Result<Vec<OrderByItem>, GenError> {
+    let max_items = num_result_cols.max(1);
+    let num_items = ctx.gen_range_inclusive(1, max_items);
+    let mut items = Vec::with_capacity(num_items);
 
-#[trace_gen(Origin::CompoundIntersect)]
-fn generate_compound_intersect<C: Capabilities>(
-    _generator: &SqlGen<C>,
-    _ctx: &mut Context,
-) -> Result<SelectStmt, GenError> {
-    todo!("INTERSECT generation")
-}
+    for _ in 0..num_items {
+        let pos = ctx.gen_range_inclusive(1, num_result_cols.max(1));
+        let expr = Expr::Literal(Literal::Integer(pos as i64));
+        let direction = select_order_direction(ctx, &select_config.order_direction_weights);
+        let nulls = select_nulls_order(ctx, &select_config.nulls_order_weights);
+        items.push(OrderByItem {
+            expr,
+            direction,
+            nulls,
+        });
+    }
 
-#[trace_gen(Origin::CompoundExcept)]
-fn generate_compound_except<C: Capabilities>(
-    _generator: &SqlGen<C>,
-    _ctx: &mut Context,
-) -> Result<SelectStmt, GenError> {
-    todo!("EXCEPT generation")
+    Ok(items)
 }
 
 /// Generate a WITH clause containing 1..max_ctes CTEs.
@@ -1736,6 +1866,7 @@ mod tests {
             limit_probability: 1.0,
             order_by_probability: 0.0,
             require_order_by_with_limit: true,
+            compound_probability: 0.0,
             ..Default::default()
         });
         let schema = SchemaBuilder::new()

--- a/testing/differential-oracle/sql_gen/src/generate/stmt.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/stmt.rs
@@ -1113,7 +1113,7 @@ fn generate_trigger_body_stmt<C: Capabilities>(
             _ => unreachable!(),
         },
         TriggerBodyStmtKind::Select => match generate_select(generator, ctx)? {
-            Stmt::Select(stmt) => Ok(TriggerStmt::Select(stmt)),
+            Stmt::Select(stmt) => Ok(TriggerStmt::Select(Box::new(stmt))),
             _ => unreachable!(),
         },
     }

--- a/testing/differential-oracle/sql_gen/src/lib.rs
+++ b/testing/differential-oracle/sql_gen/src/lib.rs
@@ -60,11 +60,12 @@ pub use context::Context;
 pub use error::{GenError, GenErrorKind};
 pub use functions::{FunctionCategory, FunctionDef, SCALAR_FUNCTIONS};
 pub use policy::{
-    BinOpCategoryWeights, BinOpWeights, CompoundOpWeights, CteConfig, CteMaterializationWeights,
-    DeleteConfig, ExprConfig, ExprWeights, FunctionConfig, IdentifierConfig, InsertConfig,
-    LiteralConfig, LiteralTypeWeights, NullsOrderWeights, OrderDirectionWeights, Policy,
-    SelectConfig, StmtWeights, StringCharset, TriggerBodyStmtWeights, TriggerConfig,
-    TriggerEventWeights, TriggerTimingWeights, UnaryOpWeights, UpdateConfig,
+    BinOpCategoryWeights, BinOpWeights, CompoundOpWeights, CompoundOperatorWeights, CteConfig,
+    CteMaterializationWeights, DeleteConfig, ExprConfig, ExprWeights, FunctionConfig,
+    IdentifierConfig, InsertConfig, LiteralConfig, LiteralTypeWeights, NullsOrderWeights,
+    OrderDirectionWeights, Policy, SelectConfig, StmtWeights, StringCharset,
+    TriggerBodyStmtWeights, TriggerConfig, TriggerEventWeights, TriggerTimingWeights,
+    UnaryOpWeights, UpdateConfig,
 };
 pub use schema::{ColumnDef, DataType, Index, Schema, SchemaBuilder, Table};
 pub use strategy::{GeneratedSql, SqlStrategy};

--- a/testing/differential-oracle/sql_gen/src/policy.rs
+++ b/testing/differential-oracle/sql_gen/src/policy.rs
@@ -1152,10 +1152,25 @@ pub struct SelectConfig {
     /// Probability of generating a CTE (WITH clause).
     pub cte_probability: f64,
 
-    // Stubs (not yet implemented, probability 0.0)
     /// Probability of generating a compound SELECT (UNION/INTERSECT/EXCEPT).
     pub compound_probability: f64,
 
+    /// Maximum number of compound arms (each arm is a UNION/INTERSECT/EXCEPT SELECT).
+    pub compound_max_arms: usize,
+
+    /// Probability of generating ORDER BY on a compound SELECT.
+    pub compound_order_by_probability: f64,
+
+    /// Probability of generating LIMIT on a compound SELECT.
+    pub compound_limit_probability: f64,
+
+    /// Probability of generating WHERE on each compound arm.
+    pub compound_where_probability: f64,
+
+    /// Weights for compound operator selection.
+    pub compound_operator_weights: CompoundOperatorWeights,
+
+    // Stubs (not yet implemented, probability 0.0)
     /// Probability of generating a derived table (subquery in FROM).
     pub derived_table_probability: f64,
 }
@@ -1192,8 +1207,13 @@ impl Default for SelectConfig {
             join_config: JoinConfig::default(),
             cte_config: CteConfig::default(),
             cte_probability: 0.15,
+            compound_probability: 0.15,
+            compound_max_arms: 4,
+            compound_order_by_probability: 0.7,
+            compound_limit_probability: 0.3,
+            compound_where_probability: 0.5,
+            compound_operator_weights: CompoundOperatorWeights::default(),
             // Stubs
-            compound_probability: 0.0,
             derived_table_probability: 0.0,
         }
     }
@@ -1215,6 +1235,7 @@ impl SelectConfig {
             subquery_group_by_probability: 0.0,
             subquery_distinct_probability: 0.0,
             cte_probability: 0.0,
+            compound_probability: 0.0,
             ..Default::default()
         }
     }
@@ -1272,6 +1293,26 @@ impl Default for NullsOrderWeights {
             first: 10,
             last: 10,
             unspecified: 80,
+        }
+    }
+}
+
+/// Weights for compound SELECT operator selection (UNION/INTERSECT/EXCEPT).
+#[derive(Debug, Clone)]
+pub struct CompoundOperatorWeights {
+    pub union: u32,
+    pub union_all: u32,
+    pub intersect: u32,
+    pub except: u32,
+}
+
+impl Default for CompoundOperatorWeights {
+    fn default() -> Self {
+        Self {
+            union: 30,
+            union_all: 40,
+            intersect: 15,
+            except: 15,
         }
     }
 }

--- a/testing/sqltests/tests/compound-select-orderby.sqltest
+++ b/testing/sqltests/tests/compound-select-orderby.sqltest
@@ -1,0 +1,853 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t1 (a INTEGER, b TEXT, c INTEGER);
+    INSERT INTO t1 VALUES (3, 'cherry', 30);
+    INSERT INTO t1 VALUES (1, 'apple', 10);
+    INSERT INTO t1 VALUES (5, 'elderberry', 50);
+    INSERT INTO t1 VALUES (2, 'banana', 20);
+    INSERT INTO t1 VALUES (4, 'date', 40);
+
+    CREATE TABLE t2 (a INTEGER, b TEXT, c INTEGER);
+    INSERT INTO t2 VALUES (6, 'fig', 60);
+    INSERT INTO t2 VALUES (2, 'banana', 20);
+    INSERT INTO t2 VALUES (8, 'honeydew', 80);
+    INSERT INTO t2 VALUES (4, 'date', 40);
+    INSERT INTO t2 VALUES (7, 'grape', 70);
+
+    CREATE TABLE t3 (x INTEGER, y TEXT);
+    INSERT INTO t3 VALUES (10, 'zulu');
+    INSERT INTO t3 VALUES (1, 'alpha');
+    INSERT INTO t3 VALUES (5, 'echo');
+}
+
+# ===== UNION ALL + ORDER BY =====
+
+@setup schema
+test union-all-order-by-col-number {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    ORDER BY 1;
+}
+expect {
+    1|apple
+    2|banana
+    2|banana
+    3|cherry
+    4|date
+    4|date
+    5|elderberry
+    6|fig
+    7|grape
+    8|honeydew
+}
+
+@setup schema
+test union-all-order-by-col-name {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    ORDER BY b;
+}
+expect {
+    1|apple
+    2|banana
+    2|banana
+    3|cherry
+    4|date
+    4|date
+    5|elderberry
+    6|fig
+    7|grape
+    8|honeydew
+}
+
+@setup schema
+test union-all-order-by-desc {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    ORDER BY 1 DESC;
+}
+expect {
+    8|honeydew
+    7|grape
+    6|fig
+    5|elderberry
+    4|date
+    4|date
+    3|cherry
+    2|banana
+    2|banana
+    1|apple
+}
+
+@setup schema
+test union-all-order-by-second-col {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    ORDER BY 2 DESC;
+}
+expect {
+    8|honeydew
+    7|grape
+    6|fig
+    5|elderberry
+    4|date
+    4|date
+    3|cherry
+    2|banana
+    2|banana
+    1|apple
+}
+
+@setup schema
+test union-all-order-by-multiple-cols {
+    SELECT a, b, c FROM t1
+    UNION ALL
+    SELECT a, b, c FROM t2
+    ORDER BY c, a;
+}
+expect {
+    1|apple|10
+    2|banana|20
+    2|banana|20
+    3|cherry|30
+    4|date|40
+    4|date|40
+    5|elderberry|50
+    6|fig|60
+    7|grape|70
+    8|honeydew|80
+}
+
+# ===== UNION (distinct) + ORDER BY =====
+
+@setup schema
+test union-order-by-col-number {
+    SELECT a, b FROM t1
+    UNION
+    SELECT a, b FROM t2
+    ORDER BY 1;
+}
+expect {
+    1|apple
+    2|banana
+    3|cherry
+    4|date
+    5|elderberry
+    6|fig
+    7|grape
+    8|honeydew
+}
+
+@setup schema
+test union-order-by-col-name {
+    SELECT a, b FROM t1
+    UNION
+    SELECT a, b FROM t2
+    ORDER BY b;
+}
+expect {
+    1|apple
+    2|banana
+    3|cherry
+    4|date
+    5|elderberry
+    6|fig
+    7|grape
+    8|honeydew
+}
+
+@setup schema
+test union-order-by-desc {
+    SELECT a, b FROM t1
+    UNION
+    SELECT a, b FROM t2
+    ORDER BY 1 DESC;
+}
+expect {
+    8|honeydew
+    7|grape
+    6|fig
+    5|elderberry
+    4|date
+    3|cherry
+    2|banana
+    1|apple
+}
+
+@setup schema
+test union-order-by-multiple-cols {
+    SELECT a, b, c FROM t1
+    UNION
+    SELECT a, b, c FROM t2
+    ORDER BY c DESC, a ASC;
+}
+expect {
+    8|honeydew|80
+    7|grape|70
+    6|fig|60
+    5|elderberry|50
+    4|date|40
+    3|cherry|30
+    2|banana|20
+    1|apple|10
+}
+
+# ===== INTERSECT + ORDER BY =====
+
+@setup schema
+test intersect-order-by {
+    SELECT a, b FROM t1
+    INTERSECT
+    SELECT a, b FROM t2
+    ORDER BY 1;
+}
+expect {
+    2|banana
+    4|date
+}
+
+@setup schema
+test intersect-order-by-desc {
+    SELECT a, b FROM t1
+    INTERSECT
+    SELECT a, b FROM t2
+    ORDER BY 1 DESC;
+}
+expect {
+    4|date
+    2|banana
+}
+
+@setup schema
+test intersect-order-by-col-name {
+    SELECT a, b FROM t1
+    INTERSECT
+    SELECT a, b FROM t2
+    ORDER BY b DESC;
+}
+expect {
+    4|date
+    2|banana
+}
+
+# ===== EXCEPT + ORDER BY =====
+
+@setup schema
+test except-order-by {
+    SELECT a, b FROM t1
+    EXCEPT
+    SELECT a, b FROM t2
+    ORDER BY 1;
+}
+expect {
+    1|apple
+    3|cherry
+    5|elderberry
+}
+
+@setup schema
+test except-order-by-desc {
+    SELECT a, b FROM t1
+    EXCEPT
+    SELECT a, b FROM t2
+    ORDER BY 1 DESC;
+}
+expect {
+    5|elderberry
+    3|cherry
+    1|apple
+}
+
+@setup schema
+test except-order-by-col-name {
+    SELECT a, b FROM t1
+    EXCEPT
+    SELECT a, b FROM t2
+    ORDER BY b;
+}
+expect {
+    1|apple
+    3|cherry
+    5|elderberry
+}
+
+# ===== ORDER BY + LIMIT =====
+
+@setup schema
+test union-all-order-by-limit {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    ORDER BY 1
+    LIMIT 3;
+}
+expect {
+    1|apple
+    2|banana
+    2|banana
+}
+
+@setup schema
+test union-order-by-limit {
+    SELECT a, b FROM t1
+    UNION
+    SELECT a, b FROM t2
+    ORDER BY 1
+    LIMIT 4;
+}
+expect {
+    1|apple
+    2|banana
+    3|cherry
+    4|date
+}
+
+@setup schema
+test except-order-by-limit {
+    SELECT a, b FROM t1
+    EXCEPT
+    SELECT a, b FROM t2
+    ORDER BY 1
+    LIMIT 2;
+}
+expect {
+    1|apple
+    3|cherry
+}
+
+@setup schema
+test intersect-order-by-limit {
+    SELECT a, b FROM t1
+    INTERSECT
+    SELECT a, b FROM t2
+    ORDER BY 1
+    LIMIT 1;
+}
+expect {
+    2|banana
+}
+
+# ===== ORDER BY + LIMIT + OFFSET =====
+
+@setup schema
+test union-all-order-by-limit-offset {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    ORDER BY 1
+    LIMIT 3 OFFSET 2;
+}
+expect {
+    2|banana
+    3|cherry
+    4|date
+}
+
+@setup schema
+test union-order-by-limit-offset {
+    SELECT a, b FROM t1
+    UNION
+    SELECT a, b FROM t2
+    ORDER BY 1
+    LIMIT 3 OFFSET 3;
+}
+expect {
+    4|date
+    5|elderberry
+    6|fig
+}
+
+# ===== Three-way compound + ORDER BY =====
+
+@setup schema
+test three-way-union-all-order-by {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    UNION ALL
+    SELECT x, y FROM t3
+    ORDER BY 1;
+}
+expect {
+    1|apple
+    1|alpha
+    2|banana
+    2|banana
+    3|cherry
+    4|date
+    4|date
+    5|elderberry
+    5|echo
+    6|fig
+    7|grape
+    8|honeydew
+    10|zulu
+}
+
+@setup schema
+test three-way-union-order-by {
+    SELECT a, b FROM t1
+    UNION
+    SELECT a, b FROM t2
+    UNION
+    SELECT x, y FROM t3
+    ORDER BY 1;
+}
+expect {
+    1|alpha
+    1|apple
+    2|banana
+    3|cherry
+    4|date
+    5|echo
+    5|elderberry
+    6|fig
+    7|grape
+    8|honeydew
+    10|zulu
+}
+
+@setup schema
+test three-way-union-order-by-desc {
+    SELECT a, b FROM t1
+    UNION
+    SELECT a, b FROM t2
+    UNION
+    SELECT x, y FROM t3
+    ORDER BY 2 DESC;
+}
+expect {
+    10|zulu
+    8|honeydew
+    7|grape
+    6|fig
+    5|elderberry
+    5|echo
+    4|date
+    3|cherry
+    2|banana
+    1|apple
+    1|alpha
+}
+
+# ===== Mixed compound operators + ORDER BY =====
+
+@setup schema
+test union-then-union-all-order-by {
+    SELECT a, b FROM t1
+    UNION
+    SELECT a, b FROM t2
+    UNION ALL
+    SELECT x, y FROM t3
+    ORDER BY 1;
+}
+expect {
+    1|apple
+    1|alpha
+    2|banana
+    3|cherry
+    4|date
+    5|elderberry
+    5|echo
+    6|fig
+    7|grape
+    8|honeydew
+    10|zulu
+}
+
+@setup schema
+test union-all-then-except-order-by {
+    SELECT a FROM t1
+    UNION ALL
+    SELECT a FROM t2
+    EXCEPT
+    SELECT x FROM t3
+    ORDER BY 1;
+}
+expect {
+    2
+    3
+    4
+    6
+    7
+    8
+}
+
+@setup schema
+test union-then-intersect-order-by {
+    SELECT a FROM t1
+    UNION
+    SELECT a FROM t2
+    INTERSECT
+    SELECT x FROM t3
+    ORDER BY 1;
+}
+expect {
+    1
+    5
+}
+
+# ===== Single-column ORDER BY =====
+
+@setup schema
+test simple-union-order-by-1 {
+    SELECT 2 UNION SELECT 1 UNION SELECT 3 ORDER BY 1;
+}
+expect {
+    1
+    2
+    3
+}
+
+@setup schema
+test simple-union-all-order-by-1 {
+    SELECT 2 UNION ALL SELECT 1 UNION ALL SELECT 3 ORDER BY 1;
+}
+expect {
+    1
+    2
+    3
+}
+
+@setup schema
+test simple-union-order-by-1-desc {
+    SELECT 2 UNION SELECT 1 UNION SELECT 3 ORDER BY 1 DESC;
+}
+expect {
+    3
+    2
+    1
+}
+
+# ===== ORDER BY with alias =====
+
+@setup schema
+test union-order-by-alias {
+    SELECT a AS num, b AS name FROM t1
+    UNION
+    SELECT a, b FROM t2
+    ORDER BY num;
+}
+expect {
+    1|apple
+    2|banana
+    3|cherry
+    4|date
+    5|elderberry
+    6|fig
+    7|grape
+    8|honeydew
+}
+
+@setup schema
+test union-all-order-by-alias-desc {
+    SELECT a AS val, b AS label FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    ORDER BY val DESC;
+}
+expect {
+    8|honeydew
+    7|grape
+    6|fig
+    5|elderberry
+    4|date
+    4|date
+    3|cherry
+    2|banana
+    2|banana
+    1|apple
+}
+
+# ===== ORDER BY with expressions in SELECT =====
+
+@setup schema
+test union-all-expressions-order-by {
+    SELECT a * 10 AS val FROM t1
+    UNION ALL
+    SELECT a * 10 FROM t2
+    ORDER BY 1;
+}
+expect {
+    10
+    20
+    20
+    30
+    40
+    40
+    50
+    60
+    70
+    80
+}
+
+# ===== Compound with NULLs + ORDER BY =====
+
+@setup schema
+test union-all-nulls-order-by {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT NULL, NULL
+    ORDER BY 1;
+}
+expect {
+    |
+    1|apple
+    2|banana
+    3|cherry
+    4|date
+    5|elderberry
+}
+
+@setup schema
+test union-nulls-order-by-desc {
+    SELECT NULL AS a UNION SELECT 1 UNION SELECT 2 UNION SELECT NULL ORDER BY 1 DESC;
+}
+expect {
+    2
+    1
+
+}
+
+# ===== ORDER BY with WHERE in subselects =====
+
+@setup schema
+test union-all-where-order-by {
+    SELECT a, b FROM t1 WHERE a > 2
+    UNION ALL
+    SELECT a, b FROM t2 WHERE a < 7
+    ORDER BY 1;
+}
+expect {
+    2|banana
+    3|cherry
+    4|date
+    4|date
+    5|elderberry
+    6|fig
+}
+
+# ===== ORDER BY with three-way + LIMIT =====
+
+@setup schema
+test three-way-union-all-order-by-limit {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    UNION ALL
+    SELECT x, y FROM t3
+    ORDER BY 1
+    LIMIT 5;
+}
+expect {
+    1|apple
+    1|alpha
+    2|banana
+    2|banana
+    3|cherry
+}
+
+@setup schema
+test three-way-union-all-order-by-limit-offset {
+    SELECT a, b FROM t1
+    UNION ALL
+    SELECT a, b FROM t2
+    UNION ALL
+    SELECT x, y FROM t3
+    ORDER BY 1
+    LIMIT 3 OFFSET 5;
+}
+expect {
+    4|date
+    4|date
+    5|elderberry
+}
+
+# ===== EXCEPT order reversed =====
+
+@setup schema
+test except-reversed-order-by {
+    SELECT a, b FROM t2
+    EXCEPT
+    SELECT a, b FROM t1
+    ORDER BY 1;
+}
+expect {
+    6|fig
+    7|grape
+    8|honeydew
+}
+
+# ===== INTERSECT with three-way + ORDER BY =====
+
+@setup schema
+test intersect-union-order-by {
+    SELECT a FROM t1
+    INTERSECT
+    SELECT a FROM t2
+    UNION
+    SELECT x FROM t3
+    ORDER BY 1;
+}
+expect {
+    1
+    2
+    4
+    5
+    10
+}
+
+# ===== ORDER BY multiple columns with mixed ASC/DESC =====
+
+@setup schema
+test union-all-order-by-mixed-asc-desc {
+    SELECT a, b, c FROM t1
+    UNION ALL
+    SELECT a, b, c FROM t2
+    ORDER BY c ASC, b DESC;
+}
+expect {
+    1|apple|10
+    2|banana|20
+    2|banana|20
+    3|cherry|30
+    4|date|40
+    4|date|40
+    5|elderberry|50
+    6|fig|60
+    7|grape|70
+    8|honeydew|80
+}
+
+# ===== Compound select with subquery in FROM =====
+
+@setup schema
+test subquery-union-order-by {
+    SELECT * FROM (
+        SELECT a, b FROM t1
+        UNION
+        SELECT a, b FROM t2
+        ORDER BY 1
+    );
+}
+expect {
+    1|apple
+    2|banana
+    3|cherry
+    4|date
+    5|elderberry
+    6|fig
+    7|grape
+    8|honeydew
+}
+
+# ===== ORDER BY 1 with single-value selects =====
+
+@setup schema
+test union-literals-order-by {
+    SELECT 'c' UNION SELECT 'a' UNION SELECT 'b' ORDER BY 1;
+}
+expect {
+    a
+    b
+    c
+}
+
+@setup schema
+test union-all-literals-order-by-desc {
+    SELECT 'c' UNION ALL SELECT 'a' UNION ALL SELECT 'b' ORDER BY 1 DESC;
+}
+expect {
+    c
+    b
+    a
+}
+
+# ===== Large UNION ALL to verify stability =====
+
+@setup schema
+test union-all-many-order-by {
+    SELECT 5 AS v
+    UNION ALL SELECT 3
+    UNION ALL SELECT 7
+    UNION ALL SELECT 1
+    UNION ALL SELECT 9
+    UNION ALL SELECT 2
+    UNION ALL SELECT 8
+    UNION ALL SELECT 4
+    UNION ALL SELECT 6
+    UNION ALL SELECT 10
+    ORDER BY 1;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+}
+
+@setup schema
+test union-all-many-order-by-desc {
+    SELECT 5 AS v
+    UNION ALL SELECT 3
+    UNION ALL SELECT 7
+    UNION ALL SELECT 1
+    UNION ALL SELECT 9
+    UNION ALL SELECT 2
+    UNION ALL SELECT 8
+    UNION ALL SELECT 4
+    UNION ALL SELECT 6
+    UNION ALL SELECT 10
+    ORDER BY 1 DESC;
+}
+expect {
+    10
+    9
+    8
+    7
+    6
+    5
+    4
+    3
+    2
+    1
+}
+
+# ===== UNION with ORDER BY + LIMIT 0 =====
+
+@setup schema
+test union-order-by-limit-zero {
+    SELECT a FROM t1
+    UNION
+    SELECT a FROM t2
+    ORDER BY 1
+    LIMIT 0;
+}
+expect {
+}
+
+# ===== EXCEPT with ORDER BY + LIMIT =====
+
+@setup schema
+test except-order-by-limit-offset {
+    SELECT a, b FROM t1
+    EXCEPT
+    SELECT a, b FROM t2
+    ORDER BY 1
+    LIMIT 2 OFFSET 1;
+}
+expect {
+    3|cherry
+    5|elderberry
+}


### PR DESCRIPTION
Previously compound SELECT (UNION, UNION ALL, INTERSECT, EXCEPT) ignored ORDER BY clauses, returning results in arbitrary order. This was a significant SQLite compatibility gap.

The implementation uses a Sorter-based approach:
- When ORDER BY is present on a compound SELECT, results from all subselects are collected into an ephemeral index as before, but LIMIT/OFFSET are deferred to the final sorted output rather than applied during collection.
- ORDER BY column references (by number, name, or alias) are resolved against the first SELECT result columns, matching SQLite semantics.
- A Sorter is opened with the appropriate collation and sort order for each ORDER BY key. Sort keys that overlap with result columns are deduplicated to avoid redundant storage in the sorter.
- After all subselects have been collected and deduplicated (for UNION, INTERSECT, EXCEPT), rows are fed into the Sorter, which then outputs them in sorted order with LIMIT/OFFSET applied.
- Three-way and mixed compound operators (e.g. UNION then INTERSECT) with ORDER BY are fully supported.

The order_by field is added to the CompoundSelect plan variant and threaded through planning, display, and emission.

Includes 49 tests covering all compound operators, ASC/DESC, multiple sort keys, LIMIT/OFFSET, aliases, expressions, NULLs, three-way compounds, mixed operators, and subqueries.

Also add compound statements to the differential fuzzer. No issues found in a 1h run.
