### PR TITLE
Fix DELETE trigger panic on tables with virtual generated columns

### DIFF
--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -8,7 +8,8 @@ use crate::{
         emitter::{
             emit_cdc_autocommit_commit, emit_cdc_full_record, emit_cdc_insns,
             emit_index_column_value_old_image, emit_program_for_select,
-            get_relevant_triggers_type_and_time, init_limit, OperationMode, TriggerTime,
+            gencol::compute_virtual_columns, get_relevant_triggers_type_and_time, init_limit,
+            OperationMode, TriggerTime,
         },
         expr::{
             emit_returning_results, emit_returning_scan_back, restore_returning_row_image_in_cache,
@@ -28,7 +29,7 @@ use crate::{
         trigger_exec::{fire_trigger, has_relevant_triggers_type_only, TriggerContext},
     },
     vdbe::{
-        builder::{CursorKey, CursorType, ProgramBuilder},
+        builder::{CursorKey, CursorType, DmlColumnContext, ProgramBuilder},
         insn::{Insn, RegisterOrLiteral},
     },
     CaptureDataChangesExt, Connection,
@@ -515,6 +516,19 @@ fn emit_delete_insns<'a>(
                 program.emit_column_or_rowid(main_table_cursor_id, i, columns_start_reg + i);
             }
 
+            // Compute virtual generated column values from the stored columns
+            // so that triggers referencing OLD.virtual_col see correct values.
+            if let Some(btree_table) = unsafe { &*table_reference }.btree() {
+                if btree_table.has_virtual_columns() {
+                    let columns = unsafe { &*table_reference }.columns();
+                    let col_regs = (0..cols_len)
+                        .map(|i| columns_start_reg + i)
+                        .collect::<Vec<_>>();
+                    let dml_ctx = DmlColumnContext::indexed(columns.to_vec(), col_regs);
+                    compute_virtual_columns(program, columns, &dml_ctx, resolver)?;
+                }
+            }
+
             (Some(columns_start_reg), rowid_reg)
         }
     };
@@ -892,6 +906,18 @@ fn emit_delete_insns_when_triggers_present(
         for (i, _column) in unsafe { &*table_reference }.columns().iter().enumerate() {
             program.emit_column_or_rowid(main_table_cursor_id, i, columns_start_reg + i);
         }
+
+        if let Some(btree_table) = unsafe { &*table_reference }.btree() {
+            if btree_table.has_virtual_columns() {
+                let columns = unsafe { &*table_reference }.columns();
+                let col_regs = (0..cols_len)
+                    .map(|i| columns_start_reg + i)
+                    .collect::<Vec<_>>();
+                let dml_ctx = DmlColumnContext::indexed(columns.to_vec(), col_regs);
+                compute_virtual_columns(program, columns, &dml_ctx, &t_ctx.resolver)?;
+            }
+        }
+
         Some(columns_start_reg)
     };
 

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1089,11 +1089,7 @@ fn emit_update_insns<'a>(
                 (0..col_len)
                     .map(|i| {
                         let reg = program.alloc_register();
-                        if columns[i].is_virtual_generated() {
-                            program.emit_null(reg, None);
-                        } else {
-                            program.emit_column_or_rowid(target_table_cursor_id, i, reg);
-                        }
+                        program.emit_column_or_rowid(target_table_cursor_id, i, reg);
                         reg
                     })
                     .chain(std::iter::once(beg))

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -412,16 +412,8 @@ pub fn emit_upsert(
 
     let current_start = program.alloc_registers(num_cols);
     for i in 0..num_cols {
-        let col = &table.columns()[i];
         let reg = layout.to_register(current_start, i);
-        if col.is_virtual_generated() {
-            program.emit_insn(Insn::Null {
-                dest: reg,
-                dest_end: None,
-            });
-        } else {
-            program.emit_column_or_rowid(ctx.cursor_id, i, reg);
-        }
+        program.emit_column_or_rowid(ctx.cursor_id, i, reg);
     }
 
     if ctx.table.has_virtual_columns() {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1646,6 +1646,11 @@ impl ProgramBuilder {
                     cursor_id,
                     dest: out,
                 });
+            } else if column_def.is_virtual_generated() {
+                // Virtual generated columns are not stored on disk.
+                // Emit NULL; the caller computes them from other columns if needed.
+                self.suppress_column_default = false;
+                self.emit_null(out, None);
             } else {
                 self.emit_column(cursor_id, column, out);
             }

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -3703,3 +3703,90 @@ expect {
     2|210
     3|310
 }
