### PR TITLE
core/translate: Support compound SELECT in WHERE-clause subqueries

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -1088,10 +1088,10 @@ pub fn try_hash_join_access_method(
         // Check if the subquery references the build or probe table
         if let SubqueryState::Unevaluated { plan } = &subquery.state {
             if let Some(plan) = plan.as_ref() {
-                let outer_refs = plan.table_references.outer_query_refs();
-                for outer_ref in outer_refs {
-                    if outer_ref.internal_id == build_table.internal_id
-                        || outer_ref.internal_id == probe_table.internal_id
+                let outer_ref_ids = plan.used_outer_query_ref_ids();
+                for outer_ref_id in &outer_ref_ids {
+                    if *outer_ref_id == build_table.internal_id
+                        || *outer_ref_id == probe_table.internal_id
                     {
                         return None;
                     }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -646,11 +646,16 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
     // unnesting sees the plan without an artificial LIMIT.
     for sub in &mut plan.non_from_clause_subqueries {
         if matches!(sub.query_type, ast::SubqueryType::Exists { .. }) {
-            if let SubqueryState::Unevaluated { plan: Some(inner) } = &mut sub.state {
-                if inner.limit.is_none() {
-                    inner.limit = Some(Box::new(Expr::Literal(ast::Literal::Numeric(
-                        "1".to_string(),
-                    ))));
+            if let SubqueryState::Unevaluated {
+                plan: Some(inner), ..
+            } = &mut sub.state
+            {
+                if let Plan::Select(ref mut inner) = inner.as_mut() {
+                    if inner.limit.is_none() {
+                        inner.limit = Some(Box::new(Expr::Literal(ast::Literal::Numeric(
+                            "1".to_string(),
+                        ))));
+                    }
                 }
             }
         }
@@ -1143,6 +1148,9 @@ fn reoptimize_correlated_subqueries(plan: &mut SelectPlan, schema: &Schema) -> R
             plan: Some(inner_plan),
         } = &mut subquery.state
         else {
+            continue;
+        };
+        let Plan::Select(ref mut inner_plan) = inner_plan.as_mut() else {
             continue;
         };
         if !select_plan_contains_cte_from_clause_subquery(inner_plan) {

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -35,6 +35,8 @@
 use smallvec::SmallVec;
 use turso_parser::ast::{self, Expr, TableInternalId, UnaryOperator};
 
+use crate::translate::plan::Plan;
+
 use crate::function::{Deterministic, Func};
 use crate::translate::{
     expr::{walk_expr, WalkControl},
@@ -78,6 +80,10 @@ fn try_unnest_exists(plan: &mut SelectPlan, subquery_idx: usize) -> bool {
             return false;
         };
         let Some(inner) = inner.as_ref() else {
+            return false;
+        };
+        let Plan::Select(inner) = inner.as_ref() else {
+            // Compound selects cannot be unnested.
             return false;
         };
         inner.clone()

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -355,24 +355,67 @@ impl Plan {
         }
     }
 
-    /// Returns the result columns for Select/CompoundSelect plans.
-    /// Returns None for Delete/Update plans.
-    pub fn select_result_columns(&self) -> Option<&[ResultSetColumn]> {
+    /// Returns the result columns of a SELECT or compound SELECT plan. For a
+    /// compound SELECT the columns of the right-most component are returned,
+    /// since every component must agree on column count and naming.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a DELETE or UPDATE plan, which have no result
+    /// columns.
+    pub fn select_result_columns(&self) -> &[ResultSetColumn] {
         match self {
-            Plan::Select(select_plan) => Some(&select_plan.result_columns),
-            Plan::CompoundSelect { right_most, .. } => Some(&right_most.result_columns),
-            Plan::Delete(_) | Plan::Update(_) => None,
+            Plan::Select(select_plan) => &select_plan.result_columns,
+            Plan::CompoundSelect { right_most, .. } => &right_most.result_columns,
+            Plan::Delete(_) | Plan::Update(_) => {
+                panic!("select_result_columns called on a non-SELECT plan")
+            }
         }
     }
 
-    /// Returns the table references for Select/CompoundSelect plans.
-    /// Returns None for Delete/Update plans.
-    pub fn select_table_references(&self) -> Option<&TableReferences> {
+    /// Returns the table references of a SELECT or compound SELECT plan. For
+    /// a compound SELECT the references of the right-most component are
+    /// returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a DELETE or UPDATE plan.
+    pub fn select_table_references(&self) -> &TableReferences {
         match self {
-            Plan::Select(select_plan) => Some(&select_plan.table_references),
-            Plan::CompoundSelect { right_most, .. } => Some(&right_most.table_references),
-            Plan::Delete(_) | Plan::Update(_) => None,
+            Plan::Select(select_plan) => &select_plan.table_references,
+            Plan::CompoundSelect { right_most, .. } => &right_most.table_references,
+            Plan::Delete(_) | Plan::Update(_) => {
+                panic!("select_table_references called on a non-SELECT plan")
+            }
         }
+    }
+
+    /// Returns the IDs of every outer-query reference that this plan actually
+    /// uses. For a compound SELECT, the result spans all of its component
+    /// SELECTs. DELETE and UPDATE plans have no outer-query references and
+    /// always return an empty vector.
+    pub fn used_outer_query_ref_ids(&self) -> Vec<TableInternalId> {
+        fn collect_from_select(plan: &SelectPlan, out: &mut Vec<TableInternalId>) {
+            for outer_ref in plan.table_references.outer_query_refs().iter() {
+                if outer_ref.is_used() {
+                    out.push(outer_ref.internal_id);
+                }
+            }
+        }
+        let mut ids = Vec::new();
+        match self {
+            Plan::Select(plan) => collect_from_select(plan, &mut ids),
+            Plan::CompoundSelect {
+                left, right_most, ..
+            } => {
+                for (plan, _) in left {
+                    collect_from_select(plan, &mut ids);
+                }
+                collect_from_select(right_most, &mut ids);
+            }
+            Plan::Delete(_) | Plan::Update(_) => {}
+        }
+        ids
     }
 
     /// Returns true if this plan or any of its subplans read from the given table.
@@ -2524,7 +2567,7 @@ pub enum SubqueryState {
     /// The subquery has not been evaluated yet.
     /// The 'plan' field is only optional because it is .take()'d when the the subquery
     /// is translated into bytecode.
-    Unevaluated { plan: Option<Box<SelectPlan>> },
+    Unevaluated { plan: Option<Box<Plan>> },
     /// The subquery has been evaluated.
     /// The [evaluated_at] field contains the loop index where the subquery was evaluated.
     /// The query plan struct no longer exists because translating the plan currently
@@ -2601,7 +2644,7 @@ impl NonFromClauseSubquery {
     pub fn reads_table(&self, database_id: usize, table_name: &str) -> bool {
         match &self.state {
             SubqueryState::Unevaluated { plan: Some(plan) } => {
-                plan.reads_table(database_id, table_name)
+                Plan::reads_table(plan, database_id, table_name)
             }
             _ => false,
         }
@@ -2623,26 +2666,19 @@ impl NonFromClauseSubquery {
                 return Ok(*evaluated_at);
             }
         };
-        eval_at_for_select_plan(plan, join_order, table_references)
+        eval_at_for_plan(plan, join_order, table_references)
     }
 
     /// Consumes the plan and returns it, and sets the subquery to the evaluated state.
     ///
     /// This captures any outer references before the plan is moved so later
     /// phases can still reason about dependencies.
-    pub fn consume_plan(&mut self, evaluated_at: EvalAt) -> Box<SelectPlan> {
+    pub fn consume_plan(&mut self, evaluated_at: EvalAt) -> Box<Plan> {
         match &mut self.state {
             SubqueryState::Unevaluated { plan } => {
                 let outer_ref_ids = plan
                     .as_ref()
-                    .map(|plan| {
-                        plan.table_references
-                            .outer_query_refs()
-                            .iter()
-                            .filter(|t| t.is_used())
-                            .map(|t| t.internal_id)
-                            .collect::<Vec<_>>()
-                    })
+                    .map(|plan| plan.used_outer_query_ref_ids())
                     .unwrap_or_default();
                 let plan = plan.take().unwrap();
                 self.state = SubqueryState::Evaluated {
@@ -2734,7 +2770,7 @@ pub fn plan_has_outer_scope_dependency(plan: &Plan) -> bool {
                     .any(|subquery| match &subquery.state {
                         SubqueryState::Unevaluated {
                             plan: Some(subquery_plan),
-                        } => select_plan_has_outer_scope_dependency(
+                        } => plan_has_outer_scope_dependency_with_tables(
                             subquery_plan,
                             accessible_table_ids,
                         ),

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -557,10 +557,7 @@ fn plan_cte(
         // Validate explicit column count only on actual references (matching SQLite behavior,
         // which defers this check until the CTE is used).
         if let Some(cols) = explicit_cols {
-            let result_col_count = cte_plan
-                .select_result_columns()
-                .expect("should be a select plan")
-                .len();
+            let result_col_count = cte_plan.select_result_columns().len();
             if cols.len() != result_col_count {
                 crate::bail_parse_error!(
                     "table {} has {} columns but {} column names were provided",
@@ -903,10 +900,7 @@ fn parse_table(
             // Validate explicit column count on actual CTE reference (matching SQLite
             // behavior, which defers this check until the CTE is used).
             if let Some(cols) = explicit_cols {
-                let result_col_count = cte_plan
-                    .select_result_columns()
-                    .expect("should be a select plan")
-                    .len();
+                let result_col_count = cte_plan.select_result_columns().len();
                 if cols.len() != result_col_count {
                     crate::bail_parse_error!(
                         "table {} has {} columns but {} column names were provided",
@@ -1596,18 +1590,12 @@ pub fn table_mask_from_expr(
                 };
                 match &subquery.state {
                     SubqueryState::Unevaluated { plan } => {
-                        let used_outer_query_refs = plan
-                            .as_ref()
-                            .unwrap()
-                            .table_references
-                            .outer_query_refs()
-                            .iter()
-                            .filter(|t| t.is_used());
-                        for outer_query_ref in used_outer_query_refs {
+                        let outer_ref_ids = plan.as_ref().unwrap().used_outer_query_ref_ids();
+                        for outer_ref_id in &outer_ref_ids {
                             if let Some(table_idx) = table_references
                                 .joined_tables()
                                 .iter()
-                                .position(|t| t.internal_id == outer_query_ref.internal_id)
+                                .position(|t| t.internal_id == *outer_ref_id)
                             {
                                 mask.add_table(table_idx);
                             }
@@ -1691,17 +1679,11 @@ pub fn determine_where_to_eval_expr(
                         eval_at = eval_at.max(*evaluated_at);
                     }
                     SubqueryState::Unevaluated { plan } => {
-                        let used_outer_refs = plan
-                            .as_ref()
-                            .unwrap()
-                            .table_references
-                            .outer_query_refs()
-                            .iter()
-                            .filter(|t| t.is_used());
-                        for outer_ref in used_outer_refs {
+                        let outer_ref_ids = plan.as_ref().unwrap().used_outer_query_ref_ids();
+                        for outer_ref_id in &outer_ref_ids {
                             let join_idx = join_order
                                 .iter()
-                                .position(|t| t.table_id == outer_ref.internal_id)
+                                .position(|t| t.table_id == *outer_ref_id)
                                 .or_else(|| {
                                     let tables = table_references?;
                                     for (probe_idx, member) in join_order.iter().enumerate() {
@@ -1710,7 +1692,7 @@ pub fn determine_where_to_eval_expr(
                                         if let Operation::HashJoin(ref hj) = probe_table.op {
                                             let build_table =
                                                 &tables.joined_tables()[hj.build_table_idx];
-                                            if build_table.internal_id == outer_ref.internal_id {
+                                            if build_table.internal_id == *outer_ref_id {
                                                 return Some(probe_idx);
                                             }
                                         }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -123,8 +123,10 @@ fn select_plan_first_virtual_table_name(select_plan: &SelectPlan) -> Option<Stri
     }
     for subquery in &select_plan.non_from_clause_subqueries {
         if let SubqueryState::Unevaluated { plan: Some(plan) } = &subquery.state {
-            if let Some(name) = select_plan_first_virtual_table_name(plan) {
-                return Some(name);
+            if let Plan::Select(plan) = plan.as_ref() {
+                if let Some(name) = select_plan_first_virtual_table_name(plan) {
+                    return Some(name);
+                }
             }
         }
     }
@@ -919,7 +921,7 @@ fn reject_outer_query_refs_in_group_by_expr(
                 else {
                     unreachable!("GROUP BY subquery must be in unevaluated state during planning");
                 };
-                reject_outer_scope_refs_inside_select_plan(subquery_plan, table_references)?;
+                reject_outer_scope_refs_inside_plan_tree(subquery_plan, table_references)?;
             }
             _ => {}
         }
@@ -985,7 +987,7 @@ fn reject_outer_scope_refs_inside_select_plan(
         else {
             continue;
         };
-        reject_outer_scope_refs_inside_select_plan(subquery_plan, current_scope_table_refs)?;
+        reject_outer_scope_refs_inside_plan_tree(subquery_plan, current_scope_table_refs)?;
     }
 
     for joined_table in plan.table_references.joined_tables().iter() {

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -127,7 +127,7 @@ fn mark_shared_cte_materialization_requirements(program: &ProgramBuilder, plan: 
         else {
             continue;
         };
-        mark_shared_cte_materialization_requirements(program, subquery_plan);
+        annotate_plan(program, subquery_plan);
     }
 }
 
@@ -535,7 +535,7 @@ fn get_subquery_parser<'a>(
                     internal_id: subquery_id,
                     query_type: subquery_type,
                     state: SubqueryState::Unevaluated {
-                        plan: Some(Box::new(plan)),
+                        plan: Some(Box::new(Plan::Select(plan))),
                     },
                     correlated,
                     origin,
@@ -626,7 +626,7 @@ fn get_subquery_parser<'a>(
                         num_regs: reg_count,
                     },
                     state: SubqueryState::Unevaluated {
-                        plan: Some(Box::new(plan)),
+                        plan: Some(Box::new(Plan::Select(plan))),
                     },
                     correlated,
                     origin,
@@ -649,12 +649,34 @@ fn get_subquery_parser<'a>(
                     QueryDestination::Unset,
                     connection,
                 )?;
-                let Plan::Select(mut plan) = plan else {
-                    crate::bail_parse_error!(
-                        "compound SELECT queries not supported yet in WHERE clause subqueries"
-                    );
+                let mut plan = match plan {
+                    Plan::Select(mut select_plan) => {
+                        optimize_select_plan(&mut select_plan, resolver.schema())?;
+                        Plan::Select(select_plan)
+                    }
+                    Plan::CompoundSelect {
+                        mut left,
+                        mut right_most,
+                        limit,
+                        offset,
+                        order_by,
+                    } => {
+                        optimize_select_plan(&mut right_most, resolver.schema())?;
+                        for (select_plan, _) in left.iter_mut() {
+                            optimize_select_plan(select_plan, resolver.schema())?;
+                        }
+                        Plan::CompoundSelect {
+                            left,
+                            right_most,
+                            limit,
+                            offset,
+                            order_by,
+                        }
+                    }
+                    _ => unreachable!("prepare_select_plan cannot return Delete/Update"),
                 };
-                optimize_select_plan(&mut plan, resolver.schema())?;
+                let result_columns = plan.select_result_columns();
+                let table_references = plan.select_table_references();
                 // e.g. (x,y) IN (SELECT ...)
                 // or x IN (SELECT ...)
                 let lhs_columns = match unwrap_parens(lhs.as_ref())? {
@@ -664,10 +686,10 @@ fn get_subquery_parser<'a>(
                     expr => either::Right(core::iter::once(expr)),
                 };
                 let lhs_column_count = lhs_columns.len();
-                if lhs_column_count != plan.result_columns.len() {
+                if lhs_column_count != result_columns.len() {
                     crate::bail_parse_error!(
                         "sub-select returns {} columns - expected {lhs_column_count}",
-                        plan.result_columns.len()
+                        result_columns.len()
                     );
                 }
                 // Collect affinity and LHS collation in a single pass over lhs_columns.
@@ -682,9 +704,9 @@ fn get_subquery_parser<'a>(
                         get_expr_affinity_info(lhs_expr, Some(referenced_tables), None);
                     affinity_chars.push(
                         compare_affinity(
-                            &plan.result_columns[i].expr,
+                            &result_columns[i].expr,
                             lhs_affinity,
-                            Some(&plan.table_references),
+                            Some(table_references),
                             None,
                         )
                         .aff_mask(),
@@ -693,14 +715,13 @@ fn get_subquery_parser<'a>(
                 }
                 let in_affinity_str: Arc<String> = Arc::new(affinity_chars);
 
-                let columns = plan
-                    .result_columns
+                let columns = result_columns
                     .iter()
                     .enumerate()
                     .map(|(i, c)| {
-                        let rhs_collation = get_collseq_from_expr(&c.expr, &plan.table_references)?;
+                        let rhs_collation = get_collseq_from_expr(&c.expr, table_references)?;
                         Ok(IndexColumn {
-                            name: c.name(&plan.table_references).unwrap_or("").to_string(),
+                            name: c.name(table_references).unwrap_or("").to_string(),
                             order: SortOrder::Asc,
                             pos_in_table: i,
                             collation: lhs_collations[i].or(rhs_collation),
@@ -726,7 +747,7 @@ fn get_subquery_parser<'a>(
                 let cursor_id =
                     program.alloc_cursor_id(CursorType::BTreeIndex(ephemeral_index.clone()));
 
-                plan.query_destination = QueryDestination::EphemeralIndex {
+                *plan.select_query_destination_mut().unwrap() = QueryDestination::EphemeralIndex {
                     cursor_id,
                     index: ephemeral_index,
                     affinity_str: Some(in_affinity_str.clone()),
@@ -743,7 +764,7 @@ fn get_subquery_parser<'a>(
                     },
                 };
 
-                let correlated = plan.is_correlated();
+                let correlated = plan_is_correlated(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
 
                 out_subqueries.push(NonFromClauseSubquery {
@@ -875,7 +896,7 @@ fn update_column_used_masks(
             panic!("subquery has no plan");
         };
 
-        propagate_outer_refs_from_select_plan(table_refs, child_plan);
+        propagate_outer_refs_from_plan(table_refs, child_plan);
     }
 
     // Collect raw plan pointers to avoid cloning while sidestepping borrow rules.
@@ -946,7 +967,7 @@ fn pre_materialize_multi_ref_ctes_in_non_from_subqueries(
         else {
             continue;
         };
-        pre_materialize_multi_ref_ctes_in_select_plan(program, subquery_plan.as_mut(), t_ctx)?;
+        pre_materialize_multi_ref_ctes(program, subquery_plan.as_mut(), t_ctx)?;
     }
     Ok(())
 }
@@ -1593,7 +1614,7 @@ fn emit_materialized_subquery_table(
 pub fn emit_non_from_clause_subquery(
     program: &mut ProgramBuilder,
     resolver: &Resolver,
-    plan: SelectPlan,
+    plan: Plan,
     query_type: &SubqueryType,
     is_correlated: bool,
     preserve_outer_expr_cache: bool,
@@ -1632,6 +1653,32 @@ pub fn emit_non_from_clause_subquery(
             None
         };
 
+        // Helper closure to emit a select plan (simple or compound). The
+        // closure captures `resolver`, `plan`, and `preserve_outer_expr_cache`
+        // from the enclosing scope; only `program` is passed explicitly so
+        // that the outer scope can keep emitting instructions in between.
+        // Called at most once, hence `FnOnce`.
+        let emit_plan = move |program: &mut ProgramBuilder| -> Result<()> {
+            match plan {
+                Plan::Select(select_plan) => {
+                    if preserve_outer_expr_cache {
+                        emit_program_for_select_with_resolver(
+                            program,
+                            resolver.fork_with_expr_cache(),
+                            select_plan,
+                        )
+                    } else {
+                        emit_program_for_select(program, resolver, select_plan)
+                    }
+                }
+                compound @ Plan::CompoundSelect { .. } => {
+                    emit_program_for_compound_select(program, resolver, compound)?;
+                    Ok(())
+                }
+                _ => unreachable!("DML plans cannot be subqueries"),
+            }
+        };
+
         match query_type {
             SubqueryType::Exists { result_reg, .. } => {
                 let subroutine_reg = program.alloc_register();
@@ -1643,15 +1690,7 @@ pub fn emit_non_from_clause_subquery(
                     value: 0,
                     dest: *result_reg,
                 });
-                if preserve_outer_expr_cache {
-                    emit_program_for_select_with_resolver(
-                        program,
-                        resolver.fork_with_expr_cache(),
-                        plan,
-                    )?;
-                } else {
-                    emit_program_for_select(program, resolver, plan)?;
-                }
+                emit_plan(program)?;
                 program.emit_insn(Insn::Return {
                     return_reg: subroutine_reg,
                     can_fallthrough: true,
@@ -1662,15 +1701,7 @@ pub fn emit_non_from_clause_subquery(
                     cursor_id: *cursor_id,
                     is_table: false,
                 });
-                if preserve_outer_expr_cache {
-                    emit_program_for_select_with_resolver(
-                        program,
-                        resolver.fork_with_expr_cache(),
-                        plan,
-                    )?;
-                } else {
-                    emit_program_for_select(program, resolver, plan)?;
-                }
+                emit_plan(program)?;
             }
             SubqueryType::RowValue {
                 result_reg_start,
@@ -1687,15 +1718,7 @@ pub fn emit_non_from_clause_subquery(
                         dest_end: None,
                     });
                 }
-                if preserve_outer_expr_cache {
-                    emit_program_for_select_with_resolver(
-                        program,
-                        resolver.fork_with_expr_cache(),
-                        plan,
-                    )?;
-                } else {
-                    emit_program_for_select(program, resolver, plan)?;
-                }
+                emit_plan(program)?;
                 program.emit_insn(Insn::Return {
                     return_reg: subroutine_reg,
                     can_fallthrough: true,

--- a/testing/sqltests/tests/subquery/compound_select_in_where.sqltest
+++ b/testing/sqltests/tests/subquery/compound_select_in_where.sqltest
@@ -1,0 +1,145 @@
+@database :memory:
+
+# Regression tests for compound SELECT (UNION / UNION ALL / INTERSECT /
+# EXCEPT) inside WHERE-clause IN subqueries. Previously these were rejected at
+# parse time; the query planner now threads compound selects through the IN
+# subquery code path.
+#
+# EXISTS and scalar (RowValue) subqueries still reject compound selects at
+# parse time and are intentionally not covered here.
+
+setup fruits {
+    CREATE TABLE fruit (id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO fruit VALUES (1, 'apple'), (2, 'banana'), (3, 'cherry'),
+                             (4, 'date'), (5, 'elderberry');
+
+    CREATE TABLE red_fruit (name TEXT);
+    INSERT INTO red_fruit VALUES ('apple'), ('cherry');
+
+    CREATE TABLE yellow_fruit (name TEXT);
+    INSERT INTO yellow_fruit VALUES ('banana');
+
+    CREATE TABLE tropical_fruit (name TEXT);
+    INSERT INTO tropical_fruit VALUES ('banana'), ('date'), ('mango');
+}
+
+# -----------------------------------------------------------------------------
+# IN subquery with UNION / UNION ALL / INTERSECT / EXCEPT
+# -----------------------------------------------------------------------------
+
+@setup fruits
+test in-union {
+    SELECT id, name FROM fruit
+    WHERE name IN (SELECT name FROM red_fruit
+                   UNION
+                   SELECT name FROM yellow_fruit)
+    ORDER BY id;
+}
+expect {
+    1|apple
+    2|banana
+    3|cherry
+}
+
+@setup fruits
+test in-union-all {
+    SELECT id, name FROM fruit
+    WHERE name IN (SELECT name FROM red_fruit
+                   UNION ALL
+                   SELECT name FROM yellow_fruit
+                   UNION ALL
+                   SELECT name FROM tropical_fruit)
+    ORDER BY id;
+}
+expect {
+    1|apple
+    2|banana
+    3|cherry
+    4|date
+}
+
+@setup fruits
+test in-intersect {
+    SELECT id, name FROM fruit
+    WHERE name IN (SELECT name FROM tropical_fruit
+                   INTERSECT
+                   SELECT name FROM yellow_fruit)
+    ORDER BY id;
+}
+expect {
+    2|banana
+}
+
+@setup fruits
+test in-except {
+    SELECT id, name FROM fruit
+    WHERE name IN (SELECT name FROM tropical_fruit
+                   EXCEPT
+                   SELECT name FROM yellow_fruit)
+    ORDER BY id;
+}
+expect {
+    4|date
+}
+
+@setup fruits
+test not-in-union {
+    SELECT id, name FROM fruit
+    WHERE name NOT IN (SELECT name FROM red_fruit
+                       UNION
+                       SELECT name FROM yellow_fruit)
+    ORDER BY id;
+}
+expect {
+    4|date
+    5|elderberry
+}
+
+# -----------------------------------------------------------------------------
+# Row-value IN with a compound select returning multiple columns
+# -----------------------------------------------------------------------------
+
+setup pairs {
+    CREATE TABLE pair (a INTEGER, b INTEGER);
+    INSERT INTO pair VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+
+    CREATE TABLE want_a (a INTEGER, b INTEGER);
+    INSERT INTO want_a VALUES (1, 10), (3, 30);
+
+    CREATE TABLE want_b (a INTEGER, b INTEGER);
+    INSERT INTO want_b VALUES (2, 20);
+}
+
+@setup pairs
+test row-value-in-union {
+    SELECT a, b FROM pair
+    WHERE (a, b) IN (SELECT a, b FROM want_a
+                     UNION
+                     SELECT a, b FROM want_b)
+    ORDER BY a;
+}
+expect {
+    1|10
+    2|20
+    3|30
+}
+
+# -----------------------------------------------------------------------------
+# Compound SELECT in a WHERE IN subquery that references the outer query.
+# This exercises Plan::used_outer_query_ref_ids(), which must walk every
+# component SELECT of the compound to collect outer-query refs.
+# -----------------------------------------------------------------------------
+
+@setup fruits
+test correlated-in-union {
+    SELECT id, name FROM fruit f
+    WHERE name IN (SELECT name FROM red_fruit    WHERE LENGTH(name) = LENGTH(f.name)
+                   UNION
+                   SELECT name FROM yellow_fruit WHERE LENGTH(name) = LENGTH(f.name))
+    ORDER BY id;
+}
+expect {
+    1|apple
+    2|banana
+    3|cherry
+}


### PR DESCRIPTION
Previously, compound SELECT queries (UNION, INTERSECT, EXCEPT) inside WHERE-clause subqueries were explicitly rejected with a parse error. This change adds support for them by widening SubqueryState::Unevaluated to hold a `Box<Plan>` instead of `Box<SelectPlan>`, allowing it to carry compound selects through planning, optimization, and bytecode emission.

Key changes:
- SubqueryState::Unevaluated now stores `Box<Plan>` instead of `Box<SelectPlan>`
- Add Plan::used_outer_query_ref_ids() to collect outer refs across all component selects in a compound query
- Handle Plan::CompoundSelect in optimization passes (EXISTS limit injection, unnesting, CTE materialization)
- Emit compound selects via emit_program_for_compound_select in non-FROM-clause subquery codegen

Fixes select1-6.20 in testing/sqlite3/all.test.