### PR TITLE
Add Linux aarch64 and macOS x86_64 to Python wheel build targets in CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -139,14 +139,18 @@ jobs:
         run: uvx ruff check
 
   linux:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     defaults:
       run:
         working-directory: ${{ env.working-directory }}
     strategy:
       matrix:
-        target: [x86_64]
+        include:
+          - target: x86_64
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - target: aarch64
+            runner: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v3
       - uses: useblacksmith/setup-python@v6
@@ -163,10 +167,10 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux
+          name: wheels-linux-${{ matrix.target }}
           path: bindings/python/dist
 
-  macos-arm64:
+  macos:
     runs-on: macos-latest
     timeout-minutes: 30
     defaults:
@@ -174,7 +178,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
     strategy:
       matrix:
-        target: [aarch64]
+        target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -193,7 +197,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-arm64
+          name: wheels-macos-${{ matrix.target }}
           path: bindings/python/dist
 
   sdist:
@@ -221,7 +225,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, macos-arm64, sdist]
+    needs: [linux, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Description
This PR adds Linux aarch64 and macOS x86_64 (Intel Mac) to the Python wheel build targets in CI.

## Motivation and context
Currently, CI only builds Python wheels for Linux x86_64 and macOS arm64. But turso supports more build targets:
https://github.com/tursodatabase/turso/blob/eebe5d2bd7ff0c36297cb58efd44a81e9895a1cc/dist-workspace.toml#L13
The Java bindings build for `x86_64-apple-darwin`:
https://github.com/tursodatabase/turso/blob/eebe5d2bd7ff0c36297cb58efd44a81e9895a1cc/.github/workflows/java-publish.yml#L20-L23
The .NET bindings build for `x86_64-apple-darwin`:
https://github.com/tursodatabase/turso/blob/eebe5d2bd7ff0c36297cb58efd44a81e9895a1cc/.github/workflows/dotnet-publish.yml#L21-L24
The JS bindings build for `aarch64-unknown-linux-gnu`:
https://github.com/tursodatabase/turso/blob/eebe5d2bd7ff0c36297cb58efd44a81e9895a1cc/.github/workflows/napi.yml#L62-L69

So I think it's fair to add those build targets to the Python bindings wheel builds.

## Description of AI Usage
I used Claude Code with Opus 4.6 to verify the changes I did. I also used it to search through the issues on GitHub to gather more context.
