### PR TITLE
core: Add read-only support for `locking_mode` pragma

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -179,7 +179,7 @@ ongoing work to pass the full SQLite TCL test suite.
 | PRAGMA journal_size_limit        | ❌ No         |                                              |
 | PRAGMA legacy_alter_table        | ❌ No         |                                              |
 | PRAGMA legacy_file_format        | ✅ Yes        |                                              |
-| PRAGMA locking_mode              | ❌ No         |                                              |
+| PRAGMA locking_mode              | 🚧 Partial    | `EXCLUSIVE` only                             |
 | PRAGMA max_page_count            | ✅ Yes        |                                              |
 | PRAGMA mmap_size                 | ❌ No         |                                              |
 | PRAGMA module_list               | ❌ No         |                                              |

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -59,6 +59,7 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NeedSchema | PragmaFlags::Result0 | PragmaFlags::SchemaReq,
             &["journal_mode"],
         ),
+        LockingMode => Pragma::new(PragmaFlags::Result0, &["locking_mode"]),
         FullColumnNames | ShortColumnNames => {
             unreachable!("pragma_for() called with FullColumnNames/ShortColumnNames, which are deprecated no-ops")
         }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -226,6 +226,28 @@ fn update_pragma(
             program.add_pragma_result_column("journal_mode".into());
             Ok(TransactionMode::None)
         }
+        PragmaName::LockingMode => {
+            let mode = match &value {
+                Expr::Name(name) => name.as_str().to_string(),
+                Expr::Literal(Literal::Keyword(kw)) => kw.clone(),
+                Expr::Literal(Literal::String(s)) => s.clone(),
+                _ => parse_string(&value)?,
+            };
+            let mode_bytes = mode.as_bytes();
+            match_ignore_ascii_case!(match mode_bytes {
+                b"EXCLUSIVE" => {}
+                _ => bail_parse_error!("locking_mode must be EXCLUSIVE"),
+            });
+            query_pragma(
+                PragmaName::LockingMode,
+                resolver,
+                None,
+                pager,
+                connection,
+                database_id,
+                program,
+            )
+        }
         PragmaName::FullColumnNames => {
             let enabled = parse_pragma_enabled(&value);
             connection.set_full_column_names(enabled);
@@ -646,6 +668,12 @@ fn query_pragma(
                 dest: register,
                 new_mode: None,
             });
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::LockingMode => {
+            program.emit_string8("exclusive".to_string(), register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1687,6 +1687,8 @@ pub enum PragmaName {
     IntegrityCheck,
     /// `journal_mode` pragma
     JournalMode,
+    /// `locking_mode` pragma
+    LockingMode,
     /// Run a quick integrity check (skips expensive index consistency validation)
     QuickCheck,
     /// encryption key for encrypted databases, specified as hexadecimal string.


### PR DESCRIPTION
The SQLite select1.test TCL test needs it.