### PR TITLE
core/translate: Propagate error from function resolution

### DIFF
--- a/bindings/go/driver_db_test.go
+++ b/bindings/go/driver_db_test.go
@@ -321,7 +321,7 @@ func TestConnectionError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}
-	expectedErr := "turso: error: Parse error: unknown function notafunction"
+	expectedErr := "turso: error: Parse error: no such function: notafunction"
 	if err.Error() != expectedErr {
 		t.Fatalf("Error test failed, expected: %s, found: %v", expectedErr, err)
 	}

--- a/core/function.rs
+++ b/core/function.rs
@@ -1173,21 +1173,21 @@ impl Func {
     pub fn needs_star_expansion(&self) -> bool {
         false
     }
-    pub fn resolve_function(name: &str, arg_count: usize) -> Result<Self, LimboError> {
+    pub fn resolve_function(name: &str, arg_count: usize) -> Result<Option<Self>, LimboError> {
         let normalized_name = crate::util::normalize_ident(name);
         match normalized_name.as_str() {
             "avg" => {
                 if arg_count != 1 {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
-                Ok(Self::Agg(AggFunc::Avg))
+                Ok(Some(Self::Agg(AggFunc::Avg)))
             }
             "count" => {
                 // Handle both COUNT() and COUNT(expr) cases
                 if arg_count == 0 {
-                    Ok(Self::Agg(AggFunc::Count0)) // COUNT() case
+                    Ok(Some(Self::Agg(AggFunc::Count0))) // COUNT() case
                 } else if arg_count == 1 {
-                    Ok(Self::Agg(AggFunc::Count)) // COUNT(expr) case
+                    Ok(Some(Self::Agg(AggFunc::Count))) // COUNT(expr) case
                 } else {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
@@ -1197,251 +1197,251 @@ impl Func {
                     println!("{arg_count}");
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
-                Ok(Self::Agg(AggFunc::GroupConcat))
+                Ok(Some(Self::Agg(AggFunc::GroupConcat)))
             }
-            "max" if arg_count > 1 => Ok(Self::Scalar(ScalarFunc::Max)),
+            "max" if arg_count > 1 => Ok(Some(Self::Scalar(ScalarFunc::Max))),
             "max" => {
                 if arg_count < 1 {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
-                Ok(Self::Agg(AggFunc::Max))
+                Ok(Some(Self::Agg(AggFunc::Max)))
             }
-            "min" if arg_count > 1 => Ok(Self::Scalar(ScalarFunc::Min)),
+            "min" if arg_count > 1 => Ok(Some(Self::Scalar(ScalarFunc::Min))),
             "min" => {
                 if arg_count < 1 {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
-                Ok(Self::Agg(AggFunc::Min))
+                Ok(Some(Self::Agg(AggFunc::Min)))
             }
-            "nullif" if arg_count == 2 => Ok(Self::Scalar(ScalarFunc::Nullif)),
+            "nullif" if arg_count == 2 => Ok(Some(Self::Scalar(ScalarFunc::Nullif))),
             "string_agg" => {
                 if arg_count != 2 {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
-                Ok(Self::Agg(AggFunc::StringAgg))
+                Ok(Some(Self::Agg(AggFunc::StringAgg)))
             }
             "sum" => {
                 if arg_count != 1 {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
-                Ok(Self::Agg(AggFunc::Sum))
+                Ok(Some(Self::Agg(AggFunc::Sum)))
             }
             "total" => {
                 if arg_count != 1 {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
-                Ok(Self::Agg(AggFunc::Total))
+                Ok(Some(Self::Agg(AggFunc::Total)))
             }
             "row_number" => {
                 if arg_count != 0 {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
-                Ok(Self::Window(WindowFunc::RowNumber))
+                Ok(Some(Self::Window(WindowFunc::RowNumber)))
             }
             "timediff" => {
                 if arg_count != 2 {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
-                Ok(Self::Scalar(ScalarFunc::TimeDiff))
+                Ok(Some(Self::Scalar(ScalarFunc::TimeDiff)))
             }
-            "array_agg" => Ok(Self::Agg(AggFunc::ArrayAgg)),
+            "array_agg" => Ok(Some(Self::Agg(AggFunc::ArrayAgg))),
             #[cfg(feature = "json")]
-            "jsonb_group_array" => Ok(Self::Agg(AggFunc::JsonbGroupArray)),
+            "jsonb_group_array" => Ok(Some(Self::Agg(AggFunc::JsonbGroupArray))),
             #[cfg(feature = "json")]
-            "json_group_array" => Ok(Self::Agg(AggFunc::JsonGroupArray)),
+            "json_group_array" => Ok(Some(Self::Agg(AggFunc::JsonGroupArray))),
             #[cfg(feature = "json")]
-            "jsonb_group_object" => Ok(Self::Agg(AggFunc::JsonbGroupObject)),
+            "jsonb_group_object" => Ok(Some(Self::Agg(AggFunc::JsonbGroupObject))),
             #[cfg(feature = "json")]
-            "json_group_object" => Ok(Self::Agg(AggFunc::JsonGroupObject)),
-            "char" => Ok(Self::Scalar(ScalarFunc::Char)),
-            "coalesce" => Ok(Self::Scalar(ScalarFunc::Coalesce)),
-            "concat" => Ok(Self::Scalar(ScalarFunc::Concat)),
-            "concat_ws" => Ok(Self::Scalar(ScalarFunc::ConcatWs)),
-            "changes" => Ok(Self::Scalar(ScalarFunc::Changes)),
-            "total_changes" => Ok(Self::Scalar(ScalarFunc::TotalChanges)),
-            "glob" => Ok(Self::Scalar(ScalarFunc::Glob)),
-            "ifnull" => Ok(Self::Scalar(ScalarFunc::IfNull)),
-            "if" | "iif" => Ok(Self::Scalar(ScalarFunc::Iif)),
-            "instr" => Ok(Self::Scalar(ScalarFunc::Instr)),
-            "like" => Ok(Self::Scalar(ScalarFunc::Like)),
-            "abs" => Ok(Self::Scalar(ScalarFunc::Abs)),
-            "upper" => Ok(Self::Scalar(ScalarFunc::Upper)),
-            "lower" => Ok(Self::Scalar(ScalarFunc::Lower)),
-            "random" => Ok(Self::Scalar(ScalarFunc::Random)),
-            "randomblob" => Ok(Self::Scalar(ScalarFunc::RandomBlob)),
-            "trim" => Ok(Self::Scalar(ScalarFunc::Trim)),
-            "ltrim" => Ok(Self::Scalar(ScalarFunc::LTrim)),
-            "rtrim" => Ok(Self::Scalar(ScalarFunc::RTrim)),
-            "round" => Ok(Self::Scalar(ScalarFunc::Round)),
-            "length" => Ok(Self::Scalar(ScalarFunc::Length)),
-            "octet_length" => Ok(Self::Scalar(ScalarFunc::OctetLength)),
-            "sign" => Ok(Self::Scalar(ScalarFunc::Sign)),
-            "substr" => Ok(Self::Scalar(ScalarFunc::Substr)),
-            "substring" => Ok(Self::Scalar(ScalarFunc::Substring)),
-            "date" => Ok(Self::Scalar(ScalarFunc::Date)),
-            "time" => Ok(Self::Scalar(ScalarFunc::Time)),
-            "datetime" => Ok(Self::Scalar(ScalarFunc::DateTime)),
-            "typeof" => Ok(Self::Scalar(ScalarFunc::Typeof)),
-            "last_insert_rowid" => Ok(Self::Scalar(ScalarFunc::LastInsertRowid)),
-            "unicode" => Ok(Self::Scalar(ScalarFunc::Unicode)),
-            "quote" => Ok(Self::Scalar(ScalarFunc::Quote)),
-            "sqlite_version" => Ok(Self::Scalar(ScalarFunc::SqliteVersion)),
-            "turso_version" => Ok(Self::Scalar(ScalarFunc::TursoVersion)),
-            "sqlite_source_id" => Ok(Self::Scalar(ScalarFunc::SqliteSourceId)),
-            "replace" => Ok(Self::Scalar(ScalarFunc::Replace)),
-            "likely" => Ok(Self::Scalar(ScalarFunc::Likely)),
-            "likelihood" => Ok(Self::Scalar(ScalarFunc::Likelihood)),
-            "unlikely" => Ok(Self::Scalar(ScalarFunc::Unlikely)),
+            "json_group_object" => Ok(Some(Self::Agg(AggFunc::JsonGroupObject))),
+            "char" => Ok(Some(Self::Scalar(ScalarFunc::Char))),
+            "coalesce" => Ok(Some(Self::Scalar(ScalarFunc::Coalesce))),
+            "concat" => Ok(Some(Self::Scalar(ScalarFunc::Concat))),
+            "concat_ws" => Ok(Some(Self::Scalar(ScalarFunc::ConcatWs))),
+            "changes" => Ok(Some(Self::Scalar(ScalarFunc::Changes))),
+            "total_changes" => Ok(Some(Self::Scalar(ScalarFunc::TotalChanges))),
+            "glob" => Ok(Some(Self::Scalar(ScalarFunc::Glob))),
+            "ifnull" => Ok(Some(Self::Scalar(ScalarFunc::IfNull))),
+            "if" | "iif" => Ok(Some(Self::Scalar(ScalarFunc::Iif))),
+            "instr" => Ok(Some(Self::Scalar(ScalarFunc::Instr))),
+            "like" => Ok(Some(Self::Scalar(ScalarFunc::Like))),
+            "abs" => Ok(Some(Self::Scalar(ScalarFunc::Abs))),
+            "upper" => Ok(Some(Self::Scalar(ScalarFunc::Upper))),
+            "lower" => Ok(Some(Self::Scalar(ScalarFunc::Lower))),
+            "random" => Ok(Some(Self::Scalar(ScalarFunc::Random))),
+            "randomblob" => Ok(Some(Self::Scalar(ScalarFunc::RandomBlob))),
+            "trim" => Ok(Some(Self::Scalar(ScalarFunc::Trim))),
+            "ltrim" => Ok(Some(Self::Scalar(ScalarFunc::LTrim))),
+            "rtrim" => Ok(Some(Self::Scalar(ScalarFunc::RTrim))),
+            "round" => Ok(Some(Self::Scalar(ScalarFunc::Round))),
+            "length" => Ok(Some(Self::Scalar(ScalarFunc::Length))),
+            "octet_length" => Ok(Some(Self::Scalar(ScalarFunc::OctetLength))),
+            "sign" => Ok(Some(Self::Scalar(ScalarFunc::Sign))),
+            "substr" => Ok(Some(Self::Scalar(ScalarFunc::Substr))),
+            "substring" => Ok(Some(Self::Scalar(ScalarFunc::Substring))),
+            "date" => Ok(Some(Self::Scalar(ScalarFunc::Date))),
+            "time" => Ok(Some(Self::Scalar(ScalarFunc::Time))),
+            "datetime" => Ok(Some(Self::Scalar(ScalarFunc::DateTime))),
+            "typeof" => Ok(Some(Self::Scalar(ScalarFunc::Typeof))),
+            "last_insert_rowid" => Ok(Some(Self::Scalar(ScalarFunc::LastInsertRowid))),
+            "unicode" => Ok(Some(Self::Scalar(ScalarFunc::Unicode))),
+            "quote" => Ok(Some(Self::Scalar(ScalarFunc::Quote))),
+            "sqlite_version" => Ok(Some(Self::Scalar(ScalarFunc::SqliteVersion))),
+            "turso_version" => Ok(Some(Self::Scalar(ScalarFunc::TursoVersion))),
+            "sqlite_source_id" => Ok(Some(Self::Scalar(ScalarFunc::SqliteSourceId))),
+            "replace" => Ok(Some(Self::Scalar(ScalarFunc::Replace))),
+            "likely" => Ok(Some(Self::Scalar(ScalarFunc::Likely))),
+            "likelihood" => Ok(Some(Self::Scalar(ScalarFunc::Likelihood))),
+            "unlikely" => Ok(Some(Self::Scalar(ScalarFunc::Unlikely))),
             #[cfg(feature = "json")]
-            "json" => Ok(Self::Json(JsonFunc::Json)),
+            "json" => Ok(Some(Self::Json(JsonFunc::Json))),
             #[cfg(feature = "json")]
-            "jsonb" => Ok(Self::Json(JsonFunc::Jsonb)),
+            "jsonb" => Ok(Some(Self::Json(JsonFunc::Jsonb))),
             #[cfg(feature = "json")]
-            "json_array_length" => Ok(Self::Json(JsonFunc::JsonArrayLength)),
+            "json_array_length" => Ok(Some(Self::Json(JsonFunc::JsonArrayLength))),
             #[cfg(feature = "json")]
-            "json_array" => Ok(Self::Json(JsonFunc::JsonArray)),
+            "json_array" => Ok(Some(Self::Json(JsonFunc::JsonArray))),
             #[cfg(feature = "json")]
-            "jsonb_array" => Ok(Self::Json(JsonFunc::JsonbArray)),
+            "jsonb_array" => Ok(Some(Self::Json(JsonFunc::JsonbArray))),
             #[cfg(feature = "json")]
-            "json_extract" => Ok(Func::Json(JsonFunc::JsonExtract)),
+            "json_extract" => Ok(Some(Func::Json(JsonFunc::JsonExtract))),
             #[cfg(feature = "json")]
-            "jsonb_extract" => Ok(Func::Json(JsonFunc::JsonbExtract)),
+            "jsonb_extract" => Ok(Some(Func::Json(JsonFunc::JsonbExtract))),
             #[cfg(feature = "json")]
-            "json_object" => Ok(Func::Json(JsonFunc::JsonObject)),
+            "json_object" => Ok(Some(Func::Json(JsonFunc::JsonObject))),
             #[cfg(feature = "json")]
-            "jsonb_object" => Ok(Func::Json(JsonFunc::JsonbObject)),
+            "jsonb_object" => Ok(Some(Func::Json(JsonFunc::JsonbObject))),
             #[cfg(feature = "json")]
-            "json_type" => Ok(Func::Json(JsonFunc::JsonType)),
+            "json_type" => Ok(Some(Func::Json(JsonFunc::JsonType))),
             #[cfg(feature = "json")]
-            "json_error_position" => Ok(Self::Json(JsonFunc::JsonErrorPosition)),
+            "json_error_position" => Ok(Some(Self::Json(JsonFunc::JsonErrorPosition))),
             #[cfg(feature = "json")]
-            "json_valid" => Ok(Self::Json(JsonFunc::JsonValid)),
+            "json_valid" => Ok(Some(Self::Json(JsonFunc::JsonValid))),
             #[cfg(feature = "json")]
-            "json_patch" => Ok(Self::Json(JsonFunc::JsonPatch)),
+            "json_patch" => Ok(Some(Self::Json(JsonFunc::JsonPatch))),
             #[cfg(feature = "json")]
-            "json_remove" => Ok(Self::Json(JsonFunc::JsonRemove)),
+            "json_remove" => Ok(Some(Self::Json(JsonFunc::JsonRemove))),
             #[cfg(feature = "json")]
-            "jsonb_remove" => Ok(Self::Json(JsonFunc::JsonbRemove)),
+            "jsonb_remove" => Ok(Some(Self::Json(JsonFunc::JsonbRemove))),
             #[cfg(feature = "json")]
-            "json_replace" => Ok(Self::Json(JsonFunc::JsonReplace)),
+            "json_replace" => Ok(Some(Self::Json(JsonFunc::JsonReplace))),
             #[cfg(feature = "json")]
-            "json_insert" => Ok(Self::Json(JsonFunc::JsonInsert)),
+            "json_insert" => Ok(Some(Self::Json(JsonFunc::JsonInsert))),
             #[cfg(feature = "json")]
-            "jsonb_insert" => Ok(Self::Json(JsonFunc::JsonbInsert)),
+            "jsonb_insert" => Ok(Some(Self::Json(JsonFunc::JsonbInsert))),
             #[cfg(feature = "json")]
-            "jsonb_replace" => Ok(Self::Json(JsonFunc::JsonReplace)),
+            "jsonb_replace" => Ok(Some(Self::Json(JsonFunc::JsonReplace))),
             #[cfg(feature = "json")]
-            "json_pretty" => Ok(Self::Json(JsonFunc::JsonPretty)),
+            "json_pretty" => Ok(Some(Self::Json(JsonFunc::JsonPretty))),
             #[cfg(feature = "json")]
-            "json_set" => Ok(Self::Json(JsonFunc::JsonSet)),
+            "json_set" => Ok(Some(Self::Json(JsonFunc::JsonSet))),
             #[cfg(feature = "json")]
-            "jsonb_set" => Ok(Self::Json(JsonFunc::JsonbSet)),
+            "jsonb_set" => Ok(Some(Self::Json(JsonFunc::JsonbSet))),
             #[cfg(feature = "json")]
-            "json_quote" => Ok(Self::Json(JsonFunc::JsonQuote)),
-            "unixepoch" => Ok(Self::Scalar(ScalarFunc::UnixEpoch)),
-            "julianday" => Ok(Self::Scalar(ScalarFunc::JulianDay)),
-            "hex" => Ok(Self::Scalar(ScalarFunc::Hex)),
-            "unhex" => Ok(Self::Scalar(ScalarFunc::Unhex)),
-            "zeroblob" => Ok(Self::Scalar(ScalarFunc::ZeroBlob)),
-            "soundex" => Ok(Self::Scalar(ScalarFunc::Soundex)),
-            "table_columns_json_array" => Ok(Self::Scalar(ScalarFunc::TableColumnsJsonArray)),
-            "bin_record_json_object" => Ok(Self::Scalar(ScalarFunc::BinRecordJsonObject)),
-            "conn_txn_id" => Ok(Self::Scalar(ScalarFunc::ConnTxnId)),
-            "is_autocommit" => Ok(Self::Scalar(ScalarFunc::IsAutocommit)),
-            "acos" => Ok(Self::Math(MathFunc::Acos)),
-            "acosh" => Ok(Self::Math(MathFunc::Acosh)),
-            "asin" => Ok(Self::Math(MathFunc::Asin)),
-            "asinh" => Ok(Self::Math(MathFunc::Asinh)),
-            "atan" => Ok(Self::Math(MathFunc::Atan)),
-            "atan2" => Ok(Self::Math(MathFunc::Atan2)),
-            "atanh" => Ok(Self::Math(MathFunc::Atanh)),
-            "ceil" => Ok(Self::Math(MathFunc::Ceil)),
-            "ceiling" => Ok(Self::Math(MathFunc::Ceiling)),
-            "cos" => Ok(Self::Math(MathFunc::Cos)),
-            "cosh" => Ok(Self::Math(MathFunc::Cosh)),
-            "degrees" => Ok(Self::Math(MathFunc::Degrees)),
-            "exp" => Ok(Self::Math(MathFunc::Exp)),
-            "floor" => Ok(Self::Math(MathFunc::Floor)),
-            "ln" => Ok(Self::Math(MathFunc::Ln)),
-            "log" => Ok(Self::Math(MathFunc::Log)),
-            "log10" => Ok(Self::Math(MathFunc::Log10)),
-            "log2" => Ok(Self::Math(MathFunc::Log2)),
-            "mod" => Ok(Self::Math(MathFunc::Mod)),
-            "pi" => Ok(Self::Math(MathFunc::Pi)),
-            "pow" => Ok(Self::Math(MathFunc::Pow)),
-            "power" => Ok(Self::Math(MathFunc::Power)),
-            "radians" => Ok(Self::Math(MathFunc::Radians)),
-            "sin" => Ok(Self::Math(MathFunc::Sin)),
-            "sinh" => Ok(Self::Math(MathFunc::Sinh)),
-            "sqrt" => Ok(Self::Math(MathFunc::Sqrt)),
-            "tan" => Ok(Self::Math(MathFunc::Tan)),
-            "tanh" => Ok(Self::Math(MathFunc::Tanh)),
-            "trunc" => Ok(Self::Math(MathFunc::Trunc)),
+            "json_quote" => Ok(Some(Self::Json(JsonFunc::JsonQuote))),
+            "unixepoch" => Ok(Some(Self::Scalar(ScalarFunc::UnixEpoch))),
+            "julianday" => Ok(Some(Self::Scalar(ScalarFunc::JulianDay))),
+            "hex" => Ok(Some(Self::Scalar(ScalarFunc::Hex))),
+            "unhex" => Ok(Some(Self::Scalar(ScalarFunc::Unhex))),
+            "zeroblob" => Ok(Some(Self::Scalar(ScalarFunc::ZeroBlob))),
+            "soundex" => Ok(Some(Self::Scalar(ScalarFunc::Soundex))),
+            "table_columns_json_array" => Ok(Some(Self::Scalar(ScalarFunc::TableColumnsJsonArray))),
+            "bin_record_json_object" => Ok(Some(Self::Scalar(ScalarFunc::BinRecordJsonObject))),
+            "conn_txn_id" => Ok(Some(Self::Scalar(ScalarFunc::ConnTxnId))),
+            "is_autocommit" => Ok(Some(Self::Scalar(ScalarFunc::IsAutocommit))),
+            "acos" => Ok(Some(Self::Math(MathFunc::Acos))),
+            "acosh" => Ok(Some(Self::Math(MathFunc::Acosh))),
+            "asin" => Ok(Some(Self::Math(MathFunc::Asin))),
+            "asinh" => Ok(Some(Self::Math(MathFunc::Asinh))),
+            "atan" => Ok(Some(Self::Math(MathFunc::Atan))),
+            "atan2" => Ok(Some(Self::Math(MathFunc::Atan2))),
+            "atanh" => Ok(Some(Self::Math(MathFunc::Atanh))),
+            "ceil" => Ok(Some(Self::Math(MathFunc::Ceil))),
+            "ceiling" => Ok(Some(Self::Math(MathFunc::Ceiling))),
+            "cos" => Ok(Some(Self::Math(MathFunc::Cos))),
+            "cosh" => Ok(Some(Self::Math(MathFunc::Cosh))),
+            "degrees" => Ok(Some(Self::Math(MathFunc::Degrees))),
+            "exp" => Ok(Some(Self::Math(MathFunc::Exp))),
+            "floor" => Ok(Some(Self::Math(MathFunc::Floor))),
+            "ln" => Ok(Some(Self::Math(MathFunc::Ln))),
+            "log" => Ok(Some(Self::Math(MathFunc::Log))),
+            "log10" => Ok(Some(Self::Math(MathFunc::Log10))),
+            "log2" => Ok(Some(Self::Math(MathFunc::Log2))),
+            "mod" => Ok(Some(Self::Math(MathFunc::Mod))),
+            "pi" => Ok(Some(Self::Math(MathFunc::Pi))),
+            "pow" => Ok(Some(Self::Math(MathFunc::Pow))),
+            "power" => Ok(Some(Self::Math(MathFunc::Power))),
+            "radians" => Ok(Some(Self::Math(MathFunc::Radians))),
+            "sin" => Ok(Some(Self::Math(MathFunc::Sin))),
+            "sinh" => Ok(Some(Self::Math(MathFunc::Sinh))),
+            "sqrt" => Ok(Some(Self::Math(MathFunc::Sqrt))),
+            "tan" => Ok(Some(Self::Math(MathFunc::Tan))),
+            "tanh" => Ok(Some(Self::Math(MathFunc::Tanh))),
+            "trunc" => Ok(Some(Self::Math(MathFunc::Trunc))),
             #[cfg(feature = "fs")]
             #[cfg(not(target_family = "wasm"))]
-            "load_extension" => Ok(Self::Scalar(ScalarFunc::LoadExtension)),
-            "strftime" => Ok(Self::Scalar(ScalarFunc::StrfTime)),
-            "printf" | "format" => Ok(Self::Scalar(ScalarFunc::Printf)),
-            "vector" => Ok(Self::Vector(VectorFunc::Vector)),
-            "vector32" => Ok(Self::Vector(VectorFunc::Vector32)),
-            "vector32_sparse" => Ok(Self::Vector(VectorFunc::Vector32Sparse)),
-            "vector64" => Ok(Self::Vector(VectorFunc::Vector64)),
-            "vector8" => Ok(Self::Vector(VectorFunc::Vector8)),
-            "vector1bit" => Ok(Self::Vector(VectorFunc::Vector1Bit)),
-            "vector_extract" => Ok(Self::Vector(VectorFunc::VectorExtract)),
-            "vector_distance_cos" => Ok(Self::Vector(VectorFunc::VectorDistanceCos)),
-            "vector_distance_l2" => Ok(Self::Vector(VectorFunc::VectorDistanceL2)),
-            "vector_distance_jaccard" => Ok(Self::Vector(VectorFunc::VectorDistanceJaccard)),
-            "vector_distance_dot" => Ok(Self::Vector(VectorFunc::VectorDistanceDot)),
-            "vector_concat" => Ok(Self::Vector(VectorFunc::VectorConcat)),
-            "vector_slice" => Ok(Self::Vector(VectorFunc::VectorSlice)),
+            "load_extension" => Ok(Some(Self::Scalar(ScalarFunc::LoadExtension))),
+            "strftime" => Ok(Some(Self::Scalar(ScalarFunc::StrfTime))),
+            "printf" | "format" => Ok(Some(Self::Scalar(ScalarFunc::Printf))),
+            "vector" => Ok(Some(Self::Vector(VectorFunc::Vector))),
+            "vector32" => Ok(Some(Self::Vector(VectorFunc::Vector32))),
+            "vector32_sparse" => Ok(Some(Self::Vector(VectorFunc::Vector32Sparse))),
+            "vector64" => Ok(Some(Self::Vector(VectorFunc::Vector64))),
+            "vector8" => Ok(Some(Self::Vector(VectorFunc::Vector8))),
+            "vector1bit" => Ok(Some(Self::Vector(VectorFunc::Vector1Bit))),
+            "vector_extract" => Ok(Some(Self::Vector(VectorFunc::VectorExtract))),
+            "vector_distance_cos" => Ok(Some(Self::Vector(VectorFunc::VectorDistanceCos))),
+            "vector_distance_l2" => Ok(Some(Self::Vector(VectorFunc::VectorDistanceL2))),
+            "vector_distance_jaccard" => Ok(Some(Self::Vector(VectorFunc::VectorDistanceJaccard))),
+            "vector_distance_dot" => Ok(Some(Self::Vector(VectorFunc::VectorDistanceDot))),
+            "vector_concat" => Ok(Some(Self::Vector(VectorFunc::VectorConcat))),
+            "vector_slice" => Ok(Some(Self::Vector(VectorFunc::VectorSlice))),
             // FTS functions
             #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-            "fts_score" => Ok(Self::Fts(FtsFunc::Score)),
+            "fts_score" => Ok(Some(Self::Fts(FtsFunc::Score))),
             #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-            "fts_match" => Ok(Self::Fts(FtsFunc::Match)),
+            "fts_match" => Ok(Some(Self::Fts(FtsFunc::Match))),
             #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-            "fts_highlight" => Ok(Self::Fts(FtsFunc::Highlight)),
+            "fts_highlight" => Ok(Some(Self::Fts(FtsFunc::Highlight))),
             // Test type functions (for custom type system testing)
-            "test_uint_encode" => Ok(Self::Scalar(ScalarFunc::TestUintEncode)),
-            "test_uint_decode" => Ok(Self::Scalar(ScalarFunc::TestUintDecode)),
-            "test_uint_add" => Ok(Self::Scalar(ScalarFunc::TestUintAdd)),
-            "test_uint_sub" => Ok(Self::Scalar(ScalarFunc::TestUintSub)),
-            "test_uint_mul" => Ok(Self::Scalar(ScalarFunc::TestUintMul)),
-            "test_uint_div" => Ok(Self::Scalar(ScalarFunc::TestUintDiv)),
-            "test_uint_lt" => Ok(Self::Scalar(ScalarFunc::TestUintLt)),
-            "test_uint_eq" => Ok(Self::Scalar(ScalarFunc::TestUintEq)),
-            "string_reverse" => Ok(Self::Scalar(ScalarFunc::StringReverse)),
+            "test_uint_encode" => Ok(Some(Self::Scalar(ScalarFunc::TestUintEncode))),
+            "test_uint_decode" => Ok(Some(Self::Scalar(ScalarFunc::TestUintDecode))),
+            "test_uint_add" => Ok(Some(Self::Scalar(ScalarFunc::TestUintAdd))),
+            "test_uint_sub" => Ok(Some(Self::Scalar(ScalarFunc::TestUintSub))),
+            "test_uint_mul" => Ok(Some(Self::Scalar(ScalarFunc::TestUintMul))),
+            "test_uint_div" => Ok(Some(Self::Scalar(ScalarFunc::TestUintDiv))),
+            "test_uint_lt" => Ok(Some(Self::Scalar(ScalarFunc::TestUintLt))),
+            "test_uint_eq" => Ok(Some(Self::Scalar(ScalarFunc::TestUintEq))),
+            "string_reverse" => Ok(Some(Self::Scalar(ScalarFunc::StringReverse))),
             // Built-in type support functions
-            "boolean_to_int" => Ok(Self::Scalar(ScalarFunc::BooleanToInt)),
-            "int_to_boolean" => Ok(Self::Scalar(ScalarFunc::IntToBoolean)),
-            "validate_ipaddr" => Ok(Self::Scalar(ScalarFunc::ValidateIpAddr)),
-            "numeric_encode" => Ok(Self::Scalar(ScalarFunc::NumericEncode)),
-            "numeric_decode" => Ok(Self::Scalar(ScalarFunc::NumericDecode)),
-            "numeric_add" => Ok(Self::Scalar(ScalarFunc::NumericAdd)),
-            "numeric_sub" => Ok(Self::Scalar(ScalarFunc::NumericSub)),
-            "numeric_mul" => Ok(Self::Scalar(ScalarFunc::NumericMul)),
-            "numeric_div" => Ok(Self::Scalar(ScalarFunc::NumericDiv)),
-            "numeric_lt" => Ok(Self::Scalar(ScalarFunc::NumericLt)),
-            "numeric_eq" => Ok(Self::Scalar(ScalarFunc::NumericEq)),
+            "boolean_to_int" => Ok(Some(Self::Scalar(ScalarFunc::BooleanToInt))),
+            "int_to_boolean" => Ok(Some(Self::Scalar(ScalarFunc::IntToBoolean))),
+            "validate_ipaddr" => Ok(Some(Self::Scalar(ScalarFunc::ValidateIpAddr))),
+            "numeric_encode" => Ok(Some(Self::Scalar(ScalarFunc::NumericEncode))),
+            "numeric_decode" => Ok(Some(Self::Scalar(ScalarFunc::NumericDecode))),
+            "numeric_add" => Ok(Some(Self::Scalar(ScalarFunc::NumericAdd))),
+            "numeric_sub" => Ok(Some(Self::Scalar(ScalarFunc::NumericSub))),
+            "numeric_mul" => Ok(Some(Self::Scalar(ScalarFunc::NumericMul))),
+            "numeric_div" => Ok(Some(Self::Scalar(ScalarFunc::NumericDiv))),
+            "numeric_lt" => Ok(Some(Self::Scalar(ScalarFunc::NumericLt))),
+            "numeric_eq" => Ok(Some(Self::Scalar(ScalarFunc::NumericEq))),
             // Array construction / element access (desugared from syntax)
-            "array" => Ok(Self::Scalar(ScalarFunc::Array)),
-            "array_element" => Ok(Self::Scalar(ScalarFunc::ArrayElement)),
-            "array_set_element" => Ok(Self::Scalar(ScalarFunc::ArraySetElement)),
+            "array" => Ok(Some(Self::Scalar(ScalarFunc::Array))),
+            "array_element" => Ok(Some(Self::Scalar(ScalarFunc::ArrayElement))),
+            "array_set_element" => Ok(Some(Self::Scalar(ScalarFunc::ArraySetElement))),
             // Array functions
-            "array_length" => Ok(Self::Scalar(ScalarFunc::ArrayLength)),
-            "array_append" => Ok(Self::Scalar(ScalarFunc::ArrayAppend)),
-            "array_prepend" => Ok(Self::Scalar(ScalarFunc::ArrayPrepend)),
-            "array_cat" => Ok(Self::Scalar(ScalarFunc::ArrayCat)),
-            "array_remove" => Ok(Self::Scalar(ScalarFunc::ArrayRemove)),
-            "array_contains" => Ok(Self::Scalar(ScalarFunc::ArrayContains)),
-            "array_position" => Ok(Self::Scalar(ScalarFunc::ArrayPosition)),
-            "array_slice" => Ok(Self::Scalar(ScalarFunc::ArraySlice)),
-            "string_to_array" => Ok(Self::Scalar(ScalarFunc::StringToArray)),
-            "array_to_string" => Ok(Self::Scalar(ScalarFunc::ArrayToString)),
-            "array_overlap" | "array_overlaps" => Ok(Self::Scalar(ScalarFunc::ArrayOverlap)),
-            "array_contains_all" => Ok(Self::Scalar(ScalarFunc::ArrayContainsAll)),
-            _ => crate::bail_parse_error!("no such function: {}", name),
+            "array_length" => Ok(Some(Self::Scalar(ScalarFunc::ArrayLength))),
+            "array_append" => Ok(Some(Self::Scalar(ScalarFunc::ArrayAppend))),
+            "array_prepend" => Ok(Some(Self::Scalar(ScalarFunc::ArrayPrepend))),
+            "array_cat" => Ok(Some(Self::Scalar(ScalarFunc::ArrayCat))),
+            "array_remove" => Ok(Some(Self::Scalar(ScalarFunc::ArrayRemove))),
+            "array_contains" => Ok(Some(Self::Scalar(ScalarFunc::ArrayContains))),
+            "array_position" => Ok(Some(Self::Scalar(ScalarFunc::ArrayPosition))),
+            "array_slice" => Ok(Some(Self::Scalar(ScalarFunc::ArraySlice))),
+            "string_to_array" => Ok(Some(Self::Scalar(ScalarFunc::StringToArray))),
+            "array_to_string" => Ok(Some(Self::Scalar(ScalarFunc::ArrayToString))),
+            "array_overlap" | "array_overlaps" => Ok(Some(Self::Scalar(ScalarFunc::ArrayOverlap))),
+            "array_contains_all" => Ok(Some(Self::Scalar(ScalarFunc::ArrayContainsAll))),
+            _ => Ok(None),
         }
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3719,7 +3719,7 @@ impl Index {
         let is_tbl = |ns: &str| normalize_ident(ns) == tbl_norm;
         let is_deterministic_fn = |name: &str, argc: usize| {
             let n = normalize_ident(name);
-            Func::resolve_function(&n, argc).is_ok_and(|f| f.is_deterministic())
+            Func::resolve_function(&n, argc).is_ok_and(|f| f.is_some_and(|f| f.is_deterministic()))
         };
 
         let mut ok = true;

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -199,13 +199,17 @@ impl<'a> Resolver<'a> {
         });
     }
 
-    pub fn resolve_function(&self, func_name: &str, arg_count: usize) -> Option<Func> {
-        match Func::resolve_function(func_name, arg_count).ok() {
-            Some(func) => Some(func),
-            None => self
+    pub fn resolve_function(
+        &self,
+        func_name: &str,
+        arg_count: usize,
+    ) -> Result<Option<Func>, LimboError> {
+        match Func::resolve_function(func_name, arg_count)? {
+            Some(func) => Ok(Some(func)),
+            None => Ok(self
                 .symbol_table
                 .resolve_function(func_name, arg_count)
-                .map(Func::External),
+                .map(Func::External)),
         }
     }
 
@@ -821,7 +825,7 @@ fn emit_cdc_insns_v1(
     });
     program.mark_last_insn_constant();
 
-    let Some(unixepoch_fn) = resolver.resolve_function("unixepoch", 0) else {
+    let Some(unixepoch_fn) = resolver.resolve_function("unixepoch", 0)? else {
         bail_parse_error!("no function {}", "unixepoch");
     };
     let unixepoch_fn_ctx = crate::function::FuncCtx {
@@ -933,7 +937,7 @@ fn emit_cdc_insns_v2(
     program.mark_last_insn_constant();
 
     // change_time = unixepoch()
-    let Some(unixepoch_fn) = resolver.resolve_function("unixepoch", 0) else {
+    let Some(unixepoch_fn) = resolver.resolve_function("unixepoch", 0)? else {
         bail_parse_error!("no function {}", "unixepoch");
     };
     let unixepoch_fn_ctx = crate::function::FuncCtx {
@@ -955,7 +959,7 @@ fn emit_cdc_insns_v2(
         rowid_reg: candidate_reg,
         prev_largest_reg: 0,
     });
-    let Some(conn_txn_id_fn) = resolver.resolve_function("conn_txn_id", 1) else {
+    let Some(conn_txn_id_fn) = resolver.resolve_function("conn_txn_id", 1)? else {
         bail_parse_error!("no function {}", "conn_txn_id");
     };
     let conn_txn_id_fn_ctx = crate::function::FuncCtx {
@@ -1068,7 +1072,7 @@ pub fn emit_cdc_commit_insns(
     program.mark_last_insn_constant();
 
     // reg+1: change_time = unixepoch()
-    let Some(unixepoch_fn) = resolver.resolve_function("unixepoch", 0) else {
+    let Some(unixepoch_fn) = resolver.resolve_function("unixepoch", 0)? else {
         bail_parse_error!("no function {}", "unixepoch");
     };
     let unixepoch_fn_ctx = crate::function::FuncCtx {
@@ -1086,7 +1090,7 @@ pub fn emit_cdc_commit_insns(
     // Pass -1 as candidate: if a txn_id exists, return it; if not, -1 is stored (and will be reset).
     let minus_one_reg = program.alloc_register();
     program.emit_int(-1, minus_one_reg);
-    let Some(conn_txn_id_fn) = resolver.resolve_function("conn_txn_id", 1) else {
+    let Some(conn_txn_id_fn) = resolver.resolve_function("conn_txn_id", 1)? else {
         bail_parse_error!("no function {}", "conn_txn_id");
     };
     let conn_txn_id_fn_ctx = crate::function::FuncCtx {
@@ -1147,7 +1151,7 @@ pub fn emit_cdc_autocommit_commit(
     let cdc_info = program.capture_data_changes_info().as_ref();
     if cdc_info.is_some_and(|info| info.cdc_version().has_commit_record()) {
         // Check if we're in autocommit mode; if so, emit a COMMIT record.
-        let Some(is_autocommit_fn) = resolver.resolve_function("is_autocommit", 0) else {
+        let Some(is_autocommit_fn) = resolver.resolve_function("is_autocommit", 0)? else {
             bail_parse_error!("no function {}", "is_autocommit");
         };
         let is_autocommit_fn_ctx = crate::function::FuncCtx {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1502,10 +1502,10 @@ pub fn translate_expr(
             order_by: _,
         } => {
             let args_count = args.len();
-            let func_type = resolver.resolve_function(name.as_str(), args_count);
+            let func_type = resolver.resolve_function(name.as_str(), args_count)?;
 
             if func_type.is_none() {
-                crate::bail_parse_error!("unknown function {}", name.as_str());
+                crate::bail_parse_error!("no such function: {}", name.as_str());
             }
 
             let func_ctx = FuncCtx {
@@ -2827,10 +2827,10 @@ pub fn translate_expr(
             // Handle func(*) syntax as a function call with 0 arguments
             // This is equivalent to func() for functions that accept 0 arguments
             let args_count = 0;
-            let func_type = resolver.resolve_function(name.as_str(), args_count);
+            let func_type = resolver.resolve_function(name.as_str(), args_count)?;
 
             if func_type.is_none() {
-                crate::bail_parse_error!("unknown function {}", name.as_str());
+                crate::bail_parse_error!("no such function: {}", name.as_str());
             }
 
             let func = func_type.unwrap();
@@ -4502,7 +4502,7 @@ pub(crate) fn expr_is_array(expr: &Expr, referenced_tables: Option<&TableReferen
             }
         }
         Expr::FunctionCall { name, args, .. } => {
-            if let Ok(f) = Func::resolve_function(name.as_str(), args.len()) {
+            if let Ok(Some(f)) = Func::resolve_function(name.as_str(), args.len()) {
                 match &f {
                     Func::Scalar(sf) if sf.returns_array_blob() => return true,
                     Func::Agg(AggFunc::ArrayAgg) => return true,
@@ -5003,7 +5003,7 @@ fn translate_like_base(
             if escape.is_some() {
                 crate::bail_parse_error!("wrong number of arguments to function regexp()");
             }
-            let func = resolver.resolve_function("regexp", 2);
+            let func = resolver.resolve_function("regexp", 2)?;
             let Some(func) = func else {
                 crate::bail_parse_error!("no such function: regexp");
             };
@@ -5734,7 +5734,7 @@ pub fn bind_and_rewrite_expr<'a>(
                     // expand the * to all columns from the referenced tables as key-value pairs
                     // This needs to happen during bind/rewrite so WHERE clauses can use these functions
                     if let Some(referenced_tables) = &mut referenced_tables {
-                        if let Ok(func) = Func::resolve_function(name.as_str(), 0) {
+                        if let Ok(Some(func)) = Func::resolve_function(name.as_str(), 0) {
                             if func.needs_star_expansion() {
                                 // Only expand if there are actual tables - otherwise leave as
                                 // FunctionCallStar so translate_expr can generate the error
@@ -6731,7 +6731,7 @@ fn emit_custom_type_operator(
     resolver: &Resolver,
 ) -> Result<usize> {
     let func = resolver
-        .resolve_function(&resolved.func_name, 2)
+        .resolve_function(&resolved.func_name, 2)?
         .ok_or_else(|| {
             LimboError::InternalError(format!("function not found: {}", resolved.func_name))
         })?;

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -664,7 +664,8 @@ fn validate_index_expression(expr: &Expr, table: &BTreeTable) -> bool {
     let is_tbl = |ns: &str| normalize_ident(ns).eq_ignore_ascii_case(&tbl_norm);
     let is_deterministic_fn = |name: &str, args: &[Box<Expr>]| {
         let n = normalize_ident(name);
-        Func::resolve_function(&n, args.len()).is_ok_and(|f| is_valid_index_function_call(&f, args))
+        Func::resolve_function(&n, args.len())
+            .is_ok_and(|f| f.is_some_and(|f| is_valid_index_function_call(&f, args)))
     };
 
     let mut ok = true;

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -1728,7 +1728,9 @@ impl<'a> LogicalPlanBuilder<'a> {
                         args: vec![],
                         distinct: false,
                     })
-                } else if let Ok(func) = crate::function::Func::resolve_function(&func_name, 0) {
+                } else if let Ok(Some(func)) =
+                    crate::function::Func::resolve_function(&func_name, 0)
+                {
                     // Check if this function supports star expansion (e.g., json_object, jsonb_object)
                     if func.needs_star_expansion() {
                         // Expand * to all columns as alternating key-value pairs

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1441,7 +1441,8 @@ fn expr_has_null_masking_for_table(expr: &ast::Expr, table_id: ast::TableInterna
     let _ = walk_expr(expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
         match e {
             ast::Expr::FunctionCall { name, args, .. } => {
-                if let Ok(func) = crate::function::Func::resolve_function(name.as_str(), args.len())
+                if let Ok(Some(func)) =
+                    crate::function::Func::resolve_function(name.as_str(), args.len())
                 {
                     // IIF(cond, then, else) is like CASE WHEN cond THEN then ELSE else END.
                     // If the condition is a null check on the target table, IIF masks nulls.
@@ -2729,7 +2730,11 @@ impl Optimizable for ast::Expr {
                 if filter_over.over_clause.is_some() {
                     return false;
                 }
-                let Some(func) = resolver.resolve_function(name.as_str(), args.len()) else {
+                let Some(func) = resolver
+                    .resolve_function(name.as_str(), args.len())
+                    .ok()
+                    .flatten()
+                else {
                     return false;
                 };
                 func.is_deterministic() && args.iter().all(|arg| arg.is_constant(resolver))

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -419,7 +419,7 @@ fn contains_nondeterministic_function(expr: &Expr) -> bool {
     let _ = walk_expr(expr, &mut |e: &Expr| -> Result<WalkControl> {
         match e {
             Expr::FunctionCall { name, args, .. } => {
-                if let Ok(func) = Func::resolve_function(name.as_str(), args.len()) {
+                if let Ok(Some(func)) = Func::resolve_function(name.as_str(), args.len()) {
                     if !func.is_deterministic() {
                         found = true;
                     }
@@ -427,7 +427,7 @@ fn contains_nondeterministic_function(expr: &Expr) -> bool {
             }
             Expr::FunctionCallStar { name, .. } => {
                 // Star functions like count(*) — resolve with 0 args
-                if let Ok(func) = Func::resolve_function(name.as_str(), 0) {
+                if let Ok(Some(func)) = Func::resolve_function(name.as_str(), 0) {
                     if !func.is_deterministic() {
                         found = true;
                     }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -216,8 +216,8 @@ pub fn resolve_window_and_aggregate_functions(
                 let args_count = args.len();
                 let distinctness = Distinctness::from_ast(distinctness.as_ref());
 
-                match Func::resolve_function(name.as_str(), args_count) {
-                    Ok(Func::Agg(f)) => {
+                match Func::resolve_function(name.as_str(), args_count)? {
+                    Some(Func::Agg(f)) => {
                         if let Some(over_clause) = filter_over.over_clause.as_ref() {
                             link_with_window(
                                 windows.as_deref_mut(),
@@ -232,7 +232,7 @@ pub fn resolve_window_and_aggregate_functions(
                         }
                         return Ok(WalkControl::SkipChildren);
                     }
-                    Ok(Func::Window(f)) => {
+                    Some(Func::Window(f)) => {
                         if let Some(over_clause) = filter_over.over_clause.as_ref() {
                             link_with_window(
                                 windows.as_deref_mut(),
@@ -246,7 +246,7 @@ pub fn resolve_window_and_aggregate_functions(
                         }
                         return Ok(WalkControl::SkipChildren);
                     }
-                    Err(e) => {
+                    None => {
                         if let Some(f) = resolver
                             .symbol_table
                             .resolve_function(name.as_str(), args_count)
@@ -273,8 +273,6 @@ pub fn resolve_window_and_aggregate_functions(
                                 }
                                 return Ok(WalkControl::SkipChildren);
                             }
-                        } else {
-                            return Err(e);
                         }
                     }
                     _ => {
@@ -289,8 +287,8 @@ pub fn resolve_window_and_aggregate_functions(
             }
             Expr::FunctionCallStar { name, filter_over } => {
                 validate_aggregate_function_tail(filter_over, &[])?;
-                match Func::resolve_function(name.as_str(), 0) {
-                    Ok(Func::Agg(f)) => {
+                match Func::resolve_function(name.as_str(), 0)? {
+                    Some(Func::Agg(f)) => {
                         if let Some(over_clause) = filter_over.over_clause.as_ref() {
                             link_with_window(
                                 windows.as_deref_mut(),
@@ -311,7 +309,7 @@ pub fn resolve_window_and_aggregate_functions(
                         }
                         return Ok(WalkControl::SkipChildren);
                     }
-                    Ok(Func::Window(f)) => {
+                    Some(Func::Window(f)) => {
                         if let Some(over_clause) = filter_over.over_clause.as_ref() {
                             link_with_window(
                                 windows.as_deref_mut(),
@@ -325,7 +323,7 @@ pub fn resolve_window_and_aggregate_functions(
                         }
                         return Ok(WalkControl::SkipChildren);
                     }
-                    Ok(_) => {
+                    Some(func) => {
                         if filter_over.over_clause.is_some() {
                             crate::bail_parse_error!(
                                 "{} may not be used as a window function",
@@ -334,36 +332,43 @@ pub fn resolve_window_and_aggregate_functions(
                         }
 
                         // Check if the function supports (*) syntax using centralized logic
-                        match crate::function::Func::resolve_function(name.as_str(), 0) {
-                            Ok(func) => {
-                                if func.supports_star_syntax() {
-                                    return Ok(WalkControl::Continue);
-                                } else {
-                                    crate::bail_parse_error!(
-                                        "wrong number of arguments to function {}()",
-                                        name.as_str()
-                                    );
-                                }
-                            }
-                            Err(_) => {
-                                crate::bail_parse_error!(
-                                    "wrong number of arguments to function {}()",
-                                    name.as_str()
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => match e {
-                        crate::LimboError::ParseError(e) => {
-                            crate::bail_parse_error!("{}", e);
-                        }
-                        _ => {
+                        if func.supports_star_syntax() {
+                            return Ok(WalkControl::Continue);
+                        } else {
                             crate::bail_parse_error!(
-                                "Invalid aggregate function: {}",
+                                "wrong number of arguments to function {}()",
                                 name.as_str()
                             );
                         }
-                    },
+                    }
+                    None => {
+                        if let Some(f) = resolver.symbol_table.resolve_function(name.as_str(), 0) {
+                            let func = AggFunc::External(f.func.clone().into());
+                            if let ExtFunc::Aggregate { .. } = f.as_ref().func {
+                                if let Some(over_clause) = filter_over.over_clause.as_ref() {
+                                    link_with_window(
+                                        windows.as_deref_mut(),
+                                        expr,
+                                        WindowFunctionKind::Agg(func),
+                                        over_clause,
+                                        Distinctness::NonDistinct,
+                                    )?;
+                                } else {
+                                    add_aggregate_if_not_exists(
+                                        aggs,
+                                        expr,
+                                        &[],
+                                        Distinctness::NonDistinct,
+                                        func,
+                                    )?;
+                                    contains_aggregates = true;
+                                }
+                                return Ok(WalkControl::SkipChildren);
+                            }
+                        } else {
+                            crate::bail_parse_error!("no such function: {}", name.as_str());
+                        }
+                    }
                 }
             }
             _ => {}

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -78,7 +78,7 @@ pub(crate) fn validate_check_expr(
                 if filter_over.over_clause.is_some() {
                     bail_parse_error!("misuse of window function {}()", name.as_str());
                 }
-                if let Some(func) = resolver.resolve_function(name.as_str(), args.len()) {
+                if let Some(func) = resolver.resolve_function(name.as_str(), args.len())? {
                     if matches!(func, Func::Agg(..)) {
                         bail_parse_error!("misuse of aggregate function {}()", name.as_str());
                     }
@@ -93,7 +93,7 @@ pub(crate) fn validate_check_expr(
                 if filter_over.over_clause.is_some() {
                     bail_parse_error!("misuse of window function {}()", name.as_str());
                 }
-                if let Some(func) = resolver.resolve_function(name.as_str(), 0) {
+                if let Some(func) = resolver.resolve_function(name.as_str(), 0)? {
                     if matches!(func, Func::Agg(..)) {
                         bail_parse_error!("misuse of aggregate function {}()", name.as_str());
                     }
@@ -339,7 +339,7 @@ fn resolve_check_expr_type(
         }
         ast::Expr::NotNull(_) | ast::Expr::IsNull(_) => Ok(CheckExprType::Integer),
         ast::Expr::FunctionCall { name, args, .. } => {
-            if let Some(func) = resolver.resolve_function(name.as_str(), args.len()) {
+            if let Some(func) = resolver.resolve_function(name.as_str(), args.len())? {
                 resolve_func_return_type(&func, name.as_str(), args, columns, resolver)
             } else {
                 bail_parse_error!(
@@ -351,7 +351,7 @@ fn resolve_check_expr_type(
             }
         }
         ast::Expr::FunctionCallStar { name, .. } => {
-            if let Some(func) = resolver.resolve_function(name.as_str(), 0) {
+            if let Some(func) = resolver.resolve_function(name.as_str(), 0)? {
                 resolve_func_return_type(&func, name.as_str(), &[], columns, resolver)
             } else {
                 bail_parse_error!(
@@ -1956,7 +1956,7 @@ fn validate_type_expr(expr: &ast::Expr, kind: &str, resolver: &Resolver) -> Resu
                 if filter_over.over_clause.is_some() {
                     bail_parse_error!("window functions prohibited in {kind} expressions");
                 }
-                if let Some(func) = resolver.resolve_function(name.as_str(), args.len()) {
+                if let Some(func) = resolver.resolve_function(name.as_str(), args.len())? {
                     if matches!(func, Func::Agg(..)) {
                         bail_parse_error!(
                             "aggregate functions prohibited in {kind} expressions: {}",

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1460,7 +1460,7 @@ fn check_aliased_aggregate_misuse(
             Expr::FunctionCall { name, args, .. } => {
                 let is_agg = matches!(
                     crate::function::Func::resolve_function(name.as_str(), args.len()),
-                    Ok(crate::function::Func::Agg(_))
+                    Ok(Some(crate::function::Func::Agg(_)))
                 );
                 if is_agg {
                     for arg in args.iter() {
@@ -1472,7 +1472,7 @@ fn check_aliased_aggregate_misuse(
             Expr::FunctionCallStar { name, .. } => {
                 if matches!(
                     crate::function::Func::resolve_function(name.as_str(), 0),
-                    Ok(crate::function::Func::Agg(_))
+                    Ok(Some(crate::function::Func::Agg(_)))
                 ) {
                     return Ok(WalkControl::SkipChildren);
                 }


### PR DESCRIPTION
The `Func::resolve_function()` function returns specific errors like "wrong number of arguments to function count()" but resolve_function() in the emitter was calling .ok() which discarded the error and converted it to None. Callers then emitted a generic "unknown function" error instead.

Change Emitter::resolve_function() to return Result<Option<Func>> so that specific errors (e.g. wrong arg count) propagate to the caller while "not found" remains None.

Fixes select1-3.9 in testing/sqlite3/all.test.