### PR TITLE
core/io: improve windows IO back-end

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -27,13 +27,21 @@ cfg_block! {
         pub use PlatformIO as SyscallIO;
     }
 
+    #[cfg(all(target_os = "windows", not(miri)))] {
+        mod windows;
+        #[cfg(feature = "fs")]
+        pub use windows::WindowsIO;
+        pub use windows::WindowsIO as PlatformIO;
+        pub use PlatformIO as SyscallIO;
+    }
+
     #[cfg(all(target_os = "windows", feature = "experimental_win_iocp", not(miri)))] {
         mod win_iocp;
         #[cfg(feature = "fs")]
         pub use win_iocp::WindowsIOCP;
     }
 
-    #[cfg(any(not(any(target_family = "unix", target_os = "android", target_os = "ios")), miri))] {
+    #[cfg(any(not(any(target_family = "unix", target_os = "windows")), miri))] {
         mod generic;
         pub use generic::GenericIO as PlatformIO;
         pub use PlatformIO as SyscallIO;

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -2,10 +2,13 @@ use crate::error::io_error;
 use crate::io::clock::{DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::io::common;
 use crate::io::FileSyncType;
-use crate::sync::Arc;
+use crate::sync::{Arc, Mutex};
 use crate::{Clock, Completion, CompletionError, File, LimboError, OpenFlags, Result, IO};
+use std::collections::HashMap;
 use std::io::ErrorKind;
+use std::path::PathBuf;
 use std::ptr;
+use std::sync::OnceLock;
 #[cfg(feature = "fs")]
 use tracing::debug;
 use tracing::{instrument, trace, Level};
@@ -43,6 +46,134 @@ fn overlapped_at(pos: u64) -> OVERLAPPED {
 fn last_os_error(context: &'static str) -> LimboError {
     let err = std::io::Error::last_os_error();
     io_error(err, context)
+}
+
+/// Process-wide cross-process advisory lock for a single path.
+///
+/// `LockFileEx` is per-handle on Windows: two handles in the same process — even
+/// to the same file — race against each other instead of sharing a lock the way
+/// POSIX `fcntl` locks do per-process. Acquiring an exclusive byte-range lock on
+/// every `open_file` therefore breaks legitimate same-process patterns (multiple
+/// connections, busy-timeout retries, parallel readers).
+///
+/// To match Unix semantics — one OS lock per (process, path) — we hold a single
+/// dedicated lock handle in a process-global registry, ref-counted across all
+/// `WindowsFile`s for the same canonical path. The first opener acquires the
+/// `LockFileEx`; subsequent in-process openers just bump the refcount. Once the
+/// last opener drops its guard, the dedicated handle is closed and the OS lock
+/// is released, freeing the path for other processes.
+///
+/// The lock targets a single sentinel byte at an offset far beyond any
+/// realistic database size: `LockFileEx` blocks `ReadFile`/`WriteFile` on
+/// locked regions across *all* handles (including ones in our own process), so
+/// locking the data region itself would deadlock our own writes. The sentinel
+/// byte is never read or written by the engine, only locked.
+const PROCESS_LOCK_OFFSET: u64 = 0x4000_0000_0000_0000;
+
+struct ProcessFileLockEntry {
+    handle: HANDLE,
+    refcount: usize,
+}
+
+// HANDLE is a raw pointer; the registry mutex serializes all access to it.
+unsafe impl Send for ProcessFileLockEntry {}
+
+type ProcessFileLockRegistry = Mutex<HashMap<PathBuf, ProcessFileLockEntry>>;
+
+fn process_file_lock_registry() -> &'static ProcessFileLockRegistry {
+    static REGISTRY: OnceLock<ProcessFileLockRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+struct ProcessFileLockGuard {
+    key: PathBuf,
+}
+
+impl Drop for ProcessFileLockGuard {
+    fn drop(&mut self) {
+        let mut registry = process_file_lock_registry().lock();
+        let Some(entry) = registry.get_mut(&self.key) else {
+            return;
+        };
+        entry.refcount -= 1;
+        if entry.refcount > 0 {
+            return;
+        }
+        // Release the OS lock and close the handle while still holding the
+        // registry mutex. A concurrent acquirer for the same path is blocked
+        // on the mutex; once we drop it the entry is gone and they'll open a
+        // fresh dedicated handle. Releasing inside the critical section
+        // ensures the previous `LockFileEx` is fully unwound before any new
+        // `LockFileEx` is attempted, otherwise the new attempt would race
+        // and fail with `ERROR_LOCK_VIOLATION`.
+        let handle = registry.remove(&self.key).expect("entry just observed").handle;
+        unsafe {
+            let mut overlapped = overlapped_at(PROCESS_LOCK_OFFSET);
+            UnlockFileEx(handle, 0, 1, 0, &mut overlapped);
+            CloseHandle(handle);
+        }
+    }
+}
+
+fn acquire_process_file_lock(path: &str) -> Result<ProcessFileLockGuard> {
+    // Canonicalize so that different path strings resolving to the same file
+    // (e.g. relative vs. absolute) share a single registry entry. Fall back
+    // to the raw path if canonicalize fails for any reason; collisions across
+    // distinct paths only matter if the same caller mixes spellings, and the
+    // OS lock still provides correctness in that case.
+    let key = std::fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path));
+    let mut registry = process_file_lock_registry().lock();
+    if let Some(entry) = registry.get_mut(&key) {
+        entry.refcount += 1;
+        return Ok(ProcessFileLockGuard { key });
+    }
+
+    // First opener for this path in this process. Open a dedicated handle whose
+    // sole purpose is to hold the byte-range lock. Its lifetime is tied to the
+    // registry entry, decoupled from any individual `WindowsFile`.
+    let wide_path: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    let handle = unsafe {
+        CreateFileW(
+            wide_path.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(last_os_error("open lock handle"));
+    }
+
+    let mut overlapped = overlapped_at(PROCESS_LOCK_OFFSET);
+    let ok = unsafe {
+        LockFileEx(
+            handle,
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            1,
+            0,
+            &mut overlapped,
+        )
+    };
+    if ok == FALSE {
+        let err = std::io::Error::last_os_error();
+        unsafe {
+            CloseHandle(handle);
+        }
+        let message = match err.kind() {
+            ErrorKind::WouldBlock => {
+                "Failed locking file. File is locked by another process".to_string()
+            }
+            _ => format!("Failed locking file, {err}"),
+        };
+        return Err(LimboError::LockingError(message));
+    }
+
+    registry.insert(key.clone(), ProcessFileLockEntry { handle, refcount: 1 });
+    Ok(ProcessFileLockGuard { key })
 }
 
 pub struct WindowsIO {}
@@ -92,18 +223,28 @@ impl IO for WindowsIO {
             return Err(last_os_error("open"));
         }
 
-        let windows_file = Arc::new(WindowsFile {
-            handle: file_handle,
-        });
-
-        if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
-            && !flags.contains(OpenFlags::ReadOnly)
+        // Cross-process advisory lock: rejects opens from other processes while
+        // permitting multiple in-process handles. See `ProcessFileLockEntry`.
+        let process_lock = if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
+            && !flags.intersects(OpenFlags::ReadOnly | OpenFlags::NoLock)
         {
-            // Drop will handle CloseHandle if lock_file fails
-            windows_file.lock_file(true)?;
-        }
+            match acquire_process_file_lock(path) {
+                Ok(guard) => Some(guard),
+                Err(e) => {
+                    unsafe {
+                        CloseHandle(file_handle);
+                    }
+                    return Err(e);
+                }
+            }
+        } else {
+            None
+        };
 
