### PR TITLE
core/translate: Handle ORDER BY/GROUP BY +N as column index reference

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -991,7 +991,21 @@ fn replace_column_number_with_copy_of_column_expr(
     order_by_or_group_by_expr: &mut ast::Expr,
     columns: &[ResultSetColumn],
 ) -> Result<()> {
-    if let ast::Expr::Literal(ast::Literal::Numeric(num)) = order_by_or_group_by_expr {
+    // Extract the numeric literal string, handling both bare integers (e.g. `2`)
+    // and unary-plus integers (e.g. `+2`). In SQLite, `ORDER BY +2` strips the
+    // unary plus and still resolves `2` as a column index reference.
+    let num_str = match order_by_or_group_by_expr {
+        ast::Expr::Literal(ast::Literal::Numeric(num)) => Some(num.clone()),
+        ast::Expr::Unary(ast::UnaryOperator::Positive, inner) => {
+            if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner.as_ref() {
+                Some(num.clone())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+    if let Some(num) = num_str {
         // Only treat as column reference if it parses as a positive integer.
         // Float literals like "0.5" or "1.0" are valid constant expressions, not column references.
         if let Ok(column_number) = num.parse::<usize>() {

--- a/testing/sqltests/tests/orderby/memory.sqltest
+++ b/testing/sqltests/tests/orderby/memory.sqltest
@@ -140,3 +140,50 @@ expect {
     1
 }
 
+# Unary-plus on integer literals should still resolve as column index
+# references, matching SQLite behavior.
+# Fixes select1-4.9.2 in testing/sqlite3/all.test.
+
+test order-by-plus-2 {
+    CREATE TABLE t8(a, b);
+    INSERT INTO t8 VALUES(1,10);
+    INSERT INTO t8 VALUES(2,9);
+    SELECT * FROM t8 ORDER BY +2;
+}
+expect {
+    2|9
+    1|10
+}
+
+test order-by-plus-1 {
+    CREATE TABLE t9(a, b);
+    INSERT INTO t9 VALUES(2,10);
+    INSERT INTO t9 VALUES(1,9);
+    SELECT * FROM t9 ORDER BY +1;
+}
+expect {
+    1|9
+    2|10
+}
+
+test order-by-plus-2-desc {
+    CREATE TABLE t10(a, b);
+    INSERT INTO t10 VALUES(1,10);
+    INSERT INTO t10 VALUES(2,9);
+    SELECT * FROM t10 ORDER BY +2 DESC;
+}
+expect {
+    1|10
+    2|9
+}
+
+test group-by-plus-1 {
+    CREATE TABLE t11(a text, b int);
+    INSERT INTO t11 VALUES('x',1),('x',2),('y',3);
+    SELECT a, sum(b) FROM t11 GROUP BY +1;
+}
+expect {
+    x|3
+    y|3
+}
+


### PR DESCRIPTION
In SQLite, ORDER BY +2 and GROUP BY +1 strip the unary plus and resolve the integer as a column position reference. Turso was treating +N as a constant expression, so no reordering or grouping occurred.

Extend replace_column_number_with_copy_of_column_expr() to match Unary(Positive, Literal(Numeric)) in addition to bare Literal(Numeric). This fixes both ORDER BY and GROUP BY since both call the same function.

Fixes select1-4.9.2 in testing/sqlite3/all.test.