### PR TITLE
serverless: add query timeout support with AbortSignal

### DIFF
--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -1,6 +1,7 @@
 import { AsyncLock } from './async-lock.js';
 import { Session, type SessionConfig } from './session.js';
 import { Statement } from './statement.js';
+import { type QueryOptions } from './protocol.js';
 
 /**
  * Configuration options for connecting to a Turso database.
@@ -127,13 +128,13 @@ export class Connection {
    * console.log(result.rows);
    * ```
    */
-  async execute(sql: string, args?: any[]): Promise<any> {
+  async execute(sql: string, args?: any[], queryOptions?: QueryOptions): Promise<any> {
     if (!this.isOpen) {
       throw new TypeError("The database connection is not open");
     }
     await this.execLock.acquire();
     try {
-      return await this.session.execute(sql, args || [], this.defaultSafeIntegerMode);
+      return await this.session.execute(sql, args || [], this.defaultSafeIntegerMode, queryOptions);
     } finally {
       this.execLock.release();
     }
@@ -151,13 +152,13 @@ export class Connection {
    * console.log(result.rows);
    * ```
    */
-  async exec(sql: string): Promise<any> {
+  async exec(sql: string, queryOptions?: QueryOptions): Promise<any> {
     if (!this.isOpen) {
       throw new TypeError("The database connection is not open");
     }
     await this.execLock.acquire();
     try {
-      return await this.session.sequence(sql);
+      return await this.session.sequence(sql, queryOptions);
     } finally {
       this.execLock.release();
     }
@@ -180,13 +181,13 @@ export class Connection {
    * ]);
    * ```
    */
-  async batch(statements: string[], mode?: string): Promise<any> {
+  async batch(statements: string[], mode?: string, queryOptions?: QueryOptions): Promise<any> {
     if (!this.isOpen) {
       throw new TypeError("The database connection is not open");
     }
     await this.execLock.acquire();
     try {
-      return await this.session.batch(statements);
+      return await this.session.batch(statements, queryOptions);
     } finally {
       this.execLock.release();
     }
@@ -198,14 +199,14 @@ export class Connection {
    * @param pragma - The pragma to execute
    * @returns Promise resolving to the result of the pragma
    */
-  async pragma(pragma: string): Promise<any> {
+  async pragma(pragma: string, queryOptions?: QueryOptions): Promise<any> {
     if (!this.isOpen) {
       throw new TypeError("The database connection is not open");
     }
     await this.execLock.acquire();
     try {
       const sql = `PRAGMA ${pragma}`;
-      return await this.session.execute(sql);
+      return await this.session.execute(sql, [], false, queryOptions);
     } finally {
       this.execLock.release();
     }

--- a/serverless/javascript/src/error.ts
+++ b/serverless/javascript/src/error.ts
@@ -15,3 +15,18 @@ export class DatabaseError extends Error {
     Object.setPrototypeOf(this, DatabaseError.prototype);
   }
 }
+
+/**
+ * Error thrown when a query exceeds the configured timeout.
+ *
+ * This is a subclass of `DatabaseError` with `code` set to `"TIMEOUT"`.
+ * Catch this type to distinguish timeouts from other database errors
+ * and decide whether to retry or fail gracefully.
+ */
+export class TimeoutError extends DatabaseError {
+  constructor(message: string = 'Query timed out', cause?: Error) {
+    super(message, 'TIMEOUT', undefined, cause);
+    this.name = 'TimeoutError';
+    Object.setPrototypeOf(this, TimeoutError.prototype);
+  }
+}

--- a/serverless/javascript/src/index.ts
+++ b/serverless/javascript/src/index.ts
@@ -2,5 +2,5 @@
 export { Connection, connect, type Config } from './connection.js';
 export { Statement } from './statement.js';
 export { Session, type SessionConfig } from './session.js';
-export { DatabaseError } from './error.js';
-export { type Column, ENCRYPTION_KEY_HEADER } from './protocol.js';
+export { DatabaseError, TimeoutError } from './error.js';
+export { type Column, type QueryOptions, ENCRYPTION_KEY_HEADER } from './protocol.js';

--- a/serverless/javascript/src/protocol.ts
+++ b/serverless/javascript/src/protocol.ts
@@ -1,4 +1,4 @@
-import { DatabaseError } from './error.js';
+import { DatabaseError, TimeoutError } from './error.js';
 
 export interface Value {
   type: 'null' | 'integer' | 'float' | 'text' | 'blob';
@@ -183,11 +183,25 @@ export interface CursorEntry {
 /** HTTP header key for the encryption key */
 export const ENCRYPTION_KEY_HEADER = 'x-turso-encryption-key';
 
+/** Per-query timeout options. Overrides defaultQueryTimeout for this call. */
+export interface QueryOptions {
+  /** Per-query timeout in milliseconds. Overrides defaultQueryTimeout for this call. */
+  queryTimeout?: number;
+}
+
+function wrapAbortError(error: unknown): never {
+  if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
+    throw new TimeoutError('Query timed out');
+  }
+  throw error;
+}
+
 export async function executeCursor(
   url: string,
   authToken: string | undefined,
   request: CursorRequest,
-  remoteEncryptionKey?: string
+  remoteEncryptionKey?: string,
+  signal?: AbortSignal
 ): Promise<{ response: CursorResponse; entries: AsyncGenerator<CursorEntry> }> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -199,11 +213,17 @@ export async function executeCursor(
     headers[ENCRYPTION_KEY_HEADER] = remoteEncryptionKey;
   }
 
-  const response = await fetch(`${url}/v3/cursor`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(request),
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${url}/v3/cursor`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(request),
+      signal,
+    });
+  } catch (error) {
+    wrapAbortError(error);
+  }
 
   if (!response.ok) {
     let errorMessage = `HTTP error! status: ${response.status}`;
@@ -229,25 +249,31 @@ export async function executeCursor(
   let cursorResponse: CursorResponse | undefined;
 
   // First, read until we get the cursor response (first line)
-  while (!cursorResponse) {
-    const { done, value } = await reader.read();
-    if (done) break;
+  try {
+    while (!cursorResponse) {
+      const { done, value } = await reader.read();
+      if (done) break;
 
-    buffer += decoder.decode(value, { stream: true });
-    
-    const newlineIndex = buffer.indexOf('\n');
-    if (newlineIndex !== -1) {
-      const line = buffer.slice(0, newlineIndex).trim();
-      buffer = buffer.slice(newlineIndex + 1);
-      
-      if (line) {
-        cursorResponse = JSON.parse(line);
-        break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+
+        if (line) {
+          cursorResponse = JSON.parse(line);
+          break;
+        }
       }
     }
+  } catch (error) {
+    reader.releaseLock();
+    wrapAbortError(error);
   }
 
   if (!cursorResponse) {
+    reader.releaseLock();
     throw new DatabaseError('No cursor response received');
   }
 
@@ -258,7 +284,7 @@ export async function executeCursor(
       while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
         const line = buffer.slice(0, newlineIndex).trim();
         buffer = buffer.slice(newlineIndex + 1);
-        
+
         if (line) {
           yield JSON.parse(line) as CursorEntry;
         }
@@ -266,15 +292,20 @@ export async function executeCursor(
 
       // Continue reading from the stream
       while (true) {
-        const { done, value } = await reader!.read();
-        if (done) break;
+        let readResult: ReadableStreamReadResult<Uint8Array>;
+        try {
+          readResult = await reader!.read();
+        } catch (error) {
+          wrapAbortError(error);
+        }
+        if (readResult.done) break;
 
-        buffer += decoder.decode(value, { stream: true });
-        
+        buffer += decoder.decode(readResult.value, { stream: true });
+
         while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
           const line = buffer.slice(0, newlineIndex).trim();
           buffer = buffer.slice(newlineIndex + 1);
-          
+
           if (line) {
             yield JSON.parse(line) as CursorEntry;
           }
@@ -297,7 +328,8 @@ export async function executePipeline(
   url: string,
   authToken: string | undefined,
   request: PipelineRequest,
-  remoteEncryptionKey?: string
+  remoteEncryptionKey?: string,
+  signal?: AbortSignal
 ): Promise<PipelineResponse> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -309,11 +341,17 @@ export async function executePipeline(
     headers[ENCRYPTION_KEY_HEADER] = remoteEncryptionKey;
   }
 
-  const response = await fetch(`${url}/v3/pipeline`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(request),
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${url}/v3/pipeline`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(request),
+      signal,
+    });
+  } catch (error) {
+    wrapAbortError(error);
+  }
 
   if (!response.ok) {
     throw new DatabaseError(`HTTP error! status: ${response.status}`);

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -1,8 +1,8 @@
-import { 
-  executeCursor, 
+import {
+  executeCursor,
   executePipeline,
-  encodeValue, 
-  decodeValue, 
+  encodeValue,
+  decodeValue,
   type CursorRequest,
   type CursorResponse,
   type CursorEntry,
@@ -11,6 +11,7 @@ import {
   type CloseRequest,
   type DescribeRequest,
   type DescribeResult,
+  type QueryOptions,
   type NamedArg,
   type Value
 } from './protocol.js';
@@ -29,6 +30,8 @@ export interface SessionConfig {
    * to enable access to encrypted Turso Cloud databases.
    */
   remoteEncryptionKey?: string;
+  /** Default maximum query execution time in milliseconds before interruption. */
+  defaultQueryTimeout?: number;
 }
 
 function normalizeUrl(url: string): string {
@@ -55,13 +58,21 @@ export class Session {
     this.baseUrl = normalizeUrl(config.url);
   }
 
+  private createAbortSignal(queryOptions?: QueryOptions): AbortSignal | undefined {
+    const timeout = queryOptions?.queryTimeout ?? this.config.defaultQueryTimeout;
+    if (timeout != null && timeout > 0) {
+      return AbortSignal.timeout(timeout);
+    }
+    return undefined;
+  }
+
   /**
    * Describe a SQL statement to get its column metadata.
    * 
    * @param sql - The SQL statement to describe
    * @returns Promise resolving to the statement description
    */
-  async describe(sql: string): Promise<DescribeResult> {
+  async describe(sql: string, queryOptions?: QueryOptions): Promise<DescribeResult> {
     const request: PipelineRequest = {
       baton: this.baton,
       requests: [{
@@ -70,7 +81,7 @@ export class Session {
       } as DescribeRequest]
     };
 
-    const response = await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey);
+    const response = await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
 
     this.baton = response.baton;
     if (response.base_url) {
@@ -100,8 +111,8 @@ export class Session {
    * @param safeIntegers - Whether to return integers as BigInt
    * @returns Promise resolving to the complete result set
    */
-  async execute(sql: string, args: any[] | Record<string, any> = [], safeIntegers: boolean = false): Promise<any> {
-    const { response, entries } = await this.executeRaw(sql, args);
+  async execute(sql: string, args: any[] | Record<string, any> = [], safeIntegers: boolean = false, queryOptions?: QueryOptions): Promise<any> {
+    const { response, entries } = await this.executeRaw(sql, args, queryOptions);
     const result = await this.processCursorEntries(entries, safeIntegers);
     return result;
   }
@@ -113,7 +124,7 @@ export class Session {
    * @param args - Optional array of parameter values or object with named parameters
    * @returns Promise resolving to the raw response and cursor entries
    */
-  async executeRaw(sql: string, args: any[] | Record<string, any> = []): Promise<{ response: CursorResponse; entries: AsyncGenerator<CursorEntry> }> {
+  async executeRaw(sql: string, args: any[] | Record<string, any> = [], queryOptions?: QueryOptions): Promise<{ response: CursorResponse; entries: AsyncGenerator<CursorEntry> }> {
     let positionalArgs: Value[] = [];
     let namedArgs: NamedArg[] = [];
 
@@ -166,7 +177,7 @@ export class Session {
       }
     };
 
-    const { response, entries } = await executeCursor(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey);
+    const { response, entries } = await executeCursor(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
 
     this.baton = response.baton;
     if (response.base_url) {
@@ -259,7 +270,7 @@ export class Session {
    * @param statements - Array of SQL statements to execute
    * @returns Promise resolving to batch execution results
    */
-  async batch(statements: string[]): Promise<any> {
+  async batch(statements: string[], queryOptions?: QueryOptions): Promise<any> {
     const request: CursorRequest = {
       baton: this.baton,
       batch: {
@@ -274,7 +285,7 @@ export class Session {
       }
     };
 
-    const { response, entries } = await executeCursor(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey);
+    const { response, entries } = await executeCursor(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
 
     this.baton = response.baton;
     if (response.base_url) {
@@ -312,7 +323,7 @@ export class Session {
    * @param sql - SQL string containing multiple statements separated by semicolons
    * @returns Promise resolving when all statements are executed
    */
-  async sequence(sql: string): Promise<void> {
+  async sequence(sql: string, queryOptions?: QueryOptions): Promise<void> {
     const request: PipelineRequest = {
       baton: this.baton,
       requests: [{
@@ -321,7 +332,7 @@ export class Session {
       } as SequenceRequest]
     };
 
-    const response = await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey);
+    const response = await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
 
     this.baton = response.baton;
     if (response.base_url) {
@@ -355,9 +366,9 @@ export class Session {
         };
 
         await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey);
-      } catch (error) {
-        // Ignore errors during close, as the connection might already be closed
-        console.error('Error closing session:', error);
+      } catch {
+        // Ignore errors during close — the connection might already be closed
+        // or the baton may be stale after a timeout.
       }
     }
 

--- a/serverless/javascript/src/statement.ts
+++ b/serverless/javascript/src/statement.ts
@@ -1,7 +1,8 @@
-import { 
-  decodeValue, 
+import {
+  decodeValue,
   type CursorEntry,
-  type Column
+  type Column,
+  type QueryOptions
 } from './protocol.js';
 import { Session, type SessionConfig } from './session.js';
 import { DatabaseError } from './error.js';
@@ -127,9 +128,9 @@ export class Statement {
    * console.log(`Inserted user with ID ${result.lastInsertRowid}`);
    * ```
    */
-  async run(args?: any): Promise<any> {
+  async run(args?: any, queryOptions?: QueryOptions): Promise<any> {
     const normalizedArgs = this.normalizeArgs(args);
-    const result = await this.session.execute(this.sql, normalizedArgs, this.safeIntegerMode);
+    const result = await this.session.execute(this.sql, normalizedArgs, this.safeIntegerMode, queryOptions);
     return { changes: result.rowsAffected, lastInsertRowid: result.lastInsertRowid };
   }
 
@@ -148,9 +149,9 @@ export class Statement {
    * }
    * ```
    */
-  async get(args?: any): Promise<any> {
+  async get(args?: any, queryOptions?: QueryOptions): Promise<any> {
     const normalizedArgs = this.normalizeArgs(args);
-    const result = await this.session.execute(this.sql, normalizedArgs, this.safeIntegerMode);
+    const result = await this.session.execute(this.sql, normalizedArgs, this.safeIntegerMode, queryOptions);
     const row = result.rows[0];
     if (!row) {
       return undefined;
@@ -188,9 +189,9 @@ export class Statement {
    * console.log(`Found ${activeUsers.length} active users`);
    * ```
    */
-  async all(args?: any): Promise<any[]> {
+  async all(args?: any, queryOptions?: QueryOptions): Promise<any[]> {
     const normalizedArgs = this.normalizeArgs(args);
-    const result = await this.session.execute(this.sql, normalizedArgs, this.safeIntegerMode);
+    const result = await this.session.execute(this.sql, normalizedArgs, this.safeIntegerMode, queryOptions);
     
     if (this.presentationMode === 'pluck') {
       // In pluck mode, return only the first column value from each row
@@ -229,9 +230,9 @@ export class Statement {
    * }
    * ```
    */
-  async *iterate(args?: any): AsyncGenerator<any> {
+  async *iterate(args?: any, queryOptions?: QueryOptions): AsyncGenerator<any> {
     const normalizedArgs = this.normalizeArgs(args);
-    const { response, entries } = await this.session.executeRaw(this.sql, normalizedArgs);
+    const { response, entries } = await this.session.executeRaw(this.sql, normalizedArgs, queryOptions);
     
     let columns: string[] = [];
     

--- a/testing/javascript/__test__/async.test.js
+++ b/testing/javascript/__test__/async.test.js
@@ -648,6 +648,114 @@ test.serial("Open database after rename", async (t) => {
   }
 });
 
+// ==========================================================================
+// Query timeout (serverless only — uses AbortSignal under the hood)
+// ==========================================================================
+
+test.serial("defaultQueryTimeout interrupts long-running query", async (t) => {
+  if (process.env.PROVIDER !== "serverless") {
+    t.pass("Skipping serverless-only test");
+    return;
+  }
+  const turso = await import("@tursodatabase/serverless");
+  const db = turso.connect({
+    url: process.env.TURSO_DATABASE_URL,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+    defaultQueryTimeout: 100,
+  });
+
+  const error = await t.throwsAsync(async () => {
+    await db.execute(
+      "WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM r) SELECT * FROM r;"
+    );
+  });
+  t.truthy(error);
+  t.true(error instanceof turso.TimeoutError);
+  t.is(error.code, "TIMEOUT");
+
+  await db.close();
+});
+
+test.serial("defaultQueryTimeout allows short-running query", async (t) => {
+  if (process.env.PROVIDER !== "serverless") {
+    t.pass("Skipping serverless-only test");
+    return;
+  }
+  const turso = await import("@tursodatabase/serverless");
+  const db = turso.connect({
+    url: process.env.TURSO_DATABASE_URL,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+    defaultQueryTimeout: 5000,
+  });
+
+  const result = await db.execute("SELECT 1 AS value");
+  t.is(result.rows.length, 1);
+  t.is(result.rows[0].value, 1);
+
+  await db.close();
+});
+
+test.serial("Per-query queryTimeout interrupts long-running query", async (t) => {
+  if (process.env.PROVIDER !== "serverless") {
+    t.pass("Skipping serverless-only test");
+    return;
+  }
+  const turso = await import("@tursodatabase/serverless");
+  const db = turso.connect({
+    url: process.env.TURSO_DATABASE_URL,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  });
+
+  const error = await t.throwsAsync(async () => {
+    await db.execute(
+      "WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM r) SELECT * FROM r;",
+      [],
+      { queryTimeout: 100 }
+    );
+  });
+  t.truthy(error);
+  t.true(error instanceof turso.TimeoutError);
+  t.is(error.code, "TIMEOUT");
+
+  await db.close();
+});
+
+test.serial("Per-query queryTimeout is accepted by exec()", async (t) => {
+  if (process.env.PROVIDER !== "serverless") {
+    t.pass("Skipping serverless-only test");
+    return;
+  }
+  const turso = await import("@tursodatabase/serverless");
+  const db = turso.connect({
+    url: process.env.TURSO_DATABASE_URL,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  });
+
+  await t.notThrowsAsync(async () => {
+    await db.exec("SELECT 1", { queryTimeout: 5000 });
+  });
+
+  await db.close();
+});
+
+test.serial("Per-query queryTimeout on Statement.get()", async (t) => {
+  if (process.env.PROVIDER !== "serverless") {
+    t.pass("Skipping serverless-only test");
+    return;
+  }
+  const turso = await import("@tursodatabase/serverless");
+  const db = turso.connect({
+    url: process.env.TURSO_DATABASE_URL,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  });
+
+  const stmt = await db.prepare("SELECT 1 AS value");
+  const row = await stmt.get(undefined, { queryTimeout: 5000 });
+  t.is(row.value, 1);
+
+  await db.close();
+});
+
 const connect = async (path, options = {}) => {
   if (!path) {
     path = genDatabaseFilename();

--- a/testing/javascript/package-lock.json
+++ b/testing/javascript/package-lock.json
@@ -17,10 +17,10 @@
     },
     "../../bindings/javascript/packages/native": {
       "name": "@tursodatabase/database",
-      "version": "0.6.0-pre.9",
+      "version": "0.6.0-pre.11",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0-pre.9"
+        "@tursodatabase/database-common": "^0.6.0-pre.11"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -34,7 +34,7 @@
     },
     "../../serverless/javascript": {
       "name": "@tursodatabase/serverless",
-      "version": "0.2.4",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.13",


### PR DESCRIPTION
Add per-connection defaultQueryTimeout and per-query queryTimeout options to the serverless driver, matching the API from the native JS bindings. Stalled fetch() or stream reads now abort instead of hanging forever, which prevents the AsyncLock from blocking all subsequent queries on the connection.

Introduces TimeoutError (subclass of DatabaseError, code "TIMEOUT") so callers can distinguish timeouts from other errors and decide whether to retry or fail gracefully.