### PR TITLE
parser: Reject "#" as illegal token

### DIFF
--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -252,7 +252,16 @@ impl<'a> Iterator for Lexer<'a> {
                         Some(self.mark(|l| l.eat_var()))
                     }
                 }
-                b'?' | b'$' | b'#' => Some(self.mark(|l| l.eat_var())),
+                b'?' | b'$' => Some(self.mark(|l| l.eat_var())),
+                b'#' => {
+                    let start = self.offset;
+                    self.eat(); // consume '#'
+                    self.eat_while(is_identifier_continue);
+                    Some(Ok(Token::new(
+                        &self.input[start..self.offset],
+                        TokenType::TK_ILLEGAL,
+                    )))
+                }
                 b':' => {
                     // `:name` is a named parameter, but `:` followed by a digit
                     // or non-identifier char is a standalone colon (used in slice syntax).
@@ -823,7 +832,7 @@ impl<'a> Lexer<'a> {
     fn eat_var(&mut self) -> Result<Token<'a>> {
         let start = self.offset;
         let tok = self.eat().unwrap();
-        debug_assert!(tok == b'?' || tok == b'$' || tok == b'@' || tok == b'#' || tok == b':');
+        debug_assert!(tok == b'?' || tok == b'$' || tok == b'@' || tok == b':');
 
         match tok {
             b'?' => {
@@ -1049,10 +1058,6 @@ mod tests {
             (
                 b"@param".as_slice(),
                 Token::new(b"@param", TokenType::TK_VARIABLE),
-            ),
-            (
-                b"#comment".as_slice(),
-                Token::new(b"#comment", TokenType::TK_VARIABLE),
             ),
             (
                 b":named_param".as_slice(),

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -186,7 +186,7 @@ impl<'a> Parser<'a> {
             self.last_variable_id += 1;
             let index = NonZeroU32::new(self.last_variable_id).unwrap();
             Ok(Expr::Variable(Variable::indexed(index)))
-        } else if matches!(token[0], b':' | b'@' | b'$' | b'#') {
+        } else if matches!(token[0], b':' | b'@' | b'$') {
             let index = if let Some(index) = self.named_variables.get(token).copied() {
                 index
             } else {


### PR DESCRIPTION
SQLite does not recognize '#' as a variable prefix, but our parser was accepting tokens like '#1' as variables. This caused confusing runtime errors ("datatype mismatch") instead of proper syntax errors. Now the lexer emits TK_ILLEGAL for '#'-prefixed tokens, producing the correct 'near "#1": syntax error' diagnostic.