### PR TITLE
core/translate: Implement ORDER BY NULLS FIRST/LAST

### DIFF
--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1212,6 +1212,7 @@ fn key_info() -> KeyInfo {
     KeyInfo {
         sort_order: SortOrder::Asc,
         collation: CollationSeq::Binary,
+        nulls_order: None,
     }
 }
 

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -396,6 +396,7 @@ fn key_info() -> KeyInfo {
     KeyInfo {
         collation: CollationSeq::Binary,
         sort_order: SortOrder::Asc,
+        nulls_order: None,
     }
 }
 

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -781,7 +781,7 @@ fn create_collection_index(
 #[allow(clippy::too_many_arguments)]
 fn emit_compound_order_by(
     program: &mut ProgramBuilder,
-    order_by: &[(usize, SortOrder)],
+    order_by: &[(usize, SortOrder, Option<turso_parser::ast::NullsOrder>)],
     collection_cursor_id: usize,
     collection_index: &Index,
     num_result_cols: usize,
@@ -798,21 +798,22 @@ fn emit_compound_order_by(
     // We append a sequence number as an extra sort key after the ORDER BY columns
     // to break ties by insertion order, matching SQLite's merge-based compound SELECT
     // which naturally outputs left-arm rows before right-arm rows for equal keys.
-    let mut order_and_collations: Vec<(
+    let mut order_collations_nulls: Vec<(
         SortOrder,
         Option<crate::translate::collate::CollationSeq>,
+        Option<turso_parser::ast::NullsOrder>,
     )> = order_by
         .iter()
-        .map(|(col_idx, order)| {
+        .map(|(col_idx, order, nulls)| {
             let collation = collection_index
                 .columns
                 .get(*col_idx)
                 .and_then(|c| c.collation);
-            (*order, collation)
+            (*order, collation, *nulls)
         })
         .collect();
     // Sequence tie-breaker: preserves insertion order for rows with equal ORDER BY keys
-    order_and_collations.push((SortOrder::Asc, None));
+    order_collations_nulls.push((SortOrder::Asc, None, None));
 
     // Compute deduplication remappings: which result columns share a sort key slot.
     // The sorter layout is: [order_by_keys..., sequence, non-dedup data cols...]
@@ -824,7 +825,7 @@ fn emit_compound_order_by(
         if let Some((sort_key_idx, _)) = order_by
             .iter()
             .enumerate()
-            .find(|(_, (ob_col, _))| *ob_col == col_idx)
+            .find(|(_, (ob_col, _, _))| *ob_col == col_idx)
         {
             // This result column is also a sort key - deduplicate
             remappings.push((sort_key_idx, true));
@@ -840,7 +841,7 @@ fn emit_compound_order_by(
     // NumericLt to sort correctly instead of default blob/text comparison).
     let mut comparators: Vec<Option<crate::vdbe::insn::SortComparatorType>> = order_by
         .iter()
-        .map(|(col_idx, _)| {
+        .map(|(col_idx, _, _)| {
             program.result_columns.get(*col_idx).and_then(|rc| {
                 custom_type_comparator(
                     &rc.expr,
@@ -854,8 +855,8 @@ fn emit_compound_order_by(
     comparators.push(None);
     program.emit_insn(Insn::SorterOpen {
         cursor_id: sort_cursor,
-        columns: order_and_collations.len(),
-        order_and_collations,
+        columns: order_collations_nulls.len(),
+        order_collations_nulls,
         comparators,
     });
 
@@ -892,7 +893,7 @@ fn emit_compound_order_by(
     // Build sorter record: [sort_keys..., sequence, non-dedup result cols...]
     let sorter_regs = program.alloc_registers(sorter_column_count);
     // First emit sort keys
-    for (sort_key_idx, (col_idx, _)) in order_by.iter().enumerate() {
+    for (sort_key_idx, (col_idx, _, _)) in order_by.iter().enumerate() {
         program.emit_insn(Insn::Copy {
             src_reg: read_regs + col_idx,
             dst_reg: sorter_regs + sort_key_idx,

--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -20,6 +20,25 @@ use super::plan::{
     SelectPlan, SetOperation, UpdatePlan,
 };
 
+fn fmt_order_by_item(
+    f: &mut fmt::Formatter<'_>,
+    expr: &impl fmt::Display,
+    dir: SortOrder,
+    nulls: Option<turso_parser::ast::NullsOrder>,
+) -> fmt::Result {
+    let dir_str = match dir {
+        SortOrder::Asc => "ASC",
+        SortOrder::Desc => "DESC",
+    };
+    match nulls {
+        Some(turso_parser::ast::NullsOrder::First) => {
+            writeln!(f, "  - {expr} {dir_str} NULLS FIRST")
+        }
+        Some(turso_parser::ast::NullsOrder::Last) => writeln!(f, "  - {expr} {dir_str} NULLS LAST"),
+        None => writeln!(f, "  - {expr} {dir_str}"),
+    }
+}
+
 /// Format the EXPLAIN QUERY PLAN detail string for a table operation.
 /// Used by DELETE/UPDATE emitters to emit EQP annotations.
 pub(crate) fn format_eqp_detail(table: &JoinedTable) -> String {
@@ -203,17 +222,8 @@ impl Display for Plan {
                 }
                 if let Some(order_by) = order_by {
                     writeln!(f, "ORDER BY:")?;
-                    for (expr, dir) in order_by {
-                        writeln!(
-                            f,
-                            "  - {} {}",
-                            expr,
-                            if *dir == SortOrder::Asc {
-                                "ASC"
-                            } else {
-                                "DESC"
-                            }
-                        )?;
+                    for (expr, dir, nulls) in order_by {
+                        fmt_order_by_item(f, expr, *dir, *nulls)?;
                     }
                 }
                 Ok(())
@@ -579,17 +589,8 @@ impl fmt::Display for UpdatePlan {
         }
         if !self.order_by.is_empty() {
             writeln!(f, "ORDER BY:")?;
-            for (expr, dir) in &self.order_by {
-                writeln!(
-                    f,
-                    "  - {} {}",
-                    expr,
-                    if *dir == SortOrder::Asc {
-                        "ASC"
-                    } else {
-                        "DESC"
-                    }
-                )?;
+            for (expr, dir, nulls) in &self.order_by {
+                fmt_order_by_item(f, expr, *dir, *nulls)?;
             }
         }
         if let Some(limit) = self.limit.as_ref() {
@@ -672,13 +673,15 @@ impl ToTokens for Plan {
                     s.append(TokenType::TK_BY, None)?;
 
                     s.comma(
-                        order_by.iter().map(|(col_idx, order)| ast::SortedColumn {
-                            expr: Box::new(ast::Expr::Literal(ast::Literal::Numeric(
-                                (col_idx + 1).to_string(),
-                            ))),
-                            order: Some(*order),
-                            nulls: None,
-                        }),
+                        order_by
+                            .iter()
+                            .map(|(col_idx, order, nulls)| ast::SortedColumn {
+                                expr: Box::new(ast::Expr::Literal(ast::Literal::Numeric(
+                                    (col_idx + 1).to_string(),
+                                ))),
+                                order: Some(*order),
+                                nulls: *nulls,
+                            }),
                         context,
                     )?;
                 }
@@ -842,10 +845,10 @@ impl ToTokens for SelectPlan {
                         window
                             .order_by
                             .iter()
-                            .map(|(expr, order)| ast::SortedColumn {
+                            .map(|(expr, order, nulls)| ast::SortedColumn {
                                 expr: Box::new(expr.clone()),
                                 order: Some(*order),
-                                nulls: None,
+                                nulls: *nulls,
                             }),
                         context,
                     )?;
@@ -860,11 +863,13 @@ impl ToTokens for SelectPlan {
             s.append(TokenType::TK_BY, None)?;
 
             s.comma(
-                self.order_by.iter().map(|(expr, order)| ast::SortedColumn {
-                    expr: expr.clone(),
-                    order: Some(*order),
-                    nulls: None,
-                }),
+                self.order_by
+                    .iter()
+                    .map(|(expr, order, nulls)| ast::SortedColumn {
+                        expr: expr.clone(),
+                        order: Some(*order),
+                        nulls: *nulls,
+                    }),
                 context,
             )?;
         }
@@ -922,11 +927,13 @@ impl ToTokens for DeletePlan {
             s.append(TokenType::TK_BY, None)?;
 
             s.comma(
-                self.order_by.iter().map(|(expr, order)| ast::SortedColumn {
-                    expr: expr.clone(),
-                    order: Some(*order),
-                    nulls: None,
-                }),
+                self.order_by
+                    .iter()
+                    .map(|(expr, order, nulls)| ast::SortedColumn {
+                        expr: expr.clone(),
+                        order: Some(*order),
+                        nulls: *nulls,
+                    }),
                 context,
             )?;
         }
@@ -1003,11 +1010,13 @@ impl ToTokens for UpdatePlan {
             s.append(TokenType::TK_BY, None)?;
 
             s.comma(
-                self.order_by.iter().map(|(expr, order)| ast::SortedColumn {
-                    expr: expr.clone(),
-                    order: Some(*order),
-                    nulls: None,
-                }),
+                self.order_by
+                    .iter()
+                    .map(|(expr, order, nulls)| ast::SortedColumn {
+                        expr: expr.clone(),
+                        order: Some(*order),
+                        nulls: *nulls,
+                    }),
                 context,
             )?;
         }

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -94,7 +94,11 @@ impl EmitGroupBy {
         group_by: &'a GroupBy,
         plan: &SelectPlan,
         result_columns: &'a [ResultSetColumn],
-        order_by: &'a [(Box<ast::Expr>, ast::SortOrder)],
+        order_by: &'a [(
+            Box<ast::Expr>,
+            ast::SortOrder,
+            Option<turso_parser::ast::NullsOrder>,
+        )],
     ) -> Result<()> {
         collect_non_aggregate_expressions(
             &mut t_ctx.non_aggregate_expressions,
@@ -154,13 +158,18 @@ impl EmitGroupBy {
              * then the collating sequence of the column is used to determine sort order.
              * If the expression is not a column and has no COLLATE clause, then the BINARY collating sequence is used.
              */
-            let order_and_collations: Vec<(SortOrder, Option<CollationSeq>)> = group_by
+            let order_collations_nulls: Vec<(
+                SortOrder,
+                Option<CollationSeq>,
+                Option<turso_parser::ast::NullsOrder>,
+            )> = group_by
                 .exprs
                 .iter()
                 .zip(sort_order.iter())
-                .map(|(expr, ord)| {
+                .zip(group_by.nulls_order.iter())
+                .map(|((expr, ord), nulls)| {
                     let collation = get_collseq_from_expr(expr, &plan.table_references)?;
-                    Ok((*ord, collation))
+                    Ok((*ord, collation, *nulls))
                 })
                 .collect::<Result<Vec<_>>>()?;
 
@@ -176,7 +185,7 @@ impl EmitGroupBy {
             program.emit_insn(Insn::SorterOpen {
                 cursor_id: sort_cursor,
                 columns: column_count,
-                order_and_collations,
+                order_collations_nulls,
                 comparators,
             });
             emit_explain!(program, false, "USE SORTER FOR GROUP BY".to_owned());
@@ -285,33 +294,43 @@ pub fn is_orderby_agg_or_const(resolver: &Resolver, e: &ast::Expr, aggs: &[Aggre
 /// appears in ORDER BY, and the remaining keys default to `ASC`.
 pub fn compute_group_by_sort_order(
     group_by_exprs: &[ast::Expr],
-    order_by: &[(Box<ast::Expr>, SortOrder)],
+    order_by: &[(
+        Box<ast::Expr>,
+        SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )],
     aggs: &[Aggregate],
     resolver: &Resolver,
-) -> Vec<SortOrder> {
+) -> (Vec<SortOrder>, Vec<Option<ast::NullsOrder>>) {
     let groupby_len = group_by_exprs.len();
     if groupby_len == 0 || order_by.is_empty() {
-        return vec![SortOrder::Asc; groupby_len];
+        return (vec![SortOrder::Asc; groupby_len], vec![None; groupby_len]);
     }
     let only_agg_or_const = order_by
         .iter()
-        .all(|(e, _)| is_orderby_agg_or_const(resolver, e, aggs));
+        .all(|(e, _, _)| is_orderby_agg_or_const(resolver, e, aggs));
 
     if only_agg_or_const {
         let first_direction = order_by[0].1;
-        return vec![first_direction; groupby_len];
+        let first_nulls = order_by[0].2;
+        return (
+            vec![first_direction; groupby_len],
+            vec![first_nulls; groupby_len],
+        );
     }
 
-    let mut result = vec![SortOrder::Asc; groupby_len];
+    let mut sort_order = vec![SortOrder::Asc; groupby_len];
+    let mut nulls_order = vec![None; groupby_len];
     for (idx, groupby_expr) in group_by_exprs.iter().enumerate() {
-        if let Some((_, direction)) = order_by
+        if let Some((_, direction, nulls)) = order_by
             .iter()
-            .find(|(expr, _)| exprs_are_equivalent(expr, groupby_expr))
+            .find(|(expr, _, _)| exprs_are_equivalent(expr, groupby_expr))
         {
-            result[idx] = *direction;
+            sort_order[idx] = *direction;
+            nulls_order[idx] = *nulls;
         }
     }
-    result
+    (sort_order, nulls_order)
 }
 
 /// Extracts unique leaf column references from all aggregate function arguments.
@@ -348,13 +367,17 @@ fn collect_non_aggregate_expressions<'a>(
     group_by: &'a GroupBy,
     plan: &SelectPlan,
     root_result_columns: &'a [ResultSetColumn],
-    order_by: &'a [(Box<ast::Expr>, ast::SortOrder)],
+    order_by: &'a [(
+        Box<ast::Expr>,
+        ast::SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )],
 ) -> Result<()> {
     let mut result_columns = Vec::new();
     for expr in root_result_columns
         .iter()
         .map(|col| &col.expr)
-        .chain(order_by.iter().map(|(e, _)| e.as_ref()))
+        .chain(order_by.iter().map(|(e, _, _)| e.as_ref()))
         .chain(group_by.having.iter().flatten())
     {
         collect_result_columns(expr, plan, &mut result_columns)?;
@@ -606,6 +629,7 @@ pub fn group_by_process_single_group(
         .map(|_| KeyInfo {
             sort_order: SortOrder::Asc,
             collation: CollationSeq::default(),
+            nulls_order: None,
         })
         .collect::<Vec<_>>();
     for (i, c) in compare_key_info

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -361,13 +361,17 @@ pub fn translate_create_index(
         });
         program.preassign_label_to_next_insn(loop_end_label);
     } else if index_method.is_none() {
-        // determine the order and collation of the columns in the index for the sorter
-        let order_and_collations = idx.columns.iter().map(|c| (c.order, c.collation)).collect();
+        // determine the order, collation, and nulls ordering of the columns in the index for the sorter
+        let order_collations_nulls = idx
+            .columns
+            .iter()
+            .map(|c| (c.order, c.collation, None))
+            .collect();
         // open the sorter and the pseudo table
         program.emit_insn(Insn::SorterOpen {
             cursor_id: sorter_cursor_id,
             columns: columns.len(),
-            order_and_collations,
+            order_collations_nulls,
             comparators: vec![],
         });
         let content_reg = program.alloc_register();

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -134,7 +134,11 @@ fn try_match_index_method_pattern(
     pattern: &ast::Select,
     table: &JoinedTable,
     query_where_terms: &[WhereTerm],
-    order_by: &[(Box<ast::Expr>, SortOrder)],
+    order_by: &[(
+        Box<ast::Expr>,
+        SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )],
     limit: &Option<Box<Expr>>,
     offset: &Option<Box<Expr>>,
     pattern_idx: usize,
@@ -219,10 +223,15 @@ fn try_match_index_method_pattern(
 
     // Match ORDER BY if pattern has it
     if pattern_has_order_by {
-        for (pattern_column, (query_column, query_order)) in
+        for (pattern_column, (query_column, query_order, query_nulls)) in
             pattern.order_by.iter().zip(order_by.iter())
         {
             if *query_order != pattern_column.order.unwrap_or(SortOrder::Asc) {
+                return None;
+            }
+            // If the query has explicit NULLS ordering, the index pattern cannot
+            // satisfy it (index methods have no NULLS awareness).
+            if query_nulls.is_some() {
                 return None;
             }
             let num_col_args = count_fts_column_args(&pattern_column.expr);
@@ -344,7 +353,11 @@ fn collect_index_method_candidates(
     table_references: &TableReferences,
     available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
     where_clause: &[WhereTerm],
-    order_by: &[(Box<ast::Expr>, SortOrder)],
+    order_by: &[(
+        Box<ast::Expr>,
+        SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )],
     group_by: &Option<GroupBy>,
     limit: &Option<Box<Expr>>,
     offset: &Option<Box<Expr>>,
@@ -1182,7 +1195,11 @@ fn optimize_table_access_with_custom_modules(
     table_references: &mut TableReferences,
     available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
     where_query: &mut [WhereTerm],
-    order_by: &mut Vec<(Box<ast::Expr>, SortOrder)>,
+    order_by: &mut Vec<(
+        Box<ast::Expr>,
+        SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )>,
     group_by: &mut Option<GroupBy>,
     limit: &mut Option<Box<Expr>>,
     offset: &mut Option<Box<Expr>>,
@@ -1303,14 +1320,18 @@ fn optimize_table_access_with_custom_modules(
 fn register_expression_index_usages_for_plan(
     table_references: &mut TableReferences,
     result_columns: &[ResultSetColumn],
-    order_by: &[(Box<ast::Expr>, SortOrder)],
+    order_by: &[(
+        Box<ast::Expr>,
+        SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )],
     group_by: Option<&GroupBy>,
 ) {
     table_references.reset_expression_index_usages();
     for rc in result_columns {
         table_references.register_expression_index_usage(&rc.expr);
     }
-    for (expr, _) in order_by {
+    for (expr, _, _) in order_by {
         table_references.register_expression_index_usage(expr);
     }
     if let Some(group_by) = group_by {
@@ -1574,7 +1595,11 @@ fn optimize_table_access(
     table_references: &mut TableReferences,
     available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
     where_clause: &mut [WhereTerm],
-    order_by: &mut Vec<(Box<ast::Expr>, SortOrder)>,
+    order_by: &mut Vec<(
+        Box<ast::Expr>,
+        SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )>,
     group_by: &mut Option<GroupBy>,
     simple_aggregate: Option<&SimpleAggregate>,
     subqueries: &[NonFromClauseSubquery],

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -40,6 +40,7 @@ pub struct ColumnOrder {
     pub target: ColumnTarget,
     pub order: SortOrder,
     pub collation: CollationSeq,
+    pub nulls_order: Option<ast::NullsOrder>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -85,7 +86,7 @@ impl OrderTarget {
     /// Build an `OrderTarget` from a list of expressions if they can all be
     /// satisfied by a single-table ordering (needed for index satisfaction).
     fn maybe_from_iterator<'a>(
-        list: impl Iterator<Item = (&'a ast::Expr, SortOrder)> + Clone,
+        list: impl Iterator<Item = (&'a ast::Expr, SortOrder, Option<ast::NullsOrder>)> + Clone,
         tables: &crate::translate::plan::TableReferences,
         purpose: OrderTargetPurpose,
     ) -> Option<Self> {
@@ -93,8 +94,8 @@ impl OrderTarget {
             return None;
         }
         let mut cols = Vec::new();
-        for (expr, order) in list {
-            let col = expr_to_column_order(expr, order, tables)?;
+        for (expr, order, nulls) in list {
+            let col = expr_to_column_order(expr, order, nulls, tables)?;
             cols.push(col);
         }
         Some(OrderTarget {
@@ -118,7 +119,7 @@ pub fn simple_aggregate_order_target(
     };
 
     let mut target = OrderTarget::maybe_from_iterator(
-        std::iter::once((&min_max.argument, min_max.order)),
+        std::iter::once((&min_max.argument, min_max.order, None)),
         tables,
         OrderTargetPurpose::Extremum,
     )?;
@@ -136,7 +137,7 @@ pub fn simple_aggregate_order_target(
 /// TODO: this does not currently handle the case where we definitely cannot eliminate
 /// the ORDER BY sorter, but we could still eliminate the GROUP BY sorter.
 pub fn compute_order_target(
-    order_by: &mut Vec<(Box<ast::Expr>, SortOrder)>,
+    order_by: &mut Vec<(Box<ast::Expr>, SortOrder, Option<ast::NullsOrder>)>,
     group_by_opt: Option<&mut GroupBy>,
     tables: &TableReferences,
 ) -> Option<OrderTarget> {
@@ -145,13 +146,18 @@ pub fn compute_order_target(
         (true, None) => None,
         // Only ORDER BY - we would like the joined result rows to be in the order specified by the ORDER BY
         (false, None) => OrderTarget::maybe_from_iterator(
-            order_by.iter().map(|(expr, order)| (expr.as_ref(), *order)),
+            order_by
+                .iter()
+                .map(|(expr, order, nulls)| (expr.as_ref(), *order, *nulls)),
             tables,
             OrderTargetPurpose::EliminatesSort(EliminatesSortBy::Order),
         ),
         // Only GROUP BY - we would like the joined result rows to be in the order specified by the GROUP BY
         (true, Some(group_by)) => OrderTarget::maybe_from_iterator(
-            group_by.exprs.iter().map(|expr| (expr, SortOrder::Asc)),
+            group_by
+                .exprs
+                .iter()
+                .map(|expr| (expr, SortOrder::Asc, None)),
             tables,
             OrderTargetPurpose::EliminatesSort(EliminatesSortBy::Group),
         ),
@@ -166,7 +172,7 @@ pub fn compute_order_target(
         // however in this case we must take the ASC/DESC from ORDER BY into account.
         (false, Some(group_by)) => {
             // Does the group by contain all expressions in the order by?
-            let group_by_contains_all = order_by.iter().all(|(expr, _)| {
+            let group_by_contains_all = order_by.iter().all(|(expr, _, _)| {
                 group_by
                     .exprs
                     .iter()
@@ -175,7 +181,10 @@ pub fn compute_order_target(
             // If not, let's try to target an ordering that matches the group by -- we don't care about ASC/DESC
             if !group_by_contains_all {
                 return OrderTarget::maybe_from_iterator(
-                    group_by.exprs.iter().map(|expr| (expr, SortOrder::Asc)),
+                    group_by
+                        .exprs
+                        .iter()
+                        .map(|expr| (expr, SortOrder::Asc, None)),
                     tables,
                     OrderTargetPurpose::EliminatesSort(EliminatesSortBy::Group),
                 );
@@ -185,24 +194,26 @@ pub fn compute_order_target(
             group_by.exprs.sort_by_key(|expr| {
                 order_by
                     .iter()
-                    .position(|(order_by_expr, _)| exprs_are_equivalent(expr, order_by_expr))
+                    .position(|(order_by_expr, _, _)| exprs_are_equivalent(expr, order_by_expr))
                     .map_or(usize::MAX, |i| i)
             });
 
             // Now, regardless of whether we can eventually eliminate the sorting entirely in the optimizer,
             // we know that we don't need ORDER BY sorting anyway, because the GROUP BY will sort the result since
             // it contains all the necessary columns required for the ORDER BY, and the GROUP BY columns are now in the correct order.
-            // First, however, we need to make sure the GROUP BY sorter's column sort directions match the ORDER BY requirements.
+            // First, however, we need to make sure the GROUP BY sorter's column sort directions and NULLS
+            // ordering match the ORDER BY requirements.
             turso_assert_greater_than_or_equal!(group_by.exprs.len(), order_by.len());
-            let sort_order = &mut group_by.sort_order;
-            for (i, (_, order_by_dir)) in order_by.iter().enumerate() {
-                sort_order[i] = *order_by_dir;
+            for (i, (_, order_by_dir, order_by_nulls)) in order_by.iter().enumerate() {
+                group_by.sort_order[i] = *order_by_dir;
+                group_by.nulls_order[i] = *order_by_nulls;
             }
             // The sort_by_key above reordered group_by.exprs but not sort_order,
             // so remaining positions may have stale values. GROUP BY columns not
             // in ORDER BY should default to ASC (matching SQLite's tie-breaking).
-            for s in &mut sort_order[order_by.len()..] {
-                *s = SortOrder::Asc;
+            for i in order_by.len()..group_by.sort_order.len() {
+                group_by.sort_order[i] = SortOrder::Asc;
+                group_by.nulls_order[i] = None;
             }
             // Now we can remove the ORDER BY from the query.
             order_by.clear();
@@ -212,7 +223,8 @@ pub fn compute_order_target(
                     .exprs
                     .iter()
                     .zip(group_by.sort_order.iter())
-                    .map(|(expr, dir)| (expr, *dir)),
+                    .zip(group_by.nulls_order.iter())
+                    .map(|((expr, dir), nulls)| (expr, *dir, *nulls)),
                 tables,
                 OrderTargetPurpose::EliminatesSort(EliminatesSortBy::GroupByAndOrder),
             )
@@ -446,7 +458,7 @@ pub fn subquery_intrinsic_order_consumed(
             select_plan
                 .order_by
                 .iter()
-                .map(|(expr, order)| (expr.as_ref(), *order)),
+                .map(|(expr, order, nulls)| (expr.as_ref(), *order, *nulls)),
         );
         return match_intrinsic_order(&intrinsic, iter_dir, target);
     }
@@ -459,7 +471,9 @@ pub fn subquery_intrinsic_order_consumed(
             group_by
                 .exprs
                 .iter()
-                .zip(group_by.sort_order.iter().copied()),
+                .zip(group_by.sort_order.iter().copied())
+                .zip(group_by.nulls_order.iter().copied())
+                .map(|((expr, order), nulls)| (expr, order, nulls)),
         );
         let consumed = match_intrinsic_order(&intrinsic, iter_dir, target);
         if consumed > 0 {
@@ -474,10 +488,16 @@ pub fn subquery_intrinsic_order_consumed(
 fn build_intrinsic_order(
     table_id: TableInternalId,
     select_plan: &crate::translate::plan::SelectPlan,
-    exprs: impl Iterator<Item = (impl std::borrow::Borrow<ast::Expr>, SortOrder)>,
+    exprs: impl Iterator<
+        Item = (
+            impl std::borrow::Borrow<ast::Expr>,
+            SortOrder,
+            Option<ast::NullsOrder>,
+        ),
+    >,
 ) -> Vec<ColumnOrder> {
     let mut intrinsic = Vec::new();
-    for (expr, order) in exprs {
+    for (expr, order, nulls) in exprs {
         let expr = expr.borrow();
         let Some((col_idx, result_col)) = select_plan
             .result_columns
@@ -500,6 +520,7 @@ fn build_intrinsic_order(
                     .flatten()
                     .unwrap_or_default()
             }),
+            nulls_order: nulls,
         });
     }
     intrinsic
@@ -530,6 +551,19 @@ fn match_intrinsic_order(
         };
         if expected_order != target_col.order {
             return 0;
+        }
+        // If the target requests an explicit NULLS ordering, the intrinsic
+        // order must provide the same. When the intrinsic order has no explicit
+        // NULLS (None), it follows the default (ASC → NULLS FIRST,
+        // DESC → NULLS LAST), so only a matching explicit request is compatible.
+        if let Some(target_nulls) = target_col.nulls_order {
+            let intrinsic_nulls = intrinsic_col.nulls_order.unwrap_or(match expected_order {
+                SortOrder::Asc => ast::NullsOrder::First,
+                SortOrder::Desc => ast::NullsOrder::Last,
+            });
+            if intrinsic_nulls != target_nulls {
+                return 0;
+            }
         }
     }
     target_len
@@ -601,6 +635,7 @@ fn finalized_scan_subquery_order_consumed(
         let Some(mut inner_target_col) = expr_to_column_order(
             &result_col.expr,
             target_col.order,
+            target_col.nulls_order,
             &select_plan.table_references,
         ) else {
             return 0;
@@ -643,6 +678,7 @@ fn finalized_scan_subquery_order_consumed(
 fn expr_to_column_order(
     expr: &ast::Expr,
     order: SortOrder,
+    nulls_order: Option<ast::NullsOrder>,
     tables: &TableReferences,
 ) -> Option<ColumnOrder> {
     match expr {
@@ -658,6 +694,7 @@ fn expr_to_column_order(
                 target: ColumnTarget::Column(*column),
                 order,
                 collation: col.collation(),
+                nulls_order,
             });
         }
         ast::Expr::Collate(expr, collation) => {
@@ -673,6 +710,7 @@ fn expr_to_column_order(
                     target: ColumnTarget::Column(*column),
                     order,
                     collation,
+                    nulls_order,
                 });
             };
         }
@@ -682,6 +720,7 @@ fn expr_to_column_order(
                 target: ColumnTarget::RowId,
                 order,
                 collation: CollationSeq::default(),
+                nulls_order,
             });
         }
         _ => {}
@@ -704,6 +743,7 @@ fn expr_to_column_order(
         target: ColumnTarget::Expr(expr as *const ast::Expr),
         order,
         collation,
+        nulls_order,
     })
 }
 
@@ -843,14 +883,30 @@ pub(super) fn btree_access_order_consumed(
                     break;
                 }
 
-                let correct_order = if iter_dir == IterationDirection::Forwards {
+                let correct_order_for_direction = if iter_dir == IterationDirection::Forwards {
                     target_col.order == idx_col.order
                 } else {
                     target_col.order != idx_col.order
                 };
-                if !correct_order {
+                if !correct_order_for_direction {
                     break;
                 }
+
+                // An index scan delivers NULLs in a fixed position:
+                //   Forward scan  → NULLs first  (B-tree stores NULLs at start)
+                //   Reverse scan  → NULLs last
+                // If the query explicitly requests a different NULLS order,
+                // the index cannot satisfy it and we must fall back to a sorter.
+                if let Some(requested_nulls) = target_col.nulls_order {
+                    let default_nulls = match target_col.order {
+                        SortOrder::Asc => ast::NullsOrder::First,
+                        SortOrder::Desc => ast::NullsOrder::Last,
+                    };
+                    if requested_nulls != default_nulls {
+                        break;
+                    }
+                }
+
                 col_idx += 1;
                 idx_pos += 1;
             }

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -156,14 +156,18 @@ impl EmitOrderBy {
         program: &mut ProgramBuilder,
         t_ctx: &mut TranslateCtx,
         result_columns: &[ResultSetColumn],
-        order_by: &[(Box<ast::Expr>, SortOrder)],
+        order_by: &[(
+            Box<ast::Expr>,
+            SortOrder,
+            Option<turso_parser::ast::NullsOrder>,
+        )],
         referenced_tables: &TableReferences,
         has_group_by: bool,
         has_distinct: bool,
         aggregates: &[Aggregate],
     ) -> Result<()> {
         // Block ORDER BY on custom type columns without OPERATOR '<'
-        for (expr, _) in order_by.iter() {
+        for (expr, _, _) in order_by.iter() {
             if is_custom_type_without_lt(expr, referenced_tables, t_ctx.resolver.schema()) {
                 if let Some((col, type_def)) =
                     result_column_custom_type_info(expr, referenced_tables, t_ctx.resolver.schema())
@@ -183,9 +187,11 @@ impl EmitOrderBy {
 
         let only_aggs = order_by
             .iter()
-            .all(|(e, _)| is_orderby_agg_or_const(&t_ctx.resolver, e, aggregates));
+            .all(|(e, _, _)| is_orderby_agg_or_const(&t_ctx.resolver, e, aggregates));
 
-        let use_heap_sort = !has_distinct && !has_group_by && t_ctx.limit_ctx.is_some();
+        let has_explicit_nulls = order_by.iter().any(|(_, _, nulls)| nulls.is_some());
+        let use_heap_sort =
+            !has_distinct && !has_group_by && t_ctx.limit_ctx.is_some() && !has_explicit_nulls;
 
         // only emit sequence column if (we have GROUP BY and ORDER BY is not only aggregates or constants) OR (we decided to use heap-sort)
         let has_sequence = (has_group_by && !only_aggs) || use_heap_sort;
@@ -195,7 +201,7 @@ impl EmitOrderBy {
         let sort_cursor = if use_heap_sort {
             let index_name = format!("heap_sort_{}", program.offset().as_offset_int()); // we don't really care about the name that much, just enough that we don't get name collisions
             let mut index_columns = Vec::with_capacity(order_by.len() + result_columns.len());
-            for (column, order) in order_by {
+            for (column, order, _nulls) in order_by {
                 let collation = get_collseq_from_expr(column, referenced_tables)?;
                 let pos_in_table = index_columns.len();
                 index_columns.push(IndexColumn {
@@ -265,11 +271,15 @@ impl EmitOrderBy {
              * then the collating sequence of the column is used to determine sort order.
              * If the expression is not a column and has no COLLATE clause, then the BINARY collating sequence is used.
              */
-            let mut order_and_collations: Vec<(SortOrder, Option<CollationSeq>)> = order_by
+            let mut order_collations_nulls: Vec<(
+                SortOrder,
+                Option<CollationSeq>,
+                Option<turso_parser::ast::NullsOrder>,
+            )> = order_by
                 .iter()
-                .map(|(expr, dir)| {
+                .map(|(expr, dir, nulls)| {
                     let collation = get_collseq_from_expr(expr, referenced_tables)?;
-                    Ok((*dir, collation))
+                    Ok((*dir, collation, *nulls))
                 })
                 .collect::<Result<Vec<_>>>()?;
 
@@ -277,23 +287,23 @@ impl EmitOrderBy {
             // For types with a `<` operator, the comparator is used for correct sort ordering.
             let mut comparators: Vec<Option<SortComparatorType>> = order_by
                 .iter()
-                .map(|(expr, _)| {
+                .map(|(expr, _, _)| {
                     custom_type_comparator(expr, referenced_tables, t_ctx.resolver.schema())
                 })
                 .collect();
 
             if has_sequence {
-                // sequence column: ascending with BINARY collation, no comparator
-                order_and_collations.push((SortOrder::Asc, Some(CollationSeq::default())));
+                // sequence column: ascending with BINARY collation, no comparator, no nulls order
+                order_collations_nulls.push((SortOrder::Asc, Some(CollationSeq::default()), None));
                 comparators.push(None);
             }
 
-            let key_len = order_and_collations.len();
+            let key_len = order_collations_nulls.len();
 
             program.emit_insn(Insn::SorterOpen {
                 cursor_id: sort_cursor,
                 columns: key_len,
-                order_and_collations,
+                order_collations_nulls,
                 comparators,
             });
         }
@@ -470,7 +480,7 @@ impl EmitOrderBy {
                 - result_columns_to_skip_len;
 
         let start_reg = program.alloc_registers(orderby_sorter_column_count);
-        for (i, (expr, _)) in order_by.iter().enumerate() {
+        for (i, (expr, _, _)) in order_by.iter().enumerate() {
             let key_reg = start_reg + i;
 
             // Check if this ORDER BY expression matches a finalized aggregate
@@ -710,7 +720,11 @@ pub struct OrderByRemapping {
 /// If we skip a result column, we need to keep track what index in the ORDER BY sorter the result columns have,
 /// because the result columns should be emitted in the SELECT clause order, not the ORDER BY clause order.
 pub fn order_by_deduplicate_result_columns(
-    order_by: &[(Box<ast::Expr>, SortOrder)],
+    order_by: &[(
+        Box<ast::Expr>,
+        SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )],
     result_columns: &[ResultSetColumn],
     has_sequence: bool,
 ) -> Vec<OrderByRemapping> {
@@ -725,7 +739,7 @@ pub fn order_by_deduplicate_result_columns(
         let found = order_by
             .iter()
             .enumerate()
-            .find(|(_, (expr, _))| exprs_are_equivalent(expr, &rc.expr));
+            .find(|(_, (expr, _, _))| exprs_are_equivalent(expr, &rc.expr));
         if let Some((j, _)) = found {
             result_column_remapping.push(OrderByRemapping {
                 orderby_sorter_idx: j,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -112,6 +112,9 @@ pub struct GroupBy {
     /// `compute_group_by_sort_order` has run; the outer optimizer reads
     /// this to derive the materialized CTE's output order.
     pub sort_order: Vec<SortOrder>,
+    /// NULLS ordering for each GROUP BY key column. Populated when ORDER BY
+    /// with explicit NULLS FIRST/LAST is merged into GROUP BY.
+    pub nulls_order: Vec<Option<ast::NullsOrder>>,
     /// When true the scan already provides the GROUP BY order and no
     /// sorter is emitted. The `sort_order` is kept so that the outer
     /// query can still read the effective output order.
@@ -300,9 +303,9 @@ pub enum Plan {
         right_most: SelectPlan,
         limit: Option<Box<Expr>>,
         offset: Option<Box<Expr>>,
-        /// ORDER BY for compound selects. Each entry is (result_column_index, sort_order).
+        /// ORDER BY for compound selects. Each entry is (result_column_index, sort_order, nulls_order).
         /// The column index is 0-based into the result set.
-        order_by: Option<Vec<(usize, SortOrder)>>,
+        order_by: Option<Vec<(usize, SortOrder, Option<ast::NullsOrder>)>>,
     },
     Delete(DeletePlan),
     Update(UpdatePlan),
@@ -565,7 +568,7 @@ pub struct SelectPlan {
     /// group by clause
     pub group_by: Option<GroupBy>,
     /// order by clause
-    pub order_by: Vec<(Box<ast::Expr>, SortOrder)>,
+    pub order_by: Vec<(Box<ast::Expr>, SortOrder, Option<ast::NullsOrder>)>,
     /// all the aggregates collected from the result columns, order by, and (TODO) having clauses
     pub aggregates: Vec<Aggregate>,
     /// limit clause
@@ -687,7 +690,7 @@ pub struct DeletePlan {
     /// where clause split into a vec at 'AND' boundaries.
     pub where_clause: Vec<WhereTerm>,
     /// order by clause
-    pub order_by: Vec<(Box<ast::Expr>, SortOrder)>,
+    pub order_by: Vec<(Box<ast::Expr>, SortOrder, Option<ast::NullsOrder>)>,
     /// limit clause
     pub limit: Option<Box<Expr>>,
     /// offset clause
@@ -714,7 +717,7 @@ pub struct UpdatePlan {
     // (column index, new value) pairs
     pub set_clauses: Vec<(usize, Box<ast::Expr>)>,
     pub where_clause: Vec<WhereTerm>,
-    pub order_by: Vec<(Box<ast::Expr>, SortOrder)>,
+    pub order_by: Vec<(Box<ast::Expr>, SortOrder, Option<ast::NullsOrder>)>,
     pub limit: Option<Box<Expr>>,
     pub offset: Option<Box<Expr>>,
     // TODO: optional RETURNING clause
@@ -2361,7 +2364,7 @@ pub struct Window {
     /// the leftmost columns in the subquery output make up the partition key.
     pub deduplicated_partition_by_len: Option<usize>,
     /// Expressions from the ORDER BY clause.
-    pub order_by: Vec<(Expr, SortOrder)>,
+    pub order_by: Vec<(Expr, SortOrder, Option<ast::NullsOrder>)>,
     /// All window functions associated with this window.
     pub functions: Vec<WindowFunction>,
 }
@@ -2385,6 +2388,7 @@ impl Window {
                     (
                         *col.expr.clone(),
                         col.order.unwrap_or(Self::DEFAULT_SORT_ORDER),
+                        col.nulls,
                     )
                 })
                 .collect(),
@@ -2415,9 +2419,10 @@ impl Window {
         self.order_by
             .iter()
             .zip(&ast.order_by)
-            .all(|((expr_a, order_a), col_b)| {
+            .all(|((expr_a, order_a, nulls_a), col_b)| {
                 exprs_are_equivalent(expr_a, &col_b.expr)
                     && *order_a == col_b.order.unwrap_or(Self::DEFAULT_SORT_ORDER)
+                    && *nulls_a == col_b.nulls
             })
     }
 

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -213,14 +213,6 @@ pub fn prepare_select_plan(
             let order_by = if select.order_by.is_empty() {
                 None
             } else {
-                if select
-                    .order_by
-                    .iter()
-                    .filter_map(|o| o.nulls)
-                    .any(|n| n == ast::NullsOrder::Last)
-                {
-                    crate::bail_parse_error!("NULLS LAST is not supported yet in ORDER BY");
-                }
                 let mut key = Vec::with_capacity(select.order_by.len());
                 for o in &select.order_by {
                     let col_idx = resolve_compound_order_by_expr(
@@ -228,7 +220,7 @@ pub fn prepare_select_plan(
                         leftmost_result_columns,
                         leftmost_table_refs,
                     )?;
-                    key.push((col_idx, o.order.unwrap_or(ast::SortOrder::Asc)));
+                    key.push((col_idx, o.order.unwrap_or(ast::SortOrder::Asc), o.nulls));
                 }
                 Some(key)
             };
@@ -256,13 +248,6 @@ fn prepare_one_select_plan(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<SelectPlan> {
-    if order_by
-        .iter()
-        .filter_map(|o| o.nulls)
-        .any(|n| n == ast::NullsOrder::Last)
-    {
-        crate::bail_parse_error!("NULLS LAST is not supported yet in ORDER BY");
-    }
     match select {
         ast::OneSelect::Select {
             columns,
@@ -379,7 +364,7 @@ fn prepare_one_select_plan(
                         BindingBehavior::ResultColumnsNotAllowed,
                     )?;
                 }
-                for (expr, _) in window.order_by.iter_mut() {
+                for (expr, _, _) in window.order_by.iter_mut() {
                     bind_and_rewrite_expr(
                         expr,
                         Some(&mut plan.table_references),
@@ -515,6 +500,7 @@ fn prepare_one_select_plan(
 
                     plan.group_by = Some(GroupBy {
                         sort_order: Vec::new(),
+                        nulls_order: Vec::new(),
                         sort_elided: false,
                         exprs: group_by.exprs.iter().map(|expr| *expr.clone()).collect(),
                         having: having_predicates,
@@ -523,6 +509,7 @@ fn prepare_one_select_plan(
                     // HAVING without GROUP BY: treat as ungrouped aggregation with filter
                     plan.group_by = Some(GroupBy {
                         sort_order: Vec::new(),
+                        nulls_order: Vec::new(),
                         sort_elided: false,
                         exprs: vec![],
                         having: having_predicates,
@@ -578,7 +565,7 @@ fn prepare_one_select_plan(
                     crate::bail_parse_error!("misuse of aggregate: {}()", agg.func);
                 }
 
-                key.push((o.expr, o.order.unwrap_or(ast::SortOrder::Asc)));
+                key.push((o.expr, o.order.unwrap_or(ast::SortOrder::Asc), o.nulls));
             }
             // Remove duplicate ORDER BY expressions, keeping the first occurrence.
             // Duplicates are semantically redundant.
@@ -586,7 +573,7 @@ fn prepare_one_select_plan(
             while i < key.len() {
                 if key[..i]
                     .iter()
-                    .any(|(prev, _)| exprs_are_equivalent(prev, &key[i].0))
+                    .any(|(prev, _, _)| exprs_are_equivalent(prev, &key[i].0))
                 {
                     key.remove(i);
                 } else {
@@ -633,7 +620,7 @@ fn prepare_one_select_plan(
             if let Some(group_by) = &mut plan.group_by {
                 // now that we have resolved the ORDER BY expressions and aggregates, we can
                 // compute the necessary sort order for the GROUP BY clause
-                group_by.sort_order = compute_group_by_sort_order(
+                (group_by.sort_order, group_by.nulls_order) = compute_group_by_sort_order(
                     &group_by.exprs,
                     &plan.order_by,
                     &plan.aggregates,
@@ -754,7 +741,7 @@ fn validate_expr_correct_column_counts(plan: &SelectPlan) -> Result<()> {
             crate::bail_parse_error!("result column must return 1 value, got {}", vec_size);
         }
     }
-    for (expr, _) in plan.order_by.iter() {
+    for (expr, _, _) in plan.order_by.iter() {
         let vec_size = expr_vector_size(expr)?;
         if vec_size != 1 {
             crate::bail_parse_error!("order by expression must return 1 value, got {}", vec_size);

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -205,7 +205,7 @@ pub fn plan_subqueries_from_select_plan(
         &mut plan.non_from_clause_subqueries,
         &mut plan.table_references,
         resolver,
-        plan.order_by.iter_mut().map(|(expr, _)| &mut **expr),
+        plan.order_by.iter_mut().map(|(expr, _, _)| &mut **expr),
         connection,
         SubqueryPosition::OrderBy,
         SubqueryOrigin::SelectOrderBy,
@@ -792,7 +792,7 @@ fn recollect_aggregates(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()
     }
 
     // Collect from ORDER BY
-    for (expr, _) in &plan.order_by {
+    for (expr, _, _) in &plan.order_by {
         resolve_window_and_aggregate_functions(expr, resolver, &mut new_aggregates, None)?;
     }
 

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -414,7 +414,7 @@ pub fn prepare_update_plan(
                 resolver,
                 BindingBehavior::ResultColumnsNotAllowed,
             );
-            (o.expr.clone(), o.order.unwrap_or(SortOrder::Asc))
+            (o.expr.clone(), o.order.unwrap_or(SortOrder::Asc), o.nulls)
         })
         .collect();
 

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -31,7 +31,7 @@ const SUBQUERY_DATABASE_ID: usize = 0;
 
 struct WindowSubqueryContext<'a> {
     resolver: &'a Resolver<'a>,
-    subquery_order_by: &'a mut Vec<(Box<Expr>, SortOrder)>,
+    subquery_order_by: &'a mut Vec<(Box<Expr>, SortOrder, Option<turso_parser::ast::NullsOrder>)>,
     subquery_result_columns: &'a mut Vec<ResultSetColumn>,
     subquery_id: &'a TableInternalId,
 }
@@ -161,11 +161,11 @@ fn prepare_window_subquery(
     // columns with its ORDER BY columns.This ensures that rows in the subquery are returned
     // in the correct order for partitioning and window function evaluation.
     for expr in current_window.partition_by.iter_mut() {
-        append_order_by(outer_plan, expr, &SortOrder::Asc, &mut ctx)?;
+        append_order_by(outer_plan, expr, &SortOrder::Asc, None, &mut ctx)?;
         current_window.deduplicated_partition_by_len = Some(ctx.subquery_result_columns.len())
     }
-    for (expr, order) in current_window.order_by.iter_mut() {
-        append_order_by(outer_plan, expr, order, &mut ctx)?;
+    for (expr, order, nulls) in current_window.order_by.iter_mut() {
+        append_order_by(outer_plan, expr, order, *nulls, &mut ctx)?;
     }
 
     // Rewrite expressions from the outer query’s result columns and ORDER BY clause so that
@@ -179,7 +179,7 @@ fn prepare_window_subquery(
             &mut ctx,
         )?;
     }
-    for (expr, _) in outer_plan.order_by.iter_mut() {
+    for (expr, _, _) in outer_plan.order_by.iter_mut() {
         rewrite_terminal_expr(
             &mut outer_plan.aggregates,
             expr,
@@ -265,6 +265,7 @@ fn append_order_by(
     plan: &mut SelectPlan,
     expr: &mut Expr,
     sort_order: &SortOrder,
+    nulls_order: Option<turso_parser::ast::NullsOrder>,
     ctx: &mut WindowSubqueryContext,
 ) -> crate::Result<()> {
     // Deduplicate: if an equivalent expression already exists in the subquery ORDER BY,
@@ -274,10 +275,10 @@ fn append_order_by(
     let already_exists = ctx
         .subquery_order_by
         .iter()
-        .any(|(existing, _)| exprs_are_equivalent(existing, expr));
+        .any(|(existing, _, _)| exprs_are_equivalent(existing, expr));
     if !already_exists {
         ctx.subquery_order_by
-            .push((Box::new(expr.clone()), *sort_order));
+            .push((Box::new(expr.clone()), *sort_order, nulls_order));
     }
 
     let contains_aggregates =
@@ -509,7 +510,7 @@ impl EmitWindow {
         window: &'a Window,
         plan: &SelectPlan,
         result_columns: &'a [ResultSetColumn],
-        order_by: &'a [(Box<Expr>, SortOrder)],
+        order_by: &'a [(Box<Expr>, SortOrder, Option<turso_parser::ast::NullsOrder>)],
     ) -> crate::Result<()> {
         let joined_tables = &plan.joined_tables();
         turso_assert_eq!(joined_tables.len(), 1, "expected only one joined table");
@@ -692,7 +693,7 @@ fn alloc_optional_registers(program: &mut ProgramBuilder, count: usize) -> Optio
 
 fn collect_expressions_referencing_subquery<'a>(
     result_columns: &'a [ResultSetColumn],
-    order_by: &'a [(Box<Expr>, SortOrder)],
+    order_by: &'a [(Box<Expr>, SortOrder, Option<turso_parser::ast::NullsOrder>)],
     subquery_id: &TableInternalId,
 ) -> crate::Result<Vec<(&'a Expr, usize)>> {
     let mut expressions_referencing_subquery: Vec<(&'a Expr, usize)> = Vec::new();
@@ -700,7 +701,7 @@ fn collect_expressions_referencing_subquery<'a>(
     for root_expr in result_columns
         .iter()
         .map(|col| &col.expr)
-        .chain(order_by.iter().map(|(e, _)| e.as_ref()))
+        .chain(order_by.iter().map(|(e, _, _)| e.as_ref()))
     {
         walk_expr(
             root_expr,
@@ -760,6 +761,7 @@ fn emit_flush_buffer_if_new_partition(
             .map(|_| KeyInfo {
                 sort_order: SortOrder::Asc,
                 collation: CollationSeq::default(),
+                nulls_order: None,
             })
             .collect::<Vec<_>>();
         for (i, c) in compare_key_info
@@ -877,6 +879,7 @@ fn emit_flush_buffer_if_not_peer(
             .map(|_| KeyInfo {
                 sort_order: SortOrder::Asc,
                 collation: CollationSeq::default(),
+                nulls_order: None,
             })
             .collect::<Vec<_>>();
         for (i, c) in compare_key_info
@@ -927,7 +930,7 @@ fn emit_load_order_by_columns(
         // Source columns are deduplicated and may appear in a different order than
         // the ORDER BY terms. Therefore, we must restore the original ORDER BY layout
         // here by copying the values into an array of registers.
-        for (i, (expr, _)) in window.order_by.iter().enumerate() {
+        for (i, (expr, _, _)) in window.order_by.iter().enumerate() {
             match expr {
                 Expr::Column { column, .. } => {
                     program.emit_insn(Insn::Copy {

--- a/core/types.rs
+++ b/core/types.rs
@@ -1796,6 +1796,7 @@ impl<'a> Ord for ValueRef<'a> {
 pub struct KeyInfo {
     pub sort_order: SortOrder,
     pub collation: CollationSeq,
+    pub nulls_order: Option<turso_parser::ast::NullsOrder>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1836,12 +1837,14 @@ impl IndexInfo {
                     .map(|c| KeyInfo {
                         sort_order: c.order,
                         collation: c.collation.unwrap_or_default(),
+                        nulls_order: None,
                     })
                     .collect();
                 if index.has_rowid {
                     key_info.push(KeyInfo {
                         sort_order: SortOrder::Asc,
                         collation: CollationSeq::Binary,
+                        nulls_order: None,
                     });
                 }
                 key_info
@@ -3166,6 +3169,7 @@ mod tests {
                 .map(|(sort_order, collation)| KeyInfo {
                     sort_order,
                     collation,
+                    nulls_order: None,
                 })
                 .collect(),
             has_rowid: false,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5650,7 +5650,7 @@ pub fn op_sorter_open(
         SorterOpen {
             cursor_id,
             columns: _,
-            order_and_collations,
+            order_collations_nulls,
             comparators,
         },
         insn
@@ -5671,10 +5671,14 @@ pub fn op_sorter_open(
     } else {
         (cache_size as usize) * page_size
     };
-    let (order, collations): (Vec<_>, Vec<_>) = order_and_collations
-        .iter()
-        .map(|(ord, coll)| (*ord, coll.unwrap_or_default()))
-        .unzip();
+    let mut order = Vec::with_capacity(order_collations_nulls.len());
+    let mut collations = Vec::with_capacity(order_collations_nulls.len());
+    let mut nulls_orders = Vec::with_capacity(order_collations_nulls.len());
+    for (ord, coll, nulls) in order_collations_nulls.iter() {
+        order.push(*ord);
+        collations.push(coll.unwrap_or_default());
+        nulls_orders.push(*nulls);
+    }
     let comparators = comparators
         .iter()
         .map(|c| c.as_ref().map(make_sort_comparator))
@@ -5683,6 +5687,7 @@ pub fn op_sorter_open(
     let cursor = Sorter::new(
         &order,
         collations,
+        nulls_orders,
         comparators,
         max_buffer_size_bytes,
         page_size,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1166,20 +1166,25 @@ pub fn insn_to_row(
             Insn::SorterOpen {
                 cursor_id,
                 columns,
-                order_and_collations,
+                order_collations_nulls,
                 ..
             } => {
-                let to_print: Vec<String> = order_and_collations
+                let to_print: Vec<String> = order_collations_nulls
                     .iter()
-                    .map(|(order, collation)| {
+                    .map(|(order, collation, nulls)| {
                         let sign = match order {
                             SortOrder::Asc => "",
                             SortOrder::Desc => "-",
                         };
-                        if let Some(coll) = collation {
+                        let coll_str = if let Some(coll) = collation {
                             format!("{sign}{coll}")
                         } else {
                             format!("{sign}B")
+                        };
+                        match nulls {
+                            Some(turso_parser::ast::NullsOrder::First) => format!("{coll_str} NF"),
+                            Some(turso_parser::ast::NullsOrder::Last) => format!("{coll_str} NL"),
+                            None => coll_str,
                         }
                     })
                     .collect();
@@ -1188,7 +1193,7 @@ pub fn insn_to_row(
                     *cursor_id as i64,
                     *columns as i64,
                     0,
-                    Value::build_text(format!("k({},{})", order_and_collations.len(), to_print.join(","))),
+                    Value::build_text(format!("k({},{})", order_collations_nulls.len(), to_print.join(","))),
                     0,
                     format!("cursor={cursor_id}"),
                 )

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -929,8 +929,12 @@ pub enum Insn {
     SorterOpen {
         cursor_id: CursorID, // P1
         columns: usize,      // P2
-        /// Combined order and collation per column (keeps Insn small, and order+collations are always the same length).
-        order_and_collations: Vec<(SortOrder, Option<CollationSeq>)>,
+        /// Combined order, collation, and nulls ordering per column.
+        order_collations_nulls: Vec<(
+            SortOrder,
+            Option<CollationSeq>,
+            Option<turso_parser::ast::NullsOrder>,
+        )>,
         /// Per-column custom type comparators for ORDER BY sorting.
         /// When present, the comparator is used instead of standard value comparison.
         comparators: Vec<Option<SortComparatorType>>,

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -96,9 +96,11 @@ pub struct Sorter {
 }
 
 impl Sorter {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         order: &[SortOrder],
         collations: Vec<CollationSeq>,
+        nulls_orders: Vec<Option<turso_parser::ast::NullsOrder>>,
         comparators: Vec<Option<SortComparator>>,
         max_buffer_size_bytes: usize,
         min_chunk_read_buffer_size_bytes: usize,
@@ -115,9 +117,11 @@ impl Sorter {
                 order
                     .iter()
                     .zip(collations)
-                    .map(|(order, collation)| KeyInfo {
+                    .zip(nulls_orders)
+                    .map(|((order, collation), nulls)| KeyInfo {
                         sort_order: *order,
                         collation,
+                        nulls_order: nulls,
                     })
                     .collect(),
             ),
@@ -836,6 +840,19 @@ impl Ord for ArenaSortableRecord {
                 }
             };
             if cmp != Ordering::Equal {
+                let involves_null =
+                    matches!(self_val, ValueRef::Null) || matches!(other_val, ValueRef::Null);
+                if involves_null {
+                    if let Some(nulls_order) = key_info.nulls_order {
+                        // ValueRef ordering: NULL < non-NULL.
+                        // NULLS FIRST: keep that natural order regardless of ASC/DESC.
+                        // NULLS LAST: reverse it regardless of ASC/DESC.
+                        return match nulls_order {
+                            turso_parser::ast::NullsOrder::First => cmp,
+                            turso_parser::ast::NullsOrder::Last => cmp.reverse(),
+                        };
+                    }
+                }
                 return match key_info.sort_order {
                     SortOrder::Asc => cmp,
                     SortOrder::Desc => cmp.reverse(),
@@ -938,6 +955,16 @@ impl Ord for BoxedSortableRecord {
                 }
             };
             if cmp != Ordering::Equal {
+                let involves_null =
+                    matches!(self_val, ValueRef::Null) || matches!(other_val, ValueRef::Null);
+                if involves_null {
+                    if let Some(nulls_order) = key_info.nulls_order {
+                        return match nulls_order {
+                            turso_parser::ast::NullsOrder::First => cmp,
+                            turso_parser::ast::NullsOrder::Last => cmp.reverse(),
+                        };
+                    }
+                }
                 return match key_info.sort_order {
                     SortOrder::Asc => cmp,
                     SortOrder::Desc => cmp.reverse(),
@@ -1010,6 +1037,7 @@ mod tests {
             let mut sorter = Sorter::new(
                 &[SortOrder::Asc],
                 vec![CollationSeq::Binary],
+                vec![None],
                 vec![None],
                 256,
                 64,

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -60,8 +60,6 @@ impl SqlGenBackend {
             .with_function_config(
                 sql_gen::FunctionConfig::deterministic().disable(&["LIKELY", "UNLIKELY"]),
             );
-        policy.select_config.nulls_order_weights.first = 0;
-        policy.select_config.nulls_order_weights.last = 0;
         policy.select_config.require_order_by_with_limit = true;
         // Disable expression values and conflict clauses for now
         policy.insert_config.expression_value_probability = 0.0;

--- a/testing/differential-oracle/sql_gen_prop/select.rs
+++ b/testing/differential-oracle/sql_gen_prop/select.rs
@@ -41,12 +41,29 @@ impl fmt::Display for OrderDirection {
     }
 }
 
+/// NULLS FIRST/LAST ordering.
+#[derive(Debug, Clone, Copy)]
+pub enum NullsOrder {
+    First,
+    Last,
+}
+
+impl fmt::Display for NullsOrder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NullsOrder::First => write!(f, "NULLS FIRST"),
+            NullsOrder::Last => write!(f, "NULLS LAST"),
+        }
+    }
+}
+
 /// An ORDER BY clause item.
 #[derive(Debug, Clone)]
 pub struct OrderByItem {
     /// The expression to order by (can be a column, function call, etc.).
     pub expr: Expression,
     pub direction: OrderDirection,
+    pub nulls: Option<NullsOrder>,
 }
 
 impl OrderByItem {
@@ -55,19 +72,33 @@ impl OrderByItem {
         Self {
             expr: Expression::Column(name.into()),
             direction,
+            nulls: None,
         }
     }
 }
 
 impl fmt::Display for OrderByItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}", self.expr, self.direction)
+        write!(f, "{} {}", self.expr, self.direction)?;
+        if let Some(nulls) = &self.nulls {
+            write!(f, " {nulls}")?;
+        }
+        Ok(())
     }
 }
 
 /// Generate an order direction.
 pub fn order_direction() -> impl Strategy<Value = OrderDirection> {
     prop_oneof![Just(OrderDirection::Asc), Just(OrderDirection::Desc),]
+}
+
+/// Generate an optional NULLS FIRST/LAST ordering.
+pub fn nulls_order() -> impl Strategy<Value = Option<NullsOrder>> {
+    prop_oneof![
+        8 => Just(None),
+        1 => Just(Some(NullsOrder::First)),
+        1 => Just(Some(NullsOrder::Last)),
+    ]
 }
 
 // =============================================================================
@@ -636,13 +667,21 @@ pub fn order_by_for_table(
         .with_profile(profile_for_order_by);
 
     proptest::collection::vec(
-        (crate::expression::expression(&ctx), order_direction()),
+        (
+            crate::expression::expression(&ctx),
+            order_direction(),
+            nulls_order(),
+        ),
         0..=max_items,
     )
     .prop_map(|items| {
         items
             .into_iter()
-            .map(|(expr, direction)| OrderByItem { expr, direction })
+            .map(|(expr, direction, nulls)| OrderByItem {
+                expr,
+                direction,
+                nulls,
+            })
             .collect()
     })
     .boxed()
@@ -708,6 +747,7 @@ mod tests {
             order_by: vec![OrderByItem {
                 expr: Expression::Value(SqlValue::Integer(1)),
                 direction: OrderDirection::Asc,
+                nulls: None,
             }],
             limit: Some(1),
             offset: None,
@@ -726,6 +766,7 @@ mod tests {
             order_by: vec![OrderByItem {
                 expr: Expression::Column("id".to_string()),
                 direction: OrderDirection::Asc,
+                nulls: None,
             }],
             limit: Some(1),
             offset: None,

--- a/testing/sqltests/tests/nulls-first-last.sqltest
+++ b/testing/sqltests/tests/nulls-first-last.sqltest
@@ -1,0 +1,854 @@
+@database :memory:
+
+# ===== Basic NULLS FIRST / NULLS LAST with integers =====
+
+setup base-table {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+    INSERT INTO t VALUES (1, NULL), (2, 3), (3, 1), (4, NULL), (5, 2);
+}
+
+# Default ASC: NULLs come first (SQLite default behavior)
+@setup base-table
+test asc-default-nulls-first {
+    SELECT id, val FROM t ORDER BY val, id;
+}
+expect {
+    1|
+    4|
+    3|1
+    5|2
+    2|3
+}
+
+# Default DESC: NULLs come last (SQLite default behavior)
+@setup base-table
+test desc-default-nulls-last {
+    SELECT id, val FROM t ORDER BY val DESC, id;
+}
+expect {
+    2|3
+    5|2
+    3|1
+    1|
+    4|
+}
+
+# ASC NULLS FIRST — same as default ASC
+@setup base-table
+test asc-nulls-first {
+    SELECT id, val FROM t ORDER BY val ASC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    3|1
+    5|2
+    2|3
+}
+
+# ASC NULLS LAST — overrides default, NULLs at end
+@setup base-table
+test asc-nulls-last {
+    SELECT id, val FROM t ORDER BY val ASC NULLS LAST, id;
+}
+expect {
+    3|1
+    5|2
+    2|3
+    1|
+    4|
+}
+
+# DESC NULLS FIRST — overrides default, NULLs at start
+@setup base-table
+test desc-nulls-first {
+    SELECT id, val FROM t ORDER BY val DESC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    2|3
+    5|2
+    3|1
+}
+
+# DESC NULLS LAST — same as default DESC
+@setup base-table
+test desc-nulls-last {
+    SELECT id, val FROM t ORDER BY val DESC NULLS LAST, id;
+}
+expect {
+    2|3
+    5|2
+    3|1
+    1|
+    4|
+}
+
+# ===== Implicit ASC with NULLS =====
+
+# Implicit ASC (no ASC keyword) with NULLS LAST
+@setup base-table
+test implicit-asc-nulls-last {
+    SELECT id, val FROM t ORDER BY val NULLS LAST, id;
+}
+expect {
+    3|1
+    5|2
+    2|3
+    1|
+    4|
+}
+
+# Implicit ASC (no ASC keyword) with NULLS FIRST
+@setup base-table
+test implicit-asc-nulls-first {
+    SELECT id, val FROM t ORDER BY val NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    3|1
+    5|2
+    2|3
+}
+
+# ===== TEXT values =====
+
+setup text-table {
+    CREATE TABLE t_text(id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO t_text VALUES (1, NULL), (2, 'banana'), (3, 'apple'), (4, NULL), (5, 'cherry');
+}
+
+@setup text-table
+test text-asc-nulls-last {
+    SELECT id, name FROM t_text ORDER BY name ASC NULLS LAST, id;
+}
+expect {
+    3|apple
+    2|banana
+    5|cherry
+    1|
+    4|
+}
+
+@setup text-table
+test text-desc-nulls-first {
+    SELECT id, name FROM t_text ORDER BY name DESC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    5|cherry
+    2|banana
+    3|apple
+}
+
+@setup text-table
+test text-asc-nulls-first {
+    SELECT id, name FROM t_text ORDER BY name ASC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    3|apple
+    2|banana
+    5|cherry
+}
+
+@setup text-table
+test text-desc-nulls-last {
+    SELECT id, name FROM t_text ORDER BY name DESC NULLS LAST, id;
+}
+expect {
+    5|cherry
+    2|banana
+    3|apple
+    1|
+    4|
+}
+
+# ===== REAL values =====
+
+setup real-table {
+    CREATE TABLE t_real(id INTEGER PRIMARY KEY, val REAL);
+    INSERT INTO t_real VALUES (1, NULL), (2, 3.14), (3, 1.5), (4, NULL), (5, 2.7);
+}
+
+@setup real-table
+test real-asc-nulls-last {
+    SELECT id, val FROM t_real ORDER BY val ASC NULLS LAST, id;
+}
+expect {
+    3|1.5
+    5|2.7
+    2|3.14
+    1|
+    4|
+}
+
+@setup real-table
+test real-desc-nulls-first {
+    SELECT id, val FROM t_real ORDER BY val DESC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    2|3.14
+    5|2.7
+    3|1.5
+}
+
+# ===== Multiple sort keys with NULLS =====
+
+setup multi-key-table {
+    CREATE TABLE t_multi(id INTEGER PRIMARY KEY, a INT, b INT);
+    INSERT INTO t_multi VALUES (1, NULL, 10), (2, 1, NULL), (3, NULL, 20), (4, 1, 30), (5, 2, NULL);
+}
+
+@setup multi-key-table
+test multi-key-nulls-last-nulls-first {
+    SELECT id, a, b FROM t_multi ORDER BY a ASC NULLS LAST, b DESC NULLS FIRST;
+}
+expect {
+    2|1|
+    4|1|30
+    5|2|
+    3||20
+    1||10
+}
+
+@setup multi-key-table
+test multi-key-nulls-first-nulls-last {
+    SELECT id, a, b FROM t_multi ORDER BY a DESC NULLS FIRST, b ASC NULLS LAST;
+}
+expect {
+    1||10
+    3||20
+    5|2|
+    4|1|30
+    2|1|
+}
+
+@setup multi-key-table
+test multi-key-both-nulls-last {
+    SELECT id, a, b FROM t_multi ORDER BY a ASC NULLS LAST, b ASC NULLS LAST;
+}
+expect {
+    4|1|30
+    2|1|
+    5|2|
+    1||10
+    3||20
+}
+
+@setup multi-key-table
+test multi-key-both-nulls-first {
+    SELECT id, a, b FROM t_multi ORDER BY a ASC NULLS FIRST, b ASC NULLS FIRST;
+}
+expect {
+    1||10
+    3||20
+    2|1|
+    4|1|30
+    5|2|
+}
+
+# ===== NULLS with LIMIT =====
+
+@setup base-table
+test asc-nulls-last-limit {
+    SELECT id, val FROM t ORDER BY val ASC NULLS LAST LIMIT 3;
+}
+expect {
+    3|1
+    5|2
+    2|3
+}
+
+@setup base-table
+test desc-nulls-first-limit {
+    SELECT id, val FROM t ORDER BY val DESC NULLS FIRST LIMIT 3;
+}
+expect {
+    1|
+    4|
+    2|3
+}
+
+# ===== NULLS with LIMIT and OFFSET =====
+
+@setup base-table
+test asc-nulls-last-limit-offset {
+    SELECT id, val FROM t ORDER BY val ASC NULLS LAST LIMIT 2 OFFSET 1;
+}
+expect {
+    5|2
+    2|3
+}
+
+@setup base-table
+test desc-nulls-first-limit-offset {
+    SELECT id, val FROM t ORDER BY val DESC NULLS FIRST LIMIT 2 OFFSET 1;
+}
+expect {
+    4|
+    2|3
+}
+
+# ===== All NULLs =====
+
+setup all-nulls-table {
+    CREATE TABLE t_allnull(id INTEGER PRIMARY KEY, val INT);
+    INSERT INTO t_allnull VALUES (1, NULL), (2, NULL), (3, NULL);
+}
+
+@setup all-nulls-table
+test all-nulls-asc-nulls-last {
+    SELECT id, val FROM t_allnull ORDER BY val ASC NULLS LAST, id;
+}
+expect {
+    1|
+    2|
+    3|
+}
+
+@setup all-nulls-table
+test all-nulls-desc-nulls-first {
+    SELECT id, val FROM t_allnull ORDER BY val DESC NULLS FIRST, id;
+}
+expect {
+    1|
+    2|
+    3|
+}
+
+@setup all-nulls-table
+test all-nulls-asc-nulls-first {
+    SELECT id, val FROM t_allnull ORDER BY val ASC NULLS FIRST, id;
+}
+expect {
+    1|
+    2|
+    3|
+}
+
+@setup all-nulls-table
+test all-nulls-desc-nulls-last {
+    SELECT id, val FROM t_allnull ORDER BY val DESC NULLS LAST, id;
+}
+expect {
+    1|
+    2|
+    3|
+}
+
+# ===== No NULLs (NULLS FIRST/LAST should be no-op) =====
+
+setup no-nulls-table {
+    CREATE TABLE t_nonull(id INTEGER PRIMARY KEY, val INT);
+    INSERT INTO t_nonull VALUES (1, 3), (2, 1), (3, 2);
+}
+
+@setup no-nulls-table
+test no-nulls-asc-nulls-last {
+    SELECT id, val FROM t_nonull ORDER BY val ASC NULLS LAST;
+}
+expect {
+    2|1
+    3|2
+    1|3
+}
+
+@setup no-nulls-table
+test no-nulls-desc-nulls-first {
+    SELECT id, val FROM t_nonull ORDER BY val DESC NULLS FIRST;
+}
+expect {
+    1|3
+    3|2
+    2|1
+}
+
+# ===== Empty table =====
+
+setup empty-table {
+    CREATE TABLE t_empty(id INTEGER PRIMARY KEY, val INT);
+}
+
+@setup empty-table
+test empty-table-asc-nulls-last {
+    SELECT id, val FROM t_empty ORDER BY val ASC NULLS LAST;
+}
+expect {
+}
+
+@setup empty-table
+test empty-table-desc-nulls-first {
+    SELECT id, val FROM t_empty ORDER BY val DESC NULLS FIRST;
+}
+expect {
+}
+
+# ===== Single row with NULL =====
+
+setup single-null-table {
+    CREATE TABLE t_single(id INTEGER PRIMARY KEY, val INT);
+    INSERT INTO t_single VALUES (1, NULL);
+}
+
+@setup single-null-table
+test single-null-asc-nulls-last {
+    SELECT id, val FROM t_single ORDER BY val ASC NULLS LAST;
+}
+expect {
+    1|
+}
+
+@setup single-null-table
+test single-null-desc-nulls-first {
+    SELECT id, val FROM t_single ORDER BY val DESC NULLS FIRST;
+}
+expect {
+    1|
+}
+
+# ===== Expression in ORDER BY =====
+
+@setup base-table
+test expression-asc-nulls-last {
+    SELECT id, val FROM t ORDER BY val+0 ASC NULLS LAST, id;
+}
+expect {
+    3|1
+    5|2
+    2|3
+    1|
+    4|
+}
+
+@setup base-table
+test expression-desc-nulls-first {
+    SELECT id, val FROM t ORDER BY val+0 DESC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    2|3
+    5|2
+    3|1
+}
+
+# ===== GROUP BY with ORDER BY NULLS =====
+
+setup group-table {
+    CREATE TABLE t_group(grp TEXT, val INT);
+    INSERT INTO t_group VALUES ('a', 1), ('a', NULL), ('b', 3), ('b', NULL), (NULL, 5), (NULL, 6);
+}
+
+@setup group-table
+test group-by-nulls-last {
+    SELECT grp, sum(val) FROM t_group GROUP BY grp ORDER BY grp ASC NULLS LAST;
+}
+expect {
+    a|1
+    b|3
+    |11
+}
+
+@setup group-table
+test group-by-desc-nulls-first {
+    SELECT grp, sum(val) FROM t_group GROUP BY grp ORDER BY grp DESC NULLS FIRST;
+}
+expect {
+    |11
+    b|3
+    a|1
+}
+
+# ===== Subquery with ORDER BY NULLS =====
+
+@setup base-table
+test subquery-nulls-last {
+    SELECT * FROM (SELECT id, val FROM t) ORDER BY val ASC NULLS LAST, id;
+}
+expect {
+    3|1
+    5|2
+    2|3
+    1|
+    4|
+}
+
+@setup base-table
+test subquery-nulls-first-desc {
+    SELECT * FROM (SELECT id, val FROM t) ORDER BY val DESC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    2|3
+    5|2
+    3|1
+}
+
+# ===== UNION ALL with ORDER BY NULLS =====
+
+@setup base-table
+test union-all-nulls-last {
+    SELECT val FROM t WHERE id <= 3
+    UNION ALL
+    SELECT val FROM t WHERE id > 3
+    ORDER BY val ASC NULLS LAST;
+}
+expect {
+    1
+    2
+    3
+
+
+}
+
+@setup base-table
+test union-all-desc-nulls-first {
+    SELECT val FROM t WHERE id <= 3
+    UNION ALL
+    SELECT val FROM t WHERE id > 3
+    ORDER BY val DESC NULLS FIRST;
+}
+expect {
+
+
+    3
+    2
+    1
+}
+
+# ===== DISTINCT with NULLS =====
+
+setup distinct-table {
+    CREATE TABLE t_dist(id INTEGER PRIMARY KEY, val INT);
+    INSERT INTO t_dist VALUES (1, NULL), (2, 3), (3, 1), (4, NULL), (5, 2), (6, 3), (7, NULL);
+}
+
+@setup distinct-table
+test distinct-nulls-last {
+    SELECT DISTINCT val FROM t_dist ORDER BY val ASC NULLS LAST;
+}
+expect {
+    1
+    2
+    3
+
+}
+
+@setup distinct-table
+test distinct-desc-nulls-first {
+    SELECT DISTINCT val FROM t_dist ORDER BY val DESC NULLS FIRST;
+}
+expect {
+
+    3
+    2
+    1
+}
+
+# ===== Window functions with NULLS in ORDER BY =====
+
+@setup base-table
+test window-row-number-nulls-last {
+    SELECT id, val, row_number() OVER (ORDER BY val ASC NULLS LAST) as rn FROM t ORDER BY rn;
+}
+expect {
+    3|1|1
+    5|2|2
+    2|3|3
+    1||4
+    4||5
+}
+
+@setup base-table
+test window-row-number-desc-nulls-first {
+    SELECT id, val, row_number() OVER (ORDER BY val DESC NULLS FIRST) as rn FROM t ORDER BY rn;
+}
+expect {
+    1||1
+    4||2
+    2|3|3
+    5|2|4
+    3|1|5
+}
+
+# ===== NULLS with indexed column =====
+
+setup indexed-table {
+    CREATE TABLE t_idx(id INTEGER PRIMARY KEY, val INT);
+    CREATE INDEX idx_val ON t_idx(val);
+    INSERT INTO t_idx VALUES (1, NULL), (2, 3), (3, 1), (4, NULL), (5, 2);
+}
+
+@setup indexed-table
+test indexed-asc-nulls-last {
+    SELECT id, val FROM t_idx ORDER BY val ASC NULLS LAST, id;
+}
+expect {
+    3|1
+    5|2
+    2|3
+    1|
+    4|
+}
+
+@setup indexed-table
+test indexed-desc-nulls-first {
+    SELECT id, val FROM t_idx ORDER BY val DESC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    2|3
+    5|2
+    3|1
+}
+
+@setup indexed-table
+test indexed-asc-nulls-first {
+    SELECT id, val FROM t_idx ORDER BY val ASC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    3|1
+    5|2
+    2|3
+}
+
+@setup indexed-table
+test indexed-desc-nulls-last {
+    SELECT id, val FROM t_idx ORDER BY val DESC NULLS LAST, id;
+}
+expect {
+    2|3
+    5|2
+    3|1
+    1|
+    4|
+}
+
+# ===== Composite index with NULLS (sort elision edge cases) =====
+
+setup composite-index-table {
+    CREATE TABLE t_comp(id INTEGER PRIMARY KEY, a INT, b INT);
+    CREATE INDEX idx_ab ON t_comp(a, b);
+    INSERT INTO t_comp VALUES (1, NULL, 10), (2, 1, NULL), (3, NULL, 20), (4, 1, 30), (5, 2, NULL), (6, 2, 5);
+}
+
+# Leading column NULLS LAST — cannot use simple index scan
+@setup composite-index-table
+test composite-idx-a-nulls-last-b-asc {
+    SELECT id, a, b FROM t_comp ORDER BY a ASC NULLS LAST, b ASC;
+}
+expect {
+    2|1|
+    4|1|30
+    5|2|
+    6|2|5
+    1||10
+    3||20
+}
+
+# Second column NULLS LAST — partial sort needed
+@setup composite-index-table
+test composite-idx-a-asc-b-nulls-last {
+    SELECT id, a, b FROM t_comp ORDER BY a ASC, b ASC NULLS LAST;
+}
+expect {
+    1||10
+    3||20
+    4|1|30
+    2|1|
+    6|2|5
+    5|2|
+}
+
+# Both columns DESC with NULLS FIRST
+@setup composite-index-table
+test composite-idx-a-desc-nulls-first-b-desc {
+    SELECT id, a, b FROM t_comp ORDER BY a DESC NULLS FIRST, b DESC;
+}
+expect {
+    3||20
+    1||10
+    6|2|5
+    5|2|
+    4|1|30
+    2|1|
+}
+
+# Equality prefix + NULLS LAST on remaining column
+@setup composite-index-table
+test composite-idx-where-eq-nulls-last {
+    SELECT id, a, b FROM t_comp WHERE a = 1 ORDER BY b ASC NULLS LAST;
+}
+expect {
+    4|1|30
+    2|1|
+}
+
+# Equality prefix + NULLS FIRST on remaining column (matches default)
+@setup composite-index-table
+test composite-idx-where-eq-nulls-first {
+    SELECT id, a, b FROM t_comp WHERE a = 2 ORDER BY b ASC NULLS FIRST;
+}
+expect {
+    5|2|
+    6|2|5
+}
+
+# Index with NULLS LAST + LIMIT (optimizer must not elide sort incorrectly)
+@setup composite-index-table
+test composite-idx-nulls-last-limit {
+    SELECT id, a, b FROM t_comp ORDER BY a ASC NULLS LAST, b ASC LIMIT 3;
+}
+expect {
+    2|1|
+    4|1|30
+    5|2|
+}
+
+# ===== Multiple columns, some with NULLS directives, some without =====
+
+setup mixed-directive-table {
+    CREATE TABLE t_mixed(id INTEGER PRIMARY KEY, a INT, b TEXT);
+    INSERT INTO t_mixed VALUES (1, NULL, 'x'), (2, 1, NULL), (3, NULL, 'y'), (4, 1, 'z'), (5, 2, NULL);
+}
+
+@setup mixed-directive-table
+test mixed-first-col-nulls-last-second-default {
+    SELECT id, a, b FROM t_mixed ORDER BY a ASC NULLS LAST, b ASC, id;
+}
+expect {
+    2|1|
+    4|1|z
+    5|2|
+    1||x
+    3||y
+}
+
+@setup mixed-directive-table
+test mixed-first-default-second-nulls-last {
+    SELECT id, a, b FROM t_mixed ORDER BY a ASC, b ASC NULLS LAST, id;
+}
+expect {
+    1||x
+    3||y
+    4|1|z
+    2|1|
+    5|2|
+}
+
+# ===== NULLS with CASE expression =====
+
+@setup base-table
+test case-expr-nulls-last {
+    SELECT id, val FROM t ORDER BY CASE WHEN val IS NULL THEN val ELSE val END ASC NULLS LAST, id;
+}
+expect {
+    3|1
+    5|2
+    2|3
+    1|
+    4|
+}
+
+# ===== NULLS with negative values =====
+
+setup negative-table {
+    CREATE TABLE t_neg(id INTEGER PRIMARY KEY, val INT);
+    INSERT INTO t_neg VALUES (1, NULL), (2, -3), (3, 1), (4, NULL), (5, -1), (6, 0);
+}
+
+@setup negative-table
+test negative-asc-nulls-last {
+    SELECT id, val FROM t_neg ORDER BY val ASC NULLS LAST, id;
+}
+expect {
+    2|-3
+    5|-1
+    6|0
+    3|1
+    1|
+    4|
+}
+
+@setup negative-table
+test negative-desc-nulls-first {
+    SELECT id, val FROM t_neg ORDER BY val DESC NULLS FIRST, id;
+}
+expect {
+    1|
+    4|
+    3|1
+    6|0
+    5|-1
+    2|-3
+}
+
+# ===== NULLS in compound SELECT with UNION =====
+
+setup compound-tables {
+    CREATE TABLE t_a(val INT);
+    INSERT INTO t_a VALUES (NULL), (1), (3);
+    CREATE TABLE t_b(val INT);
+    INSERT INTO t_b VALUES (NULL), (2), (4);
+}
+
+@setup compound-tables
+test union-nulls-last {
+    SELECT val FROM t_a
+    UNION
+    SELECT val FROM t_b
+    ORDER BY val ASC NULLS LAST;
+}
+expect {
+    1
+    2
+    3
+    4
+
+}
+
+@setup compound-tables
+test union-desc-nulls-first {
+    SELECT val FROM t_a
+    UNION
+    SELECT val FROM t_b
+    ORDER BY val DESC NULLS FIRST;
+}
+expect {
+
+    4
+    3
+    2
+    1
+}
+
+# ===== Window functions with different NULLS orderings in same query =====
+
+# Two windows with different NULLS orderings must produce different row numbers.
+# This tests that window equivalence correctly distinguishes NULLS ordering,
+# preventing the optimizer from merging windows with different NULLS clauses.
+@setup base-table
+test window-two-different-nulls-orderings {
+    SELECT id, val,
+        ROW_NUMBER() OVER (ORDER BY val ASC NULLS FIRST) as rn_first,
+        ROW_NUMBER() OVER (ORDER BY val ASC NULLS LAST) as rn_last
+    FROM t;
+}
+expect {
+    1||1|4
+    4||2|5
+    3|1|3|1
+    5|2|4|2
+    2|3|5|3
+}


### PR DESCRIPTION
Thread NullsOrder from the parser AST through the entire query pipeline: plan types, sort key emission, SorterOpen instruction, and sorter comparison. Previously NULLS LAST was rejected with a parse error and NULLS FIRST was silently ignored.

Key changes:
- Add nulls_order field to KeyInfo and extend SorterOpen to carry per-column NullsOrder
- Change all order_by tuple types from 2-tuples to 3-tuples with Option<NullsOrder> across plan.rs, select.rs, compound_select.rs, group_by.rs, window.rs, order_by.rs, and optimizer
- Implement NULL-aware comparison in both ArenaSortableRecord and BoxedSortableRecord: when nulls_order is set, NULL ordering is determined solely by NullsOrder, independent of ASC/DESC
- Block sort elision in the optimizer when the requested NULLS order differs from the index natural order (ASC=NULLS FIRST, DESC=NULLS LAST)
- Add nulls_order to GroupBy so ORDER BY with explicit NULLS can be merged into the GROUP BY sorter without losing NULLS info
- Ensure Window::is_equivalent compares NULLS ordering so windows with different NULLS clauses are not incorrectly merged
- Show NULLS FIRST/LAST in Display and EXPLAIN output

Tests are added, and NULLS support is added to the fuzzer.

Fixes #5534.
