### PR TITLE
fix: OFFSET label use-after-free when emit_query is called twice

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -508,6 +508,8 @@ pub struct TranslateCtx<'a> {
     // label for the instruction that jumps to the next phase of the query after the main loop
     // we don't know ahead of time what that is (GROUP BY, ORDER BY, etc.)
     pub label_main_loop_end: Option<BranchOffset>,
+    // Dedicated label for OFFSET continue (avoids label reuse issues with nested emit_query calls)
+    pub label_offset_continue: Option<BranchOffset>,
     // First register of the aggregation results
     pub reg_agg_start: Option<usize>,
     // In non-group-by statements with aggregations (e.g. SELECT foo, bar, sum(baz) FROM t),
@@ -579,6 +581,7 @@ impl<'a> TranslateCtx<'a> {
         TranslateCtx {
             labels_main_loop: (0..table_count).map(|_| LoopLabels::new(program)).collect(),
             label_main_loop_end: None,
+            label_offset_continue: None,
             reg_agg_start: None,
             reg_nonagg_emit_once_flag: None,
             limit_ctx: None,

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -79,6 +79,8 @@ pub fn emit_query<'a>(
 ) -> Result<usize> {
     let after_main_loop_label = program.allocate_label();
     t_ctx.label_main_loop_end = Some(after_main_loop_label);
+    let offset_continue_label = program.allocate_label();
+    t_ctx.label_offset_continue = Some(offset_continue_label);
 
     // Evaluate uncorrelated subqueries as early as possible, because even LIMIT can reference a subquery.
     // This must happen before VALUES emission since VALUES expressions may contain scalar subqueries.

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -114,12 +114,13 @@ impl<'prog, 'ctx, 'plan> LoopBody<'prog, 'ctx, 'plan> {
 
     /// Emit the loop body once all required entry labels are fixed.
     fn emit(mut self) -> Result<()> {
+        let emit_target = self.select_emit_target();
         self.resolve_anti_join_entry();
         emit_loop_source(
             self.program,
             self.t_ctx,
             self.plan,
-            self.select_emit_target(),
+            emit_target,
         )
     }
 }
@@ -385,11 +386,7 @@ fn emit_loop_source<'a>(
                 plan.aggregates.is_empty(),
                 "QueryResult target should not have aggregates"
             );
-            let offset_jump_to = t_ctx
-                .labels_main_loop
-                .first()
-                .map(|l| l.next)
-                .or(t_ctx.label_main_loop_end);
+            let offset_jump_to = t_ctx.label_offset_continue;
             emit_select_result(
                 program,
                 &t_ctx.resolver,

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -23,7 +23,7 @@ impl CloseLoop {
         //     CLOSE t3
         //   CLOSE t2
         // CLOSE t1
-        for join in join_order.iter().rev() {
+        for (rev_idx, join) in join_order.iter().rev().enumerate() {
             let table_index = join.original_idx;
             let table = &tables.joined_tables()[table_index];
             let loop_labels = *t_ctx
@@ -65,6 +65,13 @@ impl CloseLoop {
                 program.resolve_label(loop_labels.next, pc);
                 semi_anti_next_pc = Some(pc);
             };
+            // Also resolve the dedicated offset continue label when closing the first table
+            // (last in the reverse iteration)
+            if rev_idx == join_order.len() - 1 {
+                if let Some(label) = t_ctx.label_offset_continue {
+                    program.resolve_label(label, program.offset());
+                }
+            }
             match &table.op {
                 Operation::Scan(scan) => {
                     resolve_next(program);

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1352,6 +1352,7 @@ pub fn emit_from_clause_subquery(
                     .map(|_| LoopLabels::new(program))
                     .collect(),
                 label_main_loop_end: None,
+                label_offset_continue: None,
                 meta_group_by: None,
                 meta_left_joins: (0..select_plan.joined_tables().len())
                     .map(|_| None)
@@ -1438,6 +1439,7 @@ fn emit_indexed_materialized_subquery(
                     .map(|_| LoopLabels::new(program))
                     .collect(),
                 label_main_loop_end: None,
+                label_offset_continue: None,
                 meta_group_by: None,
                 meta_left_joins: (0..select_plan.joined_tables().len())
                     .map(|_| None)
@@ -1533,6 +1535,7 @@ fn emit_materialized_subquery_table(
                     .map(|_| LoopLabels::new(program))
                     .collect(),
                 label_main_loop_end: None,
+                label_offset_continue: None,
                 meta_group_by: None,
                 meta_left_joins: (0..select_plan.joined_tables().len())
                     .map(|_| None)


### PR DESCRIPTION
## What

Queries with JOIN + LIMIT + OFFSET crash at runtime with:

```
Error: Reference to undefined or unresolved label in IfPos: 2
```

This affects any query that materializes intermediate results (e.g., hash join,
grace join, subqueries) while also using OFFSET.

## Reproduction

```sql
CREATE TABLE t1(a INT);
CREATE TABLE t2(b INT);
INSERT INTO t1 VALUES(1),(2),(3);
INSERT INTO t2 VALUES(1),(2);

SELECT * FROM t1 INNER JOIN t2 ON t1.a = t2.b LIMIT 1 OFFSET 0;
-- Error: Reference to undefined or unresolved label in IfPos: 2
```

The crash also occurs with LEFT JOIN and with subqueries that get materialized.

## Root cause

When a query needs to re-emit rows (for materialization), `emit_query` gets called
more than once. Both calls share the same `TranslateCtx`.

The OFFSET skip logic was using `labels_main_loop.first().next` as the jump target
after skipping rows. On the first `emit_query` call this works fine. But when a
second `emit_query` call happens (for the materialized version), it overwrites the
label resolution in `label_to_resolved_offset`. Now when the first call's
IfPos instruction tries to resolve its label, it finds a stale entry -- the label
was reassigned by the second call.

This is a classic use-after-free situation for labels: the first emitter holds a
reference to a label that gets invalidated by the second emitter.

## Fix

Instead of sharing `labels_main_loop.first().next` across multiple `emit_query`
calls, each call now allocates its own dedicated label for the OFFSET continue
target. The new `label_offset_continue` field in `TranslateCtx` is allocated fresh
in `emit_query` and resolved when closing the first loop (which is the last in
the reverse close iteration).

Files changed:
- `core/translate/emitter/mod.rs` -- add `label_offset_continue` to TranslateCtx
- `core/translate/emitter/select.rs` -- allocate the new label at start of emit_query
- `core/translate/main_loop/body.rs` -- use `label_offset_continue` instead of the shared label
- `core/translate/main_loop/close.rs` -- resolve the dedicated label when closing the first table
- `core/translate/subquery.rs` -- initialize `label_offset_continue` in subquery contexts

## Testing

The query from the reproduction case now executes without error and returns the
expected single row. Additional join patterns (LEFT JOIN, nested subqueries) also
pass.
