### PR TITLE
core: Add unistr_quote(X) scalar function

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -471,6 +471,7 @@ pub enum ScalarFunc {
     Typeof,
     Unicode,
     Unistr,
+    UnistrQuote,
     Quote,
     SqliteVersion,
     TursoVersion,
@@ -581,6 +582,7 @@ impl Deterministic for ScalarFunc {
             ScalarFunc::Typeof => true,
             ScalarFunc::Unicode => true,
             ScalarFunc::Unistr => true,
+            ScalarFunc::UnistrQuote => true,
             ScalarFunc::Quote => true,
             ScalarFunc::SqliteVersion => false,
             ScalarFunc::TursoVersion => false,
@@ -710,6 +712,7 @@ impl Display for ScalarFunc {
             Self::Typeof => "typeof",
             Self::Unicode => "unicode",
             Self::Unistr => "unistr",
+            Self::UnistrQuote => "unistr_quote",
             Self::Quote => "quote",
             Self::SqliteVersion => "sqlite_version",
             Self::TursoVersion => "turso_version",
@@ -821,6 +824,7 @@ impl ScalarFunc {
             | Self::Lower
             | Self::OctetLength
             | Self::Quote
+            | Self::UnistrQuote
             | Self::RandomBlob
             | Self::Sign
             | Self::Soundex
@@ -1289,6 +1293,7 @@ impl Func {
             "last_insert_rowid" => Ok(Some(Self::Scalar(ScalarFunc::LastInsertRowid))),
             "unicode" => Ok(Some(Self::Scalar(ScalarFunc::Unicode))),
             "unistr" => Ok(Some(Self::Scalar(ScalarFunc::Unistr))),
+            "unistr_quote" => Ok(Some(Self::Scalar(ScalarFunc::UnistrQuote))),
             "quote" => Ok(Some(Self::Scalar(ScalarFunc::Quote))),
             "sqlite_version" => Ok(Some(Self::Scalar(ScalarFunc::SqliteVersion))),
             "turso_version" => Ok(Some(Self::Scalar(ScalarFunc::TursoVersion))),

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -2123,6 +2123,7 @@ pub fn translate_expr(
                         | ScalarFunc::Typeof
                         | ScalarFunc::Unicode
                         | ScalarFunc::Unistr
+                        | ScalarFunc::UnistrQuote
                         | ScalarFunc::Quote
                         | ScalarFunc::RandomBlob
                         | ScalarFunc::Sign

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6488,6 +6488,7 @@ pub fn op_function(
             | ScalarFunc::Typeof
             | ScalarFunc::Unicode
             | ScalarFunc::Unistr
+            | ScalarFunc::UnistrQuote
             | ScalarFunc::Quote
             | ScalarFunc::RandomBlob
             | ScalarFunc::Sign
@@ -6505,6 +6506,7 @@ pub fn op_function(
                     ScalarFunc::Unicode => Some(reg_value.exec_unicode()),
                     ScalarFunc::Unistr => Some(reg_value.exec_unistr()?),
                     ScalarFunc::Quote => Some(reg_value.exec_quote()),
+                    ScalarFunc::UnistrQuote => Some(reg_value.exec_unistr_quote()),
                     ScalarFunc::RandomBlob => {
                         Some(reg_value.exec_randomblob(|dest| pager.io.fill_bytes(dest))?)
                     }

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -383,6 +383,65 @@ impl Value {
         }
     }
 
+    pub fn exec_unistr_quote(&self) -> Self {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+
+        match self {
+            Value::Text(s) => {
+                let s = s.as_str();
+                let mut end = s.len();
+                let mut has_ctrl = false;
+
+                for (i, &b) in s.as_bytes().iter().enumerate() {
+                    match b {
+                        0 => {
+                            end = i;
+                            break;
+                        }
+                        1..=0x1f => has_ctrl = true,
+                        _ => {}
+                    }
+                }
+
+                if !has_ctrl {
+                    return self.exec_quote();
+                }
+
+                let prefix = &s[..end];
+                let mut extra = 0;
+                for &b in prefix.as_bytes() {
+                    extra += match b {
+                        1..=0x1f => 5, // \u00xx is 6 output bytes, replacing 1 input byte.
+                        b'\\' | b'\'' => 1,
+                        _ => 0,
+                    };
+                }
+
+                let mut out = String::with_capacity(prefix.len() + extra + "unistr('')".len());
+                out.push_str("unistr('");
+                for c in prefix.chars() {
+                    match c {
+                        '\x01'..='\x1f' => {
+                            let b = c as u8;
+                            out.push('\\');
+                            out.push('u');
+                            out.push('0');
+                            out.push('0');
+                            out.push(HEX[(b >> 4) as usize] as char);
+                            out.push(HEX[(b & 0x0f) as usize] as char);
+                        }
+                        '\\' => out.push_str("\\\\"),
+                        '\'' => out.push_str("''"),
+                        _ => out.push(c),
+                    }
+                }
+                out.push_str("')");
+                Value::build_text(out)
+            }
+            _ => self.exec_quote(),
+        }
+    }
+
     pub fn exec_nullif(&self, second_value: &Self) -> Self {
         if self != second_value {
             self.clone()
@@ -2052,6 +2111,97 @@ mod tests {
         assert!(Value::build_text(r"\u00GG").exec_unistr().is_err());
         assert!(Value::build_text(r"\+01FG00").exec_unistr().is_err());
         assert!(Value::build_text(r"\U0001F6GG").exec_unistr().is_err());
+    }
+
+    #[test]
+    fn test_unistr_quote() {
+        assert_eq!(Value::Null.exec_unistr_quote(), Value::build_text("NULL"));
+        assert_eq!(
+            Value::from_i64(42).exec_unistr_quote(),
+            Value::build_text("42")
+        );
+        assert_eq!(
+            Value::from_f64(1.5).exec_unistr_quote(),
+            Value::build_text("1.5")
+        );
+        assert_eq!(
+            Value::Blob(vec![0xDE, 0xAD]).exec_unistr_quote(),
+            Value::build_text("X'DEAD'")
+        );
+        assert_eq!(
+            Value::build_text("hello").exec_unistr_quote(),
+            Value::build_text("'hello'")
+        );
+        // Backslash is NOT doubled when no control chars are present
+        assert_eq!(
+            Value::build_text("a\\b").exec_unistr_quote(),
+            Value::build_text("'a\\b'")
+        );
+        assert_eq!(
+            Value::build_text("it's").exec_unistr_quote(),
+            Value::build_text("'it''s'")
+        );
+        assert_eq!(
+            Value::build_text("a\tb").exec_unistr_quote(),
+            Value::build_text("unistr('a\\u0009b')")
+        );
+        assert_eq!(
+            Value::build_text("a\t\\b").exec_unistr_quote(),
+            Value::build_text("unistr('a\\u0009\\\\b')")
+        );
+        assert_eq!(
+            Value::build_text("a\tb'c").exec_unistr_quote(),
+            Value::build_text("unistr('a\\u0009b''c')")
+        );
+        assert_eq!(
+            Value::build_text("\x01abc'\\\t\n\r\x1fXYZ\0\x01tail").exec_unistr_quote(),
+            Value::build_text(r"unistr('\u0001abc''\\\u0009\u000a\u000d\u001fXYZ')")
+        );
+        assert_eq!(
+            Value::build_text("a\x01b\0c").exec_unistr_quote(),
+            Value::build_text("unistr('a\\u0001b')")
+        );
+        assert_eq!(
+            Value::build_text("\x01").exec_unistr_quote(),
+            Value::build_text("unistr('\\u0001')")
+        );
+        assert_eq!(
+            Value::build_text("\x01\x1f").exec_unistr_quote(),
+            Value::build_text("unistr('\\u0001\\u001f')")
+        );
+        assert_eq!(
+            Value::build_text("\x10").exec_unistr_quote(),
+            Value::build_text("unistr('\\u0010')")
+        );
+        assert_eq!(
+            Value::build_text("\x1f").exec_unistr_quote(),
+            Value::build_text("unistr('\\u001f')")
+        );
+        // 0x20 is the first char outside the control range
+        assert_eq!(
+            Value::build_text(" ").exec_unistr_quote(),
+            Value::build_text("' '")
+        );
+        assert_eq!(
+            Value::build_text("\0abc").exec_unistr_quote(),
+            Value::build_text("''")
+        );
+        assert_eq!(
+            Value::build_text("").exec_unistr_quote(),
+            Value::build_text("''")
+        );
+        assert_eq!(
+            Value::build_text("a\nb").exec_unistr_quote(),
+            Value::build_text("unistr('a\\u000ab')")
+        );
+        assert_eq!(
+            Value::build_text("a\rb").exec_unistr_quote(),
+            Value::build_text("unistr('a\\u000db')")
+        );
+        assert_eq!(
+            Value::build_text("a\0\t").exec_unistr_quote(),
+            Value::build_text("'a'")
+        );
     }
 
     #[test]

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -2283,3 +2283,99 @@ test unistr-error-non-hex-capital-U {
 expect error {
     invalid Unicode escape
 }
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-plain-text {
+    SELECT unistr_quote('hello');
+}
+expect {
+    'hello'
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-null {
+    SELECT unistr_quote(NULL);
+}
+expect {
+    NULL
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-integer {
+    SELECT unistr_quote(42);
+}
+expect {
+    42
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-float {
+    SELECT unistr_quote(3.14);
+}
+expect {
+    3.14
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-with-tab {
+    SELECT unistr_quote(char(97, 9, 98));
+}
+expect {
+    unistr('a\u0009b')
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-with-newline {
+    SELECT unistr_quote(char(97, 10, 98));
+}
+expect {
+    unistr('a\u000ab')
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-backslash-no-ctrl {
+    SELECT unistr_quote('a\b');
+}
+expect {
+    'a\b'
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-backslash-with-ctrl {
+    SELECT unistr_quote(char(97, 9, 92, 98));
+}
+expect {
+    unistr('a\u0009\\\\b')
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-single-quote-with-ctrl {
+    SELECT unistr_quote(char(97, 1) || '''');
+}
+expect {
+    unistr('a\u0001''')
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-blob {
+    SELECT unistr_quote(X'DEADBEEF');
+}
+expect {
+    X'DEADBEEF'
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-matches-quote-no-ctrl {
+    SELECT unistr_quote('hello world') = quote('hello world');
+}
+expect {
+    1
+}
+
+@skip-if sqlite "unistr_quote not available in CI SQLite build"
+test unistr-quote-ignores-control-after-nul {
+    SELECT unistr_quote(char(97, 0, 9));
+}
+expect {
+    'a'
+}


### PR DESCRIPTION
## Description

Add the `unistr_quote(X)` scalar function, matching SQLite's implementation in [`quoteFunc`](https://github.com/sqlite/sqlite/blob/53197b79403497886c40ec658d50385d8ccc01c2/src/func.c#L1265-L1278) (added in 3.50).

**Tests:** 12 sqltests + 22 Rust unit test assertions.
- The sqltests have `@skip-if sqlite` since `scripts/install-sqlite3.sh` defaults to 3.49.1 (pre-`unistr_quote`). Bumping it to match the CI version (3.51.1) would let the annotations be removed.

`unistr_quote(X)` is currently missing in `COMPAT.md`.

## Motivation and context

This is the companion function to `unistr(X)` from #6132. The `unistr_quote(X)` function returns the text of an SQL literal or constant expression that encodes the value of its argument X and is suitable for inclusion into an SQL statement. In most cases, the output of `unistr_quote(X)` is identical to `quote(X)`. However, if X is text that contains control characters in the range U+0001 through U+001f, then those characters and any "\" characters in X are escaped using JSON-style backslash escapes and the entire output is enclosed within "unistr(..)". This makes the resulting text safe for display on devices that interpret ANSI escape codes.

## Description of AI Usage

Developed collaboratively with Opus 4.6. Used for cross-referencing SQLite source and benchmarking different variants before settling on the final `unistr_quote()` implementation. Codex with GPT 5.4 xhigh was used for a final code review before submitting the PR.
