### PR TITLE
core/translate: Allow duplicate table aliases, detect ambiguity at column resolution

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5692,6 +5692,20 @@ pub fn bind_and_rewrite_expr<'a>(
                         );
                     };
                     let normalized_table_name = normalize_ident(tbl.as_str());
+                    // Check for duplicate table aliases — if multiple joined tables
+                    // share the same identifier, the qualified column ref is ambiguous.
+                    let duplicate_count = referenced_tables
+                        .joined_tables()
+                        .iter()
+                        .filter(|t| t.identifier == normalized_table_name)
+                        .count();
+                    if duplicate_count > 1 {
+                        crate::bail_parse_error!(
+                            "ambiguous column name: {}.{}",
+                            tbl.as_str(),
+                            id.as_str()
+                        );
+                    }
                     let matching_tbl = referenced_tables
                         .find_table_and_internal_id_by_identifier(&normalized_table_name);
                     if matching_tbl.is_none() {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -746,7 +746,7 @@ pub fn select_star(
     tables: &[JoinedTable],
     out_columns: &mut Vec<ResultSetColumn>,
     right_join_swapped: bool,
-) {
+) -> crate::Result<()> {
     // RIGHT JOIN swapped tables; iterate in reverse to restore original column order.
     let table_iter: Vec<&JoinedTable> = if right_join_swapped {
         tables.iter().rev().collect()
@@ -762,6 +762,36 @@ pub fn select_star(
             .is_some_and(|ji| ji.is_semi_or_anti())
         {
             continue;
+        }
+        // If this table's identifier appears more than once in the FROM clause,
+        // expanding * would produce ambiguous column references (matches SQLite).
+        // However, columns deduplicated by USING/NATURAL are not ambiguous.
+        let has_duplicate_identifier = tables
+            .iter()
+            .filter(|t| t.identifier == table.identifier)
+            .count()
+            > 1;
+        if has_duplicate_identifier {
+            // Collect all USING columns from duplicate tables (both this table's
+            // own join_info and the join_info of other tables with the same identifier).
+            let using_cols: Vec<&str> = tables
+                .iter()
+                .filter(|t| t.identifier == table.identifier)
+                .filter_map(|t| t.join_info.as_ref())
+                .flat_map(|ji| ji.using.iter().map(|u| u.as_str()))
+                .collect();
+            for col in table.columns().iter().filter(|c| !c.hidden()) {
+                if let Some(col_name) = &col.name {
+                    let in_using = using_cols.iter().any(|u| u.eq_ignore_ascii_case(col_name));
+                    if !in_using {
+                        crate::bail_parse_error!(
+                            "ambiguous column name: {}.{}",
+                            table.identifier,
+                            col_name
+                        );
+                    }
+                }
+            }
         }
         out_columns.extend(
             table
@@ -794,6 +824,7 @@ pub fn select_star(
                 }),
         );
     }
+    Ok(())
 }
 
 /// The type of join between two tables.

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1822,27 +1822,9 @@ fn parse_join(
         crate::bail_parse_error!("NATURAL JOIN cannot be combined with ON or USING clause");
     }
 
-    // this is called once for each join, so we only need to check the rightmost table
-    // against all previous tables for duplicates
+    // SQLite allows duplicate table names/aliases in FROM clauses.
+    // Ambiguity is detected later during column resolution.
     let rightmost_table = table_references.joined_tables().last().unwrap();
-    let has_duplicate = table_references
-        .joined_tables()
-        .iter()
-        .take(table_references.joined_tables().len() - 1)
-        .any(|t| t.identifier == rightmost_table.identifier);
-
-    if has_duplicate
-        && !natural
-        && constraint
-            .as_ref()
-            .is_none_or(|c| !matches!(c, ast::JoinConstraint::Using(_)))
-    {
-        // Duplicate table names are only allowed for NATURAL or USING joins
-        crate::bail_parse_error!(
-            "table name {} specified more than once - use an alias to disambiguate",
-            rightmost_table.identifier
-        );
-    }
     let constraint = if natural {
         turso_assert_greater_than_or_equal!(table_references.joined_tables().len(), 2);
         // NATURAL JOIN is first transformed into a USING join with the common columns

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -400,7 +400,7 @@ fn prepare_one_select_plan(
                             plan.table_references.joined_tables(),
                             &mut plan.result_columns,
                             plan.table_references.right_join_swapped(),
-                        );
+                        )?;
                         for table in plan.table_references.joined_tables_mut() {
                             for idx in 0..table.columns().len() {
                                 let column = &table.columns()[idx];
@@ -413,6 +413,34 @@ fn prepare_one_select_plan(
                     }
                     ResultColumn::TableStar(name) => {
                         let name_normalized = normalize_ident(name.as_str());
+                        // If this table identifier appears more than once in the FROM
+                        // clause, `A.*` is ambiguous (matches SQLite behavior).
+                        let dup_count = plan
+                            .table_references
+                            .joined_tables()
+                            .iter()
+                            .filter(|t| t.identifier == name_normalized)
+                            .count();
+                        if dup_count > 1 {
+                            let first_tbl = plan
+                                .table_references
+                                .joined_tables()
+                                .iter()
+                                .find(|t| t.identifier == name_normalized)
+                                .unwrap(); // safe: dup_count > 1 guarantees a match
+                            let col_name = first_tbl
+                                .columns()
+                                .iter()
+                                .find(|c| !c.hidden())
+                                .and_then(|c| c.name.as_ref())
+                                .map(|n| n.as_str())
+                                .unwrap_or("?");
+                            crate::bail_parse_error!(
+                                "ambiguous column name: {}.{}",
+                                name.as_str(),
+                                col_name
+                            );
+                        }
                         let referenced_table = plan
                             .table_references
                             .joined_tables_mut()

--- a/testing/sqltests/tests/select/memory.sqltest
+++ b/testing/sqltests/tests/select/memory.sqltest
@@ -1199,6 +1199,18 @@ expect error {
     ambiguous column name: f1
 }
 
+# Regression test: duplicate table alias produces "ambiguous column name" not
+# "table name specified more than once" (matches SQLite behavior)
+@cross-check-integrity
+test duplicate-alias-ambiguous-column {
+    CREATE TABLE test1(f1 int, f2 int);
+    INSERT INTO test1 VALUES(11,22);
+    SELECT A.f1, f1 FROM test1 AS A, test1 AS A ORDER BY f2;
+}
+expect error {
+    ambiguous column name: A.f1
+}
+
 @cross-check-integrity
 test unambiguous-self-join {
     CREATE TABLE T(a);


### PR DESCRIPTION
SQLite permits duplicate table names/aliases in FROM clauses and only errors when a column reference is actually ambiguous. Turso rejected them early with "table name specified more than once".

Remove the early rejection in parse_join and instead detect ambiguity at three column resolution sites: qualified refs (A.col), SELECT *, and table-star (A.*). This matches SQLite's select1-6.8c behavior.