### PR TITLE
bindings/javascript: Add per-connection and per-statement query timeout

### DIFF
--- a/bindings/javascript/docs/API.md
+++ b/bindings/javascript/docs/API.md
@@ -16,6 +16,16 @@ Creates a new database connection.
 The `path` parameter points to the SQLite database file to open. If the file pointed to by `path` does not exists, it will be created.
 To open an in-memory database, please pass `:memory:` as the `path` parameter.
 
+Supported `options` fields include:
+
+- `timeout`: busy timeout in milliseconds
+- `defaultQueryTimeout`: default maximum query execution time in milliseconds before interruption
+
+Per-query timeout override is available via `queryOptions`, for example:
+
+- `db.exec("SELECT 1", { queryTimeout: 100 })`
+- `stmt.get(undefined, { queryTimeout: 100 })`
+
 The function returns a `Database` object.
 
 ### prepare(sql) ⇒ Statement
@@ -195,4 +205,3 @@ This function is currently not supported.
 | bindParameters | <code>array of objects</code> | The bind parameters for executing the statement. |
 
 Binds **permanently** the given parameters to the statement. After a statement's parameters are bound this way, you may no longer provide it with execution-specific (temporary) bound parameters.
-

--- a/bindings/javascript/packages/common/compat.ts
+++ b/bindings/javascript/packages/common/compat.ts
@@ -1,6 +1,6 @@
 import { bindParams } from "./bind.js";
 import { SqliteError } from "./sqlite-error.js";
-import { NativeDatabase, NativeStatement, STEP_IO, STEP_ROW, STEP_DONE } from "./types.js";
+import { NativeDatabase, NativeStatement, QueryOptions, STEP_IO, STEP_ROW, STEP_DONE } from "./types.js";
 
 const convertibleErrorTypes = { TypeError };
 const CONVERTIBLE_ERROR_PREFIX = "[TURSO_CONVERT_TYPE]";
@@ -25,6 +25,33 @@ function createErrorByName(name, message) {
   return new ErrorConstructor(message);
 }
 
+function isQueryOptions(value) {
+  return value != null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.prototype.hasOwnProperty.call(value, "queryTimeout");
+}
+
+function splitBindParameters(bindParameters) {
+  if (bindParameters.length === 0) {
+    return { params: undefined, queryOptions: undefined };
+  }
+  if (bindParameters.length > 1 && isQueryOptions(bindParameters[bindParameters.length - 1])) {
+    return {
+      params: bindParameters.length === 2 ? bindParameters[0] : bindParameters.slice(0, -1),
+      queryOptions: bindParameters[bindParameters.length - 1],
+    };
+  }
+  return { params: bindParameters.length === 1 ? bindParameters[0] : bindParameters, queryOptions: undefined };
+}
+
+function toBindArgs(params) {
+  if (params === undefined) {
+    return [];
+  }
+  return [params];
+}
+
 /**
  * Database represents a connection that can prepare and execute SQL statements.
  */
