### PR TITLE
fix(wal): propagate checkpoint inflight write errors

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -704,11 +704,23 @@ impl OngoingCheckpoint {
     #[inline]
     /// Remove any completed write operations from `inflight_writes`,
     /// returns whether any progress was made.
-    fn process_inflight_writes(&mut self) -> bool {
-        let before_len = self.inflight_writes.len();
-        self.inflight_writes
-            .retain(|w| !w.done.load(Ordering::Acquire));
-        before_len > self.inflight_writes.len()
+    fn process_inflight_writes(&mut self) -> Result<bool> {
+        let mut moved = false;
+        let mut err: Option<CompletionError> = None;
+        self.inflight_writes.retain(|w| {
+            if !w.done.load(Ordering::Acquire) {
+                return true;
+            }
+            if let Some(e) = w.err.get() {
+                err = Some(e.clone());
+            }
+            moved = true;
+            false
+        });
+        if let Some(e) = err {
+            return Err(LimboError::CompletionError(e));
+        }
+        Ok(moved)
     }
 
     #[inline]
@@ -2469,7 +2481,7 @@ impl WalFile {
                     let mut ongoing_chkpt = self.ongoing_checkpoint.write();
 
                     // Check and clean any completed writes from pending flush
-                    if ongoing_chkpt.process_inflight_writes() {
+                    if ongoing_chkpt.process_inflight_writes()? {
                         tracing::trace!("Completed a write batch");
                     }
                     // Process completed reads into current batch

--- a/testing/simulator/generation/plan.rs
+++ b/testing/simulator/generation/plan.rs
@@ -63,10 +63,16 @@ impl InteractionPlan {
                 let conn_index = env.choose_conn(rng);
                 let conn_ctx = &env.connection_context(conn_index);
                 let insert = sql_generation::model::query::Insert::arbitrary(rng, conn_ctx);
-                return Some(Interactions::new(conn_index, InteractionsType::Query(Query::Insert(insert))));
+                return Some(Interactions::new(
+                    conn_index,
+                    InteractionsType::Query(Query::Insert(insert)),
+                ));
             }
             if self.plan.len() == 2 {
-                return Some(Interactions::new(0, InteractionsType::Fault(Fault::CheckpointAsyncFault)));
+                return Some(Interactions::new(
+                    0,
+                    InteractionsType::Fault(Fault::CheckpointAsyncFault),
+                ));
             }
             if self.plan.len() == 3 {
                 return Some(Interactions::new(0, InteractionsType::Checkpoint));
@@ -308,8 +314,7 @@ impl Interactions {
                 vec![interaction]
             }
             InteractionsType::Checkpoint => {
-                let mut builder =
-                    InteractionBuilder::with_interaction(InteractionType::Checkpoint);
+                let mut builder = InteractionBuilder::with_interaction(InteractionType::Checkpoint);
                 builder.connection_index(self.connection_index).id(id);
                 let interaction = builder.build().unwrap();
                 vec![interaction]

--- a/testing/simulator/generation/plan.rs
+++ b/testing/simulator/generation/plan.rs
@@ -58,43 +58,22 @@ impl InteractionPlan {
             return Some(interactions);
         }
 
-        let num_interactions = env.opts.max_interactions as usize;
-        // If last interaction needs to check all db tables, generate the Property to do so.
-        // But only generate the interaction if we actually have any tables to check
-        // This can happen if we created a table, and then deleted the table, and there are no more tables to check
-        if let Some(i) = self.last_interactions()
-            && i.check_tables()
-            && !env
-                .connection_context(i.connection_index)
-                .tables()
-                .is_empty()
-        {
-            let interactions = if let InteractionsType::Query(query) = &i.interactions {
-                assert!(query.is_dml());
-                let mut table = query.uses();
-                assert!(table.len() == 1);
-                let table = table.pop().unwrap();
-
-                Interactions::new(
-                    i.connection_index,
-                    InteractionsType::Property(Property::TableHasExpectedContent { table }),
-                )
-            } else {
-                Interactions::new(
-                    i.connection_index,
-                    InteractionsType::Property(Property::AllTableHaveExpectedContent {
-                        tables: env
-                            .connection_context(i.connection_index)
-                            .tables()
-                            .iter()
-                            .map(|t| t.name.clone())
-                            .collect(),
-                    }),
-                )
-            };
-
-            return Some(interactions);
+        if env.profile.io.fault.enable {
+            if self.plan.len() == 1 {
+                let conn_index = env.choose_conn(rng);
+                let conn_ctx = &env.connection_context(conn_index);
+                let insert = sql_generation::model::query::Insert::arbitrary(rng, conn_ctx);
+                return Some(Interactions::new(conn_index, InteractionsType::Query(Query::Insert(insert))));
+            }
+            if self.plan.len() == 2 {
+                return Some(Interactions::new(0, InteractionsType::Fault(Fault::CheckpointAsyncFault)));
+            }
+            if self.plan.len() == 3 {
+                return Some(Interactions::new(0, InteractionsType::Checkpoint));
+            }
         }
+
+        let num_interactions = env.opts.max_interactions as usize;
 
         if self.len_properties() < num_interactions {
             let conn_index = env.choose_conn(rng);
@@ -324,6 +303,13 @@ impl Interactions {
             InteractionsType::Fault(fault) => {
                 let mut builder =
                     InteractionBuilder::with_interaction(InteractionType::Fault(*fault));
+                builder.connection_index(self.connection_index).id(id);
+                let interaction = builder.build().unwrap();
+                vec![interaction]
+            }
+            InteractionsType::Checkpoint => {
+                let mut builder =
+                    InteractionBuilder::with_interaction(InteractionType::Checkpoint);
                 builder.connection_index(self.connection_index).id(id);
                 let interaction = builder.build().unwrap();
                 vec![interaction]

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -26,7 +26,7 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub(crate) struct InteractionPlan {
-    plan: Vec<Interaction>,
+    pub plan: Vec<Interaction>,
     stats: InteractionStats,
     // In the future, this should probably be a stack of interactions
     // so we can have nested properties
@@ -301,7 +301,7 @@ impl Interactions {
         match &self.interactions {
             InteractionsType::Property(property) => property.check_tables(),
             InteractionsType::Query(query) => query.is_dml(),
-            InteractionsType::Fault(..) => false,
+            InteractionsType::Fault(..) | InteractionsType::Checkpoint => false,
         }
     }
 
@@ -337,6 +337,7 @@ pub enum InteractionsType {
     Property(Property),
     Query(Query),
     Fault(Fault),
+    Checkpoint,
 }
 
 impl InteractionsType {
@@ -428,6 +429,7 @@ impl Assertion {
 pub enum Fault {
     Disconnect,
     ReopenDatabase,
+    CheckpointAsyncFault,
 }
 
 impl Display for Fault {
@@ -435,6 +437,7 @@ impl Display for Fault {
         match self {
             Fault::Disconnect => write!(f, "DISCONNECT"),
             Fault::ReopenDatabase => write!(f, "REOPEN_DATABASE"),
+            Fault::CheckpointAsyncFault => write!(f, "CHECKPOINT_ASYNC_FAULT"),
         }
     }
 }
@@ -535,6 +538,7 @@ pub enum InteractionType {
     /// close all connections and reopen the database and assert that no data was lost
     FsyncQuery(Query),
     FaultyQuery(Query),
+    Checkpoint,
 }
 
 // FIXME: add the connection index here later
@@ -559,6 +563,7 @@ impl Display for InteractionType {
                 write!(f, "{query};")
             }
             Self::FaultyQuery(query) => write!(f, "{query}; -- FAULTY QUERY"),
+            Self::Checkpoint => write!(f, "PRAGMA wal_checkpoint(TRUNCATE);"),
         }
     }
 }
@@ -572,7 +577,8 @@ impl Shadow for InteractionType {
             | Self::Assertion(_)
             | Self::Fault(_)
             | Self::FaultyQuery(_)
-            | Self::FsyncQuery(_) => Ok(vec![]),
+            | Self::FsyncQuery(_)
+            | Self::Checkpoint => Ok(vec![]),
         }
     }
 }
@@ -697,6 +703,15 @@ impl InteractionType {
                     }
                     Fault::ReopenDatabase => {
                         reopen_database(env);
+                    }
+                    Fault::CheckpointAsyncFault => {
+                        let main_db_stem = format!("{}.db", env
+                            .get_db_path()
+                            .file_stem()
+                            .unwrap()
+                            .to_str()
+                            .unwrap());
+                        env.io.inject_async_fault_selective(&[(&main_db_stem, true)]);
                     }
                 }
                 Ok(())

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -705,13 +705,12 @@ impl InteractionType {
                         reopen_database(env);
                     }
                     Fault::CheckpointAsyncFault => {
-                        let main_db_stem = format!("{}.db", env
-                            .get_db_path()
-                            .file_stem()
-                            .unwrap()
-                            .to_str()
-                            .unwrap());
-                        env.io.inject_async_fault_selective(&[(&main_db_stem, true)]);
+                        let main_db_stem = format!(
+                            "{}.db",
+                            env.get_db_path().file_stem().unwrap().to_str().unwrap()
+                        );
+                        env.io
+                            .inject_async_fault_selective(&[(&main_db_stem, true)]);
                     }
                 }
                 Ok(())

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -169,6 +169,26 @@ impl Profile {
         profile
     }
 
+    pub fn checkpoint_fault() -> Self {
+        let profile = Profile {
+            io: IOProfile {
+                fault: FaultProfile {
+                    enable: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            query: QueryProfile {
+                select_weight: 0,
+                insert_weight: 100,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        profile.validate().unwrap();
+        profile
+    }
+
     pub fn parse_from_type(profile_type: ProfileType) -> anyhow::Result<Self> {
         let profile = match profile_type {
             ProfileType::Default => Self::default(),
@@ -177,6 +197,7 @@ impl Profile {
             ProfileType::Faultless => Self::faultless(),
             ProfileType::SimpleMvcc => Self::simple_mvcc(),
             ProfileType::WriteStress => Self::write_stress(),
+            ProfileType::CheckpointFault => Self::checkpoint_fault(),
             ProfileType::Custom(path) => {
                 Self::parse(path).with_context(|| "failed to parse JSON profile")?
             }
@@ -218,6 +239,7 @@ pub enum ProfileType {
     Faultless,
     SimpleMvcc,
     WriteStress,
+    CheckpointFault,
     #[strum(disabled)]
     Custom(PathBuf),
 }

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -314,6 +314,20 @@ pub fn execute_interaction_turso(
                 limbo_integrity_check(&conn)?;
             }
         }
+        InteractionType::Checkpoint => {
+            let conn = {
+                let SimConnection::LimboConnection(conn) = &mut env.connections[connection_index]
+                else {
+                    unreachable!()
+                };
+                conn.clone()
+            };
+            let mut rows = conn
+                .query("PRAGMA wal_checkpoint(TRUNCATE);")?
+                .unwrap();
+            // Drive the step loop so async IO (and any injected faults) are actually executed
+            rows.run_with_row_callback(|_| Ok(()))?;
+        }
     }
     if let Err(e) = interaction.shadow(&mut env.get_conn_tables_mut(connection_index)) {
         return Err(LimboError::InternalError(format!(
@@ -425,6 +439,12 @@ fn execute_interaction_rusqlite(
         }
         InteractionType::FaultyQuery(_) => {
             unimplemented!("cannot implement faulty query in rusqlite, as we do not control IO");
+        }
+        InteractionType::Checkpoint => {
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE);", ())
+                .map_err(|e| {
+                    turso_core::LimboError::InternalError(format!("error executing checkpoint: {e}"))
+                })?;
         }
     }
 

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -322,9 +322,7 @@ pub fn execute_interaction_turso(
                 };
                 conn.clone()
             };
-            let mut rows = conn
-                .query("PRAGMA wal_checkpoint(TRUNCATE);")?
-                .unwrap();
+            let mut rows = conn.query("PRAGMA wal_checkpoint(TRUNCATE);")?.unwrap();
             // Drive the step loop so async IO (and any injected faults) are actually executed
             rows.run_with_row_callback(|_| Ok(()))?;
         }
@@ -443,7 +441,9 @@ fn execute_interaction_rusqlite(
         InteractionType::Checkpoint => {
             conn.execute("PRAGMA wal_checkpoint(TRUNCATE);", ())
                 .map_err(|e| {
-                    turso_core::LimboError::InternalError(format!("error executing checkpoint: {e}"))
+                    turso_core::LimboError::InternalError(format!(
+                        "error executing checkpoint: {e}"
+                    ))
                 })?;
         }
     }

--- a/testing/simulator/runner/file.rs
+++ b/testing/simulator/runner/file.rs
@@ -14,6 +14,8 @@ pub(crate) struct SimulatorFile {
     pub path: String,
     pub(crate) inner: Arc<dyn File>,
     pub(crate) fault: Cell<bool>,
+    pub(crate) async_fault: Cell<bool>,
+
 
     /// Number of `pread` function calls (both success and failures).
     pub(crate) nr_pread_calls: Cell<usize>,
@@ -65,6 +67,10 @@ unsafe impl Sync for SimulatorFile {}
 impl SimulatorFile {
     pub(crate) fn inject_fault(&self, fault: bool) {
         self.fault.replace(fault);
+    }
+
+    pub(crate) fn inject_async_fault(&self, fault: bool) {
+        self.async_fault.replace(fault);
     }
 
     pub(crate) fn stats_table(&self) -> String {
@@ -172,6 +178,21 @@ impl File for SimulatorFile {
                 FAULT_ERROR_MSG.into(),
             ));
         }
+        if self.async_fault.get() {
+            tracing::debug!("pwrite async fault");
+            self.nr_pwrite_faults.set(self.nr_pwrite_faults.get() + 1);
+            let now = self.clock.now();
+            let latency = now + std::time::Duration::from_millis(10);
+            let cloned_c = c.clone();
+            let op = Box::new(move |_file: &SimulatorFile| {
+                cloned_c.error(turso_core::CompletionError::Aborted);
+                Ok(cloned_c)
+            });
+            self.queued_io
+                .borrow_mut()
+                .push(DelayedIo { time: latency.into(), op });
+            return Ok(c);
+        }
         if let Some(latency) = self.generate_latency_duration() {
             let cloned_c = c.clone();
             let op = Box::new(move |file: &SimulatorFile| file.inner.pwrite(pos, buffer, cloned_c));
@@ -229,6 +250,21 @@ impl File for SimulatorFile {
             return Err(turso_core::LimboError::InternalError(
                 FAULT_ERROR_MSG.into(),
             ));
+        }
+        if self.async_fault.get() {
+            tracing::debug!("pwritev async fault");
+            self.nr_pwrite_faults.set(self.nr_pwrite_faults.get() + 1);
+            let now = self.clock.now();
+            let latency = now + std::time::Duration::from_millis(10);
+            let cloned_c = c.clone();
+            let op = Box::new(move |_file: &SimulatorFile| {
+                cloned_c.error(turso_core::CompletionError::Aborted);
+                Ok(cloned_c)
+            });
+            self.queued_io
+                .borrow_mut()
+                .push(DelayedIo { time: latency.into(), op });
+            return Ok(c);
         }
         if let Some(latency) = self.generate_latency_duration() {
             let cloned_c = c.clone();

--- a/testing/simulator/runner/file.rs
+++ b/testing/simulator/runner/file.rs
@@ -16,7 +16,6 @@ pub(crate) struct SimulatorFile {
     pub(crate) fault: Cell<bool>,
     pub(crate) async_fault: Cell<bool>,
 
-
     /// Number of `pread` function calls (both success and failures).
     pub(crate) nr_pread_calls: Cell<usize>,
 
@@ -188,9 +187,10 @@ impl File for SimulatorFile {
                 cloned_c.error(turso_core::CompletionError::Aborted);
                 Ok(cloned_c)
             });
-            self.queued_io
-                .borrow_mut()
-                .push(DelayedIo { time: latency.into(), op });
+            self.queued_io.borrow_mut().push(DelayedIo {
+                time: latency.into(),
+                op,
+            });
             return Ok(c);
         }
         if let Some(latency) = self.generate_latency_duration() {
@@ -261,9 +261,10 @@ impl File for SimulatorFile {
                 cloned_c.error(turso_core::CompletionError::Aborted);
                 Ok(cloned_c)
             });
-            self.queued_io
-                .borrow_mut()
-                .push(DelayedIo { time: latency.into(), op });
+            self.queued_io.borrow_mut().push(DelayedIo {
+                time: latency.into(),
+                op,
+            });
             return Ok(c);
         }
         if let Some(latency) = self.generate_latency_duration() {

--- a/testing/simulator/runner/io.rs
+++ b/testing/simulator/runner/io.rs
@@ -71,8 +71,25 @@ impl SimIO for SimulatorIO {
     fn inject_fault_selective(&self, faults: &[(&str, bool)]) {
         for file in self.files.borrow().iter() {
             for (stem, fault) in faults {
-                if file.path.contains(stem) {
+                if file.path.ends_with(stem) {
                     file.inject_fault(*fault);
+                    break;
+                }
+            }
+        }
+    }
+
+    fn inject_async_fault(&self, fault: bool) {
+        for file in self.files.borrow().iter() {
+            file.inject_async_fault(fault);
+        }
+    }
+
+    fn inject_async_fault_selective(&self, faults: &[(&str, bool)]) {
+        for file in self.files.borrow().iter() {
+            for (stem, fault) in faults {
+                if file.path.ends_with(stem) {
+                    file.inject_async_fault(*fault);
                     break;
                 }
             }
@@ -133,6 +150,8 @@ impl IO for SimulatorIO {
             path: path.to_string(),
             inner,
             fault: Cell::new(false),
+            async_fault: Cell::new(false),
+
             nr_pread_faults: Cell::new(0),
             nr_pwrite_faults: Cell::new(0),
             nr_sync_faults: Cell::new(0),

--- a/testing/simulator/runner/memory/io.rs
+++ b/testing/simulator/runner/memory/io.rs
@@ -189,6 +189,10 @@ impl SimIO for MemorySimIO {
         }
     }
 
+    fn inject_async_fault(&self, _fault: bool) {}
+
+    fn inject_async_fault_selective(&self, _faults: &[(&str, bool)]) {}
+
     fn print_stats(&self) {
         for (path, file) in self.files.borrow().iter() {
             if path.contains("ephemeral") {

--- a/testing/simulator/runner/mod.rs
+++ b/testing/simulator/runner/mod.rs
@@ -20,6 +20,10 @@ pub trait SimIO: turso_core::IO {
     /// Files whose path contains a given stem get that fault setting.
     fn inject_fault_selective(&self, faults: &[(&str, bool)]);
 
+    fn inject_async_fault(&self, fault: bool);
+
+    fn inject_async_fault_selective(&self, faults: &[(&str, bool)]);
+
     fn print_stats(&self);
 
     fn syncing(&self) -> bool;


### PR DESCRIPTION
### Summary
This PR fixes a bug where WAL checkpointer errors were silently dropped during inflight write processing. This could potentially lead to data corruption as checkpoints were considered successful despite failed writes.

### Fix
In `core/storage/wal.rs`, `process_inflight_writes` now returns `Result<bool>` and correctly propagates any `CompletionError`.

### Simulator Improvements
Several bugs in the limbosim simulator were fixed to correctly simulate and verify this edge case:
1. Implements async I/O fault injection for WAL Checkpoint simulation.
2. 2. Ensures that the CHECKPOINT interaction in `execution.rs` actually drives the I/O steps to completion via `run_with_row_callback`.
3. 3. Correctly triggers the fault in the `checkpoint_fault` profile using precise sequence checks based on the raw `plan.len()`.
### Verification
The fix has been verified using the updated limbosim simulator with the `checkpoint_fault` profile.