### PR TITLE
Fix CI sccache setup to gracefully handle network failures

### DIFF
--- a/.github/shared/setup-sccache/action.yml
+++ b/.github/shared/setup-sccache/action.yml
@@ -10,10 +10,15 @@ runs:
       shell: bash
       run: |
         export SCCACHE_GHA_ENABLED=true
-        if sccache -s >/dev/null 2>&1; then
+        # Start the sccache server explicitly to verify it can connect to
+        # the cache backend. `sccache -s` alone doesn't test connectivity —
+        # a DNS or network failure only surfaces on the first real rustc
+        # invocation, which kills the entire build.
+        if sccache --start-server 2>/dev/null && sccache -s >/dev/null 2>&1; then
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "sccache is available and configured"
+          echo "sccache server started and configured"
         else
+          sccache --stop-server 2>/dev/null || true
           echo "::warning::sccache cache service is unavailable, building without cache"
         fi


### PR DESCRIPTION
Start the sccache server explicitly during setup to verify it can connect to the cache backend. Previously, `sccache -s` would succeed without testing connectivity, and the build would fail on the first rustc invocation when DNS was unavailable on the runner.