### PR TITLE
sdk-kit: Fix Database.close() not finalizing statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,6 +1117,7 @@ dependencies = [
  "turso_core",
  "turso_macros",
  "turso_parser",
+ "turso_sdk_kit",
  "twox-hash",
  "zerocopy 0.8.26",
 ]

--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -3,9 +3,7 @@ use pyo3::{
     types::{PyBytes, PyTuple},
 };
 use std::sync::Arc;
-use turso_sdk_kit::rsapi::{
-    self, EncryptionOpts, Numeric, TursoError, TursoStatusCode, Value, ValueRef,
-};
+use turso_sdk_kit::rsapi::{self, EncryptionOpts, Numeric, TursoError, TursoStatusCode, Value};
 
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
@@ -359,13 +357,13 @@ impl PyTursoStatement {
     }
 }
 
-fn db_value_to_py(py: Python, value: rsapi::ValueRef) -> PyResult<Py<PyAny>> {
+fn db_value_to_py(py: Python, value: Value) -> PyResult<Py<PyAny>> {
     match value {
-        ValueRef::Null => Ok(py.None()),
-        ValueRef::Numeric(Numeric::Integer(i)) => Ok(i.into_pyobject(py)?.into()),
-        ValueRef::Numeric(Numeric::Float(f)) => Ok(f64::from(f).into_pyobject(py)?.into()),
-        ValueRef::Text(s) => Ok(s.as_str().into_pyobject(py)?.into()),
-        ValueRef::Blob(b) => Ok(PyBytes::new(py, b).into()),
+        Value::Null => Ok(py.None()),
+        Value::Numeric(Numeric::Integer(i)) => Ok(i.into_pyobject(py)?.into()),
+        Value::Numeric(Numeric::Float(f)) => Ok(f64::from(f).into_pyobject(py)?.into()),
+        Value::Text(s) => Ok(s.value.as_ref().into_pyobject(py)?.into()),
+        Value::Blob(b) => Ok(PyBytes::new(py, &b).into()),
     }
 }
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -329,7 +329,7 @@ impl Statement {
                     let mut values = Vec::with_capacity(columns);
                     for i in 0..columns {
                         let value = stmt.row_value(i)?;
-                        values.push(value.to_owned());
+                        values.push(value);
                     }
                     Poll::Ready(Ok(Some(Row { values })))
                 } else {
@@ -416,8 +416,7 @@ impl Statement {
         }
         Ok(stmt
             .column_name(idx)
-            .expect("column index must be within valid range")
-            .into_owned())
+            .expect("column index must be within valid range"))
     }
 
     /// Returns the names of all columns in the result set.
@@ -428,7 +427,6 @@ impl Statement {
             .map(|i| {
                 stmt.column_name(i)
                     .expect("column index must be within valid range")
-                    .into_owned()
             })
             .collect()
     }
