### PR TITLE
core/translate: Fix column names of unaliased expressions

### DIFF
--- a/bindings/javascript/packages/native/promise.test.ts
+++ b/bindings/javascript/packages/native/promise.test.ts
@@ -118,9 +118,9 @@ test('avg-bug', async () => {
         'value 6', null, null, 150,
     );
 
-    expect(await db.prepare(`select avg("a") from "aggregate_table";`).get()).toEqual({ 'avg (aggregate_table.a)': 24 });
-    expect(await db.prepare(`select avg("null_only") from "aggregate_table";`).get()).toEqual({ 'avg (aggregate_table.null_only)': null });
-    expect(await db.prepare(`select avg(distinct "b") from "aggregate_table";`).get()).toEqual({ 'avg (DISTINCT aggregate_table.b)': 42.5 });
+    expect(await db.prepare(`select avg("a") from "aggregate_table";`).get()).toEqual({ 'avg("a")': 24 });
+    expect(await db.prepare(`select avg("null_only") from "aggregate_table";`).get()).toEqual({ 'avg("null_only")': null });
+    expect(await db.prepare(`select avg(distinct "b") from "aggregate_table";`).get()).toEqual({ 'avg(distinct "b")': 42.5 });
 })
 
 test('insert returning test', async () => {

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -472,10 +472,10 @@ impl IncrementalView {
 
                 // Store the alias mapping if there is an alias
                 if let Some(alias_enum) = alias {
-                    let alias_name = match alias_enum {
-                        ast::As::As(name) | ast::As::Elided(name) => name.as_str(),
-                    };
-                    aliases.insert(alias_name.to_string(), table_name.to_string());
+                    aliases.insert(
+                        alias_enum.name().as_str().to_string(),
+                        table_name.to_string(),
+                    );
                 }
             } else {
                 return Err(LimboError::ParseError(format!(

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -360,6 +360,7 @@ fn ensure_delete_uses_rowset(program: &mut ProgramBuilder, plan: &mut DeletePlan
                 table: rowid_internal_id,
             },
             alias: None,
+            implicit_column_name: None,
             contains_aggregates: false,
         }],
         where_clause: std::mem::take(&mut plan.where_clause),

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -910,6 +910,7 @@ fn build_materialized_build_input_plan(
                 table: build_internal_id,
             },
             alias: None,
+            implicit_column_name: None,
             contains_aggregates: false,
         }],
         MaterializedBuildInputMode::KeyPayload { num_keys, .. } => {
@@ -922,6 +923,7 @@ fn build_materialized_build_input_plan(
                 result_columns.push(ResultSetColumn {
                     expr: expr.clone(),
                     alias: None,
+                    implicit_column_name: None,
                     contains_aggregates: false,
                 });
             }
@@ -945,6 +947,7 @@ fn build_materialized_build_input_plan(
                 result_columns.push(ResultSetColumn {
                     expr,
                     alias: None,
+                    implicit_column_name: None,
                     contains_aggregates: false,
                 });
             }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -6255,10 +6255,7 @@ pub fn process_returning_clause(
 ) -> Result<Vec<ResultSetColumn>> {
     let mut result_columns = Vec::with_capacity(returning.len());
 
-    let alias_to_string = |alias: &ast::As| match alias {
-        ast::As::Elided(alias) => alias.as_str().to_string(),
-        ast::As::As(alias) => alias.as_str().to_string(),
-    };
+    let alias_to_string = |alias: &ast::As| alias.name().as_str().to_string();
 
     for rc in returning.iter_mut() {
         match rc {
@@ -6282,6 +6279,7 @@ pub fn process_returning_clause(
                 result_columns.push(ResultSetColumn {
                     expr: expr.as_ref().clone(),
                     alias: alias.as_ref().map(alias_to_string),
+                    implicit_column_name: None,
                     contains_aggregates: false,
                 });
             }
@@ -6305,6 +6303,7 @@ pub fn process_returning_clause(
                     result_columns.push(ResultSetColumn {
                         expr: column_expr,
                         alias: column.name.clone(),
+                        implicit_column_name: None,
                         contains_aggregates: false,
                     });
                 }

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -604,10 +604,7 @@ impl<'a> LogicalPlanBuilder<'a> {
                 }
 
                 // Regular table scan
-                let table_alias = alias.as_ref().map(|a| match a {
-                    ast::As::As(name) => Self::name_to_string(name),
-                    ast::As::Elided(name) => Self::name_to_string(name),
-                });
+                let table_alias = alias.as_ref().map(|a| Self::name_to_string(a.name()));
                 let table_schema = self.get_table_schema(&table_name, table_alias.as_deref())?;
                 Ok(LogicalPlan::TableScan(TableScan {
                     table_name,
@@ -930,10 +927,9 @@ impl<'a> LogicalPlanBuilder<'a> {
             match col {
                 ast::ResultColumn::Expr(expr, alias) => {
                     let logical_expr = self.build_expr(expr, input_schema)?;
-                    let col_name = match alias {
-                        Some(as_alias) => match as_alias {
-                            ast::As::As(name) | ast::As::Elided(name) => Self::name_to_string(name),
-                        },
+                    let explicit_alias = alias.as_ref().filter(|a| a.is_explicit());
+                    let col_name = match explicit_alias {
+                        Some(as_alias) => Self::name_to_string(as_alias.name()),
                         None => Self::expr_to_column_name(expr),
                     };
                     let col_type = Self::infer_expr_type(&logical_expr, input_schema)?;
@@ -946,10 +942,8 @@ impl<'a> LogicalPlanBuilder<'a> {
                         table_alias: None,
                     });
 
-                    if let Some(as_alias) = alias {
-                        let alias_name = match as_alias {
-                            ast::As::As(name) | ast::As::Elided(name) => Self::name_to_string(name),
-                        };
+                    if let Some(as_alias) = explicit_alias {
+                        let alias_name = Self::name_to_string(as_alias.name());
                         proj_exprs.push(LogicalExpr::Alias {
                             expr: Box::new(logical_expr),
                             alias: alias_name,
@@ -1167,11 +1161,8 @@ impl<'a> LogicalPlanBuilder<'a> {
                 let logical_expr = self.build_expr(expr, input_schema)?;
                 select_exprs.push(logical_expr.clone());
 
-                if let Some(alias) = alias {
-                    let alias_name = match alias {
-                        ast::As::As(name) | ast::As::Elided(name) => Self::name_to_string(name),
-                    };
-                    alias_to_expr.insert(alias_name, logical_expr);
+                if let Some(alias) = alias.as_ref().filter(|a| a.is_explicit()) {
+                    alias_to_expr.insert(Self::name_to_string(alias.name()), logical_expr);
                 }
             }
         }
@@ -1257,10 +1248,8 @@ impl<'a> LogicalPlanBuilder<'a> {
                     let logical_expr = self.build_expr(expr, input_schema)?;
 
                     // Determine the column name for this expression
-                    let col_name = match alias {
-                        Some(as_alias) => match as_alias {
-                            ast::As::As(name) | ast::As::Elided(name) => Self::name_to_string(name),
-                        },
+                    let col_name = match alias.as_ref().filter(|a| a.is_explicit()) {
+                        Some(as_alias) => Self::name_to_string(as_alias.name()),
                         None => Self::expr_to_column_name(expr),
                     };
 
@@ -1392,12 +1381,12 @@ impl<'a> LogicalPlanBuilder<'a> {
         for (i, expr) in projection_exprs.iter().enumerate() {
             let col_name = if i < columns.len() {
                 match &columns[i] {
-                    ast::ResultColumn::Expr(e, alias) => match alias {
-                        Some(as_alias) => match as_alias {
-                            ast::As::As(name) | ast::As::Elided(name) => Self::name_to_string(name),
-                        },
-                        None => Self::expr_to_column_name(e),
-                    },
+                    ast::ResultColumn::Expr(e, alias) => {
+                        match alias.as_ref().filter(|a| a.is_explicit()) {
+                            Some(as_alias) => Self::name_to_string(as_alias.name()),
+                            None => Self::expr_to_column_name(e),
+                        }
+                    }
                     _ => format!("col_{i}"),
                 }
             } else {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1012,6 +1012,7 @@ fn add_ephemeral_table_to_update_plan(
                 table: rowid_internal_id,
             },
             alias: None,
+            implicit_column_name: None,
             contains_aggregates: false,
         }],
         where_clause: plan.where_clause.drain(..).collect(),

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -57,6 +57,11 @@ fn infer_type_from_expr(
 pub struct ResultSetColumn {
     pub expr: ast::Expr,
     pub alias: Option<String>,
+    /// Original SQL expression text for display as column name.
+    /// Only used when there is no explicit alias and the expression is not
+    /// a simple column reference. This preserves the verbatim SQL text
+    /// (e.g. "f1+F2") as the column name, matching SQLite behavior.
+    pub implicit_column_name: Option<String>,
     // TODO: encode which aggregates (e.g. index bitmask of plan.aggregates) are present in this column
     pub contains_aggregates: bool,
 }
@@ -100,7 +105,7 @@ impl ResultSetColumn {
                 // If there is no rowid alias, use "rowid".
                 Some("rowid")
             }
-            _ => None,
+            _ => self.implicit_column_name.as_deref(),
         }
     }
 }
@@ -784,6 +789,7 @@ pub fn select_star(
                 })
                 .map(|(i, col)| ResultSetColumn {
                     alias: None,
+                    implicit_column_name: None,
                     expr: ast::Expr::Column {
                         database: None,
                         table: table.internal_id,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -772,11 +772,7 @@ fn parse_from_clause_table(
             }
             let cur_table_index = table_references.joined_tables().len();
             let identifier = maybe_alias
-                .map(|a| match a {
-                    ast::As::As(id) => id,
-                    ast::As::Elided(id) => id,
-                })
-                .map(|id| normalize_ident(id.as_str()))
+                .map(|a| normalize_ident(a.name().as_str()))
                 .unwrap_or_else(|| format!("subquery_{cur_table_index}"));
             table_references.add_joined_table(JoinedTable::new_subquery_from_plan(
                 identifier,
@@ -845,11 +841,7 @@ fn parse_table(
 
         // If there's an alias provided, update the identifier to use that alias
         if let Some(a) = maybe_alias {
-            let alias = match a {
-                ast::As::As(id) => id,
-                ast::As::Elided(id) => id,
-            };
-            cte_table.identifier = normalize_ident(alias.as_str());
+            cte_table.identifier = normalize_ident(a.name().as_str());
         }
 
         // Mark the pre-planned outer_query_ref as "CTE definition only" so it is
@@ -880,12 +872,7 @@ fn parse_table(
         if let Some(cte_id) = outer_ref.cte_id {
             program.increment_cte_reference(cte_id);
         }
-        let alias = maybe_alias
-            .map(|a| match a {
-                ast::As::As(id) => id,
-                ast::As::Elided(id) => id,
-            })
-            .map(|a| normalize_ident(a.as_str()));
+        let alias = maybe_alias.map(|a| normalize_ident(a.name().as_str()));
         // Clone fields we need before dropping the borrow on table_references.
         let cte_select = outer_ref.cte_select.clone();
         let cte_explicit_columns = outer_ref.cte_explicit_columns.clone();
@@ -967,12 +954,7 @@ fn parse_table(
     let table = resolver.with_schema(database_id, |schema| schema.get_table(table_name.as_str()));
 
     if let Some(table) = table {
-        let alias = maybe_alias
-            .map(|a| match a {
-                ast::As::As(id) => id,
-                ast::As::Elided(id) => id,
-            })
-            .map(|a| normalize_ident(a.as_str()));
+        let alias = maybe_alias.map(|a| normalize_ident(a.name().as_str()));
         let internal_id = program.table_reference_counter.next();
         let tbl_ref = if let Table::Virtual(tbl) = table.as_ref() {
             transform_args_into_where_terms(args, internal_id, vtab_predicates, table.as_ref())?;
@@ -1091,12 +1073,7 @@ fn parse_table(
         });
         drop(view_guard);
 
-        let alias = maybe_alias
-            .map(|a| match a {
-                ast::As::As(id) => id,
-                ast::As::Elided(id) => id,
-            })
-            .map(|a| normalize_ident(a.as_str()));
+        let alias = maybe_alias.map(|a| normalize_ident(a.name().as_str()));
 
         table_references.add_joined_table(JoinedTable {
             op: Operation::Scan(Scan::BTreeTable {

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -437,6 +437,7 @@ fn prepare_one_select_plan(
                                     is_rowid_alias: column.is_rowid_alias(),
                                 },
                                 alias: None,
+                                implicit_column_name: None,
                                 contains_aggregates: false,
                             });
                             table.mark_column_used(idx);
@@ -456,11 +457,18 @@ fn prepare_one_select_plan(
                             &mut aggregate_expressions,
                             Some(&mut windows),
                         )?;
+                        let (alias, implicit_column_name) = match &maybe_alias {
+                            Some(ast::As::As(name)) | Some(ast::As::Elided(name)) => {
+                                (Some(name.as_str().to_string()), None)
+                            }
+                            Some(ast::As::ImplicitColumnName(name)) => {
+                                (None, Some(name.as_str().to_string()))
+                            }
+                            None => (None, None),
+                        };
                         plan.result_columns.push(ResultSetColumn {
-                            alias: maybe_alias.as_ref().map(|alias| match alias {
-                                ast::As::Elided(alias) => alias.as_str().to_string(),
-                                ast::As::As(alias) => alias.as_str().to_string(),
-                            }),
+                            alias,
+                            implicit_column_name,
                             expr: *expr,
                             contains_aggregates,
                         });
@@ -685,6 +693,7 @@ fn prepare_one_select_plan(
                     // these result_columns work as placeholders for the values, so the expr doesn't matter
                     expr: ast::Expr::Literal(ast::Literal::Numeric(i.to_string())),
                     alias: Some(format!("column{}", i + 1)),
+                    implicit_column_name: None,
                     contains_aggregates: false,
                 });
             }

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -186,6 +186,7 @@ fn prepare_window_subquery(
         subquery_result_columns.push(ResultSetColumn {
             expr: Expr::Literal(Literal::Numeric("0".to_string())),
             alias: None,
+            implicit_column_name: None,
             contains_aggregates: false,
         });
     }
@@ -419,6 +420,7 @@ fn rewrite_expr_as_subquery_column(
         ctx.subquery_result_columns.push(ResultSetColumn {
             expr: subquery_expr,
             alias: None,
+            implicit_column_name: None,
             contains_aggregates,
         });
     }

--- a/core/util.rs
+++ b/core/util.rs
@@ -1784,10 +1784,7 @@ pub fn extract_view_columns(
                     tables.push(ViewTable {
                         name: table_name,
                         db_name,
-                        alias: alias.as_ref().map(|a| match a {
-                            ast::As::As(name) => normalize_ident(name.as_str()),
-                            ast::As::Elided(name) => normalize_ident(name.as_str()),
-                        }),
+                        alias: alias.as_ref().map(|a| normalize_ident(a.name().as_str())),
                     });
                 }
                 _ => {
@@ -1807,10 +1804,7 @@ pub fn extract_view_columns(
                         tables.push(ViewTable {
                             name: table_name,
                             db_name,
-                            alias: alias.as_ref().map(|a| match a {
-                                ast::As::As(name) => normalize_ident(name.as_str()),
-                                ast::As::Elided(name) => normalize_ident(name.as_str()),
-                            }),
+                            alias: alias.as_ref().map(|a| normalize_ident(a.name().as_str())),
                         });
                     }
                     _ => {
@@ -1852,10 +1846,10 @@ pub fn extract_view_columns(
 
                     let col_name = alias
                         .as_ref()
-                        .map(|a| match a {
-                            ast::As::Elided(name) => name.as_str().to_string(),
-                            ast::As::As(name) => name.as_str().to_string(),
-                        })
+                        // ImplicitColumnName is only for display; skip it
+                        // so we derive the proper column name below.
+                        .filter(|a| !matches!(a, ast::As::ImplicitColumnName(_)))
+                        .map(|a| a.name().as_str().to_string())
                         .or_else(|| extract_column_name_from_expr(expr))
                         .unwrap_or_else(|| {
                             // If we can't extract a simple column name, use the expression itself
@@ -2305,9 +2299,7 @@ mod rename_column_view {
     }
 
     fn alias_name(alias: &ast::As) -> &str {
-        match alias {
-            ast::As::As(name) | ast::As::Elided(name) => name.as_str(),
-        }
+        alias.name().as_str()
     }
 
     #[derive(Clone)]

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -774,6 +774,7 @@ impl ProgramBuilder {
         self.result_columns.push(ResultSetColumn {
             expr,
             alias: Some(col_name),
+            implicit_column_name: None,
             contains_aggregates: false,
         });
     }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -922,6 +922,25 @@ pub enum As {
     As(Name),
     /// no `AS`
     Elided(Name), // FIXME Ids
+    /// Implicit column name from original SQL text (not serialized to SQL).
+    /// Used to preserve the original expression text as the column name
+    /// for unaliased expressions, matching SQLite behavior.
+    ImplicitColumnName(Name),
+}
+
+impl As {
+    /// Returns the inner `Name` regardless of variant.
+    pub fn name(&self) -> &Name {
+        match self {
+            As::As(name) | As::Elided(name) | As::ImplicitColumnName(name) => name,
+        }
+    }
+
+    /// Returns `true` if this is a user-provided alias (`AS foo` or elided `foo`),
+    /// not a system-generated implicit column name.
+    pub fn is_explicit(&self) -> bool {
+        matches!(self, As::As(_) | As::Elided(_))
+    }
 }
 
 /// `JOIN` clause

--- a/parser/src/ast/fmt.rs
+++ b/parser/src/ast/fmt.rs
@@ -1321,6 +1321,7 @@ impl ToTokens for As {
                 name.to_tokens(s, context)
             }
             Self::Elided(ref name) => name.to_tokens(s, context),
+            Self::ImplicitColumnName(_) => Ok(()),
         }
     }
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -2669,8 +2669,24 @@ impl<'a> Parser<'a> {
                     }
                 }
 
+                let expr_start = self.offset();
                 let expr = self.parse_expr(0)?;
+                let expr_end = self.offset();
                 let alias = self.parse_as()?;
+                // When there is no explicit AS alias, use the original SQL
+                // text of the expression as an implicit column name. This
+                // matches SQLite's behavior of preserving the verbatim
+                // expression text as the column name.
+                let alias = alias.or_else(|| {
+                    let text = std::str::from_utf8(&self.lexer.input[expr_start..expr_end])
+                        .ok()?
+                        .trim();
+                    if text.is_empty() {
+                        None
+                    } else {
+                        Some(As::ImplicitColumnName(Name::exact(text.to_string())))
+                    }
+                });
                 Ok(ResultColumn::Expr(expr, alias))
             }
         }
@@ -12201,15 +12217,20 @@ mod tests {
                 results.push(cmd.unwrap());
             }
 
-            assert_eq!(results, expected, "Input: {input_str:?}");
+            // Compare serialized forms since ImplicitColumnName (display-only
+            // metadata) serializes to nothing, making comparison insensitive
+            // to its presence.
+            let results_str: Vec<String> = results.iter().map(|c| c.to_string()).collect();
+            let expected_str: Vec<String> = expected.iter().map(|c| c.to_string()).collect();
+            assert_eq!(results_str, expected_str, "Input: {input_str:?}");
 
-            // to_string tests
+            // to_string round-trip tests
             for (i, r) in results.iter().enumerate() {
                 let rstring = r.to_string();
                 // put new string into parser again
                 let result = Parser::new(rstring.as_bytes()).next().unwrap().unwrap();
-                let expected = &expected[i];
-                assert_eq!(result, expected.clone(), "Input: {rstring:?}");
+                let result_str = result.to_string();
+                assert_eq!(result_str, expected_str[i], "Input: {rstring:?}");
             }
         }
     }

--- a/testing/sqltests/tests/column_name_case.sqltest
+++ b/testing/sqltests/tests/column_name_case.sqltest
@@ -118,6 +118,45 @@ expect {
     1
 }
 
+@backend cli
+@cross-check-integrity
+test expr_column_name_preserves_original_text {
+    .headers on
+    CREATE TABLE texpr(f1 int, f2 int);
+    INSERT INTO texpr VALUES(11,22);
+    SELECT f1+F2 FROM texpr ORDER BY f2;
+}
+expect {
+    f1+F2
+    33
+}
+
+@backend cli
+@cross-check-integrity
+test expr_column_name_with_spaces {
+    .headers on
+    CREATE TABLE texpr2(a int, b int);
+    INSERT INTO texpr2 VALUES(1,2);
+    SELECT a + b FROM texpr2;
+}
+expect {
+    a + b
+    3
+}
+
+@backend cli
+@cross-check-integrity
+test func_column_name_preserves_original_text {
+    .headers on
+    CREATE TABLE texpr3(x int);
+    INSERT INTO texpr3 VALUES(5);
+    SELECT max(x) FROM texpr3;
+}
+expect {
+    max(x)
+    5
+}
+
 @cross-check-integrity
 test quoted_identifiers {
     CREATE TABLE t12("MixedCase" INT);

--- a/testing/sqltests/turso-tests/json_object_star.sqltest
+++ b/testing/sqltests/turso-tests/json_object_star.sqltest
@@ -145,12 +145,12 @@ expect {
     {"id":1,"name":"Widget","double_price":19.98}
 }
 
-# Test json_object(*) with default column naming (column1, column2, etc.)
+# Test json_object(*) with expression text as column names (matching SQLite)
 test json_object_star_default_column_names {
     SELECT json_object(*) FROM (SELECT 1+1, 2+2 as a, 3+3);
 }
 expect {
-    {"column1":2,"a":4,"column3":6}
+    {"1+1":2,"a":4,"3+3":6}
 }
 
 # Test json_object(*) in materialized view

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -594,8 +594,8 @@ fn test_avg_agg(tmp_db: TempDatabase) -> anyhow::Result<()> {
     })?;
 
     assert_eq!(stmt.num_columns(), 2);
-    assert_eq!(stmt.get_column_name(0), "avg (t.x)");
-    assert_eq!(stmt.get_column_name(1), "avg (t.y)");
+    assert_eq!(stmt.get_column_name(0), "avg(x)");
+    assert_eq!(stmt.get_column_name(1), "avg(y)");
 
     assert_eq!(
         rows,


### PR DESCRIPTION
Fix column naming for unaliased expressions to match SQLite behavior. Previously, tursodb would reconstruct column names from the resolved AST, producing fully-qualified reformatted names like "test1.f1 + test1.f2" instead of preserving the original SQL text "f1+F2". This fixes TCL test select1-6.4a and related failures (select1-6.5, select1-6.6, select1-6.8, select1-6.9.*) in testing/sqlite3/all.test.

The fix captures the raw expression text at parse time (matching SQLite's scanpt/zEName/ENAME_SPAN mechanism) and stores it as a new As::ImplicitColumnName variant, which is used as a fallback column name when there is no explicit alias and the expression is not a simple column reference.