### PR TITLE
fix: mark expression-index columns in col_used_mask during UPDATE planning

### DIFF
--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -442,58 +442,72 @@ pub fn prepare_update_plan(
     let indexes: Vec<_> = resolver.with_schema(database_id, |s| {
         s.get_indices(table_name).cloned().collect()
     });
+    let target_table_ref = table_references
+        .joined_tables()
+        .first()
+        .expect("UPDATE must have a target table reference");
+    let target_table_internal_id = target_table_ref.internal_id;
+    let target_table_ref = target_table_ref.clone();
     let rowid_alias_used = set_clauses
         .iter()
         .any(|(idx, _)| *idx == ROWID_SENTINEL || columns[*idx].is_rowid_alias());
-    let indexes_to_update = if rowid_alias_used {
-        // If the rowid alias is used in the SET clause, we need to update all indexes
-        indexes
-    } else {
-        let updated_cols: HashSet<usize> = set_clauses.iter().map(|(i, _)| *i).collect();
-        let affected_cols = columns_affected_by_update(columns, &updated_cols);
-        let target_table_ref = table_references
-            .joined_tables()
-            .first()
-            .expect("UPDATE must have a target table reference");
-        let mut indexes_to_update = Vec::new();
+    let updated_cols = (!rowid_alias_used).then(|| set_clauses.iter().map(|(i, _)| *i).collect());
+    let affected_cols = updated_cols
+        .as_ref()
+        .map(|updated_cols: &HashSet<usize>| columns_affected_by_update(columns, updated_cols));
+    let mut indexes_to_update = Vec::new();
 
-        // else, we update indexes that match certain conditions
-        for idx in indexes {
-            let mut needs = false;
-            for col in idx.columns.iter() {
-                if let Some(expr) = col.expr.as_ref() {
-                    let cols_used =
-                        expression_index_column_usage(expr.as_ref(), target_table_ref, resolver)?;
+    for idx in indexes {
+        let mut must_update = rowid_alias_used;
+        let mut expression_cols_used = ColumnUsedMask::default();
 
-                    if cols_used.iter().any(|cidx| affected_cols.contains(&cidx)) {
-                        needs = true;
-                        break;
-                    }
-                } else if affected_cols.contains(&col.pos_in_table) {
-                    needs = true;
-                    break;
+        for col in idx.columns.iter() {
+            if let Some(expr) = col.expr.as_ref() {
+                let cols_used =
+                    expression_index_column_usage(expr.as_ref(), &target_table_ref, resolver)?;
+                // if it turns out that we need to update the index, we'll need to use all columns
+                // that are used by indexed expressions
+                expression_cols_used |= &cols_used;
+
+                if !must_update
+                    && affected_cols.as_ref().is_some_and(|affected_cols| {
+                        cols_used.iter().any(|cidx| affected_cols.contains(&cidx))
+                    })
+                {
+                    // an index must be updated if any of the affected columns is used in an indexed expression
+                    must_update = true;
                 }
-            }
-
-            if !needs {
-                if let Some(where_expr) = &idx.where_clause {
-                    let cols_used = expression_index_column_usage(
-                        where_expr.as_ref(),
-                        target_table_ref,
-                        resolver,
-                    )?;
-                    // If any column used in the partial index WHERE clause is affected,
-                    // this index must be updated as well.
-                    needs = cols_used.iter().any(|cidx| affected_cols.contains(&cidx));
-                }
-            }
-
-            if needs {
-                indexes_to_update.push(idx);
+            } else if !must_update
+                && affected_cols
+                    .as_ref()
+                    .is_some_and(|affected_cols| affected_cols.contains(&col.pos_in_table))
+            {
+                // an index must be updated if any of its columns is affected by the update
+                must_update = true;
             }
         }
-        indexes_to_update
-    };
+
+        if !must_update {
+            if let Some(where_expr) = &idx.where_clause {
+                let cols_used = expression_index_column_usage(
+                    where_expr.as_ref(),
+                    &target_table_ref,
+                    resolver,
+                )?;
+                // a partial index must be updated if any column of its WHERE clause is affected
+                must_update = affected_cols.as_ref().is_some_and(|affected_cols| {
+                    cols_used.iter().any(|cidx| affected_cols.contains(&cidx))
+                });
+            }
+        }
+
+        if must_update {
+            for col_idx in expression_cols_used.iter() {
+                table_references.mark_column_used(target_table_internal_id, col_idx);
+            }
+            indexes_to_update.push(idx);
+        }
+    }
 
     Ok(Plan::Update(UpdatePlan {
         table_references,

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -2446,6 +2446,85 @@ expect {
     ok
 }
 
+# UPDATE with indexed virtual column + TEXT PK
+@cross-check-integrity
+test update-text-pk-with-indexed-virtual-column {
+    CREATE TABLE t(id TEXT PRIMARY KEY, col_a TEXT);
+    ALTER TABLE t ADD COLUMN v TEXT GENERATED ALWAYS AS (CAST(col_a AS TEXT)) VIRTUAL;
+    CREATE INDEX t_v_idx ON t(v);
+    INSERT INTO t VALUES ('r1', 'hello');
+    UPDATE t SET col_a = 'world' WHERE id = 'r1';
+    SELECT count(*) FROM t WHERE v = 'world';
+    PRAGMA integrity_check;
+}
+expect {
+    1
+    ok
+}
+
+# DELETE with indexed virtual column + TEXT PK
+@cross-check-integrity
+@skip "Same col_used_mask bug exists in DELETE path - panics (see #6206)"
+test delete-text-pk-indexed-virtual-column {
+    CREATE TABLE t3(id TEXT PRIMARY KEY, col_a TEXT);
+    ALTER TABLE t3 ADD COLUMN v TEXT GENERATED ALWAYS AS (CAST(col_a AS TEXT)) VIRTUAL;
+    CREATE INDEX t3_v_idx ON t3(v);
+    INSERT INTO t3 VALUES ('r1', 'hello'), ('r2', 'world');
+    DELETE FROM t3 WHERE id = 'r1';
+    SELECT count(*) FROM t3 WHERE v = 'hello';
+    PRAGMA integrity_check;
+}
+expect {
+    0
+    ok
+}
+
+# UPDATE with expression index (not virtual column) + TEXT PK
+@cross-check-integrity
+test update-text-pk-expression-index {
+    CREATE TABLE t4(id TEXT PRIMARY KEY, col_a TEXT);
+    CREATE INDEX t4_expr_idx ON t4(LOWER(col_a));
+    INSERT INTO t4 VALUES ('r1', 'Hello');
+    UPDATE t4 SET col_a = 'World' WHERE id = 'r1';
+    SELECT count(*) FROM t4 WHERE LOWER(col_a) = 'world';
+    PRAGMA integrity_check;
+}
+expect {
+    1
+    ok
+}
+
+# UPDATE with virtual column depending on multiple base columns
+@cross-check-integrity
+test update-text-pk-virtual-multi-dep {
+    CREATE TABLE t5(id TEXT PRIMARY KEY, a TEXT, b TEXT);
+    ALTER TABLE t5 ADD COLUMN v TEXT GENERATED ALWAYS AS (a || '-' || b) VIRTUAL;
+    CREATE INDEX t5_v_idx ON t5(v);
+    INSERT INTO t5 VALUES ('r1', 'foo', 'bar');
+    UPDATE t5 SET a = 'baz' WHERE id = 'r1';
+    SELECT count(*) FROM t5 WHERE v = 'baz-bar';
+    PRAGMA integrity_check;
+}
+expect {
+    1
+    ok
+}
+
+# UPDATE with mixed indexes (expression-based + plain) + TEXT PK
+@cross-check-integrity
+test update-text-pk-mixed-indexes {
+    CREATE TABLE t6(id TEXT PRIMARY KEY, col_a TEXT, col_b TEXT);
+    ALTER TABLE t6 ADD COLUMN v TEXT GENERATED ALWAYS AS (UPPER(col_a)) VIRTUAL;
+    CREATE INDEX t6_v_idx ON t6(v);
+    CREATE INDEX t6_b_idx ON t6(col_b);
+    INSERT INTO t6 VALUES ('r1', 'hello', 'x');
+    UPDATE t6 SET col_a = 'world', col_b = 'y' WHERE id = 'r1';
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
 # =============================================================================
 # 12. Triggers
 # =============================================================================


### PR DESCRIPTION
## Description

When a table has a TEXT PRIMARY KEY and a virtual column with an index, UPDATE panicked because the autoindex was incorrectly considered "covering" -- the col_used_mask only included columns from WHERE/SET expressions, not columns referenced by virtual column expressions in indexes needing update. This caused the table cursor to not be opened, and subsequent reads of non-indexed columns hit an out-of-bounds panic.

The fix accumulates all columns referenced by expression-index columns and marks them in col_used_mask, so the covering-index check sees all columns the UPDATE actually needs to read.

Closes #6206

## Description of AI Usage

I used this sequence:

1. Claude planned
2. codex implemented
3. codex reviewed for performance and correctness and fixed
4. claude reviewed for performance, correctness and code coverage and fixed

then I added some comments