@@ -47,6 +74,7 @@ class Database {
    * @param {boolean} [opts.readonly=false] - Open the database in read-only mode.
    * @param {boolean} [opts.fileMustExist=false] - If true, throws if database file does not exist.
    * @param {number} [opts.timeout=0] - Timeout duration in milliseconds for database operations. Defaults to 0 (no timeout).
+   * @param {number} [opts.defaultQueryTimeout=0] - Default maximum query execution time in milliseconds before interruption.
    */
   constructor(db: NativeDatabase) {
     this.db = db;
@@ -175,11 +203,11 @@ class Database {
    *
    * @param {string} sql - The string containing SQL statements to execute
    */
-  exec(sql) {
+  exec(sql, queryOptions?: QueryOptions) {
     if (!this.open) {
       throw new TypeError("The database connection is not open");
     }
-    const exec = this.db.executor(sql);
+    const exec = this.db.executor(sql, queryOptions);
     try {
       while (true) {
         const stepResult = exec.stepSync();
@@ -293,8 +321,10 @@ class Statement {
   run(...bindParameters) {
     const totalChangesBefore = this.db.totalChanges();
 
+    const { params, queryOptions } = splitBindParameters(bindParameters);
     this.stmt.reset();
-    bindParams(this.stmt, bindParameters);
+    this.stmt.setQueryTimeout(queryOptions);
+    bindParams(this.stmt, toBindArgs(params));
     for (; ;) {
       const stepResult = this.stmt.stepSync();
       if (stepResult === STEP_IO) {
@@ -322,8 +352,10 @@ class Statement {
    * @param bindParameters - The bind parameters for executing the statement.
    */
   get(...bindParameters) {
+    const { params, queryOptions } = splitBindParameters(bindParameters);
     this.stmt.reset();
-    bindParams(this.stmt, bindParameters);
+    this.stmt.setQueryTimeout(queryOptions);
+    bindParams(this.stmt, toBindArgs(params));
     let row = undefined;
     for (; ;) {
       const stepResult = this.stmt.stepSync();
@@ -347,8 +379,10 @@ class Statement {
    * @param bindParameters - The bind parameters for executing the statement.
    */
   *iterate(...bindParameters) {
+    const { params, queryOptions } = splitBindParameters(bindParameters);
     this.stmt.reset();
-    bindParams(this.stmt, bindParameters);
+    this.stmt.setQueryTimeout(queryOptions);
+    bindParams(this.stmt, toBindArgs(params));
 
     while (true) {
       const stepResult = this.stmt.stepSync();
@@ -371,8 +405,10 @@ class Statement {
    * @param bindParameters - The bind parameters for executing the statement.
    */
   all(...bindParameters) {
+    const { params, queryOptions } = splitBindParameters(bindParameters);
     this.stmt.reset();
-    bindParams(this.stmt, bindParameters);
+    this.stmt.setQueryTimeout(queryOptions);
+    bindParams(this.stmt, toBindArgs(params));
     const rows: any[] = [];
     for (; ;) {
       const stepResult = this.stmt.stepSync();

--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -1,7 +1,7 @@
 import { AsyncLock } from "./async-lock.js";
 import { bindParams } from "./bind.js";
 import { SqliteError } from "./sqlite-error.js";
-import { NativeDatabase, NativeStatement, STEP_IO, STEP_ROW, STEP_DONE, DatabaseOpts } from "./types.js";
+import { NativeDatabase, NativeStatement, QueryOptions, STEP_IO, STEP_ROW, STEP_DONE, DatabaseOpts } from "./types.js";
 
 const convertibleErrorTypes = { TypeError };
 const CONVERTIBLE_ERROR_PREFIX = "[TURSO_CONVERT_TYPE]";
@@ -24,6 +24,33 @@ function createErrorByName(name, message) {
   }
 
   return new ErrorConstructor(message);
+}
+
+function isQueryOptions(value) {
+  return value != null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.prototype.hasOwnProperty.call(value, "queryTimeout");
+}
+
+function splitBindParameters(bindParameters) {
+  if (bindParameters.length === 0) {
+    return { params: undefined, queryOptions: undefined };
+  }
+  if (bindParameters.length > 1 && isQueryOptions(bindParameters[bindParameters.length - 1])) {
+    return {
+      params: bindParameters.length === 2 ? bindParameters[0] : bindParameters.slice(0, -1),
+      queryOptions: bindParameters[bindParameters.length - 1],
+    };
+  }
+  return { params: bindParameters.length === 1 ? bindParameters[0] : bindParameters, queryOptions: undefined };
+}
+
+function toBindArgs(params) {
+  if (params === undefined) {
+    return [];
+  }
+  return [params];
 }
 
 /**
@@ -184,12 +211,12 @@ class Database {
    *
    * @param {string} sql - The string containing SQL statements to execute
    */
-  async exec(sql) {
+  async exec(sql, queryOptions?: QueryOptions) {
     if (!this.open) {
       throw new TypeError("The database connection is not open");
     }
     await this.execLock.acquire();
-    const exec = this.db.executor(sql);
+    const exec = this.db.executor(sql, queryOptions);
     try {
       while (true) {
         const stepResult = exec.stepSync();
@@ -362,8 +389,10 @@ class Statement {
    */
   async run(...bindParameters) {
     let stmt = await this.stmt.resolve();
+    const { params, queryOptions } = splitBindParameters(bindParameters);
 
-    bindParams(stmt, bindParameters);
+    stmt.setQueryTimeout(queryOptions);
+    bindParams(stmt, toBindArgs(params));
 
     const totalChangesBefore = this.db.totalChanges();
     await this.execLock.acquire();
@@ -400,8 +429,10 @@ class Statement {
    */
   async get(...bindParameters) {
     let stmt = await this.stmt.resolve();
+    const { params, queryOptions } = splitBindParameters(bindParameters);
 
-    bindParams(stmt, bindParameters);
+    stmt.setQueryTimeout(queryOptions);
+    bindParams(stmt, toBindArgs(params));
 
     await this.execLock.acquire();
     let row = undefined;
@@ -434,8 +465,10 @@ class Statement {
    */
   async *iterate(...bindParameters) {
     let stmt = await this.stmt.resolve();
+    const { params, queryOptions } = splitBindParameters(bindParameters);
 
-    bindParams(stmt, bindParameters);
+    stmt.setQueryTimeout(queryOptions);
+    bindParams(stmt, toBindArgs(params));
 
     await this.execLock.acquire();
     try {
@@ -465,8 +498,10 @@ class Statement {
    */
   async all(...bindParameters) {
     let stmt = await this.stmt.resolve();
+    const { params, queryOptions } = splitBindParameters(bindParameters);
 
-    bindParams(stmt, bindParameters);
+    stmt.setQueryTimeout(queryOptions);
+    bindParams(stmt, toBindArgs(params));
     const rows: any[] = [];
 
     await this.execLock.acquire();

--- a/bindings/javascript/packages/common/types.ts
+++ b/bindings/javascript/packages/common/types.ts
@@ -14,11 +14,18 @@ export interface DatabaseOpts {
     readonly?: boolean,
     fileMustExist?: boolean,
     timeout?: number
+    /** Default maximum query execution time in milliseconds before interruption. */
+    defaultQueryTimeout?: number
     tracing?: 'info' | 'debug' | 'trace'
     /** Experimental features to enable */
     experimental?: ExperimentalFeature[]
     /** Optional local encryption configuration */
     encryption?: EncryptionOpts
+}
+
+export interface QueryOptions {
+    /** Per-query timeout in milliseconds. Overrides defaultQueryTimeout for this call. */
+    queryTimeout?: number
 }
 
 export interface NativeDatabase {
@@ -35,7 +42,7 @@ export interface NativeDatabase {
     ioLoopAsync(): Promise<void>;
 
     prepare(sql: string): NativeStatement;
-    executor(sql: string): NativeExecutor;
+    executor(sql: string, queryOptions?: QueryOptions): NativeExecutor;
 
     defaultSafeIntegers(toggle: boolean);
     totalChanges(): number;
@@ -60,6 +67,7 @@ export interface NativeExecutor {
     reset();
 }
 export interface NativeStatement {
+    setQueryTimeout(queryOptions?: QueryOptions): void;
     stepAsync(): Promise<number>;
     stepSync(): number;
 

--- a/bindings/javascript/packages/native/index.d.ts
+++ b/bindings/javascript/packages/native/index.d.ts
@@ -5,6 +5,10 @@ export declare class BatchExecutor {
   reset(): void
 }
 
+export interface QueryOptions {
+  queryTimeout?: number
+}
+
 /** A database connection. */
 export declare class Database {
   /**
@@ -44,7 +48,7 @@ export declare class Database {
    * A `Statement` instance.
    */
   prepare(sql: string): Statement
-  executor(sql: string): BatchExecutor
+  executor(sql: string, queryOptions?: QueryOptions | undefined | null): BatchExecutor
   /**
    * Returns the rowid of the last row inserted.
    *
@@ -96,6 +100,7 @@ export declare class Database {
 /** A prepared statement. */
 export declare class Statement {
   reset(): void
+  setQueryTimeout(queryOptions?: QueryOptions | undefined | null): void
   /** Returns the number of parameters in the statement. */
   parameterCount(): number
   /**
@@ -148,6 +153,7 @@ export declare class Statement {
 export interface DatabaseOpts {
   readonly?: boolean
   timeout?: number
+  defaultQueryTimeout?: number
   fileMustExist?: boolean
   tracing?: string
   /** Experimental features to enable */

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -172,12 +172,19 @@ pub struct EncryptionOpts {
 pub struct DatabaseOpts {
     pub readonly: Option<bool>,
     pub timeout: Option<u32>,
+    pub default_query_timeout: Option<u32>,
     pub file_must_exist: Option<bool>,
     pub tracing: Option<String>,
     /// Experimental features to enable
     pub experimental: Option<Vec<String>>,
     /// Optional encryption configuration for local database encryption
     pub encryption: Option<EncryptionOpts>,
+}
+
+#[napi(object)]
+#[derive(Clone)]
+pub struct QueryOptions {
+    pub query_timeout: Option<u32>,
 }
 
 fn step_sync(stmt: &StatementHandle) -> napi::Result<u32> {
@@ -213,6 +220,22 @@ fn create_error(status: napi::Status, message: &str) -> napi::Error {
     Error::new(status, message)
 }
 
+fn query_timeout_duration(timeout_ms: u32) -> Option<std::time::Duration> {
+    if timeout_ms > 0 {
+        Some(std::time::Duration::from_millis(timeout_ms as u64))
+    } else {
+        None
+    }
+}
+
+fn query_timeout_override_from_query_options(
+    query_options: Option<QueryOptions>,
+) -> Option<Option<std::time::Duration>> {
+    query_options
+        .and_then(|o| o.query_timeout)
+        .map(query_timeout_duration)
+}
+
 fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
     if db.connect.get().is_some() {
         return Ok(());
@@ -220,6 +243,7 @@ fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
 
     let mut flags = turso_core::OpenFlags::Create;
     let mut busy_timeout = None;
+    let mut query_timeout = None;
     let mut core_opts = turso_core::DatabaseOpts::new();
     let mut encryption_opts = None;
     if let Some(opts) = &db.opts {
@@ -232,6 +256,9 @@ fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
         }
         if let Some(timeout) = opts.timeout {
             busy_timeout = Some(std::time::Duration::from_millis(timeout as u64));
+        }
+        if let Some(timeout) = opts.default_query_timeout {
+            query_timeout = query_timeout_duration(timeout);
         }
         if let Some(experimental) = &opts.experimental {
             for feature in experimental {
@@ -289,6 +316,9 @@ fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
 
     if let Some(busy_timeout) = busy_timeout {
         conn.set_busy_timeout(busy_timeout);
+    }
+    if let Some(query_timeout) = query_timeout {
+        conn.set_query_timeout(query_timeout);
     }
 
     let connect = DatabaseConnect {
@@ -445,12 +475,17 @@ impl Database {
     }
 
     #[napi]
-    pub fn executor(&self, sql: String) -> napi::Result<BatchExecutor> {
+    pub fn executor(
+        &self,
+        sql: String,
+        query_options: Option<QueryOptions>,
+    ) -> napi::Result<BatchExecutor> {
         Ok(BatchExecutor {
             conn: Some(self.conn()?),
             sql,
             position: 0,
             stmt: None,
+            query_timeout_override: query_timeout_override_from_query_options(query_options),
         })
     }
 
@@ -568,6 +603,7 @@ pub struct BatchExecutor {
     sql: String,
     position: usize,
     stmt: Option<StatementHandle>,
+    query_timeout_override: Option<Option<std::time::Duration>>,
 }
 
 #[napi]
@@ -584,7 +620,12 @@ impl BatchExecutor {
                     #[allow(clippy::arc_with_non_send_sync)]
                     Ok(Some((stmt, offset))) => {
                         self.position += offset;
-                        self.stmt = Some(Arc::new(RefCell::new(Some(stmt))));
+                        let stmt: StatementHandle = Arc::new(RefCell::new(Some(stmt)));
+                        stmt.borrow_mut()
+                            .as_mut()
+                            .unwrap()
+                            .set_query_timeout_override(self.query_timeout_override);
+                        self.stmt = Some(stmt);
                     }
                     Ok(None) => return Ok(STEP_DONE),
                     Err(err) => return Err(to_generic_error("failed to consume stmt", err)),
@@ -633,6 +674,17 @@ impl Statement {
             .ok_or_else(|| create_generic_error("statement has been finalized"))?
             .reset()
             .map_err(|e| to_generic_error("reset failed", e))?;
+        Ok(())
+    }
+
+    #[napi(js_name = "setQueryTimeout")]
+    pub fn set_query_timeout(&self, query_options: Option<QueryOptions>) -> Result<()> {
+        let timeout_override = query_timeout_override_from_query_options(query_options);
+        let mut guard = self.statement_handle()?.borrow_mut();
+        guard
+            .as_mut()
+            .ok_or_else(|| create_generic_error("statement has been finalized"))?
+            .set_query_timeout_override(timeout_override);
         Ok(())
     }
 

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -241,6 +241,7 @@ impl SyncEngine {
                 file_must_exist: None,
                 readonly: None,
                 timeout: None,
+                default_query_timeout: None,
                 tracing: opts.tracing.clone(),
                 experimental: None,
                 encryption: None, // Local encryption not supported in sync mode

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -121,6 +121,9 @@ pub struct Connection {
     /// Busy handler for lock contention
     /// Default is BusyHandler::None (return SQLITE_BUSY immediately)
     pub(super) busy_handler: RwLock<BusyHandler>,
+    /// Maximum execution time for a single statement on this connection.
+    /// `Duration::ZERO` means disabled.
+    pub(super) query_timeout_ms: AtomicU64,
     /// Whether this is an internal connection used for MVCC bootstrap
     pub(super) is_mvcc_bootstrap_connection: AtomicBool,
     /// Whether pragma foreign_keys=ON for this connection
@@ -1987,6 +1990,18 @@ impl Connection {
             BusyHandler::Timeout(d) => *d,
             _ => Duration::ZERO,
         }
+    }
+
+    /// Sets the maximum duration a statement is allowed to run.
+    /// `Duration::ZERO` disables query timeout.
+    pub fn set_query_timeout(&self, duration: Duration) {
+        let millis = duration.as_millis().min(u128::from(u64::MAX)) as u64;
+        self.query_timeout_ms.store(millis, Ordering::SeqCst);
+    }
+
+    /// Get the query timeout duration.
+    pub fn get_query_timeout(&self) -> Duration {
+        Duration::from_millis(self.query_timeout_ms.load(Ordering::SeqCst))
     }
 
     /// Get a reference to the busy handler.

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1380,6 +1380,7 @@ impl Database {
             temp_store: AtomicTempStore::new(TempStore::Default),
             data_sync_retry: AtomicBool::new(false),
             busy_handler: RwLock::new(BusyHandler::None),
+            query_timeout_ms: AtomicU64::new(0),
             is_mvcc_bootstrap_connection: AtomicBool::new(is_mvcc_bootstrap_connection),
             fk_pragma: AtomicBool::new(false),
             fk_deferred_violations: AtomicIsize::new(0),

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -4,6 +4,7 @@ use std::{
     ops::Deref,
     sync::{atomic::Ordering, Arc},
     task::Waker,
+    time::Duration,
 };
 
 use tracing::{instrument, Level};
@@ -40,6 +41,11 @@ pub struct Statement {
     busy: bool,
     /// Busy handler state for tracking invocations and timeouts
     busy_handler_state: Option<BusyHandlerState>,
+    /// Per-execution timeout override for this statement.
+    /// - `None`: use connection default
+    /// - `Some(Some(duration))`: override with a query-specific timeout
+    /// - `Some(None)`: disable timeout for this execution
+    query_timeout_override: Option<Option<Duration>>,
     /// True once step() has returned Row for a write statement (INSERT/UPDATE/DELETE
     /// with RETURNING). With ephemeral-buffered RETURNING, the first Row proves all
     /// DML completed — only the scan-back remains. Used by reset_internal to decide
@@ -84,6 +90,7 @@ impl Statement {
             query_mode,
             busy: false,
             busy_handler_state: None,
+            query_timeout_override: None,
             has_returned_row: false,
             tail_offset,
         }
@@ -123,6 +130,15 @@ impl Statement {
         self.state.interrupt();
     }
 
+    /// Sets a per-execution timeout override for this statement.
+    ///
+    /// - `None`: use connection default
+    /// - `Some(Some(duration))`: use query-specific timeout
+    /// - `Some(None)`: disable timeout for this execution
+    pub fn set_query_timeout_override(&mut self, timeout: Option<Option<Duration>>) {
+        self.query_timeout_override = timeout;
+    }
+
     pub fn execution_state(&self) -> ProgramExecutionState {
         self.state.execution_state
     }
@@ -143,6 +159,37 @@ impl Statement {
         self.state.io_completions.take()
     }
 
+    fn arm_query_timeout_if_needed(&mut self) {
+        if !matches!(self.state.execution_state, ProgramExecutionState::Init)
+            || self.state.query_deadline.is_some()
+        {
+            return;
+        }
+        let timeout = match self.query_timeout_override {
+            Some(timeout_override) => timeout_override,
+            None => {
+                let connection_timeout = self.program.connection.get_query_timeout();
+                if connection_timeout.is_zero() {
+                    None
+                } else {
+                    Some(connection_timeout)
+                }
+            }
+        };
+        let Some(timeout) = timeout else {
+            return;
+        };
+        self.state.query_deadline = Some(self.pager.io.current_time_monotonic() + timeout);
+    }
+
+    fn maybe_interrupt_for_query_timeout(&mut self) {
+        if let Some(deadline) = self.state.query_deadline {
+            if self.pager.io.current_time_monotonic() >= deadline {
+                self.state.interrupt();
+            }
+        }
+    }
+
     fn _step(&mut self, waker: Option<&Waker>) -> Result<StepResult> {
         if matches!(self.state.execution_state, ProgramExecutionState::Init)
             && !self
@@ -152,6 +199,10 @@ impl Statement {
         {
             self.reprepare()?;
         }
+
+        self.arm_query_timeout_if_needed();
+        self.maybe_interrupt_for_query_timeout();
+
         // If we're waiting for a busy handler timeout, check if we can proceed
         if let Some(busy_state) = self.busy_handler_state.as_ref() {
             if self.pager.io.current_time_monotonic() < busy_state.timeout() {
@@ -188,6 +239,7 @@ impl Statement {
                 .record_statement(&self.state.metrics);
             self.busy = false;
             self.busy_handler_state = None; // Reset busy state on completion
+            self.state.query_deadline = None;
 
             // After ANALYZE completes, refresh in-memory stats so planners can use them.
             let sql = self.program.sql.trim_start().as_bytes();
@@ -696,6 +748,7 @@ impl Statement {
         self.state.n_change.store(0, Ordering::SeqCst);
         self.busy = false;
         self.busy_handler_state = None;
+        self.query_timeout_override = None;
         self.has_returned_row = false;
 
         if let Some(err) = reset_error {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -437,6 +437,9 @@ pub struct ProgramState {
     /// Indicate whether an [Insn::Once] instruction at a given program counter position has already been executed, well, once.
     once: SmallVec<[u32; 4]>,
     pub execution_state: ProgramExecutionState,
+    /// Per-execution statement deadline derived from the connection query timeout.
+    /// `None` means no timeout.
+    pub query_deadline: Option<crate::MonotonicInstant>,
     pub parameters: Vec<Value>,
     commit_state: CommitState,
     #[cfg(feature = "json")]
@@ -537,6 +540,7 @@ impl ProgramState {
             ended_coroutine: vec![],
             once: SmallVec::<[u32; 4]>::new(),
             execution_state: ProgramExecutionState::Init,
+            query_deadline: None,
             parameters: Vec::new(),
             commit_state: CommitState::Ready,
             #[cfg(feature = "json")]
@@ -668,6 +672,7 @@ impl ProgramState {
         self.ended_coroutine.clear();
         self.once.clear();
         self.execution_state = ProgramExecutionState::Init;
+        self.query_deadline = None;
         self.current_collation = None;
         #[cfg(feature = "json")]
         self.json_cache.clear();
@@ -1144,6 +1149,12 @@ impl Program {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
 
+        if let Some(deadline) = state.query_deadline {
+            if pager.io.current_time_monotonic() >= deadline {
+                state.execution_state = ProgramExecutionState::Interrupting;
+            }
+        }
+
         if matches!(state.execution_state, ProgramExecutionState::Interrupting) {
             return Ok(StepResult::Interrupt);
         }
@@ -1245,6 +1256,12 @@ impl Program {
                 return Err(LimboError::InternalError("Connection closed".to_string()));
             }
 
+            if let Some(deadline) = state.query_deadline {
+                if pager.io.current_time_monotonic() >= deadline {
+                    state.execution_state = ProgramExecutionState::Interrupting;
+                }
+            }
+
             if matches!(state.execution_state, ProgramExecutionState::Interrupting) {
                 return Ok(StepResult::Interrupt);
             }
@@ -1291,6 +1308,11 @@ impl Program {
                     pager.rollback_tx(&self.connection);
                 }
                 return Err(LimboError::InternalError("Connection closed".to_string()));
+            }
+            if let Some(deadline) = state.query_deadline {
+                if pager.io.current_time_monotonic() >= deadline {
+                    state.execution_state = ProgramExecutionState::Interrupting;
+                }
             }
             if matches!(state.execution_state, ProgramExecutionState::Interrupting) {
                 self.abort(pager, None, state)?;

--- a/docs/javascript-api-reference.md
+++ b/docs/javascript-api-reference.md
@@ -20,6 +20,16 @@ Opens a new database connection.
 The `path` parameter points to the SQLite database file to open. If the file pointed to by `path` does not exists, it will be created.
 To open an in-memory database, please pass `:memory:` as the `path` parameter.
 
+Supported `options` fields include:
+
+- `timeout`: busy timeout in milliseconds
+- `defaultQueryTimeout`: default maximum query execution time in milliseconds before interruption
+
+Per-query timeout override is available via `queryOptions`, for example:
+
+- `db.exec("SELECT 1", { queryTimeout: 100 })`
+- `stmt.get(undefined, { queryTimeout: 100 })`
+
 The function returns a `Database` object.
 
 ## class Database

--- a/testing/javascript/__test__/async.test.js
+++ b/testing/javascript/__test__/async.test.js
@@ -536,6 +536,57 @@ test.skip("Statement.interrupt()", async (t) => {
   });
 });
 
+test.serial("Query timeout option interrupts long-running query", async (t) => {
+  const path = genDatabaseFilename();
+  const [db] = await connect(path, { defaultQueryTimeout: 50 });
+  const stmt = await db.prepare("SELECT sum(value) FROM generate_series(1, 1000000000);");
+
+  const error = await t.throwsAsync(async () => {
+    await stmt.get();
+  });
+  t.truthy(error);
+  t.true(error.message.toLowerCase().includes("interrupt"));
+
+  await db.close();
+  cleanupDatabaseFiles(path);
+});
+
+test.serial("Query timeout option allows short-running query", async (t) => {
+  const path = genDatabaseFilename();
+  const [db] = await connect(path, { defaultQueryTimeout: 50 });
+  const stmt = await db.prepare("SELECT 1 AS value");
+  t.deepEqual(await stmt.get(), { value: 1 });
+
+  await db.close();
+  cleanupDatabaseFiles(path);
+});
+
+test.serial("Per-query timeout option interrupts long-running Statement.get()", async (t) => {
+  const path = genDatabaseFilename();
+  const [db] = await connect(path);
+  const stmt = await db.prepare("SELECT sum(value) FROM generate_series(1, 1000000000);");
+
+  const error = await t.throwsAsync(async () => {
+    await stmt.get(undefined, { queryTimeout: 50 });
+  });
+  t.truthy(error);
+  t.true(error.message.toLowerCase().includes("interrupt"));
+
+  await db.close();
+  cleanupDatabaseFiles(path);
+});
+
+test.serial("Per-query timeout option is accepted by Database.exec()", async (t) => {
+  const path = genDatabaseFilename();
+  const [db] = await connect(path);
+  await t.notThrowsAsync(async () => {
+    await db.exec("SELECT 1", { queryTimeout: 50 });
+  });
+
+  await db.close();
+  cleanupDatabaseFiles(path);
+});
+
 test.skip("Timeout option", async (t) => {
   const timeout = 1000;
   const path = genDatabaseFilename();
@@ -789,4 +840,13 @@ const connect = async (path, options = {}) => {
 /// Generate a unique database filename
 const genDatabaseFilename = () => {
   return `test-${crypto.randomBytes(8).toString('hex')}.db`;
+};
+
+const cleanupDatabaseFiles = (path) => {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const file = path + suffix;
+    if (fs.existsSync(file)) {
+      fs.unlinkSync(file);
+    }
+  }
 };

--- a/testing/javascript/__test__/sync.test.js
+++ b/testing/javascript/__test__/sync.test.js
@@ -546,6 +546,65 @@ test.serial("Statement.reader [DELETE RETURNING is true]", (t) => {
   t.is(stmt.reader, true);
 });
 
+test.serial("Query timeout option interrupts long-running query", async (t) => {
+  const path = genDatabaseFilename();
+  const [db] = await connect(path, { defaultQueryTimeout: 50 });
+  const stmt = db.prepare("SELECT sum(value) FROM generate_series(1, 1000000000);");
+
+  const error = t.throws(() => {
+    stmt.get();
+  });
+  t.truthy(error);
+  t.true(error.message.toLowerCase().includes("interrupt"));
+
+  db.close();
+  cleanupDatabaseFiles(path);
+});
+
+test.serial("Query timeout option allows short-running query", async (t) => {
+  const path = genDatabaseFilename();
+  const [db] = await connect(path, { defaultQueryTimeout: 50 });
+  const stmt = db.prepare("SELECT 1 AS value");
+  t.deepEqual(stmt.get(), { value: 1 });
+
+  db.close();
+  cleanupDatabaseFiles(path);
+});
+
+test.serial("Per-query timeout option interrupts long-running Statement.get()", async (t) => {
+  if (t.context.provider !== "turso") {
+    t.pass("Skipping queryTimeout test for non-Turso providers");
+    return;
+  }
+
+  const path = genDatabaseFilename();
+  const [db] = await connect(path);
+  const stmt = db.prepare("SELECT sum(value) FROM generate_series(1, 1000000000);");
+
+  const error = t.throws(() => {
+    stmt.get(undefined, { queryTimeout: 50 });
+  });
+  t.truthy(error);
+  t.true(error.message.toLowerCase().includes("interrupt"));
+
+  db.close();
+  cleanupDatabaseFiles(path);
+});
+
+test.serial("Per-query timeout option is accepted by Database.exec()", async (t) => {
+  if (t.context.provider !== "turso") {
+    t.pass("Skipping queryTimeout test for non-Turso providers");
+    return;
+  }
+
+  const path = genDatabaseFilename();
+  const [db] = await connect(path);
+  t.notThrows(() => db.exec("SELECT 1", { queryTimeout: 50 }));
+
+  db.close();
+  cleanupDatabaseFiles(path);
+});
+
 test.skip("Timeout option", async (t) => {
   const timeout = 1000;
   const path = genDatabaseFilename();
@@ -641,4 +700,13 @@ const connect = async (path, options = {}) => {
 /// Generate a unique database filename
 const genDatabaseFilename = () => {
   return `test-${crypto.randomBytes(8).toString('hex')}.db`;
+};
+
+const cleanupDatabaseFiles = (path) => {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const file = path + suffix;
+    if (fs.existsSync(file)) {
+      fs.unlinkSync(file);
+    }
+  }
 };

--- a/testing/javascript/package-lock.json
+++ b/testing/javascript/package-lock.json
@@ -9,7 +9,7 @@
         "@tursodatabase/database": "../../bindings/javascript/packages/native",
         "@tursodatabase/serverless": "../../serverless/javascript",
         "better-sqlite3": "^11.9.1",
-        "libsql": "^0.6.0-pre.29"
+        "libsql": "^0.6.0-pre.30"
       },
       "devDependencies": {
         "ava": "^5.3.0"
@@ -3031,7 +3031,9 @@
       }
     },
     "node_modules/libsql": {
-      "version": "0.6.0-pre.29",
+      "version": "0.6.0-pre.30",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.6.0-pre.30.tgz",
+      "integrity": "sha512-6KJlMlTJD1nQl9H7EBeCCDj68ZihRnGMUZg/i0DHnB9g7ldlZHn6q31SU6Vl2o8YajcevHRCQie75157lKJs7g==",
       "cpu": [
         "x64",
         "arm64",
@@ -3048,17 +3050,19 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "libsql-darwin-arm64": "0.6.0-pre.29",
-        "libsql-darwin-x64": "0.6.0-pre.29",
-        "libsql-linux-arm64-gnu": "0.6.0-pre.29",
-        "libsql-linux-arm64-musl": "0.6.0-pre.29",
-        "libsql-linux-x64-gnu": "0.6.0-pre.29",
-        "libsql-linux-x64-musl": "0.6.0-pre.29",
-        "libsql-win32-x64-msvc": "0.6.0-pre.29"
+        "libsql-darwin-arm64": "0.6.0-pre.30",
+        "libsql-darwin-x64": "0.6.0-pre.30",
+        "libsql-linux-arm64-gnu": "0.6.0-pre.30",
+        "libsql-linux-arm64-musl": "0.6.0-pre.30",
+        "libsql-linux-x64-gnu": "0.6.0-pre.30",
+        "libsql-linux-x64-musl": "0.6.0-pre.30",
+        "libsql-win32-x64-msvc": "0.6.0-pre.30"
       }
     },
     "node_modules/libsql-darwin-arm64": {
-      "version": "0.6.0-pre.29",
+      "version": "0.6.0-pre.30",
+      "resolved": "https://registry.npmjs.org/libsql-darwin-arm64/-/libsql-darwin-arm64-0.6.0-pre.30.tgz",
+      "integrity": "sha512-zafUt72dtvIRdSY1N1HpZgJ2pN3TnQMZihIagopcgaK3b6VY6ZrGrdocr9nEC7tyttEyJplXsIMxDyYAQbTV6Q==",
       "cpu": [
         "arm64"
       ],
@@ -3066,6 +3070,70 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/libsql-darwin-x64": {
+      "version": "0.6.0-pre.30",
+      "resolved": "https://registry.npmjs.org/libsql-darwin-x64/-/libsql-darwin-x64-0.6.0-pre.30.tgz",
+      "integrity": "sha512-QWVzIp9TWXMSPm4uKKnx6VD15hFyQLhVvUXQAAQq8rmYZP78QrOOX8ETiVDBWBBYmKG7N/B8r/3UKWdV+ynB8g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/libsql-linux-arm64-gnu": {
+      "version": "0.6.0-pre.30",
+      "resolved": "https://registry.npmjs.org/libsql-linux-arm64-gnu/-/libsql-linux-arm64-gnu-0.6.0-pre.30.tgz",
+      "integrity": "sha512-GSOe+0bPgxrIMvw+QzAgS5gbfJG3pZsWIP+xIbrfUs+BKnkAfKSSh/qr+5FoCb92/v5BhFK+OrdOO+mUPhXM+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/libsql-linux-x64-gnu": {
+      "version": "0.6.0-pre.30",
+      "resolved": "https://registry.npmjs.org/libsql-linux-x64-gnu/-/libsql-linux-x64-gnu-0.6.0-pre.30.tgz",
+      "integrity": "sha512-jsJHv2mDxqMX73DVDuJgU0VbYaV9CIzLL4k390i0ObnlPEbd82b3k3mQTw2rdN9MbfsMbyAMFtDaue7JlI1cdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/libsql-linux-x64-musl": {
+      "version": "0.6.0-pre.30",
+      "resolved": "https://registry.npmjs.org/libsql-linux-x64-musl/-/libsql-linux-x64-musl-0.6.0-pre.30.tgz",
+      "integrity": "sha512-LzCiwK0x/ivXRLHgNndETNULxSjYOclwCvho4nEAwA6s47gZEPkEY2gibVFCrznaoWTZPsCt7QGmfC7Sq3YerA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 10"

--- a/testing/javascript/package.json
+++ b/testing/javascript/package.json
@@ -16,6 +16,6 @@
     "@tursodatabase/serverless": "../../serverless/javascript",
     "@tursodatabase/database": "../../bindings/javascript/packages/native",
     "better-sqlite3": "^11.9.1",
-    "libsql": "^0.6.0-pre.29"
+    "libsql": "^0.6.0-pre.30"
   }
 }

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -10,6 +10,7 @@ mod integrity_check;
 mod mvcc;
 mod pragma;
 mod query_processing;
+mod query_timeout;
 mod statement_reset;
 mod stmt_journal;
 mod storage;

--- a/tests/integration/query_timeout.rs
+++ b/tests/integration/query_timeout.rs
@@ -1,0 +1,45 @@
+use crate::common::TempDatabase;
+use std::time::Duration;
+use turso_core::vdbe::StepResult;
+
+fn run_until_terminal(stmt: &mut turso_core::Statement) -> turso_core::Result<StepResult> {
+    loop {
+        match stmt.step()? {
+            StepResult::IO => stmt._io().step()?,
+            StepResult::Row => continue,
+            result => return Ok(result),
+        }
+    }
+}
+
+#[turso_macros::test]
+fn query_timeout_interrupts_long_running_query(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(x INTEGER);")?;
+    for i in 0..200 {
+        conn.execute(format!("INSERT INTO t VALUES ({i});"))?;
+    }
+    conn.set_query_timeout(Duration::from_millis(10));
+
+    let mut stmt = conn.prepare("SELECT a.x FROM t a, t b, t c, t d, t e;")?;
+    let result = run_until_terminal(&mut stmt)?;
+    assert!(
+        matches!(result, StepResult::Interrupt),
+        "expected interrupt, got {result:?}"
+    );
+    Ok(())
+}
+
+#[turso_macros::test]
+fn query_timeout_allows_short_running_query(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.set_query_timeout(Duration::from_millis(10));
+
+    let mut stmt = conn.prepare("SELECT 1 AS value;")?;
+    let result = run_until_terminal(&mut stmt)?;
+    assert!(
+        matches!(result, StepResult::Done),
+        "expected done, got {result:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Introduce a configurable query timeout that interrupts long-running statements after a deadline. Supports a connection-level default (set_query_timeout) and per-statement overrides via the JS bindings. The VM checks the monotonic clock in its execution loops and transitions to Interrupting state when the deadline is exceeded.

This adds the functionality that was recently added to libSQL: https://github.com/tursodatabase/libsql-js/pull/209