### PR TITLE
core: Implement initial support for multi-process database access

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -319,6 +319,18 @@ jobs:
   concurrent-simulator:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
+    strategy:
+      matrix:
+        profile:
+          - name: in-process
+            iterations: 100
+            args: "--reopen-probability 0.001"
+          - name: multiprocess
+            iterations: 20
+            args: "--multiprocess --max-connections 4"
+          - name: multiprocess-kill
+            iterations: 10
+            args: "--multiprocess --max-connections 4 --kill-probability 0.01"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -330,13 +342,14 @@ jobs:
           cache-on-failure: true
       - uses: "./.github/shared/setup-sccache"
       - name: Run turso_whopper regression tests
+        if: matrix.profile.name == 'in-process'
         run: cargo test -p turso_whopper --test regression_tests
         timeout-minutes: 5
-      - name: Run turso_whopper
+      - name: Run turso_whopper (${{ matrix.profile.name }})
         run: |
-          cargo build -p turso_whopper
-          for i in $(seq 1 100); do
-            ./target/debug/turso_whopper --reopen-probability 0.001 || exit 1
+          cargo build -p turso_whopper --release
+          for i in $(seq 1 ${{ matrix.profile.iterations }}); do
+            ./target/release/turso_whopper ${{ matrix.profile.args }} || exit 1
           done
 
   test-sqlite:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -318,19 +318,19 @@ jobs:
 
   concurrent-simulator:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       matrix:
         profile:
           - name: in-process
             iterations: 100
-            args: "--reopen-probability 0.001"
+            args: "--mode fast --reopen-probability 0.001"
           - name: multiprocess
             iterations: 20
-            args: "--multiprocess --max-connections 4"
+            args: "--mode fast --multiprocess --connections-per-process 4 --processes 4"
           - name: multiprocess-kill
             iterations: 10
-            args: "--multiprocess --max-connections 4 --kill-probability 0.01"
+            args: "--mode fast --multiprocess --connections-per-process 4 --processes 4 --kill-probability 0.01"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ dist/
 **/*.db-wal
 **/*.db-shm
 **/*-wal
+**/*.db-tshm
+
 # perf
 **/*/Mobibench
 perf/mobibench/plot/results.csv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6779,6 +6779,8 @@ dependencies = [
  "memmap2",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
+ "serde",
+ "serde_json",
  "sql_generation",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6786,6 +6786,7 @@ dependencies = [
  "tracing-subscriber",
  "turso_core",
  "turso_parser",
+ "twox-hash",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,10 @@ test-constraint: build uv-sync-test
 	fi
 .PHONY: test-constraint
 
+test-multiprocess:
+	cargo run --release -p turso_whopper -- --mode fast --multiprocess --max-connections 4
+.PHONY: test-multiprocess
+
 bench-vfs: uv-sync-test build-release
 	RUST_LOG=$(RUST_LOG) uv run --project limbo_test bench-vfs "$(SQL)" "$(N)"
 

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ test-constraint: build uv-sync-test
 .PHONY: test-constraint
 
 test-multiprocess:
-	cargo run --release -p turso_whopper -- --mode fast --multiprocess --max-connections 4
+	cargo run --release -p turso_whopper -- --mode fast --multiprocess --connections-per-process 4 --processes 4 --kill-probability 0.01
 .PHONY: test-multiprocess
 
 bench-vfs: uv-sync-test build-release

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The database has the following experimental features:
 * **Encryption at rest** for protecting the data locally.
 * **Incremental computation** using DBSP for incremental view maintenance and query subscriptions.
 * **Full-Text-Search** powered by the awesome [tantivy](https://github.com/quickwit-oss/tantivy) library
+* **Multi-process WAL coordination** via the `.tshm` sidecar for cross-process WAL readers and writers.
 
 The following features are on our current roadmap:
 

--- a/bindings/javascript/packages/common/types.ts
+++ b/bindings/javascript/packages/common/types.ts
@@ -1,4 +1,4 @@
-export type ExperimentalFeature = 'views' | 'strict' | 'encryption' | 'index_method' | 'autovacuum' | 'triggers' | 'attach';
+export type ExperimentalFeature = 'views' | 'strict' | 'encryption' | 'index_method' | 'autovacuum' | 'triggers' | 'attach' | 'multiprocess_wal';
 
 /** Supported encryption ciphers for local database encryption. */
 export type EncryptionCipher = 'aes128gcm' | 'aes256gcm' | 'aegis256' | 'aegis256x2' | 'aegis128l' | 'aegis128x2' | 'aegis128x4'

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -281,6 +281,7 @@ fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
                     "autovacuum" => core_opts.with_autovacuum(true),
                     "attach" => core_opts.with_attach(true),
                     "generated_columns" => core_opts.with_generated_columns(true),
+                    "multiprocess_wal" => core_opts.with_multiprocess_wal(true),
                     _ => core_opts,
                 };
             }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -145,6 +145,7 @@ pub struct Builder {
     enable_index_method: bool,
     enable_materialized_views: bool,
     enable_generated_columns: bool,
+    enable_multiprocess_wal: bool,
     vfs: Option<String>,
     encryption_opts: Option<turso_sdk_kit::rsapi::EncryptionOpts>,
     io: Option<Arc<dyn turso_core::IO>>,
@@ -161,6 +162,7 @@ impl Builder {
             enable_index_method: false,
             enable_materialized_views: false,
             enable_generated_columns: false,
+            enable_multiprocess_wal: false,
             vfs: None,
             encryption_opts: None,
             io: None,
@@ -212,6 +214,11 @@ impl Builder {
         self
     }
 
+    pub fn experimental_multiprocess_wal(mut self, enabled: bool) -> Self {
+        self.enable_multiprocess_wal = enabled;
+        self
+    }
+
     pub fn with_io(mut self, vfs: String) -> Self {
         self.vfs = Some(vfs);
         self
@@ -242,6 +249,9 @@ impl Builder {
         }
         if self.enable_generated_columns {
             features.push("generated_columns");
+        }
+        if self.enable_multiprocess_wal {
+            features.push("multiprocess_wal");
         }
         if features.is_empty() {
             return None;

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -93,6 +93,8 @@ pub struct Opts {
     pub experimental_attach: bool,
     #[clap(long, help = "Enable experimental generated columns feature")]
     pub experimental_generated_columns: bool,
+    #[clap(long, help = "Enable experimental multiprocess WAL coordination")]
+    pub experimental_multiprocess_wal: bool,
     #[cfg(feature = "mvcc_repl")]
     #[clap(long, help = "Start MVCC concurrent transaction harness")]
     pub mvcc: bool,
@@ -233,6 +235,7 @@ impl Limbo {
             .with_autovacuum(opts.experimental_autovacuum)
             .with_attach(opts.experimental_attach)
             .with_generated_columns(opts.experimental_generated_columns)
+            .with_multiprocess_wal(opts.experimental_multiprocess_wal)
             .with_unsafe_testing(opts.unsafe_testing);
 
         let db_file = normalize_db_path(db_file);

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -791,6 +791,7 @@ impl Connection {
     /// In multi-process mode, this is the only way to discover schema changes made by other processes.
     pub fn maybe_reparse_schema(self: &Arc<Connection>) -> Result<()> {
         let pager = self.pager.load().clone();
+        let mv_store = self.mv_store();
 
         // maybe_reparse_schema must be called outside any explicit transaction
         // because it starts its own read transaction to load a fresh view of
@@ -807,24 +808,32 @@ impl Connection {
             pager.set_schema_cookie(None);
         }
 
-        // first, quickly read schema_version from the root page in order to check if schema changed
-        pager.begin_read_tx()?;
-        let on_disk_schema_version = pager
-            .io
-            .block(|| pager.with_header(|header| header.schema_cookie));
+        let on_disk_schema_version = if mv_store.as_ref().is_some() {
+            self.read_current_schema_cookie().or_else(|err| match err {
+                LimboError::Page1NotAlloc => Ok(0),
+                other => Err(other),
+            })?
+        } else {
+            // first, quickly read schema_version from the root page in order to check if schema changed
+            pager.begin_read_tx()?;
+            let on_disk_schema_version = pager
+                .io
+                .block(|| pager.with_header(|header| header.schema_cookie));
 
-        let on_disk_schema_version = match on_disk_schema_version {
-            Ok(db_schema_version) => db_schema_version.get(),
-            Err(LimboError::Page1NotAlloc) => {
-                // this means this is a fresh db, so return a schema version of 0
-                0
-            }
-            Err(err) => {
-                pager.end_read_tx();
-                return Err(err);
-            }
+            let on_disk_schema_version = match on_disk_schema_version {
+                Ok(db_schema_version) => db_schema_version.get(),
+                Err(LimboError::Page1NotAlloc) => {
+                    // this means this is a fresh db, so return a schema version of 0
+                    0
+                }
+                Err(err) => {
+                    pager.end_read_tx();
+                    return Err(err);
+                }
+            };
+            pager.end_read_tx();
+            on_disk_schema_version
         };
-        pager.end_read_tx();
 
         let db_schema_version = self.db.schema.lock().schema_version;
         tracing::debug!(
@@ -866,14 +875,12 @@ impl Connection {
     }
 
     pub(crate) fn reparse_schema(self: &Arc<Connection>) -> Result<()> {
-        let pager = self.pager.load().clone();
-
         // read cookie before consuming statement program - otherwise we can end up reading cookie with closed transaction state
-        let cookie = pager
-            .io
-            .block(|| pager.with_header(|header| header.schema_cookie))?
-            .get();
+        let cookie = self.read_current_schema_cookie()?;
+        self.reparse_schema_with_cookie(cookie)
+    }
 
+    pub(crate) fn reparse_schema_with_cookie(self: &Arc<Connection>, cookie: u32) -> Result<()> {
         // create fresh schema as some objects can be deleted
         let mut fresh = Schema::with_options(self.experimental_custom_types_enabled());
         fresh.generated_columns_enabled = self.db.experimental_generated_columns_enabled();
@@ -974,6 +981,19 @@ impl Connection {
             *schema = fresh;
         });
         Result::Ok(())
+    }
+
+    pub(crate) fn read_current_schema_cookie(&self) -> Result<u32> {
+        if let Some(mv_store) = self.mv_store().as_ref() {
+            let tx_id = self.get_mv_tx_id();
+            mv_store.with_header(|header| header.schema_cookie.get(), tx_id.as_ref())
+        } else {
+            let pager = self.pager.load();
+            pager
+                .io
+                .block(|| pager.with_header(|header| header.schema_cookie))
+                .map(|cookie| cookie.get())
+        }
     }
 
     #[instrument(skip_all, level = Level::INFO)]
@@ -1225,6 +1245,8 @@ impl Connection {
         let current_schema_version = self.schema.read().schema_version;
         let schema = self.db.schema.lock();
         if matches!(self.get_tx_state(), TransactionState::None)
+            && self.get_mv_tx().is_none()
+            && self.next_attached_mv_tx().is_none()
             && current_schema_version != schema.schema_version
         {
             *self.schema.write() = schema.clone();
@@ -1556,7 +1578,7 @@ impl Connection {
             .block(|| pager.checkpoint(mode, SyncMode::Full, true))
     }
 
-    #[cfg(feature = "simulator")]
+    #[cfg(all(feature = "simulator", target_pointer_width = "64", unix))]
     pub fn install_unpublished_backfill_proof_for_testing(
         &self,
         upper_bound_inclusive: u64,

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -8,6 +8,7 @@ use crate::sync::{
     Arc, RwLock,
 };
 use crate::turso_assert;
+use crate::types::ImmutableRecord;
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
 #[cfg(feature = "fs")]
@@ -730,11 +731,18 @@ impl Connection {
             .store(true, Ordering::SeqCst);
     }
 
-    /// Parse schema from scratch if version of schema for the connection differs from the schema cookie in the root page
-    /// This function must be called outside of any transaction because internally it will start transaction session by itself
-    #[allow(dead_code)]
-    fn maybe_reparse_schema(self: &Arc<Connection>) -> Result<()> {
+    /// Parse schema from scratch if version of schema for the connection differs from the schema cookie in the root page.
+    /// This function must be called outside of any transaction because internally it will start transaction session by itself.
+    /// In multi-process mode, this is the only way to discover schema changes made by other processes.
+    pub fn maybe_reparse_schema(self: &Arc<Connection>) -> Result<()> {
         let pager = self.pager.load().clone();
+
+        // maybe_reparse_schema must be called outside any explicit transaction
+        // because it starts its own read transaction to load a fresh view of
+        // sqlite_schema from disk.
+        if self.get_tx_state() != TransactionState::None {
+            return Ok(());
+        }
 
         // first, quickly read schema_version from the root page in order to check if schema changed
         pager.begin_read_tx()?;
@@ -766,11 +774,6 @@ impl Connection {
         if db_schema_version == on_disk_schema_version {
             return Ok(());
         }
-        // maybe_reparse_schema must be called outside of any transaction
-        turso_assert!(
-            self.get_tx_state() == TransactionState::None,
-            "unexpected start transaction"
-        );
         // start read transaction manually, because we will read schema cookie once again and
         // we must be sure that it will consistent with schema content
         //
@@ -813,6 +816,24 @@ impl Connection {
         fresh.generated_columns_enabled = self.db.experimental_generated_columns_enabled();
         fresh.schema_version = cookie;
 
+        // Capture built-in table-valued functions (e.g. generate_series, json_each)
+        // before dropping the old schema. These are registered programmatically and
+        // don't survive re-parsing from sqlite_schema alone.
+        let table_valued_functions: Vec<_> = self
+            .schema
+            .read()
+            .tables
+            .values()
+            .filter_map(|table| match table.as_ref() {
+                crate::schema::Table::Virtual(vtab)
+                    if matches!(vtab.kind, turso_ext::VTabKind::TableValuedFunction) =>
+                {
+                    Some(vtab.clone())
+                }
+                _ => None,
+            })
+            .collect();
+
         // TODO: this is hack to avoid a cyclical problem with schema reprepare
         // The problem here is that we prepare a statement here, but when the statement tries
         // to execute it, it first checks the schema cookie to see if it needs to reprepare the statement.
@@ -846,6 +867,15 @@ impl Connection {
             mv_tx,
             &attached_resolver,
         )?;
+
+        // Rehydrate built-in table-valued functions that were captured above.
+        for vtab in &table_valued_functions {
+            let normalized = crate::util::normalize_ident(&vtab.name);
+            fresh
+                .tables
+                .entry(normalized)
+                .or_insert_with(|| Arc::new(crate::schema::Table::Virtual(vtab.clone())));
+        }
 
         // Load custom types from __turso_internal_types if the table exists
         // and custom types are enabled. Type loading errors are non-fatal: we log
@@ -1053,12 +1083,12 @@ impl Connection {
             (Some(_), None) => {
                 return Err(LimboError::InvalidArgument(
                     "hexkey is required when cipher is provided".to_string(),
-                ))
+                ));
             }
             (None, Some(_)) => {
                 return Err(LimboError::InvalidArgument(
                     "cipher is required when hexkey is provided".to_string(),
-                ))
+                ));
             }
             (None, None) => None,
         };
@@ -1101,12 +1131,12 @@ impl Connection {
             (Some(_), None) => {
                 return Err(LimboError::InvalidArgument(
                     "hexkey is required when cipher is provided".to_string(),
-                ))
+                ));
             }
             (None, Some(_)) => {
                 return Err(LimboError::InvalidArgument(
                     "cipher is required when hexkey is provided".to_string(),
-                ))
+                ));
             }
             (None, None) => None,
         };
@@ -1481,7 +1511,18 @@ impl Connection {
             }
         }
 
-        if self.db.n_connections.fetch_sub(1, Ordering::SeqCst).eq(&1) && !self.db.is_readonly() {
+        let is_memory_db = self.db.path == ":memory:"
+            || self.db.path.starts_with("file::memory:")
+            || self.db.path.is_empty();
+        let should_checkpoint_on_close = pager
+            .wal
+            .as_ref()
+            .map_or(true, |wal| wal.should_checkpoint_on_close());
+        if self.db.n_connections.fetch_sub(1, Ordering::SeqCst).eq(&1)
+            && !self.db.is_readonly()
+            && !is_memory_db
+            && should_checkpoint_on_close
+        {
             self.pager.load().checkpoint_shutdown(
                 self.is_wal_auto_checkpoint_disabled(),
                 self.get_sync_mode(),
@@ -2944,6 +2985,32 @@ impl Connection {
 
     pub(crate) fn clear_named_savepoints(&self) {
         self.named_savepoints.write().clear();
+    }
+
+    /// Roll back the current main-db transaction state and any attached-db
+    /// transaction state on this connection.
+    pub(crate) fn rollback_current_txn_state(
+        &self,
+        pager: &Arc<Pager>,
+        clear_attached_schemas: bool,
+    ) {
+        if let Some(mv_store) = self.mv_store().as_ref() {
+            if let Some(tx_id) = self.get_mv_tx_id() {
+                self.auto_commit.store(true, Ordering::SeqCst);
+                if mv_store.is_tx_rollbackable(tx_id) {
+                    mv_store.rollback_tx(tx_id, pager.clone(), self, crate::MAIN_DB_ID);
+                } else {
+                    self.set_mv_tx(None);
+                }
+            }
+            pager.end_read_tx();
+            self.rollback_attached_mvcc_txs(clear_attached_schemas);
+        } else {
+            pager.rollback_tx(self);
+            self.auto_commit.store(true, Ordering::SeqCst);
+        }
+        self.rollback_attached_wal_txns();
+        self.set_tx_state(TransactionState::None);
     }
 
     /// Iterate over all attached MVCC transactions, calling `f(db_id, tx_id)` for each.

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -294,16 +294,18 @@ impl Drop for Connection {
             }
 
             // Also release WAL locks on all attached database pagers
-            for attached_pager in self.get_all_attached_pagers() {
-                if let Some(wal) = &attached_pager.wal {
-                    if wal.holds_write_lock() {
-                        wal.end_write_tx();
-                    }
-                    if wal.holds_read_lock() {
-                        wal.end_read_tx();
+            self.with_all_attached_pagers_with_index(|attached_pagers| {
+                for (_, attached_pager) in attached_pagers {
+                    if let Some(wal) = &attached_pager.wal {
+                        if wal.holds_write_lock() {
+                            wal.end_write_tx();
+                        }
+                        if wal.holds_read_lock() {
+                            wal.end_read_tx();
+                        }
                     }
                 }
-            }
+            });
 
             // if connection wasn't properly closed, decrement the connection counter
             self.db
@@ -556,7 +558,7 @@ impl Connection {
     /// Check if a specific trigger is currently compiling (for recursive trigger prevention)
     pub fn trigger_is_compiling(&self, trigger: &Arc<Trigger>) -> bool {
         let compiling = self.compiling_triggers.read();
-        if let Some(trigger) = compiling.iter().find(|t| Arc::ptr_eq(t, trigger)) {
+        if let Some(trigger) = compiling.iter().find(|t| t.name == trigger.name) {
             tracing::debug!("Trigger is already compiling: {}", trigger.name);
             return true;
         }
@@ -579,7 +581,7 @@ impl Connection {
     /// Check if a specific trigger is currently executing (for recursive trigger prevention)
     pub fn is_trigger_executing(&self, trigger: &Arc<Trigger>) -> bool {
         let executing = self.executing_triggers.read();
-        if let Some(trigger) = executing.iter().find(|t| Arc::ptr_eq(t, trigger)) {
+        if let Some(trigger) = executing.iter().find(|t| t.name == trigger.name) {
             tracing::debug!("Trigger is already executing: {}", trigger.name);
             return true;
         }
@@ -2054,23 +2056,23 @@ impl Connection {
         self.db.initialized()
     }
 
-    pub(crate) fn get_pager_from_database_index(&self, index: &usize) -> Arc<Pager> {
+    pub(crate) fn get_pager_from_database_index(&self, index: &usize) -> Result<Arc<Pager>> {
         match *index {
-            crate::MAIN_DB_ID => self.pager.load().clone(),
+            crate::MAIN_DB_ID => Ok(self.pager.load().clone()),
             crate::TEMP_DB_ID => {
                 // Lazily initialize the temp database if it hasn't been created yet.
                 if self.temp.database.read().is_none() {
-                    self.ensure_temp_database()
-                        .expect("failed to initialize temp database");
+                    self.ensure_temp_database()?;
                 }
-                self.temp
+                Ok(self
+                    .temp
                     .database
                     .read()
                     .as_ref()
                     .map(|temp_db| temp_db.pager.clone())
-                    .expect("temp database should be initialized")
+                    .expect("temp database should be initialized after ensure_temp_database"))
             }
-            _ => self.attached_databases.read().get_pager_by_index(index),
+            _ => Ok(self.attached_databases.read().get_pager_by_index(index)),
         }
     }
 
@@ -2430,7 +2432,9 @@ impl Connection {
         // Rollback any active transaction on this database before detaching.
         // After the Database is removed from the catalog, the MvStore / Pager
         // become unreachable and the transaction would leak forever.
-        let pager = self.get_pager_from_database_index(&database_id);
+        let pager = self
+            .get_pager_from_database_index(&database_id)
+            .expect("attached database should always have a pager");
         if let Some((tx_id, _mode)) = self.get_mv_tx_for_db(database_id) {
             if let Some(mv_store) = self.mv_store_for_db(database_id) {
                 mv_store.rollback_tx(tx_id, pager.clone(), self, database_id);
@@ -2466,22 +2470,6 @@ impl Connection {
             .keys()
             .cloned()
             .collect()
-    }
-
-    /// Get all non-main database pagers (temp + attached).
-    pub fn get_all_attached_pagers(&self) -> Vec<Arc<Pager>> {
-        let mut pagers = Vec::new();
-        if let Some(temp_db) = self.temp.database.read().as_ref() {
-            pagers.push(temp_db.pager.clone());
-        }
-        let catalog = self.attached_databases.read();
-        pagers.extend(
-            catalog
-                .index_to_data
-                .values()
-                .map(|(_db, pager)| pager.clone()),
-        );
-        pagers
     }
 
     /// Invoke `f` with a slice of all non-main database (index, pager) pairs
@@ -2961,7 +2949,9 @@ impl Connection {
         let mut cleared_any_schema = false;
         for (&db_id, &(tx_id, _mode)) in &txs {
             if let Some(attached_mv_store) = self.mv_store_for_db(db_id) {
-                let attached_pager = self.get_pager_from_database_index(&db_id);
+                let attached_pager = self
+                    .get_pager_from_database_index(&db_id)
+                    .expect("attached MVCC transaction should always have a pager");
                 if attached_mv_store.is_tx_rollbackable(tx_id) {
                     attached_mv_store.rollback_tx(tx_id, attached_pager.clone(), self, db_id);
                 } else {

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3430,4 +3430,32 @@ mod tests {
         assert_eq!(query_single_i64(&conn, "SELECT COUNT(*) FROM temp.u"), 0);
         assert_eq!(query_single_i64(&conn, "SELECT COUNT(*) FROM temp.t"), 0);
     }
+
+    #[test]
+    fn test_distinct_triggers_with_same_name_in_different_schemas_can_fire_nested() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("main.db");
+        let conn = open_connection(&db_path);
+
+        conn.execute("CREATE TABLE src(x INTEGER)").unwrap();
+        conn.execute("CREATE TABLE dst(y INTEGER)").unwrap();
+        conn.execute("CREATE TABLE audit(z INTEGER)").unwrap();
+        conn.execute(
+            "CREATE TRIGGER shared_name AFTER INSERT ON dst BEGIN \
+             INSERT INTO audit VALUES (NEW.y); \
+             END;",
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TEMP TRIGGER shared_name AFTER INSERT ON main.src BEGIN \
+             INSERT INTO dst VALUES (NEW.x); \
+             END;",
+        )
+        .unwrap();
+
+        conn.execute("INSERT INTO src VALUES(7)").unwrap();
+
+        assert_eq!(query_single_i64(&conn, "SELECT COUNT(*) FROM main.dst"), 1);
+        assert_eq!(query_single_i64(&conn, "SELECT SUM(z) FROM main.audit"), 7);
+    }
 }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -8,7 +8,6 @@ use crate::sync::{
     Arc, RwLock,
 };
 use crate::turso_assert;
-use crate::types::ImmutableRecord;
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
 #[cfg(feature = "fs")]
@@ -26,8 +25,8 @@ use crate::{
     BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
     Completion, ConnectionMetrics, Database, DatabaseCatalog, DatabaseOpts, Duration,
     EncryptionKey, EncryptionOpts, IndexMethod, LimboError, MvStore, OpenFlags, PageSize, Pager,
-    Parser, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode, TransactionMode, Trigger,
-    Value, VirtualTable,
+    Parser, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode, TransactionMode,
+    Trigger, Value, VirtualTable,
 };
 use crate::{MAIN_DB_ID, TEMP_DB_ID};
 use arc_swap::ArcSwap;
@@ -35,10 +34,29 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
 use std::fmt::Display;
 use std::ops::Deref;
+#[cfg(feature = "simulator")]
+use std::path::Path;
 #[cfg(not(target_family = "wasm"))]
 use tempfile::TempDir;
 use tracing::{instrument, Level};
 use turso_macros::{turso_assert_ne, AtomicEnum};
+
+#[cfg(feature = "simulator")]
+fn db_identity_for_testing(db_path: &Path) -> Result<(u32, u32)> {
+    let bytes =
+        std::fs::read(db_path).map_err(|e| io_error(e, "read db header for simulator testing"))?;
+    let db_header_size = crate::storage::sqlite3_ondisk::DatabaseHeader::SIZE;
+    if bytes.len() < db_header_size {
+        return Err(LimboError::InternalError(format!(
+            "database file is smaller than the header: got {}, need at least {}",
+            bytes.len(),
+            db_header_size
+        )));
+    }
+    let db_size_pages = u32::from_be_bytes(bytes[28..32].try_into().unwrap());
+    let crc = crc32c::crc32c(&bytes[..db_header_size]);
+    Ok((db_size_pages, crc))
+}
 
 #[derive(Clone, AtomicEnum, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum TransactionState {
@@ -580,6 +598,61 @@ impl Connection {
         );
         self.executing_triggers.write().pop();
     }
+
+    fn should_retry_cross_process_schema_lookup(
+        self: &Arc<Connection>,
+        err: &LimboError,
+    ) -> Result<bool> {
+        let LimboError::ParseError(msg) = err else {
+            return Ok(false);
+        };
+        if !msg.contains("no such table") && !msg.contains("table not found") {
+            return Ok(false);
+        }
+        if self.get_tx_state() != TransactionState::None {
+            return Ok(false);
+        }
+        if self.db.shared_wal_coordination()?.is_none() {
+            return Ok(false);
+        }
+        self.maybe_reparse_schema()?;
+        Ok(true)
+    }
+
+    fn compile_cmd(
+        self: &Arc<Connection>,
+        cmd: &Cmd,
+        input: &str,
+    ) -> Result<(Program, Arc<Pager>, QueryMode)> {
+        let mut retried_after_schema_refresh = false;
+        loop {
+            self.maybe_update_schema();
+            let syms = self.syms.read();
+            let pager = self.pager.load().clone();
+            let mode = QueryMode::new(cmd);
+            let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd.clone();
+            let schema = self.schema.read().clone();
+            match translate::translate(
+                &schema,
+                stmt,
+                pager.clone(),
+                self.clone(),
+                &syms,
+                mode,
+                input,
+            ) {
+                Ok(program) => return Ok((program, pager, mode)),
+                Err(err)
+                    if !retried_after_schema_refresh
+                        && self.should_retry_cross_process_schema_lookup(&err)? =>
+                {
+                    retried_after_schema_refresh = true;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
     pub fn prepare(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
         self._prepare(sql)
     }
@@ -626,29 +699,11 @@ impl Connection {
                     ));
                 }
             };
-            let syms = self.syms.read();
             let byte_offset_end = parser.offset();
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            self.maybe_update_schema();
-            let pager = self.pager.load().clone();
-            let mode = QueryMode::new(&cmd);
-            let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
-
-            // Read lock + Arc::Clone the schema here to avoid a possible recursive read lock in `op_parse_schema`,
-            // where we try to read the schema again there
-            let schema = self.schema.read().clone();
-
-            let program = translate::translate(
-                &schema,
-                stmt,
-                pager.clone(),
-                self.clone(),
-                &syms,
-                mode,
-                input,
-            )?;
+            let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
             Ok(Statement::new_with_origin(
                 program,
                 pager,
@@ -742,6 +797,14 @@ impl Connection {
         // sqlite_schema from disk.
         if self.get_tx_state() != TransactionState::None {
             return Ok(());
+        }
+
+        if self.db.shared_wal_coordination()?.is_some() {
+            // Cross-process schema changes can leave page 1 and sqlite_schema
+            // pages cached from an earlier WAL snapshot. Drop the cache before
+            // probing the cookie so reparsing observes the current committed view.
+            pager.clear_page_cache(false);
+            pager.set_schema_cookie(None);
         }
 
         // first, quickly read schema_version from the root page in order to check if schema changed
@@ -923,29 +986,15 @@ impl Connection {
                 "The supplied SQL string contains no statements".to_string(),
             ));
         }
-        self.maybe_update_schema();
         let sql = sql.as_ref();
         tracing::trace!("Preparing and executing batch: {}", sql);
         let mut parser = Parser::new(sql.as_bytes());
         while let Some(cmd) = parser.next_cmd()? {
-            let syms = self.syms.read();
-            let pager = self.pager.load().clone();
             let byte_offset_end = parser.offset();
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let mode = QueryMode::new(&cmd);
-            let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
-            let schema = self.schema.read().clone();
-            let program = translate::translate(
-                &schema,
-                stmt,
-                pager.clone(),
-                self.clone(),
-                &syms,
-                mode,
-                input,
-            )?;
+            let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
             Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
         }
         Ok(())
@@ -957,7 +1006,6 @@ impl Connection {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
         let sql = sql.as_ref();
-        self.maybe_update_schema();
         tracing::trace!("Querying: {}", sql);
         let mut parser = Parser::new(sql.as_bytes());
         let cmd = parser.next_cmd()?;
@@ -980,20 +1028,7 @@ impl Connection {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
-        let syms = self.syms.read();
-        let pager = self.pager.load().clone();
-        let mode = QueryMode::new(&cmd);
-        let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
-        let schema = self.schema.read().clone();
-        let program = translate::translate(
-            &schema,
-            stmt,
-            pager.clone(),
-            self.clone(),
-            &syms,
-            mode,
-            input,
-        )?;
+        let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
         let stmt = Statement::new(program, pager, mode, 0);
         Ok(Some(stmt))
     }
@@ -1010,27 +1045,13 @@ impl Connection {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
         let sql = sql.as_ref();
-        self.maybe_update_schema();
         let mut parser = Parser::new(sql.as_bytes());
         while let Some(cmd) = parser.next_cmd()? {
-            let syms = self.syms.read();
-            let pager = self.pager.load().clone();
             let byte_offset_end = parser.offset();
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let mode = QueryMode::new(&cmd);
-            let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
-            let schema = self.schema.read().clone();
-            let program = translate::translate(
-                &schema,
-                stmt,
-                pager.clone(),
-                self.clone(),
-                &syms,
-                mode,
-                input,
-            )?;
+            let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
             Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
         }
         Ok(())
@@ -1045,24 +1066,11 @@ impl Connection {
         let Some(cmd) = parser.next_cmd()? else {
             return Ok(None);
         };
-        let syms = self.syms.read();
-        let pager = self.pager.load().clone();
         let byte_offset_end = parser.offset();
         let input = str::from_utf8(&sql.as_ref().as_bytes()[..byte_offset_end])
             .unwrap()
             .trim();
-        let mode = QueryMode::new(&cmd);
-        let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
-        let schema = self.schema.read().clone();
-        let program = translate::translate(
-            &schema,
-            stmt,
-            pager.clone(),
-            self.clone(),
-            &syms,
-            mode,
-            input,
-        )?;
+        let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
         let stmt = Statement::new(program, pager, mode, 0);
         Ok(Some((stmt, parser.offset())))
     }
@@ -1517,7 +1525,7 @@ impl Connection {
         let should_checkpoint_on_close = pager
             .wal
             .as_ref()
-            .map_or(true, |wal| wal.should_checkpoint_on_close());
+            .is_none_or(|wal| wal.should_checkpoint_on_close());
         if self.db.n_connections.fetch_sub(1, Ordering::SeqCst).eq(&1)
             && !self.db.is_readonly()
             && !is_memory_db
@@ -1538,6 +1546,46 @@ impl Connection {
 
     pub fn is_wal_auto_checkpoint_disabled(&self) -> bool {
         self.wal_auto_checkpoint_disabled.load(Ordering::SeqCst) || self.db.get_mv_store().is_some()
+    }
+
+    #[cfg(feature = "simulator")]
+    pub fn checkpoint_for_testing(&self, mode: CheckpointMode) -> Result<CheckpointResult> {
+        let pager = self.pager.load();
+        pager
+            .io
+            .block(|| pager.checkpoint(mode, SyncMode::Full, true))
+    }
+
+    #[cfg(feature = "simulator")]
+    pub fn install_unpublished_backfill_proof_for_testing(
+        &self,
+        upper_bound_inclusive: u64,
+    ) -> Result<()> {
+        let pager = self.pager.load();
+        let proof_nbackfills =
+            pager.run_checkpoint_until_post_sync_gap_for_testing(CheckpointMode::Passive {
+                upper_bound_inclusive: Some(upper_bound_inclusive),
+            })?;
+        let authority = self.db.shared_wal_coordination()?.ok_or_else(|| {
+            LimboError::InternalError("shared WAL authority is unavailable".into())
+        })?;
+        let snapshot_before_publish = authority.snapshot();
+        if snapshot_before_publish.nbackfills != 0 {
+            return Err(LimboError::InternalError(
+                "unpublished-proof setup requires nbackfills to remain unpublished".into(),
+            ));
+        }
+
+        let (db_size_pages, db_header_crc32c) = db_identity_for_testing(Path::new(&self.db.path))?;
+        authority.install_backfill_proof(
+            crate::storage::shared_wal_coordination::SharedWalCoordinationHeader {
+                nbackfills: proof_nbackfills,
+                ..snapshot_before_publish
+            },
+            db_size_pages,
+            db_header_crc32c,
+        );
+        Ok(())
     }
 
     pub fn last_insert_rowid(&self) -> i64 {

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -558,8 +558,9 @@ impl Connection {
     /// Check if a specific trigger is currently compiling (for recursive trigger prevention)
     pub fn trigger_is_compiling(&self, trigger: &Arc<Trigger>) -> bool {
         let compiling = self.compiling_triggers.read();
-        if let Some(trigger) = compiling.iter().find(|t| t.name == trigger.name) {
+        if let Some(active_trigger) = compiling.iter().find(|t| Arc::ptr_eq(t, trigger)) {
             tracing::debug!("Trigger is already compiling: {}", trigger.name);
+            debug_assert!(Arc::ptr_eq(active_trigger, trigger));
             return true;
         }
         false
@@ -581,8 +582,9 @@ impl Connection {
     /// Check if a specific trigger is currently executing (for recursive trigger prevention)
     pub fn is_trigger_executing(&self, trigger: &Arc<Trigger>) -> bool {
         let executing = self.executing_triggers.read();
-        if let Some(trigger) = executing.iter().find(|t| t.name == trigger.name) {
+        if let Some(active_trigger) = executing.iter().find(|t| Arc::ptr_eq(t, trigger)) {
             tracing::debug!("Trigger is already executing: {}", trigger.name);
+            debug_assert!(Arc::ptr_eq(active_trigger, trigger));
             return true;
         }
         false

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -7,7 +7,6 @@ use crate::sync::{
     atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, Ordering},
     Arc, RwLock,
 };
-use crate::turso_assert;
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
 #[cfg(feature = "fs")]
@@ -28,6 +27,7 @@ use crate::{
     Parser, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode, TransactionMode,
     Trigger, Value, VirtualTable,
 };
+use crate::{is_memory_like, turso_assert};
 use crate::{MAIN_DB_ID, TEMP_DB_ID};
 use arc_swap::ArcSwap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -558,9 +558,8 @@ impl Connection {
     /// Check if a specific trigger is currently compiling (for recursive trigger prevention)
     pub fn trigger_is_compiling(&self, trigger: &Arc<Trigger>) -> bool {
         let compiling = self.compiling_triggers.read();
-        if let Some(active_trigger) = compiling.iter().find(|t| Arc::ptr_eq(t, trigger)) {
+        if let Some(trigger) = compiling.iter().find(|t| Arc::ptr_eq(t, trigger)) {
             tracing::debug!("Trigger is already compiling: {}", trigger.name);
-            debug_assert!(Arc::ptr_eq(active_trigger, trigger));
             return true;
         }
         false
@@ -1562,9 +1561,7 @@ impl Connection {
             }
         }
 
-        let is_memory_db = self.db.path == ":memory:"
-            || self.db.path.starts_with("file::memory:")
-            || self.db.path.is_empty();
+        let is_memory_db = is_memory_like(&self.db.path);
         let should_checkpoint_on_close = pager
             .wal
             .as_ref()

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -621,35 +621,52 @@ impl Connection {
 
     fn compile_cmd(
         self: &Arc<Connection>,
-        cmd: &Cmd,
+        cmd: Cmd,
         input: &str,
     ) -> Result<(Program, Arc<Pager>, QueryMode)> {
-        let mut retried_after_schema_refresh = false;
-        loop {
-            self.maybe_update_schema();
-            let syms = self.syms.read();
-            let pager = self.pager.load().clone();
-            let mode = QueryMode::new(cmd);
-            let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd.clone();
-            let schema = self.schema.read().clone();
-            match translate::translate(
-                &schema,
-                stmt,
-                pager.clone(),
-                self.clone(),
-                &syms,
-                mode,
-                input,
-            ) {
-                Ok(program) => return Ok((program, pager, mode)),
-                Err(err)
-                    if !retried_after_schema_refresh
-                        && self.should_retry_cross_process_schema_lookup(&err)? =>
-                {
-                    retried_after_schema_refresh = true;
-                }
-                Err(err) => return Err(err),
+        self.maybe_update_schema();
+        let syms = self.syms.read();
+        let pager = self.pager.load().clone();
+        let mode = QueryMode::new(&cmd);
+        let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
+        let schema = self.schema.read().clone();
+        match translate::translate(
+            &schema,
+            stmt,
+            pager.clone(),
+            self.clone(),
+            &syms,
+            mode,
+            input,
+        ) {
+            Ok(program) => Ok((program, pager, mode)),
+            Err(err) if self.should_retry_cross_process_schema_lookup(&err)? => {
+                // Cold path: re-parse the SQL from scratch after schema refresh rather
+                // than cloning the original AST, which can overflow the stack
+                // on deeply nested expression trees.
+                drop(syms);
+                let mut parser = Parser::new(input.as_bytes());
+                let Some(cmd) = parser.next_cmd()? else {
+                    return Err(err);
+                };
+                self.maybe_update_schema();
+                let syms = self.syms.read();
+                let pager = self.pager.load().clone();
+                let mode = QueryMode::new(&cmd);
+                let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
+                let schema = self.schema.read().clone();
+                translate::translate(
+                    &schema,
+                    stmt,
+                    pager.clone(),
+                    self.clone(),
+                    &syms,
+                    mode,
+                    input,
+                )
+                .map(|program| (program, pager, mode))
             }
+            Err(err) => Err(err),
         }
     }
 
@@ -703,7 +720,7 @@ impl Connection {
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
+            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
             Ok(Statement::new_with_origin(
                 program,
                 pager,
@@ -1014,7 +1031,7 @@ impl Connection {
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
+            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
             Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
         }
         Ok(())
@@ -1048,7 +1065,7 @@ impl Connection {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
-        let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
+        let (program, pager, mode) = self.compile_cmd(cmd, input)?;
         let stmt = Statement::new(program, pager, mode, 0);
         Ok(Some(stmt))
     }
@@ -1071,7 +1088,7 @@ impl Connection {
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
+            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
             Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
         }
         Ok(())
@@ -1090,7 +1107,7 @@ impl Connection {
         let input = str::from_utf8(&sql.as_ref().as_bytes()[..byte_offset_end])
             .unwrap()
             .trim();
-        let (program, pager, mode) = self.compile_cmd(&cmd, input)?;
+        let (program, pager, mode) = self.compile_cmd(cmd, input)?;
         let stmt = Statement::new(program, pager, mode, 0);
         Ok(Some((stmt, parser.offset())))
     }

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -395,6 +395,7 @@ mod tests {
                 enable_autovacuum: false,
                 enable_attach: false,
                 enable_generated_columns: false,
+                enable_multiprocess_wal: false,
                 unsafe_testing: false,
             },
             None,

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1850,7 +1850,7 @@ impl FtsCursor {
         let index_name = format!("{}_key", self.dir_table_name);
 
         // Get root page for HybridBTreeDirectory
-        let pager = conn.get_pager_from_database_index(&database_id);
+        let pager = conn.get_pager_from_database_index(&database_id)?;
         let scratch = conn
             .with_schema(database_id, |schema| {
                 schema.get_index(&self.dir_table_name, &index_name).cloned()

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -177,7 +177,7 @@ pub(crate) fn open_table_cursor(
     database_id: usize,
     table: &str,
 ) -> Result<BTreeCursor> {
-    let pager = connection.get_pager_from_database_index(&database_id);
+    let pager = connection.get_pager_from_database_index(&database_id)?;
     let Some(table) = connection.with_schema(database_id, |schema| schema.get_table(table)) else {
         return Err(LimboError::InternalError(format!(
             "table {table} not found",
@@ -195,7 +195,7 @@ pub(crate) fn open_index_cursor(
     index: &str,
     keys: Vec<KeyInfo>,
 ) -> Result<BTreeCursor> {
-    let pager = connection.get_pager_from_database_index(&database_id);
+    let pager = connection.get_pager_from_database_index(&database_id)?;
     let Some(scratch) = connection.with_schema(database_id, |schema| {
         schema.get_index(table, index).cloned()
     }) else {

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -1,7 +1,13 @@
 #![allow(clippy::arc_with_non_send_sync)]
 
-use super::{common, Completion, CompletionInner, File, OpenFlags, IO};
+use super::{
+    common, Completion, CompletionInner, File, OpenFlags, SharedWalLockKind,
+    SharedWalMappedRegion, IO,
+};
 use crate::io::clock::{Clock, DefaultClock, MonotonicInstant, WallClockInstant};
+use crate::io::unix::{
+    unix_shared_wal_lock_byte, unix_shared_wal_map, unix_shared_wal_unlock_byte,
+};
 use crate::storage::wal::CKPT_BATCH_PAGES;
 use crate::sync::Mutex;
 use crate::turso_assert;
@@ -484,6 +490,10 @@ impl WrappedIOUring {
 }
 
 impl IO for UringIO {
+    fn supports_shared_wal_coordination(&self) -> bool {
+        true
+    }
+
     fn open_file(&self, path: &str, flags: OpenFlags, direct: bool) -> Result<Arc<dyn File>> {
         trace!("open_file(path = {})", path);
         let mut file = std::fs::File::options();
@@ -858,6 +868,38 @@ impl File for UringFile {
                 Err(e) => Err(io_error(e, "truncate")),
             }
         }
+    }
+
+    fn shared_wal_lock_byte(
+        &self,
+        offset: u64,
+        exclusive: bool,
+        kind: SharedWalLockKind,
+    ) -> Result<()> {
+        unix_shared_wal_lock_byte(self.file.as_raw_fd(), offset, exclusive, true, kind).map(|_| ())
+    }
+
+    fn shared_wal_try_lock_byte(
+        &self,
+        offset: u64,
+        exclusive: bool,
+        kind: SharedWalLockKind,
+    ) -> Result<bool> {
+        unix_shared_wal_lock_byte(self.file.as_raw_fd(), offset, exclusive, false, kind)
+    }
+
+    fn shared_wal_unlock_byte(&self, offset: u64, kind: SharedWalLockKind) -> Result<()> {
+        unix_shared_wal_unlock_byte(self.file.as_raw_fd(), offset, kind)
+    }
+
+    fn shared_wal_set_len(&self, len: u64) -> Result<()> {
+        self.file
+            .set_len(len)
+            .map_err(|err| io_error(err, "resize shared WAL coordination file"))
+    }
+
+    fn shared_wal_map(&self, offset: u64, len: usize) -> Result<Box<dyn SharedWalMappedRegion>> {
+        unix_shared_wal_map(offset, len, self.file.as_raw_fd())
     }
 }
 

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::arc_with_non_send_sync)]
 
 use super::{
-    common, Completion, CompletionInner, File, OpenFlags, SharedWalLockKind,
-    SharedWalMappedRegion, IO,
+    common, Completion, CompletionInner, File, OpenFlags, SharedWalLockKind, SharedWalMappedRegion,
+    IO,
 };
+use crate::error::io_error;
 use crate::io::clock::{Clock, DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::io::unix::{
     unix_shared_wal_lock_byte, unix_shared_wal_map, unix_shared_wal_unlock_byte,
@@ -11,7 +12,6 @@ use crate::io::unix::{
 use crate::storage::wal::CKPT_BATCH_PAGES;
 use crate::sync::Mutex;
 use crate::turso_assert;
-use crate::error::io_error;
 use crate::{CompletionError, LimboError, Result};
 use rustix::fs::{self, FlockOperation, OFlags};
 use std::ptr::NonNull;
@@ -31,10 +31,6 @@ const ENTRIES: u32 = 512;
 /// to be woken back up by a call IORING_ENTER_SQ_WAKEUP flag.
 /// (handled by the io_uring crate in `submit_and_wait`)
 const SQPOLL_IDLE: u32 = 1000;
-
-/// Number of file descriptors we preallocate for io_uring.
-/// NOTE: we may need to increase this when `attach` is fully implemented.
-const FILES: u32 = 8;
 
 /// Number of Vec<Box<[iovec]>> we preallocate on initialization
 const IOVEC_POOL_SIZE: usize = 64;
@@ -79,7 +75,6 @@ struct WrappedIOUring {
 
 struct InnerUringIO {
     ring: WrappedIOUring,
-    free_files: VecDeque<u32>,
     free_arenas: [Option<(NonNull<u8>, usize)>; ARENA_COUNT],
 }
 
@@ -125,13 +120,12 @@ impl UringIO {
             Ok(ring) => ring,
             Err(_) => io_uring::IoUring::new(ENTRIES).map_err(|e| io_error(e, "io_uring_setup"))?,
         };
-        // we only ever have 2 files open at a time for the moment
-        ring.submitter().register_files_sparse(FILES).map_err(|e| io_error(e, "register_files"))?;
         // RL_MEMLOCK cap is typically 8MB, the current design is to have one large arena
         // registered at startup and therefore we can simply use the zero index, falling back
         // to similar logic as the existing buffer pool for cases where it is over capacity.
         ring.submitter()
-            .register_buffers_sparse(ARENA_COUNT as u32).map_err(|e| io_error(e, "register_buffers"))?;
+            .register_buffers_sparse(ARENA_COUNT as u32)
+            .map_err(|e| io_error(e, "register_buffers"))?;
         // Probe supported opcodes so we can fall back to POSIX for unsupported ones.
         let mut probe = io_uring::register::Probe::new();
         let caps = if ring.submitter().register_probe(&mut probe).is_ok() {
@@ -152,7 +146,6 @@ impl UringIO {
                 writev_states: HashMap::default(),
                 iov_pool: IovecPool::new(),
             },
-            free_files: (0..FILES).collect(),
             free_arenas: [const { None }; ARENA_COUNT],
         };
         debug!("Using IO backend 'io-uring'");
@@ -163,54 +156,11 @@ impl UringIO {
     }
 }
 
-/// io_uring crate decides not to export their `UseFixed` trait, so we
-/// are forced to use a macro here to handle either fixed or raw file descriptors.
-macro_rules! with_fd {
-    ($file:expr, |$fd:ident| $body:expr) => {
-        match $file.id() {
-            Some(id) => {
-                let $fd = io_uring::types::Fixed(id);
-                $body
-            }
-            None => {
-                let $fd = io_uring::types::Fd($file.as_raw_fd());
-                $body
-            }
-        }
-    };
-}
-
-/// wrapper type to represent a possibly registered file descriptor,
-/// only used in WritevState, and piggy-backs on the available methods from
-/// `UringFile`, so we don't have to store the file on `WritevState`.
-#[derive(Clone)]
-enum Fd {
-    Fixed(u32),
-    RawFd(i32),
-}
-
-impl Fd {
-    /// to match the behavior of the File, we need to implement the same methods
-    fn id(&self) -> Option<u32> {
-        match self {
-            Fd::Fixed(id) => Some(*id),
-            Fd::RawFd(_) => None,
-        }
-    }
-    /// ONLY to be called by the macro, in the case where id() is None
-    fn as_raw_fd(&self) -> i32 {
-        match self {
-            Fd::RawFd(fd) => *fd,
-            _ => panic!("Cannot call as_raw_fd on a Fixed Fd"),
-        }
-    }
-}
-
 /// State to track an ongoing writev operation in
 /// the case of a partial write.
 struct WritevState {
     /// File descriptor/id of the file we are writing to
-    file_id: Fd,
+    file_id: io_uring::types::Fd,
     /// absolute file offset for next submit
     file_pos: u64,
     /// current buffer index in `bufs`
@@ -229,13 +179,10 @@ struct WritevState {
 
 impl WritevState {
     fn new(file: &UringFile, pos: u64, bufs: Vec<Arc<crate::Buffer>>) -> Self {
-        let file_id = file
-            .id()
-            .map(Fd::Fixed)
-            .unwrap_or_else(|| Fd::RawFd(file.as_raw_fd()));
+        let file_id = file.file.as_raw_fd();
         let total_len = bufs.iter().map(|b| b.len()).sum();
         Self {
-            file_id,
+            file_id: io_uring::types::Fd(file_id),
             file_pos: pos,
             current_buffer_idx: 0,
             current_buffer_offset: 0,
@@ -282,28 +229,6 @@ impl WritevState {
 }
 
 impl InnerUringIO {
-    fn register_file(&mut self, fd: i32) -> Result<u32> {
-        if let Some(slot) = self.free_files.pop_front() {
-            self.ring
-                .ring
-                .submitter()
-                .register_files_update(slot, &[fd.as_raw_fd()]).map_err(|e| io_error(e, "register_files_update"))?;
-            return Ok(slot);
-        }
-        Err(crate::error::CompletionError::UringIOError(
-            "unable to register file, no free slots available",
-        )
-        .into())
-    }
-    fn unregister_file(&mut self, id: u32) -> Result<()> {
-        self.ring
-            .ring
-            .submitter()
-            .register_files_update(id, &[-1]).map_err(|e| io_error(e, "register_files_update"))?;
-        self.free_files.push_back(id);
-        Ok(())
-    }
-
     #[cfg(debug_assertions)]
     fn debug_check_fixed(&self, idx: u32, ptr: *const u8, len: usize) {
         let (base, blen) = self.free_arenas[idx as usize].expect("slot not registered");
@@ -344,7 +269,9 @@ impl WrappedIOUring {
         }
         // place cancel op at the front, if overflowed
         self.overflow.push_front(entry.clone());
-        self.ring.submit().map_err(|e| io_error(e, "io_uring_submit"))?;
+        self.ring
+            .submit()
+            .map_err(|e| io_error(e, "io_uring_submit"))?;
         Ok(())
     }
 
@@ -380,7 +307,9 @@ impl WrappedIOUring {
         }
         let wants = std::cmp::min(self.pending_ops, MAX_WAIT);
         tracing::trace!("submit_and_wait for {wants} pending operations to complete");
-        self.ring.submit_and_wait(wants).map_err(|e| io_error(e, "io_uring_submit_and_wait"))?;
+        self.ring
+            .submit_and_wait(wants)
+            .map_err(|e| io_error(e, "io_uring_submit_and_wait"))?;
         Ok(())
     }
 
@@ -437,12 +366,10 @@ impl WrappedIOUring {
 
         let ptr = iov_allocation.as_ptr() as *mut libc::iovec;
         st.last_iov_allocation = Some(iov_allocation);
-        let entry = with_fd!(st.file_id, |fd| {
-            io_uring::opcode::Writev::new(fd, ptr, iov_count as u32)
-                .offset(st.file_pos)
-                .build()
-                .user_data(key)
-        });
+        let entry = io_uring::opcode::Writev::new(st.file_id, ptr, iov_count as u32)
+            .offset(st.file_pos)
+            .build()
+            .user_data(key);
         self.writev_states.insert(key, st);
         self.submit_entry(&entry);
     }
@@ -514,12 +441,10 @@ impl IO for UringIO {
                 Err(error) => debug!("Error {error:?} returned when setting O_DIRECT flag to read file. The performance of the system may be affected"),
             }
         }
-        let id = self.inner.lock().register_file(file.as_raw_fd()).ok();
         let uring_file = Arc::new(UringFile {
             io: self.inner.clone(),
             caps: self.caps.clone(),
             file,
-            id,
         });
         if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
             && !flags.intersects(OpenFlags::ReadOnly | OpenFlags::NoLock)
@@ -571,7 +496,8 @@ impl IO for UringIO {
                 if result < 0 {
                     let errno = -result;
                     let err = std::io::Error::from_raw_os_error(errno);
-                    completion_from_key(user_data).error(CompletionError::IOError(err.kind(), "io_uring_cqe"));
+                    completion_from_key(user_data)
+                        .error(CompletionError::IOError(err.kind(), "io_uring_cqe"));
                 } else {
                     completion_from_key(user_data).complete(result)
                 }
@@ -625,7 +551,8 @@ impl IO for UringIO {
             if result < 0 {
                 let errno = -result;
                 let err = std::io::Error::from_raw_os_error(errno);
-                completion_from_key(user_data).error(CompletionError::IOError(err.kind(), "io_uring_cqe"));
+                completion_from_key(user_data)
+                    .error(CompletionError::IOError(err.kind(), "io_uring_cqe"));
             } else {
                 completion_from_key(user_data).complete(result)
             }
@@ -643,14 +570,19 @@ impl IO for UringIO {
                 crate::error::CompletionError::UringIOError("no free fixed buffer slots")
             })?;
         unsafe {
-            inner.ring.ring.submitter().register_buffers_update(
-                slot as u32,
-                &[libc::iovec {
-                    iov_base: ptr.as_ptr() as *mut libc::c_void,
-                    iov_len: len,
-                }],
-                None,
-            ).map_err(|e| io_error(e, "register_buffers_update"))?
+            inner
+                .ring
+                .ring
+                .submitter()
+                .register_buffers_update(
+                    slot as u32,
+                    &[libc::iovec {
+                        iov_base: ptr.as_ptr() as *mut libc::c_void,
+                        iov_len: len,
+                    }],
+                    None,
+                )
+                .map_err(|e| io_error(e, "register_buffers_update"))?
         };
         inner.free_arenas[slot] = Some((ptr, len));
         Ok(slot as u32)
@@ -687,7 +619,6 @@ pub struct UringFile {
     io: Arc<Mutex<InnerUringIO>>,
     caps: Arc<UringCapabilities>,
     file: std::fs::File,
-    id: Option<u32>,
 }
 
 impl Deref for UringFile {
@@ -697,11 +628,6 @@ impl Deref for UringFile {
     }
 }
 
-impl UringFile {
-    fn id(&self) -> Option<u32> {
-        self.id
-    }
-}
 unsafe impl Send for UringFile {}
 unsafe impl Sync for UringFile {}
 crate::assert::assert_send_sync!(UringFile);
@@ -749,32 +675,31 @@ impl File for UringFile {
         let read_e = {
             let buf = r.buf();
             let ptr = buf.as_mut_ptr();
+            let fd = io_uring::types::Fd(self.file.as_raw_fd());
             let len = buf.len();
-            with_fd!(self, |fd| {
-                if let Some(idx) = buf.fixed_id() {
-                    trace!(
-                        "pread_fixed(pos = {}, length = {}, idx = {})",
-                        pos,
-                        len,
-                        idx
-                    );
-                    #[cfg(debug_assertions)]
-                    {
-                        self.io.lock().debug_check_fixed(idx, ptr, len);
-                    }
-                    io_uring::opcode::ReadFixed::new(fd, ptr, len as u32, idx as u16)
-                        .offset(pos)
-                        .build()
-                        .user_data(get_key(c.clone()))
-                } else {
-                    trace!("pread(pos = {}, length = {})", pos, len);
-                    // Use Read opcode if fixed buffer is not available
-                    io_uring::opcode::Read::new(fd, buf.as_mut_ptr(), len as u32)
-                        .offset(pos)
-                        .build()
-                        .user_data(get_key(c.clone()))
+            if let Some(idx) = buf.fixed_id() {
+                trace!(
+                    "pread_fixed(pos = {}, length = {}, idx = {})",
+                    pos,
+                    len,
+                    idx
+                );
+                #[cfg(debug_assertions)]
+                {
+                    self.io.lock().debug_check_fixed(idx, ptr, len);
                 }
-            })
+                io_uring::opcode::ReadFixed::new(fd, ptr, len as u32, idx as u16)
+                    .offset(pos)
+                    .build()
+                    .user_data(get_key(c.clone()))
+            } else {
+                trace!("pread(pos = {}, length = {})", pos, len);
+                // Use Read opcode if fixed buffer is not available
+                io_uring::opcode::Read::new(fd, buf.as_mut_ptr(), len as u32)
+                    .offset(pos)
+                    .build()
+                    .user_data(get_key(c.clone()))
+            }
         };
         self.io.lock().ring.submit_entry(&read_e);
         Ok(c)
@@ -785,30 +710,29 @@ impl File for UringFile {
         let write = {
             let ptr = buffer.as_ptr();
             let len = buffer.len();
-            with_fd!(self, |fd| {
-                if let Some(idx) = buffer.fixed_id() {
-                    trace!(
-                        "pwrite_fixed(pos = {}, length = {}, idx= {})",
-                        pos,
-                        len,
-                        idx
-                    );
-                    #[cfg(debug_assertions)]
-                    {
-                        io.debug_check_fixed(idx, ptr, len);
-                    }
-                    io_uring::opcode::WriteFixed::new(fd, ptr, len as u32, idx as u16)
-                        .offset(pos)
-                        .build()
-                        .user_data(get_key(c.clone()))
-                } else {
-                    trace!("pwrite(pos = {}, length = {})", pos, buffer.len());
-                    io_uring::opcode::Write::new(fd, ptr, len as u32)
-                        .offset(pos)
-                        .build()
-                        .user_data(get_key(c.clone()))
+            let fd = io_uring::types::Fd(self.file.as_raw_fd());
+            if let Some(idx) = buffer.fixed_id() {
+                trace!(
+                    "pwrite_fixed(pos = {}, length = {}, idx= {})",
+                    pos,
+                    len,
+                    idx
+                );
+                #[cfg(debug_assertions)]
+                {
+                    io.debug_check_fixed(idx, ptr, len);
                 }
-            })
+                io_uring::opcode::WriteFixed::new(fd, ptr, len as u32, idx as u16)
+                    .offset(pos)
+                    .build()
+                    .user_data(get_key(c.clone()))
+            } else {
+                trace!("pwrite(pos = {}, length = {})", pos, buffer.len());
+                io_uring::opcode::Write::new(fd, ptr, len as u32)
+                    .offset(pos)
+                    .build()
+                    .user_data(get_key(c.clone()))
+            }
         };
 
         // Keep the buffer alive until the completion is processed. For non-fixed
@@ -821,11 +745,10 @@ impl File for UringFile {
 
     fn sync(&self, c: Completion, _sync_type: crate::io::FileSyncType) -> Result<Completion> {
         trace!("sync()");
-        let sync = with_fd!(self, |fd| {
-            io_uring::opcode::Fsync::new(fd)
-                .build()
-                .user_data(get_key(c.clone()))
-        });
+        let fd = io_uring::types::Fd(self.file.as_raw_fd());
+        let sync = io_uring::opcode::Fsync::new(fd)
+            .build()
+            .user_data(get_key(c.clone()));
         self.io.lock().ring.submit_entry(&sync);
         Ok(c)
     }
@@ -845,16 +768,19 @@ impl File for UringFile {
     }
 
     fn size(&self) -> Result<u64> {
-        Ok(self.file.metadata().map_err(|e| io_error(e, "metadata"))?.len())
+        Ok(self
+            .file
+            .metadata()
+            .map_err(|e| io_error(e, "metadata"))?
+            .len())
     }
 
     fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+        let fd = io_uring::types::Fd(self.file.as_raw_fd());
         if self.caps.ftruncate {
-            let truncate = with_fd!(self, |fd| {
-                io_uring::opcode::Ftruncate::new(fd, len)
-                    .build()
-                    .user_data(get_key(c.clone()))
-            });
+            let truncate = io_uring::opcode::Ftruncate::new(fd, len)
+                .build()
+                .user_data(get_key(c.clone()));
             self.io.lock().ring.submit_entry(&truncate);
             Ok(c)
         } else {
@@ -906,15 +832,6 @@ impl File for UringFile {
 impl Drop for UringFile {
     fn drop(&mut self) {
         self.unlock_file().expect("Failed to unlock file");
-        if let Some(id) = self.id {
-            self.io
-                .lock()
-                .unregister_file(id)
-                .inspect_err(|e| {
-                    debug!("Failed to unregister file: {e}");
-                })
-                .ok();
-        }
     }
 }
 

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -522,7 +522,7 @@ impl IO for UringIO {
             id,
         });
         if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
-            || !flags.contains(OpenFlags::ReadOnly)
+            && !flags.intersects(OpenFlags::ReadOnly | OpenFlags::NoLock)
         {
             uring_file.lock_file(true)?;
         }

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -81,6 +81,10 @@ impl IO for MemoryIO {
     fn file_id(&self, path: &str) -> Result<super::FileId> {
         Ok(super::FileId::from_path_hash(path))
     }
+
+    fn supports_shared_wal_coordination(&self) -> bool {
+        false
+    }
 }
 
 pub struct MemoryFile {

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -119,6 +119,17 @@ pub enum FileSyncType {
     FullFsync,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SharedWalLockKind {
+    LinuxOfd,
+    ProcessScopedFcntl,
+}
+
+pub trait SharedWalMappedRegion: Send + Sync {
+    fn ptr(&self) -> NonNull<u8>;
+    fn len(&self) -> usize;
+}
+
 pub trait File: Send + Sync {
     fn lock_file(&self, exclusive: bool) -> Result<()>;
     fn unlock_file(&self) -> Result<()>;
@@ -182,6 +193,46 @@ pub trait File: Send + Sync {
     // todo: need to add custom completion type?
     fn punch_hole(&self, _pos: usize, _len: usize) -> Result<()> {
         panic!("punch_hole is not supported for the given IO implementation")
+    }
+
+    fn shared_wal_lock_byte(
+        &self,
+        _offset: u64,
+        _exclusive: bool,
+        _kind: SharedWalLockKind,
+    ) -> Result<()> {
+        Err(crate::LimboError::InternalError(
+            "shared WAL coordination byte locking is not supported for this file".into(),
+        ))
+    }
+
+    fn shared_wal_try_lock_byte(
+        &self,
+        _offset: u64,
+        _exclusive: bool,
+        _kind: SharedWalLockKind,
+    ) -> Result<bool> {
+        Err(crate::LimboError::InternalError(
+            "shared WAL coordination byte locking is not supported for this file".into(),
+        ))
+    }
+
+    fn shared_wal_unlock_byte(&self, _offset: u64, _kind: SharedWalLockKind) -> Result<()> {
+        Err(crate::LimboError::InternalError(
+            "shared WAL coordination byte unlocking is not supported for this file".into(),
+        ))
+    }
+
+    fn shared_wal_set_len(&self, _len: u64) -> Result<()> {
+        Err(crate::LimboError::InternalError(
+            "shared WAL coordination resizing is not supported for this file".into(),
+        ))
+    }
+
+    fn shared_wal_map(&self, _offset: u64, _len: usize) -> Result<Box<dyn SharedWalMappedRegion>> {
+        Err(crate::LimboError::InternalError(
+            "shared WAL coordination memory mapping is not supported for this file".into(),
+        ))
     }
 }
 
@@ -284,6 +335,7 @@ bitflags! {
         const None = 0b00000000;
         const Create = 0b0000001;
         const ReadOnly = 0b0000010;
+        const NoLock = 0b0000100;
     }
 }
 
@@ -296,8 +348,17 @@ impl Default for OpenFlags {
 pub trait IO: Clock + Send + Sync {
     fn open_file(&self, path: &str, flags: OpenFlags, direct: bool) -> Result<Arc<dyn File>>;
 
+    fn open_shared_wal_file(&self, path: &str) -> Result<Arc<dyn File>> {
+        self.open_file(path, OpenFlags::Create | OpenFlags::NoLock, false)
+    }
+
     // remove_file is used in the sync-engine
     fn remove_file(&self, path: &str) -> Result<()>;
+
+    /// Whether this IO backend can back host-filesystem shared WAL coordination.
+    fn supports_shared_wal_coordination(&self) -> bool {
+        false
+    }
 
     fn step(&self) -> Result<()> {
         Ok(())

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -128,6 +128,10 @@ pub enum SharedWalLockKind {
 pub trait SharedWalMappedRegion: Send + Sync {
     fn ptr(&self) -> NonNull<u8>;
     fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 pub trait File: Send + Sync {

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -1,15 +1,16 @@
-use super::{Completion, File, OpenFlags, IO};
+use super::{Completion, File, OpenFlags, SharedWalLockKind, SharedWalMappedRegion, IO};
 use crate::error::{io_error, CompletionError, LimboError};
 use crate::io::clock::{Clock, DefaultClock, MonotonicInstant, WallClockInstant};
 use crate::io::common;
 use crate::io::FileSyncType;
-use crate::Result;
 use crate::sync::Mutex;
+use crate::Result;
 use rustix::{
     fd::{AsFd, AsRawFd},
     fs::{self, FlockOperation},
 };
 use std::os::fd::RawFd;
+use std::ptr::NonNull;
 
 use std::{io::ErrorKind, sync::Arc};
 #[cfg(feature = "fs")]
@@ -92,6 +93,10 @@ fn try_pwritev_raw(
 }
 
 impl IO for UnixIO {
+    fn supports_shared_wal_coordination(&self) -> bool {
+        true
+    }
+
     fn open_file(&self, path: &str, flags: OpenFlags, _direct: bool) -> Result<Arc<dyn File>> {
         trace!("open_file(path = {})", path);
         let mut file = std::fs::File::options();
@@ -107,9 +112,10 @@ impl IO for UnixIO {
         #[allow(clippy::arc_with_non_send_sync)]
         let unix_file = Arc::new(UnixFile {
             file: Arc::new(Mutex::new(file)),
+            path: path.to_string(),
         });
         if std::env::var(common::ENV_DISABLE_FILE_LOCK).is_err()
-            && !flags.contains(OpenFlags::ReadOnly)
+            && !flags.intersects(OpenFlags::ReadOnly | OpenFlags::NoLock)
         {
             unix_file.lock_file(true)?;
         }
@@ -129,6 +135,149 @@ impl IO for UnixIO {
 
 pub struct UnixFile {
     file: Arc<Mutex<std::fs::File>>,
+    path: String,
+}
+
+pub(crate) struct UnixSharedWalMapping {
+    ptr: NonNull<u8>,
+    len: usize,
+}
+
+unsafe impl Send for UnixSharedWalMapping {}
+unsafe impl Sync for UnixSharedWalMapping {}
+
+impl SharedWalMappedRegion for UnixSharedWalMapping {
+    fn ptr(&self) -> NonNull<u8> {
+        self.ptr
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl Drop for UnixSharedWalMapping {
+    fn drop(&mut self) {
+        let rc = unsafe { libc::munmap(self.ptr.as_ptr().cast(), self.len) };
+        if rc != 0 {
+            panic!(
+                "munmap failed for shared WAL coordination region: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+}
+
+pub(crate) fn unix_shared_wal_lock_byte(
+    fd: RawFd,
+    offset: u64,
+    exclusive: bool,
+    blocking: bool,
+    kind: SharedWalLockKind,
+) -> Result<bool> {
+    let mut flock = libc::flock {
+        l_type: if exclusive {
+            libc::F_WRLCK as libc::c_short
+        } else {
+            libc::F_RDLCK as libc::c_short
+        },
+        l_whence: libc::SEEK_SET as libc::c_short,
+        l_start: offset as libc::off_t,
+        l_len: 1,
+        l_pid: 0,
+    };
+    let cmd = match (kind, blocking) {
+        #[cfg(target_os = "linux")]
+        (SharedWalLockKind::LinuxOfd, true) => libc::F_OFD_SETLKW,
+        #[cfg(target_os = "linux")]
+        (SharedWalLockKind::LinuxOfd, false) => libc::F_OFD_SETLK,
+        (SharedWalLockKind::ProcessScopedFcntl, true) => libc::F_SETLKW,
+        (SharedWalLockKind::ProcessScopedFcntl, false) => libc::F_SETLK,
+        #[cfg(not(target_os = "linux"))]
+        (SharedWalLockKind::LinuxOfd, _) => {
+            return Err(LimboError::InternalError(
+                "linux OFD locks are not supported on this platform".into(),
+            ))
+        }
+    };
+    let rc = unsafe { libc::fcntl(fd, cmd, &mut flock) };
+    if rc == -1 {
+        let error = std::io::Error::last_os_error();
+        if !blocking && error.kind() == ErrorKind::WouldBlock {
+            return Ok(false);
+        }
+        let message = match error.kind() {
+            ErrorKind::WouldBlock => {
+                "Failed locking shared WAL coordination file. File is locked by another process"
+                    .to_string()
+            }
+            _ => format!("Failed locking shared WAL coordination file, {error}"),
+        };
+        Err(LimboError::LockingError(message))
+    } else {
+        Ok(true)
+    }
+}
+
+pub(crate) fn unix_shared_wal_unlock_byte(
+    fd: RawFd,
+    offset: u64,
+    kind: SharedWalLockKind,
+) -> Result<()> {
+    let mut flock = libc::flock {
+        l_type: libc::F_UNLCK as libc::c_short,
+        l_whence: libc::SEEK_SET as libc::c_short,
+        l_start: offset as libc::off_t,
+        l_len: 1,
+        l_pid: 0,
+    };
+    let cmd = match kind {
+        #[cfg(target_os = "linux")]
+        SharedWalLockKind::LinuxOfd => libc::F_OFD_SETLK,
+        SharedWalLockKind::ProcessScopedFcntl => libc::F_SETLK,
+        #[cfg(not(target_os = "linux"))]
+        SharedWalLockKind::LinuxOfd => {
+            return Err(LimboError::InternalError(
+                "linux OFD locks are not supported on this platform".into(),
+            ))
+        }
+    };
+    let rc = unsafe { libc::fcntl(fd, cmd, &mut flock) };
+    if rc == -1 {
+        Err(LimboError::LockingError(format!(
+            "Failed to release shared WAL coordination lock: {}",
+            std::io::Error::last_os_error()
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn unix_shared_wal_map(
+    offset: u64,
+    len: usize,
+    fd: RawFd,
+) -> Result<Box<dyn SharedWalMappedRegion>> {
+    let ptr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            len,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED,
+            fd,
+            offset as libc::off_t,
+        )
+    };
+    if ptr == libc::MAP_FAILED {
+        return Err(io_error(
+            std::io::Error::last_os_error(),
+            "mmap shared WAL coordination file",
+        ));
+    }
+    Ok(Box::new(UnixSharedWalMapping {
+        ptr: NonNull::new(ptr.cast::<u8>()).expect("mmap returned null"),
+        len,
+    }))
 }
 
 impl File for UnixFile {
@@ -148,10 +297,11 @@ impl File for UnixFile {
         .map_err(|e| {
             let io_error = std::io::Error::from(e);
             let message = match io_error.kind() {
-                ErrorKind::WouldBlock => {
-                    "Failed locking file. File is locked by another process".to_string()
-                }
-                _ => format!("Failed locking file, {io_error}"),
+                ErrorKind::WouldBlock => format!(
+                    "Failed locking file '{}'. File is locked by another process",
+                    self.path
+                ),
+                _ => format!("Failed locking file '{}', {io_error}", self.path),
             };
             LimboError::LockingError(message)
         })?;
@@ -362,6 +512,42 @@ impl File for UnixFile {
             }
             Err(e) => Err(io_error(e, "truncate")),
         }
+    }
+
+    fn shared_wal_lock_byte(
+        &self,
+        offset: u64,
+        exclusive: bool,
+        kind: SharedWalLockKind,
+    ) -> Result<()> {
+        let file = self.file.lock();
+        unix_shared_wal_lock_byte(file.as_raw_fd(), offset, exclusive, true, kind).map(|_| ())
+    }
+
+    fn shared_wal_try_lock_byte(
+        &self,
+        offset: u64,
+        exclusive: bool,
+        kind: SharedWalLockKind,
+    ) -> Result<bool> {
+        let file = self.file.lock();
+        unix_shared_wal_lock_byte(file.as_raw_fd(), offset, exclusive, false, kind)
+    }
+
+    fn shared_wal_unlock_byte(&self, offset: u64, kind: SharedWalLockKind) -> Result<()> {
+        let file = self.file.lock();
+        unix_shared_wal_unlock_byte(file.as_raw_fd(), offset, kind)
+    }
+
+    fn shared_wal_set_len(&self, len: u64) -> Result<()> {
+        let file = self.file.lock();
+        file.set_len(len)
+            .map_err(|err| io_error(err, "resize shared WAL coordination file"))
+    }
+
+    fn shared_wal_map(&self, offset: u64, len: usize) -> Result<Box<dyn SharedWalMappedRegion>> {
+        let file = self.file.lock();
+        unix_shared_wal_map(offset, len, file.as_raw_fd())
     }
 }
 

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -139,6 +139,8 @@ pub struct UnixFile {
 }
 
 pub(crate) struct UnixSharedWalMapping {
+    mapping_ptr: NonNull<u8>,
+    mapping_len: usize,
     ptr: NonNull<u8>,
     len: usize,
 }
@@ -158,9 +160,11 @@ impl SharedWalMappedRegion for UnixSharedWalMapping {
 
 impl Drop for UnixSharedWalMapping {
     fn drop(&mut self) {
-        let rc = unsafe { libc::munmap(self.ptr.as_ptr().cast(), self.len) };
+        let rc = unsafe { libc::munmap(self.mapping_ptr.as_ptr().cast(), self.mapping_len) };
         if rc != 0 {
-            panic!(
+            // Log rather than panic — panicking in Drop aborts if we're already
+            // unwinding (double panic).
+            tracing::error!(
                 "munmap failed for shared WAL coordination region: {}",
                 std::io::Error::last_os_error()
             );
@@ -200,22 +204,26 @@ pub(crate) fn unix_shared_wal_lock_byte(
             ))
         }
     };
-    let rc = unsafe { libc::fcntl(fd, cmd, &mut flock) };
-    if rc == -1 {
-        let error = std::io::Error::last_os_error();
-        if !blocking && error.kind() == ErrorKind::WouldBlock {
-            return Ok(false);
-        }
-        let message = match error.kind() {
-            ErrorKind::WouldBlock => {
-                "Failed locking shared WAL coordination file. File is locked by another process"
-                    .to_string()
+    loop {
+        let rc = unsafe { libc::fcntl(fd, cmd, &mut flock) };
+        if rc == -1 {
+            let error = std::io::Error::last_os_error();
+            if blocking && error.kind() == ErrorKind::Interrupted {
+                continue;
             }
-            _ => format!("Failed locking shared WAL coordination file, {error}"),
-        };
-        Err(LimboError::LockingError(message))
-    } else {
-        Ok(true)
+            if !blocking && error.kind() == ErrorKind::WouldBlock {
+                return Ok(false);
+            }
+            let message = match error.kind() {
+                ErrorKind::WouldBlock => {
+                    "Failed locking shared WAL coordination file. File is locked by another process"
+                        .to_string()
+                }
+                _ => format!("Failed locking shared WAL coordination file, {error}"),
+            };
+            return Err(LimboError::LockingError(message));
+        }
+        return Ok(true);
     }
 }
 
@@ -258,24 +266,56 @@ pub(crate) fn unix_shared_wal_map(
     len: usize,
     fd: RawFd,
 ) -> Result<Box<dyn SharedWalMappedRegion>> {
-    let ptr = unsafe {
+    if len == 0 {
+        return Err(LimboError::InternalError(
+            "cannot mmap shared WAL coordination region with zero length".into(),
+        ));
+    }
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page_size <= 0 {
+        return Err(LimboError::LockingError(format!(
+            "failed to determine shared WAL mmap page size: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    let page_size = page_size as u64;
+    let aligned_offset = offset / page_size * page_size;
+    let prefix_len = (offset - aligned_offset) as usize;
+    let mapping_len = prefix_len
+        .checked_add(len)
+        .ok_or_else(|| LimboError::InternalError("shared WAL mmap length overflow".into()))?;
+    let mapping_ptr = unsafe {
         libc::mmap(
             std::ptr::null_mut(),
-            len,
+            mapping_len,
             libc::PROT_READ | libc::PROT_WRITE,
             libc::MAP_SHARED,
             fd,
-            offset as libc::off_t,
+            aligned_offset as libc::off_t,
         )
     };
-    if ptr == libc::MAP_FAILED {
-        return Err(io_error(
-            std::io::Error::last_os_error(),
-            "mmap shared WAL coordination file",
-        ));
+    if mapping_ptr == libc::MAP_FAILED {
+        let error = std::io::Error::last_os_error();
+        let file_size = unsafe {
+            let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+            if libc::fstat(fd, stat.as_mut_ptr()) == 0 {
+                stat.assume_init().st_size
+            } else {
+                -1
+            }
+        };
+        return Err(LimboError::LockingError(format!(
+            "mmap shared WAL coordination file failed: {error} (offset={offset}, aligned_offset={aligned_offset}, len={len}, mapping_len={mapping_len}, fd={fd}, file_size={file_size})"
+        )));
     }
+    let mapping_ptr =
+        NonNull::new(mapping_ptr.cast::<u8>()).expect("mmap returned null for shared WAL map");
+    let ptr = NonNull::new(unsafe { mapping_ptr.as_ptr().add(prefix_len) })
+        .expect("aligned mmap base plus prefix_len returned null");
     Ok(Box::new(UnixSharedWalMapping {
-        ptr: NonNull::new(ptr.cast::<u8>()).expect("mmap returned null"),
+        mapping_ptr,
+        mapping_len,
+        ptr,
         len,
     }))
 }
@@ -560,9 +600,25 @@ impl Drop for UnixFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn test_multiple_processes_cannot_open_file() {
         common::tests::test_multiple_processes_cannot_open_file(UnixIO::new);
+    }
+
+    #[test]
+    fn test_shared_wal_map_supports_unaligned_logical_offset() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let backing_len = 128 * 1024;
+        let bytes: Vec<u8> = (0..backing_len).map(|i| (i % 251) as u8).collect();
+        file.as_file().write_all(&bytes).unwrap();
+        file.as_file().sync_all().unwrap();
+
+        let mapped = unix_shared_wal_map(4096, 81920, file.as_file().as_raw_fd()).unwrap();
+        assert_eq!(mapped.len(), 81920);
+        let slice = unsafe { std::slice::from_raw_parts(mapped.ptr().as_ptr(), mapped.len()) };
+        assert_eq!(&slice[..128], &bytes[4096..4096 + 128]);
+        assert_eq!(&slice[mapped.len() - 128..], &bytes[4096 + 81920 - 128..4096 + 81920]);
     }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -254,6 +254,31 @@ impl DatabaseOpts {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SharedWalCoordinationOpenTelemetryMode {
+    Exclusive,
+    MultiProcess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SharedWalOpenTelemetry {
+    pub loaded_from_disk_scan: bool,
+    pub reopened_max_frame: u64,
+    pub reopened_nbackfills: u64,
+    pub reopened_checkpoint_seq: u32,
+    pub coordination_open_mode: Option<SharedWalCoordinationOpenTelemetryMode>,
+    pub sanitized_backfill_proof_on_open: bool,
+}
+
+#[cfg(feature = "simulator")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SharedWalTestingSnapshot {
+    pub max_frame: u64,
+    pub nbackfills: u64,
+    pub checkpoint_seq: u32,
+    pub frame_index_overflowed: bool,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct EncryptionOpts {
     pub cipher: String,
@@ -1228,8 +1253,8 @@ impl Database {
 
         if is_autovacuumed_db && !self.opts.enable_autovacuum {
             tracing::warn!(
-                        "Database has autovacuum enabled but --experimental-autovacuum flag is not set. Opening in readonly mode."
-                    );
+                "Database has autovacuum enabled but --experimental-autovacuum flag is not set. Opening in readonly mode."
+            );
             self.open_flags |= OpenFlags::ReadOnly;
         }
 
@@ -1337,7 +1362,10 @@ impl Database {
         let header_modified = match read_version {
             Version::Legacy => {
                 if is_readonly {
-                    tracing::warn!("Database {} is opened in readonly mode, cannot convert Legacy mode to WAL. Running in Legacy mode.", self.path);
+                    tracing::warn!(
+                        "Database {} is opened in readonly mode, cannot convert Legacy mode to WAL. Running in Legacy mode.",
+                        self.path
+                    );
                     false
                 } else {
                     // Convert Legacy to WAL mode
@@ -1391,7 +1419,8 @@ impl Database {
                             &self.io,
                             &self.wal_path,
                             flags,
-                            authority.snapshot(),
+                            authority,
+                            &self.db_file,
                         )?
                     } else {
                         WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
@@ -1688,9 +1717,6 @@ impl Database {
         let is_memory_like = |path: &str| {
             path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
         };
-        if self.open_flags.contains(OpenFlags::ReadOnly) {
-            return Ok(None);
-        }
         if !self.io.supports_shared_wal_coordination() {
             return Ok(None);
         }
@@ -1711,11 +1737,23 @@ impl Database {
         }
 
         let path = storage::wal::coordination_path_for_wal_path(&self.wal_path);
-        let authority = Arc::new(MappedSharedWalCoordination::create_or_open(
-            &self.io,
-            std::path::Path::new(&path),
-            64,
-        )?);
+        let authority = if self.open_flags.contains(OpenFlags::ReadOnly) {
+            let Some(authority) = MappedSharedWalCoordination::open_existing(
+                &self.io,
+                std::path::Path::new(&path),
+                64,
+            )?
+            else {
+                return Ok(None);
+            };
+            Arc::new(authority)
+        } else {
+            Arc::new(MappedSharedWalCoordination::create_or_open(
+                &self.io,
+                std::path::Path::new(&path),
+                64,
+            )?)
+        };
         let _ = self.shared_wal_coordination.set(authority.clone());
         Ok(Some(
             self.shared_wal_coordination
@@ -1732,9 +1770,6 @@ impl Database {
         let is_memory_like = |path: &str| {
             path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
         };
-        if self.open_flags.contains(OpenFlags::ReadOnly) {
-            return Ok(None);
-        }
         if !self.io.supports_shared_wal_coordination() {
             return Ok(None);
         }
@@ -1749,11 +1784,23 @@ impl Database {
         }
 
         let path = storage::wal::coordination_path_for_wal_path(&self.wal_path);
-        let authority = Arc::new(MappedSharedWalCoordination::create_or_open(
-            &self.io,
-            std::path::Path::new(&path),
-            64,
-        )?);
+        let authority = if self.open_flags.contains(OpenFlags::ReadOnly) {
+            let Some(authority) = MappedSharedWalCoordination::open_existing(
+                &self.io,
+                std::path::Path::new(&path),
+                64,
+            )?
+            else {
+                return Ok(None);
+            };
+            Arc::new(authority)
+        } else {
+            Arc::new(MappedSharedWalCoordination::create_or_open(
+                &self.io,
+                std::path::Path::new(&path),
+                64,
+            )?)
+        };
         let _ = self.shared_wal_coordination.set(authority.clone());
         Ok(Some(
             self.shared_wal_coordination
@@ -1761,6 +1808,114 @@ impl Database {
                 .cloned()
                 .unwrap_or(authority),
         ))
+    }
+
+    pub fn shared_wal_open_telemetry(&self) -> Result<SharedWalOpenTelemetry> {
+        let shared_wal = self.shared_wal.read();
+        let loaded_from_disk_scan = shared_wal
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire);
+        let reopened_max_frame = shared_wal.metadata.max_frame.load(Ordering::Acquire);
+        let reopened_nbackfills = shared_wal.metadata.nbackfills.load(Ordering::Acquire);
+        let reopened_checkpoint_seq = shared_wal.metadata.wal_header.lock().checkpoint_seq;
+        drop(shared_wal);
+
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        let (coordination_open_mode, sanitized_backfill_proof_on_open) =
+            if let Some(authority) = self.shared_wal_coordination()? {
+                let mode = match authority.open_mode() {
+                storage::shared_wal_coordination::SharedWalCoordinationOpenMode::Exclusive => {
+                    SharedWalCoordinationOpenTelemetryMode::Exclusive
+                }
+                storage::shared_wal_coordination::SharedWalCoordinationOpenMode::MultiProcess => {
+                    SharedWalCoordinationOpenTelemetryMode::MultiProcess
+                }
+            };
+                (Some(mode), authority.sanitized_backfill_proof_on_open())
+            } else {
+                (None, false)
+            };
+        #[cfg(not(all(unix, target_pointer_width = "64")))]
+        let (coordination_open_mode, sanitized_backfill_proof_on_open) = (None, false);
+
+        Ok(SharedWalOpenTelemetry {
+            loaded_from_disk_scan,
+            reopened_max_frame,
+            reopened_nbackfills,
+            reopened_checkpoint_seq,
+            coordination_open_mode,
+            sanitized_backfill_proof_on_open,
+        })
+    }
+
+    #[cfg(feature = "simulator")]
+    pub fn shared_wal_snapshot_for_testing(&self) -> Result<Option<SharedWalTestingSnapshot>> {
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        if let Some(authority) = self.shared_wal_coordination()? {
+            let snapshot = authority.snapshot();
+            return Ok(Some(SharedWalTestingSnapshot {
+                max_frame: snapshot.max_frame,
+                nbackfills: snapshot.nbackfills,
+                checkpoint_seq: snapshot.checkpoint_seq,
+                frame_index_overflowed: authority.frame_index_overflowed(),
+            }));
+        }
+
+        Ok(None)
+    }
+
+    #[cfg(feature = "simulator")]
+    pub fn shared_wal_find_frame_for_testing(&self, page_id: u64) -> Result<Option<u64>> {
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        if let Some(authority) = self.shared_wal_coordination()? {
+            let snapshot = authority.snapshot();
+            return Ok(authority.find_frame(page_id, 0, snapshot.max_frame, None));
+        }
+
+        Ok(None)
+    }
+
+    #[cfg(feature = "simulator")]
+    pub fn local_wal_find_frame_for_testing(&self, page_id: u64) -> Result<Option<u64>> {
+        let shared = self.shared_wal.read();
+        let max_frame = shared.metadata.max_frame.load(Ordering::Acquire);
+        let frame_cache = shared.runtime.frame_cache.lock();
+        Ok(frame_cache.get(&page_id).and_then(|frames| {
+            frames
+                .iter()
+                .rfind(|&&frame_id| frame_id <= max_frame)
+                .copied()
+        }))
+    }
+
+    #[cfg(feature = "simulator")]
+    pub fn local_wal_max_frame_for_testing(&self) -> Result<u64> {
+        Ok(self
+            .shared_wal
+            .read()
+            .metadata
+            .max_frame
+            .load(Ordering::Acquire))
+    }
+
+    #[cfg(feature = "simulator")]
+    pub fn clear_backfill_proof_for_testing(&self) -> Result<()> {
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        {
+            let authority = self.shared_wal_coordination()?.ok_or_else(|| {
+                LimboError::InternalError("shared WAL authority is unavailable".into())
+            })?;
+            authority.clear_backfill_proof();
+            Ok(())
+        }
+
+        #[cfg(not(all(unix, target_pointer_width = "64")))]
+        {
+            Err(LimboError::InternalError(
+                "shared WAL authority is unavailable on this platform".into(),
+            ))
+        }
     }
 
     fn build_wal(

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -636,24 +636,28 @@ impl Database {
     }
 
     #[cfg(feature = "fs")]
+    #[cfg(all(unix, target_pointer_width = "64"))]
     fn effective_open_flags_for_path(
         path: &str,
         flags: OpenFlags,
         opts: DatabaseOpts,
     ) -> OpenFlags {
-        #[cfg(all(unix, target_pointer_width = "64"))]
-        {
-            let is_memory_like = path.starts_with(":memory:")
-                || path.starts_with("file::memory:")
-                || path.is_empty();
-            if opts.enable_multiprocess_wal
-                && !flags.contains(OpenFlags::ReadOnly)
-                && !is_memory_like
-            {
-                return flags | OpenFlags::NoLock;
-            }
+        let is_memory_like =
+            path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty();
+        if opts.enable_multiprocess_wal && !flags.contains(OpenFlags::ReadOnly) && !is_memory_like {
+            return flags | OpenFlags::NoLock;
         }
 
+        flags
+    }
+
+    #[cfg(feature = "fs")]
+    #[cfg(not(all(unix, target_pointer_width = "64")))]
+    fn effective_open_flags_for_path(
+        _path: &str,
+        flags: OpenFlags,
+        _opts: DatabaseOpts,
+    ) -> OpenFlags {
         flags
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1223,6 +1223,7 @@ impl Database {
             }
         }
 
+
         // Read header within the read transaction, ensuring cleanup on error
         let result = (|| -> Result<AutoVacuumMode> {
             let header_ref = pager.io.block(|| HeaderRef::from_pager(&pager))?;
@@ -1977,8 +1978,6 @@ impl Database {
                 // For encryption, use the cipher's metadata size
                 Some(cipher.metadata_size() as u8)
             } else {
-                // For non-encrypted databases, don't set reserved_bytes here.
-                // This allows checksums to be enabled by default (disable_checksums will be false).
                 None
             }
         });

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1783,6 +1783,11 @@ impl Database {
         ))
     }
 
+    #[cfg(not(all(unix, target_pointer_width = "64")))]
+    pub(crate) fn shared_wal_coordination(&self) -> Result<Option<()>> {
+        Ok(None)
+    }
+
     #[cfg(all(unix, target_pointer_width = "64"))]
     pub(crate) fn open_shared_wal_coordination_for_open(
         &self,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -323,6 +323,10 @@ pub(crate) type MvStore = mvcc::MvStore<mvcc::MvccClock>;
 
 pub(crate) type MvCursor = mvcc::cursor::MvccLazyCursor<mvcc::MvccClock>;
 
+fn is_memory_like(path: &str) -> bool {
+    path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
+}
+
 /// Creates a read completion for database header reads that checks for short reads.
 /// The header is always on page 1, so this function hardcodes that page index.
 fn new_header_read_completion(buf: Arc<Buffer>) -> Completion {
@@ -638,27 +642,128 @@ impl Database {
     #[cfg(feature = "fs")]
     #[cfg(all(unix, target_pointer_width = "64"))]
     fn effective_open_flags_for_path(
+        io: &Arc<dyn IO>,
         path: &str,
         flags: OpenFlags,
         opts: DatabaseOpts,
-    ) -> OpenFlags {
-        let is_memory_like =
-            path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty();
-        if opts.enable_multiprocess_wal && !flags.contains(OpenFlags::ReadOnly) && !is_memory_like {
-            return flags | OpenFlags::NoLock;
+    ) -> Result<OpenFlags> {
+        if !opts.enable_multiprocess_wal {
+            return Ok(flags);
         }
 
-        flags
+        if is_memory_like(path) {
+            return Err(LimboError::InvalidArgument(format!(
+                "experimental multiprocess WAL is not supported for in-memory database path '{path}'"
+            )));
+        }
+        if !io.supports_shared_wal_coordination() {
+            return Err(LimboError::InvalidArgument(format!(
+                "experimental multiprocess WAL is not supported by the active IO backend for '{path}'"
+            )));
+        }
+        if !Self::path_allows_shared_wal_coordination(Path::new(path))? {
+            return Err(LimboError::InvalidArgument(format!(
+                "experimental multiprocess WAL is not supported on the filesystem backing '{path}'"
+            )));
+        }
+
+        if !flags.contains(OpenFlags::ReadOnly) {
+            return Ok(flags | OpenFlags::NoLock);
+        }
+
+        Ok(flags)
     }
 
     #[cfg(feature = "fs")]
     #[cfg(not(all(unix, target_pointer_width = "64")))]
     fn effective_open_flags_for_path(
+        _io: &Arc<dyn IO>,
         _path: &str,
         flags: OpenFlags,
         _opts: DatabaseOpts,
-    ) -> OpenFlags {
-        flags
+    ) -> Result<OpenFlags> {
+        // On unsupported platforms, keep the flag as a no-op so generic
+        // cross-platform helpers/tests can request multiprocess WAL without
+        // breaking legacy single-process behavior.
+        Ok(flags)
+    }
+
+    #[cfg(feature = "fs")]
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    fn reject_live_multiprocess_wal_for_legacy_open(
+        io: &Arc<dyn IO>,
+        path: &str,
+        opts: DatabaseOpts,
+    ) -> Result<()> {
+        if opts.enable_multiprocess_wal
+            || is_memory_like(path)
+            || !io.supports_shared_wal_coordination()
+            || !Self::path_allows_shared_wal_coordination(Path::new(path))?
+        {
+            return Ok(());
+        }
+
+        let coordination_path =
+            storage::wal::coordination_path_for_wal_path(&format!("{path}-wal"));
+        let Some(authority) =
+            MappedSharedWalCoordination::open_existing(io, Path::new(&coordination_path), 64)?
+        else {
+            return Ok(());
+        };
+
+        if matches!(
+            authority.open_mode(),
+            storage::shared_wal_coordination::SharedWalCoordinationOpenMode::MultiProcess
+        ) {
+            return Err(LimboError::LockingError(format!(
+                "Failed opening database '{path}'. Database is already open with experimental multiprocess WAL in another process"
+            )));
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "fs")]
+    #[cfg(not(all(unix, target_pointer_width = "64")))]
+    fn reject_live_multiprocess_wal_for_legacy_open(
+        _io: &Arc<dyn IO>,
+        _path: &str,
+        _opts: DatabaseOpts,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    #[cfg(feature = "fs")]
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    fn reject_live_legacy_wal_for_multiprocess_open(
+        io: &Arc<dyn IO>,
+        path: &str,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+    ) -> Result<()> {
+        if !opts.enable_multiprocess_wal || flags.contains(OpenFlags::ReadOnly) {
+            return Ok(());
+        }
+
+        let probe_flags = (flags | OpenFlags::Create) & !OpenFlags::NoLock & !OpenFlags::ReadOnly;
+        match io.open_file(path, probe_flags, true) {
+            Ok(_probe_file) => Ok(()),
+            Err(LimboError::LockingError(_)) => Err(LimboError::LockingError(format!(
+                "Failed opening database '{path}'. Database is already open without experimental multiprocess WAL in another process"
+            ))),
+            Err(err) => Err(err),
+        }
+    }
+
+    #[cfg(feature = "fs")]
+    #[cfg(not(all(unix, target_pointer_width = "64")))]
+    fn reject_live_legacy_wal_for_multiprocess_open(
+        _io: &Arc<dyn IO>,
+        _path: &str,
+        _flags: OpenFlags,
+        _opts: DatabaseOpts,
+    ) -> Result<()> {
+        Ok(())
     }
 
     /// Look up a database in the process-wide registry by file identity.
@@ -730,8 +835,22 @@ impl Database {
             }
             return Ok(db);
         }
-        let effective_flags = Self::effective_open_flags_for_path(path, flags, opts);
+        // Mixed legacy/multiprocess opens are incompatible, but the two modes
+        // advertise themselves through different lock domains (`.tshm` vs DB
+        // file lock). We therefore probe both directions around the actual file
+        // open to narrow the TOCTOU window:
+        //
+        // 1. legacy open rejects an already-live multiprocess authority
+        Self::reject_live_multiprocess_wal_for_legacy_open(&io, path, opts)?;
+        let effective_flags = Self::effective_open_flags_for_path(&io, path, flags, opts)?;
+
+        // 2. multiprocess open rejects an already-live legacy DB-file lock
+        Self::reject_live_legacy_wal_for_multiprocess_open(&io, path, flags, opts)?;
         let file = io.open_file(path, effective_flags, true)?;
+
+        // 3. legacy open re-checks after `open_file()` in case a multiprocess
+        //    authority appeared between the initial probe and the actual open
+        Self::reject_live_multiprocess_wal_for_legacy_open(&io, path, opts)?;
         let db_file = Arc::new(DatabaseFile::new(file));
         Self::open_with_flags(
             io,
@@ -1730,7 +1849,9 @@ impl Database {
         let probe_path = if path.exists() {
             path
         } else {
-            path.parent().unwrap_or_else(|| Path::new("."))
+            path.parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."))
         };
         let c_path = CString::new(probe_path.as_os_str().as_bytes()).map_err(|_| {
             LimboError::InvalidArgument(format!(
@@ -1764,7 +1885,9 @@ impl Database {
         let probe_path = if path.exists() {
             path
         } else {
-            path.parent().unwrap_or_else(|| Path::new("."))
+            path.parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."))
         };
         let c_path = CString::new(probe_path.as_os_str().as_bytes()).map_err(|_| {
             LimboError::InvalidArgument(format!(
@@ -1796,56 +1919,12 @@ impl Database {
     pub(crate) fn shared_wal_coordination(
         &self,
     ) -> Result<Option<Arc<MappedSharedWalCoordination>>> {
-        let is_memory_like = |path: &str| {
-            path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
-        };
-        if !self.opts.enable_multiprocess_wal {
-            return Ok(None);
-        }
-        if !self.io.supports_shared_wal_coordination() {
-            return Ok(None);
-        }
-        if is_memory_like(&self.path) || is_memory_like(&self.wal_path) {
-            return Ok(None);
-        }
-        if !Self::path_allows_shared_wal_coordination(Path::new(&self.path))? {
-            return Ok(None);
-        }
         let shared_wal = self.shared_wal.read();
         if !shared_wal.metadata.enabled.load(Ordering::Acquire) {
             return Ok(None);
         }
         drop(shared_wal);
-
-        if let Some(authority) = self.shared_wal_coordination.get() {
-            return Ok(Some(authority.clone()));
-        }
-
-        let path = storage::wal::coordination_path_for_wal_path(&self.wal_path);
-        let authority = if self.open_flags.contains(OpenFlags::ReadOnly) {
-            let Some(authority) = MappedSharedWalCoordination::open_existing(
-                &self.io,
-                std::path::Path::new(&path),
-                64,
-            )?
-            else {
-                return Ok(None);
-            };
-            Arc::new(authority)
-        } else {
-            Arc::new(MappedSharedWalCoordination::create_or_open(
-                &self.io,
-                std::path::Path::new(&path),
-                64,
-            )?)
-        };
-        let _ = self.shared_wal_coordination.set(authority.clone());
-        Ok(Some(
-            self.shared_wal_coordination
-                .get()
-                .cloned()
-                .unwrap_or(authority),
-        ))
+        self.open_shared_wal_coordination_inner()
     }
 
     #[cfg(not(all(unix, target_pointer_width = "64")))]
@@ -1857,20 +1936,33 @@ impl Database {
     pub(crate) fn open_shared_wal_coordination_for_open(
         &self,
     ) -> Result<Option<Arc<MappedSharedWalCoordination>>> {
-        let is_memory_like = |path: &str| {
-            path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
-        };
+        self.open_shared_wal_coordination_inner()
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    fn open_shared_wal_coordination_inner(
+        &self,
+    ) -> Result<Option<Arc<MappedSharedWalCoordination>>> {
         if !self.opts.enable_multiprocess_wal {
             return Ok(None);
         }
         if !self.io.supports_shared_wal_coordination() {
-            return Ok(None);
+            return Err(LimboError::InvalidArgument(format!(
+                "experimental multiprocess WAL is not supported by the active IO backend for '{}'",
+                self.path
+            )));
         }
         if is_memory_like(&self.path) || is_memory_like(&self.wal_path) {
-            return Ok(None);
+            return Err(LimboError::InvalidArgument(format!(
+                "experimental multiprocess WAL is not supported for in-memory database path '{}'",
+                self.path
+            )));
         }
         if !Self::path_allows_shared_wal_coordination(Path::new(&self.path))? {
-            return Ok(None);
+            return Err(LimboError::InvalidArgument(format!(
+                "experimental multiprocess WAL is not supported on the filesystem backing '{}'",
+                self.path
+            )));
         }
         if let Some(authority) = self.shared_wal_coordination.get() {
             return Ok(Some(authority.clone()));
@@ -1884,6 +1976,11 @@ impl Database {
                 64,
             )?
             else {
+                // Read-only opens cannot create `.tshm`. If no shared
+                // coordination file exists, degrade to the legacy read-only WAL
+                // path rather than failing the open. This keeps binding-level
+                // option plumbing advisory for readers while writable opens
+                // still enforce the stricter multiprocess contract.
                 return Ok(None);
             };
             Arc::new(authority)

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -7,6 +7,8 @@ pub mod index_method;
 pub mod io;
 #[cfg(all(feature = "json", any(feature = "fuzz", feature = "bench")))]
 pub mod json;
+#[cfg(test)]
+mod multiprocess_tests;
 pub mod mvcc;
 #[cfg(any(feature = "fuzz", feature = "bench"))]
 pub mod numeric;
@@ -89,6 +91,10 @@ use arc_swap::{ArcSwap, ArcSwapOption};
 use core::str;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use schema::Schema;
+#[cfg(all(unix, target_pointer_width = "64"))]
+use std::path::Path;
+#[cfg(all(unix, target_pointer_width = "64"))]
+use std::sync::OnceLock;
 use std::{
     fmt::{self},
     ops::Deref,
@@ -96,6 +102,8 @@ use std::{
 };
 #[cfg(feature = "fs")]
 use storage::database::DatabaseFile;
+#[cfg(all(unix, target_pointer_width = "64"))]
+use storage::shared_wal_coordination::MappedSharedWalCoordination;
 use storage::{page_cache::PageCache, sqlite3_ondisk::PageSize};
 use tracing::{instrument, Level};
 use turso_macros::{match_ignore_ascii_case, AtomicEnum};
@@ -413,6 +421,8 @@ pub struct Database {
     /// (commit, sync, checkpoint thresholds, etc.) instead of the built-in storage.
     durable_storage: Option<Arc<dyn crate::mvcc::persistent_storage::DurableStorage>>,
     shared_wal: Arc<RwLock<WalFileShared>>,
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    shared_wal_coordination: OnceLock<Arc<MappedSharedWalCoordination>>,
     init_lock: Arc<Mutex<()>>,
     open_flags: OpenFlags,
     // Use parking lot RwLock here and not `crate::sync::RwLock` because it relies on `data_ptr` and that is experimental
@@ -462,7 +472,7 @@ impl fmt::Debug for Database {
         debug_struct.field("init_lock", &init_lock_status);
 
         let wal_status = match self.shared_wal.try_read() {
-            Some(wal) if wal.enabled.load(Ordering::SeqCst) => "enabled",
+            Some(wal) if wal.metadata.enabled.load(Ordering::SeqCst) => "enabled",
             Some(_) => "disabled",
             None => "locked_for_write",
         };
@@ -535,6 +545,8 @@ impl Database {
             }))),
             _shared_page_cache: shared_page_cache,
             shared_wal,
+            #[cfg(all(unix, target_pointer_width = "64"))]
+            shared_wal_coordination: OnceLock::new(),
             db_file,
             builtin_syms: parking_lot::RwLock::new(syms),
             io: io.clone(),
@@ -590,6 +602,21 @@ impl Database {
         }
         registry.insert(key, RegistryEntry::Ready(Arc::downgrade(&db)));
         Ok(db)
+    }
+
+    #[cfg(feature = "fs")]
+    fn effective_open_flags_for_path(path: &str, flags: OpenFlags) -> OpenFlags {
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        {
+            let is_memory_like = path.starts_with(":memory:")
+                || path.starts_with("file::memory:")
+                || path.is_empty();
+            if !flags.contains(OpenFlags::ReadOnly) && !is_memory_like {
+                return flags | OpenFlags::NoLock;
+            }
+        }
+
+        flags
     }
 
     /// Look up a database in the process-wide registry by file identity.
@@ -661,13 +688,14 @@ impl Database {
             }
             return Ok(db);
         }
-        let file = io.open_file(path, flags, true)?;
+        let effective_flags = Self::effective_open_flags_for_path(path, flags);
+        let file = io.open_file(path, effective_flags, true)?;
         let db_file = Arc::new(DatabaseFile::new(file));
         Self::open_with_flags(
             io,
             path,
             db_file,
-            flags,
+            effective_flags,
             opts,
             encryption_opts,
             durable_storage,
@@ -954,7 +982,8 @@ impl Database {
 
                     #[cfg(debug_assertions)]
                     {
-                        let wal_enabled = db.shared_wal.read().enabled.load(Ordering::SeqCst);
+                        let wal_enabled =
+                            db.shared_wal.read().metadata.enabled.load(Ordering::SeqCst);
                         let mv_store_enabled = db.get_mv_store().is_some();
                         assert!(
                             db.is_readonly() || wal_enabled || mv_store_enabled,
@@ -1132,9 +1161,25 @@ impl Database {
             pager.set_encryption_context(cipher_mode, key)?;
         }
 
-        // Start read transaction before reading page 1 to acquire a read lock
-        // that prevents concurrent checkpoints from truncating the WAL
-        pager.begin_read_tx()?;
+        // Start a read transaction before reading page 1 to prevent a concurrent
+        // checkpoint from truncating the WAL underneath bootstrap. Under heavy
+        // same-process connection churn, the shared WAL bootstrap path can
+        // briefly contend on short-lived in-process locks, so treat Busy here as
+        // a transient and retry rather than failing `connect()`.
+        let mut read_tx_attempts = 0u32;
+        loop {
+            match pager.begin_read_tx() {
+                Ok(()) => break,
+                Err(LimboError::Busy) => {
+                    read_tx_attempts += 1;
+                    if read_tx_attempts > 1 {
+                        return Err(LimboError::Busy);
+                    }
+                    pager.io.yield_now();
+                }
+                Err(err) => return Err(err),
+            }
+        }
 
         // Read header within the read transaction, ensuring cleanup on error
         let result = (|| -> Result<AutoVacuumMode> {
@@ -1329,17 +1374,40 @@ impl Database {
 
         // Always Open shared wal and set it in the Database and Pager.
         // MVCC currently requires a WAL open to function
-        let shared_wal = WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?;
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        let shared_authority = self.open_shared_wal_coordination_for_open()?;
+        #[cfg(not(all(unix, target_pointer_width = "64")))]
+        let shared_authority: Option<()> = None;
 
-        let last_checksum_and_max_frame = shared_wal.read().last_checksum_and_max_frame();
-        let wal = Arc::new(WalFile::new(
-            self.io.clone(),
-            Arc::clone(&shared_wal),
-            last_checksum_and_max_frame,
-            pager.buffer_pool.clone(),
-        ));
-
+        let shared_wal = {
+            #[cfg(all(unix, target_pointer_width = "64"))]
+            {
+                if let Some(authority) = shared_authority.as_ref() {
+                    // The no-scan open path only works if the shared frame index
+                    // is complete. If the reserved shared index space was fully
+                    // exhausted, rebuild local WAL state from the file instead.
+                    if !authority.frame_index_overflowed() {
+                        WalFileShared::open_shared_from_authority_if_exists(
+                            &self.io,
+                            &self.wal_path,
+                            flags,
+                            authority.snapshot(),
+                        )?
+                    } else {
+                        WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
+                    }
+                } else {
+                    WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
+                }
+            }
+            #[cfg(not(all(unix, target_pointer_width = "64")))]
+            {
+                WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
+            }
+        };
         self.shared_wal = shared_wal;
+        let last_checksum_and_max_frame = self.shared_wal.read().last_checksum_and_max_frame();
+        let wal = self.build_wal(last_checksum_and_max_frame, pager.buffer_pool.clone())?;
         pager.set_wal(wal);
 
         // Clear page cache after attaching WAL since pages may have been cached
@@ -1518,7 +1586,7 @@ impl Database {
         shared_wal: &WalFileShared,
         requested_page_size: Option<usize>,
     ) -> Result<PageSize> {
-        if shared_wal.enabled.load(Ordering::SeqCst) {
+        if shared_wal.metadata.enabled.load(Ordering::SeqCst) {
             let size_in_wal = shared_wal.page_size();
             if size_in_wal != 0 {
                 let Some(page_size) = PageSize::new(size_in_wal) else {
@@ -1550,6 +1618,175 @@ impl Database {
         }
     }
 
+    #[cfg(all(unix, target_pointer_width = "64", target_os = "linux"))]
+    fn filesystem_magic_allows_shared_wal(filesystem_magic: libc::c_long) -> bool {
+        const AFS_SUPER_MAGIC: libc::c_long = 0x5346_414f;
+        const CIFS_SUPER_MAGIC: libc::c_long = 0xFF53_4D42u32 as libc::c_long;
+        const CODA_SUPER_MAGIC: libc::c_long = 0x7375_7245;
+        const CEPH_SUPER_MAGIC: libc::c_long = 0x00C3_6400;
+        const GFS2_SUPER_MAGIC: libc::c_long = 0x0116_1970;
+        const LUSTRE_SUPER_MAGIC: libc::c_long = 0x0BD0_0BD0;
+        const NCP_SUPER_MAGIC: libc::c_long = 0x564c;
+        const NFS_SUPER_MAGIC: libc::c_long = 0x6969;
+        const OCFS2_SUPER_MAGIC: libc::c_long = 0x7461_636f;
+        const SMB2_SUPER_MAGIC: libc::c_long = 0xFE53_4D42u32 as libc::c_long;
+        const V9FS_SUPER_MAGIC: libc::c_long = 0x0102_1997;
+
+        !matches!(
+            filesystem_magic,
+            AFS_SUPER_MAGIC
+                | CIFS_SUPER_MAGIC
+                | CODA_SUPER_MAGIC
+                | CEPH_SUPER_MAGIC
+                | GFS2_SUPER_MAGIC
+                | LUSTRE_SUPER_MAGIC
+                | NCP_SUPER_MAGIC
+                | NFS_SUPER_MAGIC
+                | OCFS2_SUPER_MAGIC
+                | SMB2_SUPER_MAGIC
+                | V9FS_SUPER_MAGIC
+        )
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64", target_os = "linux"))]
+    fn path_allows_shared_wal_coordination(path: &Path) -> Result<bool> {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let probe_path = if path.exists() {
+            path
+        } else {
+            path.parent().unwrap_or_else(|| Path::new("."))
+        };
+        let c_path = CString::new(probe_path.as_os_str().as_bytes()).map_err(|_| {
+            LimboError::InvalidArgument(format!(
+                "path contains interior NUL bytes: {}",
+                probe_path.display()
+            ))
+        })?;
+        let mut stat = std::mem::MaybeUninit::<libc::statfs>::uninit();
+        let rc = unsafe { libc::statfs(c_path.as_ptr(), stat.as_mut_ptr()) };
+        if rc != 0 {
+            return Err(io_error(
+                std::io::Error::last_os_error(),
+                "statfs shared WAL coordination path",
+            ));
+        }
+        let stat = unsafe { stat.assume_init() };
+        Ok(Self::filesystem_magic_allows_shared_wal(stat.f_type))
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64", not(target_os = "linux")))]
+    fn path_allows_shared_wal_coordination(_path: &Path) -> Result<bool> {
+        Ok(true)
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub(crate) fn shared_wal_coordination(
+        &self,
+    ) -> Result<Option<Arc<MappedSharedWalCoordination>>> {
+        let is_memory_like = |path: &str| {
+            path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
+        };
+        if self.open_flags.contains(OpenFlags::ReadOnly) {
+            return Ok(None);
+        }
+        if !self.io.supports_shared_wal_coordination() {
+            return Ok(None);
+        }
+        if is_memory_like(&self.path) || is_memory_like(&self.wal_path) {
+            return Ok(None);
+        }
+        if !Self::path_allows_shared_wal_coordination(Path::new(&self.path))? {
+            return Ok(None);
+        }
+        let shared_wal = self.shared_wal.read();
+        if !shared_wal.metadata.enabled.load(Ordering::Acquire) {
+            return Ok(None);
+        }
+        drop(shared_wal);
+
+        if let Some(authority) = self.shared_wal_coordination.get() {
+            return Ok(Some(authority.clone()));
+        }
+
+        let path = storage::wal::coordination_path_for_wal_path(&self.wal_path);
+        let authority = Arc::new(MappedSharedWalCoordination::create_or_open(
+            &self.io,
+            std::path::Path::new(&path),
+            64,
+        )?);
+        let _ = self.shared_wal_coordination.set(authority.clone());
+        Ok(Some(
+            self.shared_wal_coordination
+                .get()
+                .cloned()
+                .unwrap_or(authority),
+        ))
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub(crate) fn open_shared_wal_coordination_for_open(
+        &self,
+    ) -> Result<Option<Arc<MappedSharedWalCoordination>>> {
+        let is_memory_like = |path: &str| {
+            path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
+        };
+        if self.open_flags.contains(OpenFlags::ReadOnly) {
+            return Ok(None);
+        }
+        if !self.io.supports_shared_wal_coordination() {
+            return Ok(None);
+        }
+        if is_memory_like(&self.path) || is_memory_like(&self.wal_path) {
+            return Ok(None);
+        }
+        if !Self::path_allows_shared_wal_coordination(Path::new(&self.path))? {
+            return Ok(None);
+        }
+        if let Some(authority) = self.shared_wal_coordination.get() {
+            return Ok(Some(authority.clone()));
+        }
+
+        let path = storage::wal::coordination_path_for_wal_path(&self.wal_path);
+        let authority = Arc::new(MappedSharedWalCoordination::create_or_open(
+            &self.io,
+            std::path::Path::new(&path),
+            64,
+        )?);
+        let _ = self.shared_wal_coordination.set(authority.clone());
+        Ok(Some(
+            self.shared_wal_coordination
+                .get()
+                .cloned()
+                .unwrap_or(authority),
+        ))
+    }
+
+    fn build_wal(
+        &self,
+        last_checksum_and_max_frame: ((u32, u32), u64),
+        buffer_pool: Arc<BufferPool>,
+    ) -> Result<Arc<dyn Wal>> {
+        #[cfg(all(unix, target_pointer_width = "64"))]
+        if let Some(authority) = self.shared_wal_coordination()? {
+            return Ok(Arc::new(WalFile::new_with_shared_coordination(
+                self.io.clone(),
+                self.shared_wal.clone(),
+                authority,
+                last_checksum_and_max_frame,
+                buffer_pool,
+            )));
+        }
+
+        Ok(Arc::new(WalFile::new(
+            self.io.clone(),
+            self.shared_wal.clone(),
+            last_checksum_and_max_frame,
+            buffer_pool,
+        )))
+    }
+
     fn init_pager(&self, requested_page_size: Option<usize>) -> Result<Pager> {
         let cipher = self.encryption_cipher_mode.get();
         let reserved_bytes = self.maybe_get_reserved_space_bytes()?.or_else(|| {
@@ -1578,13 +1815,11 @@ impl Database {
             buffer_pool.finalize_with_page_size(page_size.get() as usize)?;
         }
 
-        let pager_wal: Option<Arc<dyn Wal>> = if shared_wal.enabled.load(Ordering::SeqCst) {
-            Some(Arc::new(WalFile::new(
-                self.io.clone(),
-                self.shared_wal.clone(),
-                shared_wal.last_checksum_and_max_frame(),
-                buffer_pool.clone(),
-            )))
+        let wal_enabled = shared_wal.metadata.enabled.load(Ordering::SeqCst);
+        let last_checksum_and_max_frame = shared_wal.last_checksum_and_max_frame();
+        drop(shared_wal);
+        let pager_wal: Option<Arc<dyn Wal>> = if wal_enabled {
+            Some(self.build_wal(last_checksum_and_max_frame, buffer_pool.clone())?)
         } else {
             None
         };

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1223,7 +1223,6 @@ impl Database {
             }
         }
 
-
         // Read header within the read transaction, ensuring cleanup on error
         let result = (|| -> Result<AutoVacuumMode> {
             let header_ref = pager.io.block(|| HeaderRef::from_pager(&pager))?;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1664,7 +1664,31 @@ impl Database {
         }
     }
 
-    #[cfg(all(unix, target_pointer_width = "64", target_os = "linux"))]
+    #[cfg(all(unix, target_pointer_width = "64", target_os = "macos"))]
+    fn filesystem_type_allows_shared_wal(fs_type: &str) -> bool {
+        // Network and distributed filesystems where mmap'd shared memory
+        // cannot guarantee cross-process coherency.
+        !matches!(
+            fs_type,
+            "nfs" | "smbfs" | "afpfs" | "webdav" | "cifs" | "acfs"
+        )
+    }
+
+    #[cfg(all(
+        unix,
+        target_pointer_width = "64",
+        not(any(target_os = "linux", target_os = "android")),
+        not(target_os = "macos")
+    ))]
+    fn filesystem_type_allows_shared_wal(_fs_type: &str) -> bool {
+        true
+    }
+
+    #[cfg(all(
+        unix,
+        target_pointer_width = "64",
+        any(target_os = "linux", target_os = "android")
+    ))]
     fn filesystem_magic_allows_shared_wal(filesystem_magic: libc::c_long) -> bool {
         const AFS_SUPER_MAGIC: libc::c_long = 0x5346_414f;
         const CIFS_SUPER_MAGIC: libc::c_long = 0xFF53_4D42u32 as libc::c_long;
@@ -1694,7 +1718,11 @@ impl Database {
         )
     }
 
-    #[cfg(all(unix, target_pointer_width = "64", target_os = "linux"))]
+    #[cfg(all(
+        unix,
+        target_pointer_width = "64",
+        any(target_os = "linux", target_os = "android")
+    ))]
     fn path_allows_shared_wal_coordination(path: &Path) -> Result<bool> {
         use std::ffi::CString;
         use std::os::unix::ffi::OsStrExt;
@@ -1719,12 +1747,49 @@ impl Database {
             ));
         }
         let stat = unsafe { stat.assume_init() };
-        Ok(Self::filesystem_magic_allows_shared_wal(stat.f_type))
+        Ok(Self::filesystem_magic_allows_shared_wal(
+            stat.f_type as libc::c_long,
+        ))
     }
 
-    #[cfg(all(unix, target_pointer_width = "64", not(target_os = "linux")))]
-    fn path_allows_shared_wal_coordination(_path: &Path) -> Result<bool> {
-        Ok(true)
+    #[cfg(all(
+        unix,
+        target_pointer_width = "64",
+        not(any(target_os = "linux", target_os = "android"))
+    ))]
+    fn path_allows_shared_wal_coordination(path: &Path) -> Result<bool> {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let probe_path = if path.exists() {
+            path
+        } else {
+            path.parent().unwrap_or_else(|| Path::new("."))
+        };
+        let c_path = CString::new(probe_path.as_os_str().as_bytes()).map_err(|_| {
+            LimboError::InvalidArgument(format!(
+                "path contains interior NUL bytes: {}",
+                probe_path.display()
+            ))
+        })?;
+        let mut stat = std::mem::MaybeUninit::<libc::statfs>::uninit();
+        let rc = unsafe { libc::statfs(c_path.as_ptr(), stat.as_mut_ptr()) };
+        if rc != 0 {
+            return Err(io_error(
+                std::io::Error::last_os_error(),
+                "statfs shared WAL coordination path",
+            ));
+        }
+        let stat = unsafe { stat.assume_init() };
+        // macOS and other BSDs expose the filesystem type as a
+        // null-terminated string in f_fstypename rather than an
+        // integer magic number.
+        let fs_type = unsafe {
+            std::ffi::CStr::from_ptr(stat.f_fstypename.as_ptr())
+                .to_str()
+                .unwrap_or("")
+        };
+        Ok(Self::filesystem_type_allows_shared_wal(fs_type))
     }
 
     #[cfg(all(unix, target_pointer_width = "64"))]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -7,7 +7,7 @@ pub mod index_method;
 pub mod io;
 #[cfg(all(feature = "json", any(feature = "fuzz", feature = "bench")))]
 pub mod json;
-#[cfg(test)]
+#[cfg(all(test, feature = "fs", unix, target_pointer_width = "64"))]
 mod multiprocess_tests;
 pub mod mvcc;
 #[cfg(any(feature = "fuzz", feature = "bench"))]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -395,6 +395,15 @@ impl OpenDbAsyncState {
     }
 }
 
+impl Drop for OpenDbAsyncState {
+    fn drop(&mut self) {
+        if let Some(registry_key) = self.registry_key.take() {
+            let mut registry = DATABASE_MANAGER.lock();
+            registry.remove(&registry_key);
+        }
+    }
+}
+
 /// Per-path entry in the database registry.
 enum RegistryEntry {
     /// Another caller is currently opening this database. Callers that see

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -198,6 +198,7 @@ pub struct DatabaseOpts {
     pub enable_autovacuum: bool,
     pub enable_attach: bool,
     pub enable_generated_columns: bool,
+    pub enable_multiprocess_wal: bool,
     pub unsafe_testing: bool,
     enable_load_extension: bool,
 }
@@ -245,6 +246,11 @@ impl DatabaseOpts {
 
     pub fn with_generated_columns(mut self, enable: bool) -> Self {
         self.enable_generated_columns = enable;
+        self
+    }
+
+    pub fn with_multiprocess_wal(mut self, enable: bool) -> Self {
+        self.enable_multiprocess_wal = enable;
         self
     }
 
@@ -630,13 +636,20 @@ impl Database {
     }
 
     #[cfg(feature = "fs")]
-    fn effective_open_flags_for_path(path: &str, flags: OpenFlags) -> OpenFlags {
+    fn effective_open_flags_for_path(
+        path: &str,
+        flags: OpenFlags,
+        opts: DatabaseOpts,
+    ) -> OpenFlags {
         #[cfg(all(unix, target_pointer_width = "64"))]
         {
             let is_memory_like = path.starts_with(":memory:")
                 || path.starts_with("file::memory:")
                 || path.is_empty();
-            if !flags.contains(OpenFlags::ReadOnly) && !is_memory_like {
+            if opts.enable_multiprocess_wal
+                && !flags.contains(OpenFlags::ReadOnly)
+                && !is_memory_like
+            {
                 return flags | OpenFlags::NoLock;
             }
         }
@@ -713,7 +726,7 @@ impl Database {
             }
             return Ok(db);
         }
-        let effective_flags = Self::effective_open_flags_for_path(path, flags);
+        let effective_flags = Self::effective_open_flags_for_path(path, flags, opts);
         let file = io.open_file(path, effective_flags, true)?;
         let db_file = Arc::new(DatabaseFile::new(file));
         Self::open_with_flags(
@@ -1717,6 +1730,9 @@ impl Database {
         let is_memory_like = |path: &str| {
             path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
         };
+        if !self.opts.enable_multiprocess_wal {
+            return Ok(None);
+        }
         if !self.io.supports_shared_wal_coordination() {
             return Ok(None);
         }
@@ -1770,6 +1786,9 @@ impl Database {
         let is_memory_like = |path: &str| {
             path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
         };
+        if !self.opts.enable_multiprocess_wal {
+            return Ok(None);
+        }
         if !self.io.supports_shared_wal_coordination() {
             return Ok(None);
         }
@@ -2116,6 +2135,10 @@ impl Database {
 
     pub fn experimental_generated_columns_enabled(&self) -> bool {
         self.opts.enable_generated_columns
+    }
+
+    pub fn experimental_multiprocess_wal_enabled(&self) -> bool {
+        self.opts.enable_multiprocess_wal
     }
 
     /// check if database is currently in MVCC mode

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -1,27 +1,19 @@
 use super::*;
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 use std::os::unix::process::ExitStatusExt;
 use std::process::Command;
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 const MULTIPROCESS_SHM_INSERT_CHILD_TEST: &str =
     "multiprocess_tests::multiprocess_shm_insert_child_process";
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 const MULTIPROCESS_SHM_COUNT_CHILD_TEST: &str =
     "multiprocess_tests::multiprocess_shm_count_child_process";
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 const MULTIPROCESS_SHM_HOLD_READ_TX_CHILD_TEST: &str =
     "multiprocess_tests::multiprocess_shm_hold_read_tx_child_process";
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 const MULTIPROCESS_SHM_SCHEMA_CHILD_TEST: &str =
     "multiprocess_tests::multiprocess_shm_schema_child_process";
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 const MULTIPROCESS_SHM_INSERT_AND_CLOSE_CHILD_TEST: &str =
     "multiprocess_tests::multiprocess_shm_insert_and_close_child_process";
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 const DEFAULT_LOCKED_DB_CHILD_TEST: &str = "multiprocess_tests::default_locked_db_child_process";
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn count_test_rows(conn: &Arc<Connection>) -> i64 {
     let mut stmt = conn.prepare("select count(*) from test").unwrap();
     let mut count = 0;
@@ -33,7 +25,6 @@ fn count_test_rows(conn: &Arc<Connection>) -> i64 {
     count
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
     for _attempt in 0..3 {
         let mut stmt = match conn.prepare(query) {
@@ -61,7 +52,6 @@ fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
     panic!("get_rows: exhausted SchemaUpdated retries for: {query}");
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn get_rows_without_schema_retry(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
     let mut stmt = conn.prepare(query).unwrap();
     let mut rows = Vec::new();
@@ -73,7 +63,6 @@ fn get_rows_without_schema_retry(conn: &Arc<Connection>, query: &str) -> Vec<Vec
     rows
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn run_checkpoint(conn: &Arc<Connection>, mode: CheckpointMode) -> CheckpointResult {
     let pager = conn.pager.load();
     pager
@@ -82,7 +71,6 @@ fn run_checkpoint(conn: &Arc<Connection>, mode: CheckpointMode) -> CheckpointRes
         .unwrap()
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn wal_max_frame(conn: &Arc<Connection>) -> u64 {
     conn.pager
         .load()
@@ -92,7 +80,6 @@ fn wal_max_frame(conn: &Arc<Connection>) -> u64 {
         .get_max_frame_in_wal()
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn wait_for_file(path: &std::path::Path) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     while std::time::Instant::now() < deadline {
@@ -104,12 +91,10 @@ fn wait_for_file(path: &std::path::Path) {
     panic!("timed out waiting for {}", path.display());
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn multiprocess_wal_db_opts() -> DatabaseOpts {
     DatabaseOpts::new().with_multiprocess_wal(true)
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn open_multiprocess_db(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
     Database::open_file_with_flags(
         io,
@@ -120,7 +105,6 @@ fn open_multiprocess_db(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
     )
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn open_multiprocess_db_with_flags(
     io: Arc<dyn IO>,
     path: &str,
@@ -129,7 +113,6 @@ fn open_multiprocess_db_with_flags(
     Database::open_file_with_flags(io, path, flags, multiprocess_wal_db_opts(), None)
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn flip_db_header_reserved_byte(path: &std::path::Path) {
     use std::io::{Read, Seek, SeekFrom, Write};
 
@@ -164,7 +147,6 @@ fn flip_db_header_reserved_byte(path: &std::path::Path) {
     }
 }
 
-#[cfg(all(feature = "fs", target_os = "linux", target_pointer_width = "64"))]
 #[test]
 fn shared_wal_coordination_rejects_remote_filesystem_magic_values() {
     assert!(!Database::filesystem_magic_allows_shared_wal(0x6969));
@@ -176,7 +158,6 @@ fn shared_wal_coordination_rejects_remote_filesystem_magic_values() {
     assert!(Database::filesystem_magic_allows_shared_wal(0x0102_1994));
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_without_experimental_multiprocess_wal_uses_in_process_backend() {
     let dir = tempfile::tempdir().unwrap();
@@ -197,7 +178,6 @@ fn database_open_without_experimental_multiprocess_wal_uses_in_process_backend()
     assert!(!std::path::Path::new(&shm_path).exists());
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_without_experimental_multiprocess_wal_rejects_second_process() {
     let dir = tempfile::tempdir().unwrap();
@@ -222,7 +202,6 @@ fn database_open_without_experimental_multiprocess_wal_rejects_second_process() 
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_selects_shm_wal_backend() {
     let dir = tempfile::tempdir().unwrap();
@@ -242,7 +221,6 @@ fn database_open_selects_shm_wal_backend() {
     assert!(std::path::Path::new(&shm_path).exists());
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_rebuilds_from_disk_scan_when_exclusive_shm_snapshot_is_stale() {
     let dir = tempfile::tempdir().unwrap();
@@ -293,7 +271,6 @@ fn database_open_rebuilds_from_disk_scan_when_exclusive_shm_snapshot_is_stale() 
     assert_eq!(rows[1][1].to_string(), "after-stale");
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_reuses_trusted_tshm_snapshot_after_partial_checkpoint_with_backfill_proof() {
     let dir = tempfile::tempdir().unwrap();
@@ -367,7 +344,6 @@ fn database_open_reuses_trusted_tshm_snapshot_after_partial_checkpoint_with_back
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_rebuilds_from_disk_scan_after_partial_checkpoint_without_backfill_proof() {
     let dir = tempfile::tempdir().unwrap();
@@ -446,7 +422,6 @@ fn database_open_rebuilds_from_disk_scan_after_partial_checkpoint_without_backfi
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_rebuilds_from_disk_scan_after_wal_append_invalidates_backfill_proof() {
     let dir = tempfile::tempdir().unwrap();
@@ -519,7 +494,6 @@ fn database_open_rebuilds_from_disk_scan_after_wal_append_invalidates_backfill_p
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_rebuilds_from_disk_scan_after_db_header_mismatch_invalidates_backfill_proof() {
     let dir = tempfile::tempdir().unwrap();
@@ -594,7 +568,6 @@ fn database_open_rebuilds_from_disk_scan_after_db_header_mismatch_invalidates_ba
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn default_locked_db_child_process() {
     let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
@@ -610,7 +583,6 @@ fn default_locked_db_child_process() {
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn multiprocess_shm_insert_child_process() {
     let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
@@ -632,7 +604,6 @@ fn multiprocess_shm_insert_child_process() {
         .unwrap();
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn multiprocess_shm_insert_and_close_child_process() {
     let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
@@ -655,7 +626,6 @@ fn multiprocess_shm_insert_and_close_child_process() {
     conn.close().unwrap();
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn multiprocess_shm_count_child_process() {
     let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
@@ -680,7 +650,6 @@ fn multiprocess_shm_count_child_process() {
     assert_eq!(count_test_rows(&conn), expected_count);
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn multiprocess_shm_hold_read_tx_child_process() {
     let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
@@ -727,7 +696,6 @@ fn multiprocess_shm_hold_read_tx_child_process() {
     wal.end_read_tx();
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn multiprocess_shm_schema_child_process() {
     let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
@@ -803,7 +771,6 @@ fn subprocess_database_open_selects_multiprocess_shm_backend() {
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn subprocess_child_close_skips_shutdown_checkpoint_in_multiprocess_wal_mode() {
     let dir = tempfile::tempdir().unwrap();
@@ -853,7 +820,6 @@ fn subprocess_child_close_skips_shutdown_checkpoint_in_multiprocess_wal_mode() {
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn subprocess_database_open_survives_truncate_rewrite_cycles() {
     let dir = tempfile::tempdir().unwrap();
@@ -917,7 +883,6 @@ fn subprocess_database_open_survives_truncate_rewrite_cycles() {
     assert_eq!(count_test_rows(&conn), 3);
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn subprocess_database_open_peer_refreshes_remote_schema_without_reopen() {
     let dir = tempfile::tempdir().unwrap();
@@ -981,7 +946,6 @@ fn subprocess_database_open_peer_refreshes_remote_schema_without_reopen() {
     assert_eq!(inserted_rows[2][1].to_string(), "4");
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn subprocess_database_open_parent_directly_uses_child_created_table() {
     let dir = tempfile::tempdir().unwrap();
@@ -1019,7 +983,6 @@ fn subprocess_database_open_parent_directly_uses_child_created_table() {
     assert_eq!(child_rows[1][0].to_string(), "parent-schema");
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn subprocess_database_open_parent_execute_uses_child_created_table() {
     let dir = tempfile::tempdir().unwrap();
@@ -1055,7 +1018,6 @@ fn subprocess_database_open_parent_execute_uses_child_created_table() {
     assert_eq!(child_rows[1][0].to_string(), "parent-schema");
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn subprocess_readonly_child_reader_blocks_restart_and_truncate_checkpoints() {
     let dir = tempfile::tempdir().unwrap();
@@ -1150,7 +1112,6 @@ fn subprocess_readonly_child_reader_blocks_restart_and_truncate_checkpoints() {
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn subprocess_readonly_disk_scan_child_reader_stays_in_shared_coordination() {
     let dir = tempfile::tempdir().unwrap();
@@ -1285,7 +1246,6 @@ fn subprocess_readonly_disk_scan_child_reader_stays_in_shared_coordination() {
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn subprocess_database_truncate_checkpoint_reclaims_dead_child_reader_slot() {
     let dir = tempfile::tempdir().unwrap();
@@ -1385,7 +1345,6 @@ fn subprocess_database_truncate_checkpoint_reclaims_dead_child_reader_slot() {
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_reopen_with_live_child_reader_does_not_clobber_authority() {
     let dir = tempfile::tempdir().unwrap();
@@ -1485,7 +1444,6 @@ fn database_open_reopen_with_live_child_reader_does_not_clobber_authority() {
     );
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn database_open_rebuilds_from_disk_scan_when_shared_frame_index_overflowed() {
     let dir = tempfile::tempdir().unwrap();
@@ -1569,7 +1527,6 @@ fn database_open_rebuilds_from_disk_scan_when_shared_frame_index_overflowed() {
     assert_eq!(rows[1][0].to_string(), "after-overflow");
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn memory_database_keeps_in_process_wal_backend() {
     let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
@@ -1583,7 +1540,6 @@ fn memory_database_keeps_in_process_wal_backend() {
     assert_eq!(wal_file.coordination_backend_name(), "in_process");
 }
 
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
 fn memory_database_query_can_close_without_checkpointing() {
     let io: Arc<dyn IO> = Arc::new(MemoryIO::new());

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -12,6 +12,8 @@ const MULTIPROCESS_SHM_SCHEMA_CHILD_TEST: &str =
     "multiprocess_tests::multiprocess_shm_schema_child_process";
 const MULTIPROCESS_SHM_INSERT_AND_CLOSE_CHILD_TEST: &str =
     "multiprocess_tests::multiprocess_shm_insert_and_close_child_process";
+const MULTIPROCESS_SHM_EXPECT_OPEN_FAILURE_CHILD_TEST: &str =
+    "multiprocess_tests::multiprocess_shm_expect_open_failure_child_process";
 const DEFAULT_LOCKED_DB_CHILD_TEST: &str = "multiprocess_tests::default_locked_db_child_process";
 
 fn count_test_rows(conn: &Arc<Connection>) -> i64 {
@@ -148,6 +150,7 @@ fn flip_db_header_reserved_byte(path: &std::path::Path) {
 }
 
 #[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn shared_wal_coordination_rejects_remote_filesystem_magic_values() {
     assert!(!Database::filesystem_magic_allows_shared_wal(0x6969));
     assert!(!Database::filesystem_magic_allows_shared_wal(
@@ -156,6 +159,18 @@ fn shared_wal_coordination_rejects_remote_filesystem_magic_values() {
     assert!(!Database::filesystem_magic_allows_shared_wal(0x0102_1997));
     assert!(Database::filesystem_magic_allows_shared_wal(0xEF53));
     assert!(Database::filesystem_magic_allows_shared_wal(0x0102_1994));
+}
+
+#[test]
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn shared_wal_coordination_path_probe_accepts_nonexistent_relative_paths() {
+    let result = Database::path_allows_shared_wal_coordination(std::path::Path::new(
+        "nonexistent-relative-multiprocess-wal.db",
+    ));
+    assert!(
+        result.is_ok(),
+        "nonexistent relative paths should probe the current directory instead of erroring: {result:?}"
+    );
 }
 
 #[test]
@@ -197,6 +212,94 @@ fn database_open_without_experimental_multiprocess_wal_rejects_second_process() 
     assert!(
         child_output.status.success(),
         "second default-open child process unexpectedly succeeded: stdout={}; stderr={}",
+        String::from_utf8_lossy(&child_output.stdout),
+        String::from_utf8_lossy(&child_output.stderr)
+    );
+}
+
+#[test]
+fn database_open_with_experimental_multiprocess_wal_rejects_unsupported_io_backend() {
+    let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+    let err = Database::open_file_with_flags(
+        io,
+        "unsupported-multiprocess.db",
+        OpenFlags::default(),
+        multiprocess_wal_db_opts(),
+        None,
+    )
+    .expect_err("multiprocess WAL should reject IO backends without shared coordination");
+    assert!(
+        matches!(err, LimboError::InvalidArgument(ref message) if message.contains("active IO backend")),
+        "expected InvalidArgument about unsupported IO backend, got {err:?}"
+    );
+}
+
+#[test]
+fn readonly_open_with_experimental_multiprocess_wal_allows_missing_coordination_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("readonly-multiprocess-no-tshm.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    {
+        let db = Database::open_file(io.clone(), db_path_str).unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("create table test(id integer primary key, value text)")
+            .unwrap();
+    }
+
+    let readonly = open_multiprocess_db_with_flags(io, db_path_str, OpenFlags::ReadOnly)
+        .expect("read-only open should degrade gracefully when no .tshm exists");
+    assert!(readonly.shared_wal_coordination().unwrap().is_none());
+}
+
+#[test]
+fn database_open_with_experimental_multiprocess_wal_rejects_second_default_process() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir
+        .path()
+        .join("coordination-multiprocess-parent-default-child.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let _db = open_multiprocess_db(io, db_path_str).unwrap();
+
+    let current_exe = std::env::current_exe().unwrap();
+    let child_output = Command::new(&current_exe)
+        .arg(DEFAULT_LOCKED_DB_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .output()
+        .unwrap();
+    assert!(
+        child_output.status.success(),
+        "default-open child process unexpectedly succeeded against multiprocess parent: stdout={}; stderr={}",
+        String::from_utf8_lossy(&child_output.stdout),
+        String::from_utf8_lossy(&child_output.stderr)
+    );
+}
+
+#[test]
+fn database_open_without_experimental_multiprocess_wal_rejects_second_multiprocess_process() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir
+        .path()
+        .join("coordination-default-parent-multiprocess-child.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let _db = Database::open_file(io, db_path_str).unwrap();
+
+    let current_exe = std::env::current_exe().unwrap();
+    let child_output = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_EXPECT_OPEN_FAILURE_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .output()
+        .unwrap();
+    assert!(
+        child_output.status.success(),
+        "multiprocess child process unexpectedly opened against default parent: stdout={}; stderr={}",
         String::from_utf8_lossy(&child_output.stdout),
         String::from_utf8_lossy(&child_output.stderr)
     );
@@ -272,44 +375,35 @@ fn database_open_rebuilds_from_disk_scan_when_exclusive_shm_snapshot_is_stale() 
 }
 
 #[test]
-fn database_open_reuses_trusted_tshm_snapshot_after_partial_checkpoint_with_backfill_proof() {
+fn database_open_reuses_trusted_tshm_snapshot_without_disk_scan_when_no_backfill_proof_is_needed() {
     let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("coordination-partial-checkpoint-reopen.db");
+    let db_path = dir.path().join("coordination-trusted-tail-reopen.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
     let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
-    conn.wal_auto_checkpoint_disable();
-    conn.execute("create table test(id integer primary key, value blob)")
+    conn.execute("create table test(id integer primary key, value text)")
         .unwrap();
-    conn.execute("begin immediate").unwrap();
-    for _ in 0..32 {
-        conn.execute("insert into test(value) values (randomblob(2048))")
-            .unwrap();
-    }
-    conn.execute("commit").unwrap();
-    assert!(
-        wal_max_frame(&conn) > 1,
-        "partial-checkpoint reopen coverage requires more than one WAL frame before checkpointing"
-    );
-
-    run_checkpoint(
-        &conn,
-        CheckpointMode::Passive {
-            upper_bound_inclusive: Some(1),
-        },
-    );
+    conn.execute("insert into test(value) values ('before-reopen')")
+        .unwrap();
+    conn.execute("insert into test(value) values ('after-reopen')")
+        .unwrap();
 
     let authority = db.shared_wal_coordination().unwrap().unwrap();
     let snapshot_before = authority.snapshot();
     assert!(
-        snapshot_before.nbackfills > 0,
-        "partial-checkpoint reopen coverage requires persisted positive nbackfills"
+        snapshot_before.max_frame > 0,
+        "trusted-tail reopen coverage requires committed WAL frames before reopen"
     );
+    assert_eq!(
+        snapshot_before.nbackfills, 0,
+        "this coverage only applies when no positive backfill proof is required"
+    );
+    let frames_before = authority.iter_latest_frames(0, snapshot_before.max_frame);
     assert!(
-        snapshot_before.max_frame > snapshot_before.nbackfills,
-        "partial-checkpoint reopen coverage requires live WAL frames beyond the backfill point"
+        !frames_before.is_empty(),
+        "trusted-tail reopen coverage requires a populated durable frame index"
     );
 
     drop(conn);
@@ -326,22 +420,23 @@ fn database_open_reuses_trusted_tshm_snapshot_after_partial_checkpoint_with_back
             .metadata
             .loaded_from_disk_scan
             .load(Ordering::Acquire),
-        "reopen should reuse the persisted tshm snapshot when the backfill proof still matches the WAL and DB header"
+        "reopen should trust the persisted tshm snapshot when no backfill-proof validation is needed"
     );
 
     let reopened_authority = reopened.shared_wal_coordination().unwrap().unwrap();
     assert_eq!(
         reopened_authority.snapshot(),
         snapshot_before,
-        "trusted reopen must preserve the authoritative partial-checkpoint snapshot"
+        "trusted reopen must preserve the authoritative WAL snapshot"
+    );
+    assert_eq!(
+        reopened_authority.iter_latest_frames(0, snapshot_before.max_frame),
+        frames_before,
+        "trusted reopen must preserve durable frame-index content"
     );
 
     let reopened_conn = reopened.connect().unwrap();
-    assert_eq!(
-        count_test_rows(&reopened_conn),
-        32,
-        "trusted partial-checkpoint reopen should preserve committed rows without a disk scan"
-    );
+    assert_eq!(count_test_rows(&reopened_conn), 2);
 }
 
 #[test]
@@ -580,6 +675,21 @@ fn default_locked_db_child_process() {
     assert!(
         matches!(err, LimboError::LockingError(_)),
         "expected LockingError from second default open, got {err:?}"
+    );
+}
+
+#[test]
+fn multiprocess_shm_expect_open_failure_child_process() {
+    let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
+        return;
+    };
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let err = open_multiprocess_db(io, db_path.to_str().unwrap())
+        .expect_err("multiprocess open should fail when a legacy opener already owns the DB");
+    assert!(
+        matches!(err, LimboError::LockingError(_)),
+        "expected LockingError from incompatible multiprocess open, got {err:?}"
     );
 }
 

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -115,6 +115,29 @@ fn open_multiprocess_db_with_flags(
     Database::open_file_with_flags(io, path, flags, multiprocess_wal_db_opts(), None)
 }
 
+#[test]
+fn open_db_async_state_drop_clears_opening_registry_entry() {
+    let key = DatabaseKey::SharedMemory(
+        "open-db-async-state-drop-clears-opening-registry-entry".to_string(),
+    );
+    {
+        let mut manager = DATABASE_MANAGER.lock();
+        manager.clear();
+        manager.insert(key.clone(), RegistryEntry::Opening);
+    }
+
+    let mut state = OpenDbAsyncState::new();
+    state.registry_key = Some(key.clone());
+    drop(state);
+
+    let mut manager = DATABASE_MANAGER.lock();
+    assert!(
+        !manager.contains_key(&key),
+        "dropping an incomplete async open must clear the Opening sentinel"
+    );
+    manager.clear();
+}
+
 fn flip_db_header_reserved_byte(path: &std::path::Path) {
     use std::io::{Read, Seek, SeekFrom, Write};
 

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -18,6 +18,8 @@ const MULTIPROCESS_SHM_SCHEMA_CHILD_TEST: &str =
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 const MULTIPROCESS_SHM_INSERT_AND_CLOSE_CHILD_TEST: &str =
     "multiprocess_tests::multiprocess_shm_insert_and_close_child_process";
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+const DEFAULT_LOCKED_DB_CHILD_TEST: &str = "multiprocess_tests::default_locked_db_child_process";
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn count_test_rows(conn: &Arc<Connection>) -> i64 {
@@ -103,6 +105,31 @@ fn wait_for_file(path: &std::path::Path) {
 }
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn multiprocess_wal_db_opts() -> DatabaseOpts {
+    DatabaseOpts::new().with_multiprocess_wal(true)
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn open_multiprocess_db(io: Arc<dyn IO>, path: &str) -> Result<Arc<Database>> {
+    Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        multiprocess_wal_db_opts(),
+        None,
+    )
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn open_multiprocess_db_with_flags(
+    io: Arc<dyn IO>,
+    path: &str,
+    flags: OpenFlags,
+) -> Result<Arc<Database>> {
+    Database::open_file_with_flags(io, path, flags, multiprocess_wal_db_opts(), None)
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn flip_db_header_reserved_byte(path: &std::path::Path) {
     use std::io::{Read, Seek, SeekFrom, Write};
 
@@ -151,12 +178,58 @@ fn shared_wal_coordination_rejects_remote_filesystem_magic_values() {
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
+fn database_open_without_experimental_multiprocess_wal_uses_in_process_backend() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-default-off.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path_str).unwrap();
+
+    let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db
+        .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "in_process");
+    assert!(db.shared_wal_coordination().unwrap().is_none());
+
+    let shm_path = storage::wal::coordination_path_for_wal_path(&format!("{db_path_str}-wal"));
+    assert!(!std::path::Path::new(&shm_path).exists());
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_without_experimental_multiprocess_wal_rejects_second_process() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-default-locked.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let _db = Database::open_file(io, db_path_str).unwrap();
+
+    let current_exe = std::env::current_exe().unwrap();
+    let child_output = Command::new(&current_exe)
+        .arg(DEFAULT_LOCKED_DB_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .output()
+        .unwrap();
+    assert!(
+        child_output.status.success(),
+        "second default-open child process unexpectedly succeeded: stdout={}; stderr={}",
+        String::from_utf8_lossy(&child_output.stdout),
+        String::from_utf8_lossy(&child_output.stderr)
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
 fn database_open_selects_shm_wal_backend() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("coordination.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
 
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
@@ -177,7 +250,7 @@ fn database_open_rebuilds_from_disk_scan_when_exclusive_shm_snapshot_is_stale() 
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-    let db_a = Database::open_file(io.clone(), db_path_str).unwrap();
+    let db_a = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn_a = db_a.connect().unwrap();
     conn_a
         .execute("create table test(id integer primary key, value text)")
@@ -201,7 +274,7 @@ fn database_open_rebuilds_from_disk_scan_when_exclusive_shm_snapshot_is_stale() 
     manager.clear();
     drop(manager);
 
-    let db_b = Database::open_file(io, db_path_str).unwrap();
+    let db_b = open_multiprocess_db(io, db_path_str).unwrap();
     assert!(
         db_b.shared_wal
             .read()
@@ -228,7 +301,7 @@ fn database_open_reuses_trusted_tshm_snapshot_after_partial_checkpoint_with_back
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.wal_auto_checkpoint_disable();
     conn.execute("create table test(id integer primary key, value blob)")
@@ -268,7 +341,7 @@ fn database_open_reuses_trusted_tshm_snapshot_after_partial_checkpoint_with_back
     manager.clear();
     drop(manager);
 
-    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened = open_multiprocess_db(io, db_path_str).unwrap();
     assert!(
         !reopened
             .shared_wal
@@ -304,7 +377,7 @@ fn database_open_rebuilds_from_disk_scan_after_partial_checkpoint_without_backfi
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.wal_auto_checkpoint_disable();
     conn.execute("create table test(id integer primary key, value blob)")
@@ -345,7 +418,7 @@ fn database_open_rebuilds_from_disk_scan_after_partial_checkpoint_without_backfi
     manager.clear();
     drop(manager);
 
-    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened = open_multiprocess_db(io, db_path_str).unwrap();
     let mut expected_snapshot = snapshot_before;
     expected_snapshot.nbackfills = 0;
     assert!(
@@ -383,7 +456,7 @@ fn database_open_rebuilds_from_disk_scan_after_wal_append_invalidates_backfill_p
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.wal_auto_checkpoint_disable();
     conn.execute("create table test(id integer primary key, value blob)")
@@ -427,7 +500,7 @@ fn database_open_rebuilds_from_disk_scan_after_wal_append_invalidates_backfill_p
     manager.clear();
     drop(manager);
 
-    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened = open_multiprocess_db(io, db_path_str).unwrap();
     assert!(
         reopened
             .shared_wal
@@ -456,7 +529,7 @@ fn database_open_rebuilds_from_disk_scan_after_db_header_mismatch_invalidates_ba
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.wal_auto_checkpoint_disable();
     conn.execute("create table test(id integer primary key, value blob)")
@@ -493,7 +566,7 @@ fn database_open_rebuilds_from_disk_scan_after_db_header_mismatch_invalidates_ba
     manager.clear();
     drop(manager);
 
-    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened = open_multiprocess_db(io, db_path_str).unwrap();
     let mut expected_snapshot = snapshot_before;
     expected_snapshot.nbackfills = 0;
     assert!(
@@ -523,13 +596,29 @@ fn database_open_rebuilds_from_disk_scan_after_db_header_mismatch_invalidates_ba
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
+fn default_locked_db_child_process() {
+    let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
+        return;
+    };
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let err = Database::open_file(io, db_path.to_str().unwrap())
+        .expect_err("default non-multiprocess open should stay DB-file locked across processes");
+    assert!(
+        matches!(err, LimboError::LockingError(_)),
+        "expected LockingError from second default open, got {err:?}"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
 fn multiprocess_shm_insert_child_process() {
     let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
         return;
     };
 
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let db = open_multiprocess_db(io, db_path.to_str().unwrap()).unwrap();
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
         .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
@@ -551,7 +640,7 @@ fn multiprocess_shm_insert_and_close_child_process() {
     };
 
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let db = open_multiprocess_db(io, db_path.to_str().unwrap()).unwrap();
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
         .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
@@ -578,7 +667,7 @@ fn multiprocess_shm_count_child_process() {
         .unwrap();
 
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let db = open_multiprocess_db(io, db_path.to_str().unwrap()).unwrap();
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
         .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
@@ -608,16 +697,9 @@ fn multiprocess_shm_hold_read_tx_child_process() {
 
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
     let db = if readonly {
-        Database::open_file_with_flags(
-            io,
-            db_path.to_str().unwrap(),
-            OpenFlags::ReadOnly,
-            DatabaseOpts::new(),
-            None,
-        )
-        .unwrap()
+        open_multiprocess_db_with_flags(io, db_path.to_str().unwrap(), OpenFlags::ReadOnly).unwrap()
     } else {
-        Database::open_file(io, db_path.to_str().unwrap()).unwrap()
+        open_multiprocess_db(io, db_path.to_str().unwrap()).unwrap()
     };
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
@@ -653,7 +735,7 @@ fn multiprocess_shm_schema_child_process() {
     };
 
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let db = open_multiprocess_db(io, db_path.to_str().unwrap()).unwrap();
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
         .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
@@ -675,7 +757,7 @@ fn subprocess_database_open_selects_multiprocess_shm_backend() {
     let db_path = dir.path().join("coordination-subprocess.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
         .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
@@ -728,7 +810,7 @@ fn subprocess_child_close_skips_shutdown_checkpoint_in_multiprocess_wal_mode() {
     let db_path = dir.path().join("close-skip-shutdown-checkpoint.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
     let conn = db.connect().unwrap();
 
     conn.execute("create table test(id integer primary key, value text)")
@@ -778,7 +860,7 @@ fn subprocess_database_open_survives_truncate_rewrite_cycles() {
     let db_path = dir.path().join("coordination-truncate-rewrite.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.execute("create table test(id integer primary key, value text)")
         .unwrap();
@@ -842,7 +924,7 @@ fn subprocess_database_open_peer_refreshes_remote_schema_without_reopen() {
     let db_path = dir.path().join("coordination-peer-schema-refresh.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.execute("create table t(value integer, next_value integer)")
         .unwrap();
@@ -906,7 +988,7 @@ fn subprocess_database_open_parent_directly_uses_child_created_table() {
     let db_path = dir.path().join("coordination-direct-child-table-use.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.execute("create table t(value integer)").unwrap();
 
@@ -944,7 +1026,7 @@ fn subprocess_database_open_parent_execute_uses_child_created_table() {
     let db_path = dir.path().join("coordination-execute-child-table-use.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.execute("create table t(value integer)").unwrap();
 
@@ -985,7 +1067,7 @@ fn subprocess_readonly_child_reader_blocks_restart_and_truncate_checkpoints() {
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.wal_auto_checkpoint_disable();
     conn.execute("create table test(id integer primary key, value blob)")
@@ -1080,7 +1162,7 @@ fn subprocess_readonly_disk_scan_child_reader_stays_in_shared_coordination() {
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.wal_auto_checkpoint_disable();
     conn.execute("create table test(id integer primary key, value blob)")
@@ -1143,7 +1225,7 @@ fn subprocess_readonly_disk_scan_child_reader_stays_in_shared_coordination() {
         "disk-scan read-only child should protect the live WAL tail, not the checkpointed prefix"
     );
 
-    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened = open_multiprocess_db(io, db_path_str).unwrap();
     let reopened_conn = reopened.connect().unwrap();
 
     let restart_err = reopened_conn
@@ -1185,7 +1267,7 @@ fn subprocess_readonly_disk_scan_child_reader_stays_in_shared_coordination() {
         "disk-scan read-only child should exit cleanly after releasing its read transaction: {child_status:?}"
     );
 
-    let reopened = Database::open_file(Arc::new(PlatformIO::new().unwrap()), db_path_str).unwrap();
+    let reopened = open_multiprocess_db(Arc::new(PlatformIO::new().unwrap()), db_path_str).unwrap();
     let reopened_conn = reopened.connect().unwrap();
     let checkpoint = reopened_conn
         .checkpoint(CheckpointMode::Truncate {
@@ -1212,7 +1294,7 @@ fn subprocess_database_truncate_checkpoint_reclaims_dead_child_reader_slot() {
     let release_file = dir.path().join("child-release");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path_str).unwrap();
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.execute("create table test(id integer primary key, value text)")
         .unwrap();
@@ -1294,7 +1376,7 @@ fn subprocess_database_truncate_checkpoint_reclaims_dead_child_reader_slot() {
     drop(manager);
 
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened = open_multiprocess_db(io, db_path_str).unwrap();
     let reopened_conn = reopened.connect().unwrap();
     assert_eq!(
         count_test_rows(&reopened_conn),
@@ -1313,7 +1395,7 @@ fn database_open_reopen_with_live_child_reader_does_not_clobber_authority() {
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
     conn.wal_auto_checkpoint_disable();
     conn.execute("create table test(id integer primary key, value blob)")
@@ -1374,7 +1456,7 @@ fn database_open_reopen_with_live_child_reader_does_not_clobber_authority() {
     manager.clear();
     drop(manager);
 
-    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened = open_multiprocess_db(io, db_path_str).unwrap();
     let reopened_authority = reopened.shared_wal_coordination().unwrap().unwrap();
     assert_eq!(reopened_authority.snapshot(), snapshot_before);
     assert_eq!(
@@ -1413,7 +1495,7 @@ fn database_open_rebuilds_from_disk_scan_when_shared_frame_index_overflowed() {
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
-    let db_a = Database::open_file(io.clone(), db_path_str).unwrap();
+    let db_a = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn_a = db_a.connect().unwrap();
     conn_a
         .execute("create table test(id integer primary key, value text)")
@@ -1458,7 +1540,7 @@ fn database_open_rebuilds_from_disk_scan_when_shared_frame_index_overflowed() {
     manager.clear();
     drop(manager);
 
-    let db_b = Database::open_file(io, db_path_str).unwrap();
+    let db_b = open_multiprocess_db(io, db_path_str).unwrap();
     assert!(
         db_b.shared_wal
             .read()

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -91,28 +91,6 @@ fn wal_max_frame(conn: &Arc<Connection>) -> u64 {
 }
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
-fn grow_wal_past_frame_boundary(conn: &Arc<Connection>, target_frame: u64) {
-    conn.wal_auto_checkpoint_disable();
-
-    for _ in 0..64 {
-        if wal_max_frame(conn) > target_frame {
-            return;
-        }
-
-        conn.execute("begin immediate").unwrap();
-        for _ in 0..128 {
-            conn.execute("insert into test(value) values (randomblob(8192))")
-                .unwrap();
-        }
-        conn.execute("commit").unwrap();
-    }
-    panic!(
-        "failed to grow WAL beyond frame boundary {target_frame}; max_frame={}",
-        wal_max_frame(conn)
-    );
-}
-
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 fn wait_for_file(path: &std::path::Path) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     while std::time::Instant::now() < deadline {
@@ -122,6 +100,41 @@ fn wait_for_file(path: &std::path::Path) {
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
     panic!("timed out waiting for {}", path.display());
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn flip_db_header_reserved_byte(path: &std::path::Path) {
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .unwrap();
+
+    #[cfg(feature = "checksum")]
+    {
+        let mut page = vec![0u8; 4096];
+        file.read_exact(&mut page).unwrap();
+        page[72] ^= 0x01;
+        crate::storage::checksum::ChecksumContext::new()
+            .add_checksum_to_page(&mut page, 1)
+            .unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write_all(&page).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    #[cfg(not(feature = "checksum"))]
+    {
+        file.seek(SeekFrom::Start(72)).unwrap();
+        let mut byte = [0u8; 1];
+        file.read_exact(&mut byte).unwrap();
+        byte[0] ^= 0x01;
+        file.seek(SeekFrom::Start(72)).unwrap();
+        file.write_all(&byte).unwrap();
+        file.sync_all().unwrap();
+    }
 }
 
 #[cfg(all(feature = "fs", target_os = "linux", target_pointer_width = "64"))]
@@ -154,101 +167,6 @@ fn database_open_selects_shm_wal_backend() {
 
     let shm_path = storage::wal::coordination_path_for_wal_path(&format!("{db_path_str}-wal"));
     assert!(std::path::Path::new(&shm_path).exists());
-}
-
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
-#[test]
-fn database_open_reuses_valid_exclusive_shm_authority_without_disk_scan() {
-    let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("coordination-reopen.db");
-    let db_path_str = db_path.to_str().unwrap();
-    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-
-    let db_a = Database::open_file(io.clone(), db_path_str).unwrap();
-    let conn_a = db_a.connect().unwrap();
-    conn_a
-        .execute("create table test(id integer primary key, value text)")
-        .unwrap();
-    conn_a
-        .execute("insert into test(value) values ('parent')")
-        .unwrap();
-
-    let db_b = Database::open_file(io, db_path_str).unwrap();
-    assert!(!db_b
-        .shared_wal
-        .read()
-        .metadata
-        .loaded_from_disk_scan
-        .load(Ordering::Acquire));
-
-    let last_checksum_and_max_frame = db_b.shared_wal.read().last_checksum_and_max_frame();
-    let wal = db_b
-        .build_wal(last_checksum_and_max_frame, db_b.buffer_pool.clone())
-        .unwrap();
-    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
-    assert_eq!(wal_file.coordination_backend_name(), "tshm");
-
-    let conn_b = db_b.connect().unwrap();
-    assert_eq!(count_test_rows(&conn_b), 1);
-}
-
-#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
-#[test]
-fn database_open_reuses_valid_shm_authority_after_clean_last_close_across_repeated_reopens() {
-    let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("coordination-clean-reopen.db");
-    let db_path_str = db_path.to_str().unwrap();
-    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let tshm_path = storage::wal::coordination_path_for_wal_path(&format!("{db_path_str}-wal"));
-
-    let db = Database::open_file(io.clone(), db_path_str).unwrap();
-    let conn = db.connect().unwrap();
-    conn.execute("create table test(id integer primary key, value text)")
-        .unwrap();
-    conn.execute("insert into test(value) values ('persisted')")
-        .unwrap();
-    wait_for_file(std::path::Path::new(&tshm_path));
-    let initial_tshm_len = std::fs::metadata(&tshm_path).unwrap().len();
-    assert!(
-        initial_tshm_len > 0,
-        "clean last-close coverage requires a persisted non-empty tshm file"
-    );
-
-    drop(conn);
-    drop(db);
-    let mut manager = DATABASE_MANAGER.lock();
-    manager.clear();
-    drop(manager);
-
-    for cycle in 0..3 {
-        let reopened = Database::open_file(io.clone(), db_path_str).unwrap();
-        assert!(
-            !reopened
-                .shared_wal
-                .read()
-                .metadata
-                .loaded_from_disk_scan
-                .load(Ordering::Acquire),
-            "cold reopen cycle {cycle} should reuse validated tshm authority without a WAL disk scan"
-        );
-
-        let reopened_conn = reopened.connect().unwrap();
-        assert_eq!(
-            count_test_rows(&reopened_conn),
-            1,
-            "cold reopen cycle {cycle} should preserve committed rows"
-        );
-        assert!(
-            std::fs::metadata(&tshm_path).unwrap().len() >= initial_tshm_len,
-            "cold reopen cycle {cycle} should keep tshm persisted on disk"
-        );
-
-        drop(reopened_conn);
-        drop(reopened);
-        let mut manager = DATABASE_MANAGER.lock();
-        manager.clear();
-        drop(manager);
-    }
 }
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
@@ -304,83 +222,302 @@ fn database_open_rebuilds_from_disk_scan_when_exclusive_shm_snapshot_is_stale() 
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
-fn database_open_reuses_valid_shm_authority_after_large_wal_crosses_frame_index_block_boundary() {
+fn database_open_reuses_trusted_tshm_snapshot_after_partial_checkpoint_with_backfill_proof() {
     let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("coordination-large-wal-reopen.db");
+    let db_path = dir.path().join("coordination-partial-checkpoint-reopen.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let tshm_path = storage::wal::coordination_path_for_wal_path(&format!("{db_path_str}-wal"));
 
-    let db_a = Database::open_file(io.clone(), db_path_str).unwrap();
-    let conn_a = db_a.connect().unwrap();
-    conn_a
-        .execute("create table test(id integer primary key, value blob)")
+    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.wal_auto_checkpoint_disable();
+    conn.execute("create table test(id integer primary key, value blob)")
         .unwrap();
-    wait_for_file(std::path::Path::new(&tshm_path));
-    let initial_tshm_len = std::fs::metadata(&tshm_path).unwrap().len();
+    conn.execute("begin immediate").unwrap();
+    for _ in 0..32 {
+        conn.execute("insert into test(value) values (randomblob(2048))")
+            .unwrap();
+    }
+    conn.execute("commit").unwrap();
+    assert!(
+        wal_max_frame(&conn) > 1,
+        "partial-checkpoint reopen coverage requires more than one WAL frame before checkpointing"
+    );
 
-    grow_wal_past_frame_boundary(&conn_a, 4096);
-    assert!(
-        wal_max_frame(&conn_a) > 4096,
-        "test setup should cross the first shared frame-index block boundary"
+    run_checkpoint(
+        &conn,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: Some(1),
+        },
     );
-    let grown_tshm_len = std::fs::metadata(&tshm_path).unwrap().len();
-    assert!(
-        grown_tshm_len > initial_tshm_len,
-        "shared WAL coordination map should grow when the frame index crosses one block boundary"
-    );
-    let authority = db_a.shared_wal_coordination().unwrap().unwrap();
-    let snapshot = authority.snapshot();
-    assert_eq!(
-        snapshot.nbackfills, 0,
-        "large-WAL reopen coverage requires uncheckpointed WAL frames"
-    );
-    let wal_bytes = std::fs::read(format!("{db_path_str}-wal")).unwrap();
-    let frame_size =
-        crate::storage::sqlite3_ondisk::WAL_FRAME_HEADER_SIZE + snapshot.page_size as usize;
-    let expected_wal_len =
-        crate::storage::sqlite3_ondisk::WAL_HEADER_SIZE + snapshot.max_frame as usize * frame_size;
-    assert_eq!(
-        wal_bytes.len(),
-        expected_wal_len,
-        "authority snapshot should match on-disk WAL length before reopen"
-    );
-    let last_frame_offset = crate::storage::sqlite3_ondisk::WAL_HEADER_SIZE
-        + (snapshot.max_frame as usize - 1) * frame_size;
-    let (last_frame_header, _) =
-        crate::storage::sqlite3_ondisk::parse_wal_frame_header(&wal_bytes[last_frame_offset..]);
-    assert!(
-        last_frame_header.is_commit_frame(),
-        "large-WAL setup should end on a commit frame"
-    );
-    assert_eq!(last_frame_header.salt_1, snapshot.salt_1);
-    assert_eq!(last_frame_header.salt_2, snapshot.salt_2);
-    assert_eq!(last_frame_header.checksum_1, snapshot.checksum_1);
-    assert_eq!(last_frame_header.checksum_2, snapshot.checksum_2);
 
-    drop(conn_a);
-    drop(db_a);
+    let authority = db.shared_wal_coordination().unwrap().unwrap();
+    let snapshot_before = authority.snapshot();
+    assert!(
+        snapshot_before.nbackfills > 0,
+        "partial-checkpoint reopen coverage requires persisted positive nbackfills"
+    );
+    assert!(
+        snapshot_before.max_frame > snapshot_before.nbackfills,
+        "partial-checkpoint reopen coverage requires live WAL frames beyond the backfill point"
+    );
+
+    drop(conn);
+    drop(db);
     let mut manager = DATABASE_MANAGER.lock();
     manager.clear();
     drop(manager);
 
-    let db_b = Database::open_file(io, db_path_str).unwrap();
+    let reopened = Database::open_file(io, db_path_str).unwrap();
     assert!(
-        !db_b
+        !reopened
             .shared_wal
             .read()
             .metadata
             .loaded_from_disk_scan
             .load(Ordering::Acquire),
-        "cold reopen should still trust tshm after the shared frame index grows past one block"
+        "reopen should reuse the persisted tshm snapshot when the backfill proof still matches the WAL and DB header"
     );
 
-    let conn_b = db_b.connect().unwrap();
-    let rows = get_rows(&conn_b, "select count(*) from test");
-    assert_eq!(rows.len(), 1);
+    let reopened_authority = reopened.shared_wal_coordination().unwrap().unwrap();
+    assert_eq!(
+        reopened_authority.snapshot(),
+        snapshot_before,
+        "trusted reopen must preserve the authoritative partial-checkpoint snapshot"
+    );
+
+    let reopened_conn = reopened.connect().unwrap();
+    assert_eq!(
+        count_test_rows(&reopened_conn),
+        32,
+        "trusted partial-checkpoint reopen should preserve committed rows without a disk scan"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_rebuilds_from_disk_scan_after_partial_checkpoint_without_backfill_proof() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir
+        .path()
+        .join("coordination-partial-checkpoint-reopen-no-proof.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.wal_auto_checkpoint_disable();
+    conn.execute("create table test(id integer primary key, value blob)")
+        .unwrap();
+    conn.execute("begin immediate").unwrap();
+    for _ in 0..32 {
+        conn.execute("insert into test(value) values (randomblob(2048))")
+            .unwrap();
+    }
+    conn.execute("commit").unwrap();
     assert!(
-        rows[0][0].as_int().unwrap() > 0,
-        "large WAL reopen should preserve committed rows across the frame-index block boundary"
+        wal_max_frame(&conn) > 1,
+        "partial-checkpoint reopen coverage requires more than one WAL frame before checkpointing"
+    );
+
+    run_checkpoint(
+        &conn,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: Some(1),
+        },
+    );
+
+    let authority = db.shared_wal_coordination().unwrap().unwrap();
+    let snapshot_before = authority.snapshot();
+    assert!(
+        snapshot_before.nbackfills > 0,
+        "partial-checkpoint reopen coverage requires persisted positive nbackfills"
+    );
+    assert!(
+        snapshot_before.max_frame > snapshot_before.nbackfills,
+        "partial-checkpoint reopen coverage requires live WAL frames beyond the backfill point"
+    );
+    authority.clear_backfill_proof();
+
+    drop(conn);
+    drop(db);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let mut expected_snapshot = snapshot_before;
+    expected_snapshot.nbackfills = 0;
+    assert!(
+        reopened
+            .shared_wal
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire),
+        "reopen must rebuild shared WAL state from disk when positive nbackfills are not durably provable"
+    );
+
+    let reopened_authority = reopened.shared_wal_coordination().unwrap().unwrap();
+    assert_eq!(
+        reopened_authority.snapshot(),
+        expected_snapshot,
+        "disk-scan reopen must preserve the WAL generation while clearing untrusted positive nbackfills"
+    );
+
+    let reopened_conn = reopened.connect().unwrap();
+    assert_eq!(
+        count_test_rows(&reopened_conn),
+        32,
+        "partial-checkpoint reopen should preserve committed rows after the conservative disk scan"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_rebuilds_from_disk_scan_after_wal_append_invalidates_backfill_proof() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir
+        .path()
+        .join("coordination-partial-checkpoint-reopen-stale-proof.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.wal_auto_checkpoint_disable();
+    conn.execute("create table test(id integer primary key, value blob)")
+        .unwrap();
+    conn.execute("begin immediate").unwrap();
+    for _ in 0..32 {
+        conn.execute("insert into test(value) values (randomblob(2048))")
+            .unwrap();
+    }
+    conn.execute("commit").unwrap();
+
+    run_checkpoint(
+        &conn,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: Some(1),
+        },
+    );
+
+    let authority = db.shared_wal_coordination().unwrap().unwrap();
+    let snapshot_after_checkpoint = authority.snapshot();
+    assert!(
+        snapshot_after_checkpoint.nbackfills > 0,
+        "stale-proof coverage requires a partial checkpoint that publishes positive nbackfills"
+    );
+    assert!(
+        snapshot_after_checkpoint.max_frame > snapshot_after_checkpoint.nbackfills,
+        "stale-proof coverage requires live WAL frames beyond the backfill point"
+    );
+
+    conn.execute("insert into test(value) values (randomblob(2048))")
+        .unwrap();
+    let snapshot_after_append = authority.snapshot();
+    assert!(
+        snapshot_after_append.max_frame > snapshot_after_checkpoint.max_frame,
+        "stale-proof coverage requires a WAL append after proof installation"
+    );
+
+    drop(conn);
+    drop(db);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    let reopened = Database::open_file(io, db_path_str).unwrap();
+    assert!(
+        reopened
+            .shared_wal
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire),
+        "reopen must rebuild from disk after a WAL append invalidates the tshm backfill proof"
+    );
+
+    let reopened_conn = reopened.connect().unwrap();
+    assert_eq!(
+        count_test_rows(&reopened_conn),
+        33,
+        "stale-proof reopen should preserve rows committed after the partial checkpoint"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_rebuilds_from_disk_scan_after_db_header_mismatch_invalidates_backfill_proof() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir
+        .path()
+        .join("coordination-partial-checkpoint-reopen-db-header-mismatch.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.wal_auto_checkpoint_disable();
+    conn.execute("create table test(id integer primary key, value blob)")
+        .unwrap();
+    conn.execute("begin immediate").unwrap();
+    for _ in 0..32 {
+        conn.execute("insert into test(value) values (randomblob(2048))")
+            .unwrap();
+    }
+    conn.execute("commit").unwrap();
+
+    run_checkpoint(
+        &conn,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: Some(1),
+        },
+    );
+
+    let authority = db.shared_wal_coordination().unwrap().unwrap();
+    let snapshot_before = authority.snapshot();
+    assert!(
+        snapshot_before.nbackfills > 0,
+        "DB-header mismatch coverage requires a partial checkpoint that publishes positive nbackfills"
+    );
+    assert!(
+        snapshot_before.max_frame > snapshot_before.nbackfills,
+        "DB-header mismatch coverage requires live WAL frames beyond the backfill point"
+    );
+
+    drop(conn);
+    drop(db);
+    flip_db_header_reserved_byte(&db_path);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let mut expected_snapshot = snapshot_before;
+    expected_snapshot.nbackfills = 0;
+    assert!(
+        reopened
+            .shared_wal
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire),
+        "reopen must rebuild from disk when the DB header fingerprint no longer matches the tshm backfill proof"
+    );
+
+    let reopened_authority = reopened.shared_wal_coordination().unwrap().unwrap();
+    assert_eq!(
+        reopened_authority.snapshot(),
+        expected_snapshot,
+        "disk-scan reopen must preserve the WAL generation while clearing untrusted positive nbackfills"
+    );
+
+    let reopened_conn = reopened.connect().unwrap();
+    assert_eq!(
+        count_test_rows(&reopened_conn),
+        32,
+        "DB-header-mismatch reopen should preserve committed rows after the conservative disk scan"
     );
 }
 
@@ -466,9 +603,22 @@ fn multiprocess_shm_hold_read_tx_child_process() {
     let release_file = std::env::var_os("TURSO_MULTIPROCESS_RELEASE_FILE")
         .map(std::path::PathBuf::from)
         .unwrap();
+    let readonly = std::env::var_os("TURSO_MULTIPROCESS_READONLY").is_some();
+    let expect_disk_scan = std::env::var_os("TURSO_MULTIPROCESS_EXPECT_DISK_SCAN").is_some();
 
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let db = if readonly {
+        Database::open_file_with_flags(
+            io,
+            db_path.to_str().unwrap(),
+            OpenFlags::ReadOnly,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap()
+    } else {
+        Database::open_file(io, db_path.to_str().unwrap()).unwrap()
+    };
     let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
     let wal = db
         .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
@@ -476,6 +626,15 @@ fn multiprocess_shm_hold_read_tx_child_process() {
     let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
     assert_eq!(wal_file.coordination_backend_name(), "tshm");
     assert_eq!(wal_file.coordination_open_mode_name(), Some("multiprocess"));
+    assert_eq!(
+        db.shared_wal
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire),
+        expect_disk_scan,
+        "child reopen path did not match expected disk-scan behavior"
+    );
 
     let conn = db.connect().unwrap();
     let pager = conn.pager.load();
@@ -742,6 +901,310 @@ fn subprocess_database_open_peer_refreshes_remote_schema_without_reopen() {
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
+fn subprocess_database_open_parent_directly_uses_child_created_table() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-direct-child-table-use.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("create table t(value integer)").unwrap();
+
+    let current_exe = std::env::current_exe().unwrap();
+    let schema_output = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_SCHEMA_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .output()
+        .unwrap();
+    assert!(
+        schema_output.status.success(),
+        "child schema process failed: stdout={}; stderr={}",
+        String::from_utf8_lossy(&schema_output.stdout),
+        String::from_utf8_lossy(&schema_output.stderr)
+    );
+
+    let mut stmt = conn
+        .prepare("insert into child_table(value) values ('parent-schema')")
+        .unwrap();
+    stmt.run_ignore_rows().unwrap();
+
+    let child_rows =
+        get_rows_without_schema_retry(&conn, "select value from child_table order by rowid");
+    assert_eq!(child_rows.len(), 2);
+    assert_eq!(child_rows[0][0].to_string(), "child-schema");
+    assert_eq!(child_rows[1][0].to_string(), "parent-schema");
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn subprocess_database_open_parent_execute_uses_child_created_table() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-execute-child-table-use.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("create table t(value integer)").unwrap();
+
+    let current_exe = std::env::current_exe().unwrap();
+    let schema_output = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_SCHEMA_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .output()
+        .unwrap();
+    assert!(
+        schema_output.status.success(),
+        "child schema process failed: stdout={}; stderr={}",
+        String::from_utf8_lossy(&schema_output.stdout),
+        String::from_utf8_lossy(&schema_output.stderr)
+    );
+
+    conn.execute("insert into child_table(value) values ('parent-schema')")
+        .unwrap();
+
+    let child_rows =
+        get_rows_without_schema_retry(&conn, "select value from child_table order by rowid");
+    assert_eq!(child_rows.len(), 2);
+    assert_eq!(child_rows[0][0].to_string(), "child-schema");
+    assert_eq!(child_rows[1][0].to_string(), "parent-schema");
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn subprocess_readonly_child_reader_blocks_restart_and_truncate_checkpoints() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir
+        .path()
+        .join("coordination-readonly-reader-blocks-checkpoint.db");
+    let ready_file = dir.path().join("child-ready");
+    let release_file = dir.path().join("child-release");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db = Database::open_file(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.wal_auto_checkpoint_disable();
+    conn.execute("create table test(id integer primary key, value blob)")
+        .unwrap();
+    conn.execute("begin immediate").unwrap();
+    for _ in 0..32 {
+        conn.execute("insert into test(value) values (randomblob(2048))")
+            .unwrap();
+    }
+    conn.execute("commit").unwrap();
+    assert!(
+        wal_max_frame(&conn) > 0,
+        "read-only reader coverage requires committed WAL frames"
+    );
+
+    let authority = db.shared_wal_coordination().unwrap().unwrap();
+    assert_eq!(
+        authority.min_active_reader_frame(),
+        None,
+        "setup should start without active shared readers"
+    );
+
+    let current_exe = std::env::current_exe().unwrap();
+    let mut child = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_HOLD_READ_TX_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .env("TURSO_MULTIPROCESS_READY_FILE", &ready_file)
+        .env("TURSO_MULTIPROCESS_RELEASE_FILE", &release_file)
+        .env("TURSO_MULTIPROCESS_READONLY", "1")
+        .spawn()
+        .unwrap();
+
+    wait_for_file(&ready_file);
+    let reader_frame = authority
+        .min_active_reader_frame()
+        .expect("read-only child should publish an active shared reader slot");
+    assert!(
+        reader_frame > 0,
+        "read-only child should pin a positive WAL frame while its read transaction is active"
+    );
+
+    let restart_err = conn.checkpoint(CheckpointMode::Restart).unwrap_err();
+    assert!(
+        matches!(restart_err, LimboError::Busy),
+        "restart checkpoint should fail with Busy while the read-only child holds a WAL snapshot: {restart_err:?}",
+    );
+
+    let truncate_err = conn
+        .checkpoint(CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        })
+        .unwrap_err();
+    assert!(
+        matches!(truncate_err, LimboError::Busy),
+        "truncate checkpoint should fail with Busy while the read-only child holds a WAL snapshot: {truncate_err:?}",
+    );
+
+    std::fs::write(&release_file, b"release").unwrap();
+    let child_status = child.wait().unwrap();
+    assert!(
+        child_status.success(),
+        "read-only child should exit cleanly after releasing its read transaction: {child_status:?}"
+    );
+
+    let checkpoint = conn
+        .checkpoint(CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        })
+        .unwrap();
+    assert!(
+        checkpoint.everything_backfilled(),
+        "truncate checkpoint should succeed once the read-only child releases its WAL snapshot"
+    );
+    assert_eq!(
+        authority.min_active_reader_frame(),
+        None,
+        "shared reader state should clear once the read-only child releases its WAL snapshot"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn subprocess_readonly_disk_scan_child_reader_stays_in_shared_coordination() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir
+        .path()
+        .join("coordination-readonly-disk-scan-reader-blocks-checkpoint.db");
+    let ready_file = dir.path().join("child-ready");
+    let release_file = dir.path().join("child-release");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.wal_auto_checkpoint_disable();
+    conn.execute("create table test(id integer primary key, value blob)")
+        .unwrap();
+    conn.execute("begin immediate").unwrap();
+    for _ in 0..32 {
+        conn.execute("insert into test(value) values (randomblob(2048))")
+            .unwrap();
+    }
+    conn.execute("commit").unwrap();
+    assert!(
+        wal_max_frame(&conn) > 1,
+        "disk-scan read-only coverage requires more than one WAL frame before partial checkpoint"
+    );
+
+    run_checkpoint(
+        &conn,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: Some(1),
+        },
+    );
+
+    let authority = db.shared_wal_coordination().unwrap().unwrap();
+    let snapshot_before = authority.snapshot();
+    assert!(
+        snapshot_before.nbackfills > 0,
+        "disk-scan read-only coverage requires persisted positive nbackfills before proof removal"
+    );
+    assert!(
+        snapshot_before.max_frame > snapshot_before.nbackfills,
+        "disk-scan read-only coverage requires a live WAL tail beyond the backfill point"
+    );
+    authority.clear_backfill_proof();
+
+    drop(conn);
+    drop(db);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    let current_exe = std::env::current_exe().unwrap();
+    let mut child = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_HOLD_READ_TX_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .env("TURSO_MULTIPROCESS_READY_FILE", &ready_file)
+        .env("TURSO_MULTIPROCESS_RELEASE_FILE", &release_file)
+        .env("TURSO_MULTIPROCESS_READONLY", "1")
+        .env("TURSO_MULTIPROCESS_EXPECT_DISK_SCAN", "1")
+        .spawn()
+        .unwrap();
+
+    wait_for_file(&ready_file);
+    let reader_frame = authority
+        .min_active_reader_frame()
+        .expect("disk-scan read-only child should publish an active shared reader slot");
+    assert!(
+        reader_frame > snapshot_before.nbackfills,
+        "disk-scan read-only child should protect the live WAL tail, not the checkpointed prefix"
+    );
+
+    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened_conn = reopened.connect().unwrap();
+
+    let restart_err = reopened_conn
+        .checkpoint(CheckpointMode::Restart)
+        .unwrap_err();
+    assert!(
+        matches!(restart_err, LimboError::Busy),
+        "restart checkpoint should fail with Busy while the disk-scan read-only child holds a WAL snapshot: {restart_err:?}",
+    );
+
+    let truncate_err = reopened_conn
+        .checkpoint(CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        })
+        .unwrap_err();
+    assert!(
+        matches!(truncate_err, LimboError::Busy),
+        "truncate checkpoint should fail with Busy while the disk-scan read-only child holds a WAL snapshot: {truncate_err:?}",
+    );
+
+    drop(reopened_conn);
+    drop(reopened);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    let wal_len = std::fs::metadata(format!("{db_path_str}-wal"))
+        .unwrap_or_else(|_| panic!("expected WAL file at {db_path_str}-wal"))
+        .len();
+    assert!(
+        wal_len > 0,
+        "closing the other process must not run shutdown checkpoint while the disk-scan read-only child still holds a shared reader slot"
+    );
+
+    std::fs::write(&release_file, b"release").unwrap();
+    let child_status = child.wait().unwrap();
+    assert!(
+        child_status.success(),
+        "disk-scan read-only child should exit cleanly after releasing its read transaction: {child_status:?}"
+    );
+
+    let reopened = Database::open_file(Arc::new(PlatformIO::new().unwrap()), db_path_str).unwrap();
+    let reopened_conn = reopened.connect().unwrap();
+    let checkpoint = reopened_conn
+        .checkpoint(CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        })
+        .unwrap();
+    assert!(
+        checkpoint.everything_backfilled(),
+        "truncate checkpoint should succeed once the disk-scan read-only child releases its WAL snapshot"
+    );
+    assert_eq!(
+        count_test_rows(&reopened_conn),
+        32,
+        "disk-scan read-only reopen should preserve committed rows"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
 fn subprocess_database_truncate_checkpoint_reclaims_dead_child_reader_slot() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("coordination-dead-reader-slot.db");
@@ -842,9 +1305,111 @@ fn subprocess_database_truncate_checkpoint_reclaims_dead_child_reader_slot() {
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
 #[test]
-fn database_open_reuses_valid_shm_authority_after_truncate_rewrite_without_disk_scan() {
+fn database_open_reopen_with_live_child_reader_does_not_clobber_authority() {
     let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("coordination-truncate-rewrite-reopen.db");
+    let db_path = dir.path().join("coordination-live-reader-reopen.db");
+    let ready_file = dir.path().join("child-ready");
+    let release_file = dir.path().join("child-release");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.wal_auto_checkpoint_disable();
+    conn.execute("create table test(id integer primary key, value blob)")
+        .unwrap();
+    conn.execute("begin immediate").unwrap();
+    for _ in 0..32 {
+        conn.execute("insert into test(value) values (randomblob(2048))")
+            .unwrap();
+    }
+    conn.execute("commit").unwrap();
+    assert!(
+        wal_max_frame(&conn) > 1,
+        "disk-scan reopen coverage requires more than one WAL frame before partial checkpoint"
+    );
+
+    run_checkpoint(
+        &conn,
+        CheckpointMode::Passive {
+            upper_bound_inclusive: Some(1),
+        },
+    );
+
+    let authority = db.shared_wal_coordination().unwrap().unwrap();
+    let snapshot_before = authority.snapshot();
+    assert!(
+        snapshot_before.nbackfills > 0,
+        "disk-scan reopen coverage requires a persisted authority snapshot with positive nbackfills"
+    );
+    assert!(
+        snapshot_before.max_frame > snapshot_before.nbackfills,
+        "disk-scan reopen coverage requires live WAL frames beyond the backfill point"
+    );
+    let frames_before = authority.iter_latest_frames(0, snapshot_before.max_frame);
+    assert!(
+        !frames_before.is_empty(),
+        "setup should publish durable frame-index entries before reopen repair"
+    );
+
+    let current_exe = std::env::current_exe().unwrap();
+    let mut child = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_HOLD_READ_TX_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .env("TURSO_MULTIPROCESS_READY_FILE", &ready_file)
+        .env("TURSO_MULTIPROCESS_RELEASE_FILE", &release_file)
+        .spawn()
+        .unwrap();
+
+    wait_for_file(&ready_file);
+    let reader_frame = authority
+        .min_active_reader_frame()
+        .expect("child read transaction should publish an active shared reader slot");
+
+    drop(conn);
+    drop(db);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened_authority = reopened.shared_wal_coordination().unwrap().unwrap();
+    assert_eq!(reopened_authority.snapshot(), snapshot_before);
+    assert_eq!(
+        reopened_authority.iter_latest_frames(0, snapshot_before.max_frame),
+        frames_before,
+        "reopen repair must preserve durable frame-index content while the child reader is still alive"
+    );
+    assert_eq!(
+        reopened_authority.min_active_reader_frame(),
+        Some(reader_frame),
+        "reopen repair must not reclaim the live child reader slot"
+    );
+
+    std::fs::write(&release_file, b"release").unwrap();
+    let child_status = child.wait().unwrap();
+    assert!(
+        child_status.success(),
+        "child reader should exit cleanly after reopen repair: {child_status:?}"
+    );
+
+    let reopened_conn = reopened.connect().unwrap();
+    assert_eq!(
+        count_test_rows(&reopened_conn),
+        32,
+        "reopen repair should preserve committed rows while leaving the child reader intact"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_rebuilds_from_disk_scan_when_shared_frame_index_overflowed() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir
+        .path()
+        .join("coordination-overflowed-frame-index-reopen.db");
     let db_path_str = db_path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
@@ -854,41 +1419,72 @@ fn database_open_reuses_valid_shm_authority_after_truncate_rewrite_without_disk_
         .execute("create table test(id integer primary key, value text)")
         .unwrap();
     conn_a
-        .execute("insert into test(value) values ('before-truncate')")
+        .execute("insert into test(value) values ('before-overflow')")
+        .unwrap();
+    conn_a
+        .execute("insert into test(value) values ('after-overflow')")
         .unwrap();
 
-    let checkpoint = run_checkpoint(
-        &conn_a,
-        CheckpointMode::Truncate {
-            upper_bound_inclusive: None,
-        },
+    let authority = db_a.shared_wal_coordination().unwrap().unwrap();
+    let snapshot = authority.snapshot();
+    assert!(
+        snapshot.max_frame > 0,
+        "overflow reopen coverage requires committed WAL frames before the authority is marked incomplete"
     );
     assert!(
-        checkpoint.everything_backfilled(),
-        "truncate checkpoint should fully backfill before WAL rewrite"
+        !authority
+            .iter_latest_frames(0, snapshot.max_frame)
+            .is_empty(),
+        "overflow reopen coverage requires a populated durable frame index before it is discarded"
     );
 
-    conn_a
-        .execute("insert into test(value) values ('after-truncate')")
-        .unwrap();
+    authority.discard_durable_frame_index_for_exclusive_rebuild();
+    authority.mark_frame_index_overflowed_for_tests();
+
+    assert!(
+        authority
+            .iter_latest_frames(0, snapshot.max_frame)
+            .is_empty(),
+        "test setup should clear durable frame-index entries before reopen"
+    );
+    assert!(
+        authority.frame_index_overflowed(),
+        "test setup should mark the shared frame index incomplete before reopen"
+    );
+
+    drop(conn_a);
+    drop(db_a);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
 
     let db_b = Database::open_file(io, db_path_str).unwrap();
-    assert!(!db_b
-        .shared_wal
-        .read()
-        .metadata
-        .loaded_from_disk_scan
-        .load(Ordering::Acquire));
+    assert!(
+        db_b.shared_wal
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire),
+        "overflowed shared frame index must force a conservative WAL disk scan on reopen"
+    );
 
-    let last_checksum_and_max_frame = db_b.shared_wal.read().last_checksum_and_max_frame();
-    let wal = db_b
-        .build_wal(last_checksum_and_max_frame, db_b.buffer_pool.clone())
-        .unwrap();
-    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
-    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+    let reopened_authority = db_b.shared_wal_coordination().unwrap().unwrap();
+    assert!(
+        !reopened_authority.frame_index_overflowed(),
+        "disk-scan reopen should rebuild the durable frame index instead of leaving it overflowed"
+    );
+    assert!(
+        !reopened_authority
+            .iter_latest_frames(0, snapshot.max_frame)
+            .is_empty(),
+        "disk-scan reopen should repopulate the durable frame index from the WAL"
+    );
 
     let conn_b = db_b.connect().unwrap();
-    assert_eq!(count_test_rows(&conn_b), 2);
+    let rows = get_rows(&conn_b, "select value from test order by id");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].to_string(), "before-overflow");
+    assert_eq!(rows[1][0].to_string(), "after-overflow");
 }
 
 #[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -1,0 +1,917 @@
+use super::*;
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+use std::os::unix::process::ExitStatusExt;
+use std::process::Command;
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+const MULTIPROCESS_SHM_INSERT_CHILD_TEST: &str =
+    "multiprocess_tests::multiprocess_shm_insert_child_process";
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+const MULTIPROCESS_SHM_COUNT_CHILD_TEST: &str =
+    "multiprocess_tests::multiprocess_shm_count_child_process";
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+const MULTIPROCESS_SHM_HOLD_READ_TX_CHILD_TEST: &str =
+    "multiprocess_tests::multiprocess_shm_hold_read_tx_child_process";
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+const MULTIPROCESS_SHM_SCHEMA_CHILD_TEST: &str =
+    "multiprocess_tests::multiprocess_shm_schema_child_process";
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+const MULTIPROCESS_SHM_INSERT_AND_CLOSE_CHILD_TEST: &str =
+    "multiprocess_tests::multiprocess_shm_insert_and_close_child_process";
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn count_test_rows(conn: &Arc<Connection>) -> i64 {
+    let mut stmt = conn.prepare("select count(*) from test").unwrap();
+    let mut count = 0;
+    stmt.run_with_row_callback(|row| {
+        count = row.get(0).unwrap();
+        Ok(())
+    })
+    .unwrap();
+    count
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
+    for _attempt in 0..3 {
+        let mut stmt = match conn.prepare(query) {
+            Ok(s) => s,
+            Err(LimboError::SchemaUpdated) => {
+                conn.maybe_reparse_schema().unwrap();
+                continue;
+            }
+            Err(e) => panic!("prepare failed: {e}"),
+        };
+        let mut rows = Vec::new();
+        match stmt.run_with_row_callback(|row| {
+            rows.push(row.get_values().cloned().collect::<Vec<_>>());
+            Ok(())
+        }) {
+            Ok(()) => return rows,
+            Err(LimboError::SchemaUpdated) => {
+                drop(stmt);
+                conn.maybe_reparse_schema().unwrap();
+                continue;
+            }
+            Err(e) => panic!("run_with_row_callback failed: {e}"),
+        }
+    }
+    panic!("get_rows: exhausted SchemaUpdated retries for: {query}");
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn get_rows_without_schema_retry(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
+    let mut stmt = conn.prepare(query).unwrap();
+    let mut rows = Vec::new();
+    stmt.run_with_row_callback(|row| {
+        rows.push(row.get_values().cloned().collect::<Vec<_>>());
+        Ok(())
+    })
+    .unwrap();
+    rows
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn run_checkpoint(conn: &Arc<Connection>, mode: CheckpointMode) -> CheckpointResult {
+    let pager = conn.pager.load();
+    pager
+        .io
+        .block(|| pager.checkpoint(mode, SyncMode::Full, true))
+        .unwrap()
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn wal_max_frame(conn: &Arc<Connection>) -> u64 {
+    conn.pager
+        .load()
+        .wal
+        .as_ref()
+        .expect("wal should be present")
+        .get_max_frame_in_wal()
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn grow_wal_past_frame_boundary(conn: &Arc<Connection>, target_frame: u64) {
+    conn.wal_auto_checkpoint_disable();
+
+    for _ in 0..64 {
+        if wal_max_frame(conn) > target_frame {
+            return;
+        }
+
+        conn.execute("begin immediate").unwrap();
+        for _ in 0..128 {
+            conn.execute("insert into test(value) values (randomblob(8192))")
+                .unwrap();
+        }
+        conn.execute("commit").unwrap();
+    }
+    panic!(
+        "failed to grow WAL beyond frame boundary {target_frame}; max_frame={}",
+        wal_max_frame(conn)
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+fn wait_for_file(path: &std::path::Path) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
+#[cfg(all(feature = "fs", target_os = "linux", target_pointer_width = "64"))]
+#[test]
+fn shared_wal_coordination_rejects_remote_filesystem_magic_values() {
+    assert!(!Database::filesystem_magic_allows_shared_wal(0x6969));
+    assert!(!Database::filesystem_magic_allows_shared_wal(
+        0xFF53_4D42u32 as libc::c_long,
+    ));
+    assert!(!Database::filesystem_magic_allows_shared_wal(0x0102_1997));
+    assert!(Database::filesystem_magic_allows_shared_wal(0xEF53));
+    assert!(Database::filesystem_magic_allows_shared_wal(0x0102_1994));
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_selects_shm_wal_backend() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path_str).unwrap();
+
+    let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db
+        .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+
+    let shm_path = storage::wal::coordination_path_for_wal_path(&format!("{db_path_str}-wal"));
+    assert!(std::path::Path::new(&shm_path).exists());
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_reuses_valid_exclusive_shm_authority_without_disk_scan() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-reopen.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db_a = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn_a = db_a.connect().unwrap();
+    conn_a
+        .execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    conn_a
+        .execute("insert into test(value) values ('parent')")
+        .unwrap();
+
+    let db_b = Database::open_file(io, db_path_str).unwrap();
+    assert!(!db_b
+        .shared_wal
+        .read()
+        .metadata
+        .loaded_from_disk_scan
+        .load(Ordering::Acquire));
+
+    let last_checksum_and_max_frame = db_b.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db_b
+        .build_wal(last_checksum_and_max_frame, db_b.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+
+    let conn_b = db_b.connect().unwrap();
+    assert_eq!(count_test_rows(&conn_b), 1);
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_reuses_valid_shm_authority_after_clean_last_close_across_repeated_reopens() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-clean-reopen.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let tshm_path = storage::wal::coordination_path_for_wal_path(&format!("{db_path_str}-wal"));
+
+    let db = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    conn.execute("insert into test(value) values ('persisted')")
+        .unwrap();
+    wait_for_file(std::path::Path::new(&tshm_path));
+    let initial_tshm_len = std::fs::metadata(&tshm_path).unwrap().len();
+    assert!(
+        initial_tshm_len > 0,
+        "clean last-close coverage requires a persisted non-empty tshm file"
+    );
+
+    drop(conn);
+    drop(db);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    for cycle in 0..3 {
+        let reopened = Database::open_file(io.clone(), db_path_str).unwrap();
+        assert!(
+            !reopened
+                .shared_wal
+                .read()
+                .metadata
+                .loaded_from_disk_scan
+                .load(Ordering::Acquire),
+            "cold reopen cycle {cycle} should reuse validated tshm authority without a WAL disk scan"
+        );
+
+        let reopened_conn = reopened.connect().unwrap();
+        assert_eq!(
+            count_test_rows(&reopened_conn),
+            1,
+            "cold reopen cycle {cycle} should preserve committed rows"
+        );
+        assert!(
+            std::fs::metadata(&tshm_path).unwrap().len() >= initial_tshm_len,
+            "cold reopen cycle {cycle} should keep tshm persisted on disk"
+        );
+
+        drop(reopened_conn);
+        drop(reopened);
+        let mut manager = DATABASE_MANAGER.lock();
+        manager.clear();
+        drop(manager);
+    }
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_rebuilds_from_disk_scan_when_exclusive_shm_snapshot_is_stale() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-stale-reopen.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db_a = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn_a = db_a.connect().unwrap();
+    conn_a
+        .execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    conn_a
+        .execute("insert into test(value) values ('before-stale')")
+        .unwrap();
+
+    let authority = db_a.shared_wal_coordination().unwrap().unwrap();
+    let stale_snapshot = authority.snapshot();
+
+    conn_a
+        .execute("insert into test(value) values ('after-stale')")
+        .unwrap();
+
+    authority.install_snapshot(stale_snapshot);
+
+    drop(conn_a);
+    drop(db_a);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    let db_b = Database::open_file(io, db_path_str).unwrap();
+    assert!(
+        db_b.shared_wal
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire),
+        "cold reopen should fall back to a WAL disk scan when tshm snapshot is stale"
+    );
+
+    let conn_b = db_b.connect().unwrap();
+    let rows = get_rows(&conn_b, "select id, value from test order by id");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "before-stale");
+    assert_eq!(rows[1][0].as_int().unwrap(), 2);
+    assert_eq!(rows[1][1].to_string(), "after-stale");
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_reuses_valid_shm_authority_after_large_wal_crosses_frame_index_block_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-large-wal-reopen.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let tshm_path = storage::wal::coordination_path_for_wal_path(&format!("{db_path_str}-wal"));
+
+    let db_a = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn_a = db_a.connect().unwrap();
+    conn_a
+        .execute("create table test(id integer primary key, value blob)")
+        .unwrap();
+    wait_for_file(std::path::Path::new(&tshm_path));
+    let initial_tshm_len = std::fs::metadata(&tshm_path).unwrap().len();
+
+    grow_wal_past_frame_boundary(&conn_a, 4096);
+    assert!(
+        wal_max_frame(&conn_a) > 4096,
+        "test setup should cross the first shared frame-index block boundary"
+    );
+    let grown_tshm_len = std::fs::metadata(&tshm_path).unwrap().len();
+    assert!(
+        grown_tshm_len > initial_tshm_len,
+        "shared WAL coordination map should grow when the frame index crosses one block boundary"
+    );
+    let authority = db_a.shared_wal_coordination().unwrap().unwrap();
+    let snapshot = authority.snapshot();
+    assert_eq!(
+        snapshot.nbackfills, 0,
+        "large-WAL reopen coverage requires uncheckpointed WAL frames"
+    );
+    let wal_bytes = std::fs::read(format!("{db_path_str}-wal")).unwrap();
+    let frame_size =
+        crate::storage::sqlite3_ondisk::WAL_FRAME_HEADER_SIZE + snapshot.page_size as usize;
+    let expected_wal_len =
+        crate::storage::sqlite3_ondisk::WAL_HEADER_SIZE + snapshot.max_frame as usize * frame_size;
+    assert_eq!(
+        wal_bytes.len(),
+        expected_wal_len,
+        "authority snapshot should match on-disk WAL length before reopen"
+    );
+    let last_frame_offset = crate::storage::sqlite3_ondisk::WAL_HEADER_SIZE
+        + (snapshot.max_frame as usize - 1) * frame_size;
+    let (last_frame_header, _) =
+        crate::storage::sqlite3_ondisk::parse_wal_frame_header(&wal_bytes[last_frame_offset..]);
+    assert!(
+        last_frame_header.is_commit_frame(),
+        "large-WAL setup should end on a commit frame"
+    );
+    assert_eq!(last_frame_header.salt_1, snapshot.salt_1);
+    assert_eq!(last_frame_header.salt_2, snapshot.salt_2);
+    assert_eq!(last_frame_header.checksum_1, snapshot.checksum_1);
+    assert_eq!(last_frame_header.checksum_2, snapshot.checksum_2);
+
+    drop(conn_a);
+    drop(db_a);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    let db_b = Database::open_file(io, db_path_str).unwrap();
+    assert!(
+        !db_b
+            .shared_wal
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire),
+        "cold reopen should still trust tshm after the shared frame index grows past one block"
+    );
+
+    let conn_b = db_b.connect().unwrap();
+    let rows = get_rows(&conn_b, "select count(*) from test");
+    assert_eq!(rows.len(), 1);
+    assert!(
+        rows[0][0].as_int().unwrap() > 0,
+        "large WAL reopen should preserve committed rows across the frame-index block boundary"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_shm_insert_child_process() {
+    let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
+        return;
+    };
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db
+        .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+    assert_eq!(wal_file.coordination_open_mode_name(), Some("multiprocess"));
+
+    let conn = db.connect().unwrap();
+    conn.execute("insert into test(value) values ('child')")
+        .unwrap();
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_shm_insert_and_close_child_process() {
+    let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
+        return;
+    };
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db
+        .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+    assert_eq!(wal_file.coordination_open_mode_name(), Some("multiprocess"));
+
+    let conn = db.connect().unwrap();
+    conn.execute("insert into test(value) values ('child-close')")
+        .unwrap();
+    conn.close().unwrap();
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_shm_count_child_process() {
+    let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
+        return;
+    };
+    let expected_count = std::env::var("TURSO_MULTIPROCESS_EXPECTED_COUNT")
+        .unwrap()
+        .parse::<i64>()
+        .unwrap();
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db
+        .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+    assert_eq!(wal_file.coordination_open_mode_name(), Some("multiprocess"));
+
+    let conn = db.connect().unwrap();
+    assert_eq!(count_test_rows(&conn), expected_count);
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_shm_hold_read_tx_child_process() {
+    let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
+        return;
+    };
+    let ready_file = std::env::var_os("TURSO_MULTIPROCESS_READY_FILE")
+        .map(std::path::PathBuf::from)
+        .unwrap();
+    let release_file = std::env::var_os("TURSO_MULTIPROCESS_RELEASE_FILE")
+        .map(std::path::PathBuf::from)
+        .unwrap();
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db
+        .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+    assert_eq!(wal_file.coordination_open_mode_name(), Some("multiprocess"));
+
+    let conn = db.connect().unwrap();
+    let pager = conn.pager.load();
+    let wal = pager.wal.as_ref().unwrap();
+    wal.begin_read_tx().unwrap();
+    std::fs::write(&ready_file, b"ready").unwrap();
+    wait_for_file(&release_file);
+    wal.end_read_tx();
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_shm_schema_child_process() {
+    let Some(db_path) = std::env::var_os("TURSO_MULTIPROCESS_DB_PATH") else {
+        return;
+    };
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db
+        .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+    assert_eq!(wal_file.coordination_open_mode_name(), Some("multiprocess"));
+
+    let conn = db.connect().unwrap();
+    conn.execute("create table child_table(id integer primary key, value text)")
+        .unwrap();
+    conn.execute("insert into child_table(value) values ('child-schema')")
+        .unwrap();
+}
+
+#[test]
+fn subprocess_database_open_selects_multiprocess_shm_backend() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-subprocess.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path_str).unwrap();
+    let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db
+        .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+    assert_eq!(wal_file.coordination_open_mode_name(), Some("exclusive"));
+
+    let conn = db.connect().unwrap();
+    conn.execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    conn.execute("insert into test(value) values ('parent')")
+        .unwrap();
+
+    let current_exe = std::env::current_exe().unwrap();
+    let insert_output = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_INSERT_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .output()
+        .unwrap();
+    assert!(
+        insert_output.status.success(),
+        "child process failed: stdout={}; stderr={}",
+        String::from_utf8_lossy(&insert_output.stdout),
+        String::from_utf8_lossy(&insert_output.stderr)
+    );
+
+    let count_output = Command::new(current_exe)
+        .arg(MULTIPROCESS_SHM_COUNT_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .env("TURSO_MULTIPROCESS_EXPECTED_COUNT", "2")
+        .output()
+        .unwrap();
+    assert!(
+        count_output.status.success(),
+        "count child process failed: stdout={}; stderr={}",
+        String::from_utf8_lossy(&count_output.stdout),
+        String::from_utf8_lossy(&count_output.stderr)
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn subprocess_child_close_skips_shutdown_checkpoint_in_multiprocess_wal_mode() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("close-skip-shutdown-checkpoint.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    run_checkpoint(
+        &conn,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+
+    let current_exe = std::env::current_exe().unwrap();
+    let child_output = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_INSERT_AND_CLOSE_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .output()
+        .unwrap();
+    assert!(
+        child_output.status.success(),
+        "child process failed: stdout={}; stderr={}",
+        String::from_utf8_lossy(&child_output.stdout),
+        String::from_utf8_lossy(&child_output.stderr)
+    );
+
+    let wal_path = format!("{db_path_str}-wal");
+    let wal_len = std::fs::metadata(&wal_path)
+        .unwrap_or_else(|_| panic!("expected WAL file at {wal_path}"))
+        .len();
+    assert!(
+        wal_len > 0,
+        "child close should not run shutdown checkpoint while another process still has the DB open"
+    );
+
+    assert_eq!(
+        count_test_rows(&conn),
+        1,
+        "parent connection should still see the child commit via WAL"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn subprocess_database_open_survives_truncate_rewrite_cycles() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-truncate-rewrite.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    conn.execute("insert into test(value) values ('parent-0')")
+        .unwrap();
+
+    let current_exe = std::env::current_exe().unwrap();
+    for expected_count in [2_i64, 3_i64] {
+        let insert_output = Command::new(&current_exe)
+            .arg(MULTIPROCESS_SHM_INSERT_CHILD_TEST)
+            .arg("--exact")
+            .arg("--nocapture")
+            .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+            .output()
+            .unwrap();
+        assert!(
+            insert_output.status.success(),
+            "child insert failed: stdout={}; stderr={}",
+            String::from_utf8_lossy(&insert_output.stdout),
+            String::from_utf8_lossy(&insert_output.stderr)
+        );
+        assert_eq!(count_test_rows(&conn), expected_count);
+
+        let checkpoint = run_checkpoint(
+            &conn,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
+        );
+        assert!(
+            checkpoint.everything_backfilled(),
+            "truncate checkpoint should fully backfill before WAL rewrite"
+        );
+
+        let count_output = Command::new(&current_exe)
+            .arg(MULTIPROCESS_SHM_COUNT_CHILD_TEST)
+            .arg("--exact")
+            .arg("--nocapture")
+            .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+            .env(
+                "TURSO_MULTIPROCESS_EXPECTED_COUNT",
+                expected_count.to_string(),
+            )
+            .output()
+            .unwrap();
+        assert!(
+            count_output.status.success(),
+            "child count after truncate failed: stdout={}; stderr={}",
+            String::from_utf8_lossy(&count_output.stdout),
+            String::from_utf8_lossy(&count_output.stderr)
+        );
+    }
+
+    assert_eq!(count_test_rows(&conn), 3);
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn subprocess_database_open_peer_refreshes_remote_schema_without_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-peer-schema-refresh.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("create table t(value integer, next_value integer)")
+        .unwrap();
+
+    let series_rows = get_rows(&conn, "select value from generate_series(1, 3)");
+    assert_eq!(series_rows.len(), 3);
+    assert_eq!(series_rows[0][0].to_string(), "1");
+    assert_eq!(series_rows[1][0].to_string(), "2");
+    assert_eq!(series_rows[2][0].to_string(), "3");
+
+    let initial_schema_rows = get_rows(
+        &conn,
+        "select name, type from sqlite_schema where name = 'child_table'",
+    );
+    assert!(
+        initial_schema_rows.is_empty(),
+        "fresh parent connection should not see child_table before child creates it"
+    );
+
+    let current_exe = std::env::current_exe().unwrap();
+    let schema_output = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_SCHEMA_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .output()
+        .unwrap();
+    assert!(
+        schema_output.status.success(),
+        "child schema process failed: stdout={}; stderr={}",
+        String::from_utf8_lossy(&schema_output.stdout),
+        String::from_utf8_lossy(&schema_output.stderr)
+    );
+
+    let schema_rows = get_rows_without_schema_retry(
+        &conn,
+        "select name, type from sqlite_schema where name = 'child_table'",
+    );
+    assert_eq!(schema_rows.len(), 1);
+    assert_eq!(schema_rows[0][0].to_string(), "child_table");
+    assert_eq!(schema_rows[0][1].to_string(), "table");
+
+    let child_rows = get_rows_without_schema_retry(&conn, "select value from child_table");
+    assert_eq!(child_rows.len(), 1);
+    assert_eq!(child_rows[0][0].to_string(), "child-schema");
+
+    conn.execute("insert into t select value, value + 1 from generate_series(1, 3)")
+        .unwrap();
+    let inserted_rows = get_rows(&conn, "select value, next_value from t order by value");
+    assert_eq!(inserted_rows.len(), 3);
+    assert_eq!(inserted_rows[0][0].to_string(), "1");
+    assert_eq!(inserted_rows[0][1].to_string(), "2");
+    assert_eq!(inserted_rows[2][0].to_string(), "3");
+    assert_eq!(inserted_rows[2][1].to_string(), "4");
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn subprocess_database_truncate_checkpoint_reclaims_dead_child_reader_slot() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-dead-reader-slot.db");
+    let ready_file = dir.path().join("child-ready");
+    let release_file = dir.path().join("child-release");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    conn.execute("insert into test(value) values ('before-reader')")
+        .unwrap();
+
+    let authority = db.shared_wal_coordination().unwrap().unwrap();
+    assert_eq!(
+        authority.min_active_reader_frame(),
+        None,
+        "setup should start without active shared reader slots"
+    );
+
+    let current_exe = std::env::current_exe().unwrap();
+    let mut child = Command::new(&current_exe)
+        .arg(MULTIPROCESS_SHM_HOLD_READ_TX_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env("TURSO_MULTIPROCESS_DB_PATH", db_path_str)
+        .env("TURSO_MULTIPROCESS_READY_FILE", &ready_file)
+        .env("TURSO_MULTIPROCESS_RELEASE_FILE", &release_file)
+        .spawn()
+        .unwrap();
+
+    wait_for_file(&ready_file);
+    let reader_frame = authority
+        .min_active_reader_frame()
+        .expect("child read transaction should publish an active shared reader slot");
+
+    conn.execute("insert into test(value) values ('after-reader')")
+        .unwrap();
+    assert!(
+        wal_max_frame(&conn) > reader_frame,
+        "parent should append newer WAL frames after the child pins its read snapshot"
+    );
+
+    let err = conn
+        .checkpoint(CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        })
+        .unwrap_err();
+    assert!(
+        matches!(err, LimboError::Busy),
+        "truncate checkpoint should fail with Busy while child process holds a shared reader slot: {err:?}",
+    );
+
+    child.kill().unwrap();
+    let child_status = child.wait().unwrap();
+    assert_eq!(
+        child_status.signal(),
+        Some(libc::SIGKILL),
+        "expected killed child process to exit via SIGKILL, got {child_status:?}"
+    );
+
+    let checkpoint = conn
+        .checkpoint(CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        })
+        .unwrap();
+    assert!(
+        checkpoint.everything_backfilled(),
+        "truncate checkpoint should succeed after reclaiming the dead child shared reader slot"
+    );
+    assert_eq!(
+        authority.min_active_reader_frame(),
+        None,
+        "successful checkpoint should reclaim the dead child shared reader slot"
+    );
+
+    let wal_len = std::fs::metadata(format!("{db_path_str}-wal"))
+        .map(|meta| meta.len())
+        .unwrap_or(0);
+    assert_eq!(wal_len, 0, "truncate checkpoint should leave the WAL empty");
+
+    drop(conn);
+    drop(db);
+    let mut manager = DATABASE_MANAGER.lock();
+    manager.clear();
+    drop(manager);
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let reopened = Database::open_file(io, db_path_str).unwrap();
+    let reopened_conn = reopened.connect().unwrap();
+    assert_eq!(
+        count_test_rows(&reopened_conn),
+        2,
+        "cold reopen after reader-slot reclamation should preserve committed rows"
+    );
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn database_open_reuses_valid_shm_authority_after_truncate_rewrite_without_disk_scan() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("coordination-truncate-rewrite-reopen.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db_a = Database::open_file(io.clone(), db_path_str).unwrap();
+    let conn_a = db_a.connect().unwrap();
+    conn_a
+        .execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    conn_a
+        .execute("insert into test(value) values ('before-truncate')")
+        .unwrap();
+
+    let checkpoint = run_checkpoint(
+        &conn_a,
+        CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        },
+    );
+    assert!(
+        checkpoint.everything_backfilled(),
+        "truncate checkpoint should fully backfill before WAL rewrite"
+    );
+
+    conn_a
+        .execute("insert into test(value) values ('after-truncate')")
+        .unwrap();
+
+    let db_b = Database::open_file(io, db_path_str).unwrap();
+    assert!(!db_b
+        .shared_wal
+        .read()
+        .metadata
+        .loaded_from_disk_scan
+        .load(Ordering::Acquire));
+
+    let last_checksum_and_max_frame = db_b.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db_b
+        .build_wal(last_checksum_and_max_frame, db_b.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "tshm");
+
+    let conn_b = db_b.connect().unwrap();
+    assert_eq!(count_test_rows(&conn_b), 2);
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn memory_database_keeps_in_process_wal_backend() {
+    let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:").unwrap();
+
+    let last_checksum_and_max_frame = db.shared_wal.read().last_checksum_and_max_frame();
+    let wal = db
+        .build_wal(last_checksum_and_max_frame, db.buffer_pool.clone())
+        .unwrap();
+    let wal_file = wal.as_any().downcast_ref::<WalFile>().unwrap();
+    assert_eq!(wal_file.coordination_backend_name(), "in_process");
+}
+
+#[cfg(all(feature = "fs", unix, target_pointer_width = "64"))]
+#[test]
+fn memory_database_query_can_close_without_checkpointing() {
+    let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:").unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.query("VALUES ('ok')").unwrap();
+    conn.close().unwrap();
+}

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -383,6 +383,8 @@ enum SavepointKind {
 pub struct Savepoint {
     kind: SavepointKind,
     deferred_fk_violations: isize,
+    header: DatabaseHeader,
+    header_dirty: bool,
     /// Versions CREATED during this savepoint (insert operations).
     /// On rollback: these versions are removed from their chains.
     created_table_versions: Vec<(RowID, u64)>,
@@ -398,18 +400,30 @@ pub struct Savepoint {
 
 impl Savepoint {
     /// Creates an internal statement savepoint used for per-statement rollback.
-    fn statement() -> Self {
-        Self::default()
+    fn statement(header: DatabaseHeader, header_dirty: bool) -> Self {
+        Self {
+            header,
+            header_dirty,
+            ..Default::default()
+        }
     }
 
     /// Creates a user-visible named savepoint snapshot.
-    fn named(name: String, starts_transaction: bool, deferred_fk_violations: isize) -> Self {
+    fn named(
+        name: String,
+        starts_transaction: bool,
+        deferred_fk_violations: isize,
+        header: DatabaseHeader,
+        header_dirty: bool,
+    ) -> Self {
         Self {
             kind: SavepointKind::Named {
                 name,
                 starts_transaction,
             },
             deferred_fk_violations,
+            header,
+            header_dirty,
             ..Default::default()
         }
     }
@@ -512,7 +526,11 @@ impl Transaction {
     fn begin_savepoint(&self) {
         let depth = self.savepoint_stack.read().len();
         tracing::debug!("begin_savepoint(tx_id={}, depth={})", self.tx_id, depth);
-        self.savepoint_stack.write().push(Savepoint::statement());
+        let header = *self.header.read();
+        let header_dirty = self.header_dirty.load(Ordering::Acquire);
+        self.savepoint_stack
+            .write()
+            .push(Savepoint::statement(header, header_dirty));
     }
 
     /// Begin a new named savepoint. If `starts_transaction` is true, this savepoint represents the
@@ -531,10 +549,14 @@ impl Transaction {
             depth,
             name
         );
+        let header = *self.header.read();
+        let header_dirty = self.header_dirty.load(Ordering::Acquire);
         self.savepoint_stack.write().push(Savepoint::named(
             name,
             starts_transaction,
             deferred_fk_violations,
+            header,
+            header_dirty,
         ));
     }
 
@@ -636,12 +658,16 @@ impl Transaction {
             }
         );
         let deferred_fk_violations = savepoints[target_idx].deferred_fk_violations;
+        let header = savepoints[target_idx].header;
+        let header_dirty = savepoints[target_idx].header_dirty;
 
         let drained: Vec<Savepoint> = savepoints.drain(target_idx..).collect();
         savepoints.push(Savepoint::named(
             target_name,
             starts_transaction,
             deferred_fk_violations,
+            header,
+            header_dirty,
         ));
         Some(SavepointRollbackResult {
             rolledback_savepoints: drained,
@@ -1807,17 +1833,24 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
             }
             CommitState::EndCommitLogicalLog { end_ts } => {
                 let connection = self.connection.clone();
-                let schema_did_change = self.did_commit_schema_change;
-                if schema_did_change {
-                    let schema = connection.schema.read().clone();
-                    connection.db.update_schema_if_newer(schema);
-                }
                 let tx = mvcc_store
                     .txs
                     .get(&self.tx_id)
                     .ok_or_else(|| LimboError::NoSuchTransactionID(self.tx_id.to_string()))?;
                 let tx_unlocked = tx.value();
-                self.header.write().replace(*tx_unlocked.header.read());
+                let tx_header = *tx_unlocked.header.read();
+                let schema_did_change = self.did_commit_schema_change
+                    || self
+                        .header
+                        .read()
+                        .as_ref()
+                        .map(|header| header.schema_cookie.get())
+                        != Some(tx_header.schema_cookie.get());
+                if schema_did_change {
+                    let schema = connection.schema.read().clone();
+                    connection.db.update_schema_if_newer(schema);
+                }
+                self.header.write().replace(tx_header);
                 tracing::trace!("end_commit_logical_log(tx_id={})", self.tx_id);
                 self.state = CommitState::CommitEnd { end_ts: *end_ts };
                 return Ok(TransitionResult::Continue);
@@ -3709,6 +3742,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
     fn rollback_savepoint_changes(&self, tx_id: TxID, savepoint: Savepoint) {
         let Savepoint {
+            header,
+            header_dirty,
             created_table_versions,
             created_index_versions,
             deleted_table_versions,
@@ -3796,6 +3831,14 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
         touched_rowids.extend(newly_added_to_write_set);
         self.remove_rolled_back_rows_from_write_set(tx_id, touched_rowids.clone());
+
+        let tx = self
+            .txs
+            .get(&tx_id)
+            .unwrap_or_else(|| panic!("Transaction {tx_id} not found while restoring savepoint"));
+        let tx = tx.value();
+        *tx.header.write() = header;
+        tx.header_dirty.store(header_dirty, Ordering::Release);
     }
 
     fn row_has_uncommitted_version_for_tx(&self, rowid: &RowID, tx_id: TxID) -> bool {

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -23,7 +23,7 @@ use crate::{
         self,
         explain::{EXPLAIN_COLUMNS_TYPE, EXPLAIN_QUERY_PLAN_COLUMNS_TYPE},
     },
-    LimboError, MvStore, Pager, QueryMode, Result, Value, EXPLAIN_COLUMNS,
+    LimboError, MvStore, Pager, QueryMode, Result, TransactionState, Value, EXPLAIN_COLUMNS,
     EXPLAIN_QUERY_PLAN_COLUMNS,
 };
 
@@ -323,6 +323,18 @@ impl Statement {
             if !matches!(res, Err(LimboError::SchemaUpdated)) {
                 break;
             }
+            // Read transactions can safely reprepare inside an explicit
+            // transaction, but write transactions cannot refresh schema from
+            // disk mid-transaction. Surface SchemaUpdated in that case so the
+            // caller can roll back and retry from a fresh transaction.
+            if !self.program.connection.get_auto_commit()
+                && matches!(
+                    self.program.connection.get_tx_state(),
+                    TransactionState::Write { .. } | TransactionState::PendingUpgrade { .. }
+                )
+            {
+                break;
+            }
             tracing::debug!("reprepare: attempt={}", attempt);
             if let Err(err) = self.reprepare() {
                 self.release_active_root_if_counted();
@@ -490,6 +502,31 @@ impl Statement {
     fn reprepare(&mut self) -> Result<()> {
         tracing::trace!("repreparing statement");
         let conn = self.program.connection.clone();
+        let main_pager = conn.pager.load().clone();
+
+        // SchemaUpdated bypasses the normal abort rollback path, so in
+        // autocommit mode we must unwind any implicit transaction state here
+        // before reparsing. This must clear both pager locks and MVCC tx ids;
+        // otherwise the retried statement can stack a fresh snapshot on top of
+        // leaked transaction state from the failed attempt.
+        let attached_leaked = conn
+            .get_all_attached_pagers_with_index()
+            .into_iter()
+            .any(|(_, pager)| pager.holds_write_lock() || pager.holds_read_lock());
+        let has_implicit_txn_state = main_pager.holds_write_lock()
+            || main_pager.holds_read_lock()
+            || conn.get_tx_state() != TransactionState::None
+            || conn.get_mv_tx().is_some()
+            || conn.next_attached_mv_tx().is_some()
+            || attached_leaked
+            || self.state.auto_txn_cleanup != vdbe::TxnCleanup::None;
+        if conn.get_auto_commit() && has_implicit_txn_state {
+            conn.rollback_current_txn_state(&main_pager, true);
+            self.state.auto_txn_cleanup = vdbe::TxnCleanup::None;
+        }
+        if conn.get_auto_commit() {
+            conn.maybe_reparse_schema()?;
+        }
 
         // End transactions on attached database pagers so they get a fresh view
         // of the database. Without this, the pager would still see the old page 1
@@ -525,7 +562,7 @@ impl Statement {
                 *conn_schema = conn.db.clone_schema();
             }
         }
-        self.program = {
+        let new_program = {
             let mut parser = Parser::new(self.program.sql.as_bytes());
             let cmd = parser.next_cmd()?;
             let cmd = cmd.expect("Same SQL string should be able to be parsed");
@@ -550,7 +587,7 @@ impl Statement {
         // Save parameters before they are reset
         let parameters = std::mem::take(&mut self.state.parameters);
         let (max_registers, cursor_count) = match self.query_mode {
-            QueryMode::Normal => (self.program.max_registers, self.program.cursor_ref.len()),
+            QueryMode::Normal => (new_program.max_registers, new_program.cursor_ref.len()),
             QueryMode::Explain => (EXPLAIN_COLUMNS.len(), 0),
             QueryMode::ExplainQueryPlan => (EXPLAIN_QUERY_PLAN_COLUMNS.len(), 0),
         };
@@ -562,6 +599,7 @@ impl Statement {
             self.counted_as_active_root,
         )?;
         self.state.metrics.reprepares = self.state.metrics.reprepares.saturating_add(1);
+        self.program = new_program;
         // Load the parameters back into the state
         self.state.parameters = parameters;
         Ok(())

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -323,11 +323,19 @@ impl Statement {
             if !matches!(res, Err(LimboError::SchemaUpdated)) {
                 break;
             }
-            // In multiprocess mode, a cross-process schema change during a
-            // write transaction cannot be resolved by reprepare alone (the
-            // in-memory db.schema hasn't been refreshed from disk). The
-            // MAX_SCHEMA_RETRY loop will exhaust attempts and surface
-            // SchemaUpdated naturally in that case.
+            // In a write transaction, reprepare may not help (e.g. cross-process
+            // schema change where the in-memory schema hasn't been refreshed from
+            // disk). Allow a few retries for the in-process case where reprepare
+            // *can* resolve the issue, but bail early to avoid burning 50 attempts.
+            if attempt >= 2
+                && !self.program.connection.get_auto_commit()
+                && matches!(
+                    self.program.connection.get_tx_state(),
+                    TransactionState::Write { .. } | TransactionState::PendingUpgrade { .. }
+                )
+            {
+                break;
+            }
             tracing::debug!("reprepare: attempt={}", attempt);
             if let Err(err) = self.reprepare() {
                 self.release_active_root_if_counted();

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -323,18 +323,11 @@ impl Statement {
             if !matches!(res, Err(LimboError::SchemaUpdated)) {
                 break;
             }
-            // Read transactions can safely reprepare inside an explicit
-            // transaction, but write transactions cannot refresh schema from
-            // disk mid-transaction. Surface SchemaUpdated in that case so the
-            // caller can roll back and retry from a fresh transaction.
-            if !self.program.connection.get_auto_commit()
-                && matches!(
-                    self.program.connection.get_tx_state(),
-                    TransactionState::Write { .. } | TransactionState::PendingUpgrade { .. }
-                )
-            {
-                break;
-            }
+            // In multiprocess mode, a cross-process schema change during a
+            // write transaction cannot be resolved by reprepare alone (the
+            // in-memory db.schema hasn't been refreshed from disk). The
+            // MAX_SCHEMA_RETRY loop will exhaust attempts and surface
+            // SchemaUpdated naturally in that case.
             tracing::debug!("reprepare: attempt={}", attempt);
             if let Err(err) = self.reprepare() {
                 self.release_active_root_if_counted();

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -511,9 +511,9 @@ impl Statement {
         // otherwise the retried statement can stack a fresh snapshot on top of
         // leaked transaction state from the failed attempt.
         let attached_leaked = conn
-            .get_all_attached_pagers_with_index()
+            .get_all_attached_pagers()
             .into_iter()
-            .any(|(_, pager)| pager.holds_write_lock() || pager.holds_read_lock());
+            .any(|pager| pager.holds_write_lock() || pager.holds_read_lock());
         let has_implicit_txn_state = main_pager.holds_write_lock()
             || main_pager.holds_read_lock()
             || conn.get_tx_state() != TransactionState::None

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -510,13 +510,12 @@ impl Statement {
         // before reparsing. This must clear both pager locks and MVCC tx ids;
         // otherwise the retried statement can stack a fresh snapshot on top of
         // leaked transaction state from the failed attempt.
-        let attached_leaked = conn
-            .get_all_attached_pagers()
-            .into_iter()
-            .any(|pager| pager.holds_write_lock() || pager.holds_read_lock());
-        let has_implicit_txn_state = main_pager.holds_write_lock()
-            || main_pager.holds_read_lock()
-            || conn.get_tx_state() != TransactionState::None
+        let attached_leaked = conn.with_all_attached_pagers_with_index(|pagers| {
+            pagers
+                .iter()
+                .any(|(_, pager)| pager.holds_write_lock() || pager.holds_read_lock())
+        });
+        let has_implicit_txn_state = conn.get_tx_state() != TransactionState::None
             || conn.get_mv_tx().is_some()
             || conn.next_attached_mv_tx().is_some()
             || attached_leaked
@@ -549,7 +548,7 @@ impl Statement {
             if db_id == crate::TEMP_DB_ID && conn.temp.database.read().is_none() {
                 continue;
             }
-            let pager = conn.get_pager_from_database_index(&db_id);
+            let pager = conn.get_pager_from_database_index(&db_id)?;
             if pager.holds_read_lock() {
                 pager.rollback_attached();
             }

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -297,14 +297,11 @@ fn checksum_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &ChecksumContext) 
     buffer
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "checksum"))]
 mod tests {
     use super::*;
-    #[cfg(feature = "checksum")]
-    use crate::io::IO;
     use crate::File;
-    #[cfg(feature = "checksum")]
-    use crate::MemoryIO;
+    use crate::{io::IO, MemoryIO};
 
     struct MockFile {
         read_result: std::result::Result<i32, CompletionError>,
@@ -347,11 +344,8 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "checksum")]
     #[test]
     fn checksum_read_wrapper_propagates_callback_errors() {
-        use crate::{MemoryIO, IO};
-
         let db_file = DatabaseFile {
             file: Arc::new(MockFile { read_result: Ok(0) }),
         };
@@ -389,11 +383,8 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "checksum")]
     #[test]
     fn checksum_read_wrapper_propagates_transport_errors_to_original_completion() {
-        use crate::{MemoryIO, IO};
-
         let db_file = DatabaseFile {
             file: Arc::new(MockFile {
                 read_result: Err(CompletionError::Aborted),

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -300,7 +300,11 @@ fn checksum_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &ChecksumContext) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "checksum")]
+    use crate::io::IO;
     use crate::File;
+    #[cfg(feature = "checksum")]
+    use crate::MemoryIO;
 
     struct MockFile {
         read_result: std::result::Result<i32, CompletionError>,

--- a/core/storage/journal_mode.rs
+++ b/core/storage/journal_mode.rs
@@ -1,6 +1,5 @@
 use crate::sync::Arc;
 
-#[cfg(all(unix, target_pointer_width = "64"))]
 use crate::storage::sqlite3_ondisk::Version;
 use crate::{mvcc, LimboError, MvStore, OpenFlags, Result, IO};
 

--- a/core/storage/journal_mode.rs
+++ b/core/storage/journal_mode.rs
@@ -1,5 +1,6 @@
 use crate::sync::Arc;
 
+#[cfg(all(unix, target_pointer_width = "64"))]
 use crate::storage::sqlite3_ondisk::Version;
 use crate::{mvcc, LimboError, MvStore, OpenFlags, Result, IO};
 
@@ -93,7 +94,5 @@ pub fn open_mv_store(
             ))
         };
 
-    let mv_store = MvStore::new(mvcc::MvccClock::new(), storage);
-    let mv_store = Arc::new(mv_store);
-    Ok(mv_store)
+    Ok(Arc::new(MvStore::new(mvcc::MvccClock::new(), storage)))
 }

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -19,6 +19,9 @@ pub(crate) mod journal_mode;
 pub(crate) mod page_cache;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[allow(dead_code)]
+pub(crate) mod shared_wal_coordination;
 #[allow(dead_code)]
 pub(super) mod slot_bitmap;
 pub mod sqlite3_ondisk;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1020,7 +1020,15 @@ struct CheckpointState {
     mode: Option<CheckpointMode>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug)]
+struct PendingCheckpointDbIdentityRead {
+    max_frame: u64,
+    header_buf: Arc<Buffer>,
+    bytes_read: Arc<AtomicUsize>,
+    read_sent: bool,
+}
+
+#[derive(Clone, Debug, Default)]
 enum CheckpointPhase {
     #[default]
     NotCheckpointing,
@@ -1039,6 +1047,21 @@ enum CheckpointPhase {
     },
     /// Sync the database file after checkpoint (if sync_mode != Off and we backfilled any frames from the WAL).
     SyncDbFile { clear_page_cache: bool },
+    /// Read the synced database header before installing the durable backfill proof.
+    ReadDbIdentity {
+        clear_page_cache: bool,
+        read: PendingCheckpointDbIdentityRead,
+    },
+    /// Wait for backend-specific durable proof sync to finish before publishing nbackfills.
+    SyncBackfillProof {
+        clear_page_cache: bool,
+        max_frame: u64,
+    },
+    /// Publish the durable backfill progress after the proof is installed and synced.
+    PublishBackfill {
+        clear_page_cache: bool,
+        max_frame: u64,
+    },
     /// Truncate the WAL file after DB file is safely synced (only for TRUNCATE checkpoint mode).
     /// This must happen AFTER SyncDbFile to ensure data durability.
     TruncateWalFile { clear_page_cache: bool },
@@ -3908,7 +3931,10 @@ impl Pager {
     }
 
     pub fn is_checkpointing(&self) -> bool {
-        self.checkpoint_state.read().phase != CheckpointPhase::NotCheckpointing
+        !matches!(
+            self.checkpoint_state.read().phase.clone(),
+            CheckpointPhase::NotCheckpointing
+        )
     }
 
     fn reset_checkpoint_state(&self) {
@@ -3931,6 +3957,33 @@ impl Pager {
         self.reset_checkpoint_state();
         if let Some(wal) = self.wal.as_ref() {
             wal.abort_checkpoint();
+        }
+    }
+
+    fn next_post_sync_checkpoint_phase(&self, clear_page_cache: bool) -> CheckpointPhase {
+        let state = self.checkpoint_state.read();
+        let result = state.result.as_ref().expect("result should be set");
+        let mode = state.mode.expect("mode should be set");
+        if result.wal_checkpoint_backfilled > 0
+            && !matches!(
+                mode,
+                CheckpointMode::Restart | CheckpointMode::Truncate { .. }
+            )
+        {
+            return CheckpointPhase::ReadDbIdentity {
+                clear_page_cache,
+                read: PendingCheckpointDbIdentityRead {
+                    max_frame: result.wal_total_backfilled,
+                    header_buf: Arc::new(Buffer::new_temporary(PageSize::MIN as usize)),
+                    bytes_read: Arc::new(AtomicUsize::new(usize::MAX)),
+                    read_sent: false,
+                },
+            };
+        }
+        if matches!(mode, CheckpointMode::Truncate { .. }) {
+            CheckpointPhase::TruncateWalFile { clear_page_cache }
+        } else {
+            CheckpointPhase::Finalize { clear_page_cache }
         }
     }
 
@@ -4089,23 +4142,8 @@ impl Pager {
                             !self.syncing.load(Ordering::SeqCst),
                             "syncing should be done"
                         );
-                        {
-                            let mut state = self.checkpoint_state.write();
-                            let result = state.result.as_mut().expect("result should be set");
-                            wal.complete_checkpoint_sync(self, result)?;
-                        }
-                        // After DB is synced, truncate WAL if in TRUNCATE mode
-                        let is_truncate_mode = {
-                            let state = self.checkpoint_state.read();
-                            matches!(state.mode, Some(CheckpointMode::Truncate { .. }))
-                        };
-                        if is_truncate_mode {
-                            self.checkpoint_state.write().phase =
-                                CheckpointPhase::TruncateWalFile { clear_page_cache };
-                        } else {
-                            self.checkpoint_state.write().phase =
-                                CheckpointPhase::Finalize { clear_page_cache };
-                        }
+                        self.checkpoint_state.write().phase =
+                            self.next_post_sync_checkpoint_phase(clear_page_cache);
                         continue;
                     }
 
@@ -4121,6 +4159,83 @@ impl Pager {
                         .expect("result should be set")
                         .db_sync_sent = true;
                     io_yield_one!(c);
+                }
+                CheckpointPhase::ReadDbIdentity {
+                    clear_page_cache,
+                    mut read,
+                } => {
+                    if !read.read_sent {
+                        let header_buf = read.header_buf.clone();
+                        let bytes_read = read.bytes_read.clone();
+                        let c = self.db_file.read_header(Completion::new_read(header_buf, {
+                            Box::new(move |res| {
+                                if let Ok((_buf, count)) = res {
+                                    bytes_read.store(count as usize, Ordering::Release);
+                                }
+                                None
+                            })
+                        }))?;
+                        read.read_sent = true;
+                        self.checkpoint_state.write().phase = CheckpointPhase::ReadDbIdentity {
+                            clear_page_cache,
+                            read,
+                        };
+                        io_yield_one!(c);
+                    }
+
+                    let bytes_read = read.bytes_read.load(Ordering::Acquire);
+                    if bytes_read < DatabaseHeader::SIZE {
+                        return Err(LimboError::Corrupt(
+                            "database header unreadable after checkpoint sync".into(),
+                        ));
+                    }
+                    let (db_size_pages, db_header_crc32c) =
+                        super::wal::database_identity_from_header_bytes(
+                            &read.header_buf.as_slice()[..DatabaseHeader::SIZE],
+                        )?;
+                    if let Some(c) = wal.install_durable_backfill_proof(
+                        read.max_frame,
+                        db_size_pages,
+                        db_header_crc32c,
+                        self.get_sync_type(),
+                    )? {
+                        self.checkpoint_state.write().phase = CheckpointPhase::SyncBackfillProof {
+                            clear_page_cache,
+                            max_frame: read.max_frame,
+                        };
+                        io_yield_one!(c);
+                    }
+                    self.checkpoint_state.write().phase = CheckpointPhase::PublishBackfill {
+                        clear_page_cache,
+                        max_frame: read.max_frame,
+                    };
+                    continue;
+                }
+                CheckpointPhase::SyncBackfillProof {
+                    clear_page_cache,
+                    max_frame,
+                } => {
+                    self.checkpoint_state.write().phase = CheckpointPhase::PublishBackfill {
+                        clear_page_cache,
+                        max_frame,
+                    };
+                    continue;
+                }
+                CheckpointPhase::PublishBackfill {
+                    clear_page_cache,
+                    max_frame,
+                } => {
+                    wal.publish_backfill(max_frame);
+                    let next_phase = {
+                        let state = self.checkpoint_state.read();
+                        if matches!(state.mode, Some(CheckpointMode::Truncate { .. })) {
+                            CheckpointPhase::TruncateWalFile { clear_page_cache }
+                        } else {
+                            CheckpointPhase::Finalize { clear_page_cache }
+                        }
+                    };
+                    self.checkpoint_state.write().phase = next_phase;
+                    continue;
                 }
                 CheckpointPhase::TruncateWalFile { clear_page_cache } => {
                     // Truncate WAL file after DB is safely synced - this ensures data durability.
@@ -4194,7 +4309,7 @@ impl Pager {
             let Some(result) = state.result.as_ref() else {
                 continue;
             };
-            if matches!(state.phase, CheckpointPhase::SyncDbFile { .. })
+            if matches!(state.phase, CheckpointPhase::ReadDbIdentity { .. })
                 && result.db_sync_sent
                 && !self.syncing.load(Ordering::SeqCst)
             {
@@ -5469,7 +5584,7 @@ mod checkpoint_phase_tests {
             let Some(result) = state.result.as_ref() else {
                 continue;
             };
-            if matches!(state.phase, CheckpointPhase::SyncDbFile { .. })
+            if matches!(state.phase, CheckpointPhase::ReadDbIdentity { .. })
                 && result.db_sync_sent
                 && !pager.syncing.load(Ordering::SeqCst)
             {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4086,6 +4086,11 @@ impl Pager {
                             !self.syncing.load(Ordering::SeqCst),
                             "syncing should be done"
                         );
+                        {
+                            let mut state = self.checkpoint_state.write();
+                            let result = state.result.as_mut().expect("result should be set");
+                            wal.complete_checkpoint_sync(self, result)?;
+                        }
                         // After DB is synced, truncate WAL if in TRUNCATE mode
                         let is_truncate_mode = {
                             let state = self.checkpoint_state.read();
@@ -4162,6 +4167,35 @@ impl Pager {
 
                     return Ok(IOResult::Done(res));
                 }
+            }
+        }
+    }
+
+    #[cfg(feature = "simulator")]
+    pub fn run_checkpoint_until_post_sync_gap_for_testing(
+        &self,
+        mode: CheckpointMode,
+    ) -> Result<u64> {
+        loop {
+            match self.checkpoint(mode, crate::SyncMode::Full, true)? {
+                IOResult::Done(_) => {
+                    return Err(LimboError::InternalError(
+                        "checkpoint completed before reaching the post-sync pre-publish gap"
+                            .to_string(),
+                    ));
+                }
+                IOResult::IO(io) => io.wait(self.io.as_ref())?,
+            }
+
+            let state = self.checkpoint_state.read();
+            let Some(result) = state.result.as_ref() else {
+                continue;
+            };
+            if matches!(state.phase, CheckpointPhase::SyncDbFile { .. })
+                && result.db_sync_sent
+                && !self.syncing.load(Ordering::SeqCst)
+            {
+                return Ok(result.wal_total_backfilled);
             }
         }
     }
@@ -5348,6 +5382,129 @@ mod ptrmap_tests {
         assert_eq!(
             get_ptrmap_offset_in_page(108, 105, page_size).unwrap(),
             2 * PTRMAP_ENTRY_SIZE
+        );
+    }
+}
+
+#[cfg(all(test, feature = "fs", unix, target_pointer_width = "64"))]
+mod checkpoint_phase_tests {
+    use super::*;
+    use crate::io::{PlatformIO, IO};
+    use crate::storage::sqlite3_ondisk::DatabaseHeader;
+    use crate::storage::wal::CheckpointMode;
+    use crate::sync::atomic::Ordering;
+    use crate::types::IOResult;
+    use crate::Database;
+
+    fn open_checkpoint_test_database() -> (Arc<Database>, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap().keep();
+        let db_path = dir.join("test.db");
+        {
+            let connection = rusqlite::Connection::open(&db_path).unwrap();
+            connection
+                .pragma_update(None, "journal_mode", "wal")
+                .unwrap();
+        }
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+        (db, dir)
+    }
+
+    fn db_identity(db_path: &std::path::Path) -> (u32, u32) {
+        let bytes = std::fs::read(db_path).unwrap();
+        assert!(bytes.len() >= DatabaseHeader::SIZE);
+        let db_size_pages = u32::from_be_bytes(bytes[28..32].try_into().unwrap());
+        let crc = crc32c::crc32c(&bytes[..DatabaseHeader::SIZE]);
+        (db_size_pages, crc)
+    }
+
+    #[test]
+    fn checkpoint_db_sync_completion_still_leaves_backfill_unpublished_until_proof_install() {
+        let (db, dir) = open_checkpoint_test_database();
+        let db_path = dir.join("test.db");
+        let conn = db.connect().unwrap();
+        conn.wal_auto_checkpoint_disable();
+        conn.execute("create table test(id integer primary key, value blob)")
+            .unwrap();
+        conn.execute("begin immediate").unwrap();
+        for _ in 0..32 {
+            conn.execute("insert into test(value) values (randomblob(2048))")
+                .unwrap();
+        }
+        conn.execute("commit").unwrap();
+        assert!(
+            db.shared_wal
+                .read()
+                .metadata
+                .max_frame
+                .load(Ordering::SeqCst)
+                > 1,
+            "checkpoint setup requires more than one WAL frame"
+        );
+
+        let pager = conn.pager.load();
+        let mode = CheckpointMode::Passive {
+            upper_bound_inclusive: Some(1),
+        };
+
+        loop {
+            match pager.checkpoint(mode, crate::SyncMode::Full, true).unwrap() {
+                IOResult::Done(_) => {
+                    panic!("checkpoint should not finish before we observe the post-sync gap")
+                }
+                IOResult::IO(io) => io.wait(pager.io.as_ref()).unwrap(),
+            }
+
+            let state = pager.checkpoint_state.read();
+            let Some(result) = state.result.as_ref() else {
+                continue;
+            };
+            if matches!(state.phase, CheckpointPhase::SyncDbFile { .. })
+                && result.db_sync_sent
+                && !pager.syncing.load(Ordering::SeqCst)
+            {
+                break;
+            }
+        }
+
+        let authority = db.shared_wal_coordination().unwrap().unwrap();
+        let snapshot_before_publish = authority.snapshot();
+        let (db_size_pages, db_header_crc32c) = db_identity(&db_path);
+        assert_eq!(
+            snapshot_before_publish.nbackfills, 0,
+            "DB sync completion alone must not publish positive nbackfills"
+        );
+        assert!(
+            !authority.validate_backfill_proof(
+                snapshot_before_publish,
+                db_size_pages,
+                db_header_crc32c
+            ),
+            "DB sync completion must still leave the durable backfill proof absent"
+        );
+
+        let result = pager
+            .io
+            .block(|| pager.checkpoint(mode, crate::SyncMode::Full, true))
+            .unwrap();
+        assert!(
+            result.wal_total_backfilled > 0 && !result.everything_backfilled(),
+            "resumed checkpoint should complete the partial checkpoint after proof installation"
+        );
+
+        let snapshot_after_publish = authority.snapshot();
+        let (db_size_pages_after, db_header_crc32c_after) = db_identity(&db_path);
+        assert!(
+            snapshot_after_publish.nbackfills > 0,
+            "proof installation step must publish positive nbackfills"
+        );
+        assert!(
+            authority.validate_backfill_proof(
+                snapshot_after_publish,
+                db_size_pages_after,
+                db_header_crc32c_after
+            ),
+            "resuming after the post-sync gap must install a valid durable backfill proof"
         );
     }
 }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -5406,7 +5406,14 @@ mod checkpoint_phase_tests {
                 .unwrap();
         }
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+        let db = Database::open_file_with_flags(
+            io,
+            db_path.to_str().unwrap(),
+            crate::OpenFlags::default(),
+            crate::DatabaseOpts::new().with_multiprocess_wal(true),
+            None,
+        )
+        .unwrap();
         (db, dir)
     }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2792,6 +2792,9 @@ impl Pager {
         } else {
             self.cleanup_read_tx();
         }
+        if wal.holds_read_lock() {
+            wal.end_read_tx();
+        }
     }
 
     /// Reads a page from disk (either WAL or DB file) bypassing page-cache

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -23,13 +23,14 @@
 //! conservatism, never correctness: if the authority cannot prove a slot is
 //! dead, it must leave that slot in place.
 
-use crate::io::{
-    Completion, File, FileSyncType, OpenFlags, SharedWalLockKind, SharedWalMappedRegion, IO,
+use crate::{
+    io::{Completion, File, FileSyncType, OpenFlags, SharedWalLockKind, SharedWalMappedRegion, IO},
+    sync::{
+        atomic::{AtomicU32, AtomicU64, Ordering},
+        Arc, LazyLock, Mutex, RwLock,
+    },
+    turso_assert, CompletionError, HashMap, LimboError, Result,
 };
-use crate::sync::atomic::{AtomicU32, AtomicU64, Ordering};
-use crate::sync::{Arc, LazyLock, Mutex, RwLock};
-use crate::HashMap;
-use crate::{turso_assert, CompletionError, LimboError, Result};
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
 use std::ptr::NonNull;
@@ -37,7 +38,7 @@ use std::ptr::NonNull;
 /// Durable file-format magic stored at the start of every `.tshm` mapping.
 const SHARED_WAL_COORDINATION_MAGIC: [u8; 8] = *b"TSHMWAL\0";
 /// Durable `.tshm` file-format version. Bump whenever persisted layout changes.
-const SHARED_WAL_COORDINATION_VERSION: u32 = 10;
+const SHARED_WAL_COORDINATION_VERSION: u32 = 1;
 /// Version for the optional persisted backfill-proof payload.
 const SHARED_WAL_BACKFILL_PROOF_VERSION: u32 = 1;
 /// Sentinel meaning a reader slot is not currently pinning any WAL frame.
@@ -735,6 +736,45 @@ impl MappedSharedWalCoordination {
         Self::lock_kind_for_mode(self.ownership_mode)
     }
 
+    fn new_region(
+        file: Arc<dyn File>,
+        base_mapping: Box<dyn SharedWalMappedRegion>,
+        base_ptr: NonNull<u8>,
+        base_len: usize,
+        reader_slot_count: u32,
+        ownership_mode: SharedWalOwnershipMode,
+        open_mode: SharedWalCoordinationOpenMode,
+    ) -> Self {
+        Self {
+            file,
+            _base_mapping: base_mapping,
+            base_ptr,
+            base_len,
+            owner_record: SharedOwnerRecord::current_process(next_shared_owner_instance_id()),
+            ownership_mode,
+            frame_index_blocks: RwLock::new(Vec::new()),
+            frame_index_publish_lock: Arc::new(Mutex::new(())),
+            process_local_ownership: Arc::new(Mutex::new(ProcessLocalOwnershipState::new(
+                reader_slot_count,
+            ))),
+            local_lock_state: Mutex::new(LocalLockState {
+                writer_lock_held: false,
+                checkpoint_lock_held: false,
+                reader_locks: vec![0; reader_slot_count as usize],
+            }),
+            open_mode,
+            sanitized_backfill_proof_on_open: false,
+            registry_path: None,
+        }
+    }
+
+    fn reacquire_shared_lifetime_lock(
+        file: &Arc<dyn File>,
+        lock_kind: SharedWalLockKind,
+    ) -> Result<()> {
+        file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)
+    }
+
     /// Register this mapping in `PROCESS_LOCAL_COORDINATION_OPENS`.
     ///
     /// Returns shared Arcs for locks and ownership state so that multiple
@@ -874,27 +914,15 @@ impl MappedSharedWalCoordination {
         let base_mapping = file.shared_wal_map(0, base_len)?;
         let base_ptr = base_mapping.ptr();
 
-        let mut region = Self {
+        let mut region = Self::new_region(
             file,
-            _base_mapping: base_mapping,
+            base_mapping,
             base_ptr,
             base_len,
-            owner_record: SharedOwnerRecord::current_process(next_shared_owner_instance_id()),
+            reader_slot_count,
             ownership_mode,
-            frame_index_blocks: RwLock::new(Vec::new()),
-            frame_index_publish_lock: Arc::new(Mutex::new(())),
-            process_local_ownership: Arc::new(Mutex::new(ProcessLocalOwnershipState::new(
-                reader_slot_count,
-            ))),
-            local_lock_state: Mutex::new(LocalLockState {
-                writer_lock_held: false,
-                checkpoint_lock_held: false,
-                reader_locks: vec![0; reader_slot_count as usize],
-            }),
             open_mode,
-            sanitized_backfill_proof_on_open: false,
-            registry_path: None,
-        };
+        );
         if initialize {
             region.initialize(reader_slot_count);
         } else if let Err(err) = region.validate_existing(reader_slot_count, metadata_len) {
@@ -962,27 +990,15 @@ impl MappedSharedWalCoordination {
 
         let base_mapping = file.shared_wal_map(0, base_len)?;
         let base_ptr = base_mapping.ptr();
-        let mut region = Self {
+        let mut region = Self::new_region(
             file,
-            _base_mapping: base_mapping,
+            base_mapping,
             base_ptr,
             base_len,
-            owner_record: SharedOwnerRecord::current_process(next_shared_owner_instance_id()),
+            reader_slot_count,
             ownership_mode,
-            frame_index_blocks: RwLock::new(Vec::new()),
-            frame_index_publish_lock: Arc::new(Mutex::new(())),
-            process_local_ownership: Arc::new(Mutex::new(ProcessLocalOwnershipState::new(
-                reader_slot_count,
-            ))),
-            local_lock_state: Mutex::new(LocalLockState {
-                writer_lock_held: false,
-                checkpoint_lock_held: false,
-                reader_locks: vec![0; reader_slot_count as usize],
-            }),
             open_mode,
-            sanitized_backfill_proof_on_open: false,
-            registry_path: None,
-        };
+        );
         if let Err(err) = region.validate_existing(reader_slot_count, metadata_len) {
             region
                 .file
@@ -1017,7 +1033,7 @@ impl MappedSharedWalCoordination {
         match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
             true => {
                 file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
-                file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+                Self::reacquire_shared_lifetime_lock(file, lock_kind)?;
                 let metadata_len_after_probe = file.size()? as usize;
                 if metadata_len_before_probe < base_len && metadata_len_after_probe >= base_len {
                     Ok(SharedWalCoordinationOpenMode::MultiProcess)
@@ -1026,7 +1042,7 @@ impl MappedSharedWalCoordination {
                 }
             }
             false => {
-                file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+                Self::reacquire_shared_lifetime_lock(file, lock_kind)?;
                 Ok(SharedWalCoordinationOpenMode::MultiProcess)
             }
         }
@@ -1051,9 +1067,7 @@ impl MappedSharedWalCoordination {
         let _ = self
             .file
             .shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, self.lock_kind());
-        let _ =
-            self.file
-                .shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, self.lock_kind());
+        let _ = Self::reacquire_shared_lifetime_lock(&self.file, self.lock_kind());
         true
     }
 

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -3291,11 +3291,19 @@ mod tests {
         );
 
         let mapped_b = create_mapping(&path);
-        assert_eq!(
-            mapped_b.open_mode(),
-            SharedWalCoordinationOpenMode::MultiProcess,
-            "lifetime lock probe must leave the original mapping holding the shared lifetime lock"
-        );
+        if mapped_a.uses_linux_ofd_locking() {
+            assert_eq!(
+                mapped_b.open_mode(),
+                SharedWalCoordinationOpenMode::MultiProcess,
+                "lifetime lock probe must leave the original mapping holding the shared lifetime lock"
+            );
+        } else {
+            assert_eq!(
+                mapped_b.open_mode(),
+                SharedWalCoordinationOpenMode::Exclusive,
+                "process-scoped fcntl locks are per-process, so a same-process duplicate open cannot observe the lifetime shared lock"
+            );
+        }
     }
 
     #[test]

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -1477,11 +1477,9 @@ impl MappedSharedWalCoordination {
             )
     }
 
-    /// fsync the `.tshm` coordination file when the caller needs durable publication.
-    pub(crate) fn sync(&self, io: &Arc<dyn IO>, sync_type: FileSyncType) -> Result<()> {
-        let c = self.file.sync(Completion::new_sync(|_| {}), sync_type)?;
-        io.wait_for_completion(c)?;
-        Ok(())
+    /// Begin syncing the `.tshm` coordination file when the caller needs durable publication.
+    pub(crate) fn begin_sync(&self, sync_type: FileSyncType) -> Result<Completion> {
+        self.file.sync(Completion::new_sync(|_| {}), sync_type)
     }
 
     /// On exclusive open, discard any persisted backfill proof that is malformed or stale.

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -256,7 +256,7 @@ impl SharedOwnerRecord {
         Self::new(std::process::id(), instance_id)
     }
 
-    pub(crate) const fn new(pid: u32, instance_id: u32) -> Self {
+    pub(crate) fn new(pid: u32, instance_id: u32) -> Self {
         let raw = ((pid as u64) << 32) | instance_id as u64;
         turso_assert!(raw != UNOWNED_LOCK, "shared owner record must be non-zero");
         Self(raw)

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -4260,7 +4260,7 @@ mod tests {
                 Some(&wal_path),
                 db_file.clone(),
                 OpenFlags::default(),
-                DatabaseOpts::new(),
+                DatabaseOpts::new().with_multiprocess_wal(true),
                 None,
                 None,
             )? {

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -26,53 +26,75 @@
 use crate::io::{
     Completion, File, FileSyncType, OpenFlags, SharedWalLockKind, SharedWalMappedRegion, IO,
 };
-use crate::storage::slot_bitmap::AtomicSlotBitmap;
 use crate::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use crate::sync::{Arc, LazyLock, Mutex, RwLock};
+use crate::HashMap;
 use crate::{turso_assert, CompletionError, LimboError, Result};
-use std::collections::HashMap;
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
 use std::ptr::NonNull;
-use std::sync::{Arc, LazyLock, Mutex, RwLock};
 
+/// Durable file-format magic stored at the start of every `.tshm` mapping.
 const SHARED_WAL_COORDINATION_MAGIC: [u8; 8] = *b"TSHMWAL\0";
+/// Durable `.tshm` file-format version. Bump whenever persisted layout changes.
 const SHARED_WAL_COORDINATION_VERSION: u32 = 9;
+/// Version for the optional persisted backfill-proof payload.
 const SHARED_WAL_BACKFILL_PROOF_VERSION: u32 = 1;
+/// Sentinel meaning a reader slot is not currently pinning any WAL frame.
 const UNUSED_READER_FRAME: u64 = u64::MAX;
+/// Sentinel meaning a shared owner slot is unclaimed.
 const UNOWNED_LOCK: u64 = 0;
+/// Mmap alignment for the fixed `.tshm` header region.
 const SHARED_WAL_COORDINATION_MAP_ALIGNMENT: usize = 4096;
+/// Byte 0: lifetime lock used only to detect whether another process is present.
 const PROCESS_LIFETIME_LOCK_OFFSET: u64 = 0;
+/// Byte 1: single-writer ownership byte.
 const WRITER_LOCK_OFFSET: u64 = 1;
+/// Byte 2: single-checkpointer ownership byte.
 const CHECKPOINT_LOCK_OFFSET: u64 = 2;
+/// Byte range starting at 3: one reader-byte lock per shared reader slot.
 const READER_LOCK_START_OFFSET: u64 = 3;
+/// Entries per frame-index block in the append-only shared page->frame index.
 const FRAME_INDEX_BLOCK_CAPACITY: u32 = 4096;
+/// Open-addressing hash slots per frame-index block.
+///
+/// Mirroring SQLite's oversubscription keeps probe chains short without making
+/// each block materially larger.
 const FRAME_INDEX_BLOCK_HASH_SLOTS: u32 = FRAME_INDEX_BLOCK_CAPACITY * 2;
+/// Hard cap on reserved frame-index blocks in one `.tshm` generation.
 const MAX_FRAME_INDEX_BLOCKS: u32 = 64;
+/// Blocks provisioned on first open before the index grows lazily.
 const INITIAL_FRAME_INDEX_BLOCKS: u32 = 1;
+/// Maximum number of shared frame-index entries representable by the mapping.
 const MAX_FRAME_INDEX_CAPACITY: u32 = FRAME_INDEX_BLOCK_CAPACITY * MAX_FRAME_INDEX_BLOCKS;
 
 /// Monotonic counter for generating unique per-connection instance IDs within
 /// a process. Combined with the PID to form a `SharedOwnerRecord`.
 static NEXT_SHARED_OWNER_INSTANCE_ID: AtomicU32 = AtomicU32::new(1);
 
-/// Global registry of open tshm mappings, keyed by canonical file path.
 /// Defensive dedup registry for tshm mappings within a single process.
 ///
 /// In production, `DATABASE_MANAGER` already ensures one `Database` (and
-/// therefore one `Arc<MappedSharedWalCoordination>`) per file per process,
-/// so `open_count` is always 1. This registry exists as a safety net for
-/// test code that may bypass `DATABASE_MANAGER` and open the same file
-/// multiple times. The shared Arcs it provides (`frame_index_publish_lock`,
-/// `process_local_ownership`) ensure those test-only re-opens still
-/// coordinate correctly within the process.
+/// therefore one `Arc<MappedSharedWalCoordination>`) per file per process.
+/// This registry enforces that invariant for callers that bypass the manager.
+///
+/// Unit tests still use it as a shim to share same-process bookkeeping across
+/// duplicate opens, but only under `cfg(test)`. That test-only convenience must
+/// not change the durable cross-process meaning of `open_mode`.
 static PROCESS_LOCAL_COORDINATION_OPENS: LazyLock<
     Mutex<HashMap<PathBuf, ProcessLocalCoordinationEntry>>,
-> = LazyLock::new(|| Mutex::new(HashMap::new()));
+> = LazyLock::new(|| Mutex::new(HashMap::default()));
 
 #[derive(Debug)]
 struct ProcessLocalCoordinationEntry {
+    /// Number of live mappings in this process for the same canonical tshm path.
     open_count: usize,
+    /// Shared publish mutex reused only by tests that bypass `DATABASE_MANAGER`.
+    #[cfg(test)]
     frame_index_publish_lock: Arc<Mutex<()>>,
+    /// Same-process ownership registry shared only by tests that bypass
+    /// `DATABASE_MANAGER`.
+    #[cfg(test)]
     ownership: Arc<Mutex<ProcessLocalOwnershipState>>,
 }
 
@@ -115,6 +137,8 @@ struct SharedReadMarkRegistration {
 }
 
 impl ProcessLocalOwnershipState {
+    /// Create empty same-process ownership state for a mapping with
+    /// `reader_slot_count` shared reader slots.
     fn new(reader_slot_count: u32) -> Self {
         Self {
             writer_owner: None,
@@ -124,6 +148,7 @@ impl ProcessLocalOwnershipState {
         }
     }
 
+    /// Record that one local connection now owns the process-local writer slot.
     fn try_acquire_writer(&mut self, owner: SharedOwnerRecord) -> bool {
         if self.writer_owner.is_some() {
             return false;
@@ -132,6 +157,7 @@ impl ProcessLocalOwnershipState {
         true
     }
 
+    /// Release the process-local writer slot, asserting the recorded owner matches.
     fn release_writer(&mut self, owner: SharedOwnerRecord) {
         turso_assert!(
             self.writer_owner == Some(owner),
@@ -140,10 +166,12 @@ impl ProcessLocalOwnershipState {
         self.writer_owner = None;
     }
 
+    /// Return whether any sibling connection in this process currently owns the writer slot.
     fn writer_active(&self) -> bool {
         self.writer_owner.is_some()
     }
 
+    /// Record that one local connection now owns the process-local checkpoint slot.
     fn try_acquire_checkpoint(&mut self, owner: SharedOwnerRecord) -> bool {
         if self.checkpoint_owner.is_some() {
             return false;
@@ -152,6 +180,7 @@ impl ProcessLocalOwnershipState {
         true
     }
 
+    /// Release the process-local checkpoint slot, asserting the recorded owner matches.
     fn release_checkpoint(&mut self, owner: SharedOwnerRecord) {
         turso_assert!(
             self.checkpoint_owner == Some(owner),
@@ -160,10 +189,12 @@ impl ProcessLocalOwnershipState {
         self.checkpoint_owner = None;
     }
 
+    /// Return whether any sibling connection in this process currently owns the checkpoint slot.
     fn checkpoint_active(&self) -> bool {
         self.checkpoint_owner.is_some()
     }
 
+    /// Mark one reader slot as owned by a same-process sibling connection.
     fn try_register_reader(&mut self, slot_index: u32, owner: SharedOwnerRecord) -> bool {
         let slot = &mut self.reader_owners[slot_index as usize];
         if slot.is_some() {
@@ -173,6 +204,7 @@ impl ProcessLocalOwnershipState {
         true
     }
 
+    /// Clear same-process ownership for one reader slot.
     fn unregister_reader(&mut self, slot_index: u32, owner: SharedOwnerRecord) {
         let slot = &mut self.reader_owners[slot_index as usize];
         turso_assert!(
@@ -182,20 +214,24 @@ impl ProcessLocalOwnershipState {
         *slot = None;
     }
 
+    /// Return the same-process owner recorded for one reader slot, if any.
     fn reader_owner(&self, slot_index: u32) -> Option<SharedOwnerRecord> {
         self.reader_owners[slot_index as usize]
     }
 
+    /// Return the published shared-snapshot registration for `max_frame`, if any.
     fn shared_snapshot_reader(&self, max_frame: u64) -> Option<SharedReadMarkRegistration> {
         self.shared_snapshot_readers.get(&max_frame).copied()
     }
 
+    /// Reuse an existing shared-snapshot reader registration and bump its refcount.
     fn retain_shared_snapshot_reader(&mut self, max_frame: u64) -> Option<SharedReaderSlot> {
         let registration = self.shared_snapshot_readers.get_mut(&max_frame)?;
         registration.ref_count += 1;
         Some(registration.slot)
     }
 
+    /// Publish a fresh shared-snapshot reader registration for reuse by sibling connections.
     fn publish_shared_snapshot_reader(&mut self, slot: SharedReaderSlot) {
         let previous = self.shared_snapshot_readers.insert(
             slot.max_frame,
@@ -208,6 +244,10 @@ impl ProcessLocalOwnershipState {
         );
     }
 
+    /// Drop one reference to a shared-snapshot reader registration.
+    ///
+    /// Returns `true` only when the caller must also release the underlying
+    /// shared reader slot.
     fn release_shared_snapshot_reader(&mut self, slot: SharedReaderSlot) -> bool {
         let registration = self
             .shared_snapshot_readers
@@ -236,8 +276,8 @@ impl ProcessLocalOwnershipState {
 }
 
 /// Packed (PID, instance_id) pair identifying a specific connection across
-/// processes. Stored in shared memory owner slots so that stale-owner
-/// reclamation can `kill(pid, 0)` to check liveness on non-OFD platforms.
+/// processes. Stored in shared memory owner slots for diagnostics and to make
+/// ownership mismatches explicit in assertions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SharedOwnerRecord(u64);
 
@@ -252,10 +292,12 @@ impl SharedOwnerRecord {
         }
     }
 
+    /// Build an owner record for one connection in the current process.
     pub(crate) fn current_process(instance_id: u32) -> Self {
         Self::new(std::process::id(), instance_id)
     }
 
+    /// Pack a `(pid, instance_id)` pair into the durable owner-slot format.
     pub(crate) fn new(pid: u32, instance_id: u32) -> Self {
         let raw = ((pid as u64) << 32) | instance_id as u64;
         turso_assert!(raw != UNOWNED_LOCK, "shared owner record must be non-zero");
@@ -275,6 +317,10 @@ impl SharedOwnerRecord {
     }
 }
 
+/// Allocate the next process-local connection instance ID.
+///
+/// IDs only need to be unique within one process lifetime; wraparound back to
+/// `1` is acceptable once the full `u32` space is exhausted.
 fn next_shared_owner_instance_id() -> u32 {
     loop {
         let current = NEXT_SHARED_OWNER_INSTANCE_ID.load(Ordering::Relaxed);
@@ -325,6 +371,7 @@ pub(crate) struct SharedWalCoordinationHeader {
 impl SharedWalCoordinationHeader {
     pub(crate) const BYTE_LEN: usize = 76;
 
+    /// Encode the durable header payload stored at the start of the `.tshm` file.
     pub(crate) fn encode(self) -> [u8; Self::BYTE_LEN] {
         let mut bytes = [0u8; Self::BYTE_LEN];
         bytes[0..8].copy_from_slice(&SHARED_WAL_COORDINATION_MAGIC);
@@ -344,6 +391,7 @@ impl SharedWalCoordinationHeader {
         bytes
     }
 
+    /// Decode and validate the durable header payload read from the `.tshm` file.
     pub(crate) fn decode(bytes: &[u8]) -> Result<Self> {
         if bytes.len() != Self::BYTE_LEN {
             return Err(LimboError::Corrupt(format!(
@@ -388,38 +436,21 @@ pub(crate) struct SharedReaderSlot {
     pub owner: SharedOwnerRecord,
 }
 
-/// Process-local atomic counters and slot bitmaps for WAL coordination.
-///
-/// Holds WAL snapshot metadata, reader/writer ownership
-pub(crate) struct SharedWalCoordinationState {
-    max_frame: AtomicU64,
-    nbackfills: AtomicU64,
-    transaction_count: AtomicU64,
-    visibility_generation: AtomicU64,
-    checkpoint_seq: AtomicU32,
-    checkpoint_epoch: AtomicU32,
-    page_size: AtomicU32,
-    salt_1: AtomicU32,
-    salt_2: AtomicU32,
-    checksum_1: AtomicU32,
-    checksum_2: AtomicU32,
-    writer_owner: AtomicU64,
-    checkpoint_owner: AtomicU64,
-    reader_frames: Box<[AtomicU64]>,
-    reader_owners: Box<[AtomicU64]>,
-    reader_slots: AtomicSlotBitmap,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SharedWalBackfillProof {
+    /// Durable checkpoint progress being claimed.
     nbackfills: u64,
+    /// WAL tail this proof belongs to.
     max_frame: u64,
+    /// WAL generation identity. A proof must not survive RESTART/TRUNCATE.
     checkpoint_seq: u32,
     page_size: u32,
     salt_1: u32,
     salt_2: u32,
     checksum_1: u32,
     checksum_2: u32,
+    /// Main-database identity after backfill. This ties the proof to the DB file,
+    /// not just to the WAL metadata.
     db_size_pages: u32,
     db_header_crc32c: u32,
 }
@@ -427,6 +458,7 @@ struct SharedWalBackfillProof {
 impl SharedWalBackfillProof {
     const CRC_INPUT_LEN: usize = 52;
 
+    /// Build the durable checkpoint-proof payload tied to one WAL snapshot and DB header.
     fn from_snapshot_and_db(
         snapshot: SharedWalCoordinationHeader,
         db_size_pages: u32,
@@ -446,6 +478,7 @@ impl SharedWalBackfillProof {
         }
     }
 
+    /// Compute the checksum covering the serialized proof payload.
     fn crc32c(self) -> u32 {
         let mut bytes = [0u8; Self::CRC_INPUT_LEN];
         bytes[0..4].copy_from_slice(&SHARED_WAL_BACKFILL_PROOF_VERSION.to_le_bytes());
@@ -462,12 +495,17 @@ impl SharedWalBackfillProof {
         crc32c::crc32c(&bytes)
     }
 
+    /// Reject impossible proof payloads before trusting the checksum or contents.
     fn is_structurally_valid(self) -> bool {
         self.nbackfills != 0 && self.nbackfills <= self.max_frame && self.page_size != 0
     }
 }
 
 #[repr(C)]
+/// Fixed header stored at the beginning of the `.tshm` mapping.
+///
+/// The layout is part of the durable file format. Fields here must stay
+/// append-only or be changed with a coordinated version bump.
 struct SharedWalCoordinationMapHeader {
     magic: [u8; 8],
     version: u32,
@@ -514,6 +552,10 @@ struct SharedWalCoordinationMapHeader {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// One append-only page->frame mapping in the shared frame index.
+///
+/// Entries are stored in monotonically increasing `frame_id` order so reverse
+/// scans can find the newest visible version of a page without sorting.
 struct SharedWalFrameIndexEntry {
     page_id: u64,
     frame_id: u64,
@@ -538,7 +580,8 @@ enum SharedWalOwnershipMode {
     /// across separate `open()` calls. Stale detection: probe the lock.
     LinuxOfd,
     /// `F_SETLK`: per-process, shared across all fds to the same file.
-    /// Stale detection: `kill(pid, 0)` on the owner's PID.
+    /// Stale detection must probe the lock byte itself because PID liveness is
+    /// not a reliable ownership proof after PID reuse.
     ProcessScopedFcntl,
 }
 
@@ -560,8 +603,10 @@ enum SharedWalOwnershipMode {
 ///   the owner is dead.
 ///
 /// - **macOS / other Unix (process-scoped fcntl)**: Classical `F_SETLK`
-///   locks (per-process, not per-fd). Stale-owner detection falls back to
-///   `kill(pid, 0)` liveness checks on the `SharedOwnerRecord` PID.
+///   locks (per-process, not per-fd). Stale-owner detection must still probe
+///   the lock byte itself; PID liveness is not a reliable ownership proof once
+///   PIDs can be recycled. The shared owner fields remain metadata used for
+///   diagnostics and non-owner assertions.
 ///
 /// ## Lock byte layout on the tshm file
 ///
@@ -573,25 +618,44 @@ enum SharedWalOwnershipMode {
 /// | 3..3+N    | Reader slot locks (one byte per slot)
 pub(crate) struct MappedSharedWalCoordination {
     file: Arc<dyn File>,
+    /// Mapping containing the fixed header and reader arrays.
     _base_mapping: Box<dyn SharedWalMappedRegion>,
+    /// Base address of `_base_mapping`, used to slice the header/arrays without
+    /// remapping or re-parsing on every access.
     base_ptr: NonNull<u8>,
     base_len: usize,
+    /// This process mapping's owner identity written into shared owner slots.
     owner_record: SharedOwnerRecord,
     ownership_mode: SharedWalOwnershipMode,
+    /// Lazily mapped frame-index blocks after the fixed header region.
     frame_index_blocks: RwLock<Vec<FrameIndexBlockMapping>>,
+    /// Same-process serialization for appending to the shared frame index.
     frame_index_publish_lock: Arc<Mutex<()>>,
+    /// Same-process ownership bookkeeping layered on top of shared memory.
     process_local_ownership: Arc<Mutex<ProcessLocalOwnershipState>>,
+    /// Per-mapping lock counts used to make `Drop` and stale probing precise.
     local_lock_state: Mutex<LocalLockState>,
     open_mode: SharedWalCoordinationOpenMode,
+    /// Whether exclusive open had to discard an invalid persisted backfill proof.
     sanitized_backfill_proof_on_open: bool,
-    primary_process_mapping: bool,
+    /// Canonical path used as the key in `PROCESS_LOCAL_COORDINATION_OPENS`.
     registry_path: Option<PathBuf>,
 }
 
+/// One lazily mapped frame-index block.
+///
+/// The mapped bytes hold two logical regions:
+/// 1. `entries_ptr`: the append-only `SharedWalFrameIndexEntry` array
+/// 2. `hash_ptr`: the per-block open-addressing hash table used to avoid
+///    scanning every entry in the block during page lookups
 struct FrameIndexBlockMapping {
+    /// Owns the mmap for this block so `entries_ptr`/`hash_ptr` stay valid.
     _mapping: Box<dyn SharedWalMappedRegion>,
+    /// Start of the block's frame-index entry array.
     entries_ptr: NonNull<SharedWalFrameIndexEntry>,
+    /// Start of the block's hash table region.
     hash_ptr: NonNull<u16>,
+    /// Total mapped byte length for this block.
     byte_len: usize,
 }
 
@@ -600,18 +664,13 @@ unsafe impl Sync for MappedSharedWalCoordination {}
 
 impl std::fmt::Debug for MappedSharedWalCoordination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mapped_blocks = self
-            .frame_index_blocks
-            .read()
-            .expect("shared WAL frame index lock poisoned")
-            .len();
+        let mapped_blocks = self.frame_index_blocks.read().len();
         f.debug_struct("MappedSharedWalCoordination")
             .field("base_len", &self.base_len)
             .field("owner_record", &self.owner_record)
             .field("ownership_mode", &self.ownership_mode)
             .field("mapped_blocks", &mapped_blocks)
             .field("open_mode", &self.open_mode)
-            .field("primary_process_mapping", &self.primary_process_mapping)
             .field("snapshot", &self.snapshot())
             .finish()
     }
@@ -621,9 +680,7 @@ impl Drop for MappedSharedWalCoordination {
     fn drop(&mut self) {
         self.release_owned_locks_on_drop();
         if let Some(path) = self.registry_path.as_ref() {
-            let mut opens = PROCESS_LOCAL_COORDINATION_OPENS
-                .lock()
-                .expect("process-local coordination registry poisoned");
+            let mut opens = PROCESS_LOCAL_COORDINATION_OPENS.lock();
             let count = opens
                 .get_mut(path)
                 .expect("shared WAL coordination registry entry missing");
@@ -636,243 +693,18 @@ impl Drop for MappedSharedWalCoordination {
                 opens.remove(path);
             }
         }
-        self.frame_index_blocks
-            .get_mut()
-            .expect("shared WAL frame index lock poisoned")
-            .clear();
+        self.frame_index_blocks.get_mut().clear();
         let _ = self
             .file
             .shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, self.lock_kind());
     }
 }
 
-impl std::fmt::Debug for SharedWalCoordinationState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SharedWalCoordinationState")
-            .field("snapshot", &self.snapshot())
-            .finish()
-    }
-}
-
-impl SharedWalCoordinationState {
-    pub(crate) fn new(reader_slot_count: u32) -> Self {
-        turso_assert!(
-            reader_slot_count >= 64 && reader_slot_count % 64 == 0,
-            "reader_slot_count must be a non-zero multiple of 64"
-        );
-        let reader_frames = (0..reader_slot_count)
-            .map(|_| AtomicU64::new(UNUSED_READER_FRAME))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        let reader_owners = (0..reader_slot_count)
-            .map(|_| AtomicU64::new(UNOWNED_LOCK))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        Self {
-            max_frame: AtomicU64::new(0),
-            nbackfills: AtomicU64::new(0),
-            transaction_count: AtomicU64::new(0),
-            visibility_generation: AtomicU64::new(0),
-            checkpoint_seq: AtomicU32::new(0),
-            checkpoint_epoch: AtomicU32::new(0),
-            page_size: AtomicU32::new(0),
-            salt_1: AtomicU32::new(0),
-            salt_2: AtomicU32::new(0),
-            checksum_1: AtomicU32::new(0),
-            checksum_2: AtomicU32::new(0),
-            writer_owner: AtomicU64::new(UNOWNED_LOCK),
-            checkpoint_owner: AtomicU64::new(UNOWNED_LOCK),
-            reader_frames,
-            reader_owners,
-            reader_slots: AtomicSlotBitmap::new(reader_slot_count),
-        }
-    }
-
-    pub(crate) fn snapshot(&self) -> SharedWalCoordinationHeader {
-        SharedWalCoordinationHeader {
-            max_frame: self.max_frame.load(Ordering::Acquire),
-            nbackfills: self.nbackfills.load(Ordering::Acquire),
-            transaction_count: self.transaction_count.load(Ordering::Acquire),
-            visibility_generation: self.visibility_generation.load(Ordering::Acquire),
-            checkpoint_seq: self.checkpoint_seq.load(Ordering::Acquire),
-            checkpoint_epoch: self.checkpoint_epoch.load(Ordering::Acquire),
-            page_size: self.page_size.load(Ordering::Acquire),
-            salt_1: self.salt_1.load(Ordering::Acquire),
-            salt_2: self.salt_2.load(Ordering::Acquire),
-            checksum_1: self.checksum_1.load(Ordering::Acquire),
-            checksum_2: self.checksum_2.load(Ordering::Acquire),
-            reader_slot_count: self.reader_frames.len() as u32,
-        }
-    }
-
-    pub(crate) fn install_snapshot(&self, snapshot: SharedWalCoordinationHeader) {
-        self.max_frame.store(snapshot.max_frame, Ordering::Release);
-        self.nbackfills
-            .store(snapshot.nbackfills, Ordering::Release);
-        self.transaction_count
-            .store(snapshot.transaction_count, Ordering::Release);
-        self.visibility_generation
-            .store(snapshot.visibility_generation, Ordering::Release);
-        self.checkpoint_seq
-            .store(snapshot.checkpoint_seq, Ordering::Release);
-        self.checkpoint_epoch
-            .store(snapshot.checkpoint_epoch, Ordering::Release);
-        self.page_size.store(snapshot.page_size, Ordering::Release);
-        self.salt_1.store(snapshot.salt_1, Ordering::Release);
-        self.salt_2.store(snapshot.salt_2, Ordering::Release);
-        self.checksum_1
-            .store(snapshot.checksum_1, Ordering::Release);
-        self.checksum_2
-            .store(snapshot.checksum_2, Ordering::Release);
-    }
-
-    pub(crate) fn publish_commit(
-        &self,
-        max_frame: u64,
-        checksum_1: u32,
-        checksum_2: u32,
-        transaction_count: u64,
-    ) {
-        self.max_frame.store(max_frame, Ordering::Release);
-        self.checksum_1.store(checksum_1, Ordering::Release);
-        self.checksum_2.store(checksum_2, Ordering::Release);
-        self.transaction_count
-            .store(transaction_count, Ordering::Release);
-        self.visibility_generation.fetch_add(1, Ordering::AcqRel);
-    }
-
-    pub(crate) fn publish_backfill(&self, nbackfills: u64) {
-        self.nbackfills.store(nbackfills, Ordering::Release);
-    }
-
-    pub(crate) fn install_header_fields(&self, page_size: u32, salt_1: u32, salt_2: u32) {
-        self.page_size.store(page_size, Ordering::Release);
-        self.salt_1.store(salt_1, Ordering::Release);
-        self.salt_2.store(salt_2, Ordering::Release);
-    }
-
-    pub(crate) fn bump_checkpoint_seq(&self) -> u32 {
-        self.checkpoint_seq.fetch_add(1, Ordering::AcqRel) + 1
-    }
-
-    pub(crate) fn checkpoint_epoch(&self) -> u32 {
-        self.checkpoint_epoch.load(Ordering::Acquire)
-    }
-
-    pub(crate) fn bump_checkpoint_epoch(&self) -> u32 {
-        self.checkpoint_epoch.fetch_add(1, Ordering::AcqRel)
-    }
-
-    pub(crate) fn try_acquire_writer(&self, owner: SharedOwnerRecord) -> bool {
-        self.writer_owner
-            .compare_exchange(
-                UNOWNED_LOCK,
-                owner.raw(),
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            )
-            .is_ok()
-    }
-
-    pub(crate) fn release_writer(&self, owner: SharedOwnerRecord) {
-        turso_assert!(
-            self.writer_owner
-                .compare_exchange(
-                    owner.raw(),
-                    UNOWNED_LOCK,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                )
-                .is_ok(),
-            "writer released by non-owner"
-        );
-    }
-
-    pub(crate) fn writer_owner(&self) -> Option<SharedOwnerRecord> {
-        SharedOwnerRecord::from_raw(self.writer_owner.load(Ordering::Acquire))
-    }
-
-    pub(crate) fn try_acquire_checkpoint(&self, owner: SharedOwnerRecord) -> bool {
-        self.checkpoint_owner
-            .compare_exchange(
-                UNOWNED_LOCK,
-                owner.raw(),
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            )
-            .is_ok()
-    }
-
-    pub(crate) fn release_checkpoint(&self, owner: SharedOwnerRecord) {
-        turso_assert!(
-            self.checkpoint_owner
-                .compare_exchange(
-                    owner.raw(),
-                    UNOWNED_LOCK,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                )
-                .is_ok(),
-            "checkpoint released by non-owner"
-        );
-    }
-
-    pub(crate) fn checkpoint_owner(&self) -> Option<SharedOwnerRecord> {
-        SharedOwnerRecord::from_raw(self.checkpoint_owner.load(Ordering::Acquire))
-    }
-
-    pub(crate) fn register_reader(
-        &self,
-        owner: SharedOwnerRecord,
-        max_frame: u64,
-    ) -> Option<SharedReaderSlot> {
-        let slot_index = self.reader_slots.alloc_one()?;
-        self.reader_owners[slot_index as usize].store(owner.raw(), Ordering::Release);
-        self.reader_frames[slot_index as usize].store(max_frame, Ordering::Release);
-        Some(SharedReaderSlot {
-            slot_index,
-            max_frame,
-            owner,
-        })
-    }
-
-    pub(crate) fn update_reader(&self, slot: SharedReaderSlot, max_frame: u64) -> SharedReaderSlot {
-        turso_assert!(
-            self.reader_owners[slot.slot_index as usize].load(Ordering::Acquire)
-                == slot.owner.raw(),
-            "reader slot updated by non-owner"
-        );
-        self.reader_frames[slot.slot_index as usize].store(max_frame, Ordering::Release);
-        SharedReaderSlot {
-            slot_index: slot.slot_index,
-            max_frame,
-            owner: slot.owner,
-        }
-    }
-
-    pub(crate) fn unregister_reader(&self, slot: SharedReaderSlot) {
-        turso_assert!(
-            self.reader_owners[slot.slot_index as usize].load(Ordering::Acquire)
-                == slot.owner.raw(),
-            "reader slot released by non-owner"
-        );
-        self.reader_frames[slot.slot_index as usize].store(UNUSED_READER_FRAME, Ordering::Release);
-        self.reader_owners[slot.slot_index as usize].store(UNOWNED_LOCK, Ordering::Release);
-        self.reader_slots.free_one(slot.slot_index);
-    }
-
-    pub(crate) fn reader_owner(&self, slot_index: u32) -> Option<SharedOwnerRecord> {
-        SharedOwnerRecord::from_raw(self.reader_owners[slot_index as usize].load(Ordering::Acquire))
-    }
-
-    pub(crate) fn min_active_reader_frame(&self) -> Option<u64> {
-        self.reader_frames
-            .iter()
-            .map(|frame| frame.load(Ordering::Acquire))
-            .filter(|&frame| frame != UNUSED_READER_FRAME)
-            .min()
-    }
-}
+type ProcessMappingResult = (
+    PathBuf,
+    Arc<Mutex<()>>,
+    Arc<Mutex<ProcessLocalOwnershipState>>,
+);
 
 impl MappedSharedWalCoordination {
     const fn default_ownership_mode() -> SharedWalOwnershipMode {
@@ -903,59 +735,55 @@ impl MappedSharedWalCoordination {
     /// Returns shared Arcs for locks and ownership state so that multiple
     /// mappings of the same file (only possible in tests — production uses
     /// `DATABASE_MANAGER` which ensures one `Database` per file) coordinate
-    /// correctly. Also returns whether this is the first mapping for this path
-    /// (`primary_process_mapping`), which controls invalidation-on-close.
+    /// correctly.
     fn register_process_mapping(
         path: &Path,
         reader_slot_count: u32,
-    ) -> (
-        PathBuf,
-        bool,
-        Arc<Mutex<()>>,
-        Arc<Mutex<ProcessLocalOwnershipState>>,
-    ) {
+        frame_index_publish_lock: Arc<Mutex<()>>,
+        process_local_ownership: Arc<Mutex<ProcessLocalOwnershipState>>,
+    ) -> Result<ProcessMappingResult> {
         let canonical_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-        let mut opens = PROCESS_LOCAL_COORDINATION_OPENS
-            .lock()
-            .expect("process-local coordination registry poisoned");
-        let entry =
-            opens
-                .entry(canonical_path.clone())
-                .or_insert_with(|| ProcessLocalCoordinationEntry {
-                    open_count: 0,
-                    frame_index_publish_lock: Arc::new(Mutex::new(())),
-                    ownership: Arc::new(Mutex::new(ProcessLocalOwnershipState::new(
-                        reader_slot_count,
-                    ))),
-                });
-        turso_assert!(
-            entry
-                .ownership
-                .lock()
-                .expect("process-local ownership registry poisoned")
-                .reader_owners
-                .len()
-                == reader_slot_count as usize,
-            "process-local coordination slot count mismatch"
-        );
-        let primary_process_mapping = entry.open_count == 0;
-        entry.open_count += 1;
-        (
-            canonical_path,
-            primary_process_mapping,
-            entry.frame_index_publish_lock.clone(),
-            entry.ownership.clone(),
-        )
-    }
+        let mut opens = PROCESS_LOCAL_COORDINATION_OPENS.lock();
+        #[cfg(not(test))]
+        let _ = reader_slot_count;
 
-    fn process_already_has_mapping(path: &Path) -> bool {
-        let canonical_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-        let opens = PROCESS_LOCAL_COORDINATION_OPENS
-            .lock()
-            .expect("process-local coordination registry poisoned");
-        opens
-            .get(&canonical_path)
-            .is_some_and(|entry| entry.open_count > 0)
+        #[cfg(test)]
+        if let Some(entry) = opens.get_mut(&canonical_path) {
+            turso_assert!(
+                entry.ownership.lock().reader_owners.len() == reader_slot_count as usize,
+                "process-local coordination slot count mismatch"
+            );
+            entry.open_count += 1;
+            return Ok((
+                canonical_path,
+                entry.frame_index_publish_lock.clone(),
+                entry.ownership.clone(),
+            ));
+        }
+
+        #[cfg(not(test))]
+        if opens.contains_key(&canonical_path) {
+            return Err(LimboError::InternalError(format!(
+                "duplicate same-process shared WAL coordination open for '{}' is unsupported; callers must reuse the existing Database/authority",
+                canonical_path.display()
+            )));
+        }
+
+        opens.insert(
+            canonical_path.clone(),
+            ProcessLocalCoordinationEntry {
+                open_count: 1,
+                #[cfg(test)]
+                frame_index_publish_lock: frame_index_publish_lock.clone(),
+                #[cfg(test)]
+                ownership: process_local_ownership.clone(),
+            },
+        );
+        Ok((
+            canonical_path,
+            frame_index_publish_lock,
+            process_local_ownership,
+        ))
     }
 
     /// Open (or create) the `.tshm` coordination file at `path`.
@@ -973,6 +801,9 @@ impl MappedSharedWalCoordination {
         Self::create_or_open_with_mode(io, path, reader_slot_count, Self::default_ownership_mode())
     }
 
+    /// Open an already-existing `.tshm` file without creating or resizing it.
+    ///
+    /// Returns `Ok(None)` when the file does not exist yet.
     pub(crate) fn open_existing(
         io: &Arc<dyn IO>,
         path: &Path,
@@ -996,6 +827,7 @@ impl MappedSharedWalCoordination {
     }
 
     #[cfg(test)]
+    /// Force the overflow bit for tests that need to exercise fallback WAL scans.
     pub(crate) fn mark_frame_index_overflowed_for_tests(&self) {
         self.header()
             .frame_index_overflowed
@@ -1020,10 +852,7 @@ impl MappedSharedWalCoordination {
             LimboError::InternalError("shared WAL coordination path is not valid UTF-8".into())
         })?)?;
         let lock_kind = Self::lock_kind_for_mode(ownership_mode);
-        let open_mode = if Self::process_already_has_mapping(path) {
-            file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
-            SharedWalCoordinationOpenMode::MultiProcess
-        } else {
+        let open_mode =
             match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
                 true => {
                     file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
@@ -1034,8 +863,7 @@ impl MappedSharedWalCoordination {
                     file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
                     SharedWalCoordinationOpenMode::MultiProcess
                 }
-            }
-        };
+            };
         let metadata_len = file.size()? as usize;
         let initialize = metadata_len == 0
             || (open_mode == SharedWalCoordinationOpenMode::Exclusive && metadata_len < base_len);
@@ -1071,7 +899,6 @@ impl MappedSharedWalCoordination {
             }),
             open_mode,
             sanitized_backfill_proof_on_open: false,
-            primary_process_mapping: false,
             registry_path: None,
         };
         if initialize {
@@ -1090,15 +917,15 @@ impl MappedSharedWalCoordination {
         }
         let mapped_blocks = region.header().frame_index_blocks.load(Ordering::Acquire);
         region.ensure_mapped_frame_index_blocks(mapped_blocks)?;
-        let (
-            registry_path,
-            primary_process_mapping,
-            frame_index_publish_lock,
-            process_local_ownership,
-        ) = Self::register_process_mapping(path, reader_slot_count);
+        let (registry_path, frame_index_publish_lock, process_local_ownership) =
+            Self::register_process_mapping(
+                path,
+                reader_slot_count,
+                region.frame_index_publish_lock.clone(),
+                region.process_local_ownership.clone(),
+            )?;
         region.frame_index_publish_lock = frame_index_publish_lock;
         region.process_local_ownership = process_local_ownership;
-        region.primary_process_mapping = primary_process_mapping;
         region.registry_path = Some(registry_path);
         Ok(region)
     }
@@ -1130,10 +957,7 @@ impl MappedSharedWalCoordination {
             Err(err) => return Err(err),
         };
         let lock_kind = Self::lock_kind_for_mode(ownership_mode);
-        let open_mode = if Self::process_already_has_mapping(path) {
-            file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
-            SharedWalCoordinationOpenMode::MultiProcess
-        } else {
+        let open_mode =
             match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
                 true => {
                     file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
@@ -1144,8 +968,7 @@ impl MappedSharedWalCoordination {
                     file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
                     SharedWalCoordinationOpenMode::MultiProcess
                 }
-            }
-        };
+            };
         let metadata_len = file.size()? as usize;
         if metadata_len < base_len {
             file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
@@ -1175,7 +998,6 @@ impl MappedSharedWalCoordination {
             }),
             open_mode,
             sanitized_backfill_proof_on_open: false,
-            primary_process_mapping: false,
             registry_path: None,
         };
         if let Err(err) = region.validate_existing(reader_slot_count, metadata_len) {
@@ -1186,15 +1008,15 @@ impl MappedSharedWalCoordination {
         }
         let mapped_blocks = region.header().frame_index_blocks.load(Ordering::Acquire);
         region.ensure_mapped_frame_index_blocks(mapped_blocks)?;
-        let (
-            registry_path,
-            primary_process_mapping,
-            frame_index_publish_lock,
-            process_local_ownership,
-        ) = Self::register_process_mapping(path, reader_slot_count);
+        let (registry_path, frame_index_publish_lock, process_local_ownership) =
+            Self::register_process_mapping(
+                path,
+                reader_slot_count,
+                region.frame_index_publish_lock.clone(),
+                region.process_local_ownership.clone(),
+            )?;
         region.frame_index_publish_lock = frame_index_publish_lock;
         region.process_local_ownership = process_local_ownership;
-        region.primary_process_mapping = primary_process_mapping;
         region.registry_path = Some(registry_path);
         Ok(Some(region))
     }
@@ -1203,6 +1025,11 @@ impl MappedSharedWalCoordination {
         READER_LOCK_START_OFFSET + slot_index as u64
     }
 
+    /// Return whether dropping this mapping would leave no other process with
+    /// the lifetime byte lock held.
+    ///
+    /// Close-time shutdown checkpointing uses this to approximate SQLite's
+    /// "last connection cleans up shared state" behavior.
     pub(crate) fn is_last_process_mapping(&self) -> bool {
         if !matches!(
             self.file.shared_wal_try_lock_byte(
@@ -1220,12 +1047,14 @@ impl MappedSharedWalCoordination {
         true
     }
 
+    /// Best-effort cleanup for locks held by this mapping.
+    ///
+    /// This must tolerate partially stale owner fields because drop can run
+    /// during error unwinding or after external repair paths have already
+    /// cleared shared metadata.
     fn release_owned_locks_on_drop(&mut self) {
         let (writer_lock_held, checkpoint_lock_held, reader_locks) = {
-            let local = self
-                .local_lock_state
-                .get_mut()
-                .expect("shared WAL local lock state poisoned");
+            let local = self.local_lock_state.get_mut();
             let writer_lock_held = local.writer_lock_held;
             let checkpoint_lock_held = local.checkpoint_lock_held;
             let reader_locks = std::mem::take(&mut local.reader_locks);
@@ -1317,6 +1146,12 @@ impl MappedSharedWalCoordination {
         }
     }
 
+    /// Read a consistent snapshot of the shared coordination header.
+    ///
+    /// # Safety invariant
+    /// Individual fields are read with atomic loads, but the multi-field read is
+    /// NOT an atomic snapshot. Consistency relies on the writer lock serializing
+    /// all modifications — any concurrent modifier MUST hold the writer lock.
     pub(crate) fn snapshot(&self) -> SharedWalCoordinationHeader {
         let header = self.header();
         SharedWalCoordinationHeader {
@@ -1339,18 +1174,20 @@ impl MappedSharedWalCoordination {
         self.open_mode
     }
 
+    /// Return whether exclusive open sanitized an invalid persisted backfill proof.
     pub(crate) const fn sanitized_backfill_proof_on_open(&self) -> bool {
         self.sanitized_backfill_proof_on_open
     }
 
+    /// Return this mapping's durable owner identity.
     pub(crate) const fn owner_record(&self) -> SharedOwnerRecord {
         self.owner_record
     }
 
-    pub(crate) const fn is_primary_process_mapping(&self) -> bool {
-        self.primary_process_mapping
-    }
-
+    /// Replace the authoritative shared snapshot visible to all processes.
+    ///
+    /// Any frame-index entries beyond the new tail are discarded first so the
+    /// published header and published page-to-frame index stay in sync.
     pub(crate) fn install_snapshot(&self, snapshot: SharedWalCoordinationHeader) {
         self.clear_backfill_proof();
         // Snapshots define the authoritative visible WAL range. If the shared
@@ -1402,10 +1239,9 @@ impl MappedSharedWalCoordination {
     /// "reader slot released by non-owner" when they try to end their read
     /// transactions, corrupting the shared WAL state.
     ///
-    /// - **OFD (Linux)**: probe each slot's OFD byte-range lock. If the lock
-    ///   can be acquired, the owner is dead and the slot is safe to reclaim.
-    /// - **Process-scoped fcntl (macOS)**: check `kill(pid, 0)` on the slot's
-    ///   `SharedOwnerRecord` PID. Same semantics — dead owner ⇒ reclaim.
+    /// Probe the slot byte lock directly on every platform. That lock is the
+    /// authoritative liveness signal for this database file; relying on PID
+    /// probes here is weaker and can misclassify recycled PIDs as live.
     pub(crate) fn repair_transient_state_for_exclusive_open(&self) {
         let header = self.header();
         header.writer_owner.store(UNOWNED_LOCK, Ordering::Release);
@@ -1413,59 +1249,36 @@ impl MappedSharedWalCoordination {
             .checkpoint_owner
             .store(UNOWNED_LOCK, Ordering::Release);
 
-        // For reader slots, we must check OFD locks before
+        // For reader slots, we must check byte-range locks before
         // clearing: another live process may hold a slot. Blindly clearing
         // would cause that process to panic with "reader slot released by
         // non-owner" and corrupt the shared WAL state.
-        if self.uses_linux_ofd_locking() {
-            for slot_index in 0..header.reader_slot_count {
-                let offset = Self::process_lock_offset_for_reader(slot_index);
-                match self
-                    .file
-                    .shared_wal_try_lock_byte(offset, true, self.lock_kind())
-                {
-                    Ok(true) => {
-                        // Lock acquired → slot is stale (owner is dead), safe to clear.
-                        self.reader_frames()[slot_index as usize]
-                            .store(UNUSED_READER_FRAME, Ordering::Release);
-                        self.reader_owners()[slot_index as usize]
-                            .store(UNOWNED_LOCK, Ordering::Release);
-                        let word_idx = (slot_index >> 6) as usize;
-                        let bit = slot_index & 63;
-                        self.reader_bitmap_words()[word_idx]
-                            .fetch_or(1u64 << bit, Ordering::Release);
-                        self.file
-                            .shared_wal_unlock_byte(offset, self.lock_kind())
-                            .expect("failed to release reader slot lock during reset");
-                    }
-                    Ok(false) | Err(_) => {
-                        // Lock held by another live process → leave this slot alone.
-                    }
-                }
+        for slot_index in 0..header.reader_slot_count {
+            if !self.uses_linux_ofd_locking()
+                && self
+                    .with_process_local_ownership(|entry| entry.reader_owner(slot_index).is_some())
+            {
+                continue;
             }
-        } else {
-            // Non-OFD path (macOS, etc.): use PID liveness checks to avoid
-            // clearing reader slots owned by live processes.
-            for slot_index in 0..header.reader_slot_count {
-                let owner = self.reader_owner(slot_index);
-                match owner {
-                    None => {
-                        // Already unowned — ensure bitmap marks it available.
-                        self.reader_frames()[slot_index as usize]
-                            .store(UNUSED_READER_FRAME, Ordering::Release);
-                        let word_idx = (slot_index >> 6) as usize;
-                        let bit = slot_index & 63;
-                        self.reader_bitmap_words()[word_idx]
-                            .fetch_or(1u64 << bit, Ordering::Release);
-                    }
-                    Some(owner_rec) => {
-                        if pid_is_alive(owner_rec.pid()) {
-                            // Owner is alive — leave this slot alone.
-                            continue;
-                        }
-                        // Owner is dead — safe to reclaim.
-                        self.try_reclaim_dead_reader_owner(slot_index, owner_rec);
-                    }
+            let offset = Self::process_lock_offset_for_reader(slot_index);
+            match self
+                .file
+                .shared_wal_try_lock_byte(offset, true, self.lock_kind())
+            {
+                Ok(true) => {
+                    self.reader_frames()[slot_index as usize]
+                        .store(UNUSED_READER_FRAME, Ordering::Release);
+                    self.reader_owners()[slot_index as usize]
+                        .store(UNOWNED_LOCK, Ordering::Release);
+                    let word_idx = (slot_index >> 6) as usize;
+                    let bit = slot_index & 63;
+                    self.reader_bitmap_words()[word_idx].fetch_or(1u64 << bit, Ordering::Release);
+                    self.file
+                        .shared_wal_unlock_byte(offset, self.lock_kind())
+                        .expect("failed to release reader slot lock during reset");
+                }
+                Ok(false) | Err(_) => {
+                    // Lock held by another live process → leave this slot alone.
                 }
             }
         }
@@ -1475,19 +1288,23 @@ impl MappedSharedWalCoordination {
     /// from a local WAL scan. The caller must decide separately when that is
     /// safe; this is intentionally distinct from transient-state repair.
     pub(crate) fn discard_durable_frame_index_for_exclusive_rebuild(&self) {
-        let _publish_guard = self
-            .frame_index_publish_lock
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _publish_guard = self.frame_index_publish_lock.lock();
         let header = self.header();
         header.frame_index_len.store(0, Ordering::Release);
         header.frame_index_overflowed.store(0, Ordering::Release);
     }
 
+    /// Return whether the durable shared frame index exhausted its reserved capacity.
     pub(crate) fn frame_index_overflowed(&self) -> bool {
         self.header().frame_index_overflowed.load(Ordering::Acquire) != 0
     }
 
+    /// Publish a committed transaction to the shared coordination header.
+    ///
+    /// # Precondition
+    /// The caller MUST hold the WAL writer lock. The multi-field update is not
+    /// atomic; the writer lock serializes all writers so readers see a consistent
+    /// state (the checksum TOCTOU below is safe only under this invariant).
     pub(crate) fn publish_commit(
         &self,
         max_frame: u64,
@@ -1510,10 +1327,14 @@ impl MappedSharedWalCoordination {
         }
         header
             .transaction_count
-            .store(transaction_count, Ordering::Release);
+            .fetch_max(transaction_count, Ordering::AcqRel);
         header.visibility_generation.fetch_add(1, Ordering::AcqRel);
     }
 
+    /// Publish durable checkpoint progress after a successful backfill step.
+    ///
+    /// A zero publish also clears any persisted proof because no positive
+    /// checkpoint claim remains to be validated on reopen.
     pub(crate) fn publish_backfill(&self, nbackfills: u64) {
         if nbackfills == 0 {
             self.clear_backfill_proof();
@@ -1523,6 +1344,7 @@ impl MappedSharedWalCoordination {
             .store(nbackfills, Ordering::Release);
     }
 
+    /// Clear the persisted durable proof that positive checkpoint progress is safe to trust.
     pub(crate) fn clear_backfill_proof(&self) {
         let header = self.header();
         header.backfill_proof_version.store(0, Ordering::Release);
@@ -1545,6 +1367,7 @@ impl MappedSharedWalCoordination {
         header.backfill_proof_crc32c.store(0, Ordering::Release);
     }
 
+    /// Persist a proof that the current positive `nbackfills` state matches the main DB file.
     pub(crate) fn install_backfill_proof(
         &self,
         snapshot: SharedWalCoordinationHeader,
@@ -1597,6 +1420,7 @@ impl MappedSharedWalCoordination {
             .store(SHARED_WAL_BACKFILL_PROOF_VERSION, Ordering::Release);
     }
 
+    /// Validate the persisted backfill proof against the current WAL snapshot and DB header.
     pub(crate) fn validate_backfill_proof(
         &self,
         snapshot: SharedWalCoordinationHeader,
@@ -1637,12 +1461,14 @@ impl MappedSharedWalCoordination {
             )
     }
 
+    /// fsync the `.tshm` coordination file when the caller needs durable publication.
     pub(crate) fn sync(&self, io: &Arc<dyn IO>, sync_type: FileSyncType) -> Result<()> {
         let c = self.file.sync(Completion::new_sync(|_| {}), sync_type)?;
         io.wait_for_completion(c)?;
         Ok(())
     }
 
+    /// On exclusive open, discard any persisted backfill proof that is malformed or stale.
     fn sanitize_backfill_proof_for_exclusive_open(&self) -> bool {
         let header = self.header();
         let version = header.backfill_proof_version.load(Ordering::Acquire);
@@ -1675,6 +1501,7 @@ impl MappedSharedWalCoordination {
         false
     }
 
+    /// Seed only the WAL header identity fields needed before the first commit is published.
     pub(crate) fn install_header_fields(&self, page_size: u32, salt_1: u32, salt_2: u32) {
         let header = self.header();
         header.page_size.store(page_size, Ordering::Release);
@@ -1682,85 +1509,40 @@ impl MappedSharedWalCoordination {
         header.salt_2.store(salt_2, Ordering::Release);
     }
 
+    /// Advance the durable WAL generation counter and return the new value.
     pub(crate) fn bump_checkpoint_seq(&self) -> u32 {
         self.header().checkpoint_seq.fetch_add(1, Ordering::AcqRel) + 1
     }
 
+    /// Read the checkpoint epoch used to detect same-generation visibility changes.
     pub(crate) fn checkpoint_epoch(&self) -> u32 {
         self.header().checkpoint_epoch.load(Ordering::Acquire)
     }
 
+    /// Bump the checkpoint epoch after a visibility-affecting checkpoint step.
     pub(crate) fn bump_checkpoint_epoch(&self) -> u32 {
         self.header()
             .checkpoint_epoch
             .fetch_add(1, Ordering::AcqRel)
     }
 
+    /// Borrow the per-process local lock counters under the mapping mutex.
     fn with_local_lock_state<T>(&self, f: impl FnOnce(&mut LocalLockState) -> T) -> T {
-        let mut entry = self
-            .local_lock_state
-            .lock()
-            .expect("shared WAL local lock state poisoned");
+        let mut entry = self.local_lock_state.lock();
         f(&mut entry)
     }
 
+    /// Borrow the same-process ownership registry under the mapping mutex.
     fn with_process_local_ownership<T>(
         &self,
         f: impl FnOnce(&mut ProcessLocalOwnershipState) -> T,
     ) -> T {
-        let mut entry = self
-            .process_local_ownership
-            .lock()
-            .expect("process-local ownership registry poisoned");
+        let mut entry = self.process_local_ownership.lock();
         f(&mut entry)
     }
 
-    fn try_acquire_shared_owner_slot(slot: &AtomicU64, owner: SharedOwnerRecord) -> bool {
-        let desired = owner.raw();
-        loop {
-            let current = slot.load(Ordering::Acquire);
-            if current == UNOWNED_LOCK {
-                return slot
-                    .compare_exchange(UNOWNED_LOCK, desired, Ordering::AcqRel, Ordering::Acquire)
-                    .is_ok();
-            }
-            if current == desired {
-                return false;
-            }
-            let Some(current_owner) = SharedOwnerRecord::from_raw(current) else {
-                continue;
-            };
-            if pid_is_alive(current_owner.pid()) {
-                return false;
-            }
-            if slot
-                .compare_exchange(current, desired, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-            {
-                return true;
-            }
-        }
-    }
-
-    fn shared_owner_slot_active(slot: &AtomicU64) -> bool {
-        loop {
-            let current = slot.load(Ordering::Acquire);
-            let Some(owner) = SharedOwnerRecord::from_raw(current) else {
-                return false;
-            };
-            if pid_is_alive(owner.pid()) {
-                return true;
-            }
-            if slot
-                .compare_exchange(current, UNOWNED_LOCK, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-            {
-                return false;
-            }
-        }
-    }
-
-    fn release_shared_owner_slot(slot: &AtomicU64, owner: SharedOwnerRecord, _what: &str) {
+    /// Clear one shared owner slot, asserting it still records `owner`.
+    fn release_shared_owner_slot(slot: &AtomicU64, owner: SharedOwnerRecord) {
         turso_assert!(
             slot.compare_exchange(
                 owner.raw(),
@@ -1773,12 +1555,35 @@ impl MappedSharedWalCoordination {
         );
     }
 
-    /// Try to reclaim a reader slot whose owner PID is dead (non-OFD path).
-    /// Uses `kill(pid, 0)` to check liveness, then CAS to atomically clear
-    /// the owner. Returns true if the slot was successfully reclaimed.
+    /// Try to reclaim a reader slot whose lock byte is no longer held.
+    /// Returns true if the slot was successfully reclaimed.
     fn try_reclaim_dead_reader_owner(&self, slot_index: u32, owner: SharedOwnerRecord) -> bool {
         if self.with_process_local_ownership(|entry| entry.reader_owner(slot_index).is_some()) {
             return false;
+        }
+        if !self.uses_linux_ofd_locking() {
+            let offset = Self::process_lock_offset_for_reader(slot_index);
+            if !self.try_acquire_supplemental_byte_lock(offset) {
+                return false;
+            }
+            let reclaimed = self.reader_owners()[slot_index as usize]
+                .compare_exchange(
+                    owner.raw(),
+                    UNOWNED_LOCK,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok();
+            if !reclaimed {
+                self.release_supplemental_byte_lock(offset);
+                return false;
+            }
+            self.reader_frames()[slot_index as usize].store(UNUSED_READER_FRAME, Ordering::Release);
+            let word_idx = (slot_index >> 6) as usize;
+            let bit = slot_index & 63;
+            self.reader_bitmap_words()[word_idx].fetch_or(1u64 << bit, Ordering::Release);
+            self.release_supplemental_byte_lock(offset);
+            return true;
         }
         if pid_is_alive(owner.pid()) {
             return false;
@@ -1801,6 +1606,7 @@ impl MappedSharedWalCoordination {
         true
     }
 
+    /// Attempt to acquire a supplemental byte lock for this mapping.
     fn try_acquire_supplemental_byte_lock(&self, offset: u64) -> bool {
         matches!(
             self.file
@@ -1809,17 +1615,16 @@ impl MappedSharedWalCoordination {
         )
     }
 
+    /// Release a supplemental byte lock previously acquired by this mapping.
     fn release_supplemental_byte_lock(&self, offset: u64) {
         self.file
             .shared_wal_unlock_byte(offset, self.lock_kind())
             .expect("failed to release shared WAL supplemental byte lock");
     }
 
+    /// Attempt to acquire the writer lock for this mapping.
     pub(crate) fn try_acquire_writer(&self, owner: SharedOwnerRecord) -> bool {
-        let mut local = self
-            .local_lock_state
-            .lock()
-            .expect("shared WAL local lock state poisoned");
+        let mut local = self.local_lock_state.lock();
         if local.writer_lock_held {
             return false;
         }
@@ -1835,15 +1640,13 @@ impl MappedSharedWalCoordination {
             if !self.with_process_local_ownership(|entry| entry.try_acquire_writer(owner)) {
                 return false;
             }
-            if !Self::try_acquire_shared_owner_slot(&self.header().writer_owner, owner) {
-                self.with_process_local_ownership(|entry| entry.release_writer(owner));
-                return false;
-            }
             if !self.try_acquire_supplemental_byte_lock(WRITER_LOCK_OFFSET) {
-                Self::release_shared_owner_slot(&self.header().writer_owner, owner, "writer");
                 self.with_process_local_ownership(|entry| entry.release_writer(owner));
                 return false;
             }
+            self.header()
+                .writer_owner
+                .store(owner.raw(), Ordering::Release);
         }
         local.writer_lock_held = true;
         drop(local);
@@ -1855,11 +1658,9 @@ impl MappedSharedWalCoordination {
         true
     }
 
+    /// Release the writer lock held by this mapping.
     pub(crate) fn release_writer(&self, owner: SharedOwnerRecord) {
-        let mut local = self
-            .local_lock_state
-            .lock()
-            .expect("shared WAL local lock state poisoned");
+        let mut local = self.local_lock_state.lock();
         turso_assert!(local.writer_lock_held, "writer registry count underflow");
         if self.uses_linux_ofd_locking() {
             let observed_owner = self.header().writer_owner.load(Ordering::Acquire);
@@ -1878,12 +1679,19 @@ impl MappedSharedWalCoordination {
                 .expect("failed to release shared WAL writer lock");
         } else {
             self.release_supplemental_byte_lock(WRITER_LOCK_OFFSET);
-            Self::release_shared_owner_slot(&self.header().writer_owner, owner, "writer");
+            self.header()
+                .writer_owner
+                .store(UNOWNED_LOCK, Ordering::Release);
             self.with_process_local_ownership(|entry| entry.release_writer(owner));
         }
         local.writer_lock_held = false;
     }
 
+    /// Probe whether a given coordination byte lock is currently held.
+    ///
+    /// The lock byte is the authoritative cross-process liveness signal for
+    /// writer/checkpoint/reader ownership. Shared owner fields are metadata and
+    /// may legitimately lag behind crash recovery or repair paths.
     fn byte_lock_is_held(&self, offset: u64, local_held: bool) -> bool {
         if local_held {
             return true;
@@ -1906,6 +1714,7 @@ impl MappedSharedWalCoordination {
         }
     }
 
+    /// Determine whether the writer or checkpoint lock is currently held by any process.
     pub(crate) fn writer_or_checkpoint_lock_active(&self) -> bool {
         let (writer_held, checkpoint_held) = self
             .with_local_lock_state(|entry| (entry.writer_lock_held, entry.checkpoint_lock_held));
@@ -1918,10 +1727,11 @@ impl MappedSharedWalCoordination {
         }) {
             return true;
         }
-        Self::shared_owner_slot_active(&self.header().writer_owner)
-            || Self::shared_owner_slot_active(&self.header().checkpoint_owner)
+        self.byte_lock_is_held(WRITER_LOCK_OFFSET, false)
+            || self.byte_lock_is_held(CHECKPOINT_LOCK_OFFSET, false)
     }
 
+    /// Determine whether the checkpoint lock is currently held by any process.
     pub(crate) fn checkpoint_lock_active(&self) -> bool {
         let checkpoint_held = self.with_local_lock_state(|entry| entry.checkpoint_lock_held);
         if self.uses_linux_ofd_locking() {
@@ -1930,18 +1740,18 @@ impl MappedSharedWalCoordination {
         if self.with_process_local_ownership(|entry| entry.checkpoint_active()) {
             return true;
         }
-        Self::shared_owner_slot_active(&self.header().checkpoint_owner)
+        self.byte_lock_is_held(CHECKPOINT_LOCK_OFFSET, false)
     }
 
+    /// Return the owner record of the current writer, if any.
+    /// This is metadata and may legitimately lag behind crash recovery or repair paths;
     pub(crate) fn writer_owner(&self) -> Option<SharedOwnerRecord> {
         SharedOwnerRecord::from_raw(self.header().writer_owner.load(Ordering::Acquire))
     }
 
+    /// Attempt to acquire the checkpoint lock for this mapping.
     pub(crate) fn try_acquire_checkpoint(&self, owner: SharedOwnerRecord) -> bool {
-        let mut local = self
-            .local_lock_state
-            .lock()
-            .expect("shared WAL local lock state poisoned");
+        let mut local = self.local_lock_state.lock();
         if local.checkpoint_lock_held {
             return false;
         }
@@ -1957,19 +1767,13 @@ impl MappedSharedWalCoordination {
             if !self.with_process_local_ownership(|entry| entry.try_acquire_checkpoint(owner)) {
                 return false;
             }
-            if !Self::try_acquire_shared_owner_slot(&self.header().checkpoint_owner, owner) {
-                self.with_process_local_ownership(|entry| entry.release_checkpoint(owner));
-                return false;
-            }
             if !self.try_acquire_supplemental_byte_lock(CHECKPOINT_LOCK_OFFSET) {
-                Self::release_shared_owner_slot(
-                    &self.header().checkpoint_owner,
-                    owner,
-                    "checkpoint",
-                );
                 self.with_process_local_ownership(|entry| entry.release_checkpoint(owner));
                 return false;
             }
+            self.header()
+                .checkpoint_owner
+                .store(owner.raw(), Ordering::Release);
         }
         local.checkpoint_lock_held = true;
         drop(local);
@@ -1981,11 +1785,9 @@ impl MappedSharedWalCoordination {
         true
     }
 
+    /// Release the checkpoint lock held by this mapping.
     pub(crate) fn release_checkpoint(&self, owner: SharedOwnerRecord) {
-        let mut local = self
-            .local_lock_state
-            .lock()
-            .expect("shared WAL local lock state poisoned");
+        let mut local = self.local_lock_state.lock();
         turso_assert!(
             local.checkpoint_lock_held,
             "checkpoint registry count underflow"
@@ -2007,16 +1809,23 @@ impl MappedSharedWalCoordination {
                 .expect("failed to release shared WAL checkpoint lock");
         } else {
             self.release_supplemental_byte_lock(CHECKPOINT_LOCK_OFFSET);
-            Self::release_shared_owner_slot(&self.header().checkpoint_owner, owner, "checkpoint");
+            self.header()
+                .checkpoint_owner
+                .store(UNOWNED_LOCK, Ordering::Release);
             self.with_process_local_ownership(|entry| entry.release_checkpoint(owner));
         }
         local.checkpoint_lock_held = false;
     }
 
+    /// Return the owner record of the current checkpoint holder, if any.
     pub(crate) fn checkpoint_owner(&self) -> Option<SharedOwnerRecord> {
         SharedOwnerRecord::from_raw(self.header().checkpoint_owner.load(Ordering::Acquire))
     }
 
+    /// Attempt to reclaim a reader slot whose lock byte is no longer held.
+    ///
+    /// This is the safe stale-reader path because the reader byte lock is what
+    /// actually blocks checkpoints; shared owner metadata can be stale.
     fn try_reclaim_stale_reader_slot(&self, slot_index: u32) -> bool {
         if self.uses_linux_ofd_locking() {
             let should_probe = self.with_local_lock_state(|entry| {
@@ -2054,6 +1863,7 @@ impl MappedSharedWalCoordination {
         self.try_reclaim_dead_reader_owner(slot_index, owner)
     }
 
+    /// Probe every occupied reader slot once, reclaiming the ones proven dead.
     fn reclaim_stale_reader_slots(&self) {
         for slot_index in 0..self.header().reader_slot_count {
             let word_idx = (slot_index >> 6) as usize;
@@ -2083,14 +1893,8 @@ impl MappedSharedWalCoordination {
     ) -> Option<SharedReaderSlot> {
         for attempt in 0..2 {
             let bitmap = self.reader_bitmap_words();
-            let mut local = self
-                .local_lock_state
-                .lock()
-                .expect("shared WAL local lock state poisoned");
-            let mut process_local = self
-                .process_local_ownership
-                .lock()
-                .expect("process-local ownership registry poisoned");
+            let mut local = self.local_lock_state.lock();
+            let mut process_local = self.process_local_ownership.lock();
             for slot_index in 0..self.header().reader_slot_count {
                 if local.reader_locks[slot_index as usize] > 0 {
                     continue;
@@ -2145,31 +1949,15 @@ impl MappedSharedWalCoordination {
                                     word.fetch_or(mask, Ordering::Release);
                                     break;
                                 }
-                                if self.reader_owners()[slot_index as usize]
-                                    .compare_exchange(
-                                        UNOWNED_LOCK,
-                                        owner.raw(),
-                                        Ordering::AcqRel,
-                                        Ordering::Acquire,
-                                    )
-                                    .is_err()
-                                {
-                                    process_local.unregister_reader(slot_index, owner);
-                                    word.fetch_or(mask, Ordering::Release);
-                                    break;
-                                }
                                 let offset = Self::process_lock_offset_for_reader(slot_index);
                                 if !self.try_acquire_supplemental_byte_lock(offset) {
-                                    Self::release_shared_owner_slot(
-                                        &self.reader_owners()[slot_index as usize],
-                                        owner,
-                                        "reader slot",
-                                    );
                                     process_local.unregister_reader(slot_index, owner);
                                     word.fetch_or(mask, Ordering::Release);
                                     break;
                                 }
                                 local.reader_locks[slot_index as usize] += 1;
+                                self.reader_owners()[slot_index as usize]
+                                    .store(owner.raw(), Ordering::Release);
                                 self.reader_frames()[slot_index as usize]
                                     .store(max_frame, Ordering::Release);
                                 drop(process_local);
@@ -2194,6 +1982,7 @@ impl MappedSharedWalCoordination {
         None
     }
 
+    /// Update the pinned frame for an already-owned reader slot.
     pub(crate) fn update_reader(&self, slot: SharedReaderSlot, max_frame: u64) -> SharedReaderSlot {
         turso_assert!(
             self.reader_owners()[slot.slot_index as usize].load(Ordering::Acquire)
@@ -2208,26 +1997,24 @@ impl MappedSharedWalCoordination {
         }
     }
 
+    /// Reuse a same-process shared reader slot for identical snapshots when possible.
+    ///
+    /// Multiple sibling connections reading the same `max_frame` should share
+    /// one slot so they do not exhaust the global reader-slot pool.
     pub(crate) fn register_reader_for_snapshot(
         &self,
         owner: SharedOwnerRecord,
         max_frame: u64,
     ) -> Option<SharedReaderSlot> {
         {
-            let mut process_local = self
-                .process_local_ownership
-                .lock()
-                .expect("process-local ownership registry poisoned");
+            let mut process_local = self.process_local_ownership.lock();
             if let Some(slot) = process_local.retain_shared_snapshot_reader(max_frame) {
                 return Some(slot);
             }
         }
 
         let slot = self.register_reader(owner, max_frame)?;
-        let mut process_local = self
-            .process_local_ownership
-            .lock()
-            .expect("process-local ownership registry poisoned");
+        let mut process_local = self.process_local_ownership.lock();
         if let Some(existing_slot) = process_local.shared_snapshot_reader(max_frame) {
             let retained = process_local.retain_shared_snapshot_reader(max_frame);
             turso_assert!(
@@ -2249,10 +2036,7 @@ impl MappedSharedWalCoordination {
     /// thought we held it, which is a correctness bug in the coordination
     /// layer (see `repair_transient_state_for_exclusive_open`).
     pub(crate) fn unregister_reader(&self, slot: SharedReaderSlot) {
-        let mut local = self
-            .local_lock_state
-            .lock()
-            .expect("shared WAL local lock state poisoned");
+        let mut local = self.local_lock_state.lock();
         turso_assert!(
             local.reader_locks[slot.slot_index as usize] > 0,
             "reader registry count underflow"
@@ -2280,7 +2064,6 @@ impl MappedSharedWalCoordination {
             Self::release_shared_owner_slot(
                 &self.reader_owners()[slot.slot_index as usize],
                 slot.owner,
-                "reader slot",
             );
         }
         local.reader_locks[slot.slot_index as usize] -= 1;
@@ -2294,12 +2077,10 @@ impl MappedSharedWalCoordination {
         self.reader_bitmap_words()[word_idx].fetch_or(1u64 << bit, Ordering::Release);
     }
 
+    /// Drop one snapshot-scoped reader reference, releasing the slot on the final ref.
     pub(crate) fn unregister_reader_for_snapshot(&self, slot: SharedReaderSlot) {
         let release_slot = {
-            let mut process_local = self
-                .process_local_ownership
-                .lock()
-                .expect("process-local ownership registry poisoned");
+            let mut process_local = self.process_local_ownership.lock();
             process_local.release_shared_snapshot_reader(slot)
         };
         if release_slot {
@@ -2307,6 +2088,7 @@ impl MappedSharedWalCoordination {
         }
     }
 
+    /// Read the shared owner metadata stored for one reader slot.
     pub(crate) fn reader_owner(&self, slot_index: u32) -> Option<SharedOwnerRecord> {
         SharedOwnerRecord::from_raw(
             self.reader_owners()[slot_index as usize].load(Ordering::Acquire),
@@ -2340,7 +2122,8 @@ impl MappedSharedWalCoordination {
                     if local_owner.is_some() {
                         return Some(frame);
                     }
-                    if pid_is_alive(owner.pid()) {
+                    let offset = Self::process_lock_offset_for_reader(slot_index as u32);
+                    if self.byte_lock_is_held(offset, false) {
                         return Some(frame);
                     }
                     let _ = self.try_reclaim_dead_reader_owner(slot_index as u32, owner);
@@ -2395,10 +2178,7 @@ impl MappedSharedWalCoordination {
     /// is reset to empty before appending.
     #[track_caller]
     pub(crate) fn record_frame(&self, page_id: u64, frame_id: u64) {
-        let _publish_guard = self
-            .frame_index_publish_lock
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _publish_guard = self.frame_index_publish_lock.lock();
         let header = self.header();
         if frame_id == 1 && header.max_frame.load(Ordering::Acquire) == 0 {
             header.frame_index_len.store(0, Ordering::Release);
@@ -2431,10 +2211,7 @@ impl MappedSharedWalCoordination {
         let required_blocks = (slot / FRAME_INDEX_BLOCK_CAPACITY) + 1;
         self.ensure_mapped_frame_index_blocks(required_blocks)
             .expect("shared WAL frame index block missing");
-        let mappings = self
-            .frame_index_blocks
-            .read()
-            .expect("shared WAL frame index block lock poisoned");
+        let mappings = self.frame_index_blocks.read();
         if slot > 0 {
             let previous = Self::frame_index_entry(&mappings, slot - 1);
             assert!(
@@ -2474,10 +2251,7 @@ impl MappedSharedWalCoordination {
     /// clear the entire index) and by `install_snapshot` to trim stale
     /// entries from a previous WAL generation.
     pub(crate) fn rollback_frames(&self, max_frame: u64) {
-        let _publish_guard = self
-            .frame_index_publish_lock
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
+        let _publish_guard = self.frame_index_publish_lock.lock();
         let header = self.header();
         let len = header
             .frame_index_len
@@ -2489,10 +2263,7 @@ impl MappedSharedWalCoordination {
         let old_blocks = len.div_ceil(FRAME_INDEX_BLOCK_CAPACITY);
         self.ensure_mapped_frame_index_blocks(old_blocks)
             .expect("shared WAL frame index block missing");
-        let mappings = self
-            .frame_index_blocks
-            .read()
-            .expect("shared WAL frame index block lock poisoned");
+        let mappings = self.frame_index_blocks.read();
         let mut new_len = len;
         while new_len > 0 {
             let last = Self::frame_index_entry(&mappings, new_len - 1);
@@ -2553,10 +2324,7 @@ impl MappedSharedWalCoordination {
         let required_blocks = len.div_ceil(FRAME_INDEX_BLOCK_CAPACITY);
         self.ensure_mapped_frame_index_blocks(required_blocks)
             .expect("shared WAL frame index block missing");
-        let mappings = self
-            .frame_index_blocks
-            .read()
-            .expect("shared WAL frame index block lock poisoned");
+        let mappings = self.frame_index_blocks.read();
         let visible_slots = Self::visible_frame_index_slots(&mappings, len, upper_frame);
         if visible_slots == 0 {
             return None;
@@ -2598,10 +2366,7 @@ impl MappedSharedWalCoordination {
         let required_blocks = len.div_ceil(FRAME_INDEX_BLOCK_CAPACITY);
         self.ensure_mapped_frame_index_blocks(required_blocks)
             .expect("shared WAL frame index block missing");
-        let mappings = self
-            .frame_index_blocks
-            .read()
-            .expect("shared WAL frame index block lock poisoned");
+        let mappings = self.frame_index_blocks.read();
         let visible_slots = Self::visible_frame_index_slots(&mappings, len, max_frame);
         if visible_slots == 0 {
             return Vec::new();
@@ -2633,6 +2398,10 @@ impl MappedSharedWalCoordination {
 
     fn base_mapped_len(reader_slot_count: u32) -> usize {
         let reader_bitmap_words = (reader_slot_count / 64) as usize;
+        // Layout after header: reader_bitmap | reader_frames | reader_owners
+        // Only 3 arrays are currently used; the remaining 2 are reserved space
+        // for future per-reader arrays (e.g. backfill proof bitmaps) and must
+        // not be removed without a coordinated file format version bump.
         let raw_len = size_of::<SharedWalCoordinationMapHeader>()
             + reader_bitmap_words * size_of::<AtomicU64>()
             + reader_slot_count as usize * size_of::<AtomicU64>()
@@ -2705,6 +2474,10 @@ impl MappedSharedWalCoordination {
         unsafe { std::slice::from_raw_parts(ptr, header.reader_slot_count as usize) }
     }
 
+    /// Map one frame-index block on demand.
+    ///
+    /// Blocks are kept separate from the fixed header mapping so we only pay
+    /// for the shared index capacity we actually need to touch in this process.
     fn map_frame_index_block(&self, block_index: u32) -> Result<FrameIndexBlockMapping> {
         let offset = (Self::base_mapped_len(self.header().reader_slot_count)
             + block_index as usize * Self::frame_index_block_byte_len())
@@ -2727,11 +2500,9 @@ impl MappedSharedWalCoordination {
         })
     }
 
+    /// Ensure the first `target_blocks` frame-index blocks are mapped locally.
     fn ensure_mapped_frame_index_blocks(&self, target_blocks: u32) -> Result<()> {
-        let mut mappings = self
-            .frame_index_blocks
-            .write()
-            .expect("shared WAL frame index block lock poisoned");
+        let mut mappings = self.frame_index_blocks.write();
         while mappings.len() < target_blocks as usize {
             let block_index = mappings.len() as u32;
             mappings.push(self.map_frame_index_block(block_index)?);
@@ -2739,6 +2510,10 @@ impl MappedSharedWalCoordination {
         Ok(())
     }
 
+    /// Publish a larger shared frame-index capacity by extending the file.
+    ///
+    /// This only changes the durable mapping size metadata; callers still need
+    /// `ensure_mapped_frame_index_blocks()` locally before dereferencing.
     fn try_grow_frame_index_blocks(&self, target_blocks: u32) -> bool {
         let target_len = Self::file_len_for_blocks(self.header().reader_slot_count, target_blocks);
         if self.file.shared_wal_set_len(target_len as u64).is_err() {
@@ -2772,18 +2547,18 @@ impl MappedSharedWalCoordination {
         unsafe { mappings[block_index].entries_ptr.as_ptr().add(entry_index) }
     }
 
-    #[allow(clippy::mut_from_ref)]
-    fn frame_index_block_hash_slice(mapping: &FrameIndexBlockMapping) -> &mut [u16] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                mapping.hash_ptr.as_ptr(),
-                FRAME_INDEX_BLOCK_HASH_SLOTS as usize,
-            )
-        }
+    fn frame_index_block_hash_ptr(mapping: &FrameIndexBlockMapping) -> *mut u16 {
+        mapping.hash_ptr.as_ptr()
     }
 
     fn clear_frame_index_block_hash(mapping: &FrameIndexBlockMapping) {
-        Self::frame_index_block_hash_slice(mapping).fill(0);
+        unsafe {
+            std::ptr::write_bytes(
+                Self::frame_index_block_hash_ptr(mapping),
+                0,
+                FRAME_INDEX_BLOCK_HASH_SLOTS as usize,
+            );
+        }
     }
 
     /// sqlite wal.c:
@@ -2805,13 +2580,15 @@ impl MappedSharedWalCoordination {
             local_index < FRAME_INDEX_BLOCK_CAPACITY,
             "frame index block local index out of range"
         );
-        let hash = Self::frame_index_block_hash_slice(mapping);
+        let hash_ptr = Self::frame_index_block_hash_ptr(mapping);
         let mut slot = Self::hash_page_id(page_id);
         let value = (local_index + 1) as u16;
         for _ in 0..FRAME_INDEX_BLOCK_HASH_SLOTS {
-            if hash[slot] == 0 {
-                hash[slot] = value;
-                return;
+            unsafe {
+                if std::ptr::read(hash_ptr.add(slot)) == 0 {
+                    std::ptr::write(hash_ptr.add(slot), value);
+                    return;
+                }
             }
             slot = (slot + 1) % FRAME_INDEX_BLOCK_HASH_SLOTS as usize;
         }
@@ -2853,7 +2630,11 @@ impl MappedSharedWalCoordination {
             }
             let local_index = local_plus_one as u32 - 1;
             if local_index >= visible_entries {
-                break;
+                // In a linear-probing hash table, an entry beyond visible_entries
+                // does not terminate the probe chain — valid entries may follow.
+                // (A writer may have built the hash with more entries than this
+                // reader's snapshot makes visible.)
+                continue;
             }
             let entry = unsafe { *mapping.entries_ptr.as_ptr().add(local_index as usize) };
             if entry.page_id == page_id {
@@ -2874,7 +2655,7 @@ impl MappedSharedWalCoordination {
                 FRAME_INDEX_BLOCK_HASH_SLOTS as usize,
             )
         };
-        let mut latest_entries: HashMap<u64, u32> = HashMap::new();
+        let mut latest_entries: HashMap<u64, u32> = HashMap::default();
         for &local_plus_one in hash {
             if local_plus_one == 0 {
                 continue;
@@ -3051,12 +2832,7 @@ impl MappedSharedWalCoordination {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::io::{OpenFlags, PlatformIO, IO};
-    use crate::storage::database::DatabaseFile;
-    use crate::storage::wal::{CheckpointMode, CheckpointResult};
-    use crate::types::Value;
-    use crate::util::IOExt;
-    use crate::{Connection, Database, DatabaseOpts, IOResult, OpenDbAsyncState, Result, SyncMode};
+    use crate::io::{PlatformIO, IO};
     use std::sync::Arc;
 
     fn colliding_page_ids(count: usize) -> Vec<u64> {
@@ -3179,67 +2955,6 @@ mod tests {
     }
 
     #[test]
-    fn shared_owner_slot_active_clears_dead_owner() {
-        let dead_owner = SharedOwnerRecord::new(exited_child_pid(), 99);
-        let slot = AtomicU64::new(dead_owner.raw());
-
-        assert!(!MappedSharedWalCoordination::shared_owner_slot_active(
-            &slot
-        ));
-        assert_eq!(slot.load(Ordering::Acquire), UNOWNED_LOCK);
-    }
-
-    #[test]
-    fn mapped_shared_wal_coordination_reclaims_dead_writer_owner() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("coordination.tshm");
-        let mapped = create_mapping(&path);
-        let dead_owner = SharedOwnerRecord::new(exited_child_pid(), 41);
-
-        mapped
-            .header()
-            .writer_owner
-            .store(dead_owner.raw(), Ordering::Release);
-
-        assert!(MappedSharedWalCoordination::try_acquire_shared_owner_slot(
-            &mapped.header().writer_owner,
-            mapped.owner_record(),
-        ));
-        assert_eq!(mapped.writer_owner(), Some(mapped.owner_record()));
-        MappedSharedWalCoordination::release_shared_owner_slot(
-            &mapped.header().writer_owner,
-            mapped.owner_record(),
-            "writer",
-        );
-        assert_eq!(mapped.writer_owner(), None);
-    }
-
-    #[test]
-    fn mapped_shared_wal_coordination_reclaims_dead_checkpoint_owner() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("coordination.tshm");
-        let mapped = create_mapping(&path);
-        let dead_owner = SharedOwnerRecord::new(exited_child_pid(), 42);
-
-        mapped
-            .header()
-            .checkpoint_owner
-            .store(dead_owner.raw(), Ordering::Release);
-
-        assert!(MappedSharedWalCoordination::try_acquire_shared_owner_slot(
-            &mapped.header().checkpoint_owner,
-            mapped.owner_record(),
-        ));
-        assert_eq!(mapped.checkpoint_owner(), Some(mapped.owner_record()));
-        MappedSharedWalCoordination::release_shared_owner_slot(
-            &mapped.header().checkpoint_owner,
-            mapped.owner_record(),
-            "checkpoint",
-        );
-        assert_eq!(mapped.checkpoint_owner(), None);
-    }
-
-    #[test]
     fn mapped_shared_wal_coordination_reclaims_dead_reader_owner() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("coordination.tshm");
@@ -3316,72 +3031,42 @@ mod tests {
     }
 
     #[test]
-    fn shared_wal_coordination_tracks_writer_and_checkpoint_owners() {
-        let state = SharedWalCoordinationState::new(64);
-        let writer = SharedOwnerRecord::new(11, 1);
-        let checkpoint = SharedOwnerRecord::new(21, 2);
+    fn process_scoped_mapping_ignores_stale_same_pid_writer_owner_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_process_scoped_mapping(&path);
+        let stale_owner = SharedOwnerRecord::new(std::process::id(), 7);
+        assert_ne!(stale_owner, mapped.owner_record());
 
-        assert!(state.try_acquire_writer(writer));
-        assert_eq!(state.writer_owner(), Some(writer));
-        assert!(!state.try_acquire_writer(SharedOwnerRecord::new(12, 1)));
-        state.release_writer(writer);
-        assert_eq!(state.writer_owner(), None);
+        mapped
+            .header()
+            .writer_owner
+            .store(stale_owner.raw(), Ordering::Release);
 
-        assert!(state.try_acquire_checkpoint(checkpoint));
-        assert_eq!(state.checkpoint_owner(), Some(checkpoint));
-        assert!(!state.try_acquire_checkpoint(SharedOwnerRecord::new(22, 2)));
-        state.release_checkpoint(checkpoint);
-        assert_eq!(state.checkpoint_owner(), None);
+        assert!(mapped.try_acquire_writer(mapped.owner_record()));
+        assert_eq!(mapped.writer_owner(), Some(mapped.owner_record()));
+        mapped.release_writer(mapped.owner_record());
+        assert_eq!(mapped.writer_owner(), None);
     }
 
     #[test]
-    fn shared_wal_coordination_tracks_reader_registrations() {
-        let state = SharedWalCoordinationState::new(64);
-        let owner_a = SharedOwnerRecord::new(31, 1);
-        let owner_b = SharedOwnerRecord::new(31, 2);
+    fn process_scoped_mapping_reclaims_stale_same_pid_reader_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_process_scoped_mapping(&path);
+        let stale_owner = SharedOwnerRecord::new(std::process::id(), 9);
+        assert_ne!(stale_owner, mapped.owner_record());
 
-        let reader_a = state.register_reader(owner_a, 9).unwrap();
-        let reader_b = state.register_reader(owner_b, 5).unwrap();
-        assert_eq!(state.reader_owner(reader_a.slot_index), Some(owner_a));
-        assert_eq!(state.reader_owner(reader_b.slot_index), Some(owner_b));
-        assert_eq!(state.min_active_reader_frame(), Some(5));
+        mapped.reader_bitmap_words()[0].fetch_and(!1u64, Ordering::Release);
+        mapped.reader_frames()[0].store(17, Ordering::Release);
+        mapped.reader_owners()[0].store(stale_owner.raw(), Ordering::Release);
 
-        let reader_a = state.update_reader(reader_a, 3);
-        assert_eq!(reader_a.max_frame, 3);
-        assert_eq!(state.min_active_reader_frame(), Some(3));
+        assert_eq!(mapped.min_active_reader_frame(), None);
+        assert_eq!(mapped.reader_owner(0), None);
 
-        state.unregister_reader(reader_b);
-        assert_eq!(state.reader_owner(reader_b.slot_index), None);
-        assert_eq!(state.min_active_reader_frame(), Some(3));
-
-        state.unregister_reader(reader_a);
-        assert_eq!(state.reader_owner(reader_a.slot_index), None);
-        assert_eq!(state.min_active_reader_frame(), None);
-    }
-
-    #[test]
-    fn shared_wal_coordination_publishes_snapshot_fields() {
-        let state = SharedWalCoordinationState::new(64);
-
-        state.install_header_fields(4096, 17, 23);
-        state.publish_commit(14, 31, 37, 9);
-        state.publish_backfill(8);
-        assert_eq!(state.bump_checkpoint_seq(), 1);
-        assert_eq!(state.bump_checkpoint_epoch(), 0);
-
-        let snapshot = state.snapshot();
-        assert_eq!(snapshot.max_frame, 14);
-        assert_eq!(snapshot.nbackfills, 8);
-        assert_eq!(snapshot.transaction_count, 9);
-        assert_eq!(snapshot.visibility_generation, 1);
-        assert_eq!(snapshot.checkpoint_seq, 1);
-        assert_eq!(snapshot.checkpoint_epoch, 1);
-        assert_eq!(snapshot.page_size, 4096);
-        assert_eq!(snapshot.salt_1, 17);
-        assert_eq!(snapshot.salt_2, 23);
-        assert_eq!(snapshot.checksum_1, 31);
-        assert_eq!(snapshot.checksum_2, 37);
-        assert_eq!(snapshot.reader_slot_count, 64);
+        let reader = mapped.register_reader(mapped.owner_record(), 23).unwrap();
+        assert_eq!(reader.slot_index, 0);
+        mapped.unregister_reader(reader);
     }
 
     #[test]
@@ -3556,26 +3241,6 @@ mod tests {
         assert_eq!(mapped_a.checkpoint_owner(), Some(mapped_b.owner_record()));
         mapped_b.release_checkpoint(mapped_b.owner_record());
         assert_eq!(mapped_a.checkpoint_owner(), None);
-    }
-
-    #[test]
-    fn mapped_shared_wal_coordination_second_process_local_mapping_is_multiprocess() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("coordination.tshm");
-
-        let mapped_a = create_mapping(&path);
-        assert_eq!(
-            mapped_a.open_mode(),
-            SharedWalCoordinationOpenMode::Exclusive
-        );
-        assert!(mapped_a.is_primary_process_mapping());
-
-        let mapped_b = create_mapping(&path);
-        assert_eq!(
-            mapped_b.open_mode(),
-            SharedWalCoordinationOpenMode::MultiProcess
-        );
-        assert!(!mapped_b.is_primary_process_mapping());
     }
 
     #[test]
@@ -3911,13 +3576,45 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("coordination.tshm");
         let mapped = create_mapping(&path);
+        let stale_owner = SharedOwnerRecord::new(exited_child_pid(), 7);
 
         mapped
             .header()
             .writer_owner
-            .store(SharedOwnerRecord::new(99, 7).raw(), Ordering::Release);
+            .store(stale_owner.raw(), Ordering::Release);
         assert!(mapped.try_acquire_writer(mapped.owner_record()));
         mapped.release_writer(mapped.owner_record());
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_ignores_stale_checkpoint_owner_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let stale_owner = SharedOwnerRecord::new(exited_child_pid(), 8);
+
+        mapped
+            .header()
+            .checkpoint_owner
+            .store(stale_owner.raw(), Ordering::Release);
+        assert!(mapped.try_acquire_checkpoint(mapped.owner_record()));
+        mapped.release_checkpoint(mapped.owner_record());
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_publish_commit_keeps_monotonic_transaction_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+
+        mapped.publish_commit(12, 31, 37, 9);
+        mapped.publish_commit(11, 41, 43, 8);
+
+        let snapshot = mapped.snapshot();
+        assert_eq!(snapshot.max_frame, 12);
+        assert_eq!(snapshot.transaction_count, 9);
+        assert_eq!(snapshot.checksum_1, 31);
+        assert_eq!(snapshot.checksum_2, 37);
     }
 
     #[test]
@@ -3925,10 +3622,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("coordination.tshm");
         let mapped = create_mapping(&path);
+        let stale_owner = SharedOwnerRecord::new(exited_child_pid(), 9);
 
         mapped.reader_bitmap_words()[0].fetch_and(!1u64, Ordering::Release);
         mapped.reader_frames()[0].store(17, Ordering::Release);
-        mapped.reader_owners()[0].store(SharedOwnerRecord::new(42, 9).raw(), Ordering::Release);
+        mapped.reader_owners()[0].store(stale_owner.raw(), Ordering::Release);
 
         assert_eq!(mapped.min_active_reader_frame(), None);
         assert_eq!(mapped.reader_owner(0), None);
@@ -4239,523 +3937,5 @@ mod tests {
             mapped.find_frame(7, 0, boundary + 3, None),
             Some(boundary + 3)
         );
-    }
-
-    fn try_open_isolated_database(
-        db_path: &std::path::Path,
-    ) -> Result<(Arc<Database>, Arc<Connection>)> {
-        let db_path_str = db_path.to_str().unwrap();
-        let wal_path = format!("{db_path_str}-wal");
-        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let file = io
-            .open_file(db_path_str, OpenFlags::default(), true)
-            .unwrap();
-        let db_file = Arc::new(DatabaseFile::new(file));
-        let mut state = OpenDbAsyncState::new();
-        let db = loop {
-            match Database::open_with_flags_bypass_registry_async(
-                &mut state,
-                io.clone(),
-                db_path_str,
-                Some(&wal_path),
-                db_file.clone(),
-                OpenFlags::default(),
-                DatabaseOpts::new().with_multiprocess_wal(true),
-                None,
-                None,
-            )? {
-                IOResult::Done(db) => break db,
-                IOResult::IO(io_completion) => io_completion.wait(&*io)?,
-            }
-        };
-        let conn = db.connect()?;
-        Ok((db, conn))
-    }
-
-    fn open_mp_database() -> (Arc<Database>, Arc<Connection>, tempfile::TempDir) {
-        let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("test.db");
-        {
-            let conn = rusqlite::Connection::open(&db_path).unwrap();
-            conn.pragma_update(None, "journal_mode", "wal").unwrap();
-        }
-        let (db, conn) = try_open_isolated_database(&db_path).unwrap();
-        (db, conn, dir)
-    }
-
-    fn open_second_process(dir: &std::path::Path) -> (Arc<Database>, Arc<Connection>) {
-        try_open_isolated_database(&dir.join("test.db")).unwrap()
-    }
-
-    fn exec(conn: &Arc<Connection>, sql: &str) {
-        conn.execute(sql).unwrap();
-    }
-
-    fn query_i64(conn: &Arc<Connection>, sql: &str) -> i64 {
-        try_query_i64(conn, sql).unwrap()
-    }
-
-    fn try_query_i64(conn: &Arc<Connection>, sql: &str) -> Result<i64> {
-        let mut stmt = conn.prepare(sql).unwrap();
-        let mut value = 0i64;
-        stmt.run_with_row_callback(|row| {
-            value = row.get(0).unwrap();
-            Ok(())
-        })?;
-        Ok(value)
-    }
-
-    fn query_rows(conn: &Arc<Connection>, sql: &str) -> Vec<Vec<Value>> {
-        let mut stmt = conn.prepare(sql).unwrap();
-        stmt.run_collect_rows().unwrap()
-    }
-
-    fn run_checkpoint(conn: &Arc<Connection>, mode: CheckpointMode) -> CheckpointResult {
-        let pager = conn.pager.load();
-        pager
-            .io
-            .block(|| pager.checkpoint(mode, SyncMode::Full, true))
-            .unwrap()
-    }
-
-    fn assert_integrity_ok(conn: &Arc<Connection>) {
-        let rows = query_rows(conn, "PRAGMA integrity_check");
-        assert!(!rows.is_empty(), "integrity_check returned no rows");
-        match &rows[0][0] {
-            Value::Text(s) => assert_eq!(s.as_ref(), "ok", "integrity_check failed: {s}"),
-            other => panic!("unexpected integrity_check result: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_mp_snapshot_isolation() {
-        let (_db_writer, conn_writer, dir) = open_mp_database();
-
-        exec(
-            &conn_writer,
-            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
-        );
-        exec(&conn_writer, "INSERT INTO t VALUES (1,'a'), (2,'b')");
-        let (_db_reader, conn_reader) = open_second_process(dir.path());
-
-        exec(&conn_reader, "BEGIN");
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 2);
-
-        exec(&conn_writer, "INSERT INTO t VALUES (3,'c'), (4,'d')");
-
-        assert_eq!(
-            query_i64(&conn_reader, "SELECT count(*) FROM t"),
-            2,
-            "reader should keep its original snapshot while the transaction stays open"
-        );
-
-        exec(&conn_reader, "COMMIT");
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 4);
-
-        assert_integrity_ok(&conn_writer);
-    }
-
-    #[test]
-    fn test_mp_checkpoint_respects_active_reader() {
-        let (_db_writer, conn_writer, dir) = open_mp_database();
-
-        exec(
-            &conn_writer,
-            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
-        );
-
-        exec(&conn_writer, "BEGIN");
-        for i in 0..100 {
-            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
-        }
-        exec(&conn_writer, "COMMIT");
-        let (_db_reader, conn_reader) = open_second_process(dir.path());
-
-        exec(&conn_reader, "BEGIN");
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 100);
-
-        exec(&conn_writer, "BEGIN");
-        for i in 100..200 {
-            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
-        }
-        exec(&conn_writer, "COMMIT");
-
-        let first_checkpoint = run_checkpoint(
-            &conn_writer,
-            CheckpointMode::Passive {
-                upper_bound_inclusive: None,
-            },
-        );
-        assert!(
-            !first_checkpoint.everything_backfilled(),
-            "passive checkpoint should stop at the active reader snapshot"
-        );
-
-        exec(&conn_reader, "COMMIT");
-
-        let second_checkpoint = run_checkpoint(
-            &conn_writer,
-            CheckpointMode::Passive {
-                upper_bound_inclusive: None,
-            },
-        );
-        assert!(
-            second_checkpoint.everything_backfilled(),
-            "checkpoint should fully backfill after the reader releases its snapshot"
-        );
-        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 200);
-        assert_integrity_ok(&conn_writer);
-    }
-
-    #[test]
-    fn test_mp_reader_crash_recovery_releases_checkpoint_barrier() {
-        let (_db_writer, conn_writer, dir) = open_mp_database();
-
-        exec(
-            &conn_writer,
-            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
-        );
-        exec(&conn_writer, "INSERT INTO t VALUES (1,'a'), (2,'b')");
-
-        let (_db_reader, conn_reader) = open_second_process(dir.path());
-        exec(&conn_reader, "BEGIN");
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 2);
-
-        exec(&conn_writer, "INSERT INTO t VALUES (3,'c')");
-
-        let checkpoint_with_reader = run_checkpoint(
-            &conn_writer,
-            CheckpointMode::Passive {
-                upper_bound_inclusive: None,
-            },
-        );
-        assert!(
-            !checkpoint_with_reader.everything_backfilled(),
-            "active reader snapshot should limit passive checkpoint progress"
-        );
-
-        drop(conn_reader);
-        drop(_db_reader);
-
-        let checkpoint_after_crash = run_checkpoint(
-            &conn_writer,
-            CheckpointMode::Passive {
-                upper_bound_inclusive: None,
-            },
-        );
-        assert!(
-            checkpoint_after_crash.everything_backfilled(),
-            "dropped reader process should no longer block checkpoint progress"
-        );
-
-        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 3);
-        assert_integrity_ok(&conn_writer);
-    }
-
-    #[test]
-    fn test_mp_writer_crash_recovery_only_exposes_committed_rows() {
-        let (_db_writer, conn_writer, dir) = open_mp_database();
-
-        exec(
-            &conn_writer,
-            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
-        );
-        exec(&conn_writer, "BEGIN");
-        for i in 0..10 {
-            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
-        }
-        exec(&conn_writer, "COMMIT");
-        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 10);
-
-        exec(&conn_writer, "BEGIN");
-        for i in 10..20 {
-            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
-        }
-
-        drop(conn_writer);
-        drop(_db_writer);
-
-        let (_db_recovered, conn_recovered) = open_second_process(dir.path());
-        assert_eq!(
-            query_i64(&conn_recovered, "SELECT count(*) FROM t"),
-            10,
-            "recovery should ignore uncommitted rows from the crashed writer"
-        );
-        assert_integrity_ok(&conn_recovered);
-    }
-
-    #[test]
-    fn test_mp_multiple_readers_hold_distinct_snapshots() {
-        let (_db_writer, conn_writer, dir) = open_mp_database();
-
-        exec(
-            &conn_writer,
-            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
-        );
-
-        exec(&conn_writer, "BEGIN");
-        for i in 0..10 {
-            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
-        }
-        exec(&conn_writer, "COMMIT");
-
-        let (_db_reader1, conn_reader1) = open_second_process(dir.path());
-        exec(&conn_reader1, "BEGIN");
-        assert_eq!(query_i64(&conn_reader1, "SELECT count(*) FROM t"), 10);
-
-        exec(&conn_writer, "BEGIN");
-        for i in 10..20 {
-            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
-        }
-        exec(&conn_writer, "COMMIT");
-
-        let (_db_reader2, conn_reader2) = open_second_process(dir.path());
-        exec(&conn_reader2, "BEGIN");
-        assert_eq!(query_i64(&conn_reader2, "SELECT count(*) FROM t"), 20);
-
-        exec(&conn_writer, "BEGIN");
-        for i in 20..30 {
-            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
-        }
-        exec(&conn_writer, "COMMIT");
-
-        let (_db_reader3, conn_reader3) = open_second_process(dir.path());
-        exec(&conn_reader3, "BEGIN");
-        assert_eq!(query_i64(&conn_reader3, "SELECT count(*) FROM t"), 30);
-
-        assert_eq!(query_i64(&conn_reader1, "SELECT count(*) FROM t"), 10);
-        assert_eq!(query_i64(&conn_reader2, "SELECT count(*) FROM t"), 20);
-        assert_eq!(query_i64(&conn_reader3, "SELECT count(*) FROM t"), 30);
-
-        let checkpoint = run_checkpoint(
-            &conn_writer,
-            CheckpointMode::Passive {
-                upper_bound_inclusive: None,
-            },
-        );
-        assert!(
-            !checkpoint.everything_backfilled(),
-            "oldest reader snapshot should limit passive checkpoint progress"
-        );
-
-        exec(&conn_reader1, "COMMIT");
-        exec(&conn_reader2, "COMMIT");
-        exec(&conn_reader3, "COMMIT");
-
-        let final_checkpoint = run_checkpoint(
-            &conn_writer,
-            CheckpointMode::Passive {
-                upper_bound_inclusive: None,
-            },
-        );
-        assert!(
-            final_checkpoint.everything_backfilled(),
-            "checkpoint should complete once all reader snapshots are released"
-        );
-
-        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 30);
-        assert_integrity_ok(&conn_writer);
-    }
-
-    #[test]
-    fn test_mp_stale_frame_cache_after_repeated_truncate() {
-        let (_db0, conn0, dir) = open_mp_database();
-
-        exec(&conn0, "CREATE TABLE t1(id INTEGER PRIMARY KEY)");
-        exec(&conn0, "CREATE TABLE t2(id INTEGER PRIMARY KEY)");
-        run_checkpoint(
-            &conn0,
-            CheckpointMode::Truncate {
-                upper_bound_inclusive: None,
-            },
-        );
-
-        let (_db1, conn1) = open_second_process(dir.path());
-        let (_db2, conn2) = open_second_process(dir.path());
-
-        exec(&conn1, "INSERT INTO t1 VALUES (1)");
-        assert_eq!(query_i64(&conn2, "SELECT count(*) FROM t1"), 1);
-
-        run_checkpoint(
-            &conn0,
-            CheckpointMode::Truncate {
-                upper_bound_inclusive: None,
-            },
-        );
-
-        exec(&conn1, "INSERT INTO t2 VALUES (100)");
-        assert_eq!(query_i64(&conn2, "SELECT count(*) FROM t2"), 1);
-        assert_integrity_ok(&conn2);
-    }
-
-    #[test]
-    fn test_mp_restart_checkpoint_on_empty_wal() {
-        let (_db1, conn1, dir) = open_mp_database();
-
-        exec(&conn1, "CREATE TABLE t1 (id INTEGER PRIMARY KEY)");
-        exec(&conn1, "INSERT INTO t1 VALUES (1)");
-
-        run_checkpoint(
-            &conn1,
-            CheckpointMode::Truncate {
-                upper_bound_inclusive: None,
-            },
-        );
-
-        let (_db2, conn2) = open_second_process(dir.path());
-        run_checkpoint(&conn2, CheckpointMode::Restart);
-        exec(&conn2, "INSERT INTO t1 VALUES (2)");
-
-        assert_eq!(query_i64(&conn2, "SELECT count(*) FROM t1"), 2);
-        assert_integrity_ok(&conn2);
-    }
-
-    #[test]
-    fn test_mp_uncommitted_frames_not_visible_cross_process() {
-        let (_db_writer, conn_writer, dir) = open_mp_database();
-
-        exec(&conn_writer, "CREATE TABLE t(id INTEGER PRIMARY KEY)");
-        exec(&conn_writer, "INSERT INTO t VALUES (1)");
-
-        let (_db_reader, conn_reader) = open_second_process(dir.path());
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 1);
-
-        exec(&conn_writer, "BEGIN");
-        exec(&conn_writer, "INSERT INTO t VALUES (2)");
-
-        assert_eq!(
-            query_i64(&conn_reader, "SELECT count(*) FROM t"),
-            1,
-            "uncommitted frames must stay invisible to other processes"
-        );
-
-        exec(&conn_writer, "COMMIT");
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 2);
-    }
-
-    #[test]
-    fn test_mp_rollback_wal_index_cross_process() {
-        let (_db_writer, conn_writer, dir) = open_mp_database();
-
-        exec(
-            &conn_writer,
-            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
-        );
-        exec(&conn_writer, "INSERT INTO t VALUES (1, 'baseline')");
-
-        let (_db_reader, conn_reader) = open_second_process(dir.path());
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 1);
-
-        exec(&conn_writer, "BEGIN");
-        exec(&conn_writer, "INSERT INTO t VALUES (2, 'will_rollback')");
-        exec(&conn_writer, "INSERT INTO t VALUES (3, 'will_rollback')");
-        exec(&conn_writer, "ROLLBACK");
-
-        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 1);
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 1);
-
-        let rows = query_rows(&conn_reader, "SELECT val FROM t WHERE id = 1");
-        match &rows[0][0] {
-            Value::Text(s) => assert_eq!(s.as_ref(), "baseline"),
-            other => panic!("unexpected val: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_mp_truncate_then_cross_process_write() {
-        let (_db_writer, conn_writer, dir) = open_mp_database();
-
-        exec(
-            &conn_writer,
-            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
-        );
-        exec(&conn_writer, "INSERT INTO t VALUES (1, 'before_truncate')");
-
-        let (_db_reader, conn_reader) = open_second_process(dir.path());
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 1);
-
-        run_checkpoint(
-            &conn_writer,
-            CheckpointMode::Truncate {
-                upper_bound_inclusive: None,
-            },
-        );
-
-        exec(&conn_reader, "INSERT INTO t VALUES (2, 'after_truncate')");
-
-        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 2);
-        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 2);
-        assert_integrity_ok(&conn_writer);
-        assert_integrity_ok(&conn_reader);
-    }
-
-    #[test]
-    fn test_mp_rapid_open_close_cycles() {
-        let (_db_writer, conn_writer, dir) = open_mp_database();
-
-        exec(
-            &conn_writer,
-            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
-        );
-        for i in 1..=10 {
-            exec(
-                &conn_writer,
-                &format!("INSERT INTO t VALUES ({i}, 'row{i}')"),
-            );
-        }
-
-        for cycle in 0..50 {
-            let (db, conn) = open_second_process(dir.path());
-            let count = query_i64(&conn, "SELECT count(*) FROM t");
-            assert_eq!(count, 10, "cycle {cycle}: expected 10 rows, got {count}");
-            drop(conn);
-            drop(db);
-        }
-
-        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 10);
-        assert_integrity_ok(&conn_writer);
-
-        exec(&conn_writer, "INSERT INTO t VALUES (11, 'after_churn')");
-        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 11);
-    }
-
-    #[test]
-    fn test_mp_dbfile_readers_do_not_consume_shared_reader_slots() {
-        let (db, conn_writer, _dir) = open_mp_database();
-
-        exec(
-            &conn_writer,
-            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
-        );
-        exec(&conn_writer, "INSERT INTO t VALUES (1, 'baseline')");
-        run_checkpoint(
-            &conn_writer,
-            CheckpointMode::Truncate {
-                upper_bound_inclusive: None,
-            },
-        );
-
-        let mut readers = Vec::new();
-        for slot in 0..128 {
-            let conn = db.connect().unwrap();
-            exec(&conn, "BEGIN");
-            assert_eq!(
-                query_i64(&conn, "SELECT count(*) FROM t"),
-                1,
-                "db-file reader {slot} should not fail due to shared-reader slot pressure"
-            );
-            readers.push(conn);
-        }
-
-        let authority = db.shared_wal_coordination().unwrap().unwrap();
-        assert_eq!(
-            authority.min_active_reader_frame(),
-            None,
-            "db-file-only readers should not publish shared WAL reader slots"
-        );
-
-        for conn in readers {
-            exec(&conn, "COMMIT");
-        }
     }
 }

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -1,0 +1,3876 @@
+//! Cross-process shared WAL coordination backed by the `.tshm` file.
+//!
+//! The mmap stores three kinds of state:
+//!
+//! 1. An authoritative WAL snapshot header (`max_frame`, checksums, salts,
+//!    checkpoint counters).
+//! 2. Cross-process ownership state for the single writer, the single
+//!    checkpointer, and every active reader slot.
+//! 3. A shared page-to-frame index so readers can resolve WAL pages without a
+//!    process-local WAL scan.
+//!
+//! The design intentionally splits responsibilities between shared memory and
+//! process-local bookkeeping:
+//!
+//! - Shared memory is the source of truth across processes.
+//! - Process-local registries prevent same-process re-opens from reclaiming or
+//!   double-using slots that are still owned by sibling connections.
+//! - The shared frame index is append-only within a WAL generation and is only
+//!   published after each entry is fully written, so other processes never
+//!   observe half-written mappings.
+//!
+//! Stale-owner reclamation is best-effort and must only trade performance for
+//! conservatism, never correctness: if the authority cannot prove a slot is
+//! dead, it must leave that slot in place.
+
+use crate::io::{File, SharedWalLockKind, SharedWalMappedRegion, IO};
+use crate::storage::slot_bitmap::AtomicSlotBitmap;
+use crate::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use crate::{turso_assert, LimboError, Result};
+use std::collections::HashMap;
+use std::mem::size_of;
+use std::path::{Path, PathBuf};
+use std::ptr::NonNull;
+use std::sync::{Arc, LazyLock, Mutex, RwLock};
+
+const SHARED_WAL_COORDINATION_MAGIC: [u8; 8] = *b"TSHMWAL\0";
+const SHARED_WAL_COORDINATION_VERSION: u32 = 8;
+const UNUSED_READER_FRAME: u64 = u64::MAX;
+const UNOWNED_LOCK: u64 = 0;
+const SHARED_WAL_COORDINATION_MAP_ALIGNMENT: usize = 4096;
+const PROCESS_LIFETIME_LOCK_OFFSET: u64 = 0;
+const WRITER_LOCK_OFFSET: u64 = 1;
+const CHECKPOINT_LOCK_OFFSET: u64 = 2;
+const READER_LOCK_START_OFFSET: u64 = 3;
+const FRAME_INDEX_BLOCK_CAPACITY: u32 = 4096;
+const FRAME_INDEX_BLOCK_HASH_SLOTS: u32 = FRAME_INDEX_BLOCK_CAPACITY * 2;
+const MAX_FRAME_INDEX_BLOCKS: u32 = 64;
+const INITIAL_FRAME_INDEX_BLOCKS: u32 = 1;
+const MAX_FRAME_INDEX_CAPACITY: u32 = FRAME_INDEX_BLOCK_CAPACITY * MAX_FRAME_INDEX_BLOCKS;
+
+/// Monotonic counter for generating unique per-connection instance IDs within
+/// a process. Combined with the PID to form a `SharedOwnerRecord`.
+static NEXT_SHARED_OWNER_INSTANCE_ID: AtomicU32 = AtomicU32::new(1);
+
+/// Global registry of open tshm mappings, keyed by canonical file path.
+/// Defensive dedup registry for tshm mappings within a single process.
+///
+/// In production, `DATABASE_MANAGER` already ensures one `Database` (and
+/// therefore one `Arc<MappedSharedWalCoordination>`) per file per process,
+/// so `open_count` is always 1. This registry exists as a safety net for
+/// test code that may bypass `DATABASE_MANAGER` and open the same file
+/// multiple times. The shared Arcs it provides (`frame_index_publish_lock`,
+/// `process_local_ownership`) ensure those test-only re-opens still
+/// coordinate correctly within the process.
+static PROCESS_LOCAL_COORDINATION_OPENS: LazyLock<
+    Mutex<HashMap<PathBuf, ProcessLocalCoordinationEntry>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Debug)]
+struct ProcessLocalCoordinationEntry {
+    open_count: usize,
+    frame_index_publish_lock: Arc<Mutex<()>>,
+    ownership: Arc<Mutex<ProcessLocalOwnershipState>>,
+}
+
+/// Process-private mirror of which locks THIS process currently holds.
+///
+/// Multiple `Connection`s to the same `Database` share a single
+/// `MappedSharedWalCoordination` (and therefore a single `LocalLockState`).
+/// The per-slot counts (not booleans) track how many connections within this
+/// process hold each slot, so `register_reader` can skip slots already
+/// occupied by a sibling connection, and `min_active_reader_frame` can
+/// recognize "our own slot" without probing the cross-process lock.
+#[derive(Debug)]
+struct LocalLockState {
+    writer_lock_held: bool,
+    checkpoint_lock_held: bool,
+    reader_locks: Vec<usize>,
+}
+
+/// Per-connection ownership bookkeeping within a single process.
+///
+/// Multiple connections share the same `MappedSharedWalCoordination` and the
+/// same `SharedOwnerRecord`, so the shared-memory owner field alone cannot
+/// distinguish which connection holds a slot. This struct fills that gap.
+///
+/// On non-OFD platforms (macOS) it is also the only way to distinguish
+/// "same-process sibling connection" from "another process" during stale
+/// reclamation, because POSIX fcntl locks are per-process, not per-fd.
+#[derive(Debug)]
+struct ProcessLocalOwnershipState {
+    writer_owner: Option<SharedOwnerRecord>,
+    checkpoint_owner: Option<SharedOwnerRecord>,
+    reader_owners: Vec<Option<SharedOwnerRecord>>,
+}
+
+impl ProcessLocalOwnershipState {
+    fn new(reader_slot_count: u32) -> Self {
+        Self {
+            writer_owner: None,
+            checkpoint_owner: None,
+            reader_owners: vec![None; reader_slot_count as usize],
+        }
+    }
+
+    fn try_acquire_writer(&mut self, owner: SharedOwnerRecord) -> bool {
+        if self.writer_owner.is_some() {
+            return false;
+        }
+        self.writer_owner = Some(owner);
+        true
+    }
+
+    fn release_writer(&mut self, owner: SharedOwnerRecord) {
+        turso_assert!(
+            self.writer_owner == Some(owner),
+            "process-local writer released by non-owner"
+        );
+        self.writer_owner = None;
+    }
+
+    fn writer_active(&self) -> bool {
+        self.writer_owner.is_some()
+    }
+
+    fn try_acquire_checkpoint(&mut self, owner: SharedOwnerRecord) -> bool {
+        if self.checkpoint_owner.is_some() {
+            return false;
+        }
+        self.checkpoint_owner = Some(owner);
+        true
+    }
+
+    fn release_checkpoint(&mut self, owner: SharedOwnerRecord) {
+        turso_assert!(
+            self.checkpoint_owner == Some(owner),
+            "process-local checkpoint released by non-owner"
+        );
+        self.checkpoint_owner = None;
+    }
+
+    fn checkpoint_active(&self) -> bool {
+        self.checkpoint_owner.is_some()
+    }
+
+    fn try_register_reader(&mut self, slot_index: u32, owner: SharedOwnerRecord) -> bool {
+        let slot = &mut self.reader_owners[slot_index as usize];
+        if slot.is_some() {
+            return false;
+        }
+        *slot = Some(owner);
+        true
+    }
+
+    fn unregister_reader(&mut self, slot_index: u32, owner: SharedOwnerRecord) {
+        let slot = &mut self.reader_owners[slot_index as usize];
+        turso_assert!(
+            *slot == Some(owner),
+            "process-local reader slot released by non-owner"
+        );
+        *slot = None;
+    }
+
+    fn reader_owner(&self, slot_index: u32) -> Option<SharedOwnerRecord> {
+        self.reader_owners[slot_index as usize]
+    }
+}
+
+/// Packed (PID, instance_id) pair identifying a specific connection across
+/// processes. Stored in shared memory owner slots so that stale-owner
+/// reclamation can `kill(pid, 0)` to check liveness on non-OFD platforms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SharedOwnerRecord(u64);
+
+impl SharedOwnerRecord {
+    pub(crate) const UNOWNED: Self = Self(UNOWNED_LOCK);
+
+    pub(crate) const fn from_raw(raw: u64) -> Option<Self> {
+        if raw == UNOWNED_LOCK {
+            None
+        } else {
+            Some(Self(raw))
+        }
+    }
+
+    pub(crate) fn current_process(instance_id: u32) -> Self {
+        Self::new(std::process::id(), instance_id)
+    }
+
+    pub(crate) const fn new(pid: u32, instance_id: u32) -> Self {
+        let raw = ((pid as u64) << 32) | instance_id as u64;
+        turso_assert!(raw != UNOWNED_LOCK, "shared owner record must be non-zero");
+        Self(raw)
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) const fn pid(self) -> u32 {
+        (self.0 >> 32) as u32
+    }
+
+    pub(crate) const fn instance_id(self) -> u32 {
+        self.0 as u32
+    }
+}
+
+fn next_shared_owner_instance_id() -> u32 {
+    loop {
+        let current = NEXT_SHARED_OWNER_INSTANCE_ID.load(Ordering::Relaxed);
+        let next = if current == u32::MAX { 1 } else { current + 1 };
+        if NEXT_SHARED_OWNER_INSTANCE_ID
+            .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return current;
+        }
+    }
+}
+
+/// Check whether a process is still running via `kill(pid, 0)`.
+/// Signal 0 is a no-op probe: the kernel checks permissions and existence
+/// without delivering a signal. Returns true if the process exists (or we
+/// lack permission to signal it — EPERM means it's alive but owned by
+/// another user). False-negatives are impossible; false-positives can occur
+/// if the PID has been recycled by an unrelated process.
+fn pid_is_alive(pid: u32) -> bool {
+    if pid == 0 || pid > i32::MAX as u32 {
+        return false;
+    }
+    let rc = unsafe { libc::kill(pid as i32, 0) };
+    if rc == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+/// Serializable snapshot of the authoritative shared WAL coordination state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SharedWalCoordinationHeader {
+    pub max_frame: u64,
+    pub nbackfills: u64,
+    pub transaction_count: u64,
+    pub visibility_generation: u64,
+    pub checkpoint_seq: u32,
+    pub checkpoint_epoch: u32,
+    pub page_size: u32,
+    pub salt_1: u32,
+    pub salt_2: u32,
+    pub checksum_1: u32,
+    pub checksum_2: u32,
+    pub reader_slot_count: u32,
+}
+
+impl SharedWalCoordinationHeader {
+    pub(crate) const BYTE_LEN: usize = 76;
+
+    pub(crate) fn encode(self) -> [u8; Self::BYTE_LEN] {
+        let mut bytes = [0u8; Self::BYTE_LEN];
+        bytes[0..8].copy_from_slice(&SHARED_WAL_COORDINATION_MAGIC);
+        bytes[8..12].copy_from_slice(&SHARED_WAL_COORDINATION_VERSION.to_le_bytes());
+        bytes[12..16].copy_from_slice(&self.reader_slot_count.to_le_bytes());
+        bytes[16..24].copy_from_slice(&self.max_frame.to_le_bytes());
+        bytes[24..32].copy_from_slice(&self.nbackfills.to_le_bytes());
+        bytes[32..40].copy_from_slice(&self.transaction_count.to_le_bytes());
+        bytes[40..48].copy_from_slice(&self.visibility_generation.to_le_bytes());
+        bytes[48..52].copy_from_slice(&self.checkpoint_seq.to_le_bytes());
+        bytes[52..56].copy_from_slice(&self.checkpoint_epoch.to_le_bytes());
+        bytes[56..60].copy_from_slice(&self.page_size.to_le_bytes());
+        bytes[60..64].copy_from_slice(&self.salt_1.to_le_bytes());
+        bytes[64..68].copy_from_slice(&self.salt_2.to_le_bytes());
+        bytes[68..72].copy_from_slice(&self.checksum_1.to_le_bytes());
+        bytes[72..76].copy_from_slice(&self.checksum_2.to_le_bytes());
+        bytes
+    }
+
+    pub(crate) fn decode(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != Self::BYTE_LEN {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination header must be {} bytes, got {}",
+                Self::BYTE_LEN,
+                bytes.len()
+            )));
+        }
+        if bytes[0..8] != SHARED_WAL_COORDINATION_MAGIC {
+            return Err(LimboError::Corrupt(
+                "shared WAL coordination header magic mismatch".into(),
+            ));
+        }
+        let version = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        if version != SHARED_WAL_COORDINATION_VERSION {
+            return Err(LimboError::Corrupt(format!(
+                "unsupported shared WAL coordination header version: {version}"
+            )));
+        }
+        Ok(Self {
+            reader_slot_count: u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
+            max_frame: u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+            nbackfills: u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
+            transaction_count: u64::from_le_bytes(bytes[32..40].try_into().unwrap()),
+            visibility_generation: u64::from_le_bytes(bytes[40..48].try_into().unwrap()),
+            checkpoint_seq: u32::from_le_bytes(bytes[48..52].try_into().unwrap()),
+            checkpoint_epoch: u32::from_le_bytes(bytes[52..56].try_into().unwrap()),
+            page_size: u32::from_le_bytes(bytes[56..60].try_into().unwrap()),
+            salt_1: u32::from_le_bytes(bytes[60..64].try_into().unwrap()),
+            salt_2: u32::from_le_bytes(bytes[64..68].try_into().unwrap()),
+            checksum_1: u32::from_le_bytes(bytes[68..72].try_into().unwrap()),
+            checksum_2: u32::from_le_bytes(bytes[72..76].try_into().unwrap()),
+        })
+    }
+}
+
+/// A registered reader slot in the shared coordination table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SharedReaderSlot {
+    pub slot_index: u32,
+    pub max_frame: u64,
+    pub owner: SharedOwnerRecord,
+}
+
+/// Process-local atomic counters and slot bitmaps for WAL coordination.
+///
+/// Holds WAL snapshot metadata, reader/writer ownership
+pub(crate) struct SharedWalCoordinationState {
+    max_frame: AtomicU64,
+    nbackfills: AtomicU64,
+    transaction_count: AtomicU64,
+    visibility_generation: AtomicU64,
+    checkpoint_seq: AtomicU32,
+    checkpoint_epoch: AtomicU32,
+    page_size: AtomicU32,
+    salt_1: AtomicU32,
+    salt_2: AtomicU32,
+    checksum_1: AtomicU32,
+    checksum_2: AtomicU32,
+    writer_owner: AtomicU64,
+    checkpoint_owner: AtomicU64,
+    reader_frames: Box<[AtomicU64]>,
+    reader_owners: Box<[AtomicU64]>,
+    reader_slots: AtomicSlotBitmap,
+}
+
+#[repr(C)]
+struct SharedWalCoordinationMapHeader {
+    magic: [u8; 8],
+    version: u32,
+    reader_slot_count: u32,
+    reader_bitmap_word_count: u32,
+    frame_index_block_capacity: u32,
+    frame_index_block_hash_slots: u32,
+    frame_index_max_blocks: u32,
+    frame_index_blocks: AtomicU32,
+    frame_index_capacity: u32,
+    frame_index_len: AtomicU32,
+    /// Set once the reserved shared frame index space is exhausted.
+    ///
+    /// Normal operation grows the index a block at a time. This overflow bit
+    /// only exists as a last-resort guard once we have consumed the full mapped
+    /// region.
+    frame_index_overflowed: AtomicU32,
+    max_frame: AtomicU64,
+    nbackfills: AtomicU64,
+    transaction_count: AtomicU64,
+    visibility_generation: AtomicU64,
+    checkpoint_seq: AtomicU32,
+    checkpoint_epoch: AtomicU32,
+    page_size: AtomicU32,
+    salt_1: AtomicU32,
+    salt_2: AtomicU32,
+    checksum_1: AtomicU32,
+    checksum_2: AtomicU32,
+    writer_owner: AtomicU64,
+    checkpoint_owner: AtomicU64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SharedWalFrameIndexEntry {
+    page_id: u64,
+    frame_id: u64,
+}
+
+/// How the tshm file was opened, determined at open time by probing byte 0.
+///
+/// - `Exclusive`: no other process had the file open. The opener is free to
+///   reinitialize or repair any shared state.
+/// - `MultiProcess`: at least one other process already has the file open.
+///   The opener must not clobber state that the peer may be relying on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SharedWalCoordinationOpenMode {
+    Exclusive,
+    MultiProcess,
+}
+
+/// Which locking primitive is used for cross-process slot ownership.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SharedWalOwnershipMode {
+    /// `F_OFD_SETLK`: per file-description, survives `dup()`, independent
+    /// across separate `open()` calls. Stale detection: probe the lock.
+    LinuxOfd,
+    /// `F_SETLK`: per-process, shared across all fds to the same file.
+    /// Stale detection: `kill(pid, 0)` on the owner's PID.
+    ProcessScopedFcntl,
+}
+
+/// mmap-backed shared WAL coordination region (the `.tshm` file).
+///
+/// This is the cross-process source of truth for WAL snapshot metadata,
+/// reader/writer/checkpoint ownership and the shared page-to-frame index.
+/// One instance exists per `Database` open (one per
+/// process in normal operation). All `Connection`s to the same `Database`
+/// share a single `Arc<MappedSharedWalCoordination>`.
+///
+/// ## Ownership model
+///
+/// Two ownership backends exist, selected at compile time:
+///
+/// - **Linux (OFD)**: `F_OFD_SETLK` byte-range locks on the tshm file.
+///   Per file-description, so two opens in the same process get independent
+///   locks. Stale-owner detection probes the lock: if it can be acquired,
+///   the owner is dead.
+///
+/// - **macOS / other Unix (process-scoped fcntl)**: Classical `F_SETLK`
+///   locks (per-process, not per-fd). Stale-owner detection falls back to
+///   `kill(pid, 0)` liveness checks on the `SharedOwnerRecord` PID.
+///
+/// ## Lock byte layout on the tshm file
+///
+/// | Offset    | Purpose
+/// |-----------|---------------
+/// | 0         | Process-lifetime shared/exclusive lock (determines Exclusive vs MultiProcess open)
+/// | 1         | Writer lock
+/// | 2         | Checkpoint lock
+/// | 3..3+N    | Reader slot locks (one byte per slot)
+pub(crate) struct MappedSharedWalCoordination {
+    file: Arc<dyn File>,
+    _base_mapping: Box<dyn SharedWalMappedRegion>,
+    base_ptr: NonNull<u8>,
+    base_len: usize,
+    owner_record: SharedOwnerRecord,
+    ownership_mode: SharedWalOwnershipMode,
+    frame_index_blocks: RwLock<Vec<FrameIndexBlockMapping>>,
+    frame_index_publish_lock: Arc<Mutex<()>>,
+    process_local_ownership: Arc<Mutex<ProcessLocalOwnershipState>>,
+    local_lock_state: Mutex<LocalLockState>,
+    open_mode: SharedWalCoordinationOpenMode,
+    primary_process_mapping: bool,
+    registry_path: Option<PathBuf>,
+}
+
+struct FrameIndexBlockMapping {
+    _mapping: Box<dyn SharedWalMappedRegion>,
+    entries_ptr: NonNull<SharedWalFrameIndexEntry>,
+    hash_ptr: NonNull<u16>,
+    byte_len: usize,
+}
+
+unsafe impl Send for MappedSharedWalCoordination {}
+unsafe impl Sync for MappedSharedWalCoordination {}
+
+impl std::fmt::Debug for MappedSharedWalCoordination {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mapped_blocks = self
+            .frame_index_blocks
+            .read()
+            .expect("shared WAL frame index lock poisoned")
+            .len();
+        f.debug_struct("MappedSharedWalCoordination")
+            .field("base_len", &self.base_len)
+            .field("owner_record", &self.owner_record)
+            .field("ownership_mode", &self.ownership_mode)
+            .field("mapped_blocks", &mapped_blocks)
+            .field("open_mode", &self.open_mode)
+            .field("primary_process_mapping", &self.primary_process_mapping)
+            .field("snapshot", &self.snapshot())
+            .finish()
+    }
+}
+
+impl Drop for MappedSharedWalCoordination {
+    fn drop(&mut self) {
+        self.release_owned_locks_on_drop();
+        if let Some(path) = self.registry_path.as_ref() {
+            let mut opens = PROCESS_LOCAL_COORDINATION_OPENS
+                .lock()
+                .expect("process-local coordination registry poisoned");
+            let count = opens
+                .get_mut(path)
+                .expect("shared WAL coordination registry entry missing");
+            turso_assert!(
+                count.open_count > 0,
+                "shared WAL coordination registry count underflow"
+            );
+            count.open_count -= 1;
+            if count.open_count == 0 {
+                opens.remove(path);
+            }
+        }
+        self.frame_index_blocks
+            .get_mut()
+            .expect("shared WAL frame index lock poisoned")
+            .clear();
+        let _ = self
+            .file
+            .shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, self.lock_kind());
+    }
+}
+
+impl std::fmt::Debug for SharedWalCoordinationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedWalCoordinationState")
+            .field("snapshot", &self.snapshot())
+            .finish()
+    }
+}
+
+impl SharedWalCoordinationState {
+    pub(crate) fn new(reader_slot_count: u32) -> Self {
+        turso_assert!(
+            reader_slot_count >= 64 && reader_slot_count % 64 == 0,
+            "reader_slot_count must be a non-zero multiple of 64"
+        );
+        let reader_frames = (0..reader_slot_count)
+            .map(|_| AtomicU64::new(UNUSED_READER_FRAME))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let reader_owners = (0..reader_slot_count)
+            .map(|_| AtomicU64::new(UNOWNED_LOCK))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            max_frame: AtomicU64::new(0),
+            nbackfills: AtomicU64::new(0),
+            transaction_count: AtomicU64::new(0),
+            visibility_generation: AtomicU64::new(0),
+            checkpoint_seq: AtomicU32::new(0),
+            checkpoint_epoch: AtomicU32::new(0),
+            page_size: AtomicU32::new(0),
+            salt_1: AtomicU32::new(0),
+            salt_2: AtomicU32::new(0),
+            checksum_1: AtomicU32::new(0),
+            checksum_2: AtomicU32::new(0),
+            writer_owner: AtomicU64::new(UNOWNED_LOCK),
+            checkpoint_owner: AtomicU64::new(UNOWNED_LOCK),
+            reader_frames,
+            reader_owners,
+            reader_slots: AtomicSlotBitmap::new(reader_slot_count),
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> SharedWalCoordinationHeader {
+        SharedWalCoordinationHeader {
+            max_frame: self.max_frame.load(Ordering::Acquire),
+            nbackfills: self.nbackfills.load(Ordering::Acquire),
+            transaction_count: self.transaction_count.load(Ordering::Acquire),
+            visibility_generation: self.visibility_generation.load(Ordering::Acquire),
+            checkpoint_seq: self.checkpoint_seq.load(Ordering::Acquire),
+            checkpoint_epoch: self.checkpoint_epoch.load(Ordering::Acquire),
+            page_size: self.page_size.load(Ordering::Acquire),
+            salt_1: self.salt_1.load(Ordering::Acquire),
+            salt_2: self.salt_2.load(Ordering::Acquire),
+            checksum_1: self.checksum_1.load(Ordering::Acquire),
+            checksum_2: self.checksum_2.load(Ordering::Acquire),
+            reader_slot_count: self.reader_frames.len() as u32,
+        }
+    }
+
+    pub(crate) fn install_snapshot(&self, snapshot: SharedWalCoordinationHeader) {
+        self.max_frame.store(snapshot.max_frame, Ordering::Release);
+        self.nbackfills
+            .store(snapshot.nbackfills, Ordering::Release);
+        self.transaction_count
+            .store(snapshot.transaction_count, Ordering::Release);
+        self.visibility_generation
+            .store(snapshot.visibility_generation, Ordering::Release);
+        self.checkpoint_seq
+            .store(snapshot.checkpoint_seq, Ordering::Release);
+        self.checkpoint_epoch
+            .store(snapshot.checkpoint_epoch, Ordering::Release);
+        self.page_size.store(snapshot.page_size, Ordering::Release);
+        self.salt_1.store(snapshot.salt_1, Ordering::Release);
+        self.salt_2.store(snapshot.salt_2, Ordering::Release);
+        self.checksum_1
+            .store(snapshot.checksum_1, Ordering::Release);
+        self.checksum_2
+            .store(snapshot.checksum_2, Ordering::Release);
+    }
+
+    pub(crate) fn publish_commit(
+        &self,
+        max_frame: u64,
+        checksum_1: u32,
+        checksum_2: u32,
+        transaction_count: u64,
+    ) {
+        self.max_frame.store(max_frame, Ordering::Release);
+        self.checksum_1.store(checksum_1, Ordering::Release);
+        self.checksum_2.store(checksum_2, Ordering::Release);
+        self.transaction_count
+            .store(transaction_count, Ordering::Release);
+        self.visibility_generation.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub(crate) fn publish_backfill(&self, nbackfills: u64) {
+        self.nbackfills.store(nbackfills, Ordering::Release);
+    }
+
+    pub(crate) fn install_header_fields(&self, page_size: u32, salt_1: u32, salt_2: u32) {
+        self.page_size.store(page_size, Ordering::Release);
+        self.salt_1.store(salt_1, Ordering::Release);
+        self.salt_2.store(salt_2, Ordering::Release);
+    }
+
+    pub(crate) fn bump_checkpoint_seq(&self) -> u32 {
+        self.checkpoint_seq.fetch_add(1, Ordering::AcqRel) + 1
+    }
+
+    pub(crate) fn checkpoint_epoch(&self) -> u32 {
+        self.checkpoint_epoch.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn bump_checkpoint_epoch(&self) -> u32 {
+        self.checkpoint_epoch.fetch_add(1, Ordering::AcqRel)
+    }
+
+    pub(crate) fn try_acquire_writer(&self, owner: SharedOwnerRecord) -> bool {
+        self.writer_owner
+            .compare_exchange(
+                UNOWNED_LOCK,
+                owner.raw(),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    pub(crate) fn release_writer(&self, owner: SharedOwnerRecord) {
+        turso_assert!(
+            self.writer_owner
+                .compare_exchange(
+                    owner.raw(),
+                    UNOWNED_LOCK,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok(),
+            "writer released by non-owner"
+        );
+    }
+
+    pub(crate) fn writer_owner(&self) -> Option<SharedOwnerRecord> {
+        SharedOwnerRecord::from_raw(self.writer_owner.load(Ordering::Acquire))
+    }
+
+    pub(crate) fn try_acquire_checkpoint(&self, owner: SharedOwnerRecord) -> bool {
+        self.checkpoint_owner
+            .compare_exchange(
+                UNOWNED_LOCK,
+                owner.raw(),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    pub(crate) fn release_checkpoint(&self, owner: SharedOwnerRecord) {
+        turso_assert!(
+            self.checkpoint_owner
+                .compare_exchange(
+                    owner.raw(),
+                    UNOWNED_LOCK,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok(),
+            "checkpoint released by non-owner"
+        );
+    }
+
+    pub(crate) fn checkpoint_owner(&self) -> Option<SharedOwnerRecord> {
+        SharedOwnerRecord::from_raw(self.checkpoint_owner.load(Ordering::Acquire))
+    }
+
+    pub(crate) fn register_reader(
+        &self,
+        owner: SharedOwnerRecord,
+        max_frame: u64,
+    ) -> Option<SharedReaderSlot> {
+        let slot_index = self.reader_slots.alloc_one()?;
+        self.reader_owners[slot_index as usize].store(owner.raw(), Ordering::Release);
+        self.reader_frames[slot_index as usize].store(max_frame, Ordering::Release);
+        Some(SharedReaderSlot {
+            slot_index,
+            max_frame,
+            owner,
+        })
+    }
+
+    pub(crate) fn update_reader(&self, slot: SharedReaderSlot, max_frame: u64) -> SharedReaderSlot {
+        turso_assert!(
+            self.reader_owners[slot.slot_index as usize].load(Ordering::Acquire)
+                == slot.owner.raw(),
+            "reader slot updated by non-owner"
+        );
+        self.reader_frames[slot.slot_index as usize].store(max_frame, Ordering::Release);
+        SharedReaderSlot {
+            slot_index: slot.slot_index,
+            max_frame,
+            owner: slot.owner,
+        }
+    }
+
+    pub(crate) fn unregister_reader(&self, slot: SharedReaderSlot) {
+        turso_assert!(
+            self.reader_owners[slot.slot_index as usize].load(Ordering::Acquire)
+                == slot.owner.raw(),
+            "reader slot released by non-owner"
+        );
+        self.reader_frames[slot.slot_index as usize].store(UNUSED_READER_FRAME, Ordering::Release);
+        self.reader_owners[slot.slot_index as usize].store(UNOWNED_LOCK, Ordering::Release);
+        self.reader_slots.free_one(slot.slot_index);
+    }
+
+    pub(crate) fn reader_owner(&self, slot_index: u32) -> Option<SharedOwnerRecord> {
+        SharedOwnerRecord::from_raw(self.reader_owners[slot_index as usize].load(Ordering::Acquire))
+    }
+
+    pub(crate) fn min_active_reader_frame(&self) -> Option<u64> {
+        self.reader_frames
+            .iter()
+            .map(|frame| frame.load(Ordering::Acquire))
+            .filter(|&frame| frame != UNUSED_READER_FRAME)
+            .min()
+    }
+}
+
+impl MappedSharedWalCoordination {
+    const fn default_ownership_mode() -> SharedWalOwnershipMode {
+        if cfg!(target_os = "linux") {
+            SharedWalOwnershipMode::LinuxOfd
+        } else {
+            SharedWalOwnershipMode::ProcessScopedFcntl
+        }
+    }
+
+    fn uses_linux_ofd_locking(&self) -> bool {
+        self.ownership_mode == SharedWalOwnershipMode::LinuxOfd
+    }
+
+    const fn lock_kind_for_mode(mode: SharedWalOwnershipMode) -> SharedWalLockKind {
+        match mode {
+            SharedWalOwnershipMode::LinuxOfd => SharedWalLockKind::LinuxOfd,
+            SharedWalOwnershipMode::ProcessScopedFcntl => SharedWalLockKind::ProcessScopedFcntl,
+        }
+    }
+
+    const fn lock_kind(&self) -> SharedWalLockKind {
+        Self::lock_kind_for_mode(self.ownership_mode)
+    }
+
+    /// Register this mapping in `PROCESS_LOCAL_COORDINATION_OPENS`.
+    ///
+    /// Returns shared Arcs for locks and ownership state so that multiple
+    /// mappings of the same file (only possible in tests — production uses
+    /// `DATABASE_MANAGER` which ensures one `Database` per file) coordinate
+    /// correctly. Also returns whether this is the first mapping for this path
+    /// (`primary_process_mapping`), which controls invalidation-on-close.
+    fn register_process_mapping(
+        path: &Path,
+        reader_slot_count: u32,
+    ) -> (
+        PathBuf,
+        bool,
+        Arc<Mutex<()>>,
+        Arc<Mutex<ProcessLocalOwnershipState>>,
+    ) {
+        let canonical_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let mut opens = PROCESS_LOCAL_COORDINATION_OPENS
+            .lock()
+            .expect("process-local coordination registry poisoned");
+        let entry =
+            opens
+                .entry(canonical_path.clone())
+                .or_insert_with(|| ProcessLocalCoordinationEntry {
+                    open_count: 0,
+                    frame_index_publish_lock: Arc::new(Mutex::new(())),
+                    ownership: Arc::new(Mutex::new(ProcessLocalOwnershipState::new(
+                        reader_slot_count,
+                    ))),
+                });
+        turso_assert!(
+            entry
+                .ownership
+                .lock()
+                .expect("process-local ownership registry poisoned")
+                .reader_owners
+                .len()
+                == reader_slot_count as usize,
+            "process-local coordination slot count mismatch"
+        );
+        let primary_process_mapping = entry.open_count == 0;
+        entry.open_count += 1;
+        (
+            canonical_path,
+            primary_process_mapping,
+            entry.frame_index_publish_lock.clone(),
+            entry.ownership.clone(),
+        )
+    }
+
+    /// Open (or create) the `.tshm` coordination file at `path`.
+    ///
+    /// On first open within a host, the file is created, sized, and
+    /// initialized. Subsequent opens in other processes mmap the existing
+    /// file. The open-mode (Exclusive vs MultiProcess) is determined by
+    /// attempting an exclusive lock on byte 0: if it succeeds no other
+    /// process has the file open, so we are exclusive.
+    pub(crate) fn create_or_open(
+        io: &Arc<dyn IO>,
+        path: &Path,
+        reader_slot_count: u32,
+    ) -> Result<Self> {
+        Self::create_or_open_with_mode(io, path, reader_slot_count, Self::default_ownership_mode())
+    }
+
+    #[cfg(test)]
+    fn create_or_open_process_scoped_for_tests(
+        io: &Arc<dyn IO>,
+        path: &Path,
+        reader_slot_count: u32,
+    ) -> Result<Self> {
+        Self::create_or_open_with_mode(
+            io,
+            path,
+            reader_slot_count,
+            SharedWalOwnershipMode::ProcessScopedFcntl,
+        )
+    }
+
+    fn create_or_open_with_mode(
+        io: &Arc<dyn IO>,
+        path: &Path,
+        reader_slot_count: u32,
+        ownership_mode: SharedWalOwnershipMode,
+    ) -> Result<Self> {
+        turso_assert!(
+            reader_slot_count >= 64 && reader_slot_count % 64 == 0,
+            "reader_slot_count must be a non-zero multiple of 64"
+        );
+
+        let base_len = Self::base_mapped_len(reader_slot_count);
+        let initial_file_len =
+            Self::file_len_for_blocks(reader_slot_count, INITIAL_FRAME_INDEX_BLOCKS);
+        let file = io.open_shared_wal_file(path.to_str().ok_or_else(|| {
+            LimboError::InternalError("shared WAL coordination path is not valid UTF-8".into())
+        })?)?;
+        let lock_kind = Self::lock_kind_for_mode(ownership_mode);
+        let open_mode =
+            match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
+                true => {
+                    file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
+                    file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+                    SharedWalCoordinationOpenMode::Exclusive
+                }
+                false => {
+                    file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+                    SharedWalCoordinationOpenMode::MultiProcess
+                }
+            };
+        let metadata_len = file.size()? as usize;
+        let initialize = metadata_len == 0
+            || (open_mode == SharedWalCoordinationOpenMode::Exclusive && metadata_len < base_len);
+        if open_mode == SharedWalCoordinationOpenMode::MultiProcess && metadata_len < base_len {
+            file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination file is smaller than the coordination header: got {metadata_len}, minimum {base_len}"
+            )));
+        }
+        if initialize {
+            file.shared_wal_set_len(initial_file_len as u64)?;
+        }
+
+        let base_mapping = file.shared_wal_map(0, base_len)?;
+        let base_ptr = base_mapping.ptr();
+
+        let mut region = Self {
+            file,
+            _base_mapping: base_mapping,
+            base_ptr,
+            base_len,
+            owner_record: SharedOwnerRecord::current_process(next_shared_owner_instance_id()),
+            ownership_mode,
+            frame_index_blocks: RwLock::new(Vec::new()),
+            frame_index_publish_lock: Arc::new(Mutex::new(())),
+            process_local_ownership: Arc::new(Mutex::new(ProcessLocalOwnershipState::new(
+                reader_slot_count,
+            ))),
+            local_lock_state: Mutex::new(LocalLockState {
+                writer_lock_held: false,
+                checkpoint_lock_held: false,
+                reader_locks: vec![0; reader_slot_count as usize],
+            }),
+            open_mode,
+            primary_process_mapping: false,
+            registry_path: None,
+        };
+        if initialize {
+            region.initialize(reader_slot_count);
+        } else if let Err(err) = region.validate_existing(reader_slot_count, metadata_len) {
+            if open_mode == SharedWalCoordinationOpenMode::Exclusive {
+                region.file.shared_wal_set_len(initial_file_len as u64)?;
+                region.initialize(reader_slot_count);
+            } else {
+                return Err(err);
+            }
+        }
+        let mapped_blocks = region.header().frame_index_blocks.load(Ordering::Acquire);
+        region.ensure_mapped_frame_index_blocks(mapped_blocks)?;
+        let (
+            registry_path,
+            primary_process_mapping,
+            frame_index_publish_lock,
+            process_local_ownership,
+        ) = Self::register_process_mapping(path, reader_slot_count);
+        region.frame_index_publish_lock = frame_index_publish_lock;
+        region.process_local_ownership = process_local_ownership;
+        region.primary_process_mapping = primary_process_mapping;
+        region.registry_path = Some(registry_path);
+        Ok(region)
+    }
+
+    fn process_lock_offset_for_reader(slot_index: u32) -> u64 {
+        READER_LOCK_START_OFFSET + slot_index as u64
+    }
+
+    pub(crate) fn is_last_process_mapping(&self) -> bool {
+        if !matches!(
+            self.file.shared_wal_try_lock_byte(
+                PROCESS_LIFETIME_LOCK_OFFSET,
+                true,
+                self.lock_kind(),
+            ),
+            Ok(true)
+        ) {
+            return false;
+        }
+        let _ = self
+            .file
+            .shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, self.lock_kind());
+        true
+    }
+
+    fn release_owned_locks_on_drop(&mut self) {
+        let (writer_lock_held, checkpoint_lock_held, reader_locks) = {
+            let local = self
+                .local_lock_state
+                .get_mut()
+                .expect("shared WAL local lock state poisoned");
+            let writer_lock_held = local.writer_lock_held;
+            let checkpoint_lock_held = local.checkpoint_lock_held;
+            let reader_locks = std::mem::take(&mut local.reader_locks);
+            local.writer_lock_held = false;
+            local.checkpoint_lock_held = false;
+            (writer_lock_held, checkpoint_lock_held, reader_locks)
+        };
+
+        if writer_lock_held {
+            if self.uses_linux_ofd_locking() {
+                let _ = self
+                    .file
+                    .shared_wal_unlock_byte(WRITER_LOCK_OFFSET, self.lock_kind());
+                self.header()
+                    .writer_owner
+                    .store(UNOWNED_LOCK, Ordering::Release);
+            } else {
+                let _ = self
+                    .file
+                    .shared_wal_unlock_byte(WRITER_LOCK_OFFSET, self.lock_kind());
+                let _ = self.header().writer_owner.compare_exchange(
+                    self.owner_record.raw(),
+                    UNOWNED_LOCK,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                );
+                self.with_process_local_ownership(|entry| {
+                    if entry.writer_owner == Some(self.owner_record) {
+                        entry.writer_owner = None;
+                    }
+                });
+            }
+        }
+
+        if checkpoint_lock_held {
+            if self.uses_linux_ofd_locking() {
+                let _ = self
+                    .file
+                    .shared_wal_unlock_byte(CHECKPOINT_LOCK_OFFSET, self.lock_kind());
+                self.header()
+                    .checkpoint_owner
+                    .store(UNOWNED_LOCK, Ordering::Release);
+            } else {
+                let _ = self
+                    .file
+                    .shared_wal_unlock_byte(CHECKPOINT_LOCK_OFFSET, self.lock_kind());
+                let _ = self.header().checkpoint_owner.compare_exchange(
+                    self.owner_record.raw(),
+                    UNOWNED_LOCK,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                );
+                self.with_process_local_ownership(|entry| {
+                    if entry.checkpoint_owner == Some(self.owner_record) {
+                        entry.checkpoint_owner = None;
+                    }
+                });
+            }
+        }
+
+        for (slot_index, held_count) in reader_locks.into_iter().enumerate() {
+            if held_count == 0 {
+                continue;
+            }
+            let slot_index_u32 = slot_index as u32;
+            let _ = self.file.shared_wal_unlock_byte(
+                Self::process_lock_offset_for_reader(slot_index_u32),
+                self.lock_kind(),
+            );
+            self.reader_frames()[slot_index].store(UNUSED_READER_FRAME, Ordering::Release);
+            if self.uses_linux_ofd_locking() {
+                self.reader_owners()[slot_index].store(UNOWNED_LOCK, Ordering::Release);
+            } else {
+                let _ = self.reader_owners()[slot_index].compare_exchange(
+                    self.owner_record.raw(),
+                    UNOWNED_LOCK,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                );
+                self.with_process_local_ownership(|entry| {
+                    if entry.reader_owner(slot_index_u32) == Some(self.owner_record) {
+                        entry.reader_owners[slot_index] = None;
+                    }
+                });
+            }
+            let word_idx = slot_index >> 6;
+            let bit = slot_index & 63;
+            self.reader_bitmap_words()[word_idx].fetch_or(1u64 << bit, Ordering::Release);
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> SharedWalCoordinationHeader {
+        let header = self.header();
+        SharedWalCoordinationHeader {
+            max_frame: header.max_frame.load(Ordering::Acquire),
+            nbackfills: header.nbackfills.load(Ordering::Acquire),
+            transaction_count: header.transaction_count.load(Ordering::Acquire),
+            visibility_generation: header.visibility_generation.load(Ordering::Acquire),
+            checkpoint_seq: header.checkpoint_seq.load(Ordering::Acquire),
+            checkpoint_epoch: header.checkpoint_epoch.load(Ordering::Acquire),
+            page_size: header.page_size.load(Ordering::Acquire),
+            salt_1: header.salt_1.load(Ordering::Acquire),
+            salt_2: header.salt_2.load(Ordering::Acquire),
+            checksum_1: header.checksum_1.load(Ordering::Acquire),
+            checksum_2: header.checksum_2.load(Ordering::Acquire),
+            reader_slot_count: header.reader_slot_count,
+        }
+    }
+
+    pub(crate) const fn open_mode(&self) -> SharedWalCoordinationOpenMode {
+        self.open_mode
+    }
+
+    pub(crate) const fn owner_record(&self) -> SharedOwnerRecord {
+        self.owner_record
+    }
+
+    pub(crate) const fn is_primary_process_mapping(&self) -> bool {
+        self.primary_process_mapping
+    }
+
+    pub(crate) fn install_snapshot(&self, snapshot: SharedWalCoordinationHeader) {
+        // Snapshots define the authoritative visible WAL range. If the shared
+        // frame index still carries entries from an older generation past that
+        // range, trim them before publishing the new header so later frame
+        // appends cannot observe a stale tail.
+        self.rollback_frames(snapshot.max_frame);
+
+        let header = self.header();
+        header
+            .max_frame
+            .store(snapshot.max_frame, Ordering::Release);
+        header
+            .nbackfills
+            .store(snapshot.nbackfills, Ordering::Release);
+        header
+            .transaction_count
+            .store(snapshot.transaction_count, Ordering::Release);
+        header
+            .visibility_generation
+            .store(snapshot.visibility_generation, Ordering::Release);
+        header
+            .checkpoint_seq
+            .store(snapshot.checkpoint_seq, Ordering::Release);
+        header
+            .checkpoint_epoch
+            .store(snapshot.checkpoint_epoch, Ordering::Release);
+        header
+            .page_size
+            .store(snapshot.page_size, Ordering::Release);
+        header.salt_1.store(snapshot.salt_1, Ordering::Release);
+        header.salt_2.store(snapshot.salt_2, Ordering::Release);
+        header
+            .checksum_1
+            .store(snapshot.checksum_1, Ordering::Release);
+        header
+            .checksum_2
+            .store(snapshot.checksum_2, Ordering::Release);
+    }
+
+    /// Reset transient runtime state when a process determines that it can
+    /// repair the tshm from a local WAL disk scan.
+    ///
+    /// Clears writer/checkpoint owners and the frame index unconditionally
+    /// (the caller holds the writer lock or has verified no writer is active).
+    ///
+    /// For reader slots, we must NOT blindly clear slots owned by
+    /// live processes: doing so would cause those processes to panic with
+    /// "reader slot released by non-owner" when they try to end their read
+    /// transactions, corrupting the shared WAL state.
+    ///
+    /// - **OFD (Linux)**: probe each slot's OFD byte-range lock. If the lock
+    ///   can be acquired, the owner is dead and the slot is safe to reclaim.
+    /// - **Process-scoped fcntl (macOS)**: check `kill(pid, 0)` on the slot's
+    ///   `SharedOwnerRecord` PID. Same semantics — dead owner ⇒ reclaim.
+    pub(crate) fn reset_runtime_state_for_exclusive_open(&self) {
+        let header = self.header();
+        header.writer_owner.store(UNOWNED_LOCK, Ordering::Release);
+        header
+            .checkpoint_owner
+            .store(UNOWNED_LOCK, Ordering::Release);
+        header.frame_index_len.store(0, Ordering::Release);
+        header.frame_index_overflowed.store(0, Ordering::Release);
+
+        // For reader slots, we must check OFD locks before
+        // clearing: another live process may hold a slot. Blindly clearing
+        // would cause that process to panic with "reader slot released by
+        // non-owner" and corrupt the shared WAL state.
+        if self.uses_linux_ofd_locking() {
+            for slot_index in 0..header.reader_slot_count {
+                let offset = Self::process_lock_offset_for_reader(slot_index);
+                match self
+                    .file
+                    .shared_wal_try_lock_byte(offset, true, self.lock_kind())
+                {
+                    Ok(true) => {
+                        // Lock acquired → slot is stale (owner is dead), safe to clear.
+                        self.reader_frames()[slot_index as usize]
+                            .store(UNUSED_READER_FRAME, Ordering::Release);
+                        self.reader_owners()[slot_index as usize]
+                            .store(UNOWNED_LOCK, Ordering::Release);
+                        let word_idx = (slot_index >> 6) as usize;
+                        let bit = slot_index & 63;
+                        self.reader_bitmap_words()[word_idx]
+                            .fetch_or(1u64 << bit, Ordering::Release);
+                        self.file
+                            .shared_wal_unlock_byte(offset, self.lock_kind())
+                            .expect("failed to release reader slot lock during reset");
+                    }
+                    Ok(false) | Err(_) => {
+                        // Lock held by another live process → leave this slot alone.
+                    }
+                }
+            }
+        } else {
+            // Non-OFD path (macOS, etc.): use PID liveness checks to avoid
+            // clearing reader slots owned by live processes.
+            for slot_index in 0..header.reader_slot_count {
+                let owner = self.reader_owner(slot_index);
+                match owner {
+                    None => {
+                        // Already unowned — ensure bitmap marks it available.
+                        self.reader_frames()[slot_index as usize]
+                            .store(UNUSED_READER_FRAME, Ordering::Release);
+                        let word_idx = (slot_index >> 6) as usize;
+                        let bit = slot_index & 63;
+                        self.reader_bitmap_words()[word_idx]
+                            .fetch_or(1u64 << bit, Ordering::Release);
+                    }
+                    Some(owner_rec) => {
+                        if pid_is_alive(owner_rec.pid()) {
+                            // Owner is alive — leave this slot alone.
+                            continue;
+                        }
+                        // Owner is dead — safe to reclaim.
+                        self.try_reclaim_dead_reader_owner(slot_index, owner_rec);
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn frame_index_overflowed(&self) -> bool {
+        self.header().frame_index_overflowed.load(Ordering::Acquire) != 0
+    }
+
+    pub(crate) fn publish_commit(
+        &self,
+        max_frame: u64,
+        checksum_1: u32,
+        checksum_2: u32,
+        transaction_count: u64,
+    ) {
+        let header = self.header();
+        // Use fetch_max to ensure we never lower max_frame. In multi-process
+        // mode, another process may have committed frames after ours, advancing
+        // max_frame beyond our local value. Overwriting with a smaller value
+        // would make those later frames invisible to checkpoints, causing data loss.
+        header.max_frame.fetch_max(max_frame, Ordering::AcqRel);
+        // Only update checksums if we are the latest writer (our max_frame is the current max).
+        // Otherwise, a later writer's checksums are authoritative.
+        if header.max_frame.load(Ordering::Acquire) == max_frame {
+            header.checksum_1.store(checksum_1, Ordering::Release);
+            header.checksum_2.store(checksum_2, Ordering::Release);
+        }
+        header
+            .transaction_count
+            .store(transaction_count, Ordering::Release);
+        header.visibility_generation.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub(crate) fn publish_backfill(&self, nbackfills: u64) {
+        self.header()
+            .nbackfills
+            .store(nbackfills, Ordering::Release);
+    }
+
+    pub(crate) fn install_header_fields(&self, page_size: u32, salt_1: u32, salt_2: u32) {
+        let header = self.header();
+        header.page_size.store(page_size, Ordering::Release);
+        header.salt_1.store(salt_1, Ordering::Release);
+        header.salt_2.store(salt_2, Ordering::Release);
+    }
+
+    pub(crate) fn bump_checkpoint_seq(&self) -> u32 {
+        self.header().checkpoint_seq.fetch_add(1, Ordering::AcqRel) + 1
+    }
+
+    pub(crate) fn checkpoint_epoch(&self) -> u32 {
+        self.header().checkpoint_epoch.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn bump_checkpoint_epoch(&self) -> u32 {
+        self.header()
+            .checkpoint_epoch
+            .fetch_add(1, Ordering::AcqRel)
+    }
+
+    fn with_local_lock_state<T>(&self, f: impl FnOnce(&mut LocalLockState) -> T) -> T {
+        let mut entry = self
+            .local_lock_state
+            .lock()
+            .expect("shared WAL local lock state poisoned");
+        f(&mut entry)
+    }
+
+    fn with_process_local_ownership<T>(
+        &self,
+        f: impl FnOnce(&mut ProcessLocalOwnershipState) -> T,
+    ) -> T {
+        let mut entry = self
+            .process_local_ownership
+            .lock()
+            .expect("process-local ownership registry poisoned");
+        f(&mut entry)
+    }
+
+    fn try_acquire_shared_owner_slot(slot: &AtomicU64, owner: SharedOwnerRecord) -> bool {
+        let desired = owner.raw();
+        loop {
+            let current = slot.load(Ordering::Acquire);
+            if current == UNOWNED_LOCK {
+                return slot
+                    .compare_exchange(UNOWNED_LOCK, desired, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok();
+            }
+            if current == desired {
+                return false;
+            }
+            let Some(current_owner) = SharedOwnerRecord::from_raw(current) else {
+                continue;
+            };
+            if pid_is_alive(current_owner.pid()) {
+                return false;
+            }
+            if slot
+                .compare_exchange(current, desired, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return true;
+            }
+        }
+    }
+
+    fn shared_owner_slot_active(slot: &AtomicU64) -> bool {
+        loop {
+            let current = slot.load(Ordering::Acquire);
+            let Some(owner) = SharedOwnerRecord::from_raw(current) else {
+                return false;
+            };
+            if pid_is_alive(owner.pid()) {
+                return true;
+            }
+            if slot
+                .compare_exchange(current, UNOWNED_LOCK, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return false;
+            }
+        }
+    }
+
+    fn release_shared_owner_slot(slot: &AtomicU64, owner: SharedOwnerRecord, _what: &str) {
+        turso_assert!(
+            slot.compare_exchange(
+                owner.raw(),
+                UNOWNED_LOCK,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok(),
+            "shared owner slot released by non-owner"
+        );
+    }
+
+    /// Try to reclaim a reader slot whose owner PID is dead (non-OFD path).
+    /// Uses `kill(pid, 0)` to check liveness, then CAS to atomically clear
+    /// the owner. Returns true if the slot was successfully reclaimed.
+    fn try_reclaim_dead_reader_owner(&self, slot_index: u32, owner: SharedOwnerRecord) -> bool {
+        if self.with_process_local_ownership(|entry| entry.reader_owner(slot_index).is_some()) {
+            return false;
+        }
+        if pid_is_alive(owner.pid()) {
+            return false;
+        }
+        if self.reader_owners()[slot_index as usize]
+            .compare_exchange(
+                owner.raw(),
+                UNOWNED_LOCK,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return false;
+        }
+        self.reader_frames()[slot_index as usize].store(UNUSED_READER_FRAME, Ordering::Release);
+        let word_idx = (slot_index >> 6) as usize;
+        let bit = slot_index & 63;
+        self.reader_bitmap_words()[word_idx].fetch_or(1u64 << bit, Ordering::Release);
+        true
+    }
+
+    fn try_acquire_supplemental_byte_lock(&self, offset: u64) -> bool {
+        matches!(
+            self.file
+                .shared_wal_try_lock_byte(offset, true, self.lock_kind()),
+            Ok(true)
+        )
+    }
+
+    fn release_supplemental_byte_lock(&self, offset: u64) {
+        self.file
+            .shared_wal_unlock_byte(offset, self.lock_kind())
+            .expect("failed to release shared WAL supplemental byte lock");
+    }
+
+    pub(crate) fn try_acquire_writer(&self, owner: SharedOwnerRecord) -> bool {
+        let mut local = self
+            .local_lock_state
+            .lock()
+            .expect("shared WAL local lock state poisoned");
+        if local.writer_lock_held {
+            return false;
+        }
+        if self.uses_linux_ofd_locking() {
+            if !matches!(
+                self.file
+                    .shared_wal_try_lock_byte(WRITER_LOCK_OFFSET, true, self.lock_kind(),),
+                Ok(true)
+            ) {
+                return false;
+            }
+        } else {
+            if !self.with_process_local_ownership(|entry| entry.try_acquire_writer(owner)) {
+                return false;
+            }
+            if !Self::try_acquire_shared_owner_slot(&self.header().writer_owner, owner) {
+                self.with_process_local_ownership(|entry| entry.release_writer(owner));
+                return false;
+            }
+            if !self.try_acquire_supplemental_byte_lock(WRITER_LOCK_OFFSET) {
+                Self::release_shared_owner_slot(&self.header().writer_owner, owner, "writer");
+                self.with_process_local_ownership(|entry| entry.release_writer(owner));
+                return false;
+            }
+        }
+        local.writer_lock_held = true;
+        drop(local);
+        if self.uses_linux_ofd_locking() {
+            self.header()
+                .writer_owner
+                .store(owner.raw(), Ordering::Release);
+        }
+        true
+    }
+
+    pub(crate) fn release_writer(&self, owner: SharedOwnerRecord) {
+        let mut local = self
+            .local_lock_state
+            .lock()
+            .expect("shared WAL local lock state poisoned");
+        turso_assert!(local.writer_lock_held, "writer registry count underflow");
+        if self.uses_linux_ofd_locking() {
+            let observed_owner = self.header().writer_owner.load(Ordering::Acquire);
+            if observed_owner != owner.raw() {
+                tracing::debug!(
+                    observed_owner,
+                    owner = owner.raw(),
+                    "releasing shared WAL writer lock with stale owner field"
+                );
+            }
+            self.header()
+                .writer_owner
+                .store(UNOWNED_LOCK, Ordering::Release);
+            self.file
+                .shared_wal_unlock_byte(WRITER_LOCK_OFFSET, self.lock_kind())
+                .expect("failed to release shared WAL writer lock");
+        } else {
+            self.release_supplemental_byte_lock(WRITER_LOCK_OFFSET);
+            Self::release_shared_owner_slot(&self.header().writer_owner, owner, "writer");
+            self.with_process_local_ownership(|entry| entry.release_writer(owner));
+        }
+        local.writer_lock_held = false;
+    }
+
+    fn byte_lock_is_held(&self, offset: u64, local_held: bool) -> bool {
+        if local_held {
+            return true;
+        }
+        match self
+            .file
+            .shared_wal_try_lock_byte(offset, true, self.lock_kind())
+        {
+            Ok(true) => {
+                self.file
+                    .shared_wal_unlock_byte(offset, self.lock_kind())
+                    .expect("failed to release probed shared WAL byte lock");
+                false
+            }
+            Ok(false) => true,
+            Err(err) => {
+                tracing::debug!(offset, ?err, "failed probing shared WAL byte lock state");
+                true
+            }
+        }
+    }
+
+    pub(crate) fn writer_or_checkpoint_lock_active(&self) -> bool {
+        let (writer_held, checkpoint_held) = self
+            .with_local_lock_state(|entry| (entry.writer_lock_held, entry.checkpoint_lock_held));
+        if self.uses_linux_ofd_locking() {
+            return self.byte_lock_is_held(WRITER_LOCK_OFFSET, writer_held)
+                || self.byte_lock_is_held(CHECKPOINT_LOCK_OFFSET, checkpoint_held);
+        }
+        if self.with_process_local_ownership(|entry| {
+            entry.writer_active() || entry.checkpoint_active()
+        }) {
+            return true;
+        }
+        Self::shared_owner_slot_active(&self.header().writer_owner)
+            || Self::shared_owner_slot_active(&self.header().checkpoint_owner)
+    }
+
+    pub(crate) fn checkpoint_lock_active(&self) -> bool {
+        let checkpoint_held = self.with_local_lock_state(|entry| entry.checkpoint_lock_held);
+        if self.uses_linux_ofd_locking() {
+            return self.byte_lock_is_held(CHECKPOINT_LOCK_OFFSET, checkpoint_held);
+        }
+        if self.with_process_local_ownership(|entry| entry.checkpoint_active()) {
+            return true;
+        }
+        Self::shared_owner_slot_active(&self.header().checkpoint_owner)
+    }
+
+    pub(crate) fn writer_owner(&self) -> Option<SharedOwnerRecord> {
+        SharedOwnerRecord::from_raw(self.header().writer_owner.load(Ordering::Acquire))
+    }
+
+    pub(crate) fn try_acquire_checkpoint(&self, owner: SharedOwnerRecord) -> bool {
+        let mut local = self
+            .local_lock_state
+            .lock()
+            .expect("shared WAL local lock state poisoned");
+        if local.checkpoint_lock_held {
+            return false;
+        }
+        if self.uses_linux_ofd_locking() {
+            if !matches!(
+                self.file
+                    .shared_wal_try_lock_byte(CHECKPOINT_LOCK_OFFSET, true, self.lock_kind(),),
+                Ok(true)
+            ) {
+                return false;
+            }
+        } else {
+            if !self.with_process_local_ownership(|entry| entry.try_acquire_checkpoint(owner)) {
+                return false;
+            }
+            if !Self::try_acquire_shared_owner_slot(&self.header().checkpoint_owner, owner) {
+                self.with_process_local_ownership(|entry| entry.release_checkpoint(owner));
+                return false;
+            }
+            if !self.try_acquire_supplemental_byte_lock(CHECKPOINT_LOCK_OFFSET) {
+                Self::release_shared_owner_slot(
+                    &self.header().checkpoint_owner,
+                    owner,
+                    "checkpoint",
+                );
+                self.with_process_local_ownership(|entry| entry.release_checkpoint(owner));
+                return false;
+            }
+        }
+        local.checkpoint_lock_held = true;
+        drop(local);
+        if self.uses_linux_ofd_locking() {
+            self.header()
+                .checkpoint_owner
+                .store(owner.raw(), Ordering::Release);
+        }
+        true
+    }
+
+    pub(crate) fn release_checkpoint(&self, owner: SharedOwnerRecord) {
+        let mut local = self
+            .local_lock_state
+            .lock()
+            .expect("shared WAL local lock state poisoned");
+        turso_assert!(
+            local.checkpoint_lock_held,
+            "checkpoint registry count underflow"
+        );
+        if self.uses_linux_ofd_locking() {
+            let observed_owner = self.header().checkpoint_owner.load(Ordering::Acquire);
+            if observed_owner != owner.raw() {
+                tracing::debug!(
+                    observed_owner,
+                    owner = owner.raw(),
+                    "releasing shared WAL checkpoint lock with stale owner field"
+                );
+            }
+            self.header()
+                .checkpoint_owner
+                .store(UNOWNED_LOCK, Ordering::Release);
+            self.file
+                .shared_wal_unlock_byte(CHECKPOINT_LOCK_OFFSET, self.lock_kind())
+                .expect("failed to release shared WAL checkpoint lock");
+        } else {
+            self.release_supplemental_byte_lock(CHECKPOINT_LOCK_OFFSET);
+            Self::release_shared_owner_slot(&self.header().checkpoint_owner, owner, "checkpoint");
+            self.with_process_local_ownership(|entry| entry.release_checkpoint(owner));
+        }
+        local.checkpoint_lock_held = false;
+    }
+
+    pub(crate) fn checkpoint_owner(&self) -> Option<SharedOwnerRecord> {
+        SharedOwnerRecord::from_raw(self.header().checkpoint_owner.load(Ordering::Acquire))
+    }
+
+    fn try_reclaim_stale_reader_slot(&self, slot_index: u32) -> bool {
+        if self.uses_linux_ofd_locking() {
+            let should_probe = self.with_local_lock_state(|entry| {
+                turso_assert!(
+                    (slot_index as usize) < entry.reader_locks.len(),
+                    "reader slot registry index out of range"
+                );
+                entry.reader_locks[slot_index as usize] == 0
+            });
+            if !should_probe {
+                return false;
+            }
+            let offset = Self::process_lock_offset_for_reader(slot_index);
+            if !matches!(
+                self.file
+                    .shared_wal_try_lock_byte(offset, true, self.lock_kind()),
+                Ok(true)
+            ) {
+                return false;
+            }
+            self.reader_frames()[slot_index as usize].store(UNUSED_READER_FRAME, Ordering::Release);
+            self.reader_owners()[slot_index as usize].store(UNOWNED_LOCK, Ordering::Release);
+            let word_idx = (slot_index >> 6) as usize;
+            let bit = slot_index & 63;
+            self.reader_bitmap_words()[word_idx].fetch_or(1u64 << bit, Ordering::Release);
+            self.file
+                .shared_wal_unlock_byte(offset, self.lock_kind())
+                .expect("failed to release reclaimed reader slot lock");
+            return true;
+        }
+        let expected_owner = self.reader_owner(slot_index);
+        let Some(owner) = expected_owner else {
+            return false;
+        };
+        self.try_reclaim_dead_reader_owner(slot_index, owner)
+    }
+
+    fn reclaim_stale_reader_slots(&self) {
+        for slot_index in 0..self.header().reader_slot_count {
+            let word_idx = (slot_index >> 6) as usize;
+            let bit = slot_index & 63;
+            let mask = 1u64 << bit;
+            if self.reader_bitmap_words()[word_idx].load(Ordering::Acquire) & mask == 0 {
+                self.try_reclaim_stale_reader_slot(slot_index);
+            }
+        }
+    }
+
+    /// Claim a shared reader slot for a read transaction.
+    ///
+    /// Scans the bitmap for a free slot, atomically clears its bit, then
+    /// acquires the platform-specific lock (OFD byte lock on Linux, supplemental
+    /// fcntl lock on macOS). On success, stores `owner` and `max_frame` in
+    /// shared memory so checkpoints can see where this reader is pinned.
+    ///
+    /// If all slots are taken, one retry is attempted after running stale-slot
+    /// reclamation (which probes whether slot owners are still alive).
+    ///
+    /// Returns `None` if no slot could be acquired (all occupied by live processes).
+    pub(crate) fn register_reader(
+        &self,
+        owner: SharedOwnerRecord,
+        max_frame: u64,
+    ) -> Option<SharedReaderSlot> {
+        for attempt in 0..2 {
+            let bitmap = self.reader_bitmap_words();
+            let mut local = self
+                .local_lock_state
+                .lock()
+                .expect("shared WAL local lock state poisoned");
+            let mut process_local = self
+                .process_local_ownership
+                .lock()
+                .expect("process-local ownership registry poisoned");
+            for slot_index in 0..self.header().reader_slot_count {
+                if local.reader_locks[slot_index as usize] > 0 {
+                    continue;
+                }
+                if !self.uses_linux_ofd_locking()
+                    && process_local.reader_owner(slot_index).is_some()
+                {
+                    continue;
+                }
+                let word_idx = (slot_index >> 6) as usize;
+                let bit = slot_index & 63;
+                let mask = 1u64 << bit;
+                let word = &bitmap[word_idx];
+                let mut current = word.load(Ordering::Acquire);
+                while current & mask != 0 {
+                    let desired = current & !mask;
+                    match word.compare_exchange_weak(
+                        current,
+                        desired,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    ) {
+                        Ok(_) => {
+                            if self.uses_linux_ofd_locking() {
+                                let offset = Self::process_lock_offset_for_reader(slot_index);
+                                match self.file.shared_wal_try_lock_byte(
+                                    offset,
+                                    true,
+                                    self.lock_kind(),
+                                ) {
+                                    Ok(true) => {
+                                        local.reader_locks[slot_index as usize] += 1;
+                                        self.reader_owners()[slot_index as usize]
+                                            .store(owner.raw(), Ordering::Release);
+                                        self.reader_frames()[slot_index as usize]
+                                            .store(max_frame, Ordering::Release);
+                                        drop(process_local);
+                                        drop(local);
+                                        return Some(SharedReaderSlot {
+                                            slot_index,
+                                            max_frame,
+                                            owner,
+                                        });
+                                    }
+                                    Ok(false) | Err(_) => {
+                                        word.fetch_or(mask, Ordering::Release);
+                                        break;
+                                    }
+                                }
+                            } else {
+                                if !process_local.try_register_reader(slot_index, owner) {
+                                    word.fetch_or(mask, Ordering::Release);
+                                    break;
+                                }
+                                if self.reader_owners()[slot_index as usize]
+                                    .compare_exchange(
+                                        UNOWNED_LOCK,
+                                        owner.raw(),
+                                        Ordering::AcqRel,
+                                        Ordering::Acquire,
+                                    )
+                                    .is_err()
+                                {
+                                    process_local.unregister_reader(slot_index, owner);
+                                    word.fetch_or(mask, Ordering::Release);
+                                    break;
+                                }
+                                let offset = Self::process_lock_offset_for_reader(slot_index);
+                                if !self.try_acquire_supplemental_byte_lock(offset) {
+                                    Self::release_shared_owner_slot(
+                                        &self.reader_owners()[slot_index as usize],
+                                        owner,
+                                        "reader slot",
+                                    );
+                                    process_local.unregister_reader(slot_index, owner);
+                                    word.fetch_or(mask, Ordering::Release);
+                                    break;
+                                }
+                                local.reader_locks[slot_index as usize] += 1;
+                                self.reader_frames()[slot_index as usize]
+                                    .store(max_frame, Ordering::Release);
+                                drop(process_local);
+                                drop(local);
+                                return Some(SharedReaderSlot {
+                                    slot_index,
+                                    max_frame,
+                                    owner,
+                                });
+                            }
+                        }
+                        Err(actual) => current = actual,
+                    }
+                }
+            }
+            drop(process_local);
+            drop(local);
+            if attempt == 0 {
+                self.reclaim_stale_reader_slots();
+            }
+        }
+        None
+    }
+
+    pub(crate) fn update_reader(&self, slot: SharedReaderSlot, max_frame: u64) -> SharedReaderSlot {
+        turso_assert!(
+            self.reader_owners()[slot.slot_index as usize].load(Ordering::Acquire)
+                == slot.owner.raw(),
+            "reader slot updated by non-owner"
+        );
+        self.reader_frames()[slot.slot_index as usize].store(max_frame, Ordering::Release);
+        SharedReaderSlot {
+            slot_index: slot.slot_index,
+            max_frame,
+            owner: slot.owner,
+        }
+    }
+
+    /// Release a reader slot previously acquired by `register_reader`.
+    ///
+    /// Asserts that the current shared-memory owner matches `slot.owner` —
+    /// a mismatch means another process reclaimed this slot while we still
+    /// thought we held it, which is a correctness bug in the coordination
+    /// layer (see `reset_runtime_state_for_exclusive_open`).
+    pub(crate) fn unregister_reader(&self, slot: SharedReaderSlot) {
+        let mut local = self
+            .local_lock_state
+            .lock()
+            .expect("shared WAL local lock state poisoned");
+        turso_assert!(
+            local.reader_locks[slot.slot_index as usize] > 0,
+            "reader registry count underflow"
+        );
+        let current_owner = self.reader_owners()[slot.slot_index as usize].load(Ordering::Acquire);
+        turso_assert!(
+            current_owner == slot.owner.raw(),
+            "reader slot released by non-owner",
+            { "slot_index": slot.slot_index, "expected_owner": slot.owner.raw(), "current_owner": current_owner, "local_reader_count": local.reader_locks[slot.slot_index as usize] }
+        );
+        if self.uses_linux_ofd_locking() {
+            self.file
+                .shared_wal_unlock_byte(
+                    Self::process_lock_offset_for_reader(slot.slot_index),
+                    self.lock_kind(),
+                )
+                .expect("failed to release shared WAL reader slot lock");
+        } else {
+            self.with_process_local_ownership(|entry| {
+                entry.unregister_reader(slot.slot_index, slot.owner)
+            });
+            self.release_supplemental_byte_lock(Self::process_lock_offset_for_reader(
+                slot.slot_index,
+            ));
+            Self::release_shared_owner_slot(
+                &self.reader_owners()[slot.slot_index as usize],
+                slot.owner,
+                "reader slot",
+            );
+        }
+        local.reader_locks[slot.slot_index as usize] -= 1;
+        self.reader_frames()[slot.slot_index as usize]
+            .store(UNUSED_READER_FRAME, Ordering::Release);
+        if self.uses_linux_ofd_locking() {
+            self.reader_owners()[slot.slot_index as usize].store(UNOWNED_LOCK, Ordering::Release);
+        }
+        let word_idx = (slot.slot_index >> 6) as usize;
+        let bit = slot.slot_index & 63;
+        self.reader_bitmap_words()[word_idx].fetch_or(1u64 << bit, Ordering::Release);
+    }
+
+    pub(crate) fn reader_owner(&self, slot_index: u32) -> Option<SharedOwnerRecord> {
+        SharedOwnerRecord::from_raw(
+            self.reader_owners()[slot_index as usize].load(Ordering::Acquire),
+        )
+    }
+
+    /// Return the smallest `max_frame` across all live reader slots, or `None`
+    /// if no readers are active.
+    ///
+    /// Checkpoints use this to determine the safe backfill boundary: frames
+    /// above the minimum active reader's mark cannot be checkpointed because
+    /// that reader may still need to read the old page from the DB file.
+    ///
+    /// **Side-effect**: for each slot whose owner is detected as dead (OFD
+    /// lock can be acquired, or PID is no longer alive), the slot is reclaimed
+    /// inline and excluded from the result.
+    pub(crate) fn min_active_reader_frame(&self) -> Option<u64> {
+        self.reader_frames()
+            .iter()
+            .enumerate()
+            .filter_map(|(slot_index, frame)| {
+                if !self.uses_linux_ofd_locking() {
+                    let owner = self.reader_owner(slot_index as u32)?;
+                    let frame = frame.load(Ordering::Acquire);
+                    if frame == UNUSED_READER_FRAME {
+                        return None;
+                    }
+                    let local_owner = self.with_process_local_ownership(|entry| {
+                        entry.reader_owner(slot_index as u32)
+                    });
+                    if local_owner.is_some() {
+                        return Some(frame);
+                    }
+                    if pid_is_alive(owner.pid()) {
+                        return Some(frame);
+                    }
+                    let _ = self.try_reclaim_dead_reader_owner(slot_index as u32, owner);
+                    return None;
+                }
+                let frame = frame.load(Ordering::Acquire);
+                if frame == UNUSED_READER_FRAME {
+                    return None;
+                }
+                let local_lock_held =
+                    self.with_local_lock_state(|entry| entry.reader_locks[slot_index] > 0);
+                if local_lock_held {
+                    return Some(frame);
+                }
+                let offset = Self::process_lock_offset_for_reader(slot_index as u32);
+                match self
+                    .file
+                    .shared_wal_try_lock_byte(offset, true, self.lock_kind())
+                {
+                    Ok(true) => {
+                        self.reader_frames()[slot_index]
+                            .store(UNUSED_READER_FRAME, Ordering::Release);
+                        self.reader_owners()[slot_index].store(UNOWNED_LOCK, Ordering::Release);
+                        let word_idx = slot_index >> 6;
+                        let bit = slot_index & 63;
+                        self.reader_bitmap_words()[word_idx]
+                            .fetch_or(1u64 << bit, Ordering::Release);
+                        self.file
+                            .shared_wal_unlock_byte(offset, self.lock_kind())
+                            .expect("failed to release reclaimed reader slot lock");
+                        None
+                    }
+                    Ok(false) => Some(frame),
+                    Err(err) => panic!("failed probing shared WAL reader slot lock: {err}"),
+                }
+            })
+            .min()
+    }
+
+    /// Append a (page_id, frame_id) entry to the shared frame index.
+    ///
+    /// Called by the writer after each WAL frame is written. The frame index
+    /// is an append-only log of page→frame mappings that grows in fixed-size
+    /// blocks. Readers use it to find the latest WAL frame for a given page
+    /// without scanning the WAL file.
+    ///
+    /// The entry is written behind `frame_index_publish_lock`, and the
+    /// `frame_index_len` counter is bumped with Release ordering only after
+    /// the payload is fully written, so readers never observe a half-written slot.
+    ///
+    /// When frame_id == 1 and max_frame == 0 (WAL just restarted), the index
+    /// is reset to empty before appending.
+    #[track_caller]
+    pub(crate) fn record_frame(&self, page_id: u64, frame_id: u64) {
+        let _publish_guard = self
+            .frame_index_publish_lock
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let header = self.header();
+        if frame_id == 1 && header.max_frame.load(Ordering::Acquire) == 0 {
+            header.frame_index_len.store(0, Ordering::Release);
+            header.frame_index_overflowed.store(0, Ordering::Release);
+        }
+        let slot = loop {
+            let len = header.frame_index_len.load(Ordering::Acquire);
+            if len >= header.frame_index_capacity {
+                // The shared index has exhausted every reserved block.
+                header.frame_index_overflowed.store(1, Ordering::Release);
+                return;
+            }
+            let blocks = header.frame_index_blocks.load(Ordering::Acquire);
+            let current_capacity = blocks
+                .checked_mul(header.frame_index_block_capacity)
+                .expect("shared WAL frame index capacity overflow");
+            if len >= current_capacity {
+                if blocks >= header.frame_index_max_blocks {
+                    header.frame_index_overflowed.store(1, Ordering::Release);
+                    return;
+                }
+                if !self.try_grow_frame_index_blocks(blocks + 1) {
+                    header.frame_index_overflowed.store(1, Ordering::Release);
+                    return;
+                }
+                continue;
+            }
+            break len;
+        };
+        let required_blocks = (slot / FRAME_INDEX_BLOCK_CAPACITY) + 1;
+        self.ensure_mapped_frame_index_blocks(required_blocks)
+            .expect("shared WAL frame index block missing");
+        let mappings = self
+            .frame_index_blocks
+            .read()
+            .expect("shared WAL frame index block lock poisoned");
+        if slot > 0 {
+            let previous = Self::frame_index_entry(&mappings, slot - 1);
+            assert!(
+                frame_id > previous.frame_id,
+                "shared WAL frame ids must increase monotonically: new_frame_id={}, previous_frame_id={}, slot={}, shared_max_frame={}",
+                frame_id,
+                previous.frame_id,
+                slot,
+                header.max_frame.load(Ordering::Acquire)
+            );
+        }
+        let entry = Self::frame_index_entry_ptr(&mappings, slot);
+        let block_index = slot / FRAME_INDEX_BLOCK_CAPACITY;
+        let local_index = slot % FRAME_INDEX_BLOCK_CAPACITY;
+        if local_index == 0 {
+            Self::clear_frame_index_block_hash(&mappings[block_index as usize]);
+        }
+        unsafe {
+            std::ptr::addr_of_mut!((*entry).page_id).write(page_id);
+            std::ptr::addr_of_mut!((*entry).frame_id).write(frame_id);
+        }
+        Self::insert_frame_index_block_hash(&mappings[block_index as usize], local_index, page_id);
+        // Publish the new entry only after its payload is fully written, so
+        // readers that synchronize via frame_index_len never observe an
+        // uninitialized slot.
+        turso_assert!(
+            header
+                .frame_index_len
+                .compare_exchange(slot, slot + 1, Ordering::Release, Ordering::Acquire)
+                .is_ok(),
+            "shared WAL frame index length changed while publishing an entry"
+        );
+    }
+
+    /// Truncate the shared frame index to only contain entries with
+    /// `frame_id <= max_frame`. Called during WAL restart (max_frame=0 to
+    /// clear the entire index) and by `install_snapshot` to trim stale
+    /// entries from a previous WAL generation.
+    pub(crate) fn rollback_frames(&self, max_frame: u64) {
+        let _publish_guard = self
+            .frame_index_publish_lock
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let header = self.header();
+        let len = header
+            .frame_index_len
+            .load(Ordering::Acquire)
+            .min(header.frame_index_capacity);
+        if len == 0 {
+            return;
+        }
+        let old_blocks = len.div_ceil(FRAME_INDEX_BLOCK_CAPACITY);
+        self.ensure_mapped_frame_index_blocks(old_blocks)
+            .expect("shared WAL frame index block missing");
+        let mappings = self
+            .frame_index_blocks
+            .read()
+            .expect("shared WAL frame index block lock poisoned");
+        let mut new_len = len;
+        while new_len > 0 {
+            let last = Self::frame_index_entry(&mappings, new_len - 1);
+            if last.frame_id <= max_frame {
+                break;
+            }
+            new_len -= 1;
+        }
+        if new_len == len {
+            return;
+        }
+        header.frame_index_len.store(new_len, Ordering::Release);
+        if new_len == 0 {
+            return;
+        }
+        let retained_entries = new_len % FRAME_INDEX_BLOCK_CAPACITY;
+        if retained_entries != 0 {
+            let retained_block = (new_len - 1) / FRAME_INDEX_BLOCK_CAPACITY;
+            Self::rebuild_frame_index_block_hash(
+                &mappings[retained_block as usize],
+                retained_entries,
+            );
+        }
+    }
+
+    /// Look up the latest WAL frame containing `page_id` within the visible
+    /// range. Returns `None` if the page has no entry in the frame index
+    /// (caller should read from the DB file instead).
+    ///
+    /// `min_frame..=max_frame` is the connection's WAL window (derived from
+    /// the snapshot taken at `begin_read_tx`). `frame_watermark` optionally
+    /// narrows the upper bound for MVCC snapshot reads.
+    ///
+    /// Uses per-block hash tables for O(1) lookup within each block, scanning
+    /// blocks in reverse order so the most recent entry wins.
+    pub(crate) fn find_frame(
+        &self,
+        page_id: u64,
+        min_frame: u64,
+        max_frame: u64,
+        frame_watermark: Option<u64>,
+    ) -> Option<u64> {
+        let upper_frame = frame_watermark.unwrap_or(max_frame);
+        if upper_frame < min_frame {
+            return None;
+        }
+        let range = frame_watermark
+            .map(|watermark| 0..=watermark)
+            .unwrap_or(min_frame..=max_frame);
+        let header = self.header();
+        let len = header
+            .frame_index_len
+            .load(Ordering::Acquire)
+            .min(header.frame_index_capacity);
+        if len == 0 {
+            return None;
+        }
+        let required_blocks = len.div_ceil(FRAME_INDEX_BLOCK_CAPACITY);
+        self.ensure_mapped_frame_index_blocks(required_blocks)
+            .expect("shared WAL frame index block missing");
+        let mappings = self
+            .frame_index_blocks
+            .read()
+            .expect("shared WAL frame index block lock poisoned");
+        let visible_slots = Self::visible_frame_index_slots(&mappings, len, upper_frame);
+        if visible_slots == 0 {
+            return None;
+        }
+        let last_block = (visible_slots - 1) / FRAME_INDEX_BLOCK_CAPACITY;
+        for block_index in (0..=last_block).rev() {
+            let block_start_slot = block_index * FRAME_INDEX_BLOCK_CAPACITY;
+            let visible_entries = visible_slots
+                .saturating_sub(block_start_slot)
+                .min(FRAME_INDEX_BLOCK_CAPACITY);
+            if let Some(local_entry) =
+                Self::find_frame_in_block(&mappings[block_index as usize], page_id, visible_entries)
+            {
+                let slot = block_start_slot + local_entry;
+                let frame_id = Self::frame_index_entry(&mappings, slot).frame_id;
+                if range.contains(&frame_id) {
+                    return Some(frame_id);
+                }
+            }
+        }
+        None
+    }
+
+    /// Return the latest (page_id, frame_id) for every distinct page that has
+    /// at least one frame index entry in `min_frame..=max_frame`.
+    ///
+    /// Used by checkpoint to determine which pages need to be copied from the
+    /// WAL to the DB file. For each page, only the highest-numbered frame is
+    /// returned (that frame contains the most recent version of the page).
+    pub(crate) fn iter_latest_frames(&self, min_frame: u64, max_frame: u64) -> Vec<(u64, u64)> {
+        let header = self.header();
+        let len = header
+            .frame_index_len
+            .load(Ordering::Acquire)
+            .min(header.frame_index_capacity);
+        if len == 0 {
+            return Vec::new();
+        }
+        let required_blocks = len.div_ceil(FRAME_INDEX_BLOCK_CAPACITY);
+        self.ensure_mapped_frame_index_blocks(required_blocks)
+            .expect("shared WAL frame index block missing");
+        let mappings = self
+            .frame_index_blocks
+            .read()
+            .expect("shared WAL frame index block lock poisoned");
+        let visible_slots = Self::visible_frame_index_slots(&mappings, len, max_frame);
+        if visible_slots == 0 {
+            return Vec::new();
+        }
+        let mut seen_pages = std::collections::BTreeSet::new();
+        let mut entries = Vec::new();
+        let last_block = (visible_slots - 1) / FRAME_INDEX_BLOCK_CAPACITY;
+        for block_index in (0..=last_block).rev() {
+            let block_start_slot = block_index * FRAME_INDEX_BLOCK_CAPACITY;
+            let visible_entries = visible_slots
+                .saturating_sub(block_start_slot)
+                .min(FRAME_INDEX_BLOCK_CAPACITY);
+            let latest_in_block =
+                Self::latest_entries_in_block(&mappings[block_index as usize], visible_entries);
+            for (page_id, local_index) in latest_in_block {
+                if !seen_pages.insert(page_id) {
+                    continue;
+                }
+                let slot = block_start_slot + local_index;
+                let frame_id = Self::frame_index_entry(&mappings, slot).frame_id;
+                if (min_frame..=max_frame).contains(&frame_id) {
+                    entries.push((page_id, frame_id));
+                }
+            }
+        }
+        entries.sort_unstable_by_key(|&(page_id, _)| page_id);
+        entries
+    }
+
+    fn base_mapped_len(reader_slot_count: u32) -> usize {
+        let reader_bitmap_words = (reader_slot_count / 64) as usize;
+        let raw_len = size_of::<SharedWalCoordinationMapHeader>()
+            + reader_bitmap_words * size_of::<AtomicU64>()
+            + reader_slot_count as usize * size_of::<AtomicU64>()
+            + reader_slot_count as usize * size_of::<AtomicU64>()
+            + reader_bitmap_words * size_of::<AtomicU64>()
+            + reader_slot_count as usize * size_of::<AtomicU64>();
+        raw_len.div_ceil(SHARED_WAL_COORDINATION_MAP_ALIGNMENT)
+            * SHARED_WAL_COORDINATION_MAP_ALIGNMENT
+    }
+
+    fn frame_index_block_entry_bytes() -> usize {
+        FRAME_INDEX_BLOCK_CAPACITY as usize * size_of::<SharedWalFrameIndexEntry>()
+    }
+
+    fn frame_index_block_hash_bytes() -> usize {
+        FRAME_INDEX_BLOCK_HASH_SLOTS as usize * size_of::<u16>()
+    }
+
+    fn frame_index_block_byte_len() -> usize {
+        Self::frame_index_block_entry_bytes() + Self::frame_index_block_hash_bytes()
+    }
+
+    fn file_len_for_blocks(reader_slot_count: u32, blocks: u32) -> usize {
+        Self::base_mapped_len(reader_slot_count)
+            + blocks as usize * Self::frame_index_block_byte_len()
+    }
+
+    fn header(&self) -> &SharedWalCoordinationMapHeader {
+        unsafe {
+            &*self
+                .base_ptr
+                .as_ptr()
+                .cast::<SharedWalCoordinationMapHeader>()
+        }
+    }
+
+    fn reader_bitmap_words(&self) -> &[AtomicU64] {
+        let header = self.header();
+        let ptr = unsafe {
+            self.base_ptr
+                .as_ptr()
+                .add(size_of::<SharedWalCoordinationMapHeader>())
+                .cast::<AtomicU64>()
+        };
+        unsafe { std::slice::from_raw_parts(ptr, header.reader_bitmap_word_count as usize) }
+    }
+
+    fn reader_frames(&self) -> &[AtomicU64] {
+        let header = self.header();
+        let ptr = unsafe {
+            self.base_ptr
+                .as_ptr()
+                .add(size_of::<SharedWalCoordinationMapHeader>())
+                .add(header.reader_bitmap_word_count as usize * size_of::<AtomicU64>())
+                .cast::<AtomicU64>()
+        };
+        unsafe { std::slice::from_raw_parts(ptr, header.reader_slot_count as usize) }
+    }
+
+    fn reader_owners(&self) -> &[AtomicU64] {
+        let header = self.header();
+        let ptr = unsafe {
+            self.base_ptr
+                .as_ptr()
+                .add(size_of::<SharedWalCoordinationMapHeader>())
+                .add(header.reader_bitmap_word_count as usize * size_of::<AtomicU64>())
+                .add(header.reader_slot_count as usize * size_of::<AtomicU64>())
+                .cast::<AtomicU64>()
+        };
+        unsafe { std::slice::from_raw_parts(ptr, header.reader_slot_count as usize) }
+    }
+
+    fn map_frame_index_block(&self, block_index: u32) -> Result<FrameIndexBlockMapping> {
+        let offset = (Self::base_mapped_len(self.header().reader_slot_count)
+            + block_index as usize * Self::frame_index_block_byte_len())
+            as u64;
+        let byte_len = Self::frame_index_block_byte_len();
+        let mapping = self.file.shared_wal_map(offset, byte_len)?;
+        let ptr = mapping.ptr();
+        let entries_ptr = ptr.cast::<SharedWalFrameIndexEntry>();
+        let hash_ptr = NonNull::new(unsafe {
+            ptr.as_ptr()
+                .add(Self::frame_index_block_entry_bytes())
+                .cast::<u16>()
+        })
+        .expect("mmap returned null");
+        Ok(FrameIndexBlockMapping {
+            _mapping: mapping,
+            entries_ptr,
+            hash_ptr,
+            byte_len,
+        })
+    }
+
+    fn ensure_mapped_frame_index_blocks(&self, target_blocks: u32) -> Result<()> {
+        let mut mappings = self
+            .frame_index_blocks
+            .write()
+            .expect("shared WAL frame index block lock poisoned");
+        while mappings.len() < target_blocks as usize {
+            let block_index = mappings.len() as u32;
+            mappings.push(self.map_frame_index_block(block_index)?);
+        }
+        Ok(())
+    }
+
+    fn try_grow_frame_index_blocks(&self, target_blocks: u32) -> bool {
+        let target_len = Self::file_len_for_blocks(self.header().reader_slot_count, target_blocks);
+        if self.file.shared_wal_set_len(target_len as u64).is_err() {
+            return false;
+        }
+        if self
+            .ensure_mapped_frame_index_blocks(target_blocks)
+            .is_err()
+        {
+            return false;
+        }
+        self.header()
+            .frame_index_blocks
+            .store(target_blocks, Ordering::Release);
+        true
+    }
+
+    fn frame_index_entry(
+        mappings: &[FrameIndexBlockMapping],
+        slot: u32,
+    ) -> SharedWalFrameIndexEntry {
+        unsafe { *Self::frame_index_entry_ptr(mappings, slot) }
+    }
+
+    fn frame_index_entry_ptr(
+        mappings: &[FrameIndexBlockMapping],
+        slot: u32,
+    ) -> *mut SharedWalFrameIndexEntry {
+        let block_index = (slot / FRAME_INDEX_BLOCK_CAPACITY) as usize;
+        let entry_index = (slot % FRAME_INDEX_BLOCK_CAPACITY) as usize;
+        unsafe { mappings[block_index].entries_ptr.as_ptr().add(entry_index) }
+    }
+
+    fn frame_index_block_hash_slice(mapping: &FrameIndexBlockMapping) -> &mut [u16] {
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                mapping.hash_ptr.as_ptr(),
+                FRAME_INDEX_BLOCK_HASH_SLOTS as usize,
+            )
+        }
+    }
+
+    fn clear_frame_index_block_hash(mapping: &FrameIndexBlockMapping) {
+        Self::frame_index_block_hash_slice(mapping).fill(0);
+    }
+
+    /// sqlite wal.c:
+    /// ** To look for page P in the hash table, first compute a hash iKey on
+    /// ** P as follows:
+    /// ** iKey = (P * 383) % HASHTABLE_NSLOT
+    fn hash_page_id(page_id: u64) -> usize {
+        page_id
+            .wrapping_mul(383)
+            .rem_euclid(FRAME_INDEX_BLOCK_HASH_SLOTS as u64) as usize
+    }
+
+    fn insert_frame_index_block_hash(
+        mapping: &FrameIndexBlockMapping,
+        local_index: u32,
+        page_id: u64,
+    ) {
+        turso_assert!(
+            local_index < FRAME_INDEX_BLOCK_CAPACITY,
+            "frame index block local index out of range"
+        );
+        let hash = Self::frame_index_block_hash_slice(mapping);
+        let mut slot = Self::hash_page_id(page_id);
+        let value = (local_index + 1) as u16;
+        for _ in 0..FRAME_INDEX_BLOCK_HASH_SLOTS {
+            if hash[slot] == 0 {
+                hash[slot] = value;
+                return;
+            }
+            slot = (slot + 1) % FRAME_INDEX_BLOCK_HASH_SLOTS as usize;
+        }
+        panic!("shared WAL frame index block hash table is full");
+    }
+
+    fn rebuild_frame_index_block_hash(mapping: &FrameIndexBlockMapping, visible_entries: u32) {
+        turso_assert!(
+            visible_entries <= FRAME_INDEX_BLOCK_CAPACITY,
+            "visible block entries out of range"
+        );
+        Self::clear_frame_index_block_hash(mapping);
+        for local_index in 0..visible_entries {
+            let entry = unsafe { *mapping.entries_ptr.as_ptr().add(local_index as usize) };
+            Self::insert_frame_index_block_hash(mapping, local_index, entry.page_id);
+        }
+    }
+
+    fn find_frame_in_block(
+        mapping: &FrameIndexBlockMapping,
+        page_id: u64,
+        visible_entries: u32,
+    ) -> Option<u32> {
+        if visible_entries == 0 {
+            return None;
+        }
+        let hash = unsafe {
+            std::slice::from_raw_parts(
+                mapping.hash_ptr.as_ptr(),
+                FRAME_INDEX_BLOCK_HASH_SLOTS as usize,
+            )
+        };
+        let mut slot = Self::hash_page_id(page_id);
+        let mut latest = None;
+        for _ in 0..FRAME_INDEX_BLOCK_HASH_SLOTS {
+            let local_plus_one = hash[slot];
+            if local_plus_one == 0 {
+                break;
+            }
+            let local_index = local_plus_one as u32 - 1;
+            if local_index >= visible_entries {
+                break;
+            }
+            let entry = unsafe { *mapping.entries_ptr.as_ptr().add(local_index as usize) };
+            if entry.page_id == page_id {
+                latest = Some(local_index);
+            }
+            slot = (slot + 1) % FRAME_INDEX_BLOCK_HASH_SLOTS as usize;
+        }
+        latest
+    }
+
+    fn latest_entries_in_block(
+        mapping: &FrameIndexBlockMapping,
+        visible_entries: u32,
+    ) -> HashMap<u64, u32> {
+        let hash = unsafe {
+            std::slice::from_raw_parts(
+                mapping.hash_ptr.as_ptr(),
+                FRAME_INDEX_BLOCK_HASH_SLOTS as usize,
+            )
+        };
+        let mut latest_entries: HashMap<u64, u32> = HashMap::new();
+        for &local_plus_one in hash {
+            if local_plus_one == 0 {
+                continue;
+            }
+            let local_index = local_plus_one as u32 - 1;
+            if local_index >= visible_entries {
+                continue;
+            }
+            let entry = unsafe { *mapping.entries_ptr.as_ptr().add(local_index as usize) };
+            latest_entries
+                .entry(entry.page_id)
+                .and_modify(|latest| *latest = (*latest).max(local_index))
+                .or_insert(local_index);
+        }
+        latest_entries
+    }
+
+    /// Binary-search the frame index to find how many entries have
+    /// `frame_id <= max_frame`. Since frame IDs are monotonically increasing,
+    /// this gives the number of slots visible to a reader whose snapshot
+    /// caps out at `max_frame`.
+    fn visible_frame_index_slots(
+        mappings: &[FrameIndexBlockMapping],
+        len: u32,
+        max_frame: u64,
+    ) -> u32 {
+        let mut low = 0;
+        let mut high = len;
+        while low < high {
+            let mid = low + (high - low) / 2;
+            let frame_id = Self::frame_index_entry(mappings, mid).frame_id;
+            if frame_id <= max_frame {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        low
+    }
+
+    fn initialize(&self, reader_slot_count: u32) {
+        let header = self
+            .base_ptr
+            .as_ptr()
+            .cast::<SharedWalCoordinationMapHeader>();
+        unsafe {
+            std::ptr::addr_of_mut!((*header).magic).write(SHARED_WAL_COORDINATION_MAGIC);
+            std::ptr::addr_of_mut!((*header).version).write(SHARED_WAL_COORDINATION_VERSION);
+            std::ptr::addr_of_mut!((*header).reader_slot_count).write(reader_slot_count);
+            std::ptr::addr_of_mut!((*header).reader_bitmap_word_count)
+                .write(reader_slot_count / 64);
+            std::ptr::addr_of_mut!((*header).frame_index_block_capacity)
+                .write(FRAME_INDEX_BLOCK_CAPACITY);
+            std::ptr::addr_of_mut!((*header).frame_index_block_hash_slots)
+                .write(FRAME_INDEX_BLOCK_HASH_SLOTS);
+            std::ptr::addr_of_mut!((*header).frame_index_max_blocks).write(MAX_FRAME_INDEX_BLOCKS);
+            std::ptr::addr_of_mut!((*header).frame_index_blocks)
+                .write(AtomicU32::new(INITIAL_FRAME_INDEX_BLOCKS));
+            std::ptr::addr_of_mut!((*header).frame_index_capacity).write(MAX_FRAME_INDEX_CAPACITY);
+            std::ptr::addr_of_mut!((*header).frame_index_len).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).frame_index_overflowed).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).writer_owner).write(AtomicU64::new(UNOWNED_LOCK));
+            std::ptr::addr_of_mut!((*header).checkpoint_owner).write(AtomicU64::new(UNOWNED_LOCK));
+        }
+        // A freshly truncated file-backed mapping is already zero-filled. Avoid
+        // touching the full reserved region here, because large sparse `.tshm`
+        // files can SIGBUS on tmpfs/quota-constrained test environments if we
+        // eagerly fault in every page up front.
+        for word in self.reader_bitmap_words() {
+            word.store(u64::MAX, Ordering::Release);
+        }
+        for frame in self.reader_frames() {
+            frame.store(UNUSED_READER_FRAME, Ordering::Release);
+        }
+        for owner in self.reader_owners() {
+            owner.store(UNOWNED_LOCK, Ordering::Release);
+        }
+    }
+
+    fn validate_existing(
+        &self,
+        expected_reader_slot_count: u32,
+        metadata_len: usize,
+    ) -> Result<()> {
+        let header = self.header();
+        if header.magic != SHARED_WAL_COORDINATION_MAGIC {
+            return Err(LimboError::Corrupt(
+                "shared WAL coordination map magic mismatch".into(),
+            ));
+        }
+        if header.version != SHARED_WAL_COORDINATION_VERSION {
+            return Err(LimboError::Corrupt(format!(
+                "unsupported shared WAL coordination map version: {}",
+                header.version
+            )));
+        }
+        if header.reader_slot_count != expected_reader_slot_count {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination map slot count mismatch: got {}, expected {}",
+                header.reader_slot_count, expected_reader_slot_count
+            )));
+        }
+        if header.frame_index_block_capacity != FRAME_INDEX_BLOCK_CAPACITY {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination map frame index block capacity mismatch: got {}, expected {}",
+                header.frame_index_block_capacity, FRAME_INDEX_BLOCK_CAPACITY
+            )));
+        }
+        if header.frame_index_block_hash_slots != FRAME_INDEX_BLOCK_HASH_SLOTS {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination map frame index hash slot count mismatch: got {}, expected {}",
+                header.frame_index_block_hash_slots, FRAME_INDEX_BLOCK_HASH_SLOTS
+            )));
+        }
+        if header.frame_index_max_blocks != MAX_FRAME_INDEX_BLOCKS {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination map frame index max blocks mismatch: got {}, expected {}",
+                header.frame_index_max_blocks, MAX_FRAME_INDEX_BLOCKS
+            )));
+        }
+        let blocks = header.frame_index_blocks.load(Ordering::Acquire);
+        if !(INITIAL_FRAME_INDEX_BLOCKS..=MAX_FRAME_INDEX_BLOCKS).contains(&blocks) {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination map frame index block count out of range: {}",
+                blocks
+            )));
+        }
+        if header.frame_index_capacity != MAX_FRAME_INDEX_CAPACITY {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination map frame index capacity mismatch: got {}, expected {}",
+                header.frame_index_capacity, MAX_FRAME_INDEX_CAPACITY
+            )));
+        }
+        if header.frame_index_len.load(Ordering::Acquire) > header.frame_index_capacity {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination map frame index length exceeds capacity: len={}, capacity={}",
+                header.frame_index_len.load(Ordering::Acquire),
+                header.frame_index_capacity
+            )));
+        }
+        let current_capacity = blocks
+            .checked_mul(header.frame_index_block_capacity)
+            .expect("shared WAL frame index capacity overflow");
+        if header.frame_index_len.load(Ordering::Acquire) > current_capacity {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination map frame index length exceeds active block capacity: len={}, capacity={}",
+                header.frame_index_len.load(Ordering::Acquire),
+                current_capacity
+            )));
+        }
+        let expected_file_len = Self::file_len_for_blocks(expected_reader_slot_count, blocks);
+        if metadata_len != expected_file_len {
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination file has unexpected size: got {metadata_len}, expected {expected_file_len}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::{OpenFlags, PlatformIO, IO};
+    use crate::storage::database::DatabaseFile;
+    use crate::storage::wal::{CheckpointMode, CheckpointResult};
+    use crate::types::Value;
+    use crate::util::IOExt;
+    use crate::{Connection, Database, DatabaseOpts, IOResult, OpenDbAsyncState, Result, SyncMode};
+    use std::sync::Arc;
+
+    fn colliding_page_ids(count: usize) -> Vec<u64> {
+        turso_assert!(count > 0, "must request at least one colliding page id");
+        let target_bucket = MappedSharedWalCoordination::hash_page_id(1);
+        let mut page_ids = Vec::with_capacity(count);
+        let mut candidate = 1u64;
+        while page_ids.len() < count {
+            if MappedSharedWalCoordination::hash_page_id(candidate) == target_bucket {
+                page_ids.push(candidate);
+            }
+            candidate += 1;
+        }
+        page_ids
+    }
+
+    fn test_shared_wal_io() -> Arc<dyn IO> {
+        Arc::new(PlatformIO::new().unwrap())
+    }
+
+    fn create_mapping(path: &Path) -> MappedSharedWalCoordination {
+        MappedSharedWalCoordination::create_or_open(&test_shared_wal_io(), path, 64).unwrap()
+    }
+
+    fn create_process_scoped_mapping(path: &Path) -> MappedSharedWalCoordination {
+        MappedSharedWalCoordination::create_or_open_process_scoped_for_tests(
+            &test_shared_wal_io(),
+            path,
+            64,
+        )
+        .unwrap()
+    }
+
+    fn exited_child_pid() -> u32 {
+        let child = unsafe { libc::fork() };
+        assert!(child >= 0, "fork failed");
+        if child == 0 {
+            unsafe { libc::_exit(0) };
+        }
+        let mut status: libc::c_int = 0;
+        let waited = unsafe { libc::waitpid(child, &mut status, 0) };
+        assert_eq!(waited, child, "waitpid failed");
+        assert!(libc::WIFEXITED(status), "child did not exit cleanly");
+        child as u32
+    }
+
+    #[test]
+    fn shared_wal_coordination_header_round_trips() {
+        let header = SharedWalCoordinationHeader {
+            max_frame: 11,
+            nbackfills: 7,
+            transaction_count: 13,
+            visibility_generation: 17,
+            checkpoint_seq: 19,
+            checkpoint_epoch: 23,
+            page_size: 4096,
+            salt_1: 29,
+            salt_2: 31,
+            checksum_1: 37,
+            checksum_2: 41,
+            reader_slot_count: 64,
+        };
+
+        let encoded = header.encode();
+        let decoded = SharedWalCoordinationHeader::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.max_frame, header.max_frame);
+        assert_eq!(decoded.nbackfills, header.nbackfills);
+        assert_eq!(decoded.transaction_count, header.transaction_count);
+        assert_eq!(decoded.visibility_generation, header.visibility_generation);
+        assert_eq!(decoded.checkpoint_seq, header.checkpoint_seq);
+        assert_eq!(decoded.checkpoint_epoch, header.checkpoint_epoch);
+        assert_eq!(decoded.page_size, header.page_size);
+        assert_eq!(decoded.salt_1, header.salt_1);
+        assert_eq!(decoded.salt_2, header.salt_2);
+        assert_eq!(decoded.checksum_1, header.checksum_1);
+        assert_eq!(decoded.checksum_2, header.checksum_2);
+        assert_eq!(decoded.reader_slot_count, header.reader_slot_count);
+    }
+
+    #[test]
+    fn shared_wal_coordination_header_rejects_invalid_magic() {
+        let mut encoded = [0u8; SharedWalCoordinationHeader::BYTE_LEN];
+        encoded[0..8].copy_from_slice(b"badmagic");
+
+        let err = SharedWalCoordinationHeader::decode(&encoded).unwrap_err();
+        assert!(matches!(err, LimboError::Corrupt(_)));
+    }
+
+    #[test]
+    fn shared_owner_record_round_trips_pid_and_instance() {
+        let owner = SharedOwnerRecord::new(17, 23);
+
+        assert_eq!(owner.pid(), 17);
+        assert_eq!(owner.instance_id(), 23);
+        assert_eq!(SharedOwnerRecord::from_raw(owner.raw()), Some(owner));
+        assert_eq!(SharedOwnerRecord::from_raw(UNOWNED_LOCK), None);
+    }
+
+    #[test]
+    fn process_local_ownership_state_tracks_same_process_exclusion() {
+        let owner_a = SharedOwnerRecord::new(11, 1);
+        let owner_b = SharedOwnerRecord::new(11, 2);
+        let mut state = ProcessLocalOwnershipState::new(64);
+
+        assert!(state.try_acquire_writer(owner_a));
+        assert!(!state.try_acquire_writer(owner_b));
+        state.release_writer(owner_a);
+        assert!(state.try_acquire_writer(owner_b));
+        state.release_writer(owner_b);
+
+        assert!(state.try_acquire_checkpoint(owner_a));
+        assert!(!state.try_acquire_checkpoint(owner_b));
+        state.release_checkpoint(owner_a);
+        assert!(state.try_register_reader(7, owner_a));
+        assert!(!state.try_register_reader(7, owner_b));
+        assert_eq!(state.reader_owner(7), Some(owner_a));
+        state.unregister_reader(7, owner_a);
+        assert_eq!(state.reader_owner(7), None);
+    }
+
+    #[test]
+    fn shared_owner_slot_active_clears_dead_owner() {
+        let dead_owner = SharedOwnerRecord::new(exited_child_pid(), 99);
+        let slot = AtomicU64::new(dead_owner.raw());
+
+        assert!(!MappedSharedWalCoordination::shared_owner_slot_active(
+            &slot
+        ));
+        assert_eq!(slot.load(Ordering::Acquire), UNOWNED_LOCK);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_reclaims_dead_writer_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let dead_owner = SharedOwnerRecord::new(exited_child_pid(), 41);
+
+        mapped
+            .header()
+            .writer_owner
+            .store(dead_owner.raw(), Ordering::Release);
+
+        assert!(MappedSharedWalCoordination::try_acquire_shared_owner_slot(
+            &mapped.header().writer_owner,
+            mapped.owner_record(),
+        ));
+        assert_eq!(mapped.writer_owner(), Some(mapped.owner_record()));
+        MappedSharedWalCoordination::release_shared_owner_slot(
+            &mapped.header().writer_owner,
+            mapped.owner_record(),
+            "writer",
+        );
+        assert_eq!(mapped.writer_owner(), None);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_reclaims_dead_checkpoint_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let dead_owner = SharedOwnerRecord::new(exited_child_pid(), 42);
+
+        mapped
+            .header()
+            .checkpoint_owner
+            .store(dead_owner.raw(), Ordering::Release);
+
+        assert!(MappedSharedWalCoordination::try_acquire_shared_owner_slot(
+            &mapped.header().checkpoint_owner,
+            mapped.owner_record(),
+        ));
+        assert_eq!(mapped.checkpoint_owner(), Some(mapped.owner_record()));
+        MappedSharedWalCoordination::release_shared_owner_slot(
+            &mapped.header().checkpoint_owner,
+            mapped.owner_record(),
+            "checkpoint",
+        );
+        assert_eq!(mapped.checkpoint_owner(), None);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_reclaims_dead_reader_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let dead_owner = SharedOwnerRecord::new(exited_child_pid(), 43);
+
+        mapped.reader_bitmap_words()[0].fetch_and(!1u64, Ordering::Release);
+        mapped.reader_frames()[0].store(17, Ordering::Release);
+        mapped.reader_owners()[0].store(dead_owner.raw(), Ordering::Release);
+
+        assert!(mapped.try_reclaim_dead_reader_owner(0, dead_owner));
+        assert_eq!(mapped.reader_owner(0), None);
+        assert_eq!(mapped.min_active_reader_frame(), None);
+    }
+
+    #[test]
+    fn process_scoped_mapping_drop_releases_same_process_ownership() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+
+        let mapped = create_process_scoped_mapping(&path);
+        let owner = mapped.owner_record();
+        assert!(mapped.try_acquire_writer(owner));
+        assert!(mapped.try_acquire_checkpoint(owner));
+        let reader = mapped.register_reader(owner, 9).unwrap();
+        drop(mapped);
+
+        let reopened = create_process_scoped_mapping(&path);
+        assert!(reopened.try_acquire_writer(reopened.owner_record()));
+        reopened.release_writer(reopened.owner_record());
+        assert!(reopened.try_acquire_checkpoint(reopened.owner_record()));
+        reopened.release_checkpoint(reopened.owner_record());
+        let reader2 = reopened
+            .register_reader(reopened.owner_record(), 5)
+            .unwrap();
+        reopened.unregister_reader(reader2);
+
+        let probe = create_process_scoped_mapping(&path);
+        assert_eq!(probe.writer_owner(), None);
+        assert_eq!(probe.checkpoint_owner(), None);
+        assert_eq!(probe.reader_owner(reader.slot_index), None);
+    }
+
+    #[test]
+    fn process_scoped_mapping_reopens_after_stale_owner_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let stale_owner = SharedOwnerRecord::new(exited_child_pid(), 77);
+
+        {
+            let mapped = create_process_scoped_mapping(&path);
+            mapped
+                .header()
+                .writer_owner
+                .store(stale_owner.raw(), Ordering::Release);
+            mapped
+                .header()
+                .checkpoint_owner
+                .store(stale_owner.raw(), Ordering::Release);
+            mapped.reader_bitmap_words()[0].fetch_and(!1u64, Ordering::Release);
+            mapped.reader_frames()[0].store(17, Ordering::Release);
+            mapped.reader_owners()[0].store(stale_owner.raw(), Ordering::Release);
+        }
+
+        let reopened = create_process_scoped_mapping(&path);
+        assert!(reopened.try_acquire_writer(reopened.owner_record()));
+        reopened.release_writer(reopened.owner_record());
+        assert!(reopened.try_acquire_checkpoint(reopened.owner_record()));
+        reopened.release_checkpoint(reopened.owner_record());
+        let reader = reopened
+            .register_reader(reopened.owner_record(), 5)
+            .unwrap();
+        reopened.unregister_reader(reader);
+    }
+
+    #[test]
+    fn shared_wal_coordination_tracks_writer_and_checkpoint_owners() {
+        let state = SharedWalCoordinationState::new(64);
+        let writer = SharedOwnerRecord::new(11, 1);
+        let checkpoint = SharedOwnerRecord::new(21, 2);
+
+        assert!(state.try_acquire_writer(writer));
+        assert_eq!(state.writer_owner(), Some(writer));
+        assert!(!state.try_acquire_writer(SharedOwnerRecord::new(12, 1)));
+        state.release_writer(writer);
+        assert_eq!(state.writer_owner(), None);
+
+        assert!(state.try_acquire_checkpoint(checkpoint));
+        assert_eq!(state.checkpoint_owner(), Some(checkpoint));
+        assert!(!state.try_acquire_checkpoint(SharedOwnerRecord::new(22, 2)));
+        state.release_checkpoint(checkpoint);
+        assert_eq!(state.checkpoint_owner(), None);
+    }
+
+    #[test]
+    fn shared_wal_coordination_tracks_reader_registrations() {
+        let state = SharedWalCoordinationState::new(64);
+        let owner_a = SharedOwnerRecord::new(31, 1);
+        let owner_b = SharedOwnerRecord::new(31, 2);
+
+        let reader_a = state.register_reader(owner_a, 9).unwrap();
+        let reader_b = state.register_reader(owner_b, 5).unwrap();
+        assert_eq!(state.reader_owner(reader_a.slot_index), Some(owner_a));
+        assert_eq!(state.reader_owner(reader_b.slot_index), Some(owner_b));
+        assert_eq!(state.min_active_reader_frame(), Some(5));
+
+        let reader_a = state.update_reader(reader_a, 3);
+        assert_eq!(reader_a.max_frame, 3);
+        assert_eq!(state.min_active_reader_frame(), Some(3));
+
+        state.unregister_reader(reader_b);
+        assert_eq!(state.reader_owner(reader_b.slot_index), None);
+        assert_eq!(state.min_active_reader_frame(), Some(3));
+
+        state.unregister_reader(reader_a);
+        assert_eq!(state.reader_owner(reader_a.slot_index), None);
+        assert_eq!(state.min_active_reader_frame(), None);
+    }
+
+    #[test]
+    fn shared_wal_coordination_publishes_snapshot_fields() {
+        let state = SharedWalCoordinationState::new(64);
+
+        state.install_header_fields(4096, 17, 23);
+        state.publish_commit(14, 31, 37, 9);
+        state.publish_backfill(8);
+        assert_eq!(state.bump_checkpoint_seq(), 1);
+        assert_eq!(state.bump_checkpoint_epoch(), 0);
+
+        let snapshot = state.snapshot();
+        assert_eq!(snapshot.max_frame, 14);
+        assert_eq!(snapshot.nbackfills, 8);
+        assert_eq!(snapshot.transaction_count, 9);
+        assert_eq!(snapshot.visibility_generation, 1);
+        assert_eq!(snapshot.checkpoint_seq, 1);
+        assert_eq!(snapshot.checkpoint_epoch, 1);
+        assert_eq!(snapshot.page_size, 4096);
+        assert_eq!(snapshot.salt_1, 17);
+        assert_eq!(snapshot.salt_2, 23);
+        assert_eq!(snapshot.checksum_1, 31);
+        assert_eq!(snapshot.checksum_2, 37);
+        assert_eq!(snapshot.reader_slot_count, 64);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_persists_file_after_last_close() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let expected_len = MappedSharedWalCoordination::file_len_for_blocks(64, 1) as u64;
+
+        {
+            let mapped = create_mapping(&path);
+            assert_eq!(mapped.open_mode(), SharedWalCoordinationOpenMode::Exclusive);
+            mapped.install_header_fields(4096, 17, 23);
+            mapped.publish_commit(14, 31, 37, 9);
+            mapped.publish_backfill(8);
+            assert_eq!(mapped.bump_checkpoint_seq(), 1);
+            assert_eq!(mapped.bump_checkpoint_epoch(), 0);
+        }
+
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), expected_len);
+
+        let reopened = create_mapping(&path);
+        assert_eq!(
+            reopened.open_mode(),
+            SharedWalCoordinationOpenMode::Exclusive
+        );
+        let snapshot = reopened.snapshot();
+        assert_eq!(snapshot.max_frame, 14);
+        assert_eq!(snapshot.nbackfills, 8);
+        assert_eq!(snapshot.transaction_count, 9);
+        assert_eq!(snapshot.visibility_generation, 1);
+        assert_eq!(snapshot.checkpoint_seq, 1);
+        assert_eq!(snapshot.checkpoint_epoch, 1);
+        assert_eq!(snapshot.page_size, 4096);
+        assert_eq!(snapshot.salt_1, 17);
+        assert_eq!(snapshot.salt_2, 23);
+        assert_eq!(snapshot.checksum_1, 31);
+        assert_eq!(snapshot.checksum_2, 37);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_rebuilds_undersized_file_on_exclusive_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        std::fs::write(&path, [0u8; 32]).unwrap();
+
+        let reopened = create_mapping(&path);
+        assert_eq!(
+            reopened.open_mode(),
+            SharedWalCoordinationOpenMode::Exclusive
+        );
+        assert_eq!(
+            reopened.file.size().unwrap() as usize,
+            MappedSharedWalCoordination::file_len_for_blocks(64, 1)
+        );
+        assert_eq!(reopened.snapshot().max_frame, 0);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_shares_lock_and_reader_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped_a = create_mapping(&path);
+        assert_eq!(
+            mapped_a.open_mode(),
+            SharedWalCoordinationOpenMode::Exclusive
+        );
+        let mapped_b = create_mapping(&path);
+        assert_ne!(
+            mapped_a.owner_record().instance_id(),
+            mapped_b.owner_record().instance_id()
+        );
+
+        assert!(mapped_a.try_acquire_writer(mapped_a.owner_record()));
+        assert_eq!(mapped_a.writer_owner(), Some(mapped_a.owner_record()));
+        assert!(!mapped_b.try_acquire_writer(mapped_b.owner_record()));
+        mapped_a.release_writer(mapped_a.owner_record());
+        assert!(mapped_b.try_acquire_writer(mapped_b.owner_record()));
+        assert_eq!(mapped_a.writer_owner(), Some(mapped_b.owner_record()));
+        mapped_b.release_writer(mapped_b.owner_record());
+        assert_eq!(mapped_a.writer_owner(), None);
+
+        let reader = mapped_a
+            .register_reader(mapped_a.owner_record(), 9)
+            .unwrap();
+        let reader_slot = reader.slot_index;
+        assert_eq!(
+            mapped_b.reader_owner(reader_slot),
+            Some(mapped_a.owner_record())
+        );
+        assert_eq!(mapped_b.min_active_reader_frame(), Some(9));
+        let reader = mapped_b.update_reader(reader, 5);
+        assert_eq!(mapped_a.min_active_reader_frame(), Some(5));
+        mapped_a.unregister_reader(reader);
+        assert_eq!(mapped_a.reader_owner(reader_slot), None);
+        assert_eq!(mapped_a.min_active_reader_frame(), None);
+
+        assert_eq!(mapped_a.bump_checkpoint_epoch(), 0);
+        assert_eq!(mapped_b.checkpoint_epoch(), 1);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_prevents_checkpoint_lock_reuse_across_mappings() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped_a = create_mapping(&path);
+        let mapped_b = create_mapping(&path);
+
+        assert!(mapped_a.try_acquire_checkpoint(mapped_a.owner_record()));
+        assert_eq!(mapped_a.checkpoint_owner(), Some(mapped_a.owner_record()));
+        assert!(!mapped_b.try_acquire_checkpoint(mapped_b.owner_record()));
+        mapped_a.release_checkpoint(mapped_a.owner_record());
+        assert_eq!(mapped_b.checkpoint_owner(), None);
+
+        assert!(mapped_b.try_acquire_checkpoint(mapped_b.owner_record()));
+        assert_eq!(mapped_a.checkpoint_owner(), Some(mapped_b.owner_record()));
+        mapped_b.release_checkpoint(mapped_b.owner_record());
+        assert_eq!(mapped_a.checkpoint_owner(), None);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_prevents_reentrant_lock_reuse_within_same_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+
+        assert!(mapped.try_acquire_writer(mapped.owner_record()));
+        assert!(!mapped.try_acquire_writer(mapped.owner_record()));
+        mapped.release_writer(mapped.owner_record());
+
+        let reader_a = mapped.register_reader(mapped.owner_record(), 9).unwrap();
+        let reader_b = mapped.register_reader(mapped.owner_record(), 5).unwrap();
+        assert_ne!(reader_a.slot_index, reader_b.slot_index);
+        assert_eq!(mapped.min_active_reader_frame(), Some(5));
+
+        mapped.unregister_reader(reader_a);
+        mapped.unregister_reader(reader_b);
+        assert_eq!(mapped.min_active_reader_frame(), None);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_ignores_stale_writer_owner_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+
+        mapped
+            .header()
+            .writer_owner
+            .store(SharedOwnerRecord::new(99, 7).raw(), Ordering::Release);
+        assert!(mapped.try_acquire_writer(mapped.owner_record()));
+        mapped.release_writer(mapped.owner_record());
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_reclaims_stale_reader_slots() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+
+        mapped.reader_bitmap_words()[0].fetch_and(!1u64, Ordering::Release);
+        mapped.reader_frames()[0].store(17, Ordering::Release);
+        mapped.reader_owners()[0].store(SharedOwnerRecord::new(42, 9).raw(), Ordering::Release);
+
+        assert_eq!(mapped.min_active_reader_frame(), None);
+        assert_eq!(mapped.reader_owner(0), None);
+
+        let reader = mapped.register_reader(mapped.owner_record(), 23).unwrap();
+        assert_eq!(reader.slot_index, 0);
+        assert_eq!(
+            mapped.reader_owner(reader.slot_index),
+            Some(mapped.owner_record())
+        );
+        assert_eq!(mapped.min_active_reader_frame(), Some(23));
+        mapped.unregister_reader(reader);
+        assert_eq!(mapped.min_active_reader_frame(), None);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_tracks_frame_index_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+
+        mapped.record_frame(7, 2);
+        mapped.record_frame(9, 4);
+        mapped.record_frame(7, 5);
+
+        assert_eq!(mapped.find_frame(7, 0, 5, None), Some(5));
+        assert_eq!(mapped.find_frame(7, 0, 5, Some(4)), Some(2));
+        assert_eq!(mapped.iter_latest_frames(0, 5), vec![(7, 5), (9, 4)]);
+
+        mapped.rollback_frames(4);
+
+        assert_eq!(mapped.find_frame(7, 0, 5, None), Some(2));
+        assert_eq!(mapped.iter_latest_frames(0, 5), vec![(7, 2), (9, 4)]);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_grows_frame_index_across_block_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let boundary = FRAME_INDEX_BLOCK_CAPACITY as u64;
+
+        mapped.record_frame(7, 2);
+        for frame_id in 3..=boundary + 1 {
+            mapped.record_frame(100 + (frame_id % 17), frame_id);
+        }
+        mapped.record_frame(7, boundary + 2);
+
+        let header = mapped.header();
+        assert_eq!(
+            header.frame_index_blocks.load(Ordering::Acquire),
+            INITIAL_FRAME_INDEX_BLOCKS + 1
+        );
+        assert_eq!(
+            mapped.find_frame(7, 0, boundary + 2, None),
+            Some(boundary + 2)
+        );
+        assert_eq!(
+            mapped.find_frame(7, 0, boundary + 2, Some(boundary + 1)),
+            Some(2)
+        );
+        assert!(!mapped.frame_index_overflowed());
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_iterates_latest_frames_across_full_blocks() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let boundary = FRAME_INDEX_BLOCK_CAPACITY as u64;
+
+        for frame_id in 1..=boundary {
+            let page_id = match frame_id % 3 {
+                1 => 7,
+                2 => 9,
+                _ => 11,
+            };
+            mapped.record_frame(page_id, frame_id);
+        }
+        mapped.record_frame(9, boundary + 1);
+        mapped.record_frame(13, boundary + 2);
+
+        assert_eq!(
+            mapped.iter_latest_frames(0, boundary + 2),
+            vec![
+                (7, boundary),
+                (9, boundary + 1),
+                (11, boundary - 1),
+                (13, boundary + 2),
+            ]
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_marks_overflow_once_reserved_space_is_full() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let header = mapped.header();
+        assert!(mapped.try_grow_frame_index_blocks(header.frame_index_max_blocks));
+        header
+            .frame_index_len
+            .store(header.frame_index_capacity, Ordering::Release);
+
+        mapped.record_frame(7, 2);
+        assert_eq!(
+            header.frame_index_len.load(Ordering::Acquire),
+            header.frame_index_capacity
+        );
+        assert!(mapped.frame_index_overflowed());
+        assert_eq!(mapped.find_frame(7, 1, u64::MAX, None), None);
+        mapped.rollback_frames(1);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_rebuilds_block_hash_after_rollback() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+
+        mapped.record_frame(7, 1);
+        mapped.record_frame(9, 2);
+        mapped.record_frame(7, 3);
+        mapped.record_frame(11, 4);
+
+        mapped.rollback_frames(2);
+        assert_eq!(mapped.find_frame(7, 0, 2, None), Some(1));
+        assert_eq!(mapped.find_frame(11, 0, 2, None), None);
+
+        mapped.record_frame(15, 3);
+        mapped.record_frame(7, 4);
+        assert_eq!(mapped.find_frame(7, 0, 4, None), Some(4));
+        assert_eq!(mapped.find_frame(15, 0, 4, None), Some(3));
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_clears_stale_frame_index_when_wal_restarts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let header = mapped.header();
+
+        mapped.record_frame(7, 2);
+        mapped.record_frame(9, 4);
+        header.max_frame.store(0, Ordering::Release);
+
+        mapped.record_frame(11, 1);
+
+        assert_eq!(header.frame_index_len.load(Ordering::Acquire), 1);
+        assert_eq!(mapped.find_frame(11, 0, 1, None), Some(1));
+        assert_eq!(mapped.find_frame(7, 0, 1, None), None);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_install_snapshot_trims_stale_frame_index_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let mut snapshot = mapped.snapshot();
+
+        mapped.record_frame(7, 2);
+        mapped.record_frame(9, 4);
+        mapped.record_frame(11, 6);
+
+        snapshot.max_frame = 2;
+        mapped.install_snapshot(snapshot);
+
+        assert_eq!(mapped.header().frame_index_len.load(Ordering::Acquire), 1);
+        assert_eq!(mapped.find_frame(7, 0, 2, None), Some(2));
+        assert_eq!(mapped.find_frame(9, 0, 2, None), None);
+
+        mapped.record_frame(13, 3);
+        assert_eq!(mapped.find_frame(13, 0, 3, None), Some(3));
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_handles_hash_collisions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let colliding = colliding_page_ids(3);
+
+        mapped.record_frame(colliding[0], 2);
+        mapped.record_frame(colliding[1], 4);
+        mapped.record_frame(colliding[0], 6);
+        mapped.record_frame(colliding[2], 8);
+        mapped.record_frame(colliding[1], 10);
+
+        assert_eq!(mapped.find_frame(colliding[0], 0, 10, None), Some(6));
+        assert_eq!(mapped.find_frame(colliding[1], 0, 10, None), Some(10));
+        assert_eq!(mapped.find_frame(colliding[2], 0, 10, None), Some(8));
+        assert_eq!(mapped.find_frame(colliding[1], 0, 10, Some(9)), Some(4));
+        assert_eq!(
+            mapped.iter_latest_frames(0, 10),
+            vec![(colliding[0], 6), (colliding[1], 10), (colliding[2], 8),]
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_reuses_block_hash_slots_after_rollback() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let colliding = colliding_page_ids(3);
+
+        mapped.record_frame(colliding[0], 1);
+        mapped.record_frame(colliding[1], 2);
+
+        mapped.rollback_frames(1);
+        mapped.record_frame(colliding[2], 2);
+
+        assert_eq!(mapped.find_frame(colliding[0], 0, 2, None), Some(1));
+        assert_eq!(mapped.find_frame(colliding[1], 0, 2, None), None);
+        assert_eq!(mapped.find_frame(colliding[2], 0, 2, None), Some(2));
+        assert_eq!(
+            mapped.iter_latest_frames(0, 2),
+            vec![(colliding[0], 1), (colliding[2], 2)]
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_keeps_initial_file_small() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+
+        let mapped = create_mapping(&path);
+        let metadata_len = mapped.file.size().unwrap() as usize;
+
+        assert_eq!(
+            metadata_len,
+            MappedSharedWalCoordination::file_len_for_blocks(64, 1)
+        );
+        assert!(metadata_len < 128 * 1024);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_respects_sparse_frame_watermarks() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+
+        mapped.record_frame(7, 2);
+        mapped.record_frame(9, 4);
+        mapped.record_frame(11, 8);
+        mapped.record_frame(7, 13);
+        mapped.record_frame(9, 21);
+
+        assert_eq!(mapped.find_frame(7, 0, 21, None), Some(13));
+        assert_eq!(mapped.find_frame(7, 0, 21, Some(12)), Some(2));
+        assert_eq!(mapped.find_frame(9, 0, 21, Some(20)), Some(4));
+        assert_eq!(mapped.find_frame(9, 5, 20, None), None);
+        assert_eq!(mapped.find_frame(11, 0, 21, Some(7)), None);
+        assert_eq!(
+            mapped.iter_latest_frames(0, 13),
+            vec![(7, 13), (9, 4), (11, 8)]
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_rolls_back_across_block_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let boundary = FRAME_INDEX_BLOCK_CAPACITY as u64;
+
+        mapped.record_frame(7, 2);
+        for frame_id in 3..=boundary + 1 {
+            mapped.record_frame(100 + (frame_id % 17), frame_id);
+        }
+        mapped.record_frame(7, boundary + 2);
+        mapped.record_frame(19, boundary + 3);
+
+        assert_eq!(
+            mapped.find_frame(7, 0, boundary + 3, None),
+            Some(boundary + 2)
+        );
+
+        mapped.rollback_frames(boundary + 1);
+        assert_eq!(mapped.find_frame(7, 0, boundary + 3, None), Some(2));
+        assert_eq!(mapped.find_frame(19, 0, boundary + 3, None), None);
+
+        mapped.record_frame(23, boundary + 2);
+        mapped.record_frame(7, boundary + 3);
+        assert_eq!(
+            mapped.find_frame(23, 0, boundary + 3, None),
+            Some(boundary + 2)
+        );
+        assert_eq!(
+            mapped.find_frame(7, 0, boundary + 3, None),
+            Some(boundary + 3)
+        );
+    }
+
+    fn try_open_isolated_database(
+        db_path: &std::path::Path,
+    ) -> Result<(Arc<Database>, Arc<Connection>)> {
+        let db_path_str = db_path.to_str().unwrap();
+        let wal_path = format!("{db_path_str}-wal");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let file = io
+            .open_file(db_path_str, OpenFlags::default(), true)
+            .unwrap();
+        let db_file = Arc::new(DatabaseFile::new(file));
+        let mut state = OpenDbAsyncState::new();
+        let db = loop {
+            match Database::open_with_flags_bypass_registry_async(
+                &mut state,
+                io.clone(),
+                db_path_str,
+                Some(&wal_path),
+                db_file.clone(),
+                OpenFlags::default(),
+                DatabaseOpts::new(),
+                None,
+                None,
+            )? {
+                IOResult::Done(db) => break db,
+                IOResult::IO(io_completion) => io_completion.wait(&*io)?,
+            }
+        };
+        let conn = db.connect()?;
+        Ok((db, conn))
+    }
+
+    fn open_mp_database() -> (Arc<Database>, Arc<Connection>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.pragma_update(None, "journal_mode", "wal").unwrap();
+        }
+        let (db, conn) = try_open_isolated_database(&db_path).unwrap();
+        (db, conn, dir)
+    }
+
+    fn open_second_process(dir: &std::path::Path) -> (Arc<Database>, Arc<Connection>) {
+        try_open_isolated_database(&dir.join("test.db")).unwrap()
+    }
+
+    fn exec(conn: &Arc<Connection>, sql: &str) {
+        conn.execute(sql).unwrap();
+    }
+
+    fn query_i64(conn: &Arc<Connection>, sql: &str) -> i64 {
+        try_query_i64(conn, sql).unwrap()
+    }
+
+    fn try_query_i64(conn: &Arc<Connection>, sql: &str) -> Result<i64> {
+        let mut stmt = conn.prepare(sql).unwrap();
+        let mut value = 0i64;
+        stmt.run_with_row_callback(|row| {
+            value = row.get(0).unwrap();
+            Ok(())
+        })?;
+        Ok(value)
+    }
+
+    fn query_rows(conn: &Arc<Connection>, sql: &str) -> Vec<Vec<Value>> {
+        let mut stmt = conn.prepare(sql).unwrap();
+        stmt.run_collect_rows().unwrap()
+    }
+
+    fn run_checkpoint(conn: &Arc<Connection>, mode: CheckpointMode) -> CheckpointResult {
+        let pager = conn.pager.load();
+        pager
+            .io
+            .block(|| pager.checkpoint(mode, SyncMode::Full, true))
+            .unwrap()
+    }
+
+    fn assert_integrity_ok(conn: &Arc<Connection>) {
+        let rows = query_rows(conn, "PRAGMA integrity_check");
+        assert!(!rows.is_empty(), "integrity_check returned no rows");
+        match &rows[0][0] {
+            Value::Text(s) => assert_eq!(s.as_ref(), "ok", "integrity_check failed: {s}"),
+            other => panic!("unexpected integrity_check result: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_mp_snapshot_isolation() {
+        let (_db_writer, conn_writer, dir) = open_mp_database();
+
+        exec(
+            &conn_writer,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
+        );
+        exec(&conn_writer, "INSERT INTO t VALUES (1,'a'), (2,'b')");
+        let (_db_reader, conn_reader) = open_second_process(dir.path());
+
+        exec(&conn_reader, "BEGIN");
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 2);
+
+        exec(&conn_writer, "INSERT INTO t VALUES (3,'c'), (4,'d')");
+
+        assert_eq!(
+            query_i64(&conn_reader, "SELECT count(*) FROM t"),
+            2,
+            "reader should keep its original snapshot while the transaction stays open"
+        );
+
+        exec(&conn_reader, "COMMIT");
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 4);
+
+        assert_integrity_ok(&conn_writer);
+    }
+
+    #[test]
+    fn test_mp_checkpoint_respects_active_reader() {
+        let (_db_writer, conn_writer, dir) = open_mp_database();
+
+        exec(
+            &conn_writer,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
+        );
+
+        exec(&conn_writer, "BEGIN");
+        for i in 0..100 {
+            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+        }
+        exec(&conn_writer, "COMMIT");
+        let (_db_reader, conn_reader) = open_second_process(dir.path());
+
+        exec(&conn_reader, "BEGIN");
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 100);
+
+        exec(&conn_writer, "BEGIN");
+        for i in 100..200 {
+            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+        }
+        exec(&conn_writer, "COMMIT");
+
+        let first_checkpoint = run_checkpoint(
+            &conn_writer,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            },
+        );
+        assert!(
+            !first_checkpoint.everything_backfilled(),
+            "passive checkpoint should stop at the active reader snapshot"
+        );
+
+        exec(&conn_reader, "COMMIT");
+
+        let second_checkpoint = run_checkpoint(
+            &conn_writer,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            },
+        );
+        assert!(
+            second_checkpoint.everything_backfilled(),
+            "checkpoint should fully backfill after the reader releases its snapshot"
+        );
+        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 200);
+        assert_integrity_ok(&conn_writer);
+    }
+
+    #[test]
+    fn test_mp_reader_crash_recovery_releases_checkpoint_barrier() {
+        let (_db_writer, conn_writer, dir) = open_mp_database();
+
+        exec(
+            &conn_writer,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
+        );
+        exec(&conn_writer, "INSERT INTO t VALUES (1,'a'), (2,'b')");
+
+        let (_db_reader, conn_reader) = open_second_process(dir.path());
+        exec(&conn_reader, "BEGIN");
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 2);
+
+        exec(&conn_writer, "INSERT INTO t VALUES (3,'c')");
+
+        let checkpoint_with_reader = run_checkpoint(
+            &conn_writer,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            },
+        );
+        assert!(
+            !checkpoint_with_reader.everything_backfilled(),
+            "active reader snapshot should limit passive checkpoint progress"
+        );
+
+        drop(conn_reader);
+        drop(_db_reader);
+
+        let checkpoint_after_crash = run_checkpoint(
+            &conn_writer,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            },
+        );
+        assert!(
+            checkpoint_after_crash.everything_backfilled(),
+            "dropped reader process should no longer block checkpoint progress"
+        );
+
+        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 3);
+        assert_integrity_ok(&conn_writer);
+    }
+
+    #[test]
+    fn test_mp_writer_crash_recovery_only_exposes_committed_rows() {
+        let (_db_writer, conn_writer, dir) = open_mp_database();
+
+        exec(
+            &conn_writer,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
+        );
+        exec(&conn_writer, "BEGIN");
+        for i in 0..10 {
+            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+        }
+        exec(&conn_writer, "COMMIT");
+        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 10);
+
+        exec(&conn_writer, "BEGIN");
+        for i in 10..20 {
+            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+        }
+
+        drop(conn_writer);
+        drop(_db_writer);
+
+        let (_db_recovered, conn_recovered) = open_second_process(dir.path());
+        assert_eq!(
+            query_i64(&conn_recovered, "SELECT count(*) FROM t"),
+            10,
+            "recovery should ignore uncommitted rows from the crashed writer"
+        );
+        assert_integrity_ok(&conn_recovered);
+    }
+
+    #[test]
+    fn test_mp_multiple_readers_hold_distinct_snapshots() {
+        let (_db_writer, conn_writer, dir) = open_mp_database();
+
+        exec(
+            &conn_writer,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
+        );
+
+        exec(&conn_writer, "BEGIN");
+        for i in 0..10 {
+            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+        }
+        exec(&conn_writer, "COMMIT");
+
+        let (_db_reader1, conn_reader1) = open_second_process(dir.path());
+        exec(&conn_reader1, "BEGIN");
+        assert_eq!(query_i64(&conn_reader1, "SELECT count(*) FROM t"), 10);
+
+        exec(&conn_writer, "BEGIN");
+        for i in 10..20 {
+            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+        }
+        exec(&conn_writer, "COMMIT");
+
+        let (_db_reader2, conn_reader2) = open_second_process(dir.path());
+        exec(&conn_reader2, "BEGIN");
+        assert_eq!(query_i64(&conn_reader2, "SELECT count(*) FROM t"), 20);
+
+        exec(&conn_writer, "BEGIN");
+        for i in 20..30 {
+            exec(&conn_writer, &format!("INSERT INTO t VALUES ({i}, 'v{i}')"));
+        }
+        exec(&conn_writer, "COMMIT");
+
+        let (_db_reader3, conn_reader3) = open_second_process(dir.path());
+        exec(&conn_reader3, "BEGIN");
+        assert_eq!(query_i64(&conn_reader3, "SELECT count(*) FROM t"), 30);
+
+        assert_eq!(query_i64(&conn_reader1, "SELECT count(*) FROM t"), 10);
+        assert_eq!(query_i64(&conn_reader2, "SELECT count(*) FROM t"), 20);
+        assert_eq!(query_i64(&conn_reader3, "SELECT count(*) FROM t"), 30);
+
+        let checkpoint = run_checkpoint(
+            &conn_writer,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            },
+        );
+        assert!(
+            !checkpoint.everything_backfilled(),
+            "oldest reader snapshot should limit passive checkpoint progress"
+        );
+
+        exec(&conn_reader1, "COMMIT");
+        exec(&conn_reader2, "COMMIT");
+        exec(&conn_reader3, "COMMIT");
+
+        let final_checkpoint = run_checkpoint(
+            &conn_writer,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: None,
+            },
+        );
+        assert!(
+            final_checkpoint.everything_backfilled(),
+            "checkpoint should complete once all reader snapshots are released"
+        );
+
+        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 30);
+        assert_integrity_ok(&conn_writer);
+    }
+
+    #[test]
+    fn test_mp_stale_frame_cache_after_repeated_truncate() {
+        let (_db0, conn0, dir) = open_mp_database();
+
+        exec(&conn0, "CREATE TABLE t1(id INTEGER PRIMARY KEY)");
+        exec(&conn0, "CREATE TABLE t2(id INTEGER PRIMARY KEY)");
+        run_checkpoint(
+            &conn0,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
+        );
+
+        let (_db1, conn1) = open_second_process(dir.path());
+        let (_db2, conn2) = open_second_process(dir.path());
+
+        exec(&conn1, "INSERT INTO t1 VALUES (1)");
+        assert_eq!(query_i64(&conn2, "SELECT count(*) FROM t1"), 1);
+
+        run_checkpoint(
+            &conn0,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
+        );
+
+        exec(&conn1, "INSERT INTO t2 VALUES (100)");
+        assert_eq!(query_i64(&conn2, "SELECT count(*) FROM t2"), 1);
+        assert_integrity_ok(&conn2);
+    }
+
+    #[test]
+    fn test_mp_restart_checkpoint_on_empty_wal() {
+        let (_db1, conn1, dir) = open_mp_database();
+
+        exec(&conn1, "CREATE TABLE t1 (id INTEGER PRIMARY KEY)");
+        exec(&conn1, "INSERT INTO t1 VALUES (1)");
+
+        run_checkpoint(
+            &conn1,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
+        );
+
+        let (_db2, conn2) = open_second_process(dir.path());
+        run_checkpoint(&conn2, CheckpointMode::Restart);
+        exec(&conn2, "INSERT INTO t1 VALUES (2)");
+
+        assert_eq!(query_i64(&conn2, "SELECT count(*) FROM t1"), 2);
+        assert_integrity_ok(&conn2);
+    }
+
+    #[test]
+    fn test_mp_uncommitted_frames_not_visible_cross_process() {
+        let (_db_writer, conn_writer, dir) = open_mp_database();
+
+        exec(&conn_writer, "CREATE TABLE t(id INTEGER PRIMARY KEY)");
+        exec(&conn_writer, "INSERT INTO t VALUES (1)");
+
+        let (_db_reader, conn_reader) = open_second_process(dir.path());
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 1);
+
+        exec(&conn_writer, "BEGIN");
+        exec(&conn_writer, "INSERT INTO t VALUES (2)");
+
+        assert_eq!(
+            query_i64(&conn_reader, "SELECT count(*) FROM t"),
+            1,
+            "uncommitted frames must stay invisible to other processes"
+        );
+
+        exec(&conn_writer, "COMMIT");
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 2);
+    }
+
+    #[test]
+    fn test_mp_rollback_wal_index_cross_process() {
+        let (_db_writer, conn_writer, dir) = open_mp_database();
+
+        exec(
+            &conn_writer,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
+        );
+        exec(&conn_writer, "INSERT INTO t VALUES (1, 'baseline')");
+
+        let (_db_reader, conn_reader) = open_second_process(dir.path());
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 1);
+
+        exec(&conn_writer, "BEGIN");
+        exec(&conn_writer, "INSERT INTO t VALUES (2, 'will_rollback')");
+        exec(&conn_writer, "INSERT INTO t VALUES (3, 'will_rollback')");
+        exec(&conn_writer, "ROLLBACK");
+
+        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 1);
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 1);
+
+        let rows = query_rows(&conn_reader, "SELECT val FROM t WHERE id = 1");
+        match &rows[0][0] {
+            Value::Text(s) => assert_eq!(s.as_ref(), "baseline"),
+            other => panic!("unexpected val: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_mp_truncate_then_cross_process_write() {
+        let (_db_writer, conn_writer, dir) = open_mp_database();
+
+        exec(
+            &conn_writer,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
+        );
+        exec(&conn_writer, "INSERT INTO t VALUES (1, 'before_truncate')");
+
+        let (_db_reader, conn_reader) = open_second_process(dir.path());
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 1);
+
+        run_checkpoint(
+            &conn_writer,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
+        );
+
+        exec(&conn_reader, "INSERT INTO t VALUES (2, 'after_truncate')");
+
+        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 2);
+        assert_eq!(query_i64(&conn_reader, "SELECT count(*) FROM t"), 2);
+        assert_integrity_ok(&conn_writer);
+        assert_integrity_ok(&conn_reader);
+    }
+
+    #[test]
+    fn test_mp_rapid_open_close_cycles() {
+        let (_db_writer, conn_writer, dir) = open_mp_database();
+
+        exec(
+            &conn_writer,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
+        );
+        for i in 1..=10 {
+            exec(
+                &conn_writer,
+                &format!("INSERT INTO t VALUES ({i}, 'row{i}')"),
+            );
+        }
+
+        for cycle in 0..50 {
+            let (db, conn) = open_second_process(dir.path());
+            let count = query_i64(&conn, "SELECT count(*) FROM t");
+            assert_eq!(count, 10, "cycle {cycle}: expected 10 rows, got {count}");
+            drop(conn);
+            drop(db);
+        }
+
+        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 10);
+        assert_integrity_ok(&conn_writer);
+
+        exec(&conn_writer, "INSERT INTO t VALUES (11, 'after_churn')");
+        assert_eq!(query_i64(&conn_writer, "SELECT count(*) FROM t"), 11);
+    }
+
+    #[test]
+    fn test_mp_dbfile_read_blocks_when_shared_reader_slots_are_exhausted() {
+        let (db, conn_writer, _dir) = open_mp_database();
+
+        exec(
+            &conn_writer,
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)",
+        );
+        exec(&conn_writer, "INSERT INTO t VALUES (1, 'baseline')");
+        run_checkpoint(
+            &conn_writer,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
+        );
+
+        let mut readers = Vec::new();
+        for slot in 0..64 {
+            let conn = db.connect().unwrap();
+            exec(&conn, "BEGIN");
+            assert_eq!(
+                query_i64(&conn, "SELECT count(*) FROM t"),
+                1,
+                "reader slot {slot} should acquire a shared reader slot"
+            );
+            readers.push(conn);
+        }
+
+        let err = match db.connect() {
+            Ok(_) => {
+                panic!("65th reader should not connect while all shared reader slots are occupied")
+            }
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, LimboError::Busy),
+            "slot exhaustion should surface as Busy, got {err:?}"
+        );
+
+        let released_conn = readers.pop().unwrap();
+        exec(&released_conn, "COMMIT");
+        drop(released_conn);
+
+        let overflow_conn = db.connect().unwrap();
+        assert_eq!(
+            query_i64(&overflow_conn, "SELECT count(*) FROM t"),
+            1,
+            "read should succeed once a shared reader slot is released"
+        );
+    }
+}

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -23,10 +23,12 @@
 //! conservatism, never correctness: if the authority cannot prove a slot is
 //! dead, it must leave that slot in place.
 
-use crate::io::{File, SharedWalLockKind, SharedWalMappedRegion, IO};
+use crate::io::{
+    Completion, File, FileSyncType, OpenFlags, SharedWalLockKind, SharedWalMappedRegion, IO,
+};
 use crate::storage::slot_bitmap::AtomicSlotBitmap;
 use crate::sync::atomic::{AtomicU32, AtomicU64, Ordering};
-use crate::{turso_assert, LimboError, Result};
+use crate::{turso_assert, CompletionError, LimboError, Result};
 use std::collections::HashMap;
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
@@ -34,7 +36,8 @@ use std::ptr::NonNull;
 use std::sync::{Arc, LazyLock, Mutex, RwLock};
 
 const SHARED_WAL_COORDINATION_MAGIC: [u8; 8] = *b"TSHMWAL\0";
-const SHARED_WAL_COORDINATION_VERSION: u32 = 8;
+const SHARED_WAL_COORDINATION_VERSION: u32 = 9;
+const SHARED_WAL_BACKFILL_PROOF_VERSION: u32 = 1;
 const UNUSED_READER_FRAME: u64 = u64::MAX;
 const UNOWNED_LOCK: u64 = 0;
 const SHARED_WAL_COORDINATION_MAP_ALIGNMENT: usize = 4096;
@@ -102,6 +105,13 @@ struct ProcessLocalOwnershipState {
     writer_owner: Option<SharedOwnerRecord>,
     checkpoint_owner: Option<SharedOwnerRecord>,
     reader_owners: Vec<Option<SharedOwnerRecord>>,
+    shared_snapshot_readers: HashMap<u64, SharedReadMarkRegistration>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SharedReadMarkRegistration {
+    slot: SharedReaderSlot,
+    ref_count: usize,
 }
 
 impl ProcessLocalOwnershipState {
@@ -110,6 +120,7 @@ impl ProcessLocalOwnershipState {
             writer_owner: None,
             checkpoint_owner: None,
             reader_owners: vec![None; reader_slot_count as usize],
+            shared_snapshot_readers: HashMap::default(),
         }
     }
 
@@ -173,6 +184,54 @@ impl ProcessLocalOwnershipState {
 
     fn reader_owner(&self, slot_index: u32) -> Option<SharedOwnerRecord> {
         self.reader_owners[slot_index as usize]
+    }
+
+    fn shared_snapshot_reader(&self, max_frame: u64) -> Option<SharedReadMarkRegistration> {
+        self.shared_snapshot_readers.get(&max_frame).copied()
+    }
+
+    fn retain_shared_snapshot_reader(&mut self, max_frame: u64) -> Option<SharedReaderSlot> {
+        let registration = self.shared_snapshot_readers.get_mut(&max_frame)?;
+        registration.ref_count += 1;
+        Some(registration.slot)
+    }
+
+    fn publish_shared_snapshot_reader(&mut self, slot: SharedReaderSlot) {
+        let previous = self.shared_snapshot_readers.insert(
+            slot.max_frame,
+            SharedReadMarkRegistration { slot, ref_count: 1 },
+        );
+        turso_assert!(
+            previous.is_none(),
+            "process-local shared snapshot publication replaced a live registration",
+            { "max_frame": slot.max_frame }
+        );
+    }
+
+    fn release_shared_snapshot_reader(&mut self, slot: SharedReaderSlot) -> bool {
+        let registration = self
+            .shared_snapshot_readers
+            .get_mut(&slot.max_frame)
+            .expect("shared snapshot registration missing for release");
+        turso_assert!(
+            registration.slot == slot,
+            "shared snapshot released with mismatched reader slot",
+            {
+                "published_slot_index": registration.slot.slot_index,
+                "released_slot_index": slot.slot_index,
+                "max_frame": slot.max_frame
+            }
+        );
+        turso_assert!(
+            registration.ref_count > 0,
+            "shared snapshot refcount underflow"
+        );
+        registration.ref_count -= 1;
+        if registration.ref_count != 0 {
+            return false;
+        }
+        self.shared_snapshot_readers.remove(&slot.max_frame);
+        true
     }
 }
 
@@ -351,6 +410,63 @@ pub(crate) struct SharedWalCoordinationState {
     reader_slots: AtomicSlotBitmap,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SharedWalBackfillProof {
+    nbackfills: u64,
+    max_frame: u64,
+    checkpoint_seq: u32,
+    page_size: u32,
+    salt_1: u32,
+    salt_2: u32,
+    checksum_1: u32,
+    checksum_2: u32,
+    db_size_pages: u32,
+    db_header_crc32c: u32,
+}
+
+impl SharedWalBackfillProof {
+    const CRC_INPUT_LEN: usize = 52;
+
+    fn from_snapshot_and_db(
+        snapshot: SharedWalCoordinationHeader,
+        db_size_pages: u32,
+        db_header_crc32c: u32,
+    ) -> Self {
+        Self {
+            nbackfills: snapshot.nbackfills,
+            max_frame: snapshot.max_frame,
+            checkpoint_seq: snapshot.checkpoint_seq,
+            page_size: snapshot.page_size,
+            salt_1: snapshot.salt_1,
+            salt_2: snapshot.salt_2,
+            checksum_1: snapshot.checksum_1,
+            checksum_2: snapshot.checksum_2,
+            db_size_pages,
+            db_header_crc32c,
+        }
+    }
+
+    fn crc32c(self) -> u32 {
+        let mut bytes = [0u8; Self::CRC_INPUT_LEN];
+        bytes[0..4].copy_from_slice(&SHARED_WAL_BACKFILL_PROOF_VERSION.to_le_bytes());
+        bytes[4..12].copy_from_slice(&self.nbackfills.to_le_bytes());
+        bytes[12..20].copy_from_slice(&self.max_frame.to_le_bytes());
+        bytes[20..24].copy_from_slice(&self.checkpoint_seq.to_le_bytes());
+        bytes[24..28].copy_from_slice(&self.page_size.to_le_bytes());
+        bytes[28..32].copy_from_slice(&self.salt_1.to_le_bytes());
+        bytes[32..36].copy_from_slice(&self.salt_2.to_le_bytes());
+        bytes[36..40].copy_from_slice(&self.checksum_1.to_le_bytes());
+        bytes[40..44].copy_from_slice(&self.checksum_2.to_le_bytes());
+        bytes[44..48].copy_from_slice(&self.db_size_pages.to_le_bytes());
+        bytes[48..52].copy_from_slice(&self.db_header_crc32c.to_le_bytes());
+        crc32c::crc32c(&bytes)
+    }
+
+    fn is_structurally_valid(self) -> bool {
+        self.nbackfills != 0 && self.nbackfills <= self.max_frame && self.page_size != 0
+    }
+}
+
 #[repr(C)]
 struct SharedWalCoordinationMapHeader {
     magic: [u8; 8],
@@ -380,6 +496,18 @@ struct SharedWalCoordinationMapHeader {
     salt_2: AtomicU32,
     checksum_1: AtomicU32,
     checksum_2: AtomicU32,
+    backfill_proof_version: AtomicU32,
+    backfill_proof_nbackfills: AtomicU64,
+    backfill_proof_max_frame: AtomicU64,
+    backfill_proof_checkpoint_seq: AtomicU32,
+    backfill_proof_page_size: AtomicU32,
+    backfill_proof_salt_1: AtomicU32,
+    backfill_proof_salt_2: AtomicU32,
+    backfill_proof_checksum_1: AtomicU32,
+    backfill_proof_checksum_2: AtomicU32,
+    backfill_proof_db_size_pages: AtomicU32,
+    backfill_proof_db_header_crc32c: AtomicU32,
+    backfill_proof_crc32c: AtomicU32,
     writer_owner: AtomicU64,
     checkpoint_owner: AtomicU64,
 }
@@ -455,6 +583,7 @@ pub(crate) struct MappedSharedWalCoordination {
     process_local_ownership: Arc<Mutex<ProcessLocalOwnershipState>>,
     local_lock_state: Mutex<LocalLockState>,
     open_mode: SharedWalCoordinationOpenMode,
+    sanitized_backfill_proof_on_open: bool,
     primary_process_mapping: bool,
     registry_path: Option<PathBuf>,
 }
@@ -819,6 +948,16 @@ impl MappedSharedWalCoordination {
         )
     }
 
+    fn process_already_has_mapping(path: &Path) -> bool {
+        let canonical_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let opens = PROCESS_LOCAL_COORDINATION_OPENS
+            .lock()
+            .expect("process-local coordination registry poisoned");
+        opens
+            .get(&canonical_path)
+            .is_some_and(|entry| entry.open_count > 0)
+    }
+
     /// Open (or create) the `.tshm` coordination file at `path`.
     ///
     /// On first open within a host, the file is created, sized, and
@@ -834,6 +973,14 @@ impl MappedSharedWalCoordination {
         Self::create_or_open_with_mode(io, path, reader_slot_count, Self::default_ownership_mode())
     }
 
+    pub(crate) fn open_existing(
+        io: &Arc<dyn IO>,
+        path: &Path,
+        reader_slot_count: u32,
+    ) -> Result<Option<Self>> {
+        Self::open_existing_with_mode(io, path, reader_slot_count, Self::default_ownership_mode())
+    }
+
     #[cfg(test)]
     fn create_or_open_process_scoped_for_tests(
         io: &Arc<dyn IO>,
@@ -846,6 +993,13 @@ impl MappedSharedWalCoordination {
             reader_slot_count,
             SharedWalOwnershipMode::ProcessScopedFcntl,
         )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mark_frame_index_overflowed_for_tests(&self) {
+        self.header()
+            .frame_index_overflowed
+            .store(1, Ordering::Release);
     }
 
     fn create_or_open_with_mode(
@@ -866,7 +1020,10 @@ impl MappedSharedWalCoordination {
             LimboError::InternalError("shared WAL coordination path is not valid UTF-8".into())
         })?)?;
         let lock_kind = Self::lock_kind_for_mode(ownership_mode);
-        let open_mode =
+        let open_mode = if Self::process_already_has_mapping(path) {
+            file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+            SharedWalCoordinationOpenMode::MultiProcess
+        } else {
             match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
                 true => {
                     file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
@@ -877,7 +1034,8 @@ impl MappedSharedWalCoordination {
                     file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
                     SharedWalCoordinationOpenMode::MultiProcess
                 }
-            };
+            }
+        };
         let metadata_len = file.size()? as usize;
         let initialize = metadata_len == 0
             || (open_mode == SharedWalCoordinationOpenMode::Exclusive && metadata_len < base_len);
@@ -912,6 +1070,7 @@ impl MappedSharedWalCoordination {
                 reader_locks: vec![0; reader_slot_count as usize],
             }),
             open_mode,
+            sanitized_backfill_proof_on_open: false,
             primary_process_mapping: false,
             registry_path: None,
         };
@@ -924,6 +1083,10 @@ impl MappedSharedWalCoordination {
             } else {
                 return Err(err);
             }
+        }
+        if open_mode == SharedWalCoordinationOpenMode::Exclusive {
+            region.sanitized_backfill_proof_on_open =
+                region.sanitize_backfill_proof_for_exclusive_open();
         }
         let mapped_blocks = region.header().frame_index_blocks.load(Ordering::Acquire);
         region.ensure_mapped_frame_index_blocks(mapped_blocks)?;
@@ -938,6 +1101,102 @@ impl MappedSharedWalCoordination {
         region.primary_process_mapping = primary_process_mapping;
         region.registry_path = Some(registry_path);
         Ok(region)
+    }
+
+    fn open_existing_with_mode(
+        io: &Arc<dyn IO>,
+        path: &Path,
+        reader_slot_count: u32,
+        ownership_mode: SharedWalOwnershipMode,
+    ) -> Result<Option<Self>> {
+        turso_assert!(
+            reader_slot_count >= 64 && reader_slot_count % 64 == 0,
+            "reader_slot_count must be a non-zero multiple of 64"
+        );
+
+        let base_len = Self::base_mapped_len(reader_slot_count);
+        let file = match io.open_file(
+            path.to_str().ok_or_else(|| {
+                LimboError::InternalError("shared WAL coordination path is not valid UTF-8".into())
+            })?,
+            OpenFlags::NoLock,
+            false,
+        ) {
+            Ok(file) => file,
+            Err(LimboError::CompletionError(CompletionError::IOError(
+                std::io::ErrorKind::NotFound,
+                _,
+            ))) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let lock_kind = Self::lock_kind_for_mode(ownership_mode);
+        let open_mode = if Self::process_already_has_mapping(path) {
+            file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+            SharedWalCoordinationOpenMode::MultiProcess
+        } else {
+            match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
+                true => {
+                    file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
+                    file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+                    SharedWalCoordinationOpenMode::Exclusive
+                }
+                false => {
+                    file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+                    SharedWalCoordinationOpenMode::MultiProcess
+                }
+            }
+        };
+        let metadata_len = file.size()? as usize;
+        if metadata_len < base_len {
+            file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
+            return Err(LimboError::Corrupt(format!(
+                "shared WAL coordination file is smaller than the coordination header: got {metadata_len}, minimum {base_len}"
+            )));
+        }
+
+        let base_mapping = file.shared_wal_map(0, base_len)?;
+        let base_ptr = base_mapping.ptr();
+        let mut region = Self {
+            file,
+            _base_mapping: base_mapping,
+            base_ptr,
+            base_len,
+            owner_record: SharedOwnerRecord::current_process(next_shared_owner_instance_id()),
+            ownership_mode,
+            frame_index_blocks: RwLock::new(Vec::new()),
+            frame_index_publish_lock: Arc::new(Mutex::new(())),
+            process_local_ownership: Arc::new(Mutex::new(ProcessLocalOwnershipState::new(
+                reader_slot_count,
+            ))),
+            local_lock_state: Mutex::new(LocalLockState {
+                writer_lock_held: false,
+                checkpoint_lock_held: false,
+                reader_locks: vec![0; reader_slot_count as usize],
+            }),
+            open_mode,
+            sanitized_backfill_proof_on_open: false,
+            primary_process_mapping: false,
+            registry_path: None,
+        };
+        if let Err(err) = region.validate_existing(reader_slot_count, metadata_len) {
+            region
+                .file
+                .shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
+            return Err(err);
+        }
+        let mapped_blocks = region.header().frame_index_blocks.load(Ordering::Acquire);
+        region.ensure_mapped_frame_index_blocks(mapped_blocks)?;
+        let (
+            registry_path,
+            primary_process_mapping,
+            frame_index_publish_lock,
+            process_local_ownership,
+        ) = Self::register_process_mapping(path, reader_slot_count);
+        region.frame_index_publish_lock = frame_index_publish_lock;
+        region.process_local_ownership = process_local_ownership;
+        region.primary_process_mapping = primary_process_mapping;
+        region.registry_path = Some(registry_path);
+        Ok(Some(region))
     }
 
     fn process_lock_offset_for_reader(slot_index: u32) -> u64 {
@@ -977,12 +1236,12 @@ impl MappedSharedWalCoordination {
 
         if writer_lock_held {
             if self.uses_linux_ofd_locking() {
-                let _ = self
-                    .file
-                    .shared_wal_unlock_byte(WRITER_LOCK_OFFSET, self.lock_kind());
                 self.header()
                     .writer_owner
                     .store(UNOWNED_LOCK, Ordering::Release);
+                let _ = self
+                    .file
+                    .shared_wal_unlock_byte(WRITER_LOCK_OFFSET, self.lock_kind());
             } else {
                 let _ = self
                     .file
@@ -1003,12 +1262,12 @@ impl MappedSharedWalCoordination {
 
         if checkpoint_lock_held {
             if self.uses_linux_ofd_locking() {
-                let _ = self
-                    .file
-                    .shared_wal_unlock_byte(CHECKPOINT_LOCK_OFFSET, self.lock_kind());
                 self.header()
                     .checkpoint_owner
                     .store(UNOWNED_LOCK, Ordering::Release);
+                let _ = self
+                    .file
+                    .shared_wal_unlock_byte(CHECKPOINT_LOCK_OFFSET, self.lock_kind());
             } else {
                 let _ = self
                     .file
@@ -1080,6 +1339,10 @@ impl MappedSharedWalCoordination {
         self.open_mode
     }
 
+    pub(crate) const fn sanitized_backfill_proof_on_open(&self) -> bool {
+        self.sanitized_backfill_proof_on_open
+    }
+
     pub(crate) const fn owner_record(&self) -> SharedOwnerRecord {
         self.owner_record
     }
@@ -1089,6 +1352,7 @@ impl MappedSharedWalCoordination {
     }
 
     pub(crate) fn install_snapshot(&self, snapshot: SharedWalCoordinationHeader) {
+        self.clear_backfill_proof();
         // Snapshots define the authoritative visible WAL range. If the shared
         // frame index still carries entries from an older generation past that
         // range, trim them before publishing the new header so later frame
@@ -1127,11 +1391,11 @@ impl MappedSharedWalCoordination {
             .store(snapshot.checksum_2, Ordering::Release);
     }
 
-    /// Reset transient runtime state when a process determines that it can
-    /// repair the tshm from a local WAL disk scan.
+    /// Repair transient runtime state when a process determines that it can
+    /// reconcile the tshm with a local WAL disk scan.
     ///
-    /// Clears writer/checkpoint owners and the frame index unconditionally
-    /// (the caller holds the writer lock or has verified no writer is active).
+    /// Clears writer/checkpoint owners and reclaims stale reader slots, but
+    /// leaves the durable frame index intact.
     ///
     /// For reader slots, we must NOT blindly clear slots owned by
     /// live processes: doing so would cause those processes to panic with
@@ -1142,14 +1406,12 @@ impl MappedSharedWalCoordination {
     ///   can be acquired, the owner is dead and the slot is safe to reclaim.
     /// - **Process-scoped fcntl (macOS)**: check `kill(pid, 0)` on the slot's
     ///   `SharedOwnerRecord` PID. Same semantics — dead owner ⇒ reclaim.
-    pub(crate) fn reset_runtime_state_for_exclusive_open(&self) {
+    pub(crate) fn repair_transient_state_for_exclusive_open(&self) {
         let header = self.header();
         header.writer_owner.store(UNOWNED_LOCK, Ordering::Release);
         header
             .checkpoint_owner
             .store(UNOWNED_LOCK, Ordering::Release);
-        header.frame_index_len.store(0, Ordering::Release);
-        header.frame_index_overflowed.store(0, Ordering::Release);
 
         // For reader slots, we must check OFD locks before
         // clearing: another live process may hold a slot. Blindly clearing
@@ -1209,6 +1471,19 @@ impl MappedSharedWalCoordination {
         }
     }
 
+    /// Discard the durable shared frame index so the caller can rebuild it
+    /// from a local WAL scan. The caller must decide separately when that is
+    /// safe; this is intentionally distinct from transient-state repair.
+    pub(crate) fn discard_durable_frame_index_for_exclusive_rebuild(&self) {
+        let _publish_guard = self
+            .frame_index_publish_lock
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let header = self.header();
+        header.frame_index_len.store(0, Ordering::Release);
+        header.frame_index_overflowed.store(0, Ordering::Release);
+    }
+
     pub(crate) fn frame_index_overflowed(&self) -> bool {
         self.header().frame_index_overflowed.load(Ordering::Acquire) != 0
     }
@@ -1220,6 +1495,7 @@ impl MappedSharedWalCoordination {
         checksum_2: u32,
         transaction_count: u64,
     ) {
+        self.clear_backfill_proof();
         let header = self.header();
         // Use fetch_max to ensure we never lower max_frame. In multi-process
         // mode, another process may have committed frames after ours, advancing
@@ -1239,9 +1515,164 @@ impl MappedSharedWalCoordination {
     }
 
     pub(crate) fn publish_backfill(&self, nbackfills: u64) {
+        if nbackfills == 0 {
+            self.clear_backfill_proof();
+        }
         self.header()
             .nbackfills
             .store(nbackfills, Ordering::Release);
+    }
+
+    pub(crate) fn clear_backfill_proof(&self) {
+        let header = self.header();
+        header.backfill_proof_version.store(0, Ordering::Release);
+        header.backfill_proof_nbackfills.store(0, Ordering::Release);
+        header.backfill_proof_max_frame.store(0, Ordering::Release);
+        header
+            .backfill_proof_checkpoint_seq
+            .store(0, Ordering::Release);
+        header.backfill_proof_page_size.store(0, Ordering::Release);
+        header.backfill_proof_salt_1.store(0, Ordering::Release);
+        header.backfill_proof_salt_2.store(0, Ordering::Release);
+        header.backfill_proof_checksum_1.store(0, Ordering::Release);
+        header.backfill_proof_checksum_2.store(0, Ordering::Release);
+        header
+            .backfill_proof_db_size_pages
+            .store(0, Ordering::Release);
+        header
+            .backfill_proof_db_header_crc32c
+            .store(0, Ordering::Release);
+        header.backfill_proof_crc32c.store(0, Ordering::Release);
+    }
+
+    pub(crate) fn install_backfill_proof(
+        &self,
+        snapshot: SharedWalCoordinationHeader,
+        db_size_pages: u32,
+        db_header_crc32c: u32,
+    ) {
+        turso_assert!(
+            snapshot.nbackfills != 0,
+            "backfill proof requires positive nbackfills"
+        );
+        let proof =
+            SharedWalBackfillProof::from_snapshot_and_db(snapshot, db_size_pages, db_header_crc32c);
+        let header = self.header();
+        header.backfill_proof_version.store(0, Ordering::Release);
+        header
+            .backfill_proof_nbackfills
+            .store(proof.nbackfills, Ordering::Release);
+        header
+            .backfill_proof_max_frame
+            .store(proof.max_frame, Ordering::Release);
+        header
+            .backfill_proof_checkpoint_seq
+            .store(proof.checkpoint_seq, Ordering::Release);
+        header
+            .backfill_proof_page_size
+            .store(proof.page_size, Ordering::Release);
+        header
+            .backfill_proof_salt_1
+            .store(proof.salt_1, Ordering::Release);
+        header
+            .backfill_proof_salt_2
+            .store(proof.salt_2, Ordering::Release);
+        header
+            .backfill_proof_checksum_1
+            .store(proof.checksum_1, Ordering::Release);
+        header
+            .backfill_proof_checksum_2
+            .store(proof.checksum_2, Ordering::Release);
+        header
+            .backfill_proof_db_size_pages
+            .store(proof.db_size_pages, Ordering::Release);
+        header
+            .backfill_proof_db_header_crc32c
+            .store(proof.db_header_crc32c, Ordering::Release);
+        header
+            .backfill_proof_crc32c
+            .store(proof.crc32c(), Ordering::Release);
+        header
+            .backfill_proof_version
+            .store(SHARED_WAL_BACKFILL_PROOF_VERSION, Ordering::Release);
+    }
+
+    pub(crate) fn validate_backfill_proof(
+        &self,
+        snapshot: SharedWalCoordinationHeader,
+        db_size_pages: u32,
+        db_header_crc32c: u32,
+    ) -> bool {
+        let header = self.header();
+        let version = header.backfill_proof_version.load(Ordering::Acquire);
+        if version != SHARED_WAL_BACKFILL_PROOF_VERSION {
+            return false;
+        }
+        let proof = SharedWalBackfillProof {
+            nbackfills: header.backfill_proof_nbackfills.load(Ordering::Acquire),
+            max_frame: header.backfill_proof_max_frame.load(Ordering::Acquire),
+            checkpoint_seq: header.backfill_proof_checkpoint_seq.load(Ordering::Acquire),
+            page_size: header.backfill_proof_page_size.load(Ordering::Acquire),
+            salt_1: header.backfill_proof_salt_1.load(Ordering::Acquire),
+            salt_2: header.backfill_proof_salt_2.load(Ordering::Acquire),
+            checksum_1: header.backfill_proof_checksum_1.load(Ordering::Acquire),
+            checksum_2: header.backfill_proof_checksum_2.load(Ordering::Acquire),
+            db_size_pages: header.backfill_proof_db_size_pages.load(Ordering::Acquire),
+            db_header_crc32c: header
+                .backfill_proof_db_header_crc32c
+                .load(Ordering::Acquire),
+        };
+        if !proof.is_structurally_valid() {
+            return false;
+        }
+        let stored_crc = header.backfill_proof_crc32c.load(Ordering::Acquire);
+        if proof.crc32c() != stored_crc {
+            return false;
+        }
+        proof
+            == SharedWalBackfillProof::from_snapshot_and_db(
+                snapshot,
+                db_size_pages,
+                db_header_crc32c,
+            )
+    }
+
+    pub(crate) fn sync(&self, io: &Arc<dyn IO>, sync_type: FileSyncType) -> Result<()> {
+        let c = self.file.sync(Completion::new_sync(|_| {}), sync_type)?;
+        io.wait_for_completion(c)?;
+        Ok(())
+    }
+
+    fn sanitize_backfill_proof_for_exclusive_open(&self) -> bool {
+        let header = self.header();
+        let version = header.backfill_proof_version.load(Ordering::Acquire);
+        if version == 0 {
+            return false;
+        }
+        if version != SHARED_WAL_BACKFILL_PROOF_VERSION {
+            self.clear_backfill_proof();
+            return true;
+        }
+        let proof = SharedWalBackfillProof {
+            nbackfills: header.backfill_proof_nbackfills.load(Ordering::Acquire),
+            max_frame: header.backfill_proof_max_frame.load(Ordering::Acquire),
+            checkpoint_seq: header.backfill_proof_checkpoint_seq.load(Ordering::Acquire),
+            page_size: header.backfill_proof_page_size.load(Ordering::Acquire),
+            salt_1: header.backfill_proof_salt_1.load(Ordering::Acquire),
+            salt_2: header.backfill_proof_salt_2.load(Ordering::Acquire),
+            checksum_1: header.backfill_proof_checksum_1.load(Ordering::Acquire),
+            checksum_2: header.backfill_proof_checksum_2.load(Ordering::Acquire),
+            db_size_pages: header.backfill_proof_db_size_pages.load(Ordering::Acquire),
+            db_header_crc32c: header
+                .backfill_proof_db_header_crc32c
+                .load(Ordering::Acquire),
+        };
+        let stored_crc = header.backfill_proof_crc32c.load(Ordering::Acquire);
+        if !proof.is_structurally_valid() || proof.crc32c() != stored_crc {
+            self.clear_backfill_proof();
+            return true;
+        }
+        false
     }
 
     pub(crate) fn install_header_fields(&self, page_size: u32, salt_1: u32, salt_2: u32) {
@@ -1777,12 +2208,46 @@ impl MappedSharedWalCoordination {
         }
     }
 
+    pub(crate) fn register_reader_for_snapshot(
+        &self,
+        owner: SharedOwnerRecord,
+        max_frame: u64,
+    ) -> Option<SharedReaderSlot> {
+        {
+            let mut process_local = self
+                .process_local_ownership
+                .lock()
+                .expect("process-local ownership registry poisoned");
+            if let Some(slot) = process_local.retain_shared_snapshot_reader(max_frame) {
+                return Some(slot);
+            }
+        }
+
+        let slot = self.register_reader(owner, max_frame)?;
+        let mut process_local = self
+            .process_local_ownership
+            .lock()
+            .expect("process-local ownership registry poisoned");
+        if let Some(existing_slot) = process_local.shared_snapshot_reader(max_frame) {
+            let retained = process_local.retain_shared_snapshot_reader(max_frame);
+            turso_assert!(
+                retained == Some(existing_slot.slot),
+                "shared snapshot retention should return the published slot"
+            );
+            drop(process_local);
+            self.unregister_reader(slot);
+            return Some(existing_slot.slot);
+        }
+        process_local.publish_shared_snapshot_reader(slot);
+        Some(slot)
+    }
+
     /// Release a reader slot previously acquired by `register_reader`.
     ///
     /// Asserts that the current shared-memory owner matches `slot.owner` —
     /// a mismatch means another process reclaimed this slot while we still
     /// thought we held it, which is a correctness bug in the coordination
-    /// layer (see `reset_runtime_state_for_exclusive_open`).
+    /// layer (see `repair_transient_state_for_exclusive_open`).
     pub(crate) fn unregister_reader(&self, slot: SharedReaderSlot) {
         let mut local = self
             .local_lock_state
@@ -1827,6 +2292,19 @@ impl MappedSharedWalCoordination {
         let word_idx = (slot.slot_index >> 6) as usize;
         let bit = slot.slot_index & 63;
         self.reader_bitmap_words()[word_idx].fetch_or(1u64 << bit, Ordering::Release);
+    }
+
+    pub(crate) fn unregister_reader_for_snapshot(&self, slot: SharedReaderSlot) {
+        let release_slot = {
+            let mut process_local = self
+                .process_local_ownership
+                .lock()
+                .expect("process-local ownership registry poisoned");
+            process_local.release_shared_snapshot_reader(slot)
+        };
+        if release_slot {
+            self.unregister_reader(slot);
+        }
     }
 
     pub(crate) fn reader_owner(&self, slot_index: u32) -> Option<SharedOwnerRecord> {
@@ -2294,6 +2772,7 @@ impl MappedSharedWalCoordination {
         unsafe { mappings[block_index].entries_ptr.as_ptr().add(entry_index) }
     }
 
+    #[allow(clippy::mut_from_ref)]
     fn frame_index_block_hash_slice(mapping: &FrameIndexBlockMapping) -> &mut [u16] {
         unsafe {
             std::slice::from_raw_parts_mut(
@@ -2457,6 +2936,20 @@ impl MappedSharedWalCoordination {
             std::ptr::addr_of_mut!((*header).frame_index_capacity).write(MAX_FRAME_INDEX_CAPACITY);
             std::ptr::addr_of_mut!((*header).frame_index_len).write(AtomicU32::new(0));
             std::ptr::addr_of_mut!((*header).frame_index_overflowed).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_version).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_nbackfills).write(AtomicU64::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_max_frame).write(AtomicU64::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_checkpoint_seq)
+                .write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_page_size).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_salt_1).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_salt_2).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_checksum_1).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_checksum_2).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_db_size_pages).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_db_header_crc32c)
+                .write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).backfill_proof_crc32c).write(AtomicU32::new(0));
             std::ptr::addr_of_mut!((*header).writer_owner).write(AtomicU64::new(UNOWNED_LOCK));
             std::ptr::addr_of_mut!((*header).checkpoint_owner).write(AtomicU64::new(UNOWNED_LOCK));
         }
@@ -2519,8 +3012,7 @@ impl MappedSharedWalCoordination {
         let blocks = header.frame_index_blocks.load(Ordering::Acquire);
         if !(INITIAL_FRAME_INDEX_BLOCKS..=MAX_FRAME_INDEX_BLOCKS).contains(&blocks) {
             return Err(LimboError::Corrupt(format!(
-                "shared WAL coordination map frame index block count out of range: {}",
-                blocks
+                "shared WAL coordination map frame index block count out of range: {blocks}"
             )));
         }
         if header.frame_index_capacity != MAX_FRAME_INDEX_CAPACITY {
@@ -2930,6 +3422,63 @@ mod tests {
     }
 
     #[test]
+    fn mapped_shared_wal_coordination_repair_reclaims_dead_owners_without_clearing_frame_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+
+        mapped.record_frame(7, 2);
+        mapped.record_frame(9, 4);
+        mapped
+            .header()
+            .writer_owner
+            .store(SharedOwnerRecord::new(u32::MAX, 1).raw(), Ordering::Release);
+        mapped
+            .header()
+            .checkpoint_owner
+            .store(SharedOwnerRecord::new(u32::MAX, 2).raw(), Ordering::Release);
+        mapped.reader_bitmap_words()[0].fetch_and(!1u64, Ordering::Release);
+        mapped.reader_frames()[0].store(4, Ordering::Release);
+        mapped.reader_owners()[0]
+            .store(SharedOwnerRecord::new(u32::MAX, 3).raw(), Ordering::Release);
+
+        mapped.repair_transient_state_for_exclusive_open();
+
+        assert_eq!(mapped.writer_owner(), None);
+        assert_eq!(mapped.checkpoint_owner(), None);
+        assert_eq!(mapped.reader_owner(0), None);
+        assert_eq!(mapped.min_active_reader_frame(), None);
+        assert_eq!(mapped.find_frame(7, 0, 4, None), Some(2));
+        assert_eq!(mapped.find_frame(9, 0, 4, None), Some(4));
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_repair_preserves_live_reader_slots_and_frame_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped_a = create_mapping(&path);
+        let mapped_b = create_mapping(&path);
+
+        mapped_a.record_frame(7, 2);
+        mapped_a.record_frame(9, 4);
+        let reader = mapped_b
+            .register_reader(mapped_b.owner_record(), 4)
+            .unwrap();
+
+        mapped_a.repair_transient_state_for_exclusive_open();
+
+        assert_eq!(mapped_a.reader_owner(reader.slot_index), Some(reader.owner));
+        assert_eq!(mapped_a.min_active_reader_frame(), Some(4));
+        assert_eq!(mapped_a.find_frame(7, 0, 4, None), Some(2));
+        assert_eq!(mapped_a.find_frame(9, 0, 4, None), Some(4));
+
+        mapped_b.unregister_reader(reader);
+        assert_eq!(mapped_a.min_active_reader_frame(), None);
+        assert_eq!(mapped_a.find_frame(7, 0, 4, None), Some(2));
+        assert_eq!(mapped_a.find_frame(9, 0, 4, None), Some(4));
+    }
+
+    #[test]
     fn mapped_shared_wal_coordination_rebuilds_undersized_file_on_exclusive_open() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("coordination.tshm");
@@ -3010,6 +3559,334 @@ mod tests {
     }
 
     #[test]
+    fn mapped_shared_wal_coordination_second_process_local_mapping_is_multiprocess() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+
+        let mapped_a = create_mapping(&path);
+        assert_eq!(
+            mapped_a.open_mode(),
+            SharedWalCoordinationOpenMode::Exclusive
+        );
+        assert!(mapped_a.is_primary_process_mapping());
+
+        let mapped_b = create_mapping(&path);
+        assert_eq!(
+            mapped_b.open_mode(),
+            SharedWalCoordinationOpenMode::MultiProcess
+        );
+        assert!(!mapped_b.is_primary_process_mapping());
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_persists_backfill_proof_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 14,
+            nbackfills: 8,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        {
+            let mapped = create_mapping(&path);
+            mapped.install_snapshot(snapshot);
+            mapped.install_backfill_proof(snapshot, 11, 0xAABB_CCDD);
+            assert!(mapped.validate_backfill_proof(snapshot, 11, 0xAABB_CCDD));
+        }
+
+        let reopened = create_mapping(&path);
+        assert!(reopened.validate_backfill_proof(snapshot, 11, 0xAABB_CCDD));
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_publish_commit_clears_backfill_proof() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 14,
+            nbackfills: 8,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        mapped.install_snapshot(snapshot);
+        mapped.install_backfill_proof(snapshot, 11, 0xAABB_CCDD);
+        assert!(mapped.validate_backfill_proof(snapshot, 11, 0xAABB_CCDD));
+
+        mapped.publish_commit(15, 41, 43, 10);
+
+        assert!(!mapped.validate_backfill_proof(snapshot, 11, 0xAABB_CCDD));
+        assert_eq!(
+            mapped
+                .header()
+                .backfill_proof_version
+                .load(Ordering::Acquire),
+            0
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_install_snapshot_clears_backfill_proof() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 14,
+            nbackfills: 8,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        mapped.install_snapshot(snapshot);
+        mapped.install_backfill_proof(snapshot, 11, 0xAABB_CCDD);
+        assert!(mapped.validate_backfill_proof(snapshot, 11, 0xAABB_CCDD));
+
+        mapped.install_snapshot(SharedWalCoordinationHeader {
+            max_frame: 0,
+            nbackfills: 0,
+            checkpoint_seq: 6,
+            salt_1: 19,
+            salt_2: 29,
+            ..snapshot
+        });
+
+        assert!(!mapped.validate_backfill_proof(snapshot, 11, 0xAABB_CCDD));
+        assert_eq!(
+            mapped
+                .header()
+                .backfill_proof_version
+                .load(Ordering::Acquire),
+            0
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_rejects_corrupt_backfill_proof_crc() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 14,
+            nbackfills: 8,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        mapped.install_snapshot(snapshot);
+        mapped.install_backfill_proof(snapshot, 11, 0xAABB_CCDD);
+        mapped
+            .header()
+            .backfill_proof_crc32c
+            .store(0xDEAD_BEEF, Ordering::Release);
+
+        assert!(!mapped.validate_backfill_proof(snapshot, 11, 0xAABB_CCDD));
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_rejects_structurally_impossible_backfill_proof() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 14,
+            nbackfills: 8,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        mapped.install_snapshot(snapshot);
+        mapped.install_backfill_proof(snapshot, 11, 0xAABB_CCDD);
+        mapped
+            .header()
+            .backfill_proof_max_frame
+            .store(3, Ordering::Release);
+        mapped.header().backfill_proof_crc32c.store(
+            SharedWalBackfillProof {
+                max_frame: 3,
+                ..SharedWalBackfillProof::from_snapshot_and_db(snapshot, 11, 0xAABB_CCDD)
+            }
+            .crc32c(),
+            Ordering::Release,
+        );
+
+        assert!(
+            !mapped.validate_backfill_proof(snapshot, 11, 0xAABB_CCDD),
+            "proof with nbackfills beyond max_frame must be rejected even if CRC matches"
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_exclusive_reopen_clears_corrupt_backfill_proof() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 14,
+            nbackfills: 8,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        {
+            let mapped = create_mapping(&path);
+            mapped.install_snapshot(snapshot);
+            mapped.install_backfill_proof(snapshot, 11, 0xAABB_CCDD);
+            mapped
+                .header()
+                .backfill_proof_crc32c
+                .store(0xDEAD_BEEF, Ordering::Release);
+        }
+
+        let reopened = create_mapping(&path);
+        assert_eq!(
+            reopened
+                .header()
+                .backfill_proof_version
+                .load(Ordering::Acquire),
+            0,
+            "exclusive reopen should clear corrupt backfill proof state instead of rejecting the map"
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_exclusive_reopen_clears_unsupported_backfill_proof_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 14,
+            nbackfills: 8,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        {
+            let mapped = create_mapping(&path);
+            mapped.install_snapshot(snapshot);
+            mapped.install_backfill_proof(snapshot, 11, 0xAABB_CCDD);
+            mapped
+                .header()
+                .backfill_proof_version
+                .store(SHARED_WAL_BACKFILL_PROOF_VERSION + 1, Ordering::Release);
+        }
+
+        let reopened = create_mapping(&path);
+        assert_eq!(
+            reopened
+                .header()
+                .backfill_proof_version
+                .load(Ordering::Acquire),
+            0,
+            "exclusive reopen should clear unsupported proof versions instead of discarding the whole map"
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_exclusive_reopen_clears_impossible_backfill_proof_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 14,
+            nbackfills: 8,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        {
+            let mapped = create_mapping(&path);
+            mapped.install_snapshot(snapshot);
+            mapped.install_backfill_proof(snapshot, 11, 0xAABB_CCDD);
+            mapped
+                .header()
+                .backfill_proof_max_frame
+                .store(3, Ordering::Release);
+            mapped.header().backfill_proof_crc32c.store(
+                SharedWalBackfillProof {
+                    max_frame: 3,
+                    ..SharedWalBackfillProof::from_snapshot_and_db(snapshot, 11, 0xAABB_CCDD)
+                }
+                .crc32c(),
+                Ordering::Release,
+            );
+        }
+
+        let reopened = create_mapping(&path);
+        assert_eq!(
+            reopened
+                .header()
+                .backfill_proof_version
+                .load(Ordering::Acquire),
+            0,
+            "exclusive reopen should clear structurally impossible proof payloads"
+        );
+    }
+
+    #[test]
     fn mapped_shared_wal_coordination_prevents_reentrant_lock_reuse_within_same_mapping() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("coordination.tshm");
@@ -3085,6 +3962,25 @@ mod tests {
 
         assert_eq!(mapped.find_frame(7, 0, 5, None), Some(2));
         assert_eq!(mapped.iter_latest_frames(0, 5), vec![(7, 2), (9, 4)]);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_finds_simple_kv_page_after_seed_frame_sequence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = create_mapping(&path);
+
+        for (frame_id, page_id) in [1, 702, 703, 1377, 1378, 559, 560, 1, 1066, 1067, 1377]
+            .into_iter()
+            .enumerate()
+            .map(|(idx, page_id)| ((idx + 1) as u64, page_id as u64))
+        {
+            mapped.record_frame(page_id, frame_id);
+        }
+
+        assert_eq!(mapped.find_frame(1066, 0, 11, None), Some(9));
+        assert_eq!(mapped.find_frame(1067, 0, 11, None), Some(10));
+        assert_eq!(mapped.find_frame(1377, 0, 11, None), Some(11));
     }
 
     #[test]
@@ -3824,7 +4720,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mp_dbfile_read_blocks_when_shared_reader_slots_are_exhausted() {
+    fn test_mp_dbfile_readers_do_not_consume_shared_reader_slots() {
         let (db, conn_writer, _dir) = open_mp_database();
 
         exec(
@@ -3840,37 +4736,26 @@ mod tests {
         );
 
         let mut readers = Vec::new();
-        for slot in 0..64 {
+        for slot in 0..128 {
             let conn = db.connect().unwrap();
             exec(&conn, "BEGIN");
             assert_eq!(
                 query_i64(&conn, "SELECT count(*) FROM t"),
                 1,
-                "reader slot {slot} should acquire a shared reader slot"
+                "db-file reader {slot} should not fail due to shared-reader slot pressure"
             );
             readers.push(conn);
         }
 
-        let err = match db.connect() {
-            Ok(_) => {
-                panic!("65th reader should not connect while all shared reader slots are occupied")
-            }
-            Err(err) => err,
-        };
-        assert!(
-            matches!(err, LimboError::Busy),
-            "slot exhaustion should surface as Busy, got {err:?}"
-        );
-
-        let released_conn = readers.pop().unwrap();
-        exec(&released_conn, "COMMIT");
-        drop(released_conn);
-
-        let overflow_conn = db.connect().unwrap();
+        let authority = db.shared_wal_coordination().unwrap().unwrap();
         assert_eq!(
-            query_i64(&overflow_conn, "SELECT count(*) FROM t"),
-            1,
-            "read should succeed once a shared reader slot is released"
+            authority.min_active_reader_frame(),
+            None,
+            "db-file-only readers should not publish shared WAL reader slots"
         );
+
+        for conn in readers {
+            exec(&conn, "COMMIT");
+        }
     }
 }

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -37,7 +37,7 @@ use std::ptr::NonNull;
 /// Durable file-format magic stored at the start of every `.tshm` mapping.
 const SHARED_WAL_COORDINATION_MAGIC: [u8; 8] = *b"TSHMWAL\0";
 /// Durable `.tshm` file-format version. Bump whenever persisted layout changes.
-const SHARED_WAL_COORDINATION_VERSION: u32 = 9;
+const SHARED_WAL_COORDINATION_VERSION: u32 = 10;
 /// Version for the optional persisted backfill-proof payload.
 const SHARED_WAL_BACKFILL_PROOF_VERSION: u32 = 1;
 /// Sentinel meaning a reader slot is not currently pinning any WAL frame.
@@ -523,6 +523,11 @@ struct SharedWalCoordinationMapHeader {
     /// only exists as a last-resort guard once we have consumed the full mapped
     /// region.
     frame_index_overflowed: AtomicU32,
+    /// Sequence lock protecting multi-field snapshot reads and writes.
+    ///
+    /// Even values mean stable. Odd values mean a writer is publishing a new
+    /// snapshot, so readers must retry.
+    snapshot_seq: AtomicU64,
     max_frame: AtomicU64,
     nbackfills: AtomicU64,
     transaction_count: AtomicU64,
@@ -852,18 +857,7 @@ impl MappedSharedWalCoordination {
             LimboError::InternalError("shared WAL coordination path is not valid UTF-8".into())
         })?)?;
         let lock_kind = Self::lock_kind_for_mode(ownership_mode);
-        let open_mode =
-            match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
-                true => {
-                    file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
-                    file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
-                    SharedWalCoordinationOpenMode::Exclusive
-                }
-                false => {
-                    file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
-                    SharedWalCoordinationOpenMode::MultiProcess
-                }
-            };
+        let open_mode = Self::detect_open_mode(&file, lock_kind, base_len)?;
         let metadata_len = file.size()? as usize;
         let initialize = metadata_len == 0
             || (open_mode == SharedWalCoordinationOpenMode::Exclusive && metadata_len < base_len);
@@ -957,18 +951,7 @@ impl MappedSharedWalCoordination {
             Err(err) => return Err(err),
         };
         let lock_kind = Self::lock_kind_for_mode(ownership_mode);
-        let open_mode =
-            match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
-                true => {
-                    file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
-                    file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
-                    SharedWalCoordinationOpenMode::Exclusive
-                }
-                false => {
-                    file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
-                    SharedWalCoordinationOpenMode::MultiProcess
-                }
-            };
+        let open_mode = Self::detect_open_mode(&file, lock_kind, base_len)?;
         let metadata_len = file.size()? as usize;
         if metadata_len < base_len {
             file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
@@ -1025,6 +1008,30 @@ impl MappedSharedWalCoordination {
         READER_LOCK_START_OFFSET + slot_index as u64
     }
 
+    fn detect_open_mode(
+        file: &Arc<dyn File>,
+        lock_kind: SharedWalLockKind,
+        base_len: usize,
+    ) -> Result<SharedWalCoordinationOpenMode> {
+        let metadata_len_before_probe = file.size()? as usize;
+        match file.shared_wal_try_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, true, lock_kind)? {
+            true => {
+                file.shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, lock_kind)?;
+                file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+                let metadata_len_after_probe = file.size()? as usize;
+                if metadata_len_before_probe < base_len && metadata_len_after_probe >= base_len {
+                    Ok(SharedWalCoordinationOpenMode::MultiProcess)
+                } else {
+                    Ok(SharedWalCoordinationOpenMode::Exclusive)
+                }
+            }
+            false => {
+                file.shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, lock_kind)?;
+                Ok(SharedWalCoordinationOpenMode::MultiProcess)
+            }
+        }
+    }
+
     /// Return whether dropping this mapping would leave no other process with
     /// the lifetime byte lock held.
     ///
@@ -1044,6 +1051,9 @@ impl MappedSharedWalCoordination {
         let _ = self
             .file
             .shared_wal_unlock_byte(PROCESS_LIFETIME_LOCK_OFFSET, self.lock_kind());
+        let _ =
+            self.file
+                .shared_wal_lock_byte(PROCESS_LIFETIME_LOCK_OFFSET, false, self.lock_kind());
         true
     }
 
@@ -1147,26 +1157,33 @@ impl MappedSharedWalCoordination {
     }
 
     /// Read a consistent snapshot of the shared coordination header.
-    ///
-    /// # Safety invariant
-    /// Individual fields are read with atomic loads, but the multi-field read is
-    /// NOT an atomic snapshot. Consistency relies on the writer lock serializing
-    /// all modifications — any concurrent modifier MUST hold the writer lock.
     pub(crate) fn snapshot(&self) -> SharedWalCoordinationHeader {
         let header = self.header();
-        SharedWalCoordinationHeader {
-            max_frame: header.max_frame.load(Ordering::Acquire),
-            nbackfills: header.nbackfills.load(Ordering::Acquire),
-            transaction_count: header.transaction_count.load(Ordering::Acquire),
-            visibility_generation: header.visibility_generation.load(Ordering::Acquire),
-            checkpoint_seq: header.checkpoint_seq.load(Ordering::Acquire),
-            checkpoint_epoch: header.checkpoint_epoch.load(Ordering::Acquire),
-            page_size: header.page_size.load(Ordering::Acquire),
-            salt_1: header.salt_1.load(Ordering::Acquire),
-            salt_2: header.salt_2.load(Ordering::Acquire),
-            checksum_1: header.checksum_1.load(Ordering::Acquire),
-            checksum_2: header.checksum_2.load(Ordering::Acquire),
-            reader_slot_count: header.reader_slot_count,
+        loop {
+            let seq_before = header.snapshot_seq.load(Ordering::Acquire);
+            if seq_before & 1 != 0 {
+                std::hint::spin_loop();
+                continue;
+            }
+            let snapshot = SharedWalCoordinationHeader {
+                max_frame: header.max_frame.load(Ordering::Acquire),
+                nbackfills: header.nbackfills.load(Ordering::Acquire),
+                transaction_count: header.transaction_count.load(Ordering::Acquire),
+                visibility_generation: header.visibility_generation.load(Ordering::Acquire),
+                checkpoint_seq: header.checkpoint_seq.load(Ordering::Acquire),
+                checkpoint_epoch: header.checkpoint_epoch.load(Ordering::Acquire),
+                page_size: header.page_size.load(Ordering::Acquire),
+                salt_1: header.salt_1.load(Ordering::Acquire),
+                salt_2: header.salt_2.load(Ordering::Acquire),
+                checksum_1: header.checksum_1.load(Ordering::Acquire),
+                checksum_2: header.checksum_2.load(Ordering::Acquire),
+                reader_slot_count: header.reader_slot_count,
+            };
+            let seq_after = header.snapshot_seq.load(Ordering::Acquire);
+            if seq_before == seq_after {
+                return snapshot;
+            }
+            std::hint::spin_loop();
         }
     }
 
@@ -1195,37 +1212,37 @@ impl MappedSharedWalCoordination {
         // range, trim them before publishing the new header so later frame
         // appends cannot observe a stale tail.
         self.rollback_frames(snapshot.max_frame);
-
-        let header = self.header();
-        header
-            .max_frame
-            .store(snapshot.max_frame, Ordering::Release);
-        header
-            .nbackfills
-            .store(snapshot.nbackfills, Ordering::Release);
-        header
-            .transaction_count
-            .store(snapshot.transaction_count, Ordering::Release);
-        header
-            .visibility_generation
-            .store(snapshot.visibility_generation, Ordering::Release);
-        header
-            .checkpoint_seq
-            .store(snapshot.checkpoint_seq, Ordering::Release);
-        header
-            .checkpoint_epoch
-            .store(snapshot.checkpoint_epoch, Ordering::Release);
-        header
-            .page_size
-            .store(snapshot.page_size, Ordering::Release);
-        header.salt_1.store(snapshot.salt_1, Ordering::Release);
-        header.salt_2.store(snapshot.salt_2, Ordering::Release);
-        header
-            .checksum_1
-            .store(snapshot.checksum_1, Ordering::Release);
-        header
-            .checksum_2
-            .store(snapshot.checksum_2, Ordering::Release);
+        self.with_snapshot_write(|header| {
+            header
+                .max_frame
+                .store(snapshot.max_frame, Ordering::Release);
+            header
+                .nbackfills
+                .store(snapshot.nbackfills, Ordering::Release);
+            header
+                .transaction_count
+                .store(snapshot.transaction_count, Ordering::Release);
+            header
+                .visibility_generation
+                .store(snapshot.visibility_generation, Ordering::Release);
+            header
+                .checkpoint_seq
+                .store(snapshot.checkpoint_seq, Ordering::Release);
+            header
+                .checkpoint_epoch
+                .store(snapshot.checkpoint_epoch, Ordering::Release);
+            header
+                .page_size
+                .store(snapshot.page_size, Ordering::Release);
+            header.salt_1.store(snapshot.salt_1, Ordering::Release);
+            header.salt_2.store(snapshot.salt_2, Ordering::Release);
+            header
+                .checksum_1
+                .store(snapshot.checksum_1, Ordering::Release);
+            header
+                .checksum_2
+                .store(snapshot.checksum_2, Ordering::Release);
+        });
     }
 
     /// Repair transient runtime state when a process determines that it can
@@ -1302,9 +1319,7 @@ impl MappedSharedWalCoordination {
     /// Publish a committed transaction to the shared coordination header.
     ///
     /// # Precondition
-    /// The caller MUST hold the WAL writer lock. The multi-field update is not
-    /// atomic; the writer lock serializes all writers so readers see a consistent
-    /// state (the checksum TOCTOU below is safe only under this invariant).
+    /// The caller MUST hold the WAL writer lock.
     pub(crate) fn publish_commit(
         &self,
         max_frame: u64,
@@ -1313,22 +1328,23 @@ impl MappedSharedWalCoordination {
         transaction_count: u64,
     ) {
         self.clear_backfill_proof();
-        let header = self.header();
-        // Use fetch_max to ensure we never lower max_frame. In multi-process
-        // mode, another process may have committed frames after ours, advancing
-        // max_frame beyond our local value. Overwriting with a smaller value
-        // would make those later frames invisible to checkpoints, causing data loss.
-        header.max_frame.fetch_max(max_frame, Ordering::AcqRel);
-        // Only update checksums if we are the latest writer (our max_frame is the current max).
-        // Otherwise, a later writer's checksums are authoritative.
-        if header.max_frame.load(Ordering::Acquire) == max_frame {
-            header.checksum_1.store(checksum_1, Ordering::Release);
-            header.checksum_2.store(checksum_2, Ordering::Release);
-        }
-        header
-            .transaction_count
-            .fetch_max(transaction_count, Ordering::AcqRel);
-        header.visibility_generation.fetch_add(1, Ordering::AcqRel);
+        self.with_snapshot_write(|header| {
+            // Use fetch_max to ensure we never lower max_frame. In multi-process
+            // mode, another process may have committed frames after ours, advancing
+            // max_frame beyond our local value. Overwriting with a smaller value
+            // would make those later frames invisible to checkpoints, causing data loss.
+            header.max_frame.fetch_max(max_frame, Ordering::AcqRel);
+            // Only update checksums if we are the latest writer (our max_frame is the current max).
+            // Otherwise, a later writer's checksums are authoritative.
+            if header.max_frame.load(Ordering::Acquire) == max_frame {
+                header.checksum_1.store(checksum_1, Ordering::Release);
+                header.checksum_2.store(checksum_2, Ordering::Release);
+            }
+            header
+                .transaction_count
+                .fetch_max(transaction_count, Ordering::AcqRel);
+            header.visibility_generation.fetch_add(1, Ordering::AcqRel);
+        });
     }
 
     /// Publish durable checkpoint progress after a successful backfill step.
@@ -1339,9 +1355,9 @@ impl MappedSharedWalCoordination {
         if nbackfills == 0 {
             self.clear_backfill_proof();
         }
-        self.header()
-            .nbackfills
-            .store(nbackfills, Ordering::Release);
+        self.with_snapshot_write(|header| {
+            header.nbackfills.store(nbackfills, Ordering::Release);
+        });
     }
 
     /// Clear the persisted durable proof that positive checkpoint progress is safe to trust.
@@ -1503,15 +1519,23 @@ impl MappedSharedWalCoordination {
 
     /// Seed only the WAL header identity fields needed before the first commit is published.
     pub(crate) fn install_header_fields(&self, page_size: u32, salt_1: u32, salt_2: u32) {
-        let header = self.header();
-        header.page_size.store(page_size, Ordering::Release);
-        header.salt_1.store(salt_1, Ordering::Release);
-        header.salt_2.store(salt_2, Ordering::Release);
+        self.with_snapshot_write(|header| {
+            header.page_size.store(page_size, Ordering::Release);
+            header.salt_1.store(salt_1, Ordering::Release);
+            header.salt_2.store(salt_2, Ordering::Release);
+        });
     }
 
     /// Advance the durable WAL generation counter and return the new value.
     pub(crate) fn bump_checkpoint_seq(&self) -> u32 {
-        self.header().checkpoint_seq.fetch_add(1, Ordering::AcqRel) + 1
+        self.with_snapshot_write(|header| {
+            let next = header
+                .checkpoint_seq
+                .load(Ordering::Acquire)
+                .wrapping_add(1);
+            header.checkpoint_seq.store(next, Ordering::Release);
+            next
+        })
     }
 
     /// Read the checkpoint epoch used to detect same-generation visibility changes.
@@ -1521,9 +1545,13 @@ impl MappedSharedWalCoordination {
 
     /// Bump the checkpoint epoch after a visibility-affecting checkpoint step.
     pub(crate) fn bump_checkpoint_epoch(&self) -> u32 {
-        self.header()
-            .checkpoint_epoch
-            .fetch_add(1, Ordering::AcqRel)
+        self.with_snapshot_write(|header| {
+            let prev = header.checkpoint_epoch.load(Ordering::Acquire);
+            header
+                .checkpoint_epoch
+                .store(prev.wrapping_add(1), Ordering::Release);
+            prev
+        })
     }
 
     /// Borrow the per-process local lock counters under the mapping mutex.
@@ -1539,6 +1567,34 @@ impl MappedSharedWalCoordination {
     ) -> T {
         let mut entry = self.process_local_ownership.lock();
         f(&mut entry)
+    }
+
+    fn with_snapshot_write<T>(&self, f: impl FnOnce(&SharedWalCoordinationMapHeader) -> T) -> T {
+        let header = self.header();
+        loop {
+            let seq = header.snapshot_seq.load(Ordering::Acquire);
+            if seq & 1 != 0 {
+                std::hint::spin_loop();
+                continue;
+            }
+            if header
+                .snapshot_seq
+                .compare_exchange(
+                    seq,
+                    seq.wrapping_add(1),
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                let result = f(header);
+                header
+                    .snapshot_seq
+                    .store(seq.wrapping_add(2), Ordering::Release);
+                return result;
+            }
+            std::hint::spin_loop();
+        }
     }
 
     /// Clear one shared owner slot, asserting it still records `owner`.
@@ -2717,6 +2773,7 @@ impl MappedSharedWalCoordination {
             std::ptr::addr_of_mut!((*header).frame_index_capacity).write(MAX_FRAME_INDEX_CAPACITY);
             std::ptr::addr_of_mut!((*header).frame_index_len).write(AtomicU32::new(0));
             std::ptr::addr_of_mut!((*header).frame_index_overflowed).write(AtomicU32::new(0));
+            std::ptr::addr_of_mut!((*header).snapshot_seq).write(AtomicU64::new(0));
             std::ptr::addr_of_mut!((*header).backfill_proof_version).write(AtomicU32::new(0));
             std::ptr::addr_of_mut!((*header).backfill_proof_nbackfills).write(AtomicU64::new(0));
             std::ptr::addr_of_mut!((*header).backfill_proof_max_frame).write(AtomicU64::new(0));
@@ -3222,6 +3279,102 @@ mod tests {
 
         assert_eq!(mapped_a.bump_checkpoint_epoch(), 0);
         assert_eq!(mapped_b.checkpoint_epoch(), 1);
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_last_process_probe_reacquires_shared_lifetime_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped_a = create_mapping(&path);
+
+        assert!(
+            mapped_a.is_last_process_mapping(),
+            "single mapping should identify itself as the last live process mapping"
+        );
+
+        let mapped_b = create_mapping(&path);
+        assert_eq!(
+            mapped_b.open_mode(),
+            SharedWalCoordinationOpenMode::MultiProcess,
+            "lifetime lock probe must leave the original mapping holding the shared lifetime lock"
+        );
+    }
+
+    #[test]
+    fn mapped_shared_wal_coordination_snapshot_waits_for_stable_sequence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coordination.tshm");
+        let mapped = Arc::new(create_mapping(&path));
+        let expected = SharedWalCoordinationHeader {
+            max_frame: 14,
+            nbackfills: 8,
+            transaction_count: 9,
+            visibility_generation: 10,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        let header = mapped.header();
+        let seq = header.snapshot_seq.load(Ordering::Acquire);
+        assert_eq!(
+            seq & 1,
+            0,
+            "fresh mapping should start with a stable snapshot sequence"
+        );
+        assert!(
+            header
+                .snapshot_seq
+                .compare_exchange(seq, seq + 1, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok(),
+            "test must acquire the snapshot write sequence"
+        );
+
+        let reader = mapped.clone();
+        let handle = std::thread::spawn(move || reader.snapshot());
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        assert!(
+            !handle.is_finished(),
+            "snapshot readers must wait while a writer holds the sequence lock"
+        );
+
+        header
+            .max_frame
+            .store(expected.max_frame, Ordering::Release);
+        header
+            .nbackfills
+            .store(expected.nbackfills, Ordering::Release);
+        header
+            .transaction_count
+            .store(expected.transaction_count, Ordering::Release);
+        header
+            .visibility_generation
+            .store(expected.visibility_generation, Ordering::Release);
+        header
+            .checkpoint_seq
+            .store(expected.checkpoint_seq, Ordering::Release);
+        header
+            .checkpoint_epoch
+            .store(expected.checkpoint_epoch, Ordering::Release);
+        header
+            .page_size
+            .store(expected.page_size, Ordering::Release);
+        header.salt_1.store(expected.salt_1, Ordering::Release);
+        header.salt_2.store(expected.salt_2, Ordering::Release);
+        header
+            .checksum_1
+            .store(expected.checksum_1, Ordering::Release);
+        header
+            .checksum_2
+            .store(expected.checksum_2, Ordering::Release);
+        header.snapshot_seq.store(seq + 2, Ordering::Release);
+
+        assert_eq!(handle.join().unwrap(), expected);
     }
 
     #[test]

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -1054,7 +1054,7 @@ impl MappedSharedWalCoordination {
     /// cleared shared metadata.
     fn release_owned_locks_on_drop(&mut self) {
         let (writer_lock_held, checkpoint_lock_held, reader_locks) = {
-            let local = self.local_lock_state.get_mut();
+            let mut local = self.local_lock_state.lock();
             let writer_lock_held = local.writer_lock_held;
             let checkpoint_lock_held = local.checkpoint_lock_held;
             let reader_locks = std::mem::take(&mut local.reader_locks);

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -51,7 +51,7 @@ use tracing::{instrument, Level};
 
 use super::pager::PageRef;
 pub use super::pager::{PageContent, PageInner};
-use super::wal::TursoRwLock;
+use super::wal::{TursoRwLock, WalSharedMetadata, WalSharedRuntime};
 use crate::error::LimboError;
 use crate::fast_lock::SpinLock;
 use crate::io::{Buffer, Completion, FileSyncType, ReadComplete};
@@ -1429,25 +1429,34 @@ pub fn build_shared_wal(
     }
 
     let wal_file_shared = Arc::new(RwLock::new(WalFileShared {
-        enabled: AtomicBool::new(true),
-        wal_header: header.clone(),
-        min_frame: AtomicU64::new(0),
-        max_frame: AtomicU64::new(0),
-        nbackfills: AtomicU64::new(0),
-        transaction_count: AtomicU64::new(0),
-        frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
-        last_checksum: (0, 0),
-        file: Some(file.clone()),
-        read_locks,
-        write_lock: TursoRwLock::new(),
-        loaded: AtomicBool::new(false),
-        checkpoint_lock: TursoRwLock::new(),
-        initialized: AtomicBool::new(false),
-        epoch: AtomicU32::new(0),
+        metadata: WalSharedMetadata {
+            enabled: AtomicBool::new(true),
+            wal_header: header.clone(),
+            min_frame: AtomicU64::new(0),
+            max_frame: AtomicU64::new(0),
+            nbackfills: AtomicU64::new(0),
+            transaction_count: AtomicU64::new(0),
+            last_checksum: (0, 0),
+            loaded: AtomicBool::new(false),
+            loaded_from_disk_scan: AtomicBool::new(true),
+            initialized: AtomicBool::new(false),
+        },
+        runtime: WalSharedRuntime {
+            frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
+            file: Some(file.clone()),
+            read_locks,
+            write_lock: TursoRwLock::new(),
+            checkpoint_lock: TursoRwLock::new(),
+            epoch: AtomicU32::new(0),
+        },
     }));
 
     if size < WAL_HEADER_SIZE as u64 {
-        wal_file_shared.write().loaded.store(true, Ordering::SeqCst);
+        wal_file_shared
+            .write()
+            .metadata
+            .loaded
+            .store(true, Ordering::SeqCst);
         return Ok(wal_file_shared);
     }
 
@@ -1721,7 +1730,7 @@ impl StreamingWalReader {
         }
         let wfs = self.wal_shared.read();
         {
-            let mut frame_cache = wfs.frame_cache.lock();
+            let mut frame_cache = wfs.runtime.frame_cache.lock();
             for (page, mut frames) in state.pending_frames.drain() {
                 // Only include frames up to last valid commit
                 frames.retain(|&f| f <= state.last_valid_frame);
@@ -1730,7 +1739,8 @@ impl StreamingWalReader {
                 }
             }
         }
-        wfs.max_frame
+        wfs.metadata
+            .max_frame
             .store(state.last_valid_frame, Ordering::Release);
     }
 
@@ -1741,21 +1751,21 @@ impl StreamingWalReader {
 
         let max_frame = st.last_valid_frame;
         if max_frame > 0 {
-            let mut frame_cache = wfs.frame_cache.lock();
+            let mut frame_cache = wfs.runtime.frame_cache.lock();
             for frames in frame_cache.values_mut() {
                 frames.retain(|&f| f <= max_frame);
             }
             frame_cache.retain(|_, frames| !frames.is_empty());
         }
 
-        wfs.max_frame.store(max_frame, Ordering::SeqCst);
+        wfs.metadata.max_frame.store(max_frame, Ordering::SeqCst);
         // use checksum of last valid commit frame, not necessarily the last frame
-        wfs.last_checksum = st.last_valid_checksum;
+        wfs.metadata.last_checksum = st.last_valid_checksum;
         if st.header_valid {
-            wfs.initialized.store(true, Ordering::SeqCst);
+            wfs.metadata.initialized.store(true, Ordering::SeqCst);
         }
-        wfs.nbackfills.store(0, Ordering::SeqCst);
-        wfs.loaded.store(true, Ordering::SeqCst);
+        wfs.metadata.nbackfills.store(0, Ordering::SeqCst);
+        wfs.metadata.loaded.store(true, Ordering::SeqCst);
 
         self.done.store(true, Ordering::Release);
         tracing::debug!(
@@ -2259,13 +2269,13 @@ mod tests {
 
         let shared = build_shared_wal(&file, &io).unwrap();
         let guard = shared.read();
-        assert_eq!(guard.max_frame.load(Ordering::Acquire), 1);
-        assert_eq!(guard.last_checksum, commit_checksum);
+        assert_eq!(guard.metadata.max_frame.load(Ordering::Acquire), 1);
+        assert_eq!(guard.metadata.last_checksum, commit_checksum);
 
         // checksum should only include committed frame.
-        assert_ne!(guard.last_checksum, after_frame3_checksum);
+        assert_ne!(guard.metadata.last_checksum, after_frame3_checksum);
 
-        let frame_cache = guard.frame_cache.lock();
+        let frame_cache = guard.runtime.frame_cache.lock();
         assert_eq!(frame_cache.get(&1), Some(&vec![1u64]));
         assert!(frame_cache.get(&2).is_none());
     }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -51,7 +51,7 @@ use tracing::{instrument, Level};
 
 use super::pager::PageRef;
 pub use super::pager::{PageContent, PageInner};
-use super::wal::{TursoRwLock, WalSharedMetadata, WalSharedRuntime};
+use super::wal::{OverflowFallbackCoverage, TursoRwLock, WalSharedMetadata, WalSharedRuntime};
 use crate::error::LimboError;
 use crate::fast_lock::SpinLock;
 use crate::io::{Buffer, Completion, FileSyncType, ReadComplete};
@@ -1448,6 +1448,9 @@ pub fn build_shared_wal(
             write_lock: TursoRwLock::new(),
             checkpoint_lock: TursoRwLock::new(),
             epoch: AtomicU32::new(0),
+            overflow_fallback_coverage: Arc::new(
+                SpinLock::new(OverflowFallbackCoverage::default()),
+            ),
         },
     }));
 
@@ -1796,6 +1799,15 @@ impl StreamingWalReader {
                 frames.retain(|&f| f <= max_frame);
             }
             frame_cache.retain(|_, frames| !frames.is_empty());
+            let header = wfs.metadata.wal_header.lock();
+            wfs.runtime.overflow_fallback_coverage.lock().record(
+                header.checkpoint_seq,
+                header.salt_1,
+                header.salt_2,
+                max_frame,
+            );
+        } else {
+            wfs.runtime.overflow_fallback_coverage.lock().clear();
         }
 
         wfs.metadata.max_frame.store(max_frame, Ordering::SeqCst);

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1626,6 +1626,21 @@ impl StreamingWalReader {
                 calc == (h.checksum_1, h.checksum_2),
             )
         };
+        #[cfg(debug_assertions)]
+        {
+            let header = self.header.lock();
+            tracing::debug!(
+                "WAL_SCAN header page_size={} checkpoint_seq={} salts=({}, {}) checksum=({}, {}) use_native={} valid={}",
+                page_sz,
+                header.checkpoint_seq,
+                header.salt_1,
+                header.salt_2,
+                c1,
+                c2,
+                use_native,
+                ok
+            );
+        }
         if PageSize::new(page_sz).is_none() || !ok {
             self.finalize_loading();
             return;
@@ -1692,6 +1707,14 @@ impl StreamingWalReader {
             }
             if s1 != header.salt_1 || s2 != header.salt_2 {
                 tracing::debug!(
+                    "WAL_SCAN stop: frame={} salt mismatch frame=({}, {}) header=({}, {})",
+                    st.frame_idx,
+                    s1,
+                    s2,
+                    header.salt_1,
+                    header.salt_2
+                );
+                tracing::debug!(
                     "process_frames: salt mismatch, stop reading WAL at initialization phase"
                 );
                 break;
@@ -1701,7 +1724,12 @@ impl StreamingWalReader {
             let calc = checksum_wal(page, header, seed, use_native);
             if calc != (c1, c2) {
                 tracing::debug!(
-                    "process_frames: checksum mismatch, stop reading WAL at initialization phase"
+                    " WAL_SCAN stop: process_frames, checksum mismatch, stop reading WAL at initialization phase: frame={} checksum mismatch calc=({},{}) file=({},{})",
+                    st.frame_idx,
+                    calc.0,
+                    calc.1,
+                    c1,
+                    c2
                 );
                 break;
             }
@@ -1716,6 +1744,12 @@ impl StreamingWalReader {
             if db_size > 0 {
                 st.last_valid_frame = st.frame_idx;
                 st.last_valid_checksum = calc;
+                tracing::debug!(
+                    "WAL_SCAN commit frame={} page_no={} db_size={}",
+                    st.frame_idx,
+                    page_no,
+                    db_size
+                );
                 self.flush_pending_frames(&mut st);
             }
             st.frame_idx += 1;
@@ -1748,6 +1782,12 @@ impl StreamingWalReader {
     fn finalize_loading(&self) {
         let mut wfs = self.wal_shared.write();
         let st = self.state.read();
+        tracing::debug!(
+            "WAL_SCAN finalize last_valid_frame={} pending_pages={} header_valid={}",
+            st.last_valid_frame,
+            st.pending_frames.len(),
+            st.header_valid
+        );
 
         let max_frame = st.last_valid_frame;
         if max_frame > 0 {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -356,7 +356,13 @@ impl TursoRwLock {
         turso_debug_assert!(Self::has_writer(cur));
         // Preserve value bits, replace writer with one reader
         let desired = (cur & Self::VALUE_MASK) | Self::READER_INC;
-        self.0.store(desired, Ordering::Release);
+        let prev = self
+            .0
+            .compare_exchange(cur, desired, Ordering::AcqRel, Ordering::Relaxed);
+        turso_debug_assert!(
+            prev.is_ok(),
+            "downgrade CAS failed — lock was mutated concurrently"
+        );
     }
 
     #[inline]
@@ -431,6 +437,15 @@ enum CoordinationCheckpointGuardKind {
 trait WalCoordination: Debug + Send + Sync {
     /// Load the current authoritative WAL snapshot.
     fn load_snapshot(&self) -> WalSnapshot;
+
+    /// Ensure any process-local fallback cache is complete for `snapshot`.
+    fn ensure_local_frame_cache_covers(
+        &self,
+        _io: &Arc<dyn IO>,
+        _snapshot: WalSnapshot,
+    ) -> Result<()> {
+        Ok(())
+    }
 
     /// Publish a newly committed WAL state snapshot.
     fn publish_commit(&self, commit: WalCommitState);
@@ -816,6 +831,10 @@ impl WalCoordination for InProcessWalCoordination {
     }
 
     fn try_begin_read_tx(&self, snapshot: WalSnapshot) -> Option<ReadGuardKind> {
+        turso_assert!(
+            snapshot.max_frame <= u32::MAX as u64,
+            "max_frame exceeds u32 read mark range"
+        );
         if snapshot.max_frame == snapshot.nbackfills {
             if !self.try_read_mark_shared(0) {
                 return None;
@@ -946,6 +965,10 @@ impl WalCoordination for InProcessWalCoordination {
     }
 
     fn determine_max_safe_checkpoint_frame(&self, max_frame: u64) -> u64 {
+        turso_assert!(
+            max_frame <= u32::MAX as u64,
+            "max_frame exceeds u32 read mark range"
+        );
         let mut max_safe_frame = max_frame;
         for read_lock_idx in 1..5 {
             let this_mark = self.read_mark_value(read_lock_idx);
@@ -1152,6 +1175,61 @@ struct ShmWalCoordination {
 
 #[cfg(all(unix, target_pointer_width = "64"))]
 impl ShmWalCoordination {
+    fn overflow_fallback_covers(
+        &self,
+        snapshot: SharedWalCoordinationHeader,
+        max_frame: u64,
+    ) -> bool {
+        self.shared
+            .read()
+            .runtime
+            .overflow_fallback_coverage
+            .lock()
+            .covers(snapshot, max_frame)
+    }
+
+    fn clear_overflow_fallback_coverage(&self) {
+        self.shared
+            .read()
+            .runtime
+            .overflow_fallback_coverage
+            .lock()
+            .clear();
+    }
+
+    fn local_overflow_scan_covers_snapshot(
+        authority_snapshot: SharedWalCoordinationHeader,
+        required_snapshot: WalSnapshot,
+        scanned: SharedWalCoordinationHeader,
+    ) -> bool {
+        scanned.checkpoint_seq == required_snapshot.checkpoint_seq
+            && scanned.page_size == authority_snapshot.page_size
+            && scanned.salt_1 == authority_snapshot.salt_1
+            && scanned.salt_2 == authority_snapshot.salt_2
+            && scanned.max_frame >= required_snapshot.max_frame
+    }
+
+    fn local_authority_snapshot_from_shared(
+        shared: &WalFileShared,
+        authority_snapshot: SharedWalCoordinationHeader,
+    ) -> SharedWalCoordinationHeader {
+        let header = shared.metadata.wal_header.lock();
+        SharedWalCoordinationHeader {
+            max_frame: shared.metadata.max_frame.load(Ordering::Acquire),
+            nbackfills: shared.metadata.nbackfills.load(Ordering::Acquire),
+            transaction_count: shared.metadata.transaction_count.load(Ordering::Acquire),
+            visibility_generation: authority_snapshot.visibility_generation,
+            checkpoint_seq: header.checkpoint_seq,
+            checkpoint_epoch: shared.runtime.epoch.load(Ordering::Acquire),
+            page_size: header.page_size,
+            salt_1: header.salt_1,
+            salt_2: header.salt_2,
+            checksum_1: shared.metadata.last_checksum.0,
+            checksum_2: shared.metadata.last_checksum.1,
+            reader_slot_count: authority_snapshot.reader_slot_count,
+        }
+    }
+
     fn new(
         shared: Arc<RwLock<WalFileShared>>,
         authority: Arc<MappedSharedWalCoordination>,
@@ -1185,21 +1263,7 @@ impl ShmWalCoordination {
     fn local_authority_snapshot(&self) -> SharedWalCoordinationHeader {
         let authority_snapshot = self.authority.snapshot();
         let shared = self.shared.read();
-        let header = shared.metadata.wal_header.lock();
-        SharedWalCoordinationHeader {
-            max_frame: shared.metadata.max_frame.load(Ordering::Acquire),
-            nbackfills: shared.metadata.nbackfills.load(Ordering::Acquire),
-            transaction_count: shared.metadata.transaction_count.load(Ordering::Acquire),
-            visibility_generation: authority_snapshot.visibility_generation,
-            checkpoint_seq: header.checkpoint_seq,
-            checkpoint_epoch: shared.runtime.epoch.load(Ordering::Acquire),
-            page_size: header.page_size,
-            salt_1: header.salt_1,
-            salt_2: header.salt_2,
-            checksum_1: shared.metadata.last_checksum.0,
-            checksum_2: shared.metadata.last_checksum.1,
-            reader_slot_count: authority_snapshot.reader_slot_count,
-        }
+        Self::local_authority_snapshot_from_shared(&shared, authority_snapshot)
     }
 
     fn sync_local_from_authority(&self, snapshot: SharedWalCoordinationHeader) {
@@ -1267,6 +1331,7 @@ impl ShmWalCoordination {
             header.checksum_2 = snapshot.checksum_2;
         }
         shared.runtime.frame_cache.lock().clear();
+        shared.runtime.overflow_fallback_coverage.lock().clear();
     }
 
     fn sync_authority_frames_from_local(&self) {
@@ -1286,22 +1351,6 @@ impl ShmWalCoordination {
         for (frame_id, page_id) in entries {
             self.authority.record_frame(page_id, frame_id);
         }
-    }
-
-    fn authority_frame_index_matches_local_scan(&self, max_frame: u64) -> bool {
-        let local_entries = {
-            let shared = self.shared.read();
-            let frame_cache = shared.runtime.frame_cache.lock();
-            let mut entries = Vec::with_capacity(frame_cache.len());
-            for (&page_id, frames) in frame_cache.iter() {
-                if let Some(&frame_id) = frames.iter().rfind(|&&frame_id| frame_id <= max_frame) {
-                    entries.push((page_id, frame_id));
-                }
-            }
-            entries.sort_unstable_by_key(|&(page_id, _)| page_id);
-            entries
-        };
-        self.authority.iter_latest_frames(0, max_frame) == local_entries
     }
 
     fn repair_or_reseed_authority_from_local_disk_scan(
@@ -1333,8 +1382,37 @@ impl ShmWalCoordination {
         }
         if Self::authority_matches_local_wal_scan(authority_snapshot, local_snapshot) {
             self.sync_local_from_authority(authority_snapshot);
+            // Matching header metadata is not enough to trust the durable
+            // frame index. A restart or interrupted reopen can leave stale or
+            // empty page->frame mappings behind while max_frame/checksums
+            // still match the scanned WAL. When both snapshots describe the
+            // same visible WAL generation, compare the latest per-page
+            // mappings directly and rebuild if they diverge.
             if self.authority.frame_index_overflowed()
-                || !self.authority_frame_index_matches_local_scan(local_snapshot.max_frame)
+                || (self.authority.open_mode() == SharedWalCoordinationOpenMode::Exclusive
+                    && !self.authority_frame_index_matches_local_wal_scan(local_snapshot.max_frame))
+            {
+                self.authority
+                    .discard_durable_frame_index_for_exclusive_rebuild();
+                self.sync_authority_frames_from_local();
+            }
+            return;
+        }
+        // The authority and disk scan are from the same generation (matching
+        // checkpoint_seq/salts) but disagree on max_frame or checksums. This
+        // happens when a concurrent write advances the authority between the
+        // snapshot read and the disk scan.  Or the authority is from a strictly
+        // newer generation (higher checkpoint_seq) because the WAL was
+        // restarted but the on-disk header hasn't been rewritten yet.
+        //
+        // In both cases the authority's header fields are at least as current
+        // as the disk, so adopt them.  As above, preserve the authority's
+        // frame index — it is maintained by writers and must not be replaced
+        // with a potentially incomplete reconstruction.
+        if Self::authority_is_same_or_newer_generation(authority_snapshot, local_snapshot) {
+            self.sync_local_from_authority(authority_snapshot);
+            if authority_snapshot.checkpoint_seq == local_snapshot.checkpoint_seq
+                && self.authority.frame_index_overflowed()
             {
                 self.authority
                     .discard_durable_frame_index_for_exclusive_rebuild();
@@ -1380,6 +1458,36 @@ impl ShmWalCoordination {
             && local_snapshot.salt_2 == authority_snapshot.salt_2
     }
 
+    /// The authority is from a strictly newer WAL generation (higher
+    /// checkpoint_seq), OR from the same generation with at least as many
+    /// frames.  In either case the authority's header fields were updated
+    /// atomically by writers and are at least as current as a point-in-time
+    /// disk scan of the WAL file.
+    ///
+    /// When the generations match but the authority has a *lower* max_frame,
+    /// the authority was likely rolled back or corrupted; the disk scan's
+    /// higher max_frame is more accurate, so we must NOT match here.
+    fn authority_is_same_or_newer_generation(
+        authority_snapshot: SharedWalCoordinationHeader,
+        local_snapshot: SharedWalCoordinationHeader,
+    ) -> bool {
+        if Self::authority_is_uninitialized(authority_snapshot) {
+            return false;
+        }
+        // Strictly newer generation — always trust authority.
+        if authority_snapshot.checkpoint_seq > local_snapshot.checkpoint_seq {
+            return true;
+        }
+        // Same generation: the authority is atomically updated by writers,
+        // so its max_frame is at least as current as what the disk scan
+        // observed.  Only match when authority.max_frame >= local to
+        // avoid masking a genuinely rolled-back authority.
+        authority_snapshot.checkpoint_seq == local_snapshot.checkpoint_seq
+            && authority_snapshot.salt_1 == local_snapshot.salt_1
+            && authority_snapshot.salt_2 == local_snapshot.salt_2
+            && authority_snapshot.max_frame >= local_snapshot.max_frame
+    }
+
     fn authority_matches_local_wal_scan(
         authority_snapshot: SharedWalCoordinationHeader,
         local_snapshot: SharedWalCoordinationHeader,
@@ -1391,6 +1499,11 @@ impl ShmWalCoordination {
             && authority_snapshot.salt_2 == local_snapshot.salt_2
             && authority_snapshot.checksum_1 == local_snapshot.checksum_1
             && authority_snapshot.checksum_2 == local_snapshot.checksum_2
+    }
+
+    fn authority_frame_index_matches_local_wal_scan(&self, max_frame: u64) -> bool {
+        self.authority.iter_latest_frames(0, max_frame)
+            == self.fallback.iter_latest_frames(0, max_frame)
     }
 
     fn local_zero_frame_generation_is_initialized(
@@ -1516,6 +1629,7 @@ impl ShmWalCoordination {
             }
 
             shared.runtime.frame_cache.lock().clear();
+            shared.runtime.overflow_fallback_coverage.lock().clear();
             shared.runtime.read_locks[0].set_value_exclusive(0);
             shared.runtime.read_locks[1].set_value_exclusive(0);
             for lock in &shared.runtime.read_locks[2..] {
@@ -1548,6 +1662,51 @@ impl ShmWalCoordination {
             transaction_count: snapshot.transaction_count,
         }
     }
+
+    fn ensure_local_frame_cache_covers_snapshot(
+        &self,
+        io: &Arc<dyn IO>,
+        required_snapshot: WalSnapshot,
+    ) -> Result<()> {
+        if required_snapshot.max_frame == 0 || !self.authority.frame_index_overflowed() {
+            return Ok(());
+        }
+
+        let authority_snapshot = self.authority.snapshot();
+        if authority_snapshot.checkpoint_seq != required_snapshot.checkpoint_seq {
+            return Err(LimboError::Busy);
+        }
+        if self.overflow_fallback_covers(authority_snapshot, required_snapshot.max_frame) {
+            return Ok(());
+        }
+
+        let wal_file = self.fallback.wal_file()?;
+        let scanned = sqlite3_ondisk::build_shared_wal(&wal_file, io)?;
+        let (scanned_snapshot, scanned_frame_cache) = {
+            let scanned_guard = scanned.read();
+            let snapshot =
+                Self::local_authority_snapshot_from_shared(&scanned_guard, authority_snapshot);
+            let frame_cache = scanned_guard.runtime.frame_cache.lock().clone();
+            (snapshot, frame_cache)
+        };
+
+        if !Self::local_overflow_scan_covers_snapshot(
+            authority_snapshot,
+            required_snapshot,
+            scanned_snapshot,
+        ) {
+            return Err(LimboError::Busy);
+        }
+
+        let shared = self.shared.write();
+        *shared.runtime.frame_cache.lock() = scanned_frame_cache;
+        shared
+            .runtime
+            .overflow_fallback_coverage
+            .lock()
+            .record_snapshot(scanned_snapshot, scanned_snapshot.max_frame);
+        Ok(())
+    }
 }
 
 #[cfg(all(unix, target_pointer_width = "64"))]
@@ -1561,6 +1720,14 @@ impl WalCoordination for ShmWalCoordination {
             checkpoint_seq: snapshot.checkpoint_seq,
             transaction_count: snapshot.transaction_count,
         }
+    }
+
+    fn ensure_local_frame_cache_covers(
+        &self,
+        io: &Arc<dyn IO>,
+        snapshot: WalSnapshot,
+    ) -> Result<()> {
+        self.ensure_local_frame_cache_covers_snapshot(io, snapshot)
     }
 
     fn publish_commit(&self, commit: WalCommitState) {
@@ -1585,6 +1752,14 @@ impl WalCoordination for ShmWalCoordination {
             commit.last_checksum.1,
             commit.transaction_count,
         );
+        if self.authority.frame_index_overflowed() {
+            let snapshot = self.authority.snapshot();
+            let shared = self.shared.read();
+            let mut coverage = shared.runtime.overflow_fallback_coverage.lock();
+            if coverage.covers(snapshot, commit.max_frame.saturating_sub(1)) {
+                coverage.record_snapshot(snapshot, commit.max_frame);
+            }
+        }
     }
 
     fn publish_backfill(&self, max_frame: u64) {
@@ -1668,6 +1843,10 @@ impl WalCoordination for ShmWalCoordination {
     }
 
     fn try_begin_read_tx(&self, snapshot: WalSnapshot) -> Option<ReadGuardKind> {
+        turso_assert!(
+            snapshot.max_frame <= u32::MAX as u64,
+            "max_frame exceeds u32 read mark range"
+        );
         let shared = self.shared.read();
         let read_locks = &shared.runtime.read_locks;
 
@@ -1823,6 +2002,10 @@ impl WalCoordination for ShmWalCoordination {
     }
 
     fn determine_max_safe_checkpoint_frame(&self, max_frame: u64) -> u64 {
+        turso_assert!(
+            max_frame <= u32::MAX as u64,
+            "max_frame exceeds u32 read mark range"
+        );
         let mut max_safe_frame = max_frame;
         for read_lock_idx in 1..5 {
             let this_mark = self.fallback.read_mark_value(read_lock_idx);
@@ -1970,6 +2153,7 @@ impl WalCoordination for ShmWalCoordination {
     fn rollback_cache(&self, max_frame: u64) {
         self.fallback.rollback_cache(max_frame);
         self.authority.rollback_frames(max_frame);
+        self.clear_overflow_fallback_coverage();
     }
 
     fn should_checkpoint_on_close(&self) -> bool {
@@ -2406,12 +2590,69 @@ pub struct WalSharedRuntime {
     /// Increments on each checkpoint, used to prevent stale cached pages being used for
     /// backfilling.
     pub epoch: AtomicU32,
+    /// Tracks how far the process-local `frame_cache` is known to be complete
+    /// for overflow fallback in the current WAL generation.
+    pub overflow_fallback_coverage: Arc<SpinLock<OverflowFallbackCoverage>>,
 }
 
 /// WalFileShared holds process-wide WAL metadata plus process-local coordination state.
 pub struct WalFileShared {
     pub metadata: WalSharedMetadata,
     pub runtime: WalSharedRuntime,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct OverflowFallbackCoverage {
+    checkpoint_seq: u32,
+    salt_1: u32,
+    salt_2: u32,
+    max_frame: u64,
+    valid: bool,
+}
+
+impl OverflowFallbackCoverage {
+    pub(crate) fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    pub(crate) fn record(&mut self, checkpoint_seq: u32, salt_1: u32, salt_2: u32, max_frame: u64) {
+        if max_frame == 0 {
+            self.clear();
+            return;
+        }
+        self.checkpoint_seq = checkpoint_seq;
+        self.salt_1 = salt_1;
+        self.salt_2 = salt_2;
+        self.max_frame = max_frame;
+        self.valid = true;
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub(crate) fn record_snapshot(
+        &mut self,
+        snapshot: SharedWalCoordinationHeader,
+        max_frame: u64,
+    ) {
+        self.record(
+            snapshot.checkpoint_seq,
+            snapshot.salt_1,
+            snapshot.salt_2,
+            max_frame,
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub(crate) fn same_generation(&self, snapshot: SharedWalCoordinationHeader) -> bool {
+        self.valid
+            && self.checkpoint_seq == snapshot.checkpoint_seq
+            && self.salt_1 == snapshot.salt_1
+            && self.salt_2 == snapshot.salt_2
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub(crate) fn covers(&self, snapshot: SharedWalCoordinationHeader, max_frame: u64) -> bool {
+        self.same_generation(snapshot) && self.max_frame >= max_frame
+    }
 }
 
 impl fmt::Debug for WalFileShared {
@@ -2478,6 +2719,8 @@ enum TryBeginReadResult {
     Ok(bool),
     /// Transient condition, caller should retry immediately (like SQLite's WAL_RETRY)
     Retry,
+    /// Non-retriable failure while preparing the local WAL view.
+    Err(LimboError),
 }
 
 impl WalFile {
@@ -2542,6 +2785,15 @@ impl WalFile {
             shared_snapshot.checkpoint_seq,
             shared_snapshot.transaction_count
         );
+        if let Err(err) = self
+            .coordination
+            .ensure_local_frame_cache_covers(&self.io, shared_snapshot)
+        {
+            return match err {
+                LimboError::Busy => TryBeginReadResult::Retry,
+                other => TryBeginReadResult::Err(other),
+            };
+        }
 
         // Check if database changed since this connection's last read transaction.
         // If it has, the connection will invalidate its page cache.
@@ -2586,6 +2838,7 @@ impl Wal for WalFile {
             tracing::trace!("begin_read_tx: cnt={cnt}");
             match self.try_begin_read_tx() {
                 TryBeginReadResult::Ok(changed) => return Ok(changed),
+                TryBeginReadResult::Err(err) => return Err(err),
                 TryBeginReadResult::Retry => {
                     cnt += 1;
                     if cnt > 100 {
@@ -2658,7 +2911,11 @@ impl Wal for WalFile {
                 // Return BusySnapshot instead of Busy so the caller knows it must
                 // restart the read transaction to get a fresh snapshot.
                 // Retrying with busy_timeout will NEVER HELP.
-                tracing::info!("unable to upgrade transaction from read to write: snapshot is stale, give up and let caller retry from scratch, self.max_frame={}, shared_max={}", self.max_frame.load(Ordering::Acquire), self.load_coordination_snapshot().max_frame);
+                tracing::info!(
+                    "unable to upgrade transaction from read to write: snapshot is stale, give up and let caller retry from scratch, self.max_frame={}, shared_max={}",
+                    self.max_frame.load(Ordering::Acquire),
+                    self.load_coordination_snapshot().max_frame
+                );
                 self.coordination.end_write_tx();
                 return Err(LimboError::BusySnapshot);
             }
@@ -2765,6 +3022,16 @@ impl Wal for WalFile {
         }
         let min_frame = self.min_frame.load(Ordering::Acquire);
         let max_frame = self.max_frame.load(Ordering::Acquire);
+        self.coordination.ensure_local_frame_cache_covers(
+            &self.io,
+            WalSnapshot {
+                max_frame,
+                nbackfills: self.min_frame.load(Ordering::Acquire).saturating_sub(1),
+                last_checksum: *self.last_checksum.read(),
+                checkpoint_seq: self.coordination.wal_header().checkpoint_seq,
+                transaction_count: self.transaction_count.load(Ordering::Acquire),
+            },
+        )?;
         tracing::debug!(
             "find_frame(page_id={}, frame_watermark={:?}): min_frame={}, max_frame={}",
             page_id,
@@ -3176,8 +3443,36 @@ impl Wal for WalFile {
 
         self.max_frame.store(0, Ordering::Release);
         let file = self.coordination.wal_file()?;
-        let c = sqlite3_ondisk::begin_write_wal_header(file.as_ref(), &header)?;
-        Ok(Some(c))
+        let header_c = sqlite3_ondisk::begin_write_wal_header(file.as_ref(), &header)?;
+
+        // After a RESTART or try_restart_log_before_write the WAL file may
+        // still contain orphaned frames from the previous epoch. Truncate
+        // them so that classify_authority_snapshot_against_wal does not see a
+        // length mismatch and unnecessarily fall back to a full disk scan
+        // (which can race with concurrent writers and corrupt the authority).
+        let should_skip_truncate = match file.size() {
+            Ok(size) => size <= WAL_HEADER_SIZE as u64,
+            Err(_) => {
+                tracing::warn!("Failed to get WAL file size");
+                true
+            }
+        };
+        if !should_skip_truncate {
+            let trunc_c = file.truncate(
+                WAL_HEADER_SIZE as u64,
+                Completion::new_trunc(|res| {
+                    if let Err(err) = res {
+                        tracing::warn!("WAL truncate of orphaned frames failed: {err}");
+                    }
+                }),
+            )?;
+            let mut group = CompletionGroup::new(|_| {});
+            group.add(&header_c);
+            group.add(&trunc_c);
+            Ok(Some(group.build()))
+        } else {
+            Ok(Some(header_c))
+        }
     }
 
     fn prepare_wal_finish(&self, sync_type: FileSyncType) -> Result<Completion> {
@@ -3679,7 +3974,16 @@ impl WalFile {
                         let oc = self.ongoing_checkpoint.read();
                         (oc.min_frame, oc.max_frame)
                     };
-                    tracing::info!("checkpoint_inner::Start: min_frame={oc_min_frame}, max_frame={oc_max_frame}");
+                    self.coordination.ensure_local_frame_cache_covers(
+                        &self.io,
+                        WalSnapshot {
+                            max_frame: oc_max_frame,
+                            ..self.load_coordination_snapshot()
+                        },
+                    )?;
+                    tracing::info!(
+                        "checkpoint_inner::Start: min_frame={oc_min_frame}, max_frame={oc_max_frame}"
+                    );
                     let mut to_checkpoint = self
                         .coordination
                         .iter_latest_frames(oc_min_frame, oc_max_frame);
@@ -4515,6 +4819,9 @@ impl WalFileShared {
                 write_lock: TursoRwLock::new(),
                 checkpoint_lock: TursoRwLock::new(),
                 epoch: AtomicU32::new(snapshot.checkpoint_epoch),
+                overflow_fallback_coverage: Arc::new(SpinLock::new(
+                    OverflowFallbackCoverage::default(),
+                )),
             },
         };
         Ok(Arc::new(RwLock::new(shared)))
@@ -4579,6 +4886,9 @@ impl WalFileShared {
                 write_lock: TursoRwLock::new(),
                 checkpoint_lock: TursoRwLock::new(),
                 epoch: AtomicU32::new(0),
+                overflow_fallback_coverage: Arc::new(SpinLock::new(
+                    OverflowFallbackCoverage::default(),
+                )),
             },
         };
         Arc::new(RwLock::new(shared))
@@ -4616,6 +4926,9 @@ impl WalFileShared {
                 write_lock: TursoRwLock::new(),
                 checkpoint_lock: TursoRwLock::new(),
                 epoch: AtomicU32::new(0),
+                overflow_fallback_coverage: Arc::new(SpinLock::new(
+                    OverflowFallbackCoverage::default(),
+                )),
             },
         };
         Ok(Arc::new(RwLock::new(shared)))
@@ -5882,21 +6195,23 @@ pub mod test {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
-    fn test_open_shared_from_authority_reuses_trusted_positive_snapshot() {
+    fn test_open_shared_from_authority_reuses_trusted_snapshot_after_exclusive_reopen() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test.db-wal");
         let shm_path = dir.path().join("test.db-tshm");
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
         let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
-        let authority =
-            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
-        authority.install_snapshot(snapshot);
-        authority.record_frame(7, 1);
+        {
+            let authority =
+                Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+            authority.install_snapshot(snapshot);
+            authority.record_frame(7, 1);
+        }
         let reopened_authority =
             Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
         assert_eq!(
             reopened_authority.open_mode(),
-            SharedWalCoordinationOpenMode::MultiProcess
+            SharedWalCoordinationOpenMode::Exclusive
         );
 
         let shared = WalFileShared::open_shared_from_authority_if_exists(
@@ -5929,6 +6244,53 @@ pub mod test {
             .loaded_from_disk_scan
             .load(Ordering::Acquire));
         assert!(shared.runtime.frame_cache.lock().is_empty());
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_live_overflow_refreshes_reused_fallback_for_active_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-live-overflow.db-wal");
+        let shm_path = dir.path().join("test-live-overflow.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        authority.install_snapshot(snapshot);
+        authority.record_frame(7, 1);
+
+        let reopened_authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        let shared = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            &reopened_authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
+        )
+        .unwrap();
+        assert!(shared.read().runtime.frame_cache.lock().is_empty());
+
+        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        buffer_pool.finalize_with_page_size(4096).unwrap();
+        let wal = WalFile::new_with_shared_coordination(
+            io.clone(),
+            shared.clone(),
+            reopened_authority.clone(),
+            ((0, 0), 0),
+            buffer_pool,
+        );
+
+        wal.begin_read_tx().unwrap();
+        reopened_authority.mark_frame_index_overflowed_for_tests();
+
+        assert_eq!(wal.find_frame(7, None).unwrap(), Some(1));
+        assert_eq!(
+            shared.read().runtime.frame_cache.lock().get(&7).cloned(),
+            Some(vec![1])
+        );
+
+        wal.end_read_tx();
     }
 
     #[cfg(all(unix, target_pointer_width = "64"))]
@@ -6075,7 +6437,7 @@ pub mod test {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
-    fn test_open_shared_from_authority_exclusive_disk_scan_rebuilds_authority_via_coordination() {
+    fn test_open_shared_from_authority_rebuilt_authority_persists_across_exclusive_reopen() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test-republish.db-wal");
         let shm_path = dir.path().join("test-republish.db-tshm");
@@ -6107,11 +6469,14 @@ pub mod test {
         assert_eq!(authority.iter_latest_frames(0, u64::MAX), vec![(7, 1)]);
         assert_eq!(exclusive_coordination.find_frame(7, 0, 1, None), Some(1));
 
+        drop(exclusive_coordination);
+        drop(authority);
+
         let reopened_authority =
             Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
         assert_eq!(
             reopened_authority.open_mode(),
-            SharedWalCoordinationOpenMode::MultiProcess
+            SharedWalCoordinationOpenMode::Exclusive
         );
 
         let reopened_shared = WalFileShared::open_shared_from_authority_if_exists(
@@ -6193,28 +6558,30 @@ pub mod test {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
-    fn test_open_shared_from_authority_ignores_unpublished_backfill_proof() {
+    fn test_open_shared_from_authority_ignores_unpublished_backfill_proof_after_exclusive_reopen() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test-unpublished-proof.db-wal");
         let shm_path = dir.path().join("test-unpublished-proof.db-tshm");
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
         let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
-        let authority =
-            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
-        authority.install_snapshot(snapshot);
-        authority.install_backfill_proof(
-            SharedWalCoordinationHeader {
-                nbackfills: snapshot.max_frame,
-                ..snapshot
-            },
-            11,
-            0xAABB_CCDD,
-        );
+        {
+            let authority =
+                Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+            authority.install_snapshot(snapshot);
+            authority.install_backfill_proof(
+                SharedWalCoordinationHeader {
+                    nbackfills: snapshot.max_frame,
+                    ..snapshot
+                },
+                11,
+                0xAABB_CCDD,
+            );
+        }
         let reopened_authority =
             Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
         assert_eq!(
             reopened_authority.open_mode(),
-            SharedWalCoordinationOpenMode::MultiProcess
+            SharedWalCoordinationOpenMode::Exclusive
         );
 
         let shared = WalFileShared::open_shared_from_authority_if_exists(
@@ -6490,7 +6857,8 @@ pub mod test {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
-    fn test_open_shared_from_authority_keeps_zero_length_wal_uninitialized() {
+    fn test_open_shared_from_authority_keeps_zero_length_wal_uninitialized_after_exclusive_reopen()
+    {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test-empty.db-wal");
         let shm_path = dir.path().join("test-empty.db-tshm");
@@ -6498,27 +6866,29 @@ pub mod test {
 
         io.open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
             .unwrap();
-        let authority =
-            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
-        authority.install_snapshot(SharedWalCoordinationHeader {
-            max_frame: 0,
-            nbackfills: 0,
-            transaction_count: 9,
-            visibility_generation: 1,
-            checkpoint_seq: 5,
-            checkpoint_epoch: 7,
-            page_size: 4096,
-            salt_1: 17,
-            salt_2: 23,
-            checksum_1: 31,
-            checksum_2: 37,
-            reader_slot_count: 64,
-        });
+        {
+            let authority =
+                Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+            authority.install_snapshot(SharedWalCoordinationHeader {
+                max_frame: 0,
+                nbackfills: 0,
+                transaction_count: 9,
+                visibility_generation: 1,
+                checkpoint_seq: 5,
+                checkpoint_epoch: 7,
+                page_size: 4096,
+                salt_1: 17,
+                salt_2: 23,
+                checksum_1: 31,
+                checksum_2: 37,
+                reader_slot_count: 64,
+            });
+        }
         let reopened_authority =
             Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
         assert_eq!(
             reopened_authority.open_mode(),
-            SharedWalCoordinationOpenMode::MultiProcess
+            SharedWalCoordinationOpenMode::Exclusive
         );
 
         let shared = WalFileShared::open_shared_from_authority_if_exists(
@@ -6716,9 +7086,11 @@ pub mod test {
             header.checksum_1 = authoritative.last_checksum.0;
             header.checksum_2 = authoritative.last_checksum.1;
         }
-        let (authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
-        coordination_a.cache_frame(7, 2);
-        coordination_a.cache_frame(9, 4);
+        {
+            let (_authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
+            coordination_a.cache_frame(7, 2);
+            coordination_a.cache_frame(9, 4);
+        }
 
         let file_b = io
             .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
@@ -6741,7 +7113,11 @@ pub mod test {
             shared.runtime.frame_cache.lock().insert(9, vec![5]);
         }
 
-        let (_authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
+        let (authority, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
+        assert_eq!(
+            authority.open_mode(),
+            SharedWalCoordinationOpenMode::Exclusive
+        );
 
         let reopened = coordination_b.load_snapshot();
         assert_eq!(reopened.max_frame, authoritative.max_frame);

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4202,7 +4202,6 @@ fn wal_header_matches_authority_snapshot(
         && wal_header.salt_2 == snapshot.salt_2
 }
 
-#[cfg(all(unix, target_pointer_width = "64"))]
 fn database_identity_from_header_bytes(header_bytes: &[u8]) -> Result<(u32, u32)> {
     if header_bytes.len() < DatabaseHeader::SIZE {
         return Err(LimboError::Corrupt(format!(
@@ -4219,7 +4218,6 @@ fn database_identity_from_header_bytes(header_bytes: &[u8]) -> Result<(u32, u32)
     Ok((db_size_pages, header_crc32c))
 }
 
-#[cfg(all(unix, target_pointer_width = "64"))]
 fn read_database_identity_from_storage(
     io: &Arc<dyn IO>,
     db_file: &Arc<dyn DatabaseStorage>,

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -65,7 +65,6 @@ pub struct CheckpointResult {
     maybe_guard: Option<CheckpointLocks>,
     pub db_truncate_sent: bool,
     pub db_sync_sent: bool,
-    pending_durable_backfill: Option<u64>,
     /// Whether WAL truncation I/O has been submitted (for TRUNCATE checkpoint mode)
     pub wal_truncate_sent: bool,
     /// Whether WAL sync I/O has been submitted after truncation
@@ -91,7 +90,6 @@ impl CheckpointResult {
             maybe_guard: None,
             db_sync_sent: false,
             db_truncate_sent: false,
-            pending_durable_backfill: None,
             wal_truncate_sent: false,
             wal_sync_sent: false,
         }
@@ -107,14 +105,6 @@ impl CheckpointResult {
     }
     pub fn release_guard(&mut self) {
         let _ = self.maybe_guard.take();
-    }
-
-    fn set_pending_durable_backfill(&mut self, max_frame: u64) {
-        self.pending_durable_backfill = Some(max_frame);
-    }
-
-    fn take_pending_durable_backfill(&mut self) -> Option<u64> {
-        self.pending_durable_backfill.take()
     }
 }
 
@@ -460,15 +450,15 @@ trait WalCoordination: Debug + Send + Sync {
     /// Publish the highest frame durably backfilled during checkpoint.
     fn publish_backfill(&self, max_frame: u64);
 
-    /// Publish backfill only after any backend-specific durable proof is installed.
-    fn publish_durable_backfill(
+    /// Install any backend-specific durable proof before publishing backfill.
+    /// Returns an optional completion that must finish before `publish_backfill`.
+    fn install_durable_backfill_proof(
         &self,
-        io: &Arc<dyn IO>,
         max_frame: u64,
         db_size_pages: u32,
         db_header_crc32c: u32,
         sync_type: FileSyncType,
-    ) -> Result<()>;
+    ) -> Result<Option<Completion>>;
 
     /// Find the newest frame for `page_id` within the caller's visible range.
     fn find_frame(
@@ -653,7 +643,14 @@ pub trait Wal: Debug + Send + Sync {
     fn should_checkpoint(&self) -> bool;
     fn checkpoint(&self, pager: &Pager, mode: CheckpointMode)
         -> Result<IOResult<CheckpointResult>>;
-    fn complete_checkpoint_sync(&self, pager: &Pager, result: &mut CheckpointResult) -> Result<()>;
+    fn install_durable_backfill_proof(
+        &self,
+        max_frame: u64,
+        db_size_pages: u32,
+        db_header_crc32c: u32,
+        sync_type: FileSyncType,
+    ) -> Result<Option<Completion>>;
+    fn publish_backfill(&self, max_frame: u64);
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion>;
     fn is_syncing(&self) -> bool;
     fn get_max_frame_in_wal(&self) -> u64;
@@ -777,16 +774,14 @@ impl WalCoordination for InProcessWalCoordination {
             .store(max_frame, Ordering::Release);
     }
 
-    fn publish_durable_backfill(
+    fn install_durable_backfill_proof(
         &self,
-        _io: &Arc<dyn IO>,
-        max_frame: u64,
+        _max_frame: u64,
         _db_size_pages: u32,
         _db_header_crc32c: u32,
         _sync_type: FileSyncType,
-    ) -> Result<()> {
-        self.publish_backfill(max_frame);
-        Ok(())
+    ) -> Result<Option<Completion>> {
+        Ok(None)
     }
 
     fn find_frame(
@@ -1202,18 +1197,6 @@ impl ShmWalCoordination {
             .overflow_fallback_coverage
             .lock()
             .clear();
-    }
-
-    fn local_overflow_scan_covers_snapshot(
-        authority_snapshot: SharedWalCoordinationHeader,
-        required_snapshot: WalSnapshot,
-        scanned: SharedWalCoordinationHeader,
-    ) -> bool {
-        scanned.checkpoint_seq == required_snapshot.checkpoint_seq
-            && scanned.page_size == authority_snapshot.page_size
-            && scanned.salt_1 == authority_snapshot.salt_1
-            && scanned.salt_2 == authority_snapshot.salt_2
-            && scanned.max_frame >= required_snapshot.max_frame
     }
 
     fn local_authority_snapshot_from_shared(
@@ -1687,32 +1670,14 @@ impl ShmWalCoordination {
             return Ok(());
         }
 
-        let wal_file = self.fallback.wal_file()?;
-        let scanned = sqlite3_ondisk::build_shared_wal(&wal_file, io)?;
-        let (scanned_snapshot, scanned_frame_cache) = {
-            let scanned_guard = scanned.read();
-            let snapshot =
-                Self::local_authority_snapshot_from_shared(&scanned_guard, authority_snapshot);
-            let frame_cache = scanned_guard.runtime.frame_cache.lock().clone();
-            (snapshot, frame_cache)
-        };
-
-        if !Self::local_overflow_scan_covers_snapshot(
-            authority_snapshot,
-            required_snapshot,
-            scanned_snapshot,
-        ) {
-            return Err(LimboError::Busy);
-        }
-
-        let shared = self.shared.write();
-        *shared.runtime.frame_cache.lock() = scanned_frame_cache;
-        shared
-            .runtime
-            .overflow_fallback_coverage
-            .lock()
-            .record_snapshot(scanned_snapshot, scanned_snapshot.max_frame);
-        Ok(())
+        let _ = io;
+        tracing::debug!(
+            required_max_frame = required_snapshot.max_frame,
+            authority_max_frame = authority_snapshot.max_frame,
+            authority_checkpoint_seq = authority_snapshot.checkpoint_seq,
+            "refusing live overflow fallback refresh on a read path because it would require blocking WAL scan I/O"
+        );
+        Err(LimboError::Busy)
     }
 }
 
@@ -1778,14 +1743,13 @@ impl WalCoordination for ShmWalCoordination {
         self.authority.publish_backfill(max_frame);
     }
 
-    fn publish_durable_backfill(
+    fn install_durable_backfill_proof(
         &self,
-        io: &Arc<dyn IO>,
         nbackfills: u64,
         db_size_pages: u32,
         db_header_crc32c: u32,
         sync_type: FileSyncType,
-    ) -> Result<()> {
+    ) -> Result<Option<Completion>> {
         let snapshot = self.authority.snapshot();
         turso_assert!(
             (snapshot.nbackfills..=snapshot.max_frame).contains(&nbackfills),
@@ -1802,9 +1766,7 @@ impl WalCoordination for ShmWalCoordination {
         };
         self.authority
             .install_backfill_proof(proof_snapshot, db_size_pages, db_header_crc32c);
-        self.authority.sync(io, sync_type)?;
-        self.publish_backfill(nbackfills);
-        Ok(())
+        Ok(Some(self.authority.begin_sync(sync_type)?))
     }
 
     fn find_frame(
@@ -3311,24 +3273,23 @@ impl Wal for WalFile {
         })
     }
 
-    fn complete_checkpoint_sync(&self, pager: &Pager, result: &mut CheckpointResult) -> Result<()> {
-        let Some(max_frame) = result.take_pending_durable_backfill() else {
-            return Ok(());
-        };
-        let Some((db_size_pages, db_header_crc32c)) =
-            read_database_identity_from_storage(&self.io, &pager.db_file)?
-        else {
-            return Err(LimboError::Corrupt(
-                "database header unreadable after checkpoint sync".into(),
-            ));
-        };
-        self.coordination.publish_durable_backfill(
-            &self.io,
+    fn install_durable_backfill_proof(
+        &self,
+        max_frame: u64,
+        db_size_pages: u32,
+        db_header_crc32c: u32,
+        sync_type: FileSyncType,
+    ) -> Result<Option<Completion>> {
+        self.coordination.install_durable_backfill_proof(
             max_frame,
             db_size_pages,
             db_header_crc32c,
-            pager.get_sync_type(),
+            sync_type,
         )
+    }
+
+    fn publish_backfill(&self, max_frame: u64) {
+        self.coordination.publish_backfill(max_frame);
     }
 
     #[instrument(err, skip_all, level = Level::DEBUG)]
@@ -4140,15 +4101,12 @@ impl WalFile {
                     let wal_checkpoint_backfilled =
                         wal_total_backfilled.saturating_sub(ongoing_chkpt.min_frame - 1);
 
-                    let mut checkpoint_result = CheckpointResult::new(
+                    let checkpoint_result = CheckpointResult::new(
                         wal_max_frame,
                         wal_total_backfilled,
                         wal_checkpoint_backfilled,
                     );
                     tracing::info!("checkpoint_result={:?}, mode={:?}", checkpoint_result, mode);
-                    if wal_checkpoint_backfilled > 0 && !mode.should_restart_log() {
-                        checkpoint_result.set_pending_durable_backfill(ongoing_chkpt.max_frame);
-                    }
                     if mode.require_all_backfilled() && !checkpoint_result.everything_backfilled() {
                         return Err(LimboError::Busy);
                     }
@@ -4534,7 +4492,7 @@ fn wal_header_matches_authority_snapshot(
         && wal_header.salt_2 == snapshot.salt_2
 }
 
-fn database_identity_from_header_bytes(header_bytes: &[u8]) -> Result<(u32, u32)> {
+pub(crate) fn database_identity_from_header_bytes(header_bytes: &[u8]) -> Result<(u32, u32)> {
     if header_bytes.len() < DatabaseHeader::SIZE {
         return Err(LimboError::Corrupt(format!(
             "database header must be at least {} bytes, got {}",
@@ -6255,7 +6213,7 @@ pub mod test {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
-    fn test_shm_coordination_live_overflow_refreshes_reused_fallback_for_active_reader() {
+    fn test_shm_coordination_live_overflow_returns_busy_without_runtime_disk_scan() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test-live-overflow.db-wal");
         let shm_path = dir.path().join("test-live-overflow.db-tshm");
@@ -6291,13 +6249,20 @@ pub mod test {
         wal.begin_read_tx().unwrap();
         reopened_authority.mark_frame_index_overflowed_for_tests();
 
-        assert_eq!(wal.find_frame(7, None).unwrap(), Some(1));
-        assert_eq!(
-            shared.read().runtime.frame_cache.lock().get(&7).cloned(),
-            Some(vec![1])
+        assert!(
+            matches!(wal.find_frame(7, None), Err(LimboError::Busy)),
+            "page lookup must refuse the overflowed path instead of rescanning the WAL synchronously"
+        );
+        assert!(
+            shared.read().runtime.frame_cache.lock().is_empty(),
+            "refusing the overflow refresh must leave the local fallback cache untouched"
         );
 
         wal.end_read_tx();
+        assert!(
+            matches!(wal.begin_read_tx(), Err(LimboError::Busy)),
+            "new readers must also refuse an uncovered overflowed frame index without blocking"
+        );
     }
 
     #[cfg(all(unix, target_pointer_width = "64"))]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1256,8 +1256,11 @@ impl ShmWalCoordination {
         Self::local_authority_snapshot_from_shared(&shared, authority_snapshot)
     }
 
-    fn sync_local_from_authority(&self, snapshot: SharedWalCoordinationHeader) {
-        let mut shared = self.shared.write();
+    fn install_local_snapshot(
+        shared: &mut WalFileShared,
+        snapshot: SharedWalCoordinationHeader,
+        install_header: bool,
+    ) {
         shared
             .metadata
             .max_frame
@@ -1275,8 +1278,8 @@ impl ShmWalCoordination {
             .runtime
             .epoch
             .store(snapshot.checkpoint_epoch, Ordering::Release);
-        let mut header = shared.metadata.wal_header.lock();
-        if snapshot.page_size != 0 {
+        if install_header {
+            let mut header = shared.metadata.wal_header.lock();
             header.checkpoint_seq = snapshot.checkpoint_seq;
             header.page_size = snapshot.page_size;
             header.salt_1 = snapshot.salt_1;
@@ -1284,6 +1287,11 @@ impl ShmWalCoordination {
             header.checksum_1 = snapshot.checksum_1;
             header.checksum_2 = snapshot.checksum_2;
         }
+    }
+
+    fn sync_local_from_authority(&self, snapshot: SharedWalCoordinationHeader) {
+        let mut shared = self.shared.write();
+        Self::install_local_snapshot(&mut shared, snapshot, snapshot.page_size != 0);
     }
 
     fn sync_authority_from_local(&self) {
@@ -1293,33 +1301,8 @@ impl ShmWalCoordination {
 
     fn sync_local_to_zero_frame_authority(&self, snapshot: SharedWalCoordinationHeader) {
         let mut shared = self.shared.write();
-        shared
-            .metadata
-            .max_frame
-            .store(snapshot.max_frame, Ordering::Release);
-        shared
-            .metadata
-            .nbackfills
-            .store(snapshot.nbackfills, Ordering::Release);
-        shared.metadata.last_checksum = (snapshot.checksum_1, snapshot.checksum_2);
-        shared
-            .metadata
-            .transaction_count
-            .store(snapshot.transaction_count, Ordering::Release);
-        shared
-            .runtime
-            .epoch
-            .store(snapshot.checkpoint_epoch, Ordering::Release);
+        Self::install_local_snapshot(&mut shared, snapshot, true);
         shared.metadata.initialized.store(false, Ordering::Release);
-        {
-            let mut header = shared.metadata.wal_header.lock();
-            header.checkpoint_seq = snapshot.checkpoint_seq;
-            header.page_size = snapshot.page_size;
-            header.salt_1 = snapshot.salt_1;
-            header.salt_2 = snapshot.salt_2;
-            header.checksum_1 = snapshot.checksum_1;
-            header.checksum_2 = snapshot.checksum_2;
-        }
         shared.runtime.frame_cache.lock().clear();
         shared.runtime.overflow_fallback_coverage.lock().clear();
     }
@@ -1592,32 +1575,25 @@ impl ShmWalCoordination {
         let checkpoint_seq = snapshot.checkpoint_seq.wrapping_add(1);
         let salt_1 = snapshot.salt_1.wrapping_add(1);
         let salt_2 = io.generate_random_number() as u32;
+        let restarted = SharedWalCoordinationHeader {
+            max_frame: 0,
+            nbackfills: 0,
+            transaction_count: snapshot.transaction_count,
+            visibility_generation: snapshot.visibility_generation,
+            checkpoint_seq,
+            checkpoint_epoch: snapshot.checkpoint_epoch,
+            page_size: snapshot.page_size,
+            salt_1,
+            salt_2,
+            checksum_1: snapshot.checksum_1,
+            checksum_2: snapshot.checksum_2,
+            reader_slot_count: snapshot.reader_slot_count,
+        };
 
         {
             let mut shared = self.shared.write();
-            shared.metadata.max_frame.store(0, Ordering::Release);
-            shared.metadata.nbackfills.store(0, Ordering::Release);
-            shared.metadata.last_checksum = (snapshot.checksum_1, snapshot.checksum_2);
-            shared
-                .metadata
-                .transaction_count
-                .store(snapshot.transaction_count, Ordering::Release);
-            shared
-                .runtime
-                .epoch
-                .store(snapshot.checkpoint_epoch, Ordering::Release);
+            Self::install_local_snapshot(&mut shared, restarted, true);
             shared.metadata.initialized.store(false, Ordering::Release);
-
-            {
-                let mut header = shared.metadata.wal_header.lock();
-                header.checkpoint_seq = checkpoint_seq;
-                header.page_size = snapshot.page_size;
-                header.salt_1 = salt_1;
-                header.salt_2 = salt_2;
-                header.checksum_1 = snapshot.checksum_1;
-                header.checksum_2 = snapshot.checksum_2;
-            }
-
             shared.runtime.frame_cache.lock().clear();
             shared.runtime.overflow_fallback_coverage.lock().clear();
             shared.runtime.read_locks[0].set_value_exclusive(0);
@@ -1628,28 +1604,14 @@ impl ShmWalCoordination {
         }
 
         self.authority.rollback_frames(0);
-        self.authority
-            .install_snapshot(SharedWalCoordinationHeader {
-                max_frame: 0,
-                nbackfills: 0,
-                transaction_count: snapshot.transaction_count,
-                visibility_generation: snapshot.visibility_generation,
-                checkpoint_seq,
-                checkpoint_epoch: snapshot.checkpoint_epoch,
-                page_size: snapshot.page_size,
-                salt_1,
-                salt_2,
-                checksum_1: snapshot.checksum_1,
-                checksum_2: snapshot.checksum_2,
-                reader_slot_count: snapshot.reader_slot_count,
-            });
+        self.authority.install_snapshot(restarted);
 
         WalSnapshot {
-            max_frame: 0,
-            nbackfills: 0,
-            last_checksum: (snapshot.checksum_1, snapshot.checksum_2),
-            checkpoint_seq,
-            transaction_count: snapshot.transaction_count,
+            max_frame: restarted.max_frame,
+            nbackfills: restarted.nbackfills,
+            last_checksum: (restarted.checksum_1, restarted.checksum_2),
+            checkpoint_seq: restarted.checkpoint_seq,
+            transaction_count: restarted.transaction_count,
         }
     }
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -356,13 +356,20 @@ impl TursoRwLock {
         turso_debug_assert!(Self::has_writer(cur));
         // Preserve value bits, replace writer with one reader
         let desired = (cur & Self::VALUE_MASK) | Self::READER_INC;
-        let prev = self
-            .0
-            .compare_exchange(cur, desired, Ordering::AcqRel, Ordering::Relaxed);
-        turso_debug_assert!(
-            prev.is_ok(),
-            "downgrade CAS failed — lock was mutated concurrently"
-        );
+        #[cfg(debug_assertions)]
+        {
+            let prev = self
+                .0
+                .compare_exchange(cur, desired, Ordering::AcqRel, Ordering::Relaxed);
+            turso_debug_assert!(
+                prev.is_ok(),
+                "downgrade CAS failed — lock was mutated concurrently"
+            );
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            self.0.store(desired, Ordering::Release);
+        }
     }
 
     #[inline]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -5116,6 +5116,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(all(unix, target_pointer_width = "64"))]
     fn test_read_frame_keeps_epoch_from_issue_time() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("epoch-race.db-wal");

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -28,7 +28,7 @@ use crate::io::clock::MonotonicInstant;
 use crate::io::CompletionGroup;
 use crate::io::{File, IO};
 use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum};
-#[cfg(all(test, unix, target_pointer_width = "64"))]
+#[cfg(all(unix, target_pointer_width = "64"))]
 use crate::storage::shared_wal_coordination::SharedWalCoordinationOpenMode;
 #[cfg(all(unix, target_pointer_width = "64"))]
 use crate::storage::shared_wal_coordination::{
@@ -4416,6 +4416,16 @@ impl WalFileShared {
             );
             return sqlite3_ondisk::build_shared_wal(&file, io);
         }
+        if snapshot.nbackfills != 0
+            && authority.open_mode() == SharedWalCoordinationOpenMode::Exclusive
+        {
+            tracing::debug!(
+                nbackfills = snapshot.nbackfills,
+                max_frame = snapshot.max_frame,
+                "rebuilding WAL state from disk because an exclusive reopen must conservatively clear published backfill progress"
+            );
+            return sqlite3_ondisk::build_shared_wal(&file, io);
+        }
         if snapshot.max_frame > snapshot.nbackfills
             && authority
                 .iter_latest_frames(0, snapshot.max_frame)
@@ -5897,6 +5907,57 @@ pub mod test {
             .loaded_from_disk_scan
             .load(Ordering::Acquire));
         assert!(shared.runtime.frame_cache.lock().is_empty());
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_open_shared_from_authority_exclusive_rebuilds_positive_snapshot_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-exclusive-positive.db-wal");
+        let shm_path = dir.path().join("test-exclusive-positive.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+        {
+            let authority =
+                Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+            authority.install_snapshot(SharedWalCoordinationHeader {
+                nbackfills: snapshot.max_frame,
+                ..snapshot
+            });
+            authority.record_frame(7, 1);
+            assert_eq!(
+                authority.open_mode(),
+                SharedWalCoordinationOpenMode::Exclusive
+            );
+        }
+
+        let reopened_authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        assert_eq!(
+            reopened_authority.open_mode(),
+            SharedWalCoordinationOpenMode::Exclusive
+        );
+
+        let shared = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            &reopened_authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
+        )
+        .unwrap();
+
+        let shared = shared.read();
+        assert_eq!(shared.metadata.max_frame.load(Ordering::Acquire), 1);
+        assert_eq!(shared.metadata.nbackfills.load(Ordering::Acquire), 0);
+        assert!(shared
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire));
+        assert_eq!(
+            shared.runtime.frame_cache.lock().get(&7).cloned(),
+            Some(vec![1])
+        );
     }
 
     #[cfg(all(unix, target_pointer_width = "64"))]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -9,6 +9,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::array;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 use strum::EnumString;
 use tracing::{instrument, Level};
 
@@ -25,6 +26,12 @@ use crate::io::clock::MonotonicInstant;
 use crate::io::CompletionGroup;
 use crate::io::{File, IO};
 use crate::storage::database::EncryptionOrChecksum;
+#[cfg(all(test, unix, target_pointer_width = "64"))]
+use crate::storage::shared_wal_coordination::SharedWalCoordinationOpenMode;
+#[cfg(all(unix, target_pointer_width = "64"))]
+use crate::storage::shared_wal_coordination::{
+    MappedSharedWalCoordination, SharedOwnerRecord, SharedReaderSlot, SharedWalCoordinationHeader,
+};
 use crate::storage::sqlite3_ondisk::{
     begin_read_wal_frame, begin_read_wal_frame_raw, finish_read_page, prepare_wal_frame,
     write_pages_vectored, PageSize, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
@@ -99,6 +106,15 @@ impl CheckpointResult {
     }
 }
 
+#[cfg(all(unix, target_pointer_width = "64"))]
+pub(crate) fn coordination_path_for_wal_path(wal_path: &str) -> String {
+    if let Some(db_path) = wal_path.strip_suffix("-wal") {
+        format!("{db_path}-tshm")
+    } else {
+        format!("{wal_path}-tshm")
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, EnumString)]
 #[strum(ascii_case_insensitive)]
 pub enum CheckpointMode {
@@ -126,7 +142,7 @@ impl CheckpointMode {
         )
     }
     /// All modes other than Passive require a complete backfilling of all available frames
-    /// from `shared.nbackfills + 1 -> shared.max_frame`
+    /// from `shared.metadata.nbackfills + 1 -> shared.metadata.max_frame`
     fn require_all_backfilled(&self) -> bool {
         !matches!(self, CheckpointMode::Passive { .. })
     }
@@ -154,7 +170,7 @@ impl WalSnapshot {
 enum ReadGuardKind {
     None,
     DbFile,
-    ReadMark(usize),
+    ReadMark(NonZeroUsize),
 }
 
 impl ReadGuardKind {
@@ -163,16 +179,16 @@ impl ReadGuardKind {
         match lock_index {
             NO_LOCK_HELD => Self::None,
             0 => Self::DbFile,
-            idx => Self::ReadMark(idx),
+            idx => Self::ReadMark(NonZeroUsize::new(idx).expect("idx checked to be non-zero")),
         }
     }
 
     /// Convert the semantic guard kind back into the legacy lock index representation.
-    const fn lock_index(self) -> usize {
+    fn lock_index(self) -> usize {
         match self {
             Self::None => NO_LOCK_HELD,
             Self::DbFile => 0,
-            Self::ReadMark(idx) => idx,
+            Self::ReadMark(idx) => idx.into(),
         }
     }
 }
@@ -385,6 +401,118 @@ pub struct PreparedFrames {
     pub epoch: u32,
 }
 
+/// Metadata published by the coordination backend once a WAL commit becomes visible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WalCommitState {
+    max_frame: u64,
+    last_checksum: (u32, u32),
+    transaction_count: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CoordinationCheckpointGuardKind {
+    Read0,
+    Writer,
+}
+
+/// Coordination operations that back the WAL's authoritative state.
+trait WalCoordination: Debug + Send + Sync {
+    /// Load the current authoritative WAL snapshot.
+    fn load_snapshot(&self) -> WalSnapshot;
+
+    /// Publish a newly committed WAL state snapshot.
+    fn publish_commit(&self, commit: WalCommitState);
+
+    /// Publish the highest frame durably backfilled during checkpoint.
+    fn publish_backfill(&self, max_frame: u64);
+
+    /// Find the newest frame for `page_id` within the caller's visible range.
+    fn find_frame(
+        &self,
+        page_id: u64,
+        min_frame: u64,
+        max_frame: u64,
+        frame_watermark: Option<u64>,
+    ) -> Option<u64>;
+
+    /// Enumerate the latest visible frame per page in the requested frame range.
+    fn iter_latest_frames(&self, min_frame: u64, max_frame: u64) -> Vec<(u64, u64)>;
+
+    /// Read the current checkpoint epoch used to tag cached WAL pages.
+    fn checkpoint_epoch(&self) -> u32;
+
+    /// Advance the checkpoint epoch after checkpoint or restart invalidates cached pages.
+    fn bump_checkpoint_epoch(&self) -> u32;
+
+    /// Try to acquire the reader protection needed for `snapshot`.
+    fn try_begin_read_tx(&self, snapshot: WalSnapshot) -> Option<ReadGuardKind>;
+
+    /// Release a read guard previously returned by `try_begin_read_tx`.
+    fn end_read_tx(&self, guard: ReadGuardKind);
+
+    /// Try to acquire the WAL writer guard.
+    fn try_begin_write_tx(&self) -> bool;
+
+    /// Release a previously acquired WAL writer guard.
+    fn end_write_tx(&self);
+
+    /// Acquire the checkpoint-related locks needed for `mode`.
+    fn acquire_checkpoint_guard(
+        &self,
+        mode: CheckpointMode,
+    ) -> Result<CoordinationCheckpointGuardKind>;
+
+    /// Release the checkpoint-related locks previously acquired for `guard`.
+    fn release_checkpoint_guard(&self, guard: CoordinationCheckpointGuardKind);
+
+    /// Compute the highest frame a checkpoint may safely backfill and refresh read marks.
+    fn determine_max_safe_checkpoint_frame(&self, max_frame: u64) -> u64;
+
+    /// Begin a restart while the caller holds the required external checkpoint/write guards.
+    fn begin_restart(&self, io: &dyn IO) -> Result<WalSnapshot>;
+
+    /// Release any restart-only coordination state held by `begin_restart`.
+    fn end_restart(&self);
+
+    /// Attempt the restart path used by a writer holding read-mark 0.
+    fn try_restart_log_for_write(&self, io: &dyn IO) -> Result<Option<WalSnapshot>>;
+
+    /// Mark the WAL uninitialized before truncation and return the WAL file handle.
+    fn prepare_truncate(&self) -> Result<Arc<dyn File>>;
+
+    /// Return the current WAL header snapshot.
+    fn wal_header(&self) -> WalHeader;
+
+    /// Return the WAL file used for durable reads and writes.
+    fn wal_file(&self) -> Result<Arc<dyn File>>;
+
+    /// Report whether the WAL header has already been written and synced.
+    fn wal_is_initialized(&self) -> bool;
+
+    /// Initialize or refresh the WAL header before the first append after restart/truncate.
+    fn prepare_wal_header(&self, io: &dyn IO, page_size: PageSize) -> Option<WalHeader>;
+
+    /// Mark the WAL header durable after the header sync completes.
+    fn mark_initialized(&self);
+
+    /// Record a newly appended frame in the backend's page-to-frame lookup state.
+    fn cache_frame(&self, page_id: u64, frame_id: u64);
+
+    /// Drop any cached frame mappings newer than `max_frame`.
+    fn rollback_cache(&self, max_frame: u64);
+
+    /// Whether a process-local "last connection" close may run shutdown checkpointing.
+    fn should_checkpoint_on_close(&self) -> bool;
+
+    #[cfg(test)]
+    fn backend_name(&self) -> &'static str;
+
+    #[cfg(test)]
+    fn open_mode_name(&self) -> Option<&'static str> {
+        None
+    }
+}
+
 /// Write-ahead log (WAL).
 pub trait Wal: Debug + Send + Sync {
     /// Begin a read transaction.
@@ -407,6 +535,9 @@ pub trait Wal: Debug + Send + Sync {
 
     /// Returns true if this WAL instance currently holds the write lock.
     fn holds_write_lock(&self) -> bool;
+
+    /// Whether shutdown checkpointing is valid when this process closes its last connection.
+    fn should_checkpoint_on_close(&self) -> bool;
 
     /// Find the latest frame containing a page.
     ///
@@ -506,6 +637,1103 @@ pub trait Wal: Debug + Send + Sync {
 
     #[cfg(any(test, debug_assertions))]
     fn as_any(&self) -> &dyn std::any::Any;
+}
+
+#[derive(Debug)]
+struct InProcessWalCoordination {
+    shared: Arc<RwLock<WalFileShared>>,
+}
+
+impl InProcessWalCoordination {
+    /// Build the in-process coordination backend over the existing shared WAL state.
+    fn new(shared: Arc<RwLock<WalFileShared>>) -> Self {
+        Self { shared }
+    }
+
+    fn try_read_mark_shared(&self, slot: usize) -> bool {
+        self.shared.read().runtime.read_locks[slot].read()
+    }
+
+    fn try_read_mark_exclusive(&self, slot: usize) -> bool {
+        self.shared.read().runtime.read_locks[slot].write()
+    }
+
+    fn unlock_read_mark(&self, slot: usize) {
+        self.shared.read().runtime.read_locks[slot].unlock();
+    }
+
+    fn read_mark_value(&self, slot: usize) -> u32 {
+        self.shared.read().runtime.read_locks[slot].get_value()
+    }
+
+    fn set_read_mark_value_exclusive(&self, slot: usize, value: u32) {
+        self.shared.read().runtime.read_locks[slot].set_value_exclusive(value);
+    }
+
+    fn try_upgrade_read_mark(&self, slot: usize) -> bool {
+        self.shared.read().runtime.read_locks[slot].upgrade()
+    }
+
+    fn downgrade_read_mark(&self, slot: usize) {
+        self.shared.read().runtime.read_locks[slot].downgrade();
+    }
+
+    fn try_write_lock(&self) -> bool {
+        self.shared.read().runtime.write_lock.write()
+    }
+
+    fn unlock_write_lock(&self) {
+        self.shared.read().runtime.write_lock.unlock();
+    }
+
+    fn try_checkpoint_lock(&self) -> bool {
+        self.shared.read().runtime.checkpoint_lock.write()
+    }
+
+    fn unlock_checkpoint_lock(&self) {
+        self.shared.read().runtime.checkpoint_lock.unlock();
+    }
+}
+
+impl WalCoordination for InProcessWalCoordination {
+    fn load_snapshot(&self) -> WalSnapshot {
+        let shared = self.shared.read();
+        let checkpoint_seq = shared.metadata.wal_header.lock().checkpoint_seq;
+        WalSnapshot {
+            max_frame: shared.metadata.max_frame.load(Ordering::Acquire),
+            nbackfills: shared.metadata.nbackfills.load(Ordering::Acquire),
+            last_checksum: shared.metadata.last_checksum,
+            checkpoint_seq,
+            transaction_count: shared.metadata.transaction_count.load(Ordering::Acquire),
+        }
+    }
+
+    fn publish_commit(&self, commit: WalCommitState) {
+        let mut shared = self.shared.write();
+        shared
+            .metadata
+            .max_frame
+            .store(commit.max_frame, Ordering::Release);
+        shared.metadata.last_checksum = commit.last_checksum;
+        shared
+            .metadata
+            .transaction_count
+            .store(commit.transaction_count, Ordering::Release);
+    }
+
+    fn publish_backfill(&self, max_frame: u64) {
+        self.shared
+            .write()
+            .metadata
+            .nbackfills
+            .store(max_frame, Ordering::Release);
+    }
+
+    fn find_frame(
+        &self,
+        page_id: u64,
+        min_frame: u64,
+        max_frame: u64,
+        frame_watermark: Option<u64>,
+    ) -> Option<u64> {
+        let shared = self.shared.read();
+        let frame_cache = shared.runtime.frame_cache.lock();
+        let range = frame_watermark
+            .map(|x| 0..=x)
+            .unwrap_or(min_frame..=max_frame);
+        frame_cache.get(&page_id).and_then(|frames| {
+            frames
+                .iter()
+                .rfind(|&&frame| range.contains(&frame))
+                .copied()
+        })
+    }
+
+    fn iter_latest_frames(&self, min_frame: u64, max_frame: u64) -> Vec<(u64, u64)> {
+        let shared = self.shared.read();
+        let frame_cache = shared.runtime.frame_cache.lock();
+        let mut list = Vec::with_capacity(frame_cache.len());
+        for (&page_id, frames) in frame_cache.iter() {
+            if let Some(&frame_id) = frames
+                .iter()
+                .rfind(|&&frame| (min_frame..=max_frame).contains(&frame))
+            {
+                list.push((page_id, frame_id));
+            }
+        }
+        list.sort_unstable_by_key(|&(page_id, _)| page_id);
+        list
+    }
+
+    fn checkpoint_epoch(&self) -> u32 {
+        self.shared.read().runtime.epoch.load(Ordering::Acquire)
+    }
+
+    fn bump_checkpoint_epoch(&self) -> u32 {
+        self.shared
+            .read()
+            .runtime
+            .epoch
+            .fetch_add(1, Ordering::Release)
+    }
+
+    fn try_begin_read_tx(&self, snapshot: WalSnapshot) -> Option<ReadGuardKind> {
+        if snapshot.max_frame == snapshot.nbackfills {
+            if !self.try_read_mark_shared(0) {
+                return None;
+            }
+            if self.load_snapshot() != snapshot {
+                self.unlock_read_mark(0);
+                return None;
+            }
+            return Some(ReadGuardKind::DbFile);
+        }
+
+        let mut best_idx: i64 = -1;
+        let mut best_mark: u32 = 0;
+        for idx in 1..5 {
+            let mark = self.read_mark_value(idx);
+            if mark != READMARK_NOT_USED && mark <= snapshot.max_frame as u32 && mark > best_mark {
+                best_mark = mark;
+                best_idx = idx as i64;
+            }
+        }
+
+        if best_idx == -1 || (best_mark as u64) < snapshot.max_frame {
+            for idx in 1..5 {
+                if !self.try_read_mark_exclusive(idx) {
+                    continue;
+                }
+                self.set_read_mark_value_exclusive(idx, snapshot.max_frame as u32);
+                best_idx = idx as i64;
+                best_mark = snapshot.max_frame as u32;
+                self.unlock_read_mark(idx);
+                break;
+            }
+        }
+
+        if best_idx == -1 || !self.try_read_mark_shared(best_idx as usize) {
+            return None;
+        }
+
+        let snapshot_after_lock = self.load_snapshot();
+        let current_slot_mark = self.read_mark_value(best_idx as usize);
+        if current_slot_mark != best_mark || snapshot_after_lock != snapshot {
+            self.unlock_read_mark(best_idx as usize);
+            return None;
+        }
+
+        Some(ReadGuardKind::ReadMark(
+            NonZeroUsize::new(best_idx as usize)
+                .expect("best_idx checked to be non-negative and non-zero"),
+        ))
+    }
+
+    fn end_read_tx(&self, guard: ReadGuardKind) {
+        match guard {
+            ReadGuardKind::None => {}
+            ReadGuardKind::DbFile => self.unlock_read_mark(0),
+            ReadGuardKind::ReadMark(slot) => self.unlock_read_mark(slot.into()),
+        }
+    }
+
+    fn try_begin_write_tx(&self) -> bool {
+        self.try_write_lock()
+    }
+
+    fn end_write_tx(&self) {
+        self.unlock_write_lock();
+    }
+
+    fn acquire_checkpoint_guard(
+        &self,
+        mode: CheckpointMode,
+    ) -> Result<CoordinationCheckpointGuardKind> {
+        if !self.try_checkpoint_lock() {
+            tracing::trace!("CheckpointGuard::new: checkpoint lock failed, returning Busy");
+            return Err(LimboError::Busy);
+        }
+        match mode {
+            CheckpointMode::Passive { .. } => {
+                if !self.try_read_mark_exclusive(0) {
+                    self.unlock_checkpoint_lock();
+                    tracing::trace!("CheckpointGuard: read0 lock failed, returning Busy");
+                    return Err(LimboError::Busy);
+                }
+                Ok(CoordinationCheckpointGuardKind::Read0)
+            }
+            CheckpointMode::Full => {
+                if !self.try_read_mark_exclusive(0) {
+                    self.unlock_checkpoint_lock();
+                    tracing::trace!("CheckpointGuard: read0 lock failed (Full), Busy");
+                    return Err(LimboError::Busy);
+                }
+                if !self.try_write_lock() {
+                    self.unlock_read_mark(0);
+                    self.unlock_checkpoint_lock();
+                    tracing::trace!("CheckpointGuard: write lock failed (Full), Busy");
+                    return Err(LimboError::Busy);
+                }
+                Ok(CoordinationCheckpointGuardKind::Writer)
+            }
+            CheckpointMode::Restart | CheckpointMode::Truncate { .. } => {
+                if !self.try_read_mark_exclusive(0) {
+                    self.unlock_checkpoint_lock();
+                    tracing::trace!("CheckpointGuard: read0 lock failed, returning Busy");
+                    return Err(LimboError::Busy);
+                }
+                if !self.try_write_lock() {
+                    self.unlock_checkpoint_lock();
+                    self.unlock_read_mark(0);
+                    tracing::trace!("CheckpointGuard: write lock failed, returning Busy");
+                    return Err(LimboError::Busy);
+                }
+                Ok(CoordinationCheckpointGuardKind::Writer)
+            }
+        }
+    }
+
+    fn release_checkpoint_guard(&self, guard: CoordinationCheckpointGuardKind) {
+        match guard {
+            CoordinationCheckpointGuardKind::Writer => {
+                self.unlock_write_lock();
+                self.unlock_read_mark(0);
+                self.unlock_checkpoint_lock();
+            }
+            CoordinationCheckpointGuardKind::Read0 => {
+                self.unlock_read_mark(0);
+                self.unlock_checkpoint_lock();
+            }
+        }
+    }
+
+    fn determine_max_safe_checkpoint_frame(&self, max_frame: u64) -> u64 {
+        let mut max_safe_frame = max_frame;
+        for read_lock_idx in 1..5 {
+            let this_mark = self.read_mark_value(read_lock_idx);
+            if this_mark < max_safe_frame as u32 {
+                let busy = !self.try_read_mark_exclusive(read_lock_idx);
+                if !busy {
+                    let val = if read_lock_idx == 1 {
+                        max_safe_frame as u32
+                    } else {
+                        READMARK_NOT_USED
+                    };
+                    self.set_read_mark_value_exclusive(read_lock_idx, val);
+                    self.unlock_read_mark(read_lock_idx);
+                } else {
+                    max_safe_frame = this_mark as u64;
+                }
+            }
+        }
+        max_safe_frame
+    }
+
+    fn begin_restart(&self, io: &dyn IO) -> Result<WalSnapshot> {
+        for idx in 1..5 {
+            if !self.try_read_mark_exclusive(idx) {
+                for j in 1..idx {
+                    self.unlock_read_mark(j);
+                }
+                return Err(LimboError::Busy);
+            }
+            self.set_read_mark_value_exclusive(idx, READMARK_NOT_USED);
+        }
+        let mut shared = self.shared.write();
+        shared.restart_wal_header(io);
+        let checkpoint_seq = shared.metadata.wal_header.lock().checkpoint_seq;
+        Ok(WalSnapshot {
+            max_frame: shared.metadata.max_frame.load(Ordering::Acquire),
+            nbackfills: shared.metadata.nbackfills.load(Ordering::Acquire),
+            last_checksum: shared.metadata.last_checksum,
+            checkpoint_seq,
+            transaction_count: shared.metadata.transaction_count.load(Ordering::Acquire),
+        })
+    }
+
+    fn end_restart(&self) {
+        for idx in 1..5 {
+            self.unlock_read_mark(idx);
+        }
+    }
+
+    fn try_restart_log_for_write(&self, io: &dyn IO) -> Result<Option<WalSnapshot>> {
+        if !self.try_upgrade_read_mark(0) {
+            return Ok(None);
+        }
+        let result = self.begin_restart(io);
+        self.downgrade_read_mark(0);
+        match result {
+            Ok(snapshot) => {
+                self.end_restart();
+                Ok(Some(snapshot))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn prepare_truncate(&self) -> Result<Arc<dyn File>> {
+        let shared = self.shared.read();
+        turso_assert!(
+            shared.metadata.enabled.load(Ordering::Relaxed),
+            "WAL must be enabled"
+        );
+        shared.metadata.initialized.store(false, Ordering::Release);
+        shared.runtime.file.as_ref().cloned().ok_or_else(|| {
+            mark_unlikely();
+            LimboError::InternalError("WAL file not open".into())
+        })
+    }
+
+    fn wal_header(&self) -> WalHeader {
+        *self.shared.read().metadata.wal_header.lock()
+    }
+
+    fn wal_file(&self) -> Result<Arc<dyn File>> {
+        let shared = self.shared.read();
+        turso_assert!(
+            shared.metadata.enabled.load(Ordering::Relaxed),
+            "WAL must be enabled"
+        );
+        shared.runtime.file.as_ref().cloned().ok_or_else(|| {
+            mark_unlikely();
+            LimboError::InternalError("WAL file not open".into())
+        })
+    }
+
+    fn wal_is_initialized(&self) -> bool {
+        self.shared
+            .read()
+            .metadata
+            .initialized
+            .load(Ordering::Acquire)
+    }
+
+    fn prepare_wal_header(&self, io: &dyn IO, page_size: PageSize) -> Option<WalHeader> {
+        let mut shared: crate::sync::RwLockWriteGuard<'_, WalFileShared> = self.shared.write();
+        if shared.metadata.initialized.load(Ordering::Acquire) {
+            return None;
+        }
+
+        let (header, checksum) = {
+            let mut hdr = shared.metadata.wal_header.lock();
+            hdr.magic = if cfg!(target_endian = "big") {
+                WAL_MAGIC_BE
+            } else {
+                WAL_MAGIC_LE
+            };
+            if hdr.page_size == 0 {
+                hdr.page_size = page_size.get();
+            }
+            if hdr.salt_1 == 0 && hdr.salt_2 == 0 {
+                hdr.salt_1 = io.generate_random_number() as u32;
+                hdr.salt_2 = io.generate_random_number() as u32;
+            }
+
+            let prefix = &hdr.as_bytes()[..WAL_HEADER_SIZE - 8];
+            let use_native = (hdr.magic & 1) != 0;
+            let (c1, c2) = checksum_wal(prefix, &hdr, (0, 0), use_native);
+            hdr.checksum_1 = c1;
+            hdr.checksum_2 = c2;
+            (*hdr, (c1, c2))
+        };
+        shared.metadata.last_checksum = checksum;
+        Some(header)
+    }
+
+    fn mark_initialized(&self) {
+        self.shared
+            .read()
+            .metadata
+            .initialized
+            .store(true, Ordering::Release);
+    }
+
+    fn cache_frame(&self, page_id: u64, frame_id: u64) {
+        let shared = self.shared.read();
+        let mut frame_cache = shared.runtime.frame_cache.lock();
+        match frame_cache.get_mut(&page_id) {
+            Some(frames) => {
+                frames.push(frame_id);
+            }
+            None => {
+                frame_cache.insert(page_id, vec![frame_id]);
+            }
+        }
+    }
+
+    fn rollback_cache(&self, max_frame: u64) {
+        let shared = self.shared.read();
+        let mut frame_cache = shared.runtime.frame_cache.lock();
+        frame_cache.retain(|_page_id, frames| {
+            while frames.last().is_some_and(|&frame| frame > max_frame) {
+                frames.pop();
+            }
+            !frames.is_empty()
+        });
+    }
+
+    fn should_checkpoint_on_close(&self) -> bool {
+        true
+    }
+
+    #[cfg(test)]
+    fn backend_name(&self) -> &'static str {
+        "in_process"
+    }
+}
+
+/// Per-connection WAL coordination that delegates to the mmap'd tshm authority.
+///
+/// One instance exists per `WalFile` (i.e. per `Connection`). All instances
+/// within a process share the same `Arc<MappedSharedWalCoordination>` and the
+/// same `SharedOwnerRecord` (derived from the authority at construction time).
+///
+/// `fallback` provides the process-local read-mark / write-lock layer (the
+/// same locks used in single-process mode). `authority` provides the
+/// cross-process shared state (reader slots, frame index, snapshot metadata).
+/// Both are consulted: the fallback serializes same-process connections, the
+/// authority serializes across processes.
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[derive(Debug)]
+struct ShmWalCoordination {
+    shared: Arc<RwLock<WalFileShared>>,
+    fallback: InProcessWalCoordination,
+    authority: Arc<MappedSharedWalCoordination>,
+    /// This connection's currently held reader slot, if any.
+    active_reader: Mutex<Option<SharedReaderSlot>>,
+    /// Copied from `authority.owner_record()` at construction — all connections
+    /// in the same process share the same owner identity.
+    owner: SharedOwnerRecord,
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+impl ShmWalCoordination {
+    fn new(
+        shared: Arc<RwLock<WalFileShared>>,
+        authority: Arc<MappedSharedWalCoordination>,
+    ) -> Self {
+        let fallback = InProcessWalCoordination::new(shared.clone());
+        let coordination = Self {
+            shared,
+            fallback,
+            owner: authority.owner_record(),
+            authority,
+            active_reader: Mutex::new(None),
+        };
+        coordination.seed_or_sync_authority();
+        coordination
+    }
+
+    fn authority_is_uninitialized(snapshot: SharedWalCoordinationHeader) -> bool {
+        snapshot.max_frame == 0
+            && snapshot.nbackfills == 0
+            && snapshot.transaction_count == 0
+            && snapshot.visibility_generation == 0
+            && snapshot.checkpoint_seq == 0
+            && snapshot.checkpoint_epoch == 0
+            && snapshot.page_size == 0
+            && snapshot.salt_1 == 0
+            && snapshot.salt_2 == 0
+            && snapshot.checksum_1 == 0
+            && snapshot.checksum_2 == 0
+    }
+
+    fn local_authority_snapshot(&self) -> SharedWalCoordinationHeader {
+        let authority_snapshot = self.authority.snapshot();
+        let shared = self.shared.read();
+        let header = shared.metadata.wal_header.lock();
+        SharedWalCoordinationHeader {
+            max_frame: shared.metadata.max_frame.load(Ordering::Acquire),
+            nbackfills: shared.metadata.nbackfills.load(Ordering::Acquire),
+            transaction_count: shared.metadata.transaction_count.load(Ordering::Acquire),
+            visibility_generation: authority_snapshot.visibility_generation,
+            checkpoint_seq: header.checkpoint_seq,
+            checkpoint_epoch: shared.runtime.epoch.load(Ordering::Acquire),
+            page_size: header.page_size,
+            salt_1: header.salt_1,
+            salt_2: header.salt_2,
+            checksum_1: shared.metadata.last_checksum.0,
+            checksum_2: shared.metadata.last_checksum.1,
+            reader_slot_count: authority_snapshot.reader_slot_count,
+        }
+    }
+
+    fn sync_local_from_authority(&self, snapshot: SharedWalCoordinationHeader) {
+        let mut shared = self.shared.write();
+        shared
+            .metadata
+            .max_frame
+            .store(snapshot.max_frame, Ordering::Release);
+        shared
+            .metadata
+            .nbackfills
+            .store(snapshot.nbackfills, Ordering::Release);
+        shared.metadata.last_checksum = (snapshot.checksum_1, snapshot.checksum_2);
+        shared
+            .metadata
+            .transaction_count
+            .store(snapshot.transaction_count, Ordering::Release);
+        shared
+            .runtime
+            .epoch
+            .store(snapshot.checkpoint_epoch, Ordering::Release);
+
+        let mut header = shared.metadata.wal_header.lock();
+        header.checkpoint_seq = snapshot.checkpoint_seq;
+        header.page_size = snapshot.page_size;
+        header.salt_1 = snapshot.salt_1;
+        header.salt_2 = snapshot.salt_2;
+        header.checksum_1 = snapshot.checksum_1;
+        header.checksum_2 = snapshot.checksum_2;
+    }
+
+    fn sync_authority_from_local(&self) {
+        self.authority
+            .install_snapshot(self.local_authority_snapshot());
+    }
+
+    fn sync_authority_frames_from_local(&self) {
+        let entries = {
+            let shared = self.shared.read();
+            let frame_cache = shared.runtime.frame_cache.lock();
+            let mut entries = Vec::new();
+            for (&page_id, frames) in frame_cache.iter() {
+                for &frame_id in frames {
+                    entries.push((frame_id, page_id));
+                }
+            }
+            entries
+        };
+        let mut entries = entries;
+        entries.sort_unstable();
+        for (frame_id, page_id) in entries {
+            self.authority.record_frame(page_id, frame_id);
+        }
+    }
+
+    /// Called once at `ShmWalCoordination` construction to reconcile the
+    /// process-local WAL view (built from a WAL file scan or inherited from
+    /// a previous connection) with the shared tshm authority.
+    ///
+    /// Three cases:
+    ///
+    /// 1. **Authority uninitialized** (fresh tshm): seed it from our local
+    ///    WAL scan — we are the first process.
+    ///
+    /// 2. **Authority initialized but stale** (our local view came from a
+    ///    disk scan AND no writer/checkpoint is active): reset transient
+    ///    runtime state and re-seed from our scan. The reset only reclaims
+    ///    reader/MVCC slots whose owners are verified dead (see
+    ///    `reset_runtime_state_for_exclusive_open`).
+    ///
+    /// 3. **Authority initialized and trustworthy**: adopt the authority's
+    ///    snapshot as our local state. If our local view also came from a
+    ///    disk scan and the authority's frame index is empty, backfill it
+    ///    from our local frame cache.
+    fn seed_or_sync_authority(&self) {
+        let snapshot = self.authority.snapshot();
+        let local_wal_view_loaded_from_disk = self
+            .shared
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire);
+        if Self::authority_is_uninitialized(snapshot) {
+            self.sync_authority_from_local();
+            self.sync_authority_frames_from_local();
+        } else if local_wal_view_loaded_from_disk
+            && !self.authority.writer_or_checkpoint_lock_active()
+        {
+            self.authority.reset_runtime_state_for_exclusive_open();
+            self.sync_authority_from_local();
+            self.sync_authority_frames_from_local();
+        } else {
+            self.sync_local_from_authority(snapshot);
+            if local_wal_view_loaded_from_disk
+                && !self.authority.writer_or_checkpoint_lock_active()
+                && self.authority.iter_latest_frames(0, u64::MAX).is_empty()
+            {
+                self.sync_authority_frames_from_local();
+            }
+        }
+    }
+
+    fn restart_snapshot_from_authority(
+        &self,
+        snapshot: SharedWalCoordinationHeader,
+        io: &dyn IO,
+    ) -> WalSnapshot {
+        let checkpoint_seq = snapshot.checkpoint_seq.wrapping_add(1);
+        let salt_1 = snapshot.salt_1.wrapping_add(1);
+        let salt_2 = io.generate_random_number() as u32;
+
+        {
+            let mut shared = self.shared.write();
+            shared.metadata.max_frame.store(0, Ordering::Release);
+            shared.metadata.nbackfills.store(0, Ordering::Release);
+            shared.metadata.last_checksum = (snapshot.checksum_1, snapshot.checksum_2);
+            shared
+                .metadata
+                .transaction_count
+                .store(snapshot.transaction_count, Ordering::Release);
+            shared
+                .runtime
+                .epoch
+                .store(snapshot.checkpoint_epoch, Ordering::Release);
+            shared.metadata.initialized.store(false, Ordering::Release);
+
+            {
+                let mut header = shared.metadata.wal_header.lock();
+                header.checkpoint_seq = checkpoint_seq;
+                header.page_size = snapshot.page_size;
+                header.salt_1 = salt_1;
+                header.salt_2 = salt_2;
+                header.checksum_1 = snapshot.checksum_1;
+                header.checksum_2 = snapshot.checksum_2;
+            }
+
+            shared.runtime.frame_cache.lock().clear();
+            shared.runtime.read_locks[0].set_value_exclusive(0);
+            shared.runtime.read_locks[1].set_value_exclusive(0);
+            for lock in &shared.runtime.read_locks[2..] {
+                lock.set_value_exclusive(READMARK_NOT_USED);
+            }
+        }
+
+        self.authority.rollback_frames(0);
+        self.authority
+            .install_snapshot(SharedWalCoordinationHeader {
+                max_frame: 0,
+                nbackfills: 0,
+                transaction_count: snapshot.transaction_count,
+                visibility_generation: snapshot.visibility_generation,
+                checkpoint_seq,
+                checkpoint_epoch: snapshot.checkpoint_epoch,
+                page_size: snapshot.page_size,
+                salt_1,
+                salt_2,
+                checksum_1: snapshot.checksum_1,
+                checksum_2: snapshot.checksum_2,
+                reader_slot_count: snapshot.reader_slot_count,
+            });
+
+        WalSnapshot {
+            max_frame: 0,
+            nbackfills: 0,
+            last_checksum: (snapshot.checksum_1, snapshot.checksum_2),
+            checkpoint_seq,
+            transaction_count: snapshot.transaction_count,
+        }
+    }
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+impl WalCoordination for ShmWalCoordination {
+    fn load_snapshot(&self) -> WalSnapshot {
+        let snapshot = self.authority.snapshot();
+        WalSnapshot {
+            max_frame: snapshot.max_frame,
+            nbackfills: snapshot.nbackfills,
+            last_checksum: (snapshot.checksum_1, snapshot.checksum_2),
+            checkpoint_seq: snapshot.checkpoint_seq,
+            transaction_count: snapshot.transaction_count,
+        }
+    }
+
+    fn publish_commit(&self, commit: WalCommitState) {
+        {
+            let mut shared = self.shared.write();
+            shared
+                .metadata
+                .max_frame
+                .store(commit.max_frame, Ordering::Release);
+            shared.metadata.last_checksum = commit.last_checksum;
+            shared
+                .metadata
+                .transaction_count
+                .store(commit.transaction_count, Ordering::Release);
+            let mut header = shared.metadata.wal_header.lock();
+            header.checksum_1 = commit.last_checksum.0;
+            header.checksum_2 = commit.last_checksum.1;
+        }
+        self.authority.publish_commit(
+            commit.max_frame,
+            commit.last_checksum.0,
+            commit.last_checksum.1,
+            commit.transaction_count,
+        );
+    }
+
+    fn publish_backfill(&self, max_frame: u64) {
+        self.shared
+            .write()
+            .metadata
+            .nbackfills
+            .store(max_frame, Ordering::Release);
+        self.authority.publish_backfill(max_frame);
+    }
+
+    fn find_frame(
+        &self,
+        page_id: u64,
+        min_frame: u64,
+        max_frame: u64,
+        frame_watermark: Option<u64>,
+    ) -> Option<u64> {
+        // Exhausting the reserved shared index space leaves the authority
+        // incomplete. Fall back to the local scanned cache rather than trusting
+        // a truncated shared index.
+        if self.authority.frame_index_overflowed() {
+            return self
+                .fallback
+                .find_frame(page_id, min_frame, max_frame, frame_watermark);
+        }
+        self.authority
+            .find_frame(page_id, min_frame, max_frame, frame_watermark)
+    }
+
+    fn iter_latest_frames(&self, min_frame: u64, max_frame: u64) -> Vec<(u64, u64)> {
+        // Same trade-off as find_frame(): if the reserved shared index space is
+        // exhausted, keep correctness by consulting the local scanned cache.
+        if self.authority.frame_index_overflowed() {
+            return self.fallback.iter_latest_frames(min_frame, max_frame);
+        }
+        self.authority.iter_latest_frames(min_frame, max_frame)
+    }
+
+    fn checkpoint_epoch(&self) -> u32 {
+        self.authority.checkpoint_epoch()
+    }
+
+    fn bump_checkpoint_epoch(&self) -> u32 {
+        let prev = self.authority.bump_checkpoint_epoch();
+        self.shared
+            .write()
+            .runtime
+            .epoch
+            .store(prev + 1, Ordering::Release);
+        prev
+    }
+
+    fn try_begin_read_tx(&self, snapshot: WalSnapshot) -> Option<ReadGuardKind> {
+        let shared = self.shared.read();
+        let read_locks = &shared.runtime.read_locks;
+
+        if snapshot.max_frame == snapshot.nbackfills {
+            if !read_locks[0].read() {
+                return None;
+            }
+            if self.load_snapshot() != snapshot {
+                read_locks[0].unlock();
+                return None;
+            }
+            // In multi-process mode, we must register with the shared authority
+            // even for DbFile-only reads. Otherwise, a RESTART/TRUNCATE checkpoint
+            // in another process won't see us and may truncate the WAL while we
+            // still have an active read transaction — leading to data loss.
+            // We use max_frame as the reader frame to signal "I'm active".
+            let reader = self
+                .authority
+                .register_reader(self.owner, snapshot.max_frame.max(1));
+            match reader {
+                Some(slot) => {
+                    let mut active_reader = self.active_reader.lock();
+                    turso_assert!(active_reader.is_none(), "shared reader registration leaked");
+                    *active_reader = Some(slot);
+                }
+                None => {
+                    // RESTART/TRUNCATE checkpoints only consult the shared
+                    // authority for cross-process readers. Proceeding without a
+                    // shared reader slot would let another process restart or
+                    // truncate the WAL underneath this read transaction.
+                    read_locks[0].unlock();
+                    return None;
+                }
+            }
+            return Some(ReadGuardKind::DbFile);
+        }
+
+        let mut best_idx: i64 = -1;
+        let mut best_mark: u32 = 0;
+        for (idx, lock) in read_locks.iter().enumerate().take(5).skip(1) {
+            let mark = lock.get_value();
+            if mark != READMARK_NOT_USED && mark <= snapshot.max_frame as u32 && mark > best_mark {
+                best_mark = mark;
+                best_idx = idx as i64;
+            }
+        }
+
+        if best_idx == -1 || (best_mark as u64) < snapshot.max_frame {
+            for (idx, lock) in read_locks.iter().enumerate().take(5).skip(1) {
+                if !lock.write() {
+                    continue;
+                }
+                lock.set_value_exclusive(snapshot.max_frame as u32);
+                best_idx = idx as i64;
+                best_mark = snapshot.max_frame as u32;
+                read_locks[idx].unlock();
+                break;
+            }
+        }
+
+        if best_idx == -1 || !read_locks[best_idx as usize].read() {
+            return None;
+        }
+
+        let current_slot_mark = read_locks[best_idx as usize].get_value();
+        if current_slot_mark != best_mark || self.load_snapshot() != snapshot {
+            read_locks[best_idx as usize].unlock();
+            return None;
+        }
+
+        let reader = self
+            .authority
+            .register_reader(self.owner, snapshot.max_frame)?;
+        if self.load_snapshot() != snapshot {
+            self.authority.unregister_reader(reader);
+            read_locks[best_idx as usize].unlock();
+            return None;
+        }
+
+        let mut active_reader = self.active_reader.lock();
+        turso_assert!(active_reader.is_none(), "shared reader registration leaked");
+        *active_reader = Some(reader);
+        Some(ReadGuardKind::ReadMark(
+            NonZeroUsize::new(best_idx as usize)
+                .expect("best_idx checked to be non-negative and non-zero"),
+        ))
+    }
+
+    fn end_read_tx(&self, guard: ReadGuardKind) {
+        if let Some(reader) = self.active_reader.lock().take() {
+            self.authority.unregister_reader(reader);
+        }
+        self.fallback.end_read_tx(guard);
+    }
+
+    fn try_begin_write_tx(&self) -> bool {
+        if !self.authority.try_acquire_writer(self.owner) {
+            return false;
+        }
+        if !self.fallback.try_write_lock() {
+            self.authority.release_writer(self.owner);
+            return false;
+        }
+        true
+    }
+
+    fn end_write_tx(&self) {
+        self.fallback.unlock_write_lock();
+        self.authority.release_writer(self.owner);
+    }
+
+    fn acquire_checkpoint_guard(
+        &self,
+        mode: CheckpointMode,
+    ) -> Result<CoordinationCheckpointGuardKind> {
+        if !self.authority.try_acquire_checkpoint(self.owner) {
+            return Err(LimboError::Busy);
+        }
+        let needs_writer = !matches!(mode, CheckpointMode::Passive { .. });
+        if needs_writer && !self.authority.try_acquire_writer(self.owner) {
+            self.authority.release_checkpoint(self.owner);
+            return Err(LimboError::Busy);
+        }
+        if !self.fallback.try_checkpoint_lock() {
+            if needs_writer {
+                self.authority.release_writer(self.owner);
+            }
+            self.authority.release_checkpoint(self.owner);
+            return Err(LimboError::Busy);
+        }
+        match mode {
+            CheckpointMode::Passive { .. } => {
+                if !self.fallback.try_read_mark_exclusive(0) {
+                    self.fallback.unlock_checkpoint_lock();
+                    if needs_writer {
+                        self.authority.release_writer(self.owner);
+                    }
+                    self.authority.release_checkpoint(self.owner);
+                    return Err(LimboError::Busy);
+                }
+                Ok(CoordinationCheckpointGuardKind::Read0)
+            }
+            CheckpointMode::Full | CheckpointMode::Restart | CheckpointMode::Truncate { .. } => {
+                if !self.fallback.try_read_mark_exclusive(0) {
+                    self.fallback.unlock_checkpoint_lock();
+                    self.authority.release_writer(self.owner);
+                    self.authority.release_checkpoint(self.owner);
+                    return Err(LimboError::Busy);
+                }
+                if !self.fallback.try_write_lock() {
+                    self.fallback.unlock_read_mark(0);
+                    self.fallback.unlock_checkpoint_lock();
+                    self.authority.release_writer(self.owner);
+                    self.authority.release_checkpoint(self.owner);
+                    return Err(LimboError::Busy);
+                }
+                Ok(CoordinationCheckpointGuardKind::Writer)
+            }
+        }
+    }
+
+    fn release_checkpoint_guard(&self, guard: CoordinationCheckpointGuardKind) {
+        match guard {
+            CoordinationCheckpointGuardKind::Writer => {
+                self.fallback.unlock_write_lock();
+                self.fallback.unlock_read_mark(0);
+                self.fallback.unlock_checkpoint_lock();
+                self.authority.release_writer(self.owner);
+                self.authority.release_checkpoint(self.owner);
+            }
+            CoordinationCheckpointGuardKind::Read0 => {
+                self.fallback.unlock_read_mark(0);
+                self.fallback.unlock_checkpoint_lock();
+                self.authority.release_checkpoint(self.owner);
+            }
+        }
+    }
+
+    fn determine_max_safe_checkpoint_frame(&self, max_frame: u64) -> u64 {
+        let mut max_safe_frame = max_frame;
+        for read_lock_idx in 1..5 {
+            let this_mark = self.fallback.read_mark_value(read_lock_idx);
+            if this_mark < max_safe_frame as u32 {
+                let busy = !self.fallback.try_read_mark_exclusive(read_lock_idx);
+                if !busy {
+                    let val = if read_lock_idx == 1 {
+                        max_safe_frame as u32
+                    } else {
+                        READMARK_NOT_USED
+                    };
+                    self.fallback
+                        .set_read_mark_value_exclusive(read_lock_idx, val);
+                    self.fallback.unlock_read_mark(read_lock_idx);
+                } else {
+                    max_safe_frame = this_mark as u64;
+                }
+            }
+        }
+        match self.authority.min_active_reader_frame() {
+            Some(shared_min) => max_safe_frame.min(shared_min),
+            None => max_safe_frame,
+        }
+    }
+
+    fn begin_restart(&self, io: &dyn IO) -> Result<WalSnapshot> {
+        for idx in 1..5 {
+            if !self.fallback.try_read_mark_exclusive(idx) {
+                for held_idx in 1..idx {
+                    self.fallback.unlock_read_mark(held_idx);
+                }
+                return Err(LimboError::Busy);
+            }
+        }
+        // In multi-process mode, readers register with the authority (tshm shared
+        // memory), not with fallback OFD byte-range locks. We must also check for
+        // active cross-process readers before proceeding with the WAL restart,
+        // otherwise we reset the shared WAL state while another process still has
+        // an active read transaction, leading to data loss.
+        if self.authority.min_active_reader_frame().is_some() {
+            for idx in 1..5 {
+                self.fallback.unlock_read_mark(idx);
+            }
+            return Err(LimboError::Busy);
+        }
+        Ok(self.restart_snapshot_from_authority(self.authority.snapshot(), io))
+    }
+
+    fn end_restart(&self) {
+        self.fallback.end_restart();
+    }
+
+    fn try_restart_log_for_write(&self, io: &dyn IO) -> Result<Option<WalSnapshot>> {
+        if !self.fallback.try_upgrade_read_mark(0) {
+            return Ok(None);
+        }
+        let result = self.begin_restart(io);
+        self.fallback.downgrade_read_mark(0);
+        match result {
+            Ok(snapshot) => {
+                self.end_restart();
+                Ok(Some(snapshot))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn prepare_truncate(&self) -> Result<Arc<dyn File>> {
+        self.fallback.prepare_truncate()
+    }
+
+    fn wal_header(&self) -> WalHeader {
+        let snapshot = self.authority.snapshot();
+        let mut header = self.fallback.wal_header();
+        header.page_size = snapshot.page_size;
+        header.checkpoint_seq = snapshot.checkpoint_seq;
+        header.salt_1 = snapshot.salt_1;
+        header.salt_2 = snapshot.salt_2;
+        header.checksum_1 = snapshot.checksum_1;
+        header.checksum_2 = snapshot.checksum_2;
+        header
+    }
+
+    fn wal_file(&self) -> Result<Arc<dyn File>> {
+        self.fallback.wal_file()
+    }
+
+    fn wal_is_initialized(&self) -> bool {
+        self.fallback.wal_is_initialized()
+    }
+
+    fn prepare_wal_header(&self, io: &dyn IO, page_size: PageSize) -> Option<WalHeader> {
+        let header = self.fallback.prepare_wal_header(io, page_size);
+        if header.is_some() {
+            let authority_snapshot = self.authority.snapshot();
+            // A zero-frame authority snapshot after RESTART/TRUNCATE is still
+            // authoritative: it carries the latest transaction_count,
+            // checkpoint_seq, salts, and checksums for readers. Only treat the
+            // authority as "seed from local" when it is truly uninitialized.
+            if Self::authority_is_uninitialized(authority_snapshot) {
+                self.sync_authority_from_local();
+            } else {
+                self.sync_local_from_authority(authority_snapshot);
+            }
+        }
+        header
+    }
+
+    fn mark_initialized(&self) {
+        self.fallback.mark_initialized();
+    }
+
+    fn cache_frame(&self, page_id: u64, frame_id: u64) {
+        self.fallback.cache_frame(page_id, frame_id);
+        self.authority.record_frame(page_id, frame_id);
+    }
+
+    fn rollback_cache(&self, max_frame: u64) {
+        self.fallback.rollback_cache(max_frame);
+        self.authority.rollback_frames(max_frame);
+    }
+
+    fn should_checkpoint_on_close(&self) -> bool {
+        self.authority.is_last_process_mapping()
+    }
+
+    #[cfg(test)]
+    fn backend_name(&self) -> &'static str {
+        "tshm"
+    }
+
+    #[cfg(test)]
+    fn open_mode_name(&self) -> Option<&'static str> {
+        Some(match self.authority.open_mode() {
+            SharedWalCoordinationOpenMode::Exclusive => "exclusive",
+            SharedWalCoordinationOpenMode::MultiProcess => "multiprocess",
+        })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -778,11 +2006,11 @@ impl fmt::Debug for OngoingCheckpoint {
 pub struct WalFile {
     io: Arc<dyn IO>,
     buffer_pool: Arc<BufferPool>,
+    coordination: Arc<dyn WalCoordination>,
 
     syncing: Arc<AtomicBool>,
     write_lock_held: AtomicBool,
 
-    shared: Arc<RwLock<WalFileShared>>,
     ongoing_checkpoint: RwLock<OngoingCheckpoint>,
     checkpoint_threshold: usize,
     /// This is the index to the read_lock in WalFileShared that we are holding. This lock contains
@@ -808,7 +2036,6 @@ impl fmt::Debug for WalFile {
         f.debug_struct("WalFile")
             .field("syncing", &self.syncing.load(Ordering::Relaxed))
             .field("page_size", &self.page_size())
-            .field("shared", &self.shared)
             .field("ongoing_checkpoint", &*self.ongoing_checkpoint.read())
             .field("checkpoint_threshold", &self.checkpoint_threshold)
             .field("max_frame_read_lock_index", &self.max_frame_read_lock_index)
@@ -874,16 +2101,22 @@ impl fmt::Debug for WalFile {
 ** writing new content beginning at frame 1.
 */
 
-// TODO(pere): lock only important parts + pin WalFileShared
-/// WalFileShared is the part of a WAL that will be shared between threads. A wal has information
-/// that needs to be communicated between threads so this struct does the job.
-pub struct WalFileShared {
+/// Authoritative WAL metadata currently shared by all connections in a process.
+pub struct WalSharedMetadata {
     pub enabled: AtomicBool,
     pub wal_header: Arc<SpinLock<WalHeader>>,
     pub min_frame: AtomicU64,
     pub max_frame: AtomicU64,
     pub nbackfills: AtomicU64,
     pub transaction_count: AtomicU64,
+    pub last_checksum: (u32, u32), // Check of last frame in WAL, this is a cumulative checksum over all frames in the WAL
+    pub loaded: AtomicBool,
+    pub loaded_from_disk_scan: AtomicBool,
+    pub initialized: AtomicBool,
+}
+
+/// Process-local coordination and caches layered around the shared WAL metadata.
+pub struct WalSharedRuntime {
     // Frame cache maps a Page to all the frames it has stored in WAL in ascending order.
     // This is to easily find the frame it must checkpoint each connection if a checkpoint is
     // necessary.
@@ -891,7 +2124,6 @@ pub struct WalFileShared {
     // we don't need WAL's index file. So we can do stuff like this without shared memory.
     // TODO: this will need refactoring because this is incredible memory inefficient.
     pub frame_cache: Arc<SpinLock<FxHashMap<u64, Vec<u64>>>>,
-    pub last_checksum: (u32, u32), // Check of last frame in WAL, this is a cumulative checksum over all frames in the WAL
     pub file: Option<Arc<dyn File>>,
     /// Read locks advertise the maximum WAL frame a reader may access.
     /// Slot 0 is special, when it is held (shared) the reader bypasses the WAL and uses the main DB file.
@@ -906,23 +2138,27 @@ pub struct WalFileShared {
 
     /// Serialises checkpointer threads, only one checkpoint can be in flight at any time. Blocking and exclusive only
     pub checkpoint_lock: TursoRwLock,
-    pub loaded: AtomicBool,
-    pub initialized: AtomicBool,
     /// Increments on each checkpoint, used to prevent stale cached pages being used for
     /// backfilling.
     pub epoch: AtomicU32,
 }
 
+/// WalFileShared holds process-wide WAL metadata plus process-local coordination state.
+pub struct WalFileShared {
+    pub metadata: WalSharedMetadata,
+    pub runtime: WalSharedRuntime,
+}
+
 impl fmt::Debug for WalFileShared {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WalFileShared")
-            .field("enabled", &self.enabled.load(Ordering::Relaxed))
-            .field("wal_header", &self.wal_header)
-            .field("min_frame", &self.min_frame)
-            .field("max_frame", &self.max_frame)
-            .field("nbackfills", &self.nbackfills)
-            .field("frame_cache", &self.frame_cache)
-            .field("last_checksum", &self.last_checksum)
+            .field("enabled", &self.metadata.enabled.load(Ordering::Relaxed))
+            .field("wal_header", &self.metadata.wal_header)
+            .field("min_frame", &self.metadata.min_frame)
+            .field("max_frame", &self.metadata.max_frame)
+            .field("nbackfills", &self.metadata.nbackfills)
+            .field("frame_cache", &self.runtime.frame_cache)
+            .field("last_checksum", &self.metadata.last_checksum)
             // Excluding `file`, `read_locks`, and `write_lock`
             .finish()
     }
@@ -933,8 +2169,12 @@ impl fmt::Debug for WalFileShared {
 /// the case of errors. It is held by the WalFile while checkpoint is ongoing
 /// then transferred to the CheckpointResult if necessary.
 enum CheckpointLocks {
-    Writer { ptr: Arc<RwLock<WalFileShared>> },
-    Read0 { ptr: Arc<RwLock<WalFileShared>> },
+    Writer {
+        coordination: Arc<dyn WalCoordination>,
+    },
+    Read0 {
+        coordination: Arc<dyn WalCoordination>,
+    },
 }
 
 /// Database checkpointers takes the following locks, in order:
@@ -945,73 +2185,23 @@ enum CheckpointLocks {
 /// Exclusive lock on read-mark slots 1-N again. These are immediately released after being taken (RESTART and TRUNCATE only).
 /// All of the above use blocking locks.
 impl CheckpointLocks {
-    fn new(ptr: Arc<RwLock<WalFileShared>>, mode: CheckpointMode) -> Result<Self> {
-        let ptr_clone = ptr.clone();
-        {
-            let shared = ptr.write();
-            if !shared.checkpoint_lock.write() {
-                tracing::trace!("CheckpointGuard::new: checkpoint lock failed, returning Busy");
-                return Err(LimboError::Busy);
-            }
-            match mode {
-                CheckpointMode::Passive { .. } => {
-                    if !shared.read_locks[0].write() {
-                        shared.checkpoint_lock.unlock();
-                        tracing::trace!("CheckpointGuard: read0 lock failed, returning Busy");
-                        return Err(LimboError::Busy);
-                    }
-                }
-                CheckpointMode::Full => {
-                    if !shared.read_locks[0].write() {
-                        shared.checkpoint_lock.unlock();
-                        tracing::trace!("CheckpointGuard: read0 lock failed (Full), Busy");
-                        return Err(LimboError::Busy);
-                    }
-                    if !shared.write_lock.write() {
-                        shared.read_locks[0].unlock();
-                        shared.checkpoint_lock.unlock();
-                        tracing::trace!("CheckpointGuard: write lock failed (Full), Busy");
-                        return Err(LimboError::Busy);
-                    }
-                }
-                CheckpointMode::Restart | CheckpointMode::Truncate { .. } => {
-                    if !shared.read_locks[0].write() {
-                        shared.checkpoint_lock.unlock();
-                        tracing::trace!("CheckpointGuard: read0 lock failed, returning Busy");
-                        return Err(LimboError::Busy);
-                    }
-                    if !shared.write_lock.write() {
-                        shared.checkpoint_lock.unlock();
-                        shared.read_locks[0].unlock();
-                        tracing::trace!("CheckpointGuard: write lock failed, returning Busy");
-                        return Err(LimboError::Busy);
-                    }
-                }
-            }
-        }
-
-        match mode {
-            CheckpointMode::Passive { .. } => Ok(Self::Read0 { ptr: ptr_clone }),
-            CheckpointMode::Full | CheckpointMode::Restart | CheckpointMode::Truncate { .. } => {
-                Ok(Self::Writer { ptr: ptr_clone })
-            }
-        }
+    fn new(coordination: Arc<dyn WalCoordination>, mode: CheckpointMode) -> Result<Self> {
+        let guard = coordination.acquire_checkpoint_guard(mode)?;
+        Ok(match guard {
+            CoordinationCheckpointGuardKind::Read0 => Self::Read0 { coordination },
+            CoordinationCheckpointGuardKind::Writer => Self::Writer { coordination },
+        })
     }
 }
 
 impl Drop for CheckpointLocks {
     fn drop(&mut self) {
         match self {
-            CheckpointLocks::Writer { ptr: shared } => {
-                let guard = shared.write();
-                guard.write_lock.unlock();
-                guard.read_locks[0].unlock();
-                guard.checkpoint_lock.unlock();
+            CheckpointLocks::Writer { coordination } => {
+                coordination.release_checkpoint_guard(CoordinationCheckpointGuardKind::Writer);
             }
-            CheckpointLocks::Read0 { ptr: shared } => {
-                let guard = shared.write();
-                guard.read_locks[0].unlock();
-                guard.checkpoint_lock.unlock();
+            CheckpointLocks::Read0 { coordination } => {
+                coordination.release_checkpoint_guard(CoordinationCheckpointGuardKind::Read0);
             }
         }
     }
@@ -1026,15 +2216,9 @@ enum TryBeginReadResult {
 }
 
 impl WalFile {
-    /// Read the shared WAL metadata that defines a connection snapshot.
-    fn load_shared_snapshot(shared: &WalFileShared) -> WalSnapshot {
-        WalSnapshot {
-            max_frame: shared.max_frame.load(Ordering::Acquire),
-            nbackfills: shared.nbackfills.load(Ordering::Acquire),
-            last_checksum: shared.last_checksum,
-            checkpoint_seq: shared.wal_header.lock().checkpoint_seq,
-            transaction_count: shared.transaction_count.load(Ordering::Acquire),
-        }
+    /// Load the authoritative WAL snapshot through the coordination backend.
+    fn load_coordination_snapshot(&self) -> WalSnapshot {
+        self.coordination.load_snapshot()
     }
 
     /// Reconstruct the connection-local WAL state stored on this `WalFile`.
@@ -1084,7 +2268,7 @@ impl WalFile {
 
         // Snapshot the shared WAL state. We haven't taken a read lock yet, so we need
         // to validate these values later.
-        let shared_snapshot = self.with_shared(Self::load_shared_snapshot);
+        let shared_snapshot = self.load_coordination_snapshot();
         tracing::debug!(
             "try_begin_read_tx: shared_max={}, nbackfills={}, last_checksum={:?}, checkpoint_seq={:?}, transaction_count={}",
             shared_snapshot.max_frame,
@@ -1108,131 +2292,17 @@ impl WalFile {
                 shared_snapshot.max_frame,
                 shared_snapshot.nbackfills
             );
-            if !self.with_shared(|shared| shared.read_locks[0].read()) {
-                tracing::debug!("begin_read_tx: unable to acquire read-0 lock slot, retrying");
-                return TryBeginReadResult::Retry;
-            }
-            // Re-validate: a writer could have appended frames between our snapshot
-            // and lock acquisition. If so, we cannot proceed because we'd not be reading
-            // up to date committed content from the WAL.
-            let snapshot_after_lock = self.with_shared(Self::load_shared_snapshot);
-            if snapshot_after_lock != shared_snapshot {
-                tracing::debug!(
-                    "begin_read_tx: shared data changed ({}, {}, {:?}, {}, {}) != ({}, {}, {:?}, {}, {}), retrying",
-                    shared_snapshot.max_frame,
-                    shared_snapshot.nbackfills,
-                    shared_snapshot.last_checksum,
-                    shared_snapshot.checkpoint_seq,
-                    shared_snapshot.transaction_count,
-                    snapshot_after_lock.max_frame,
-                    snapshot_after_lock.nbackfills,
-                    snapshot_after_lock.last_checksum,
-                    snapshot_after_lock.checkpoint_seq,
-                    snapshot_after_lock.transaction_count
-                );
-                self.with_shared(|shared| shared.read_locks[0].unlock());
-                return TryBeginReadResult::Retry;
-            }
-            self.install_connection_state(WalConnectionState::new(
-                shared_snapshot,
-                ReadGuardKind::DbFile,
-            ));
-            return TryBeginReadResult::Ok(db_changed);
         }
 
-        // If we get this far, it means that the reader will want to use
-        // the WAL to get at content from recent commits.  The job now is
-        // to select one of the aReadMark[] entries that is closest to
-        // but not exceeding pWal->hdr.mxFrame and lock that entry.
-        // Find largest mark <= mx among slots 1..N
-        let mut best_idx: i64 = -1;
-        let mut best_mark: u32 = 0;
-        self.with_shared(|shared| {
-            for (idx, lock) in shared.read_locks.iter().enumerate().skip(1) {
-                let m = lock.get_value();
-                if m != READMARK_NOT_USED && m <= shared_snapshot.max_frame as u32 && m > best_mark
-                {
-                    best_mark = m;
-                    best_idx = idx as i64;
-                }
-            }
-        });
-        tracing::debug!(
-            "try_begin_read_tx: best_idx={}, best_mark={}",
-            best_idx,
-            best_mark
-        );
-
-        // If none found or lagging, try to claim/update a slot
-        if best_idx == -1 || (best_mark as u64) < shared_snapshot.max_frame {
-            self.with_shared(|shared| {
-                for (idx, lock) in shared.read_locks.iter().enumerate().skip(1) {
-                    if !lock.write() {
-                        continue; // busy slot
-                    }
-                    // claim or bump this slot
-                    lock.set_value_exclusive(shared_snapshot.max_frame as u32);
-                    best_idx = idx as i64;
-                    best_mark = shared_snapshot.max_frame as u32;
-                    lock.unlock();
-                    break;
-                }
-            })
-        }
-
-        // SQLite only requires finding SOME slot (mxI != 0), not that the mark equals mxFrame.
-        // A stale mark is fine - the reader uses shared_max for reading,
-        // and the mark just tells the checkpointer what frames are protected.
-        if best_idx == -1 {
-            return TryBeginReadResult::Retry;
-        }
-
-        // Now acquire shared read lock on the chosen slot.
-        let read_result = self.with_shared(|shared| {
-            if !shared.read_locks[best_idx as usize].read() {
-                return None;
-            }
-            Some((
-                Self::load_shared_snapshot(shared),
-                shared.read_locks[best_idx as usize].get_value(),
-            ))
-        });
-
-        tracing::debug!("try_begin_read_tx: read_result={:?}", read_result);
-
-        let Some((snapshot_after_lock, current_slot_mark)) = read_result else {
+        let Some(read_guard) = self.coordination.try_begin_read_tx(shared_snapshot) else {
             return TryBeginReadResult::Retry;
         };
-
-        // Re-validate state after acquiring the lock. Each check prevents a correctness violation:
-        //
-        // - current_slot_mark != best_mark: Between releasing the exclusive lock (after updating
-        //   the slot) and acquiring this shared lock, another thread can exclusively lock and
-        //   modify the slot. The checkpointer uses the slot's value to decide how far it can
-        //   checkpoint. If the slot now says 700 but we recorded 500, the checkpointer may
-        //   overwrite DB pages for frames 501-700 that we expect to read from the WAL.
-        //
-        // - mx2 != shared_max: A writer appended frames. We must retry to see them.
-        //
-        // - nb2 != nbackfills: A checkpointer advanced. We'd set min_frame wrong, potentially
-        //   trying to read frames from WAL that were already overwritten.
-        //
-        // - cksm2 != last_checksum: WAL content changed (e.g., rollback reused frame slots).
-        //
-        // - ckpt_seq2 != checkpoint_seq: WAL was reset. Frame numbers are now meaningless.
-        if current_slot_mark != best_mark || snapshot_after_lock != shared_snapshot {
-            self.with_shared(|shared| shared.read_locks[best_idx as usize].unlock());
-            return TryBeginReadResult::Retry;
-        }
-        self.install_connection_state(WalConnectionState::new(
-            shared_snapshot,
-            ReadGuardKind::ReadMark(best_idx as usize),
-        ));
+        self.install_connection_state(WalConnectionState::new(shared_snapshot, read_guard));
         tracing::debug!(
             "begin_read_tx(min={}, max={}, slot={}, max_frame_in_wal={})",
             self.min_frame.load(Ordering::Acquire),
             self.max_frame.load(Ordering::Acquire),
-            best_idx,
+            read_guard.lock_index(),
             shared_snapshot.max_frame
         );
         TryBeginReadResult::Ok(db_changed)
@@ -1285,7 +2355,8 @@ impl Wal for WalFile {
     fn end_read_tx(&self) {
         let slot = self.max_frame_read_lock_index.load(Ordering::Acquire);
         if slot != NO_LOCK_HELD {
-            self.with_shared(|shared| shared.read_locks[slot].unlock());
+            self.coordination
+                .end_read_tx(ReadGuardKind::from_lock_index(slot));
             self.max_frame_read_lock_index
                 .store(NO_LOCK_HELD, Ordering::Release);
             tracing::debug!("end_read_tx(slot={slot})");
@@ -1298,7 +2369,7 @@ impl Wal for WalFile {
     #[instrument(skip_all, level = Level::DEBUG)]
     fn begin_write_tx(&self) -> Result<()> {
         tracing::debug!("begin_write_tx");
-        self.with_shared(|shared| {
+        let begin_write_result: Result<()> = {
             // sqlite/src/wal.c 3702
             // Cannot start a write transaction without first holding a read
             // transaction.
@@ -1312,28 +2383,30 @@ impl Wal for WalFile {
                 !self.holds_write_lock(),
                 "write lock already held by this connection"
             );
-            if !shared.write_lock.write() {
+            if !self.coordination.try_begin_write_tx() {
                 return Err(LimboError::Busy);
             }
-            let db_changed = self.db_changed(shared);
+            let db_changed =
+                self.db_changed_against(self.load_coordination_snapshot(), self.connection_state());
             if db_changed {
                 // Snapshot is stale, give up and let caller retry from scratch.
                 // Return BusySnapshot instead of Busy so the caller knows it must
                 // restart the read transaction to get a fresh snapshot.
                 // Retrying with busy_timeout will NEVER HELP.
                 tracing::info!("unable to upgrade transaction from read to write: snapshot is stale, give up and let caller retry from scratch, self.max_frame={}, shared_max={}", self.max_frame.load(Ordering::Acquire), shared.max_frame.load(Ordering::Acquire));
-                shared.write_lock.unlock();
+                self.coordination.end_write_tx();
                 return Err(LimboError::BusySnapshot);
             }
 
             Ok(())
-        })?;
+        };
+        begin_write_result?;
         if self
             .write_lock_held
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
-            self.with_shared(|shared| shared.write_lock.unlock());
+            self.coordination.end_write_tx();
             turso_assert!(
                 false,
                 "begin_write_tx called while write lock already held according to connection state"
@@ -1347,9 +2420,7 @@ impl Wal for WalFile {
         }
 
         // don't forget to release the write-lock if
-        self.with_shared(|shared| {
-            shared.write_lock.unlock();
-        });
+        self.coordination.end_write_tx();
         turso_assert!(
             self.write_lock_held
                 .compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire)
@@ -1369,7 +2440,7 @@ impl Wal for WalFile {
                 .is_ok(),
             "end_write_tx called while write lock not held according to connection state"
         );
-        self.with_shared(|shared| shared.write_lock.unlock());
+        self.coordination.end_write_tx();
     }
 
     /// Returns true if this WAL instance currently holds a read lock.
@@ -1380,6 +2451,10 @@ impl Wal for WalFile {
     /// Returns true if this WAL instance currently holds the write lock.
     fn holds_write_lock(&self) -> bool {
         self.write_lock_held.load(Ordering::Acquire)
+    }
+
+    fn should_checkpoint_on_close(&self) -> bool {
+        self.coordination.should_checkpoint_on_close()
     }
 
     /// Find the latest frame containing a page.
@@ -1400,14 +2475,12 @@ impl Wal for WalFile {
         //
         // if it's not, than pages from WAL range [frame_watermark..nBackfill] are already in the DB file,
         // and in case if page first occurrence in WAL was after frame_watermark - we will be unable to read proper previous version of the page
-        self.with_shared(|shared| {
-            let nbackfills = shared.nbackfills.load(Ordering::Acquire);
-            turso_assert!(
-                frame_watermark.is_none() || frame_watermark.unwrap() >= nbackfills,
-                "frame_watermark must be >= than current WAL backfill amount",
-                { "frame_watermark": frame_watermark, "nbackfills": nbackfills }
-            );
-        });
+        let nbackfills = self.load_coordination_snapshot().nbackfills;
+        turso_assert!(
+            frame_watermark.is_none() || frame_watermark.unwrap() >= nbackfills,
+            "frame_watermark must be >= than current WAL backfill amount",
+            { "frame_watermark": frame_watermark, "nbackfills": nbackfills }
+        );
 
         // if we are holding read_lock 0 and didn't write anything to the WAL, skip and read right from db file.
         //
@@ -1425,31 +2498,27 @@ impl Wal for WalFile {
             );
             return Ok(None);
         }
-        self.with_shared(|shared| {
-            let frames = shared.frame_cache.lock();
-            let range = frame_watermark.map(|x| 0..=x).unwrap_or_else(|| {
-                self.min_frame.load(Ordering::Acquire)..=self.max_frame.load(Ordering::Acquire)
-            });
+        let min_frame = self.min_frame.load(Ordering::Acquire);
+        let max_frame = self.max_frame.load(Ordering::Acquire);
+        tracing::debug!(
+            "find_frame(page_id={}, frame_watermark={:?}): min_frame={}, max_frame={}",
+            page_id,
+            frame_watermark,
+            min_frame,
+            max_frame
+        );
+        let frame = self
+            .coordination
+            .find_frame(page_id, min_frame, max_frame, frame_watermark);
+        if let Some(frame) = frame {
             tracing::debug!(
-                "find_frame(page_id={}, frame_watermark={:?}): min_frame={}, max_frame={}",
+                "find_frame(page_id={}, frame_watermark={:?}): found frame={}",
                 page_id,
                 frame_watermark,
-                self.min_frame.load(Ordering::Acquire),
-                self.max_frame.load(Ordering::Acquire)
+                frame
             );
-            if let Some(list) = frames.get(&page_id) {
-                if let Some(f) = list.iter().rfind(|&&f| range.contains(&f)) {
-                    tracing::debug!(
-                        "find_frame(page_id={}, frame_watermark={:?}): found frame={}",
-                        page_id,
-                        frame_watermark,
-                        *f
-                    );
-                    return Ok(Some(*f));
-                }
-            }
-            Ok(None)
-        })
+        }
+        Ok(frame)
     }
 
     /// Read a frame from the WAL.
@@ -1469,7 +2538,7 @@ impl Wal for WalFile {
         page.set_locked();
         let frame = page.clone();
         let page_idx = page.get().id;
-        let shared_file = self.shared.clone();
+        let coordination = self.coordination.clone();
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 tracing::debug!(err = ?res.unwrap_err());
@@ -1492,28 +2561,13 @@ impl Wal for WalFile {
             }
             let cloned = frame.clone();
             finish_read_page(page.get().id, buf, cloned);
-            let epoch = shared_file.read().epoch.load(Ordering::Acquire);
+            let epoch = coordination.checkpoint_epoch();
             frame.set_wal_tag(frame_id, epoch);
             None
         });
-        let file = self.with_shared(|shared| {
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            // important not to hold shared lock beyond this point to avoid deadlock scenario where:
-            // thread 1: takes readlock here, passes reference to shared.file to begin_read_wal_frame
-            // thread 2: tries to acquire write lock elsewhere
-            // thread 1: tries to re-acquire read lock in the completion (see 'complete' above)
-            //
-            // this causes a deadlock due to the locking policy in parking_lot:
-            // from https://docs.rs/parking_lot/latest/parking_lot/type.RwLock.html:
-            // "This lock uses a task-fair locking policy which avoids both reader and writer starvation.
-            // This means that readers trying to acquire the lock will block even if the lock is unlocked
-            // when there are writers waiting to acquire the lock.
-            // Because of this, attempts to recursively acquire a read lock within a single thread may result in a deadlock."
-            shared.file.as_ref().unwrap().clone()
-        });
+        // important not to hold shared state locks beyond this point to avoid deadlock with
+        // completions that re-enter WAL state while a writer is waiting.
+        let file = self.coordination.wal_file()?;
         begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
@@ -1584,13 +2638,7 @@ impl Wal for WalFile {
             }
             None
         });
-        let file = self.with_shared(|shared| {
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            shared.file.as_ref().unwrap().clone()
-        });
+        let file = self.coordination.wal_file()?;
         let c = begin_read_wal_frame_raw(&self.buffer_pool, file.as_ref(), offset, complete)?;
         Ok(c)
     }
@@ -1661,13 +2709,7 @@ impl Wal for WalFile {
                     None
                 }
             });
-            let file = self.with_shared(|shared| {
-                turso_assert!(
-                    shared.enabled.load(Ordering::Relaxed),
-                    "WAL must be enabled"
-                );
-                shared.file.as_ref().unwrap().clone()
-            });
+            let file = self.coordination.wal_file()?;
             let c = begin_read_wal_frame(
                 file.as_ref(),
                 offset + WAL_FRAME_HEADER_SIZE as u64,
@@ -1688,16 +2730,8 @@ impl Wal for WalFile {
 
         // perform actual write
         let offset = self.frame_offset(frame_id);
-        let (header, file) = self.with_shared(|shared| {
-            let header = shared.wal_header.clone();
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            let file = shared.file.as_ref().unwrap().clone();
-            (header, file)
-        });
-        let header = header.lock();
+        let header = self.coordination.wal_header();
+        let file = self.coordination.wal_file()?;
         let checksums = *self.last_checksum.read();
         let (checksums, frame_bytes) = prepare_wal_frame(
             &self.buffer_pool,
@@ -1720,11 +2754,8 @@ impl Wal for WalFile {
 
     #[instrument(skip_all, level = Level::DEBUG)]
     fn should_checkpoint(&self) -> bool {
-        self.with_shared(|shared| {
-            let frame_id = shared.max_frame.load(Ordering::Acquire) as usize;
-            let nbackfills = shared.nbackfills.load(Ordering::Acquire) as usize;
-            frame_id > self.checkpoint_threshold + nbackfills
-        })
+        let snapshot = self.load_coordination_snapshot();
+        snapshot.max_frame as usize > self.checkpoint_threshold + snapshot.nbackfills as usize
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
@@ -1751,13 +2782,7 @@ impl Wal for WalFile {
             }
             syncing.store(false, Ordering::Release);
         });
-        let file = self.with_shared(|shared| {
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            shared.file.as_ref().unwrap().clone()
-        });
+        let file = self.coordination.wal_file()?;
         self.syncing.store(true, Ordering::Release);
         let c = file.sync(completion, sync_type)?;
         Ok(c)
@@ -1769,11 +2794,11 @@ impl Wal for WalFile {
     }
 
     fn get_max_frame_in_wal(&self) -> u64 {
-        self.with_shared(|shared| shared.max_frame.load(Ordering::Acquire))
+        self.load_coordination_snapshot().max_frame
     }
 
     fn get_checkpoint_seq(&self) -> u32 {
-        self.with_shared(|shared| shared.wal_header.lock().checkpoint_seq)
+        self.load_coordination_snapshot().checkpoint_seq
     }
 
     fn get_max_frame(&self) -> u64 {
@@ -1791,25 +2816,16 @@ impl Wal for WalFile {
 
     fn rollback(&self, rollback_to: Option<RollbackTo>) {
         let is_savepoint = rollback_to.is_some();
-        let (max_frame, last_checksum) = self.with_shared(|shared| {
-            let max_frame = rollback_to
-                .as_ref()
-                .map(|r| r.frame)
-                .unwrap_or_else(|| shared.max_frame.load(Ordering::Acquire));
-            let last_checksum = rollback_to
-                .as_ref()
-                .map(|r| r.checksum)
-                .unwrap_or(shared.last_checksum);
-            let mut frame_cache = shared.frame_cache.lock();
-            frame_cache.retain(|_page_id, frames| {
-                // keep frames <= max_frame
-                while frames.last().is_some_and(|&f| f > max_frame) {
-                    frames.pop();
-                }
-                !frames.is_empty()
-            });
-            (max_frame, last_checksum)
-        });
+        let snapshot = self.load_coordination_snapshot();
+        let max_frame = rollback_to
+            .as_ref()
+            .map(|r| r.frame)
+            .unwrap_or(snapshot.max_frame);
+        let last_checksum = rollback_to
+            .as_ref()
+            .map(|r| r.checksum)
+            .unwrap_or(snapshot.last_checksum);
+        self.coordination.rollback_cache(max_frame);
         *self.last_checksum.write() = last_checksum;
         self.max_frame.store(max_frame, Ordering::Release);
         if !is_savepoint {
@@ -1824,20 +2840,16 @@ impl Wal for WalFile {
 
     #[instrument(skip_all, level = Level::DEBUG)]
     fn finish_append_frames_commit(&self) -> Result<()> {
-        self.with_shared_mut_dangerous(|shared| {
-            shared
-                .max_frame
-                .store(self.max_frame.load(Ordering::Acquire), Ordering::Release);
-            let last_checksum = *self.last_checksum.read();
-            tracing::trace!(
-                max_frame = self.max_frame.load(Ordering::Acquire),
-                ?last_checksum
-            );
-            shared.last_checksum = last_checksum;
-            let new_count = self.transaction_count.fetch_add(1, Ordering::AcqRel) + 1;
-            shared.transaction_count.store(new_count, Ordering::Release);
-            Ok(())
-        })
+        let max_frame = self.max_frame.load(Ordering::Acquire);
+        let last_checksum = *self.last_checksum.read();
+        tracing::trace!(max_frame, ?last_checksum);
+        let transaction_count = self.transaction_count.fetch_add(1, Ordering::AcqRel) + 1;
+        self.coordination.publish_commit(WalCommitState {
+            max_frame,
+            last_checksum,
+            transaction_count,
+        });
+        Ok(())
     }
 
     fn changed_pages_after(&self, frame_watermark: u64) -> Result<Vec<u32>> {
@@ -1863,65 +2875,30 @@ impl Wal for WalFile {
     }
 
     fn prepare_wal_start(&self, page_size: PageSize) -> Result<Option<Completion>> {
-        if self.with_shared(|shared| shared.is_initialized())? {
+        if self.coordination.wal_is_initialized() {
             return Ok(None);
         }
         tracing::debug!("ensure_header_if_needed");
-        *self.last_checksum.write() = self.with_shared_mut_dangerous(|shared| {
-            let checksum = {
-                let mut hdr = shared.wal_header.lock();
-                hdr.magic = if cfg!(target_endian = "big") {
-                    WAL_MAGIC_BE
-                } else {
-                    WAL_MAGIC_LE
-                };
-                if hdr.page_size == 0 {
-                    hdr.page_size = page_size.get();
-                }
-                if hdr.salt_1 == 0 && hdr.salt_2 == 0 {
-                    hdr.salt_1 = self.io.generate_random_number() as u32;
-                    hdr.salt_2 = self.io.generate_random_number() as u32;
-                }
-
-                // recompute header checksum
-                let prefix = &hdr.as_bytes()[..WAL_HEADER_SIZE - 8];
-                let use_native = (hdr.magic & 1) != 0;
-                let (c1, c2) = checksum_wal(prefix, &hdr, (0, 0), use_native);
-                hdr.checksum_1 = c1;
-                hdr.checksum_2 = c2;
-                (c1, c2)
-            };
-            shared.last_checksum = checksum;
-            checksum
-        });
+        let Some(header) = self
+            .coordination
+            .prepare_wal_header(self.io.as_ref(), page_size)
+        else {
+            return Ok(None);
+        };
+        *self.last_checksum.write() = (header.checksum_1, header.checksum_2);
 
         self.max_frame.store(0, Ordering::Release);
-        let (header, file) = self.with_shared(|shared| {
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            (
-                *shared.wal_header.lock(),
-                shared.file.as_ref().unwrap().clone(),
-            )
-        });
+        let file = self.coordination.wal_file()?;
         let c = sqlite3_ondisk::begin_write_wal_header(file.as_ref(), &header)?;
         Ok(Some(c))
     }
 
     fn prepare_wal_finish(&self, sync_type: FileSyncType) -> Result<Completion> {
-        let file = self.with_shared(|shared| {
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            shared.file.as_ref().unwrap().clone()
-        });
-        let shared = self.shared.clone();
+        let file = self.coordination.wal_file()?;
+        let coordination = self.coordination.clone();
         let c = file.sync(
             Completion::new_sync(move |_| {
-                shared.read().initialized.store(true, Ordering::Release);
+                coordination.mark_initialized();
             }),
             sync_type,
         )?;
@@ -1951,15 +2928,12 @@ impl Wal for WalFile {
             "supported up to IOV_MAX pages at once"
         );
         turso_assert!(
-            self.with_shared(|shared| shared.is_initialized())?,
+            self.coordination.wal_is_initialized(),
             "WAL must be initialized"
         );
 
-        let (header, epoch) = self.with_shared(|shared| {
-            let hdr = *shared.wal_header.lock();
-            let epoch = shared.epoch.load(Ordering::Acquire);
-            (hdr, epoch)
-        });
+        let header = self.coordination.wal_header();
+        let epoch = self.coordination.checkpoint_epoch();
 
         turso_assert!(
             header.page_size == page_sz.get(),
@@ -1967,13 +2941,24 @@ impl Wal for WalFile {
             { "header_page_size": header.page_size, "requested_page_size": page_sz.get() }
         );
 
-        // Either chain from previous batch of PreparedFrames or use committed WAL state
+        // Either chain from previous batch of PreparedFrames or use committed WAL state.
+        // For the first batch, also check the authority's max_frame to handle
+        // cross-process WAL restarts where our local max_frame is stale.
         let (mut rolling_checksum, mut next_frame_id) = match prev {
             Some(p) => (p.final_checksum, p.final_max_frame + 1),
-            None => (
-                *self.last_checksum.read(),
-                self.max_frame.load(Ordering::Acquire) + 1,
-            ),
+            None => {
+                let local_max = self.max_frame.load(Ordering::Acquire);
+                let snapshot = self.load_coordination_snapshot();
+                if snapshot.max_frame > local_max {
+                    // Another process committed frames we don't know about.
+                    // Use the authority's state to avoid overwriting their frames.
+                    self.max_frame.store(snapshot.max_frame, Ordering::Release);
+                    *self.last_checksum.write() = snapshot.last_checksum;
+                    (snapshot.last_checksum, snapshot.max_frame + 1)
+                } else {
+                    (*self.last_checksum.read(), local_max + 1)
+                }
+            }
         };
 
         let first_frame_id = next_frame_id;
@@ -2059,16 +3044,7 @@ impl Wal for WalFile {
 
     /// Get WAL file for durable writes.
     fn wal_file(&self) -> Result<Arc<dyn File>> {
-        self.with_shared(|shared| {
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            shared.file.as_ref().cloned().ok_or_else(|| {
-                mark_unlikely();
-                LimboError::InternalError("WAL file not open".into())
-            })
-        })
+        self.coordination.wal_file()
     }
 
     /// Use pwritev to append many frames to the log at once.
@@ -2083,17 +3059,13 @@ impl Wal for WalFile {
             "we limit number of iovecs to IOV_MAX"
         );
         turso_assert!(
-            self.with_shared(|shared| shared.is_initialized())?,
+            self.coordination.wal_is_initialized(),
             "WAL must be prepared with prepare_wal_start/prepare_wal_finish method"
         );
 
-        let (header, shared_page_size, epoch) = self.with_shared(|shared| {
-            let hdr_guard = shared.wal_header.lock();
-            let header: WalHeader = *hdr_guard;
-            let shared_page_size = header.page_size;
-            let epoch = shared.epoch.load(Ordering::Acquire);
-            (header, shared_page_size, epoch)
-        });
+        let header = self.coordination.wal_header();
+        let shared_page_size = header.page_size;
+        let epoch = self.coordination.checkpoint_epoch();
         turso_assert!(
             shared_page_size == page_sz.get(),
             "page size mismatch, tried to change page size after WAL header was already initialized",
@@ -2173,13 +3145,7 @@ impl Wal for WalFile {
 
         let c = Completion::new_write(cmp);
 
-        let file = self.with_shared(|shared| {
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            shared.file.as_ref().unwrap().clone()
-        });
+        let file = self.coordination.wal_file()?;
         let c = file.pwritev(start_off, iovecs, c)?;
 
         self.io.drain()?;
@@ -2201,10 +3167,8 @@ impl Wal for WalFile {
     }
 
     fn update_max_frame(&self) {
-        self.with_shared(|shared| {
-            let new_max_frame = shared.max_frame.load(Ordering::Acquire);
-            self.max_frame.store(new_max_frame, Ordering::Release);
-        })
+        let new_max_frame = self.load_coordination_snapshot().max_frame;
+        self.max_frame.store(new_max_frame, Ordering::Release);
     }
 
     fn truncate_wal(
@@ -2217,18 +3181,49 @@ impl Wal for WalFile {
 }
 
 impl WalFile {
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub(crate) fn new_with_shared_coordination(
+        io: Arc<dyn IO>,
+        shared: Arc<RwLock<WalFileShared>>,
+        authority: Arc<MappedSharedWalCoordination>,
+        _last_checksum_and_max_frame: ((u32, u32), u64),
+        buffer_pool: Arc<BufferPool>,
+    ) -> Self {
+        let coordination: Arc<dyn WalCoordination> =
+            Arc::new(ShmWalCoordination::new(shared, authority));
+        let snapshot = coordination.load_snapshot();
+        Self::new_with_coordination(
+            io,
+            coordination,
+            (snapshot.last_checksum, snapshot.max_frame),
+            buffer_pool,
+        )
+    }
+
     pub fn new(
         io: Arc<dyn IO>,
         shared: Arc<RwLock<WalFileShared>>,
         (last_checksum, max_frame): ((u32, u32), u64),
         buffer_pool: Arc<BufferPool>,
     ) -> Self {
+        let coordination: Arc<dyn WalCoordination> =
+            Arc::new(InProcessWalCoordination::new(shared.clone()));
+        Self::new_with_coordination(io, coordination, (last_checksum, max_frame), buffer_pool)
+    }
+
+    /// Construct a WAL using an explicit coordination backend.
+    fn new_with_coordination(
+        io: Arc<dyn IO>,
+        coordination: Arc<dyn WalCoordination>,
+        (last_checksum, max_frame): ((u32, u32), u64),
+        buffer_pool: Arc<BufferPool>,
+    ) -> Self {
         let now = io.current_time_monotonic();
         Self {
             io,
+            coordination,
             // default to max frame in WAL, so that when we read schema we can read from WAL too if it's there.
             max_frame: AtomicU64::new(max_frame),
-            shared,
             ongoing_checkpoint: RwLock::new(OngoingCheckpoint {
                 time: now,
                 pending_writes: WriteBatch::new(),
@@ -2259,8 +3254,17 @@ impl WalFile {
         Arc::as_ptr(&self.shared) as usize
     }
 
+    pub(crate) fn coordination_backend_name(&self) -> &'static str {
+        self.coordination.backend_name()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn coordination_open_mode_name(&self) -> Option<&'static str> {
+        self.coordination.open_mode_name()
+    }
+
     fn page_size(&self) -> u32 {
-        self.with_shared(|shared| shared.wal_header.lock().page_size)
+        self.coordination.wal_header().page_size
     }
 
     fn frame_offset(&self, frame_id: u64) -> u64 {
@@ -2269,87 +3273,15 @@ impl WalFile {
         WAL_HEADER_SIZE as u64 + page_offset
     }
 
-    fn _get_shared_mut(&self) -> crate::sync::RwLockWriteGuard<'_, WalFileShared> {
-        // WASM in browser main thread doesn't have a way to "park" a thread
-        // so, we spin way here instead of calling blocking lock
-        #[cfg(target_family = "wasm")]
-        {
-            loop {
-                let Some(lock) = self.shared.try_write() else {
-                    std::hint::spin_loop();
-                    continue;
-                };
-                return lock;
-            }
-        }
-        #[cfg(not(target_family = "wasm"))]
-        {
-            self.shared.write()
-        }
-    }
-
-    fn _get_shared(&self) -> crate::sync::RwLockReadGuard<'_, WalFileShared> {
-        // WASM in browser main thread doesn't have a way to "park" a thread
-        // so, we spin way here instead of calling blocking lock
-        #[cfg(target_family = "wasm")]
-        {
-            loop {
-                let Some(lock) = self.shared.try_read() else {
-                    std::hint::spin_loop();
-                    continue;
-                };
-                return lock;
-            }
-        }
-        #[cfg(not(target_family = "wasm"))]
-        {
-            self.shared.read()
-        }
-    }
-
-    #[inline]
-    /// Get a mutable shared lock on the WAL file shared state.
-    /// Be very intentional about when you need this because it can easily cause a deadlock.
-    /// If you're modifying e.g. the WAL locks, all of those operations are atomic and do not
-    /// need shared_mut.
-    fn with_shared_mut_dangerous<F, R>(&self, func: F) -> R
-    where
-        F: FnOnce(&mut WalFileShared) -> R,
-    {
-        let mut shared = self._get_shared_mut();
-        func(&mut shared)
-    }
-
-    #[inline]
-    fn with_shared<F, R>(&self, func: F) -> R
-    where
-        F: FnOnce(&WalFileShared) -> R,
-    {
-        let shared = self._get_shared();
-        func(&shared)
-    }
-
     fn increment_checkpoint_epoch(&self) {
-        self.with_shared(|shared| {
-            let prev = shared.epoch.fetch_add(1, Ordering::Release);
-            tracing::info!("increment checkpoint epoch: prev={}", prev);
-        });
+        let prev = self.coordination.bump_checkpoint_epoch();
+        tracing::info!("increment checkpoint epoch: prev={}", prev);
     }
 
     fn complete_append_frame(&self, page_id: u64, frame_id: u64, checksums: (u32, u32)) {
         *self.last_checksum.write() = checksums;
         self.max_frame.store(frame_id, Ordering::Release);
-        self.with_shared(|shared| {
-            let mut frame_cache = shared.frame_cache.lock();
-            match frame_cache.get_mut(&page_id) {
-                Some(frames) => {
-                    frames.push(frame_id);
-                }
-                None => {
-                    frame_cache.insert(page_id, vec![frame_id]);
-                }
-            }
-        })
+        self.coordination.cache_frame(page_id, frame_id);
     }
 
     /// Reset connection-private WAL state.
@@ -2383,12 +3315,10 @@ impl WalFile {
                 // so no other checkpointer can run. fsync WAL if there are unapplied frames.
                 // Decide the largest frame we are allowed to back‑fill.
                 CheckpointState::Start => {
-                    let (max_frame, nbackfills) = self.with_shared(|shared| {
-                        let max_frame = shared.max_frame.load(Ordering::Acquire);
-                        let n_backfills = shared.nbackfills.load(Ordering::Acquire);
-                        (max_frame, n_backfills)
-                    });
                     tracing::info!("shared_wal: max_frame={max_frame}, nbackfills={nbackfills}");
+                    let snapshot = self.load_coordination_snapshot();
+                    let max_frame = snapshot.max_frame;
+                    let nbackfills = snapshot.nbackfills;
                     let needs_backfill = max_frame > nbackfills;
                     if !needs_backfill && !mode.should_restart_log() {
                         // there are no frames to copy over and we don't need to reset
@@ -2427,26 +3357,11 @@ impl WalFile {
                         (oc.min_frame, oc.max_frame)
                     };
                     tracing::info!("checkpoint_inner::Start: min_frame={oc_min_frame}, max_frame={oc_max_frame}");
-                    let to_checkpoint = self.with_shared(|shared| {
-                        let frame_cache = shared.frame_cache.lock();
-                        let mut list = Vec::with_capacity(
-                            oc_max_frame.checked_sub(nbackfills).unwrap_or_default() as usize,
-                        );
-                        for (&page_id, frames) in frame_cache.iter() {
-                            // for each page in the frame cache, grab the last (latest) frame for
-                            // that page that falls in the range of our safe min..max frame
-                            if let Some(&frame) = frames
-                                .iter()
-                                .rev()
-                                .find(|&&f| f >= oc_min_frame && f <= oc_max_frame)
-                            {
-                                list.push((page_id, frame));
-                            }
-                        }
-                        // sort by frame_id for read locality
-                        list.sort_unstable_by(|a, b| (a.1, a.0).cmp(&(b.1, b.0)));
-                        list
-                    });
+                    let mut to_checkpoint = self
+                        .coordination
+                        .iter_latest_frames(oc_min_frame, oc_max_frame);
+                    // sort by frame_id for read locality
+                    to_checkpoint.sort_unstable_by(|a, b| (a.1, a.0).cmp(&(b.1, b.0)));
                     {
                         let mut oc = self.ongoing_checkpoint.write();
                         oc.pages_to_checkpoint = to_checkpoint;
@@ -2493,7 +3408,7 @@ impl WalFile {
                         pager.io.drain()?;
                         return Err(LimboError::CompletionError(e));
                     }
-                    let epoch = self.with_shared(|shared| shared.epoch.load(Ordering::Acquire));
+                    let epoch = self.coordination.checkpoint_epoch();
                     // Issue reads until we hit limits
                     'inner: while ongoing_chkpt.should_issue_reads() {
                         let (page_id, target_frame) = {
@@ -2582,30 +3497,23 @@ impl WalFile {
                         ongoing_chkpt.complete(),
                         "checkpoint pending flush must have finished"
                     );
-                    let checkpoint_result = self.with_shared(|shared| {
-                        let wal_max_frame = shared.max_frame.load(Ordering::Acquire);
-                        let wal_total_backfilled = ongoing_chkpt.max_frame;
-                        // Record two num pages fields to return as checkpoint result to caller.
-                        // Ref: pnLog, pnCkpt on https://www.sqlite.org/c3ref/wal_checkpoint_v2.html
+                    let wal_max_frame = self.load_coordination_snapshot().max_frame;
+                    let wal_total_backfilled = ongoing_chkpt.max_frame;
+                    // Record two num pages fields to return as checkpoint result to caller.
+                    // Ref: pnLog, pnCkpt on https://www.sqlite.org/c3ref/wal_checkpoint_v2.html
 
-                        // the total # of frames we actually backfilled
-                        let wal_checkpoint_backfilled =
-                            wal_total_backfilled.saturating_sub(ongoing_chkpt.min_frame - 1);
+                    // the total # of frames we actually backfilled
+                    let wal_checkpoint_backfilled =
+                        wal_total_backfilled.saturating_sub(ongoing_chkpt.min_frame - 1);
 
-                        tracing::info!("checkpoint: wal_max_frame={wal_max_frame}, wal_total_backfilled={wal_total_backfilled}, wal_checkpoint_backfilled={wal_checkpoint_backfilled}");
-
-                        CheckpointResult::new(wal_max_frame, wal_total_backfilled, wal_checkpoint_backfilled)
-                    });
+                    let checkpoint_result = CheckpointResult::new(
+                        wal_max_frame,
+                        wal_total_backfilled,
+                        wal_checkpoint_backfilled,
+                    );
                     tracing::info!("checkpoint_result={:?}, mode={:?}", checkpoint_result, mode);
-
                     // store the max frame we were able to successfully checkpoint.
-                    // NOTE: we don't have a .shm file yet, so it's safe to update nbackfills here
-                    // before we sync, because if we crash and then recover, we will checkpoint the entire db anyway.
-                    self.with_shared(|shared| {
-                        shared
-                            .nbackfills
-                            .store(ongoing_chkpt.max_frame, Ordering::Release)
-                    });
+                    self.coordination.publish_backfill(ongoing_chkpt.max_frame);
                     if mode.require_all_backfilled() && !checkpoint_result.everything_backfilled() {
                         return Err(LimboError::Busy);
                     }
@@ -2632,7 +3540,7 @@ impl WalFile {
                     // but before DB sync, the data would be lost. By truncating the WAL
                     // only after the DB is safely synced, we guarantee recoverability.
                     if mode.should_restart_log() {
-                        Self::unlock_after_restart(&self.shared, None);
+                        Self::unlock_after_restart(&self.coordination, None);
                     }
                     let mut checkpoint_result = {
                         let mut oc = self.ongoing_checkpoint.write();
@@ -2710,30 +3618,8 @@ impl WalFile {
     /// We never modify slot values while a reader holds that slot's lock.
     /// TOOD: implement proper BUSY handling behavior
     fn determine_max_safe_checkpoint_frame(&self) -> u64 {
-        self.with_shared(|shared| {
-            let shared_max = shared.max_frame.load(Ordering::Acquire);
-            let mut max_safe_frame = shared_max;
-
-            for (read_lock_idx, read_lock) in shared.read_locks.iter().enumerate().skip(1) {
-                let this_mark = read_lock.get_value();
-                if this_mark < max_safe_frame as u32 {
-                    let busy = !read_lock.write();
-                    if !busy {
-                        let val = if read_lock_idx == 1 {
-                            // store the max_frame for the default read slot 1
-                            max_safe_frame as u32
-                        } else {
-                            READMARK_NOT_USED
-                        };
-                        read_lock.set_value_exclusive(val);
-                        read_lock.unlock();
-                    } else {
-                        max_safe_frame = this_mark as u64;
-                    }
-                }
-            }
-            max_safe_frame
-        })
+        self.coordination
+            .determine_max_safe_checkpoint_frame(self.load_coordination_snapshot().max_frame)
     }
 
     /// attempt to restart WAL header before write in order to keep WAL file size under the control
@@ -2748,12 +3634,9 @@ impl WalFile {
             tracing::debug!("try_restart_log_before_write: max_frame_read_lock_index={max_frame_read_lock_index}, writer use WAL - can't restart the log");
             return Ok(());
         }
-        let (max_frame, nbackfills) = self.with_shared(|s| {
-            (
-                s.max_frame.load(Ordering::Acquire),
-                s.nbackfills.load(Ordering::Acquire),
-            )
-        });
+        let snapshot = self.load_coordination_snapshot();
+        let max_frame = snapshot.max_frame;
+        let nbackfills = snapshot.nbackfills;
         if nbackfills == 0 {
             tracing::debug!("try_restart_log_before_write: nbackfills={nbackfills}, nothing were backfilled - can't restart the log");
             return Ok(());
@@ -2768,48 +3651,23 @@ impl WalFile {
             );
             return Ok(());
         }
-        let read_lock_0 = self.with_shared(|s| s.read_locks[0].upgrade());
-        if !read_lock_0 {
+        let Some(snapshot) = self
+            .coordination
+            .try_restart_log_for_write(self.io.as_ref())?
+        else {
             return Ok(());
-        }
-        let result = self.restart_log();
-        if result.is_ok() {
-            self.increment_checkpoint_epoch();
-            let shared = self.shared.clone();
-            Self::unlock_after_restart(&shared, result.as_ref().err());
-        }
-        self.with_shared(|s| s.read_locks[0].downgrade());
+        };
+        self.apply_restart_snapshot(snapshot);
+        self.increment_checkpoint_epoch();
+        let result = Ok(());
         tracing::debug!("try_restart_log_before_write: result={:?}", result);
         result
     }
 
     fn restart_log(&self) -> Result<()> {
         tracing::info!("restart_log");
-        self.with_shared(|shared| {
-            // Block all readers
-            for idx in 1..shared.read_locks.len() {
-                let lock = &shared.read_locks[idx];
-                if !lock.write() {
-                    // release everything we got so far
-                    for j in 1..idx {
-                        shared.read_locks[j].unlock();
-                    }
-                    // Reader is active, cannot proceed
-                    return Err(LimboError::Busy);
-                }
-                // after the log is reset, we must set all secondary marks to READMARK_NOT_USED so the next reader selects a fresh slot
-                lock.set_value_exclusive(READMARK_NOT_USED);
-            }
-            Ok(())
-        })?;
-
-        // reinitialize in‑memory state
-        self.with_shared_mut_dangerous(|shared| shared.restart_wal_header(&self.io));
-        let cksm = self.with_shared(|shared| shared.last_checksum);
-        *self.last_checksum.write() = cksm;
-        self.max_frame.store(0, Ordering::Release);
-        self.min_frame.store(0, Ordering::Release);
-        self.checkpoint_seq.fetch_add(1, Ordering::Release);
+        let snapshot = self.coordination.begin_restart(self.io.as_ref())?;
+        self.apply_restart_snapshot(snapshot);
         Ok(())
     }
 
@@ -2819,14 +3677,7 @@ impl WalFile {
         result: &mut CheckpointResult,
         sync_type: FileSyncType,
     ) -> Result<IOResult<()>> {
-        let file = self.with_shared(|shared| {
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            shared.initialized.store(false, Ordering::Release);
-            shared.file.as_ref().unwrap().clone()
-        });
+        let file = self.coordination.prepare_truncate()?;
 
         if !result.wal_truncate_sent {
             let c = Completion::new_trunc({
@@ -2861,13 +3712,17 @@ impl WalFile {
         Ok(IOResult::Done(()))
     }
 
+    fn apply_restart_snapshot(&self, snapshot: WalSnapshot) {
+        *self.last_checksum.write() = snapshot.last_checksum;
+        self.max_frame.store(snapshot.max_frame, Ordering::Release);
+        self.min_frame.store(0, Ordering::Release);
+        self.checkpoint_seq
+            .store(snapshot.checkpoint_seq, Ordering::Release);
+    }
+
     // unlock shared read locks taken by RESTART/TRUNCATE checkpoint modes
-    fn unlock_after_restart(shared: &Arc<RwLock<WalFileShared>>, e: Option<&LimboError>) {
-        // release all read locks we just acquired, the caller will take care of the others
-        let shared = shared.write();
-        for idx in 1..shared.read_locks.len() {
-            shared.read_locks[idx].unlock();
-        }
+    fn unlock_after_restart(coordination: &Arc<dyn WalCoordination>, e: Option<&LimboError>) {
+        coordination.end_restart();
         if let Some(e) = e {
             mark_unlikely();
             tracing::debug!(
@@ -2896,7 +3751,7 @@ impl WalFile {
             if self.checkpoint_guard.read().is_some() {
                 let _ = self.checkpoint_guard.write().take();
             }
-            let guard = CheckpointLocks::new(self.shared.clone(), mode)?;
+            let guard = CheckpointLocks::new(self.coordination.clone(), mode)?;
             *self.checkpoint_guard.write() = Some(guard);
         }
         Ok(())
@@ -2929,13 +3784,7 @@ impl WalFile {
             })
         };
         // schedule read of the page payload
-        let file = self.with_shared(|shared| {
-            turso_assert!(
-                shared.enabled.load(Ordering::Relaxed),
-                "WAL must be enabled"
-            );
-            shared.file.as_ref().unwrap().clone()
-        });
+        let file = self.coordination.wal_file()?;
         let c = begin_read_wal_frame(
             file.as_ref(),
             offset + WAL_FRAME_HEADER_SIZE as u64,
@@ -2952,11 +3801,6 @@ impl WalFile {
         })
     }
 
-    /// Check if database changed since this connection's last read transaction.
-    fn db_changed(&self, shared: &WalFileShared) -> bool {
-        self.db_changed_against(Self::load_shared_snapshot(shared), self.connection_state())
-    }
-
     /// MVCC helper: check if WAL state changed and refresh local snapshot without starting a read tx.
     /// FIXME: this isn't TOCTOU safe because we're not taking WAL read locks.
     ///
@@ -2965,21 +3809,230 @@ impl WalFile {
     /// FIXME: MVCC should start using pager read transactions anyway so that we can get rid of
     /// the stop-the-world MVCC checkpoint that blocks all reads.
     pub fn mvcc_refresh_if_db_changed(&self) -> bool {
-        self.with_shared(|shared| {
-            let snapshot = Self::load_shared_snapshot(shared);
-            let local_state = self.connection_state();
-            let changed = self.db_changed_against(snapshot, local_state);
-            if changed {
-                self.install_connection_state(local_state.with_snapshot(snapshot));
-            }
-            changed
-        })
+        let snapshot = self.load_coordination_snapshot();
+        let local_state = self.connection_state();
+        let changed = self.db_changed_against(snapshot, local_state);
+        if changed {
+            self.install_connection_state(local_state.with_snapshot(snapshot));
+        }
+        changed
     }
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn read_exact_bytes_from_file(
+    io: &Arc<dyn IO>,
+    file: &Arc<dyn File>,
+    offset: u64,
+    len: usize,
+) -> Result<Option<Vec<u8>>> {
+    let read_buf = Arc::new(Buffer::new_temporary(len));
+    let bytes_read = Arc::new(AtomicUsize::new(usize::MAX));
+    let c = file.pread(
+        offset,
+        Completion::new_read(read_buf.clone(), {
+            let bytes_read = bytes_read.clone();
+            Box::new(move |res| {
+                if let Ok((_buf, count)) = res {
+                    bytes_read.store(count as usize, Ordering::Release);
+                }
+                None
+            })
+        }),
+    )?;
+    io.wait_for_completion(c)?;
+    if bytes_read.load(Ordering::Acquire) != len {
+        return Ok(None);
+    }
+    Ok(Some(read_buf.as_slice()[..len].to_vec()))
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn read_validated_wal_header_from_file(
+    io: &Arc<dyn IO>,
+    file: &Arc<dyn File>,
+) -> Result<Option<WalHeader>> {
+    let Some(bytes) = read_exact_bytes_from_file(io, file, 0, WAL_HEADER_SIZE)? else {
+        return Ok(None);
+    };
+    let header = WalHeader {
+        magic: u32::from_be_bytes(bytes[0..4].try_into().unwrap()),
+        file_format: u32::from_be_bytes(bytes[4..8].try_into().unwrap()),
+        page_size: u32::from_be_bytes(bytes[8..12].try_into().unwrap()),
+        checkpoint_seq: u32::from_be_bytes(bytes[12..16].try_into().unwrap()),
+        salt_1: u32::from_be_bytes(bytes[16..20].try_into().unwrap()),
+        salt_2: u32::from_be_bytes(bytes[20..24].try_into().unwrap()),
+        checksum_1: u32::from_be_bytes(bytes[24..28].try_into().unwrap()),
+        checksum_2: u32::from_be_bytes(bytes[28..32].try_into().unwrap()),
+    };
+    if !matches!(header.magic, WAL_MAGIC_LE | WAL_MAGIC_BE) {
+        return Ok(None);
+    }
+    if PageSize::new(header.page_size).is_none() {
+        return Ok(None);
+    }
+    let use_native_endian = cfg!(target_endian = "big") == ((header.magic & 1) != 0);
+    let calc = checksum_wal(
+        &bytes[..WAL_HEADER_SIZE - 8],
+        &header,
+        (0, 0),
+        use_native_endian,
+    );
+    if calc != (header.checksum_1, header.checksum_2) {
+        return Ok(None);
+    }
+    Ok(Some(header))
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn wal_header_matches_authority_snapshot(
+    wal_header: WalHeader,
+    snapshot: SharedWalCoordinationHeader,
+) -> bool {
+    wal_header.page_size == snapshot.page_size
+        && wal_header.checkpoint_seq == snapshot.checkpoint_seq
+        && wal_header.salt_1 == snapshot.salt_1
+        && wal_header.salt_2 == snapshot.salt_2
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn validate_authority_snapshot_against_wal(
+    io: &Arc<dyn IO>,
+    file: &Arc<dyn File>,
+    snapshot: SharedWalCoordinationHeader,
+) -> Result<bool> {
+    let wal_size = file.size()?;
+    if snapshot.max_frame == 0 {
+        if wal_size == 0 {
+            return Ok(true);
+        }
+        if wal_size == WAL_HEADER_SIZE as u64 {
+            let Some(wal_header) = read_validated_wal_header_from_file(io, file)? else {
+                return Ok(false);
+            };
+            return Ok(wal_header_matches_authority_snapshot(wal_header, snapshot));
+        }
+        return Ok(false);
+    }
+
+    if wal_size < WAL_HEADER_SIZE as u64 {
+        return Ok(false);
+    }
+
+    let Some(wal_header) = read_validated_wal_header_from_file(io, file)? else {
+        return Ok(false);
+    };
+    if !wal_header_matches_authority_snapshot(wal_header, snapshot) {
+        return Ok(false);
+    }
+
+    let frame_size = WAL_FRAME_HEADER_SIZE as u64 + wal_header.page_size as u64;
+    let expected_wal_len = WAL_HEADER_SIZE as u64 + snapshot.max_frame * frame_size;
+    if wal_size != expected_wal_len {
+        return Ok(false);
+    }
+
+    let last_frame_offset = WAL_HEADER_SIZE as u64 + (snapshot.max_frame - 1) * frame_size;
+    let Some(frame_bytes) =
+        read_exact_bytes_from_file(io, file, last_frame_offset, frame_size as usize)?
+    else {
+        return Ok(false);
+    };
+    let (frame_header, _) = sqlite3_ondisk::parse_wal_frame_header(&frame_bytes);
+    if !frame_header.is_commit_frame() {
+        return Ok(false);
+    }
+    if frame_header.salt_1 != snapshot.salt_1 || frame_header.salt_2 != snapshot.salt_2 {
+        return Ok(false);
+    }
+    if frame_header.checksum_1 != snapshot.checksum_1
+        || frame_header.checksum_2 != snapshot.checksum_2
+    {
+        return Ok(false);
+    }
+    Ok(true)
 }
 
 impl WalFileShared {
     pub fn last_checksum_and_max_frame(&self) -> ((u32, u32), u64) {
-        (self.last_checksum, self.max_frame.load(Ordering::Acquire))
+        (
+            self.metadata.last_checksum,
+            self.metadata.max_frame.load(Ordering::Acquire),
+        )
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    pub(crate) fn open_shared_from_authority_if_exists(
+        io: &Arc<dyn IO>,
+        path: &str,
+        flags: crate::OpenFlags,
+        snapshot: SharedWalCoordinationHeader,
+    ) -> Result<Arc<RwLock<WalFileShared>>> {
+        let file = match io.open_file(path, flags, false) {
+            Ok(file) => file,
+            Err(LimboError::CompletionError(CompletionError::IOError(
+                std::io::ErrorKind::NotFound,
+                _,
+            ))) if flags.contains(crate::OpenFlags::ReadOnly) => {
+                return Ok(WalFileShared::new_noop());
+            }
+            Err(e) => return Err(e),
+        };
+        let wal_size = file.size()?;
+
+        // `max_frame` and the last commit checksum are provable from the WAL bytes, but
+        // `nbackfills` is not. A crash-stale `tshm` can therefore look WAL-valid while
+        // still claiming frames were checkpointed into the main DB file when they were
+        // not. Falling back to a WAL scan keeps reopened readers conservative.
+        // TODO: implement SQLite style integrity/recover protocol
+        if snapshot.nbackfills != 0 {
+            return sqlite3_ondisk::build_shared_wal(&file, io);
+        }
+
+        if !validate_authority_snapshot_against_wal(io, &file, snapshot)? {
+            return sqlite3_ondisk::build_shared_wal(&file, io);
+        }
+        let wal_is_initialized = wal_size >= WAL_HEADER_SIZE as u64;
+
+        let wal_header = WalHeader {
+            page_size: snapshot.page_size,
+            checkpoint_seq: snapshot.checkpoint_seq,
+            salt_1: snapshot.salt_1,
+            salt_2: snapshot.salt_2,
+            checksum_1: snapshot.checksum_1,
+            checksum_2: snapshot.checksum_2,
+            ..WalHeader::new()
+        };
+        let read_locks = array::from_fn(|_| TursoRwLock::new());
+        for (i, lock) in read_locks.iter().enumerate() {
+            lock.write();
+            lock.set_value_exclusive(if i < 2 { 0 } else { READMARK_NOT_USED });
+            lock.unlock();
+        }
+
+        let shared = WalFileShared {
+            metadata: WalSharedMetadata {
+                enabled: AtomicBool::new(true),
+                wal_header: Arc::new(SpinLock::new(wal_header)),
+                min_frame: AtomicU64::new(0),
+                max_frame: AtomicU64::new(snapshot.max_frame),
+                nbackfills: AtomicU64::new(snapshot.nbackfills),
+                transaction_count: AtomicU64::new(snapshot.transaction_count),
+                last_checksum: (snapshot.checksum_1, snapshot.checksum_2),
+                loaded: AtomicBool::new(true),
+                loaded_from_disk_scan: AtomicBool::new(false),
+                initialized: AtomicBool::new(wal_is_initialized),
+            },
+            runtime: WalSharedRuntime {
+                frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
+                file: Some(file),
+                read_locks,
+                write_lock: TursoRwLock::new(),
+                checkpoint_lock: TursoRwLock::new(),
+                epoch: AtomicU32::new(snapshot.checkpoint_epoch),
+            },
+        };
+        Ok(Arc::new(RwLock::new(shared)))
     }
 
     pub fn open_shared_if_exists(
@@ -3003,14 +4056,14 @@ impl WalFileShared {
         turso_assert!(
             wal_file_shared
                 .try_read()
-                .is_some_and(|wfs| wfs.loaded.load(Ordering::Acquire)),
+                .is_some_and(|wfs| wfs.metadata.loaded.load(Ordering::Acquire)),
             "Unable to read WAL shared state"
         );
         Ok(wal_file_shared)
     }
 
     pub fn is_initialized(&self) -> Result<bool> {
-        Ok(self.initialized.load(Ordering::Acquire))
+        Ok(self.metadata.initialized.load(Ordering::Acquire))
     }
 
     pub fn new_noop() -> Arc<RwLock<WalFileShared>> {
@@ -3022,21 +4075,26 @@ impl WalFileShared {
             lock.unlock();
         }
         let shared = WalFileShared {
-            enabled: AtomicBool::new(false),
-            wal_header: Arc::new(SpinLock::new(wal_header)),
-            min_frame: AtomicU64::new(0),
-            max_frame: AtomicU64::new(0),
-            nbackfills: AtomicU64::new(0),
-            transaction_count: AtomicU64::new(0),
-            frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
-            last_checksum: (0, 0),
-            file: None,
-            read_locks,
-            write_lock: TursoRwLock::new(),
-            checkpoint_lock: TursoRwLock::new(),
-            loaded: AtomicBool::new(true),
-            initialized: AtomicBool::new(false),
-            epoch: AtomicU32::new(0),
+            metadata: WalSharedMetadata {
+                enabled: AtomicBool::new(false),
+                wal_header: Arc::new(SpinLock::new(wal_header)),
+                min_frame: AtomicU64::new(0),
+                max_frame: AtomicU64::new(0),
+                nbackfills: AtomicU64::new(0),
+                transaction_count: AtomicU64::new(0),
+                last_checksum: (0, 0),
+                loaded: AtomicBool::new(true),
+                loaded_from_disk_scan: AtomicBool::new(false),
+                initialized: AtomicBool::new(false),
+            },
+            runtime: WalSharedRuntime {
+                frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
+                file: None,
+                read_locks,
+                write_lock: TursoRwLock::new(),
+                checkpoint_lock: TursoRwLock::new(),
+                epoch: AtomicU32::new(0),
+            },
         };
         Arc::new(RwLock::new(shared))
     }
@@ -3054,27 +4112,32 @@ impl WalFileShared {
             lock.unlock();
         }
         let shared = WalFileShared {
-            enabled: AtomicBool::new(true),
-            wal_header: Arc::new(SpinLock::new(wal_header)),
-            min_frame: AtomicU64::new(0),
-            max_frame: AtomicU64::new(0),
-            nbackfills: AtomicU64::new(0),
-            transaction_count: AtomicU64::new(0),
-            frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
-            last_checksum: (0, 0),
-            file: Some(file),
-            read_locks,
-            write_lock: TursoRwLock::new(),
-            checkpoint_lock: TursoRwLock::new(),
-            loaded: AtomicBool::new(true),
-            initialized: AtomicBool::new(false),
-            epoch: AtomicU32::new(0),
+            metadata: WalSharedMetadata {
+                enabled: AtomicBool::new(true),
+                wal_header: Arc::new(SpinLock::new(wal_header)),
+                min_frame: AtomicU64::new(0),
+                max_frame: AtomicU64::new(0),
+                nbackfills: AtomicU64::new(0),
+                transaction_count: AtomicU64::new(0),
+                last_checksum: (0, 0),
+                loaded: AtomicBool::new(true),
+                loaded_from_disk_scan: AtomicBool::new(false),
+                initialized: AtomicBool::new(false),
+            },
+            runtime: WalSharedRuntime {
+                frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
+                file: Some(file),
+                read_locks,
+                write_lock: TursoRwLock::new(),
+                checkpoint_lock: TursoRwLock::new(),
+                epoch: AtomicU32::new(0),
+            },
         };
         Ok(Arc::new(RwLock::new(shared)))
     }
 
     pub fn page_size(&self) -> u32 {
-        self.wal_header.lock().page_size
+        self.metadata.wal_header.lock().page_size
     }
 
     /// Called after a successful RESTART/TRUNCATE mode checkpoint
@@ -3092,27 +4155,27 @@ impl WalFileShared {
     /// This function updates the shared-memory structures so that the next
     /// client to write to the database (which may be this one) does so by
     /// writing frames into the start of the log file.
-    fn restart_wal_header(&mut self, io: &Arc<dyn IO>) {
+    fn restart_wal_header(&mut self, io: &dyn IO) {
         {
-            let mut hdr = self.wal_header.lock();
+            let mut hdr = self.metadata.wal_header.lock();
             hdr.checkpoint_seq = hdr.checkpoint_seq.wrapping_add(1);
             // keep hdr.magic, hdr.file_format, hdr.page_size as-is
             hdr.salt_1 = hdr.salt_1.wrapping_add(1);
             hdr.salt_2 = io.generate_random_number() as u32;
 
-            self.max_frame.store(0, Ordering::Release);
-            self.nbackfills.store(0, Ordering::Release);
-            self.last_checksum = (hdr.checksum_1, hdr.checksum_2);
+            self.metadata.max_frame.store(0, Ordering::Release);
+            self.metadata.nbackfills.store(0, Ordering::Release);
+            self.metadata.last_checksum = (hdr.checksum_1, hdr.checksum_2);
             // `prepare_wal_start` (used in the `commit_dirty_pages_inner`) do the work only if WAL is not initialized yet (so, self.initialized is false)
             // we change WAL state here, so on next write attempt `prepare_wal_start` will update WAL header
-            self.initialized.store(false, Ordering::Release);
+            self.metadata.initialized.store(false, Ordering::Release);
         }
 
-        self.frame_cache.lock().clear();
+        self.runtime.frame_cache.lock().clear();
         // read-marks
-        self.read_locks[0].set_value_exclusive(0);
-        self.read_locks[1].set_value_exclusive(0);
-        for lock in &self.read_locks[2..] {
+        self.runtime.read_locks[0].set_value_exclusive(0);
+        self.runtime.read_locks[1].set_value_exclusive(0);
+        for lock in &self.runtime.read_locks[2..] {
             lock.set_value_exclusive(READMARK_NOT_USED);
         }
     }
@@ -3120,13 +4183,22 @@ impl WalFileShared {
 
 #[cfg(test)]
 pub mod test {
-    use super::{ReadGuardKind, WalConnectionState, WalFile, WalSnapshot};
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    use super::ShmWalCoordination;
+    use super::{
+        InProcessWalCoordination, ReadGuardKind, Wal, WalCommitState, WalConnectionState,
+        WalCoordination, WalFile, WalSnapshot,
+    };
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    use crate::storage::shared_wal_coordination::{
+        MappedSharedWalCoordination, SharedWalCoordinationHeader, SharedWalCoordinationOpenMode,
+    };
     use crate::sync::{atomic::Ordering, Arc};
     use crate::sync::{Mutex, RwLock};
     use crate::{
         storage::{
             buffer_pool::BufferPool,
-            sqlite3_ondisk::{self, WAL_HEADER_SIZE},
+            sqlite3_ondisk::{self, PageSize, WAL_HEADER_SIZE},
             wal::READMARK_NOT_USED,
         },
         types::IOResult,
@@ -3134,6 +4206,7 @@ pub mod test {
         CheckpointMode, CheckpointResult, Completion, Connection, Database, LimboError, PlatformIO,
         WalFileShared, IO,
     };
+    use std::num::NonZeroUsize;
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
     #[allow(clippy::arc_with_non_send_sync)]
@@ -3160,7 +4233,7 @@ pub mod test {
             .unwrap();
         let _ = conn.execute("insert into test (value) values ('test1'), ('test2'), ('test3')");
         let wal = db.shared_wal.write();
-        let wal_file = wal.file.as_ref().unwrap().clone();
+        let wal_file = wal.runtime.file.as_ref().unwrap().clone();
         let done = Arc::new(Mutex::new(false));
         let _done = done.clone();
         let _ = wal_file.truncate(
@@ -3282,26 +4355,126 @@ pub mod test {
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
         let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
         let shared = WalFileShared::new_noop();
-        let wal = WalFile::new(io, shared.clone(), ((0, 0), 0), buffer_pool);
+        let coordination: Arc<dyn WalCoordination> =
+            Arc::new(InProcessWalCoordination::new(shared.clone()));
+        let wal = WalFile::new_with_coordination(io, coordination, ((0, 0), 0), buffer_pool);
         (shared, wal)
     }
 
     fn set_shared_snapshot(shared: &Arc<RwLock<WalFileShared>>, snapshot: WalSnapshot) {
         let mut guard = shared.write();
-        guard.max_frame.store(snapshot.max_frame, Ordering::Release);
         guard
+            .metadata
+            .max_frame
+            .store(snapshot.max_frame, Ordering::Release);
+        guard
+            .metadata
             .nbackfills
             .store(snapshot.nbackfills, Ordering::Release);
-        guard.last_checksum = snapshot.last_checksum;
-        guard.wal_header.lock().checkpoint_seq = snapshot.checkpoint_seq;
+        guard.metadata.last_checksum = snapshot.last_checksum;
+        guard.metadata.wal_header.lock().checkpoint_seq = snapshot.checkpoint_seq;
         guard
+            .metadata
             .transaction_count
             .store(snapshot.transaction_count, Ordering::Release);
+    }
+
+    fn make_test_coordination(shared: &Arc<RwLock<WalFileShared>>) -> InProcessWalCoordination {
+        InProcessWalCoordination::new(shared.clone())
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    fn make_test_shm_coordination(
+        shared: &Arc<RwLock<WalFileShared>>,
+        path: &std::path::Path,
+    ) -> (Arc<MappedSharedWalCoordination>, ShmWalCoordination) {
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, path, 64).unwrap());
+        let coordination = ShmWalCoordination::new(shared.clone(), authority.clone());
+        (authority, coordination)
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    fn write_test_wal_with_single_commit_frame(
+        io: &Arc<dyn IO>,
+        wal_path: &std::path::Path,
+    ) -> SharedWalCoordinationHeader {
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let mut wal_header = sqlite3_ondisk::WalHeader {
+            page_size: 4096,
+            checkpoint_seq: 5,
+            salt_1: 17,
+            salt_2: 23,
+            ..sqlite3_ondisk::WalHeader::new()
+        };
+        let use_native_endian = cfg!(target_endian = "big") == ((wal_header.magic & 1) != 0);
+        let mut header_prefix = [0u8; WAL_HEADER_SIZE - 8];
+        header_prefix[0..4].copy_from_slice(&wal_header.magic.to_be_bytes());
+        header_prefix[4..8].copy_from_slice(&wal_header.file_format.to_be_bytes());
+        header_prefix[8..12].copy_from_slice(&wal_header.page_size.to_be_bytes());
+        header_prefix[12..16].copy_from_slice(&wal_header.checkpoint_seq.to_be_bytes());
+        header_prefix[16..20].copy_from_slice(&wal_header.salt_1.to_be_bytes());
+        header_prefix[20..24].copy_from_slice(&wal_header.salt_2.to_be_bytes());
+        let header_checksum =
+            sqlite3_ondisk::checksum_wal(&header_prefix, &wal_header, (0, 0), use_native_endian);
+        wal_header.checksum_1 = header_checksum.0;
+        wal_header.checksum_2 = header_checksum.1;
+
+        io.wait_for_completion(
+            sqlite3_ondisk::begin_write_wal_header(file.as_ref(), &wal_header).unwrap(),
+        )
+        .unwrap();
+
+        let buffer_pool = BufferPool::begin_init(io, BufferPool::TEST_ARENA_SIZE);
+        buffer_pool
+            .finalize_with_page_size(wal_header.page_size as usize)
+            .unwrap();
+        let page = vec![0x5a; wal_header.page_size as usize];
+        let (frame_checksum, frame_buf) = sqlite3_ondisk::prepare_wal_frame(
+            &buffer_pool,
+            &wal_header,
+            header_checksum,
+            wal_header.page_size,
+            7,
+            1,
+            &page,
+        );
+        let c = file
+            .pwrite(
+                WAL_HEADER_SIZE as u64,
+                frame_buf,
+                Completion::new_write(|_| {}),
+            )
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+        let c = file
+            .sync(Completion::new_sync(|_| {}), crate::io::FileSyncType::Fsync)
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        SharedWalCoordinationHeader {
+            max_frame: 1,
+            nbackfills: 0,
+            transaction_count: 9,
+            visibility_generation: 3,
+            checkpoint_seq: wal_header.checkpoint_seq,
+            checkpoint_epoch: 7,
+            page_size: wal_header.page_size,
+            salt_1: wal_header.salt_1,
+            salt_2: wal_header.salt_2,
+            checksum_1: frame_checksum.0,
+            checksum_2: frame_checksum.1,
+            reader_slot_count: 64,
+        }
     }
 
     #[cfg(test)]
     fn read_slots_with_readers(shared: &WalFileShared) -> Vec<usize> {
         shared
+            .runtime
             .read_locks
             .iter()
             .enumerate()
@@ -3316,7 +4489,7 @@ pub mod test {
     fn wal_header_snapshot(shared: &Arc<RwLock<WalFileShared>>) -> (u32, u32, u32, u32) {
         // (checkpoint_seq, salt1, salt2, page_size)
         let shared_guard = shared.read();
-        let hdr = shared_guard.wal_header.lock();
+        let hdr = shared_guard.metadata.wal_header.lock();
         (hdr.checkpoint_seq, hdr.salt_1, hdr.salt_2, hdr.page_size)
     }
 
@@ -3331,13 +4504,28 @@ pub mod test {
                 checkpoint_seq: 5,
                 transaction_count: 13,
             },
-            ReadGuardKind::ReadMark(3),
+            ReadGuardKind::ReadMark(NonZeroUsize::new(3).unwrap()),
         );
 
         wal.install_connection_state(state);
 
         assert_eq!(wal.connection_state(), state);
         assert_eq!(wal.connection_state().snapshot.min_frame(), 8);
+    }
+
+    #[test]
+    fn test_wal_explicit_backend_constructor_does_not_keep_shared_handle() {
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let shared = WalFileShared::new_noop();
+        let coordination: Arc<dyn WalCoordination> =
+            Arc::new(InProcessWalCoordination::new(shared.clone()));
+
+        assert_eq!(Arc::strong_count(&shared), 2);
+
+        let _wal = WalFile::new_with_coordination(io, coordination, ((0, 0), 0), buffer_pool);
+
+        assert_eq!(Arc::strong_count(&shared), 2);
     }
 
     #[test]
@@ -3351,7 +4539,10 @@ pub mod test {
             transaction_count: 3,
         };
         set_shared_snapshot(&shared, initial);
-        wal.install_connection_state(WalConnectionState::new(initial, ReadGuardKind::ReadMark(2)));
+        wal.install_connection_state(WalConnectionState::new(
+            initial,
+            ReadGuardKind::ReadMark(NonZeroUsize::new(2).unwrap()),
+        ));
 
         assert!(!wal.mvcc_refresh_if_db_changed());
 
@@ -3367,8 +4558,932 @@ pub mod test {
         assert!(wal.mvcc_refresh_if_db_changed());
         assert_eq!(
             wal.connection_state(),
-            WalConnectionState::new(updated, ReadGuardKind::ReadMark(2))
+            WalConnectionState::new(
+                updated,
+                ReadGuardKind::ReadMark(NonZeroUsize::new(2).unwrap())
+            )
         );
+    }
+
+    #[test]
+    fn test_in_process_coordination_uses_shared_authority() {
+        let (shared, _wal) = make_test_wal();
+        let coordination = make_test_coordination(&shared);
+        let snapshot = WalSnapshot {
+            max_frame: 9,
+            nbackfills: 3,
+            last_checksum: (55, 89),
+            checkpoint_seq: 7,
+            transaction_count: 11,
+        };
+        set_shared_snapshot(&shared, snapshot);
+        {
+            let guard = shared.write();
+            guard.runtime.epoch.store(5, Ordering::Release);
+            guard.runtime.frame_cache.lock().extend([
+                (1, vec![1, 4, 8]),
+                (2, vec![2, 6]),
+                (3, vec![3]),
+            ]);
+        }
+
+        assert_eq!(coordination.load_snapshot(), snapshot);
+        assert_eq!(coordination.checkpoint_epoch(), 5);
+        assert_eq!(coordination.find_frame(1, 4, 9, None), Some(8));
+        assert_eq!(coordination.find_frame(2, 4, 9, Some(5)), Some(2));
+        assert_eq!(coordination.iter_latest_frames(4, 9), vec![(1, 8), (2, 6)]);
+
+        coordination.publish_commit(WalCommitState {
+            max_frame: 12,
+            last_checksum: (144, 233),
+            transaction_count: 12,
+        });
+        let published = coordination.load_snapshot();
+        assert_eq!(published.max_frame, 12);
+        assert_eq!(published.last_checksum, (144, 233));
+        assert_eq!(published.transaction_count, 12);
+        assert_eq!(published.nbackfills, snapshot.nbackfills);
+        assert_eq!(published.checkpoint_seq, snapshot.checkpoint_seq);
+    }
+
+    #[test]
+    fn test_in_process_coordination_publishes_checkpoint_and_restart_state() {
+        let (shared, _wal) = make_test_wal();
+        let coordination = make_test_coordination(&shared);
+        let io = PlatformIO::new().unwrap();
+        let snapshot = WalSnapshot {
+            max_frame: 9,
+            nbackfills: 3,
+            last_checksum: (55, 89),
+            checkpoint_seq: 7,
+            transaction_count: 11,
+        };
+        set_shared_snapshot(&shared, snapshot);
+        {
+            let guard = shared.write();
+            let mut header = guard.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.checksum_1 = 144;
+            header.checksum_2 = 233;
+            guard.metadata.initialized.store(true, Ordering::Release);
+            guard.runtime.epoch.store(5, Ordering::Release);
+            guard
+                .runtime
+                .frame_cache
+                .lock()
+                .extend([(1, vec![1, 4, 8]), (2, vec![2, 6])]);
+        }
+
+        coordination.publish_backfill(8);
+        assert_eq!(coordination.load_snapshot().nbackfills, 8);
+        assert_eq!(coordination.bump_checkpoint_epoch(), 5);
+        assert_eq!(coordination.checkpoint_epoch(), 6);
+
+        assert!(coordination.try_read_mark_exclusive(0));
+        let restarted = coordination.begin_restart(&io).unwrap();
+        coordination.end_restart();
+        coordination.unlock_read_mark(0);
+
+        assert_eq!(restarted.max_frame, 0);
+        assert_eq!(restarted.nbackfills, 0);
+        assert_eq!(restarted.last_checksum, (144, 233));
+        assert_eq!(restarted.checkpoint_seq, 8);
+        assert_eq!(restarted.transaction_count, 11);
+
+        let guard = shared.read();
+        assert_eq!(guard.runtime.read_locks[0].get_value(), 0);
+        assert_eq!(guard.runtime.read_locks[1].get_value(), 0);
+        for lock in &guard.runtime.read_locks[2..] {
+            assert_eq!(lock.get_value(), READMARK_NOT_USED);
+        }
+        assert!(guard.runtime.frame_cache.lock().is_empty());
+        assert!(!guard.metadata.initialized.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn test_in_process_coordination_manages_frame_cache() {
+        let (shared, _wal) = make_test_wal();
+        let coordination = make_test_coordination(&shared);
+
+        coordination.cache_frame(7, 2);
+        coordination.cache_frame(7, 5);
+        coordination.cache_frame(9, 4);
+
+        assert_eq!(coordination.find_frame(7, 0, 5, None), Some(5));
+        assert_eq!(coordination.iter_latest_frames(0, 5), vec![(7, 5), (9, 4)]);
+
+        coordination.rollback_cache(4);
+
+        assert_eq!(coordination.find_frame(7, 0, 5, None), Some(2));
+        assert_eq!(coordination.iter_latest_frames(0, 5), vec![(7, 2), (9, 4)]);
+        assert_eq!(
+            shared.read().runtime.frame_cache.lock().get(&7),
+            Some(&vec![2])
+        );
+    }
+
+    #[test]
+    fn test_in_process_coordination_transaction_guards() {
+        let (shared, _wal) = make_test_wal();
+        let coordination = make_test_coordination(&shared);
+
+        let db_file_snapshot = WalSnapshot {
+            max_frame: 0,
+            nbackfills: 0,
+            last_checksum: (0, 0),
+            checkpoint_seq: 0,
+            transaction_count: 0,
+        };
+        set_shared_snapshot(&shared, db_file_snapshot);
+        let read_guard = coordination.try_begin_read_tx(db_file_snapshot).unwrap();
+        assert_eq!(read_guard, ReadGuardKind::DbFile);
+        coordination.end_read_tx(read_guard);
+
+        let wal_snapshot = WalSnapshot {
+            max_frame: 5,
+            nbackfills: 2,
+            last_checksum: (11, 13),
+            checkpoint_seq: 1,
+            transaction_count: 2,
+        };
+        set_shared_snapshot(&shared, wal_snapshot);
+        let read_guard = coordination.try_begin_read_tx(wal_snapshot).unwrap();
+        assert!(matches!(read_guard, ReadGuardKind::ReadMark(_)));
+        coordination.end_read_tx(read_guard);
+
+        assert!(coordination.try_begin_write_tx());
+        assert!(!coordination.try_begin_write_tx());
+        coordination.end_write_tx();
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_uses_shared_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let file_a = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let file_b = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_a = WalFileShared::new_shared(file_a).unwrap();
+        let shared_b = WalFileShared::new_shared(file_b).unwrap();
+        let snapshot = WalSnapshot {
+            max_frame: 14,
+            nbackfills: 8,
+            last_checksum: (31, 37),
+            checkpoint_seq: 5,
+            transaction_count: 9,
+        };
+        set_shared_snapshot(&shared_a, snapshot);
+        {
+            let shared = shared_a.write();
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = snapshot.last_checksum.0;
+            header.checksum_2 = snapshot.last_checksum.1;
+        }
+
+        let (_authority_a, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
+        let (authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
+        coordination_a.cache_frame(7, 2);
+        coordination_a.cache_frame(9, 4);
+        coordination_a.cache_frame(7, 5);
+
+        assert_eq!(coordination_b.load_snapshot(), snapshot);
+        assert_eq!(coordination_b.wal_header().page_size, 4096);
+        assert_eq!(coordination_b.wal_header().salt_1, 17);
+        assert_eq!(coordination_b.wal_header().salt_2, 23);
+        assert_eq!(coordination_b.find_frame(7, 0, 5, None), Some(5));
+        assert_eq!(
+            coordination_b.iter_latest_frames(0, 5),
+            vec![(7, 5), (9, 4)]
+        );
+        assert_eq!(coordination_a.checkpoint_epoch(), 0);
+        assert_eq!(coordination_b.bump_checkpoint_epoch(), 0);
+        assert_eq!(coordination_a.checkpoint_epoch(), 1);
+
+        assert!(coordination_a.try_begin_write_tx());
+        assert!(!coordination_b.try_begin_write_tx());
+        coordination_a.end_write_tx();
+
+        let read_guard = coordination_a.try_begin_read_tx(snapshot).unwrap();
+        assert_eq!(
+            authority_b.min_active_reader_frame(),
+            Some(snapshot.max_frame)
+        );
+        coordination_a.end_read_tx(read_guard);
+        assert_eq!(authority_b.min_active_reader_frame(), None);
+
+        coordination_b.publish_commit(WalCommitState {
+            max_frame: 21,
+            last_checksum: (55, 89),
+            transaction_count: 10,
+        });
+        assert_eq!(
+            coordination_a.load_snapshot(),
+            WalSnapshot {
+                max_frame: 21,
+                nbackfills: 8,
+                last_checksum: (55, 89),
+                checkpoint_seq: 5,
+                transaction_count: 10,
+            }
+        );
+
+        coordination_b.rollback_cache(4);
+        assert_eq!(coordination_a.find_frame(7, 0, 5, None), Some(2));
+        assert_eq!(
+            coordination_a.iter_latest_frames(0, 5),
+            vec![(7, 2), (9, 4)]
+        );
+        assert!(shm_path.exists());
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_shared_index_grows_past_old_fixed_limit() {
+        const OLD_FIXED_LIMIT: u64 = 65_536;
+
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let file_a = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let file_b = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_a = WalFileShared::new_shared(file_a).unwrap();
+        let shared_b = WalFileShared::new_shared(file_b).unwrap();
+        let snapshot = WalSnapshot {
+            max_frame: OLD_FIXED_LIMIT + 2,
+            nbackfills: 0,
+            last_checksum: (31, 37),
+            checkpoint_seq: 5,
+            transaction_count: OLD_FIXED_LIMIT + 2,
+        };
+        set_shared_snapshot(&shared_a, snapshot);
+        {
+            let shared = shared_a.write();
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = snapshot.last_checksum.0;
+            header.checksum_2 = snapshot.last_checksum.1;
+        }
+
+        let (_authority_a, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
+        let (_authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
+
+        coordination_a.cache_frame(7, 2);
+        for frame_id in 3..=OLD_FIXED_LIMIT + 1 {
+            coordination_a.cache_frame(100 + (frame_id % 31), frame_id);
+        }
+        coordination_a.cache_frame(7, OLD_FIXED_LIMIT + 2);
+
+        assert_eq!(
+            coordination_b.find_frame(7, 0, OLD_FIXED_LIMIT + 2, None),
+            Some(OLD_FIXED_LIMIT + 2)
+        );
+        assert_eq!(
+            coordination_b.find_frame(7, 0, OLD_FIXED_LIMIT + 2, Some(OLD_FIXED_LIMIT + 1)),
+            Some(2)
+        );
+        assert!(coordination_b
+            .iter_latest_frames(0, OLD_FIXED_LIMIT + 2)
+            .contains(&(7, OLD_FIXED_LIMIT + 2)));
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_restart_uses_authority_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io = PlatformIO::new().unwrap();
+        let file_a = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let file_b = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_a = WalFileShared::new_shared(file_a).unwrap();
+        let shared_b = WalFileShared::new_shared(file_b).unwrap();
+        let snapshot = WalSnapshot {
+            max_frame: 12,
+            nbackfills: 12,
+            last_checksum: (31, 37),
+            checkpoint_seq: 5,
+            transaction_count: 9,
+        };
+        set_shared_snapshot(&shared_a, snapshot);
+        {
+            let shared = shared_a.write();
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = snapshot.last_checksum.0;
+            header.checksum_2 = snapshot.last_checksum.1;
+            shared.metadata.initialized.store(true, Ordering::Release);
+            shared.runtime.epoch.store(5, Ordering::Release);
+        }
+
+        let (_authority_a, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
+        let (_authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
+        coordination_a.cache_frame(7, 2);
+        coordination_a.cache_frame(9, 4);
+
+        {
+            let mut shared = shared_b.write();
+            shared.metadata.max_frame.store(99, Ordering::Release);
+            shared.metadata.nbackfills.store(77, Ordering::Release);
+            shared.metadata.last_checksum = (1, 2);
+            shared
+                .metadata
+                .transaction_count
+                .store(42, Ordering::Release);
+            shared.runtime.epoch.store(99, Ordering::Release);
+            shared.metadata.initialized.store(true, Ordering::Release);
+            let mut header = shared.metadata.wal_header.lock();
+            header.checkpoint_seq = 88;
+            header.page_size = 2048;
+            header.salt_1 = 91;
+            header.salt_2 = 92;
+            header.checksum_1 = 93;
+            header.checksum_2 = 94;
+        }
+
+        assert!(coordination_b.fallback.try_read_mark_exclusive(0));
+        let restarted = coordination_b.begin_restart(&io).unwrap();
+        coordination_b.end_restart();
+        coordination_b.fallback.unlock_read_mark(0);
+
+        assert_eq!(
+            restarted,
+            WalSnapshot {
+                max_frame: 0,
+                nbackfills: 0,
+                last_checksum: snapshot.last_checksum,
+                checkpoint_seq: snapshot.checkpoint_seq.wrapping_add(1),
+                transaction_count: snapshot.transaction_count,
+            }
+        );
+        assert_eq!(
+            coordination_a.load_snapshot(),
+            WalSnapshot {
+                max_frame: 0,
+                nbackfills: 0,
+                last_checksum: snapshot.last_checksum,
+                checkpoint_seq: snapshot.checkpoint_seq.wrapping_add(1),
+                transaction_count: snapshot.transaction_count,
+            }
+        );
+        let header = coordination_a.wal_header();
+        assert_eq!(header.page_size, 4096);
+        assert_eq!(
+            header.checkpoint_seq,
+            snapshot.checkpoint_seq.wrapping_add(1)
+        );
+        assert_eq!(header.salt_1, 18);
+        assert_ne!(header.salt_2, 23);
+        assert_eq!(header.checksum_1, snapshot.last_checksum.0);
+        assert_eq!(header.checksum_2, snapshot.last_checksum.1);
+        assert_eq!(coordination_a.iter_latest_frames(0, u64::MAX), Vec::new());
+        assert_eq!(coordination_a.checkpoint_epoch(), 5);
+
+        let shared = shared_b.read();
+        assert_eq!(shared.metadata.max_frame.load(Ordering::Acquire), 0);
+        assert_eq!(shared.metadata.nbackfills.load(Ordering::Acquire), 0);
+        assert_eq!(shared.metadata.last_checksum, snapshot.last_checksum);
+        assert_eq!(
+            shared.metadata.transaction_count.load(Ordering::Acquire),
+            snapshot.transaction_count
+        );
+        assert_eq!(shared.runtime.epoch.load(Ordering::Acquire), 5);
+        assert!(!shared.metadata.initialized.load(Ordering::Acquire));
+        assert!(shared.runtime.frame_cache.lock().is_empty());
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_exclusive_reopen_reuses_persisted_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        {
+            let file = io
+                .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+                .unwrap();
+            let shared = WalFileShared::new_shared(file).unwrap();
+            let snapshot = WalSnapshot {
+                max_frame: 12,
+                nbackfills: 8,
+                last_checksum: (31, 37),
+                checkpoint_seq: 5,
+                transaction_count: 9,
+            };
+            set_shared_snapshot(&shared, snapshot);
+            {
+                let shared = shared.write();
+                let mut header = shared.metadata.wal_header.lock();
+                header.page_size = 4096;
+                header.salt_1 = 17;
+                header.salt_2 = 23;
+                header.checksum_1 = snapshot.last_checksum.0;
+                header.checksum_2 = snapshot.last_checksum.1;
+            }
+
+            let (authority, coordination) = make_test_shm_coordination(&shared, &shm_path);
+            coordination.cache_frame(7, 2);
+            coordination.cache_frame(7, 5);
+            assert_eq!(
+                authority.open_mode(),
+                SharedWalCoordinationOpenMode::Exclusive
+            );
+            assert_eq!(coordination.load_snapshot(), snapshot);
+            assert_eq!(coordination.find_frame(7, 0, 5, None), Some(5));
+        }
+
+        let reopened_file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let reopened_shared = WalFileShared::new_shared(reopened_file).unwrap();
+        let (reopened_authority, reopened_coordination) =
+            make_test_shm_coordination(&reopened_shared, &shm_path);
+
+        assert_eq!(
+            reopened_authority.open_mode(),
+            SharedWalCoordinationOpenMode::Exclusive
+        );
+        assert_eq!(
+            reopened_coordination.load_snapshot(),
+            WalSnapshot {
+                max_frame: 12,
+                nbackfills: 8,
+                last_checksum: (31, 37),
+                checkpoint_seq: 5,
+                transaction_count: 9,
+            }
+        );
+        assert_eq!(
+            reopened_coordination.iter_latest_frames(0, u64::MAX),
+            vec![(7, 5)]
+        );
+        assert_eq!(reopened_authority.min_active_reader_frame(), None);
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_open_shared_from_authority_seeds_runtime_without_frame_cache_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+
+        let shared = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            snapshot,
+        )
+        .unwrap();
+
+        let shared = shared.read();
+        assert_eq!(shared.metadata.max_frame.load(Ordering::Acquire), 1);
+        assert_eq!(shared.metadata.nbackfills.load(Ordering::Acquire), 0);
+        assert_eq!(shared.metadata.transaction_count.load(Ordering::Acquire), 9);
+        assert_eq!(
+            shared.metadata.last_checksum,
+            (snapshot.checksum_1, snapshot.checksum_2)
+        );
+        assert_eq!(shared.runtime.epoch.load(Ordering::Acquire), 7);
+        assert!(shared.metadata.initialized.load(Ordering::Acquire));
+        assert!(!shared
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire));
+        assert!(shared.runtime.frame_cache.lock().is_empty());
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shared_coordination_open_uses_reconciled_snapshot_for_local_wal_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 1,
+            nbackfills: 0,
+            transaction_count: 9,
+            visibility_generation: 3,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+        authority.install_snapshot(snapshot);
+        authority.record_frame(7, 1);
+
+        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        buffer_pool.finalize_with_page_size(4096).unwrap();
+        let wal =
+            WalFile::new_with_shared_coordination(io, shared, authority, ((0, 0), 0), buffer_pool);
+
+        assert_eq!(wal.get_max_frame(), 1);
+        assert_eq!(wal.get_last_checksum(), (31, 37));
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_open_shared_from_authority_rebuilds_from_disk_when_snapshot_is_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-stale.db-wal");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let valid_snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+
+        let shared = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            SharedWalCoordinationHeader {
+                max_frame: 0,
+                nbackfills: 0,
+                transaction_count: 0,
+                visibility_generation: 0,
+                checkpoint_seq: valid_snapshot.checkpoint_seq,
+                checkpoint_epoch: 0,
+                page_size: valid_snapshot.page_size,
+                salt_1: valid_snapshot.salt_1,
+                salt_2: valid_snapshot.salt_2,
+                checksum_1: 0,
+                checksum_2: 0,
+                reader_slot_count: 64,
+            },
+        )
+        .unwrap();
+
+        let shared = shared.read();
+        assert_eq!(shared.metadata.max_frame.load(Ordering::Acquire), 1);
+        assert_eq!(
+            shared.metadata.last_checksum,
+            (valid_snapshot.checksum_1, valid_snapshot.checksum_2)
+        );
+        assert!(shared
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire));
+        assert_eq!(
+            shared.runtime.frame_cache.lock().get(&7).cloned(),
+            Some(vec![1])
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_open_shared_from_authority_rebuilds_from_disk_when_snapshot_claims_backfill() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-backfilled.db-wal");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let valid_snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+
+        let shared = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            SharedWalCoordinationHeader {
+                nbackfills: valid_snapshot.max_frame,
+                ..valid_snapshot
+            },
+        )
+        .unwrap();
+
+        let shared = shared.read();
+        assert_eq!(shared.metadata.max_frame.load(Ordering::Acquire), 1);
+        assert_eq!(shared.metadata.nbackfills.load(Ordering::Acquire), 0);
+        assert!(shared
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire));
+        assert_eq!(
+            shared.runtime.frame_cache.lock().get(&7).cloned(),
+            Some(vec![1])
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_open_shared_from_authority_keeps_zero_length_wal_uninitialized() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-empty.db-wal");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        io.open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+
+        let shared = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            SharedWalCoordinationHeader {
+                max_frame: 0,
+                nbackfills: 0,
+                transaction_count: 9,
+                visibility_generation: 1,
+                checkpoint_seq: 5,
+                checkpoint_epoch: 7,
+                page_size: 4096,
+                salt_1: 17,
+                salt_2: 23,
+                checksum_1: 31,
+                checksum_2: 37,
+                reader_slot_count: 64,
+            },
+        )
+        .unwrap();
+
+        let shared = shared.read();
+        assert_eq!(shared.metadata.max_frame.load(Ordering::Acquire), 0);
+        assert_eq!(shared.metadata.last_checksum, (31, 37));
+        assert!(!shared.metadata.initialized.load(Ordering::Acquire));
+        assert!(!shared
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire));
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_secondary_disk_scan_does_not_reseed_authority_while_writer_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let file_a = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_a = WalFileShared::new_shared(file_a).unwrap();
+        let authoritative = WalSnapshot {
+            max_frame: 5,
+            nbackfills: 0,
+            last_checksum: (31, 37),
+            checkpoint_seq: 5,
+            transaction_count: 9,
+        };
+        set_shared_snapshot(&shared_a, authoritative);
+        {
+            let shared = shared_a.write();
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = authoritative.last_checksum.0;
+            header.checksum_2 = authoritative.last_checksum.1;
+        }
+        let (authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
+        coordination_a.cache_frame(7, 2);
+        coordination_a.cache_frame(7, 5);
+        assert!(authority.try_acquire_writer(authority.owner_record()));
+
+        let file_b = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_b = WalFileShared::new_shared(file_b).unwrap();
+        let stale = WalSnapshot {
+            max_frame: 2,
+            nbackfills: 0,
+            last_checksum: (11, 13),
+            checkpoint_seq: 4,
+            transaction_count: 3,
+        };
+        set_shared_snapshot(&shared_b, stale);
+        {
+            let shared = shared_b.write();
+            shared
+                .metadata
+                .loaded_from_disk_scan
+                .store(true, Ordering::Release);
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = stale.last_checksum.0;
+            header.checksum_2 = stale.last_checksum.1;
+            shared.runtime.frame_cache.lock().insert(7, vec![2]);
+        }
+
+        let (_authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
+
+        assert_eq!(coordination_b.load_snapshot(), authoritative);
+        assert_eq!(authority.snapshot().max_frame, authoritative.max_frame);
+        assert_eq!(
+            authority.snapshot().transaction_count,
+            authoritative.transaction_count
+        );
+        assert_eq!(coordination_b.find_frame(7, 0, 5, None), Some(5));
+        authority.release_writer(authority.owner_record());
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_prepare_wal_header_does_not_clobber_zero_frame_authority_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let file_a = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_a = WalFileShared::new_shared(file_a).unwrap();
+        let authoritative = SharedWalCoordinationHeader {
+            max_frame: 0,
+            nbackfills: 0,
+            transaction_count: 9,
+            visibility_generation: 3,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+        {
+            let mut shared = shared_a.write();
+            shared.metadata.max_frame.store(0, Ordering::Release);
+            shared.metadata.nbackfills.store(0, Ordering::Release);
+            shared
+                .metadata
+                .transaction_count
+                .store(authoritative.transaction_count, Ordering::Release);
+            shared.metadata.last_checksum = (31, 37);
+            let mut header = shared.metadata.wal_header.lock();
+            header.checkpoint_seq = authoritative.checkpoint_seq;
+            header.page_size = authoritative.page_size;
+            header.salt_1 = authoritative.salt_1;
+            header.salt_2 = authoritative.salt_2;
+            header.checksum_1 = authoritative.checksum_1;
+            header.checksum_2 = authoritative.checksum_2;
+            shared
+                .runtime
+                .epoch
+                .store(authoritative.checkpoint_epoch, Ordering::Release);
+            shared.metadata.initialized.store(false, Ordering::Release);
+        }
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        authority.install_snapshot(authoritative);
+
+        let file_b = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_b = WalFileShared::new_shared(file_b).unwrap();
+        let coordination_b = ShmWalCoordination::new(shared_b.clone(), authority.clone());
+        // Simulate a long-lived process whose process-wide shared WAL metadata
+        // fell behind the authority after another process checkpointed and
+        // restarted the WAL back to frame 0.
+        {
+            let mut shared = shared_b.write();
+            shared.metadata.max_frame.store(0, Ordering::Release);
+            shared.metadata.nbackfills.store(0, Ordering::Release);
+            shared.metadata.last_checksum = (11, 13);
+            shared
+                .metadata
+                .transaction_count
+                .store(3, Ordering::Release);
+            let mut header = shared.metadata.wal_header.lock();
+            header.checkpoint_seq = 2;
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = 11;
+            header.checksum_2 = 13;
+            shared.runtime.epoch.store(1, Ordering::Release);
+            shared.metadata.initialized.store(false, Ordering::Release);
+        }
+
+        let page_size = PageSize::new(4096).unwrap();
+        assert!(coordination_b
+            .prepare_wal_header(io.as_ref(), page_size)
+            .is_some());
+
+        let snapshot = authority.snapshot();
+        assert_eq!(
+            snapshot.transaction_count, authoritative.transaction_count,
+            "first writer after restart must not downgrade authority transaction_count"
+        );
+        assert_eq!(
+            snapshot.checkpoint_seq, authoritative.checkpoint_seq,
+            "first writer after restart must not downgrade checkpoint metadata"
+        );
+        assert_eq!(snapshot.checksum_1, authoritative.checksum_1);
+        assert_eq!(snapshot.checksum_2, authoritative.checksum_2);
+    }
+
+    #[test]
+    fn test_in_process_coordination_lock_primitives() {
+        let (shared, _wal) = make_test_wal();
+        let coordination = make_test_coordination(&shared);
+
+        assert!(coordination.try_checkpoint_lock());
+        coordination.unlock_checkpoint_lock();
+
+        assert!(coordination.try_write_lock());
+        assert!(!coordination.try_write_lock());
+        coordination.unlock_write_lock();
+
+        assert!(coordination.try_read_mark_exclusive(1));
+        coordination.set_read_mark_value_exclusive(1, 42);
+        assert_eq!(coordination.read_mark_value(1), 42);
+        coordination.unlock_read_mark(1);
+
+        assert!(coordination.try_read_mark_shared(1));
+        assert!(coordination.try_upgrade_read_mark(1));
+        coordination.downgrade_read_mark(1);
+        coordination.unlock_read_mark(1);
+
+        // The coordination backend should still observe the shared state underneath.
+        assert_eq!(shared.read().runtime.read_locks[1].get_value(), 42);
+    }
+
+    #[test]
+    fn test_in_process_coordination_prepare_truncate_marks_wal_uninitialized() {
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.wal");
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+        let coordination = make_test_coordination(&shared);
+
+        shared
+            .read()
+            .metadata
+            .initialized
+            .store(true, Ordering::Release);
+        let file = coordination.prepare_truncate().unwrap();
+
+        assert!(file.size().is_ok());
+        assert!(!shared.read().metadata.initialized.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn test_in_process_coordination_exposes_wal_io_state() {
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.wal");
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+        let coordination = make_test_coordination(&shared);
+
+        assert!(!coordination.wal_is_initialized());
+        assert_eq!(coordination.wal_header().page_size, 0);
+        assert!(coordination.wal_file().unwrap().size().is_ok());
+
+        let header = coordination
+            .prepare_wal_header(io.as_ref(), PageSize::new(4096).unwrap())
+            .unwrap();
+        assert_eq!(header.page_size, 4096);
+        assert_eq!(
+            coordination.load_snapshot().last_checksum,
+            (header.checksum_1, header.checksum_2)
+        );
+        assert!(!coordination.wal_is_initialized());
+
+        coordination.mark_initialized();
+        assert!(coordination.wal_is_initialized());
+        assert!(coordination
+            .prepare_wal_header(io.as_ref(), PageSize::new(4096).unwrap())
+            .is_none());
     }
 
     #[test]
@@ -3398,8 +5513,8 @@ pub mod test {
         let (mx_before, backfill_before) = {
             let s = wal_shared.read();
             (
-                s.max_frame.load(Ordering::SeqCst),
-                s.nbackfills.load(Ordering::SeqCst),
+                s.metadata.max_frame.load(Ordering::SeqCst),
+                s.metadata.nbackfills.load(Ordering::SeqCst),
             )
         };
         assert!(mx_before > 0);
@@ -3437,8 +5552,8 @@ pub mod test {
         let (mx_after, backfill_after) = {
             let s = wal_shared.read();
             (
-                s.max_frame.load(Ordering::SeqCst),
-                s.nbackfills.load(Ordering::SeqCst),
+                s.metadata.max_frame.load(Ordering::SeqCst),
+                s.metadata.nbackfills.load(Ordering::SeqCst),
             )
         };
         assert_eq!(mx_after, 0, "mxFrame reset to 0 after RESTART");
@@ -3465,7 +5580,7 @@ pub mod test {
             .unwrap()
             .finish_append_frames_commit()
             .unwrap();
-        let new_max = wal_shared.read().max_frame.load(Ordering::SeqCst);
+        let new_max = wal_shared.read().metadata.max_frame.load(Ordering::SeqCst);
         assert_eq!(new_max, 1, "first append after RESTART starts at frame 1");
 
         std::fs::remove_dir_all(path).unwrap();
@@ -3514,7 +5629,12 @@ pub mod test {
                     upper_bound_inclusive: None,
                 },
             );
-            let maxf = db.shared_wal.read().max_frame.load(Ordering::SeqCst);
+            let maxf = db
+                .shared_wal
+                .read()
+                .metadata
+                .max_frame
+                .load(Ordering::SeqCst);
             (res, maxf)
         };
         assert_eq!(res1.wal_max_frame, max_before);
@@ -3635,7 +5755,9 @@ pub mod test {
         // Verify read marks after restart
         let read_marks_after: Vec<_> = {
             let s = wal_shared.read();
-            (0..5).map(|i| s.read_locks[i].get_value()).collect()
+            (0..5)
+                .map(|i| s.runtime.read_locks[i].get_value())
+                .collect()
         };
 
         assert_eq!(read_marks_after[0], 0, "Slot 0 should remain 0");
@@ -3721,7 +5843,7 @@ pub mod test {
         bulk_inserts(&conn, 10, 5);
 
         // get max frame before checkpoint
-        let max_frame_before = wal_shared.read().max_frame.load(Ordering::SeqCst);
+        let max_frame_before = wal_shared.read().metadata.max_frame.load(Ordering::SeqCst);
 
         {
             let pager = conn.pager.load();
@@ -3734,7 +5856,7 @@ pub mod test {
         }
 
         // check that read mark 1 (default reader) was updated to max_frame
-        let read_mark_1 = wal_shared.read().read_locks[1].get_value();
+        let read_mark_1 = wal_shared.read().runtime.read_locks[1].get_value();
 
         assert_eq!(
             read_mark_1 as u64, max_frame_before,
@@ -4166,7 +6288,7 @@ pub mod test {
 
         // Snapshot the current mxFrame before running FULL
         let wal_shared = db.shared_wal.clone();
-        let mx_before = wal_shared.read().max_frame.load(Ordering::SeqCst);
+        let mx_before = wal_shared.read().metadata.max_frame.load(Ordering::SeqCst);
         assert!(mx_before > 0, "expected frames in WAL before FULL");
 
         // Run FULL checkpoint - must backfill *all* frames up to mx_before
@@ -4218,7 +6340,12 @@ pub mod test {
         for c in completions {
             db.io.wait_for_completion(c).unwrap();
         }
-        let mx_now = db.shared_wal.read().max_frame.load(Ordering::SeqCst);
+        let mx_now = db
+            .shared_wal
+            .read()
+            .metadata
+            .max_frame
+            .load(Ordering::SeqCst);
         assert!(mx_now > r_snapshot);
 
         // FULL must return Busy while a reader is stuck behind

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -20,12 +20,14 @@ use std::{fmt, sync::Arc};
 
 use super::buffer_pool::BufferPool;
 use super::pager::{PageRef, Pager};
-use super::sqlite3_ondisk::{self, checksum_wal, WalHeader, WAL_MAGIC_BE, WAL_MAGIC_LE};
+use super::sqlite3_ondisk::{
+    self, checksum_wal, DatabaseHeader, WalHeader, WAL_MAGIC_BE, WAL_MAGIC_LE,
+};
 use crate::fast_lock::SpinLock;
 use crate::io::clock::MonotonicInstant;
 use crate::io::CompletionGroup;
 use crate::io::{File, IO};
-use crate::storage::database::EncryptionOrChecksum;
+use crate::storage::database::{DatabaseStorage, EncryptionOrChecksum};
 #[cfg(all(test, unix, target_pointer_width = "64"))]
 use crate::storage::shared_wal_coordination::SharedWalCoordinationOpenMode;
 #[cfg(all(unix, target_pointer_width = "64"))]
@@ -63,6 +65,7 @@ pub struct CheckpointResult {
     maybe_guard: Option<CheckpointLocks>,
     pub db_truncate_sent: bool,
     pub db_sync_sent: bool,
+    pending_durable_backfill: Option<u64>,
     /// Whether WAL truncation I/O has been submitted (for TRUNCATE checkpoint mode)
     pub wal_truncate_sent: bool,
     /// Whether WAL sync I/O has been submitted after truncation
@@ -88,6 +91,7 @@ impl CheckpointResult {
             maybe_guard: None,
             db_sync_sent: false,
             db_truncate_sent: false,
+            pending_durable_backfill: None,
             wal_truncate_sent: false,
             wal_sync_sent: false,
         }
@@ -103,6 +107,14 @@ impl CheckpointResult {
     }
     pub fn release_guard(&mut self) {
         let _ = self.maybe_guard.take();
+    }
+
+    fn set_pending_durable_backfill(&mut self, max_frame: u64) {
+        self.pending_durable_backfill = Some(max_frame);
+    }
+
+    fn take_pending_durable_backfill(&mut self) -> Option<u64> {
+        self.pending_durable_backfill.take()
     }
 }
 
@@ -426,6 +438,16 @@ trait WalCoordination: Debug + Send + Sync {
     /// Publish the highest frame durably backfilled during checkpoint.
     fn publish_backfill(&self, max_frame: u64);
 
+    /// Publish backfill only after any backend-specific durable proof is installed.
+    fn publish_durable_backfill(
+        &self,
+        io: &Arc<dyn IO>,
+        max_frame: u64,
+        db_size_pages: u32,
+        db_header_crc32c: u32,
+        sync_type: FileSyncType,
+    ) -> Result<()>;
+
     /// Find the newest frame for `page_id` within the caller's visible range.
     fn find_frame(
         &self,
@@ -506,6 +528,9 @@ trait WalCoordination: Debug + Send + Sync {
 
     #[cfg(test)]
     fn backend_name(&self) -> &'static str;
+
+    #[cfg(test)]
+    fn shared_ptr(&self) -> usize;
 
     #[cfg(test)]
     fn open_mode_name(&self) -> Option<&'static str> {
@@ -606,6 +631,7 @@ pub trait Wal: Debug + Send + Sync {
     fn should_checkpoint(&self) -> bool;
     fn checkpoint(&self, pager: &Pager, mode: CheckpointMode)
         -> Result<IOResult<CheckpointResult>>;
+    fn complete_checkpoint_sync(&self, pager: &Pager, result: &mut CheckpointResult) -> Result<()>;
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion>;
     fn is_syncing(&self) -> bool;
     fn get_max_frame_in_wal(&self) -> u64;
@@ -727,6 +753,18 @@ impl WalCoordination for InProcessWalCoordination {
             .metadata
             .nbackfills
             .store(max_frame, Ordering::Release);
+    }
+
+    fn publish_durable_backfill(
+        &self,
+        _io: &Arc<dyn IO>,
+        max_frame: u64,
+        _db_size_pages: u32,
+        _db_header_crc32c: u32,
+        _sync_type: FileSyncType,
+    ) -> Result<()> {
+        self.publish_backfill(max_frame);
+        Ok(())
     }
 
     fn find_frame(
@@ -1081,6 +1119,11 @@ impl WalCoordination for InProcessWalCoordination {
     fn backend_name(&self) -> &'static str {
         "in_process"
     }
+
+    #[cfg(test)]
+    fn shared_ptr(&self) -> usize {
+        Arc::as_ptr(&self.shared) as usize
+    }
 }
 
 /// Per-connection WAL coordination that delegates to the mmap'd tshm authority.
@@ -1178,19 +1221,52 @@ impl ShmWalCoordination {
             .runtime
             .epoch
             .store(snapshot.checkpoint_epoch, Ordering::Release);
-
         let mut header = shared.metadata.wal_header.lock();
-        header.checkpoint_seq = snapshot.checkpoint_seq;
-        header.page_size = snapshot.page_size;
-        header.salt_1 = snapshot.salt_1;
-        header.salt_2 = snapshot.salt_2;
-        header.checksum_1 = snapshot.checksum_1;
-        header.checksum_2 = snapshot.checksum_2;
+        if snapshot.page_size != 0 {
+            header.checkpoint_seq = snapshot.checkpoint_seq;
+            header.page_size = snapshot.page_size;
+            header.salt_1 = snapshot.salt_1;
+            header.salt_2 = snapshot.salt_2;
+            header.checksum_1 = snapshot.checksum_1;
+            header.checksum_2 = snapshot.checksum_2;
+        }
     }
 
     fn sync_authority_from_local(&self) {
         self.authority
             .install_snapshot(self.local_authority_snapshot());
+    }
+
+    fn sync_local_to_zero_frame_authority(&self, snapshot: SharedWalCoordinationHeader) {
+        let mut shared = self.shared.write();
+        shared
+            .metadata
+            .max_frame
+            .store(snapshot.max_frame, Ordering::Release);
+        shared
+            .metadata
+            .nbackfills
+            .store(snapshot.nbackfills, Ordering::Release);
+        shared.metadata.last_checksum = (snapshot.checksum_1, snapshot.checksum_2);
+        shared
+            .metadata
+            .transaction_count
+            .store(snapshot.transaction_count, Ordering::Release);
+        shared
+            .runtime
+            .epoch
+            .store(snapshot.checkpoint_epoch, Ordering::Release);
+        shared.metadata.initialized.store(false, Ordering::Release);
+        {
+            let mut header = shared.metadata.wal_header.lock();
+            header.checkpoint_seq = snapshot.checkpoint_seq;
+            header.page_size = snapshot.page_size;
+            header.salt_1 = snapshot.salt_1;
+            header.salt_2 = snapshot.salt_2;
+            header.checksum_1 = snapshot.checksum_1;
+            header.checksum_2 = snapshot.checksum_2;
+        }
+        shared.runtime.frame_cache.lock().clear();
     }
 
     fn sync_authority_frames_from_local(&self) {
@@ -1212,6 +1288,137 @@ impl ShmWalCoordination {
         }
     }
 
+    fn authority_frame_index_matches_local_scan(&self, max_frame: u64) -> bool {
+        let local_entries = {
+            let shared = self.shared.read();
+            let frame_cache = shared.runtime.frame_cache.lock();
+            let mut entries = Vec::with_capacity(frame_cache.len());
+            for (&page_id, frames) in frame_cache.iter() {
+                if let Some(&frame_id) = frames.iter().rfind(|&&frame_id| frame_id <= max_frame) {
+                    entries.push((page_id, frame_id));
+                }
+            }
+            entries.sort_unstable_by_key(|&(page_id, _)| page_id);
+            entries
+        };
+        self.authority.iter_latest_frames(0, max_frame) == local_entries
+    }
+
+    fn repair_or_reseed_authority_from_local_disk_scan(
+        &self,
+        mut authority_snapshot: SharedWalCoordinationHeader,
+    ) {
+        self.authority.repair_transient_state_for_exclusive_open();
+        if authority_snapshot.nbackfills != 0 {
+            // A local WAL scan can rebuild the visible WAL tail, but it cannot
+            // prove that positive checkpoint progress is durable in the main DB
+            // file. Stay on the conservative reopen path until we implement a
+            // SQLite-equivalent recovery protocol for trusting partial-checkpoint state.
+            authority_snapshot.nbackfills = 0;
+            self.authority.install_snapshot(authority_snapshot);
+        }
+        let local_snapshot = self.local_authority_snapshot();
+        if Self::local_scan_predates_zero_frame_authority(authority_snapshot, local_snapshot) {
+            self.sync_local_to_zero_frame_authority(authority_snapshot);
+            return;
+        }
+        if Self::local_scan_cannot_disprove_zero_frame_authority(authority_snapshot, local_snapshot)
+        {
+            self.sync_local_from_authority(authority_snapshot);
+            return;
+        }
+        if Self::local_scan_cannot_disprove_positive_authority(authority_snapshot, local_snapshot) {
+            self.sync_local_from_authority(authority_snapshot);
+            return;
+        }
+        if Self::authority_matches_local_wal_scan(authority_snapshot, local_snapshot) {
+            self.sync_local_from_authority(authority_snapshot);
+            if self.authority.frame_index_overflowed()
+                || !self.authority_frame_index_matches_local_scan(local_snapshot.max_frame)
+            {
+                self.authority
+                    .discard_durable_frame_index_for_exclusive_rebuild();
+                self.sync_authority_frames_from_local();
+            }
+            return;
+        }
+
+        self.authority
+            .discard_durable_frame_index_for_exclusive_rebuild();
+        self.sync_authority_from_local();
+        self.sync_authority_frames_from_local();
+    }
+
+    fn local_scan_cannot_disprove_zero_frame_authority(
+        authority_snapshot: SharedWalCoordinationHeader,
+        local_snapshot: SharedWalCoordinationHeader,
+    ) -> bool {
+        !Self::authority_is_uninitialized(authority_snapshot)
+            && authority_snapshot.max_frame == 0
+            && local_snapshot.max_frame == 0
+    }
+
+    fn local_scan_predates_zero_frame_authority(
+        authority_snapshot: SharedWalCoordinationHeader,
+        local_snapshot: SharedWalCoordinationHeader,
+    ) -> bool {
+        !Self::authority_is_uninitialized(authority_snapshot)
+            && authority_snapshot.max_frame == 0
+            && local_snapshot.max_frame > 0
+            && local_snapshot.checkpoint_seq < authority_snapshot.checkpoint_seq
+    }
+
+    fn local_scan_cannot_disprove_positive_authority(
+        authority_snapshot: SharedWalCoordinationHeader,
+        local_snapshot: SharedWalCoordinationHeader,
+    ) -> bool {
+        authority_snapshot.max_frame > 0
+            && local_snapshot.max_frame == 0
+            && local_snapshot.checkpoint_seq == authority_snapshot.checkpoint_seq
+            && local_snapshot.page_size == authority_snapshot.page_size
+            && local_snapshot.salt_1 == authority_snapshot.salt_1
+            && local_snapshot.salt_2 == authority_snapshot.salt_2
+    }
+
+    fn authority_matches_local_wal_scan(
+        authority_snapshot: SharedWalCoordinationHeader,
+        local_snapshot: SharedWalCoordinationHeader,
+    ) -> bool {
+        authority_snapshot.max_frame == local_snapshot.max_frame
+            && authority_snapshot.checkpoint_seq == local_snapshot.checkpoint_seq
+            && authority_snapshot.page_size == local_snapshot.page_size
+            && authority_snapshot.salt_1 == local_snapshot.salt_1
+            && authority_snapshot.salt_2 == local_snapshot.salt_2
+            && authority_snapshot.checksum_1 == local_snapshot.checksum_1
+            && authority_snapshot.checksum_2 == local_snapshot.checksum_2
+    }
+
+    fn local_zero_frame_generation_is_initialized(
+        &self,
+        authority_snapshot: SharedWalCoordinationHeader,
+    ) -> bool {
+        let shared = self.shared.read();
+        if !shared.metadata.initialized.load(Ordering::Acquire) {
+            return false;
+        }
+        Self::local_zero_frame_generation_matches_authority_snapshot(authority_snapshot, &shared)
+    }
+
+    fn local_zero_frame_generation_matches_authority_snapshot(
+        authority_snapshot: SharedWalCoordinationHeader,
+        shared: &WalFileShared,
+    ) -> bool {
+        let header = shared.metadata.wal_header.lock();
+        header.checkpoint_seq == authority_snapshot.checkpoint_seq
+            && header.page_size == authority_snapshot.page_size
+            && header.salt_1 == authority_snapshot.salt_1
+            && header.salt_2 == authority_snapshot.salt_2
+    }
+
+    fn authority_needs_local_header_seed(snapshot: SharedWalCoordinationHeader) -> bool {
+        Self::authority_is_uninitialized(snapshot) || snapshot.page_size == 0
+    }
+
     /// Called once at `ShmWalCoordination` construction to reconcile the
     /// process-local WAL view (built from a WAL file scan or inherited from
     /// a previous connection) with the shared tshm authority.
@@ -1221,11 +1428,14 @@ impl ShmWalCoordination {
     /// 1. **Authority uninitialized** (fresh tshm): seed it from our local
     ///    WAL scan — we are the first process.
     ///
-    /// 2. **Authority initialized but stale** (our local view came from a
-    ///    disk scan AND no writer/checkpoint is active): reset transient
-    ///    runtime state and re-seed from our scan. The reset only reclaims
-    ///    reader/MVCC slots whose owners are verified dead (see
-    ///    `reset_runtime_state_for_exclusive_open`).
+    /// 2. **Authority initialized and we opened from a local disk scan**
+    ///    (no writer/checkpoint is active): repair transient owner/reader
+    ///    state first. If the scan only sees an empty WAL and the durable
+    ///    authority is already at frame 0, keep the durable authority because
+    ///    the scan cannot prove newer header metadata. Otherwise, if the
+    ///    local scan agrees with the WAL-provable subset of the durable
+    ///    snapshot, keep the durable authority. If not, discard the durable
+    ///    frame index and rebuild it from the local scan.
     ///
     /// 3. **Authority initialized and trustworthy**: adopt the authority's
     ///    snapshot as our local state. If our local view also came from a
@@ -1245,11 +1455,23 @@ impl ShmWalCoordination {
         } else if local_wal_view_loaded_from_disk
             && !self.authority.writer_or_checkpoint_lock_active()
         {
-            self.authority.reset_runtime_state_for_exclusive_open();
-            self.sync_authority_from_local();
-            self.sync_authority_frames_from_local();
+            self.repair_or_reseed_authority_from_local_disk_scan(snapshot);
         } else {
+            let needs_zero_frame_header_rewrite = snapshot.max_frame == 0 && {
+                let shared = self.shared.read();
+                !shared.metadata.initialized.load(Ordering::Acquire)
+                    || !Self::local_zero_frame_generation_matches_authority_snapshot(
+                        snapshot, &shared,
+                    )
+            };
             self.sync_local_from_authority(snapshot);
+            if needs_zero_frame_header_rewrite {
+                self.shared
+                    .read()
+                    .metadata
+                    .initialized
+                    .store(false, Ordering::Release);
+            }
             if local_wal_view_loaded_from_disk
                 && !self.authority.writer_or_checkpoint_lock_active()
                 && self.authority.iter_latest_frames(0, u64::MAX).is_empty()
@@ -1374,6 +1596,35 @@ impl WalCoordination for ShmWalCoordination {
         self.authority.publish_backfill(max_frame);
     }
 
+    fn publish_durable_backfill(
+        &self,
+        io: &Arc<dyn IO>,
+        nbackfills: u64,
+        db_size_pages: u32,
+        db_header_crc32c: u32,
+        sync_type: FileSyncType,
+    ) -> Result<()> {
+        let snapshot = self.authority.snapshot();
+        turso_assert!(
+            (snapshot.nbackfills..=snapshot.max_frame).contains(&nbackfills),
+            "durable backfill proof requires nbackfills within the authoritative WAL range",
+            {
+                "nbackfills": nbackfills,
+                "authority_nbackfills": snapshot.nbackfills,
+                "authority_max_frame": snapshot.max_frame
+            }
+        );
+        let proof_snapshot = SharedWalCoordinationHeader {
+            nbackfills,
+            ..snapshot
+        };
+        self.authority
+            .install_backfill_proof(proof_snapshot, db_size_pages, db_header_crc32c);
+        self.authority.sync(io, sync_type)?;
+        self.publish_backfill(nbackfills);
+        Ok(())
+    }
+
     fn find_frame(
         &self,
         page_id: u64,
@@ -1428,29 +1679,6 @@ impl WalCoordination for ShmWalCoordination {
                 read_locks[0].unlock();
                 return None;
             }
-            // In multi-process mode, we must register with the shared authority
-            // even for DbFile-only reads. Otherwise, a RESTART/TRUNCATE checkpoint
-            // in another process won't see us and may truncate the WAL while we
-            // still have an active read transaction — leading to data loss.
-            // We use max_frame as the reader frame to signal "I'm active".
-            let reader = self
-                .authority
-                .register_reader(self.owner, snapshot.max_frame.max(1));
-            match reader {
-                Some(slot) => {
-                    let mut active_reader = self.active_reader.lock();
-                    turso_assert!(active_reader.is_none(), "shared reader registration leaked");
-                    *active_reader = Some(slot);
-                }
-                None => {
-                    // RESTART/TRUNCATE checkpoints only consult the shared
-                    // authority for cross-process readers. Proceeding without a
-                    // shared reader slot would let another process restart or
-                    // truncate the WAL underneath this read transaction.
-                    read_locks[0].unlock();
-                    return None;
-                }
-            }
             return Some(ReadGuardKind::DbFile);
         }
 
@@ -1487,11 +1715,13 @@ impl WalCoordination for ShmWalCoordination {
             return None;
         }
 
+        let read_mark_index =
+            NonZeroUsize::new(best_idx as usize).expect("best_idx checked to be positive");
         let reader = self
             .authority
-            .register_reader(self.owner, snapshot.max_frame)?;
+            .register_reader_for_snapshot(self.owner, snapshot.max_frame)?;
         if self.load_snapshot() != snapshot {
-            self.authority.unregister_reader(reader);
+            self.authority.unregister_reader_for_snapshot(reader);
             read_locks[best_idx as usize].unlock();
             return None;
         }
@@ -1499,15 +1729,12 @@ impl WalCoordination for ShmWalCoordination {
         let mut active_reader = self.active_reader.lock();
         turso_assert!(active_reader.is_none(), "shared reader registration leaked");
         *active_reader = Some(reader);
-        Some(ReadGuardKind::ReadMark(
-            NonZeroUsize::new(best_idx as usize)
-                .expect("best_idx checked to be non-negative and non-zero"),
-        ))
+        Some(ReadGuardKind::ReadMark(read_mark_index))
     }
 
     fn end_read_tx(&self, guard: ReadGuardKind) {
         if let Some(reader) = self.active_reader.lock().take() {
-            self.authority.unregister_reader(reader);
+            self.authority.unregister_reader_for_snapshot(reader);
         }
         self.fallback.end_read_tx(guard);
     }
@@ -1670,6 +1897,9 @@ impl WalCoordination for ShmWalCoordination {
     fn wal_header(&self) -> WalHeader {
         let snapshot = self.authority.snapshot();
         let mut header = self.fallback.wal_header();
+        if snapshot.page_size == 0 {
+            return header;
+        }
         header.page_size = snapshot.page_size;
         header.checkpoint_seq = snapshot.checkpoint_seq;
         header.salt_1 = snapshot.salt_1;
@@ -1684,22 +1914,46 @@ impl WalCoordination for ShmWalCoordination {
     }
 
     fn wal_is_initialized(&self) -> bool {
-        self.fallback.wal_is_initialized()
+        let authority_snapshot = self.authority.snapshot();
+        if Self::authority_needs_local_header_seed(authority_snapshot) {
+            return self.fallback.wal_is_initialized();
+        }
+        if authority_snapshot.max_frame > 0 {
+            self.sync_local_from_authority(authority_snapshot);
+            self.fallback.mark_initialized();
+            return true;
+        }
+        if self.local_zero_frame_generation_is_initialized(authority_snapshot) {
+            return true;
+        }
+
+        self.sync_local_from_authority(authority_snapshot);
+        self.shared
+            .read()
+            .metadata
+            .initialized
+            .store(false, Ordering::Release);
+        false
     }
 
     fn prepare_wal_header(&self, io: &dyn IO, page_size: PageSize) -> Option<WalHeader> {
+        let authority_snapshot = self.authority.snapshot();
+        // A zero-frame authority snapshot after RESTART/TRUNCATE is still
+        // authoritative: it carries the latest transaction_count,
+        // checkpoint_seq, salts, and checksums for readers. Sync from it
+        // before preparing the header so the bytes written to disk belong to
+        // the same generation as the authority snapshot.
+        if Self::authority_needs_local_header_seed(authority_snapshot) {
+            let header = self.fallback.prepare_wal_header(io, page_size);
+            if header.is_some() {
+                self.sync_authority_from_local();
+            }
+            return header;
+        }
+        self.sync_local_from_authority(authority_snapshot);
         let header = self.fallback.prepare_wal_header(io, page_size);
         if header.is_some() {
-            let authority_snapshot = self.authority.snapshot();
-            // A zero-frame authority snapshot after RESTART/TRUNCATE is still
-            // authoritative: it carries the latest transaction_count,
-            // checkpoint_seq, salts, and checksums for readers. Only treat the
-            // authority as "seed from local" when it is truly uninitialized.
-            if Self::authority_is_uninitialized(authority_snapshot) {
-                self.sync_authority_from_local();
-            } else {
-                self.sync_local_from_authority(authority_snapshot);
-            }
+            self.sync_authority_from_local();
         }
         header
     }
@@ -1725,6 +1979,11 @@ impl WalCoordination for ShmWalCoordination {
     #[cfg(test)]
     fn backend_name(&self) -> &'static str {
         "tshm"
+    }
+
+    #[cfg(test)]
+    fn shared_ptr(&self) -> usize {
+        Arc::as_ptr(&self.shared) as usize
     }
 
     #[cfg(test)]
@@ -2393,7 +2652,7 @@ impl Wal for WalFile {
                 // Return BusySnapshot instead of Busy so the caller knows it must
                 // restart the read transaction to get a fresh snapshot.
                 // Retrying with busy_timeout will NEVER HELP.
-                tracing::info!("unable to upgrade transaction from read to write: snapshot is stale, give up and let caller retry from scratch, self.max_frame={}, shared_max={}", self.max_frame.load(Ordering::Acquire), shared.max_frame.load(Ordering::Acquire));
+                tracing::info!("unable to upgrade transaction from read to write: snapshot is stale, give up and let caller retry from scratch, self.max_frame={}, shared_max={}", self.max_frame.load(Ordering::Acquire), self.load_coordination_snapshot().max_frame);
                 self.coordination.end_write_tx();
                 return Err(LimboError::BusySnapshot);
             }
@@ -2538,7 +2797,7 @@ impl Wal for WalFile {
         page.set_locked();
         let frame = page.clone();
         let page_idx = page.get().id;
-        let coordination = self.coordination.clone();
+        let epoch_at_issue = self.coordination.checkpoint_epoch();
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 tracing::debug!(err = ?res.unwrap_err());
@@ -2561,8 +2820,7 @@ impl Wal for WalFile {
             }
             let cloned = frame.clone();
             finish_read_page(page.get().id, buf, cloned);
-            let epoch = coordination.checkpoint_epoch();
-            frame.set_wal_tag(frame_id, epoch);
+            frame.set_wal_tag(frame_id, epoch_at_issue);
             None
         });
         // important not to hold shared state locks beyond this point to avoid deadlock with
@@ -2771,6 +3029,26 @@ impl Wal for WalFile {
         })
     }
 
+    fn complete_checkpoint_sync(&self, pager: &Pager, result: &mut CheckpointResult) -> Result<()> {
+        let Some(max_frame) = result.take_pending_durable_backfill() else {
+            return Ok(());
+        };
+        let Some((db_size_pages, db_header_crc32c)) =
+            read_database_identity_from_storage(&self.io, &pager.db_file)?
+        else {
+            return Err(LimboError::Corrupt(
+                "database header unreadable after checkpoint sync".into(),
+            ));
+        };
+        self.coordination.publish_durable_backfill(
+            &self.io,
+            max_frame,
+            db_size_pages,
+            db_header_crc32c,
+            pager.get_sync_type(),
+        )
+    }
+
     #[instrument(err, skip_all, level = Level::DEBUG)]
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion> {
         tracing::debug!("wal_sync");
@@ -2947,16 +3225,37 @@ impl Wal for WalFile {
         let (mut rolling_checksum, mut next_frame_id) = match prev {
             Some(p) => (p.final_checksum, p.final_max_frame + 1),
             None => {
-                let local_max = self.max_frame.load(Ordering::Acquire);
                 let snapshot = self.load_coordination_snapshot();
-                if snapshot.max_frame > local_max {
-                    // Another process committed frames we don't know about.
-                    // Use the authority's state to avoid overwriting their frames.
-                    self.max_frame.store(snapshot.max_frame, Ordering::Release);
-                    *self.last_checksum.write() = snapshot.last_checksum;
+                let local_state = self.connection_state();
+                let local_prepared_zero_frame_header = snapshot.max_frame == 0
+                    && self.coordination.wal_is_initialized()
+                    && local_state.snapshot.max_frame == 0
+                    && local_state.snapshot.checkpoint_seq == snapshot.checkpoint_seq
+                    && local_state.snapshot.transaction_count == snapshot.transaction_count
+                    && local_state.snapshot.last_checksum != snapshot.last_checksum;
+                if local_prepared_zero_frame_header {
+                    // We already prepared the WAL header for the current
+                    // zero-frame generation locally, but the authority snapshot
+                    // still carries the pre-header checksum until the first
+                    // commit publishes it. Seed the checksum chain from the
+                    // prepared local header, not the stale authority checksum.
+                    (
+                        local_state.snapshot.last_checksum,
+                        local_state.snapshot.max_frame + 1,
+                    )
+                } else if snapshot != local_state.snapshot {
+                    // The current generation was restarted/truncated back to
+                    // frame 0 or another process changed the durable WAL
+                    // state. Re-seed this connection from the authoritative
+                    // snapshot so replacement generations after
+                    // RESTART/TRUNCATE do not append using stale local state.
+                    self.install_connection_state(local_state.with_snapshot(snapshot));
                     (snapshot.last_checksum, snapshot.max_frame + 1)
                 } else {
-                    (*self.last_checksum.read(), local_max + 1)
+                    (
+                        local_state.snapshot.last_checksum,
+                        local_state.snapshot.max_frame + 1,
+                    )
                 }
             }
         };
@@ -3207,7 +3506,7 @@ impl WalFile {
         buffer_pool: Arc<BufferPool>,
     ) -> Self {
         let coordination: Arc<dyn WalCoordination> =
-            Arc::new(InProcessWalCoordination::new(shared.clone()));
+            Arc::new(InProcessWalCoordination::new(shared));
         Self::new_with_coordination(io, coordination, (last_checksum, max_frame), buffer_pool)
     }
 
@@ -3251,9 +3550,10 @@ impl WalFile {
 
     #[cfg(test)]
     pub(crate) fn shared_ptr(&self) -> usize {
-        Arc::as_ptr(&self.shared) as usize
+        self.coordination.shared_ptr()
     }
 
+    #[cfg(test)]
     pub(crate) fn coordination_backend_name(&self) -> &'static str {
         self.coordination.backend_name()
     }
@@ -3315,10 +3615,10 @@ impl WalFile {
                 // so no other checkpointer can run. fsync WAL if there are unapplied frames.
                 // Decide the largest frame we are allowed to back‑fill.
                 CheckpointState::Start => {
-                    tracing::info!("shared_wal: max_frame={max_frame}, nbackfills={nbackfills}");
                     let snapshot = self.load_coordination_snapshot();
                     let max_frame = snapshot.max_frame;
                     let nbackfills = snapshot.nbackfills;
+                    tracing::info!("shared_wal: max_frame={max_frame}, nbackfills={nbackfills}");
                     let needs_backfill = max_frame > nbackfills;
                     if !needs_backfill && !mode.should_restart_log() {
                         // there are no frames to copy over and we don't need to reset
@@ -3336,7 +3636,9 @@ impl WalFile {
                     } = mode
                     {
                         if max_frame > upper_bound {
-                            tracing::info!("abort checkpoint because latest frame in WAL is greater than upper_bound in TRUNCATE mode: {max_frame} != {upper_bound}");
+                            tracing::info!(
+                                "abort checkpoint because latest frame in WAL is greater than upper_bound in TRUNCATE mode: {max_frame} != {upper_bound}"
+                            );
                             return Err(LimboError::Busy);
                         }
                     }
@@ -3506,14 +3808,15 @@ impl WalFile {
                     let wal_checkpoint_backfilled =
                         wal_total_backfilled.saturating_sub(ongoing_chkpt.min_frame - 1);
 
-                    let checkpoint_result = CheckpointResult::new(
+                    let mut checkpoint_result = CheckpointResult::new(
                         wal_max_frame,
                         wal_total_backfilled,
                         wal_checkpoint_backfilled,
                     );
                     tracing::info!("checkpoint_result={:?}, mode={:?}", checkpoint_result, mode);
-                    // store the max frame we were able to successfully checkpoint.
-                    self.coordination.publish_backfill(ongoing_chkpt.max_frame);
+                    if wal_checkpoint_backfilled > 0 && !mode.should_restart_log() {
+                        checkpoint_result.set_pending_durable_backfill(ongoing_chkpt.max_frame);
+                    }
                     if mode.require_all_backfilled() && !checkpoint_result.everything_backfilled() {
                         return Err(LimboError::Busy);
                     }
@@ -3631,14 +3934,18 @@ impl WalFile {
     pub fn try_restart_log_before_write(&self) -> Result<()> {
         let max_frame_read_lock_index = self.max_frame_read_lock_index.load(Ordering::Acquire);
         if max_frame_read_lock_index != 0 {
-            tracing::debug!("try_restart_log_before_write: max_frame_read_lock_index={max_frame_read_lock_index}, writer use WAL - can't restart the log");
+            tracing::debug!(
+                "try_restart_log_before_write: max_frame_read_lock_index={max_frame_read_lock_index}, writer use WAL - can't restart the log"
+            );
             return Ok(());
         }
         let snapshot = self.load_coordination_snapshot();
         let max_frame = snapshot.max_frame;
         let nbackfills = snapshot.nbackfills;
         if nbackfills == 0 {
-            tracing::debug!("try_restart_log_before_write: nbackfills={nbackfills}, nothing were backfilled - can't restart the log");
+            tracing::debug!(
+                "try_restart_log_before_write: nbackfills={nbackfills}, nothing were backfilled - can't restart the log"
+            );
             return Ok(());
         }
         turso_assert!(
@@ -3896,61 +4203,174 @@ fn wal_header_matches_authority_snapshot(
 }
 
 #[cfg(all(unix, target_pointer_width = "64"))]
-fn validate_authority_snapshot_against_wal(
+fn database_identity_from_header_bytes(header_bytes: &[u8]) -> Result<(u32, u32)> {
+    if header_bytes.len() < DatabaseHeader::SIZE {
+        return Err(LimboError::Corrupt(format!(
+            "database header must be at least {} bytes, got {}",
+            DatabaseHeader::SIZE,
+            header_bytes.len()
+        )));
+    }
+    if header_bytes[0..16] != *b"SQLite format 3\0" {
+        return Err(LimboError::Corrupt("database header magic mismatch".into()));
+    }
+    let db_size_pages = u32::from_be_bytes(header_bytes[28..32].try_into().unwrap());
+    let header_crc32c = crc32c::crc32c(&header_bytes[..DatabaseHeader::SIZE]);
+    Ok((db_size_pages, header_crc32c))
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn read_database_identity_from_storage(
+    io: &Arc<dyn IO>,
+    db_file: &Arc<dyn DatabaseStorage>,
+) -> Result<Option<(u32, u32)>> {
+    let read_buf = Arc::new(Buffer::new_temporary(PageSize::MIN as usize));
+    let bytes_read = Arc::new(AtomicUsize::new(usize::MAX));
+    let c = db_file.read_header(Completion::new_read(read_buf.clone(), {
+        let bytes_read = bytes_read.clone();
+        Box::new(move |res| {
+            if let Ok((_buf, count)) = res {
+                bytes_read.store(count as usize, Ordering::Release);
+            }
+            None
+        })
+    }))?;
+    io.wait_for_completion(c)?;
+    if bytes_read.load(Ordering::Acquire) < DatabaseHeader::SIZE {
+        return Ok(None);
+    }
+    Ok(Some(database_identity_from_header_bytes(
+        &read_buf.as_slice()[..DatabaseHeader::SIZE],
+    )?))
+}
+
+#[cfg(all(test, unix, target_pointer_width = "64"))]
+fn read_database_identity_from_file_path(
+    io: &Arc<dyn IO>,
+    wal_path: &str,
+) -> Result<Option<(u32, u32)>> {
+    let db_path = wal_path
+        .strip_suffix("-wal")
+        .unwrap_or(wal_path)
+        .to_string();
+    let file = match io.open_file(&db_path, crate::OpenFlags::None, false) {
+        Ok(file) => file,
+        Err(LimboError::CompletionError(CompletionError::IOError(
+            std::io::ErrorKind::NotFound,
+            _,
+        ))) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let Some(bytes) = read_exact_bytes_from_file(io, &file, 0, DatabaseHeader::SIZE)? else {
+        return Ok(None);
+    };
+    Ok(Some(database_identity_from_header_bytes(&bytes)?))
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthoritySnapshotValidation {
+    Trusted,
+    RebuildFromDisk(AuthoritySnapshotRebuildReason),
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthoritySnapshotRebuildReason {
+    WalHeaderUnreadable,
+    WalHeaderMismatch,
+    WalTooShortForSnapshot,
+    WalLengthMismatch,
+    LastFrameMissing,
+    LastFrameNotCommit,
+    LastFrameSaltMismatch,
+    LastFrameChecksumMismatch,
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn classify_authority_snapshot_against_wal(
     io: &Arc<dyn IO>,
     file: &Arc<dyn File>,
     snapshot: SharedWalCoordinationHeader,
-) -> Result<bool> {
+) -> Result<AuthoritySnapshotValidation> {
     let wal_size = file.size()?;
     if snapshot.max_frame == 0 {
         if wal_size == 0 {
-            return Ok(true);
+            return Ok(AuthoritySnapshotValidation::Trusted);
         }
         if wal_size == WAL_HEADER_SIZE as u64 {
             let Some(wal_header) = read_validated_wal_header_from_file(io, file)? else {
-                return Ok(false);
+                return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+                    AuthoritySnapshotRebuildReason::WalHeaderUnreadable,
+                ));
             };
-            return Ok(wal_header_matches_authority_snapshot(wal_header, snapshot));
+            return Ok(
+                if wal_header_matches_authority_snapshot(wal_header, snapshot) {
+                    AuthoritySnapshotValidation::Trusted
+                } else {
+                    AuthoritySnapshotValidation::RebuildFromDisk(
+                        AuthoritySnapshotRebuildReason::WalHeaderMismatch,
+                    )
+                },
+            );
         }
-        return Ok(false);
+        return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+            AuthoritySnapshotRebuildReason::WalLengthMismatch,
+        ));
     }
 
     if wal_size < WAL_HEADER_SIZE as u64 {
-        return Ok(false);
+        return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+            AuthoritySnapshotRebuildReason::WalTooShortForSnapshot,
+        ));
     }
 
     let Some(wal_header) = read_validated_wal_header_from_file(io, file)? else {
-        return Ok(false);
+        return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+            AuthoritySnapshotRebuildReason::WalHeaderUnreadable,
+        ));
     };
     if !wal_header_matches_authority_snapshot(wal_header, snapshot) {
-        return Ok(false);
+        return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+            AuthoritySnapshotRebuildReason::WalHeaderMismatch,
+        ));
     }
 
     let frame_size = WAL_FRAME_HEADER_SIZE as u64 + wal_header.page_size as u64;
     let expected_wal_len = WAL_HEADER_SIZE as u64 + snapshot.max_frame * frame_size;
     if wal_size != expected_wal_len {
-        return Ok(false);
+        return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+            AuthoritySnapshotRebuildReason::WalLengthMismatch,
+        ));
     }
 
     let last_frame_offset = WAL_HEADER_SIZE as u64 + (snapshot.max_frame - 1) * frame_size;
     let Some(frame_bytes) =
         read_exact_bytes_from_file(io, file, last_frame_offset, frame_size as usize)?
     else {
-        return Ok(false);
+        return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+            AuthoritySnapshotRebuildReason::LastFrameMissing,
+        ));
     };
     let (frame_header, _) = sqlite3_ondisk::parse_wal_frame_header(&frame_bytes);
     if !frame_header.is_commit_frame() {
-        return Ok(false);
+        return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+            AuthoritySnapshotRebuildReason::LastFrameNotCommit,
+        ));
     }
     if frame_header.salt_1 != snapshot.salt_1 || frame_header.salt_2 != snapshot.salt_2 {
-        return Ok(false);
+        return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+            AuthoritySnapshotRebuildReason::LastFrameSaltMismatch,
+        ));
     }
     if frame_header.checksum_1 != snapshot.checksum_1
         || frame_header.checksum_2 != snapshot.checksum_2
     {
-        return Ok(false);
+        return Ok(AuthoritySnapshotValidation::RebuildFromDisk(
+            AuthoritySnapshotRebuildReason::LastFrameChecksumMismatch,
+        ));
     }
-    Ok(true)
+    Ok(AuthoritySnapshotValidation::Trusted)
 }
 
 impl WalFileShared {
@@ -3966,8 +4386,10 @@ impl WalFileShared {
         io: &Arc<dyn IO>,
         path: &str,
         flags: crate::OpenFlags,
-        snapshot: SharedWalCoordinationHeader,
+        authority: &Arc<MappedSharedWalCoordination>,
+        db_file: &Arc<dyn DatabaseStorage>,
     ) -> Result<Arc<RwLock<WalFileShared>>> {
+        let snapshot = authority.snapshot();
         let file = match io.open_file(path, flags, false) {
             Ok(file) => file,
             Err(LimboError::CompletionError(CompletionError::IOError(
@@ -3980,17 +4402,51 @@ impl WalFileShared {
         };
         let wal_size = file.size()?;
 
-        // `max_frame` and the last commit checksum are provable from the WAL bytes, but
-        // `nbackfills` is not. A crash-stale `tshm` can therefore look WAL-valid while
-        // still claiming frames were checkpointed into the main DB file when they were
-        // not. Falling back to a WAL scan keeps reopened readers conservative.
-        // TODO: implement SQLite style integrity/recover protocol
-        if snapshot.nbackfills != 0 {
+        match classify_authority_snapshot_against_wal(io, &file, snapshot)? {
+            AuthoritySnapshotValidation::Trusted => {}
+            AuthoritySnapshotValidation::RebuildFromDisk(reason) => {
+                tracing::debug!(
+                    ?reason,
+                    "rebuilding WAL state from disk because persisted authority is not provably reusable"
+                );
+                return sqlite3_ondisk::build_shared_wal(&file, io);
+            }
+        }
+        if authority.frame_index_overflowed() {
+            tracing::debug!(
+                "rebuilding WAL state from disk because the persisted tshm frame index is marked overflowed"
+            );
             return sqlite3_ondisk::build_shared_wal(&file, io);
         }
-
-        if !validate_authority_snapshot_against_wal(io, &file, snapshot)? {
+        if snapshot.max_frame > snapshot.nbackfills
+            && authority
+                .iter_latest_frames(0, snapshot.max_frame)
+                .is_empty()
+        {
+            tracing::debug!(
+                max_frame = snapshot.max_frame,
+                nbackfills = snapshot.nbackfills,
+                "rebuilding WAL state from disk because the persisted tshm frame index has no entries for a visible WAL tail"
+            );
             return sqlite3_ondisk::build_shared_wal(&file, io);
+        }
+        if snapshot.nbackfills != 0 {
+            let Some((db_size_pages, db_header_crc32c)) =
+                read_database_identity_from_storage(io, db_file)?
+            else {
+                tracing::debug!(
+                    nbackfills = snapshot.nbackfills,
+                    "rebuilding WAL state from disk because the main database header is unavailable for backfill-proof validation"
+                );
+                return sqlite3_ondisk::build_shared_wal(&file, io);
+            };
+            if !authority.validate_backfill_proof(snapshot, db_size_pages, db_header_crc32c) {
+                tracing::debug!(
+                    nbackfills = snapshot.nbackfills,
+                    "rebuilding WAL state from disk because persisted tshm backfill proof is not valid for the current database header"
+                );
+                return sqlite3_ondisk::build_shared_wal(&file, io);
+            }
         }
         let wal_is_initialized = wal_size >= WAL_HEADER_SIZE as u64;
 
@@ -4184,7 +4640,10 @@ impl WalFileShared {
 #[cfg(test)]
 pub mod test {
     #[cfg(all(unix, target_pointer_width = "64"))]
-    use super::ShmWalCoordination;
+    use super::{
+        classify_authority_snapshot_against_wal, AuthoritySnapshotRebuildReason,
+        AuthoritySnapshotValidation, ShmWalCoordination,
+    };
     use super::{
         InProcessWalCoordination, ReadGuardKind, Wal, WalCommitState, WalConnectionState,
         WalCoordination, WalFile, WalSnapshot,
@@ -4198,13 +4657,14 @@ pub mod test {
     use crate::{
         storage::{
             buffer_pool::BufferPool,
+            database::{DatabaseFile, DatabaseStorage},
             sqlite3_ondisk::{self, PageSize, WAL_HEADER_SIZE},
             wal::READMARK_NOT_USED,
         },
         types::IOResult,
         util::IOExt,
-        CheckpointMode, CheckpointResult, Completion, Connection, Database, LimboError, PlatformIO,
-        WalFileShared, IO,
+        Buffer, CheckpointMode, CheckpointResult, Completion, Connection, Database, File,
+        LimboError, PlatformIO, SyncMode, WalFileShared, IO,
     };
     use std::num::NonZeroUsize;
     #[cfg(unix)]
@@ -4224,6 +4684,67 @@ pub mod test {
         let db = Database::open_file(io.clone(), path.to_str().unwrap()).unwrap();
         // db + tmp directory
         (db, dbpath)
+    }
+
+    struct DeferredReadFile {
+        inner: Arc<dyn File>,
+        pending_reads: Mutex<Vec<(u64, Completion)>>,
+    }
+
+    impl DeferredReadFile {
+        fn new(inner: Arc<dyn File>) -> Self {
+            Self {
+                inner,
+                pending_reads: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn complete_pending_reads(&self) {
+            let pending_reads = std::mem::take(&mut *self.pending_reads.lock());
+            for (pos, completion) in pending_reads {
+                std::mem::drop(self.inner.pread(pos, completion).unwrap());
+            }
+        }
+    }
+
+    impl File for DeferredReadFile {
+        fn lock_file(&self, exclusive: bool) -> crate::Result<()> {
+            self.inner.lock_file(exclusive)
+        }
+
+        fn unlock_file(&self) -> crate::Result<()> {
+            self.inner.unlock_file()
+        }
+
+        fn pread(&self, pos: u64, c: Completion) -> crate::Result<Completion> {
+            self.pending_reads.lock().push((pos, c.clone()));
+            Ok(c)
+        }
+
+        fn pwrite(
+            &self,
+            pos: u64,
+            buffer: Arc<Buffer>,
+            c: Completion,
+        ) -> crate::Result<Completion> {
+            self.inner.pwrite(pos, buffer, c)
+        }
+
+        fn sync(
+            &self,
+            c: Completion,
+            sync_type: crate::io::FileSyncType,
+        ) -> crate::Result<Completion> {
+            self.inner.sync(c, sync_type)
+        }
+
+        fn size(&self) -> crate::Result<u64> {
+            self.inner.size()
+        }
+
+        fn truncate(&self, len: u64, c: Completion) -> crate::Result<Completion> {
+            self.inner.truncate(len, c)
+        }
     }
     #[test]
     fn test_truncate_file() {
@@ -4351,6 +4872,68 @@ pub mod test {
             .unwrap()
     }
 
+    fn run_wal_checkpoint_until_done(
+        db: &Database,
+        pager: &crate::Pager,
+        mode: CheckpointMode,
+    ) -> CheckpointResult {
+        let wal = pager.wal.as_ref().expect("wal should be present");
+        loop {
+            match wal.checkpoint(pager, mode) {
+                Ok(IOResult::IO(io)) => io.wait(db.io.as_ref()).unwrap(),
+                Ok(IOResult::Done(result)) => return result,
+                Err(err) => panic!("checkpoint should succeed: {err:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_wal_checkpoint_defers_backfill_publication_until_db_sync() {
+        let (db, _path) = get_database();
+        let wal_shared = db.shared_wal.clone();
+        let conn = db.connect().unwrap();
+        conn.execute("create table test(id integer primary key, value text)")
+            .unwrap();
+        bulk_inserts(&conn, 8, 2);
+
+        let pager = conn.pager.load();
+        let result = run_wal_checkpoint_until_done(&db, &pager, CheckpointMode::Full);
+        assert!(
+            result.wal_total_backfilled > 0,
+            "checkpoint setup should backfill frames before DB sync"
+        );
+        assert_eq!(
+            wal_shared.read().metadata.nbackfills.load(Ordering::SeqCst),
+            0,
+            "wal.checkpoint() must not publish positive nbackfills before DB sync completes"
+        );
+    }
+
+    #[test]
+    fn test_checkpoint_sync_mode_off_leaves_backfill_unpublished() {
+        let (db, _path) = get_database();
+        let wal_shared = db.shared_wal.clone();
+        let conn = db.connect().unwrap();
+        conn.execute("create table test(id integer primary key, value text)")
+            .unwrap();
+        bulk_inserts(&conn, 8, 2);
+
+        let pager = conn.pager.load();
+        let result = pager
+            .io
+            .block(|| pager.checkpoint(CheckpointMode::Full, SyncMode::Off, true))
+            .unwrap();
+        assert!(
+            result.wal_total_backfilled > 0,
+            "sync-mode-off checkpoint setup should still backfill frames into the DB file"
+        );
+        assert_eq!(
+            wal_shared.read().metadata.nbackfills.load(Ordering::SeqCst),
+            0,
+            "SyncMode::Off must not publish positive nbackfills as durable shared state"
+        );
+    }
+
     fn make_test_wal() -> (Arc<RwLock<WalFileShared>>, WalFile) {
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
         let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
@@ -4396,6 +4979,14 @@ pub mod test {
     }
 
     #[cfg(all(unix, target_pointer_width = "64"))]
+    fn active_shared_reader_slot_count(authority: &MappedSharedWalCoordination) -> usize {
+        let reader_slot_count = authority.snapshot().reader_slot_count;
+        (0..reader_slot_count)
+            .filter(|&slot_index| authority.reader_owner(slot_index).is_some())
+            .count()
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
     fn write_test_wal_with_single_commit_frame(
         io: &Arc<dyn IO>,
         wal_path: &std::path::Path,
@@ -4432,7 +5023,11 @@ pub mod test {
         buffer_pool
             .finalize_with_page_size(wal_header.page_size as usize)
             .unwrap();
-        let page = vec![0x5a; wal_header.page_size as usize];
+        let mut page = vec![0x5a; wal_header.page_size as usize];
+        #[cfg(feature = "checksum")]
+        crate::storage::checksum::ChecksumContext::new()
+            .add_checksum_to_page(&mut page, 7)
+            .unwrap();
         let (frame_checksum, frame_buf) = sqlite3_ondisk::prepare_wal_frame(
             &buffer_pool,
             &wal_header,
@@ -4469,6 +5064,69 @@ pub mod test {
             checksum_2: frame_checksum.1,
             reader_slot_count: 64,
         }
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    fn open_test_db_file_for_wal(
+        io: &Arc<dyn IO>,
+        wal_path: &std::path::Path,
+    ) -> Arc<dyn DatabaseStorage> {
+        let db_path = wal_path.with_extension("db");
+        Arc::new(DatabaseFile::new(
+            io.open_file(db_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+                .unwrap(),
+        ))
+    }
+
+    #[test]
+    fn test_read_frame_keeps_epoch_from_issue_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("epoch-race.db-wal");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file.clone()).unwrap();
+        let deferred_file = Arc::new(DeferredReadFile::new(file));
+        {
+            let mut shared = shared.write();
+            shared.runtime.file = Some(deferred_file.clone());
+            shared
+                .runtime
+                .epoch
+                .store(snapshot.checkpoint_epoch, Ordering::Release);
+        }
+
+        let coordination: Arc<dyn WalCoordination> = Arc::new(make_test_coordination(&shared));
+        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        buffer_pool
+            .finalize_with_page_size(snapshot.page_size as usize)
+            .unwrap();
+        let wal = WalFile::new_with_coordination(
+            io.clone(),
+            coordination,
+            (
+                (snapshot.checksum_1, snapshot.checksum_2),
+                snapshot.max_frame,
+            ),
+            buffer_pool.clone(),
+        );
+
+        let page = Arc::new(crate::storage::pager::Page::new(7));
+        let issued_epoch = wal.coordination.checkpoint_epoch();
+        let completion = wal.read_frame(1, page.clone(), buffer_pool).unwrap();
+
+        wal.increment_checkpoint_epoch();
+        deferred_file.complete_pending_reads();
+        io.wait_for_completion(completion).unwrap();
+
+        assert_eq!(
+            page.wal_tag_pair(),
+            (1, issued_epoch),
+            "WAL reads must retain the epoch from when the read was issued"
+        );
     }
 
     #[cfg(test)]
@@ -4807,6 +5465,147 @@ pub mod test {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
+    fn test_shm_coordination_many_same_snapshot_readers_share_one_published_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-many-same-snapshot-readers.db-wal");
+        let shm_path = dir.path().join("test-many-same-snapshot-readers.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+        let snapshot = WalSnapshot {
+            max_frame: 9,
+            nbackfills: 2,
+            last_checksum: (31, 37),
+            checkpoint_seq: 5,
+            transaction_count: 9,
+        };
+        set_shared_snapshot(&shared, snapshot);
+        {
+            let shared = shared.write();
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = snapshot.last_checksum.0;
+            header.checksum_2 = snapshot.last_checksum.1;
+        }
+
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        let mut readers = Vec::new();
+        for _ in 0..128 {
+            let coordination = ShmWalCoordination::new(shared.clone(), authority.clone());
+            let read_guard = coordination
+                .try_begin_read_tx(snapshot)
+                .expect("same-snapshot readers should share a published reader barrier");
+            readers.push((coordination, read_guard));
+        }
+
+        assert_eq!(
+            authority.min_active_reader_frame(),
+            Some(snapshot.max_frame)
+        );
+        assert_eq!(
+            active_shared_reader_slot_count(&authority),
+            1,
+            "same-snapshot readers should collapse onto one shared reader slot"
+        );
+
+        for (coordination, read_guard) in readers {
+            coordination.end_read_tx(read_guard);
+        }
+        assert_eq!(authority.min_active_reader_frame(), None);
+        assert_eq!(active_shared_reader_slot_count(&authority), 0);
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_uses_one_published_slot_per_active_snapshot_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-mixed-snapshot-readers.db-wal");
+        let shm_path = dir.path().join("test-mixed-snapshot-readers.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+        let snapshot_a = WalSnapshot {
+            max_frame: 5,
+            nbackfills: 2,
+            last_checksum: (31, 37),
+            checkpoint_seq: 5,
+            transaction_count: 9,
+        };
+        set_shared_snapshot(&shared, snapshot_a);
+        {
+            let shared = shared.write();
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = snapshot_a.last_checksum.0;
+            header.checksum_2 = snapshot_a.last_checksum.1;
+        }
+
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        let reader_a1 = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let guard_a1 = reader_a1.try_begin_read_tx(snapshot_a).unwrap();
+        let reader_a2 = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let guard_a2 = reader_a2.try_begin_read_tx(snapshot_a).unwrap();
+        assert_eq!(
+            authority.min_active_reader_frame(),
+            Some(snapshot_a.max_frame)
+        );
+        assert_eq!(active_shared_reader_slot_count(&authority), 1);
+
+        let snapshot_b = WalSnapshot {
+            max_frame: 9,
+            nbackfills: 2,
+            last_checksum: (41, 43),
+            checkpoint_seq: 5,
+            transaction_count: 10,
+        };
+        reader_a1.publish_commit(WalCommitState {
+            max_frame: snapshot_b.max_frame,
+            last_checksum: snapshot_b.last_checksum,
+            transaction_count: snapshot_b.transaction_count,
+        });
+
+        let reader_b1 = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let guard_b1 = reader_b1.try_begin_read_tx(snapshot_b).unwrap();
+        let reader_b2 = ShmWalCoordination::new(shared, authority.clone());
+        let guard_b2 = reader_b2.try_begin_read_tx(snapshot_b).unwrap();
+
+        assert_eq!(
+            active_shared_reader_slot_count(&authority),
+            2,
+            "distinct live snapshots should each publish one shared reader slot"
+        );
+        assert_eq!(
+            authority.min_active_reader_frame(),
+            Some(snapshot_a.max_frame),
+            "checkpoint barrier should stay pinned to the oldest active snapshot"
+        );
+
+        reader_a1.end_read_tx(guard_a1);
+        reader_a2.end_read_tx(guard_a2);
+        assert_eq!(
+            authority.min_active_reader_frame(),
+            Some(snapshot_b.max_frame)
+        );
+        assert_eq!(active_shared_reader_slot_count(&authority), 1);
+
+        reader_b1.end_read_tx(guard_b1);
+        reader_b2.end_read_tx(guard_b2);
+        assert_eq!(authority.min_active_reader_frame(), None);
+        assert_eq!(active_shared_reader_slot_count(&authority), 0);
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
     fn test_shm_coordination_shared_index_grows_past_old_fixed_limit() {
         const OLD_FIXED_LIMIT: u64 = 65_536;
 
@@ -5045,29 +5844,47 @@ pub mod test {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
-    fn test_open_shared_from_authority_seeds_runtime_without_frame_cache_rebuild() {
+    fn test_open_shared_from_authority_reuses_trusted_positive_snapshot() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
         let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        authority.install_snapshot(snapshot);
+        authority.record_frame(7, 1);
+        let reopened_authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        assert_eq!(
+            reopened_authority.open_mode(),
+            SharedWalCoordinationOpenMode::MultiProcess
+        );
 
         let shared = WalFileShared::open_shared_from_authority_if_exists(
             &io,
             wal_path.to_str().unwrap(),
             crate::OpenFlags::Create,
-            snapshot,
+            &reopened_authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
         )
         .unwrap();
 
         let shared = shared.read();
         assert_eq!(shared.metadata.max_frame.load(Ordering::Acquire), 1);
         assert_eq!(shared.metadata.nbackfills.load(Ordering::Acquire), 0);
-        assert_eq!(shared.metadata.transaction_count.load(Ordering::Acquire), 9);
+        assert_eq!(
+            shared.metadata.transaction_count.load(Ordering::Acquire),
+            snapshot.transaction_count
+        );
         assert_eq!(
             shared.metadata.last_checksum,
             (snapshot.checksum_1, snapshot.checksum_2)
         );
-        assert_eq!(shared.runtime.epoch.load(Ordering::Acquire), 7);
+        assert_eq!(
+            shared.runtime.epoch.load(Ordering::Acquire),
+            snapshot.checkpoint_epoch
+        );
         assert!(shared.metadata.initialized.load(Ordering::Acquire));
         assert!(!shared
             .metadata
@@ -5122,27 +5939,32 @@ pub mod test {
     fn test_open_shared_from_authority_rebuilds_from_disk_when_snapshot_is_stale() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test-stale.db-wal");
+        let shm_path = dir.path().join("test-stale.db-tshm");
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
         let valid_snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        authority.install_snapshot(SharedWalCoordinationHeader {
+            max_frame: 0,
+            nbackfills: 0,
+            transaction_count: 0,
+            visibility_generation: 0,
+            checkpoint_seq: valid_snapshot.checkpoint_seq,
+            checkpoint_epoch: 0,
+            page_size: valid_snapshot.page_size,
+            salt_1: valid_snapshot.salt_1,
+            salt_2: valid_snapshot.salt_2,
+            checksum_1: 0,
+            checksum_2: 0,
+            reader_slot_count: 64,
+        });
 
         let shared = WalFileShared::open_shared_from_authority_if_exists(
             &io,
             wal_path.to_str().unwrap(),
             crate::OpenFlags::Create,
-            SharedWalCoordinationHeader {
-                max_frame: 0,
-                nbackfills: 0,
-                transaction_count: 0,
-                visibility_generation: 0,
-                checkpoint_seq: valid_snapshot.checkpoint_seq,
-                checkpoint_epoch: 0,
-                page_size: valid_snapshot.page_size,
-                salt_1: valid_snapshot.salt_1,
-                salt_2: valid_snapshot.salt_2,
-                checksum_1: 0,
-                checksum_2: 0,
-                reader_slot_count: 64,
-            },
+            &authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
         )
         .unwrap();
 
@@ -5164,20 +5986,154 @@ pub mod test {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
-    fn test_open_shared_from_authority_rebuilds_from_disk_when_snapshot_claims_backfill() {
+    fn test_open_shared_from_authority_exclusive_disk_scan_rebuilds_authority_via_coordination() {
         let dir = tempfile::tempdir().unwrap();
-        let wal_path = dir.path().join("test-backfilled.db-wal");
+        let wal_path = dir.path().join("test-republish.db-wal");
+        let shm_path = dir.path().join("test-republish.db-tshm");
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let valid_snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+        let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        authority.install_snapshot(snapshot);
+
+        let exclusive = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            &authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
+        )
+        .unwrap();
+        assert!(exclusive
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire));
+        assert!(
+            authority.iter_latest_frames(0, u64::MAX).is_empty(),
+            "open_shared_from_authority_if_exists should not republish authority before coordination reconciliation"
+        );
+
+        let exclusive_coordination = ShmWalCoordination::new(exclusive, authority.clone());
+        assert_eq!(authority.iter_latest_frames(0, u64::MAX), vec![(7, 1)]);
+        assert_eq!(exclusive_coordination.find_frame(7, 0, 1, None), Some(1));
+
+        let reopened_authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        assert_eq!(
+            reopened_authority.open_mode(),
+            SharedWalCoordinationOpenMode::MultiProcess
+        );
+
+        let reopened_shared = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            &reopened_authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
+        )
+        .unwrap();
+        assert!(!reopened_shared
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire));
+        let reopened_coordination = ShmWalCoordination::new(reopened_shared, reopened_authority);
+        assert_eq!(reopened_coordination.find_frame(7, 0, 1, None), Some(1));
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_open_shared_from_authority_exclusive_disk_scan_does_not_downgrade_newer_zero_frame_generation(
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-zero-frame-reopen.db-wal");
+        let shm_path = dir.path().join("test-zero-frame-reopen.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let prior_generation = write_test_wal_with_single_commit_frame(&io, &wal_path);
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        let restarted_generation = SharedWalCoordinationHeader {
+            max_frame: 0,
+            nbackfills: 0,
+            transaction_count: prior_generation.transaction_count,
+            visibility_generation: prior_generation.visibility_generation,
+            checkpoint_seq: prior_generation.checkpoint_seq.wrapping_add(1),
+            checkpoint_epoch: prior_generation.checkpoint_epoch,
+            page_size: prior_generation.page_size,
+            salt_1: prior_generation.salt_1.wrapping_add(1),
+            salt_2: prior_generation.salt_2.wrapping_add(1),
+            checksum_1: prior_generation.checksum_1,
+            checksum_2: prior_generation.checksum_2,
+            reader_slot_count: prior_generation.reader_slot_count,
+        };
+        authority.install_snapshot(restarted_generation);
 
         let shared = WalFileShared::open_shared_from_authority_if_exists(
             &io,
             wal_path.to_str().unwrap(),
             crate::OpenFlags::Create,
+            &authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
+        )
+        .unwrap();
+        assert!(shared
+            .read()
+            .metadata
+            .loaded_from_disk_scan
+            .load(Ordering::Acquire));
+
+        let coordination = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let reopened = coordination.load_snapshot();
+        assert_eq!(reopened.max_frame, 0);
+        assert_eq!(reopened.nbackfills, 0);
+        assert_eq!(reopened.checkpoint_seq, restarted_generation.checkpoint_seq);
+        assert_eq!(
+            authority.snapshot().checkpoint_seq,
+            restarted_generation.checkpoint_seq
+        );
+        assert!(
+            !coordination.wal_is_initialized(),
+            "preserving a newer zero-frame generation must require the first append to rewrite the WAL header"
+        );
+        assert!(
+            shared.read().runtime.frame_cache.lock().is_empty(),
+            "older WAL frames from a prior generation must not survive zero-frame authority recovery"
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_open_shared_from_authority_ignores_unpublished_backfill_proof() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-unpublished-proof.db-wal");
+        let shm_path = dir.path().join("test-unpublished-proof.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        authority.install_snapshot(snapshot);
+        authority.install_backfill_proof(
             SharedWalCoordinationHeader {
-                nbackfills: valid_snapshot.max_frame,
-                ..valid_snapshot
+                nbackfills: snapshot.max_frame,
+                ..snapshot
             },
+            11,
+            0xAABB_CCDD,
+        );
+        let reopened_authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        assert_eq!(
+            reopened_authority.open_mode(),
+            SharedWalCoordinationOpenMode::MultiProcess
+        );
+
+        let shared = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            &reopened_authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
         )
         .unwrap();
 
@@ -5188,9 +6144,258 @@ pub mod test {
             .metadata
             .loaded_from_disk_scan
             .load(Ordering::Acquire));
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_restart_checkpoint_clears_backfill_proof_and_later_replaces_it() {
+        let (db, path) = get_database();
+        let wal_path = path.join("test.db-wal");
+        let wal_path_str = wal_path.to_str().unwrap();
+        let conn = db.connect().unwrap();
+        conn.wal_auto_checkpoint_disable();
+        conn.execute("create table test(id integer primary key, value text)")
+            .unwrap();
+        bulk_inserts(&conn, 8, 2);
+
+        let pager = conn.pager.load();
+        let partial = run_checkpoint_until_done(
+            &pager,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: Some(1),
+            },
+        );
+        assert!(
+            partial.wal_total_backfilled > 0 && !partial.everything_backfilled(),
+            "setup must create a partial checkpoint with a positive durable backfill proof"
+        );
+
+        let authority = db.shared_wal_coordination().unwrap().unwrap();
+        let snapshot_before_restart = authority.snapshot();
+        let (db_size_before, db_crc_before) =
+            super::read_database_identity_from_file_path(&db.io, wal_path_str)
+                .unwrap()
+                .unwrap();
+        assert!(
+            authority.validate_backfill_proof(
+                snapshot_before_restart,
+                db_size_before,
+                db_crc_before
+            ),
+            "setup must install a valid proof before RESTART"
+        );
+
+        let restart = run_checkpoint_until_done(&pager, CheckpointMode::Restart);
+        assert!(
+            restart.everything_backfilled(),
+            "RESTART should fully backfill before resetting the WAL generation"
+        );
+
+        let snapshot_after_restart = authority.snapshot();
+        assert_eq!(snapshot_after_restart.max_frame, 0);
+        assert_eq!(snapshot_after_restart.nbackfills, 0);
+        assert!(
+            !authority.validate_backfill_proof(
+                snapshot_before_restart,
+                db_size_before,
+                db_crc_before
+            ),
+            "RESTART must clear the proof for the old WAL generation"
+        );
+
+        bulk_inserts(&conn, 6, 2);
+        let replacement = run_checkpoint_until_done(
+            &pager,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: Some(1),
+            },
+        );
+        assert!(
+            replacement.wal_total_backfilled > 0 && !replacement.everything_backfilled(),
+            "replacement setup must create a new partial checkpoint after RESTART"
+        );
+
+        let snapshot_after_replacement = authority.snapshot();
+        let (db_size_after, db_crc_after) =
+            super::read_database_identity_from_file_path(&db.io, wal_path_str)
+                .unwrap()
+                .unwrap();
+        assert!(
+            authority.validate_backfill_proof(
+                snapshot_after_replacement,
+                db_size_after,
+                db_crc_after
+            ),
+            "partial checkpoint after RESTART must install a replacement proof for the new generation"
+        );
+        assert_ne!(
+            snapshot_after_replacement.checkpoint_seq, snapshot_before_restart.checkpoint_seq,
+            "replacement proof must belong to the restarted WAL generation"
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_truncate_checkpoint_clears_backfill_proof_and_later_replaces_it() {
+        let (db, path) = get_database();
+        let wal_path = path.join("test.db-wal");
+        let wal_path_str = wal_path.to_str().unwrap();
+        let conn = db.connect().unwrap();
+        conn.wal_auto_checkpoint_disable();
+        conn.execute("create table test(id integer primary key, value text)")
+            .unwrap();
+        bulk_inserts(&conn, 8, 2);
+
+        let pager = conn.pager.load();
+        let partial = run_checkpoint_until_done(
+            &pager,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: Some(1),
+            },
+        );
+        assert!(
+            partial.wal_total_backfilled > 0 && !partial.everything_backfilled(),
+            "setup must create a partial checkpoint with a positive durable backfill proof"
+        );
+
+        let authority = db.shared_wal_coordination().unwrap().unwrap();
+        let snapshot_before_truncate = authority.snapshot();
+        let (db_size_before, db_crc_before) =
+            super::read_database_identity_from_file_path(&db.io, wal_path_str)
+                .unwrap()
+                .unwrap();
+        assert!(
+            authority.validate_backfill_proof(
+                snapshot_before_truncate,
+                db_size_before,
+                db_crc_before
+            ),
+            "setup must install a valid proof before TRUNCATE"
+        );
+
+        let truncate = run_checkpoint_until_done(
+            &pager,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
+        );
+        assert!(
+            truncate.everything_backfilled(),
+            "TRUNCATE should fully backfill before truncating the WAL"
+        );
+
+        let snapshot_after_truncate = authority.snapshot();
+        assert_eq!(snapshot_after_truncate.max_frame, 0);
+        assert_eq!(snapshot_after_truncate.nbackfills, 0);
+        assert!(
+            !authority.validate_backfill_proof(
+                snapshot_before_truncate,
+                db_size_before,
+                db_crc_before
+            ),
+            "TRUNCATE must clear the proof for the truncated WAL generation"
+        );
         assert_eq!(
-            shared.runtime.frame_cache.lock().get(&7).cloned(),
-            Some(vec![1])
+            std::fs::metadata(&wal_path).unwrap().len(),
+            0,
+            "TRUNCATE must leave the WAL file empty before the new generation begins"
+        );
+
+        bulk_inserts(&conn, 6, 2);
+        let replacement = run_checkpoint_until_done(
+            &pager,
+            CheckpointMode::Passive {
+                upper_bound_inclusive: Some(1),
+            },
+        );
+        assert!(
+            replacement.wal_total_backfilled > 0 && !replacement.everything_backfilled(),
+            "replacement setup must create a new partial checkpoint after TRUNCATE"
+        );
+
+        let snapshot_after_replacement = authority.snapshot();
+        let (db_size_after, db_crc_after) =
+            super::read_database_identity_from_file_path(&db.io, wal_path_str)
+                .unwrap()
+                .unwrap();
+        assert!(
+            authority.validate_backfill_proof(
+                snapshot_after_replacement,
+                db_size_after,
+                db_crc_after
+            ),
+            "partial checkpoint after TRUNCATE must install a replacement proof for the new generation"
+        );
+        assert_ne!(
+            snapshot_after_replacement.checkpoint_seq, snapshot_before_truncate.checkpoint_seq,
+            "replacement proof must belong to the truncated WAL generation"
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_classify_authority_snapshot_marks_truncated_wal_for_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-truncated.db-wal");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let snapshot = write_test_wal_with_single_commit_frame(&io, &wal_path);
+
+        let wal_len = std::fs::metadata(&wal_path).unwrap().len();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&wal_path)
+            .unwrap()
+            .set_len(wal_len - 1)
+            .unwrap();
+
+        assert_eq!(
+            classify_authority_snapshot_against_wal(
+                &io,
+                &io.open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+                    .unwrap(),
+                snapshot,
+            )
+            .unwrap(),
+            AuthoritySnapshotValidation::RebuildFromDisk(
+                AuthoritySnapshotRebuildReason::WalLengthMismatch
+            )
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_classify_authority_snapshot_marks_corrupt_header_for_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-corrupt-header.db-wal");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        std::fs::write(&wal_path, [0u8; WAL_HEADER_SIZE]).unwrap();
+
+        let snapshot = SharedWalCoordinationHeader {
+            max_frame: 0,
+            nbackfills: 0,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+
+        assert_eq!(
+            classify_authority_snapshot_against_wal(
+                &io,
+                &io.open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+                    .unwrap(),
+                snapshot,
+            )
+            .unwrap(),
+            AuthoritySnapshotValidation::RebuildFromDisk(
+                AuthoritySnapshotRebuildReason::WalHeaderUnreadable
+            )
         );
     }
 
@@ -5199,29 +6404,40 @@ pub mod test {
     fn test_open_shared_from_authority_keeps_zero_length_wal_uninitialized() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test-empty.db-wal");
+        let shm_path = dir.path().join("test-empty.db-tshm");
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
 
         io.open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
             .unwrap();
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        authority.install_snapshot(SharedWalCoordinationHeader {
+            max_frame: 0,
+            nbackfills: 0,
+            transaction_count: 9,
+            visibility_generation: 1,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        });
+        let reopened_authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        assert_eq!(
+            reopened_authority.open_mode(),
+            SharedWalCoordinationOpenMode::MultiProcess
+        );
 
         let shared = WalFileShared::open_shared_from_authority_if_exists(
             &io,
             wal_path.to_str().unwrap(),
             crate::OpenFlags::Create,
-            SharedWalCoordinationHeader {
-                max_frame: 0,
-                nbackfills: 0,
-                transaction_count: 9,
-                visibility_generation: 1,
-                checkpoint_seq: 5,
-                checkpoint_epoch: 7,
-                page_size: 4096,
-                salt_1: 17,
-                salt_2: 23,
-                checksum_1: 31,
-                checksum_2: 37,
-                reader_slot_count: 64,
-            },
+            &reopened_authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
         )
         .unwrap();
 
@@ -5310,6 +6526,382 @@ pub mod test {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     #[test]
+    fn test_shm_coordination_disk_scan_matching_authority_keeps_frame_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let file_a = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_a = WalFileShared::new_shared(file_a).unwrap();
+        let authoritative = WalSnapshot {
+            max_frame: 5,
+            nbackfills: 2,
+            last_checksum: (31, 37),
+            checkpoint_seq: 5,
+            transaction_count: 9,
+        };
+        set_shared_snapshot(&shared_a, authoritative);
+        {
+            let shared = shared_a.write();
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = authoritative.last_checksum.0;
+            header.checksum_2 = authoritative.last_checksum.1;
+        }
+        let (authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
+        coordination_a.cache_frame(7, 2);
+        coordination_a.cache_frame(9, 5);
+
+        let file_b = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_b = WalFileShared::new_shared(file_b).unwrap();
+        set_shared_snapshot(&shared_b, authoritative);
+        {
+            let shared = shared_b.write();
+            shared
+                .metadata
+                .loaded_from_disk_scan
+                .store(true, Ordering::Release);
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = authoritative.last_checksum.0;
+            header.checksum_2 = authoritative.last_checksum.1;
+            let mut frame_cache = shared.runtime.frame_cache.lock();
+            frame_cache.insert(7, vec![2]);
+            frame_cache.insert(9, vec![5]);
+        }
+
+        let (_authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
+
+        let reopened = coordination_b.load_snapshot();
+        assert_eq!(reopened.max_frame, authoritative.max_frame);
+        assert_eq!(reopened.last_checksum, authoritative.last_checksum);
+        assert_eq!(reopened.checkpoint_seq, authoritative.checkpoint_seq);
+        assert_eq!(reopened.transaction_count, authoritative.transaction_count);
+        assert_eq!(
+            reopened.nbackfills, 0,
+            "disk-scan reconciliation must preserve the frame index without reviving positive nbackfills"
+        );
+        assert_eq!(authority.find_frame(7, 0, 5, None), Some(2));
+        assert_eq!(authority.find_frame(9, 0, 5, None), Some(5));
+        assert_eq!(
+            authority.iter_latest_frames(0, authoritative.max_frame),
+            vec![(7, 2), (9, 5)]
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_disk_scan_matching_snapshot_rebuilds_stale_frame_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let file_a = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_a = WalFileShared::new_shared(file_a).unwrap();
+        let authoritative = WalSnapshot {
+            max_frame: 5,
+            nbackfills: 0,
+            last_checksum: (31, 37),
+            checkpoint_seq: 5,
+            transaction_count: 9,
+        };
+        set_shared_snapshot(&shared_a, authoritative);
+        {
+            let shared = shared_a.write();
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = authoritative.last_checksum.0;
+            header.checksum_2 = authoritative.last_checksum.1;
+        }
+        let (authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
+        coordination_a.cache_frame(7, 2);
+        coordination_a.cache_frame(9, 4);
+
+        let file_b = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_b = WalFileShared::new_shared(file_b).unwrap();
+        set_shared_snapshot(&shared_b, authoritative);
+        {
+            let shared = shared_b.write();
+            shared
+                .metadata
+                .loaded_from_disk_scan
+                .store(true, Ordering::Release);
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = authoritative.last_checksum.0;
+            header.checksum_2 = authoritative.last_checksum.1;
+            shared.runtime.frame_cache.lock().insert(7, vec![2]);
+            shared.runtime.frame_cache.lock().insert(9, vec![5]);
+        }
+
+        let (_authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
+
+        let reopened = coordination_b.load_snapshot();
+        assert_eq!(reopened.max_frame, authoritative.max_frame);
+        assert_eq!(reopened.last_checksum, authoritative.last_checksum);
+        assert_eq!(reopened.checkpoint_seq, authoritative.checkpoint_seq);
+        assert_eq!(reopened.transaction_count, authoritative.transaction_count);
+        assert_eq!(authority.find_frame(7, 0, 5, None), Some(2));
+        assert_eq!(
+            authority.find_frame(9, 0, 5, None),
+            Some(5),
+            "matching snapshot metadata must not preserve a stale shared frame index across restart recovery"
+        );
+        assert_eq!(
+            authority.iter_latest_frames(0, authoritative.max_frame),
+            vec![(7, 2), (9, 5)]
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_empty_disk_scan_keeps_zero_frame_authority_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        let authoritative = SharedWalCoordinationHeader {
+            max_frame: 0,
+            nbackfills: 0,
+            transaction_count: 9,
+            visibility_generation: 3,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+        authority.install_snapshot(authoritative);
+
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+        {
+            let shared = shared.write();
+            shared
+                .metadata
+                .loaded_from_disk_scan
+                .store(true, Ordering::Release);
+        }
+
+        let coordination = ShmWalCoordination::new(shared, authority.clone());
+        let snapshot = authority.snapshot();
+        assert_eq!(snapshot, authoritative);
+        let header = coordination.wal_header();
+        assert_eq!(header.page_size, 4096);
+        assert_eq!(header.checkpoint_seq, authoritative.checkpoint_seq);
+        assert_eq!(header.salt_1, authoritative.salt_1);
+        assert_eq!(header.salt_2, authoritative.salt_2);
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_coordination_empty_disk_scan_does_not_clobber_positive_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let file_a = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_a = WalFileShared::new_shared(file_a).unwrap();
+        let authoritative = WalSnapshot {
+            max_frame: 5,
+            nbackfills: 0,
+            last_checksum: (31, 37),
+            checkpoint_seq: 5,
+            transaction_count: 9,
+        };
+        set_shared_snapshot(&shared_a, authoritative);
+        {
+            let shared = shared_a.write();
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = authoritative.last_checksum.0;
+            header.checksum_2 = authoritative.last_checksum.1;
+        }
+        let (authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
+        coordination_a.cache_frame(7, 2);
+        coordination_a.cache_frame(9, 5);
+
+        let file_b = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared_b = WalFileShared::new_shared(file_b).unwrap();
+        {
+            let shared = shared_b.write();
+            shared
+                .metadata
+                .loaded_from_disk_scan
+                .store(true, Ordering::Release);
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = 4096;
+            header.checkpoint_seq = authoritative.checkpoint_seq;
+            header.salt_1 = 17;
+            header.salt_2 = 23;
+            header.checksum_1 = 11;
+            header.checksum_2 = 13;
+        }
+
+        let (_authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
+        let reopened = coordination_b.load_snapshot();
+        assert_eq!(reopened.max_frame, authoritative.max_frame);
+        assert_eq!(reopened.checkpoint_seq, authoritative.checkpoint_seq);
+        assert_eq!(reopened.transaction_count, authoritative.transaction_count);
+        assert_eq!(
+            authority.find_frame(7, 0, authoritative.max_frame, None),
+            Some(2)
+        );
+        assert_eq!(
+            authority.find_frame(9, 0, authoritative.max_frame, None),
+            Some(5)
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_zero_frame_authority_invalidates_stale_local_initialized_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        let authoritative = SharedWalCoordinationHeader {
+            max_frame: 0,
+            nbackfills: 0,
+            transaction_count: 9,
+            visibility_generation: 3,
+            checkpoint_seq: 5,
+            checkpoint_epoch: 7,
+            page_size: 4096,
+            salt_1: 17,
+            salt_2: 23,
+            checksum_1: 31,
+            checksum_2: 37,
+            reader_slot_count: 64,
+        };
+        authority.install_snapshot(authoritative);
+
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+        {
+            let mut shared = shared.write();
+            shared.metadata.max_frame.store(11, Ordering::Release);
+            shared.metadata.nbackfills.store(11, Ordering::Release);
+            shared.metadata.last_checksum = (11, 13);
+            shared
+                .metadata
+                .transaction_count
+                .store(3, Ordering::Release);
+            shared.metadata.initialized.store(true, Ordering::Release);
+            let mut header = shared.metadata.wal_header.lock();
+            header.checkpoint_seq = 2;
+            header.page_size = 4096;
+            header.salt_1 = 7;
+            header.salt_2 = 13;
+            header.checksum_1 = 11;
+            header.checksum_2 = 13;
+            shared.runtime.epoch.store(1, Ordering::Release);
+        }
+
+        let coordination = ShmWalCoordination::new(shared.clone(), authority);
+        assert!(
+            !coordination.wal_is_initialized(),
+            "a stale local initialized bit must not suppress the first header rewrite after RESTART/TRUNCATE"
+        );
+        {
+            let shared = shared.read();
+            assert!(
+                !shared.metadata.initialized.load(Ordering::Acquire),
+                "stale local initialized state must be cleared"
+            );
+            let header = shared.metadata.wal_header.lock();
+            assert_eq!(header.checkpoint_seq, authoritative.checkpoint_seq);
+            assert_eq!(header.page_size, authoritative.page_size);
+            assert_eq!(header.salt_1, authoritative.salt_1);
+            assert_eq!(header.salt_2, authoritative.salt_2);
+            assert_eq!(header.checksum_1, authoritative.checksum_1);
+            assert_eq!(header.checksum_2, authoritative.checksum_2);
+        }
+
+        let prepared = coordination
+            .prepare_wal_header(io.as_ref(), PageSize::new(4096).unwrap())
+            .expect("zero-frame authority should force a header rewrite");
+        assert_eq!(prepared.checkpoint_seq, authoritative.checkpoint_seq);
+        coordination.mark_initialized();
+        assert!(
+            coordination.wal_is_initialized(),
+            "once the current-generation header is durably rewritten, wal_is_initialized should succeed"
+        );
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
+    fn test_shm_prepare_wal_header_seeds_uninitialized_authority_from_prepared_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test.db-wal");
+        let shm_path = dir.path().join("test.db-tshm");
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        let file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+        let coordination = ShmWalCoordination::new(shared, authority.clone());
+
+        let prepared = coordination
+            .prepare_wal_header(io.as_ref(), PageSize::new(4096).unwrap())
+            .expect("fresh authority should accept the first prepared header");
+
+        let snapshot = authority.snapshot();
+        assert_eq!(
+            snapshot.page_size, prepared.page_size,
+            "authority must publish the prepared page size for later writers and checkpointers"
+        );
+        assert_eq!(
+            snapshot.checkpoint_seq, prepared.checkpoint_seq,
+            "authority must publish the prepared checkpoint generation"
+        );
+        assert_eq!(snapshot.salt_1, prepared.salt_1);
+        assert_eq!(snapshot.salt_2, prepared.salt_2);
+    }
+
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    #[test]
     fn test_shm_prepare_wal_header_does_not_clobber_zero_frame_authority_snapshot() {
         let dir = tempfile::tempdir().unwrap();
         let wal_path = dir.path().join("test.db-wal");
@@ -5389,9 +6981,9 @@ pub mod test {
         }
 
         let page_size = PageSize::new(4096).unwrap();
-        assert!(coordination_b
+        let prepared = coordination_b
             .prepare_wal_header(io.as_ref(), page_size)
-            .is_some());
+            .expect("prepare_wal_header should produce a header");
 
         let snapshot = authority.snapshot();
         assert_eq!(
@@ -5402,8 +6994,22 @@ pub mod test {
             snapshot.checkpoint_seq, authoritative.checkpoint_seq,
             "first writer after restart must not downgrade checkpoint metadata"
         );
-        assert_eq!(snapshot.checksum_1, authoritative.checksum_1);
-        assert_eq!(snapshot.checksum_2, authoritative.checksum_2);
+        assert_eq!(
+            prepared.checkpoint_seq, authoritative.checkpoint_seq,
+            "header written after restart must use authority checkpoint metadata"
+        );
+        assert_eq!(prepared.page_size, authoritative.page_size);
+        assert_eq!(prepared.salt_1, authoritative.salt_1);
+        assert_eq!(prepared.salt_2, authoritative.salt_2);
+        let refreshed = authority.snapshot();
+        assert_eq!(
+            refreshed.checksum_1, prepared.checksum_1,
+            "preparing the first zero-frame header must refresh the authoritative checksum seed"
+        );
+        assert_eq!(
+            refreshed.checksum_2, prepared.checksum_2,
+            "preparing the first zero-frame header must refresh the authoritative checksum seed"
+        );
     }
 
     #[test]
@@ -6365,6 +7971,15 @@ pub mod test {
                 }
             }
         }
+        assert_eq!(
+            db.shared_wal
+                .read()
+                .metadata
+                .nbackfills
+                .load(Ordering::SeqCst),
+            0,
+            "a FULL checkpoint that returns Busy must not publish positive nbackfills before DB sync"
+        );
 
         // Release the reader, now full mode should succeed and backfill everything
         {
@@ -6378,7 +7993,10 @@ pub mod test {
             run_checkpoint_until_done(&pager, CheckpointMode::Full)
         };
 
-        assert_eq!(result.wal_checkpoint_backfilled, mx_now - r_snapshot);
+        assert_eq!(
+            result.wal_checkpoint_backfilled, mx_now,
+            "the successful FULL reruns from the last durable backfill point because the Busy attempt did not publish progress"
+        );
         assert!(result.everything_backfilled());
     }
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4681,7 +4681,14 @@ pub mod test {
                 .unwrap();
         }
         let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
-        let db = Database::open_file(io.clone(), path.to_str().unwrap()).unwrap();
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            path.to_str().unwrap(),
+            crate::OpenFlags::default(),
+            crate::DatabaseOpts::new().with_multiprocess_wal(true),
+            None,
+        )
+        .unwrap();
         // db + tmp directory
         (db, dbpath)
     }
@@ -5023,6 +5030,7 @@ pub mod test {
         buffer_pool
             .finalize_with_page_size(wal_header.page_size as usize)
             .unwrap();
+        #[allow(unused_mut)]
         let mut page = vec![0x5a; wal_header.page_size as usize];
         #[cfg(feature = "checksum")]
         crate::storage::checksum::ChecksumContext::new()

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2288,6 +2288,12 @@ pub struct WalFile {
     checkpoint_guard: RwLock<Option<CheckpointLocks>>,
 
     io_ctx: RwLock<IOContext>,
+
+    /// Set when `write_frame_raw` appends frames without a commit marker
+    /// (`db_size == 0`), meaning the coordination backend's max_frame is
+    /// behind our connection-local max_frame. Cleared once
+    /// `finish_append_frames_commit` publishes the state.
+    has_unpublished_frames: AtomicBool,
 }
 
 impl fmt::Debug for WalFile {
@@ -3006,6 +3012,8 @@ impl Wal for WalFile {
         self.complete_append_frame(page_id, frame_id, checksums);
         if db_size > 0 {
             self.finish_append_frames_commit()?;
+        } else {
+            self.has_unpublished_frames.store(true, Ordering::Release);
         }
         Ok(())
     }
@@ -3127,6 +3135,7 @@ impl Wal for WalFile {
             last_checksum,
             transaction_count,
         });
+        self.has_unpublished_frames.store(false, Ordering::Release);
         Ok(())
     }
 
@@ -3244,13 +3253,24 @@ impl Wal for WalFile {
                         local_state.snapshot.max_frame + 1,
                     )
                 } else if snapshot != local_state.snapshot {
-                    // The current generation was restarted/truncated back to
-                    // frame 0 or another process changed the durable WAL
-                    // state. Re-seed this connection from the authoritative
-                    // snapshot so replacement generations after
-                    // RESTART/TRUNCATE do not append using stale local state.
-                    self.install_connection_state(local_state.with_snapshot(snapshot));
-                    (snapshot.last_checksum, snapshot.max_frame + 1)
+                    if self.has_unpublished_frames.load(Ordering::Acquire) {
+                        // write_frame_raw appended frames without a commit
+                        // marker (db_size == 0), so the coordination backend's
+                        // max_frame is behind our local max_frame. Chain from
+                        // local state so we don't overwrite those frames.
+                        (
+                            local_state.snapshot.last_checksum,
+                            local_state.snapshot.max_frame + 1,
+                        )
+                    } else {
+                        // The current generation was restarted/truncated back to
+                        // frame 0 or another process changed the durable WAL
+                        // state. Re-seed this connection from the authoritative
+                        // snapshot so replacement generations after
+                        // RESTART/TRUNCATE do not append using stale local state.
+                        self.install_connection_state(local_state.with_snapshot(snapshot));
+                        (snapshot.last_checksum, snapshot.max_frame + 1)
+                    }
                 } else {
                     (
                         local_state.snapshot.last_checksum,
@@ -3545,6 +3565,7 @@ impl WalFile {
             last_checksum: RwLock::new(last_checksum),
             checkpoint_guard: RwLock::new(None),
             io_ctx: RwLock::new(IOContext::default()),
+            has_unpublished_frames: AtomicBool::new(false),
         }
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3843,9 +3843,13 @@ pub fn op_savepoint(
             Ok(InsnFunctionStepResult::Step)
         }
         SavepointOp::RollbackTo => {
+            let mut mvcc_tx_id = None;
             let deferred_fk_snapshot = if let Some(mv_store) = mv_store.as_ref() {
                 match conn.get_mv_tx_id() {
-                    Some(tx_id) => mv_store.rollback_to_named_savepoint(tx_id, name)?,
+                    Some(tx_id) => {
+                        mvcc_tx_id = Some(tx_id);
+                        mv_store.rollback_to_named_savepoint(tx_id, name)?
+                    }
                     None => None,
                 }
             } else {
@@ -3893,28 +3897,39 @@ pub fn op_savepoint(
             // cached schema cookie and check if a schema reparse is needed.
             pager.set_schema_cookie(None);
             let in_memory_version = conn.schema.read().schema_version;
-            let pager_ref = conn.pager.load().clone();
-            match pager_ref
-                .io
-                .block(|| pager.with_header(|h| h.schema_cookie.get()))
-            {
-                Ok(on_disk_cookie) if in_memory_version != on_disk_cookie => {
+            let current_cookie = if let Some(mv_store) = mv_store.as_ref() {
+                mv_store.with_header(|header| header.schema_cookie.get(), mvcc_tx_id.as_ref())
+            } else {
+                conn.read_current_schema_cookie()
+            };
+            match current_cookie {
+                Ok(current_cookie)
+                    if mv_store.is_some()
+                        && current_cookie == conn.db.schema.lock().schema_version =>
+                {
+                    *conn.schema.write() = conn.db.clone_schema();
+                }
+                Ok(current_cookie) if in_memory_version != current_cookie => {
                     // Schema was modified during the savepoint. Try to reparse
                     // from the restored database pages. If that fails (e.g. the
                     // database was empty at the savepoint), use an empty schema.
-                    if conn.reparse_schema().is_err() {
+                    if let Err(err) = conn.reparse_schema_with_cookie(current_cookie) {
+                        if current_cookie != 0 {
+                            return Err(err);
+                        }
                         conn.with_schema_mut(|schema| {
                             *schema = Schema::new();
                         });
                     }
                 }
-                Err(_) => {
+                Err(LimboError::Page1NotAlloc) => {
                     // Header page is not readable (database empty after rollback).
                     // Reset to an empty schema.
                     conn.with_schema_mut(|schema| {
                         *schema = Schema::new();
                     });
                 }
+                Err(err) => return Err(err),
                 _ => {} // Schema unchanged, nothing to do.
             }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -517,7 +517,7 @@ pub fn op_checkpoint(
         return Ok(InsnFunctionStepResult::Step);
     }
 
-    let pager = program.get_pager_from_database_index(database);
+    let pager = program.get_pager_from_database_index(database)?;
     if !pager.has_wal() {
         set_not_in_wal_result(state, *dest);
         state.pc += 1;
@@ -1076,7 +1076,7 @@ pub fn op_open_read(
         insn
     );
 
-    let pager = program.get_pager_from_database_index(db);
+    let pager = program.get_pager_from_database_index(db)?;
     let mv_store = program.connection.mv_store_for_db(*db);
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
@@ -3110,7 +3110,7 @@ pub fn op_transaction_inner(
     if *db == crate::TEMP_DB_ID {
         program.connection.ensure_temp_database()?;
     }
-    let pager = program.get_pager_from_database_index(db);
+    let pager = program.get_pager_from_database_index(db)?;
     // Get the MvStore for the specific database (main or attached).
     let mv_store = program.connection.mv_store_for_db(*db);
     loop {
@@ -3622,6 +3622,7 @@ pub fn op_auto_commit(
                 pager.rollback_tx(&conn);
             }
             conn.rollback_attached_wal_txns();
+            conn.rollback_temp_schema();
             conn.set_tx_state(TransactionState::None);
             conn.auto_commit.store(true, Ordering::SeqCst);
             conn.set_cdc_transaction_id(-1);
@@ -9982,7 +9983,7 @@ pub fn op_open_write(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    let pager = program.get_pager_from_database_index(db);
+    let pager = program.get_pager_from_database_index(db)?;
     let mv_store = program.connection.mv_store_for_db(*db);
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
@@ -10150,7 +10151,7 @@ pub fn op_create_btree(
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
-    let pager = program.get_pager_from_database_index(db);
+    let pager = program.get_pager_from_database_index(db)?;
     // FIXME: handle page cache is full
     let root_page = return_if_io!(pager.btree_create(flags));
     state.registers[*root].set_int(root_page as i64);
@@ -10313,7 +10314,7 @@ pub fn op_destroy(
     }
 
     let destroy_pager = if *db != MAIN_DB_ID {
-        program.get_pager_from_database_index(db)
+        program.get_pager_from_database_index(db)?
     } else {
         pager.clone()
     };
@@ -10573,7 +10574,7 @@ pub fn op_page_count(
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(PageCount { db, dest }, insn);
-    let pager = program.get_pager_from_database_index(db);
+    let pager = program.get_pager_from_database_index(db)?;
     let mv_store = program.connection.mv_store_for_db(*db);
     let count = match with_header(&pager, mv_store.as_ref(), program, *db, |header| {
         header.database_size.get()
@@ -11061,7 +11062,7 @@ pub fn op_read_cookie(
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(ReadCookie { db, dest, cookie }, insn);
-    let pager = program.get_pager_from_database_index(db);
+    let pager = program.get_pager_from_database_index(db)?;
     let mv_store = program.connection.mv_store_for_db(*db);
 
     let cookie_value =
@@ -11112,7 +11113,7 @@ pub fn op_set_cookie(
         },
         insn
     );
-    let pager = program.get_pager_from_database_index(db);
+    let pager = program.get_pager_from_database_index(db)?;
     let mv_store = program.connection.mv_store_for_db(*db);
     if let Some(mv_store) = mv_store.as_ref() {
         let Some(tx_id) = program.connection.get_mv_tx_id_for_db(*db) else {
@@ -11919,7 +11920,7 @@ pub fn op_integrity_check(
     let target_pager = if *db == MAIN_DB_ID {
         pager.clone()
     } else {
-        program.get_pager_from_database_index(db)
+        program.get_pager_from_database_index(db)?
     };
     match &mut state.op_integrity_check_state {
         OpIntegrityCheckState::Start => {
@@ -13843,7 +13844,7 @@ pub fn op_max_pgcnt(
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(MaxPgcnt { db, dest, new_max }, insn);
 
-    let pager = program.get_pager_from_database_index(db);
+    let pager = program.get_pager_from_database_index(db)?;
     let result_value = if *new_max == 0 {
         // If new_max is 0, just return current maximum without changing it
         pager.get_max_page_count()
@@ -13918,7 +13919,7 @@ fn op_journal_mode_inner(
     use crate::storage::sqlite3_ondisk::begin_write_btree_page;
 
     load_insn!(JournalMode { db, dest, new_mode }, insn);
-    let pager = program.get_pager_from_database_index(db);
+    let pager = program.get_pager_from_database_index(db)?;
     let pager = &pager;
 
     loop {
@@ -14376,7 +14377,7 @@ fn op_vacuum_into_inner(
                     // For attached db read from its own pager
                     let pager = program
                         .connection
-                        .get_pager_from_database_index(&database_id);
+                        .get_pager_from_database_index(&database_id)?;
                     pager
                         .io
                         .block(|| pager.with_header(|header| header.reserved_space))?

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1200,7 +1200,7 @@ impl Program {
 }
 
 impl Program {
-    fn get_pager_from_database_index(&self, idx: &usize) -> Arc<Pager> {
+    fn get_pager_from_database_index(&self, idx: &usize) -> Result<Arc<Pager>> {
         self.connection.get_pager_from_database_index(idx)
     }
 
@@ -1638,11 +1638,11 @@ impl Program {
             // bailing out. Defer these checks to here so the common case
             // (active main transaction) doesn't pay for the lock reads.
             let has_attached_mv_tx = self.connection.next_attached_mv_tx().is_some();
-            let has_attached_wal_tx = self
-                .connection
-                .get_all_attached_pagers()
-                .iter()
-                .any(|pager| pager.holds_read_lock());
+            let has_attached_wal_tx =
+                self.connection
+                    .with_all_attached_pagers_with_index(|pagers| {
+                        pagers.iter().any(|(_, pager)| pager.holds_read_lock())
+                    });
             if !has_attached_mv_tx && !has_attached_wal_tx {
                 return Ok(IOResult::Done(()));
             }
@@ -1661,16 +1661,19 @@ impl Program {
                 self.connection
                     .set_changes(program_state.n_change.load(Ordering::SeqCst));
             }
-            // finalize the in-memory TEMP schema. The pager's own
-            // rollback() only reinstates main's `connection.schema` from the
-            // shared `Database::schema`; TEMP has no shared Database so the
-            // connection keeps its own `committed_temp_schema` snapshot that
-            // we update here. Both methods are gated on `temp_schema_did_change`
-            // so they are cheap no-ops outside of temp DDL.
-            if rollback {
-                self.connection.rollback_temp_schema();
-            } else {
-                self.connection.commit_temp_schema();
+            let transaction_finished = self.connection.auto_commit.load(Ordering::SeqCst)
+                && self.connection.get_tx_state() == TransactionState::None;
+            if transaction_finished {
+                // Finalize the in-memory TEMP schema only when the outer
+                // transaction actually finishes. Updating the committed temp
+                // snapshot after every statement inside an explicit
+                // transaction would make a later full ROLLBACK restore
+                // uncommitted temp DDL.
+                if rollback {
+                    self.connection.rollback_temp_schema();
+                } else {
+                    self.connection.commit_temp_schema();
+                }
             }
         }
         Ok(res)
@@ -1827,7 +1830,9 @@ impl Program {
             };
             match step_result {
                 IOResult::Done(_) => {
-                    let attached_pager = conn.get_pager_from_database_index(&db_id);
+                    let attached_pager = conn
+                        .get_pager_from_database_index(&db_id)
+                        .expect("attached MVCC transaction should always have a pager");
                     conn.publish_database_schema(db_id);
                     conn.set_mv_tx_for_db(db_id, None);
                     attached_pager.end_read_tx();
@@ -1862,7 +1867,9 @@ impl Program {
             };
             match state_machine.step(&attached_mv_store)? {
                 IOResult::Done(_) => {
-                    let attached_pager = conn.get_pager_from_database_index(&db_id);
+                    let attached_pager = conn
+                        .get_pager_from_database_index(&db_id)
+                        .expect("attached MVCC transaction should always have a pager");
                     conn.publish_database_schema(db_id);
                     conn.set_mv_tx_for_db(db_id, None);
                     attached_pager.end_read_tx();
@@ -2015,11 +2022,21 @@ impl Program {
 
     /// End read transactions on all attached databases that had transactions started.
     fn end_attached_read_txns(&self, connection: &Connection) {
-        for attached_pager in connection.get_all_attached_pagers() {
-            if attached_pager.holds_read_lock() {
-                attached_pager.end_read_tx();
-            }
-        }
+        connection.with_all_attached_pagers_with_index(|pagers| {
+            pagers.iter().for_each(|(db_id, attached_pager)| {
+                if connection.mv_store_for_db(*db_id).is_some() {
+                    // MVCC-enabled attached DBs don't use WAL read transactions, so skip.
+                    return;
+                }
+                if attached_pager.holds_write_lock() {
+                    // Attached pager has a write lock, so its read transaction was ended by end_attached_write_txns: skip.
+                    return;
+                }
+                if attached_pager.holds_read_lock() {
+                    attached_pager.end_read_tx();
+                }
+            });
+        })
     }
 
     #[instrument(skip(self, commit_state, mv_store), level = Level::DEBUG)]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2231,31 +2231,7 @@ impl Program {
     }
 
     fn rollback_current_txn(&self, pager: &Arc<Pager>) {
-        if let Some(mv_store) = self.connection.mv_store().as_ref() {
-            if let Some(tx_id) = self.connection.get_mv_tx_id() {
-                self.connection.auto_commit.store(true, Ordering::SeqCst);
-                mv_store.rollback_tx(tx_id, pager.clone(), &self.connection, crate::MAIN_DB_ID);
-            }
-            pager.end_read_tx();
-            self.connection.rollback_attached_mvcc_txs(true);
-        } else {
-            let tx_state = self.connection.get_tx_state();
-            let has_attached_write = self
-                .connection
-                .get_all_attached_pagers()
-                .iter()
-                .any(|attached_pager| attached_pager.holds_write_lock());
-            match tx_state {
-                TransactionState::Write { .. } => pager.rollback_tx(&self.connection),
-                _ if pager.holds_write_lock() => pager.rollback_attached(),
-                _ if has_attached_write => pager.cleanup_read_tx(),
-                _ => pager.rollback_tx(&self.connection),
-            }
-            self.connection.auto_commit.store(true, Ordering::SeqCst);
-        }
-        self.connection.rollback_attached_wal_txns();
-        self.connection.rollback_temp_schema();
-        self.connection.set_tx_state(TransactionState::None);
+        self.connection.rollback_current_txn_state(pager, true);
     }
 
     pub fn is_trigger_subprogram(&self) -> bool {

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -156,6 +156,7 @@ The SQL shell supports the following command line options:
 | `--mcp` | Start a MCP server instead of the interactive shell |
 | `--experimental-encryption` | Enable experimental encryption at rest feature. **Note:** the feature is not production ready so do not use it for critical data right now. |
 | `--experimental-views` | Enable experimental views feature. **Note**: the feature is not production ready so do not use it for critical data right now. |
+| `--experimental-multiprocess-wal` | Enable experimental multi-process WAL coordination via the `.tshm` sidecar. **Note:** the feature is not production ready so do not use it for critical data right now. |
 
 ## Transactions
 

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -661,6 +661,7 @@ impl TursoDatabase {
                                 "encryption" => opts.with_encryption(true),
                                 "attach" => opts.with_attach(true),
                                 "generated_columns" => opts.with_generated_columns(true),
+                                "multiprocess_wal" => opts.with_multiprocess_wal(true),
                                 _ => opts,
                             };
                         }

--- a/testing/concurrent-simulator/Cargo.toml
+++ b/testing/concurrent-simulator/Cargo.toml
@@ -36,6 +36,7 @@ turso_parser = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 hex = "0.4.3"
+twox-hash = { version = "2.1.1", optional = true }
 
 [features]
-checksum = ["turso_core/checksum"]
+checksum = ["turso_core/checksum", "twox-hash"]

--- a/testing/concurrent-simulator/Cargo.toml
+++ b/testing/concurrent-simulator/Cargo.toml
@@ -31,8 +31,10 @@ rand_chacha = { workspace = true }
 sql_generation = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-turso_core = { workspace = true, features = ["simulator"]}
+turso_core = { workspace = true, features = ["simulator", "fs"]}
 turso_parser = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 hex = "0.4.3"
 
 [features]

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -21,8 +21,11 @@ use turso_parser::ast::{ColumnConstraint, SortOrder};
 pub mod chaotic_elle;
 pub mod elle;
 mod io;
-mod operations;
+pub mod multiprocess;
+pub mod operations;
 pub mod properties;
+pub mod protocol;
+pub mod worker;
 pub mod workloads;
 mod yield_injection;
 
@@ -353,6 +356,8 @@ pub struct Stats {
     pub elle_writes: usize,
     /// Elle-mode: read operations (list-read + rw-read)
     pub elle_reads: usize,
+    /// Multiprocess: corruption events detected and survived
+    pub corruption_events: usize,
 }
 
 /// Result of a single simulation step.
@@ -715,6 +720,18 @@ impl Whopper {
             let txn_id = ctx.fiber.txn_id;
 
             let op_result = step_result.map(|_| rows);
+
+            if matches!(
+                &op_result,
+                Err(turso_core::LimboError::Busy
+                    | turso_core::LimboError::BusySnapshot
+                    | turso_core::LimboError::WriteWriteConflict
+                    | turso_core::LimboError::CommitDependencyAborted)
+            ) && ctx.fiber.connection.get_auto_commit()
+            {
+                let _ = ctx.fiber.connection.execute("ROLLBACK");
+            }
+
             completed_op.finish_op(&mut ctx, &op_result);
 
             for property in &self.properties {
@@ -1096,7 +1113,7 @@ fn may_be_set_encryption(
     Ok(conn)
 }
 
-fn create_initial_indexes(rng: &mut ChaCha8Rng, tables: &[Table]) -> Vec<CreateIndex> {
+pub fn create_initial_indexes(rng: &mut ChaCha8Rng, tables: &[Table]) -> Vec<CreateIndex> {
     let mut indexes = Vec::new();
 
     // Create 0-3 indexes per table
@@ -1141,7 +1158,7 @@ fn create_initial_indexes(rng: &mut ChaCha8Rng, tables: &[Table]) -> Vec<CreateI
     indexes
 }
 
-fn create_initial_schema(rng: &mut ChaCha8Rng) -> Vec<Create> {
+pub fn create_initial_schema(rng: &mut ChaCha8Rng) -> Vec<Create> {
     let mut schema = Vec::new();
 
     // Generate random number of tables (1-5)

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -21,10 +21,13 @@ use turso_parser::ast::{ColumnConstraint, SortOrder};
 pub mod chaotic_elle;
 pub mod elle;
 mod io;
+#[cfg(all(unix, target_pointer_width = "64"))]
 pub mod multiprocess;
 pub mod operations;
 pub mod properties;
+#[cfg(all(unix, target_pointer_width = "64"))]
 pub mod protocol;
+#[cfg(all(unix, target_pointer_width = "64"))]
 pub mod worker;
 pub mod workloads;
 mod yield_injection;

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -36,6 +36,12 @@ struct Args {
     /// Max connections
     #[arg(long, default_value_t = 4)]
     max_connections: usize,
+    /// Number of worker processes in multiprocess mode. Defaults to `max_connections`.
+    #[arg(long)]
+    processes: Option<usize>,
+    /// Number of connections opened inside each worker process in multiprocess mode.
+    #[arg(long, default_value_t = 1)]
+    connections_per_process: usize,
     #[arg(long, default_value_t = 0.0)]
     reopen_probability: f64,
     /// Max steps
@@ -83,6 +89,9 @@ enum SubCmd {
         /// Enable MVCC mode
         #[arg(long)]
         enable_mvcc: bool,
+        /// Number of connections to open inside this worker process
+        #[arg(long, default_value_t = 1)]
+        connections_per_process: usize,
     },
 }
 
@@ -94,10 +103,11 @@ fn main() -> anyhow::Result<()> {
     if let Some(SubCmd::Worker {
         db_path,
         enable_mvcc,
+        connections_per_process,
     }) = &args.subcommand
     {
         #[cfg(all(unix, target_pointer_width = "64"))]
-        return turso_whopper::worker::run_worker(db_path, *enable_mvcc);
+        return turso_whopper::worker::run_worker(db_path, *enable_mvcc, *connections_per_process);
     }
 
     init_logger();
@@ -138,10 +148,12 @@ fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
 
     let (workloads, properties, elle_tables, chaotic_profiles) =
         build_workloads_and_properties(args);
+    let process_count = args.processes.unwrap_or(args.max_connections);
 
     let opts = MultiprocessOpts {
         seed: Some(seed),
-        max_connections: args.max_connections,
+        process_count,
+        connections_per_process: args.connections_per_process,
         max_steps,
         enable_mvcc: args.enable_mvcc,
         elle_tables,
@@ -154,7 +166,12 @@ fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
         keep_files: args.keep,
     };
 
-    println!("multiprocess = true ({} workers)", args.max_connections);
+    println!(
+        "multiprocess = true ({} processes, {} connections/process, {} total connections)",
+        process_count,
+        args.connections_per_process,
+        process_count.saturating_mul(args.connections_per_process)
+    );
     if args.kill_probability > 0.0 {
         println!("kill_probability = {}", args.kill_probability);
     }

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -5,10 +5,11 @@ use std::sync::Arc;
 use clap::{Parser, Subcommand, ValueEnum};
 use rand::{Rng, RngCore};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+#[cfg(all(unix, target_pointer_width = "64"))]
+use turso_whopper::multiprocess::{MultiprocessOpts, MultiprocessWhopper};
 use turso_whopper::{
     StepResult, Whopper, WhopperOpts,
     chaotic_elle::{ChaoticElleProfile, ChaoticWorkloadProfile, ElleModelKind},
-    multiprocess::{MultiprocessOpts, MultiprocessWhopper},
     properties::*,
     workloads::*,
 };
@@ -95,6 +96,7 @@ fn main() -> anyhow::Result<()> {
         enable_mvcc,
     }) = &args.subcommand
     {
+        #[cfg(all(unix, target_pointer_width = "64"))]
         return turso_whopper::worker::run_worker(db_path, *enable_mvcc);
     }
 
@@ -113,12 +115,14 @@ fn main() -> anyhow::Result<()> {
     println!("seed = {seed}");
 
     if args.multiprocess {
+        #[cfg(all(unix, target_pointer_width = "64"))]
         return run_multiprocess(&args, seed);
     }
 
     run_inprocess(&args, seed)
 }
 
+#[cfg(all(unix, target_pointer_width = "64"))]
 fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
     if args.enable_mvcc {
         eprintln!("MVCC mode not yet supported with multiprocess mode");

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -2,12 +2,13 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use clap::{Parser, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 use rand::{Rng, RngCore};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 use turso_whopper::{
     StepResult, Whopper, WhopperOpts,
     chaotic_elle::{ChaoticElleProfile, ChaoticWorkloadProfile, ElleModelKind},
+    multiprocess::{MultiprocessOpts, MultiprocessWhopper},
     properties::*,
     workloads::*,
 };
@@ -25,6 +26,9 @@ enum ElleModel {
 #[command(name = "turso_whopper")]
 #[command(about = "The Turso Whopper Simulator")]
 struct Args {
+    #[command(subcommand)]
+    subcommand: Option<SubCmd>,
+
     /// Simulation mode (fast, chaos, ragnarök/ragnarok)
     #[arg(long, default_value = "fast")]
     mode: String,
@@ -36,7 +40,7 @@ struct Args {
     /// Max steps
     #[arg(long)]
     max_steps: Option<usize>,
-    /// Keep mmap I/O files on disk after run
+    /// Keep files on disk after run
     #[arg(long)]
     keep: bool,
     /// Enable MVCC (Multi-Version Concurrency Control)
@@ -54,12 +58,47 @@ struct Args {
     /// Dump database files to simulator-output directory after run
     #[arg(long)]
     dump_db: bool,
+    /// Run in multiprocess mode (spawns OS processes instead of in-process fibers)
+    #[arg(long)]
+    multiprocess: bool,
+    /// Probability of killing a worker process per step (multiprocess mode only)
+    #[arg(long, default_value_t = 0.0)]
+    kill_probability: f64,
+    /// Probability of restarting the full worker cohort per step (multiprocess mode only)
+    #[arg(long, default_value_t = 0.0)]
+    restart_probability: f64,
+    /// Stream multiprocess operation/lifecycle history as JSONL for deterministic debugging
+    #[arg(long)]
+    history_output: Option<PathBuf>,
+}
+
+#[derive(Subcommand)]
+enum SubCmd {
+    /// Run as a worker process (internal, called by multiprocess coordinator)
+    Worker {
+        /// Path to the database file
+        #[arg(long)]
+        db_path: String,
+        /// Enable MVCC mode
+        #[arg(long)]
+        enable_mvcc: bool,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
-    init_logger();
-
     let args = Args::parse();
+
+    // Dispatch to worker BEFORE init_logger so the worker can install its own
+    // stderr-only subscriber without the coordinator's logger polluting stdout.
+    if let Some(SubCmd::Worker {
+        db_path,
+        enable_mvcc,
+    }) = &args.subcommand
+    {
+        return turso_whopper::worker::run_worker(db_path, *enable_mvcc);
+    }
+
+    init_logger();
 
     let seed = std::env::var("SEED")
         .ok()
@@ -73,7 +112,93 @@ fn main() -> anyhow::Result<()> {
     println!("mode = {}", args.mode);
     println!("seed = {seed}");
 
-    let opts = build_opts(&args, seed)?;
+    if args.multiprocess {
+        return run_multiprocess(&args, seed);
+    }
+
+    run_inprocess(&args, seed)
+}
+
+fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
+    if args.enable_mvcc {
+        eprintln!("MVCC mode not yet supported with multiprocess mode");
+        std::process::exit(1);
+    }
+    let base_max_steps = match args.mode.as_str() {
+        "fast" => 100_000,
+        "chaos" => 10_000_000,
+        "ragnarök" | "ragnarok" => 1_000_000,
+        mode => return Err(anyhow::anyhow!("Unknown mode: {}", mode)),
+    };
+    let max_steps = args.max_steps.unwrap_or(base_max_steps);
+
+    let (workloads, properties, elle_tables, chaotic_profiles) =
+        build_workloads_and_properties(args);
+
+    let opts = MultiprocessOpts {
+        seed: Some(seed),
+        max_connections: args.max_connections,
+        max_steps,
+        enable_mvcc: args.enable_mvcc,
+        elle_tables,
+        workloads,
+        properties,
+        chaotic_profiles,
+        kill_probability: args.kill_probability,
+        restart_probability: args.restart_probability,
+        history_output: args.history_output.clone(),
+        keep_files: args.keep,
+    };
+
+    println!("multiprocess = true ({} workers)", args.max_connections);
+    if args.kill_probability > 0.0 {
+        println!("kill_probability = {}", args.kill_probability);
+    }
+    if args.restart_probability > 0.0 {
+        println!("restart_probability = {}", args.restart_probability);
+    }
+    if let Some(path) = &args.history_output {
+        println!("history_output = {}", path.display());
+    }
+
+    let mut whopper = MultiprocessWhopper::new(opts)?;
+
+    let progress_interval = max_steps / 10;
+    let elle_mode = args.elle.is_some();
+    let progress_stages = progress_art(elle_mode);
+    let mut progress_index = 0;
+    println!("{}", progress_stages[progress_index]);
+    progress_index += 1;
+
+    while !whopper.is_done() {
+        whopper.step()?;
+
+        if progress_interval > 0 && whopper.current_step % progress_interval == 0 {
+            let stats = &whopper.stats;
+            let counts = format_stats(stats, elle_mode);
+            println!("{}{}", progress_stages[progress_index], counts);
+            progress_index += 1;
+        }
+    }
+
+    whopper.finalize()?;
+
+    if whopper.stats.corruption_events > 0 {
+        println!(
+            "\nWARNING: {} corruption events detected during simulation",
+            whopper.stats.corruption_events
+        );
+    }
+
+    if args.elle.is_some() {
+        println!("\nElle history exported to: {}", args.elle_output);
+    }
+
+    Ok(())
+}
+
+fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
+    let opts = build_inprocess_opts(args, seed)?;
 
     if opts.cosmic_ray_probability > 0.0 {
         println!("cosmic ray probability = {}", opts.cosmic_ray_probability);
@@ -84,23 +209,7 @@ fn main() -> anyhow::Result<()> {
     let max_steps = whopper.max_steps;
     let progress_interval = max_steps / 10;
     let elle_mode = args.elle.is_some();
-    let progress_stages = [
-        if elle_mode {
-            "       .             W/R"
-        } else {
-            "       .             I/U/D/C"
-        },
-        "       .             ",
-        "       .             ",
-        "       |             ",
-        "       |             ",
-        "      ╱|╲            ",
-        "     ╱╲|╱╲           ",
-        "    ╱╲╱|╲╱╲          ",
-        "   ╱╲╱╲|╱╲╱╲         ",
-        "  ╱╲╱╲╱|╲╱╲╱╲        ",
-        " ╱╲╱╲╱╲|╱╲╱╲╱╲       ",
-    ];
+    let progress_stages = progress_art(elle_mode);
     let mut progress_index = 0;
     println!("{}", progress_stages[progress_index]);
     progress_index += 1;
@@ -116,55 +225,29 @@ fn main() -> anyhow::Result<()> {
 
         if progress_interval > 0 && whopper.current_step % progress_interval == 0 {
             let stats = &whopper.stats;
-            let counts = if elle_mode {
-                format!("{}/{}", stats.elle_writes, stats.elle_reads)
-            } else {
-                format!(
-                    "{}/{}/{}/{}",
-                    stats.inserts, stats.updates, stats.deletes, stats.integrity_checks
-                )
-            };
+            let counts = format_stats(stats, elle_mode);
             println!("{}{}", progress_stages[progress_index], counts);
             progress_index += 1;
         }
     }
 
-    // Finalize properties (e.g., export Elle history)
     whopper.finalize_properties()?;
 
-    // Dump database files if requested
     if args.dump_db {
         whopper.dump_db_files()?;
     }
 
-    // Print Elle analysis instructions if enabled
     if args.elle.is_some() {
-        let output_path = &args.elle_output;
-        println!("\nElle history exported to: {output_path}");
+        println!("\nElle history exported to: {}", args.elle_output);
     }
 
     Ok(())
 }
 
-fn build_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
-    let mut base_opts = match args.mode.as_str() {
-        "fast" => WhopperOpts::fast(),
-        "chaos" => WhopperOpts::chaos(),
-        "ragnarök" | "ragnarok" => WhopperOpts::ragnarok(),
-        mode => return Err(anyhow::anyhow!("Unknown mode: {}", mode)),
-    };
-
-    if let Some(max_steps) = args.max_steps {
-        base_opts = base_opts.with_max_steps(max_steps);
-    }
-
-    // Build workloads and properties based on Elle mode
-    let (workloads, properties, elle_tables, chaotic_profiles) = if let Some(elle_model) = args.elle
-    {
-        // Shared counter ensures globally unique values across all Elle workloads
+fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
+    if let Some(elle_model) = args.elle {
         let elle_counter = Arc::new(std::sync::atomic::AtomicI64::new(1));
 
-        // Elle mode: only Elle workloads + transactions
         let (table_name, create_sql) = match elle_model {
             ElleModel::ListAppend => (
                 "elle_lists",
@@ -214,14 +297,11 @@ fn build_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
 
         let output_path = PathBuf::from(&args.elle_output);
         let p: Vec<Box<dyn Property>> = vec![Box::new(ElleHistoryRecorder::new(output_path))];
-
         let et = vec![(table_name.to_string(), create_sql.to_string())];
 
         (w, p, et, chaotic)
     } else {
-        // Normal mode: all workloads
         let w: Vec<(u32, Box<dyn Workload>)> = vec![
-            // Idle-only workloads
             (10, Box::new(IntegrityCheckWorkload)),
             (5, Box::new(WalCheckpointWorkload)),
             (10, Box::new(CreateSimpleTableWorkload)),
@@ -229,10 +309,8 @@ fn build_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
             (20, Box::new(SimpleInsertWorkload)),
             (15, Box::new(UpdateWorkload)),
             (15, Box::new(DeleteWorkload)),
-            // Index workloads
             (2, Box::new(CreateIndexWorkload)),
             (2, Box::new(DropIndexWorkload)),
-            // Transaction workloads
             (30, Box::new(BeginWorkload)),
             (10, Box::new(CommitWorkload)),
             (10, Box::new(RollbackWorkload)),
@@ -244,7 +322,29 @@ fn build_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         ];
 
         (w, p, vec![], vec![])
+    }
+}
+
+type WorkerWorkloads = Vec<(u32, Box<dyn Workload>)>;
+type PropertyList = Vec<Box<dyn Property>>;
+type TableSchemas = Vec<(String, String)>;
+type ChaosProfiles = Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)>;
+type BuildArtifacts = (WorkerWorkloads, PropertyList, TableSchemas, ChaosProfiles);
+
+fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
+    let mut base_opts = match args.mode.as_str() {
+        "fast" => WhopperOpts::fast(),
+        "chaos" => WhopperOpts::chaos(),
+        "ragnarök" | "ragnarok" => WhopperOpts::ragnarok(),
+        mode => return Err(anyhow::anyhow!("Unknown mode: {}", mode)),
     };
+
+    if let Some(max_steps) = args.max_steps {
+        base_opts = base_opts.with_max_steps(max_steps);
+    }
+
+    let (workloads, properties, elle_tables, chaotic_profiles) =
+        build_workloads_and_properties(args);
 
     let opts = base_opts
         .with_seed(seed)
@@ -258,6 +358,37 @@ fn build_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         .with_chaotic_profiles(chaotic_profiles);
 
     Ok(opts)
+}
+
+fn format_stats(stats: &turso_whopper::Stats, elle_mode: bool) -> String {
+    if elle_mode {
+        format!("{}/{}", stats.elle_writes, stats.elle_reads)
+    } else {
+        format!(
+            "{}/{}/{}/{}",
+            stats.inserts, stats.updates, stats.deletes, stats.integrity_checks
+        )
+    }
+}
+
+fn progress_art(elle_mode: bool) -> [&'static str; 11] {
+    [
+        if elle_mode {
+            "       .             W/R"
+        } else {
+            "       .             I/U/D/C"
+        },
+        "       .             ",
+        "       .             ",
+        "       |             ",
+        "       |             ",
+        "      ╱|╲            ",
+        "     ╱╲|╱╲           ",
+        "    ╱╲╱|╲╱╲          ",
+        "   ╱╲╱╲|╱╲╱╲         ",
+        "  ╱╲╱╲╱|╲╱╲╱╲        ",
+        " ╱╲╱╲╱╲|╱╲╱╲╱╲       ",
+    ]
 }
 
 fn init_logger() {

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -1,0 +1,1310 @@
+//! Multiprocess coordinator for Whopper.
+//!
+//! Spawns N worker processes, each opening the same on-disk database with real
+//! filesystem I/O. Reuses the existing workload generation and property
+//! validation infrastructure while exercising the full multiprocess coordination
+//! stack (OFD locks, .tshm shared memory, WAL reader slots, MVCC tx slots).
+
+use serde::Serialize;
+use std::fs::{File, create_dir_all};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rand::{Rng, RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use sql_generation::generation::Opts;
+use tracing::{debug, error, info};
+use turso_core::{Database, DatabaseOpts, LimboError, OpenFlags, UnixIO};
+
+use crate::chaotic_elle::{ChaoticWorkload, ChaoticWorkloadProfile};
+use crate::operations::{FiberState, OpResult, Operation, TxMode};
+use crate::properties::Property;
+use crate::protocol::{
+    WorkerCommand, WorkerResponse, WorkerSharedWalSnapshot, WorkerStartupTelemetry,
+};
+use crate::workloads::{Workload, WorkloadContext};
+use crate::{SimulatorState, Stats, StepResult, create_initial_indexes, create_initial_schema};
+
+/// Configuration for the multiprocess simulator.
+pub struct MultiprocessOpts {
+    pub seed: Option<u64>,
+    pub enable_mvcc: bool,
+    pub max_connections: usize,
+    pub max_steps: usize,
+    pub elle_tables: Vec<(String, String)>,
+    pub workloads: Vec<(u32, Box<dyn Workload>)>,
+    pub properties: Vec<Box<dyn Property>>,
+    pub chaotic_profiles: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)>,
+    pub kill_probability: f64,
+    pub restart_probability: f64,
+    pub history_output: Option<PathBuf>,
+    pub keep_files: bool,
+}
+
+struct OperationHistoryWriter {
+    output: Option<BufWriter<File>>,
+}
+
+impl OperationHistoryWriter {
+    fn new(output_path: Option<&Path>) -> anyhow::Result<Self> {
+        let output = if let Some(path) = output_path {
+            if let Some(parent) = path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    create_dir_all(parent)?;
+                }
+            }
+            Some(BufWriter::new(File::create(path)?))
+        } else {
+            None
+        };
+        Ok(Self { output })
+    }
+
+    fn record(&mut self, event: &HistoryEvent) -> anyhow::Result<()> {
+        let Some(output) = self.output.as_mut() else {
+            return Ok(());
+        };
+
+        serde_json::to_writer(&mut *output, event)?;
+        output.write_all(b"\n")?;
+        output.flush()?;
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum HistoryEvent {
+    WorkerSpawned {
+        step: Option<usize>,
+        worker: usize,
+        pid: u32,
+        reason: &'static str,
+        telemetry: WorkerStartupTelemetry,
+    },
+    WorkerKilled {
+        step: usize,
+        worker: usize,
+        pid: u32,
+        reason: &'static str,
+    },
+    WorkerStateAborted {
+        step: usize,
+        worker: usize,
+        reason: &'static str,
+        txn_id: Option<u64>,
+        exec_id: Option<u64>,
+        fiber_state: String,
+        current_op: Option<String>,
+    },
+    CohortRestartStarted {
+        step: usize,
+        worker_count: usize,
+    },
+    OperationStarted {
+        step: usize,
+        worker: usize,
+        exec_id: u64,
+        txn_id: Option<u64>,
+        op: String,
+        sql: String,
+    },
+    OperationFinished {
+        step: usize,
+        worker: usize,
+        exec_id: u64,
+        txn_id: Option<u64>,
+        op: String,
+        sql: String,
+        result: HistoryResult,
+    },
+    OperationTransportFailure {
+        step: usize,
+        worker: usize,
+        exec_id: Option<u64>,
+        txn_id: Option<u64>,
+        op: Option<String>,
+        sql: Option<String>,
+        error: String,
+    },
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum HistoryResult {
+    Ok { rows: Vec<Vec<turso_core::Value>> },
+    Err { error_kind: String, message: String },
+}
+
+impl From<&OpResult> for HistoryResult {
+    fn from(result: &OpResult) -> Self {
+        match result {
+            Ok(rows) => Self::Ok { rows: rows.clone() },
+            Err(error) => Self::Err {
+                error_kind: crate::protocol::limbo_error_to_kind(error).to_string(),
+                message: error.to_string(),
+            },
+        }
+    }
+}
+
+/// Handle for a worker child process.
+struct WorkerHandle {
+    child: Child,
+    stdin: BufWriter<ChildStdin>,
+    responses: Receiver<anyhow::Result<WorkerResponse>>,
+    worker_id: usize,
+}
+
+/// Mirror of each worker's state, maintained by the coordinator.
+struct WorkerState {
+    fiber_state: FiberState,
+    txn_id: Option<u64>,
+    execution_id: Option<u64>,
+    current_op: Option<Operation>,
+    chaotic_workload: Option<Box<dyn ChaoticWorkload>>,
+    last_chaotic_result: Option<OpResult>,
+}
+
+impl WorkerState {
+    fn new() -> Self {
+        Self {
+            fiber_state: FiberState::Idle,
+            txn_id: None,
+            execution_id: None,
+            current_op: None,
+            chaotic_workload: None,
+            last_chaotic_result: None,
+        }
+    }
+}
+
+/// The multiprocess Whopper coordinator.
+pub struct MultiprocessWhopper {
+    workers: Vec<WorkerHandle>,
+    worker_states: Vec<WorkerState>,
+    sim_state: SimulatorState,
+    worker_startup_telemetries: Vec<WorkerStartupTelemetry>,
+    history: OperationHistoryWriter,
+    workloads: Vec<(u32, Box<dyn Workload>)>,
+    properties: Vec<std::sync::Mutex<Box<dyn Property>>>,
+    chaotic_profiles: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)>,
+    total_weight: u32,
+    opts: Opts,
+    pub rng: ChaCha8Rng,
+    pub current_step: usize,
+    pub max_steps: usize,
+    pub seed: u64,
+    pub stats: Stats,
+    db_path: PathBuf,
+    enable_mvcc: bool,
+    kill_probability: f64,
+    restart_probability: f64,
+    keep_files: bool,
+}
+
+impl MultiprocessWhopper {
+    /// Create a new multiprocess coordinator.
+    /// Bootstraps the database schema, then spawns worker processes.
+    pub fn new(opts: MultiprocessOpts) -> anyhow::Result<Self> {
+        let seed = opts.seed.unwrap_or_else(|| {
+            let mut rng = rand::rng();
+            rng.next_u64()
+        });
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+
+        // Create database file on disk
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock is before UNIX_EPOCH")
+            .as_nanos();
+        let db_path = PathBuf::from(format!(
+            "/tmp/whopper-mp-{}-{}-{}.db",
+            seed,
+            std::process::id(),
+            unique_suffix
+        ));
+        info!("multiprocess db: {}", db_path.display());
+
+        // Bootstrap schema using real I/O
+        {
+            let io = Arc::new(UnixIO::new()?);
+            let db = Database::open_file_with_flags(
+                io,
+                db_path.to_str().unwrap(),
+                OpenFlags::default(),
+                DatabaseOpts::new(),
+                None,
+            )?;
+            let conn = db.connect()?;
+
+            if opts.enable_mvcc {
+                conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+            }
+
+            let schema = create_initial_schema(&mut rng);
+            let tables = schema.iter().map(|t| t.table.clone()).collect::<Vec<_>>();
+            for create_table in &schema {
+                conn.execute(create_table.to_string())?;
+            }
+
+            let indexes = create_initial_indexes(&mut rng, &tables);
+            for create_index in &indexes {
+                conn.execute(create_index.to_string())?;
+            }
+
+            for (_, create_sql) in &opts.elle_tables {
+                conn.execute(create_sql)?;
+            }
+
+            // Checkpoint to ensure all schema changes are in the main DB file
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+            conn.close()?;
+            // db + io dropped here, releasing all file locks
+        }
+
+        // Remove the coordination file - it gets invalidated (truncated to 0) on close.
+        // Workers will recreate it when they open the database.
+        // The WAL and log files contain actual data and must be kept.
+        let db_str = db_path.to_str().unwrap_or_default();
+        let _ = std::fs::remove_file(format!("{db_str}-tshm"));
+
+        // Build initial simulator state from the schema we just created
+        let mut schema_rng = ChaCha8Rng::seed_from_u64(seed);
+        let schema = create_initial_schema(&mut schema_rng);
+        let tables = schema.iter().map(|t| t.table.clone()).collect::<Vec<_>>();
+        let indexes = create_initial_indexes(&mut schema_rng, &tables);
+        let indexes_vec: Vec<(String, String)> = indexes
+            .iter()
+            .map(|idx| (idx.table_name.clone(), idx.index_name.clone()))
+            .collect();
+        let mut sim_state = SimulatorState::new(tables, indexes_vec);
+        for (table_name, _) in &opts.elle_tables {
+            sim_state.elle_tables.insert(table_name.clone(), ());
+        }
+
+        let total_weight: u32 = opts.workloads.iter().map(|(w, _)| w).sum();
+
+        // Spawn worker processes one at a time.
+        // Each worker must fully initialize (open DB, create .tshm) before the next
+        // starts, to avoid races on coordination file creation.
+        let mut workers = Vec::new();
+        let mut worker_states = Vec::new();
+        let mut worker_startup_telemetries = Vec::new();
+        let mut history = OperationHistoryWriter::new(opts.history_output.as_deref())?;
+        for i in 0..opts.max_connections {
+            let (handle, telemetry) = spawn_ready_worker(i, &db_path, opts.enable_mvcc)?;
+            debug!("worker {} ready: {:?}", handle.worker_id, telemetry);
+            history.record(&HistoryEvent::WorkerSpawned {
+                step: None,
+                worker: i,
+                pid: handle.child.id(),
+                reason: "initial_spawn",
+                telemetry,
+            })?;
+            worker_startup_telemetries.push(telemetry);
+            workers.push(handle);
+            worker_states.push(WorkerState::new());
+        }
+
+        info!("all {} workers ready", workers.len());
+
+        Ok(Self {
+            workers,
+            worker_states,
+            sim_state,
+            worker_startup_telemetries,
+            history,
+            workloads: opts.workloads,
+            properties: opts
+                .properties
+                .into_iter()
+                .map(std::sync::Mutex::new)
+                .collect(),
+            chaotic_profiles: opts.chaotic_profiles,
+            total_weight,
+            opts: Opts::default(),
+            rng,
+            current_step: 0,
+            max_steps: opts.max_steps,
+            seed,
+            stats: Stats::default(),
+            db_path,
+            enable_mvcc: opts.enable_mvcc,
+            kill_probability: opts.kill_probability,
+            restart_probability: opts.restart_probability,
+            keep_files: opts.keep_files,
+        })
+    }
+
+    /// Check if the simulation is complete.
+    pub fn is_done(&self) -> bool {
+        self.current_step >= self.max_steps
+    }
+
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    pub fn worker_startup_telemetries(&self) -> &[WorkerStartupTelemetry] {
+        &self.worker_startup_telemetries
+    }
+
+    /// Execute SQL directly on one worker without involving workload generation.
+    /// This is used by deterministic restart regressions.
+    pub fn execute_sql_direct(
+        &mut self,
+        worker_idx: usize,
+        sql: impl Into<String>,
+    ) -> anyhow::Result<OpResult> {
+        let sql = sql.into();
+        send_command(
+            &mut self.workers[worker_idx],
+            &WorkerCommand::Execute { sql },
+        )?;
+        let response = recv_response(&mut self.workers[worker_idx])?;
+        Ok(response.into_op_result())
+    }
+
+    /// Execute SQL on an idle worker that is not currently inside a simulated transaction.
+    pub fn execute_sql_via_idle_worker(
+        &mut self,
+        sql: impl Into<String>,
+    ) -> anyhow::Result<(usize, OpResult)> {
+        let worker_idx = self
+            .worker_states
+            .iter()
+            .enumerate()
+            .find_map(|(idx, state)| {
+                (state.fiber_state == FiberState::Idle
+                    && state.txn_id.is_none()
+                    && state.execution_id.is_none()
+                    && state.current_op.is_none()
+                    && state.chaotic_workload.is_none()
+                    && state.last_chaotic_result.is_none())
+                .then_some(idx)
+            })
+            .ok_or_else(|| anyhow::anyhow!("no idle worker available for probe"))?;
+        let result = self.execute_sql_direct(worker_idx, sql)?;
+        Ok((worker_idx, result))
+    }
+
+    pub fn disable_auto_checkpoint_direct(&mut self, worker_idx: usize) -> anyhow::Result<()> {
+        send_command(
+            &mut self.workers[worker_idx],
+            &WorkerCommand::DisableAutoCheckpoint,
+        )?;
+        match recv_response(&mut self.workers[worker_idx])? {
+            WorkerResponse::Ack => Ok(()),
+            other => Err(anyhow::anyhow!(
+                "worker {} returned unexpected response to DisableAutoCheckpoint: {:?}",
+                worker_idx,
+                other
+            )),
+        }
+    }
+
+    pub fn passive_checkpoint_direct(
+        &mut self,
+        worker_idx: usize,
+        upper_bound_inclusive: Option<u64>,
+    ) -> anyhow::Result<()> {
+        send_command(
+            &mut self.workers[worker_idx],
+            &WorkerCommand::PassiveCheckpoint {
+                upper_bound_inclusive,
+            },
+        )?;
+        match recv_response(&mut self.workers[worker_idx])? {
+            WorkerResponse::Ack => Ok(()),
+            other => Err(anyhow::anyhow!(
+                "worker {} returned unexpected response to PassiveCheckpoint: {:?}",
+                worker_idx,
+                other
+            )),
+        }
+    }
+
+    pub fn clear_backfill_proof_direct(&mut self, worker_idx: usize) -> anyhow::Result<()> {
+        send_command(
+            &mut self.workers[worker_idx],
+            &WorkerCommand::ClearBackfillProof,
+        )?;
+        match recv_response(&mut self.workers[worker_idx])? {
+            WorkerResponse::Ack => Ok(()),
+            other => Err(anyhow::anyhow!(
+                "worker {} returned unexpected response to ClearBackfillProof: {:?}",
+                worker_idx,
+                other
+            )),
+        }
+    }
+
+    pub fn install_unpublished_backfill_proof_direct(
+        &mut self,
+        worker_idx: usize,
+        upper_bound_inclusive: u64,
+    ) -> anyhow::Result<()> {
+        send_command(
+            &mut self.workers[worker_idx],
+            &WorkerCommand::InstallUnpublishedBackfillProof {
+                upper_bound_inclusive,
+            },
+        )?;
+        match recv_response(&mut self.workers[worker_idx])? {
+            WorkerResponse::Ack => Ok(()),
+            other => Err(anyhow::anyhow!(
+                "worker {} returned unexpected response to InstallUnpublishedBackfillProof: {:?}",
+                worker_idx,
+                other
+            )),
+        }
+    }
+
+    pub fn shared_wal_snapshot_direct(
+        &mut self,
+        worker_idx: usize,
+    ) -> anyhow::Result<Option<WorkerSharedWalSnapshot>> {
+        send_command(
+            &mut self.workers[worker_idx],
+            &WorkerCommand::ReadSharedWalSnapshot,
+        )?;
+        match recv_response(&mut self.workers[worker_idx])? {
+            WorkerResponse::SharedWalSnapshot { snapshot } => Ok(snapshot),
+            other => Err(anyhow::anyhow!(
+                "worker {} returned unexpected response to ReadSharedWalSnapshot: {:?}",
+                worker_idx,
+                other
+            )),
+        }
+    }
+
+    pub fn find_frame_for_page_direct(
+        &mut self,
+        worker_idx: usize,
+        page_id: u64,
+    ) -> anyhow::Result<Option<u64>> {
+        send_command(
+            &mut self.workers[worker_idx],
+            &WorkerCommand::FindFrameForPage { page_id },
+        )?;
+        match recv_response(&mut self.workers[worker_idx])? {
+            WorkerResponse::FrameLookup { frame_id } => Ok(frame_id),
+            other => Err(anyhow::anyhow!(
+                "worker {} returned unexpected response to FindFrameForPage: {:?}",
+                worker_idx,
+                other
+            )),
+        }
+    }
+
+    /// Execute SQL through a brand-new worker process, then shut it down.
+    /// This is useful for probing reopen behavior without perturbing the live cohort.
+    pub fn execute_sql_via_fresh_worker(
+        &self,
+        sql: impl Into<String>,
+    ) -> anyhow::Result<(WorkerStartupTelemetry, OpResult)> {
+        let sql = sql.into();
+        let probe_worker_id = self.workers.len();
+        let (mut worker, telemetry) =
+            spawn_ready_worker(probe_worker_id, &self.db_path, self.enable_mvcc)?;
+
+        let result = (|| -> anyhow::Result<OpResult> {
+            for _ in 0..8 {
+                send_command(&mut worker, &WorkerCommand::Execute { sql: sql.clone() })?;
+                let response = recv_response(&mut worker)?;
+                let op_result = response.into_op_result();
+                match &op_result {
+                    Err(
+                        LimboError::SchemaUpdated
+                        | LimboError::SchemaConflict
+                        | LimboError::Busy
+                        | LimboError::BusySnapshot
+                        | LimboError::TableLocked,
+                    ) => continue,
+                    _ => return Ok(op_result),
+                }
+            }
+            Ok(Err(LimboError::Busy))
+        })();
+
+        let _ = send_command(&mut worker, &WorkerCommand::Shutdown);
+        let _ = worker.child.wait();
+
+        result.map(|op_result| (telemetry, op_result))
+    }
+
+    /// Restart the entire worker cohort while preserving the on-disk database,
+    /// WAL, and tshm artifacts.
+    pub fn restart_all_workers_preserve_files(&mut self) -> anyhow::Result<()> {
+        info!(
+            "restarting all workers while preserving {}",
+            self.db_path.display()
+        );
+        self.history.record(&HistoryEvent::CohortRestartStarted {
+            step: self.current_step,
+            worker_count: self.workers.len(),
+        })?;
+
+        self.stop_all_workers_preserve_files("cohort_restart")?;
+        self.respawn_all_workers_preserve_files("cohort_restart")
+    }
+
+    pub fn mutate_on_disk_and_restart(
+        &mut self,
+        mutate: impl FnOnce(&Path) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        info!(
+            "stopping workers for on-disk mutation of {}",
+            self.db_path.display()
+        );
+        self.stop_all_workers_preserve_files("on_disk_mutation")?;
+        mutate(&self.db_path)?;
+        self.respawn_all_workers_preserve_files("on_disk_mutation")
+    }
+
+    fn stop_all_workers_preserve_files(&mut self, reason: &'static str) -> anyhow::Result<()> {
+        for worker_idx in 0..self.workers.len() {
+            let worker_id = self.workers[worker_idx].worker_id;
+            let pid = self.workers[worker_idx].child.id();
+            self.history.record(&HistoryEvent::WorkerKilled {
+                step: self.current_step,
+                worker: worker_id,
+                pid,
+                reason,
+            })?;
+            let _ = self.workers[worker_idx].child.kill();
+        }
+        for worker in &mut self.workers {
+            let _ = worker.child.wait();
+        }
+
+        for worker_idx in 0..self.worker_states.len() {
+            self.abort_worker_state(worker_idx, reason)?;
+        }
+        Ok(())
+    }
+
+    fn respawn_all_workers_preserve_files(&mut self, reason: &'static str) -> anyhow::Result<()> {
+        let mut new_workers = Vec::with_capacity(self.workers.len());
+        let mut new_telemetries = Vec::with_capacity(self.workers.len());
+        for worker_idx in 0..self.workers.len() {
+            let (handle, telemetry) =
+                spawn_ready_worker(worker_idx, &self.db_path, self.enable_mvcc)?;
+            self.history.record(&HistoryEvent::WorkerSpawned {
+                step: Some(self.current_step),
+                worker: worker_idx,
+                pid: handle.child.id(),
+                reason,
+                telemetry,
+            })?;
+            info!("worker {} restarted: {:?}", worker_idx, telemetry);
+            new_workers.push(handle);
+            new_telemetries.push(telemetry);
+        }
+
+        self.workers = new_workers;
+        self.worker_startup_telemetries = new_telemetries;
+        Ok(())
+    }
+
+    /// Perform a single simulation step.
+    pub fn step(&mut self) -> anyhow::Result<StepResult> {
+        if self.current_step >= self.max_steps {
+            return Ok(StepResult::Ok);
+        }
+
+        if self.restart_probability > 0.0 && self.rng.random_bool(self.restart_probability) {
+            self.restart_all_workers_preserve_files()?;
+            self.current_step += 1;
+            return Ok(StepResult::Ok);
+        }
+
+        let worker_idx = self.current_step % self.workers.len();
+
+        // Optionally kill a worker for crash recovery testing
+        if self.kill_probability > 0.0 && self.rng.random_bool(self.kill_probability) {
+            self.kill_and_respawn(worker_idx, "crash_recovery_test")?;
+        }
+
+        self.perform_work(worker_idx)?;
+        self.current_step += 1;
+
+        Ok(StepResult::Ok)
+    }
+
+    fn perform_work(&mut self, worker_idx: usize) -> anyhow::Result<()> {
+        let ws = &self.worker_states[worker_idx];
+        let exec_id = ws.execution_id;
+        let txn_id = ws.txn_id;
+
+        debug!(
+            "perform_work: step={}, worker={}, exec_id={:?}, txn_id={:?}, state={:?}",
+            self.current_step, worker_idx, exec_id, txn_id, ws.fiber_state
+        );
+
+        // If the worker has a pending operation (e.g., auto-rollback), use that.
+        // Otherwise, try chaotic workload, then regular workloads.
+        if self.worker_states[worker_idx].current_op.is_none() {
+            // Try chaotic workload first
+            if !self.chaotic_profiles.is_empty() {
+                self.try_resume_chaotic(worker_idx);
+            }
+
+            // Fall through to regular workloads if chaotic didn't produce an op
+            if self.worker_states[worker_idx].current_op.is_none() && self.total_weight > 0 {
+                let mut roll = self.rng.random_range(0..self.total_weight);
+                for (weight, workload) in &self.workloads {
+                    if roll >= *weight {
+                        roll = roll.saturating_sub(*weight);
+                        continue;
+                    }
+                    let ctx = WorkloadContext {
+                        fiber_state: &self.worker_states[worker_idx].fiber_state,
+                        sim_state: &self.sim_state,
+                        opts: &self.opts,
+                        enable_mvcc: self.enable_mvcc,
+                        tables_vec: self.sim_state.tables_vec(),
+                    };
+                    let Some(op) = workload.generate(&ctx, &mut self.rng) else {
+                        continue;
+                    };
+                    debug!("generated op for worker {}: {:?}", worker_idx, op);
+                    self.worker_states[worker_idx].current_op = Some(op);
+                    break;
+                }
+            }
+        }
+
+        // Execute the operation
+        let Some(op) = self.worker_states[worker_idx].current_op.take() else {
+            return Ok(()); // No operation generated this step
+        };
+
+        // Assign execution ID
+        let exec_id = self.sim_state.gen_execution_id();
+        self.worker_states[worker_idx].execution_id = Some(exec_id);
+
+        // Assign txn_id for BEGIN
+        if let Operation::Begin { .. } = &op {
+            self.worker_states[worker_idx].txn_id = Some(self.sim_state.gen_txn_id());
+        }
+        let txn_id = self.worker_states[worker_idx].txn_id;
+
+        // Notify properties: operation starting
+        for property in &self.properties {
+            let mut property = property.lock().unwrap();
+            property.init_op(self.current_step, worker_idx, txn_id, exec_id, &op)?;
+        }
+
+        // Send to worker and get result
+        let sql = op.sql();
+        let op_description = format!("{op:?}");
+        self.history.record(&HistoryEvent::OperationStarted {
+            step: self.current_step,
+            worker: worker_idx,
+            exec_id,
+            txn_id,
+            op: op_description.clone(),
+            sql: sql.clone(),
+        })?;
+        debug!("sending to worker {}: {}", worker_idx, sql);
+        send_command(
+            &mut self.workers[worker_idx],
+            &WorkerCommand::Execute { sql: sql.clone() },
+        )?;
+        let response = match recv_response(&mut self.workers[worker_idx]) {
+            Ok(r) => r,
+            Err(e) => {
+                // Worker crashed - kill old process before respawning to prevent
+                // two workers for the same slot from accessing the database simultaneously.
+                error!("worker {} crashed: {}", worker_idx, e);
+                self.history
+                    .record(&HistoryEvent::OperationTransportFailure {
+                        step: self.current_step,
+                        worker: worker_idx,
+                        exec_id: Some(exec_id),
+                        txn_id,
+                        op: Some(op_description),
+                        sql: Some(sql),
+                        error: e.to_string(),
+                    })?;
+                self.kill_and_respawn(worker_idx, "transport_failure")?;
+                return Ok(());
+            }
+        };
+        let op_result = response.into_op_result();
+        self.history.record(&HistoryEvent::OperationFinished {
+            step: self.current_step,
+            worker: worker_idx,
+            exec_id,
+            txn_id,
+            op: op_description,
+            sql,
+            result: HistoryResult::from(&op_result),
+        })?;
+        match &op_result {
+            Ok(_) => debug!("worker {} result: ok", worker_idx),
+            Err(err) => debug!("worker {} result: err={err:?}", worker_idx),
+        }
+
+        // Skip benign errors that occur in multiprocess mode
+        if let Err(ref e) = op_result {
+            let err = e.to_string().to_lowercase();
+            // Schema visibility lag across processes
+            if err.contains("no such")
+                || err.contains("already exists")
+                || err.contains("not exist")
+            {
+                debug!("worker {}: skipped op ({})", worker_idx, err);
+                self.worker_states[worker_idx].execution_id = None;
+                return Ok(());
+            }
+            // Schema/index desync after respawn or cross-process schema lag
+            if err.contains("not found in schema") {
+                debug!("worker {}: schema desync ({})", worker_idx, err);
+                self.worker_states[worker_idx].execution_id = None;
+                return Ok(());
+            }
+            // Worker's connection already auto-rolled back (state desync)
+            if err.contains("no transaction is active") || err.contains("cannot rollback") {
+                debug!("worker {}: transaction already ended ({})", worker_idx, err);
+                self.worker_states[worker_idx].fiber_state = FiberState::Idle;
+                self.worker_states[worker_idx].txn_id = None;
+                self.worker_states[worker_idx].execution_id = None;
+                self.worker_states[worker_idx].chaotic_workload = None;
+                self.worker_states[worker_idx].last_chaotic_result = None;
+                return Ok(());
+            }
+        }
+
+        // Update fiber state for BEGIN
+        if let Operation::Begin { mode } = &op {
+            if op_result.is_ok() {
+                self.worker_states[worker_idx].fiber_state = if *mode == TxMode::Concurrent {
+                    FiberState::InConcurrentTx
+                } else {
+                    FiberState::InTx
+                };
+            }
+        }
+
+        // Apply state changes (sim_state + stats)
+        let end_exec_id = self.sim_state.execution_id;
+        op.apply_state_changes(
+            &mut self.sim_state,
+            &mut self.stats,
+            &mut self.rng,
+            &op_result,
+        );
+
+        // Notify properties: operation finished
+        for property in &self.properties {
+            let mut property = property.lock().unwrap();
+            property
+                .finish_op(
+                    self.current_step,
+                    worker_idx,
+                    txn_id,
+                    exec_id,
+                    end_exec_id,
+                    &op,
+                    &op_result,
+                )
+                .inspect_err(|e| error!("property failed: {e}"))?;
+        }
+
+        // Save result for chaotic workload
+        if self.worker_states[worker_idx].chaotic_workload.is_some()
+            && self.worker_states[worker_idx].last_chaotic_result.is_none()
+        {
+            self.worker_states[worker_idx].last_chaotic_result = Some(op_result.clone());
+        }
+
+        // Update fiber state for COMMIT/ROLLBACK and auto-commit
+        if matches!(op, Operation::Commit | Operation::Rollback) && op_result.is_ok() {
+            self.worker_states[worker_idx].fiber_state = FiberState::Idle;
+            self.worker_states[worker_idx].txn_id = None;
+        }
+
+        // Handle errors: initiate auto-rollback for retryable errors
+        if let Err(ref error) = op_result {
+            match error {
+                LimboError::SchemaUpdated
+                | LimboError::SchemaConflict
+                | LimboError::TableLocked
+                | LimboError::Busy
+                | LimboError::BusySnapshot
+                | LimboError::WriteWriteConflict
+                | LimboError::CommitDependencyAborted
+                | LimboError::InvalidArgument(..) => {
+                    if self.worker_states[worker_idx].fiber_state.is_in_tx() {
+                        debug!("worker {}: auto-rollback after {:?}", worker_idx, error);
+                        self.worker_states[worker_idx].current_op = Some(Operation::Rollback);
+                    } else {
+                        self.worker_states[worker_idx].txn_id = None;
+                    }
+                }
+                // Corruption and checkpoint errors: log and respawn the worker.
+                // These are real multiprocess bugs we want to surface but not crash on.
+                LimboError::Corrupt(_) | LimboError::CheckpointFailed(_) => {
+                    error!(
+                        "worker {} hit corruption on step {}: {} -- respawning",
+                        worker_idx, self.current_step, error
+                    );
+                    self.stats.corruption_events += 1;
+                    self.kill_and_respawn(worker_idx, "corruption_recovery")?;
+                }
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "worker {} fatal error on step {}: {}",
+                        worker_idx,
+                        self.current_step,
+                        error
+                    ));
+                }
+            }
+        }
+
+        self.worker_states[worker_idx].execution_id = None;
+        Ok(())
+    }
+
+    /// Try to resume or start a chaotic workload for the given worker.
+    fn try_resume_chaotic(&mut self, worker_idx: usize) {
+        // Resume active workload with saved result
+        if let Some(result) = self.worker_states[worker_idx].last_chaotic_result.take() {
+            let mut workload = self.worker_states[worker_idx].chaotic_workload.take();
+            if let Some(ref mut wl) = workload {
+                if let Some(op) = wl.next(Some(result)) {
+                    debug!(
+                        "chaotic: resumed workload for worker {}, next op: {:?}",
+                        worker_idx, op
+                    );
+                    self.worker_states[worker_idx].current_op = Some(op);
+                    self.worker_states[worker_idx].chaotic_workload = workload;
+                    return;
+                }
+                debug!("chaotic: workload completed for worker {}", worker_idx);
+            }
+        }
+
+        // Pick a new chaotic workload (only when idle)
+        if self.worker_states[worker_idx].chaotic_workload.is_none()
+            && self.worker_states[worker_idx].fiber_state == FiberState::Idle
+        {
+            if let Some(op) = self.pick_chaotic_workload(worker_idx) {
+                self.worker_states[worker_idx].current_op = Some(op);
+            }
+        }
+    }
+
+    fn pick_chaotic_workload(&mut self, worker_idx: usize) -> Option<Operation> {
+        for (probability, name, profile) in &self.chaotic_profiles {
+            if !self.rng.random_bool(*probability) {
+                continue;
+            }
+            let fiber_rng = ChaCha8Rng::seed_from_u64(self.rng.next_u64());
+            let mut workload = profile.generate(fiber_rng, worker_idx);
+            if let Some(op) = workload.next(None) {
+                debug!(
+                    "chaotic: picked workload '{}' for worker {}",
+                    name, worker_idx
+                );
+                self.worker_states[worker_idx].chaotic_workload = Some(workload);
+                return Some(op);
+            }
+        }
+        None
+    }
+
+    fn abort_worker_state(
+        &mut self,
+        worker_idx: usize,
+        reason: &'static str,
+    ) -> anyhow::Result<()> {
+        let txn_id = self.worker_states[worker_idx].txn_id;
+        let exec_id = self.worker_states[worker_idx].execution_id;
+        let fiber_state = format!("{:?}", self.worker_states[worker_idx].fiber_state);
+        let current_op = self.worker_states[worker_idx]
+            .current_op
+            .as_ref()
+            .map(|op| format!("{op:?}"));
+        self.history.record(&HistoryEvent::WorkerStateAborted {
+            step: self.current_step,
+            worker: worker_idx,
+            reason,
+            txn_id,
+            exec_id,
+            fiber_state,
+            current_op,
+        })?;
+        for property in &self.properties {
+            let mut property = property.lock().unwrap();
+            property.abort_fiber(worker_idx, txn_id)?;
+        }
+        self.worker_states[worker_idx] = WorkerState::new();
+        Ok(())
+    }
+
+    /// Kill a worker and respawn it (tests crash recovery).
+    fn kill_and_respawn(&mut self, worker_idx: usize, reason: &'static str) -> anyhow::Result<()> {
+        let pid = self.workers[worker_idx].child.id();
+        info!("killing worker {} (pid {}) for {}", worker_idx, pid, reason);
+        self.history.record(&HistoryEvent::WorkerKilled {
+            step: self.current_step,
+            worker: worker_idx,
+            pid,
+            reason,
+        })?;
+        let _ = self.workers[worker_idx].child.kill();
+        let _ = self.workers[worker_idx].child.wait();
+
+        // Reset worker state and let properties discard or finalize any
+        // pending per-fiber state that died with the worker.
+        self.abort_worker_state(worker_idx, reason)?;
+
+        // Respawn
+        let (handle, telemetry) = spawn_ready_worker(worker_idx, &self.db_path, self.enable_mvcc)?;
+        self.history.record(&HistoryEvent::WorkerSpawned {
+            step: Some(self.current_step),
+            worker: worker_idx,
+            pid: handle.child.id(),
+            reason,
+            telemetry,
+        })?;
+        self.workers[worker_idx] = handle;
+        self.worker_startup_telemetries[worker_idx] = telemetry;
+        info!("worker {} respawned and ready: {:?}", worker_idx, telemetry);
+        Ok(())
+    }
+
+    /// Run the simulation to completion.
+    pub fn run(&mut self) -> anyhow::Result<()> {
+        while !self.is_done() {
+            self.step()?;
+        }
+        self.finalize()?;
+        Ok(())
+    }
+
+    /// Finalize: check properties, shut down workers, clean up.
+    pub fn finalize(&mut self) -> anyhow::Result<()> {
+        // Finalize properties
+        for property in &self.properties {
+            let mut property = property.lock().unwrap();
+            property.finalize()?;
+        }
+
+        // Shut down workers
+        for worker in &mut self.workers {
+            let _ = send_command(worker, &WorkerCommand::Shutdown);
+            let _ = worker.child.wait();
+        }
+
+        // Clean up database files
+        if !self.keep_files {
+            let db_str = self.db_path.to_str().unwrap_or_default();
+            let _ = std::fs::remove_file(&self.db_path);
+            let _ = std::fs::remove_file(format!("{db_str}-wal"));
+            let _ = std::fs::remove_file(format!("{db_str}-tshm"));
+            let _ = std::fs::remove_file(format!("{db_str}-log"));
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for MultiprocessWhopper {
+    fn drop(&mut self) {
+        // Ensure workers are killed on drop
+        for worker in &mut self.workers {
+            let _ = worker.child.kill();
+            let _ = worker.child.wait();
+        }
+    }
+}
+
+fn spawn_ready_worker(
+    worker_id: usize,
+    db_path: &Path,
+    enable_mvcc: bool,
+) -> anyhow::Result<(WorkerHandle, WorkerStartupTelemetry)> {
+    let mut handle = spawn_worker(worker_id, db_path, enable_mvcc)?;
+    let response = recv_response(&mut handle)?;
+    match response {
+        WorkerResponse::Ready { telemetry } => Ok((handle, telemetry)),
+        other => Err(anyhow::anyhow!(
+            "worker {} sent unexpected response during init: {:?}",
+            worker_id,
+            other
+        )),
+    }
+}
+
+/// Spawn a worker child process.
+fn spawn_worker(
+    worker_id: usize,
+    db_path: &Path,
+    enable_mvcc: bool,
+) -> anyhow::Result<WorkerHandle> {
+    let exe = worker_executable()?;
+    let mut cmd = Command::new(&exe);
+    cmd.arg("worker")
+        .arg("--db-path")
+        .arg(db_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+
+    if enable_mvcc {
+        cmd.arg("--enable-mvcc");
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("failed to spawn worker {worker_id}: {e}"))?;
+
+    let stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let responses = spawn_stdout_reader(worker_id, stdout);
+
+    Ok(WorkerHandle {
+        child,
+        stdin: BufWriter::new(stdin),
+        responses,
+        worker_id,
+    })
+}
+
+fn worker_executable() -> anyhow::Result<PathBuf> {
+    if let Some(path) = std::env::var_os("TURSO_WHOPPER_WORKER_EXE") {
+        return Ok(PathBuf::from(path));
+    }
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_turso_whopper") {
+        return Ok(PathBuf::from(path));
+    }
+    Ok(std::env::current_exe()?)
+}
+
+/// Send a command to a worker.
+fn send_command(worker: &mut WorkerHandle, cmd: &WorkerCommand) -> anyhow::Result<()> {
+    serde_json::to_writer(&mut worker.stdin, cmd)?;
+    worker.stdin.write_all(b"\n")?;
+    worker.stdin.flush()?;
+    Ok(())
+}
+
+/// Receive a response from a worker.
+fn recv_response(worker: &mut WorkerHandle) -> anyhow::Result<WorkerResponse> {
+    recv_response_timeout(worker, Duration::from_secs(10))
+}
+
+fn recv_response_timeout(
+    worker: &mut WorkerHandle,
+    timeout: Duration,
+) -> anyhow::Result<WorkerResponse> {
+    match worker.responses.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(RecvTimeoutError::Timeout) => Err(anyhow::anyhow!(
+            "worker {} timed out after {:?} waiting for response",
+            worker.worker_id,
+            timeout
+        )),
+        Err(RecvTimeoutError::Disconnected) => Err(anyhow::anyhow!(
+            "worker {} response channel disconnected",
+            worker.worker_id
+        )),
+    }
+}
+
+fn spawn_stdout_reader(
+    worker_id: usize,
+    stdout: ChildStdout,
+) -> Receiver<anyhow::Result<WorkerResponse>> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::Builder::new()
+        .name(format!("whopper-worker-{worker_id}-stdout"))
+        .spawn(move || {
+            let mut stdout = BufReader::new(stdout);
+            loop {
+                let mut line = String::new();
+                match stdout.read_line(&mut line) {
+                    Ok(0) => {
+                        let _ = tx.send(Err(anyhow::anyhow!(
+                            "worker {} closed stdout (crashed?)",
+                            worker_id
+                        )));
+                        break;
+                    }
+                    Ok(_) => {
+                        let parsed = parse_worker_response_line(worker_id, &line);
+                        let should_stop = parsed.is_err();
+                        if tx.send(parsed).is_err() || should_stop {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(e.into()));
+                        break;
+                    }
+                }
+            }
+        })
+        .expect("failed to spawn worker stdout reader thread");
+    rx
+}
+
+fn parse_worker_response_line(worker_id: usize, line: &str) -> anyhow::Result<WorkerResponse> {
+    match serde_json::from_str(line) {
+        Ok(response) => Ok(response),
+        Err(e) => {
+            let preview = if line.len() > 200 {
+                format!("{}...", &line[..200])
+            } else {
+                line.trim().to_string()
+            };
+            Err(anyhow::anyhow!(
+                "worker {} sent invalid JSON: {e} (got: {preview})",
+                worker_id
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_worker_response_line, recv_response_timeout};
+    use crate::protocol::{WorkerCoordinationOpenMode, WorkerResponse};
+    use serde_json::Value as JsonValue;
+    use std::io::BufWriter;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use super::WorkerHandle;
+
+    fn history_output_path(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "turso-whopper-history-{label}-{}-{}.jsonl",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ))
+    }
+
+    #[test]
+    fn parse_worker_response_line_rejects_invalid_json() {
+        let err =
+            parse_worker_response_line(7, "not-json\n").expect_err("invalid JSON should fail");
+        assert!(err.to_string().contains("worker 7 sent invalid JSON"));
+    }
+
+    #[test]
+    fn recv_response_times_out_when_worker_stops_responding() {
+        let (_tx, rx) = mpsc::channel();
+        let mut child = Command::new("sleep")
+            .arg("60")
+            .stdin(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn placeholder child");
+        let stdin = child.stdin.take();
+        let mut handle = WorkerHandle {
+            child,
+            stdin: BufWriter::new(stdin.expect("placeholder child should have stdin")),
+            responses: rx,
+            worker_id: 3,
+        };
+
+        let err = recv_response_timeout(&mut handle, Duration::from_millis(10))
+            .expect_err("recv_response should time out");
+        assert!(err.to_string().contains("worker 3 timed out"));
+
+        let _ = handle.child.kill();
+        let _ = handle.child.wait();
+    }
+
+    #[test]
+    fn parse_worker_response_line_accepts_valid_json() {
+        let response = parse_worker_response_line(
+            2,
+            "{\"Ready\":{\"telemetry\":{\"loaded_from_disk_scan\":false,\"reopened_max_frame\":0,\"reopened_nbackfills\":0,\"reopened_checkpoint_seq\":0,\"coordination_open_mode\":\"Exclusive\",\"sanitized_backfill_proof_on_open\":false}}}\n",
+        )
+        .expect("valid JSON line should parse");
+        assert!(matches!(
+            response,
+            WorkerResponse::Ready {
+                telemetry: crate::protocol::WorkerStartupTelemetry {
+                    coordination_open_mode: Some(WorkerCoordinationOpenMode::Exclusive),
+                    ..
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn operation_history_writer_streams_jsonl_events() {
+        let path = history_output_path("writer");
+        let mut writer =
+            super::OperationHistoryWriter::new(Some(&path)).expect("create history writer");
+        let telemetry = crate::protocol::WorkerStartupTelemetry {
+            loaded_from_disk_scan: false,
+            reopened_max_frame: 7,
+            reopened_nbackfills: 3,
+            reopened_checkpoint_seq: 9,
+            coordination_open_mode: Some(WorkerCoordinationOpenMode::MultiProcess),
+            sanitized_backfill_proof_on_open: false,
+        };
+
+        writer
+            .record(&super::HistoryEvent::WorkerSpawned {
+                step: None,
+                worker: 1,
+                pid: 4242,
+                reason: "initial_spawn",
+                telemetry,
+            })
+            .expect("record worker spawned");
+        writer
+            .record(&super::HistoryEvent::OperationFinished {
+                step: 7,
+                worker: 1,
+                exec_id: 12,
+                txn_id: Some(5),
+                op: "SimpleSelect { table_name: \"t\", key: \"k\" }".to_string(),
+                sql: "SELECT key, length(value) FROM t WHERE key = 'k'".to_string(),
+                result: super::HistoryResult::Err {
+                    error_kind: "Busy".to_string(),
+                    message: "Database is busy".to_string(),
+                },
+            })
+            .expect("record operation finished");
+
+        let contents = std::fs::read_to_string(&path).expect("read history file");
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "writer should emit one JSON object per line"
+        );
+
+        let worker_spawned: JsonValue =
+            serde_json::from_str(lines[0]).expect("parse worker spawned event");
+        assert_eq!(worker_spawned["kind"], "worker_spawned");
+        assert_eq!(worker_spawned["reason"], "initial_spawn");
+        assert_eq!(worker_spawned["telemetry"]["reopened_nbackfills"], 3);
+
+        let operation_finished: JsonValue =
+            serde_json::from_str(lines[1]).expect("parse operation finished event");
+        assert_eq!(operation_finished["kind"], "operation_finished");
+        assert_eq!(operation_finished["exec_id"], 12);
+        assert_eq!(operation_finished["result"]["status"], "err");
+        assert_eq!(operation_finished["result"]["error_kind"], "Busy");
+
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -33,7 +33,8 @@ use crate::{SimulatorState, Stats, StepResult, create_initial_indexes, create_in
 pub struct MultiprocessOpts {
     pub seed: Option<u64>,
     pub enable_mvcc: bool,
-    pub max_connections: usize,
+    pub process_count: usize,
+    pub connections_per_process: usize,
     pub max_steps: usize,
     pub elle_tables: Vec<(String, String)>,
     pub workloads: Vec<(u32, Box<dyn Workload>)>,
@@ -81,20 +82,21 @@ impl OperationHistoryWriter {
 enum HistoryEvent {
     WorkerSpawned {
         step: Option<usize>,
-        worker: usize,
+        process: usize,
         pid: u32,
         reason: &'static str,
         telemetry: WorkerStartupTelemetry,
     },
     WorkerKilled {
         step: usize,
-        worker: usize,
+        process: usize,
         pid: u32,
         reason: &'static str,
     },
     WorkerStateAborted {
         step: usize,
-        worker: usize,
+        process: usize,
+        connection: usize,
         reason: &'static str,
         txn_id: Option<u64>,
         exec_id: Option<u64>,
@@ -103,11 +105,13 @@ enum HistoryEvent {
     },
     CohortRestartStarted {
         step: usize,
-        worker_count: usize,
+        process_count: usize,
+        connection_count: usize,
     },
     OperationStarted {
         step: usize,
-        worker: usize,
+        process: usize,
+        connection: usize,
         exec_id: u64,
         txn_id: Option<u64>,
         op: String,
@@ -115,7 +119,8 @@ enum HistoryEvent {
     },
     OperationFinished {
         step: usize,
-        worker: usize,
+        process: usize,
+        connection: usize,
         exec_id: u64,
         txn_id: Option<u64>,
         op: String,
@@ -124,7 +129,8 @@ enum HistoryEvent {
     },
     OperationTransportFailure {
         step: usize,
-        worker: usize,
+        process: usize,
+        connection: usize,
         exec_id: Option<u64>,
         txn_id: Option<u64>,
         op: Option<String>,
@@ -153,15 +159,21 @@ impl From<&OpResult> for HistoryResult {
 }
 
 /// Handle for a worker child process.
-struct WorkerHandle {
+struct WorkerProcessHandle {
     child: Child,
     stdin: BufWriter<ChildStdin>,
     responses: Receiver<anyhow::Result<WorkerResponse>>,
-    worker_id: usize,
+    process_idx: usize,
 }
 
-/// Mirror of each worker's state, maintained by the coordinator.
-struct WorkerState {
+#[derive(Debug, Clone, Copy)]
+struct LogicalConnectionLocation {
+    process_idx: usize,
+    connection_idx: usize,
+}
+
+/// Mirror of each logical connection's state, maintained by the coordinator.
+struct ConnectionState {
     fiber_state: FiberState,
     txn_id: Option<u64>,
     execution_id: Option<u64>,
@@ -170,7 +182,7 @@ struct WorkerState {
     last_chaotic_result: Option<OpResult>,
 }
 
-impl WorkerState {
+impl ConnectionState {
     fn new() -> Self {
         Self {
             fiber_state: FiberState::Idle,
@@ -185,8 +197,8 @@ impl WorkerState {
 
 /// The multiprocess Whopper coordinator.
 pub struct MultiprocessWhopper {
-    workers: Vec<WorkerHandle>,
-    worker_states: Vec<WorkerState>,
+    processes: Vec<WorkerProcessHandle>,
+    connection_states: Vec<ConnectionState>,
     sim_state: SimulatorState,
     worker_startup_telemetries: Vec<WorkerStartupTelemetry>,
     history: OperationHistoryWriter,
@@ -202,6 +214,7 @@ pub struct MultiprocessWhopper {
     pub stats: Stats,
     db_path: PathBuf,
     enable_mvcc: bool,
+    connections_per_process: usize,
     kill_probability: f64,
     restart_probability: f64,
     keep_files: bool,
@@ -211,6 +224,14 @@ impl MultiprocessWhopper {
     /// Create a new multiprocess coordinator.
     /// Bootstraps the database schema, then spawns worker processes.
     pub fn new(opts: MultiprocessOpts) -> anyhow::Result<Self> {
+        if opts.process_count == 0 {
+            return Err(anyhow::anyhow!("process_count must be greater than zero"));
+        }
+        if opts.connections_per_process == 0 {
+            return Err(anyhow::anyhow!(
+                "connections_per_process must be greater than zero"
+            ));
+        }
         let seed = opts.seed.unwrap_or_else(|| {
             let mut rng = rand::rng();
             rng.next_u64()
@@ -289,34 +310,49 @@ impl MultiprocessWhopper {
         }
 
         let total_weight: u32 = opts.workloads.iter().map(|(w, _)| w).sum();
+        let total_connections = opts
+            .process_count
+            .checked_mul(opts.connections_per_process)
+            .ok_or_else(|| anyhow::anyhow!("multiprocess connection topology overflow"))?;
 
         // Spawn worker processes one at a time.
         // Each worker must fully initialize (open DB, create .tshm) before the next
         // starts, to avoid races on coordination file creation.
-        let mut workers = Vec::new();
-        let mut worker_states = Vec::new();
+        let mut processes = Vec::new();
+        let mut connection_states = Vec::with_capacity(total_connections);
         let mut worker_startup_telemetries = Vec::new();
         let mut history = OperationHistoryWriter::new(opts.history_output.as_deref())?;
-        for i in 0..opts.max_connections {
-            let (handle, telemetry) = spawn_ready_worker(i, &db_path, opts.enable_mvcc)?;
-            debug!("worker {} ready: {:?}", handle.worker_id, telemetry);
+        for process_idx in 0..opts.process_count {
+            let (handle, telemetry) = spawn_ready_worker(
+                process_idx,
+                &db_path,
+                opts.enable_mvcc,
+                opts.connections_per_process,
+            )?;
+            debug!("process {} ready: {:?}", handle.process_idx, telemetry);
             history.record(&HistoryEvent::WorkerSpawned {
                 step: None,
-                worker: i,
+                process: process_idx,
                 pid: handle.child.id(),
                 reason: "initial_spawn",
                 telemetry,
             })?;
             worker_startup_telemetries.push(telemetry);
-            workers.push(handle);
-            worker_states.push(WorkerState::new());
+            processes.push(handle);
+            for _ in 0..opts.connections_per_process {
+                connection_states.push(ConnectionState::new());
+            }
         }
 
-        info!("all {} workers ready", workers.len());
+        info!(
+            "all {} processes ready ({} total connections)",
+            processes.len(),
+            connection_states.len()
+        );
 
         Ok(Self {
-            workers,
-            worker_states,
+            processes,
+            connection_states,
             sim_state,
             worker_startup_telemetries,
             history,
@@ -336,6 +372,7 @@ impl MultiprocessWhopper {
             stats: Stats::default(),
             db_path,
             enable_mvcc: opts.enable_mvcc,
+            connections_per_process: opts.connections_per_process,
             kill_probability: opts.kill_probability,
             restart_probability: opts.restart_probability,
             keep_files: opts.keep_files,
@@ -355,29 +392,45 @@ impl MultiprocessWhopper {
         &self.worker_startup_telemetries
     }
 
-    /// Execute SQL directly on one worker without involving workload generation.
+    fn connection_location(&self, logical_connection_idx: usize) -> LogicalConnectionLocation {
+        LogicalConnectionLocation {
+            process_idx: logical_connection_idx / self.connections_per_process,
+            connection_idx: logical_connection_idx % self.connections_per_process,
+        }
+    }
+
+    fn process_connection_indices(&self, process_idx: usize) -> std::ops::Range<usize> {
+        let start = process_idx * self.connections_per_process;
+        start..start + self.connections_per_process
+    }
+
+    /// Execute SQL directly on one logical connection without involving workload generation.
     /// This is used by deterministic restart regressions.
     pub fn execute_sql_direct(
         &mut self,
-        worker_idx: usize,
+        connection_idx: usize,
         sql: impl Into<String>,
     ) -> anyhow::Result<OpResult> {
         let sql = sql.into();
+        let location = self.connection_location(connection_idx);
         send_command(
-            &mut self.workers[worker_idx],
-            &WorkerCommand::Execute { sql },
+            &mut self.processes[location.process_idx],
+            &WorkerCommand::Execute {
+                connection_idx: location.connection_idx,
+                sql,
+            },
         )?;
-        let response = recv_response(&mut self.workers[worker_idx])?;
+        let response = recv_response(&mut self.processes[location.process_idx])?;
         Ok(response.into_op_result())
     }
 
-    /// Execute SQL on an idle worker that is not currently inside a simulated transaction.
+    /// Execute SQL on an idle logical connection that is not currently inside a simulated transaction.
     pub fn execute_sql_via_idle_worker(
         &mut self,
         sql: impl Into<String>,
     ) -> anyhow::Result<(usize, OpResult)> {
-        let worker_idx = self
-            .worker_states
+        let connection_idx = self
+            .connection_states
             .iter()
             .enumerate()
             .find_map(|(idx, state)| {
@@ -389,21 +442,24 @@ impl MultiprocessWhopper {
                     && state.last_chaotic_result.is_none())
                 .then_some(idx)
             })
-            .ok_or_else(|| anyhow::anyhow!("no idle worker available for probe"))?;
-        let result = self.execute_sql_direct(worker_idx, sql)?;
-        Ok((worker_idx, result))
+            .ok_or_else(|| anyhow::anyhow!("no idle logical connection available for probe"))?;
+        let result = self.execute_sql_direct(connection_idx, sql)?;
+        Ok((connection_idx, result))
     }
 
-    pub fn disable_auto_checkpoint_direct(&mut self, worker_idx: usize) -> anyhow::Result<()> {
+    pub fn disable_auto_checkpoint_direct(&mut self, connection_idx: usize) -> anyhow::Result<()> {
+        let location = self.connection_location(connection_idx);
         send_command(
-            &mut self.workers[worker_idx],
-            &WorkerCommand::DisableAutoCheckpoint,
+            &mut self.processes[location.process_idx],
+            &WorkerCommand::DisableAutoCheckpoint {
+                connection_idx: location.connection_idx,
+            },
         )?;
-        match recv_response(&mut self.workers[worker_idx])? {
+        match recv_response(&mut self.processes[location.process_idx])? {
             WorkerResponse::Ack => Ok(()),
             other => Err(anyhow::anyhow!(
-                "worker {} returned unexpected response to DisableAutoCheckpoint: {:?}",
-                worker_idx,
+                "logical connection {} returned unexpected response to DisableAutoCheckpoint: {:?}",
+                connection_idx,
                 other
             )),
         }
@@ -411,35 +467,38 @@ impl MultiprocessWhopper {
 
     pub fn passive_checkpoint_direct(
         &mut self,
-        worker_idx: usize,
+        connection_idx: usize,
         upper_bound_inclusive: Option<u64>,
     ) -> anyhow::Result<()> {
+        let location = self.connection_location(connection_idx);
         send_command(
-            &mut self.workers[worker_idx],
+            &mut self.processes[location.process_idx],
             &WorkerCommand::PassiveCheckpoint {
+                connection_idx: location.connection_idx,
                 upper_bound_inclusive,
             },
         )?;
-        match recv_response(&mut self.workers[worker_idx])? {
+        match recv_response(&mut self.processes[location.process_idx])? {
             WorkerResponse::Ack => Ok(()),
             other => Err(anyhow::anyhow!(
-                "worker {} returned unexpected response to PassiveCheckpoint: {:?}",
-                worker_idx,
+                "logical connection {} returned unexpected response to PassiveCheckpoint: {:?}",
+                connection_idx,
                 other
             )),
         }
     }
 
-    pub fn clear_backfill_proof_direct(&mut self, worker_idx: usize) -> anyhow::Result<()> {
+    pub fn clear_backfill_proof_direct(&mut self, connection_idx: usize) -> anyhow::Result<()> {
+        let location = self.connection_location(connection_idx);
         send_command(
-            &mut self.workers[worker_idx],
+            &mut self.processes[location.process_idx],
             &WorkerCommand::ClearBackfillProof,
         )?;
-        match recv_response(&mut self.workers[worker_idx])? {
+        match recv_response(&mut self.processes[location.process_idx])? {
             WorkerResponse::Ack => Ok(()),
             other => Err(anyhow::anyhow!(
-                "worker {} returned unexpected response to ClearBackfillProof: {:?}",
-                worker_idx,
+                "logical connection {} returned unexpected response to ClearBackfillProof: {:?}",
+                connection_idx,
                 other
             )),
         }
@@ -447,20 +506,22 @@ impl MultiprocessWhopper {
 
     pub fn install_unpublished_backfill_proof_direct(
         &mut self,
-        worker_idx: usize,
+        connection_idx: usize,
         upper_bound_inclusive: u64,
     ) -> anyhow::Result<()> {
+        let location = self.connection_location(connection_idx);
         send_command(
-            &mut self.workers[worker_idx],
+            &mut self.processes[location.process_idx],
             &WorkerCommand::InstallUnpublishedBackfillProof {
+                connection_idx: location.connection_idx,
                 upper_bound_inclusive,
             },
         )?;
-        match recv_response(&mut self.workers[worker_idx])? {
+        match recv_response(&mut self.processes[location.process_idx])? {
             WorkerResponse::Ack => Ok(()),
             other => Err(anyhow::anyhow!(
-                "worker {} returned unexpected response to InstallUnpublishedBackfillProof: {:?}",
-                worker_idx,
+                "logical connection {} returned unexpected response to InstallUnpublishedBackfillProof: {:?}",
+                connection_idx,
                 other
             )),
         }
@@ -468,17 +529,18 @@ impl MultiprocessWhopper {
 
     pub fn shared_wal_snapshot_direct(
         &mut self,
-        worker_idx: usize,
+        connection_idx: usize,
     ) -> anyhow::Result<Option<WorkerSharedWalSnapshot>> {
+        let location = self.connection_location(connection_idx);
         send_command(
-            &mut self.workers[worker_idx],
+            &mut self.processes[location.process_idx],
             &WorkerCommand::ReadSharedWalSnapshot,
         )?;
-        match recv_response(&mut self.workers[worker_idx])? {
+        match recv_response(&mut self.processes[location.process_idx])? {
             WorkerResponse::SharedWalSnapshot { snapshot } => Ok(snapshot),
             other => Err(anyhow::anyhow!(
-                "worker {} returned unexpected response to ReadSharedWalSnapshot: {:?}",
-                worker_idx,
+                "logical connection {} returned unexpected response to ReadSharedWalSnapshot: {:?}",
+                connection_idx,
                 other
             )),
         }
@@ -486,18 +548,19 @@ impl MultiprocessWhopper {
 
     pub fn find_frame_for_page_direct(
         &mut self,
-        worker_idx: usize,
+        connection_idx: usize,
         page_id: u64,
     ) -> anyhow::Result<Option<u64>> {
+        let location = self.connection_location(connection_idx);
         send_command(
-            &mut self.workers[worker_idx],
+            &mut self.processes[location.process_idx],
             &WorkerCommand::FindFrameForPage { page_id },
         )?;
-        match recv_response(&mut self.workers[worker_idx])? {
+        match recv_response(&mut self.processes[location.process_idx])? {
             WorkerResponse::FrameLookup { frame_id } => Ok(frame_id),
             other => Err(anyhow::anyhow!(
-                "worker {} returned unexpected response to FindFrameForPage: {:?}",
-                worker_idx,
+                "logical connection {} returned unexpected response to FindFrameForPage: {:?}",
+                connection_idx,
                 other
             )),
         }
@@ -510,13 +573,19 @@ impl MultiprocessWhopper {
         sql: impl Into<String>,
     ) -> anyhow::Result<(WorkerStartupTelemetry, OpResult)> {
         let sql = sql.into();
-        let probe_worker_id = self.workers.len();
+        let probe_worker_id = self.processes.len();
         let (mut worker, telemetry) =
-            spawn_ready_worker(probe_worker_id, &self.db_path, self.enable_mvcc)?;
+            spawn_ready_worker(probe_worker_id, &self.db_path, self.enable_mvcc, 1)?;
 
         let result = (|| -> anyhow::Result<OpResult> {
             for _ in 0..8 {
-                send_command(&mut worker, &WorkerCommand::Execute { sql: sql.clone() })?;
+                send_command(
+                    &mut worker,
+                    &WorkerCommand::Execute {
+                        connection_idx: 0,
+                        sql: sql.clone(),
+                    },
+                )?;
                 let response = recv_response(&mut worker)?;
                 let op_result = response.into_op_result();
                 match &op_result {
@@ -548,7 +617,8 @@ impl MultiprocessWhopper {
         );
         self.history.record(&HistoryEvent::CohortRestartStarted {
             step: self.current_step,
-            worker_count: self.workers.len(),
+            process_count: self.processes.len(),
+            connection_count: self.connection_states.len(),
         })?;
 
         self.stop_all_workers_preserve_files("cohort_restart")?;
@@ -569,46 +639,49 @@ impl MultiprocessWhopper {
     }
 
     fn stop_all_workers_preserve_files(&mut self, reason: &'static str) -> anyhow::Result<()> {
-        for worker_idx in 0..self.workers.len() {
-            let worker_id = self.workers[worker_idx].worker_id;
-            let pid = self.workers[worker_idx].child.id();
+        for process_idx in 0..self.processes.len() {
+            let pid = self.processes[process_idx].child.id();
             self.history.record(&HistoryEvent::WorkerKilled {
                 step: self.current_step,
-                worker: worker_id,
+                process: process_idx,
                 pid,
                 reason,
             })?;
-            let _ = self.workers[worker_idx].child.kill();
+            let _ = self.processes[process_idx].child.kill();
         }
-        for worker in &mut self.workers {
-            let _ = worker.child.wait();
+        for process in &mut self.processes {
+            let _ = process.child.wait();
         }
 
-        for worker_idx in 0..self.worker_states.len() {
-            self.abort_worker_state(worker_idx, reason)?;
+        for process_idx in 0..self.processes.len() {
+            self.abort_process_state(process_idx, reason)?;
         }
         Ok(())
     }
 
     fn respawn_all_workers_preserve_files(&mut self, reason: &'static str) -> anyhow::Result<()> {
-        let mut new_workers = Vec::with_capacity(self.workers.len());
-        let mut new_telemetries = Vec::with_capacity(self.workers.len());
-        for worker_idx in 0..self.workers.len() {
-            let (handle, telemetry) =
-                spawn_ready_worker(worker_idx, &self.db_path, self.enable_mvcc)?;
+        let mut new_processes = Vec::with_capacity(self.processes.len());
+        let mut new_telemetries = Vec::with_capacity(self.processes.len());
+        for process_idx in 0..self.processes.len() {
+            let (handle, telemetry) = spawn_ready_worker(
+                process_idx,
+                &self.db_path,
+                self.enable_mvcc,
+                self.connections_per_process,
+            )?;
             self.history.record(&HistoryEvent::WorkerSpawned {
                 step: Some(self.current_step),
-                worker: worker_idx,
+                process: process_idx,
                 pid: handle.child.id(),
                 reason,
                 telemetry,
             })?;
-            info!("worker {} restarted: {:?}", worker_idx, telemetry);
-            new_workers.push(handle);
+            info!("process {} restarted: {:?}", process_idx, telemetry);
+            new_processes.push(handle);
             new_telemetries.push(telemetry);
         }
 
-        self.workers = new_workers;
+        self.processes = new_processes;
         self.worker_startup_telemetries = new_telemetries;
         Ok(())
     }
@@ -625,39 +698,46 @@ impl MultiprocessWhopper {
             return Ok(StepResult::Ok);
         }
 
-        let worker_idx = self.current_step % self.workers.len();
+        let connection_idx = self.current_step % self.connection_states.len();
 
-        // Optionally kill a worker for crash recovery testing
+        // Optionally kill a worker process for crash recovery testing
         if self.kill_probability > 0.0 && self.rng.random_bool(self.kill_probability) {
-            self.kill_and_respawn(worker_idx, "crash_recovery_test")?;
+            self.kill_and_respawn_process(connection_idx, "crash_recovery_test")?;
         }
 
-        self.perform_work(worker_idx)?;
+        self.perform_work(connection_idx)?;
         self.current_step += 1;
 
         Ok(StepResult::Ok)
     }
 
-    fn perform_work(&mut self, worker_idx: usize) -> anyhow::Result<()> {
-        let ws = &self.worker_states[worker_idx];
+    fn perform_work(&mut self, connection_idx: usize) -> anyhow::Result<()> {
+        let location = self.connection_location(connection_idx);
+        let ws = &self.connection_states[connection_idx];
         let exec_id = ws.execution_id;
         let txn_id = ws.txn_id;
 
         debug!(
-            "perform_work: step={}, worker={}, exec_id={:?}, txn_id={:?}, state={:?}",
-            self.current_step, worker_idx, exec_id, txn_id, ws.fiber_state
+            "perform_work: step={}, process={}, connection={}, exec_id={:?}, txn_id={:?}, state={:?}",
+            self.current_step,
+            location.process_idx,
+            connection_idx,
+            exec_id,
+            txn_id,
+            ws.fiber_state
         );
 
         // If the worker has a pending operation (e.g., auto-rollback), use that.
         // Otherwise, try chaotic workload, then regular workloads.
-        if self.worker_states[worker_idx].current_op.is_none() {
+        if self.connection_states[connection_idx].current_op.is_none() {
             // Try chaotic workload first
             if !self.chaotic_profiles.is_empty() {
-                self.try_resume_chaotic(worker_idx);
+                self.try_resume_chaotic(connection_idx);
             }
 
             // Fall through to regular workloads if chaotic didn't produce an op
-            if self.worker_states[worker_idx].current_op.is_none() && self.total_weight > 0 {
+            if self.connection_states[connection_idx].current_op.is_none() && self.total_weight > 0
+            {
                 let mut roll = self.rng.random_range(0..self.total_weight);
                 for (weight, workload) in &self.workloads {
                     if roll >= *weight {
@@ -665,7 +745,7 @@ impl MultiprocessWhopper {
                         continue;
                     }
                     let ctx = WorkloadContext {
-                        fiber_state: &self.worker_states[worker_idx].fiber_state,
+                        fiber_state: &self.connection_states[connection_idx].fiber_state,
                         sim_state: &self.sim_state,
                         opts: &self.opts,
                         enable_mvcc: self.enable_mvcc,
@@ -674,32 +754,32 @@ impl MultiprocessWhopper {
                     let Some(op) = workload.generate(&ctx, &mut self.rng) else {
                         continue;
                     };
-                    debug!("generated op for worker {}: {:?}", worker_idx, op);
-                    self.worker_states[worker_idx].current_op = Some(op);
+                    debug!("generated op for connection {}: {:?}", connection_idx, op);
+                    self.connection_states[connection_idx].current_op = Some(op);
                     break;
                 }
             }
         }
 
         // Execute the operation
-        let Some(op) = self.worker_states[worker_idx].current_op.take() else {
+        let Some(op) = self.connection_states[connection_idx].current_op.take() else {
             return Ok(()); // No operation generated this step
         };
 
         // Assign execution ID
         let exec_id = self.sim_state.gen_execution_id();
-        self.worker_states[worker_idx].execution_id = Some(exec_id);
+        self.connection_states[connection_idx].execution_id = Some(exec_id);
 
         // Assign txn_id for BEGIN
         if let Operation::Begin { .. } = &op {
-            self.worker_states[worker_idx].txn_id = Some(self.sim_state.gen_txn_id());
+            self.connection_states[connection_idx].txn_id = Some(self.sim_state.gen_txn_id());
         }
-        let txn_id = self.worker_states[worker_idx].txn_id;
+        let txn_id = self.connection_states[connection_idx].txn_id;
 
         // Notify properties: operation starting
         for property in &self.properties {
             let mut property = property.lock().unwrap();
-            property.init_op(self.current_step, worker_idx, txn_id, exec_id, &op)?;
+            property.init_op(self.current_step, connection_idx, txn_id, exec_id, &op)?;
         }
 
         // Send to worker and get result
@@ -707,41 +787,50 @@ impl MultiprocessWhopper {
         let op_description = format!("{op:?}");
         self.history.record(&HistoryEvent::OperationStarted {
             step: self.current_step,
-            worker: worker_idx,
+            process: location.process_idx,
+            connection: connection_idx,
             exec_id,
             txn_id,
             op: op_description.clone(),
             sql: sql.clone(),
         })?;
-        debug!("sending to worker {}: {}", worker_idx, sql);
+        debug!(
+            "sending to process {} connection {}: {}",
+            location.process_idx, location.connection_idx, sql
+        );
         send_command(
-            &mut self.workers[worker_idx],
-            &WorkerCommand::Execute { sql: sql.clone() },
+            &mut self.processes[location.process_idx],
+            &WorkerCommand::Execute {
+                connection_idx: location.connection_idx,
+                sql: sql.clone(),
+            },
         )?;
-        let response = match recv_response(&mut self.workers[worker_idx]) {
+        let response = match recv_response(&mut self.processes[location.process_idx]) {
             Ok(r) => r,
             Err(e) => {
-                // Worker crashed - kill old process before respawning to prevent
-                // two workers for the same slot from accessing the database simultaneously.
-                error!("worker {} crashed: {}", worker_idx, e);
+                // The worker process crashed. Kill the old process before respawning to prevent
+                // duplicate live access to the same database from one logical slot.
+                error!("process {} crashed: {}", location.process_idx, e);
                 self.history
                     .record(&HistoryEvent::OperationTransportFailure {
                         step: self.current_step,
-                        worker: worker_idx,
+                        process: location.process_idx,
+                        connection: connection_idx,
                         exec_id: Some(exec_id),
                         txn_id,
                         op: Some(op_description),
                         sql: Some(sql),
                         error: e.to_string(),
                     })?;
-                self.kill_and_respawn(worker_idx, "transport_failure")?;
+                self.kill_and_respawn_process(connection_idx, "transport_failure")?;
                 return Ok(());
             }
         };
         let op_result = response.into_op_result();
         self.history.record(&HistoryEvent::OperationFinished {
             step: self.current_step,
-            worker: worker_idx,
+            process: location.process_idx,
+            connection: connection_idx,
             exec_id,
             txn_id,
             op: op_description,
@@ -749,8 +838,8 @@ impl MultiprocessWhopper {
             result: HistoryResult::from(&op_result),
         })?;
         match &op_result {
-            Ok(_) => debug!("worker {} result: ok", worker_idx),
-            Err(err) => debug!("worker {} result: err={err:?}", worker_idx),
+            Ok(_) => debug!("connection {} result: ok", connection_idx),
+            Err(err) => debug!("connection {} result: err={err:?}", connection_idx),
         }
 
         // Skip benign errors that occur in multiprocess mode
@@ -761,24 +850,27 @@ impl MultiprocessWhopper {
                 || err.contains("already exists")
                 || err.contains("not exist")
             {
-                debug!("worker {}: skipped op ({})", worker_idx, err);
-                self.worker_states[worker_idx].execution_id = None;
+                debug!("connection {}: skipped op ({})", connection_idx, err);
+                self.connection_states[connection_idx].execution_id = None;
                 return Ok(());
             }
             // Schema/index desync after respawn or cross-process schema lag
             if err.contains("not found in schema") {
-                debug!("worker {}: schema desync ({})", worker_idx, err);
-                self.worker_states[worker_idx].execution_id = None;
+                debug!("connection {}: schema desync ({})", connection_idx, err);
+                self.connection_states[connection_idx].execution_id = None;
                 return Ok(());
             }
             // Worker's connection already auto-rolled back (state desync)
             if err.contains("no transaction is active") || err.contains("cannot rollback") {
-                debug!("worker {}: transaction already ended ({})", worker_idx, err);
-                self.worker_states[worker_idx].fiber_state = FiberState::Idle;
-                self.worker_states[worker_idx].txn_id = None;
-                self.worker_states[worker_idx].execution_id = None;
-                self.worker_states[worker_idx].chaotic_workload = None;
-                self.worker_states[worker_idx].last_chaotic_result = None;
+                debug!(
+                    "connection {}: transaction already ended ({})",
+                    connection_idx, err
+                );
+                self.connection_states[connection_idx].fiber_state = FiberState::Idle;
+                self.connection_states[connection_idx].txn_id = None;
+                self.connection_states[connection_idx].execution_id = None;
+                self.connection_states[connection_idx].chaotic_workload = None;
+                self.connection_states[connection_idx].last_chaotic_result = None;
                 return Ok(());
             }
         }
@@ -786,7 +878,8 @@ impl MultiprocessWhopper {
         // Update fiber state for BEGIN
         if let Operation::Begin { mode } = &op {
             if op_result.is_ok() {
-                self.worker_states[worker_idx].fiber_state = if *mode == TxMode::Concurrent {
+                self.connection_states[connection_idx].fiber_state = if *mode == TxMode::Concurrent
+                {
                     FiberState::InConcurrentTx
                 } else {
                     FiberState::InTx
@@ -809,7 +902,7 @@ impl MultiprocessWhopper {
             property
                 .finish_op(
                     self.current_step,
-                    worker_idx,
+                    connection_idx,
                     txn_id,
                     exec_id,
                     end_exec_id,
@@ -820,16 +913,20 @@ impl MultiprocessWhopper {
         }
 
         // Save result for chaotic workload
-        if self.worker_states[worker_idx].chaotic_workload.is_some()
-            && self.worker_states[worker_idx].last_chaotic_result.is_none()
+        if self.connection_states[connection_idx]
+            .chaotic_workload
+            .is_some()
+            && self.connection_states[connection_idx]
+                .last_chaotic_result
+                .is_none()
         {
-            self.worker_states[worker_idx].last_chaotic_result = Some(op_result.clone());
+            self.connection_states[connection_idx].last_chaotic_result = Some(op_result.clone());
         }
 
         // Update fiber state for COMMIT/ROLLBACK and auto-commit
         if matches!(op, Operation::Commit | Operation::Rollback) && op_result.is_ok() {
-            self.worker_states[worker_idx].fiber_state = FiberState::Idle;
-            self.worker_states[worker_idx].txn_id = None;
+            self.connection_states[connection_idx].fiber_state = FiberState::Idle;
+            self.connection_states[connection_idx].txn_id = None;
         }
 
         // Handle errors: initiate auto-rollback for retryable errors
@@ -843,27 +940,34 @@ impl MultiprocessWhopper {
                 | LimboError::WriteWriteConflict
                 | LimboError::CommitDependencyAborted
                 | LimboError::InvalidArgument(..) => {
-                    if self.worker_states[worker_idx].fiber_state.is_in_tx() {
-                        debug!("worker {}: auto-rollback after {:?}", worker_idx, error);
-                        self.worker_states[worker_idx].current_op = Some(Operation::Rollback);
+                    if self.connection_states[connection_idx]
+                        .fiber_state
+                        .is_in_tx()
+                    {
+                        debug!(
+                            "connection {}: auto-rollback after {:?}",
+                            connection_idx, error
+                        );
+                        self.connection_states[connection_idx].current_op =
+                            Some(Operation::Rollback);
                     } else {
-                        self.worker_states[worker_idx].txn_id = None;
+                        self.connection_states[connection_idx].txn_id = None;
                     }
                 }
                 // Corruption and checkpoint errors: log and respawn the worker.
                 // These are real multiprocess bugs we want to surface but not crash on.
                 LimboError::Corrupt(_) | LimboError::CheckpointFailed(_) => {
                     error!(
-                        "worker {} hit corruption on step {}: {} -- respawning",
-                        worker_idx, self.current_step, error
+                        "process {} hit corruption on step {} via connection {}: {} -- respawning",
+                        location.process_idx, self.current_step, connection_idx, error
                     );
                     self.stats.corruption_events += 1;
-                    self.kill_and_respawn(worker_idx, "corruption_recovery")?;
+                    self.kill_and_respawn_process(connection_idx, "corruption_recovery")?;
                 }
                 _ => {
                     return Err(anyhow::anyhow!(
-                        "worker {} fatal error on step {}: {}",
-                        worker_idx,
+                        "connection {} fatal error on step {}: {}",
+                        connection_idx,
                         self.current_step,
                         error
                     ));
@@ -871,73 +975,85 @@ impl MultiprocessWhopper {
             }
         }
 
-        self.worker_states[worker_idx].execution_id = None;
+        self.connection_states[connection_idx].execution_id = None;
         Ok(())
     }
 
-    /// Try to resume or start a chaotic workload for the given worker.
-    fn try_resume_chaotic(&mut self, worker_idx: usize) {
+    /// Try to resume or start a chaotic workload for the given logical connection.
+    fn try_resume_chaotic(&mut self, connection_idx: usize) {
         // Resume active workload with saved result
-        if let Some(result) = self.worker_states[worker_idx].last_chaotic_result.take() {
-            let mut workload = self.worker_states[worker_idx].chaotic_workload.take();
+        if let Some(result) = self.connection_states[connection_idx]
+            .last_chaotic_result
+            .take()
+        {
+            let mut workload = self.connection_states[connection_idx]
+                .chaotic_workload
+                .take();
             if let Some(ref mut wl) = workload {
                 if let Some(op) = wl.next(Some(result)) {
                     debug!(
-                        "chaotic: resumed workload for worker {}, next op: {:?}",
-                        worker_idx, op
+                        "chaotic: resumed workload for connection {}, next op: {:?}",
+                        connection_idx, op
                     );
-                    self.worker_states[worker_idx].current_op = Some(op);
-                    self.worker_states[worker_idx].chaotic_workload = workload;
+                    self.connection_states[connection_idx].current_op = Some(op);
+                    self.connection_states[connection_idx].chaotic_workload = workload;
                     return;
                 }
-                debug!("chaotic: workload completed for worker {}", worker_idx);
+                debug!(
+                    "chaotic: workload completed for connection {}",
+                    connection_idx
+                );
             }
         }
 
         // Pick a new chaotic workload (only when idle)
-        if self.worker_states[worker_idx].chaotic_workload.is_none()
-            && self.worker_states[worker_idx].fiber_state == FiberState::Idle
+        if self.connection_states[connection_idx]
+            .chaotic_workload
+            .is_none()
+            && self.connection_states[connection_idx].fiber_state == FiberState::Idle
         {
-            if let Some(op) = self.pick_chaotic_workload(worker_idx) {
-                self.worker_states[worker_idx].current_op = Some(op);
+            if let Some(op) = self.pick_chaotic_workload(connection_idx) {
+                self.connection_states[connection_idx].current_op = Some(op);
             }
         }
     }
 
-    fn pick_chaotic_workload(&mut self, worker_idx: usize) -> Option<Operation> {
+    fn pick_chaotic_workload(&mut self, connection_idx: usize) -> Option<Operation> {
         for (probability, name, profile) in &self.chaotic_profiles {
             if !self.rng.random_bool(*probability) {
                 continue;
             }
             let fiber_rng = ChaCha8Rng::seed_from_u64(self.rng.next_u64());
-            let mut workload = profile.generate(fiber_rng, worker_idx);
+            let mut workload = profile.generate(fiber_rng, connection_idx);
             if let Some(op) = workload.next(None) {
                 debug!(
-                    "chaotic: picked workload '{}' for worker {}",
-                    name, worker_idx
+                    "chaotic: picked workload '{}' for connection {}",
+                    name, connection_idx
                 );
-                self.worker_states[worker_idx].chaotic_workload = Some(workload);
+                self.connection_states[connection_idx].chaotic_workload = Some(workload);
                 return Some(op);
             }
         }
         None
     }
 
-    fn abort_worker_state(
+    fn abort_connection_state(
         &mut self,
-        worker_idx: usize,
+        connection_idx: usize,
         reason: &'static str,
     ) -> anyhow::Result<()> {
-        let txn_id = self.worker_states[worker_idx].txn_id;
-        let exec_id = self.worker_states[worker_idx].execution_id;
-        let fiber_state = format!("{:?}", self.worker_states[worker_idx].fiber_state);
-        let current_op = self.worker_states[worker_idx]
+        let location = self.connection_location(connection_idx);
+        let txn_id = self.connection_states[connection_idx].txn_id;
+        let exec_id = self.connection_states[connection_idx].execution_id;
+        let fiber_state = format!("{:?}", self.connection_states[connection_idx].fiber_state);
+        let current_op = self.connection_states[connection_idx]
             .current_op
             .as_ref()
             .map(|op| format!("{op:?}"));
         self.history.record(&HistoryEvent::WorkerStateAborted {
             step: self.current_step,
-            worker: worker_idx,
+            process: location.process_idx,
+            connection: connection_idx,
             reason,
             txn_id,
             exec_id,
@@ -946,41 +1062,67 @@ impl MultiprocessWhopper {
         })?;
         for property in &self.properties {
             let mut property = property.lock().unwrap();
-            property.abort_fiber(worker_idx, txn_id)?;
+            property.abort_fiber(connection_idx, txn_id)?;
         }
-        self.worker_states[worker_idx] = WorkerState::new();
+        self.connection_states[connection_idx] = ConnectionState::new();
         Ok(())
     }
 
-    /// Kill a worker and respawn it (tests crash recovery).
-    fn kill_and_respawn(&mut self, worker_idx: usize, reason: &'static str) -> anyhow::Result<()> {
-        let pid = self.workers[worker_idx].child.id();
-        info!("killing worker {} (pid {}) for {}", worker_idx, pid, reason);
+    fn abort_process_state(
+        &mut self,
+        process_idx: usize,
+        reason: &'static str,
+    ) -> anyhow::Result<()> {
+        for connection_idx in self.process_connection_indices(process_idx) {
+            self.abort_connection_state(connection_idx, reason)?;
+        }
+        Ok(())
+    }
+
+    /// Kill one worker process and respawn it (tests crash recovery).
+    fn kill_and_respawn_process(
+        &mut self,
+        connection_idx: usize,
+        reason: &'static str,
+    ) -> anyhow::Result<()> {
+        let location = self.connection_location(connection_idx);
+        let pid = self.processes[location.process_idx].child.id();
+        info!(
+            "killing process {} (pid {}) for {}",
+            location.process_idx, pid, reason
+        );
         self.history.record(&HistoryEvent::WorkerKilled {
             step: self.current_step,
-            worker: worker_idx,
+            process: location.process_idx,
             pid,
             reason,
         })?;
-        let _ = self.workers[worker_idx].child.kill();
-        let _ = self.workers[worker_idx].child.wait();
+        let _ = self.processes[location.process_idx].child.kill();
+        let _ = self.processes[location.process_idx].child.wait();
 
-        // Reset worker state and let properties discard or finalize any
-        // pending per-fiber state that died with the worker.
-        self.abort_worker_state(worker_idx, reason)?;
+        // Reset every logical connection hosted by the dead process.
+        self.abort_process_state(location.process_idx, reason)?;
 
         // Respawn
-        let (handle, telemetry) = spawn_ready_worker(worker_idx, &self.db_path, self.enable_mvcc)?;
+        let (handle, telemetry) = spawn_ready_worker(
+            location.process_idx,
+            &self.db_path,
+            self.enable_mvcc,
+            self.connections_per_process,
+        )?;
         self.history.record(&HistoryEvent::WorkerSpawned {
             step: Some(self.current_step),
-            worker: worker_idx,
+            process: location.process_idx,
             pid: handle.child.id(),
             reason,
             telemetry,
         })?;
-        self.workers[worker_idx] = handle;
-        self.worker_startup_telemetries[worker_idx] = telemetry;
-        info!("worker {} respawned and ready: {:?}", worker_idx, telemetry);
+        self.processes[location.process_idx] = handle;
+        self.worker_startup_telemetries[location.process_idx] = telemetry;
+        info!(
+            "process {} respawned and ready: {:?}",
+            location.process_idx, telemetry
+        );
         Ok(())
     }
 
@@ -1002,9 +1144,9 @@ impl MultiprocessWhopper {
         }
 
         // Shut down workers
-        for worker in &mut self.workers {
-            let _ = send_command(worker, &WorkerCommand::Shutdown);
-            let _ = worker.child.wait();
+        for process in &mut self.processes {
+            let _ = send_command(process, &WorkerCommand::Shutdown);
+            let _ = process.child.wait();
         }
 
         // Clean up database files
@@ -1022,26 +1164,27 @@ impl MultiprocessWhopper {
 
 impl Drop for MultiprocessWhopper {
     fn drop(&mut self) {
-        // Ensure workers are killed on drop
-        for worker in &mut self.workers {
-            let _ = worker.child.kill();
-            let _ = worker.child.wait();
+        // Ensure worker processes are killed on drop
+        for process in &mut self.processes {
+            let _ = process.child.kill();
+            let _ = process.child.wait();
         }
     }
 }
 
 fn spawn_ready_worker(
-    worker_id: usize,
+    process_idx: usize,
     db_path: &Path,
     enable_mvcc: bool,
-) -> anyhow::Result<(WorkerHandle, WorkerStartupTelemetry)> {
-    let mut handle = spawn_worker(worker_id, db_path, enable_mvcc)?;
+    connections_per_process: usize,
+) -> anyhow::Result<(WorkerProcessHandle, WorkerStartupTelemetry)> {
+    let mut handle = spawn_worker(process_idx, db_path, enable_mvcc, connections_per_process)?;
     let response = recv_response(&mut handle)?;
     match response {
         WorkerResponse::Ready { telemetry } => Ok((handle, telemetry)),
         other => Err(anyhow::anyhow!(
-            "worker {} sent unexpected response during init: {:?}",
-            worker_id,
+            "process {} sent unexpected response during init: {:?}",
+            process_idx,
             other
         )),
     }
@@ -1049,15 +1192,18 @@ fn spawn_ready_worker(
 
 /// Spawn a worker child process.
 fn spawn_worker(
-    worker_id: usize,
+    process_idx: usize,
     db_path: &Path,
     enable_mvcc: bool,
-) -> anyhow::Result<WorkerHandle> {
+    connections_per_process: usize,
+) -> anyhow::Result<WorkerProcessHandle> {
     let exe = worker_executable()?;
     let mut cmd = Command::new(&exe);
     cmd.arg("worker")
         .arg("--db-path")
         .arg(db_path)
+        .arg("--connections-per-process")
+        .arg(connections_per_process.to_string())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit());
@@ -1068,17 +1214,17 @@ fn spawn_worker(
 
     let mut child = cmd
         .spawn()
-        .map_err(|e| anyhow::anyhow!("failed to spawn worker {worker_id}: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("failed to spawn process {process_idx}: {e}"))?;
 
     let stdin = child.stdin.take().unwrap();
     let stdout = child.stdout.take().unwrap();
-    let responses = spawn_stdout_reader(worker_id, stdout);
+    let responses = spawn_stdout_reader(process_idx, stdout);
 
-    Ok(WorkerHandle {
+    Ok(WorkerProcessHandle {
         child,
         stdin: BufWriter::new(stdin),
         responses,
-        worker_id,
+        process_idx,
     })
 }
 
@@ -1093,32 +1239,32 @@ fn worker_executable() -> anyhow::Result<PathBuf> {
 }
 
 /// Send a command to a worker.
-fn send_command(worker: &mut WorkerHandle, cmd: &WorkerCommand) -> anyhow::Result<()> {
-    serde_json::to_writer(&mut worker.stdin, cmd)?;
-    worker.stdin.write_all(b"\n")?;
-    worker.stdin.flush()?;
+fn send_command(process: &mut WorkerProcessHandle, cmd: &WorkerCommand) -> anyhow::Result<()> {
+    serde_json::to_writer(&mut process.stdin, cmd)?;
+    process.stdin.write_all(b"\n")?;
+    process.stdin.flush()?;
     Ok(())
 }
 
 /// Receive a response from a worker.
-fn recv_response(worker: &mut WorkerHandle) -> anyhow::Result<WorkerResponse> {
-    recv_response_timeout(worker, Duration::from_secs(10))
+fn recv_response(process: &mut WorkerProcessHandle) -> anyhow::Result<WorkerResponse> {
+    recv_response_timeout(process, Duration::from_secs(10))
 }
 
 fn recv_response_timeout(
-    worker: &mut WorkerHandle,
+    process: &mut WorkerProcessHandle,
     timeout: Duration,
 ) -> anyhow::Result<WorkerResponse> {
-    match worker.responses.recv_timeout(timeout) {
+    match process.responses.recv_timeout(timeout) {
         Ok(result) => result,
         Err(RecvTimeoutError::Timeout) => Err(anyhow::anyhow!(
-            "worker {} timed out after {:?} waiting for response",
-            worker.worker_id,
+            "process {} timed out after {:?} waiting for response",
+            process.process_idx,
             timeout
         )),
         Err(RecvTimeoutError::Disconnected) => Err(anyhow::anyhow!(
-            "worker {} response channel disconnected",
-            worker.worker_id
+            "process {} response channel disconnected",
+            process.process_idx
         )),
     }
 }
@@ -1187,7 +1333,7 @@ mod tests {
     use std::sync::mpsc;
     use std::time::Duration;
 
-    use super::WorkerHandle;
+    use super::WorkerProcessHandle;
 
     fn history_output_path(label: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
@@ -1213,16 +1359,16 @@ mod tests {
             .spawn()
             .expect("failed to spawn placeholder child");
         let stdin = child.stdin.take();
-        let mut handle = WorkerHandle {
+        let mut handle = WorkerProcessHandle {
             child,
             stdin: BufWriter::new(stdin.expect("placeholder child should have stdin")),
             responses: rx,
-            worker_id: 3,
+            process_idx: 3,
         };
 
         let err = recv_response_timeout(&mut handle, Duration::from_millis(10))
             .expect_err("recv_response should time out");
-        assert!(err.to_string().contains("worker 3 timed out"));
+        assert!(err.to_string().contains("process 3 timed out"));
 
         let _ = handle.child.kill();
         let _ = handle.child.wait();
@@ -1263,7 +1409,7 @@ mod tests {
         writer
             .record(&super::HistoryEvent::WorkerSpawned {
                 step: None,
-                worker: 1,
+                process: 1,
                 pid: 4242,
                 reason: "initial_spawn",
                 telemetry,
@@ -1272,7 +1418,8 @@ mod tests {
         writer
             .record(&super::HistoryEvent::OperationFinished {
                 step: 7,
-                worker: 1,
+                process: 1,
+                connection: 3,
                 exec_id: 12,
                 txn_id: Some(5),
                 op: "SimpleSelect { table_name: \"t\", key: \"k\" }".to_string(),
@@ -1295,12 +1442,15 @@ mod tests {
         let worker_spawned: JsonValue =
             serde_json::from_str(lines[0]).expect("parse worker spawned event");
         assert_eq!(worker_spawned["kind"], "worker_spawned");
+        assert_eq!(worker_spawned["process"], 1);
         assert_eq!(worker_spawned["reason"], "initial_spawn");
         assert_eq!(worker_spawned["telemetry"]["reopened_nbackfills"], 3);
 
         let operation_finished: JsonValue =
             serde_json::from_str(lines[1]).expect("parse operation finished event");
         assert_eq!(operation_finished["kind"], "operation_finished");
+        assert_eq!(operation_finished["process"], 1);
+        assert_eq!(operation_finished["connection"], 3);
         assert_eq!(operation_finished["exec_id"], 12);
         assert_eq!(operation_finished["result"]["status"], "err");
         assert_eq!(operation_finished["result"]["error_kind"], "Busy");

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -11,6 +11,7 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -238,16 +239,22 @@ impl MultiprocessWhopper {
         });
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
-        // Create database file on disk
+        // Create database file on disk.
+        // Use an atomic counter alongside the timestamp to guarantee uniqueness
+        // even when parallel test threads call SystemTime::now() within the same
+        // clock tick.
+        static PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
         let unique_suffix = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock is before UNIX_EPOCH")
             .as_nanos();
+        let counter = PATH_COUNTER.fetch_add(1, AtomicOrdering::Relaxed);
         let db_path = PathBuf::from(format!(
-            "/tmp/whopper-mp-{}-{}-{}.db",
+            "/tmp/whopper-mp-{}-{}-{}-{}.db",
             seed,
             std::process::id(),
-            unique_suffix
+            unique_suffix,
+            counter
         ));
         info!("multiprocess db: {}", db_path.display());
 

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -237,7 +237,7 @@ impl MultiprocessWhopper {
                 io,
                 db_path.to_str().unwrap(),
                 OpenFlags::default(),
-                DatabaseOpts::new(),
+                DatabaseOpts::new().with_multiprocess_wal(true),
                 None,
             )?;
             let conn = db.connect()?;

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -198,6 +198,18 @@ impl Operation {
     /// Called when an operation finishes execution.
     /// Applies state changes based on operation type and result.
     pub fn finish_op(&self, ctx: &mut OpContext, result: &OpResult) {
+        self.apply_state_changes(ctx.sim_state, ctx.stats, ctx.rng, result);
+    }
+
+    /// Apply state changes without requiring a SimulatorFiber/Connection.
+    /// Used by both in-process fibers and multiprocess workers.
+    pub fn apply_state_changes(
+        &self,
+        sim_state: &mut SimulatorState,
+        stats: &mut Stats,
+        rng: &mut ChaCha8Rng,
+        result: &OpResult,
+    ) {
         // Only apply state changes on success
         if result.is_err() {
             return;
@@ -205,30 +217,30 @@ impl Operation {
 
         match self {
             Operation::CreateSimpleTable { table_name } => {
-                ctx.sim_state.simple_tables.insert(table_name.clone(), ());
+                sim_state.simple_tables.insert(table_name.clone(), ());
             }
             Operation::SimpleInsert {
                 table_name, key, ..
             } => {
                 let table_name = table_name.clone();
-                let keys = &mut ctx.sim_state.simple_tables_keys;
+                let keys = &mut sim_state.simple_tables_keys;
                 let container = keys
                     .entry(table_name)
                     .or_insert_with(|| SamplesContainer::new(MAX_SAMPLE_KEYS_PER_TABLE));
-                container.add(key.clone(), ctx.rng);
-                ctx.stats.inserts += 1;
+                container.add(key.clone(), rng);
+                stats.inserts += 1;
             }
             Operation::Insert { .. } => {
-                ctx.stats.inserts += 1;
+                stats.inserts += 1;
             }
             Operation::Delete { .. } => {
-                ctx.stats.deletes += 1;
+                stats.deletes += 1;
             }
             Operation::Update { .. } => {
-                ctx.stats.updates += 1;
+                stats.updates += 1;
             }
             Operation::IntegrityCheck => {
-                ctx.stats.integrity_checks += 1;
+                stats.integrity_checks += 1;
             }
             Operation::CreateIndex {
                 index_name,
@@ -237,19 +249,19 @@ impl Operation {
             } => {
                 let index_name = index_name.clone();
                 let table_name = table_name.clone();
-                ctx.sim_state.indexes.insert(index_name, table_name);
+                sim_state.indexes.insert(index_name, table_name);
             }
             Operation::DropIndex { index_name, .. } => {
-                ctx.sim_state.indexes.remove(index_name);
+                sim_state.indexes.remove(index_name);
             }
             Operation::CreateElleTable { table_name } => {
-                ctx.sim_state.elle_tables.insert(table_name.clone(), ());
+                sim_state.elle_tables.insert(table_name.clone(), ());
             }
             Operation::ElleAppend { .. } | Operation::ElleRwWrite { .. } => {
-                ctx.stats.elle_writes += 1;
+                stats.elle_writes += 1;
             }
             Operation::ElleRead { .. } | Operation::ElleRwRead { .. } => {
-                ctx.stats.elle_reads += 1;
+                stats.elle_reads += 1;
             }
             _ => {}
         }

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -40,6 +40,15 @@ pub trait Property: Send + Sync {
         _result: &OpResult,
     ) -> anyhow::Result<()>;
 
+    /// Called when a worker/fiber is aborted out-of-band (for example, the
+    /// multiprocess coordinator kills and respawns a worker process).
+    ///
+    /// Properties can use this to discard or finalize any pending state that
+    /// would otherwise leak across a crash boundary.
+    fn abort_fiber(&mut self, _fiber_id: usize, _txn_id: Option<u64>) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Called when the simulation finishes.
     /// Default implementation does nothing.
     fn finalize(&mut self) -> anyhow::Result<()> {
@@ -162,6 +171,14 @@ impl Property for SimpleKeysDoNotDisappear {
         }
         Ok(())
     }
+
+    fn abort_fiber(&mut self, _fiber_id: usize, txn_id: Option<u64>) -> anyhow::Result<()> {
+        if let Some(txn_id) = txn_id {
+            self.txn_started_at.remove(&txn_id);
+            self.simple_keys_added_at.remove(&Some(txn_id));
+        }
+        Ok(())
+    }
 }
 
 /// Property that validates integrity check results.
@@ -200,8 +217,9 @@ impl Property for IntegrityCheckProperty {
             Ok(rows) => {
                 if rows.len() != 1 {
                     bail!(
-                        "step {step}, fiber {fiber_id}: integrity_check returned {} rows, expected 1",
-                        rows.len()
+                        "step {step}, fiber {fiber_id}: integrity_check returned {} rows, expected 1: {:?}",
+                        rows.len(),
+                        rows
                     );
                 }
                 let row = &rows[0];
@@ -213,6 +231,8 @@ impl Property for IntegrityCheckProperty {
                 }
                 match &row[0] {
                     Value::Text(text) if text.as_str() == "ok" => Ok(()),
+                    // "Page N: never used" is informational in MVCC mode, not corruption
+                    Value::Text(text) if is_integrity_check_informational(text.as_str()) => Ok(()),
                     other => {
                         bail!(
                             "step {step}, fiber {fiber_id}: integrity_check returned {:?}, expected \"ok\"",
@@ -223,6 +243,15 @@ impl Property for IntegrityCheckProperty {
             }
         }
     }
+}
+
+/// Check if an integrity_check result is informational (not actual corruption).
+/// In MVCC mode, "Page N: never used" is expected for allocated but unused pages.
+fn is_integrity_check_informational(text: &str) -> bool {
+    text.lines().all(|line| {
+        let line = line.trim();
+        line.is_empty() || line.starts_with("***") || line.contains("never used")
+    })
 }
 
 /// A buffered Elle event to be sorted and written at the end.
@@ -631,6 +660,54 @@ impl Property for ElleHistoryRecorder {
         Ok(())
     }
 
+    fn abort_fiber(&mut self, fiber_id: usize, _txn_id: Option<u64>) -> anyhow::Result<()> {
+        if let Some(pending) = self.pending_txns.remove(&fiber_id) {
+            if let Some(invoke_index) = pending.invoke_index {
+                if !pending.ops.is_empty() {
+                    let invoke_time = pending
+                        .invoke_time
+                        .expect("invoke_time must be set when invoke_index is set");
+                    let invoke_ops = nil_reads(&pending.ops);
+                    self.add_event(
+                        invoke_index,
+                        ElleEventType::Invoke,
+                        fiber_id,
+                        invoke_ops,
+                        invoke_time,
+                    );
+                    let info_index = self.next_index();
+                    self.add_event(
+                        info_index,
+                        ElleEventType::Info,
+                        fiber_id,
+                        pending.ops,
+                        invoke_time,
+                    );
+                }
+            }
+        }
+
+        if let Some(pending) = self.pending_auto_commits.remove(&fiber_id) {
+            self.add_event(
+                pending.invoke_index,
+                ElleEventType::Invoke,
+                fiber_id,
+                vec![pending.op.clone()],
+                pending.invoke_time,
+            );
+            let info_index = self.next_index();
+            self.add_event(
+                info_index,
+                ElleEventType::Info,
+                fiber_id,
+                vec![pending.op],
+                pending.invoke_time,
+            );
+        }
+
+        Ok(())
+    }
+
     fn finalize(&mut self) -> anyhow::Result<()> {
         // Emit :info events for any pending transactions (incomplete)
         let pending_txns: Vec<_> = self.pending_txns.drain().collect();
@@ -705,6 +782,119 @@ fn nil_reads(ops: &[ElleOp]) -> Vec<ElleOp> {
             other => other.clone(),
         })
         .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::items_after_test_module)]
+mod tests {
+    use super::*;
+
+    fn test_output_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "turso-whopper-{label}-{}-{}.edn",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ))
+    }
+
+    #[test]
+    fn simple_keys_abort_fiber_drops_pending_transaction_state() {
+        let mut property = SimpleKeysDoNotDisappear::new();
+        property.txn_started_at.insert(7, 11);
+        property.simple_keys_added_at.insert(
+            Some(7),
+            HashMap::from([(("t".to_string(), "k".to_string()), 13)]),
+        );
+
+        property.abort_fiber(0, Some(7)).unwrap();
+
+        assert!(!property.txn_started_at.contains_key(&7));
+        assert!(!property.simple_keys_added_at.contains_key(&Some(7)));
+    }
+
+    #[test]
+    fn elle_history_abort_fiber_marks_pending_transaction_as_info() {
+        let mut recorder = ElleHistoryRecorder::new(test_output_path("abort-pending-transaction"));
+
+        recorder
+            .init_op(
+                0,
+                3,
+                Some(9),
+                17,
+                &Operation::Begin {
+                    mode: crate::operations::TxMode::Immediate,
+                },
+            )
+            .unwrap();
+        recorder
+            .finish_op(
+                0,
+                3,
+                Some(9),
+                17,
+                18,
+                &Operation::Begin {
+                    mode: crate::operations::TxMode::Immediate,
+                },
+                &Ok(vec![]),
+            )
+            .unwrap();
+        recorder
+            .finish_op(
+                1,
+                3,
+                Some(9),
+                21,
+                22,
+                &Operation::ElleAppend {
+                    table_name: "elle_lists".to_string(),
+                    key: "k".to_string(),
+                    value: 5,
+                },
+                &Ok(vec![]),
+            )
+            .unwrap();
+
+        recorder.abort_fiber(3, Some(9)).unwrap();
+
+        assert!(!recorder.pending_txns.contains_key(&3));
+        assert_eq!(recorder.events.len(), 2);
+        assert!(matches!(
+            recorder.events[0].event_type,
+            ElleEventType::Invoke
+        ));
+        assert!(matches!(recorder.events[1].event_type, ElleEventType::Info));
+    }
+
+    #[test]
+    fn elle_history_abort_fiber_marks_pending_autocommit_as_info() {
+        let mut recorder = ElleHistoryRecorder::new(test_output_path("abort-autocommit"));
+
+        recorder
+            .init_op(
+                0,
+                4,
+                None,
+                31,
+                &Operation::ElleRwWrite {
+                    table_name: "elle_rw".to_string(),
+                    key: "k".to_string(),
+                    value: 9,
+                },
+            )
+            .unwrap();
+
+        recorder.abort_fiber(4, None).unwrap();
+
+        assert!(!recorder.pending_auto_commits.contains_key(&4));
+        assert_eq!(recorder.events.len(), 2);
+        assert!(matches!(
+            recorder.events[0].event_type,
+            ElleEventType::Invoke
+        ));
+        assert!(matches!(recorder.events[1].event_type, ElleEventType::Info));
+    }
 }
 
 fn parse_read_result(result: &OpResult) -> Option<Vec<i64>> {

--- a/testing/concurrent-simulator/protocol.rs
+++ b/testing/concurrent-simulator/protocol.rs
@@ -1,0 +1,139 @@
+//! JSON-line protocol for coordinator-worker communication in multiprocess mode.
+
+use serde::{Deserialize, Serialize};
+use turso_core::{LimboError, Value};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerCoordinationOpenMode {
+    Exclusive,
+    MultiProcess,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerStartupTelemetry {
+    pub loaded_from_disk_scan: bool,
+    pub reopened_max_frame: u64,
+    pub reopened_nbackfills: u64,
+    pub reopened_checkpoint_seq: u32,
+    pub coordination_open_mode: Option<WorkerCoordinationOpenMode>,
+    pub sanitized_backfill_proof_on_open: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerSharedWalSnapshot {
+    pub max_frame: u64,
+    pub nbackfills: u64,
+    pub checkpoint_seq: u32,
+    pub frame_index_overflowed: bool,
+}
+
+/// Command sent from coordinator to worker over stdin.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum WorkerCommand {
+    /// Execute a SQL statement and return the result.
+    Execute { sql: String },
+    /// Disable connection-level automatic checkpointing.
+    DisableAutoCheckpoint,
+    /// Run a bounded passive checkpoint directly through the pager.
+    PassiveCheckpoint { upper_bound_inclusive: Option<u64> },
+    /// Clear the durable backfill proof without disturbing the authority snapshot.
+    ClearBackfillProof,
+    /// Install a valid durable proof while keeping published nbackfills at zero.
+    InstallUnpublishedBackfillProof { upper_bound_inclusive: u64 },
+    /// Read the authoritative shared WAL snapshot for deterministic assertions.
+    ReadSharedWalSnapshot,
+    /// Read the authoritative shared wal-index mapping for one page.
+    FindFrameForPage { page_id: u64 },
+    /// Gracefully shut down the worker.
+    Shutdown,
+}
+
+/// Response sent from worker to coordinator over stdout.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum WorkerResponse {
+    /// Worker has initialized and is ready to accept commands.
+    Ready {
+        telemetry: WorkerStartupTelemetry,
+    },
+    /// A non-query control command succeeded.
+    Ack,
+    /// Shared WAL snapshot read for deterministic restart assertions.
+    SharedWalSnapshot {
+        snapshot: Option<WorkerSharedWalSnapshot>,
+    },
+    FrameLookup {
+        frame_id: Option<u64>,
+    },
+    /// SQL execution succeeded, returning rows.
+    Ok {
+        rows: Vec<Vec<Value>>,
+    },
+    /// SQL execution failed with an error.
+    Error {
+        error_kind: String,
+        message: String,
+    },
+}
+
+impl WorkerResponse {
+    /// Convert this response into an `OpResult` for the property system.
+    pub fn into_op_result(self) -> Result<Vec<Vec<Value>>, LimboError> {
+        match self {
+            WorkerResponse::Ok { rows } => Ok(rows),
+            WorkerResponse::Error {
+                error_kind,
+                message,
+            } => Err(error_kind_to_limbo_error(&error_kind, &message)),
+            WorkerResponse::Ready { .. }
+            | WorkerResponse::Ack
+            | WorkerResponse::SharedWalSnapshot { .. }
+            | WorkerResponse::FrameLookup { .. } => Err(LimboError::InternalError(
+                "worker returned a non-SQL response to SQL execution".into(),
+            )),
+        }
+    }
+}
+
+/// Classify a `LimboError` into an error_kind string for the protocol.
+pub fn limbo_error_to_kind(err: &LimboError) -> &'static str {
+    match err {
+        LimboError::Busy => "Busy",
+        LimboError::BusySnapshot => "BusySnapshot",
+        LimboError::WriteWriteConflict => "WriteWriteConflict",
+        LimboError::CommitDependencyAborted => "CommitDependencyAborted",
+        LimboError::SchemaUpdated => "SchemaUpdated",
+        LimboError::SchemaConflict => "SchemaConflict",
+        LimboError::TableLocked => "TableLocked",
+        LimboError::InvalidArgument(_) => "InvalidArgument",
+        LimboError::Constraint(_) => "Constraint",
+        LimboError::Corrupt(_) => "Corrupt",
+        LimboError::ReadOnly => "ReadOnly",
+        LimboError::Interrupt => "Interrupt",
+        LimboError::InternalError(_) => "InternalError",
+        LimboError::Conflict(_) => "Conflict",
+        LimboError::CheckpointFailed(_) => "CheckpointFailed",
+        _ => "Other",
+    }
+}
+
+/// Map an error_kind string back to a `LimboError`.
+fn error_kind_to_limbo_error(kind: &str, message: &str) -> LimboError {
+    match kind {
+        "Busy" => LimboError::Busy,
+        "BusySnapshot" => LimboError::BusySnapshot,
+        "WriteWriteConflict" => LimboError::WriteWriteConflict,
+        "CommitDependencyAborted" => LimboError::CommitDependencyAborted,
+        "SchemaUpdated" => LimboError::SchemaUpdated,
+        "SchemaConflict" => LimboError::SchemaConflict,
+        "TableLocked" => LimboError::TableLocked,
+        "InvalidArgument" => LimboError::InvalidArgument(message.to_string()),
+        "Constraint" => LimboError::Constraint(message.to_string()),
+        "Corrupt" => LimboError::Corrupt(message.to_string()),
+        "ReadOnly" => LimboError::ReadOnly,
+        "Interrupt" => LimboError::Interrupt,
+        "InternalError" => LimboError::InternalError(message.to_string()),
+        "Conflict" => LimboError::Conflict(message.to_string()),
+        "CheckpointFailed" => LimboError::CheckpointFailed(message.to_string()),
+        _ => LimboError::InternalError(format!("{kind}: {message}")),
+    }
+}

--- a/testing/concurrent-simulator/protocol.rs
+++ b/testing/concurrent-simulator/protocol.rs
@@ -31,15 +31,21 @@ pub struct WorkerSharedWalSnapshot {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkerCommand {
     /// Execute a SQL statement and return the result.
-    Execute { sql: String },
+    Execute { connection_idx: usize, sql: String },
     /// Disable connection-level automatic checkpointing.
-    DisableAutoCheckpoint,
+    DisableAutoCheckpoint { connection_idx: usize },
     /// Run a bounded passive checkpoint directly through the pager.
-    PassiveCheckpoint { upper_bound_inclusive: Option<u64> },
+    PassiveCheckpoint {
+        connection_idx: usize,
+        upper_bound_inclusive: Option<u64>,
+    },
     /// Clear the durable backfill proof without disturbing the authority snapshot.
     ClearBackfillProof,
     /// Install a valid durable proof while keeping published nbackfills at zero.
-    InstallUnpublishedBackfillProof { upper_bound_inclusive: u64 },
+    InstallUnpublishedBackfillProof {
+        connection_idx: usize,
+        upper_bound_inclusive: u64,
+    },
     /// Read the authoritative shared WAL snapshot for deterministic assertions.
     ReadSharedWalSnapshot,
     /// Read the authoritative shared wal-index mapping for one page.

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -38,6 +38,11 @@ fn wait_for_file(path: &Path) {
 }
 
 #[cfg(all(unix, target_pointer_width = "64"))]
+fn multiprocess_wal_db_opts() -> DatabaseOpts {
+    DatabaseOpts::new().with_multiprocess_wal(true)
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
 fn flip_db_header_reserved_byte(path: &Path) {
     use std::io::{Read, Seek, SeekFrom, Write};
 
@@ -206,7 +211,7 @@ fn read_simple_kv_length(db_path: &Path, table_name: &str, key: &str) -> Option<
         io,
         db_path.to_str().expect("db path utf8"),
         OpenFlags::ReadOnly,
-        DatabaseOpts::new(),
+        multiprocess_wal_db_opts(),
         None,
     )
     .expect("open observer database");
@@ -743,7 +748,7 @@ fn multiprocess_seed_5724542806254236599_localizes_key_4362_loss() {
         observer_io,
         db_path.to_str().expect("db path utf8"),
         OpenFlags::ReadOnly,
-        DatabaseOpts::new(),
+        multiprocess_wal_db_opts(),
         None,
     )
     .expect("open observer database for diagnostics");
@@ -956,7 +961,7 @@ fn multiprocess_seed_5724542806254236599_localizes_key_4994_loss() {
         observer_io,
         db_path.to_str().expect("db path utf8"),
         OpenFlags::ReadOnly,
-        DatabaseOpts::new(),
+        multiprocess_wal_db_opts(),
         None,
     )
     .expect("open observer database after insert");

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -1,8 +1,19 @@
 use rand_chacha::ChaCha8Rng;
 use rand_chacha::rand_core::SeedableRng;
+use std::path::Path;
 use std::sync::Arc;
-use turso_core::{Database, DatabaseOpts, IO, OpenFlags, Statement};
-use turso_whopper::{IOFaultConfig, SimulatorIO};
+use turso_core::{
+    Connection, Database, DatabaseOpts, IO, LimboError, OpenFlags, PlatformIO, Statement,
+};
+use turso_whopper::{
+    IOFaultConfig, SimulatorIO,
+    multiprocess::{MultiprocessOpts, MultiprocessWhopper},
+    workloads::{
+        BeginWorkload, CommitWorkload, CreateIndexWorkload, CreateSimpleTableWorkload,
+        DeleteWorkload, DropIndexWorkload, IntegrityCheckWorkload, RollbackWorkload,
+        SimpleInsertWorkload, SimpleSelectWorkload, UpdateWorkload, WalCheckpointWorkload,
+    },
+};
 
 /// Helper: run a SQL statement to completion with round-robin IO stepping.
 fn run_to_done(stmt: &mut Statement, io: &SimulatorIO) {
@@ -13,6 +24,305 @@ fn run_to_done(stmt: &mut Statement, io: &SimulatorIO) {
             _ => {}
         }
     }
+}
+
+fn wait_for_file(path: &Path) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn flip_db_header_reserved_byte(path: &Path) {
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .expect("open db file for header mutation");
+    file.seek(SeekFrom::Start(72))
+        .expect("seek to reserved header byte");
+    let mut byte = [0u8; 1];
+    file.read_exact(&mut byte)
+        .expect("read reserved header byte");
+    byte[0] ^= 0x01;
+    file.seek(SeekFrom::Start(72))
+        .expect("seek to reserved header byte for write");
+    file.write_all(&byte).expect("write mutated header byte");
+    file.sync_all().expect("sync db header mutation");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn configure_worker_exe() {
+    unsafe {
+        std::env::set_var(
+            "TURSO_WHOPPER_WORKER_EXE",
+            env!("CARGO_BIN_EXE_turso_whopper"),
+        );
+    }
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn create_multiprocess_whopper(max_connections: usize) -> MultiprocessWhopper {
+    create_multiprocess_whopper_with_keep(max_connections, false)
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn create_multiprocess_whopper_with_keep(
+    max_connections: usize,
+    keep_files: bool,
+) -> MultiprocessWhopper {
+    configure_worker_exe();
+    MultiprocessWhopper::new(MultiprocessOpts {
+        seed: Some(7),
+        enable_mvcc: false,
+        max_connections,
+        max_steps: 0,
+        elle_tables: vec![],
+        workloads: vec![],
+        properties: vec![],
+        chaotic_profiles: vec![],
+        kill_probability: 0.0,
+        restart_probability: 0.0,
+        history_output: None,
+        keep_files,
+    })
+    .expect("create multiprocess whopper")
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn populate_blob_test_rows(whopper: &mut MultiprocessWhopper) {
+    whopper
+        .disable_auto_checkpoint_direct(0)
+        .expect("disable auto checkpoint");
+    whopper
+        .execute_sql_direct(0, "create table test(id integer primary key, value blob)")
+        .expect("create table")
+        .expect("create table should succeed");
+    whopper
+        .execute_sql_direct(0, "begin immediate")
+        .expect("begin write transaction")
+        .expect("begin should succeed");
+    for _ in 0..32 {
+        whopper
+            .execute_sql_direct(0, "insert into test(value) values (randomblob(2048))")
+            .expect("insert blob row")
+            .expect("insert should succeed");
+    }
+    whopper
+        .execute_sql_direct(0, "commit")
+        .expect("commit transaction")
+        .expect("commit should succeed");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn create_partial_checkpoint_state(whopper: &mut MultiprocessWhopper) -> (u64, u64) {
+    populate_blob_test_rows(whopper);
+
+    let snapshot_before_checkpoint = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read shared WAL snapshot before checkpoint")
+        .expect("shared WAL snapshot should be available");
+    assert!(
+        snapshot_before_checkpoint.max_frame > 1,
+        "partial-checkpoint restart coverage requires more than one WAL frame before checkpointing"
+    );
+
+    whopper
+        .passive_checkpoint_direct(0, Some(1))
+        .expect("run partial checkpoint");
+
+    let snapshot_after_checkpoint = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read shared WAL snapshot after checkpoint")
+        .expect("shared WAL snapshot should be available");
+    assert!(
+        snapshot_after_checkpoint.nbackfills > 0,
+        "partial-checkpoint restart coverage requires positive nbackfills"
+    );
+    assert!(
+        snapshot_after_checkpoint.max_frame > snapshot_after_checkpoint.nbackfills,
+        "partial-checkpoint restart coverage requires live WAL frames past the backfill point"
+    );
+
+    (
+        snapshot_after_checkpoint.max_frame,
+        snapshot_after_checkpoint.nbackfills,
+    )
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn count_test_rows(whopper: &mut MultiprocessWhopper, worker_idx: usize) -> i64 {
+    let rows = whopper
+        .execute_sql_direct(worker_idx, "select count(*) from test")
+        .expect("count rows")
+        .expect("count should succeed");
+    rows[0][0].as_int().expect("count should be integer")
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn assert_integrity_check_ok(whopper: &mut MultiprocessWhopper, worker_idx: usize) {
+    let rows = whopper
+        .execute_sql_direct(worker_idx, "PRAGMA integrity_check")
+        .expect("run integrity_check")
+        .expect("integrity_check should succeed");
+    assert_eq!(rows.len(), 1, "integrity_check should return one row");
+    assert_eq!(
+        rows[0].len(),
+        1,
+        "integrity_check row should contain one column"
+    );
+    assert_eq!(
+        rows[0][0].to_text(),
+        Some("ok"),
+        "integrity_check should report ok"
+    );
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn count_rows_in_table(conn: &Arc<Connection>, table_name: &str) -> i64 {
+    let mut stmt = conn
+        .prepare(format!("select count(*) from {table_name}"))
+        .expect("prepare count");
+    let mut count = 0;
+    stmt.run_with_row_callback(|row| {
+        count = row.get(0).expect("count column");
+        Ok(())
+    })
+    .expect("run count");
+    count
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn read_simple_kv_length(db_path: &Path, table_name: &str, key: &str) -> Option<i64> {
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().expect("platform io"));
+    let reopened = Database::open_file_with_flags(
+        io,
+        db_path.to_str().expect("db path utf8"),
+        OpenFlags::ReadOnly,
+        DatabaseOpts::new(),
+        None,
+    )
+    .expect("open observer database");
+    let conn = reopened.connect().expect("connect observer db");
+    let sql = format!("select length(value) from {table_name} where key='{key}'");
+    for _ in 0..32 {
+        let mut stmt = match conn.prepare(sql.clone()) {
+            Ok(stmt) => stmt,
+            Err(LimboError::SchemaUpdated | LimboError::SchemaConflict) => {
+                conn.maybe_reparse_schema()
+                    .expect("observer reparse after schema change");
+                continue;
+            }
+            Err(LimboError::Busy | LimboError::BusySnapshot | LimboError::TableLocked) => {
+                continue;
+            }
+            Err(err) => panic!("observer prepare should succeed: {err}"),
+        };
+        let mut result = None;
+        match stmt.run_with_row_callback(|row| {
+            result = Some(row.get::<i64>(0).expect("length column"));
+            Ok(())
+        }) {
+            Ok(()) => return result,
+            Err(LimboError::SchemaUpdated | LimboError::SchemaConflict) => {
+                drop(stmt);
+                conn.maybe_reparse_schema()
+                    .expect("observer reparse after schema change");
+                continue;
+            }
+            Err(LimboError::Busy | LimboError::BusySnapshot | LimboError::TableLocked) => {
+                continue;
+            }
+            Err(err) => panic!("observer query should succeed: {err}"),
+        }
+    }
+    panic!("observer query did not stabilize after transient multiprocess errors");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn probe_optional_int_via_fresh_worker(whopper: &MultiprocessWhopper, sql: String) -> Option<i64> {
+    for _ in 0..8 {
+        let (_startup, result) = whopper
+            .execute_sql_via_fresh_worker(sql.clone())
+            .expect("probe via fresh worker should succeed");
+        match result {
+            Ok(rows) => {
+                return match rows.as_slice() {
+                    [] => None,
+                    [row] => Some(row[0].as_int().expect("probe column should be integer")),
+                    _ => panic!("probe query should return at most one row, got {rows:?}"),
+                };
+            }
+            Err(
+                LimboError::SchemaUpdated
+                | LimboError::SchemaConflict
+                | LimboError::Busy
+                | LimboError::BusySnapshot
+                | LimboError::TableLocked,
+            ) => continue,
+            Err(err) => panic!("probe SQL should succeed: {err}"),
+        }
+    }
+    panic!("fresh-worker probe did not stabilize after transient multiprocess errors");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn probe_table_rootpage_via_fresh_worker(
+    whopper: &MultiprocessWhopper,
+    table_name: &str,
+) -> Option<i64> {
+    probe_optional_int_via_fresh_worker(
+        whopper,
+        format!("select rootpage from sqlite_schema where type='table' and name='{table_name}'"),
+    )
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn probe_simple_kv_length_via_fresh_worker(
+    whopper: &MultiprocessWhopper,
+    table_name: &str,
+    key: &str,
+) -> Option<i64> {
+    probe_optional_int_via_fresh_worker(
+        whopper,
+        format!("select length(value) from {table_name} where key='{key}'"),
+    )
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn advance_seeded_whopper_to_step(whopper: &mut MultiprocessWhopper, step_after_execution: usize) {
+    while whopper.current_step < step_after_execution {
+        whopper.step().expect("seeded whopper step");
+    }
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn wal_frame_summaries(path: &Path, page_size: usize, frame_count: usize) -> Vec<(u32, u32)> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut file = std::fs::File::open(path).expect("open wal file");
+    let frame_size = 24 + page_size as u64;
+    let mut frames = Vec::with_capacity(frame_count);
+    for frame_idx in 0..frame_count {
+        let offset = 32 + frame_idx as u64 * frame_size;
+        file.seek(SeekFrom::Start(offset))
+            .expect("seek wal frame header");
+        let mut buf = [0u8; 8];
+        file.read_exact(&mut buf)
+            .expect("read wal frame page number and db size");
+        frames.push((
+            u32::from_be_bytes(buf[0..4].try_into().expect("page bytes")),
+            u32::from_be_bytes(buf[4..8].try_into().expect("db size bytes")),
+        ));
+    }
+    frames
 }
 
 /// Regression test for MVCC concurrent commit yield-spin deadlock.
@@ -129,4 +439,1018 @@ fn test_concurrent_commit_no_yield_spin() {
         }
     }
     assert_eq!(count, 2, "both inserts should be visible");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_restart_reuses_persisted_tshm_without_disk_scan() {
+    let mut whopper = create_multiprocess_whopper(2);
+
+    whopper
+        .execute_sql_direct(0, "create table test(id integer primary key, value text)")
+        .expect("create table")
+        .expect("create table should succeed");
+    whopper
+        .execute_sql_direct(0, "insert into test(value) values ('persisted')")
+        .expect("insert row")
+        .expect("insert should succeed");
+
+    let tshm_path = whopper.db_path().with_extension("db-tshm");
+    wait_for_file(&tshm_path);
+    let tshm_len_before_restart = std::fs::metadata(&tshm_path)
+        .expect("read tshm metadata before restart")
+        .len();
+    assert!(
+        tshm_len_before_restart > 0,
+        "restart coverage requires a persisted non-empty tshm file"
+    );
+
+    whopper
+        .restart_all_workers_preserve_files()
+        .expect("restart worker cohort");
+
+    let startup = whopper
+        .worker_startup_telemetries()
+        .first()
+        .copied()
+        .expect("worker telemetry");
+    assert!(
+        !startup.loaded_from_disk_scan,
+        "first reopened worker should reuse preserved tshm authority without a WAL disk scan"
+    );
+    assert_eq!(
+        startup.reopened_nbackfills, 0,
+        "clean restart should remain on the conservative nbackfills=0 reopen path"
+    );
+
+    let row_count = whopper
+        .execute_sql_direct(1, "select count(*) from test")
+        .expect("count rows")
+        .expect("count should succeed");
+    assert_eq!(row_count.len(), 1, "count query should return one row");
+    assert_eq!(
+        row_count[0].len(),
+        1,
+        "count query should return one column"
+    );
+    assert_eq!(
+        row_count[0][0].as_int().expect("count should be integer"),
+        1,
+        "restart should preserve committed rows"
+    );
+    assert!(
+        std::fs::metadata(&tshm_path)
+            .expect("read tshm metadata after restart")
+            .len()
+            >= tshm_len_before_restart,
+        "restart should preserve the persisted tshm file"
+    );
+
+    whopper.finalize().expect("finalize multiprocess whopper");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_finalize_after_restart_preserves_simple_kv_rows() {
+    let mut whopper = create_multiprocess_whopper_with_keep(16, true);
+    let db_path = whopper.db_path().to_path_buf();
+    let table_name = "simple_kv_finalize_regression";
+
+    whopper
+        .execute_sql_direct(
+            0,
+            format!("create table {table_name}(key text primary key, value blob not null)"),
+        )
+        .expect("create table")
+        .expect("create table should succeed");
+
+    for (key, len) in [
+        ("key_912", 2933usize),
+        ("key_9544", 9956usize),
+        ("key_6190", 16191usize),
+        ("key_7791", 15328usize),
+    ] {
+        whopper
+            .execute_sql_direct(
+                0,
+                format!(
+                    "insert or replace into {table_name}(key, value) values ('{key}', zeroblob({len}))"
+                ),
+            )
+            .expect("insert baseline row")
+            .expect("baseline insert should succeed");
+    }
+
+    whopper
+        .restart_all_workers_preserve_files()
+        .expect("restart after baseline rows");
+
+    whopper
+        .execute_sql_direct(
+            1,
+            format!(
+                "insert or replace into {table_name}(key, value) values ('key_5709', zeroblob(9410))"
+            ),
+        )
+        .expect("insert post-restart row")
+        .expect("post-restart insert should succeed");
+
+    whopper
+        .restart_all_workers_preserve_files()
+        .expect("restart after post-restart insert");
+    whopper.finalize().expect("finalize multiprocess whopper");
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().expect("platform io"));
+    let reopened = Database::open_file(io, db_path.to_str().expect("db path utf8"))
+        .expect("reopen finalized database");
+    let conn = reopened.connect().expect("connect reopened db");
+    assert_eq!(
+        count_rows_in_table(&conn, table_name),
+        5,
+        "restart + graceful shutdown must preserve every simple_kv row"
+    );
+
+    let db_str = db_path.to_str().expect("db path utf8");
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_str}-wal"));
+    let _ = std::fs::remove_file(format!("{db_str}-tshm"));
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_seed_5724542806254236599_restart_then_finalize_preserves_key_684() {
+    configure_worker_exe();
+    let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
+        seed: Some(5724542806254236599),
+        enable_mvcc: false,
+        max_connections: 16,
+        max_steps: 4951,
+        elle_tables: vec![],
+        workloads: vec![
+            (10, Box::new(IntegrityCheckWorkload)),
+            (5, Box::new(WalCheckpointWorkload)),
+            (10, Box::new(CreateSimpleTableWorkload)),
+            (20, Box::new(SimpleSelectWorkload)),
+            (20, Box::new(SimpleInsertWorkload)),
+            (15, Box::new(UpdateWorkload)),
+            (15, Box::new(DeleteWorkload)),
+            (2, Box::new(CreateIndexWorkload)),
+            (2, Box::new(DropIndexWorkload)),
+            (30, Box::new(BeginWorkload)),
+            (10, Box::new(CommitWorkload)),
+            (10, Box::new(RollbackWorkload)),
+        ],
+        properties: vec![],
+        chaotic_profiles: vec![],
+        kill_probability: 0.0,
+        restart_probability: 0.05,
+        history_output: None,
+        keep_files: true,
+    })
+    .expect("create seeded multiprocess whopper");
+    let db_path = whopper.db_path().to_path_buf();
+
+    while whopper.current_step < 4950 {
+        whopper.step().expect("seeded whopper step");
+    }
+
+    let rows_after_restart = whopper
+        .execute_sql_direct(
+            0,
+            "select count(*), min(length(value)), max(length(value)) from simple_kv_19961 where key='key_684'",
+        )
+        .expect("query key_684 after restart")
+        .expect("post-restart query should succeed");
+    assert_eq!(
+        rows_after_restart[0][0].as_int(),
+        Some(1),
+        "row should remain visible immediately after the step 4950 restart",
+    );
+    assert_eq!(rows_after_restart[0][1].as_int(), Some(6871));
+    assert_eq!(rows_after_restart[0][2].as_int(), Some(6871));
+    let snapshot_after_restart = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read shared WAL snapshot after restart")
+        .expect("shared WAL snapshot should exist after restart");
+
+    whopper.step().expect("run step 4951 after restart");
+    let snapshot_after_integrity_check = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read shared WAL snapshot after integrity check")
+        .expect("shared WAL snapshot should exist after integrity check");
+    assert_eq!(
+        snapshot_after_integrity_check.max_frame, snapshot_after_restart.max_frame,
+        "integrity_check must not mutate authoritative max_frame",
+    );
+    assert_eq!(
+        snapshot_after_integrity_check.nbackfills, snapshot_after_restart.nbackfills,
+        "integrity_check must not publish checkpoint progress",
+    );
+    assert_eq!(
+        snapshot_after_integrity_check.checkpoint_seq, snapshot_after_restart.checkpoint_seq,
+        "integrity_check must not advance the WAL generation",
+    );
+
+    let pre_finalize_rows = whopper
+        .execute_sql_direct(
+            0,
+            "select count(*), min(length(value)), max(length(value)) from simple_kv_19961 where key='key_684'",
+        )
+        .expect("query key_684 before finalize")
+        .expect("pre-finalize query should succeed");
+    assert_eq!(
+        pre_finalize_rows[0][0].as_int(),
+        Some(1),
+        "row should still be visible after the step 4951 integrity check",
+    );
+    assert_eq!(pre_finalize_rows[0][1].as_int(), Some(6871));
+    assert_eq!(pre_finalize_rows[0][2].as_int(), Some(6871));
+
+    whopper
+        .finalize()
+        .expect("finalize seeded multiprocess whopper");
+
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().expect("platform io"));
+    let reopened = Database::open_file(io, db_path.to_str().expect("db path utf8"))
+        .expect("reopen finalized seeded database");
+    let conn = reopened.connect().expect("connect reopened seeded db");
+    let mut stmt = conn
+        .prepare("select count(*), min(length(value)), max(length(value)) from simple_kv_19961 where key='key_684'")
+        .expect("prepare reopened seeded query");
+    let mut reopened_rows = Vec::new();
+    stmt.run_with_row_callback(|row| {
+        reopened_rows.push((
+            row.get::<i64>(0).expect("count column"),
+            row.get::<i64>(1).expect("min length column"),
+            row.get::<i64>(2).expect("max length column"),
+        ));
+        Ok(())
+    })
+    .expect("run reopened seeded query");
+    assert_eq!(reopened_rows, vec![(1, 6871, 6871)]);
+
+    let db_str = db_path.to_str().expect("db path utf8");
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_str}-wal"));
+    let _ = std::fs::remove_file(format!("{db_str}-tshm"));
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_seed_5724542806254236599_localizes_key_4362_loss() {
+    configure_worker_exe();
+    let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
+        seed: Some(5724542806254236599),
+        enable_mvcc: false,
+        max_connections: 16,
+        max_steps: 4913,
+        elle_tables: vec![],
+        workloads: vec![
+            (10, Box::new(IntegrityCheckWorkload)),
+            (5, Box::new(WalCheckpointWorkload)),
+            (10, Box::new(CreateSimpleTableWorkload)),
+            (20, Box::new(SimpleSelectWorkload)),
+            (20, Box::new(SimpleInsertWorkload)),
+            (15, Box::new(UpdateWorkload)),
+            (15, Box::new(DeleteWorkload)),
+            (2, Box::new(CreateIndexWorkload)),
+            (2, Box::new(DropIndexWorkload)),
+            (30, Box::new(BeginWorkload)),
+            (10, Box::new(CommitWorkload)),
+            (10, Box::new(RollbackWorkload)),
+        ],
+        properties: vec![],
+        chaotic_profiles: vec![],
+        kill_probability: 0.0,
+        restart_probability: 0.05,
+        history_output: None,
+        keep_files: true,
+    })
+    .expect("create seeded multiprocess whopper");
+
+    let table_name = "simple_kv_76514";
+    let key = "key_4362";
+    let db_path = whopper.db_path().to_path_buf();
+    let wal_path = Path::new(&format!("{}-wal", db_path.display())).to_path_buf();
+    let tshm_path = Path::new(&format!("{}-tshm", db_path.display())).to_path_buf();
+
+    advance_seeded_whopper_to_step(&mut whopper, 4728);
+    unsafe {
+        std::env::set_var("WAL_SCAN_TRACE", "1");
+    }
+    let observer_io: Arc<dyn IO> = Arc::new(PlatformIO::new().expect("platform io"));
+    let observer_db = Database::open_file_with_flags(
+        observer_io,
+        db_path.to_str().expect("db path utf8"),
+        OpenFlags::ReadOnly,
+        DatabaseOpts::new(),
+        None,
+    )
+    .expect("open observer database for diagnostics");
+    unsafe {
+        std::env::remove_var("WAL_SCAN_TRACE");
+    }
+    eprintln!(
+        "after step 4727: db_path={} snapshot={:?} wal_size={:?} tshm_size={:?} frame_summaries={:?} authority_find_frame={{1066:{:?},1067:{:?},1377:{:?}}} observer_telemetry={:?} observer_find_frame_1066={:?} observer_local_max_frame={} observer_local_find_frame={{1066:{:?},1067:{:?},1377:{:?}}}",
+        db_path.display(),
+        whopper
+            .shared_wal_snapshot_direct(0)
+            .expect("read shared WAL snapshot"),
+        std::fs::metadata(&wal_path).ok().map(|m| m.len()),
+        std::fs::metadata(&tshm_path).ok().map(|m| m.len()),
+        wal_frame_summaries(&wal_path, 4096, 11),
+        whopper
+            .find_frame_for_page_direct(0, 1066)
+            .expect("lookup table root page in authority"),
+        whopper
+            .find_frame_for_page_direct(0, 1067)
+            .expect("lookup table overflow page in authority"),
+        whopper
+            .find_frame_for_page_direct(0, 1377)
+            .expect("lookup reused page in authority"),
+        observer_db
+            .shared_wal_open_telemetry()
+            .expect("observer shared wal telemetry"),
+        observer_db
+            .shared_wal_find_frame_for_testing(1066)
+            .expect("observer frame lookup"),
+        observer_db
+            .local_wal_max_frame_for_testing()
+            .expect("observer local max frame"),
+        observer_db
+            .local_wal_find_frame_for_testing(1066)
+            .expect("observer local frame lookup"),
+        observer_db
+            .local_wal_find_frame_for_testing(1067)
+            .expect("observer local overflow page lookup"),
+        observer_db
+            .local_wal_find_frame_for_testing(1377)
+            .expect("observer local reused page lookup"),
+    );
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5431),
+        "inserted row must be visible immediately after step 4727",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 4753);
+    assert!(
+        whopper
+            .worker_startup_telemetries()
+            .iter()
+            .all(|startup| startup.loaded_from_disk_scan),
+        "step 4752 should reproduce the all-workers disk-scan restart",
+    );
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5431),
+        "row disappeared during the step 4752 restart recovery",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 4758);
+    assert!(
+        whopper
+            .worker_startup_telemetries()
+            .iter()
+            .all(|startup| startup.loaded_from_disk_scan),
+        "step 4757 should reproduce the second all-workers disk-scan restart",
+    );
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5431),
+        "row disappeared during the step 4757 restart recovery",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 4829);
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5431),
+        "row disappeared by the step 4828 TRUNCATE checkpoint",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 4877);
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5431),
+        "row disappeared during the step 4876 restart",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 4883);
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5431),
+        "row disappeared during the step 4882 restart",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 4910);
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5431),
+        "row disappeared before the recorded failing read at step 4909",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 4911);
+    let after_step_4910_length = read_simple_kv_length(&db_path, table_name, key);
+    eprintln!(
+        "after step 4910 create-table commit: snapshot={:?} worker_startups={:?} observer_length={:?}",
+        whopper
+            .shared_wal_snapshot_direct(0)
+            .expect("read shared WAL snapshot after step 4910"),
+        whopper.worker_startup_telemetries(),
+        after_step_4910_length,
+    );
+    assert_eq!(
+        after_step_4910_length,
+        Some(5431),
+        "row disappeared immediately after the step 4910 create-table commit",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 4913);
+    let worker_0_rows = whopper
+        .execute_sql_direct(
+            0,
+            format!("select key, length(value) from {table_name} where key='{key}'"),
+        )
+        .expect("query failing worker directly after step 4912")
+        .expect("worker query should succeed");
+    let observer_length = read_simple_kv_length(&db_path, table_name, key);
+    eprintln!(
+        "after step 4912: snapshot={:?} worker_startups={:?} worker_0_rows={:?} observer_length={:?}",
+        whopper
+            .shared_wal_snapshot_direct(0)
+            .expect("read shared WAL snapshot after failing step"),
+        whopper.worker_startup_telemetries(),
+        worker_0_rows,
+        observer_length,
+    );
+    assert_eq!(
+        observer_length,
+        Some(5431),
+        "fresh observer lost the row by the recorded failing read at step 4912",
+    );
+    assert_eq!(
+        worker_0_rows.len(),
+        1,
+        "worker 0 still cannot see the row immediately after the recorded failing step",
+    );
+
+    whopper
+        .finalize()
+        .expect("finalize seeded multiprocess whopper");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_seed_5724542806254236599_localizes_key_4994_loss() {
+    configure_worker_exe();
+    let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
+        seed: Some(5724542806254236599),
+        enable_mvcc: false,
+        max_connections: 16,
+        max_steps: 317,
+        elle_tables: vec![],
+        workloads: vec![
+            (10, Box::new(IntegrityCheckWorkload)),
+            (5, Box::new(WalCheckpointWorkload)),
+            (10, Box::new(CreateSimpleTableWorkload)),
+            (20, Box::new(SimpleSelectWorkload)),
+            (20, Box::new(SimpleInsertWorkload)),
+            (15, Box::new(UpdateWorkload)),
+            (15, Box::new(DeleteWorkload)),
+            (2, Box::new(CreateIndexWorkload)),
+            (2, Box::new(DropIndexWorkload)),
+            (30, Box::new(BeginWorkload)),
+            (10, Box::new(CommitWorkload)),
+            (10, Box::new(RollbackWorkload)),
+        ],
+        properties: vec![],
+        chaotic_profiles: vec![],
+        kill_probability: 0.0,
+        restart_probability: 0.05,
+        history_output: None,
+        keep_files: true,
+    })
+    .expect("create seeded multiprocess whopper");
+
+    let db_path = whopper.db_path().to_path_buf();
+    let table_name = "simple_kv_57904";
+    let key = "key_4994";
+
+    advance_seeded_whopper_to_step(&mut whopper, 267);
+    let live_rows = whopper
+        .execute_sql_direct(
+            10,
+            "select count(*), min(length(value)), max(length(value)) from simple_kv_57904 where key='key_4994'",
+        )
+        .expect("query key_4994 on live worker after insert")
+        .expect("live worker query should succeed");
+    eprintln!(
+        "after step 266 insert: live_rows={:?} shared_snapshot={:?}",
+        live_rows,
+        whopper
+            .shared_wal_snapshot_direct(10)
+            .expect("read shared WAL snapshot after insert")
+    );
+    let observer_io: Arc<dyn IO> = Arc::new(PlatformIO::new().expect("platform io"));
+    let observer_db = Database::open_file_with_flags(
+        observer_io,
+        db_path.to_str().expect("db path utf8"),
+        OpenFlags::ReadOnly,
+        DatabaseOpts::new(),
+        None,
+    )
+    .expect("open observer database after insert");
+    eprintln!(
+        "after step 266 insert: observer_telemetry={:?} observer_local_max_frame={:?}",
+        observer_db
+            .shared_wal_open_telemetry()
+            .expect("observer shared WAL telemetry"),
+        observer_db.local_wal_max_frame_for_testing()
+    );
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5044),
+        "row must be visible immediately after step 266 insert",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 283);
+    eprintln!(
+        "after step 282 restart: telemetries={:?}",
+        whopper.worker_startup_telemetries()
+    );
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5044),
+        "row disappeared during the step 282 restart",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 306);
+    eprintln!(
+        "after step 305 restart: telemetries={:?}",
+        whopper.worker_startup_telemetries()
+    );
+    assert_eq!(
+        read_simple_kv_length(&db_path, table_name, key),
+        Some(5044),
+        "row disappeared during the step 305 restart",
+    );
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_seed_8849519299024683634_localizes_schema_loss_boundary() {
+    configure_worker_exe();
+    let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
+        seed: Some(8849519299024683634),
+        enable_mvcc: false,
+        max_connections: 16,
+        max_steps: 72,
+        elle_tables: vec![],
+        workloads: vec![
+            (10, Box::new(IntegrityCheckWorkload)),
+            (5, Box::new(WalCheckpointWorkload)),
+            (10, Box::new(CreateSimpleTableWorkload)),
+            (20, Box::new(SimpleSelectWorkload)),
+            (20, Box::new(SimpleInsertWorkload)),
+            (15, Box::new(UpdateWorkload)),
+            (15, Box::new(DeleteWorkload)),
+            (2, Box::new(CreateIndexWorkload)),
+            (2, Box::new(DropIndexWorkload)),
+            (30, Box::new(BeginWorkload)),
+            (10, Box::new(CommitWorkload)),
+            (10, Box::new(RollbackWorkload)),
+        ],
+        properties: vec![],
+        chaotic_profiles: vec![],
+        kill_probability: 0.0,
+        restart_probability: 0.05,
+        history_output: None,
+        keep_files: true,
+    })
+    .expect("create seeded multiprocess whopper");
+
+    advance_seeded_whopper_to_step(&mut whopper, 67);
+    assert!(
+        whopper
+            .worker_startup_telemetries()
+            .iter()
+            .all(|startup| startup.loaded_from_disk_scan),
+        "step 66 should reproduce the first all-workers disk-scan restart",
+    );
+    assert!(
+        probe_table_rootpage_via_fresh_worker(&whopper, "simple_kv_9842").is_some(),
+        "simple_kv_9842 should still exist for a fresh opener immediately after the step 66 restart",
+    );
+    assert_eq!(
+        probe_simple_kv_length_via_fresh_worker(&whopper, "simple_kv_9842", "key_6095"),
+        Some(874),
+        "baseline row should still be visible for a fresh opener immediately after the step 66 restart",
+    );
+
+    advance_seeded_whopper_to_step(&mut whopper, 70);
+    assert!(
+        whopper
+            .worker_startup_telemetries()
+            .iter()
+            .all(|startup| startup.loaded_from_disk_scan),
+        "step 70 should reproduce the second all-workers disk-scan restart",
+    );
+    assert!(
+        probe_table_rootpage_via_fresh_worker(&whopper, "simple_kv_9842").is_some(),
+        "simple_kv_9842 disappeared from sqlite_schema by the step 70 restart; cohort_telemetries={:?}",
+        whopper.worker_startup_telemetries(),
+    );
+
+    whopper
+        .finalize()
+        .expect("finalize seeded multiprocess whopper");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_truncate_generation_survives_foreign_first_append_and_restart() {
+    let mut whopper = create_multiprocess_whopper(2);
+    let table_name = "simple_kv_85275";
+
+    whopper
+        .execute_sql_direct(
+            0,
+            format!("create table {table_name}(key text primary key, value text not null)"),
+        )
+        .expect("create table")
+        .expect("create table should succeed");
+
+    let snapshot_before_truncate = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read shared WAL snapshot before TRUNCATE")
+        .expect("shared WAL snapshot should be available");
+    assert!(
+        snapshot_before_truncate.max_frame > 0,
+        "TRUNCATE regression requires schema changes to create WAL content before checkpoint"
+    );
+
+    whopper
+        .execute_sql_direct(1, "PRAGMA wal_checkpoint(TRUNCATE)")
+        .expect("run TRUNCATE checkpoint")
+        .expect("TRUNCATE checkpoint should succeed");
+
+    let snapshot_after_truncate = whopper
+        .shared_wal_snapshot_direct(1)
+        .expect("read shared WAL snapshot after TRUNCATE")
+        .expect("shared WAL snapshot should be available");
+    assert_eq!(
+        snapshot_after_truncate.max_frame, 0,
+        "TRUNCATE should reset the authoritative max_frame for the new generation"
+    );
+    assert_eq!(
+        snapshot_after_truncate.nbackfills, 0,
+        "TRUNCATE should clear published backfill progress before the next append"
+    );
+    assert_ne!(
+        snapshot_after_truncate.checkpoint_seq, snapshot_before_truncate.checkpoint_seq,
+        "TRUNCATE should advance the checkpoint generation"
+    );
+
+    whopper
+        .execute_sql_direct(
+            0,
+            format!("insert or replace into {table_name}(key, value) values ('hello', 'world')"),
+        )
+        .expect("append first row after TRUNCATE")
+        .expect("first post-TRUNCATE append should succeed");
+
+    let snapshot_after_append = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read shared WAL snapshot after first post-TRUNCATE append")
+        .expect("shared WAL snapshot should be available");
+    assert!(
+        snapshot_after_append.max_frame > 0,
+        "first post-TRUNCATE append should publish frames in the replacement generation"
+    );
+    assert_eq!(
+        snapshot_after_append.checkpoint_seq, snapshot_after_truncate.checkpoint_seq,
+        "first post-TRUNCATE append must remain in the TRUNCATE generation"
+    );
+
+    whopper
+        .restart_all_workers_preserve_files()
+        .expect("restart worker cohort");
+
+    for (worker_idx, startup) in whopper.worker_startup_telemetries().iter().enumerate() {
+        assert_eq!(
+            startup.reopened_checkpoint_seq, snapshot_after_append.checkpoint_seq,
+            "worker {worker_idx} reopened the wrong WAL generation after TRUNCATE"
+        );
+    }
+
+    let row_count = whopper
+        .execute_sql_direct(1, format!("select count(*) from {table_name}"))
+        .expect("count rows after restart")
+        .expect("count should succeed");
+    assert_eq!(row_count[0][0].as_int(), Some(1));
+    assert_integrity_check_ok(&mut whopper, 1);
+
+    whopper.finalize().expect("finalize multiprocess whopper");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_restart_rebuilds_from_disk_when_partial_checkpoint_publishes_positive_nbackfills() {
+    let mut whopper = create_multiprocess_whopper(1);
+    let (_max_frame_before_restart, nbackfills_before_restart) =
+        create_partial_checkpoint_state(&mut whopper);
+    assert!(
+        nbackfills_before_restart > 0,
+        "restart coverage requires published positive nbackfills before reopen"
+    );
+
+    whopper
+        .restart_all_workers_preserve_files()
+        .expect("restart worker cohort");
+
+    let startup = whopper
+        .worker_startup_telemetries()
+        .first()
+        .copied()
+        .expect("worker telemetry");
+    assert!(
+        startup.loaded_from_disk_scan,
+        "reopen must rebuild from disk when positive nbackfills cannot be proven safe on restart"
+    );
+    assert_eq!(
+        startup.reopened_nbackfills, 0,
+        "disk-scan reopen must not resurrect positive nbackfills from tshm authority state"
+    );
+
+    let row_count = whopper
+        .execute_sql_direct(0, "select count(*) from test")
+        .expect("count rows")
+        .expect("count should succeed");
+    assert_eq!(
+        row_count[0][0].as_int().expect("count should be integer"),
+        32,
+        "conservative reopen after a positive-nbackfills checkpoint must preserve committed rows"
+    );
+
+    whopper.finalize().expect("finalize multiprocess whopper");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_restart_rebuilds_from_disk_after_wal_append_invalidates_partial_checkpoint_proof() {
+    let mut whopper = create_multiprocess_whopper(1);
+    let (max_frame_after_checkpoint, _nbackfills_after_checkpoint) =
+        create_partial_checkpoint_state(&mut whopper);
+
+    whopper
+        .execute_sql_direct(0, "insert into test(value) values (randomblob(2048))")
+        .expect("append row after checkpoint")
+        .expect("append should succeed");
+
+    let snapshot_after_append = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read shared WAL snapshot after append")
+        .expect("shared WAL snapshot should be available");
+    assert!(
+        snapshot_after_append.max_frame > max_frame_after_checkpoint,
+        "stale-proof restart coverage requires a WAL append after proof installation"
+    );
+
+    whopper
+        .restart_all_workers_preserve_files()
+        .expect("restart worker cohort");
+
+    let startup = whopper
+        .worker_startup_telemetries()
+        .first()
+        .copied()
+        .expect("worker telemetry");
+    assert!(
+        startup.loaded_from_disk_scan,
+        "reopen must rebuild from disk after a WAL append invalidates the tshm backfill proof"
+    );
+
+    let row_count = whopper
+        .execute_sql_direct(0, "select count(*) from test")
+        .expect("count rows")
+        .expect("count should succeed");
+    assert_eq!(
+        row_count[0][0].as_int().expect("count should be integer"),
+        33,
+        "stale-proof restart should preserve rows committed after the partial checkpoint"
+    );
+
+    whopper.finalize().expect("finalize multiprocess whopper");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_restart_rebuilds_from_disk_after_partial_checkpoint_proof_is_cleared() {
+    let mut whopper = create_multiprocess_whopper(1);
+    create_partial_checkpoint_state(&mut whopper);
+
+    whopper
+        .clear_backfill_proof_direct(0)
+        .expect("clear backfill proof");
+    whopper
+        .restart_all_workers_preserve_files()
+        .expect("restart worker cohort");
+
+    let startup = whopper
+        .worker_startup_telemetries()
+        .first()
+        .copied()
+        .expect("worker telemetry");
+    assert!(
+        startup.loaded_from_disk_scan,
+        "reopen must rebuild from disk when positive nbackfills are not durably provable"
+    );
+    assert_eq!(
+        count_test_rows(&mut whopper, 0),
+        32,
+        "disk-scan reopen should preserve committed rows after proof removal"
+    );
+
+    whopper.finalize().expect("finalize multiprocess whopper");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_restart_rebuilds_from_disk_after_db_header_mismatch_invalidates_partial_checkpoint_proof()
+ {
+    let mut whopper = create_multiprocess_whopper(1);
+    create_partial_checkpoint_state(&mut whopper);
+
+    whopper
+        .mutate_on_disk_and_restart(|db_path| {
+            flip_db_header_reserved_byte(db_path);
+            Ok(())
+        })
+        .expect("mutate db header and restart");
+
+    let startup = whopper
+        .worker_startup_telemetries()
+        .first()
+        .copied()
+        .expect("worker telemetry");
+    assert!(
+        startup.loaded_from_disk_scan,
+        "reopen must rebuild from disk when the DB header fingerprint invalidates the tshm proof"
+    );
+    assert_eq!(
+        count_test_rows(&mut whopper, 0),
+        32,
+        "DB-header-mismatch restart should preserve committed rows after conservative reopen"
+    );
+
+    whopper.finalize().expect("finalize multiprocess whopper");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_restart_stays_conservative_after_unpublished_backfill_proof_install() {
+    let mut whopper = create_multiprocess_whopper(1);
+    populate_blob_test_rows(&mut whopper);
+
+    whopper
+        .install_unpublished_backfill_proof_direct(0, 1)
+        .expect("install unpublished backfill proof");
+
+    let snapshot_before_restart = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read shared WAL snapshot before restart")
+        .expect("shared WAL snapshot should be available");
+    assert_eq!(
+        snapshot_before_restart.nbackfills, 0,
+        "proof-installed-but-unpublished coverage requires nbackfills to remain unpublished"
+    );
+
+    whopper
+        .restart_all_workers_preserve_files()
+        .expect("restart worker cohort");
+
+    let startup = whopper
+        .worker_startup_telemetries()
+        .first()
+        .copied()
+        .expect("worker telemetry");
+    assert!(
+        !startup.loaded_from_disk_scan,
+        "reopen after proof install without publication should stay on the conservative authority path"
+    );
+    assert_eq!(
+        startup.reopened_nbackfills, 0,
+        "reopen after proof install without publication must keep backfill unpublished"
+    );
+    assert_eq!(
+        count_test_rows(&mut whopper, 0),
+        32,
+        "reopen after proof install without publication must preserve committed rows"
+    );
+
+    whopper.finalize().expect("finalize multiprocess whopper");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_restart_rebuilds_from_disk_after_restart_checkpoint_changes_generation() {
+    let mut whopper = create_multiprocess_whopper(1);
+    create_partial_checkpoint_state(&mut whopper);
+
+    let snapshot_before_restart_checkpoint = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read snapshot before RESTART checkpoint")
+        .expect("shared WAL snapshot should be available");
+
+    whopper
+        .execute_sql_direct(0, "PRAGMA wal_checkpoint(RESTART)")
+        .expect("run RESTART checkpoint")
+        .expect("RESTART checkpoint should succeed");
+
+    let snapshot_after_restart_checkpoint = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read snapshot after RESTART checkpoint")
+        .expect("shared WAL snapshot should be available");
+    assert_eq!(
+        snapshot_after_restart_checkpoint.max_frame, 0,
+        "RESTART should reset the authoritative max_frame for the new WAL generation"
+    );
+    assert_eq!(
+        snapshot_after_restart_checkpoint.nbackfills, 0,
+        "RESTART should clear published backfill progress before the replacement generation begins"
+    );
+    assert_ne!(
+        snapshot_after_restart_checkpoint.checkpoint_seq,
+        snapshot_before_restart_checkpoint.checkpoint_seq,
+        "RESTART should advance the checkpoint generation"
+    );
+
+    whopper
+        .execute_sql_direct(0, "begin immediate")
+        .expect("begin replacement-generation write transaction")
+        .expect("begin should succeed");
+    for _ in 0..32 {
+        whopper
+            .execute_sql_direct(0, "insert into test(value) values (randomblob(2048))")
+            .expect("insert replacement-generation row")
+            .expect("replacement-generation insert should succeed");
+    }
+    whopper
+        .execute_sql_direct(0, "commit")
+        .expect("commit replacement-generation transaction")
+        .expect("commit should succeed");
+    whopper
+        .passive_checkpoint_direct(0, Some(1))
+        .expect("run replacement partial checkpoint");
+
+    let snapshot_after_replacement = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read snapshot after replacement proof install")
+        .expect("shared WAL snapshot should be available");
+    assert!(
+        snapshot_after_replacement.nbackfills > 0,
+        "replacement generation should install a positive nbackfills proof"
+    );
+    assert!(
+        snapshot_after_replacement.max_frame > snapshot_after_replacement.nbackfills,
+        "replacement generation should retain live WAL frames beyond the backfill point"
+    );
+    assert_ne!(
+        snapshot_after_replacement.checkpoint_seq,
+        snapshot_before_restart_checkpoint.checkpoint_seq,
+        "replacement proof must belong to the restarted WAL generation"
+    );
+
+    whopper
+        .restart_all_workers_preserve_files()
+        .expect("restart worker cohort");
+
+    let startup = whopper
+        .worker_startup_telemetries()
+        .first()
+        .copied()
+        .expect("worker telemetry");
+    assert!(
+        startup.loaded_from_disk_scan,
+        "replacement-generation reopen must stay conservative when restart leaves positive nbackfills"
+    );
+    assert_eq!(
+        startup.reopened_nbackfills, 0,
+        "replacement-generation reopen must not revive positive nbackfills from tshm"
+    );
+    assert_eq!(
+        startup.reopened_checkpoint_seq, snapshot_after_replacement.checkpoint_seq,
+        "conservative reopen after RESTART must still bind to the replacement WAL generation"
+    );
+    assert_ne!(
+        startup.reopened_checkpoint_seq, snapshot_before_restart_checkpoint.checkpoint_seq,
+        "reopen after RESTART must not reuse state from the previous generation"
+    );
+    assert_eq!(
+        count_test_rows(&mut whopper, 0),
+        64,
+        "conservative reopen after RESTART-generation checkpoint churn should preserve both generations of rows"
+    );
+
+    whopper.finalize().expect("finalize multiprocess whopper");
 }

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -99,15 +99,33 @@ fn create_multiprocess_whopper(max_connections: usize) -> MultiprocessWhopper {
 }
 
 #[cfg(all(unix, target_pointer_width = "64"))]
+fn create_multiprocess_whopper_with_shape(
+    process_count: usize,
+    connections_per_process: usize,
+) -> MultiprocessWhopper {
+    create_multiprocess_whopper_with_shape_and_keep(process_count, connections_per_process, false)
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
 fn create_multiprocess_whopper_with_keep(
     max_connections: usize,
+    keep_files: bool,
+) -> MultiprocessWhopper {
+    create_multiprocess_whopper_with_shape_and_keep(max_connections, 1, keep_files)
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+fn create_multiprocess_whopper_with_shape_and_keep(
+    process_count: usize,
+    connections_per_process: usize,
     keep_files: bool,
 ) -> MultiprocessWhopper {
     configure_worker_exe();
     MultiprocessWhopper::new(MultiprocessOpts {
         seed: Some(7),
         enable_mvcc: false,
-        max_connections,
+        process_count,
+        connections_per_process,
         max_steps: 0,
         elle_tables: vec![],
         workloads: vec![],
@@ -204,6 +222,27 @@ fn count_test_rows(whopper: &mut MultiprocessWhopper, worker_idx: usize) -> i64 
 }
 
 #[cfg(all(unix, target_pointer_width = "64"))]
+fn truncate_checkpoint_until_stable(whopper: &mut MultiprocessWhopper, connection_idx: usize) {
+    for _ in 0..32 {
+        let result = whopper
+            .execute_sql_direct(connection_idx, "PRAGMA wal_checkpoint(TRUNCATE)")
+            .expect("run TRUNCATE checkpoint");
+        match result {
+            Ok(_) => return,
+            Err(
+                LimboError::Busy
+                | LimboError::BusySnapshot
+                | LimboError::SchemaUpdated
+                | LimboError::SchemaConflict
+                | LimboError::TableLocked,
+            ) => continue,
+            Err(err) => panic!("TRUNCATE checkpoint should stabilize: {err}"),
+        }
+    }
+    panic!("TRUNCATE checkpoint did not stabilize after transient multiprocess errors");
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
 fn assert_integrity_check_ok(whopper: &mut MultiprocessWhopper, worker_idx: usize) {
     let rows = whopper
         .execute_sql_direct(worker_idx, "PRAGMA integrity_check")
@@ -220,6 +259,121 @@ fn assert_integrity_check_ok(whopper: &mut MultiprocessWhopper, worker_idx: usiz
         Some("ok"),
         "integrity_check should report ok"
     );
+}
+
+#[cfg(all(unix, target_pointer_width = "64"))]
+#[test]
+fn multiprocess_same_process_sibling_reader_keeps_shared_snapshot_live_until_last_release() {
+    let mut whopper = create_multiprocess_whopper_with_shape(2, 2);
+
+    for connection_idx in 0..4 {
+        whopper
+            .disable_auto_checkpoint_direct(connection_idx)
+            .expect("disable auto checkpoint");
+    }
+
+    whopper
+        .execute_sql_direct(
+            0,
+            "create table test(id integer primary key, value text not null)",
+        )
+        .expect("create table")
+        .expect("create table should succeed");
+    whopper
+        .execute_sql_direct(2, "insert into test(value) values ('base')")
+        .expect("insert base row")
+        .expect("base insert should succeed");
+
+    let initial_snapshot = whopper
+        .shared_wal_snapshot_direct(0)
+        .expect("read initial shared WAL snapshot")
+        .expect("shared WAL snapshot should exist");
+    assert!(
+        initial_snapshot.max_frame > 0,
+        "shared reader-slot regression requires visible WAL frames before read transactions begin"
+    );
+
+    for connection_idx in [0usize, 1usize] {
+        whopper
+            .execute_sql_direct(connection_idx, "begin")
+            .expect("begin read transaction")
+            .expect("begin should succeed");
+        assert_eq!(
+            count_test_rows(&mut whopper, connection_idx),
+            1,
+            "same-process sibling readers should share the initial snapshot before the second writer commits",
+        );
+    }
+
+    whopper
+        .execute_sql_direct(2, "insert into test(value) values ('new')")
+        .expect("insert new row")
+        .expect("second insert should succeed");
+
+    let post_append_snapshot = whopper
+        .shared_wal_snapshot_direct(2)
+        .expect("read post-append shared WAL snapshot")
+        .expect("shared WAL snapshot should exist after append");
+    assert!(
+        post_append_snapshot.max_frame > initial_snapshot.max_frame,
+        "second writer should advance the authoritative WAL tail"
+    );
+
+    whopper
+        .execute_sql_direct(0, "rollback")
+        .expect("rollback first sibling reader")
+        .expect("rollback should succeed");
+
+    let truncate_while_reader_active = whopper
+        .execute_sql_direct(3, "PRAGMA wal_checkpoint(TRUNCATE)")
+        .expect("attempt TRUNCATE checkpoint while sibling reader is active");
+    match truncate_while_reader_active {
+        Ok(_) => {}
+        Err(
+            LimboError::Busy
+            | LimboError::BusySnapshot
+            | LimboError::SchemaUpdated
+            | LimboError::SchemaConflict
+            | LimboError::TableLocked,
+        ) => {}
+        Err(err) => panic!("unexpected TRUNCATE result while sibling reader is active: {err}"),
+    }
+
+    let snapshot_while_reader_active = whopper
+        .shared_wal_snapshot_direct(3)
+        .expect("read shared WAL snapshot while sibling reader is active")
+        .expect("shared WAL snapshot should exist while sibling reader is active");
+    assert!(
+        snapshot_while_reader_active.max_frame > 0,
+        "one same-process sibling must keep the shared WAL generation live after the other releases",
+    );
+    assert_eq!(
+        count_test_rows(&mut whopper, 1),
+        1,
+        "remaining same-process sibling reader must keep its original snapshot after the other connection rolls back",
+    );
+
+    whopper
+        .execute_sql_direct(1, "rollback")
+        .expect("rollback second sibling reader")
+        .expect("rollback should succeed");
+
+    truncate_checkpoint_until_stable(&mut whopper, 3);
+    let snapshot_after_release = whopper
+        .shared_wal_snapshot_direct(3)
+        .expect("read shared WAL snapshot after both readers release")
+        .expect("shared WAL snapshot should exist after both readers release");
+    assert_eq!(
+        snapshot_after_release.max_frame, 0,
+        "TRUNCATE should only reset the WAL generation after the last same-process sibling reader releases",
+    );
+    assert_eq!(
+        count_test_rows(&mut whopper, 2),
+        2,
+        "writer process should observe both committed rows after the shared reader snapshot is released",
+    );
+
+    whopper.finalize().expect("finalize multiprocess whopper");
 }
 
 #[cfg(all(unix, target_pointer_width = "64"))]
@@ -598,7 +752,8 @@ fn multiprocess_seed_5724542806254236599_restart_then_finalize_preserves_key_684
     let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
         seed: Some(5724542806254236599),
         enable_mvcc: false,
-        max_connections: 16,
+        process_count: 16,
+        connections_per_process: 1,
         max_steps: 4951,
         elle_tables: vec![],
         workloads: vec![
@@ -717,7 +872,8 @@ fn multiprocess_seed_5724542806254236599_localizes_key_4994_loss() {
     let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
         seed: Some(5724542806254236599),
         enable_mvcc: false,
-        max_connections: 16,
+        process_count: 16,
+        connections_per_process: 1,
         max_steps: 317,
         elle_tables: vec![],
         workloads: vec![
@@ -814,7 +970,8 @@ fn multiprocess_seed_8849519299024683634_localizes_schema_loss_boundary() {
     let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
         seed: Some(8849519299024683634),
         enable_mvcc: false,
-        max_connections: 16,
+        process_count: 16,
+        connections_per_process: 1,
         max_steps: 72,
         elle_tables: vec![],
         workloads: vec![

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -308,28 +308,6 @@ fn advance_seeded_whopper_to_step(whopper: &mut MultiprocessWhopper, step_after_
     }
 }
 
-#[cfg(all(unix, target_pointer_width = "64"))]
-fn wal_frame_summaries(path: &Path, page_size: usize, frame_count: usize) -> Vec<(u32, u32)> {
-    use std::io::{Read, Seek, SeekFrom};
-
-    let mut file = std::fs::File::open(path).expect("open wal file");
-    let frame_size = 24 + page_size as u64;
-    let mut frames = Vec::with_capacity(frame_count);
-    for frame_idx in 0..frame_count {
-        let offset = 32 + frame_idx as u64 * frame_size;
-        file.seek(SeekFrom::Start(offset))
-            .expect("seek wal frame header");
-        let mut buf = [0u8; 8];
-        file.read_exact(&mut buf)
-            .expect("read wal frame page number and db size");
-        frames.push((
-            u32::from_be_bytes(buf[0..4].try_into().expect("page bytes")),
-            u32::from_be_bytes(buf[4..8].try_into().expect("db size bytes")),
-        ));
-    }
-    frames
-}
-
 /// Regression test for MVCC concurrent commit yield-spin deadlock.
 ///
 /// Under round-robin cooperative scheduling, when two BEGIN CONCURRENT
@@ -702,210 +680,6 @@ fn multiprocess_seed_5724542806254236599_restart_then_finalize_preserves_key_684
 
 #[cfg(all(unix, target_pointer_width = "64"))]
 #[test]
-fn multiprocess_seed_5724542806254236599_localizes_key_4362_loss() {
-    configure_worker_exe();
-    let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
-        seed: Some(5724542806254236599),
-        enable_mvcc: false,
-        max_connections: 16,
-        max_steps: 4913,
-        elle_tables: vec![],
-        workloads: vec![
-            (10, Box::new(IntegrityCheckWorkload)),
-            (5, Box::new(WalCheckpointWorkload)),
-            (10, Box::new(CreateSimpleTableWorkload)),
-            (20, Box::new(SimpleSelectWorkload)),
-            (20, Box::new(SimpleInsertWorkload)),
-            (15, Box::new(UpdateWorkload)),
-            (15, Box::new(DeleteWorkload)),
-            (2, Box::new(CreateIndexWorkload)),
-            (2, Box::new(DropIndexWorkload)),
-            (30, Box::new(BeginWorkload)),
-            (10, Box::new(CommitWorkload)),
-            (10, Box::new(RollbackWorkload)),
-        ],
-        properties: vec![],
-        chaotic_profiles: vec![],
-        kill_probability: 0.0,
-        restart_probability: 0.05,
-        history_output: None,
-        keep_files: true,
-    })
-    .expect("create seeded multiprocess whopper");
-
-    let table_name = "simple_kv_76514";
-    let key = "key_4362";
-    let db_path = whopper.db_path().to_path_buf();
-    let wal_path = Path::new(&format!("{}-wal", db_path.display())).to_path_buf();
-    let tshm_path = Path::new(&format!("{}-tshm", db_path.display())).to_path_buf();
-
-    advance_seeded_whopper_to_step(&mut whopper, 4728);
-    unsafe {
-        std::env::set_var("WAL_SCAN_TRACE", "1");
-    }
-    let observer_io: Arc<dyn IO> = Arc::new(PlatformIO::new().expect("platform io"));
-    let observer_db = Database::open_file_with_flags(
-        observer_io,
-        db_path.to_str().expect("db path utf8"),
-        OpenFlags::ReadOnly,
-        multiprocess_wal_db_opts(),
-        None,
-    )
-    .expect("open observer database for diagnostics");
-    unsafe {
-        std::env::remove_var("WAL_SCAN_TRACE");
-    }
-    eprintln!(
-        "after step 4727: db_path={} snapshot={:?} wal_size={:?} tshm_size={:?} frame_summaries={:?} authority_find_frame={{1066:{:?},1067:{:?},1377:{:?}}} observer_telemetry={:?} observer_find_frame_1066={:?} observer_local_max_frame={} observer_local_find_frame={{1066:{:?},1067:{:?},1377:{:?}}}",
-        db_path.display(),
-        whopper
-            .shared_wal_snapshot_direct(0)
-            .expect("read shared WAL snapshot"),
-        std::fs::metadata(&wal_path).ok().map(|m| m.len()),
-        std::fs::metadata(&tshm_path).ok().map(|m| m.len()),
-        wal_frame_summaries(&wal_path, 4096, 11),
-        whopper
-            .find_frame_for_page_direct(0, 1066)
-            .expect("lookup table root page in authority"),
-        whopper
-            .find_frame_for_page_direct(0, 1067)
-            .expect("lookup table overflow page in authority"),
-        whopper
-            .find_frame_for_page_direct(0, 1377)
-            .expect("lookup reused page in authority"),
-        observer_db
-            .shared_wal_open_telemetry()
-            .expect("observer shared wal telemetry"),
-        observer_db
-            .shared_wal_find_frame_for_testing(1066)
-            .expect("observer frame lookup"),
-        observer_db
-            .local_wal_max_frame_for_testing()
-            .expect("observer local max frame"),
-        observer_db
-            .local_wal_find_frame_for_testing(1066)
-            .expect("observer local frame lookup"),
-        observer_db
-            .local_wal_find_frame_for_testing(1067)
-            .expect("observer local overflow page lookup"),
-        observer_db
-            .local_wal_find_frame_for_testing(1377)
-            .expect("observer local reused page lookup"),
-    );
-    assert_eq!(
-        read_simple_kv_length(&db_path, table_name, key),
-        Some(5431),
-        "inserted row must be visible immediately after step 4727",
-    );
-
-    advance_seeded_whopper_to_step(&mut whopper, 4753);
-    assert!(
-        whopper
-            .worker_startup_telemetries()
-            .iter()
-            .all(|startup| startup.loaded_from_disk_scan),
-        "step 4752 should reproduce the all-workers disk-scan restart",
-    );
-    assert_eq!(
-        read_simple_kv_length(&db_path, table_name, key),
-        Some(5431),
-        "row disappeared during the step 4752 restart recovery",
-    );
-
-    advance_seeded_whopper_to_step(&mut whopper, 4758);
-    assert!(
-        whopper
-            .worker_startup_telemetries()
-            .iter()
-            .all(|startup| startup.loaded_from_disk_scan),
-        "step 4757 should reproduce the second all-workers disk-scan restart",
-    );
-    assert_eq!(
-        read_simple_kv_length(&db_path, table_name, key),
-        Some(5431),
-        "row disappeared during the step 4757 restart recovery",
-    );
-
-    advance_seeded_whopper_to_step(&mut whopper, 4829);
-    assert_eq!(
-        read_simple_kv_length(&db_path, table_name, key),
-        Some(5431),
-        "row disappeared by the step 4828 TRUNCATE checkpoint",
-    );
-
-    advance_seeded_whopper_to_step(&mut whopper, 4877);
-    assert_eq!(
-        read_simple_kv_length(&db_path, table_name, key),
-        Some(5431),
-        "row disappeared during the step 4876 restart",
-    );
-
-    advance_seeded_whopper_to_step(&mut whopper, 4883);
-    assert_eq!(
-        read_simple_kv_length(&db_path, table_name, key),
-        Some(5431),
-        "row disappeared during the step 4882 restart",
-    );
-
-    advance_seeded_whopper_to_step(&mut whopper, 4910);
-    assert_eq!(
-        read_simple_kv_length(&db_path, table_name, key),
-        Some(5431),
-        "row disappeared before the recorded failing read at step 4909",
-    );
-
-    advance_seeded_whopper_to_step(&mut whopper, 4911);
-    let after_step_4910_length = read_simple_kv_length(&db_path, table_name, key);
-    eprintln!(
-        "after step 4910 create-table commit: snapshot={:?} worker_startups={:?} observer_length={:?}",
-        whopper
-            .shared_wal_snapshot_direct(0)
-            .expect("read shared WAL snapshot after step 4910"),
-        whopper.worker_startup_telemetries(),
-        after_step_4910_length,
-    );
-    assert_eq!(
-        after_step_4910_length,
-        Some(5431),
-        "row disappeared immediately after the step 4910 create-table commit",
-    );
-
-    advance_seeded_whopper_to_step(&mut whopper, 4913);
-    let worker_0_rows = whopper
-        .execute_sql_direct(
-            0,
-            format!("select key, length(value) from {table_name} where key='{key}'"),
-        )
-        .expect("query failing worker directly after step 4912")
-        .expect("worker query should succeed");
-    let observer_length = read_simple_kv_length(&db_path, table_name, key);
-    eprintln!(
-        "after step 4912: snapshot={:?} worker_startups={:?} worker_0_rows={:?} observer_length={:?}",
-        whopper
-            .shared_wal_snapshot_direct(0)
-            .expect("read shared WAL snapshot after failing step"),
-        whopper.worker_startup_telemetries(),
-        worker_0_rows,
-        observer_length,
-    );
-    assert_eq!(
-        observer_length,
-        Some(5431),
-        "fresh observer lost the row by the recorded failing read at step 4912",
-    );
-    assert_eq!(
-        worker_0_rows.len(),
-        1,
-        "worker 0 still cannot see the row immediately after the recorded failing step",
-    );
-
-    whopper
-        .finalize()
-        .expect("finalize seeded multiprocess whopper");
-}
-
-#[cfg(all(unix, target_pointer_width = "64"))]
-#[test]
 fn multiprocess_seed_5724542806254236599_localizes_key_4994_loss() {
     configure_worker_exe();
     let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
@@ -1036,13 +810,6 @@ fn multiprocess_seed_8849519299024683634_localizes_schema_loss_boundary() {
 
     advance_seeded_whopper_to_step(&mut whopper, 67);
     assert!(
-        whopper
-            .worker_startup_telemetries()
-            .iter()
-            .all(|startup| startup.loaded_from_disk_scan),
-        "step 66 should reproduce the first all-workers disk-scan restart",
-    );
-    assert!(
         probe_table_rootpage_via_fresh_worker(&whopper, "simple_kv_9842").is_some(),
         "simple_kv_9842 should still exist for a fresh opener immediately after the step 66 restart",
     );
@@ -1053,13 +820,6 @@ fn multiprocess_seed_8849519299024683634_localizes_schema_loss_boundary() {
     );
 
     advance_seeded_whopper_to_step(&mut whopper, 70);
-    assert!(
-        whopper
-            .worker_startup_telemetries()
-            .iter()
-            .all(|startup| startup.loaded_from_disk_scan),
-        "step 70 should reproduce the second all-workers disk-scan restart",
-    );
     assert!(
         probe_table_rootpage_via_fresh_worker(&whopper, "simple_kv_9842").is_some(),
         "simple_kv_9842 disappeared from sqlite_schema by the step 70 restart; cohort_telemetries={:?}",

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use turso_core::{
     Connection, Database, DatabaseOpts, IO, LimboError, OpenFlags, PlatformIO, Statement,
 };
+#[cfg(all(unix, target_pointer_width = "64"))]
+use turso_whopper::multiprocess::{MultiprocessOpts, MultiprocessWhopper};
 use turso_whopper::{
     IOFaultConfig, SimulatorIO,
-    multiprocess::{MultiprocessOpts, MultiprocessWhopper},
     workloads::{
         BeginWorkload, CommitWorkload, CreateIndexWorkload, CreateSimpleTableWorkload,
         DeleteWorkload, DropIndexWorkload, IntegrityCheckWorkload, RollbackWorkload,
@@ -183,11 +184,23 @@ fn create_partial_checkpoint_state(whopper: &mut MultiprocessWhopper) -> (u64, u
 
 #[cfg(all(unix, target_pointer_width = "64"))]
 fn count_test_rows(whopper: &mut MultiprocessWhopper, worker_idx: usize) -> i64 {
-    let rows = whopper
-        .execute_sql_direct(worker_idx, "select count(*) from test")
-        .expect("count rows")
-        .expect("count should succeed");
-    rows[0][0].as_int().expect("count should be integer")
+    for _ in 0..32 {
+        let rows = whopper
+            .execute_sql_direct(worker_idx, "select count(*) from test")
+            .expect("count rows");
+        match rows {
+            Ok(rows) => return rows[0][0].as_int().expect("count should be integer"),
+            Err(
+                LimboError::SchemaUpdated
+                | LimboError::SchemaConflict
+                | LimboError::Busy
+                | LimboError::BusySnapshot
+                | LimboError::TableLocked,
+            ) => continue,
+            Err(err) => panic!("count should succeed: {err}"),
+        }
+    }
+    panic!("count rows did not stabilize after transient multiprocess errors");
 }
 
 #[cfg(all(unix, target_pointer_width = "64"))]

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -51,15 +51,34 @@ fn flip_db_header_reserved_byte(path: &Path) {
         .write(true)
         .open(path)
         .expect("open db file for header mutation");
-    file.seek(SeekFrom::Start(72))
-        .expect("seek to reserved header byte");
-    let mut byte = [0u8; 1];
-    file.read_exact(&mut byte)
-        .expect("read reserved header byte");
-    byte[0] ^= 0x01;
-    file.seek(SeekFrom::Start(72))
-        .expect("seek to reserved header byte for write");
-    file.write_all(&byte).expect("write mutated header byte");
+
+    #[cfg(feature = "checksum")]
+    {
+        let mut page = vec![0u8; 4096];
+        file.read_exact(&mut page).expect("read page 1");
+        page[72] ^= 0x01;
+        // Recompute the page checksum (last 8 bytes) so the
+        // page-level integrity check passes and the test exercises
+        // the tshm proof validation path rather than crashing early.
+        let checksum = twox_hash::XxHash3_64::oneshot(&page[..4088]);
+        page[4088..].copy_from_slice(&checksum.to_le_bytes());
+        file.seek(SeekFrom::Start(0)).expect("seek to start");
+        file.write_all(&page).expect("write mutated page 1");
+    }
+
+    #[cfg(not(feature = "checksum"))]
+    {
+        file.seek(SeekFrom::Start(72))
+            .expect("seek to reserved header byte");
+        let mut byte = [0u8; 1];
+        file.read_exact(&mut byte)
+            .expect("read reserved header byte");
+        byte[0] ^= 0x01;
+        file.seek(SeekFrom::Start(72))
+            .expect("seek to reserved header byte for write");
+        file.write_all(&byte).expect("write mutated header byte");
+    }
+
     file.sync_all().expect("sync db header mutation");
 }
 

--- a/testing/concurrent-simulator/worker.rs
+++ b/testing/concurrent-simulator/worker.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use turso_core::{
-    CheckpointMode, Connection, Database, DatabaseOpts, OpenFlags,
+    CheckpointMode, Connection, Database, DatabaseOpts, LimboError, OpenFlags,
     SharedWalCoordinationOpenTelemetryMode, SharedWalTestingSnapshot, StepResult, UnixIO, Value,
 };
 
@@ -23,7 +23,11 @@ fn worker_trace_enabled() -> bool {
 }
 
 /// Run the worker process main loop.
-pub fn run_worker(db_path: &str, enable_mvcc: bool) -> anyhow::Result<()> {
+pub fn run_worker(
+    db_path: &str,
+    enable_mvcc: bool,
+    connections_per_process: usize,
+) -> anyhow::Result<()> {
     // Install a panic hook that writes to stderr so panics don't pollute stdout JSON protocol.
     std::panic::set_hook(Box::new(|info| {
         eprintln!("WORKER PANIC: {info}");
@@ -55,10 +59,18 @@ pub fn run_worker(db_path: &str, enable_mvcc: bool) -> anyhow::Result<()> {
         None, // encryption_opts
     )?;
 
-    let conn = db.connect()?;
+    if connections_per_process == 0 {
+        return Err(anyhow::anyhow!(
+            "connections_per_process must be greater than zero"
+        ));
+    }
+
+    let connections = (0..connections_per_process)
+        .map(|_| db.connect())
+        .collect::<turso_core::Result<Vec<_>>>()?;
 
     if enable_mvcc {
-        conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+        connections[0].execute("PRAGMA journal_mode = 'mvcc'")?;
     }
 
     let telemetry = worker_startup_telemetry(&db)?;
@@ -74,7 +86,20 @@ pub fn run_worker(db_path: &str, enable_mvcc: bool) -> anyhow::Result<()> {
         }
         let cmd: WorkerCommand = serde_json::from_str(&line)?;
         match cmd {
-            WorkerCommand::Execute { sql } => {
+            WorkerCommand::Execute {
+                connection_idx,
+                sql,
+            } => {
+                let conn = match connection_at(&connections, connection_idx) {
+                    Ok(conn) => conn,
+                    Err(err) => {
+                        send_response(&WorkerResponse::Error {
+                            error_kind: "InvalidArgument".to_string(),
+                            message: err.to_string(),
+                        })?;
+                        continue;
+                    }
+                };
                 let response = execute_sql(&conn, &sql);
                 if let WorkerResponse::Error {
                     ref error_kind,
@@ -87,13 +112,34 @@ pub fn run_worker(db_path: &str, enable_mvcc: bool) -> anyhow::Result<()> {
                 }
                 send_response(&response)?;
             }
-            WorkerCommand::DisableAutoCheckpoint => {
+            WorkerCommand::DisableAutoCheckpoint { connection_idx } => {
+                let conn = match connection_at(&connections, connection_idx) {
+                    Ok(conn) => conn,
+                    Err(err) => {
+                        send_response(&WorkerResponse::Error {
+                            error_kind: "InvalidArgument".to_string(),
+                            message: err.to_string(),
+                        })?;
+                        continue;
+                    }
+                };
                 conn.wal_auto_checkpoint_disable();
                 send_response(&WorkerResponse::Ack)?;
             }
             WorkerCommand::PassiveCheckpoint {
+                connection_idx,
                 upper_bound_inclusive,
             } => {
+                let conn = match connection_at(&connections, connection_idx) {
+                    Ok(conn) => conn,
+                    Err(err) => {
+                        send_response(&WorkerResponse::Error {
+                            error_kind: "InvalidArgument".to_string(),
+                            message: err.to_string(),
+                        })?;
+                        continue;
+                    }
+                };
                 conn.checkpoint_for_testing(CheckpointMode::Passive {
                     upper_bound_inclusive,
                 })?;
@@ -104,8 +150,19 @@ pub fn run_worker(db_path: &str, enable_mvcc: bool) -> anyhow::Result<()> {
                 send_response(&WorkerResponse::Ack)?;
             }
             WorkerCommand::InstallUnpublishedBackfillProof {
+                connection_idx,
                 upper_bound_inclusive,
             } => {
+                let conn = match connection_at(&connections, connection_idx) {
+                    Ok(conn) => conn,
+                    Err(err) => {
+                        send_response(&WorkerResponse::Error {
+                            error_kind: "InvalidArgument".to_string(),
+                            message: err.to_string(),
+                        })?;
+                        continue;
+                    }
+                };
                 conn.install_unpublished_backfill_proof_for_testing(upper_bound_inclusive)?;
                 send_response(&WorkerResponse::Ack)?;
             }
@@ -120,13 +177,24 @@ pub fn run_worker(db_path: &str, enable_mvcc: bool) -> anyhow::Result<()> {
                 send_response(&WorkerResponse::FrameLookup { frame_id })?;
             }
             WorkerCommand::Shutdown => {
-                conn.close()?;
+                for conn in &connections {
+                    conn.close()?;
+                }
                 break;
             }
         }
     }
 
     Ok(())
+}
+
+fn connection_at(
+    connections: &[Arc<Connection>],
+    connection_idx: usize,
+) -> turso_core::Result<Arc<Connection>> {
+    connections.get(connection_idx).cloned().ok_or_else(|| {
+        LimboError::InvalidArgument(format!("invalid connection index {connection_idx}"))
+    })
 }
 
 fn worker_startup_telemetry(db: &Arc<Database>) -> anyhow::Result<WorkerStartupTelemetry> {

--- a/testing/concurrent-simulator/worker.rs
+++ b/testing/concurrent-simulator/worker.rs
@@ -1,0 +1,382 @@
+//! Worker process for multiprocess mode.
+//!
+//! Each worker opens the database with real filesystem I/O (UnixIO) and
+//! executes SQL commands received from the coordinator over stdin, returning
+//! results over stdout using the JSON-line protocol.
+
+use std::io::{BufRead, BufReader, Write};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use turso_core::{
+    CheckpointMode, Connection, Database, DatabaseOpts, OpenFlags,
+    SharedWalCoordinationOpenTelemetryMode, SharedWalTestingSnapshot, StepResult, UnixIO, Value,
+};
+
+use crate::protocol::{
+    self, WorkerCommand, WorkerCoordinationOpenMode, WorkerResponse, WorkerSharedWalSnapshot,
+    WorkerStartupTelemetry,
+};
+
+fn worker_trace_enabled() -> bool {
+    std::env::var_os("WHOPPER_TRACE_WORKER").is_some()
+}
+
+/// Run the worker process main loop.
+pub fn run_worker(db_path: &str, enable_mvcc: bool) -> anyhow::Result<()> {
+    // Install a panic hook that writes to stderr so panics don't pollute stdout JSON protocol.
+    std::panic::set_hook(Box::new(|info| {
+        eprintln!("WORKER PANIC: {info}");
+    }));
+
+    // Re-initialize the tracing subscriber to explicitly write to stderr.
+    // The parent process's init_logger() may have configured a stdout writer
+    // which would corrupt the JSON-line protocol on stdout.
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+    let _ = tracing_subscriber::registry()
+        .with(
+            fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_ansi(false)
+                .with_line_number(true)
+                .without_time()
+                .with_thread_ids(false),
+        )
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")))
+        .try_init();
+
+    let io = Arc::new(UnixIO::new()?);
+    let db_opts = DatabaseOpts::new();
+    let db = Database::open_file_with_flags(
+        io,
+        db_path,
+        OpenFlags::default(),
+        db_opts,
+        None, // encryption_opts
+    )?;
+
+    let conn = db.connect()?;
+
+    if enable_mvcc {
+        conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+    }
+
+    let telemetry = worker_startup_telemetry(&db)?;
+
+    // Signal ready
+    send_response(&WorkerResponse::Ready { telemetry })?;
+
+    let stdin = BufReader::new(std::io::stdin());
+    for line in stdin.lines() {
+        let line = line?;
+        if line.is_empty() {
+            continue;
+        }
+        let cmd: WorkerCommand = serde_json::from_str(&line)?;
+        match cmd {
+            WorkerCommand::Execute { sql } => {
+                let response = execute_sql(&conn, &sql);
+                if let WorkerResponse::Error {
+                    ref error_kind,
+                    ref message,
+                } = response
+                {
+                    if error_kind == "Panic" || error_kind == "Internal" {
+                        eprintln!("WORKER SQL ERROR [{error_kind}]: {message} (sql: {sql})");
+                    }
+                }
+                send_response(&response)?;
+            }
+            WorkerCommand::DisableAutoCheckpoint => {
+                conn.wal_auto_checkpoint_disable();
+                send_response(&WorkerResponse::Ack)?;
+            }
+            WorkerCommand::PassiveCheckpoint {
+                upper_bound_inclusive,
+            } => {
+                conn.checkpoint_for_testing(CheckpointMode::Passive {
+                    upper_bound_inclusive,
+                })?;
+                send_response(&WorkerResponse::Ack)?;
+            }
+            WorkerCommand::ClearBackfillProof => {
+                db.clear_backfill_proof_for_testing()?;
+                send_response(&WorkerResponse::Ack)?;
+            }
+            WorkerCommand::InstallUnpublishedBackfillProof {
+                upper_bound_inclusive,
+            } => {
+                conn.install_unpublished_backfill_proof_for_testing(upper_bound_inclusive)?;
+                send_response(&WorkerResponse::Ack)?;
+            }
+            WorkerCommand::ReadSharedWalSnapshot => {
+                let snapshot = db
+                    .shared_wal_snapshot_for_testing()?
+                    .map(worker_shared_wal_snapshot);
+                send_response(&WorkerResponse::SharedWalSnapshot { snapshot })?;
+            }
+            WorkerCommand::FindFrameForPage { page_id } => {
+                let frame_id = db.shared_wal_find_frame_for_testing(page_id)?;
+                send_response(&WorkerResponse::FrameLookup { frame_id })?;
+            }
+            WorkerCommand::Shutdown => {
+                conn.close()?;
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn worker_startup_telemetry(db: &Arc<Database>) -> anyhow::Result<WorkerStartupTelemetry> {
+    let telemetry = db.shared_wal_open_telemetry()?;
+    let coordination_open_mode = telemetry.coordination_open_mode.map(|mode| match mode {
+        SharedWalCoordinationOpenTelemetryMode::Exclusive => WorkerCoordinationOpenMode::Exclusive,
+        SharedWalCoordinationOpenTelemetryMode::MultiProcess => {
+            WorkerCoordinationOpenMode::MultiProcess
+        }
+    });
+    Ok(WorkerStartupTelemetry {
+        loaded_from_disk_scan: telemetry.loaded_from_disk_scan,
+        reopened_max_frame: telemetry.reopened_max_frame,
+        reopened_nbackfills: telemetry.reopened_nbackfills,
+        reopened_checkpoint_seq: telemetry.reopened_checkpoint_seq,
+        coordination_open_mode,
+        sanitized_backfill_proof_on_open: telemetry.sanitized_backfill_proof_on_open,
+    })
+}
+
+fn worker_shared_wal_snapshot(snapshot: SharedWalTestingSnapshot) -> WorkerSharedWalSnapshot {
+    WorkerSharedWalSnapshot {
+        max_frame: snapshot.max_frame,
+        nbackfills: snapshot.nbackfills,
+        checkpoint_seq: snapshot.checkpoint_seq,
+        frame_index_overflowed: snapshot.frame_index_overflowed,
+    }
+}
+
+/// Execute a SQL statement to completion and return a WorkerResponse.
+fn execute_sql(conn: &Arc<Connection>, sql: &str) -> WorkerResponse {
+    // Catch panics so the coordinator gets an error response instead of a crash.
+    let sql_owned = sql.to_string();
+    let conn = conn.clone();
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        execute_sql_inner(&conn, &sql_owned)
+    })) {
+        Ok(response) => response,
+        Err(panic_info) => {
+            let msg = if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else {
+                "unknown panic".to_string()
+            };
+            eprintln!("worker panic during SQL execution: {msg}");
+            WorkerResponse::Error {
+                error_kind: "Panic".to_string(),
+                message: format!("worker panicked: {msg}"),
+            }
+        }
+    }
+}
+
+fn execute_sql_inner(conn: &Arc<Connection>, sql: &str) -> WorkerResponse {
+    fn rollback_autocommit_if_needed(conn: &Arc<Connection>) {
+        if !conn.get_auto_commit() {
+            return;
+        }
+        let _ = conn.execute("ROLLBACK");
+    }
+
+    let trace_worker = worker_trace_enabled();
+    if trace_worker {
+        eprintln!(
+            "WORKER TRACE pid={} start sql={:?} auto_commit={}",
+            std::process::id(),
+            sql,
+            conn.get_auto_commit()
+        );
+    }
+
+    // Retry loop for SchemaUpdated: when another process changes the schema,
+    // we need to reload it from disk and re-prepare the statement.
+    for _attempt in 0..3 {
+        if trace_worker {
+            eprintln!(
+                "WORKER TRACE pid={} prepare-start sql={:?} auto_commit={}",
+                std::process::id(),
+                sql,
+                conn.get_auto_commit()
+            );
+        }
+        let mut stmt = match conn.prepare(sql) {
+            Ok(stmt) => {
+                if trace_worker {
+                    eprintln!(
+                        "WORKER TRACE pid={} prepare-finish sql={:?} auto_commit={}",
+                        std::process::id(),
+                        sql,
+                        conn.get_auto_commit()
+                    );
+                }
+                stmt
+            }
+            Err(turso_core::LimboError::SchemaUpdated) => {
+                if let Err(e) = conn.maybe_reparse_schema() {
+                    eprintln!("worker: failed to reparse schema: {e}");
+                }
+                continue;
+            }
+            Err(e) => {
+                return WorkerResponse::Error {
+                    error_kind: protocol::limbo_error_to_kind(&e).to_string(),
+                    message: e.to_string(),
+                };
+            }
+        };
+
+        let mut rows: Vec<Vec<Value>> = Vec::new();
+        let mut schema_updated = false;
+        let mut rollback_autocommit = false;
+        let mut step_count: u64 = 0;
+        let mut io_count: u64 = 0;
+        let started_at = Instant::now();
+        let mut last_trace_at = started_at;
+
+        let result = loop {
+            step_count += 1;
+            if trace_worker && last_trace_at.elapsed() >= Duration::from_secs(1) {
+                eprintln!(
+                    "WORKER TRACE pid={} stepping sql={:?} steps={} ios={} elapsed_ms={} auto_commit={}",
+                    std::process::id(),
+                    sql,
+                    step_count,
+                    io_count,
+                    started_at.elapsed().as_millis(),
+                    conn.get_auto_commit()
+                );
+                last_trace_at = Instant::now();
+            }
+
+            if trace_worker && step_count == 1 {
+                eprintln!(
+                    "WORKER TRACE pid={} step-start sql={:?} auto_commit={}",
+                    std::process::id(),
+                    sql,
+                    conn.get_auto_commit()
+                );
+            }
+
+            match stmt.step() {
+                Ok(StepResult::Row) => {
+                    if let Some(row) = stmt.row() {
+                        let values: Vec<Value> = row.get_values().cloned().collect();
+                        rows.push(values);
+                    }
+                }
+                Ok(StepResult::Done) => {
+                    break WorkerResponse::Ok { rows };
+                }
+                Ok(StepResult::Busy) => {
+                    rollback_autocommit = true;
+                    break WorkerResponse::Error {
+                        error_kind: "Busy".to_string(),
+                        message: "Database is busy".to_string(),
+                    };
+                }
+                Ok(StepResult::Interrupt) => {
+                    break WorkerResponse::Error {
+                        error_kind: "Interrupt".to_string(),
+                        message: "Interrupted".to_string(),
+                    };
+                }
+                Ok(StepResult::IO) => {
+                    io_count += 1;
+                    // Real I/O: the operation needs more I/O, keep stepping
+                    continue;
+                }
+                Err(turso_core::LimboError::SchemaUpdated) => {
+                    schema_updated = true;
+                    break WorkerResponse::Error {
+                        error_kind: "SchemaUpdated".to_string(),
+                        message: "Database schema changed".to_string(),
+                    };
+                }
+                Err(e) => {
+                    if matches!(
+                        e,
+                        turso_core::LimboError::Busy
+                            | turso_core::LimboError::BusySnapshot
+                            | turso_core::LimboError::WriteWriteConflict
+                            | turso_core::LimboError::CommitDependencyAborted
+                    ) {
+                        rollback_autocommit = true;
+                    }
+                    break WorkerResponse::Error {
+                        error_kind: protocol::limbo_error_to_kind(&e).to_string(),
+                        message: e.to_string(),
+                    };
+                }
+            }
+        };
+
+        if rollback_autocommit {
+            drop(stmt);
+            rollback_autocommit_if_needed(conn);
+            if trace_worker {
+                eprintln!(
+                    "WORKER TRACE pid={} finish sql={:?} result=rollback steps={} ios={} elapsed_ms={} auto_commit={}",
+                    std::process::id(),
+                    sql,
+                    step_count,
+                    io_count,
+                    started_at.elapsed().as_millis(),
+                    conn.get_auto_commit()
+                );
+            }
+            return result;
+        }
+
+        if schema_updated {
+            // Reload schema from disk and retry (only works outside explicit transactions)
+            drop(stmt);
+            if let Err(e) = conn.maybe_reparse_schema() {
+                eprintln!("worker: failed to reparse schema after SchemaUpdated: {e}");
+                return result;
+            }
+            continue;
+        }
+
+        if trace_worker {
+            eprintln!(
+                "WORKER TRACE pid={} finish sql={:?} result={:?} steps={} ios={} elapsed_ms={} auto_commit={}",
+                std::process::id(),
+                sql,
+                &result,
+                step_count,
+                io_count,
+                started_at.elapsed().as_millis(),
+                conn.get_auto_commit()
+            );
+        }
+
+        return result;
+    }
+
+    // Exhausted retries
+    WorkerResponse::Error {
+        error_kind: "SchemaUpdated".to_string(),
+        message: "Database schema changed (exhausted retries)".to_string(),
+    }
+}
+
+/// Write a JSON-line response to stdout.
+fn send_response(response: &WorkerResponse) -> anyhow::Result<()> {
+    let mut stdout = std::io::stdout().lock();
+    serde_json::to_writer(&mut stdout, response)?;
+    stdout.write_all(b"\n")?;
+    stdout.flush()?;
+    Ok(())
+}

--- a/testing/concurrent-simulator/worker.rs
+++ b/testing/concurrent-simulator/worker.rs
@@ -46,7 +46,7 @@ pub fn run_worker(db_path: &str, enable_mvcc: bool) -> anyhow::Result<()> {
         .try_init();
 
     let io = Arc::new(UnixIO::new()?);
-    let db_opts = DatabaseOpts::new();
+    let db_opts = DatabaseOpts::new().with_multiprocess_wal(true);
     let db = Database::open_file_with_flags(
         io,
         db_path,

--- a/testing/sqltests/tests/savepoint.sqltest
+++ b/testing/sqltests/tests/savepoint.sqltest
@@ -135,6 +135,23 @@ expect {
 }
 
 @cross-check-integrity
+test savepoint-rollback-restores-uncommitted-schema {
+    BEGIN;
+    CREATE TABLE keep_t(x);
+    SAVEPOINT sp;
+    CREATE TABLE rolled_back_t(y);
+    ROLLBACK TO sp;
+    SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name;
+    INSERT INTO keep_t VALUES (1);
+    SELECT x FROM keep_t;
+    ROLLBACK;
+}
+expect {
+    keep_t
+    1
+}
+
+@cross-check-integrity
 test savepoint-release-outer-removes-inner {
     CREATE TABLE t(x);
     SAVEPOINT outer;


### PR DESCRIPTION
This PR adds a process-shared WAL coordination layer for Unix 64-bit builds.

Instead of keeping all WAL coordination state inside one process (WalFileShared), we now create a separate `-tshm` file, memory-mapped by every process that opens the database. It stores:

- the current authoritative WAL snapshot (`max_frame`, salts, checksums, checkpoint generation, transaction count)
- who currently owns the writer lock, checkpoint lock, and each shared reader slot
- a shared page-to-frame index so readers can find the newest WAL frame for a page without rescanning the whole WAL file
- extra metadata used to decide whether a reopened process can trust the saved snapshot

How it works:

1. On open, Turso decides whether this process is alone or joining an already-open database by probing byte 0 of the `-tshm` file.
2. If this is a clean exclusive open, it may repair stale lock ownership left behind by dead processes and reuse or rebuild the shared frame index from the WAL file.
3. Each writer still uses the existing in-process lock path for other connections in the same process, but it also takes a cross-process writer lock in `-tshm`.
4. Each reader still takes the normal local read mark, and also registers a shared reader slot in `-tshm` so checkpoints in other processes know how far they are allowed to backfill.
5. When a commit becomes visible, the writer publishes the new WAL snapshot into `-tshm` and appends page-to-frame mappings into the shared frame index.
6. Checkpoints consult both the local read marks and the shared reader slots, so they stop before overwriting pages that another process may still need.
7. Shutdown checkpointing is only allowed when the process can prove it is the last process still mapped to that `-tshm` file.

**How this differs from SQLite's `-shm` file:**
- On Linux, Turso uses OFD byte-range locks. On macOS and other Unix targets, it falls back to regular process-scoped `fcntl` locks plus stored owner PIDs and some extra per-process bookkeeping.

- Turso's reopen path is more conservative than SQLite's current `-shm` recovery model. It validates that the saved snapshot still matches the WAL file and may fall back to a full WAL scan instead of blindly trusting the persisted shared state. More work is still needed in the entire commit/checkpoint/recovery path to definitively trust `nbackfills > 0` in an existing `-tshm` file and prevent scanning the WAL file to build the index.