### PR TITLE
core/translate: Fix INSERT column-count mismatch error message to match SQLite

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1988,7 +1988,8 @@ fn init_source_emission<'a>(
         // If we had a single tuple in VALUES, it was inserted into the values vector parameter.
         if values.len() != required_column_count {
             crate::bail_parse_error!(
-                "{} values for {required_column_count} columns",
+                "table {} has {required_column_count} columns but {} values were supplied",
+                table.get_name(),
                 values.len()
             );
         }
@@ -2035,7 +2036,8 @@ fn init_source_emission<'a>(
                 })?;
                 if num_result_cols != required_column_count {
                     crate::bail_parse_error!(
-                        "{} values for {required_column_count} columns",
+                        "table {} has {required_column_count} columns but {} values were supplied",
+                        table.get_name(),
                         num_result_cols,
                     );
                 }

--- a/testing/sqltests/tests/insert.sqltest
+++ b/testing/sqltests/tests/insert.sqltest
@@ -2151,3 +2151,21 @@ test integer-pk-omit-column {
 expect {
     integer|1|alice
 }
+
+@cross-check-integrity
+test insert-column-count-mismatch-values {
+    CREATE TABLE t1 (x);
+    INSERT INTO t1 VALUES (1, 2, 3);
+}
+expect error {
+    table t1 has 1 columns but 3 values were supplied
+}
+
+@cross-check-integrity
+test insert-column-count-mismatch-select {
+    CREATE TABLE t1 (x);
+    INSERT INTO t1 SELECT 1,2,3,4,5,6,7 UNION ALL SELECT 1,2,3,4,5,6,7 ORDER BY 1;
+}
+expect error {
+    table t1 has 1 columns but 7 values were supplied
+}


### PR DESCRIPTION
SQLite says "table t1 has 1 columns but 7 values were supplied" but we said "7 values for 1 columns". Fix both the single-row VALUES path and the multi-row SELECT path to use the SQLite-compatible format.