### PR TITLE
Update COMPAT.md

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -67,7 +67,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 ### Limitations
 
 * ⛔️ Concurrent access from multiple processes is not supported.
-* ⛔️ Vacuum is not supported.
+* ⛔️ Plain VACUUM is not supported (VACUUM INTO is supported).
 
 ## SQLite query language
 
@@ -83,7 +83,7 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | CHECK                     | ✅ Yes     |                                                                                   |
 | CREATE INDEX              | ✅ Yes     |                                                                                   |
 | CREATE TABLE              | ✅ Yes     |                                                                                   |
-| CREATE TABLE ... STRICT   | 🚧 Partial | Strict schema mode is experimental.                                               |
+| CREATE TABLE ... STRICT   | ✅ Yes     |                                                                                   |
 | CREATE TRIGGER            | ✅ Yes     |                                                                                   |
 | CREATE VIEW               | ✅ Yes     |                                                                                   |
 | CREATE VIRTUAL TABLE      | ✅ Yes     |                                                                                   |
@@ -95,16 +95,16 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | DROP VIEW                 | ✅ Yes     |                                                                                   |
 | END TRANSACTION           | ✅ Yes     |                                                                                   |
 | EXPLAIN                   | ✅ Yes     |                                                                                   |
-| INDEXED BY                | ❌ No      |                                                                                   |
+| INDEXED BY                | ✅ Yes     |                                                                                   |
 | INSERT                    | ✅ Yes     |                                                                                   |
 | INSERT ... ON CONFLICT (UPSERT) | ✅ Yes |                                                                                   |
 | ON CONFLICT clause        | ✅ Yes     |                                                                                   |
 | REINDEX                   | ❌ No      |                                                                                   |
-| RELEASE SAVEPOINT         | ✅ No      |                                                                                   |
+| RELEASE SAVEPOINT         | ✅ Yes     |                                                                                   |
 | REPLACE                   | ✅ Yes     |                                                                                   |
 | RETURNING clause          | ✅ Yes     |                                                                                   |
 | ROLLBACK TRANSACTION      | ✅ Yes     |                                                                                   |
-| SAVEPOINT                 | ✅ No      |                                                                                   |
+| SAVEPOINT                 | ✅ Yes     |                                                                                   |
 | SELECT                    | ✅ Yes     |                                                                                   |
 | SELECT ... WHERE          | ✅ Yes     |                                                                                   |
 | SELECT ... WHERE ... LIKE | ✅ Yes     |                                                                                   |
@@ -113,15 +113,15 @@ Turso aims to be fully compatible with SQLite, with opt-in features not supporte
 | SELECT ... GROUP BY       | ✅ Yes     |                                                                                   |
 | SELECT ... HAVING         | ✅ Yes     |                                                                                   |
 | SELECT ... JOIN           | ✅ Yes     |                                                                                   |
-| SELECT ... CROSS JOIN     | ❌ No     | SQLite CROSS JOIN means "do not reorder joins". |
+| SELECT ... CROSS JOIN     | ✅ Yes     |                                                                                   |
 | SELECT ... INNER JOIN     | ✅ Yes     |                                                                                   |
-| SELECT ... OUTER JOIN     | 🚧 Partial | no RIGHT JOIN                                                                     |
+| SELECT ... OUTER JOIN     | ✅ Yes     |                                                                                   |
 | SELECT ... JOIN USING     | ✅ Yes     |                                                                                   |
 | SELECT ... NATURAL JOIN   | ✅ Yes     |                                                                                   |
 | UPDATE                    | ✅ Yes     |                                                                                   |
-| VACUUM                    | ❌ No      |                                                                                   |
+| VACUUM                    | 🚧 Partial | VACUUM INTO supported, plain VACUUM not yet                                       |
 | WITH clause               | 🚧 Partial | ❌ No RECURSIVE, no MATERIALIZED, only SELECT supported in CTEs                      |
-| WINDOW functions             | 🚧 Partial | only default frame definition, no window-specific functions (rank() etc)         |
+| WINDOW functions             | 🚧 Partial | ROW_NUMBER() supported; RANK(), DENSE_RANK(), LAG(), LEAD(), NTILE() not yet     |
 | GENERATED                 | ❌ No      |                                                                                   |
 
 #### [PRAGMA](https://www.sqlite.org/pragma.html)
@@ -214,8 +214,8 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | schema.table.column       | 🚧 Partial | Schemas aren't supported                 |
 | unary operator            | ✅ Yes     |                                          |
 | binary operator           | 🚧 Partial | Only `%`, `!<`, and `!>` are unsupported |
