### PR TITLE
Validate version in update-versions.py

### DIFF
--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -53,7 +53,7 @@ def parse_args():
     return args
 
 def validate_version(version):
-    pattern = r'^\d+\.\d+\.\d+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$'
+    pattern = r"^\d+\.\d+\.\d+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$"
     if not re.match(pattern, version):
         print(f"Error: invalid version format '{version}'", file=sys.stderr)
         print("Expected format: MAJOR.MINOR.PATCH[-pre.RELEASE] (e.g., 0.6.0, 0.6.0-pre.123)", file=sys.stderr)


### PR DESCRIPTION
## Description

This validates the version argument to `update-versions.py`, so that we don't accidentally pass it something with a leading `v` or in an incorrect format.

Tested manually:

```
% ./scripts/update-version.py mikael
Error: invalid version format 'mikael'
Expected format: MAJOR.MINOR.PATCH[-pre.RELEASE] (e.g., 0.6.0, 0.6.0-pre.123)

% ./scripts/update-version.py v1.2.3
Error: invalid version format 'v1.2.3'
Expected format: MAJOR.MINOR.PATCH[-pre.RELEASE] (e.g., 0.6.0, 0.6.0-pre.123)

% ./scripts/update-version.py v1.2.3-pre.123
Error: invalid version format 'v1.2.3-pre.123'
Expected format: MAJOR.MINOR.PATCH[-pre.RELEASE] (e.g., 0.6.0, 0.6.0-pre.123)

% ./scripts/update-version.py 1.2.3-pre.123 
Info: run npm install at path bindings/javascript
... runs correctly
```


## Description of AI Usage

clauded
