### PR TITLE
core: Switch to file ID for database registry mapping

### DIFF
--- a/bindings/javascript/src/browser.rs
+++ b/bindings/javascript/src/browser.rs
@@ -155,6 +155,10 @@ impl IO for Opfs {
     fn remove_file(&self, _: &str) -> turso_core::Result<()> {
         Ok(())
     }
+
+    fn file_id(&self, path: &str) -> turso_core::Result<turso_core::io::FileId> {
+        Ok(turso_core::io::FileId::from_path_hash(path))
+    }
 }
 
 impl File for OpfsFile {

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -77,6 +77,10 @@ impl IO for MemoryIO {
         files.remove(path);
         Ok(())
     }
+
+    fn file_id(&self, path: &str) -> Result<super::FileId> {
+        Ok(super::FileId::from_path_hash(path))
+    }
 }
 
 pub struct MemoryFile {

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -50,6 +50,63 @@ mod completions;
 pub use clock::Clock;
 pub use completions::*;
 
+/// Platform-independent file identity, analogous to SQLite's `struct unixFileId`.
+/// On Unix: (st_dev, st_ino). On Windows: (dwVolumeSerialNumber, nFileIndex).
+/// On non-filesystem backends: synthetic hash-based identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FileId {
+    pub dev: u64,
+    pub ino: u64,
+}
+
+impl FileId {
+    /// Synthetic identity from a path hash, for backends without real inodes
+    /// (MemoryIO, OPFS, simulators).
+    pub fn from_path_hash(path: &str) -> Self {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        path.hash(&mut hasher);
+        FileId {
+            dev: 0,
+            ino: hasher.finish(),
+        }
+    }
+}
+
+/// Return the OS-level file identity for a path.
+#[cfg(unix)]
+pub fn get_file_id(path: &str) -> Result<FileId, std::io::Error> {
+    use std::os::unix::fs::MetadataExt;
+    let m = std::fs::metadata(path)?;
+    Ok(FileId {
+        dev: m.dev(),
+        ino: m.ino(),
+    })
+}
+
+#[cfg(windows)]
+pub fn get_file_id(path: &str) -> Result<FileId, std::io::Error> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+    let file = std::fs::File::open(path)?;
+    let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+    let ret = unsafe { GetFileInformationByHandle(file.as_raw_handle() as _, &mut info) };
+    if ret == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(FileId {
+        dev: info.dwVolumeSerialNumber as u64,
+        ino: (info.nFileIndexHigh as u64) << 32 | info.nFileIndexLow as u64,
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn get_file_id(path: &str) -> Result<FileId, std::io::Error> {
+    Ok(FileId::from_path_hash(path))
+}
+
 /// Controls which sync mechanism to use for durability.
 /// `FullFsync` only has effect on Apple platforms (uses F_FULLFSYNC fcntl).
 /// On other platforms, both variants behave the same (regular fsync).
@@ -281,6 +338,17 @@ pub trait IO: Clock + Send + Sync {
     /// Used for progressive backoff in contended lock acquisition.
     fn sleep(&self, duration: std::time::Duration) {
         crate::thread::sleep(duration);
+    }
+
+    /// Return the file identity for the given path.
+    /// Default uses OS-level metadata; non-filesystem backends override
+    /// with synthetic hash-based identity.
+    fn file_id(&self, path: &str) -> Result<FileId> {
+        get_file_id(path).map_err(|e| {
+            crate::LimboError::InternalError(format!(
+                "failed to get file identity for '{path}': {e}"
+            ))
+        })
     }
 }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -311,10 +311,9 @@ pub struct OpenDbAsyncState {
     /// Schema lock held during LoadingSchema phase to ensure atomicity across IO yields
     schema_guard: Option<sync::ArcMutexGuard<Arc<Schema>>>,
     /// Registry lock held during open_with_flags_async to prevent concurrent opens
-    registry_guard:
-        Option<parking_lot::ArcMutexGuard<parking_lot::RawMutex, HashMap<String, Weak<Database>>>>,
-    /// Canonical path for registry insertion (computed once at start)
-    canonical_path: Option<String>,
+    registry_guard: Option<
+        parking_lot::ArcMutexGuard<parking_lot::RawMutex, HashMap<DatabaseKey, Weak<Database>>>,
+    >,
 }
 
 impl Default for OpenDbAsyncState {
@@ -334,7 +333,6 @@ impl OpenDbAsyncState {
             make_from_btree_state: schema::MakeFromBtreeState::new(),
             schema_guard: None,
             registry_guard: None,
-            canonical_path: None,
         }
     }
 }
@@ -349,8 +347,18 @@ impl OpenDbAsyncState {
 /// state between iterations, but static variables persist - using shuttle's
 /// Mutex here would cause panics when the second iteration tries to lock a
 /// mutex that belongs to a stale execution context.
+/// Registry key for the process-wide database manager.
+/// File-backed databases are keyed by their OS-level identity (dev, ino),
+/// matching SQLite's inodeList approach. Shared in-memory databases use
+/// their name as the key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum DatabaseKey {
+    File(io::FileId),
+    SharedMemory(String),
+}
+
 #[allow(clippy::type_complexity)]
-static DATABASE_MANAGER: LazyLock<Arc<parking_lot::Mutex<HashMap<String, Weak<Database>>>>> =
+static DATABASE_MANAGER: LazyLock<Arc<parking_lot::Mutex<HashMap<DatabaseKey, Weak<Database>>>>> =
     LazyLock::new(|| Arc::new(parking_lot::Mutex::new(HashMap::default())));
 
 /// The `Database` object contains per database file state that is shared
@@ -458,6 +466,8 @@ impl Database {
         db_file: Arc<dyn DatabaseStorage>,
         encryption_opts: Option<EncryptionOpts>,
     ) -> Result<Self> {
+        let path = path.into();
+        let wal_path = wal_path.into();
         let shared_wal = WalFileShared::new_noop();
         let mv_store = ArcSwapOption::empty();
 
@@ -485,11 +495,10 @@ impl Database {
             None
         };
 
-        // opts is now passed as parameter
         let db = Database {
             mv_store,
-            path: path.into(),
-            wal_path: wal_path.into(),
+            path,
+            wal_path,
             schema: Arc::new(Mutex::new(Arc::new({
                 let mut s = Schema::with_options(opts.enable_custom_types);
                 s.generated_columns_enabled = opts.enable_generated_columns;
@@ -530,11 +539,11 @@ impl Database {
     /// matching SQLite's `file:name?mode=memory&cache=shared` semantics.
     #[cfg(feature = "fs")]
     pub fn open_shared_memory(name: &str) -> Result<Arc<Database>> {
-        let registry_key = format!(":memory:shared:{name}");
+        let key = DatabaseKey::SharedMemory(name.to_string());
 
         {
             let registry = DATABASE_MANAGER.lock_arc();
-            if let Some(db) = registry.get(&registry_key).and_then(Weak::upgrade) {
+            if let Some(db) = registry.get(&key).and_then(Weak::upgrade) {
                 return Ok(db);
             }
         }
@@ -543,14 +552,14 @@ impl Database {
         let db = Self::open_file(io, ":memory:")?;
 
         let mut registry = DATABASE_MANAGER.lock_arc();
-        if let Some(existing) = registry.get(&registry_key).and_then(Weak::upgrade) {
+        if let Some(existing) = registry.get(&key).and_then(Weak::upgrade) {
             return Ok(existing);
         }
-        registry.insert(registry_key, Arc::downgrade(&db));
+        registry.insert(key, Arc::downgrade(&db));
         Ok(db)
     }
 
-    /// Look up a database in the process-wide registry by path.
+    /// Look up a database in the process-wide registry by file identity.
     /// Returns the cached Database if found, with encryption validation.
     /// This avoids opening a file (and acquiring a file lock) when the
     /// database is already open in this process.
@@ -561,15 +570,13 @@ impl Database {
         if path.starts_with(":memory:") {
             return Ok(None);
         }
-        let canonical = match std::fs::canonicalize(path)
-            .ok()
-            .and_then(|p| p.to_str().map(|s| s.to_string()))
-        {
-            Some(c) => c,
-            None => return Ok(None),
+        let file_id = match io::get_file_id(path) {
+            Ok(id) => id,
+            Err(_) => return Ok(None), // file doesn't exist yet
         };
+        let key = DatabaseKey::File(file_id);
         let registry = DATABASE_MANAGER.lock_arc();
-        let db = match registry.get(&canonical).and_then(Weak::upgrade) {
+        let db = match registry.get(&key).and_then(Weak::upgrade) {
             Some(db) => db,
             None => return Ok(None),
         };
@@ -731,37 +738,33 @@ impl Database {
             // lock the database manager for the whole duration of open_with_flags_async method
             let registry = DATABASE_MANAGER.lock_arc();
 
-            let canonical_path = std::fs::canonicalize(path)
-                .ok()
-                .and_then(|p| p.to_str().map(|s| s.to_string()))
-                .unwrap_or_else(|| path.to_string());
+            // Look up by file identity (dev, ino). If file doesn't exist
+            // yet (CREATE mode), skip lookup — no cached entry is possible.
+            if let Ok(file_id) = io.file_id(path) {
+                let key = DatabaseKey::File(file_id);
+                if let Some(db) = registry.get(&key).and_then(Weak::upgrade) {
+                    tracing::debug!("took database {path:?} from the registry");
 
-            // Check if already in registry
-            if let Some(db) = registry.get(&canonical_path).and_then(Weak::upgrade) {
-                tracing::info!("took database {canonical_path:?} from the registry");
+                    let db_is_encrypted =
+                        !matches!(db.encryption_cipher_mode.get(), CipherMode::None);
+                    if db_is_encrypted && encryption_opts.is_none() {
+                        return Err(LimboError::InvalidArgument(
+                            "Database is encrypted but no encryption options provided".to_string(),
+                        ));
+                    }
 
-                // Check encryption compatibility using cipher mode (key is not stored in Database for security)
-                let db_is_encrypted = !matches!(db.encryption_cipher_mode.get(), CipherMode::None);
-
-                if db_is_encrypted && encryption_opts.is_none() {
-                    return Err(LimboError::InvalidArgument(
-                        "Database is encrypted but no encryption options provided".to_string(),
-                    ));
+                    return Ok(IOResult::Done(db));
                 }
-
-                // Found in registry, no need to hold lock
-                return Ok(IOResult::Done(db));
             }
 
-            // Not in registry, hold the lock and store canonical path for later insertion
+            // Not in registry — hold the lock to prevent concurrent opens.
             state.registry_guard = Some(registry);
-            state.canonical_path = Some(canonical_path);
         }
 
-        // Open the database asynchronously (registry lock is held in state for not `:memory:.*` pathes)
+        // Open the database asynchronously (registry lock is held in state for not `:memory:.*` paths)
         let result = Self::open_with_flags_bypass_registry_async(
             state,
-            io,
+            io.clone(),
             path,
             None,
             db_file,
@@ -772,11 +775,11 @@ impl Database {
         )?;
 
         if let IOResult::Done(ref db) = result {
-            // will be unset in case of `:memory:.*` path
-            if let (Some(mut registry), Some(canonical_path)) =
-                (state.registry_guard.take(), state.canonical_path.take())
-            {
-                registry.insert(canonical_path, Arc::downgrade(db));
+            if let Some(mut registry) = state.registry_guard.take() {
+                // File now exists — compute identity and insert.
+                if let Ok(file_id) = io.file_id(path) {
+                    registry.insert(DatabaseKey::File(file_id), Arc::downgrade(db));
+                }
             }
         }
 

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1873,6 +1873,88 @@ mod tests {
         }
     }
 
+    /// Reproducer: stale DATABASE_MANAGER entry when old TursoDatabase/TursoConnection
+    /// haven't been GC'd (dropped) before reopening at the same path.
+    ///
+    /// Steps (mirrors the React Native bug report):
+    ///   1. Open database A via SDK, create table "cache", close connection
+    ///   2. Copy A.db → B.db, delete A.db
+    ///   3. Open a *new* database at path A.db — while old db_a/conn_a still alive
+    ///   4. CREATE TABLE cache should succeed (A.db is fresh) but fails with
+    ///      "table cache already exists" because the registry returned the stale Database
+    #[test]
+    pub fn test_stale_registry_with_live_sdk_handles() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let path_a = tmp_dir.path().join("A.db");
+        let path_b = tmp_dir.path().join("B.db");
+
+        // 1. Open database A via SDK and create a table.
+        let db_a = TursoDatabase::new(TursoDatabaseConfig {
+            path: path_a.to_str().unwrap().to_string(),
+            experimental_features: None,
+            async_io: false,
+            encryption: None,
+            vfs: None,
+            io: None,
+            db_file: None,
+        });
+        let _ = db_a.open().unwrap();
+        let conn_a = db_a.connect().unwrap();
+
+        let mut stmt = conn_a
+            .prepare_single("CREATE TABLE cache(x INTEGER)")
+            .unwrap();
+        assert_eq!(stmt.execute(None).unwrap().status, TursoStatusCode::Done);
+        drop(stmt);
+
+        // Close the connection but do NOT drop conn_a or db_a — simulates
+        // the JS GC not having collected them yet.
+        conn_a.close().unwrap();
+
+        // 2. Copy A.db → B.db, then delete A.db (and WAL/SHM files).
+        std::fs::copy(&path_a, &path_b).unwrap();
+        std::fs::remove_file(&path_a).unwrap();
+        for ext in &["-wal", "-shm"] {
+            let src = tmp_dir.path().join(format!("A.db{ext}"));
+            let dst = tmp_dir.path().join(format!("B.db{ext}"));
+            if src.exists() {
+                std::fs::copy(&src, &dst).unwrap();
+                std::fs::remove_file(&src).unwrap();
+            }
+        }
+
+        // 3. Open a new database at the same path A.db.
+        //    The old db_a and conn_a are still alive — this is the key difference
+        //    from test_sdk_close_finalizes_leaked_statements which drops everything.
+        let db_a2 = TursoDatabase::new(TursoDatabaseConfig {
+            path: path_a.to_str().unwrap().to_string(),
+            experimental_features: None,
+            async_io: false,
+            encryption: None,
+            vfs: None,
+            io: None,
+            db_file: None,
+        });
+        let _ = db_a2.open().unwrap();
+        let conn_a2 = db_a2.connect().unwrap();
+
+        // 4. A.db should be a fresh empty database — CREATE TABLE cache must succeed.
+        let mut stmt2 = conn_a2
+            .prepare_single("CREATE TABLE cache(x INTEGER)")
+            .expect("prepare should succeed on fresh database");
+        let result = stmt2.execute(None);
+        assert_eq!(
+            result.unwrap().status,
+            TursoStatusCode::Done,
+            "CREATE TABLE cache on a fresh A.db should succeed — \
+             stale DATABASE_MANAGER entry returned the old Database"
+        );
+
+        // Cleanup: drop old handles (simulates eventual GC).
+        drop(conn_a);
+        drop(db_a);
+    }
+
     /// Regression test: connection.close() must finalize all outstanding statements
     /// to break the Statement → Arc<Connection> → Arc<Database> chain that keeps the
     /// database alive in DATABASE_MANAGER after a file rename.

--- a/testing/concurrent-simulator/io.rs
+++ b/testing/concurrent-simulator/io.rs
@@ -144,6 +144,10 @@ impl IO for SimulatorIO {
         Ok(file as Arc<dyn File>)
     }
 
+    fn file_id(&self, path: &str) -> Result<turso_core::io::FileId> {
+        Ok(turso_core::io::FileId::from_path_hash(path))
+    }
+
     fn remove_file(&self, path: &str) -> Result<()> {
         let mut files = self.files.lock().unwrap();
         files.retain(|(p, _)| p != path);

--- a/testing/differential-oracle/fuzzer/memory/io.rs
+++ b/testing/differential-oracle/fuzzer/memory/io.rs
@@ -128,4 +128,8 @@ impl IO for MemorySimIO {
         self.files.borrow_mut().shift_remove(path);
         Ok(())
     }
+
+    fn file_id(&self, path: &str) -> Result<turso_core::io::FileId> {
+        Ok(turso_core::io::FileId::from_path_hash(path))
+    }
 }

--- a/testing/simulator/runner/io.rs
+++ b/testing/simulator/runner/io.rs
@@ -155,6 +155,10 @@ impl IO for SimulatorIO {
         Ok(())
     }
 
+    fn file_id(&self, path: &str) -> Result<turso_core::io::FileId> {
+        self.inner.file_id(path)
+    }
+
     fn step(&self) -> Result<()> {
         let now = self.current_time_wall_clock();
         for file in self.files.borrow().iter() {

--- a/testing/simulator/runner/memory/io.rs
+++ b/testing/simulator/runner/memory/io.rs
@@ -310,4 +310,8 @@ impl IO for MemorySimIO {
         self.files.borrow_mut().shift_remove(path);
         Ok(())
     }
+
+    fn file_id(&self, path: &str) -> Result<turso_core::io::FileId> {
+        Ok(turso_core::io::FileId::from_path_hash(path))
+    }
 }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -63,6 +63,9 @@ impl IO for TestIo {
     fn remove_file(&self, path: &str) -> turso_core::Result<()> {
         self.io.remove_file(path)
     }
+    fn file_id(&self, path: &str) -> turso_core::Result<turso_core::io::FileId> {
+        self.io.file_id(path)
+    }
     fn cancel(&self, c: &[turso_core::Completion]) -> turso_core::Result<()> {
         self.io.cancel(c)
     }


### PR DESCRIPTION
The previous approach (34db5d989) tried to detect stale DATABASE_MANAGER entries by storing the inode at open time and comparing it on lookup. This required a zero sentinel for unknown inodes, platform cfg gates everywhere, and silently assumed a match when identity couldn't be determined — all of which papered over the real problem: path strings are the wrong key for a file registry.

Like SQLite's inodeList, the process-wide database registry is now keyed by (device, inode) instead of canonical path strings. This makes stale entry detection impossible by construction: a deleted-and-recreated file has a different inode, so it naturally gets a fresh registry entry.
