### PR TITLE
Add npm packaging for Turso CLI (`npx turso`)

### DIFF
--- a/.github/workflows/publish-cli-npm.yml
+++ b/.github/workflows/publish-cli-npm.yml
@@ -1,0 +1,92 @@
+name: Publish Turso CLI to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish CLI npm packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm
+        run: npm install -g npm@11
+
+      - name: Download and extract release binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          TMPDIR=$(mktemp -d)
+
+          # Download all platform archives
+          gh release download "$TAG" \
+            --pattern "tursodb-aarch64-apple-darwin.tar.xz" \
+            --pattern "tursodb-x86_64-apple-darwin.tar.xz" \
+            --pattern "tursodb-aarch64-unknown-linux-gnu.tar.xz" \
+            --pattern "tursodb-x86_64-unknown-linux-gnu.tar.xz" \
+            --pattern "tursodb-x86_64-pc-windows-msvc.zip" \
+            --dir "$TMPDIR"
+
+          # Extract each binary into the corresponding npm package directory
+          tar -xf "$TMPDIR/tursodb-aarch64-apple-darwin.tar.xz" -C "$TMPDIR"
+          cp "$TMPDIR/tursodb-aarch64-apple-darwin/tursodb" packages/turso-cli/npm/darwin-arm64/tursodb
+
+          tar -xf "$TMPDIR/tursodb-x86_64-apple-darwin.tar.xz" -C "$TMPDIR"
+          cp "$TMPDIR/tursodb-x86_64-apple-darwin/tursodb" packages/turso-cli/npm/darwin-x64/tursodb
+
+          tar -xf "$TMPDIR/tursodb-aarch64-unknown-linux-gnu.tar.xz" -C "$TMPDIR"
+          cp "$TMPDIR/tursodb-aarch64-unknown-linux-gnu/tursodb" packages/turso-cli/npm/linux-arm64-gnu/tursodb
+
+          tar -xf "$TMPDIR/tursodb-x86_64-unknown-linux-gnu.tar.xz" -C "$TMPDIR"
+          cp "$TMPDIR/tursodb-x86_64-unknown-linux-gnu/tursodb" packages/turso-cli/npm/linux-x64-gnu/tursodb
+
+          unzip -o "$TMPDIR/tursodb-x86_64-pc-windows-msvc.zip" -d "$TMPDIR/tursodb-x86_64-pc-windows-msvc"
+          cp "$TMPDIR/tursodb-x86_64-pc-windows-msvc/tursodb.exe" packages/turso-cli/npm/win32-x64-msvc/tursodb.exe
+
+          # Set executable permissions
+          chmod +x packages/turso-cli/npm/darwin-arm64/tursodb
+          chmod +x packages/turso-cli/npm/darwin-x64/tursodb
+          chmod +x packages/turso-cli/npm/linux-arm64-gnu/tursodb
+          chmod +x packages/turso-cli/npm/linux-x64-gnu/tursodb
+
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          if echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=next" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          for dir in \
+            packages/turso-cli/npm/darwin-arm64 \
+            packages/turso-cli/npm/darwin-x64 \
+            packages/turso-cli/npm/linux-arm64-gnu \
+            packages/turso-cli/npm/linux-x64-gnu \
+            packages/turso-cli/npm/win32-x64-msvc; do
+            npm publish "$dir" --access public --provenance --tag ${{ steps.npm-tag.outputs.tag }}
+          done
+
+      - name: Publish main turso package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm publish packages/turso-cli --access public --provenance --tag ${{ steps.npm-tag.outputs.tag }}

--- a/packages/turso-cli/.gitignore
+++ b/packages/turso-cli/.gitignore
@@ -1,0 +1,2 @@
+npm/*/tursodb
+npm/*/tursodb.exe

--- a/packages/turso-cli/npm/darwin-arm64/package.json
+++ b/packages/turso-cli/npm/darwin-arm64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@tursodatabase/cli-darwin-arm64",
+  "version": "0.6.0-pre.11",
+  "description": "Turso CLI binary for macOS ARM64",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "files": ["tursodb"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/turso"
+  }
+}

--- a/packages/turso-cli/npm/darwin-x64/package.json
+++ b/packages/turso-cli/npm/darwin-x64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@tursodatabase/cli-darwin-x64",
+  "version": "0.6.0-pre.11",
+  "description": "Turso CLI binary for macOS x64",
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "files": ["tursodb"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/turso"
+  }
+}

--- a/packages/turso-cli/npm/linux-arm64-gnu/package.json
+++ b/packages/turso-cli/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@tursodatabase/cli-linux-arm64-gnu",
+  "version": "0.6.0-pre.11",
+  "description": "Turso CLI binary for Linux ARM64 (glibc)",
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "libc": ["glibc"],
+  "files": ["tursodb"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/turso"
+  }
+}

--- a/packages/turso-cli/npm/linux-x64-gnu/package.json
+++ b/packages/turso-cli/npm/linux-x64-gnu/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@tursodatabase/cli-linux-x64-gnu",
+  "version": "0.6.0-pre.11",
+  "description": "Turso CLI binary for Linux x64 (glibc)",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "libc": ["glibc"],
+  "files": ["tursodb"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/turso"
+  }
+}

