### PR TITLE
core: resolve compound SELECT ORDER BY against all constituent SELECTs

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -206,20 +206,18 @@ pub fn prepare_select_plan(
 
             // Parse ORDER BY for compound selects.
             // ORDER BY can reference columns by number (1-based) or by name/alias
-            // from the leftmost SELECT's result columns.
-            let leftmost_plan = &left[0].0;
-            let leftmost_result_columns = &leftmost_plan.result_columns;
-            let leftmost_table_refs = &leftmost_plan.table_references;
+            // from any constituent SELECT's result columns.
+            let all_plans: Vec<&SelectPlan> = left
+                .iter()
+                .map(|(plan, _)| plan)
+                .chain(std::iter::once(&last))
+                .collect();
             let order_by = if select.order_by.is_empty() {
                 None
             } else {
                 let mut key = Vec::with_capacity(select.order_by.len());
-                for o in &select.order_by {
-                    let col_idx = resolve_compound_order_by_expr(
-                        &o.expr,
-                        leftmost_result_columns,
-                        leftmost_table_refs,
-                    )?;
+                for (i, o) in select.order_by.iter().enumerate() {
+                    let col_idx = resolve_compound_order_by_expr(&o.expr, &all_plans, i + 1)?;
                     key.push((col_idx, o.order.unwrap_or(ast::SortOrder::Asc), o.nulls));
                 }
                 Some(key)
@@ -1107,60 +1105,79 @@ fn replace_column_number_with_copy_of_column_expr(
 /// Resolves a compound SELECT ORDER BY expression to a 0-based column index.
 /// ORDER BY in compound selects can reference columns by:
 /// 1. Numeric position (1-based): ORDER BY 1
-/// 2. Column name or alias from the leftmost SELECT: ORDER BY name
+/// 2. Column name or alias from any constituent SELECT: ORDER BY name
 fn resolve_compound_order_by_expr(
     expr: &ast::Expr,
-    result_columns: &[ResultSetColumn],
-    table_references: &TableReferences,
+    all_plans: &[&SelectPlan],
+    term_number: usize,
 ) -> Result<usize> {
+    let num_result_columns = all_plans[0].result_columns.len();
     match expr {
         // Case 1: Numeric column reference (e.g., ORDER BY 1)
         ast::Expr::Literal(ast::Literal::Numeric(num)) => {
             if let Ok(column_number) = num.parse::<usize>() {
-                if column_number == 0 || column_number > result_columns.len() {
+                if column_number == 0 || column_number > num_result_columns {
                     crate::bail_parse_error!(
                         "{} ORDER BY term out of range - should be between 1 and {}",
                         column_number,
-                        result_columns.len()
+                        num_result_columns
                     );
                 }
                 Ok(column_number - 1)
             } else {
                 crate::bail_parse_error!(
-                    "ORDER BY expression in compound SELECT must be a column number or name"
+                    "{} ORDER BY term does not match any column in the result set",
+                    ordinal(term_number)
                 );
             }
         }
         // Case 2: Name reference (e.g., ORDER BY name or ORDER BY alias)
         ast::Expr::Id(name) => {
             let name_normalized = normalize_ident(name.as_str());
-            // First try matching against aliases
-            for (i, rc) in result_columns.iter().enumerate() {
-                if let Some(alias) = &rc.alias {
-                    if normalize_ident(alias) == name_normalized {
-                        return Ok(i);
+            // Check aliases and column names across all constituent SELECTs
+            for plan in all_plans {
+                let result_columns = &plan.result_columns;
+                let table_references = &plan.table_references;
+                // Try matching against aliases
+                for (i, rc) in result_columns.iter().enumerate() {
+                    if let Some(alias) = &rc.alias {
+                        if normalize_ident(alias) == name_normalized {
+                            return Ok(i);
+                        }
                     }
                 }
-            }
-            // Then try matching against column names from the table references
-            for (i, rc) in result_columns.iter().enumerate() {
-                if let Some(col_name) = rc.name(table_references) {
-                    if normalize_ident(col_name) == name_normalized {
-                        return Ok(i);
+                // Try matching against column names from the table references
+                for (i, rc) in result_columns.iter().enumerate() {
+                    if let Some(col_name) = rc.name(table_references) {
+                        if normalize_ident(col_name) == name_normalized {
+                            return Ok(i);
+                        }
                     }
                 }
             }
             crate::bail_parse_error!(
-                "ORDER BY term \"{}\" does not match any result column",
-                name.as_str()
+                "{} ORDER BY term does not match any column in the result set",
+                ordinal(term_number)
             );
         }
         _ => {
             crate::bail_parse_error!(
-                "ORDER BY expression in compound SELECT must be a column number or name"
+                "{} ORDER BY term does not match any column in the result set",
+                ordinal(term_number)
             );
         }
     }
+}
+
+fn ordinal(n: usize) -> String {
+    let suffix = match (n % 10, n % 100) {
+        (1, 11) | (2, 12) | (3, 13) => "th",
+        (1, _) => "st",
+        (2, _) => "nd",
+        (3, _) => "rd",
+        _ => "th",
+    };
+    format!("{n}{suffix}")
 }
 
 /// Count required cursors for a Plan (either Select or CompoundSelect)

--- a/testing/sqltests/tests/compound-select-orderby.sqltest
+++ b/testing/sqltests/tests/compound-select-orderby.sqltest
@@ -851,3 +851,49 @@ expect {
     3|cherry
     5|elderberry
 }
+
+# ===== ORDER BY referencing column name from non-leftmost SELECT =====
+
+@setup schema
+test union-order-by-non-leftmost-col-name {
+    SELECT a FROM t1 UNION SELECT b FROM t2 ORDER BY b;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+    banana
+    date
+    fig
+    grape
+    honeydew
+}
+
+@setup schema
+test union-all-order-by-non-leftmost-col-name {
+    SELECT a FROM t1 UNION ALL SELECT a FROM t2 ORDER BY a;
+}
+expect {
+    1
+    2
+    2
+    3
+    4
+    4
+    5
+    6
+    7
+    8
+}
+
+# ===== Error: ORDER BY expression not matching any column =====
+
+@setup schema
+test union-order-by-expr-no-match {
+    SELECT a FROM t1 UNION SELECT c FROM t1 ORDER BY a+1;
+}
+expect error {
+    1st ORDER BY term does not match any column in the result set
+}


### PR DESCRIPTION
ORDER BY in compound SELECTs (UNION/INTERSECT/EXCEPT) was only resolved against the leftmost SELECT's result columns, causing queries like `SELECT f1 FROM t1 UNION SELECT f2 FROM t1 ORDER BY f2` to fail. SQLite resolves ORDER BY names against any constituent SELECT.

Fixes TCL test select1-6.10 in testing/sqlite3/select1.test.