### PR TITLE
return Result from Logical Log checkpoint callbacks

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -728,7 +728,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
                 self.mvstore
                     .storage
-                    .on_checkpoint_start(self.durable_txid_max_new);
+                    .on_checkpoint_start(self.durable_txid_max_new)?;
 
                 if self.write_set.is_empty() && self.index_write_set.is_empty() {
                     // Nothing to checkpoint, skip pager txn and go straight to WAL checkpoint.
@@ -1519,7 +1519,7 @@ impl<Clock: LogicalClock> StateTransition for CheckpointStateMachine<Clock> {
             Err(ref err) => {
                 self.mvstore
                     .storage
-                    .on_checkpoint_end(self.durable_txid_max_new, Err(err.clone()));
+                    .on_checkpoint_end(self.durable_txid_max_new, Err(err.clone()))?;
                 tracing::debug!("Error in checkpoint state machine: {err}");
                 self.cleanup_after_external_io_error();
                 res
@@ -1527,7 +1527,7 @@ impl<Clock: LogicalClock> StateTransition for CheckpointStateMachine<Clock> {
             Ok(TransitionResult::Done(ref result)) => {
                 self.mvstore
                     .storage
-                    .on_checkpoint_end(self.durable_txid_max_new, Ok(result));
+                    .on_checkpoint_end(self.durable_txid_max_new, Ok(result))?;
                 res
             }
             Ok(result) => Ok(result),

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -52,11 +52,19 @@ pub trait DurableStorage: Send + Sync + Debug {
     /// Called when a checkpoint begins, before any rows are written to the B-tree.
     /// `durable_txid_max` is the transaction watermark that will be durably persisted
     /// once the checkpoint completes.
-    fn on_checkpoint_start(&self, _durable_txid_max: u64) {}
+    fn on_checkpoint_start(&self, _durable_txid_max: u64) -> Result<()> {
+        Ok(())
+    }
 
     /// Called after the checkpoint has fully completed: rows are flushed, WAL is
     /// truncated, and the logical log is reset.
-    fn on_checkpoint_end(&self, _durable_txid_max: u64, _result: Result<&CheckpointResult>) {}
+    fn on_checkpoint_end(
+        &self,
+        _durable_txid_max: u64,
+        _result: Result<&CheckpointResult>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 pub struct Storage {


### PR DESCRIPTION
## Description
Allow implementors of the `DurableStorage` trait return errors directly from the checkpoint callbacks

