### PR TITLE
github: Publish .Net bindings to NuGet

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -97,11 +97,10 @@ jobs:
 
       # https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package
       - name: Publish to nuget
-        if: false # TODO: Get nuget api key and publish packages
         run: |
-          dotnet nuget push ${{ env.working-directory }}/src/Turso.Raw/bin/Release/Turso.Raw.*.nupkg --api-key ... --source https://api.nuget.org/v3/index.json
+          dotnet nuget push ${{ env.working-directory }}/src/Turso.Raw/bin/Release/Turso.Raw.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
-          dotnet nuget push ${{ env.working-directory }}/src/Turso/bin/Release/Turso.*.nupkg --api-key ... --source https://api.nuget.org/v3/index.json
+          dotnet nuget push ${{ env.working-directory }}/src/Turso/bin/Release/Turso.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
       - name: Upload Turso.Raw to artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

I updated the CI pipeline to publish to NuGet. I talked with the team and it seems like all that is missing is turning the CI on and using the `NUGET_API_KEY` already setup.

https://discord.com/channels/1258658826257961020/1486486153514188810

## Description of AI Usage

None used