### PR TITLE
Upgrade PyO3 to 0.28.2 and maturin to 1.12.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,12 +2682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
 name = "inferno"
 version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4153,36 +4147,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
+checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
  "anyhow",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
+checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
+checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -4190,9 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
+checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4202,9 +4193,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
+checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5632,9 +5623,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -6612,12 +6603,6 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,17 +14,13 @@ workspace = true
 name = "_turso"
 crate-type = ["cdylib"]
 
-[features]
-# must be enabled when building with `cargo build`, maturin enables this automatically
-extension-module = ["pyo3/extension-module"]
-
 [dependencies]
 anyhow = "1.0"
 turso_sdk_kit = { workspace = true }
 turso_sync_sdk_kit = { workspace = true }
-pyo3 = { version = "0.27.1", features = ["anyhow"] }
+pyo3 = { version = "0.28.2", features = ["anyhow"] }
 
 [build-dependencies]
 version_check = "0.9.5"
 # used where logic has to be version/distribution specific, e.g. pypy
-pyo3-build-config = { version = "0.27.0" }
+pyo3-build-config = { version = "0.28.2" }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['maturin>=1,<2', 'typing_extensions']
+requires = ['maturin>=1.12.6,<2', 'typing_extensions']
 build-backend = 'maturin'
 
 [project]
@@ -36,7 +36,7 @@ dev = [
     "pytest-cov==5.0.0",
     "ruff==0.5.4",
     "coverage==7.6.1",
-    "maturin==1.7.8",
+    "maturin==1.12.6",
 ]
 sqlalchemy = [
     "sqlalchemy>=2.0",
@@ -53,7 +53,6 @@ Source = "https://github.com/tursodatabase/turso"
 [tool.maturin]
 bindings = 'pyo3'
 module-name = "turso._turso"
-features = ["pyo3/extension-module"]
 
 [tool.pip-tools]
 strip-extras = true
@@ -82,7 +81,7 @@ exclude_lines = [
 dev = [
     "coverage>=7.6.1",
     "iniconfig>=2.1.0",
-    "maturin>=1.7.8",
+    "maturin>=1.12.6",
     "mypy>=1.11.0",
     "mypy-extensions>=1.1.0",
     "pluggy>=1.6.0",

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -23,7 +23,8 @@ use crate::{
 pub mod turso;
 pub mod turso_sync;
 
-#[pymodule]
+// TODO: audit thread-safety of wrapped types and Python::attach() usage before removing gil_used
+#[pymodule(gil_used = true)]
 fn _turso(m: &Bound<PyModule>) -> PyResult<()> {
     m.add("__version__", TursoDatabase::version())?;
     // database exports

--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -11,7 +11,7 @@ use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 
 // support equality for status codes
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, skip_from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)] // Add necessary traits for your use case
 pub enum PyTursoStatusCode {
     Ok = 0,
@@ -99,7 +99,7 @@ impl PyTursoSetupConfig {
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub struct PyTursoEncryptionConfig {
     pub cipher: String,

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -19,7 +19,7 @@ use crate::turso::{
     turso_error_to_py_err, Error, Misuse, PyTursoConnection, PyTursoDatabaseConfig,
 };
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub struct PyTursoPartialSyncOpts {
     // prefix bootstrap strategy which will enable partial sync which lazily pull necessary pages on demand and bootstrap db with pages from first N bytes of the db
@@ -56,7 +56,7 @@ impl PyTursoPartialSyncOpts {
 
 /// Encryption cipher for Turso Cloud remote encryption.
 /// These match the server-side encryption settings.
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PyRemoteEncryptionCipher {
     Aes256Gcm,
@@ -210,7 +210,7 @@ pub struct PyTursoAsyncOperation {
     operation: Box<TursoDatabaseAsyncOperation>,
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, skip_from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)] // Add necessary traits for your use case
 pub enum PyTursoAsyncOperationResultKind {
     /// async operation has no return value ("void" operation)
@@ -379,7 +379,7 @@ impl PyTursoAsyncOperation {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, skip_from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)] // Add necessary traits for your use case
 pub enum PyTursoSyncIoItemRequestKind {
     /// HTTP IO operation


### PR DESCRIPTION
## Description
This PR does the following:
- Upgrade PyO3 from `0.27.0` to `0.28.2`
- Upgrade maturin from `1.7.8` to `1.12.6`
- Remove deprecated `extension-module` feature which is not needed anymore since maturin `1.9.4`[^1] because maturin then sets `PYO3_BUILD_EXTENSION_MODULE` automatically[^2]
- Explicitly opt into GIL with `#[pymodule(gil_used = true)]` because starting with PyO3 0.28.0 `gil_used = false` is used by default[^3][^4]
- Annotate `pyclass` types that implement `Clone` with either `from_py_object` or `skip_from_py_object` according to PyO3 migration guide[^5] to get rid of deprecation warnings


## Motivation and context
This PR is meant to be basic maintenance and also in preparation of an attempt to use automatic type stub generation with PyO3[^6][^7] which could be a great improvement to the Python developer experience.


## Description of AI Usage
I used Claude Code with Opus 4.6 to dig through the PyO3 and maturin docs, search for relevant issues and PRs on GitHub and double check the changes I did.

[^1]: https://pyo3.rs/v0.28.2/features#extension-module
[^2]: https://pyo3.rs/v0.28.2/building-and-distribution#the-pyo3_build_extension_module-environment-variable
[^3]: https://pyo3.rs/v0.28.2/migration#default-to-supporting-free-threaded-python
[^4]: https://pyo3.rs/v0.28.0/free-threading#supporting-free-threaded-python-with-pyo3
[^5]: https://pyo3.rs/v0.28.2/migration#deprecation-of-automatic-frompyobject-for-pyclass-types-which-implement-clone
[^6]: https://pyo3.rs/v0.28.2/type-stub.html
[^7]: https://github.com/PyO3/pyo3/issues/5137