### PR TITLE
bindings/rust: Add support for read-only databases

### DIFF
--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -200,6 +200,7 @@ pub fn py_turso_database_open(config: &PyTursoDatabaseConfig) -> PyResult<PyTurs
         vfs: config.vfs.clone(),
         io: None,
         db_file: None,
+        flags: None,
     });
     let result = database.open().map_err(turso_error_to_py_err)?;
     // async_io is false - so db.open() will return result immediately

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -157,6 +157,7 @@ pub fn py_turso_sync_new(
         vfs: None,
         io: None,
         db_file: None,
+        flags: None,
     };
     // calculate and set reserved_bytes from cipher if necessary
     let reserved_bytes = sync_config

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -256,10 +256,11 @@ impl Builder {
                 vfs: self.vfs,
                 io: None,
                 db_file: None,
-                flags: if self.read_only {
-                    turso_sdk_kit::rsapi::OpenFlags::ReadOnly
+              
+             flags: if self.read_only {
+                    Some(turso_sdk_kit::rsapi::PubOpenFlags::ReadOnly)
                 } else {
-                    turso_sdk_kit::rsapi::OpenFlags::default()
+                    None
                 },
             });
         while let Some(io_c) = db.open()?.io() {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -136,6 +136,7 @@ pub type EncryptionOpts = turso_sdk_kit::rsapi::EncryptionOpts;
 /// A builder for `Database`.
 pub struct Builder {
     path: String,
+    read_only: bool,
     enable_encryption: bool,
     enable_attach: bool,
     enable_custom_types: bool,
@@ -151,6 +152,7 @@ impl Builder {
     pub fn new_local(path: &str) -> Self {
         Self {
             path: path.to_string(),
+            read_only: false,
             enable_encryption: false,
             enable_attach: false,
             enable_custom_types: false,
@@ -211,6 +213,10 @@ impl Builder {
         self.vfs = Some(vfs);
         self
     }
+    pub fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
     fn build_features_string(&self) -> Option<String> {
         let mut features = Vec::new();
         if self.enable_encryption {
@@ -250,6 +256,11 @@ impl Builder {
                 vfs: self.vfs,
                 io: None,
                 db_file: None,
+                flags: if self.read_only {
+                    turso_sdk_kit::rsapi::OpenFlags::ReadOnly
+                } else {
+                    turso_sdk_kit::rsapi::OpenFlags::default()
+                },
             });
         while let Some(io_c) = db.open()?.io() {
             // At this point IO must already be created

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -256,8 +256,8 @@ impl Builder {
                 vfs: self.vfs,
                 io: None,
                 db_file: None,
-              
-             flags: if self.read_only {
+
+                flags: if self.read_only {
                     Some(turso_sdk_kit::rsapi::PubOpenFlags::ReadOnly)
                 } else {
                     None

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -183,6 +183,7 @@ impl Builder {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         };
 
         let url = if let Some(remote_url) = &self.remote_url {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -111,6 +111,8 @@ impl TursoSetupConfig {
         })
     }
 }
+                
+pub use turso_core::io::OpenFlags as PubOpenFlags;
 
 #[derive(Clone)]
 pub struct TursoDatabaseConfig {
@@ -142,6 +144,8 @@ pub struct TursoDatabaseConfig {
     /// optional custom DatabaseStorage provided by the caller
     /// if provided, caller must guarantee that IO used by the TursoDatabase will be consistent with underlying DatabaseStorage IO
     pub db_file: Option<Arc<dyn DatabaseStorage>>,
+
+    pub flags: Option<OpenFlags>,
 }
 
 pub fn turso_slice_from_bytes(bytes: &[u8]) -> capi::c::turso_slice_ref_t {
@@ -283,6 +287,7 @@ impl TursoDatabaseConfig {
             },
             io: None,
             db_file: None,
+            flags: None,
         })
     }
 }

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -111,7 +111,7 @@ impl TursoSetupConfig {
         })
     }
 }
-                
+
 pub use turso_core::io::OpenFlags as PubOpenFlags;
 
 #[derive(Clone)]

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1294,6 +1294,7 @@ mod tests {
                 vfs: None,
                 io: None,
                 db_file: None,
+                flags: None,
             });
             let result = db.open().unwrap();
             assert!(!result.is_io());
@@ -1355,6 +1356,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1375,6 +1377,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1405,6 +1408,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1428,6 +1432,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1478,6 +1483,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1537,6 +1543,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1569,6 +1576,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1598,6 +1606,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1623,6 +1632,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1649,6 +1659,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1699,6 +1710,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1787,6 +1799,7 @@ mod tests {
                     vfs: None,
                     io: None,
                     db_file: None,
+                    flags: None,
                 });
                 let result = db.open().unwrap();
                 assert!(!result.is_io());
@@ -1827,6 +1840,7 @@ mod tests {
                     vfs: None,
                     io: None,
                     db_file: None,
+                    flags: None,
                 });
                 let result = db.open().unwrap();
                 assert!(!result.is_io());
@@ -1853,6 +1867,7 @@ mod tests {
                     vfs: None,
                     io: None,
                     db_file: None,
+                    flags: None,
                 });
                 assert!(db.open().is_err(), "Opening with wrong key should fail");
             }
@@ -1867,6 +1882,7 @@ mod tests {
                     vfs: None,
                     io: None,
                     db_file: None,
+                    flags: None,
                 });
                 let result = db.open();
                 println!("result: {result:?}");
@@ -1902,6 +1918,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let _ = db_a.open().unwrap();
         let conn_a = db_a.connect().unwrap();
@@ -1939,6 +1956,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let _ = db_a2.open().unwrap();
         let conn_a2 = db_a2.connect().unwrap();
@@ -1973,6 +1991,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2007,6 +2026,7 @@ mod tests {
             vfs: None,
             io: None,
             db_file: None,
+            flags: None,
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -94,6 +94,7 @@ fn test_sdk_close_finalizes_leaked_statements() {
         vfs: None,
         io: None,
         db_file: None,
+        flags: None,
     });
     let _ = db_a.open().unwrap();
     let conn_a = db_a.connect().unwrap();


### PR DESCRIPTION
## Description
This PR implements the requested `read_only` flag on the Rust SDK `Builder`. 

Specifically, it:
- Adds a `read_only: bool` field to the `Builder` struct (defaulting to `false` in `new_local`).
- Adds a `pub fn read_only(mut self, read_only: bool) -> Self` setter method.
- Updates the `TursoDatabaseConfig` inside `build()` to pass `OpenFlags::ReadOnly` when the flag is true, otherwise defaulting to `OpenFlags::default()`.

Closes #6246

## Motivation and context
Previously, the Builder hardcoded `OpenFlags::default()`, forcing multi-process architectures to use environment variable workarounds (like `LIMBO_DISABLE_FILE_LOCK=1`) which didn't actually prevent accidental writes. This PR exposes the core's native `OpenFlags::ReadOnly` support directly through the Rust SDK, as requested.

## Description of AI Usage
I used an AI pair-programming assistant to help navigate the project's file structure, locate the correct `lib.rs` SDK bindings, and assist with Git branch management. The final logic and implementation were manually reviewed and formatted locally before pushing.