@@ -441,7 +439,7 @@ impl Statement {
             let col_name = stmt
                 .column_name(i)
                 .expect("column index must be within valid range");
-            if col_name.eq_ignore_ascii_case(name) {
+            if col_name.as_str().eq_ignore_ascii_case(name) {
                 return Ok(i);
             }
         }
@@ -461,8 +459,7 @@ impl Statement {
         for i in 0..n {
             let name = stmt
                 .column_name(i)
-                .expect("column index must be within valid range")
-                .into_owned();
+                .expect("column index must be within valid range");
             let decl_type = stmt.column_decltype(i);
             cols.push(Column { name, decl_type });
         }

--- a/sdk-kit/src/capi.rs
+++ b/sdk-kit/src/capi.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use turso_core::{types::Text, IOResult};
+use turso_core::{types::AsValueRef, types::Text, IOResult};
 use turso_sdk_kit_macros::signature;
 
 use crate::rsapi::{
@@ -347,29 +347,55 @@ pub extern "C" fn turso_statement_column_decltype(
     }
 }
 
+/// Lock the statement handle and get a ValueRef for the given row index.
+/// Returns None if the statement is null, finalized, has no row, or index is out of bounds.
+/// The returned MutexGuard must be kept alive for the duration of ValueRef use.
+macro_rules! with_row_value {
+    ($statement:expr, $index:expr, $default:expr, $body:expr) => {{
+        let statement = match unsafe { TursoStatement::ref_from_capi($statement) } {
+            Ok(s) => s,
+            Err(_) => return $default,
+        };
+        let handle = statement.handle.lock().unwrap();
+        let Some(stmt) = handle.as_ref() else {
+            return $default;
+        };
+        let Some(row) = stmt.row() else {
+            return $default;
+        };
+        if $index >= row.len() {
+            return $default;
+        }
+        let value_ref = row.get_value($index).as_value_ref();
+        #[allow(clippy::redundant_closure_call)]
+        ($body)(value_ref)
+    }};
+}
+
 #[no_mangle]
 #[signature(c)]
 pub extern "C" fn turso_statement_row_value_kind(
     statement: *const c::turso_statement_t,
     index: usize,
 ) -> c::turso_type_t {
-    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
-        Ok(statement) => statement,
-        Err(_) => return c::turso_type_t::TURSO_TYPE_UNKNOWN,
-    };
-    let value = statement.row_value(index);
-    match value {
-        Ok(turso_core::ValueRef::Null) => c::turso_type_t::TURSO_TYPE_NULL,
-        Ok(turso_core::ValueRef::Numeric(turso_core::Numeric::Integer(..))) => {
-            c::turso_type_t::TURSO_TYPE_INTEGER
+    with_row_value!(
+        statement,
+        index,
+        c::turso_type_t::TURSO_TYPE_UNKNOWN,
+        |value_ref: turso_core::ValueRef| {
+            match value_ref {
+                turso_core::ValueRef::Null => c::turso_type_t::TURSO_TYPE_NULL,
+                turso_core::ValueRef::Numeric(turso_core::Numeric::Integer(..)) => {
+                    c::turso_type_t::TURSO_TYPE_INTEGER
+                }
+                turso_core::ValueRef::Numeric(turso_core::Numeric::Float(..)) => {
+                    c::turso_type_t::TURSO_TYPE_REAL
+                }
+                turso_core::ValueRef::Text(..) => c::turso_type_t::TURSO_TYPE_TEXT,
+                turso_core::ValueRef::Blob(..) => c::turso_type_t::TURSO_TYPE_BLOB,
+            }
         }
-        Ok(turso_core::ValueRef::Numeric(turso_core::Numeric::Float(..))) => {
-            c::turso_type_t::TURSO_TYPE_REAL
-        }
-        Ok(turso_core::ValueRef::Text(..)) => c::turso_type_t::TURSO_TYPE_TEXT,
-        Ok(turso_core::ValueRef::Blob(..)) => c::turso_type_t::TURSO_TYPE_BLOB,
-        Err(_) => c::turso_type_t::TURSO_TYPE_UNKNOWN,
-    }
+    )
 }
 
 #[no_mangle]
@@ -378,16 +404,13 @@ pub extern "C" fn turso_statement_row_value_bytes_count(
     statement: *const c::turso_statement_t,
     index: usize,
 ) -> i64 {
-    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
-        Ok(statement) => statement,
-        Err(_) => return -1,
-    };
-    let value = statement.row_value(index);
-    match value {
-        Ok(turso_core::ValueRef::Text(text)) => text.len() as i64,
-        Ok(turso_core::ValueRef::Blob(blob)) => blob.len() as i64,
-        _ => -1,
-    }
+    with_row_value!(statement, index, -1, |value_ref: turso_core::ValueRef| {
+        match value_ref {
+            turso_core::ValueRef::Text(text) => text.len() as i64,
+            turso_core::ValueRef::Blob(blob) => blob.len() as i64,
+            _ => -1,
+        }
+    })
 }
 
 #[no_mangle]
@@ -396,16 +419,20 @@ pub extern "C" fn turso_statement_row_value_bytes_ptr(
     statement: *const c::turso_statement_t,
     index: usize,
 ) -> *const std::ffi::c_char {
-    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
-        Ok(statement) => statement,
-        Err(_) => return std::ptr::null(),
-    };
-    let value = statement.row_value(index);
-    match value {
-        Ok(turso_core::ValueRef::Text(text)) => text.as_bytes().as_ptr() as *const std::ffi::c_char,
-        Ok(turso_core::ValueRef::Blob(blob)) => blob.as_ptr() as *const std::ffi::c_char,
-        _ => std::ptr::null(),
-    }
+    with_row_value!(
+        statement,
+        index,
+        std::ptr::null(),
+        |value_ref: turso_core::ValueRef| {
+            match value_ref {
+                turso_core::ValueRef::Text(text) => {
+                    text.as_bytes().as_ptr() as *const std::ffi::c_char
+                }
+                turso_core::ValueRef::Blob(blob) => blob.as_ptr() as *const std::ffi::c_char,
+                _ => std::ptr::null(),
+            }
+        }
+    )
 }
 
 #[no_mangle]
