### PR TITLE
core/translate: Add emit_table_column for transparent virtual column reads

### DIFF
--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -11,9 +11,9 @@ use crate::{
             get_relevant_triggers_type_and_time, init_limit, OperationMode, TriggerTime,
         },
         expr::{
-            emit_returning_results, emit_returning_scan_back, restore_returning_row_image_in_cache,
-            seed_returning_row_image_in_cache, translate_expr_no_constant_opt, NoConstantOptReason,
-            ReturningBufferCtx,
+            emit_returning_results, emit_returning_scan_back, emit_table_column,
+            restore_returning_row_image_in_cache, seed_returning_row_image_in_cache,
+            translate_expr_no_constant_opt, NoConstantOptReason, ReturningBufferCtx,
         },
         fkeys::{
             build_index_affinity_string, emit_guarded_fk_decrement, open_read_index,
@@ -511,8 +511,17 @@ fn emit_delete_insns<'a>(
             let columns_start_reg = program.alloc_registers(cols_len);
 
             // Read all column values from the row to be deleted
-            for (i, _column) in unsafe { &*table_reference }.columns().iter().enumerate() {
-                program.emit_column_or_rowid(main_table_cursor_id, i, columns_start_reg + i);
+            for (i, column) in unsafe { &*table_reference }.columns().iter().enumerate() {
+                emit_table_column(
+                    program,
+                    main_table_cursor_id,
+                    internal_id,
+                    table_references,
+                    column,
+                    i,
+                    columns_start_reg + i,
+                    resolver,
+                )?;
             }
 
             (Some(columns_start_reg), rowid_reg)
@@ -885,12 +894,22 @@ fn emit_delete_insns_when_triggers_present(
     };
     let cols_len = unsafe { &*table_reference }.columns().len();
 
+    let internal_id = unsafe { (*table_reference).internal_id };
     let columns_start_reg = if !has_returning && !has_delete_triggers {
         None
     } else {
         let columns_start_reg = program.alloc_registers(cols_len);
-        for (i, _column) in unsafe { &*table_reference }.columns().iter().enumerate() {
-            program.emit_column_or_rowid(main_table_cursor_id, i, columns_start_reg + i);
+        for (i, column) in unsafe { &*table_reference }.columns().iter().enumerate() {
+            emit_table_column(
+                program,
+                main_table_cursor_id,
+                internal_id,
+                table_references,
+                column,
+                i,
+                columns_start_reg + i,
+                resolver,
+            )?;
         }
         Some(columns_start_reg)
     };

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -19,9 +19,10 @@ use crate::{
             UpdateRowSource,
         },
         expr::{
-            emit_returning_results, emit_returning_scan_back, restore_returning_row_image_in_cache,
-            seed_returning_row_image_in_cache, translate_expr, translate_expr_no_constant_opt,
-            NoConstantOptReason, ReturningBufferCtx,
+            emit_returning_results, emit_returning_scan_back, emit_table_column,
+            restore_returning_row_image_in_cache, seed_returning_row_image_in_cache,
+            translate_expr, translate_expr_no_constant_opt, NoConstantOptReason,
+            ReturningBufferCtx,
         },
         fkeys::{
             emit_fk_child_update_counters, emit_fk_parent_new_key_reconcile,
@@ -1085,20 +1086,23 @@ fn emit_update_insns<'a>(
         // Only read OLD row values when triggers or FK cascades need them
         let columns = target_table.table.columns();
         let old_registers: Option<Vec<usize>> = if needs_old_registers {
-            Some(
-                (0..col_len)
-                    .map(|i| {
-                        let reg = program.alloc_register();
-                        if columns[i].is_virtual_generated() {
-                            program.emit_null(reg, None);
-                        } else {
-                            program.emit_column_or_rowid(target_table_cursor_id, i, reg);
-                        }
-                        reg
-                    })
-                    .chain(std::iter::once(beg))
-                    .collect(),
-            )
+            let mut regs = Vec::with_capacity(col_len + 1);
+            for (i, column) in columns.iter().enumerate() {
+                let reg = program.alloc_register();
+                emit_table_column(
+                    program,
+                    target_table_cursor_id,
+                    internal_id,
+                    table_references,
+                    column,
+                    i,
+                    reg,
+                    &t_ctx.resolver,
+                )?;
+                regs.push(reg);
+            }
+            regs.push(beg);
+            Some(regs)
         } else {
             None
         };
@@ -1114,10 +1118,6 @@ fn emit_update_insns<'a>(
             // Compute virtual columns for NEW values
             let new_ctx = DmlColumnContext::layout(columns, start, new_rowid_reg, layout.clone());
             compute_virtual_columns(program, columns, &new_ctx, &t_ctx.resolver)?;
-
-            // Compute virtual columns for OLD values
-            let old_ctx = DmlColumnContext::indexed(columns.clone(), old_registers.clone());
-            compute_virtual_columns(program, columns, &old_ctx, &t_ctx.resolver)?;
 
             let new_registers = (0..col_len)
                 .map(|i| layout.to_register(start, i))

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -27,7 +27,7 @@ use crate::vdbe::builder::{CursorKey, SelfTableContext};
 use crate::vdbe::{
     builder::ProgramBuilder,
     insn::{CmpInsFlags, InsertFlags, Insn},
-    BranchOffset,
+    BranchOffset, CursorID,
 };
 use crate::{LimboError, Numeric, Result, Value};
 use std::collections::HashSet;
@@ -5189,6 +5189,48 @@ fn wrap_eval_jump_expr_zero_or_null(
         dest: target_register,
     });
     program.preassign_label_to_next_insn(if_true_label);
+}
+
+/// Read a single column from a BTreeTable cursor, transparently computing
+/// virtual generated columns inline instead of hitting `emit_column`.
+/// All bulk column-reading call sites should use this instead of
+/// `emit_column_or_rowid` directly.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_table_column(
+    program: &mut ProgramBuilder,
+    cursor_id: CursorID,
+    table_ref_id: TableInternalId,
+    referenced_tables: &TableReferences,
+    column: &Column,
+    column_index: usize,
+    target_register: usize,
+    resolver: &Resolver,
+) -> Result<()> {
+    match column.generated_type() {
+        GeneratedType::Virtual { resolved: expr, .. } => {
+            program.with_self_table_context(
+                Some(&SelfTableContext::ForSelect {
+                    table_ref_id,
+                    referenced_tables: referenced_tables.clone(),
+                }),
+                |program, _| {
+                    translate_expr(
+                        program,
+                        Some(referenced_tables),
+                        expr,
+                        target_register,
+                        resolver,
+                    )?;
+                    Ok(())
+                },
+            )?;
+            program.emit_column_affinity(target_register, column.affinity());
+        }
+        _ => {
+            program.emit_column_or_rowid(cursor_id, column_index, target_register);
+        }
+    }
+    Ok(())
 }
 
 pub fn maybe_apply_affinity(col_type: Type, target_register: usize, program: &mut ProgramBuilder) {

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -451,6 +451,11 @@ pub(super) struct AutoIndexBuild<'a> {
     pub(super) num_seek_keys: usize,
     pub(super) seek_def: &'a SeekDef,
     pub(super) affinity_str: Option<&'a Arc<String>>,
+    /// Table columns needed for transparent virtual column computation.
+    pub(super) table_columns: Option<&'a [crate::schema::Column]>,
+    pub(super) table_ref_id: turso_parser::ast::TableInternalId,
+    pub(super) table_references: &'a TableReferences,
+    pub(super) resolver: &'a Resolver<'a>,
 }
 
 /// Open an ephemeral index cursor and build an automatic index on a table.
@@ -468,6 +473,10 @@ pub(super) fn emit_autoindex(
         num_seek_keys,
         seek_def,
         affinity_str,
+        table_columns,
+        table_ref_id,
+        table_references,
+        resolver,
     } = build;
     turso_assert!(index.ephemeral, "index must be ephemeral", { "index_name": &index.name });
     let label_ephemeral_build_end = program.allocate_label();
@@ -491,6 +500,23 @@ pub(super) fn emit_autoindex(
     let ephemeral_cols_start_reg = program.alloc_registers(num_regs_to_reserve);
     for (i, col) in index.columns.iter().enumerate() {
         let reg = ephemeral_cols_start_reg + i;
+        if let Some(columns) = table_columns {
+            if let Some(column_def) = columns.get(col.pos_in_table) {
+                if column_def.is_virtual_generated() {
+                    crate::translate::expr::emit_table_column(
+                        program,
+                        table_cursor_id,
+                        table_ref_id,
+                        table_references,
+                        column_def,
+                        col.pos_in_table,
+                        reg,
+                        resolver,
+                    )?;
+                    continue;
+                }
+            }
+        }
         program.emit_column_or_rowid(table_cursor_id, col.pos_in_table, reg);
     }
     if table_has_rowid {

--- a/core/translate/main_loop/open.rs
+++ b/core/translate/main_loop/open.rs
@@ -307,6 +307,11 @@ impl OpenLoop {
                                         matches!(&table.table, Table::FromClauseSubquery(_))
                                     };
                                     let num_seek_keys = seek_def.size(&seek_def.start);
+                                    let table_columns = if let Table::BTree(btree) = &table.table {
+                                        Some(btree.columns.as_slice())
+                                    } else {
+                                        None
+                                    };
                                     let AutoIndexResult {
                                         use_bloom_filter, ..
                                     } = emit_autoindex(
@@ -326,6 +331,10 @@ impl OpenLoop {
                                                 index, seek_def,
                                             )
                                             .as_ref(),
+                                            table_columns,
+                                            table_ref_id: table.internal_id,
+                                            table_references,
+                                            resolver: &t_ctx.resolver,
                                         },
                                     )?;
                                     bloom_filter = use_bloom_filter;

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -29,8 +29,8 @@ use crate::{
             emit_cdc_full_record, emit_cdc_insns, emit_cdc_patch_record, OperationMode, Resolver,
         },
         expr::{
-            emit_returning_results, translate_expr, translate_expr_no_constant_opt, walk_expr_mut,
-            NoConstantOptReason,
+            emit_returning_results, emit_table_column, translate_expr,
+            translate_expr_no_constant_opt, walk_expr_mut, NoConstantOptReason,
         },
         insert::Insertion,
         plan::{ResultSetColumn, TableReferences},
@@ -410,28 +410,25 @@ pub fn emit_upsert(
     let num_cols = ctx.table.columns.len();
     let layout = ctx.table.column_layout();
 
+    let table_ref_id = table_references
+        .joined_tables()
+        .first()
+        .expect("upsert must have a target table")
+        .internal_id;
     let current_start = program.alloc_registers(num_cols);
     for i in 0..num_cols {
         let col = &table.columns()[i];
         let reg = layout.to_register(current_start, i);
-        if col.is_virtual_generated() {
-            program.emit_insn(Insn::Null {
-                dest: reg,
-                dest_end: None,
-            });
-        } else {
-            program.emit_column_or_rowid(ctx.cursor_id, i, reg);
-        }
-    }
-
-    if ctx.table.has_virtual_columns() {
-        let dml_ctx = DmlColumnContext::layout(
-            &ctx.table.columns,
-            current_start,
-            ctx.conflict_rowid_reg,
-            layout.clone(),
-        );
-        compute_virtual_columns(program, &ctx.table.columns, &dml_ctx, resolver)?;
+        emit_table_column(
+            program,
+            ctx.cursor_id,
+            table_ref_id,
+            table_references,
+            col,
+            i,
+            reg,
+            resolver,
+        )?;
     }
 
     // BEFORE for index maintenance / CDC

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -3703,3 +3703,189 @@ expect {
     2|210
     3|310
 }
+
+# =============================================================================
+# Self-join on table with virtual generated columns (#6148)
+# =============================================================================
+
+test gencol_self_join_virtual {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b AS (a * 10));
+    INSERT INTO t1(a) VALUES(1), (2), (3);
+    SELECT a1.a, a1.b, a2.a, a2.b FROM t1 a1 JOIN t1 a2 ON a1.a = a2.a;
+}
+expect {
+    1|10|1|10
+    2|20|2|20
+    3|30|3|30
+}
+
+# =============================================================================
+# Three-table INNER JOIN with virtual generated columns (#6151)
+# =============================================================================
+
+test gencol_three_table_inner_join {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, c AS (b + 100));
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, t1_a INTEGER);
+    CREATE TABLE t3(id INTEGER PRIMARY KEY, t2_id INTEGER);
+    INSERT INTO t1 VALUES(1, 10);
+    INSERT INTO t1 VALUES(2, 20);
+    INSERT INTO t2 VALUES(1, 1);
+    INSERT INTO t2 VALUES(2, 2);
+    INSERT INTO t3 VALUES(1, 1);
+    INSERT INTO t3 VALUES(2, 2);
+    SELECT t1.a, t1.b, t1.c, t2.id, t3.id
+      FROM t1
+      INNER JOIN t2 ON t2.t1_a = t1.a
+      INNER JOIN t3 ON t3.t2_id = t2.id;
+}
+expect {
+    1|10|110|1|1
+    2|20|120|2|2
+}
+
+test gencol_three_table_inner_join_select_gencol {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, c AS (b + 100));
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, t1_a INTEGER);
+    CREATE TABLE t3(id INTEGER PRIMARY KEY, t2_id INTEGER);
+    INSERT INTO t1 VALUES(1, 10);
+    INSERT INTO t1 VALUES(2, 20);
+    INSERT INTO t2 VALUES(1, 1);
+    INSERT INTO t2 VALUES(2, 2);
+    INSERT INTO t3 VALUES(1, 1);
+    INSERT INTO t3 VALUES(2, 2);
+    SELECT t1.c
+      FROM t1
+      INNER JOIN t2 ON t2.t1_a = t1.a
+      INNER JOIN t3 ON t3.t2_id = t2.id;
+}
+expect {
+    110
+    120
+}
+
+test gencol_three_table_inner_join_where_gencol {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, c AS (b + 100));
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, t1_a INTEGER);
+    CREATE TABLE t3(id INTEGER PRIMARY KEY, t2_id INTEGER);
+    INSERT INTO t1 VALUES(1, 10);
+    INSERT INTO t1 VALUES(2, 20);
+    INSERT INTO t2 VALUES(1, 1);
+    INSERT INTO t2 VALUES(2, 2);
+    INSERT INTO t3 VALUES(1, 1);
+    INSERT INTO t3 VALUES(2, 2);
+    SELECT t1.a, t1.c
+      FROM t1
+      INNER JOIN t2 ON t2.t1_a = t1.a
+      INNER JOIN t3 ON t3.t2_id = t2.id
+      WHERE t1.c > 115;
+}
+expect {
+    2|120
+}
+
+test gencol_four_table_inner_join {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, c AS (b * 2));
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, t1_a INTEGER);
+    CREATE TABLE t3(id INTEGER PRIMARY KEY, t2_id INTEGER);
+    CREATE TABLE t4(id INTEGER PRIMARY KEY, t3_id INTEGER, val TEXT);
+    INSERT INTO t1 VALUES(1, 5);
+    INSERT INTO t2 VALUES(1, 1);
+    INSERT INTO t3 VALUES(1, 1);
+    INSERT INTO t4 VALUES(1, 1, 'ok');
+    SELECT t1.a, t1.b, t1.c, t4.val
+      FROM t1
+      INNER JOIN t2 ON t2.t1_a = t1.a
+      INNER JOIN t3 ON t3.t2_id = t2.id
+      INNER JOIN t4 ON t4.t3_id = t3.id;
+}
+expect {
+    1|5|10|ok
+}
+
+# =============================================================================
+# DELETE triggers on tables with virtual generated columns (#6150)
+# =============================================================================
+
+test gencol_delete_before_trigger_virtual {
+    CREATE TABLE t1(a INTEGER, b AS (a * 2));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr_before_del BEFORE DELETE ON t1
+    BEGIN
+        INSERT INTO log VALUES('deleting ' || OLD.a);
+    END;
+    INSERT INTO t1(a) VALUES(1), (2), (3);
+    DELETE FROM t1 WHERE a = 2;
+    SELECT * FROM log;
+    SELECT a, b FROM t1;
+}
+expect {
+    deleting 2
+    1|2
+    3|6
+}
+
+test gencol_delete_after_trigger_virtual {
+    CREATE TABLE t1(a INTEGER, b AS (a * 2));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr_after_del AFTER DELETE ON t1
+    BEGIN
+        INSERT INTO log VALUES('deleted ' || OLD.a);
+    END;
+    INSERT INTO t1(a) VALUES(10), (20);
+    DELETE FROM t1;
+    SELECT * FROM log;
+}
+expect {
+    deleted 10
+    deleted 20
+}
+
+test gencol_delete_trigger_ref_virtual_col {
+    CREATE TABLE t1(a INTEGER, b AS (a + 100));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr_del BEFORE DELETE ON t1
+    BEGIN
+        INSERT INTO log VALUES('old_b=' || OLD.b);
+    END;
+    INSERT INTO t1(a) VALUES(5);
+    DELETE FROM t1 WHERE a = 5;
+    SELECT * FROM log;
+}
+expect {
+    old_b=105
+}
+
+test gencol_delete_trigger_multiple_virtual {
+    CREATE TABLE t1(a INTEGER, b AS (a * 2), c TEXT, d AS (a || c));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr_del AFTER DELETE ON t1
+    BEGIN
+        INSERT INTO log VALUES(OLD.a || '|' || OLD.c);
+    END;
+    INSERT INTO t1(a, c) VALUES(1, 'x'), (2, 'y');
+    DELETE FROM t1 WHERE a = 1;
+    SELECT * FROM log;
+    SELECT a, b, c, d FROM t1;
+}
+expect {
+    1|x
+    2|4|y|2y
+}
+
+test gencol_upsert_trigger_virtual_col {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c AS (a || b));
+    CREATE TABLE log(msg TEXT);
+    CREATE TRIGGER tr AFTER UPDATE ON t1
+    BEGIN
+        INSERT INTO log VALUES('old_c=' || OLD.c || ' new_c=' || NEW.c);
+    END;
+    INSERT INTO t1(a, b) VALUES(1, 'x');
+    INSERT INTO t1(a, b) VALUES(1, 'y') ON CONFLICT(a) DO UPDATE SET b = excluded.b;
+    SELECT * FROM log;
+    SELECT a, b, c FROM t1;
+}
+expect {
+    old_c=1x new_c=1y
+    1|y|1y
+}
+


### PR DESCRIPTION
Create a single function in the translate layer that reads any column from a BTreeTable cursor, computing virtual generated columns inline. All bulk column-reading call sites now use this instead of emit_column_or_rowid directly, which panics on virtual columns.

Updated call sites: emit_autoindex (close.rs/open.rs), DELETE trigger old-image (delete.rs), UPDATE trigger old-image (update.rs), and UPSERT current-row snapshot (upsert.rs).

Fixes #6148, #6150, #6151