-        Ok(windows_file)
+        Ok(Arc::new(WindowsFile {
+            handle: file_handle,
+            _process_lock: process_lock,
+        }))
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
@@ -131,6 +272,10 @@ impl Clock for WindowsIO {
 
 pub struct WindowsFile {
     handle: HANDLE,
+    /// Process-wide advisory lock held while this file is open. The lock lives
+    /// in a dedicated handle managed by `ProcessFileLockEntry`; this field
+    /// just keeps the registry refcount up. Dropped automatically with `self`.
+    _process_lock: Option<ProcessFileLockGuard>,
 }
 
 unsafe impl Send for WindowsFile {}
@@ -362,10 +507,11 @@ impl File for WindowsFile {
 
 impl Drop for WindowsFile {
     fn drop(&mut self) {
-        let _ = self.unlock_file();
         unsafe {
             CloseHandle(self.handle);
         }
+        // The process-wide advisory lock is released by `ProcessFileLockGuard::drop`
+        // after the `_process_lock` field is dropped here.
     }
 }
 

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -99,10 +99,8 @@ impl IO for WindowsIO {
         if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
             && !flags.contains(OpenFlags::ReadOnly)
         {
-            if let Err(e) = windows_file.lock_file(true) {
-                unsafe { CloseHandle(windows_file.handle) };
-                return Err(e);
-            }
+            // Drop will handle CloseHandle if lock_file fails
+            windows_file.lock_file(true)?;
         }
 
         Ok(windows_file)

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -1,14 +1,54 @@
 use crate::error::io_error;
 use crate::io::clock::{DefaultClock, MonotonicInstant, WallClockInstant};
+use crate::io::common;
 use crate::io::FileSyncType;
-use crate::{Clock, Completion, File, OpenFlags, Result, IO};
-use crate::sync::RwLock;
-use std::io::{Read, Seek, Write};
 use crate::sync::Arc;
-use tracing::{debug, instrument, trace, Level};
+use crate::{Clock, Completion, CompletionError, File, LimboError, OpenFlags, Result, IO};
+use std::io::ErrorKind;
+use std::ptr;
+#[cfg(feature = "fs")]
+use tracing::debug;
+use tracing::{instrument, trace, Level};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, GetLastError, FALSE, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
+    ERROR_HANDLE_EOF,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FileEndOfFileInfo, FlushFileBuffers, GetFileSizeEx, LockFileEx, ReadFile,
+    SetFileInformationByHandle, UnlockFileEx, WriteFile, FILE_ATTRIBUTE_NORMAL,
+    FILE_END_OF_FILE_INFO, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, OPEN_ALWAYS, OPEN_EXISTING,
+};
+use windows_sys::Win32::System::IO::{OVERLAPPED, OVERLAPPED_0, OVERLAPPED_0_0};
+
+/// Creates an OVERLAPPED structure with the given file offset.
+/// Used with ReadFile/WriteFile on synchronous (non-OVERLAPPED) handles
+/// to achieve pread/pwrite semantics in a single syscall.
+#[inline]
+fn overlapped_at(pos: u64) -> OVERLAPPED {
+    OVERLAPPED {
+        Internal: 0,
+        InternalHigh: 0,
+        Anonymous: OVERLAPPED_0 {
+            Anonymous: OVERLAPPED_0_0 {
+                Offset: pos as u32,
+                OffsetHigh: (pos >> 32) as u32,
+            },
+        },
+        hEvent: 0,
+    }
+}
+
+#[inline]
+fn last_os_error(context: &'static str) -> LimboError {
+    let err = std::io::Error::last_os_error();
+    io_error(err, context)
+}
+
 pub struct WindowsIO {}
 
 impl WindowsIO {
+    #[cfg(feature = "fs")]
     pub fn new() -> Result<Self> {
         debug!("Using IO backend 'syscall'");
         Ok(Self {})
@@ -17,20 +57,53 @@ impl WindowsIO {
 
 impl IO for WindowsIO {
     #[instrument(skip_all, level = Level::TRACE)]
-    fn open_file(&self, path: &str, flags: OpenFlags, direct: bool) -> Result<Arc<dyn File>> {
+    fn open_file(&self, path: &str, flags: OpenFlags, _direct: bool) -> Result<Arc<dyn File>> {
         trace!("open_file(path = {})", path);
-        let mut file = std::fs::File::options();
-        file.read(true);
 
-        if !flags.contains(OpenFlags::ReadOnly) {
-            file.write(true);
-            file.create(flags.contains(OpenFlags::Create));
+        let wide_path: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+
+        let desired_access = if flags.contains(OpenFlags::ReadOnly) {
+            GENERIC_READ
+        } else {
+            GENERIC_READ | GENERIC_WRITE
+        };
+
+        let creation_disposition = if flags.contains(OpenFlags::Create) {
+            OPEN_ALWAYS
+        } else {
+            OPEN_EXISTING
+        };
+
+        let shared_mode = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+
+        let file_handle = unsafe {
+            CreateFileW(
+                wide_path.as_ptr(),
+                desired_access,
+                shared_mode,
+                ptr::null(),
+                creation_disposition,
+                FILE_ATTRIBUTE_NORMAL,
+                ptr::null_mut(),
+            )
+        };
+
+        if file_handle == INVALID_HANDLE_VALUE {
+            return Err(last_os_error("open"));
         }
 
-        let file = file.open(path).map_err(|e| io_error(e, "open"))?;
-        Ok(Arc::new(WindowsFile {
-            file: RwLock::new(file),
-        }))
+        let windows_file = Arc::new(WindowsFile { handle: file_handle });
+
+        if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
+            && !flags.contains(OpenFlags::ReadOnly)
+        {
+            if let Err(e) = windows_file.lock_file(true) {
+                unsafe { CloseHandle(windows_file.handle) };
+                return Err(e);
+            }
+        }
+
+        Ok(windows_file)
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
@@ -57,62 +130,251 @@ impl Clock for WindowsIO {
 }
 
 pub struct WindowsFile {
-    file: RwLock<std::fs::File>,
+    handle: HANDLE,
 }
+
+unsafe impl Send for WindowsFile {}
+unsafe impl Sync for WindowsFile {}
 
 impl File for WindowsFile {
     #[instrument(err, skip_all, level = Level::TRACE)]
     fn lock_file(&self, exclusive: bool) -> Result<()> {
-        unimplemented!()
+        trace!("lock_file(exclusive = {})", exclusive);
+
+        let flags = if exclusive {
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY
+        } else {
+            LOCKFILE_FAIL_IMMEDIATELY
+        };
+
+        let mut overlapped = overlapped_at(0);
+        let result =
+            unsafe { LockFileEx(self.handle, flags, 0, u32::MAX, u32::MAX, &mut overlapped) };
+
+        if result == FALSE {
+            let err = std::io::Error::last_os_error();
+            let message = match err.kind() {
+                ErrorKind::WouldBlock => {
+                    "Failed locking file. File is locked by another process".to_string()
+                }
+                _ => format!("Failed locking file, {err}"),
+            };
+            return Err(LimboError::LockingError(message));
+        }
+        Ok(())
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
     fn unlock_file(&self) -> Result<()> {
-        unimplemented!()
+        trace!("unlock_file");
+
+        let mut overlapped = overlapped_at(0);
+        let result = unsafe { UnlockFileEx(self.handle, 0, u32::MAX, u32::MAX, &mut overlapped) };
+
+        if result == FALSE {
+            let err = std::io::Error::last_os_error();
+            return Err(LimboError::LockingError(format!(
+                "Failed to release file lock: {err}"
+            )));
+        }
+        Ok(())
     }
 
     #[instrument(skip(self, c), level = Level::TRACE)]
     fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
-        let mut file = self.file.write();
-        file.seek(std::io::SeekFrom::Start(pos)).map_err(|e| io_error(e, "pread"))?;
-        let nr = {
+        let mut overlapped = overlapped_at(pos);
+        let mut bytes_read: u32 = 0;
+
+        let result = unsafe {
             let r = c.as_read();
             let buf = r.buf();
-            let buf = buf.as_mut_slice();
-            file.read(buf).map_err(|e| io_error(e, "pread"))? as i32
+            let slice = buf.as_mut_slice();
+            ReadFile(
+                self.handle,
+                slice.as_mut_ptr(),
+                slice.len() as u32,
+                &mut bytes_read,
+                &mut overlapped,
+            )
         };
-        c.complete(nr);
+
+        if result == FALSE {
+            let error = unsafe { GetLastError() };
+            if error == ERROR_HANDLE_EOF {
+                // EOF - report 0 bytes read, same as Unix pread at EOF
+                c.complete(0);
+                return Ok(c);
+            }
+            return Err(last_os_error("pread"));
+        }
+
+        trace!("pread n: {}", bytes_read);
+        c.complete(bytes_read as i32);
         Ok(c)
     }
 
     #[instrument(skip(self, c, buffer), level = Level::TRACE)]
     fn pwrite(&self, pos: u64, buffer: Arc<crate::Buffer>, c: Completion) -> Result<Completion> {
-        let mut file = self.file.write();
-        file.seek(std::io::SeekFrom::Start(pos)).map_err(|e| io_error(e, "pwrite"))?;
-        let buf = buffer.as_slice();
-        file.write_all(buf).map_err(|e| io_error(e, "pwrite"))?;
-        c.complete(buffer.len() as i32);
+        let buf_slice = buffer.as_slice();
+        let total_size = buf_slice.len();
+        let mut total_written = 0usize;
+        let mut current_pos = pos;
+
+        while total_written < total_size {
+            let remaining = &buf_slice[total_written..];
+            let mut bytes_written: u32 = 0;
+            let mut overlapped = overlapped_at(current_pos);
+
+            let result = unsafe {
+                WriteFile(
+                    self.handle,
+                    remaining.as_ptr(),
+                    remaining.len() as u32,
+                    &mut bytes_written,
+                    &mut overlapped,
+                )
+            };
+
+            if result == FALSE {
+                return Err(last_os_error("pwrite"));
+            }
+
+            let written = bytes_written as usize;
+            if written == 0 {
+                return Err(LimboError::CompletionError(CompletionError::IOError(
+                    ErrorKind::UnexpectedEof,
+                    "pwrite",
+                )));
+            }
+
+            total_written += written;
+            current_pos += written as u64;
+            trace!("pwrite iteration: wrote {written}, total {total_written}/{total_size}");
+        }
+
+        trace!("pwrite complete: wrote {total_written} bytes");
+        c.complete(total_written as i32);
+        Ok(c)
+    }
+
+    #[instrument(skip_all, level = Level::TRACE)]
+    fn pwritev(
+        &self,
+        pos: u64,
+        buffers: Vec<Arc<crate::Buffer>>,
+        c: Completion,
+    ) -> Result<Completion> {
+        if buffers.is_empty() {
+            c.complete(0);
+            return Ok(c);
+        }
+        if buffers.len() == 1 {
+            return self.pwrite(pos, buffers[0].clone(), c);
+        }
+
+        let total_size: usize = buffers.iter().map(|b| b.len()).sum();
+        let mut total_written = 0usize;
+        let mut current_pos = pos;
+
+        for buf in &buffers {
+            let slice = buf.as_slice();
+            let mut buf_written = 0usize;
+
+            while buf_written < slice.len() {
+                let remaining = &slice[buf_written..];
+                let mut bytes_written: u32 = 0;
+                let mut overlapped = overlapped_at(current_pos);
+
+                let result = unsafe {
+                    WriteFile(
+                        self.handle,
+                        remaining.as_ptr(),
+                        remaining.len() as u32,
+                        &mut bytes_written,
+                        &mut overlapped,
+                    )
+                };
+
+                if result == FALSE {
+                    return Err(last_os_error("pwritev"));
+                }
+
+                let written = bytes_written as usize;
+                if written == 0 {
+                    return Err(LimboError::CompletionError(CompletionError::IOError(
+                        ErrorKind::UnexpectedEof,
+                        "pwritev",
+                    )));
+                }
+
+                buf_written += written;
+                current_pos += written as u64;
+                total_written += written;
+            }
+        }
+
+        trace!("pwritev complete: wrote {total_written}/{total_size} bytes");
+        c.complete(total_written as i32);
         Ok(c)
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
     fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
-        let file = self.file.write();
-        file.sync_all().map_err(|e| io_error(e, "sync"))?;
+        let result = unsafe { FlushFileBuffers(self.handle) };
+        if result == FALSE {
+            return Err(last_os_error("sync"));
+        }
+        trace!("FlushFileBuffers");
         c.complete(0);
         Ok(c)
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
     fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
-        let file = self.file.write();
-        file.set_len(len).map_err(|e| io_error(e, "truncate"))?;
+        let file_info = FILE_END_OF_FILE_INFO {
+            EndOfFile: len as i64,
+        };
+        let result = unsafe {
+            SetFileInformationByHandle(
+                self.handle,
+                FileEndOfFileInfo,
+                (&raw const file_info).cast(),
+                std::mem::size_of::<FILE_END_OF_FILE_INFO>() as u32,
+            )
+        };
+        if result == FALSE {
+            return Err(last_os_error("truncate"));
+        }
+        trace!("file truncated to len=({})", len);
         c.complete(0);
         Ok(c)
     }
 
     fn size(&self) -> Result<u64> {
-        let file = self.file.read();
-        Ok(file.metadata().map_err(|e| io_error(e, "metadata"))?.len())
+        let mut file_size: i64 = 0;
+        let result = unsafe { GetFileSizeEx(self.handle, &mut file_size) };
+        if result == FALSE {
+            return Err(last_os_error("size"));
+        }
+        Ok(file_size as u64)
+    }
+}
+
+impl Drop for WindowsFile {
+    fn drop(&mut self) {
+        let _ = self.unlock_file();
+        unsafe {
+            CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_multiple_processes_cannot_open_file() {
+        common::tests::test_multiple_processes_cannot_open_file(WindowsIO::new);
     }
 }

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -10,8 +10,8 @@ use std::ptr;
 use tracing::debug;
 use tracing::{instrument, trace, Level};
 use windows_sys::Win32::Foundation::{
-    CloseHandle, GetLastError, FALSE, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
-    ERROR_HANDLE_EOF,
+    CloseHandle, GetLastError, ERROR_HANDLE_EOF, FALSE, GENERIC_READ, GENERIC_WRITE, HANDLE,
+    INVALID_HANDLE_VALUE,
 };
 use windows_sys::Win32::Storage::FileSystem::{
     CreateFileW, FileEndOfFileInfo, FlushFileBuffers, GetFileSizeEx, LockFileEx, ReadFile,
@@ -35,7 +35,7 @@ fn overlapped_at(pos: u64) -> OVERLAPPED {
                 OffsetHigh: (pos >> 32) as u32,
             },
         },
-        hEvent: 0,
+        hEvent: std::ptr::null_mut(),
     }
 }
 
@@ -92,7 +92,9 @@ impl IO for WindowsIO {
             return Err(last_os_error("open"));
         }
 
-        let windows_file = Arc::new(WindowsFile { handle: file_handle });
+        let windows_file = Arc::new(WindowsFile {
+            handle: file_handle,
+        });
 
         if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
             && !flags.contains(OpenFlags::ReadOnly)


### PR DESCRIPTION
Make our windows IO back-end more windows specific improvements instead of a copy of `generic.rs`