### PR TITLE
fix: partition database registry by access mode to prevent flag leak

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -200,7 +200,7 @@ impl core::ops::Deref for TempFile {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct OpenFlags(i32);
 
 // OpenFlags is a newtype over i32, which is inherently Send+Sync.
@@ -212,6 +212,26 @@ bitflags! {
         const None = 0b00000000;
         const Create = 0b0000001;
         const ReadOnly = 0b0000010;
+    }
+}
+
+impl OpenFlags {
+    /// Returns a version of the flags with transient permissions masked out.
+    ///
+    /// This is used by the process-wide `DATABASE_MANAGER` registry to identify compatible
+    /// database instances. We mask-out flags like `Create` because they only matter during
+    /// the initial file opening. Once a file is open, a database opened with `Create` and
+    /// one opened without it are operationally identical and should share the same cache
+    /// to avoid data inconsistency and redundant memory usage.
+    ///
+    /// Conversely, fundamental modes like `ReadOnly` are preserved because they require
+    /// strict isolation between instances.
+    pub fn normalize(&self) -> Self {
+        let mut normalized = *self;
+        // Create is a transient permission; once the file exists, the operational mode
+        // depends only on whether it is ReadOnly or ReadWrite.
+        normalized.remove(OpenFlags::Create);
+        normalized
     }
 }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -100,6 +100,18 @@ use turso_macros::{match_ignore_ascii_case, AtomicEnum};
 use turso_parser::{ast, ast::Cmd, parser::Parser};
 use util::parse_schema_rows;
 
+/// A unique identifier for a database instance in the process-wide registry.
+///
+/// This ensures that we only share database instances when their configuration
+/// and access modes are compatible. Keying by both path and normalized flags
+/// prevents "mode leak" (e.g. a Read-Write request receiving a cached Read-Only
+/// instance) while still allowing efficient sharing of compatible instances.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct DatabaseRegistryKey {
+    path: String,
+    flags: OpenFlags,
+}
+
 pub use connection::{resolve_ext_path, Connection, Row, StepResult, SymbolTable};
 pub(crate) use connection::{AtomicTransactionState, TransactionState};
 pub use error::{io_error, CompletionError, LimboError};
@@ -304,10 +316,14 @@ pub struct OpenDbAsyncState {
     /// Schema lock held during LoadingSchema phase to ensure atomicity across IO yields
     schema_guard: Option<sync::ArcMutexGuard<Arc<Schema>>>,
     /// Registry lock held during open_with_flags_async to prevent concurrent opens
-    registry_guard:
-        Option<parking_lot::ArcMutexGuard<parking_lot::RawMutex, HashMap<String, Weak<Database>>>>,
-    /// Canonical path for registry insertion (computed once at start)
-    canonical_path: Option<String>,
+    registry_guard: Option<
+        parking_lot::ArcMutexGuard<
+            parking_lot::RawMutex,
+            HashMap<DatabaseRegistryKey, Weak<Database>>,
+        >,
+    >,
+    /// Canonical key for registry insertion (computed once at start)
+    canonical_key: Option<DatabaseRegistryKey>,
 }
 
 impl Default for OpenDbAsyncState {
@@ -327,7 +343,7 @@ impl OpenDbAsyncState {
             make_from_btree_state: schema::MakeFromBtreeState::new(),
             schema_guard: None,
             registry_guard: None,
-            canonical_path: None,
+            canonical_key: None,
         }
     }
 }
