### PR TITLE
core/translate: Enforce FK constraints on virtual generated columns with UNIQUE INDEX

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3592,9 +3592,8 @@ impl ResolvedFkRef {
             // Without a rowid alias, a direct rowid update is represented separately with ROWID_SENTINEL
             return true;
         }
-        self.parent_pos
-            .iter()
-            .any(|p| updated_parent_positions.contains(p))
+        let affected = columns_affected_by_update(&parent_tbl.columns, updated_parent_positions);
+        self.parent_pos.iter().any(|p| affected.contains(p))
     }
 
     /// Returns if any child column of this FK is in `updated_child_positions`

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -23,7 +23,7 @@ use crate::translate::plan::{Operation, ResultSetColumn, Search};
 use crate::translate::planner::parse_row_id;
 use crate::util::{exprs_are_equivalent, normalize_ident, parse_numeric_literal};
 use crate::vdbe::affinity::Affinity;
-use crate::vdbe::builder::{CursorKey, SelfTableContext};
+use crate::vdbe::builder::{CursorKey, DmlColumnContext, SelfTableContext};
 use crate::vdbe::{
     builder::ProgramBuilder,
     insn::{CmpInsFlags, InsertFlags, Insn},
@@ -5210,24 +5210,62 @@ pub fn emit_table_column(
     target_register: usize,
     resolver: &Resolver,
 ) -> Result<()> {
+    do_emit_table_column(
+        program,
+        cursor_id,
+        &SelfTableContext::ForSelect {
+            table_ref_id,
+            referenced_tables: referenced_tables.clone(),
+        },
+        Some(referenced_tables),
+        column,
+        column_index,
+        target_register,
+        resolver,
+    )
+}
+
+/// Equivalent of [emit_table_column] for when registers are laid out for DML.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_table_column_for_dml(
+    program: &mut ProgramBuilder,
+    cursor_id: CursorID,
+    dml_column_context: DmlColumnContext,
+    column: &Column,
+    column_index: usize,
+    target_register: usize,
+    resolver: &Resolver,
+) -> Result<()> {
+    do_emit_table_column(
+        program,
+        cursor_id,
+        &SelfTableContext::ForDML(dml_column_context),
+        None,
+        column,
+        column_index,
+        target_register,
+        resolver,
+    )
+}
+
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn do_emit_table_column(
+    program: &mut ProgramBuilder,
+    cursor_id: CursorID,
+    self_table_context: &SelfTableContext,
+    referenced_tables: Option<&TableReferences>,
+    column: &Column,
+    column_index: usize,
+    target_register: usize,
+    resolver: &Resolver,
+) -> Result<()> {
     match column.generated_type() {
         GeneratedType::Virtual { resolved: expr, .. } => {
-            program.with_self_table_context(
-                Some(&SelfTableContext::ForSelect {
-                    table_ref_id,
-                    referenced_tables: referenced_tables.clone(),
-                }),
-                |program, _| {
-                    translate_expr(
-                        program,
-                        Some(referenced_tables),
-                        expr,
-                        target_register,
-                        resolver,
-                    )?;
-                    Ok(())
-                },
-            )?;
+            program.with_self_table_context(Some(self_table_context), |program, _| {
+                translate_expr(program, referenced_tables, expr, target_register, resolver)?;
+                Ok(())
+            })?;
             program.emit_column_affinity(target_register, column.affinity());
         }
         _ => {

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -2,12 +2,13 @@ use rustc_hash::FxHashSet as HashSet;
 use turso_parser::ast::{self, Expr, Literal, Name, QualifiedName, RefAct};
 
 use super::{translate_inner, ProgramBuilder, ProgramBuilderOpts};
+use crate::translate::expr::emit_table_column_for_dml;
 use crate::{
     error::SQLITE_CONSTRAINT_FOREIGNKEY,
     schema::{BTreeTable, ColumnLayout, ForeignKey, Index, ResolvedFkRef, ROWID_SENTINEL},
     translate::{collate::CollationSeq, emitter::Resolver, planner::ROWID_STRS},
     vdbe::{
-        builder::{CursorType, QueryMode},
+        builder::{CursorType, DmlColumnContext, QueryMode},
         insn::{CmpInsFlags, Insn},
         BranchOffset,
     },
@@ -433,24 +434,35 @@ pub fn emit_parent_index_key_change_checks(
     }
 
     let idx_len = index.columns.len();
+    let layout = table_btree.column_layout();
+    let some_idx_columns_are_virtual = index
+        .columns
+        .iter()
+        .any(|col| table_btree.columns[col.pos_in_table].is_virtual_generated());
 
     let old_key = program.alloc_registers(idx_len);
+    let dml_ctx = some_idx_columns_are_virtual.then(|| {
+        cursor_to_registers(
+            program,
+            table_btree,
+            layout.clone(),
+            cursor_id,
+            old_rowid_reg,
+        )
+    });
     for (i, index_col) in index.columns.iter().enumerate() {
-        let pos_in_table = index_col.pos_in_table;
-        let column = &table_btree.columns[pos_in_table];
-        if column.is_rowid_alias() {
-            program.emit_insn(Insn::Copy {
-                src_reg: old_rowid_reg,
-                dst_reg: old_key + i,
-                extra_amount: 0,
-            });
-        } else {
-            program.emit_insn(Insn::Column {
+        if let Some(ref ctx) = dml_ctx {
+            emit_table_column_for_dml(
+                program,
                 cursor_id,
-                column: pos_in_table,
-                dest: old_key + i,
-                default: None,
-            });
+                ctx.clone(),
+                &table_btree.columns[index_col.pos_in_table],
+                index_col.pos_in_table,
+                old_key + i,
+                resolver,
+            )?;
+        } else {
+            program.emit_column_or_rowid(cursor_id, index_col.pos_in_table, old_key + i);
         }
     }
     let new_key = program.alloc_registers(idx_len);
@@ -460,7 +472,7 @@ pub fn emit_parent_index_key_change_checks(
         let src = if column.is_rowid_alias() {
             new_rowid_reg
         } else {
-            new_values_start + pos_in_table
+            layout.to_register(new_values_start, pos_in_table)
         };
         program.emit_insn(Insn::Copy {
             src_reg: src,
@@ -724,6 +736,28 @@ fn emit_fk_parent_key_probe(
     Ok(())
 }
 
+/// `layout` has to be the [ColumnLayout] from `table.column_layout()`. It's passed this way
+/// because cloning it is cheaper than recreating it.
+fn cursor_to_registers(
+    program: &mut ProgramBuilder,
+    table: &BTreeTable,
+    layout: ColumnLayout,
+    cursor_id: usize,
+    rowid_reg: usize,
+) -> DmlColumnContext {
+    let ncols = table.columns.len();
+    let base = program.alloc_registers(ncols);
+    for (idx, col) in table.columns.iter().enumerate() {
+        let reg = layout.to_register(base, idx);
+        if col.is_virtual_generated() {
+            continue;
+        } else {
+            program.emit_column_or_rowid(cursor_id, idx, reg);
+        }
+    }
+    DmlColumnContext::layout(&table.columns, base, rowid_reg, layout)
+}
+
 /// Build a parent key vector (in FK parent-column order) into `dest_start`.
 /// Handles rowid aliasing and explicit ROWID names; uses current row for non-rowid columns.
 fn build_parent_key(
@@ -733,31 +767,53 @@ fn build_parent_key(
     parent_cursor_id: usize,
     parent_rowid_reg: usize,
     dest_start: usize,
+    resolver: &Resolver,
 ) -> Result<()> {
+    let some_fk_cols_are_virtual = parent_cols.iter().any(|pcol| {
+        parent_bt
+            .get_column(pcol)
+            .is_some_and(|(_, c)| c.is_virtual_generated())
+    });
+
+    let ctx = some_fk_cols_are_virtual.then(|| {
+        cursor_to_registers(
+            program,
+            parent_bt,
+            parent_bt.column_layout(),
+            parent_cursor_id,
+            parent_rowid_reg,
+        )
+    });
+
     for (i, pcol) in parent_cols.iter().enumerate() {
-        let src = if ROWID_STRS.iter().any(|s| pcol.eq_ignore_ascii_case(s)) {
-            parent_rowid_reg
-        } else {
-            let (pos, col) = parent_bt
-                .get_column(pcol)
-                .ok_or_else(|| LimboError::InternalError(format!("col {pcol} missing")))?;
-            if col.is_rowid_alias() {
-                parent_rowid_reg
-            } else {
-                program.emit_insn(Insn::Column {
-                    cursor_id: parent_cursor_id,
-                    column: pos,
-                    dest: dest_start + i,
-                    default: None,
+        let Some((pos, col)) = parent_bt.get_column(pcol) else {
+            if ROWID_STRS.iter().any(|s| pcol.eq_ignore_ascii_case(s)) {
+                // child column references parent rowid
+                program.emit_insn(Insn::Copy {
+                    src_reg: parent_rowid_reg,
+                    dst_reg: dest_start + i,
+                    extra_amount: 0,
                 });
                 continue;
             }
+            return Err(LimboError::InternalError(format!("col {pcol} missing")));
         };
-        program.emit_insn(Insn::Copy {
-            src_reg: src,
-            dst_reg: dest_start + i,
-            extra_amount: 0,
-        });
+
+        if some_fk_cols_are_virtual {
+            // the virtual column will need the registers we previously copied
+            emit_table_column_for_dml(
+                program,
+                parent_cursor_id,
+                ctx.clone()
+                    .expect("ctx is always computed if some fk cols are virtual"),
+                col,
+                pos,
+                dest_start + i,
+                resolver,
+            )?;
+        } else {
+            program.emit_column_or_rowid(parent_cursor_id, pos, dest_start + i);
+        }
     }
     Ok(())
 }
@@ -1040,6 +1096,7 @@ fn emit_fk_delete_parent_existence_check_single(
         parent_cursor_id,
         parent_rowid_reg,
         parent_key_start,
+        resolver,
     )?;
 
     let child_cols = &fk_ref.fk.child_columns;
@@ -1767,6 +1824,7 @@ impl ForeignKeyActions<PreparedFkDeleteAction> {
                 parent_cursor_id,
                 parent_rowid_reg,
                 key_regs_start,
+                resolver,
             )?;
 
             match fk_ref.fk.on_delete {
@@ -2074,6 +2132,7 @@ pub fn emit_fk_drop_table_check(
             parent_write_cur,
             current_rowid_reg,
             key_regs_start,
+            resolver,
         )?;
 
         // Decode encoded values so they match the subprogram's decoded column reads
@@ -2116,6 +2175,7 @@ pub fn emit_fk_drop_table_check(
             parent_write_cur,
             current_rowid_reg,
             parent_key_start,
+            resolver,
         )?;
 
         // Scan child table for matching rows

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4043,3 +4043,169 @@ expect {
     1|y|1y
 }
 
+
+# Parent UPDATE with default NO ACTION should fail when gen-col FK changes
+@cross-check-integrity
+test fk-gencol-unique-idx-update-no-action {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INTEGER, b INTEGER GENERATED ALWAYS AS (a*2) VIRTUAL);
+    CREATE UNIQUE INDEX idx_p_b ON p(b);
+    CREATE TABLE c(x INTEGER REFERENCES p(b));
+    INSERT INTO p(a) VALUES(1);
+    INSERT INTO c(x) VALUES(2);
+    UPDATE p SET a=3 WHERE a=1;
+}
+expect error {
+}
+
+# ON DELETE CASCADE should remove child rows
+@cross-check-integrity
+test fk-gencol-unique-idx-delete-cascade {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INTEGER, b INTEGER GENERATED ALWAYS AS (a*2) VIRTUAL);
+    CREATE UNIQUE INDEX idx_p_b ON p(b);
+    CREATE TABLE c(x INTEGER REFERENCES p(b) ON DELETE CASCADE);
+    INSERT INTO p(a) VALUES(10);
+    INSERT INTO c(x) VALUES(20);
+    DELETE FROM p WHERE a=10;
+    SELECT count(*) FROM c;
+}
+expect {
+    0
+}
+
+# ON DELETE SET NULL should null-out child FK column
+@cross-check-integrity
+test fk-gencol-unique-idx-delete-set-null {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INTEGER, b INTEGER GENERATED ALWAYS AS (a*2) VIRTUAL);
+    CREATE UNIQUE INDEX idx_p_b ON p(b);
+    CREATE TABLE c(x INTEGER REFERENCES p(b) ON DELETE SET NULL);
+    INSERT INTO p(a) VALUES(100);
+    INSERT INTO c(x) VALUES(200);
+    DELETE FROM p WHERE a=100;
+    SELECT typeof(x), x FROM c;
+}
+expect {
+    null|
+}
+
+# ON UPDATE CASCADE should propagate new generated value
+@cross-check-integrity
+test fk-gencol-unique-idx-update-cascade {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INTEGER, b INTEGER GENERATED ALWAYS AS (a*2) VIRTUAL);
+    CREATE UNIQUE INDEX idx_p_b ON p(b);
+    CREATE TABLE c(x INTEGER REFERENCES p(b) ON UPDATE CASCADE);
+    INSERT INTO p(a) VALUES(1000);
+    INSERT INTO c(x) VALUES(2000);
+    UPDATE p SET a=1001 WHERE a=1000;
+    SELECT * FROM c;
+}
+expect {
+    2002
+}
+
+# DROP TABLE should fail with default NO ACTION when child rows exist
+@cross-check-integrity
+test fk-gencol-unique-idx-drop-table {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p2(a INTEGER, b INTEGER GENERATED ALWAYS AS (a*2) VIRTUAL);
+    CREATE UNIQUE INDEX idx_p2_b ON p2(b);
+    CREATE TABLE c5(x INTEGER REFERENCES p2(b));
+    INSERT INTO p2(a) VALUES(1);
+    INSERT INTO c5(x) VALUES(2);
+    DROP TABLE p2;
+}
+expect error {
+}
+
+# Child insert validation should still work (sanity check)
+@cross-check-integrity
+test fk-gencol-unique-idx-child-insert-reject {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INTEGER, b INTEGER GENERATED ALWAYS AS (a*2) VIRTUAL);
+    CREATE UNIQUE INDEX idx_p_b ON p(b);
+    CREATE TABLE c(x INTEGER REFERENCES p(b));
+    INSERT INTO p(a) VALUES(1);
+    INSERT INTO c(x) VALUES(3);
+}
+expect error {
+}
+
+# Virtual column NOT at end of schema -- tests physical column index mapping
+@cross-check-integrity
+test fk-gencol-unique-idx-mid-schema-delete-cascade {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INTEGER, b INTEGER GENERATED ALWAYS AS (a*2) VIRTUAL, c TEXT);
+    CREATE UNIQUE INDEX idx_p_b ON p(b);
+    CREATE TABLE c(x INTEGER REFERENCES p(b) ON DELETE CASCADE);
+    INSERT INTO p(a, c) VALUES(10, 'hello');
+    INSERT INTO c(x) VALUES(20);
+    DELETE FROM p WHERE a=10;
+    SELECT count(*) FROM c;
+}
+expect {
+    0
+}
+
+@cross-check-integrity
+test fk-gencol-unique-idx-mid-schema-update-no-action {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(a INTEGER, b INTEGER GENERATED ALWAYS AS (a*2) VIRTUAL, c TEXT);
+    CREATE UNIQUE INDEX idx_p_b ON p(b);
+    CREATE TABLE c(x INTEGER REFERENCES p(b));
+    INSERT INTO p(a, c) VALUES(1, 'hi');
+    INSERT INTO c(x) VALUES(2);
+    UPDATE p SET a=3 WHERE a=1;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-child-references-parent-virtual-col {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, a INTEGER, v AS (a * 2) VIRTUAL UNIQUE);
+    CREATE TABLE child(id INTEGER PRIMARY KEY, pv INTEGER REFERENCES parent(v));
+    INSERT INTO parent(id, a) VALUES(1, 5);
+    INSERT INTO child VALUES(1, 10);
+    SELECT c.id, c.pv, p.a, p.v FROM child c JOIN parent p ON c.pv = p.v;
+}
+expect {
+    1|10|5|10
+}
+
+@cross-check-integrity
+test fk-child-references-parent-virtual-col-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, a INTEGER, v AS (a * 2) VIRTUAL UNIQUE);
+    CREATE TABLE child(id INTEGER PRIMARY KEY, pv INTEGER REFERENCES parent(v));
+    INSERT INTO parent(id, a) VALUES(1, 5);
+    INSERT INTO child VALUES(1, 99);
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-child-references-parent-virtual-col-using-rowid {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, a INTEGER, v AS (id + a) VIRTUAL UNIQUE);
+    CREATE TABLE child(id INTEGER PRIMARY KEY, pv INTEGER REFERENCES parent(v));
+    INSERT INTO parent(id, a) VALUES(10, 5);
+    INSERT INTO child VALUES(1, 15);
+    SELECT c.id, c.pv, p.id, p.a, p.v FROM child c JOIN parent p ON c.pv = p.v;
+}
+expect {
+    1|15|10|5|15
+}
+
+@cross-check-integrity
+test fk-child-references-parent-virtual-col-using-rowid-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, a INTEGER, v AS (id + a) VIRTUAL UNIQUE);
+    CREATE TABLE child(id INTEGER PRIMARY KEY, pv INTEGER REFERENCES parent(v));
+    INSERT INTO parent(id, a) VALUES(10, 5);
+    INSERT INTO child VALUES(1, 99);
+}
+expect error {
+}


### PR DESCRIPTION
Virtual columns weren't calculated in some code paths that checked foreign keys, so they were effectively skipped. I started with an implementation by Claude Code, but it wasn't good so I rewrote the whole thing by hand.