--- a/packages/turso-cli/npm/win32-x64-msvc/package.json
+++ b/packages/turso-cli/npm/win32-x64-msvc/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@tursodatabase/cli-win32-x64-msvc",
+  "version": "0.6.0-pre.11",
+  "description": "Turso CLI binary for Windows x64",
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "files": ["tursodb.exe"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/turso"
+  }
+}

--- a/packages/turso-cli/package.json
+++ b/packages/turso-cli/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "turso",
+  "version": "0.6.0-pre.11",
+  "description": "Turso CLI - SQLite for production",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/turso"
+  },
+  "bin": {
+    "turso": "src/index.js"
+  },
+  "files": ["src/index.js"],
+  "optionalDependencies": {
+    "@tursodatabase/cli-darwin-arm64": "0.6.0-pre.11",
+    "@tursodatabase/cli-darwin-x64": "0.6.0-pre.11",
+    "@tursodatabase/cli-linux-arm64-gnu": "0.6.0-pre.11",
+    "@tursodatabase/cli-linux-x64-gnu": "0.6.0-pre.11",
+    "@tursodatabase/cli-win32-x64-msvc": "0.6.0-pre.11"
+  }
+}

--- a/packages/turso-cli/src/index.js
+++ b/packages/turso-cli/src/index.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+const PLATFORMS = {
+  "darwin-arm64": "@tursodatabase/cli-darwin-arm64",
+  "darwin-x64": "@tursodatabase/cli-darwin-x64",
+  "linux-arm64": "@tursodatabase/cli-linux-arm64-gnu",
+  "linux-x64": "@tursodatabase/cli-linux-x64-gnu",
+  "win32-x64": "@tursodatabase/cli-win32-x64-msvc",
+};
+
+function getBinaryPath() {
+  const key = `${process.platform}-${process.arch}`;
+  const pkg = PLATFORMS[key];
+
+  if (!pkg) {
+    console.error(
+      `Unsupported platform: ${process.platform}-${process.arch}\n` +
+        `Turso CLI supports: macOS (arm64, x64), Linux (arm64, x64), Windows (x64)`
+    );
+    process.exit(1);
+  }
+
+  const binary = process.platform === "win32" ? "tursodb.exe" : "tursodb";
+
+  try {
+    return path.join(path.dirname(require.resolve(`${pkg}/package.json`)), binary);
+  } catch {
+    console.error(
+      `Could not find the Turso CLI binary for your platform (${key}).\n` +
+        `The package ${pkg} may not have been installed correctly.\n` +
+        `Try reinstalling with: npm install -g turso`
+    );
+    process.exit(1);
+  }
+}
+
+const result = spawnSync(getBinaryPath(), process.argv.slice(2), {
+  stdio: "inherit",
+});
+
+if (result.error) {
+  if (result.error.code === "ENOENT") {
+    console.error("Could not find the Turso CLI binary. Try reinstalling with: npm install -g turso");
+  } else {
+    console.error(`Failed to run Turso CLI: ${result.error.message}`);
+  }
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -27,12 +27,23 @@ NPM_PACKAGES = [
     "bindings/javascript/sync/packages/native",
     "bindings/javascript/sync/packages/wasm",
     "bindings/react-native",
+    "packages/turso-cli",
+    "packages/turso-cli/npm/darwin-arm64",
+    "packages/turso-cli/npm/darwin-x64",
+    "packages/turso-cli/npm/linux-arm64-gnu",
+    "packages/turso-cli/npm/linux-x64-gnu",
+    "packages/turso-cli/npm/win32-x64-msvc",
 ]
 
 NPM_WORKSPACE_PACKAGES = [
     "@tursodatabase/database-common",
     "@tursodatabase/database-wasm-common",
     "@tursodatabase/sync-common",
+    "@tursodatabase/cli-darwin-arm64",
+    "@tursodatabase/cli-darwin-x64",
+    "@tursodatabase/cli-linux-arm64-gnu",
+    "@tursodatabase/cli-linux-x64-gnu",
+    "@tursodatabase/cli-win32-x64-msvc",
 ]
 
 NPM_WORKSPACES = [
@@ -112,6 +123,11 @@ def update_package_json(dir_path, new_version):  # noqa: C901
                 if dependency not in NPM_WORKSPACE_PACKAGES:
                     continue
                 package_data["dependencies"][dependency] = f"^{new_version}"
+        if "optionalDependencies" in package_data:
+            for dependency in package_data["optionalDependencies"].keys():
+                if dependency not in NPM_WORKSPACE_PACKAGES:
+                    continue
+                package_data["optionalDependencies"][dependency] = new_version
 
         # Write updated package.json
         with open(package_path, "w") as f:


### PR DESCRIPTION
Platform-specific optional dependency pattern (like esbuild/Biome) with packages for darwin-arm64, darwin-x64, linux-arm64-gnu, linux-x64-gnu, and win32-x64-msvc. CI workflow publishes on GitHub Release events.