### PR TITLE
core/translate: Match SQLite error format for ambiguous column names

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5575,7 +5575,10 @@ pub fn bind_and_rewrite_expr<'a>(
                                     }
                                 }
                                 if !ok {
-                                    crate::bail_parse_error!("Column {} is ambiguous", id.as_str());
+                                    crate::bail_parse_error!(
+                                        "ambiguous column name: {}",
+                                        id.as_str()
+                                    );
                                 }
                             } else {
                                 let col =
@@ -5626,7 +5629,10 @@ pub fn bind_and_rewrite_expr<'a>(
                             });
                             if col_idx.is_some() {
                                 if match_result.is_some() {
-                                    crate::bail_parse_error!("Column {} is ambiguous", id.as_str());
+                                    crate::bail_parse_error!(
+                                        "ambiguous column name: {}",
+                                        id.as_str()
+                                    );
                                 }
                                 let col = outer_ref.table.columns().get(col_idx.unwrap()).unwrap();
                                 match_result = Some((

--- a/testing/sqltests/tests/select/memory.sqltest
+++ b/testing/sqltests/tests/select/memory.sqltest
@@ -1188,6 +1188,17 @@ test ambiguous-self-join {
 expect error {
 }
 
+# Regression test: ambiguous column error message must match SQLite format
+@cross-check-integrity
+test ambiguous-column-error-message-format {
+    CREATE TABLE test1(f1 int, f2 int);
+    INSERT INTO test1 VALUES(11,22);
+    SELECT A.f1, f1 FROM test1 AS A, test1 AS B ORDER BY f2;
+}
+expect error {
+    ambiguous column name: f1
+}
+
 @cross-check-integrity
 test unambiguous-self-join {
     CREATE TABLE T(a);


### PR DESCRIPTION
Change the ambiguous column error message from "Column {name} is ambiguous" to "ambiguous column name: {name}" to match SQLite's exact format (resolve.c:794). This fixes TCL test select1-6.9.3 which checks the error string verbatim.