### PR TITLE
migrate cli to use `reedline`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,15 +805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "clipboard-win"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
-dependencies = [
- "error-code",
-]
-
-[[package]]
 name = "codspeed"
 version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1295,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 1.0.7",
+ "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1769,12 +1761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,12 +1816,6 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "error-code"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "fake"
@@ -2837,6 +2817,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -3510,15 +3499,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
 ]
 
 [[package]]
@@ -4327,16 +4307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4481,6 +4451,27 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 2.0.16",
+]
+
+[[package]]
+name = "reedline"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9e7c532bfc2759bc8a28902c04e8b993fc13ebd085ee4292eb1b230fa9beef"
+dependencies = [
+ "chrono",
+ "crossterm 0.29.0",
+ "fd-lock",
+ "itertools 0.13.0",
+ "nu-ansi-term",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.16",
+ "unicase",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4799,40 +4790,6 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
-]
-
-[[package]]
-name = "rustyline"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "clipboard-win",
- "fd-lock",
- "home",
- "libc",
- "log",
- "memchr",
- "nix 0.29.0",
- "radix_trie",
- "rustyline-derive",
- "unicode-segmentation",
- "unicode-width 0.2.0",
- "utf8parse",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustyline-derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327e9d075f6df7e25fbf594f1be7ef55cf0d567a6cb5112eeccbbd51ceb48e0d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -5363,6 +5320,15 @@ name = "strict"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
 
 [[package]]
 name = "strsim"
@@ -6296,6 +6262,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
+ "crossterm 0.29.0",
  "csv",
  "ctrlc",
  "dirs 5.0.1",