@@ -414,15 +441,12 @@ pub extern "C" fn turso_statement_row_value_int(
     statement: *const c::turso_statement_t,
     index: usize,
 ) -> i64 {
-    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
-        Ok(statement) => statement,
-        Err(_) => return 0,
-    };
-    let value = statement.row_value(index);
-    match value {
-        Ok(turso_core::ValueRef::Numeric(turso_core::Numeric::Integer(value))) => value,
-        _ => 0,
-    }
+    with_row_value!(statement, index, 0, |value_ref: turso_core::ValueRef| {
+        match value_ref {
+            turso_core::ValueRef::Numeric(turso_core::Numeric::Integer(value)) => value,
+            _ => 0,
+        }
+    })
 }
 
 #[no_mangle]
@@ -431,15 +455,12 @@ pub extern "C" fn turso_statement_row_value_double(
     statement: *const c::turso_statement_t,
     index: usize,
 ) -> f64 {
-    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
-        Ok(statement) => statement,
-        Err(_) => return 0.0,
-    };
-    let value = statement.row_value(index);
-    match value {
-        Ok(turso_core::ValueRef::Numeric(turso_core::Numeric::Float(value))) => f64::from(value),
-        _ => 0.0,
-    }
+    with_row_value!(statement, index, 0.0, |value_ref: turso_core::ValueRef| {
+        match value_ref {
+            turso_core::ValueRef::Numeric(turso_core::Numeric::Float(value)) => f64::from(value),
+            _ => 0.0,
+        }
+    })
 }
 
 #[no_mangle]

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1,9 +1,11 @@
 use std::{
-    borrow::Cow,
     collections::HashMap,
     fmt::Display,
     ops::Deref,
-    sync::{Arc, Mutex, Once, RwLock},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex, Once, RwLock, Weak,
+    },
     task::Waker,
     time::Duration,
 };
@@ -789,6 +791,12 @@ pub struct TursoConnection {
     concurrent_guard: Arc<ConcurrentGuard>,
     connection: Arc<Connection>,
     cached_statements: Arc<Mutex<HashMap<String, Arc<CachedStatement>>>>,
+    /// Weak refs to every statement handle created by this connection, keyed
+    /// by a monotonic ID. Statements remove themselves on drop, so this map
+    /// only ever contains live entries. `close()` upgrades each remaining
+    /// handle and sets it to `None` to release `Arc<Connection>` → `Arc<Database>`.
+    stmts: StmtRegistry,
+    next_stmt_id: Arc<AtomicUsize>,
 }
 
 impl TursoConnection {
@@ -798,6 +806,8 @@ impl TursoConnection {
             connection,
             concurrent_guard: Arc::new(ConcurrentGuard::new()),
             cached_statements: Arc::new(Mutex::new(HashMap::new())),
+            stmts: Arc::new(Mutex::new(HashMap::new())),
+            next_stmt_id: Arc::new(AtomicUsize::new(0)),
         })
     }
     /// Set busy timeout for the connection
@@ -814,10 +824,14 @@ impl TursoConnection {
     /// prepares single SQL statement
     pub fn prepare_single(&self, sql: impl AsRef<str>) -> Result<Box<TursoStatement>, TursoError> {
         let statement = self.connection.prepare(sql)?;
+        let handle: StatementHandle = Arc::new(Mutex::new(Some(statement)));
+        let stmt_id = self.track_stmt(&handle);
         Ok(Box::new(TursoStatement {
             concurrent_guard: self.concurrent_guard.clone(),
             async_io: self.async_io,
-            statement,
+            handle,
+            stmt_id,
+            stmts: self.stmts.clone(),
         }))
     }
 
@@ -834,10 +848,14 @@ impl TursoConnection {
                 );
                 let statement =
                     Statement::new(program, self.connection.get_pager(), cached.query_mode, 0);
+                let handle: StatementHandle = Arc::new(Mutex::new(Some(statement)));
+                let stmt_id = self.track_stmt(&handle);
                 return Ok(Box::new(TursoStatement {
                     concurrent_guard: self.concurrent_guard.clone(),
                     async_io: self.async_io,
-                    statement,
+                    handle,
+                    stmt_id,
+                    stmts: self.stmts.clone(),
                 }));
             }
         }
@@ -855,10 +873,14 @@ impl TursoConnection {
             .unwrap()
             .insert(sql_str.to_string(), cached);
 
+        let handle: StatementHandle = Arc::new(Mutex::new(Some(statement)));
+        let stmt_id = self.track_stmt(&handle);
         Ok(Box::new(TursoStatement {
             concurrent_guard: self.concurrent_guard.clone(),
             async_io: self.async_io,
-            statement,
+            handle,
+            stmt_id,
+            stmts: self.stmts.clone(),
         }))
     }
 
