### PR TITLE
core/translate: Reject negative and out-of-range ORDER BY column indices

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1044,24 +1044,31 @@ fn replace_column_number_with_copy_of_column_expr(
                 None
             }
         }
+        ast::Expr::Unary(ast::UnaryOperator::Negative, inner) => {
+            if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner.as_ref() {
+                if num.parse::<usize>().is_ok() {
+                    crate::bail_parse_error!(
+                        "1st ORDER BY term out of range - should be between 1 and {}",
+                        columns.len()
+                    );
+                }
+            }
+            None
+        }
         _ => None,
     };
     if let Some(num) = num_str {
         // Only treat as column reference if it parses as a positive integer.
         // Float literals like "0.5" or "1.0" are valid constant expressions, not column references.
         if let Ok(column_number) = num.parse::<usize>() {
-            if column_number == 0 {
-                crate::bail_parse_error!("invalid column index: {}", column_number);
+            if column_number == 0 || column_number > columns.len() {
+                crate::bail_parse_error!(
+                    "1st ORDER BY term out of range - should be between 1 and {}",
+                    columns.len()
+                );
             }
-            let maybe_result_column = columns.get(column_number - 1);
-            match maybe_result_column {
-                Some(ResultSetColumn { expr, .. }) => {
-                    *order_by_or_group_by_expr = expr.clone();
-                }
-                None => {
-                    crate::bail_parse_error!("invalid column index: {}", column_number)
-                }
-            };
+            let ResultSetColumn { expr, .. } = &columns[column_number - 1];
+            *order_by_or_group_by_expr = expr.clone();
         }
         // Otherwise, leave the expression as-is (constant expression, case 3 per SQLite docs)
     }

--- a/testing/sqltests/tests/orderby/memory.sqltest
+++ b/testing/sqltests/tests/orderby/memory.sqltest
@@ -187,3 +187,46 @@ expect {
     y|3
 }
 
+# Negative integer literals in ORDER BY should be rejected as invalid
+# column index references, matching SQLite behavior.
+# Fixes select1-4.10.2 in testing/sqlite3/all.test.
+
+test order-by-negative-1 {
+    CREATE TABLE t12(a, b);
+    INSERT INTO t12 VALUES(1,10),(2,9);
+    SELECT * FROM t12 ORDER BY -1;
+}
+expect error {
+    1st ORDER BY term out of range - should be between 1 and 2
+}
+
+test order-by-negative-100 {
+    CREATE TABLE t13(a, b);
+    INSERT INTO t13 VALUES(1,10),(2,9);
+    SELECT * FROM t13 ORDER BY -100;
+}
+expect error {
+    1st ORDER BY term out of range - should be between 1 and 2
+}
+
+# Positive out-of-range and zero column indices should use SQLite-compatible
+# error messages. Fixes select1-4.10.1 in testing/sqlite3/all.test.
+
+test order-by-out-of-range {
+    CREATE TABLE t14(a, b);
+    INSERT INTO t14 VALUES(1,10),(2,9);
+    SELECT * FROM t14 ORDER BY 3;
+}
+expect error {
+    1st ORDER BY term out of range - should be between 1 and 2
+}
+
+test order-by-zero {
+    CREATE TABLE t15(a, b);
+    INSERT INTO t15 VALUES(1,10),(2,9);
+    SELECT * FROM t15 ORDER BY 0;
+}
+expect error {
+    1st ORDER BY term out of range - should be between 1 and 2
+}
+


### PR DESCRIPTION
SQLite rejects `ORDER BY -1` with "1st ORDER BY term out of range - should be between 1 and N", but Turso silently treated it as a constant expression. Add a Unary(Negative, Literal(Numeric)) match arm to detect and reject negative column index references.
    
Also fix the error message for positive out-of-range indices (e.g. ORDER BY 3 on a 2-column table, ORDER BY 0) to match SQLite's format instead of the old "invalid column index: N".
    
Fixes select1-4.10.1 and select1-4.10.2 in testing/sqlite3/all.test.