### PR TITLE
make OnSerializationComplete Callback return a `Result<()>`

### DIFF
--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -122,7 +122,7 @@ pub const DEFAULT_LOG_CHECKPOINT_THRESHOLD: i64 = 4120 * 1000;
 
 /// Optional callback invoked after serialization with a zero-copy reference to
 /// the serialized frame bytes and the running CRC, before the disk write.
-pub type OnSerializationComplete<'a> = Option<&'a dyn Fn(&[u8], u32)>;
+pub type OnSerializationComplete<'a> = Option<&'a dyn Fn(&[u8], u32) -> crate::Result<()>>;
 
 const LOG_MAGIC: u32 = 0x4C4D4C32; // "LML2" in LE
 const LOG_VERSION: u8 = 2;
@@ -383,7 +383,7 @@ impl LogicalLog {
 
         // 6. Call observer before writing — zero-copy reference into write_buf.
         if let Some(cb) = on_serialization_complete {
-            cb(&self.write_buf, crc);
+            cb(&self.write_buf, crc)?;
         }
 
         // 7. Copy write_buf into an I/O buffer and pwrite. write_buf keeps its allocation.

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -46,7 +46,7 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
     fn log_tx(
         &self,
         m: &turso_core::mvcc::database::LogRecord,
-        on_serialization_complete: Option<&dyn Fn(&[u8], u32)>,
+        on_serialization_complete: Option<&dyn Fn(&[u8], u32) -> turso_core::Result<()>>,
     ) -> turso_core::Result<(turso_core::Completion, u64)> {
         self.used_log_tx
             .store(true, std::sync::atomic::Ordering::SeqCst);


### PR DESCRIPTION
## Description
Add some more flexibility for the serialization callback

## Motivation and context
Users can execute fallible code in the callback