### PR TITLE
add unistr(X) scalar function

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -470,6 +470,7 @@ pub enum ScalarFunc {
     DateTime,
     Typeof,
     Unicode,
+    Unistr,
     Quote,
     SqliteVersion,
     TursoVersion,
@@ -579,6 +580,7 @@ impl Deterministic for ScalarFunc {
             ScalarFunc::DateTime => false,
             ScalarFunc::Typeof => true,
             ScalarFunc::Unicode => true,
+            ScalarFunc::Unistr => true,
             ScalarFunc::Quote => true,
             ScalarFunc::SqliteVersion => false,
             ScalarFunc::TursoVersion => false,
@@ -707,6 +709,7 @@ impl Display for ScalarFunc {
             Self::TotalChanges => "total_changes",
             Self::Typeof => "typeof",
             Self::Unicode => "unicode",
+            Self::Unistr => "unistr",
             Self::Quote => "quote",
             Self::SqliteVersion => "sqlite_version",
             Self::TursoVersion => "turso_version",
@@ -823,6 +826,7 @@ impl ScalarFunc {
             | Self::Soundex
             | Self::Typeof
             | Self::Unicode
+            | Self::Unistr
             | Self::Upper
             | Self::ZeroBlob
             | Self::Likely
@@ -1284,6 +1288,7 @@ impl Func {
             "typeof" => Ok(Some(Self::Scalar(ScalarFunc::Typeof))),
             "last_insert_rowid" => Ok(Some(Self::Scalar(ScalarFunc::LastInsertRowid))),
             "unicode" => Ok(Some(Self::Scalar(ScalarFunc::Unicode))),
+            "unistr" => Ok(Some(Self::Scalar(ScalarFunc::Unistr))),
             "quote" => Ok(Some(Self::Scalar(ScalarFunc::Quote))),
             "sqlite_version" => Ok(Some(Self::Scalar(ScalarFunc::SqliteVersion))),
             "turso_version" => Ok(Some(Self::Scalar(ScalarFunc::TursoVersion))),

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -2122,6 +2122,7 @@ pub fn translate_expr(
                         | ScalarFunc::OctetLength
                         | ScalarFunc::Typeof
                         | ScalarFunc::Unicode
+                        | ScalarFunc::Unistr
                         | ScalarFunc::Quote
                         | ScalarFunc::RandomBlob
                         | ScalarFunc::Sign

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6478,6 +6478,7 @@ pub fn op_function(
             | ScalarFunc::OctetLength
             | ScalarFunc::Typeof
             | ScalarFunc::Unicode
+            | ScalarFunc::Unistr
             | ScalarFunc::Quote
             | ScalarFunc::RandomBlob
             | ScalarFunc::Sign
@@ -6493,6 +6494,7 @@ pub fn op_function(
                     ScalarFunc::OctetLength => Some(reg_value.exec_octet_length()),
                     ScalarFunc::Typeof => Some(reg_value.exec_typeof()),
                     ScalarFunc::Unicode => Some(reg_value.exec_unicode()),
+                    ScalarFunc::Unistr => Some(reg_value.exec_unistr()?),
                     ScalarFunc::Quote => Some(reg_value.exec_quote()),
                     ScalarFunc::RandomBlob => {
                         Some(reg_value.exec_randomblob(|dest| pager.io.fill_bytes(dest))?)

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -627,6 +627,66 @@ impl Value {
         }
     }
 
+    pub fn exec_unistr(&self) -> Result<Value> {
+        let text = match self {
+            Value::Text(t) => std::borrow::Cow::Borrowed(t.as_str()),
+            Value::Numeric(_) | Value::Blob(_) => std::borrow::Cow::Owned(self.to_string()),
+            _ => return Ok(Value::Null),
+        };
+        let bytes = text.as_bytes();
+        let len = bytes.len();
+        let mut out = String::with_capacity(len);
+        let mut i = 0;
+
+        while i < len {
+            if bytes[i] != b'\\' {
+                let start = i;
+                while i < len && bytes[i] != b'\\' {
+                    i += 1;
+                }
+                out.push_str(&text[start..i]);
+                continue;
+            }
+
+            let v = match bytes.get(i + 1) {
+                Some(b'\\') => {
+                    out.push('\\');
+                    i += 2;
+                    continue;
+                }
+                Some(b) if b.is_ascii_hexdigit() => {
+                    let v = parse_n_hex(&bytes[i + 1..], 4)?;
+                    i += 5;
+                    v
+                }
+                Some(b'+') => {
+                    let v = parse_n_hex(&bytes[i + 2..], 6)?;
+                    i += 8;
+                    v
+                }
+                Some(b'u') => {
+                    let v = parse_n_hex(&bytes[i + 2..], 4)?;
+                    i += 6;
+                    v
+                }
+                Some(b'U') => {
+                    let v = parse_n_hex(&bytes[i + 2..], 8)?;
+                    i += 10;
+                    v
+                }
+                _ => return Err(LimboError::ParseError("invalid Unicode escape".to_string())),
+            };
+
+            // Reject surrogates and values above U+10FFFF. SQLite encodes
+            // these as raw bytes, but Value::Text requires valid UTF-8.
+            let ch = char::from_u32(v)
+                .ok_or_else(|| LimboError::ParseError("invalid Unicode escape".to_string()))?;
+            out.push(ch);
+        }
+
+        Ok(Value::build_text(out))
+    }
+
     pub fn exec_round(&self, precision: Option<&Value>) -> Value {
         let Some(f) = Numeric::from_value(self).map(|v| v.to_f64()) else {
             return Value::Null;
@@ -1206,6 +1266,24 @@ impl Value {
             .collect();
         Value::build_text(result)
     }
+}
+
+/// Parse exactly `n` hex digits into a u32. Mirrors SQLite's isNHex().
+fn parse_n_hex(bytes: &[u8], n: usize) -> Result<u32> {
+    if bytes.len() < n {
+        return Err(LimboError::ParseError("invalid Unicode escape".to_string()));
+    }
+    let mut v: u32 = 0;
+    for &b in &bytes[..n] {
+        let digit = match b {
+            b'0'..=b'9' => b - b'0',
+            b'a'..=b'f' => b - b'a' + 10,
+            b'A'..=b'F' => b - b'A' + 10,
+            _ => return Err(LimboError::ParseError("invalid Unicode escape".to_string())),
+        };
+        v = (v << 4) | digit as u32;
+    }
+    Ok(v)
 }
 
 /// Result of LIKE pattern comparison.
@@ -1896,6 +1974,84 @@ mod tests {
             Value::Blob("example".as_bytes().to_vec()).exec_unicode(),
             Value::from_i64(101)
         );
+    }
+
+    #[test]
+    fn test_unistr() {
+        // Each escape form individually
+        assert_eq!(
+            Value::build_text(r"\u0041").exec_unistr().unwrap(),
+            Value::build_text("A")
+        );
+        assert_eq!(
+            Value::build_text(r"\0041").exec_unistr().unwrap(),
+            Value::build_text("A")
+        );
+        assert_eq!(
+            Value::build_text(r"\+01F600").exec_unistr().unwrap(),
+            Value::build_text("😀")
+        );
+        assert_eq!(
+            Value::build_text(r"\U0001F600").exec_unistr().unwrap(),
+            Value::build_text("😀")
+        );
+        // Escaped backslash
+        assert_eq!(
+            Value::build_text(r"a\\b").exec_unistr().unwrap(),
+            Value::build_text(r"a\b")
+        );
+        // Hex is case-insensitive
+        assert_eq!(
+            Value::build_text(r"\u00E4").exec_unistr().unwrap(),
+            Value::build_text("ä")
+        );
+        assert_eq!(
+            Value::build_text(r"\u00e4").exec_unistr().unwrap(),
+            Value::build_text("ä")
+        );
+        // Multiple escapes in one string
+        assert_eq!(
+            Value::build_text(r"\u0048\u0065\u006C\u006C\u006F")
+                .exec_unistr()
+                .unwrap(),
+            Value::build_text("Hello")
+        );
+        // Mixed literal and escape forms
+        assert_eq!(
+            Value::build_text(r"hi \u0041 \U0001F600")
+                .exec_unistr()
+                .unwrap(),
+            Value::build_text("hi A 😀")
+        );
+        // No escapes
+        assert_eq!(
+            Value::build_text("hello").exec_unistr().unwrap(),
+            Value::build_text("hello")
+        );
+        // Empty string
+        assert_eq!(
+            Value::build_text("").exec_unistr().unwrap(),
+            Value::build_text("")
+        );
+        // NULL input
+        assert_eq!(Value::Null.exec_unistr().unwrap(), Value::Null);
+        // NUL codepoint accepted (matches SQLite, which carries NUL via explicit length)
+        assert_eq!(
+            Value::build_text(r"\u0000").exec_unistr().unwrap(),
+            Value::build_text("\0")
+        );
+        // Surrogate rejected (Value::Text requires valid UTF-8)
+        assert!(Value::build_text(r"\uD83D").exec_unistr().is_err());
+        // Above U+10FFFF rejected
+        assert!(Value::build_text(r"\U00110000").exec_unistr().is_err());
+        // Malformed escapes
+        assert!(Value::build_text(r"\q").exec_unistr().is_err());
+        assert!(Value::build_text(r"\u00").exec_unistr().is_err());
+        assert!(Value::build_text("abc\\").exec_unistr().is_err());
+        // Non-hex in fixed-width span
+        assert!(Value::build_text(r"\u00GG").exec_unistr().is_err());
+        assert!(Value::build_text(r"\+01FG00").exec_unistr().is_err());
+        assert!(Value::build_text(r"\U0001F6GG").exec_unistr().is_err());
     }
 
     #[test]

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -2113,3 +2113,173 @@ expect error {
 # do_execsql_test soundex-text {
 #  select soundex('Pfister'), soundex('husobee'), soundex('Tymczak'), soundex('Ashcraft'), soundex('Robert'), soundex('Rupert'), soundex('Rubin'), soundex('Kant'), soundex('Knuth'), soundex('x'), soundex('');
 # } {P236|H210|T522|A261|R163|R163|R150|K530|K530|X000|0000}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-u-escape {
+    SELECT unistr('\u0041');
+}
+expect {
+    A
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-bare-hex {
+    SELECT unistr('\0041');
+}
+expect {
+    A
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-plus-form {
+    SELECT unistr('\+01F600');
+}
+expect {
+    😀
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-capital-U {
+    SELECT unistr('\U0001F600');
+}
+expect {
+    😀
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-backslash-escape {
+    SELECT unistr('a\\\\b');
+}
+expect {
+    a\b
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-case-insensitive-hex {
+    SELECT unistr('\u00E4') = unistr('\u00e4');
+}
+expect {
+    1
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-multiple-escapes {
+    SELECT unistr('\u0048\u0065\u006C\u006C\u006F');
+}
+expect {
+    Hello
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-mixed {
+    SELECT unistr('hi \u0041 \U0001F600');
+}
+expect {
+    hi A 😀
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-no-escapes {
+    SELECT unistr('hello');
+}
+expect {
+    hello
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-empty-string {
+    SELECT unistr('');
+}
+expect {
+
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-null-input {
+    SELECT unistr(NULL);
+}
+expect {
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-nul-codepoint {
+    SELECT hex(unistr('\u0000'));
+}
+expect {
+    00
+}
+
+# Intentional deviation: SQLite's sqlite3AppendOneUtf8Character encodes any u32
+# as raw bytes, but Value::Text requires valid UTF-8 so we reject surrogates
+# (0xD800–0xDFFF) and values above U+10FFFF. This matches Postgres's unistr.
+@skip-if sqlite "SQLite encodes surrogates as raw bytes; we reject them for UTF-8 safety"
+test unistr-surrogate-rejected {
+    SELECT unistr('\uD83D');
+}
+expect error {
+    invalid Unicode escape
+}
+
+@skip-if sqlite "SQLite encodes above-max codepoints as raw bytes; we reject them for UTF-8 safety"
+test unistr-above-max-rejected {
+    SELECT unistr('\U00110000');
+}
+expect error {
+    invalid Unicode escape
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-max-valid {
+    SELECT unistr('\U0010FFFF') IS NOT NULL;
+}
+expect {
+    1
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-error-invalid-escape {
+    SELECT unistr('\q');
+}
+expect error {
+    invalid Unicode escape
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-error-short-hex {
+    SELECT unistr('\u00');
+}
+expect error {
+    invalid Unicode escape
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-error-trailing-backslash {
+    SELECT unistr('abc\');
+}
+expect error {
+    invalid Unicode escape
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-error-non-hex-u {
+    SELECT unistr('\u00GG');
+}
+expect error {
+    invalid Unicode escape
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-error-non-hex-plus {
+    SELECT unistr('\+01FG00');
+}
+expect error {
+    invalid Unicode escape
+}
+
+@skip-if sqlite "unistr not available in CI SQLite build"
+test unistr-error-non-hex-capital-U {
+    SELECT unistr('\U0001F6GG');
+}
+expect error {
+    invalid Unicode escape
+}


### PR DESCRIPTION
## Description

Add the `unistr(X)` scalar function, matching SQLite's [`unistrFunc`](https://github.com/sqlite/sqlite/blob/c67a538168/src/func.c#L1181-L1248) (added in 3.50).

**Deviations from SQLite:**

- **Surrogates/out-of-range codepoints**: `Value::Text` requires valid UTF-8, so `char::from_u32` rejects surrogates (0xD800–0xDFFF) and values above U+10FFFF. SQLite's [`sqlite3AppendOneUtf8Character`](https://github.com/sqlite/sqlite/blob/c67a538168/src/utf.c#L114-L135) encodes these as raw bytes. This PR's behavior matches [Postgres's `unistr`](https://github.com/postgres/postgres/blob/fba4233c832/src/backend/utils/adt/varlena.c#L5673-L5676).
- **Embedded NULs**: SQLite uses `strchr` to find backslashes, which stops at NUL bytes. Embedded NULs in text fall under SQLite's [GIGO policy for invalid UTF](https://www.sqlite.org/invalidutf.html). This implementation scans using the byte length, so escapes after embedded NULs are still processed.
  - Example: `SELECT hex(unistr(char(0) || '\u0041'))` with SQLite produces `005C7530303431` (literal `\u0041` not decoded), with this PR Turso produces `0041` (NUL + A).

**Tests:** 21 sqltests + 21 Rust unit test assertions.
- The sqltests have `@skip-if sqlite` since `scripts/install-sqlite3.sh` defaults to 3.49.1 (pre-`unistr`). Bumping it to match the CI version (3.51.1) would let the annotations be removed.
- The 2 deviation tests (`unistr-surrogate-rejected`, `unistr-above-max-rejected`) should keep `@skip-if sqlite` permanently. SQLite will still produce a result with these inputs, with this PR Turso will fail with an `invalid Unicode escape` error.

`unistr_quote(X)` which was also added in 3.50 is not included in this PR. This function is currently missing in `COMPAT.md`.

## Motivation and context

Implements `unistr(X)` tracked in `COMPAT.md`. The unistr(X) function interprets backslash escapes in input string X and returns a new string with those escapes converted into the actual Unicode codepoints that they represent.

## Description of AI Usage

Developed collaboratively with Opus 4.6. Used for cross-referencing SQLite/Postgres source, and identifying edge cases like the `strchr` NUL behavior. Codex with GPT5.4 xhigh was used as a final code review before submitting the PR.
