### PR TITLE
Add COMMENT ON support for database objects

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1364,6 +1364,134 @@ impl Limbo {
         Ok(guard)
     }
 
+    /// Get comments for a database object using PRAGMA comment_list.
+    /// Returns a map of sub_name -> description (None key = comment on the object itself).
+    fn get_object_comments(
+        &mut self,
+        obj_name: &str,
+    ) -> std::collections::HashMap<Option<String>, String> {
+        let mut comments = std::collections::HashMap::new();
+        let sql = format!("PRAGMA comment_list('{obj_name}')");
+        let handler = |row: &turso_core::Row| {
+            // Columns: object_type, object_name, sub_name, description
+            let sub_name = match row.get::<&Value>(2) {
+                Ok(Value::Text(s)) if !s.as_str().is_empty() => Some(s.as_str().to_string()),
+                _ => None,
+            };
+            if let Ok(Value::Text(desc)) = row.get::<&Value>(3) {
+                comments.insert(sub_name, desc.as_str().to_string());
+            }
+            Ok(())
+        };
+        let _ = self.handle_row(&sql, handler);
+        comments
+    }
+
+    /// Format a CREATE TABLE statement as multi-line with one column per line.
+    fn format_create_table_multiline(sql: &str) -> String {
+        // Find the opening paren after CREATE TABLE <name>
+        let Some(open_paren) = sql.find('(') else {
+            return sql.to_string();
+        };
+        let prefix = &sql[..=open_paren]; // "CREATE TABLE name("
+        let rest = &sql[open_paren + 1..];
+
+        // Find the matching closing paren (skip quoted strings)
+        let mut depth = 0;
+        let mut close_pos = None;
+        let mut in_quote = false;
+        let rest_bytes = rest.as_bytes();
+        let mut i = 0;
+        while i < rest_bytes.len() {
+            let ch = rest_bytes[i];
+            if in_quote {
+                if ch == b'\'' {
+                    // Check for escaped quote ('')
+                    if i + 1 < rest_bytes.len() && rest_bytes[i + 1] == b'\'' {
+                        i += 2;
+                        continue;
+                    }
+                    in_quote = false;
+                }
+            } else {
+                match ch {
+                    b'\'' => in_quote = true,
+                    b'(' => depth += 1,
+                    b')' => {
+                        if depth == 0 {
+                            close_pos = Some(i);
+                            break;
+                        }
+                        depth -= 1;
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+        }
+        let Some(close_pos) = close_pos else {
+            return sql.to_string();
+        };
+
+        let inner = &rest[..close_pos];
+        let suffix = &rest[close_pos..]; // includes ")" and anything after
+
+        // Split at depth-0 commas (skip quoted strings and parenthesized expressions)
+        let mut columns = Vec::new();
+        let mut current = String::new();
+        let mut depth = 0;
+        let mut in_quote = false;
+        for ch in inner.chars() {
+            if in_quote {
+                current.push(ch);
+                if ch == '\'' {
+                    // Peek: if next char is also a quote, it's an escape
+                    // We handle this by toggling in_quote off now; the next
+                    // iteration will see the second quote and toggle it back on.
+                    in_quote = false;
+                }
+                continue;
+            }
+            match ch {
+                '\'' => {
+                    in_quote = true;
+                    current.push(ch);
+                }
+                '(' => {
+                    depth += 1;
+                    current.push(ch);
+                }
+                ')' => {
+                    depth -= 1;
+                    current.push(ch);
+                }
+                ',' if depth == 0 => {
+                    columns.push(current.trim().to_string());
+                    current = String::new();
+                }
+                _ => current.push(ch),
+            }
+        }
+        if !current.trim().is_empty() {
+            columns.push(current.trim().to_string());
+        }
+
+        if columns.len() <= 1 {
+            return sql.to_string();
+        }
+
+        let mut result = format!("{prefix}\n");
+        for (i, col) in columns.iter().enumerate() {
+            if i < columns.len() - 1 {
+                result.push_str(&format!("  {col},\n"));
+            } else {
+                result.push_str(&format!("  {col}\n"));
+            }
+        }
+        result.push_str(suffix.trim_start());
+        result
+    }
+
     fn print_schema_entry(&mut self, db_display_name: &str, row: &turso_core::Row) -> bool {
         if let (Ok(Value::Text(schema)), Ok(Value::Text(obj_type)), Ok(Value::Text(obj_name))) = (
             row.get::<&Value>(0),
@@ -1373,12 +1501,8 @@ impl Limbo {
             let modified_schema = if db_display_name == "main" {
                 schema.as_str().to_string()
             } else {
-                // We need to modify the SQL to include the database prefix in table names
-                // This is a simple approach - for CREATE TABLE statements, insert db name after "TABLE "
-                // For CREATE INDEX statements, insert db name after "ON "
                 let schema_str = schema.as_str();
                 if schema_str.to_uppercase().contains("CREATE TABLE ") {
-                    // Find "CREATE TABLE " and insert database name after it
                     if let Some(pos) = schema_str.to_uppercase().find("CREATE TABLE ") {
                         let before = &schema_str[..pos + "CREATE TABLE ".len()];
                         let after = &schema_str[pos + "CREATE TABLE ".len()..];
@@ -1387,7 +1511,6 @@ impl Limbo {
                         schema_str.to_string()
                     }
                 } else if schema_str.to_uppercase().contains(" ON ") {
-                    // For indexes, find " ON " and insert database name after it
                     if let Some(pos) = schema_str.to_uppercase().find(" ON ") {
                         let before = &schema_str[..pos + " ON ".len()];
                         let after = &schema_str[pos + " ON ".len()..];
@@ -1399,17 +1522,98 @@ impl Limbo {
                     schema_str.to_string()
                 }
             };
-            let _ = self.writeln_fmt(format_args!("{modified_schema};"));
-            // For views, add the column comment like SQLite does
-            if obj_type.as_str() == "view" {
-                let columns = self
-                    .get_view_columns(obj_name.as_str())
-                    .unwrap_or_else(|_| "x".to_string());
-                let _ = self.writeln_fmt(format_args!("/* {}({}) */", obj_name.as_str(), columns));
+
+            let obj_type_str = obj_type.as_str();
+            let obj_name_str = obj_name.as_str();
+            let comments = self.get_object_comments(obj_name_str);
+
+            if obj_type_str == "table" && !comments.is_empty() {
+                // Format as multi-line and inject comments
+                let multiline = Self::format_create_table_multiline(&modified_schema);
+                if let Some(table_comment) = comments.get(&None) {
+                    let _ = self.writeln_fmt(format_args!("-- {table_comment}"));
+                }
+                if comments.iter().any(|(k, _)| k.is_some()) {
+                    // Inject column comments into the multi-line output
+                    let mut output = String::new();
+                    for line in multiline.lines() {
+                        let trimmed = line.trim();
+                        // Try to find which column this line belongs to
+                        if let Some(col_name) = Self::extract_column_name(trimmed) {
+                            if let Some(comment) = comments.get(&Some(col_name)) {
+                                output.push_str(&format!("{line} -- {comment}\n"));
+                                continue;
+                            }
+                        }
+                        output.push_str(line);
+                        output.push('\n');
+                    }
+                    let _ = self.write(format!("{};", output.trim_end()));
+                    let _ = self.writeln("");
+                } else {
+                    let _ = self.writeln_fmt(format_args!("{multiline};"));
+                }
+            } else if obj_type_str == "table" {
+                let _ = self.writeln_fmt(format_args!("{modified_schema};"));
+            } else {
+                // For non-table objects, just add a comment line before if present
+                if let Some(obj_comment) = comments.get(&None) {
+                    let _ = self.writeln_fmt(format_args!("-- {obj_comment}"));
+                }
+                let _ = self.writeln_fmt(format_args!("{modified_schema};"));
+                if obj_type_str == "view" {
+                    let columns = self
+                        .get_view_columns(obj_name_str)
+                        .unwrap_or_else(|_| "x".to_string());
+                    let _ = self.writeln_fmt(format_args!("/* {obj_name_str}({columns}) */"));
+                }
             }
             true
         } else {
             false
+        }
+    }
+
+    /// Extract the column name from a CREATE TABLE column definition line.
+    fn extract_column_name(line: &str) -> Option<String> {
+        let trimmed = line.trim().trim_end_matches(',');
+        if trimmed.is_empty() || trimmed.starts_with(')') || trimmed.starts_with('(') {
+            return None;
+        }
+        // Skip constraint definitions
+        let upper = trimmed.to_uppercase();
+        if upper.starts_with("PRIMARY KEY")
+            || upper.starts_with("UNIQUE")
+            || upper.starts_with("CHECK")
+            || upper.starts_with("FOREIGN KEY")
+            || upper.starts_with("CONSTRAINT")
+        {
+            return None;
+        }
+        // The column name is the first token, possibly quoted
+        let bytes = trimmed.as_bytes();
+        if bytes[0] == b'"' {
+            // Quoted identifier
+            if let Some(end) = trimmed[1..].find('"') {
+                return Some(trimmed[1..=end].to_string());
+            }
+        } else if bytes[0] == b'[' {
+            if let Some(end) = trimmed.find(']') {
+                return Some(trimmed[1..end].to_string());
+            }
+        } else if bytes[0] == b'`' {
+            if let Some(end) = trimmed[1..].find('`') {
+                return Some(trimmed[1..=end].to_string());
+            }
+        }
+        // Unquoted: first word
+        let end = trimmed
+            .find(|c: char| c.is_whitespace() || c == ',' || c == ')')
+            .unwrap_or(trimmed.len());
+        if end > 0 {
+            Some(trimmed[..end].to_string())
+        } else {
+            None
         }
     }
 
@@ -1784,8 +1988,11 @@ impl Limbo {
         if let Some(mut rows) = conn.query(q_tables)? {
             rows.run_with_row_callback(|row| {
                 let name: &str = row.get::<&str>(0)?;
-                // Skip sqlite_sequence and internal types metadata table
-                if name == "sqlite_sequence" || name == turso_core::schema::TURSO_TYPES_TABLE_NAME {
+                // Skip sqlite_sequence and internal metadata tables
+                if name == "sqlite_sequence"
+                    || name == turso_core::schema::TURSO_TYPES_TABLE_NAME
+                    || name == turso_core::schema::TURSO_COMMENTS_TABLE_NAME
+                {
                     return Ok(());
                 }
                 let ddl: &str = row.get::<&str>(1)?;
@@ -1797,6 +2004,7 @@ impl Limbo {
         }
         Self::dump_sqlite_sequence(&conn, out)?;
         Self::dump_schema_objects(&conn, out, &mut progress)?;
+        Self::dump_comments(&conn, out)?;
         Self::exec_all_conn(&conn, "COMMIT")?;
         writeln!(out, "COMMIT;")?;
         Ok(())
@@ -1883,6 +2091,55 @@ impl Limbo {
             rows.run_with_row_callback(|row| {
                 let sql: &str = row.get::<&str>(0)?;
                 writeln!(out, "{sql};").map_err(|e| io_error(e, "write"))?;
+                Ok(())
+            })?;
+        }
+        Ok(())
+    }
+
+    fn dump_comments<W: Write>(conn: &Arc<Connection>, out: &mut W) -> anyhow::Result<()> {
+        let check = format!(
+            "SELECT 1 FROM sqlite_schema WHERE name='{}' AND type='table'",
+            turso_core::schema::TURSO_COMMENTS_TABLE_NAME
+        );
+        let mut has_comments = false;
+        if let Some(mut rows) = conn.query(&check)? {
+            rows.run_with_row_callback(|_| {
+                has_comments = true;
+                Ok(())
+            })?;
+        }
+        if !has_comments {
+            return Ok(());
+        }
+        let q = format!(
+            "SELECT object_type, object_name, sub_name, description FROM {} ORDER BY rowid",
+            turso_core::schema::TURSO_COMMENTS_TABLE_NAME
+        );
+        if let Some(mut rows) = conn.query(&q)? {
+            rows.run_with_row_callback(|row| {
+                let obj_type: &str = row.get::<&str>(0)?;
+                let obj_name: &str = row.get::<&str>(1)?;
+                let sub_name: &str = row.get::<&str>(2)?;
+                let description: &str = row.get::<&str>(3)?;
+                let quoted_desc = sql_quote_string(description);
+                match obj_type {
+                    "column" => {
+                        writeln!(
+                            out,
+                            "COMMENT ON COLUMN {obj_name}.{sub_name} IS {quoted_desc};"
+                        )
+                        .map_err(|e| io_error(e, "write"))?;
+                    }
+                    _ => {
+                        let type_keyword = obj_type.to_uppercase();
+                        writeln!(
+                            out,
+                            "COMMENT ON {type_keyword} {obj_name} IS {quoted_desc};"
+                        )
+                        .map_err(|e| io_error(e, "write"))?;
+                    }
+                }
                 Ok(())
             })?;
         }

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -196,6 +196,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::Result0,
             &["type", "parent", "encode", "decode", "default", "operators"],
         ),
+        CommentList => Pragma::new(
+            PragmaFlags::NeedSchema | PragmaFlags::Result0 | PragmaFlags::Result1,
+            &["object_type", "object_name", "sub_name", "description"],
+        ),
     }
 }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -155,6 +155,7 @@ const SCHEMA_TABLE_NAME: &str = "sqlite_schema";
 const SCHEMA_TABLE_NAME_ALT: &str = "sqlite_master";
 pub const SQLITE_SEQUENCE_TABLE_NAME: &str = "sqlite_sequence";
 pub const TURSO_TYPES_TABLE_NAME: &str = "__turso_internal_types";
+pub const TURSO_COMMENTS_TABLE_NAME: &str = "__turso_internal_comments";
 pub const DBSP_TABLE_PREFIX: &str = "__turso_internal_dbsp_state_v";
 pub const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -153,6 +153,7 @@ pub fn translate_inner(
             | ast::Stmt::DropType { .. }
             | ast::Stmt::DropView { .. }
             | ast::Stmt::Reindex { .. }
+            | ast::Stmt::CommentOn { .. }
             | ast::Stmt::Optimize { .. }
             | ast::Stmt::Update { .. }
             | ast::Stmt::Insert { .. }
@@ -316,6 +317,19 @@ pub fn translate_inner(
             }
             schema::translate_drop_type(&type_name, if_exists, resolver, program)?
         }
+        ast::Stmt::CommentOn {
+            object_type,
+            object_name,
+            column_name,
+            comment,
+        } => schema::translate_comment_on(
+            &object_type,
+            &object_name,
+            column_name.as_ref(),
+            comment.as_deref(),
+            resolver,
+            program,
+        )?,
         ast::Stmt::Pragma { .. } => {
             bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")
         }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -14,6 +14,7 @@ use super::integrity_check::{
 use crate::function::Func;
 use crate::pragma::pragma_for;
 use crate::schema::Schema;
+use crate::schema::TURSO_COMMENTS_TABLE_NAME;
 use crate::storage::encryption::{CipherMode, EncryptionKey};
 use crate::storage::pager::AutoVacuumMode;
 use crate::storage::pager::Pager;
@@ -21,8 +22,8 @@ use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
 use crate::translate::emitter::{Resolver, TransactionMode};
 use crate::util::{normalize_ident, parse_signed_number, parse_string, IOExt as _};
-use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
-use crate::vdbe::insn::{Cookie, Insn};
+use crate::vdbe::builder::{CursorType, ProgramBuilder, ProgramBuilderOpts};
+use crate::vdbe::insn::{CmpInsFlags, Cookie, Insn};
 use crate::{bail_parse_error, CaptureDataChangesInfo, LimboError, Numeric, Value};
 use std::str::FromStr;
 use strum::IntoEnumIterator;
@@ -93,7 +94,8 @@ pub fn translate_pragma(
             | PragmaName::TableXinfo
             | PragmaName::IntegrityCheck
             | PragmaName::DatabaseList
-            | PragmaName::QuickCheck => query_pragma(
+            | PragmaName::QuickCheck
+            | PragmaName::CommentList => query_pragma(
                 pragma,
                 resolver,
                 Some(*value),
@@ -511,6 +513,7 @@ fn update_pragma(
             Ok(TransactionMode::None)
         }
         PragmaName::ListTypes => bail_parse_error!("list_types cannot be set"),
+        PragmaName::CommentList => bail_parse_error!("comment_list cannot be set"),
         PragmaName::TempStore => {
             use crate::TempStore;
             // Try to parse as a string first (default, file, memory)
@@ -1332,6 +1335,86 @@ fn query_pragma(
                 program.add_pragma_result_column(col_name.to_string());
             }
             Ok(TransactionMode::None)
+        }
+        PragmaName::CommentList => {
+            let filter_name = match value {
+                Some(ast::Expr::Name(name)) => Some(normalize_ident(name.as_str())),
+                _ => None,
+            };
+
+            // If the comments table doesn't exist, return zero rows
+            let comments_table = if let Some(t) = schema.get_btree_table(TURSO_COMMENTS_TABLE_NAME)
+            {
+                t
+            } else {
+                let pragma_meta = pragma_for(&pragma);
+                for col_name in pragma_meta.columns.iter() {
+                    program.add_pragma_result_column(col_name.to_string());
+                }
+                return Ok(TransactionMode::Read);
+            };
+
+            let opts = ProgramBuilderOpts {
+                num_cursors: 1,
+                approx_num_insns: 20,
+                approx_num_labels: 3,
+            };
+            program.extend(&opts);
+
+            let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(comments_table.clone()));
+            program.emit_insn(Insn::OpenRead {
+                cursor_id,
+                root_page: comments_table.root_page,
+                db: 0,
+            });
+
+            let end_label = program.allocate_label();
+            let loop_label = program.allocate_label();
+
+            program.emit_insn(Insn::Rewind {
+                cursor_id,
+                pc_if_empty: end_label,
+            });
+            program.preassign_label_to_next_insn(loop_label);
+
+            let base_reg = register;
+            program.alloc_registers(3); // 4 total (1 already allocated)
+
+            // Read all 4 columns: object_type, object_name, sub_name, description
+            program.emit_column_or_rowid(cursor_id, 0, base_reg);
+            program.emit_column_or_rowid(cursor_id, 1, base_reg + 1);
+            program.emit_column_or_rowid(cursor_id, 2, base_reg + 2);
+            program.emit_column_or_rowid(cursor_id, 3, base_reg + 3);
+
+            if let Some(ref name) = filter_name {
+                // Filter: skip rows where object_name != filter_name
+                let skip_label = program.allocate_label();
+                let filter_reg = program.alloc_register();
+                program.emit_string8(name.clone(), filter_reg);
+                program.emit_insn(Insn::Ne {
+                    lhs: base_reg + 1,
+                    rhs: filter_reg,
+                    target_pc: skip_label,
+                    flags: CmpInsFlags::default(),
+                    collation: program.curr_collation(),
+                });
+                program.emit_result_row(base_reg, 4);
+                program.resolve_label(skip_label, program.offset());
+            } else {
+                program.emit_result_row(base_reg, 4);
+            }
+
+            program.emit_insn(Insn::Next {
+                cursor_id,
+                pc_if_next: loop_label,
+            });
+            program.preassign_label_to_next_insn(end_label);
+
+            let pragma_meta = pragma_for(&pragma);
+            for col_name in pragma_meta.columns.iter() {
+                program.add_pragma_result_column(col_name.to_string());
+            }
+            Ok(TransactionMode::Read)
         }
     }
 }

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -4,7 +4,8 @@ use crate::ext::VTabImpl;
 use crate::function::{Deterministic, Func, MathFunc, ScalarFunc};
 use crate::schema::{
     create_table, translate_ident_to_string_literal, BTreeTable, ColDef, Column, SchemaObjectType,
-    Table, Type, RESERVED_TABLE_PREFIXES, SQLITE_SEQUENCE_TABLE_NAME, TURSO_TYPES_TABLE_NAME,
+    Table, Type, RESERVED_TABLE_PREFIXES, SQLITE_SEQUENCE_TABLE_NAME, TURSO_COMMENTS_TABLE_NAME,
+    TURSO_TYPES_TABLE_NAME,
 };
 use crate::stats::STATS_TABLE;
 use crate::storage::pager::CreateBTreeFlags;
@@ -2246,6 +2247,246 @@ pub fn translate_drop_type(
         value: (resolver.schema().schema_version + 1) as i32,
         p5: 0,
     });
+
+    Ok(())
+}
+
+pub fn translate_comment_on(
+    object_type: &ast::CommentObjectType,
+    object_name: &ast::QualifiedName,
+    column_name: Option<&ast::Name>,
+    comment: Option<&str>,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+) -> Result<()> {
+    let obj_name = normalize_ident(object_name.name.as_str());
+
+    // Determine the object_type string and validate the target exists
+    let type_str = match object_type {
+        ast::CommentObjectType::Table => {
+            if resolver.schema().get_btree_table(&obj_name).is_none() {
+                bail_parse_error!("no such table: {obj_name}");
+            }
+            "table"
+        }
+        ast::CommentObjectType::Column => {
+            let col_name = column_name.expect("column_name required for COMMENT ON COLUMN");
+            let col_name_str = normalize_ident(col_name.as_str());
+            let table = resolver
+                .schema()
+                .get_btree_table(&obj_name)
+                .ok_or_else(|| {
+                    crate::LimboError::ParseError(format!("no such table: {obj_name}"))
+                })?;
+            if !table
+                .columns
+                .iter()
+                .any(|c| c.name.as_deref() == Some(&col_name_str))
+            {
+                bail_parse_error!("no such column: {obj_name}.{col_name_str}");
+            }
+            "column"
+        }
+        ast::CommentObjectType::Index => {
+            let found = resolver.schema().indexes.values().any(|idxs| {
+                idxs.iter()
+                    .any(|idx| normalize_ident(&idx.name) == obj_name)
+            });
+            if !found {
+                bail_parse_error!("no such index: {obj_name}");
+            }
+            "index"
+        }
+        ast::CommentObjectType::View => {
+            if resolver.schema().get_view(&obj_name).is_none() {
+                bail_parse_error!("no such view: {obj_name}");
+            }
+            "view"
+        }
+        ast::CommentObjectType::Type => {
+            if resolver
+                .schema()
+                .get_type_def_unchecked(&obj_name)
+                .is_none()
+            {
+                bail_parse_error!("no such type: {obj_name}");
+            }
+            "type"
+        }
+    };
+
+    let sub_name = column_name
+        .map(|n| normalize_ident(n.as_str()))
+        .unwrap_or_default();
+
+    // Ensure __turso_internal_comments table exists (lazy creation)
+    let comments_table: Arc<BTreeTable>;
+    let comments_root_page: RegisterOrLiteral<i64>;
+
+    let need_schema_bump;
+    if let Some(existing) = resolver.schema().get_btree_table(TURSO_COMMENTS_TABLE_NAME) {
+        comments_table = existing.clone();
+        comments_root_page = RegisterOrLiteral::Literal(existing.root_page);
+        need_schema_bump = false;
+    } else {
+        let table_root_reg = program.alloc_register();
+        program.emit_insn(Insn::CreateBtree {
+            db: 0,
+            root: table_root_reg,
+            flags: CreateBTreeFlags::new_table(),
+        });
+        let create_sql = format!(
+            "CREATE TABLE {TURSO_COMMENTS_TABLE_NAME}(object_type TEXT, object_name TEXT, sub_name TEXT, description TEXT)"
+        );
+        comments_table = Arc::new(BTreeTable::from_sql(&create_sql, 0)?);
+        comments_root_page = RegisterOrLiteral::Register(table_root_reg);
+
+        let schema_table = resolver.schema().get_btree_table(SQLITE_TABLEID).unwrap();
+        let schema_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(schema_table));
+        program.emit_insn(Insn::OpenWrite {
+            cursor_id: schema_cursor_id,
+            root_page: 1i64.into(),
+            db: 0,
+        });
+        emit_schema_entry(
+            program,
+            resolver,
+            schema_cursor_id,
+            None,
+            SchemaEntryType::Table,
+            TURSO_COMMENTS_TABLE_NAME,
+            TURSO_COMMENTS_TABLE_NAME,
+            table_root_reg,
+            Some(create_sql),
+        )?;
+
+        program.emit_insn(Insn::ParseSchema {
+            db: schema_cursor_id,
+            where_clause: Some(format!(
+                "tbl_name = '{TURSO_COMMENTS_TABLE_NAME}' AND type != 'trigger'"
+            )),
+        });
+        need_schema_bump = true;
+    }
+
+    // Open comments table for writing
+    let comments_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(comments_table));
+    program.emit_insn(Insn::OpenWrite {
+        cursor_id: comments_cursor_id,
+        root_page: comments_root_page,
+        db: 0,
+    });
+
+    // Scan and delete any existing row matching (object_type, object_name, sub_name)
+    let type_match_reg = program.alloc_register();
+    program.emit_insn(Insn::String8 {
+        dest: type_match_reg,
+        value: type_str.to_string(),
+    });
+    let name_match_reg = program.alloc_register();
+    program.emit_insn(Insn::String8 {
+        dest: name_match_reg,
+        value: obj_name.clone(),
+    });
+    let sub_match_reg = program.alloc_register();
+    program.emit_insn(Insn::String8 {
+        dest: sub_match_reg,
+        value: sub_name.clone(),
+    });
+
+    let end_scan_label = program.allocate_label();
+    let scan_start_label = program.allocate_label();
+
+    program.emit_insn(Insn::Rewind {
+        cursor_id: comments_cursor_id,
+        pc_if_empty: end_scan_label,
+    });
+    program.preassign_label_to_next_insn(scan_start_label);
+
+    // Read columns and compare
+    let col0_reg = program.alloc_register();
+    let col1_reg = program.alloc_register();
+    let col2_reg = program.alloc_register();
+    program.emit_column_or_rowid(comments_cursor_id, 0, col0_reg);
+    program.emit_column_or_rowid(comments_cursor_id, 1, col1_reg);
+    program.emit_column_or_rowid(comments_cursor_id, 2, col2_reg);
+
+    let skip_delete_label = program.allocate_label();
+
+    program.emit_insn(Insn::Ne {
+        lhs: col0_reg,
+        rhs: type_match_reg,
+        target_pc: skip_delete_label,
+        flags: CmpInsFlags::default(),
+        collation: program.curr_collation(),
+    });
+    program.emit_insn(Insn::Ne {
+        lhs: col1_reg,
+        rhs: name_match_reg,
+        target_pc: skip_delete_label,
+        flags: CmpInsFlags::default(),
+        collation: program.curr_collation(),
+    });
+    program.emit_insn(Insn::Ne {
+        lhs: col2_reg,
+        rhs: sub_match_reg,
+        target_pc: skip_delete_label,
+        flags: CmpInsFlags::default(),
+        collation: program.curr_collation(),
+    });
+
+    program.emit_insn(Insn::Delete {
+        cursor_id: comments_cursor_id,
+        table_name: TURSO_COMMENTS_TABLE_NAME.to_string(),
+        is_part_of_update: false,
+    });
+
+    program.resolve_label(skip_delete_label, program.offset());
+
+    program.emit_insn(Insn::Next {
+        cursor_id: comments_cursor_id,
+        pc_if_next: scan_start_label,
+    });
+
+    program.preassign_label_to_next_insn(end_scan_label);
+
+    // If comment is not NULL, insert a new row
+    if let Some(text) = comment {
+        let rowid_reg = program.alloc_register();
+        program.emit_insn(Insn::NewRowid {
+            cursor: comments_cursor_id,
+            rowid_reg,
+            prev_largest_reg: 0,
+        });
+        let start_reg = program.emit_string8_new_reg(type_str.to_string());
+        program.emit_string8_new_reg(obj_name);
+        program.emit_string8_new_reg(sub_name);
+        program.emit_string8_new_reg(text.to_string());
+        let record_reg = program.alloc_register();
+        program.emit_insn(Insn::MakeRecord {
+            start_reg: to_u16(start_reg),
+            count: to_u16(4),
+            dest_reg: to_u16(record_reg),
+            index_name: None,
+            affinity_str: None,
+        });
+        program.emit_insn(Insn::Insert {
+            cursor: comments_cursor_id,
+            key_reg: rowid_reg,
+            record_reg,
+            flag: InsertFlags::new(),
+            table_name: TURSO_COMMENTS_TABLE_NAME.to_string(),
+        });
+    }
+
+    if need_schema_bump {
+        program.emit_insn(Insn::SetCookie {
+            db: 0,
+            cookie: Cookie::SchemaVersion,
+            value: (resolver.schema().schema_version + 1) as i32,
+            p5: 0,
+        });
+    }
 
     Ok(())
 }

--- a/docs/sql-reference/cli/shell-commands.mdx
+++ b/docs/sql-reference/cli/shell-commands.mdx
@@ -86,7 +86,7 @@ employees
 
 ### .schema
 
-Display the CREATE statement for a table, or all tables if no argument is given.
+Display the CREATE statement for a table, or all tables if no argument is given. CREATE TABLE statements are formatted with one column per line. If comments have been set with [COMMENT ON](/docs/sql-reference/statements/comment-on), they are shown inline using SQL `--` comment syntax.
 
 ```
 .schema [TABLE]
@@ -94,11 +94,36 @@ Display the CREATE statement for a table, or all tables if no argument is given.
 
 ```
 tursodb> .schema employees
-CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
+CREATE TABLE employees (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
 
 tursodb> .schema
-CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
-CREATE TABLE departments (id INTEGER PRIMARY KEY, name TEXT);
+CREATE TABLE employees (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+CREATE TABLE departments (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+```
+
+With comments:
+
+```sql
+COMMENT ON TABLE employees IS 'Company staff';
+COMMENT ON COLUMN employees.name IS 'Full legal name';
+```
+
+```
+tursodb> .schema employees
+-- Company staff
+CREATE TABLE employees (
+  id INTEGER PRIMARY KEY,
+  name TEXT -- Full legal name
+);
 ```
 
 ### .indexes
@@ -336,7 +361,7 @@ syscall
 
 ### .dump
 
-Output the entire database as SQL statements that can recreate it.
+Output the entire database as SQL statements that can recreate it. If [comments](/docs/sql-reference/statements/comment-on) have been set, they are exported as `COMMENT ON` statements.
 
 ```
 tursodb> .dump
@@ -345,6 +370,8 @@ BEGIN TRANSACTION;
 CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT);
 INSERT INTO "employees" VALUES(1,'Alice');
 INSERT INTO "employees" VALUES(2,'Bob');
+COMMENT ON TABLE employees IS 'Company staff';
+COMMENT ON COLUMN employees.name IS 'Full legal name';
 COMMIT;
 ```
 

--- a/docs/sql-reference/pragmas.mdx
+++ b/docs/sql-reference/pragmas.mdx
@@ -186,6 +186,36 @@ Similar to `index_info` but includes additional columns.
 PRAGMA index_xinfo(index-name);
 ```
 
+### comment_list
+
+<Info>
+**Turso Extension**: This pragma is a Turso-specific feature.
+</Info>
+
+Lists comments attached to database objects via `COMMENT ON`. With no argument, returns all comments. With an argument, returns comments for the named object (the object itself and its columns, if it is a table).
+
+```sql
+PRAGMA comment_list;
+-- object_type | object_name | sub_name | description
+-- table       | users       |          | Core user accounts
+-- column      | users       | name     | Full display name
+-- index       | idx_email   |          | Email lookup
+
+PRAGMA comment_list(users);
+-- object_type | object_name | sub_name | description
+-- table       | users       |          | Core user accounts
+-- column      | users       | name     | Full display name
+```
+
+| Column | Type | Description |
+|--------|------|-------------|
+| object_type | TEXT | Type of object: `table`, `column`, `index`, `view`, or `type` |
+| object_name | TEXT | Name of the object (for columns, the parent table name) |
+| sub_name | TEXT | Column name (empty for non-column objects) |
+| description | TEXT | The comment text |
+
+Returns no rows if no comments have been set. See [COMMENT ON](/docs/sql-reference/statements/comment-on) for setting comments.
+
 ### function_list
 
 Returns one row for each SQL function available.
@@ -507,4 +537,5 @@ See [CREATE TYPE](/docs/sql-reference/statements/create-type) for creating custo
 
 - [Transactions](/docs/sql-reference/statements/transactions) for transaction control
 - [CREATE TYPE](/docs/sql-reference/statements/create-type) for custom type definitions
+- [COMMENT ON](/docs/sql-reference/statements/comment-on) for attaching comments to database objects
 - [Compatibility](/docs/sql-reference/compatibility) for the full list of supported PRAGMAs

--- a/docs/sql-reference/statements/comment-on.mdx
+++ b/docs/sql-reference/statements/comment-on.mdx
@@ -1,0 +1,165 @@
+---
+title: COMMENT ON
+description: Attach descriptive comments to tables, columns, indexes, views, and types
+sidebarTitle: COMMENT ON
+---
+
+# COMMENT ON
+
+<Info>
+**Turso Extension**: COMMENT ON is a Turso-specific statement not available in standard SQLite.
+</Info>
+
+The COMMENT ON statement attaches a human-readable description to a database object. Comments are stored in an internal metadata table and can be viewed with `PRAGMA comment_list` or inline in `.schema` output.
+
+## Syntax
+
+```sql
+COMMENT ON TABLE table-name IS 'description';
+COMMENT ON COLUMN table-name.column-name IS 'description';
+COMMENT ON INDEX index-name IS 'description';
+COMMENT ON VIEW view-name IS 'description';
+COMMENT ON TYPE type-name IS 'description';
+
+-- Remove a comment
+COMMENT ON TABLE table-name IS NULL;
+```
+
+## Description
+
+Comments provide documentation for database objects directly within the database itself. They are useful for:
+
+- Documenting the purpose of tables, columns, and indexes
+- Providing context for other developers working with the schema
+- Self-documenting database designs that travel with the data
+
+Comments are stored in an internal table (`__turso_internal_comments`) that is created lazily on first use. This table is hidden from `.schema` and `.tables` output but is included in `.dump` as `COMMENT ON` statements, so comments survive backup and restore cycles.
+
+### Supported Object Types
+
+| Object Type | Syntax | Description |
+|-------------|--------|-------------|
+| Table | `COMMENT ON TABLE name IS ...` | Comment on a table |
+| Column | `COMMENT ON COLUMN table.column IS ...` | Comment on a specific column within a table |
+| Index | `COMMENT ON INDEX name IS ...` | Comment on an index |
+| View | `COMMENT ON VIEW name IS ...` | Comment on a view |
+| Type | `COMMENT ON TYPE name IS ...` | Comment on a custom type |
+
+### Updating and Removing Comments
+
+Setting a new comment on an object that already has one replaces the existing comment. Setting the comment to `NULL` removes it entirely.
+
+```sql
+-- Set a comment
+COMMENT ON TABLE users IS 'Original description';
+
+-- Replace it
+COMMENT ON TABLE users IS 'Updated description';
+
+-- Remove it
+COMMENT ON TABLE users IS NULL;
+```
+
+### Validation
+
+The target object must exist when the comment is created. Attempting to comment on a nonexistent table, column, index, view, or type produces a parse error.
+
+```sql
+COMMENT ON TABLE nonexistent IS 'fails';
+-- Error: no such table: nonexistent
+
+COMMENT ON COLUMN users.nonexistent IS 'fails';
+-- Error: no such column: users.nonexistent
+```
+
+## Viewing Comments
+
+### PRAGMA comment_list
+
+Lists all comments, or comments filtered by object name. See [PRAGMAs](/docs/sql-reference/pragmas#comment_list) for details.
+
+```sql
+PRAGMA comment_list;
+PRAGMA comment_list(users);
+```
+
+### .schema
+
+The `.schema` shell command displays comments inline using SQL `--` comment syntax:
+
+```
+tursodb> .schema
+-- Main user table
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT, -- Full display name
+  email TEXT
+);
+-- Fast email lookups
+CREATE INDEX idx_email ON users (email);
+```
+
+### .dump
+
+The `.dump` command exports comments as `COMMENT ON` statements, ensuring they can be restored into a new database:
+
+```
+tursodb> .dump
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT);
+CREATE INDEX idx_email ON users (email);
+COMMENT ON TABLE users IS 'Main user table';
+COMMENT ON COLUMN users.name IS 'Full display name';
+COMMENT ON INDEX idx_email IS 'Fast email lookups';
+COMMIT;
+```
+
+## Examples
+
+### Documenting a Schema
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_users_email ON users(email);
+
+COMMENT ON TABLE users IS 'Core user accounts';
+COMMENT ON COLUMN users.name IS 'Full display name';
+COMMENT ON COLUMN users.email IS 'Primary email, used for login';
+COMMENT ON COLUMN users.created_at IS 'Account creation timestamp (UTC)';
+COMMENT ON INDEX idx_users_email IS 'Unique email lookup for authentication';
+```
+
+### Viewing All Comments
+
+```sql
+PRAGMA comment_list;
+-- object_type | object_name     | sub_name   | description
+-- table       | users           |            | Core user accounts
+-- column      | users           | name       | Full display name
+-- column      | users           | email      | Primary email, used for login
+-- column      | users           | created_at | Account creation timestamp (UTC)
+-- index       | idx_users_email |            | Unique email lookup for authentication
+```
+
+### Filtering Comments by Object
+
+```sql
+PRAGMA comment_list(users);
+-- object_type | object_name | sub_name   | description
+-- table       | users       |            | Core user accounts
+-- column      | users       | name       | Full display name
+-- column      | users       | email      | Primary email, used for login
+-- column      | users       | created_at | Account creation timestamp (UTC)
+```
+
+## See Also
+
+- [PRAGMAs](/docs/sql-reference/pragmas#comment_list) for the `comment_list` pragma
+- [CREATE TABLE](/docs/sql-reference/statements/create-table) for table definitions
+- [CREATE INDEX](/docs/sql-reference/statements/create-index) for index definitions

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -73,6 +73,17 @@ pub struct AlterTable {
     // `ALTER TABLE` body
     pub body: AlterTableBody,
 }
+/// Object type for COMMENT ON statement
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum CommentObjectType {
+    Table,
+    Column,
+    Index,
+    View,
+    Type,
+}
+
 /// SQL statement
 // https://sqlite.org/syntax/sql-stmt.html
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -107,6 +118,17 @@ pub enum Stmt {
         // tx name
         name: Option<Name>,
     }, // TODO distinction between COMMIT and END
+    /// `COMMENT ON`
+    CommentOn {
+        /// object type (TABLE, COLUMN, INDEX, VIEW, TYPE)
+        object_type: CommentObjectType,
+        /// object name
+        object_name: QualifiedName,
+        /// column name for COMMENT ON COLUMN table.column
+        column_name: Option<Name>,
+        /// comment text, None means IS NULL (drop comment)
+        comment: Option<String>,
+    },
     /// `CREATE INDEX`
     CreateIndex {
         /// `UNIQUE`
@@ -1724,6 +1746,8 @@ pub enum PragmaName {
     MvccCheckpointThreshold,
     /// List all available types (built-in and custom)
     ListTypes,
+    /// List comments on database objects
+    CommentList,
 }
 
 /// `CREATE TRIGGER` time

--- a/parser/src/ast/fmt.rs
+++ b/parser/src/ast/fmt.rs
@@ -290,6 +290,37 @@ impl ToTokens for Stmt {
                 }
                 Ok(())
             }
+            Self::CommentOn {
+                object_type,
+                object_name,
+                column_name,
+                comment,
+            } => {
+                s.append(TK_COMMENT, None)?;
+                s.append(TK_ON, None)?;
+                match object_type {
+                    super::CommentObjectType::Table => s.append(TK_TABLE, None)?,
+                    super::CommentObjectType::Column => s.append(TK_COLUMNKW, None)?,
+                    super::CommentObjectType::Index => s.append(TK_INDEX, None)?,
+                    super::CommentObjectType::View => s.append(TK_VIEW, None)?,
+                    super::CommentObjectType::Type => s.append(TK_TYPE, None)?,
+                };
+                object_name.to_tokens(s, context)?;
+                if let Some(col) = column_name {
+                    s.append(TK_DOT, None)?;
+                    col.to_tokens(s, context)?;
+                }
+                s.append(TK_IS, None)?;
+                match comment {
+                    Some(text) => {
+                        s.append(TK_STRING, Some(text))?;
+                    }
+                    None => {
+                        s.append(TK_NULL, None)?;
+                    }
+                }
+                Ok(())
+            }
             Self::CreateIndex {
                 unique,
                 if_not_exists,

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -33,6 +33,7 @@ fn keyword_or_id_token(input: &[u8]) -> TokenType {
         b"CHECK" => TokenType::TK_CHECK,
         b"COLLATE" => TokenType::TK_COLLATE,
         b"COLUMN" => TokenType::TK_COLUMNKW,
+        b"COMMENT" => TokenType::TK_COMMENT,
         b"COMMIT" => TokenType::TK_COMMIT,
         b"CONCURRENT" => TokenType::TK_CONCURRENT,
         b"CONFLICT" => TokenType::TK_CONFLICT,

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,15 +1,16 @@
 use crate::ast::{
     check::ColumnCount, AlterTable, AlterTableBody, As, Cmd, ColumnConstraint, ColumnDefinition,
-    CommonTableExpr, CompoundOperator, CompoundSelect, CreateTableBody, CreateTypeBody,
-    CreateVirtualTable, DeferSubclause, Distinctness, Expr, ForeignKeyClause, FrameBound,
-    FrameClause, FrameExclude, FrameMode, FromClause, FunctionTail, GeneratedColumnType, GroupBy,
-    Indexed, IndexedColumn, InitDeferredPred, InsertBody, JoinConstraint, JoinOperator, JoinType,
-    JoinedSelectTable, LikeOperator, Limit, Literal, Materialized, Name, NamedColumnConstraint,
-    NamedTableConstraint, NullsOrder, OneSelect, Operator, Over, PragmaBody, PragmaValue,
-    QualifiedName, RefAct, RefArg, ResolveType, ResultColumn, Select, SelectBody, SelectTable, Set,
-    SortOrder, SortedColumn, Stmt, TableConstraint, TableOptions, TransactionType, TriggerCmd,
-    TriggerEvent, TriggerTime, Type, TypeOperator, TypeParam, TypeSize, UnaryOperator, Update,
-    Upsert, UpsertDo, UpsertIndex, Variable, Window, WindowDef, With,
+    CommentObjectType, CommonTableExpr, CompoundOperator, CompoundSelect, CreateTableBody,
+    CreateTypeBody, CreateVirtualTable, DeferSubclause, Distinctness, Expr, ForeignKeyClause,
+    FrameBound, FrameClause, FrameExclude, FrameMode, FromClause, FunctionTail,
+    GeneratedColumnType, GroupBy, Indexed, IndexedColumn, InitDeferredPred, InsertBody,
+    JoinConstraint, JoinOperator, JoinType, JoinedSelectTable, LikeOperator, Limit, Literal,
+    Materialized, Name, NamedColumnConstraint, NamedTableConstraint, NullsOrder, OneSelect,
+    Operator, Over, PragmaBody, PragmaValue, QualifiedName, RefAct, RefArg, ResolveType,
+    ResultColumn, Select, SelectBody, SelectTable, Set, SortOrder, SortedColumn, Stmt,
+    TableConstraint, TableOptions, TransactionType, TriggerCmd, TriggerEvent, TriggerTime, Type,
+    TypeOperator, TypeParam, TypeSize, UnaryOperator, Update, Upsert, UpsertDo, UpsertIndex,
+    Variable, Window, WindowDef, With,
 };
 use crate::error::Error;
 use crate::lexer::{Lexer, Token};
@@ -641,7 +642,8 @@ impl<'a> Parser<'a> {
             TK_REPLACE,
             TK_UPDATE,
             TK_REINDEX,
-            TK_OPTIMIZE
+            TK_OPTIMIZE,
+            TK_COMMENT
         );
 
         match tok.token_type {
@@ -665,6 +667,7 @@ impl<'a> Parser<'a> {
             TK_UPDATE => self.parse_update(),
             TK_REINDEX => self.parse_reindex(),
             TK_OPTIMIZE => self.parse_optimize(),
+            TK_COMMENT => self.parse_comment_on(),
             _ => unreachable!(),
         }
     }
@@ -4634,6 +4637,94 @@ impl<'a> Parser<'a> {
             },
             _ => Ok(Stmt::Optimize { idx_name: None }),
         }
+    }
+
+    /// Parse `COMMENT ON TABLE|COLUMN|INDEX|VIEW|TYPE <name> IS <string|NULL>`
+    fn parse_comment_on(&mut self) -> Result<Stmt> {
+        eat_assert!(self, TK_COMMENT);
+        eat_expect!(self, TK_ON);
+
+        // COLUMN keyword is context-sensitive — after ON it becomes TK_ID.
+        // Match TABLE, INDEX, VIEW, TYPE as keywords, and COLUMN via TK_ID value.
+        let tok = peek_expect!(self, TK_TABLE, TK_ID, TK_INDEX, TK_VIEW, TK_TYPE);
+        let object_type = match tok.token_type {
+            TK_TABLE => {
+                eat_assert!(self, TK_TABLE);
+                CommentObjectType::Table
+            }
+            TK_ID => {
+                let tok = eat_assert!(self, TK_ID);
+                if tok.value.eq_ignore_ascii_case(b"COLUMN") {
+                    CommentObjectType::Column
+                } else {
+                    let token_text = tok.to_utf8();
+                    return Err(Error::ParseUnexpectedToken {
+                        parsed_offset: (self.offset(), token_text.len()).into(),
+                        expected: &[TK_TABLE, TK_COLUMNKW, TK_INDEX, TK_VIEW, TK_TYPE],
+                        got: TK_ID,
+                        token_text,
+                        offset: self.offset(),
+                        expected_display: "TABLE, COLUMN, INDEX, VIEW, or TYPE".to_string(),
+                    });
+                }
+            }
+            TK_INDEX => {
+                eat_assert!(self, TK_INDEX);
+                CommentObjectType::Index
+            }
+            TK_VIEW => {
+                eat_assert!(self, TK_VIEW);
+                CommentObjectType::View
+            }
+            TK_TYPE => {
+                eat_assert!(self, TK_TYPE);
+                CommentObjectType::Type
+            }
+            _ => unreachable!(),
+        };
+
+        // For COLUMN, parse table_name.column_name (dot is consumed by parse_fullname)
+        // For other types, parse the object name normally
+        let (object_name, column_name) = if matches!(object_type, CommentObjectType::Column) {
+            let tbl_name = self.parse_nm()?;
+            eat_expect!(self, TK_DOT);
+            let col_name = self.parse_nm()?;
+            (
+                QualifiedName {
+                    db_name: None,
+                    name: tbl_name,
+                    alias: None,
+                },
+                Some(col_name),
+            )
+        } else {
+            (self.parse_fullname(false)?, None)
+        };
+
+        eat_expect!(self, TK_IS);
+
+        // Parse string literal or NULL
+        let tok = peek_expect!(self, TK_STRING, TK_NULL);
+        let comment = match tok.token_type {
+            TK_STRING => {
+                let tok = eat_assert!(self, TK_STRING);
+                let s = tok.to_utf8();
+                // Strip surrounding quotes
+                Some(s[1..s.len() - 1].replace("''", "'"))
+            }
+            TK_NULL => {
+                eat_assert!(self, TK_NULL);
+                None
+            }
+            _ => unreachable!(),
+        };
+
+        Ok(Stmt::CommentOn {
+            object_type,
+            object_name,
+            column_name,
+            comment,
+        })
     }
 }
 

--- a/parser/src/token.rs
+++ b/parser/src/token.rs
@@ -186,6 +186,7 @@ pub enum TokenType {
     TK_COLON = 191,
     TK_ARRAY_CONTAINS = 192, // @>
     TK_ARRAY_OVERLAP = 193,  // &&
+    TK_COMMENT = 194,
     // None token
     TK_NONE = 255,
 }
@@ -217,6 +218,7 @@ impl TokenType {
             TokenType::TK_CHECK => Some("CHECK"),
             TokenType::TK_COLLATE => Some("COLLATE"),
             TokenType::TK_COLUMNKW => Some("COLUMN"),
+            TokenType::TK_COMMENT => Some("COMMENT"),
             TokenType::TK_COMMIT => Some("COMMIT"),
             TokenType::TK_CONFLICT => Some("CONFLICT"),
             TokenType::TK_CONSTRAINT => Some("CONSTRAINT"),
@@ -500,6 +502,7 @@ impl Display for TokenType {
             TK_CONCAT => "TK_CONCAT",
             TK_PTR => "TK_PTR",
             TK_COLLATE => "TK_COLLATE",
+            TK_COMMENT => "TK_COMMENT",
             TK_BITNOT => "TK_BITNOT",
             TK_ON => "TK_ON",
             TK_INDEXED => "TK_INDEXED",
@@ -583,7 +586,7 @@ impl TokenType {
             | TK_LAST | TK_CURRENT | TK_FOLLOWING | TK_PARTITION | TK_PRECEDING | TK_RANGE
             | TK_UNBOUNDED | TK_EXCLUDE | TK_GROUPS | TK_OTHERS | TK_TIES | TK_ALWAYS
             | TK_MATERIALIZED | TK_REINDEX | TK_RENAME | TK_CTIME_KW | TK_IF | TK_OPTIMIZE
-            | TK_TYPE => TK_ID,
+            | TK_TYPE | TK_COMMENT => TK_ID,
             // | TK_COLUMNKW | TK_UNION | TK_EXCEPT | TK_INTERSECT | TK_GENERATED | TK_WITHOUT
             // see comments in `next_token` of parser
             _ => self,

--- a/testing/sqltests/turso-tests/comment_on.sqltest
+++ b/testing/sqltests/turso-tests/comment_on.sqltest
@@ -1,0 +1,206 @@
+@database :memory:
+
+# Test: COMMENT ON TABLE stores a comment
+test comment-on-table {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL);
+    COMMENT ON TABLE t IS 'Test table';
+    SELECT description FROM __turso_internal_comments
+      WHERE object_type = 'table' AND object_name = 't';
+}
+expect {
+    Test table
+}
+
+# Test: COMMENT ON COLUMN stores a comment
+test comment-on-column {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL);
+    COMMENT ON COLUMN t.name IS 'User name';
+    SELECT description FROM __turso_internal_comments
+      WHERE object_type = 'column' AND object_name = 't' AND sub_name = 'name';
+}
+expect {
+    User name
+}
+
+# Test: COMMENT ON INDEX stores a comment
+test comment-on-index {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT);
+    CREATE INDEX idx_name ON t(name);
+    COMMENT ON INDEX idx_name IS 'Name lookup index';
+    SELECT description FROM __turso_internal_comments
+      WHERE object_type = 'index' AND object_name = 'idx_name';
+}
+expect {
+    Name lookup index
+}
+
+# Test: Multiple comments on different objects
+test comment-on-multiple-objects {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL);
+    CREATE INDEX idx_name ON t(name);
+    COMMENT ON TABLE t IS 'Main table';
+    COMMENT ON COLUMN t.name IS 'User name';
+    COMMENT ON COLUMN t.score IS 'Player score';
+    COMMENT ON INDEX idx_name IS 'Name lookup';
+    SELECT object_type, object_name, sub_name, description
+      FROM __turso_internal_comments
+      ORDER BY object_type, object_name, sub_name;
+}
+expect {
+    column|t|name|User name
+    column|t|score|Player score
+    index|idx_name||Name lookup
+    table|t||Main table
+}
+
+# Test: Update an existing comment
+test comment-on-update {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT);
+    COMMENT ON TABLE t IS 'Original';
+    COMMENT ON TABLE t IS 'Updated';
+    SELECT description FROM __turso_internal_comments
+      WHERE object_type = 'table' AND object_name = 't';
+}
+expect {
+    Updated
+}
+
+# Test: Drop a comment with IS NULL
+test comment-on-drop-with-null {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT);
+    COMMENT ON TABLE t IS 'Will be removed';
+    COMMENT ON TABLE t IS NULL;
+    SELECT count(*) FROM __turso_internal_comments
+      WHERE object_type = 'table' AND object_name = 't';
+}
+expect {
+    0
+}
+
+# Test: Comment on nonexistent table produces error
+test comment-on-nonexistent-table {
+    COMMENT ON TABLE nonexistent IS 'should fail';
+}
+expect error {
+}
+
+# Test: Comment on nonexistent column produces error
+test comment-on-nonexistent-column {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT);
+    COMMENT ON COLUMN t.nonexistent IS 'should fail';
+}
+expect error {
+}
+
+# Test: Comment on nonexistent index produces error
+test comment-on-nonexistent-index {
+    COMMENT ON INDEX nonexistent IS 'should fail';
+}
+expect error {
+}
+
+# Test: Comments table is created lazily
+test comment-on-lazy-table-creation {
+    CREATE TABLE t (id INTEGER PRIMARY KEY);
+    SELECT count(*) FROM sqlite_master WHERE name = '__turso_internal_comments';
+    COMMENT ON TABLE t IS 'hello';
+    SELECT count(*) FROM sqlite_master WHERE name = '__turso_internal_comments';
+}
+expect {
+    0
+    1
+}
+
+# Test: Comment with special characters
+test comment-on-special-chars {
+    CREATE TABLE t (id INTEGER PRIMARY KEY);
+    COMMENT ON TABLE t IS 'It''s a "test" with special chars: <>&';
+    SELECT description FROM __turso_internal_comments
+      WHERE object_type = 'table' AND object_name = 't';
+}
+expect {
+    It's a "test" with special chars: <>&
+}
+
+# Test: PRAGMA comment_list returns all comments
+test pragma-comment-list-all {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL);
+    CREATE INDEX idx_name ON t(name);
+    COMMENT ON TABLE t IS 'Main table';
+    COMMENT ON COLUMN t.name IS 'User name';
+    COMMENT ON INDEX idx_name IS 'Name lookup';
+    PRAGMA comment_list;
+}
+expect unordered {
+    table|t||Main table
+    column|t|name|User name
+    index|idx_name||Name lookup
+}
+
+# Test: PRAGMA comment_list filtered by object name
+test pragma-comment-list-filtered {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL);
+    CREATE INDEX idx_name ON t(name);
+    COMMENT ON TABLE t IS 'Main table';
+    COMMENT ON COLUMN t.name IS 'User name';
+    COMMENT ON INDEX idx_name IS 'Name lookup';
+    PRAGMA comment_list(t);
+}
+expect unordered {
+    table|t||Main table
+    column|t|name|User name
+}
+
+# Test: PRAGMA comment_list on db with no comments returns no rows
+test pragma-comment-list-empty {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT);
+    PRAGMA comment_list;
+}
+expect {
+}
+
+# Test: PRAGMA comment_list after dropping a comment
+test pragma-comment-list-after-drop {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT);
+    COMMENT ON TABLE t IS 'Will be removed';
+    COMMENT ON TABLE t IS NULL;
+    PRAGMA comment_list;
+}
+expect {
+}
+
+# Test: .schema shows inline comments
+@backend cli
+test schema-with-comments {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL);
+    CREATE INDEX idx_name ON t(name);
+    COMMENT ON TABLE t IS 'Main table';
+    COMMENT ON COLUMN t.name IS 'User name';
+    COMMENT ON INDEX idx_name IS 'Name lookup';
+    .schema
+}
+expect raw {
+-- Main table
+CREATE TABLE t (
+  id INTEGER PRIMARY KEY,
+  name TEXT, -- User name
+  score REAL
+);
+-- Name lookup
+CREATE INDEX idx_name ON t (name);
+}
+
+# Test: .schema handles commas inside CHECK constraints and quoted defaults
+@backend cli
+test schema-with-check-and-quoted-default {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER CHECK(val IN (1,2,3)), name TEXT DEFAULT 'a,b');
+    COMMENT ON COLUMN t.val IS 'Allowed values';
+    .schema
+}
+expect raw {
+CREATE TABLE t (
+  id INTEGER PRIMARY KEY,
+  val INTEGER CHECK (val IN (1, 2, 3)), -- Allowed values
+  name TEXT DEFAULT 'a,b'
+);
+}


### PR DESCRIPTION
Implement the COMMENT ON statement to attach human-readable descriptions to tables, columns, indexes, views, and types. Comments are stored in a lazily-created __turso_internal_comments table. IS NULL removes a previously set comment.

Add PRAGMA comment_list with optional object_name filtering. .schema now formats CREATE TABLE as multi-line (one column per line) and injects inline -- comments when present. .dump emits COMMENT ON statements instead of raw internal table DDL so comments survive dump/restore.

Move cmdlineshell.sqltest to turso-tests/ because .schema now produces multi-line CREATE TABLE output which diverges from sqlite3 single-line format. Move comment_on.sqltest to turso-tests/ since COMMENT ON is a Turso extension not present in SQLite.