@@ -6309,8 +6276,8 @@ dependencies = [
  "nu-ansi-term",
  "prost 0.14.1",
  "rand 0.8.5",
+ "reedline",
  "roaring",
- "rustyline",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -6638,6 +6605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6790,6 +6763,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,9 +41,8 @@ nu-ansi-term = { version = "0.50.1", features = [
     "serde",
     "derive_serde_style",
 ] }
-rustyline = { version = "15.0.0", default-features = true, features = [
-    "derive",
-] }
+crossterm = "0.29.0"
+reedline = "0.46.0"
 shlex = "1.3.0"
 syntect = { git = "https://github.com/trishume/syntect.git", rev = "64644ffe064457265cbcee12a0c1baf9485ba6ee", default-features = false, features = ["default-fancy"] }
 tracing = { workspace = true }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -5,7 +5,7 @@ use crate::{
         Command, CommandParser,
     },
     config::Config,
-    helper::LimboHelper,
+    helper::{TursoCompleter, TursoHighlighter, TursoPrompt, TursoValidator},
     input::{
         get_io, get_writer, ApplyWriter, DbLocation, NoopProgress, OutputMode, ProgressSink,
         Settings, StderrProgress,
@@ -13,12 +13,14 @@ use crate::{
     manual,
     opcodes_dictionary::OPCODE_DESCRIPTIONS,
     read_state_machine::ReadState,
-    HISTORY_FILE,
 };
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use comfy_table::{Attribute, Cell, CellAlignment, ContentArrangement, Row, Table};
-use rustyline::{error::ReadlineError, history::DefaultHistory, Editor};
+use reedline::{
+    default_emacs_keybindings, ColumnarMenu, DescriptionMode, Emacs, IdeMenu, KeyCode,
+    KeyModifiers, MenuBuilder, Reedline, ReedlineEvent, ReedlineMenu, Signal,
+};
 use std::num::NonZeroUsize;
 use std::{
     fs::File,
@@ -37,6 +39,25 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 use turso_core::{
     io_error, Connection, Database, LimboError, Numeric, OpenFlags, QueryMode, Statement, Value,
 };
+
+#[derive(Debug)]
+pub enum ReadlineEvent {
+    Interrupted,
+    Eof,
+    Error(std::io::Error),
+}
+
+impl std::fmt::Display for ReadlineEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadlineEvent::Interrupted => write!(f, "interrupted"),
+            ReadlineEvent::Eof => write!(f, "eof"),
+            ReadlineEvent::Error(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for ReadlineEvent {}
 
 #[derive(Parser, Debug)]
 #[command(name = "Turso")]
@@ -106,7 +127,7 @@ pub struct Opts {
 const PROMPT: &str = "turso> ";
 
 pub struct Limbo {
-    pub prompt: String,
+    pub prompt: TursoPrompt,
     io: Arc<dyn turso_core::IO>,
     writer: Option<Box<dyn Write>>,
     conn: Arc<turso_core::Connection>,
@@ -115,7 +136,7 @@ pub struct Limbo {
     pub(crate) opts: Settings,
     db_opts: turso_core::DatabaseOpts,
     read_state: ReadState,
-    pub rl: Option<Editor<LimboHelper, DefaultHistory>>,
+    pub rl: Option<Reedline>,
     config: Option<Config>,
     had_query_error: bool,
     parameter_bindings: Vec<ParameterBinding>,
@@ -278,7 +299,7 @@ impl Limbo {
         let quiet = opts.quiet || !IsTerminal::is_terminal(&std::io::stdin());
         let config = Config::for_output_mode(opts.output_mode);
         let mut app = Self {
-            prompt: PROMPT.to_string(),
+            prompt: TursoPrompt::new(PROMPT.to_string(), nu_ansi_term::Color::Rgb(34, 197, 94)),
             io,
             writer: Some(get_writer(&opts.output)),
             conn,
@@ -301,12 +322,88 @@ impl Limbo {
         self
     }
 
-    pub fn with_readline(mut self, mut rl: Editor<LimboHelper, DefaultHistory>) -> Self {
-        let h = LimboHelper::new(
-            self.conn.clone(),
-            self.config.as_ref().map(|c| c.highlight.clone()),
+    pub fn with_readline(mut self, rl: Reedline) -> Self {
+        let highlight_config = self.config.as_ref().map(|c| c.highlight.clone());
+        // Update prompt color from config
+        if let Some(ref hc) = highlight_config {
+            self.prompt = TursoPrompt::new(PROMPT.to_string(), hc.prompt.0);
+        }
+
+        let completer = Box::new(TursoCompleter::<CommandParser>::new(self.conn.clone()));
+        let highlighter = Box::new(TursoHighlighter::new(highlight_config));
+        let validator = Box::new(TursoValidator);
+        let hinter = Box::new(
+            reedline::DefaultHinter::default().with_style(
+                nu_ansi_term::Style::new().fg(self
+                    .config
+                    .as_ref()
+                    .map(|c| c.highlight.hint.0)
+                    .unwrap_or(nu_ansi_term::Color::DarkGray)),
+            ),
         );
-        rl.set_helper(Some(h));
+
+        // Set up completion menus
+        let completion_menu = Box::new(
+            ColumnarMenu::default()
+                .with_name("completion_menu")
+                .with_text_style(nu_ansi_term::Color::Green.normal())
+                .with_selected_text_style(nu_ansi_term::Style::new().reverse())
+                .with_description_text_style(nu_ansi_term::Color::Yellow.normal())
+                .with_match_text_style(nu_ansi_term::Style::new().underline())
+                .with_selected_match_text_style(nu_ansi_term::Style::new().underline().reverse()),
+        );
+        let ide_menu = Box::new(
+            IdeMenu::default()
+                .with_name("ide_completion_menu")
+                .with_min_completion_width(0)
+                .with_max_completion_width(50)
+                .with_max_completion_height(10)
+                .with_padding(0)
+                .with_default_border()
+                .with_cursor_offset(0)
+                .with_description_mode(DescriptionMode::PreferRight)
+                .with_min_description_width(15)
+                .with_max_description_width(50)
+                .with_max_description_height(10)
+                .with_description_offset(1)
+                .with_correct_cursor_pos(false)
+                .with_marker("| ")
+                .with_only_buffer_difference(false)
+                .with_text_style(nu_ansi_term::Color::Green.normal())
+                .with_selected_text_style(nu_ansi_term::Style::new().reverse())
+                .with_description_text_style(nu_ansi_term::Color::Yellow.normal())
+                .with_match_text_style(nu_ansi_term::Style::new().underline())
+                .with_selected_match_text_style(nu_ansi_term::Style::new().underline().reverse()),
+        );
+
+        // Set up keybindings
+        let mut keybindings = default_emacs_keybindings();
+        // Tab: inline completion
+        keybindings.add_binding(
+            KeyModifiers::NONE,
+            KeyCode::Tab,
+            ReedlineEvent::UntilFound(vec![
+                ReedlineEvent::Menu("completion_menu".to_string()),
+                ReedlineEvent::MenuNext,
+            ]),
+        );
+        // Ctrl+Space: IDE-style dropdown completion
+        keybindings.add_binding(
+            KeyModifiers::CONTROL,
+            KeyCode::Char(' '),
+            ReedlineEvent::Menu("ide_completion_menu".to_string()),
+        );
+        let edit_mode = Box::new(Emacs::new(keybindings));
+
+        let rl = rl
+            .with_completer(completer)
+            .with_highlighter(highlighter)
+            .with_validator(validator)
+            .with_hinter(hinter)
+            .with_menu(ReedlineMenu::EngineCompleter(completion_menu))
+            .with_menu(ReedlineMenu::EngineCompleter(ide_menu))
+            .with_edit_mode(edit_mode);
+
         self.rl = Some(rl);
         self
     }
@@ -346,7 +443,7 @@ impl Limbo {
     }
 
     fn set_multiline_prompt(&mut self) {
-        self.prompt = match self.input_buff.chars().fold(0, |acc, c| match c {
+        let new_prompt = match self.input_buff.chars().fold(0, |acc, c| match c {
             '(' => acc + 1,
             ')' => acc - 1,
             _ => acc,
@@ -356,6 +453,7 @@ impl Limbo {
             n if n < 10 => format!("(x{n}...> "),
             _ => String::from("(.....> "),
         };
+        self.prompt.set_prompt(new_prompt);
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -414,7 +512,7 @@ impl Limbo {
     }
 
     pub fn reset_input(&mut self) {
-        self.prompt = PROMPT.to_string();
+        self.prompt.set_prompt(PROMPT.to_string());
         self.input_buff.clear();
         self.read_state = ReadState::default();
     }
@@ -1347,7 +1445,7 @@ impl Limbo {
             .with_default_directive(tracing::level_filters::LevelFilter::WARN.into())
             .from_env_lossy();
 
-        // Disable rustyline traces
+        // Disable reedline traces
         if let Err(e) = tracing_subscriber::registry()
             .with(
                 tracing_subscriber::fmt::layer()
@@ -1356,7 +1454,7 @@ impl Limbo {
                     .with_thread_ids(true)
                     .with_ansi(should_emit_ansi),
             )
-            .with(default_env_filter.add_directive("rustyline=off".parse().unwrap()))
+            .with(default_env_filter.add_directive("reedline=off".parse().unwrap()))
             .try_init()
         {
             println!("Unable to setup tracing appender: {e:?}");
@@ -1731,20 +1829,30 @@ impl Limbo {
         Ok(())
     }
 
-    // readline will read inputs from rustyline or stdin
+    // readline will read inputs from reedline or stdin
     // and write it to input_buff.
-    pub fn readline(&mut self) -> Result<(), ReadlineError> {
+    pub fn readline(&mut self) -> Result<(), ReadlineEvent> {
         use std::fmt::Write;
 
         if let Some(rl) = &mut self.rl {
-            let result = rl.readline(&self.prompt)?;
-            self.read_state.process(&result);
-            let _ = self.input_buff.write_str(result.as_str());
+            match rl.read_line(&self.prompt) {
+                Ok(Signal::Success(result)) => {
+                    self.read_state.process(&result);
+                    let _ = self.input_buff.write_str(result.as_str());
+                }
+                Ok(Signal::CtrlC) => return Err(ReadlineEvent::Interrupted),
+                Ok(Signal::CtrlD) => return Err(ReadlineEvent::Eof),
+                Err(e) => return Err(ReadlineEvent::Error(e)),
+            }
         } else {
             let mut reader = std::io::stdin().lock();
             let prev_len = self.input_buff.len();
-            if reader.read_line(&mut self.input_buff)? == 0 {
-                return Err(ReadlineError::Eof);
+            if reader
+                .read_line(&mut self.input_buff)
+                .map_err(ReadlineEvent::Error)?
+                == 0
+            {
+                return Err(ReadlineEvent::Eof);
             }
             self.read_state.process(&self.input_buff[prev_len..]);
         }
@@ -2039,7 +2147,7 @@ impl Limbo {
 
     fn save_history(&mut self) {
         if let Some(rl) = &mut self.rl {
-            let _ = rl.save_history(HISTORY_FILE.as_path());
+            let _ = rl.sync_history();
         }
     }
 

--- a/cli/helper.rs
+++ b/cli/helper.rs
@@ -1,11 +1,12 @@
 use clap::Parser;
+use crossterm::style::Color as CrosstermColor;
 use nu_ansi_term::{Color, Style};
-use rustyline::completion::{extract_word, Completer, Pair};
-use rustyline::highlight::Highlighter;
-use rustyline::hint::HistoryHinter;
-use rustyline::{Completer, Helper, Hinter, Validator};
+use reedline::{
+    Completer, Highlighter, Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus,
+    Span, StyledText, Suggestion, ValidationResult, Validator,
+};
 use shlex::Shlex;
-use std::cell::RefCell;
+use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{ffi::OsString, path::PathBuf, str::FromStr as _};
@@ -13,35 +14,161 @@ use syntect::dumps::from_uncompressed_data;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::{Scope, SyntaxSet};
-use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
+use syntect::util::LinesWithEndings;
 use turso_core::Connection;
 
-use crate::commands::CommandParser;
 use crate::config::{HighlightConfig, CONFIG_DIR};
 
 macro_rules! try_result {
     ($expr:expr, $err:expr) => {
         match $expr {
             Ok(val) => val,
-            Err(_) => return Ok($err),
+            Err(_) => return $err,
         }
     };
 }
 
-#[derive(Helper, Completer, Hinter, Validator)]
-pub struct LimboHelper {
-    #[rustyline(Completer)]
-    completer: SqlCompleter<CommandParser>,
+// --- Completer ---
+
+pub struct TursoCompleter<C: Parser + Send + Sync + 'static> {
+    conn: Arc<Connection>,
+    cmd: clap::Command,
+    _cmd_phantom: PhantomData<C>,
+}
+
+impl<C: Parser + Send + Sync + 'static> TursoCompleter<C> {
+    pub fn new(conn: Arc<Connection>) -> Self {
+        Self {
+            conn,
+            cmd: C::command(),
+            _cmd_phantom: PhantomData,
+        }
+    }
+
+    fn dot_completion(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let inner_line = &line[1..];
+        let inner_pos = pos.saturating_sub(1);
+
+        let args = Shlex::new(inner_line);
+        let mut args = std::iter::once("".to_owned())
+            .chain(args)
+            .map(OsString::from)
+            .collect::<Vec<_>>();
+        if inner_line.ends_with(' ') {
+            args.push(OsString::new());
+        }
+        let arg_index = args.len() - 1;
+
+        let prefix_pos = find_word_start(inner_line, inner_pos);
+
+        match clap_complete::engine::complete(
+            &mut self.cmd,
+            args,
+            arg_index,
+            PathBuf::from_str(".").ok().as_deref(),
+        ) {
+            Ok(candidates) => candidates
+                .iter()
+                .map(|candidate| {
+                    let value = candidate.get_value().to_string_lossy().into_owned();
+                    Suggestion {
+                        value,
+                        description: None,
+                        style: None,
+                        extra: None,
+                        span: Span::new(prefix_pos + 1, pos),
+                        append_whitespace: false,
+                        display_override: None,
+                        match_indices: None,
+                    }
+                })
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn sql_completion(&self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let prefix_pos = find_word_start(line, pos);
+        let prefix = &line[prefix_pos..pos];
+
+        let query = try_result!(
+            self.conn.query(format!(
+                "SELECT candidate FROM completion('{prefix}', '{line}') ORDER BY 1;"
+            )),
+            Vec::new()
+        );
+
+        let mut candidates = Vec::new();
+        if let Some(mut rows) = query {
+            let _ = rows.run_with_row_callback(|row| {
+                let completion: &str = row.get::<&str>(0)?;
+                candidates.push(Suggestion {
+                    value: completion.to_string(),
+                    description: None,
+                    style: None,
+                    extra: None,
+                    span: Span::new(prefix_pos, pos),
+                    append_whitespace: false,
+                    display_override: None,
+                    match_indices: None,
+                });
+                Ok(())
+            });
+        }
+
+        candidates
+    }
+}
+
+fn find_word_start(line: &str, pos: usize) -> usize {
+    let bytes = line.as_bytes();
+    let mut i = pos;
+    while i > 0 {
+        let c = bytes[i - 1] as char;
+        if is_break_char(c) {
+            break;
+        }
+        i -= 1;
+    }
+    i
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(unix)] {
+        fn is_break_char(c: char) -> bool {
+            matches!(c, ' ' | '\t' | '\n' | '"' | '\\' | '\'' | '`' | '@' | '$' | '>' | '<' | '=' | ';' | '|' | '&' |
+            '{' | '(' | '\0')
+        }
+    } else if #[cfg(windows)] {
+        fn is_break_char(c: char) -> bool {
+            matches!(c, ' ' | '\t' | '\n' | '"' | '\'' | '`' | '@' | '$' | '>' | '<' | '=' | ';' | '|' | '&' | '{' |
+            '(' | '\0')
+        }
+    } else if #[cfg(target_arch = "wasm32")] {
+        fn is_break_char(_c: char) -> bool { false }
+    }
+}
+
+impl<C: Parser + Send + Sync + 'static> Completer for TursoCompleter<C> {
+    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        if line.starts_with('.') {
+            self.dot_completion(line, pos)
+        } else {
+            self.sql_completion(line, pos)
+        }
+    }
+}
+
+// --- Highlighter ---
+
+pub struct TursoHighlighter {
     syntax_set: SyntaxSet,
     theme_set: ThemeSet,
     syntax_config: HighlightConfig,
-    #[rustyline(Hinter)]
-    hinter: HistoryHinter,
 }
 
-impl LimboHelper {
-    pub fn new(conn: Arc<Connection>, syntax_config: Option<HighlightConfig>) -> Self {
-        // Load only predefined syntax
+impl TursoHighlighter {
+    pub fn new(syntax_config: Option<HighlightConfig>) -> Self {
         let ps = from_uncompressed_data(include_bytes!(concat!(
             env!("OUT_DIR"),
             "/SQL_syntax_set_dump.packdump"
@@ -54,21 +181,19 @@ impl LimboHelper {
                 tracing::error!("{err}");
             }
         }
-        LimboHelper {
-            completer: SqlCompleter::new(conn),
+        TursoHighlighter {
             syntax_set: ps,
             theme_set: ts,
             syntax_config: syntax_config.unwrap_or_default(),
-            hinter: HistoryHinter::new(),
         }
     }
 }
 
-impl Highlighter for LimboHelper {
-    fn highlight<'l>(&self, line: &'l str, pos: usize) -> std::borrow::Cow<'l, str> {
-        let _ = pos;
+impl Highlighter for TursoHighlighter {
+    fn highlight(&self, line: &str, _cursor: usize) -> StyledText {
+        let mut styled = StyledText::new();
+
         if self.syntax_config.enable {
-            // TODO use lifetimes to store highlight lines
             let syntax = self
                 .syntax_set
                 .find_syntax_by_scope(Scope::new("source.sql").unwrap())
@@ -79,198 +204,122 @@ impl Highlighter for LimboHelper {
                 .get(&self.syntax_config.theme)
                 .unwrap_or(&self.theme_set.themes["base16-ocean.dark"]);
             let mut h = HighlightLines::new(syntax, theme);
-            let ranges = {
-                let mut ret_ranges = Vec::new();
-                for new_line in LinesWithEndings::from(line) {
-                    let ranges: Vec<(syntect::highlighting::Style, &str)> =
-                        h.highlight_line(new_line, &self.syntax_set).unwrap();
-                    ret_ranges.extend(ranges);
+
+            for new_line in LinesWithEndings::from(line) {
+                let ranges = h.highlight_line(new_line, &self.syntax_set).unwrap();
+                for (style, text) in ranges {
+                    let fg = style.foreground;
+                    let nu_style = Style::new().fg(Color::Rgb(fg.r, fg.g, fg.b));
+                    styled.push((nu_style, text.to_string()));
                 }
-                ret_ranges
-            };
-            let mut ret_line = as_24_bit_terminal_escaped(&ranges[..], false);
-            // Push this escape sequence to reset terminal color modes at the end of the string
-            ret_line.push_str("\x1b[0m");
-            std::borrow::Cow::Owned(ret_line)
-        } else {
-            // Appease Pekka in syntax highlighting
-            let style = Style::new().fg(Color::White); // Standard shell text color
-            let styled_str = style.paint(line);
-            std::borrow::Cow::Owned(styled_str.to_string())
-        }
-    }
-
-    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
-        &'s self,
-        prompt: &'p str,
-        default: bool,
-    ) -> std::borrow::Cow<'b, str> {
-        let _ = default;
-        // Dark emerald green for prompt
-        let style = Style::new().bold().fg(self.syntax_config.prompt.0);
-        let styled_str = style.paint(prompt);
-        std::borrow::Cow::Owned(styled_str.to_string())
-    }
-
-    fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
-        let style = Style::new().bold().fg(self.syntax_config.hint.0); // Brighter dark grey for hints
-        let styled_str = style.paint(hint);
-        std::borrow::Cow::Owned(styled_str.to_string())
-    }
-
-    fn highlight_candidate<'c>(
-        &self,
-        candidate: &'c str,
-        completion: rustyline::CompletionType,
-    ) -> std::borrow::Cow<'c, str> {
-        let _ = completion;
-        let style = Style::new().fg(self.syntax_config.candidate.0);
-        let styled_str = style.paint(candidate);
-        std::borrow::Cow::Owned(styled_str.to_string())
-    }
-
-    fn highlight_char(&self, line: &str, pos: usize, kind: rustyline::highlight::CmdKind) -> bool {
-        let _ = (line, pos);
-        !matches!(kind, rustyline::highlight::CmdKind::MoveCursor)
-    }
-}
-
-pub struct SqlCompleter<C: Parser + Send + Sync + 'static> {
-    conn: Arc<Connection>,
-    // Has to be a ref cell as Rustyline takes immutable reference to self
-    // This problem would be solved with Reedline as it uses &mut self for completions
-    cmd: RefCell<clap::Command>,
-    _cmd_phantom: PhantomData<C>,
-}
-
-impl<C: Parser + Send + Sync + 'static> SqlCompleter<C> {
-    pub fn new(conn: Arc<Connection>) -> Self {
-        Self {
-            conn,
-            cmd: C::command().into(),
-            _cmd_phantom: PhantomData,
-        }
-    }
-
-    fn dot_completion(
-        &self,
-        mut line: &str,
-        mut pos: usize,
-    ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        // TODO maybe check to see if the line is empty and then just output the command names
-        line = &line[1..];
-        pos -= 1;
-
-        let (prefix_pos, _) = extract_word(line, pos, ESCAPE_CHAR, default_break_chars);
-
-        let args = Shlex::new(line);
-        let mut args = std::iter::once("".to_owned())
-            .chain(args)
-            .map(OsString::from)
-            .collect::<Vec<_>>();
-        if line.ends_with(' ') {
-            args.push(OsString::new());
-        }
-        let arg_index = args.len() - 1;
-        // dbg!(&pos, line, &args, arg_index);
-
-        let mut cmd = self.cmd.borrow_mut();
-        match clap_complete::engine::complete(
-            &mut cmd,
-            args,
-            arg_index,
-            PathBuf::from_str(".").ok().as_deref(),
-        ) {
-            Ok(candidates) => {
-                let candidates = candidates
-                    .iter()
-                    .map(|candidate| Pair {
-                        display: candidate.get_value().to_string_lossy().into_owned(),
-                        replacement: candidate.get_value().to_string_lossy().into_owned(),
-                    })
-                    .collect::<Vec<Pair>>();
-
-                Ok((prefix_pos + 1, candidates))
             }
-            Err(_) => Ok((prefix_pos + 1, Vec::new())),
-        }
-    }
-
-    fn sql_completion(&self, line: &str, pos: usize) -> rustyline::Result<(usize, Vec<Pair>)> {
-        // TODO: have to differentiate words if they are enclosed in single of double quotes
-        let (prefix_pos, prefix) = extract_word(line, pos, ESCAPE_CHAR, default_break_chars);
-        let mut candidates = Vec::new();
-
-        let query = try_result!(
-            self.conn.query(format!(
-                "SELECT candidate FROM completion('{prefix}', '{line}') ORDER BY 1;"
-            )),
-            (prefix_pos, candidates)
-        );
-
-        if let Some(mut rows) = query {
-            try_result!(
-                rows.run_with_row_callback(|row| {
-                    let completion: &str = row.get::<&str>(0)?;
-                    let pair = Pair {
-                        display: completion.to_string(),
-                        replacement: completion.to_string(),
-                    };
-                    candidates.push(pair);
-                    Ok(())
-                }),
-                (prefix_pos, candidates)
-            );
-        }
-
-        Ok((prefix_pos, candidates))
-    }
-}
-
-// Got this from the FilenameCompleter.
-// TODO have to see what chars break words in Sqlite
-cfg_if::cfg_if! {
-    if #[cfg(unix)] {
-        // rl_basic_word_break_characters, rl_completer_word_break_characters
-        const fn default_break_chars(c : char) -> bool {
-            matches!(c, ' ' | '\t' | '\n' | '"' | '\\' | '\'' | '`' | '@' | '$' | '>' | '<' | '=' | ';' | '|' | '&' |
-            '{' | '(' | '\0')
-        }
-        const ESCAPE_CHAR: Option<char> = Some('\\');
-        // In double quotes, not all break_chars need to be escaped
-        // https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
-        #[allow(dead_code)]
-        const fn double_quotes_special_chars(c: char) -> bool { matches!(c, '"' | '$' | '\\' | '`') }
-    } else if #[cfg(windows)] {
-        // Remove \ to make file completion works on windows
-        const fn default_break_chars(c: char) -> bool {
-            matches!(c, ' ' | '\t' | '\n' | '"' | '\'' | '`' | '@' | '$' | '>' | '<' | '=' | ';' | '|' | '&' | '{' |
-            '(' | '\0')
-        }
-        const ESCAPE_CHAR: Option<char> = None;
-        #[allow(dead_code)]
-        const fn double_quotes_special_chars(c: char) -> bool { c == '"' } // TODO Validate: only '"' ?
-    } else if #[cfg(target_arch = "wasm32")] {
-        const fn default_break_chars(c: char) -> bool { false }
-        const ESCAPE_CHAR: Option<char> = None;
-        #[allow(dead_code)]
-        const fn double_quotes_special_chars(c: char) -> bool { false }
-    }
-}
-
-impl<C: Parser + Send + Sync + 'static> Completer for SqlCompleter<C> {
-    type Candidate = Pair;
-
-    fn complete(
-        &self,
-        line: &str,
-        pos: usize,
-        _ctx: &rustyline::Context<'_>,
-    ) -> rustyline::Result<(usize, Vec<Self::Candidate>)> {
-        if line.starts_with(".") {
-            self.dot_completion(line, pos)
         } else {
-            self.sql_completion(line, pos)
+            let style = Style::new().fg(Color::White);
+            styled.push((style, line.to_string()));
         }
+
+        styled
+    }
+}
+
+// --- Validator ---
+
+pub struct TursoValidator;
+
+impl Validator for TursoValidator {
+    fn validate(&self, _line: &str) -> ValidationResult {
+        ValidationResult::Complete
+    }
+}
+
+// --- Prompt ---
+
+pub struct TursoPrompt {
+    prompt: String,
+    prompt_color: nu_ansi_term::Color,
+}
+
+impl TursoPrompt {
+    pub fn new(prompt: String, prompt_color: nu_ansi_term::Color) -> Self {
+        Self {
+            prompt,
+            prompt_color,
+        }
+    }
+
+    pub fn set_prompt(&mut self, prompt: String) {
+        self.prompt = prompt;
+    }
+
+    fn nu_color_to_crossterm(c: nu_ansi_term::Color) -> CrosstermColor {
+        match c {
+            nu_ansi_term::Color::Rgb(r, g, b) => CrosstermColor::Rgb { r, g, b },
+            nu_ansi_term::Color::Black => CrosstermColor::Black,
+            nu_ansi_term::Color::Red => CrosstermColor::DarkRed,
+            nu_ansi_term::Color::Green => CrosstermColor::DarkGreen,
+            nu_ansi_term::Color::Yellow => CrosstermColor::DarkYellow,
+            nu_ansi_term::Color::Blue => CrosstermColor::DarkBlue,
+            nu_ansi_term::Color::Purple => CrosstermColor::DarkMagenta,
+            nu_ansi_term::Color::Cyan => CrosstermColor::DarkCyan,
+            nu_ansi_term::Color::White => CrosstermColor::White,
+            nu_ansi_term::Color::DarkGray => CrosstermColor::DarkGrey,
+            nu_ansi_term::Color::LightRed => CrosstermColor::Red,
+            nu_ansi_term::Color::LightGreen => CrosstermColor::Green,
+            nu_ansi_term::Color::LightYellow => CrosstermColor::Yellow,
+            nu_ansi_term::Color::LightBlue => CrosstermColor::Blue,
+            nu_ansi_term::Color::LightPurple => CrosstermColor::Magenta,
+            nu_ansi_term::Color::LightCyan => CrosstermColor::Cyan,
+            nu_ansi_term::Color::LightGray => CrosstermColor::Grey,
+            nu_ansi_term::Color::Fixed(n) => CrosstermColor::AnsiValue(n),
+            _ => CrosstermColor::Reset,
+        }
+    }
+}
+
+impl Prompt for TursoPrompt {
+    fn render_prompt_left(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.prompt)
+    }
+
+    fn render_prompt_right(&self) -> Cow<'_, str> {
+        Cow::Borrowed("")
+    }
+
+    fn render_prompt_indicator(&self, _edit_mode: PromptEditMode) -> Cow<'_, str> {
+        Cow::Borrowed("")
+    }
+
+    fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
+        Cow::Borrowed("   ...> ")
+    }
+
+    fn render_prompt_history_search_indicator(
+        &self,
+        history_search: PromptHistorySearch,
+    ) -> Cow<'_, str> {
+        let prefix = match history_search.status {
+            PromptHistorySearchStatus::Passing => "",
+            PromptHistorySearchStatus::Failing => "failing ",
+        };
+        Cow::Owned(format!(
+            "({}reverse-i-search)`{}': ",
+            prefix, history_search.term
+        ))
+    }
+
+    fn get_prompt_color(&self) -> CrosstermColor {
+        Self::nu_color_to_crossterm(self.prompt_color)
+    }
+
+    fn get_prompt_multiline_color(&self) -> nu_ansi_term::Color {
+        self.prompt_color
+    }
+
+    fn get_indicator_color(&self) -> CrosstermColor {
+        CrosstermColor::Reset
+    }
+
+    fn get_prompt_right_color(&self) -> CrosstermColor {
+        CrosstermColor::Reset
     }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -13,9 +13,10 @@ mod sync_server;
 #[cfg(feature = "mvcc_repl")]
 mod mvcc_repl;
 
+use app::ReadlineEvent;
 use config::CONFIG_DIR;
 use mcp_server::TursoMcpServer;
-use rustyline::{error::ReadlineError, Config, Editor};
+use reedline::{FileBackedHistory, Reedline};
 use std::{
     path::PathBuf,
     sync::{atomic::Ordering, LazyLock},
@@ -26,13 +27,6 @@ use crate::sync_server::TursoSyncServer;
 #[cfg(all(feature = "mimalloc", not(target_family = "wasm"), not(miri)))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-fn rustyline_config() -> Config {
-    Config::builder()
-        .completion_type(rustyline::CompletionType::List)
-        .auto_add_history(true)
-        .build()
-}
 
 pub static HOME_DIR: LazyLock<PathBuf> =
     LazyLock::new(|| dirs::home_dir().expect("Could not determine home directory"));
@@ -83,12 +77,13 @@ fn main() -> anyhow::Result<()> {
 
     let interactive_stdin = std::io::IsTerminal::is_terminal(&std::io::stdin());
     if interactive_stdin {
-        let mut rl = Editor::with_config(rustyline_config())?;
-        if HISTORY_FILE.exists() {
-            rl.load_history(HISTORY_FILE.as_path())?;
-        }
-        let config_file = CONFIG_DIR.join("limbo.toml");
+        let history = Box::new(
+            FileBackedHistory::with_file(1000, HISTORY_FILE.clone())
+                .expect("Error configuring history file"),
+        );
+        let rl = Reedline::create().with_history(history);
 
+        let config_file = CONFIG_DIR.join("limbo.toml");
         let config = config::Config::from_config_file(config_file);
         tracing::info!("Configuration: {:?}", config);
         app = app.with_config(config);
@@ -101,7 +96,7 @@ fn main() -> anyhow::Result<()> {
     loop {
         match app.readline() {
             Ok(_) => app.consume(false),
-            Err(ReadlineError::Interrupted) => {
+            Err(ReadlineEvent::Interrupted) => {
                 // At prompt, increment interrupt count
                 if app.interrupt_count.fetch_add(1, Ordering::SeqCst) >= 1 {
                     eprintln!("Interrupted. Exiting...");
@@ -112,7 +107,7 @@ fn main() -> anyhow::Result<()> {
                 app.reset_input();
                 continue;
             }
-            Err(ReadlineError::Eof) => {
+            Err(ReadlineEvent::Eof) => {
                 // consume remaining input before exit
                 app.consume(true);
                 let _ = app.close_conn();

--- a/cli/mvcc_repl.rs
+++ b/cli/mvcc_repl.rs
@@ -35,7 +35,7 @@
 //! [conn2] ERROR: write-write conflict (transaction rolled back)
 //! ```
 use anyhow::Context as _;
-use rustyline::DefaultEditor;
+use reedline::{DefaultPrompt, DefaultPromptSegment, Reedline, Signal};
 use std::{collections::HashMap, sync::Arc};
 use turso_core::{Connection, Database, DatabaseOpts, LimboError, OpenFlags, Value};
 
@@ -50,11 +50,15 @@ pub fn run(path: &str) -> anyhow::Result<()> {
 
     let db = open_mvcc_db(path)?;
     let mut connections: HashMap<String, Arc<Connection>> = HashMap::new();
-    let mut rl = DefaultEditor::new()?;
+    let mut rl = Reedline::create();
+    let prompt = DefaultPrompt::new(
+        DefaultPromptSegment::Basic("mvcc> ".to_string()),
+        DefaultPromptSegment::Empty,
+    );
 
     loop {
-        match rl.readline("mvcc> ") {
-            Ok(line) => {
+        match rl.read_line(&prompt) {
+            Ok(Signal::Success(line)) => {
                 let line = line.trim();
                 if line.is_empty() {
                     continue;
@@ -78,8 +82,8 @@ pub fn run(path: &str) -> anyhow::Result<()> {
                     eprintln!("Error: format is `connN SQL` (e.g. `conn1 SELECT * FROM t`)");
                 }
             }
-            Err(rustyline::error::ReadlineError::Eof) => break,
-            Err(rustyline::error::ReadlineError::Interrupted) => {
+            Ok(Signal::CtrlD) => break,
+            Ok(Signal::CtrlC) => {
                 println!();
                 continue;
             }


### PR DESCRIPTION
## Description
Reedline is a more modern REPL that supports better autocompletion and validation. For the completion menus, it supports description and independent styling for it. It's a very mature library that comes with `nushell`.  It's also easier to emit `EditCommands` to control the REPL - https://docs.rs/reedline/latest/reedline/enum.EditCommand.html

(TODO will add some screenshots of what it can do better, and how it can help for a future `SQL Completion engine` I want to build for autocomplete).


## Motivation and context
Closes #1202 


## Description of AI Usage
Used Claude to help with the migration and tests the cli to check it still works as intended