@@ -343,8 +359,9 @@ impl OpenDbAsyncState {
 /// Mutex here would cause panics when the second iteration tries to lock a
 /// mutex that belongs to a stale execution context.
 #[allow(clippy::type_complexity)]
-static DATABASE_MANAGER: LazyLock<Arc<parking_lot::Mutex<HashMap<String, Weak<Database>>>>> =
-    LazyLock::new(|| Arc::new(parking_lot::Mutex::new(HashMap::default())));
+static DATABASE_MANAGER: LazyLock<
+    Arc<parking_lot::Mutex<HashMap<DatabaseRegistryKey, Weak<Database>>>>,
+> = LazyLock::new(|| Arc::new(parking_lot::Mutex::new(HashMap::default())));
 
 /// The `Database` object contains per database file state that is shared
 /// between multiple connections.
@@ -523,6 +540,7 @@ impl Database {
     fn lookup_in_registry(
         path: &str,
         encryption_opts: &Option<EncryptionOpts>,
+        flags: OpenFlags,
     ) -> Result<Option<Arc<Database>>> {
         if path.starts_with(":memory:") {
             return Ok(None);
@@ -534,8 +552,12 @@ impl Database {
             Some(c) => c,
             None => return Ok(None),
         };
+        let canonical_key = DatabaseRegistryKey {
+            path: canonical,
+            flags: flags.normalize(),
+        };
         let registry = DATABASE_MANAGER.lock_arc();
-        let db = match registry.get(&canonical).and_then(Weak::upgrade) {
+        let db = match registry.get(&canonical_key).and_then(Weak::upgrade) {
             Some(db) => db,
             None => return Ok(None),
         };
@@ -574,7 +596,7 @@ impl Database {
     ) -> Result<Arc<Database>> {
         // Check the registry before opening the file to avoid acquiring a file
         // lock that would conflict with an already-open Database in this process.
-        if let Some(db) = Self::lookup_in_registry(path, &encryption_opts)? {
+        if let Some(db) = Self::lookup_in_registry(path, &encryption_opts, flags)? {
             if durable_storage.is_some() && db.durable_storage.is_none() {
                 return Err(LimboError::InvalidArgument(
                     "database already open without custom durable storage; \
@@ -701,10 +723,14 @@ impl Database {
                 .ok()
                 .and_then(|p| p.to_str().map(|s| s.to_string()))
                 .unwrap_or_else(|| path.to_string());
+            let canonical_key = DatabaseRegistryKey {
+                path: canonical_path,
+                flags: flags.normalize(),
+            };
 
             // Check if already in registry
-            if let Some(db) = registry.get(&canonical_path).and_then(Weak::upgrade) {
-                tracing::debug!("took database {canonical_path:?} from the registry");
+            if let Some(db) = registry.get(&canonical_key).and_then(Weak::upgrade) {
+                tracing::debug!("took database {canonical_key:?} from the registry");
 
                 // Check encryption compatibility using cipher mode (key is not stored in Database for security)
                 let db_is_encrypted = !matches!(db.encryption_cipher_mode.get(), CipherMode::None);
@@ -721,7 +747,7 @@ impl Database {
 
             // Not in registry, hold the lock and store canonical path for later insertion
             state.registry_guard = Some(registry);
-            state.canonical_path = Some(canonical_path);
+            state.canonical_key = Some(canonical_key);
         }
 
         // Open the database asynchronously (registry lock is held in state for not `:memory:.*` pathes)
@@ -739,10 +765,10 @@ impl Database {
 
         if let IOResult::Done(ref db) = result {
             // will be unset in case of `:memory:.*` path
-            if let (Some(mut registry), Some(canonical_path)) =
-                (state.registry_guard.take(), state.canonical_path.take())
+            if let (Some(mut registry), Some(canonical_key)) =
+                (state.registry_guard.take(), state.canonical_key.take())
             {
-                registry.insert(canonical_path, Arc::downgrade(db));
+                registry.insert(canonical_key, Arc::downgrade(db));
             }
         }
 
@@ -1327,7 +1353,8 @@ impl Database {
             cdc_transaction_id: AtomicI64::new(-1),
             closed: AtomicBool::new(false),
             attached_databases: RwLock::new(DatabaseCatalog::new()),
-            query_only: AtomicBool::new(false),
+            // Initialize based on the database access mode to enable early write detection in the translator
+            query_only: AtomicBool::new(self.open_flags.contains(OpenFlags::ReadOnly)),
             dml_require_where: AtomicBool::new(false),
             mv_tx: RwLock::new(None),
             attached_mv_txs: RwLock::new(HashMap::default()),

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -53,6 +53,7 @@ use crate::translate::delete::translate_delete;
 use crate::translate::emitter::Resolver;
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts, QueryMode};
 use crate::vdbe::Program;
+use crate::LimboError;
 use crate::{bail_parse_error, Connection, Result, SymbolTable};
 use alter::translate_alter_table;
 use analyze::translate_analyze;
@@ -159,6 +160,9 @@ pub fn translate_inner(
     );
 
     if is_write && connection.get_query_only() {
+        if connection.is_readonly(0) {
+            return Err(LimboError::ReadOnly);
+        }
         bail_parse_error!("Cannot execute write statement in query_only mode")
     }
 

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -934,3 +934,127 @@ fn test_too_many_columns_in_select(tmp_db: TempDatabase) {
         "Expected error for UNION with 2001 columns"
     );
 }
+
+#[test]
+fn test_database_mode_is_dependent_on_per_connection_flags_ro_isolation() -> anyhow::Result<()> {
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use turso_core::{Database, DatabaseOpts, OpenFlags};
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test_ro.db");
+    let db_path_str = db_path.to_str().unwrap();
+
+    // 1. Setup Initial Data
+    {
+        let io = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            db_path_str,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let conn = db.connect()?;
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")?;
+        conn.execute("INSERT INTO t VALUES (1)")?;
+    }
+
+    // 2. Trigger the Cache Bug
+    // Step 1: Open the database as ReadOnly. Keep this alive.
+    let io_ro = Arc::new(turso_core::PlatformIO::new().unwrap());
+    let _db_ro = Database::open_file_with_flags(
+        io_ro.clone(),
+        db_path_str,
+        OpenFlags::ReadOnly,
+        DatabaseOpts::new(),
+        None,
+    )?;
+
+    // Step 2: Attempt to open the same database file again, but this time using default flags (Read-Write).
+    let io_rw = Arc::new(turso_core::PlatformIO::new().unwrap());
+    let db_rw = Database::open_file_with_flags(
+        io_rw.clone(),
+        db_path_str,
+        OpenFlags::Create, // This is default, which should be Read-Write
+        DatabaseOpts::new(),
+        None,
+    )?;
+
+    let conn_rw = db_rw.connect()?;
+
+    // 3. Observe the Success
+    // This used to fail with "ReadOnly" because it was taking the ReadOnly instance from registry
+    let result = conn_rw.execute("INSERT INTO t VALUES (2)");
+    let err = result.as_ref().err();
+    assert!(
+        result.is_ok(),
+        "INSERT on read-write connection failed: {err:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_database_mode_is_dependent_on_per_connection_flags_rw_isolation() -> anyhow::Result<()> {
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use turso_core::{Database, DatabaseOpts, OpenFlags};
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test_rw.db");
+    let db_path_str = db_path.to_str().unwrap();
+
+    // 1. Setup Initial Data
+    {
+        let io = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            db_path_str,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let conn = db.connect()?;
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")?;
+    }
+
+    // 2. Trigger the Cache Bug
+    // Step 1: Open the database as Read-Write. Keep this alive.
+    let io_rw = Arc::new(turso_core::PlatformIO::new().unwrap());
+    let _db_rw = Database::open_file_with_flags(
+        io_rw.clone(),
+        db_path_str,
+        OpenFlags::Create,
+        DatabaseOpts::new(),
+        None,
+    )?;
+
+    // Step 2: Attempt to open the same database file again, but this time using ReadOnly flags.
+    let io_ro = Arc::new(turso_core::PlatformIO::new().unwrap());
+    let db_ro = Database::open_file_with_flags(
+        io_ro.clone(),
+        db_path_str,
+        OpenFlags::ReadOnly,
+        DatabaseOpts::new(),
+        None,
+    )?;
+
+    let conn_ro = db_ro.connect()?;
+
+    // 3. Observe the Failure
+    // This SHOULD fail because the connection is Read-Only
+    let result = conn_ro.execute("INSERT INTO t VALUES (1)");
+
+    assert!(
+        result.is_err(),
+        "INSERT on read-only connection SHOULD fail"
+    );
+    let err = result.err().unwrap();
+    assert!(
+        matches!(err, turso_core::LimboError::ReadOnly),
+        "Expected ReadOnly error, got: {err:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The DATABASE_MANAGER registry previously used only the file path as a key, causing Read-Only opens to incorrectly hit the cache for subsequent Read-Write requests (and vice-versa).

This change:
- Introduces DatabaseRegistryKey (path + normalized OpenFlags) to isolate incompatible access modes.
- Implements OpenFlags::normalize() to mask transient flags like 'Create'.
- Synchronizes Connection::query_only with the database mode for early write detection.
- Updates the SQL translator to report SQLITE_READONLY errors for illegal writes on read-only databases.

Fixes #6031

# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description


  This PR fixes a bug in the process-wide database registry (DATABASE_MANAGER) where database instances were incorrectly shared between requests with incompatible access modes (Read-Only vs. Read-Write).

  Key Changes:
   * Isolated Registry Key: Introduced a DatabaseRegistryKey struct that partitions the cache using both the file path and a normalized version of the OpenFlags.
   * Flag Normalization: Implemented OpenFlags::normalize() to mask out transient permissions like Create. This allows compatible access modes to still share a cache entry while ensuring that fundamental
     operational modes (like ReadOnly) remain isolated.
   * Connection Synchronization: Updated connection initialization to inherit the query_only state directly from the underlying database's access mode.
   * Fail-Fast Error Reporting: Modified the SQL translator to catch illegal writes on read-only databases early and return a proper LimboError::ReadOnly (mapping to SQLITE_READONLY).
   * Regression Tests: Added comprehensive integration tests in test_read_path.rs to verify that Read-Only opens do not leak into subsequent Read-Write requests and vice-versa.

## Motivation and context

  Fixes #6031


  The process-wide registry previously used only the canonical file path as a cache key. This meant that if a file was first opened as ReadOnly, any subsequent request for that same file—even if requested as
  ReadWrite—would receive the cached Read-Only instance, effectively "trapping" the user in a read-only state.

  By partitioning the cache by access mode and synchronizing the connection-level query_only flag, we ensure that:
   1. Users always receive a database instance that matches their requested access permissions.
   2. Read-only enforcement happens early at the SQL translation level, providing better compatibility with SQLite's error reporting standards.
   3. Cache efficiency is preserved by still allowing sharing between compatible configurations (e.g., sharing a Read-Write instance regardless of whether the Create flag was specified).


## Description of AI Usage

This contribution was developed with the assistance of an AI agent 


  The AI was used for:
   * Reproduction: Assisting in creating initial test cases to empirically reproduce the reported cache leak and verify the bug's impact on Read-Only/Read-Write isolation.
   * Code Flow Analysis: Mapping the execution path from the process-wide registry (DATABASE_MANAGER) through the async state machine and into the SQL translator to identify where access modes were being
     dropped or misapplied.
   * Regression Testing: Generating the integration test logic added to test_read_path.rs to ensure that access mode isolation is preserved across subsequent database opens.

All findings and generated test logic were manually reviewed, coded and refined for architectural consistency, and verified against the full project test suite.

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
