### PR TITLE
github: Fossier integration for reducing potential AI slop PRs

### DIFF
--- a/.github/fossier.toml
+++ b/.github/fossier.toml
@@ -1,0 +1,27 @@
+[repo]
+owner = "tursodatabase"
+name = "turso"
+
+[thresholds]
+allow_score = 70.0
+deny_score = 50.0
+min_confidence = 0.5
+
+[actions.deny]
+close_pr = true
+comment = true
+label = "fossier:spam-likely"
+
+[actions.review]
+comment = true
+label = "fossier:needs-review"
+
+[registry]
+url = "https://registry.fossier.io"
+report_denials = true
+check_before_scoring = true
+block_threshold = 3
+
+[trust]
+flood_threshold = 4
+flood_window_hours = 1

--- a/.github/workflows/fossier.yml
+++ b/.github/workflows/fossier.yml
@@ -1,0 +1,20 @@
+name: Fossier PR Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: PThorpe92/fossier@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          registry-api-key: ${{ secrets.FOSSIER_REGISTRY_API_KEY }}
+          contact-url: "https://discord.gg/mNUkCHs2R"


### PR DESCRIPTION
Adds `fossier:needs-review` tag to PR's which don't meet confidence level, and will auto-close spam PR's