### PR TITLE
Add STRICT/NOT NULL checks for generated columns

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2202,6 +2202,29 @@ impl BTreeTable {
         Arc::new(modified)
     }
 
+    /// Create a table reference containing ONLY virtual generated columns for
+    /// TypeCheck. Returns `None` if no virtual columns exist. Used to type-check
+    /// virtual columns in STRICT tables after they have been computed.
+    pub fn virtual_type_check_table_ref(
+        table: &Arc<BTreeTable>,
+        schema: &Schema,
+    ) -> Option<Arc<BTreeTable>> {
+        if !table.has_virtual_columns() {
+            return None;
+        }
+        let mut modified = (**table).clone();
+        modified.columns.retain(|c| c.is_virtual_generated());
+        modified.has_virtual_columns = false;
+        for col in &mut modified.columns {
+            if col.is_array() {
+                col.ty_str = "BLOB".to_string();
+            } else if let Some(type_def) = schema.get_type_def(&col.ty_str, table.is_strict) {
+                col.ty_str = type_def.base.to_uppercase();
+            }
+        }
+        Some(Arc::new(modified))
+    }
+
     /// Create a table ref for pre-encode TypeCheck that validates user input
     /// against the type's declared `value` input type (or base if not declared).
     /// For UPDATE, `only_columns` limits which columns are checked — non-SET

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -411,7 +411,7 @@ fn emit_add_virtual_column_validation(
 
     let dml_ctx =
         DmlColumnContext::layout(&resolved_table.columns, base_dest_reg, rowid_reg, layout);
-    compute_virtual_columns(program, &resolved_table.columns, &dml_ctx, resolver)?;
+    compute_virtual_columns(program, &resolved_table.columns, &dml_ctx, resolver, None)?;
     let result_reg = dml_ctx.to_column_reg(new_column_idx);
 
     if !check_constraints.is_empty() {

--- a/core/translate/emitter/gencol.rs
+++ b/core/translate/emitter/gencol.rs
@@ -1,3 +1,5 @@
+use rustc_hash::FxHashSet as HashSet;
+
 use crate::schema::{ColumnLayout, GeneratedType};
 use crate::translate::expr::translate_expr;
 use crate::vdbe::affinity::Affinity;
@@ -7,18 +9,30 @@ use turso_parser::ast;
 
 use super::{ProgramBuilder, Resolver};
 
-/// Emit bytecode to compute all virtual generated columns for a row.
+/// Emit bytecode to compute virtual generated columns for a row.
+///
+/// When `affected_columns` is `Some`, only virtual columns whose schema index
+/// is in the set are recomputed (UPDATE/UPSERT optimization — unchanged
+/// columns already hold the correct value from the cursor read).
+/// When `None`, all virtual columns are recomputed (INSERT path, trigger
+/// contexts, current-row snapshots).
 pub fn compute_virtual_columns(
     program: &mut ProgramBuilder,
     columns: &[crate::schema::Column],
     dml_ctx: &DmlColumnContext,
     resolver: &Resolver,
+    affected_columns: Option<&HashSet<usize>>,
 ) -> Result<()> {
     let ctx = SelfTableContext::ForDML(dml_ctx.clone());
     for (idx, column) in columns.iter().enumerate() {
         let GeneratedType::Virtual { resolved: expr, .. } = column.generated_type() else {
             continue;
         };
+        if let Some(affected) = affected_columns {
+            if !affected.contains(&idx) {
+                continue;
+            }
+        }
         let target_reg = dml_ctx.to_column_reg(idx);
         program.with_self_table_context(Some(&ctx), |program, _| {
             translate_expr(program, None, expr, target_reg, resolver)

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1045,7 +1045,6 @@ fn emit_update_insns<'a>(
 
     // Fire BEFORE UPDATE triggers and preserve old_registers for AFTER triggers
     let mut has_before_triggers = false;
-    let mut has_after_triggers = false;
     let preserved_old_registers: Option<Vec<usize>> = if let Some(btree_table) =
         target_table.table.btree()
     {
@@ -1062,7 +1061,7 @@ fn emit_update_insns<'a>(
                 )
                 .collect()
             });
-        has_after_triggers = t_ctx.resolver.with_schema(update_database_id, |s| {
+        let has_after_triggers = t_ctx.resolver.with_schema(update_database_id, |s| {
             get_relevant_triggers_type_and_time(
                 s,
                 TriggerEvent::Update,
@@ -1113,11 +1112,11 @@ fn emit_update_insns<'a>(
 
             // Compute virtual columns for NEW values
             let new_ctx = DmlColumnContext::layout(columns, start, new_rowid_reg, layout.clone());
-            compute_virtual_columns(program, columns, &new_ctx, &t_ctx.resolver)?;
+            compute_virtual_columns(program, columns, &new_ctx, &t_ctx.resolver, None)?;
 
             // Compute virtual columns for OLD values
             let old_ctx = DmlColumnContext::indexed(columns.clone(), old_registers.clone());
-            compute_virtual_columns(program, columns, &old_ctx, &t_ctx.resolver)?;
+            compute_virtual_columns(program, columns, &old_ctx, &t_ctx.resolver, None)?;
 
             let new_registers = (0..col_len)
                 .map(|i| layout.to_register(start, i))
@@ -1313,29 +1312,56 @@ fn emit_update_insns<'a>(
         .table
         .btree()
         .is_some_and(|bt| bt.has_virtual_columns());
-    let has_returning = returning.as_ref().is_some_and(|r| !r.is_empty());
-    let has_check_constraints = target_table
-        .table
-        .btree()
-        .is_some_and(|bt| !bt.check_constraints.is_empty());
-    if has_virtual_columns
-        && (!indexes_to_update.is_empty()
-            || has_before_triggers
-            || has_after_triggers
-            || has_returning
-            || has_check_constraints)
-    {
-        let columns = target_table.table.columns();
-        let rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
-
-        let dml_ctx = DmlColumnContext::layout(columns, start, rowid_reg, layout.clone());
-        compute_virtual_columns(program, columns, &dml_ctx, &t_ctx.resolver)?;
-    }
-
     let target_is_strict = target_table
         .table
         .btree()
         .is_some_and(|btree| btree.is_strict);
+    if has_virtual_columns {
+        let columns = target_table.table.columns();
+        let rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
+
+        let updated_cols: HashSet<usize> =
+            set_clauses.iter().map(|(col_idx, _)| *col_idx).collect();
+        let affected = columns_affected_by_update(columns, &updated_cols);
+
+        let dml_ctx = DmlColumnContext::layout(columns, start, rowid_reg, layout.clone());
+        compute_virtual_columns(program, columns, &dml_ctx, &t_ctx.resolver, Some(&affected))?;
+
+        // NOT NULL checks for virtual generated columns. These columns are never
+        // in the SET clause, so the regular NOT NULL path doesn't cover them.
+        let or_conflict = program.resolve_type;
+        for (idx, col) in columns.iter().enumerate() {
+            if !col.is_virtual_generated() || !col.notnull() {
+                continue;
+            }
+            let target_reg = layout.to_register(start, idx);
+            let effective = if program.has_statement_conflict {
+                or_conflict
+            } else {
+                col.notnull_conflict_clause.unwrap_or(ResolveType::Abort)
+            };
+            match effective {
+                ResolveType::Ignore => {
+                    program.emit_insn(Insn::IsNull {
+                        reg: target_reg,
+                        target_pc: skip_row_label,
+                    });
+                }
+                _ => {
+                    use crate::error::SQLITE_CONSTRAINT_NOTNULL;
+                    program.emit_insn(Insn::HaltIfNull {
+                        target_reg,
+                        err_code: SQLITE_CONSTRAINT_NOTNULL,
+                        description: format!(
+                            "{}.{}",
+                            table_name,
+                            col.name.as_ref().expect("Column name must be present")
+                        ),
+                    });
+                }
+            }
+        }
+    }
 
     // Non-REPLACE PK constraint check. Must run BEFORE the index preflight so that
     // PK ABORT/FAIL/ROLLBACK fires before an index IGNORE can silently skip the row.
@@ -1459,6 +1485,21 @@ fn emit_update_insns<'a>(
                     t_ctx.resolver.schema(),
                 ),
             });
+
+            // TypeCheck virtual generated columns after they have been computed.
+            let num_virtual = layout.column_count() - layout.num_non_virtual_cols();
+            if num_virtual > 0 {
+                if let Some(table_ref) =
+                    BTreeTable::virtual_type_check_table_ref(&btree_table, t_ctx.resolver.schema())
+                {
+                    program.emit_insn(Insn::TypeCheck {
+                        start_reg: start + layout.num_non_virtual_cols(),
+                        count: num_virtual,
+                        check_generated: true,
+                        table_reference: table_ref,
+                    });
+                }
+            }
         }
 
         if !btree_table.check_constraints.is_empty() {
@@ -2231,12 +2272,12 @@ fn emit_update_insns<'a>(
 
                     // Compute VIRTUAL columns for NEW values
                     let new_ctx = DmlColumnContext::layout(columns, start, beg, layout.clone());
-                    compute_virtual_columns(program, columns, &new_ctx, &t_ctx.resolver)?;
+                    compute_virtual_columns(program, columns, &new_ctx, &t_ctx.resolver, None)?;
 
                     // Compute VIRTUAL columns for OLD values if we have preserved OLD registers
                     if let Some(ref old_regs) = preserved_old_registers {
                         let old_ctx = DmlColumnContext::indexed(columns.clone(), old_regs.clone());
-                        compute_virtual_columns(program, columns, &old_ctx, &t_ctx.resolver)?;
+                        compute_virtual_columns(program, columns, &old_ctx, &t_ctx.resolver, None)?;
                     }
 
                     let new_rowid_reg = rowid_set_clause_reg.unwrap_or(beg);

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -737,6 +737,21 @@ pub fn translate_insert(
             insertion.rowid_alias_mapping(),
             resolver,
         )?;
+
+        // STRICT tables must type-check virtual generated columns after computation.
+        if ctx.table.is_strict {
+            let num_virtual = insertion.col_mappings.len() - insertion.num_non_virtual_cols;
+            if let Some(table_ref) =
+                BTreeTable::virtual_type_check_table_ref(ctx.table, resolver.schema())
+            {
+                program.emit_insn(Insn::TypeCheck {
+                    start_reg: insertion.first_col_register() + insertion.num_non_virtual_cols,
+                    count: num_virtual,
+                    check_generated: true,
+                    table_reference: table_ref,
+                });
+            }
+        }
     }
 
     // Evaluate CHECK constraints after type affinity/TypeCheck but before other constraints

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -431,7 +431,7 @@ pub fn emit_upsert(
             ctx.conflict_rowid_reg,
             layout.clone(),
         );
-        compute_virtual_columns(program, &ctx.table.columns, &dml_ctx, resolver)?;
+        compute_virtual_columns(program, &ctx.table.columns, &dml_ctx, resolver, None)?;
     }
 
     // BEFORE for index maintenance / CDC
@@ -584,11 +584,32 @@ pub fn emit_upsert(
 
     // Recompute virtual columns for the new row after SET clauses have modified base columns.
     // This must happen before CHECK constraints, triggers, and index updates.
+    // Only recompute virtual columns that transitively depend on SET clause columns.
     if ctx.table.has_virtual_columns() {
         let rowid_reg = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
         let dml_ctx =
             DmlColumnContext::layout(&ctx.table.columns, new_start, rowid_reg, layout.clone());
-        compute_virtual_columns(program, &ctx.table.columns, &dml_ctx, resolver)?;
+        let updated_cols: HashSet<usize> = set_pairs.iter().map(|(col_idx, _)| *col_idx).collect();
+        let affected = columns_affected_by_update(&ctx.table.columns, &updated_cols);
+        compute_virtual_columns(
+            program,
+            &ctx.table.columns,
+            &dml_ctx,
+            resolver,
+            Some(&affected),
+        )?;
+
+        // NOT NULL checks for virtual generated columns — not covered by the
+        // SET-clause NOT NULL checks above.
+        for (idx, col) in ctx.table.columns.iter().enumerate() {
+            if col.is_virtual_generated() && col.notnull() {
+                program.emit_insn(Insn::HaltIfNull {
+                    target_reg: layout.to_register(new_start, idx),
+                    err_code: SQLITE_CONSTRAINT_NOTNULL,
+                    description: String::from(table.get_name()) + "." + col.name.as_ref().unwrap(),
+                });
+            }
+        }
     }
 
     if let Some(bt) = table.btree() {
@@ -625,6 +646,21 @@ pub fn emit_upsert(
                 check_generated: true,
                 table_reference: BTreeTable::type_check_table_ref(&bt, resolver.schema()),
             });
+
+            // TypeCheck virtual generated columns after they have been computed.
+            let num_virtual = layout.column_count() - layout.num_non_virtual_cols();
+            if num_virtual > 0 {
+                if let Some(table_ref) =
+                    BTreeTable::virtual_type_check_table_ref(&bt, resolver.schema())
+                {
+                    program.emit_insn(Insn::TypeCheck {
+                        start_reg: new_start + layout.num_non_virtual_cols(),
+                        count: num_virtual,
+                        check_generated: true,
+                        table_reference: table_ref,
+                    });
+                }
+            }
         } else {
             // For non-STRICT tables, apply column affinity to the values.
             // This must happen early so that both index records and the table record
@@ -1297,7 +1333,7 @@ pub fn emit_upsert(
         let rowid_reg = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
         let dml_ctx =
             DmlColumnContext::layout(&ctx.table.columns, new_start, rowid_reg, layout.clone());
-        compute_virtual_columns(program, &ctx.table.columns, &dml_ctx, resolver)?;
+        compute_virtual_columns(program, &ctx.table.columns, &dml_ctx, resolver, None)?;
     }
 
     // RETURNING from NEW image + final rowid

--- a/scripts/install-sqlite3.sh
+++ b/scripts/install-sqlite3.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-SQLITE_VERSION="${SQLITE_VERSION:-3490100}"
+SQLITE_VERSION="${SQLITE_VERSION:-3510100}"
 SQLITE_YEAR="${SQLITE_YEAR:-2025}"
 
 # Get the directory where this script is located

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -3242,6 +3242,126 @@ expect {
     7|14|7!
 }
 
+# STRICT tables must type-check virtual generated columns (SQLite 3.51.0+)
+
+test gencol_strict_virtual_insert_type_error {
+    CREATE TABLE t1(a TEXT, b INTEGER AS (a) VIRTUAL) STRICT;
+    INSERT INTO t1(a) VALUES('not_a_number');
+}
+expect error {
+    cannot store TEXT value in INTEGER column
+}
+
+test gencol_strict_virtual_insert_coercible {
+    CREATE TABLE t1(a TEXT, b INTEGER AS (a) VIRTUAL) STRICT;
+    INSERT INTO t1(a) VALUES('42');
+    SELECT a, b FROM t1;
+}
+expect {
+    42|42
+}
+
+test gencol_strict_virtual_update_type_error {
+    CREATE TABLE t1(a TEXT, b INTEGER AS (a) VIRTUAL) STRICT;
+    INSERT INTO t1(a) VALUES('42');
+    UPDATE t1 SET a = 'not_a_number';
+}
+expect error {
+    cannot store TEXT value in INTEGER column
+}
+
+test gencol_strict_virtual_insert_blob_into_text {
+    CREATE TABLE t1(a BLOB, b TEXT AS (a) VIRTUAL) STRICT;
+    INSERT INTO t1(a) VALUES(x'1234');
+}
+expect error {
+    cannot store BLOB value in TEXT column
+}
+
+test gencol_strict_virtual_null_ok {
+    CREATE TABLE t1(a INTEGER, b INTEGER AS (a) VIRTUAL) STRICT;
+    INSERT INTO t1(a) VALUES(NULL);
+    SELECT a, b FROM t1;
+}
+expect {
+    |
+}
+
+test gencol_strict_virtual_int_to_text_coerce {
+    CREATE TABLE t1(a INTEGER, b TEXT AS (a) VIRTUAL) STRICT;
+    INSERT INTO t1(a) VALUES(99);
+    SELECT a, b FROM t1;
+}
+expect {
+    99|99
+}
+
+test gencol_strict_virtual_upsert_type_error {
+    CREATE TABLE t1(a TEXT, b INTEGER AS (a) VIRTUAL, c INTEGER UNIQUE) STRICT;
+    INSERT INTO t1(a, c) VALUES('42', 1);
+    INSERT INTO t1(a, c) VALUES('42', 1) ON CONFLICT(c) DO UPDATE SET a = 'not_a_number';
+}
+expect error {
+    cannot store TEXT value in INTEGER column
+}
+
+test gencol_strict_virtual_update_no_index {
+    CREATE TABLE t1(a TEXT, b INTEGER AS (a) VIRTUAL) STRICT;
+    INSERT INTO t1(a) VALUES('10');
+    UPDATE t1 SET a = 'hello';
+}
+expect error {
+    cannot store TEXT value in INTEGER column
+}
+
+test gencol_strict_virtual_multiple_cols_one_invalid {
+    CREATE TABLE t1(a TEXT, b INTEGER AS (a) VIRTUAL, c TEXT AS (a) VIRTUAL) STRICT;
+    INSERT INTO t1(a) VALUES('hello');
+}
+expect error {
+    cannot store TEXT value in INTEGER column
+}
+
+# NOT NULL on virtual generated columns must be enforced on UPDATE/UPSERT (#6159)
+
+test gencol_virtual_notnull_update {
+    CREATE TABLE t1(a INTEGER, b GENERATED ALWAYS AS (a*2) VIRTUAL NOT NULL);
+    INSERT INTO t1(a) VALUES(1),(2),(3);
+    UPDATE t1 SET a = NULL WHERE a = 2;
+}
+expect error {
+    NOT NULL constraint failed: t1.b
+}
+
+test gencol_virtual_notnull_update_ok {
+    CREATE TABLE t1(a INTEGER, b GENERATED ALWAYS AS (a*2) VIRTUAL NOT NULL);
+    INSERT INTO t1(a) VALUES(1),(2),(3);
+    UPDATE t1 SET a = 10 WHERE a = 2;
+    SELECT a, b FROM t1 ORDER BY a;
+}
+expect {
+    1|2
+    3|6
+    10|20
+}
+
+test gencol_virtual_notnull_upsert {
+    CREATE TABLE t1(a INTEGER, b GENERATED ALWAYS AS (a*2) VIRTUAL NOT NULL, c INTEGER UNIQUE);
+    INSERT INTO t1(a, c) VALUES(1, 10),(2, 20),(3, 30);
+    INSERT INTO t1(a, c) VALUES(99, 20) ON CONFLICT(c) DO UPDATE SET a = NULL;
+}
+expect error {
+    NOT NULL constraint failed: t1.b
+}
+
+test gencol_virtual_notnull_insert {
+    CREATE TABLE t1(a INTEGER, b GENERATED ALWAYS AS (a*2) VIRTUAL NOT NULL);
+    INSERT INTO t1(a) VALUES(NULL);
+}
+expect error {
+    NOT NULL constraint failed: t1.b
+}
+
 # --- Large row counts (100+ rows) ---
 
 test gencol_large_row_count {


### PR DESCRIPTION
Implement STRICT and NOT NULL checks for generated columns.

While working on it, I noticed that we are always recomputing all columns on updates, so that is changed first in preparation for STRICT / NOT NULL