@@ -869,14 +891,20 @@ impl TursoConnection {
         sql: impl AsRef<str>,
     ) -> Result<Option<(Box<TursoStatement>, usize)>, TursoError> {
         match self.connection.consume_stmt(sql)? {
-            Some((statement, position)) => Ok(Some((
-                Box::new(TursoStatement {
-                    async_io: self.async_io,
-                    concurrent_guard: Arc::new(ConcurrentGuard::new()),
-                    statement,
-                }),
-                position,
-            ))),
+            Some((statement, position)) => {
+                let handle: StatementHandle = Arc::new(Mutex::new(Some(statement)));
+                let stmt_id = self.track_stmt(&handle);
+                Ok(Some((
+                    Box::new(TursoStatement {
+                        async_io: self.async_io,
+                        concurrent_guard: Arc::new(ConcurrentGuard::new()),
+                        handle,
+                        stmt_id,
+                        stmts: self.stmts.clone(),
+                    }),
+                    position,
+                )))
+            }
             None => Ok(None),
         }
     }
@@ -884,6 +912,18 @@ impl TursoConnection {
     /// close the connection preventing any further operations executed over it
     /// SAFETY: caller must guarantee that no ongoing operations are running over connection before calling close(...) method
     pub fn close(&self) -> Result<(), TursoError> {
+        // Finalize all outstanding statements to release their Arc chain:
+        // Statement → Program → Arc<Connection> → Arc<Database>.
+        // Without this, un-finalized statements keep the Database alive in
+        // DATABASE_MANAGER, causing stale databases after file renames.
+        let mut stmts = self.stmts.lock().unwrap();
+        for (_id, weak) in stmts.drain() {
+            if let Some(handle) = weak.upgrade() {
+                // Setting to None drops the turso_core::Statement,
+                // releasing Arc<Connection> → Arc<Database>.
+                *handle.lock().unwrap() = None;
+            }
+        }
         self.connection.close()?;
         Ok(())
     }
@@ -927,12 +967,70 @@ impl TursoConnection {
     pub unsafe fn arc_from_capi(value: *const capi::c::turso_connection_t) -> Arc<Self> {
         Arc::from_raw(value as *const Self)
     }
+
+    /// Register a statement handle and return its ID. The statement removes
+    /// itself from the registry on drop via its `stmt_id` + `stmts` ref.
+    fn track_stmt(&self, handle: &StatementHandle) -> usize {
+        let id = self.next_stmt_id.fetch_add(1, Ordering::Relaxed);
+        self.stmts
+            .lock()
+            .unwrap()
+            .insert(id, Arc::downgrade(handle));
+        id
+    }
+}
+
+/// Shared ownership of a `turso_core::Statement` that can be explicitly finalized.
+/// When the inner `Option` is set to `None`, the statement is considered finalized
+/// and all operations on it will return errors / defaults.
+pub(crate) type StatementHandle = Arc<Mutex<Option<Statement>>>;
+type StmtRegistry = Arc<Mutex<HashMap<usize, Weak<Mutex<Option<Statement>>>>>>;
+
+const FINALIZED_ERR: &str = "statement has been finalized";
+
+/// Advance one step of a statement's execution.
+/// Factored out of `TursoStatement` so it can be called while holding
+/// the `StatementHandle` lock without re-entrancy issues.
+fn step_inner(
+    stmt: &mut Statement,
+    async_io: bool,
+    waker: Option<&Waker>,
+) -> Result<TursoStatusCode, TursoError> {
+    loop {
+        let result = if let Some(waker) = waker {
+            stmt.step_with_waker(waker)
+        } else {
+            stmt.step()
+        };
+        return match result? {
+            StepResult::Done => Ok(TursoStatusCode::Done),
+            StepResult::Row => Ok(TursoStatusCode::Row),
+            StepResult::Busy => Err(TursoError::Busy("database is locked".to_string())),
+            StepResult::Interrupt => Err(TursoError::Interrupt("interrupted".to_string())),
+            StepResult::IO => {
+                if async_io {
+                    Ok(TursoStatusCode::Io)
+                } else {
+                    stmt._io().step()?;
+                    continue;
+                }
+            }
+        };
+    }
 }
 
 pub struct TursoStatement {
     async_io: bool,
     concurrent_guard: Arc<ConcurrentGuard>,
-    statement: Statement,
+    pub(crate) handle: StatementHandle,
+    stmt_id: usize,
+    stmts: StmtRegistry,
+}
+
+impl Drop for TursoStatement {
+    fn drop(&mut self) {
+        self.stmts.lock().unwrap().remove(&self.stmt_id);
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -944,11 +1042,19 @@ pub struct TursoExecutionResult {
 impl TursoStatement {
     /// return amount of row modifications (insert/delete operations) made by the most recent executed statement
     pub fn n_change(&self) -> i64 {
-        self.statement.n_change()
+        let handle = self.handle.lock().unwrap();
+        match handle.as_ref() {
+            Some(stmt) => stmt.n_change(),
+            None => 0,
+        }
     }
     /// returns parameters count for the statement
     pub fn parameters_count(&self) -> usize {
-        self.statement.parameters_count()
+        let handle = self.handle.lock().unwrap();
+        match handle.as_ref() {
+            Some(stmt) => stmt.parameters_count(),
+            None => 0,
+        }
     }
     /// binds positional parameter at the corresponding index (1-based)
     pub fn bind_positional(
@@ -956,25 +1062,33 @@ impl TursoStatement {
         index: usize,
         value: turso_core::Value,
     ) -> Result<(), TursoError> {
+        let mut handle = self.handle.lock().unwrap();
+        let stmt = handle
+            .as_mut()
+            .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
         let Ok(index) = index.try_into() else {
             return Err(TursoError::Misuse(
                 "bind index must be non-zero".to_string(),
             ));
         };
-        if !self.statement.parameters().has_slot(index) {
+        if !stmt.parameters().has_slot(index) {
             return Err(TursoError::Misuse(format!(
                 "bind index {index} is out of bounds"
             )));
         }
-        self.statement.bind_at(index, value);
+        stmt.bind_at(index, value);
         Ok(())
     }
     /// named parameter position.
     ///
     /// The name must include the SQL placeholder prefix, e.g. `:name`, `@name`, `$name`, or `?1`.
     pub fn named_position(&mut self, name: impl AsRef<str>) -> Result<usize, TursoError> {
+        let handle = self.handle.lock().unwrap();
+        let stmt = handle
+            .as_ref()
+            .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
         let name = name.as_ref();
-        if let Some(index) = self.statement.parameter_index(name) {
+        if let Some(index) = stmt.parameter_index(name) {
             return Ok(index.into());
         }
 
@@ -984,7 +1098,7 @@ impl TursoStatement {
                 .and_then(|value| value.parse::<usize>().ok())
                 .and_then(|value| value.try_into().ok());
             if let Some(index) = maybe_index {
-                if self.statement.parameters().is_indexed(index) {
+                if stmt.parameters().is_indexed(index) {
                     return Ok(index.into());
                 }
             }
@@ -1002,43 +1116,26 @@ impl TursoStatement {
     pub fn step(&mut self, waker: Option<&Waker>) -> Result<TursoStatusCode, TursoError> {
         let guard = self.concurrent_guard.clone();
         let _guard = guard.try_use()?;
-        self.step_no_guard(waker)
+        let mut handle = self.handle.lock().unwrap();
+        let stmt = handle
+            .as_mut()
+            .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
+        step_inner(stmt, self.async_io, waker)
     }
 
-    #[inline]
-    fn step_no_guard(&mut self, waker: Option<&Waker>) -> Result<TursoStatusCode, TursoError> {
-        let async_io = self.async_io;
-        loop {
-            let result = if let Some(waker) = waker {
-                self.statement.step_with_waker(waker)
-            } else {
-                self.statement.step()
-            };
-            return match result? {
-                StepResult::Done => Ok(TursoStatusCode::Done),
-                StepResult::Row => Ok(TursoStatusCode::Row),
-                StepResult::Busy => Err(TursoError::Busy("database is locked".to_string())),
-                StepResult::Interrupt => Err(TursoError::Interrupt("interrupted".to_string())),
-                StepResult::IO => {
-                    if async_io {
-                        Ok(TursoStatusCode::Io)
-                    } else {
-                        self.run_io()?;
-                        continue;
-                    }
-                }
-            };
-        }
-    }
     /// execute statement to completion
     /// method returns [TursoStatusCode::Done] if execution completed
     /// method returns [TursoStatusCode::Io] if async_io was set and execution needs IO in order to make progress
     pub fn execute(&mut self, waker: Option<&Waker>) -> Result<TursoExecutionResult, TursoError> {
         let guard = self.concurrent_guard.clone();
         let _guard = guard.try_use()?;
+        let mut handle = self.handle.lock().unwrap();
+        let stmt = handle
+            .as_mut()
+            .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
 
         loop {
-            let status = self.step_no_guard(waker)?;
+            let status = step_inner(stmt, self.async_io, waker)?;
             if status == TursoStatusCode::Row {
                 continue;
             } else if status == TursoStatusCode::Io {
@@ -1049,7 +1146,7 @@ impl TursoStatement {
             } else if status == TursoStatusCode::Done {
                 return Ok(TursoExecutionResult {
                     status: TursoStatusCode::Done,
-                    rows_changed: self.statement.n_change() as u64,
+                    rows_changed: stmt.n_change() as u64,
                 });
             }
             return Err(TursoError::Error(format!(
@@ -1059,14 +1156,21 @@ impl TursoStatement {
     }
     /// run iteration of the IO backend
     pub fn run_io(&self) -> Result<(), TursoError> {
-        self.statement._io().step()?;
+        let handle = self.handle.lock().unwrap();
+        let stmt = handle
+            .as_ref()
+            .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
+        stmt._io().step()?;
         Ok(())
     }
-    /// get row value reference currently pointed by the statement
-    /// note, that this row will no longer be valid after execution of methods like [Self::step]/[Self::execute]/[Self::finalize]/[Self::reset]
+    /// get row value as an owned Value
     #[inline]
-    pub fn row_value(&self, index: usize) -> Result<turso_core::ValueRef, TursoError> {
-        let Some(row) = self.statement.row() else {
+    pub fn row_value(&self, index: usize) -> Result<turso_core::Value, TursoError> {
+        let handle = self.handle.lock().unwrap();
+        let stmt = handle
+            .as_ref()
+            .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
+        let Some(row) = stmt.row() else {
             return Err(TursoError::Misuse("statement holds no row".to_string()));
         };
         if index >= row.len() {
@@ -1074,45 +1178,62 @@ impl TursoStatement {
                 "attempt to access row value out of bounds".to_string(),
             ));
         }
-        let value = row.get_value(index);
-        Ok(value.as_value_ref())
+        Ok(row.get_value(index).as_value_ref().to_owned())
     }
     /// returns column count
     pub fn column_count(&self) -> usize {
-        self.statement.num_columns()
+        let handle = self.handle.lock().unwrap();
+        match handle.as_ref() {
+            Some(stmt) => stmt.num_columns(),
+            None => 0,
+        }
     }
     /// returns column name
-    pub fn column_name(&self, index: usize) -> Result<Cow<'_, str>, TursoError> {
-        if index >= self.column_count() {
+    pub fn column_name(&self, index: usize) -> Result<String, TursoError> {
+        let handle = self.handle.lock().unwrap();
+        let stmt = handle
+            .as_ref()
+            .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
+        if index >= stmt.num_columns() {
             return Err(TursoError::Misuse("column index out of bounds".to_string()));
         }
-        Ok(self.statement.get_column_name(index))
+        Ok(stmt.get_column_name(index).into_owned())
     }
     /// returns column declared type (e.g. "INTEGER", "TEXT", "DATETIME", etc.)
     pub fn column_decltype(&self, index: usize) -> Option<String> {
-        if index >= self.column_count() {
+        let handle = self.handle.lock().unwrap();
+        let stmt = handle.as_ref()?;
+        if index >= stmt.num_columns() {
             return None;
         }
-        self.statement.get_column_decltype(index)
+        stmt.get_column_decltype(index)
     }
     /// finalize statement execution
     /// this method must be called in the end of statement execution (either successfull or not)
     pub fn finalize(&mut self, waker: Option<&Waker>) -> Result<TursoStatusCode, TursoError> {
         let guard = self.concurrent_guard.clone();
         let _guard = guard.try_use()?;
-
-        while self.statement.execution_state().is_running() {
-            let status = self.step_no_guard(waker)?;
-            if status == TursoStatusCode::Io {
-                return Ok(status);
+        let mut handle = self.handle.lock().unwrap();
+        if let Some(stmt) = handle.as_mut() {
+            while stmt.execution_state().is_running() {
+                let status = step_inner(stmt, self.async_io, waker)?;
+                if status == TursoStatusCode::Io {
+                    return Ok(status);
+                }
             }
         }
+        // Drop the inner statement to release the Arc chain
+        *handle = None;
         Ok(TursoStatusCode::Done)
     }
     /// reset internal statement state and bindings
     pub fn reset(&mut self) -> Result<(), TursoError> {
-        self.statement.reset()?;
-        self.statement.clear_bindings();
+        let mut handle = self.handle.lock().unwrap();
+        let stmt = handle
+            .as_mut()
+            .ok_or_else(|| TursoError::Misuse(FINALIZED_ERR.to_string()))?;
+        stmt.reset()?;
+        stmt.clear_bindings();
         Ok(())
     }
 
@@ -1149,7 +1270,9 @@ impl TursoStatement {
 
 #[cfg(test)]
 mod tests {
-    use crate::rsapi::{TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode};
+    use crate::rsapi::{
+        TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode, FINALIZED_ERR,
+    };
     use turso_core::Value;
 
     #[test]
@@ -1620,7 +1743,6 @@ mod tests {
     #[cfg(feature = "encryption")]
     mod encryption_tests {
         use super::*;
-        use crate::rsapi::ValueRef;
         use tempfile::NamedTempFile;
 
         const TEST_CIPHER: &str = "aes256gcm";
@@ -1636,9 +1758,11 @@ mod tests {
             }
         }
 
-        fn assert_integer(value: ValueRef, expected: i64) {
+        fn assert_integer(value: turso_core::Value, expected: i64) {
             match value {
-                ValueRef::Numeric(turso_core::Numeric::Integer(i)) => assert_eq!(i, expected),
+                turso_core::Value::Numeric(turso_core::Numeric::Integer(i)) => {
+                    assert_eq!(i, expected)
+                }
                 _ => panic!("Expected integer {expected}, got {value:?}"),
             }
         }
@@ -1747,5 +1871,73 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Regression test: connection.close() must finalize all outstanding statements
+    /// to break the Statement → Arc<Connection> → Arc<Database> chain that keeps the
+    /// database alive in DATABASE_MANAGER after a file rename.
+    #[test]
+    pub fn test_close_finalizes_outstanding_statements() {
+        let db = TursoDatabase::new(TursoDatabaseConfig {
+            path: ":memory:".to_string(),
+            experimental_features: None,
+            async_io: false,
+            encryption: None,
+            vfs: None,
+            io: None,
+            db_file: None,
+        });
+        let result = db.open().unwrap();
+        assert!(!result.is_io());
+
+        let conn = db.connect().unwrap();
+
+        // Create a statement but do NOT finalize or drop it
+        let mut stmt = conn.prepare_single("SELECT 1").unwrap();
+        assert_eq!(stmt.step(None).unwrap(), TursoStatusCode::Row);
+
+        // close() should finalize the outstanding statement
+        conn.close().unwrap();
+
+        // The statement should now be finalized — using it returns an error
+        let result = stmt.step(None);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TursoError::Misuse(msg) => assert_eq!(msg, FINALIZED_ERR),
+            other => panic!("expected Misuse error, got: {other:?}"),
+        }
+    }
+
+    /// Test that finalize() sets the statement handle to None, making subsequent
+    /// operations return "statement has been finalized".
+    #[test]
+    pub fn test_finalize_disposes_statement() {
+        let db = TursoDatabase::new(TursoDatabaseConfig {
+            path: ":memory:".to_string(),
+            experimental_features: None,
+            async_io: false,
+            encryption: None,
+            vfs: None,
+            io: None,
+            db_file: None,
+        });
+        let result = db.open().unwrap();
+        assert!(!result.is_io());
+
+        let conn = db.connect().unwrap();
+        let mut stmt = conn.prepare_single("SELECT 1").unwrap();
+
+        // Finalize the statement
+        assert_eq!(stmt.finalize(None).unwrap(), TursoStatusCode::Done);
+
+        // All operations should now return "statement has been finalized"
+        assert!(stmt.step(None).is_err());
+        assert!(stmt.execute(None).is_err());
+        assert!(stmt.reset().is_err());
+        assert!(stmt.run_io().is_err());
+        assert!(stmt.bind_positional(1, Value::Null).is_err());
+        assert_eq!(stmt.n_change(), 0);
+        assert_eq!(stmt.column_count(), 0);
+        assert_eq!(stmt.parameters_count(), 0);
     }
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -22,6 +22,7 @@ path = "fuzz/mod.rs"
 anyhow.workspace = true
 env_logger = { workspace = true }
 turso_core = { workspace = true, features = ["conn_raw_api"] }
+turso_sdk_kit = { path = "../sdk-kit" }
 turso = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 rusqlite.workspace = true

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use turso_core::{Database, OpenFlags};
+use turso_sdk_kit::rsapi::{TursoDatabase, TursoDatabaseConfig, TursoStatusCode};
 
 /// Regression test: DATABASE_MANAGER registry returns stale Database after
 /// the underlying file is renamed.
@@ -66,5 +67,96 @@ fn test_database_rename_registry_stale() {
         result.is_err(),
         "New database at A.db should not have table 't' — \
          DATABASE_MANAGER returned stale Database after rename"
+    );
+}
+
+/// Regression test: TursoConnection.close() must finalize outstanding statements
+/// so that the Statement → Arc<Connection> → Arc<Database> chain is broken.
+///
+/// Without the fix, un-finalized statements keep the Database alive in
+/// DATABASE_MANAGER. After a file rename, reopening the same path returns
+/// the stale Database.
+///
+/// This exercises the SDK-level fix: TursoConnection tracks all prepared
+/// statements and close() drops them before closing the connection.
+#[test]
+fn test_sdk_close_finalizes_leaked_statements() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let path_a = tmp_dir.path().join("A.db");
+    let path_b = tmp_dir.path().join("B.db");
+
+    // 1. Open database A via SDK and populate it.
+    let db_a = TursoDatabase::new(TursoDatabaseConfig {
+        path: path_a.to_str().unwrap().to_string(),
+        experimental_features: None,
+        async_io: false,
+        encryption: None,
+        vfs: None,
+        io: None,
+        db_file: None,
+    });
+    let _ = db_a.open().unwrap();
+    let conn_a = db_a.connect().unwrap();
+
+    let mut create_stmt = conn_a.prepare_single("CREATE TABLE t(x INTEGER)").unwrap();
+    assert_eq!(
+        create_stmt.execute(None).unwrap().status,
+        TursoStatusCode::Done
+    );
+
+    let mut insert_stmt = conn_a.prepare_single("INSERT INTO t VALUES (42)").unwrap();
+    assert_eq!(
+        insert_stmt.execute(None).unwrap().status,
+        TursoStatusCode::Done
+    );
+
+    // 2. Prepare a statement but do NOT finalize or drop it — simulates an
+    //    un-GC'd binding-level Statement object.
+    let mut leaked_stmt = conn_a.prepare_single("SELECT x FROM t").unwrap();
+    assert_eq!(leaked_stmt.step(None).unwrap(), TursoStatusCode::Row);
+
+    // 3. close() finalizes all outstanding statements (the fix).
+    //    This drops the inner turso_core::Statement, releasing the
+    //    Arc<Connection> → Arc<Database> chain.
+    conn_a.close().unwrap();
+
+    // The leaked statement should now be finalized.
+    assert!(leaked_stmt.step(None).is_err());
+
+    // 4. Drop remaining handles.
+    drop(leaked_stmt);
+    drop(create_stmt);
+    drop(insert_stmt);
+    drop(conn_a);
+    drop(db_a);
+
+    // 5. Rename A.db → B.db on disk.
+    std::fs::rename(&path_a, &path_b).unwrap();
+    for ext in &["-wal", "-shm"] {
+        let from = tmp_dir.path().join(format!("A.db{ext}"));
+        let to = tmp_dir.path().join(format!("B.db{ext}"));
+        if from.exists() {
+            std::fs::rename(&from, &to).unwrap();
+        }
+    }
+
+    // 6. Open a new database at the original path A.db.
+    let io: Arc<dyn turso_core::IO + Send> = Arc::new(turso_core::PlatformIO::new().unwrap());
+    let db_a2 = Database::open_file_with_flags(
+        io,
+        path_a.to_str().unwrap(),
+        OpenFlags::Create,
+        turso_core::DatabaseOpts::new(),
+        None,
+    )
+    .unwrap();
+
+    // 7. The new A.db should be empty — table 't' should NOT exist.
+    let conn_a2 = db_a2.connect().unwrap();
+    let result = conn_a2.execute("SELECT x FROM t");
+    assert!(
+        result.is_err(),
+        "New database at A.db should not have table 't' — \
+         close() should have finalized statements and released the stale Database"
     );
 }


### PR DESCRIPTION
TursoConnection.close() dropped the connection but left outstanding TursoStatement objects alive. Each statement holds Arc<Connection> -> Arc<Database> through its inner turso_core::Statement, keeping the Weak in DATABASE_MANAGER upgradeable. After a file rename, reopening the same path returned the stale Database.

Fix by tracking every statement handle in TursoConnection and dropping all inner statements when close() is called. This pushes the fix from the individual bindings (JavaScript commit 93067cd75) down into the SDK so all bindings get it for free.

The statement is now wrapped in Arc<Mutex<Option<Statement>>> (StatementHandle). TursoConnection holds Weak refs to all handles and sets them to None on close(), breaking the reference chain. All TursoStatement methods check for the finalized state and return errors or defaults. finalize() also sets the handle to None after completing execution.

API changes:
- column_name() returns String instead of Cow<str>
- row_value() returns owned Value instead of borrowed ValueRef
- C API row_value_* functions access the handle directly via macro