+
+# =============================================================================
+# DELETE triggers on tables with virtual generated columns
+# =============================================================================
+
+test gencol_delete_before_trigger_virtual {
+    CREATE TABLE t1(a INTEGER, b AS (a * 2));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr_before_del BEFORE DELETE ON t1
+    BEGIN
+        INSERT INTO log VALUES('deleting ' || OLD.a);
+    END;
+    INSERT INTO t1(a) VALUES(1), (2), (3);
+    DELETE FROM t1 WHERE a = 2;
+    SELECT * FROM log;
+    SELECT a, b FROM t1;
+}
+expect {
+    deleting 2
+    1|2
+    3|6
+}
+
+test gencol_delete_after_trigger_virtual {
+    CREATE TABLE t1(a INTEGER, b AS (a * 2));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr_after_del AFTER DELETE ON t1
+    BEGIN
+        INSERT INTO log VALUES('deleted ' || OLD.a);
+    END;
+    INSERT INTO t1(a) VALUES(10), (20);
+    DELETE FROM t1;
+    SELECT * FROM log;
+}
+expect {
+    deleted 10
+    deleted 20
+}
+
+test gencol_delete_trigger_ref_virtual_col {
+    CREATE TABLE t1(a INTEGER, b AS (a + 100));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr_del BEFORE DELETE ON t1
+    BEGIN
+        INSERT INTO log VALUES('old_b=' || OLD.b);
+    END;
+    INSERT INTO t1(a) VALUES(5);
+    DELETE FROM t1 WHERE a = 5;
+    SELECT * FROM log;
+}
+expect {
+    old_b=105
+}
+
+test gencol_delete_trigger_multiple_virtual {
+    CREATE TABLE t1(a INTEGER, b AS (a * 2), c TEXT, d AS (a || c));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr_del AFTER DELETE ON t1
+    BEGIN
+        INSERT INTO log VALUES(OLD.a || '|' || OLD.c);
+    END;
+    INSERT INTO t1(a, c) VALUES(1, 'x'), (2, 'y');
+    DELETE FROM t1 WHERE a = 1;
+    SELECT * FROM log;
+    SELECT a, b, c, d FROM t1;
+}
+expect {
+    1|x
+    2|4|y|2y
+}
+
+test gencol_upsert_trigger_virtual_col {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c AS (a || b));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr AFTER UPDATE ON t1
+    BEGIN
+        INSERT INTO log VALUES('old_c=' || OLD.c || ' new_c=' || NEW.c);
+    END;
+    INSERT INTO t1(a, b) VALUES(1, 'x');
+    INSERT INTO t1(a, b) VALUES(1, 'y') ON CONFLICT(a) DO UPDATE SET b = excluded.b;
+    SELECT * FROM log;
+    SELECT a, b, c FROM t1;
+}
+expect {
+    old_c=1x new_c=1y
+    1|y|1y
+}


### PR DESCRIPTION
emit_column_or_rowid now emits NULL for virtual generated columns instead of forwarding to emit_column (which panics). After reading all stored columns, compute_virtual_columns fills in the virtual values so triggers referencing OLD.virtual_col see correct results.

Removes the per-site virtual column checks from the UPDATE and UPSERT old-image loops — emit_column_or_rowid handles it centrally.

Fixes #6150