-| agg() FILTER (WHERE ...)  | ❌ No      | Is incorrectly ignored                   |
-| ... OVER (...)            | ❌ No      | Is incorrectly ignored                   |
+| agg() FILTER (WHERE ...)  | ❌ No      |                                          |
+| ... OVER (...)            | 🚧 Partial | Supported for aggregate functions and ROW_NUMBER() |
 | (expr)                    | ✅ Yes     |                                          |
 | CAST (expr AS type)       | ✅ Yes     |                                          |
 | COLLATE                   | 🚧 Partial | Custom Collations not supported          |
@@ -440,7 +440,7 @@ Modifiers:
 | Interface              | Status  | Comment |
 |------------------------|---------|---------|
 | sqlite3_open           | ✅ Yes     |         |
-| sqlite3_open_v2        | 🚧 Partial | Delegates to sqlite3_open, flags/VFS ignored |
+| sqlite3_open_v2        | 🚧 Partial | URI filenames parsed; VFS parameter ignored |
 | sqlite3_open16         | ❌ No      |         |
 | sqlite3_close          | ✅ Yes     |         |
 | sqlite3_close_v2       | ✅ Yes     | Same as sqlite3_close |
@@ -890,7 +890,7 @@ Modifiers:
 | RowSetTest     | ✅ Yes     |         |
 | Rowid          | ✅ Yes    |         |
 | SCopy          | ❌ No     |         |
-| Savepoint      | ✅ No     |         |
+| Savepoint      | ✅ Yes    |         |
 | Seek           | ❌ No     |         |
 | SeekGe         | ✅ Yes    |         |
 | SeekGt         | ✅ Yes    |         |


### PR DESCRIPTION
INDEXED BY is now supported, per 499b052ff ("Merge 'translate: implement INDEXED BY' from Jussi Saurio").

SAVEPOINT, RELEASE SAVEPOINT, and the Savepoint opcode are now marked as supported. Named savepoints were implemented in 2706498e7 ("Merge 'Implement named savepoints' from Preston Thorpe") which predates v0.5.0 but COMPAT.md was never updated. Further hardened by 927c65e99 ("Merge 'fix: Savepoint rollback of DDL causes I/O error instead of rolling back' from Preston Thorpe").

CROSS JOIN is now supported, per 89c3ba7e9 ("Merge 'core/translate: Enable CROSS JOINs' from Preston Thorpe").

OUTER JOIN is now fully supported including RIGHT JOIN and FULL OUTER JOIN. RIGHT JOIN (rewritten to LEFT JOIN) and FULL OUTER JOIN were added in 0b0452cbb ("Merge 'partially implement FULL OUTER + LEFT and RIGHT hash joins' from Preston Thorpe") before v0.5.0 but COMPAT.md was never updated. FULL OUTER was extended to grace hash joins in 0fee68910 ("Merge 'perf: Implement Grace algorithm for hash joins to improve disk-spilling performance' from Preston Thorpe").

VACUUM is now marked as partial since VACUUM INTO works. Plain VACUUM still returns an explicit error. VACUUM INTO was hardened by b51fa9bbb ("Merge 'Preserve rowid values in VACUUM INTO output' from Kumar Ujjawal"), a8cbf3858 ("Merge 'test: add integration test for VACUUM INTO on encrypted databases #5851' from Ratnesh Mishra"), and 53219753b ("Merge 'Added VACUUM INTO tests with strict tables' from Harin").

WINDOW functions comment updated to reflect that ROW_NUMBER() is now supported per 8b12be7ac ("Merge 'Support ROW_NUMBER()' from Kumar Ujjawal"). RANK(), DENSE_RANK(), LAG(), LEAD(), and NTILE() are still missing.

The OVER clause is now marked as partial since it works for aggregate functions and ROW_NUMBER(). The old comment saying it was "incorrectly ignored" no longer applies.

The FILTER clause comment was also corrected: it now properly returns an error instead of being silently ignored.

sqlite3_open_v2 comment updated to reflect URI filename parsing, per 6ee7e43e0 ("Merge 'sqlite3: implement URI filename parsing in sqlite3_open_v2' from Joao Lucas") and 0f6d472f7 ("Merge 'sqlite3: support cache=shared for named in-memory URI databases' from Joao Lucas").

The limitations section now says plain VACUUM is not supported rather than blanket "Vacuum is not supported", since VACUUM INTO works.