### PR TITLE
core: Implement PRAGMA full_column_names and short_column_names

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -86,6 +86,10 @@ pub struct Connection {
     pub(super) query_only: AtomicBool,
     /// If enabled, the UPDATE/DELETE statements must have a WHERE clause
     pub(super) dml_require_where: AtomicBool,
+    /// Deprecated pragma: when ON, column names include table prefix (TABLE.COLUMN)
+    pub(super) full_column_names: AtomicBool,
+    /// Deprecated pragma: when ON (default), column refs use just the column name
+    pub(super) short_column_names: AtomicBool,
     pub(crate) mv_tx: RwLock<Option<(crate::mvcc::database::TxID, TransactionMode)>>,
     /// Per-attached-database MVCC transactions.
     /// Main DB uses `mv_tx` above for zero-cost hot path access.
@@ -1845,6 +1849,24 @@ impl Connection {
 
     pub fn set_dml_require_where(&self, value: bool) {
         self.dml_require_where.store(value, Ordering::SeqCst);
+    }
+
+    pub fn get_full_column_names(&self) -> bool {
+        self.full_column_names.load(Ordering::SeqCst)
+    }
+
+    pub fn set_full_column_names(&self, value: bool) {
+        self.full_column_names.store(value, Ordering::SeqCst);
+        self.bump_prepare_context_generation();
+    }
+
+    pub fn get_short_column_names(&self) -> bool {
+        self.short_column_names.load(Ordering::SeqCst)
+    }
+
+    pub fn set_short_column_names(&self, value: bool) {
+        self.short_column_names.store(value, Ordering::SeqCst);
+        self.bump_prepare_context_generation();
     }
 
     pub fn get_sync_mode(&self) -> SyncMode {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1382,6 +1382,8 @@ impl Database {
             busy_handler: RwLock::new(BusyHandler::None),
             query_timeout_ms: AtomicU64::new(0),
             is_mvcc_bootstrap_connection: AtomicBool::new(is_mvcc_bootstrap_connection),
+            full_column_names: AtomicBool::new(false),
+            short_column_names: AtomicBool::new(true),
             fk_pragma: AtomicBool::new(false),
             fk_deferred_violations: AtomicIsize::new(0),
             n_active_writes: AtomicI32::new(0),

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -59,6 +59,9 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NeedSchema | PragmaFlags::Result0 | PragmaFlags::SchemaReq,
             &["journal_mode"],
         ),
+        FullColumnNames | ShortColumnNames => {
+            unreachable!("pragma_for() called with FullColumnNames/ShortColumnNames, which are deprecated no-ops")
+        }
         LegacyFileFormat => {
             unreachable!("pragma_for() called with LegacyFileFormat, which is unsupported")
         }
@@ -210,7 +213,11 @@ pub(crate) struct PragmaVirtualTable {
 impl PragmaVirtualTable {
     pub(crate) fn functions() -> Vec<(PragmaVirtualTable, String)> {
         PragmaName::iter()
-            .filter(|name| *name != PragmaName::LegacyFileFormat)
+            .filter(|name| {
+                *name != PragmaName::LegacyFileFormat
+                    && *name != PragmaName::FullColumnNames
+                    && *name != PragmaName::ShortColumnNames
+            })
             .filter_map(|name| {
                 let pragma = pragma_for(&name);
                 if pragma

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -463,12 +463,65 @@ impl Statement {
         match self.query_mode {
             QueryMode::Normal => {
                 let column = &self.program.result_columns.get(idx).expect("No column");
-                match column.name(&self.program.table_references) {
-                    Some(name) => Cow::Borrowed(name),
-                    None => {
-                        let tables = [&self.program.table_references];
-                        let ctx = PlanContext(&tables);
-                        Cow::Owned(column.expr.displayer(&ctx).to_string())
+
+                // 1. Explicit alias (AS clause) or SELECT * expansion always wins.
+                if let Some(alias) = &column.alias {
+                    return Cow::Borrowed(alias);
+                }
+
+                let full = self.program.connection.get_full_column_names();
+                let short = self.program.connection.get_short_column_names();
+
+                // 2. For column references, apply full/short column name logic.
+                match &column.expr {
+                    turso_parser::ast::Expr::Column {
+                        table,
+                        column: col_idx,
+                        ..
+                    } => {
+                        if full {
+                            // full_column_names=ON: use REAL_TABLE_NAME.COLUMN
+                            if let Some((_, table_ref)) = self
+                                .program
+                                .table_references
+                                .find_table_by_internal_id(*table)
+                            {
+                                let col_name = table_ref
+                                    .get_column_at(*col_idx)
+                                    .and_then(|c| c.name.as_deref())
+                                    .unwrap_or("?");
+                                return Cow::Owned(format!(
+                                    "{}.{}",
+                                    table_ref.get_name(),
+                                    col_name
+                                ));
+                            }
+                        }
+                        if short || full {
+                            // short_column_names=ON: use just COLUMN
+                            if let Some(name) = column.name(&self.program.table_references) {
+                                return Cow::Borrowed(name);
+                            }
+                        }
+                        // Both OFF: use original expression text
+                        if let Some(name) = &column.implicit_column_name {
+                            Cow::Borrowed(name.as_str())
+                        } else {
+                            let tables = [&self.program.table_references];
+                            let ctx = PlanContext(&tables);
+                            Cow::Owned(column.expr.displayer(&ctx).to_string())
+                        }
+                    }
+                    _ => {
+                        // Non-column-ref: use implicit_column_name or displayer
+                        match column.name(&self.program.table_references) {
+                            Some(name) => Cow::Borrowed(name),
+                            None => {
+                                let tables = [&self.program.table_references];
+                                let ctx = PlanContext(&tables);
+                                Cow::Owned(column.expr.displayer(&ctx).to_string())
+                            }
+                        }
                     }
                 }
             }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -754,6 +754,7 @@ pub fn select_star(
     tables: &[JoinedTable],
     out_columns: &mut Vec<ResultSetColumn>,
     right_join_swapped: bool,
+    long_names: bool,
 ) -> crate::Result<()> {
     // RIGHT JOIN swapped tables; iterate in reverse to restore original column order.
     let table_iter: Vec<&JoinedTable> = if right_join_swapped {
@@ -820,16 +821,29 @@ pub fn select_star(
                         true
                     }
                 })
-                .map(|(i, col)| ResultSetColumn {
-                    alias: None,
-                    implicit_column_name: None,
-                    expr: ast::Expr::Column {
-                        database: None,
-                        table: table.internal_id,
-                        column: i,
-                        is_rowid_alias: col.is_rowid_alias(),
-                    },
-                    contains_aggregates: false,
+                .map(|(i, col)| {
+                    // Like SQLite, SELECT * sets column names as aliases (ENAME_NAME),
+                    // bypassing full/short column name logic in get_column_name().
+                    // When long_names (full=ON, short=OFF), use "TABLE.COLUMN".
+                    // Otherwise, use just "COLUMN".
+                    let alias = col.name.as_ref().map(|col_name| {
+                        if long_names {
+                            format!("{}.{}", table.identifier, col_name)
+                        } else {
+                            col_name.clone()
+                        }
+                    });
+                    ResultSetColumn {
+                        alias,
+                        implicit_column_name: None,
+                        expr: ast::Expr::Column {
+                            database: None,
+                            table: table.internal_id,
+                            column: i,
+                            is_rowid_alias: col.is_rowid_alias(),
+                        },
+                        contains_aggregates: false,
+                    }
                 }),
         );
     }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -773,7 +773,7 @@ fn parse_from_clause_table(
             let cur_table_index = table_references.joined_tables().len();
             let identifier = maybe_alias
                 .map(|a| normalize_ident(a.name().as_str()))
-                .unwrap_or_else(|| format!("subquery_{cur_table_index}"));
+                .unwrap_or_else(|| format!("(subquery-{cur_table_index})"));
             table_references.add_joined_table(JoinedTable::new_subquery_from_plan(
                 identifier,
                 subplan,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -226,6 +226,16 @@ fn update_pragma(
             program.add_pragma_result_column("journal_mode".into());
             Ok(TransactionMode::None)
         }
+        PragmaName::FullColumnNames => {
+            let enabled = parse_pragma_enabled(&value);
+            connection.set_full_column_names(enabled);
+            Ok(TransactionMode::None)
+        }
+        PragmaName::ShortColumnNames => {
+            let enabled = parse_pragma_enabled(&value);
+            connection.set_short_column_names(enabled);
+            Ok(TransactionMode::None)
+        }
         PragmaName::LegacyFileFormat => Ok(TransactionMode::None),
         PragmaName::WalCheckpoint => query_pragma(
             PragmaName::WalCheckpoint,
@@ -636,6 +646,22 @@ fn query_pragma(
                 dest: register,
                 new_mode: None,
             });
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::FullColumnNames => {
+            let enabled = connection.get_full_column_names();
+            let register = program.alloc_register();
+            program.emit_int(enabled as i64, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::ShortColumnNames => {
+            let enabled = connection.get_short_column_names();
+            let register = program.alloc_register();
+            program.emit_int(enabled as i64, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -377,6 +377,8 @@ fn prepare_one_select_plan(
                 windows.push(window);
             }
 
+            let long_names =
+                connection.get_full_column_names() && !connection.get_short_column_names();
             let mut aggregate_expressions = Vec::new();
             for column in columns.into_iter() {
                 match column {
@@ -385,6 +387,7 @@ fn prepare_one_select_plan(
                             plan.table_references.joined_tables(),
                             &mut plan.result_columns,
                             plan.table_references.right_join_swapped(),
+                            long_names,
                         )?;
                         for table in plan.table_references.joined_tables_mut() {
                             for idx in 0..table.columns().len() {
@@ -442,6 +445,13 @@ fn prepare_one_select_plan(
                             if column.hidden() {
                                 continue;
                             }
+                            let alias = column.name.as_ref().map(|col_name| {
+                                if long_names {
+                                    format!("{}.{}", table.identifier, col_name)
+                                } else {
+                                    col_name.clone()
+                                }
+                            });
                             plan.result_columns.push(ResultSetColumn {
                                 expr: ast::Expr::Column {
                                     database: None, // TODO: support different databases
@@ -449,7 +459,7 @@ fn prepare_one_select_plan(
                                     column: idx,
                                     is_rowid_alias: column.is_rowid_alias(),
                                 },
-                                alias: None,
+                                alias,
                                 implicit_column_name: None,
                                 contains_aggregates: false,
                             });

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1674,6 +1674,8 @@ pub enum PragmaName {
     FreelistCount,
     /// Enable or disable foreign key constraint enforcement
     ForeignKeys,
+    /// Deprecated: control whether column names include table name prefix
+    FullColumnNames,
     /// List all SQL functions known to the database connection
     FunctionList,
     /// Use F_FULLFSYNC instead of fsync on macOS (only supported on macOS)
@@ -1706,6 +1708,8 @@ pub enum PragmaName {
     QueryOnly,
     /// Returns schema version of the database file.
     SchemaVersion,
+    /// Deprecated: control whether unaliased column names omit the table name prefix
+    ShortColumnNames,
     /// Alias for `require_where` pragma, as an homage to MySQL (https://dev.mysql.com/doc/refman/9.6/en/mysql-tips.html#safe-updates)
     IAmADummy,
     /// Reject DELETE/UPDATE without WHERE clause

--- a/testing/sqltests/tests/pragma/full_column_names.sqltest
+++ b/testing/sqltests/tests/pragma/full_column_names.sqltest
@@ -1,0 +1,149 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE test1(f1 int, f2 int);
+    CREATE TABLE test2(t1 text, t2 text);
+    INSERT INTO test1 VALUES(11, 22);
+    INSERT INTO test1 VALUES(33, 44);
+    INSERT INTO test2 VALUES('abc', 'xyz');
+}
+
+# full_column_names=ON: explicit column refs use TABLE.COLUMN
+@setup schema
+@backend cli
+test full-column-names-explicit {
+    .headers on
+    PRAGMA full_column_names=ON;
+    SELECT f1 FROM test1 ORDER BY f2;
+}
+expect {
+    test1.f1
+    11
+    33
+}
+
+# AS alias overrides full_column_names
+@setup schema
+@backend cli
+test full-column-names-alias-overrides {
+    .headers on
+    PRAGMA full_column_names=ON;
+    SELECT f1 as 'f1' FROM test1 ORDER BY f2;
+}
+expect {
+    f1
+    11
+    33
+}
+
+# SELECT * with full=ON, short=ON (default): no table prefix
+@setup schema
+@backend cli
+test full-column-names-star-short-on {
+    .headers on
+    PRAGMA full_column_names=ON;
+    PRAGMA short_column_names=ON;
+    SELECT * FROM test1 WHERE f1==11;
+}
+expect {
+    f1|f2
+    11|22
+}
+
+# short=OFF, full=OFF: use original expression text
+@setup schema
+@backend cli
+test both-off-expression-text {
+    .headers on
+    PRAGMA short_column_names=OFF;
+    PRAGMA full_column_names=OFF;
+    SELECT test1 . f1, test1 . f2 FROM test1 LIMIT 1;
+}
+expect {
+    test1 . f1|test1 . f2
+    11|22
+}
+
+# short=OFF, full=ON: fully qualified names
+@setup schema
+@backend cli
+test short-off-full-on {
+    .headers on
+    PRAGMA short_column_names=OFF;
+    PRAGMA full_column_names=ON;
+    SELECT test1 . f1, test1 . f2 FROM test1 LIMIT 1;
+}
+expect {
+    test1.f1|test1.f2
+    11|22
+}
+
+# longNames (full=ON, short=OFF): SELECT * uses alias prefix
+@setup schema
+@backend cli
+test long-names-star-with-aliases {
+    .headers on
+    PRAGMA full_column_names=ON;
+    PRAGMA short_column_names=OFF;
+    SELECT * FROM test1 a, test1 b LIMIT 1;
+}
+expect {
+    a.f1|a.f2|b.f1|b.f2
+    11|22|11|22
+}
+
+# full=ON: explicit refs use real table name, not alias
+@setup schema
+@backend cli
+test full-on-uses-real-table-name {
+    .headers on
+    PRAGMA full_column_names=ON;
+    PRAGMA short_column_names=OFF;
+    SELECT a.f1, b.f2 FROM test1 a, test1 b LIMIT 1;
+}
+expect {
+    test1.f1|test1.f2
+    11|22
+}
+
+# full=ON: columns from different tables
+@setup schema
+@backend cli
+test full-on-different-tables {
+    .headers on
+    PRAGMA full_column_names=ON;
+    PRAGMA short_column_names=OFF;
+    SELECT f1, t1 FROM test1, test2 LIMIT 1;
+}
+expect {
+    test1.f1|test2.t1
+    11|abc
+}
+
+# short=ON, full=OFF (default): just column names
+@setup schema
+@backend cli
+test default-short-column-names {
+    .headers on
+    PRAGMA short_column_names=ON;
+    PRAGMA full_column_names=OFF;
+    SELECT a.f1, b.f1 FROM test1 a, test1 b LIMIT 1;
+}
+expect {
+    f1|f1
+    11|11
+}
+
+# longNames with subquery
+@setup schema
+@backend cli
+test full-column-names-subquery-naming {
+    .headers on
+    PRAGMA full_column_names=ON;
+    PRAGMA short_column_names=OFF;
+    SELECT * FROM test1 a, (SELECT 5, 6) LIMIT 1;
+}
+expect {
+    a.f1|a.f2|(subquery-1).5|(subquery-1).6
+    11|22|5|6
+}

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__run-length-current-window.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__run-length-current-window.snap
@@ -79,7 +79,7 @@ info:
 QUERY PLAN
 |--CORRELATED SCALAR SUBQUERY 1
 |  |--SCALAR SUBQUERY 2
-|  |  |--SCAN subquery_0
+|  |  |--SCAN (subquery-0)
 |  |  |  `--COMPOUND QUERY
 |  |  |     |--LEFT-MOST SUBQUERY
 |  |  |     |  `--SCAN user_messages

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__run-length-longest-window.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__run-length-longest-window.snap
@@ -71,7 +71,7 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN subquery_0
+|--SCAN (subquery-0)
 |  `--COMPOUND QUERY
 |     |--LEFT-MOST SUBQUERY
 |     |  `--SCAN user_messages

--- a/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q15-top-supplier.snap
+++ b/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q15-top-supplier.snap
@@ -53,7 +53,7 @@ info:
 ---
 QUERY PLAN
 |--SCALAR SUBQUERY 1
-|  `--SCAN subquery_0
+|  `--SCAN (subquery-0)
 |     |--SCAN lineitem
 |     `--USE SORTER FOR GROUP BY
 |--SCAN revenue

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
@@ -28,7 +28,7 @@ info:
 ---
 QUERY PLAN
 `--SCAN window_subquery_0
-   |--SCAN subquery_0
+   |--SCAN (subquery-0)
    |  `--SCAN window_subquery_0
    |     `--SCAN employees USING INDEX idx_employees_department
    `--USE SORTER FOR ORDER BY


### PR DESCRIPTION
These deprecated SQLite pragmas control how column names appear in result sets. They are needed to pass the upstream select1.test TCL tests (select1-6.1.1 through select1-6.9.16).

The column naming rules match SQLite:
- full=ON: explicit column refs use REAL_TABLE.COLUMN
- short=ON (default), full=OFF: explicit column refs use COLUMN
- both OFF: use original expression text (preserving spacing)
- SELECT * expansion sets aliases at compile time, bypassing the full/short logic (longNames = full=ON && short=OFF uses TABLE.COLUMN)
- AS aliases always take priority