### PR TITLE
Add JavaScript test cases for datetime('now')

### DIFF
--- a/bindings/javascript/packages/wasm/promise.test.ts
+++ b/bindings/javascript/packages/wasm/promise.test.ts
@@ -211,6 +211,13 @@ test('blobs', async () => {
     await db.close();
 })
 
+test("datetime('now')", async () => {
+    const db = await connect(":memory:");
+    const rows = await db.prepare("SELECT datetime('now') as now").all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].now).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    await db.close();
+})
 
 test('example-1', async () => {
     const db = await connect(':memory:');

--- a/testing/javascript/__test__/sync.test.js
+++ b/testing/javascript/__test__/sync.test.js
@@ -345,6 +345,18 @@ test.serial("Statement.get() values", async (t) => {
   t.deepEqual(stmt.get(9007199254740991n), [9007199254740991]);
 });
 
+
+test.serial("Statement.get() datetime('now')", async (t) => {
+  const db = t.context.db;
+
+  const stmt = db.prepare("SELECT datetime('now') AS now");
+  const row = stmt.get();
+  t.truthy(row.now, "datetime('now') should return a value");
+  // Verify the result matches the expected ISO 8601 datetime format: YYYY-MM-DD HH:MM:SS
+  t.regex(row.now, /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/, "datetime('now') should return a valid datetime string");
+});
+
+
 test.serial("Statement.get() [blob]", (t) => {
   const db = t.context.db;
 


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description
Add tests for `datetime('now')` that was changed in https://github.com/tursodatabase/turso/pull/4594

I originally made this PR to find out how the tests would behave when run in a browser. I found out that what I thought would be a regression (because nothing tested that case) is not actually one because turso includes polyfills for wasip1, which provide the SystemTime call.

Note that while the tests pass in JS bindings, this case will panic if someone tries to embed turso in a Rust app running in browser as those are predominantly built using wasm32-unknown-unknown. I think it's still a good idea to merge this PR to add the missing test cases.

With that said, there is still room for improvement to increase compatibility here

## Motivation and context

https://github.com/tursodatabase/turso/blob/d969c4d401d8c7b021af325cc8069a4395578a2d/core/functions/datetime.rs#L198-L209

This will fail on any `wasm32-unknown-unknown` target 

See https://github.com/tursodatabase/turso/issues/6199

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

- Told claude to generate the tests and tell me where to add them
- manually verified the soundness of tests and added them to file