### PR TITLE
fix: populate index expr for virtual columns in auto-generated indexes

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1128,7 +1128,13 @@ impl Schema {
             let mut pk_index_added = false;
             for unique_set in &table.unique_sets {
                 if unique_set.is_primary_key {
-                    assert!(table.primary_key_columns.len() == unique_set.columns.len(), "trying to add a {}-column primary key index for table {}, but the table has {} primary key columns", unique_set.columns.len(), table.name, table.primary_key_columns.len());
+                    assert!(
+                        table.primary_key_columns.len() == unique_set.columns.len(),
+                        "trying to add a {}-column primary key index for table {}, but the table has {} primary key columns",
+                        unique_set.columns.len(),
+                        table.name,
+                        table.primary_key_columns.len()
+                    );
                     // Add composite primary key index
                     assert!(
                         !pk_index_added,
@@ -1204,7 +1210,11 @@ impl Schema {
             // In MVCC mode during recovery, not all automatic index schema rows might be visible yet
             // during incremental schema reparsing, so we may have extra entries
             if !mvcc_enabled {
-                assert!(automatic_indexes.is_empty(), "all automatic indexes parsed from sqlite_schema should have been consumed, but {} remain", automatic_indexes.len());
+                assert!(
+                    automatic_indexes.is_empty(),
+                    "all automatic indexes parsed from sqlite_schema should have been consumed, but {} remain",
+                    automatic_indexes.len()
+                );
             }
         }
         Ok(())
@@ -1362,7 +1372,9 @@ impl Schema {
                                     // This will cause populate_materialized_views to skip this view
                                     tracing::warn!(
                                         "Skipping materialized view '{}' - has version {} but current version is {}. DROP and recreate the view to use it.",
-                                        view_name, stored_version, DBSP_CIRCUIT_VERSION
+                                        view_name,
+                                        stored_version,
+                                        DBSP_CIRCUIT_VERSION
                                     );
                                     // We can't track incompatible views here since we're in handle_schema_row
                                     // which doesn't have mutable access to self
@@ -4241,13 +4253,17 @@ impl Index {
                 )));
             };
             let (_, column) = table.get_column(col_name).unwrap();
+            let expr = match column.generated_type() {
+                GeneratedType::Virtual { resolved, .. } => Some(resolved.clone()),
+                GeneratedType::NotGenerated => None,
+            };
             primary_keys.push(IndexColumn {
                 name: normalize_ident(col_name),
                 order: *order,
                 pos_in_table,
                 collation: column.collation_opt(),
                 default: column.default.clone(),
-                expr: None,
+                expr,
             });
         }
 
@@ -4288,13 +4304,17 @@ impl Index {
                     table.name
                 )));
             };
+            let expr = match col.generated_type() {
+                GeneratedType::Virtual { resolved, .. } => Some(resolved.clone()),
+                GeneratedType::NotGenerated => None,
+            };
             unique_cols.push(IndexColumn {
                 name: normalize_ident(col.name.as_ref().unwrap()),
                 order: *sort_order,
                 pos_in_table,
                 collation: col.collation_opt(),
                 default: col.default.clone(),
-                expr: None,
+                expr,
             });
         }
 

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -1,6 +1,6 @@
 use crate::vdbe::builder::SelfTableContext;
 use crate::{
-    schema::{Index, Schema, Table},
+    schema::{GeneratedType, Index, Schema, Table},
     translate::{
         emitter::Resolver,
         expr::{
@@ -267,8 +267,20 @@ fn translate_integrity_check_impl(
                         )?)));
                         unique_nullable.push(true);
                     } else {
-                        columns.push(BoundIndexColumn::Column(col.pos_in_table));
-                        unique_nullable.push(!btree_table.columns[col.pos_in_table].notnull());
+                        let table_col = &btree_table.columns[col.pos_in_table];
+                        if let GeneratedType::Virtual { resolved: expr, .. } =
+                            table_col.generated_type()
+                        {
+                            columns.push(BoundIndexColumn::Expr(Box::new(bind_expr_for_table(
+                                expr,
+                                &mut table_references,
+                                resolver,
+                            )?)));
+                            unique_nullable.push(!table_col.notnull());
+                        } else {
+                            columns.push(BoundIndexColumn::Column(col.pos_in_table));
+                            unique_nullable.push(!table_col.notnull());
+                        }
                     }
                 }
 
@@ -297,7 +309,7 @@ fn translate_integrity_check_impl(
             .iter()
             .enumerate()
             .filter_map(|(idx, col)| {
-                if col.notnull() && !col.is_rowid_alias() {
+                if col.notnull() && !col.is_rowid_alias() && !col.is_virtual_generated() {
                     Some((
                         idx,
                         col.name.clone().unwrap_or_else(|| format!("column{idx}")),

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -2324,6 +2324,20 @@ expect {
     10|20
 }
 
+# DELETE on table with UNIQUE auto-index on virtual column
+test gencol_delete_unique_virtual_col {
+    CREATE TABLE t1(a INTEGER, b TEXT UNIQUE AS (a || '_v'));
+    INSERT INTO t1(a) VALUES(1), (2), (3);
+    DELETE FROM t1 WHERE a = 2;
+    SELECT a, b FROM t1 ORDER BY a;
+    PRAGMA integrity_check;
+}
+expect {
+    1|1_v
+    3|3_v
+    ok
+}
+
 @cross-check-integrity
 @skip-if mvcc "Expression indexes are not supported with MVCC"
 test gencol_expr_index_virtual_delete {


### PR DESCRIPTION
## Summary

- Auto-generated indexes from UNIQUE/PRIMARY KEY constraints on virtual generated
  columns were created with `expr: None`. This caused `integrity_check` (and other
  index consumers like DELETE) to emit `Column` instructions for virtual columns,
  which are not stored in the B-tree and triggered the
  `emit_column called with virtual generated column` assertion.
- Set `IndexColumn.expr` to the column''s generating expression in
  `automatic_from_unique` and `automatic_from_primary_key`, matching what
  `resolve_sorted_columns` already does for explicit `CREATE INDEX`.
- Add defense-in-depth in `integrity_check` for any indexes that still lack the
  expression, and skip virtual columns in the NOT NULL check pass.

Closes #6158

🤖 Generated with [Claude Code](https://claude.com/claude-code)