### PR TITLE
core/mvcc: Recover insert-delete cycles in sqlite_schema table

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4749,11 +4749,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     }
                     if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
                         let rowid_int = rowid.row_id.to_int_or_panic();
-                        let record = schema_rows.get(&rowid_int).ok_or_else(|| {
-                            LimboError::Corrupt(format!(
-                                "Logical log deletes sqlite_schema rowid {rowid_int} that does not exist in merged schema state"
-                            ))
-                        })?;
+                        let Some(record) = schema_rows.get(&rowid_int) else {
+                            // this can happen if a row in sqlite_schema was inserted and then
+                            // deleted in the same transaction (ex: a CREATE TABLE followed by a DROP TABLE)
+                            continue;
+                        };
                         if record.column_count() < 5 {
                             return Err(LimboError::Corrupt(format!(
                                 "sqlite_schema row must have at least 5 columns, got {}",

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -908,3 +908,27 @@ fn test_attach_memory_db_allowed_on_encrypted_mvcc_main(
     assert_eq!(aux_rows, vec![(42,)]);
     Ok(())
 }
+
+#[turso_macros::test]
+fn test_add_then_drop_table_in_same_tx_then_recover(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        [
+            "pragma journal_mode = 'mvcc'",
+            "begin",
+            "create table t(a)",
+            "drop table t",
+            "commit",
+        ]
+        .iter()
+        .try_for_each(|sql| conn.execute(sql))?;
+    }
+    drop(db);
+
+    Database::open_file(io, path.to_str().unwrap())?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

With MVCC INSERT/DELETE cycles in the same transaction are serialized as deletions in the logical log. There was a validation that checked that if the logical log contained a deletion in `sqlite_schema`, the row existed. But this doesn't hold for same-tx insert-delete cycles like a `create table `immediately followed by a `drop table`.

We didn't catch this earlier because I don't think we have fuzz tests that target DDL in MVCC.

@jussisaurio you wrote most of this code, including the validation that I removed, so I think you would be the best to review it.

## Motivation and context

Closes https://github.com/tursodatabase/turso/issues/6207

## Description of AI Usage

I used Claude Code to find the problem, then wrote the code myself.