### PR TITLE
core: Represent MonotonicInstant as u128

### DIFF
--- a/core/io/clock.rs
+++ b/core/io/clock.rs
@@ -1,24 +1,35 @@
+use std::sync::LazyLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// A monotonic instant in time, backed by `std::time::Instant`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct MonotonicInstant(std::time::Instant);
+pub struct MonotonicInstant(u128);
 
 impl MonotonicInstant {
+    pub const fn from_nanos(nanos: u128) -> Self {
+        MonotonicInstant(nanos)
+    }
+
     pub fn now() -> Self {
-        MonotonicInstant(std::time::Instant::now())
+        static EPOCH: LazyLock<std::time::Instant> = LazyLock::new(std::time::Instant::now);
+        let elapsed = EPOCH.elapsed();
+        MonotonicInstant(elapsed.as_nanos())
     }
 
     pub fn duration_since(&self, earlier: MonotonicInstant) -> Duration {
-        self.0.duration_since(earlier.0)
+        Duration::from_nanos(self.0.saturating_sub(earlier.0) as u64)
     }
 
     pub fn checked_add(&self, duration: Duration) -> Option<MonotonicInstant> {
-        self.0.checked_add(duration).map(MonotonicInstant)
+        self.0
+            .checked_add(duration.as_nanos())
+            .map(MonotonicInstant)
     }
 
     pub fn checked_sub(&self, duration: Duration) -> Option<MonotonicInstant> {
-        self.0.checked_sub(duration).map(MonotonicInstant)
+        self.0
+            .checked_sub(duration.as_nanos())
+            .map(MonotonicInstant)
     }
 }
 
@@ -26,7 +37,7 @@ impl std::ops::Add<Duration> for MonotonicInstant {
     type Output = MonotonicInstant;
 
     fn add(self, rhs: Duration) -> Self::Output {
-        MonotonicInstant(self.0 + rhs)
+        MonotonicInstant(self.0 + rhs.as_nanos())
     }
 }
 
@@ -34,7 +45,7 @@ impl std::ops::Sub<Duration> for MonotonicInstant {
     type Output = MonotonicInstant;
 
     fn sub(self, rhs: Duration) -> Self::Output {
-        MonotonicInstant(self.0 - rhs)
+        MonotonicInstant(self.0 - rhs.as_nanos())
     }
 }
 


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

https://github.com/tursodatabase/turso/pull/4600 changed the Clock interface such that only `std::time::Instant` can be used to create the `MonotonicInstant`. This broke compatibility on platforms where `std::time` is not available, which includes wasm32-unknown-unknown. See [std](https://github.com/rust-lang/rust/blob/8a703520e80d87d4423c01f9d4fbc9e5f6533a02/library/std/src/sys/time/mod.rs).

This PR makes `MonotonicInstant` hold a u128 (for nanos) instead of an `Instant`. The u128 can be derived from Instant to keep the performance gains mentioned in #4600 but crucially, can also passed in on platforms where time is provided some other way

## Motivation and context

See #6130

## Description of AI Usage

Claude Opus 4.6 was asked to evaluate solutions for #6130 and came up with the solution in this PR. It was then adapted (changed Claude's u64 -> u128) and implemented manually. It also pointed out why the first solution in the issue isn't ideal