### PR TITLE
Empty result callbacks pragma

### DIFF
--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -66,6 +66,9 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
         LegacyFileFormat => {
             unreachable!("pragma_for() called with LegacyFileFormat, which is unsupported")
         }
+        EmptyResultCallbacks => {
+            unreachable!("pragma_for() called with EmptyResultCallbacks, which is a no-op")
+        }
         ModuleList => Pragma::new(
             PragmaFlags::NeedSchema | PragmaFlags::Result0 | PragmaFlags::SchemaReq,
             &["module_list"],
@@ -218,6 +221,7 @@ impl PragmaVirtualTable {
                 *name != PragmaName::LegacyFileFormat
                     && *name != PragmaName::FullColumnNames
                     && *name != PragmaName::ShortColumnNames
+                    && *name != PragmaName::EmptyResultCallbacks
             })
             .filter_map(|name| {
                 let pragma = pragma_for(&name);

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -258,7 +258,9 @@ fn update_pragma(
             connection.set_short_column_names(enabled);
             Ok(TransactionMode::None)
         }
-        PragmaName::LegacyFileFormat => Ok(TransactionMode::None),
+        PragmaName::LegacyFileFormat | PragmaName::EmptyResultCallbacks => {
+            Ok(TransactionMode::None)
+        }
         PragmaName::WalCheckpoint => query_pragma(
             PragmaName::WalCheckpoint,
             resolver,
@@ -694,7 +696,9 @@ fn query_pragma(
             program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)
         }
-        PragmaName::LegacyFileFormat => Ok(TransactionMode::None),
+        PragmaName::LegacyFileFormat | PragmaName::EmptyResultCallbacks => {
+            Ok(TransactionMode::None)
+        }
         PragmaName::WalCheckpoint => {
             // Checkpoint uses 3 registers: P1, P2, P3. Ref Insn::Checkpoint for more info.
             // Allocate two more here as one was allocated at the top.

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1749,6 +1749,8 @@ pub enum PragmaName {
     MvccCheckpointThreshold,
     /// List all available types (built-in and custom)
     ListTypes,
+    /// Deprecated no-op: control whether callback is invoked for empty result sets
+    EmptyResultCallbacks,
 }
 
 /// `CREATE TRIGGER` time


### PR DESCRIPTION
SQLite's deprecated PRAGMA empty_result_callbacks controls whether callbacks are invoked for empty result sets. Accept and ignore it for compatibility, matching the existing LegacyFileFormat pattern.