### PR TITLE
Fix aggregate bare columns returning stale values when 0 rows match WHERE

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::{
-    emitter::{Resolver, TranslateCtx},
+    emitter::{OperationMode, Resolver, TranslateCtx},
     expr::{
         resolve_expr, translate_condition_expr, translate_expr, translate_expr_no_constant_opt,
         ConditionMetadata, NoConstantOptReason,
@@ -91,14 +91,14 @@ pub fn emit_ungrouped_aggregation<'a>(
     }
 
     // If the loop never ran (once-flag is still 0), we need to evaluate non-aggregate columns now.
-    // This ensures literals return their values and column references return NULL (since cursor
-    // is not on a valid row). The once-flag mechanism normally evaluates non-agg columns on first
+    // This ensures literals return their values and column references return NULL (since no
+    // rows matched). The once-flag mechanism normally evaluates non-agg columns on first
     // iteration, but if there were no iterations, we must do it here.
     //
-    // For direct table access, Column on an invalid cursor returns NULL naturally. But for
-    // coroutine-based sources (CTEs, FROM-clause subqueries), the output registers still hold
-    // the last yielded row's values. We null those registers first so that expressions
-    // referencing coroutine columns evaluate to NULL instead of leaking stale values.
+    // We must emit NullRow for all table cursors first, because after a WHERE-filter
+    // jump-out the cursor may still be positioned on a valid (but non-matching) row.
+    // Without NullRow, Column instructions would read stale data from that row instead
+    // of returning NULL.
     if let Some(once_flag) = t_ctx.reg_nonagg_emit_once_flag {
         let skip_nonagg_eval = program.allocate_label();
         // If once-flag is non-zero (loop ran at least once), skip evaluation
@@ -107,9 +107,15 @@ pub fn emit_ungrouped_aggregation<'a>(
             target_pc: skip_nonagg_eval,
             jump_if_null: false,
         });
-        // Null out coroutine output registers so column references from CTEs/subqueries
-        // don't leak stale values from the last yielded row.
+        // Set all table cursors to NullRow so that Column instructions return NULL
+        // instead of leaking stale values from the last scanned (but non-matching) row.
+        // Also null out coroutine output registers for CTEs/subqueries.
         for table_ref in plan.table_references.joined_tables() {
+            let (table_cursor_id, index_cursor_id) =
+                table_ref.resolve_cursors(program, OperationMode::SELECT)?;
+            for cursor_id in [table_cursor_id, index_cursor_id].into_iter().flatten() {
+                program.emit_insn(Insn::NullRow { cursor_id });
+            }
             if let Table::FromClauseSubquery(subquery) = &table_ref.table {
                 if let Some(start_reg) = subquery.result_columns_start_reg {
                     let num_cols = subquery.columns.len();

--- a/testing/sqltests/tests/aggregate-bare-column-zero-rows.sqltest
+++ b/testing/sqltests/tests/aggregate-bare-column-zero-rows.sqltest
@@ -1,0 +1,76 @@
+@database :memory:
+
+# Regression tests: bare columns in ungrouped aggregate queries with 0 matching
+# rows must return NULL, not stale values from non-matching rows.
+#
+# When no rows pass the WHERE filter, the table cursor may still be positioned
+# on a valid row from the scan. Without NullRow, Column instructions would read
+# stale data from that row instead of returning NULL.
+
+setup single-row {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT, c INTEGER NOT NULL);
+    INSERT INTO t VALUES(NULL, 'hello', 10);
+}
+
+@setup single-row
+test sum-zero-rows-bare-col {
+    SELECT SUM(a IS NOT NULL), b FROM t WHERE a < -999;
+}
+expect {
+    |
+}
+
+@setup single-row
+test sum-zero-rows-bare-col-with-order-by {
+    SELECT SUM(a IS NOT NULL), b FROM t WHERE a < -999 ORDER BY c DESC;
+}
+expect {
+    |
+}
+
+@setup single-row
+test count-zero-rows-bare-col {
+    SELECT COUNT(a), b FROM t WHERE a < -999;
+}
+expect {
+    0|
+}
+
+setup multi-row {
+    CREATE TABLE t2(a INTEGER PRIMARY KEY, b TEXT, c TEXT, d INTEGER NOT NULL);
+    INSERT INTO t2 VALUES(1, 'foo', 'bar', 10);
+    INSERT INTO t2 VALUES(2, 'baz', 'qux', 20);
+}
+
+@setup multi-row
+test count-star-zero-rows-multiple-bare-cols {
+    SELECT COUNT(*), b, c FROM t2 WHERE a > 999;
+}
+expect {
+    0||
+}
+
+@setup multi-row
+test avg-zero-rows-bare-col {
+    SELECT AVG(d), b FROM t2 WHERE a > 999;
+}
+expect {
+    |
+}
+
+@setup multi-row
+test max-zero-rows-bare-col {
+    SELECT MAX(d), b, c FROM t2 WHERE a > 999;
+}
+expect {
+    ||
+}
+
+# With matching rows the bare column should return a value from a matching row
+@setup single-row
+test sum-matching-rows-bare-col {
+    SELECT SUM(a IS NOT NULL), b FROM t WHERE c = 10;
+}
+expect {
+    1|hello
+}


### PR DESCRIPTION
When an ungrouped aggregate query (e.g. SELECT SUM(x), col FROM t WHERE ...) has no rows matching the WHERE filter, bare (non-aggregate) columns must return NULL. Instead, they were returning values from the last scanned but non-matching row.

Root cause: after Rewind + WHERE-filter jump-out, the cursor remains positioned on a valid row. The post-loop code in emit_ungrouped_aggregation evaluated Column on this cursor, reading stale data. Fix: emit NullRow for all table cursors before the post-loop Column evaluation, so Column reads return NULL.

I found this when fuzzying for some other issue, and ask Claude to fix the issue.