### PR TITLE
core/translate: Reject misuse of aggregate functions in ORDER BY

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -519,6 +519,11 @@ fn prepare_one_select_plan(
 
             // Parse the ORDER BY clause
             let mut key = Vec::new();
+            let agg_count_before_order_by = plan.aggregates.len();
+            let has_group_by = plan
+                .group_by
+                .as_ref()
+                .is_some_and(|gb| !gb.exprs.is_empty());
 
             for mut o in order_by {
                 replace_column_number_with_copy_of_column_expr(&mut o.expr, &plan.result_columns)?;
@@ -530,12 +535,23 @@ fn prepare_one_select_plan(
                     resolver,
                     BindingBehavior::TryResultColumnsFirst,
                 )?;
-                resolve_window_and_aggregate_functions(
+                let had_agg = resolve_window_and_aggregate_functions(
                     &o.expr,
                     resolver,
                     &mut plan.aggregates,
                     Some(&mut windows),
                 )?;
+
+                // SQLite rejects aggregate functions in ORDER BY when the query
+                // has a FROM clause and is not already an aggregate query (no
+                // GROUP BY and no aggregates in SELECT/HAVING).
+                // e.g. SELECT f1 FROM t ORDER BY min(f1);
+                // But SELECT 1 ORDER BY sum(1) is allowed (no FROM clause).
+                let has_from = !plan.table_references.joined_tables().is_empty();
+                if had_agg && has_from && !has_group_by && agg_count_before_order_by == 0 {
+                    let agg = &plan.aggregates[agg_count_before_order_by];
+                    crate::bail_parse_error!("misuse of aggregate: {}()", agg.func);
+                }
 
                 key.push((o.expr, o.order.unwrap_or(ast::SortOrder::Asc)));
             }

--- a/testing/sqltests/tests/agg-functions/order-by-aggregate-misuse.sqltest
+++ b/testing/sqltests/tests/agg-functions/order-by-aggregate-misuse.sqltest
@@ -1,0 +1,81 @@
+@database :memory:
+
+# Aggregate functions in ORDER BY should be rejected when the query
+# is not already an aggregate query (no GROUP BY and no aggregates
+# in SELECT/HAVING).  SQLite returns "misuse of aggregate: min()".
+
+test order-by-min-misuse {
+    CREATE TABLE test1(f1 int, f2 int);
+    INSERT INTO test1 VALUES(11,22);
+    INSERT INTO test1 VALUES(33,44);
+    SELECT f1 FROM test1 ORDER BY min(f1);
+}
+expect error {
+    misuse of aggregate: min()
+}
+
+test order-by-max-misuse {
+    CREATE TABLE test2(f1 int, f2 int);
+    INSERT INTO test2 VALUES(11,22);
+    INSERT INTO test2 VALUES(33,44);
+    SELECT f1 FROM test2 ORDER BY max(f1);
+}
+expect error {
+    misuse of aggregate: max()
+}
+
+test order-by-sum-misuse {
+    CREATE TABLE test3(f1 int, f2 int);
+    INSERT INTO test3 VALUES(11,22);
+    INSERT INTO test3 VALUES(33,44);
+    SELECT f1 FROM test3 ORDER BY sum(f1);
+}
+expect error {
+    misuse of aggregate: sum()
+}
+
+test order-by-count-misuse {
+    CREATE TABLE test4(f1 int, f2 int);
+    INSERT INTO test4 VALUES(11,22);
+    INSERT INTO test4 VALUES(33,44);
+    SELECT f1 FROM test4 ORDER BY count(f1);
+}
+expect error {
+    misuse of aggregate: count()
+}
+
+# Two-arg min() is the scalar function, not an aggregate — should succeed.
+test order-by-scalar-min-ok {
+    CREATE TABLE test5(f1 int, f2 int);
+    INSERT INTO test5 VALUES(11,22);
+    INSERT INTO test5 VALUES(33,44);
+    SELECT f1 FROM test5 ORDER BY min(f1, f2);
+}
+expect {
+    11
+    33
+}
+
+# Aggregate in ORDER BY is fine when the query has GROUP BY.
+test order-by-agg-with-group-by-ok {
+    CREATE TABLE test6(f1 int, f2 int);
+    INSERT INTO test6 VALUES(11,22);
+    INSERT INTO test6 VALUES(11,44);
+    INSERT INTO test6 VALUES(33,55);
+    SELECT f1, count(*) FROM test6 GROUP BY f1 ORDER BY min(f2);
+}
+expect {
+    11|2
+    33|1
+}
+
+# Aggregate in ORDER BY is fine when there are already aggregates in SELECT.
+test order-by-agg-with-select-agg-ok {
+    CREATE TABLE test7(f1 int, f2 int);
+    INSERT INTO test7 VALUES(11,22);
+    INSERT INTO test7 VALUES(33,44);
+    SELECT count(*) FROM test7 ORDER BY min(f1);
+}
+expect {
+    2
+}


### PR DESCRIPTION
Fix select1-4.4 TCL test failure: SQLite rejects queries like `SELECT f1 FROM t ORDER BY min(f1)` with "misuse of aggregate" when the query has a FROM clause but is not already an aggregate query (no GROUP BY, no aggregates in SELECT/HAVING).
    
Detect aggregates introduced by ORDER BY and reject them when the query has table references and no prior aggregation context. Queries without a FROM clause (e.g. `SELECT 1 ORDER BY sum(1)`) are allowed, matching SQLite behavior.
