### PR TITLE
simulator: support virtual columns

### DIFF
--- a/sql_generation/generation/generated_expr.rs
+++ b/sql_generation/generation/generated_expr.rs
@@ -1,0 +1,384 @@
+//! Expression generation for generated columns.
+
+use std::collections::HashSet;
+
+use rand::Rng;
+use turso_parser::ast::{self, Expr, Name, Operator, UnaryOperator};
+
+use crate::model::table::{Column, ColumnType};
+
+/// Generates a type-compatible expression for a generated column.
+///
+/// Returns (expression, set of column indices referenced by the expression).
+pub fn generate_column_expr_with_refs<R: Rng + ?Sized>(
+    rng: &mut R,
+    all_columns: &[Column],
+    current_col_idx: usize,
+    target_type: &ColumnType,
+    max_depth: usize,
+) -> (Expr, HashSet<usize>) {
+    let mut refs = HashSet::new();
+    let expr = generate_expr_inner(
+        rng,
+        all_columns,
+        current_col_idx,
+        target_type,
+        max_depth,
+        &mut refs,
+    );
+    (expr, refs)
+}
+
+fn generate_expr_inner<R: Rng + ?Sized>(
+    rng: &mut R,
+    all_columns: &[Column],
+    current_col_idx: usize,
+    target_type: &ColumnType,
+    depth: usize,
+    refs: &mut HashSet<usize>,
+) -> Expr {
+    let compatible_cols: Vec<(usize, &Column)> = all_columns
+        .iter()
+        .enumerate()
+        .filter(|(idx, col)| {
+            *idx != current_col_idx && types_compatible(&col.column_type, target_type)
+        })
+        .collect();
+
+    if depth == 0 || compatible_cols.is_empty() {
+        return if !compatible_cols.is_empty() && rng.random_bool(0.7) {
+            let (chosen_idx, chosen_col) =
+                compatible_cols[rng.random_range(0..compatible_cols.len())];
+            refs.insert(chosen_idx);
+            Expr::Id(Name::from_string(&chosen_col.name))
+        } else {
+            generate_literal(rng, target_type)
+        };
+    }
+
+    let choice = rng.random_range(0..10);
+    match choice {
+        // Column reference
+        0..=3 => {
+            let (idx, col) = compatible_cols[rng.random_range(0..compatible_cols.len())];
+            refs.insert(idx);
+            Expr::Id(Name::from_string(&col.name))
+        }
+        // Binary operation
+        4..=6 => {
+            if let Some(op) = pick_binary_op(rng, target_type) {
+                let lhs = generate_expr_inner(
+                    rng,
+                    all_columns,
+                    current_col_idx,
+                    target_type,
+                    depth - 1,
+                    refs,
+                );
+                let rhs = generate_expr_inner(
+                    rng,
+                    all_columns,
+                    current_col_idx,
+                    target_type,
+                    depth - 1,
+                    refs,
+                );
+                let lhs = if matches!(lhs, Expr::Binary(..)) {
+                    Expr::Parenthesized(vec![Box::new(lhs)])
+                } else {
+                    lhs
+                };
+                let rhs = if matches!(rhs, Expr::Binary(..)) {
+                    Expr::Parenthesized(vec![Box::new(rhs)])
+                } else {
+                    rhs
+                };
+                Expr::Binary(Box::new(lhs), op, Box::new(rhs))
+            } else if !compatible_cols.is_empty() && rng.random_bool(0.7) {
+                let (chosen_idx, chosen_col) =
+                    compatible_cols[rng.random_range(0..compatible_cols.len())];
+                refs.insert(chosen_idx);
+                Expr::Id(Name::from_string(&chosen_col.name))
+            } else {
+                generate_literal(rng, target_type)
+            }
+        }
+        // Unary operation (15% chance)
+        7..=8 => {
+            if let Some(op) = pick_unary_op(rng, target_type) {
+                let inner = generate_expr_inner(
+                    rng,
+                    all_columns,
+                    current_col_idx,
+                    target_type,
+                    depth - 1,
+                    refs,
+                );
+                let inner = if matches!(inner, Expr::Binary(..)) {
+                    Expr::Parenthesized(vec![Box::new(inner)])
+                } else {
+                    inner
+                };
+                Expr::Unary(op, Box::new(inner))
+            } else {
+                // Fall back to literal
+                generate_literal(rng, target_type)
+            }
+        }
+        // Parenthesized expression (5% chance)
+        9 => {
+            let inner = generate_expr_inner(
+                rng,
+                all_columns,
+                current_col_idx,
+                target_type,
+                depth - 1,
+                refs,
+            );
+            Expr::Parenthesized(vec![Box::new(inner)])
+        }
+        // Literal (10% implicit from other branches)
+        _ => generate_literal(rng, target_type),
+    }
+}
+
+/// Check if two column types are compatible for expressions.
+fn types_compatible(source: &ColumnType, target: &ColumnType) -> bool {
+    match (source, target) {
+        // Integer and Float are interchangeable
+        (ColumnType::Integer, ColumnType::Integer)
+        | (ColumnType::Integer, ColumnType::Float)
+        | (ColumnType::Float, ColumnType::Integer)
+        | (ColumnType::Float, ColumnType::Float) => true,
+        // Text only with Text
+        (ColumnType::Text, ColumnType::Text) => true,
+        // Blob only with Blob
+        (ColumnType::Blob, ColumnType::Blob) => true,
+        _ => false,
+    }
+}
+
+/// Generate a type-appropriate literal.
+fn generate_literal<R: Rng + ?Sized>(rng: &mut R, target_type: &ColumnType) -> Expr {
+    match target_type {
+        ColumnType::Integer => {
+            // Use smaller integer values to avoid overflow in expressions
+            let val = rng.random_range(-1000i64..1000);
+            Expr::Literal(ast::Literal::Numeric(val.to_string()))
+        }
+        ColumnType::Float => {
+            let val = rng.random_range(-1000.0f64..1000.0);
+            Expr::Literal(ast::Literal::Numeric(format!("{val:.4}")))
+        }
+        ColumnType::Text => {
+            // Generate a simple text literal
+            let text = format!("gen_{}", rng.random_range(0..100));
+            Expr::Literal(ast::Literal::String(format!("'{text}'")))
+        }
+        ColumnType::Blob => {
+            // Generate a simple blob literal
+            let bytes: Vec<u8> = (0..4).map(|_| rng.random()).collect();
+            Expr::Literal(ast::Literal::Blob(hex::encode(bytes)))
+        }
+    }
+}
+
+/// Pick an appropriate binary operator for the target type.
+fn pick_binary_op<R: Rng + ?Sized>(rng: &mut R, target_type: &ColumnType) -> Option<Operator> {
+    match target_type {
+        ColumnType::Integer | ColumnType::Float => {
+            let ops = [
+                Operator::Add,
+                Operator::Subtract,
+                Operator::Multiply,
+                Operator::Divide,
+                Operator::Modulus,
+                Operator::BitwiseAnd,
+                Operator::BitwiseOr,
+                Operator::LeftShift,
+                Operator::RightShift,
+            ];
+            Some(ops[rng.random_range(0..ops.len())])
+        }
+        // don't generate `||` (concat), as a workaround for
+        // https://github.com/tursodatabase/turso/issues/4860
+        ColumnType::Text | ColumnType::Blob => None,
+    }
+}
+
+/// Pick an appropriate unary operator for the target type (if any).
+fn pick_unary_op<R: Rng + ?Sized>(rng: &mut R, target_type: &ColumnType) -> Option<UnaryOperator> {
+    match target_type {
+        ColumnType::Integer | ColumnType::Float => {
+            if rng.random_bool(0.5) {
+                Some(UnaryOperator::Negative)
+            } else {
+                Some(UnaryOperator::Positive)
+            }
+        }
+        // No meaningful unary ops for text/blob
+        _ => None,
+    }
+}
+
+/// Extract all column references from an expression.
+pub fn extract_column_refs(expr: &Expr) -> HashSet<String> {
+    fn collect_refs_recursive(expr: &Expr, refs: &mut HashSet<String>) {
+        match expr {
+            Expr::Id(name) | Expr::Name(name) => {
+                refs.insert(name.as_str().to_ascii_lowercase());
+            }
+            Expr::Qualified(_, col) | Expr::DoublyQualified(_, _, col) => {
+                refs.insert(col.as_str().to_ascii_lowercase());
+            }
+            Expr::Binary(lhs, _, rhs) => {
+                collect_refs_recursive(lhs, refs);
+                collect_refs_recursive(rhs, refs);
+            }
+            Expr::Unary(_, operand) => {
+                collect_refs_recursive(operand, refs);
+            }
+            Expr::Parenthesized(exprs) => {
+                for e in exprs {
+                    collect_refs_recursive(e, refs);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut refs = HashSet::new();
+    collect_refs_recursive(expr, &mut refs);
+    refs
+}
+
+/// Rename column references in an expression from `from` to `to`.
+pub fn rename_column_refs_in_expr(expr: &mut Expr, from: &str, to: &str) {
+    let from_lower = from.to_ascii_lowercase();
+    match expr {
+        Expr::Id(name) if name.as_str().to_ascii_lowercase() == from_lower => {
+            *name = Name::exact(to.to_owned());
+        }
+        Expr::Name(name) if name.as_str().to_ascii_lowercase() == from_lower => {
+            *name = Name::exact(to.to_owned());
+        }
+        Expr::Qualified(_, col) if col.as_str().to_ascii_lowercase() == from_lower => {
+            *col = Name::exact(to.to_owned());
+        }
+        Expr::DoublyQualified(_, _, col) if col.as_str().to_ascii_lowercase() == from_lower => {
+            *col = Name::exact(to.to_owned());
+        }
+        Expr::Binary(lhs, _, rhs) => {
+            rename_column_refs_in_expr(lhs, from, to);
+            rename_column_refs_in_expr(rhs, from, to);
+        }
+        Expr::Unary(_, operand) => {
+            rename_column_refs_in_expr(operand, from, to);
+        }
+        Expr::Parenthesized(exprs) => {
+            for e in exprs {
+                rename_column_refs_in_expr(e, from, to);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_extract_column_refs() {
+        // Create a simple expression: a + b
+        let expr = Expr::Binary(
+            Box::new(Expr::Id(Name::from_string("a"))),
+            Operator::Add,
+            Box::new(Expr::Id(Name::from_string("b"))),
+        );
+        let refs = extract_column_refs(&expr);
+        assert!(refs.contains("a"));
+        assert!(refs.contains("b"));
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_column_refs_expr_name() {
+        // Test that Expr::Name is also recognized as a column reference
+        let expr = Expr::Binary(
+            Box::new(Expr::Name(Name::from_string("a"))),
+            Operator::Subtract,
+            Box::new(Expr::Name(Name::from_string("b"))),
+        );
+        let refs = extract_column_refs(&expr);
+        assert!(refs.contains("a"), "Should find column 'a' in Expr::Name");
+        assert!(refs.contains("b"), "Should find column 'b' in Expr::Name");
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_column_refs_mixed() {
+        // Test mixed Expr::Id and Expr::Name
+        let expr = Expr::Binary(
+            Box::new(Expr::Id(Name::from_string("a"))),
+            Operator::Add,
+            Box::new(Expr::Name(Name::from_string("b"))),
+        );
+        let refs = extract_column_refs(&expr);
+        assert!(refs.contains("a"));
+        assert!(refs.contains("b"));
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_column_refs_normalizes_case() {
+        let expr = Expr::Binary(
+            Box::new(Expr::Id(Name::from_string("A"))),
+            Operator::Add,
+            Box::new(Expr::Id(Name::from_string("b"))),
+        );
+        let refs = extract_column_refs(&expr);
+        assert!(refs.contains("a"));
+        assert!(refs.contains("b"));
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn test_generate_column_expr() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let columns = vec![
+            Column {
+                name: "col_a".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![],
+            },
+            Column {
+                name: "col_b".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![],
+            },
+            Column {
+                name: "col_c".to_string(),
+                column_type: ColumnType::Text,
+                constraints: vec![],
+            },
+        ];
+
+        // Generate expression for column at index 1 (col_b)
+        let (expr, refs) = generate_column_expr_with_refs(
+            &mut rng,
+            &columns,
+            1, // current column index
+            &ColumnType::Integer,
+            2,
+        );
+
+        // Should not reference itself (col_b at index 1)
+        assert!(!refs.contains(&1));
+
+        // Expression should be valid
+        assert!(!matches!(expr, Expr::Id(name) if name.as_str() == "col_b"));
+    }
+}

--- a/sql_generation/generation/mod.rs
+++ b/sql_generation/generation/mod.rs
@@ -4,6 +4,7 @@ use anarchist_readable_name_generator_lib::readable_name_custom;
 use rand::{distr::uniform::SampleUniform, Rng};
 
 pub mod expr;
+pub mod generated_expr;
 pub mod opts;
 pub mod predicate;
 pub mod query;
@@ -201,16 +202,30 @@ pub fn pick_unique<'a, T: PartialEq, R: Rng + ?Sized>(
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use crate::{
         generation::{GenerationContext, Opts},
         model::table::Table,
     };
 
-    #[derive(Debug, Default, Clone)]
+    #[derive(Debug, Clone)]
     pub struct TestContext {
         pub opts: Opts,
         pub tables: Vec<Table>,
+    }
+
+    impl Default for TestContext {
+        fn default() -> Self {
+            // Create a test context with generated columns disabled.
+            // Predicate tests create random values for all columns, which doesn't work correctly
+            // with generated columns since their values should be computed from expressions.
+            let mut ctx = Self {
+                opts: Default::default(),
+                tables: Default::default(),
+            };
+            ctx.opts.table.generated_columns.enable = false;
+            ctx
+        }
     }
 
     impl GenerationContext for TestContext {

--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -41,6 +41,8 @@ pub struct TableOpts {
     /// Range of numbers of columns to generate
     #[garde(custom(range_struct_min(1)))]
     pub column_range: Range<u32>,
+    #[garde(dive)]
+    pub generated_columns: GeneratedColumnOpts,
 }
 
 impl Default for TableOpts {
@@ -50,6 +52,28 @@ impl Default for TableOpts {
             rowid_alias_prob: 0.05,
             // Up to 10 columns
             column_range: 1..11,
+            generated_columns: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Validate)]
+#[serde(deny_unknown_fields, default)]
+pub struct GeneratedColumnOpts {
+    #[garde(skip)]
+    pub enable: bool,
+    #[garde(range(min = 0.0, max = 1.0))]
+    pub generated_column_prob: f64,
+    #[garde(range(min = 1, max = 10))]
+    pub max_expr_depth: usize,
+}
+
+impl Default for GeneratedColumnOpts {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            generated_column_prob: 0.2,
+            max_expr_depth: 3,
         }
     }
 }

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -1,6 +1,7 @@
+use crate::generation::generated_expr::extract_column_refs;
 use crate::generation::{
-    gen_random_text, pick_index, pick_n_unique, pick_unique, Arbitrary, ArbitraryFrom,
-    ArbitrarySized, GenerationContext, InsertOpts,
+    gen_random_text, pick_index, pick_unique, Arbitrary, ArbitraryFrom, ArbitrarySized,
+    GenerationContext, InsertOpts,
 };
 use crate::model::query::alter_table::{AlterTable, AlterTableType, AlterTableTypeDiscriminants};
 use crate::model::query::predicate::Predicate;
@@ -10,7 +11,8 @@ use crate::model::query::select::{
 };
 use crate::model::query::update::{SetValue, Update};
 use crate::model::query::{
-    Create, CreateIndex, Delete, Drop, DropIndex, Insert, OnConflict, Select, UpdateSetItem,
+    Create, CreateIndex, Delete, Drop, DropIndex, Insert, InsertColumns, OnConflict, Select,
+    UpdateSetItem,
 };
 use crate::model::table::{
     Column, ColumnType, Index, JoinType, JoinedTable, Name, SimValue, Table, TableContext,
@@ -262,12 +264,40 @@ impl Arbitrary for Insert {
             non_unique.first()?;
             let table = *pick(&non_unique, rng);
 
+            // For tables with generated columns, project only the non-generated columns
+            // and emit `INSERT INTO t (cols) SELECT cols ...`. SELECT * would include the
+            // generated columns, which can't be inserted into.
+            let non_generated: Vec<&str> = table
+                .columns
+                .iter()
+                .filter(|c| !c.is_generated())
+                .map(|c| c.name.as_str())
+                .collect();
+            let has_generated = non_generated.len() < table.columns.len();
+            let result_columns: Vec<ResultColumn> = if has_generated {
+                non_generated
+                    .iter()
+                    .map(|n| ResultColumn::Column((*n).to_string()))
+                    .collect()
+            } else {
+                vec![ResultColumn::Star]
+            };
+            // lazy heuristic, could be improved
+            let insert_columns = if has_generated {
+                InsertColumns::Explicit(non_generated.iter().map(|n| (*n).to_string()).collect())
+            } else {
+                InsertColumns::Implicit
+            };
+
             const MAX_SELF_INSERT_DEPTH: i32 = 5;
             let nesting_depth = rng.random_range(1..=MAX_SELF_INSERT_DEPTH);
 
-            let mut select = Select::simple(
+            let mut select = Select::single(
                 table.name.clone(),
+                result_columns,
                 Predicate::arbitrary_from(rng, env, table),
+                None,
+                Distinctness::All,
             );
 
             for _ in 1..nesting_depth {
@@ -291,23 +321,53 @@ impl Arbitrary for Insert {
 
             Some(Insert::Select {
                 table: table.name.clone(),
+                columns: insert_columns,
                 select: Box::new(select),
             })
         };
 
         let gen_select = |rng: &mut R| {
-            // Find a non-empty, not-too-large table without UNIQUE constraints
+            // Find a non-empty, not-too-large table without UNIQUE columns. Tables with
+            // generated columns are fine: we project only the non-generated columns and
+            // emit `INSERT INTO t (cols) SELECT cols ...`.
             let max_rows = insert_opts.max_rows.get() as usize;
             let select_table = env.tables().iter().find(|t| {
                 !t.rows.is_empty() && !t.has_any_unique_column() && t.rows.len() <= max_rows
             })?;
             let row = pick(&select_table.rows, rng);
             let predicate = Predicate::arbitrary_from(rng, env, (select_table, row));
+
+            let non_generated: Vec<&str> = select_table
+                .columns
+                .iter()
+                .filter(|c| !c.is_generated())
+                .map(|c| c.name.as_str())
+                .collect();
+            let has_generated = non_generated.len() < select_table.columns.len();
+            let (result_columns, insert_columns) = if has_generated {
+                let cols: Vec<String> = non_generated.iter().map(|n| (*n).to_string()).collect();
+                (
+                    cols.iter()
+                        .map(|n| ResultColumn::Column(n.clone()))
+                        .collect(),
+                    InsertColumns::Explicit(cols),
+                )
+            } else {
+                (vec![ResultColumn::Star], InsertColumns::Implicit)
+            };
+
             // TODO change for arbitrary_sized and insert from arbitrary tables
             // Build a SELECT from the same table to ensure schema matches for INSERT INTO ... SELECT
-            let select = Select::simple(select_table.name.clone(), predicate);
+            let select = Select::single(
+                select_table.name.clone(),
+                result_columns,
+                predicate,
+                None,
+                Distinctness::All,
+            );
             Some(Insert::Select {
                 table: select_table.name.clone(),
+                columns: insert_columns,
                 select: Box::new(select),
             })
         };
@@ -345,9 +405,19 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
 
     let table = pick(env.tables(), rng);
 
+    let non_generated_columns: Vec<&Column> =
+        table.columns.iter().filter(|c| !c.is_generated()).collect();
+
+    assert!(
+        !non_generated_columns.is_empty(),
+        "Table '{}' did not have at least one non-generated column",
+        table.name
+    );
+
+    let has_generated_cols = non_generated_columns.len() < table.columns.len();
+
     const INTEGER_PK_NULL_PROB: f64 = 0.05;
-    let integer_pk_idx = table
-        .columns
+    let integer_pk_idx = non_generated_columns
         .iter()
         .position(|c| matches!(c.column_type, ColumnType::Integer) && c.is_primary_key());
 
@@ -356,8 +426,7 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
 
     let values: Vec<Vec<SimValue>> = (0..num_rows)
         .map(|row_idx| {
-            table
-                .columns
+            non_generated_columns
                 .iter()
                 .enumerate()
                 .map(|(col_idx, c)| {
@@ -376,11 +445,22 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
         })
         .collect();
 
-    Some(Insert::Values {
-        table: table.name.clone(),
-        values,
-        on_conflict: None,
-    })
+    if has_generated_cols {
+        Some(Insert::ValuesWithColumns {
+            table: table.name.clone(),
+            columns: non_generated_columns
+                .iter()
+                .map(|c| c.name.clone())
+                .collect(),
+            values,
+        })
+    } else {
+        Some(Insert::Values {
+            table: table.name.clone(),
+            values,
+            on_conflict: None,
+        })
+    }
 }
 
 fn gen_insert_upsert_values<R: Rng + ?Sized, C: GenerationContext>(
@@ -590,10 +670,15 @@ impl Arbitrary for CreateIndex {
         }
 
         let num_columns_to_pick = rng.random_range(1..=table.columns.len());
-        let picked_column_indices = pick_n_unique(0..table.columns.len(), num_columns_to_pick, rng);
+        let picked_column_indices: Vec<usize> = (0..table.columns.len())
+            .collect::<Vec<usize>>()
+            .choose_multiple(rng, num_columns_to_pick)
+            .copied()
+            .collect();
 
         let columns = picked_column_indices
-            .map(|i| {
+            .iter()
+            .map(|&i| {
                 let column = &table.columns[i];
                 (
                     column.name.clone(),
@@ -635,17 +720,30 @@ impl Arbitrary for Update {
         let table = pick(env.tables(), rng);
         let update_opts = &env.opts().query.update;
 
+        let updatable_columns: Vec<&Column> =
+            table.columns.iter().filter(|c| !c.is_generated()).collect();
+
+        assert!(
+            !updatable_columns.is_empty(),
+            "Table '{}' did not have at least one non-generated column",
+            table.name
+        );
+
         let unique_columns: Vec<(usize, &Column)> = table
             .columns
             .iter()
             .enumerate()
-            .filter(|(_, c)| c.has_unique_or_pk() && !matches!(c.column_type, ColumnType::Blob))
+            .filter(|(_, c)| {
+                c.has_unique_or_pk()
+                    && !c.is_generated()
+                    && !matches!(c.column_type, ColumnType::Blob)
+            })
             .collect();
 
-        let non_unique_columns: Vec<&Column> = table
-            .columns
+        let non_unique_columns: Vec<&Column> = updatable_columns
             .iter()
             .filter(|c| !c.has_unique_or_pk())
+            .copied()
             .collect();
 
         // (first row and last row have different values)
@@ -704,7 +802,7 @@ impl Arbitrary for Update {
             ];
             (set_values, Predicate::true_())
         } else if non_unique_columns.is_empty() {
-            let column = pick(&table.columns, rng);
+            let column = pick(&updatable_columns, rng);
             let base_offset: i64 = rng.random_range(2_000_000_000i64..3_000_000_000i64);
 
             let unique_value = SimValue::unique_for_type(&column.column_type, base_offset);
@@ -773,11 +871,44 @@ const ALTER_TABLE_NO_ALTER_COL_NO_DROP: &[AlterTableTypeDiscriminants] = &[
 ];
 
 fn get_column_diff(table: &Table) -> IndexSet<&str> {
+    // Columns referenced in indexes cannot be dropped
     let mut undropable: IndexSet<&str> = table
         .indexes
         .iter()
         .flat_map(|idx| idx.columns.iter().map(|(name, _)| name.as_str()))
         .collect();
+
+    // Columns that are referenced by GENERATED columns cannot be dropped
+    for col in &table.columns {
+        if let Some(expr) = col.generated_expr() {
+            let refs = extract_column_refs(expr);
+            for ref_name in refs {
+                if let Some(ref_col) = table
+                    .columns
+                    .iter()
+                    .find(|c| c.name.eq_ignore_ascii_case(&ref_name))
+                {
+                    undropable.insert(ref_col.name.as_str());
+                }
+            }
+        }
+    }
+
+    // If dropping would leave only generated columns, protect all non-generated columns
+    let non_generated_count = table.columns.iter().filter(|c| !c.is_generated()).count();
+    if non_generated_count <= 1 {
+        // All non-generated columns are protected
+        for col in &table.columns {
+            if !col.is_generated() {
+                undropable.insert(col.name.as_str());
+            }
+        }
+    }
+
+    if undropable.len() == table.columns.len() {
+        // no columns can be dropped
+        return IndexSet::new();
+    }
 
     undropable.extend(
         table

--- a/sql_generation/generation/table.rs
+++ b/sql_generation/generation/table.rs
@@ -1,11 +1,13 @@
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use indexmap::IndexSet;
 use rand::Rng;
+use turso_parser::ast::{ColumnConstraint, GeneratedColumnType};
 
+use crate::generation::generated_expr::generate_column_expr_with_refs;
 use crate::generation::{pick, readable_name_custom, Arbitrary, GenerationContext};
 use crate::model::table::{Column, ColumnType, Name, Table};
-use turso_parser::ast::ColumnConstraint;
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -45,13 +47,80 @@ impl Table {
             column_set.insert(Column::arbitrary(rng, context));
         }
 
+        let mut columns: Vec<Column> = column_set.into_iter().collect();
+
+        // Turn some columns into generated columns
+        if opts.generated_columns.enable && columns.len() >= 2 {
+            let gen_opts = &opts.generated_columns;
+
+            // Track dependencies between columns: col_idx -> set of column indices it references
+            let mut dependencies: HashMap<usize, HashSet<usize>> = HashMap::new();
+
+            for i in 0..columns.len() {
+                let non_generated_count = columns.iter().filter(|c| !c.is_generated()).count();
+                if non_generated_count <= 1 {
+                    continue;
+                }
+
+                if !rng.random_bool(gen_opts.generated_column_prob) {
+                    continue;
+                }
+
+                let (expr, refs) = generate_column_expr_with_refs(
+                    rng,
+                    &columns,
+                    i,
+                    &columns[i].column_type,
+                    gen_opts.max_expr_depth,
+                );
+
+                if would_create_cycle(&dependencies, i, &refs) {
+                    continue;
+                }
+
+                dependencies.insert(i, refs);
+
+                columns[i].constraints.push(ColumnConstraint::Generated {
+                    expr: Box::new(expr),
+                    typ: Some(GeneratedColumnType::Virtual),
+                });
+            }
+        }
+
         Table {
             rows: Vec::new(),
             name,
-            columns: Vec::from_iter(column_set),
+            columns,
             indexes: vec![],
         }
     }
+}
+
+fn would_create_cycle(
+    deps: &HashMap<usize, HashSet<usize>>,
+    new_col: usize,
+    new_refs: &HashSet<usize>,
+) -> bool {
+    for &ref_col in new_refs {
+        if can_reach(deps, ref_col, new_col) {
+            return true;
+        }
+    }
+    false
+}
+
+fn can_reach(deps: &HashMap<usize, HashSet<usize>>, from: usize, to: usize) -> bool {
+    if from == to {
+        return true;
+    }
+    if let Some(refs) = deps.get(&from) {
+        for &r in refs {
+            if can_reach(deps, r, to) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 impl Arbitrary for Table {

--- a/sql_generation/generation/value/cmp.rs
+++ b/sql_generation/generation/value/cmp.rs
@@ -15,7 +15,11 @@ impl ArbitraryFrom<(&SimValue, ColumnType)> for LTValue {
     ) -> Self {
         let new_value = match &value.0 {
             Value::Numeric(Numeric::Integer(i)) => {
-                Value::from_i64(rng.random_range(i64::MIN..*i - 1))
+                if *i <= i64::MIN + 1 {
+                    Value::from_i64(i64::MIN) // avoid panic on empty range
+                } else {
+                    Value::from_i64(rng.random_range(i64::MIN..*i - 1))
+                }
             }
             Value::Numeric(Numeric::Float(f)) => {
                 Value::from_f64(f64::from(*f) - rng.random_range(0.0..1e10))
@@ -33,12 +37,14 @@ impl ArbitraryFrom<(&SimValue, ColumnType)> for LTValue {
             Value::Blob(b) => {
                 // Either shorten the blob, or make at least one byte smaller and mutate the rest
                 let mut b = b.clone();
-                if rng.random_bool(0.01) {
+                if b.is_empty() {
+                    Value::Blob(b)
+                } else if rng.random_bool(0.01) {
                     b.pop();
                     Value::Blob(b)
                 } else {
                     let index = rng.random_range(0..b.len());
-                    b[index] -= 1;
+                    b[index] = b[index].saturating_sub(1);
                     // Mutate the rest of the blob
                     for val in b.iter_mut().skip(index + 1) {
                         *val = rng.random_range(0..=255);
@@ -62,9 +68,19 @@ impl ArbitraryFrom<(&SimValue, ColumnType)> for GTValue {
         (value, col_type): (&SimValue, ColumnType),
     ) -> Self {
         let new_value = match &value.0 {
-            Value::Numeric(Numeric::Integer(i)) => Value::from_i64(rng.random_range(*i..i64::MAX)),
+            Value::Numeric(Numeric::Integer(i)) => {
+                if *i >= i64::MAX - 1 {
+                    Value::from_i64(i64::MAX) // avoid panic on empty range
+                } else {
+                    Value::from_i64(rng.random_range(*i + 1..=i64::MAX))
+                }
+            }
             Value::Numeric(Numeric::Float(f)) => {
-                Value::from_f64(rng.random_range(f64::from(*f)..1e10))
+                if f64::from(*f) >= 1e10 {
+                    Value::from_f64(1e10) // avoid panic on empty range
+                } else {
+                    Value::from_f64(rng.random_range(f64::from(*f)..1e10))
+                }
             }
             value @ Value::Text(..) => {
                 // Either lengthen the string, or make at least one character smaller and mutate the rest
@@ -81,14 +97,14 @@ impl ArbitraryFrom<(&SimValue, ColumnType)> for GTValue {
                 }
             }
             Value::Blob(b) => {
-                // Either lengthen the blob, or make at least one byte smaller and mutate the rest
+                // Either lengthen the blob, or make at least one byte larger and mutate the rest
                 let mut b = b.clone();
-                if rng.random_bool(0.01) {
+                if b.is_empty() || rng.random_bool(0.01) {
                     b.push(rng.random_range(0..=255));
                     Value::Blob(b)
                 } else {
                     let index = rng.random_range(0..b.len());
-                    b[index] += 1;
+                    b[index] = b[index].saturating_add(1);
                     // Mutate the rest of the blob
                     for val in b.iter_mut().skip(index + 1) {
                         *val = rng.random_range(0..=255);
@@ -191,8 +207,36 @@ fn mutate_string<R: rand::Rng + ?Sized>(
 #[cfg(test)]
 mod tests {
     use anarchist_readable_name_generator_lib::readable_name;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    use crate::generation::tests::TestContext;
 
     use super::*;
+
+    /// `random_range` panics on empty ranges. Check that boundaries and arbitrary values don't panic.
+    #[test]
+    fn lt_gt_value_boundaries_do_not_panic() {
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let ctx = TestContext::default();
+
+        let cases: [(SimValue, ColumnType); 8] = [
+            (SimValue(Value::from_i64(i64::MIN)), ColumnType::Integer),
+            (SimValue(Value::from_i64(i64::MIN + 1)), ColumnType::Integer),
+            (SimValue(Value::from_i64(i64::MAX)), ColumnType::Integer),
+            (SimValue(Value::from_i64(i64::MAX - 1)), ColumnType::Integer),
+            (SimValue(Value::from_f64(1e10)), ColumnType::Float),
+            (SimValue(Value::from_f64(2e10)), ColumnType::Float),
+            (SimValue(Value::Blob(Vec::new())), ColumnType::Blob),
+            (SimValue(Value::Blob(vec![0, 255])), ColumnType::Blob),
+        ];
+        for (val, col_type) in &cases {
+            for _ in 0..200 {
+                let _ = LTValue::arbitrary_from(&mut rng, &ctx, (val, *col_type));
+                let _ = GTValue::arbitrary_from(&mut rng, &ctx, (val, *col_type));
+            }
+        }
+    }
 
     #[test]
     fn test_mutate_string_fuzz() {

--- a/sql_generation/generation/value/mod.rs
+++ b/sql_generation/generation/value/mod.rs
@@ -48,7 +48,9 @@ impl ArbitraryFrom<&ColumnType> for SimValue {
         column_type: &ColumnType,
     ) -> Self {
         let value = match column_type {
-            ColumnType::Integer => Value::from_i64(rng.random_range(i64::MIN..i64::MAX)),
+            //TODO: widen back to the full i64 range once
+            // https://github.com/tursodatabase/turso/issues/6715 is fixed
+            ColumnType::Integer => Value::from_i64(rng.random_range(-(1i64 << 53)..(1i64 << 53))),
             ColumnType::Float => Value::from_f64(rng.random_range(-1e10..1e10)),
             ColumnType::Text => Value::build_text(gen_random_text(rng)),
             ColumnType::Blob => Value::Blob(gen_random_text(rng).into_bytes()),

--- a/sql_generation/model/query/insert.rs
+++ b/sql_generation/model/query/insert.rs
@@ -26,22 +26,42 @@ pub enum Insert {
         #[serde(default)]
         on_conflict: Option<OnConflict>,
     },
+    /// Insert with explicit column list
+    ValuesWithColumns {
+        table: String,
+        columns: Vec<String>,
+        values: Vec<Vec<SimValue>>,
+    },
     Select {
         table: String,
+        #[serde(default)]
+        columns: InsertColumns,
         select: Box<Select>,
     },
+}
+
+/// Whether an INSERT specifies an explicit column list.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub enum InsertColumns {
+    /// No column list (`INSERT INTO t ...`).
+    #[default]
+    Implicit,
+    /// Explicit column list (`INSERT INTO t (a, b, c...) ...`)
+    Explicit(Vec<String>),
 }
 
 impl Insert {
     pub fn table(&self) -> &str {
         match self {
-            Insert::Values { table, .. } | Insert::Select { table, .. } => table,
+            Insert::Values { table, .. }
+            | Insert::ValuesWithColumns { table, .. }
+            | Insert::Select { table, .. } => table,
         }
     }
 
     pub fn rows(&self) -> &[Vec<SimValue>] {
         match self {
-            Insert::Values { values, .. } => values,
+            Insert::Values { values, .. } | Insert::ValuesWithColumns { values, .. } => values,
             Insert::Select { .. } => unreachable!(),
         }
     }
@@ -74,8 +94,50 @@ impl Display for Insert {
                 }
                 Ok(())
             }
-            Insert::Select { table, select } => {
+            Insert::ValuesWithColumns {
+                table,
+                columns,
+                values,
+            } => {
+                write!(f, "INSERT INTO {table} (")?;
+                for (i, col) in columns.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{col}")?;
+                }
+                write!(f, ") VALUES ")?;
+                for (i, row) in values.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "(")?;
+                    for (j, value) in row.iter().enumerate() {
+                        if j != 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{value}")?;
+                    }
+                    write!(f, ")")?;
+                }
+                Ok(())
+            }
+            Insert::Select {
+                table,
+                columns,
+                select,
+            } => {
                 write!(f, "INSERT INTO {table} ")?;
+                if let InsertColumns::Explicit(columns) = columns {
+                    write!(f, "(")?;
+                    for (i, col) in columns.iter().enumerate() {
+                        if i != 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{col}")?;
+                    }
+                    write!(f, ") ")?;
+                }
                 write!(f, "{select}")
             }
         }

--- a/sql_generation/model/query/mod.rs
+++ b/sql_generation/model/query/mod.rs
@@ -3,7 +3,7 @@ pub use create_index::CreateIndex;
 pub use delete::Delete;
 pub use drop::Drop;
 pub use drop_index::DropIndex;
-pub use insert::{Insert, OnConflict, UpdateSetItem};
+pub use insert::{Insert, InsertColumns, OnConflict, UpdateSetItem};
 pub use select::Select;
 
 pub mod alter_table;

--- a/sql_generation/model/query/predicate.rs
+++ b/sql_generation/model/query/predicate.rs
@@ -110,6 +110,7 @@ pub fn expr_to_value<T: TableContext>(
     match expr {
         ast::Expr::DoublyQualified(_, _, col_name)
         | ast::Expr::Qualified(_, col_name)
+        | ast::Expr::Name(col_name)
         | ast::Expr::Id(col_name) => {
             let columns = table.columns().collect::<Vec<_>>();
             let col_name = col_name.as_str();
@@ -118,8 +119,15 @@ pub fn expr_to_value<T: TableContext>(
                 .iter()
                 .zip(row.iter())
                 .find(|(column, _)| column.column.name == col_name)
-                .map(|(_, value)| value)
-                .cloned()
+                .map(|(col_ctx, row_value)| {
+                    let col = &col_ctx.column;
+                    match col.generated_expr() {
+                        Some(expr) => expr_to_value(expr, row, table)
+                            .expect("could not resolve expression")
+                            .apply_affinity(col.column_type),
+                        None => row_value.clone(),
+                    }
+                })
         }
         ast::Expr::Literal(literal) => Some(literal.into()),
         ast::Expr::Binary(lhs, op, rhs) => {

--- a/sql_generation/model/query/select.rs
+++ b/sql_generation/model/query/select.rs
@@ -366,7 +366,7 @@ impl Select {
                                     }
                                     ResultColumn::Star => ast::ResultColumn::Star,
                                     ResultColumn::Column(name) => ast::ResultColumn::Expr(
-                                        ast::Expr::Id(ast::Name::exact(name.clone())).into_boxed(),
+                                        column_qualified_expr(name).into_boxed(),
                                         None,
                                     ),
                                 })

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -104,6 +104,19 @@ impl Column {
             .iter()
             .any(|c| matches!(c, ColumnConstraint::PrimaryKey { .. }))
     }
+
+    pub fn is_generated(&self) -> bool {
+        self.constraints
+            .iter()
+            .any(|c| matches!(c, ColumnConstraint::Generated { .. }))
+    }
+
+    pub fn generated_expr(&self) -> Option<&ast::Expr> {
+        self.constraints.iter().find_map(|c| match c {
+            ColumnConstraint::Generated { expr, .. } => Some(expr.as_ref()),
+            _ => None,
+        })
+    }
 }
 
 impl Display for Column {
@@ -218,9 +231,11 @@ impl SimValue {
             .unwrap_or_default()
     }
 
-    #[inline]
-    fn is_null(&self) -> bool {
-        matches!(self.0, types::Value::Null)
+    fn sqlite_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (&self.0, &other.0) {
+            (types::Value::Null, _) | (_, types::Value::Null) => None,
+            _ => Some(self.0.cmp(&other.0)),
+        }
     }
 
     pub fn unique_for_type(column_type: &ColumnType, offset: i64) -> Self {
@@ -248,7 +263,6 @@ impl SimValue {
     /// [ast::Operator::GreaterEquals], [ast::Operator::Less], [ast::Operator::LessEquals] function to be extracted
     /// into its functions in turso_core so that it can be used here. For now we just do the `not_null` check to avoid refactoring code in core
     pub fn binary_compare(&self, other: &Self, operator: ast::Operator) -> SimValue {
-        let not_null = !self.is_null() && !other.is_null();
         match operator {
             ast::Operator::Add => self.0.exec_add(&other.0).into(),
             ast::Operator::And => self.0.exec_and(&other.0).into(),
@@ -258,10 +272,19 @@ impl SimValue {
             ast::Operator::BitwiseOr => self.0.exec_bit_or(&other.0).into(),
             ast::Operator::BitwiseNot => todo!(), // TODO: Do not see any function usage of this operator in Core
             ast::Operator::Concat => self.0.exec_concat(&other.0).into(),
-            ast::Operator::Equals => not_null.then(|| self == other).into(),
+            ast::Operator::Equals => self
+                .sqlite_cmp(other)
+                .map(|o| o == std::cmp::Ordering::Equal)
+                .into(),
             ast::Operator::Divide => self.0.exec_divide(&other.0).into(),
-            ast::Operator::Greater => not_null.then(|| self > other).into(),
-            ast::Operator::GreaterEquals => not_null.then(|| self >= other).into(),
+            ast::Operator::Greater => self
+                .sqlite_cmp(other)
+                .map(|o| o == std::cmp::Ordering::Greater)
+                .into(),
+            ast::Operator::GreaterEquals => self
+                .sqlite_cmp(other)
+                .map(|o| o != std::cmp::Ordering::Less)
+                .into(),
             // TODO: Test these implementations
             ast::Operator::Is => match (&self.0, &other.0) {
                 (types::Value::Null, types::Value::Null) => true.into(),
@@ -273,11 +296,20 @@ impl SimValue {
                 .binary_compare(other, ast::Operator::Is)
                 .unary_exec(ast::UnaryOperator::Not),
             ast::Operator::LeftShift => self.0.exec_shift_left(&other.0).into(),
-            ast::Operator::Less => not_null.then(|| self < other).into(),
-            ast::Operator::LessEquals => not_null.then(|| self <= other).into(),
+            ast::Operator::Less => self
+                .sqlite_cmp(other)
+                .map(|o| o == std::cmp::Ordering::Less)
+                .into(),
+            ast::Operator::LessEquals => self
+                .sqlite_cmp(other)
+                .map(|o| o != std::cmp::Ordering::Greater)
+                .into(),
             ast::Operator::Modulus => self.0.exec_remainder(&other.0).into(),
             ast::Operator::Multiply => self.0.exec_multiply(&other.0).into(),
-            ast::Operator::NotEquals => not_null.then(|| self != other).into(),
+            ast::Operator::NotEquals => self
+                .sqlite_cmp(other)
+                .map(|o| o != std::cmp::Ordering::Equal)
+                .into(),
             ast::Operator::Or => self.0.exec_or(&other.0).into(),
             ast::Operator::RightShift => self.0.exec_shift_right(&other.0).into(),
             ast::Operator::Subtract => self.0.exec_subtract(&other.0).into(),
@@ -319,6 +351,36 @@ impl SimValue {
             ast::UnaryOperator::Positive => self.0.clone(),
         };
         Self(new_value)
+    }
+
+    pub fn apply_affinity(self, column_type: ColumnType) -> SimValue {
+        match column_type {
+            ColumnType::Integer => {
+                if let types::Value::Numeric(Numeric::Float(fl)) = &self.0 {
+                    let fl = f64::from(*fl);
+                    if fl.is_finite() && fl.trunc() == fl {
+                        let int_val = if fl < -9223372036854774784.0 {
+                            i64::MIN
+                        } else if fl > 9223372036854774784.0 {
+                            i64::MAX
+                        } else {
+                            fl as i64
+                        };
+                        if (int_val as f64) == fl && int_val != i64::MIN {
+                            return SimValue(types::Value::from_i64(int_val));
+                        }
+                    }
+                }
+                self
+            }
+            ColumnType::Float => {
+                if let types::Value::Numeric(Numeric::Integer(i)) = &self.0 {
+                    return SimValue(types::Value::from_f64(*i as f64));
+                }
+                self
+            }
+            _ => self,
+        }
     }
 }
 

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -19,7 +19,7 @@ use sql_generation::{
             transaction::{Begin, Commit, Rollback},
             update::{SetValue, Update},
         },
-        table::{ColumnType, SimValue, Table},
+        table::{Column, ColumnType, SimValue, Table},
     },
 };
 use strum::IntoEnumIterator;
@@ -31,7 +31,7 @@ use crate::{
     generation::{Shadow, WeightedDistribution, query::QueryDistribution},
     model::{
         Query, QueryCapabilities, QueryDiscriminants, ReleaseSavepoint, ResultSet,
-        RollbackToSavepoint, Savepoint,
+        RollbackToSavepoint, Savepoint, expand_with_generated_columns,
         interactions::{
             Assertion, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
         },
@@ -71,13 +71,25 @@ impl Property {
                         .find(|table| table.name == table_name)
                         .unwrap();
 
-                    let rows = insert.rows();
-                    let row = &rows[*row_index];
+                    let partial_rows = insert.rows();
+                    let partial_row = &partial_rows[*row_index];
+
+                    // full_row has its generated columns evaluated
+                    let full_row = match insert {
+                        Insert::ValuesWithColumns { columns, .. } => {
+                            expand_with_generated_columns(table, Some(columns), partial_row)
+                        }
+                        Insert::Values { .. } => {
+                            expand_with_generated_columns(table, None, partial_row)
+                        }
+                        _ => unreachable!(),
+                    };
+
                     match &query {
                         Query::Delete(Delete {
                             table: t,
                             predicate,
-                        }) if t == &table.name && predicate.test(row, table) => {
+                        }) if t == &table.name && predicate.test(&full_row, table) => {
                             // The inserted row will not be deleted.
                             None
                         }
@@ -90,7 +102,7 @@ impl Property {
                             table: t,
                             set_values: _,
                             predicate,
-                        }) if t == &table.name && predicate.test(row, table) => {
+                        }) if t == &table.name && predicate.test(&full_row, table) => {
                             // The inserted row will not be updated.
                             None
                         }
@@ -172,10 +184,17 @@ impl Property {
                             // A row that holds for the predicate will not be inserted.
                             None
                         }
-                        Query::Insert(Insert::Select {
+                        Query::Insert(Insert::ValuesWithColumns {
                             table: t,
-                            select: _,
-                        }) if t == &table.name => {
+                            columns: _,
+                            values: _,
+                        }) if *t == table_name => {
+                            // A row that holds for the predicate will not be inserted. We can't
+                            // easily test partial rows (rows with unevaluated generated columns)
+                            // against the predicate, so conservatively reject all ValuesWithColumns.
+                            None
+                        }
+                        Query::Insert(Insert::Select { table: t, .. }) if t == &table.name => {
                             // A row that holds for the predicate will not be inserted.
                             None
                         }
@@ -300,18 +319,27 @@ impl Property {
                             .iter()
                             .find(|t| t.name == table)
                             .expect("table should be in enviroment");
-                        if rows.len() != sim_table.rows.len() {
-                            print_diff(&sim_table.rows, rows, "simulator", "database");
+                        let expected: Vec<Vec<SimValue>> = sim_table
+                            .rows
+                            .iter()
+                            .map(|r| strip_virtual_cols(sim_table, r))
+                            .collect();
+                        let actual: Vec<Vec<SimValue>> = rows
+                            .iter()
+                            .map(|r| strip_virtual_cols(sim_table, r))
+                            .collect();
+                        if actual.len() != expected.len() {
+                            print_diff(&expected, &actual, "simulator", "database");
                             return Ok(Err(format!(
                                 "expected {} rows but got {} for table {}",
-                                sim_table.rows.len(),
-                                rows.len(),
+                                expected.len(),
+                                actual.len(),
                                 table.clone()
                             )));
                         }
-                        for expected_row in sim_table.rows.iter() {
-                            if !rows.contains(expected_row) {
-                                print_diff(&sim_table.rows, rows, "simulator", "database");
+                        for expected_row in expected.iter() {
+                            if !actual.contains(expected_row) {
+                                print_diff(&expected, &actual, "simulator", "database");
                                 return Ok(Err(format!(
                                     "expected row {:?} not found in table {}",
                                     expected_row,
@@ -473,16 +501,13 @@ impl Property {
                 select,
                 interactive,
             } => {
-                let (table, values) = if let Insert::Values {
-                    table,
-                    values,
-                    on_conflict: None,
-                } = insert
+                let (table, values) = if let Insert::Values { table, values, .. }
+                | Insert::ValuesWithColumns { table, values, .. } = insert
                 {
                     (table, values)
                 } else {
                     unreachable!(
-                        "insert query should be Insert::Values for Insert-Values-Select property"
+                        "insert query should be Insert::Values or Insert::ValuesWithColumns for Insert-Values-Select property"
                     )
                 };
                 // Check that the insert query has at least 1 value
@@ -1284,18 +1309,25 @@ fn random_main_table_insert<R: rand::Rng + ?Sized>(
     const UNIQUE_BASE_OFFSET_RANGE: std::ops::Range<i64> = 3_000_000_000..4_000_000_000;
     const UNIQUE_COL_STRIDE: i64 = 10_000_000;
 
+    // Generated columns are computed and cannot be inserted into.
+    let non_generated_columns: Vec<(usize, &Column)> = table
+        .columns
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| !c.is_generated())
+        .collect();
+
     let num_rows = rng.random_range(1..=5);
     let base_offset: i64 = rng.random_range(UNIQUE_BASE_OFFSET_RANGE);
-    let values = (0..num_rows)
+    let values: Vec<Vec<SimValue>> = (0..num_rows)
         .map(|row_idx| {
-            table
-                .columns
+            non_generated_columns
                 .iter()
                 .enumerate()
-                .map(|(col_idx, column)| {
+                .map(|(ng_idx, (_, column))| {
                     if column.has_unique_or_pk() {
                         let offset =
-                            base_offset + (col_idx as i64 * UNIQUE_COL_STRIDE) + row_idx as i64;
+                            base_offset + (ng_idx as i64 * UNIQUE_COL_STRIDE) + row_idx as i64;
                         SimValue::unique_for_type(&column.column_type, offset)
                     } else {
                         SimValue::arbitrary_from(rng, ctx, &column.column_type)
@@ -1305,11 +1337,24 @@ fn random_main_table_insert<R: rand::Rng + ?Sized>(
         })
         .collect();
 
-    Query::Insert(Insert::Values {
-        table: table.name.clone(),
-        values,
-        on_conflict: None,
-    })
+    // lazy heuristic, could be improved
+    let has_generated_col = non_generated_columns.len() < table.columns.len();
+    if has_generated_col {
+        Query::Insert(Insert::ValuesWithColumns {
+            table: table.name.clone(),
+            columns: non_generated_columns
+                .iter()
+                .map(|(_, c)| c.name.clone())
+                .collect(),
+            values,
+        })
+    } else {
+        Query::Insert(Insert::Values {
+            table: table.name.clone(),
+            values,
+            on_conflict: None,
+        })
+    }
 }
 
 fn random_main_table_update<R: rand::Rng + ?Sized>(
@@ -1318,23 +1363,26 @@ fn random_main_table_update<R: rand::Rng + ?Sized>(
     table: &Table,
 ) -> Query {
     let update_opts = &ctx.opts().query.update;
-    let unique_columns = table
+    // Generated columns cannot be updated
+    let unique_updatable_columns = table
         .columns
         .iter()
         .enumerate()
         .filter(|(_, column)| {
-            column.has_unique_or_pk() && !matches!(column.column_type, ColumnType::Blob)
+            column.has_unique_or_pk()
+                && !column.is_generated()
+                && !matches!(column.column_type, ColumnType::Blob)
         })
         .collect::<Vec<_>>();
-    let non_unique_columns = table
+    let non_unique_updatable_columns = table
         .columns
         .iter()
-        .filter(|column| !column.has_unique_or_pk())
+        .filter(|column| !column.has_unique_or_pk() && !column.is_generated())
         .collect::<Vec<_>>();
 
     let last_row_idx = table.rows.len().saturating_sub(1);
     let conflict_capable_columns = if table.rows.len() >= 2 {
-        unique_columns
+        unique_updatable_columns
             .iter()
             .filter(|(col_idx, _)| table.rows[0][*col_idx] != table.rows[last_row_idx][*col_idx])
             .copied()
@@ -1345,10 +1393,10 @@ fn random_main_table_update<R: rand::Rng + ?Sized>(
 
     if update_opts.force_late_failure
         && !conflict_capable_columns.is_empty()
-        && !non_unique_columns.is_empty()
+        && !non_unique_updatable_columns.is_empty()
     {
         let (col_idx, unique_col) = *pick(&conflict_capable_columns, rng);
-        let marker_col = *pick(&non_unique_columns, rng);
+        let marker_col = *pick(&non_unique_updatable_columns, rng);
         let first_val = table.rows[0][col_idx].clone();
         let last_val = table.rows[last_row_idx][col_idx].clone();
         let marker_value = match update_opts.padding_size {
@@ -1379,10 +1427,12 @@ fn random_main_table_update<R: rand::Rng + ?Sized>(
         });
     }
 
-    let column = if non_unique_columns.is_empty() {
-        pick(&table.columns, rng)
+    let updatable_columns: Vec<&Column> =
+        table.columns.iter().filter(|c| !c.is_generated()).collect();
+    let column = if non_unique_updatable_columns.is_empty() {
+        *pick(&updatable_columns, rng)
     } else {
-        *pick(&non_unique_columns, rng)
+        *pick(&non_unique_updatable_columns, rng)
     };
     let value = match (update_opts.padding_size, &column.column_type) {
         (Some(size), ColumnType::Blob) => SimValue(turso_core::Value::Blob(vec![b'X'; size])),
@@ -1474,6 +1524,16 @@ fn run_integrity_check(
     }
 }
 
+fn strip_virtual_cols(table: &Table, row: &[SimValue]) -> Vec<SimValue> {
+    table
+        .columns
+        .iter()
+        .zip(row.iter())
+        .filter(|(col, _)| !col.is_generated())
+        .map(|(_, sim_val)| sim_val.clone())
+        .collect()
+}
+
 fn assert_all_table_values(
     tables: &[String],
     connection_index: usize,
@@ -1496,13 +1556,16 @@ fn assert_all_table_values(
                     let last = stack.last().unwrap();
                     match last {
                         Ok(vals) => {
+                            let expected: Vec<Vec<SimValue>> = table.rows.iter().map(|r| strip_virtual_cols(table, r)).collect();
+                            let actual: Vec<Vec<SimValue>> = vals.iter().map(|r| strip_virtual_cols(table, r)).collect();
+
                             // Check if all values in the table are present in the result set
                             // Find a value in the table that is not in the result set
-                            let model_contains_db = table.rows.iter().find(|v| {
-                                !vals.contains(v)
+                            let model_contains_db = expected.iter().find(|v| {
+                                !actual.contains(v)
                             });
-                            let db_contains_model = vals.iter().find(|v| {
-                                !table.rows.contains(v)
+                            let db_contains_model = actual.iter().find(|v| {
+                                !expected.contains(v)
                             });
 
                             if let Some(model_contains_db) = model_contains_db {
@@ -1511,7 +1574,7 @@ fn assert_all_table_values(
                                     table.name,
                                     print_row(model_contains_db)
                                 );
-                                print_diff(&table.rows, vals, "simulator", "database");
+                                print_diff(&expected, &actual, "simulator", "database");
 
                                 Ok(Err(format!("table {} does not contain the expected values, the simulator model has more rows than the database: {:?}", table.name, print_row(model_contains_db))))
                             } else if let Some(db_contains_model) = db_contains_model {
@@ -1520,7 +1583,7 @@ fn assert_all_table_values(
                                     table.name,
                                     print_row(db_contains_model)
                                 );
-                                print_diff(&table.rows, vals, "simulator", "database");
+                                print_diff(&expected, &actual, "simulator", "database");
 
                                 Ok(Err(format!("table {} does not contain the expected values, the database has more rows than the simulator model: {:?}", table.name, print_row(db_contains_model))))
                             } else {
@@ -1555,20 +1618,50 @@ fn property_insert_values_select<R: rand::Rng + ?Sized>(
         *pick(&non_unique_tables, rng)
     };
 
+    let non_generated_columns: Vec<Column> = table
+        .columns
+        .iter()
+        .filter(|c| !c.is_generated())
+        .cloned()
+        .collect();
+
+    assert!(
+        !non_generated_columns.is_empty(),
+        "Table {} should have at least one non-generated column",
+        table.name
+    );
+
     let rows = (0..rng.random_range(1..=5))
-        .map(|_| Vec::<SimValue>::arbitrary_from(rng, ctx, table))
+        .map(|_| {
+            non_generated_columns
+                .iter()
+                .map(|c| SimValue::arbitrary_from(rng, ctx, &c.column_type))
+                .collect::<Vec<_>>()
+        })
         .collect::<Vec<_>>();
 
     // Pick a random row to select
     let row_index = pick_index(rows.len(), rng);
     let row = rows[row_index].clone();
 
-    // Insert the rows
-    let insert_query = Query::Insert(Insert::Values {
-        table: table.name.clone(),
-        values: rows,
-        on_conflict: None,
-    });
+    // lazy heuristic, could be improved
+    let has_generated = non_generated_columns.len() < table.columns.len();
+    let insert_query = if has_generated {
+        Query::Insert(Insert::ValuesWithColumns {
+            table: table.name.clone(),
+            columns: non_generated_columns
+                .iter()
+                .map(|c| c.name.clone())
+                .collect(),
+            values: rows,
+        })
+    } else {
+        Query::Insert(Insert::Values {
+            table: table.name.clone(),
+            values: rows,
+            on_conflict: None,
+        })
+    };
 
     // Choose if we want queries to be executed in an interactive transaction
     let interactive = if !mvcc && rng.random_bool(0.5) {
@@ -1602,10 +1695,31 @@ fn property_insert_values_select<R: rand::Rng + ?Sized>(
         });
     }
 
-    // Select the row
-    let select_query = Select::simple(
+    let predicate = if has_generated {
+        // For tables with generated columns, create a "virtual" table with only
+        // non-generated columns for predicate generation. This ensures the predicate
+        // only references columns we have values for.
+        let virtual_table = Table {
+            name: table.name.clone(),
+            columns: non_generated_columns.clone(),
+            rows: vec![row.clone()],
+            indexes: vec![],
+        };
+        Predicate::arbitrary_from(rng, ctx, (&virtual_table, &row))
+    } else {
+        Predicate::arbitrary_from(rng, ctx, (table, &row))
+    };
+
+    // Select only the non-generated columns so the assertion can compare with the inserted values
+    let select_query = Select::single(
         table.name.clone(),
-        Predicate::arbitrary_from(rng, ctx, (table, &row)),
+        non_generated_columns
+            .iter()
+            .map(|c| ResultColumn::Column(c.name.clone()))
+            .collect(),
+        predicate,
+        None,
+        Distinctness::All,
     );
 
     Property::InsertValuesSelect {

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -912,7 +912,8 @@ fn reopen_database(env: &mut SimulatorEnv) {
                 turso_core::OpenFlags::default(),
                 turso_core::DatabaseOpts::new()
                     .with_autovacuum(true)
-                    .with_attach(true),
+                    .with_attach(true)
+                    .with_generated_columns(true),
                 None,
             ) {
                 Ok(db) => db,

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -4,6 +4,8 @@ use anyhow::Context;
 use bitflags::bitflags;
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
+use sql_generation::generation::generated_expr::rename_column_refs_in_expr;
+use sql_generation::model::query::predicate::expr_to_value;
 use sql_generation::model::query::select::SelectTable;
 use sql_generation::model::{
     query::{
@@ -18,7 +20,7 @@ use sql_generation::model::{
 };
 use turso_core::Value;
 use turso_core::turso_assert_eq;
-use turso_parser::ast::Distinctness;
+use turso_parser::ast::{ColumnConstraint, Distinctness};
 
 use crate::runner::env::TransactionMode;
 use crate::{generation::Shadow, runner::env::ShadowTablesMut};
@@ -326,6 +328,7 @@ impl Query {
             Query::Create(_) => IndexSet::new(),
             Query::Insert(Insert::Select { table, .. })
             | Query::Insert(Insert::Values { table, .. })
+            | Query::Insert(Insert::ValuesWithColumns { table, .. })
             | Query::Delete(Delete { table, .. })
             | Query::Update(Update { table, .. })
             | Query::Drop(Drop { table, .. })
@@ -356,6 +359,7 @@ impl Query {
             Query::Select(select) => select.dependencies().into_iter().collect(),
             Query::Insert(Insert::Select { table, .. })
             | Query::Insert(Insert::Values { table, .. })
+            | Query::Insert(Insert::ValuesWithColumns { table, .. })
             | Query::Delete(Delete { table, .. })
             | Query::Update(Update { table, .. })
             | Query::Drop(Drop { table, .. })
@@ -638,13 +642,54 @@ impl Shadow for Drop {
     }
 }
 
+// TODO having &[SimValue] sometimes be expanded, and sometimes not (with NULL placeholders) is
+// error-prone. To make this type-safe, we should have domain types for expanded and non-expanded rows.
+/// Expand a partial row to a full row, by evaluating generated column expressions.
+pub(crate) fn expand_with_generated_columns(
+    table: &Table,
+    insert_columns: Option<&[String]>,
+    insert_values: &[SimValue],
+) -> Vec<SimValue> {
+    let mut full_row = vec![SimValue::NULL; table.columns.len()];
+
+    if let Some(cols) = insert_columns {
+        for (i, col_name) in cols.iter().enumerate() {
+            if let Some(pos) = table.columns.iter().position(|c| &c.name == col_name) {
+                full_row[pos] = insert_values[i].clone();
+            }
+        }
+    } else {
+        for (idx, col_idx) in table
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| !c.is_generated())
+            .map(|(idx, _)| idx)
+            .enumerate()
+        {
+            full_row[col_idx] = insert_values[idx].clone();
+        }
+    }
+
+    // Evaluate virtual generated column expressions
+    for (col_idx, col) in table.columns.iter().enumerate() {
+        if let Some(expr) = col.generated_expr() {
+            if let Some(value) = expr_to_value(expr, &full_row, table) {
+                full_row[col_idx] = value.apply_affinity(col.column_type);
+            }
+        }
+    }
+
+    full_row
+}
+
 impl Shadow for Insert {
     type Result = anyhow::Result<Vec<Vec<SimValue>>>;
 
     //FIXME this doesn't handle type affinity
     fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         match self {
-            Insert::Select { table, select } => {
+            Insert::Select { table, select, .. } => {
                 let table_name = table.clone();
                 let raw_rows = select.shadow(tables)?;
 
@@ -656,6 +701,39 @@ impl Shadow for Insert {
                 let columns = tables[table_pos].columns.clone();
                 let rows =
                     prepare_insert_rows(&table_name, &columns, &tables[table_pos].rows, &raw_rows)?;
+
+                for row in &rows {
+                    tables.record_insert(table_name.clone(), row.clone());
+                }
+                tables[table_pos].rows.extend(rows);
+                Ok(vec![])
+            }
+            Insert::ValuesWithColumns {
+                table,
+                columns: insert_columns,
+                values,
+            } => {
+                let table_name = table.clone();
+
+                let table_pos = tables
+                    .iter()
+                    .position(|t| t.name == table_name)
+                    .ok_or_else(|| anyhow::anyhow!("Table {} does not exist", table_name))?;
+
+                let table_ref = tables[table_pos].clone();
+
+                let full_rows: Vec<Vec<SimValue>> = values
+                    .iter()
+                    .map(|row| expand_with_generated_columns(&table_ref, Some(insert_columns), row))
+                    .collect();
+
+                let columns = tables[table_pos].columns.clone();
+                let rows = prepare_insert_rows(
+                    &table_name,
+                    &columns,
+                    &tables[table_pos].rows,
+                    &full_rows,
+                )?;
 
                 for row in &rows {
                     tables.record_insert(table_name.clone(), row.clone());
@@ -677,13 +755,18 @@ impl Shadow for Insert {
 
                 let columns = tables[table_pos].columns.clone();
 
+                let effective_values: Vec<Vec<SimValue>> = values
+                    .iter()
+                    .map(|row| expand_with_generated_columns(&tables[table_pos].clone(), None, row))
+                    .collect();
+
                 match on_conflict {
                     None => {
                         let new_rows = prepare_insert_rows(
                             &table_name,
                             &columns,
                             &tables[table_pos].rows,
-                            values,
+                            &effective_values,
                         )?;
 
                         for row in &new_rows {
@@ -736,7 +819,7 @@ impl Shadow for Insert {
                         }
                         let mut staged_ops: Vec<StagedOp> = Vec::new();
 
-                        for raw_row in values.iter() {
+                        for raw_row in effective_values.iter() {
                             ensure_row_width(&table_name, &columns, raw_row)?;
 
                             let excluded_row = if let (Some(pk_idx), Some(alloc)) =
@@ -1124,6 +1207,14 @@ impl Shadow for Update {
                             }
                         }
                     }
+                    // Recompute virtual generated columns after SET assignments
+                    for (col_idx, col) in columns.iter().enumerate() {
+                        if let Some(expr) = col.generated_expr() {
+                            if let Some(value) = expr_to_value(expr, &new_row, &t2) {
+                                new_row[col_idx] = value.apply_affinity(col.column_type);
+                            }
+                        }
+                    }
                     (row_idx, old_row.clone(), new_row)
                 })
                 .collect();
@@ -1274,6 +1365,15 @@ impl Shadow for AlterTable {
             AlterTableType::RenameColumn { old, new } => {
                 let col = table.columns.iter_mut().find(|c| c.name == *old).unwrap();
                 col.name.clone_from(new);
+
+                for col in &mut table.columns {
+                    for constraint in &mut col.constraints {
+                        if let ColumnConstraint::Generated { expr, .. } = constraint {
+                            rename_column_refs_in_expr(expr, old, new);
+                        }
+                    }
+                }
+
                 table.indexes.iter_mut().for_each(|index| {
                     index.columns.iter_mut().for_each(|(col_name, _)| {
                         if col_name == old {

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -11,10 +11,12 @@ use garde::Validate;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use sql_generation::generation::GenerationContext;
+use sql_generation::generation::generated_expr::rename_column_refs_in_expr;
 use sql_generation::model::query::transaction::Rollback;
 use sql_generation::model::table::{SimValue, Table};
 use tracing::trace;
 use turso_core::Database;
+use turso_parser::ast::ColumnConstraint;
 
 use crate::generation::Shadow;
 use crate::model::Query;
@@ -34,7 +36,9 @@ fn enable_mvcc_on_attached_dbs(io: &Arc<dyn SimIO>, aux_paths: impl Iterator<Ite
             io.clone(),
             aux_path.to_str().unwrap(),
             turso_core::OpenFlags::default(),
-            turso_core::DatabaseOpts::new().with_attach(true),
+            turso_core::DatabaseOpts::new()
+                .with_attach(true)
+                .with_generated_columns(true),
             None,
         )
         .unwrap_or_else(|e| panic!("Failed to open aux DB {aux_path:?}: {e}"));
@@ -747,6 +751,14 @@ where
                             .find(|c| &c.name == old_name)
                             .expect("Column should exist");
                         col.name.clone_from(new_name);
+                        // Update generated column expressions that reference the old column name
+                        for col in &mut committed.columns {
+                            for constraint in &mut col.constraints {
+                                if let ColumnConstraint::Generated { expr, .. } = constraint {
+                                    rename_column_refs_in_expr(expr, old_name, new_name);
+                                }
+                            }
+                        }
                         // Update index column names
                         for index in &mut committed.indexes {
                             for (col_name, _) in &mut index.columns {
@@ -1010,7 +1022,8 @@ impl SimulatorEnv {
             turso_core::OpenFlags::default(),
             turso_core::DatabaseOpts::new()
                 .with_autovacuum(true)
-                .with_attach(true),
+                .with_attach(true)
+                .with_generated_columns(true),
             None,
         ) {
             Ok(db) => db,
@@ -1205,7 +1218,8 @@ impl SimulatorEnv {
             turso_core::OpenFlags::default(),
             turso_core::DatabaseOpts::new()
                 .with_autovacuum(true)
-                .with_attach(true),
+                .with_attach(true)
+                .with_generated_columns(true),
             None,
         ) {
             Ok(db) => db,

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -401,8 +401,16 @@ fn execute_interaction_rusqlite(
             }
 
             tracing::debug!("{:?}", results);
-            stack.push(results);
+            stack.push(results.clone());
             env.update_conn_last_interaction(interaction.connection_index, Some(query));
+
+            if results.is_ok() {
+                interaction
+                    .shadow(&mut env.get_conn_tables_mut(interaction.connection_index))
+                    .map_err(|e| {
+                        LimboError::InternalError(format!("DB succeeded but shadow detected error: {e}. This may indicate a constraint enforcement bug."))
+                    })?;
+            }
         }
         InteractionType::FsyncQuery(..) => {
             unimplemented!("cannot implement fsync query in rusqlite, as we do not control IO");
@@ -426,14 +434,6 @@ fn execute_interaction_rusqlite(
         InteractionType::FaultyQuery(_) => {
             unimplemented!("cannot implement faulty query in rusqlite, as we do not control IO");
         }
-    }
-
-    // Check shadow result - if DB succeeded but shadow detects constraint violation,
-    // that indicates a constraint enforcement bug in the database
-    if let Err(e) = interaction.shadow(&mut env.get_conn_tables_mut(interaction.connection_index)) {
-        return Err(LimboError::InternalError(format!(
-            "DB succeeded but shadow detected error: {e}. This may indicate a constraint enforcement bug."
-        )));
     }
     Ok(ExecutionContinuation::NextInteraction)
 }


### PR DESCRIPTION
## Description

This adds support for virtual generated columns to the simulator.

I ran it for 24 process-hours with no failures.

## How to review this PR

This PR contains the simulator improvements, but also a few other fixes that are in open PRs elsewhere, and that are required to make the simulator pass. Rather than having a long long chain of stacked PRs, I decided to leave the fixes on this branch.

You can therefore review only what's under `sql_generation/` and `testing/`, ignoring everything under `core/`.