### PR TITLE
core/translate: Track scope depth in outer query references

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -735,6 +735,7 @@ pub fn translate_alter_table(
                             cte_id: None,
                             cte_definition_only: false,
                             rowid_referenced: false,
+                            scope_depth: 0,
                         }],
                     );
                     let where_copy = index

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5659,7 +5659,11 @@ pub fn bind_and_rewrite_expr<'a>(
                     // In this case, there is no ambiguity:
                     // - x in the outer query refers to t.x,
                     // - x in the inner query refers to t2.x.
+                    //
+                    // Ambiguity is only checked within the same scope depth. Once a match
+                    // is found at depth N, deeper scopes (N+1, N+2, ...) are not checked.
                     if match_result.is_none() {
+                        let mut matched_scope_depth = None;
                         for outer_ref in referenced_tables.outer_query_refs().iter() {
                             // CTEs (FromClauseSubquery) in outer_query_refs are only for table
                             // lookup (e.g., FROM cte1), not for column resolution. Columns from
@@ -5667,6 +5671,12 @@ pub fn bind_and_rewrite_expr<'a>(
                             // FROM clause, not as implicit outer references.
                             if matches!(outer_ref.table, Table::FromClauseSubquery(_)) {
                                 continue;
+                            }
+                            // Skip refs from deeper scopes once we found a match
+                            if let Some(depth) = matched_scope_depth {
+                                if outer_ref.scope_depth > depth {
+                                    continue;
+                                }
                             }
                             let col_idx = outer_ref.table.columns().iter().position(|c| {
                                 c.name
@@ -5686,6 +5696,7 @@ pub fn bind_and_rewrite_expr<'a>(
                                     col_idx.unwrap(),
                                     col.is_rowid_alias(),
                                 ));
+                                matched_scope_depth = Some(outer_ref.scope_depth);
                             }
                         }
                     }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1002,6 +1002,7 @@ fn add_ephemeral_table_to_update_plan(
                 cte_id: None,
                 cte_definition_only: false,
                 rowid_referenced: false,
+                scope_depth: 0,
             });
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -983,6 +983,10 @@ pub struct OuterQueryReference {
     /// col_used_mask because rowid is not a real column and setting a fake
     /// column index in col_used_mask could mislead covering index decisions.
     pub rowid_referenced: bool,
+    /// Scope depth for this outer reference. 0 = immediate outer scope,
+    /// 1 = grandparent scope, etc. Used to avoid false "ambiguous column"
+    /// errors when the same column name exists at different nesting depths.
+    pub scope_depth: usize,
 }
 
 impl OuterQueryReference {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -520,6 +520,7 @@ fn plan_cte(
             cte_id: Some(cte_definitions[ref_idx].cte_id),
             cte_definition_only: false,
             rowid_referenced: false,
+            scope_depth: 0,
         });
     }
 
@@ -682,6 +683,7 @@ pub fn plan_ctes_as_outer_refs(
             cte_id: None, // DML CTEs don't track CTE sharing (TODO: implement if needed)
             cte_definition_only: true,
             rowid_referenced: false,
+            scope_depth: 0,
         });
     }
 
@@ -751,6 +753,7 @@ fn parse_from_clause_table(
                     cte_id: Some(cte_def.cte_id),
                     cte_definition_only: false,
                     rowid_referenced: false,
+                    scope_depth: 0,
                 });
             }
 
@@ -1299,6 +1302,7 @@ pub fn parse_from(
                     // this scope's FROM/JOIN clause.
                     cte_definition_only: true,
                     rowid_referenced: false,
+                    scope_depth: 0,
                 });
             }
         }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -434,6 +434,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                     cte_id,
                     cte_definition_only: false,
                     rowid_referenced: false,
+                    scope_depth: 0,
                 }
             })
             .chain(
@@ -450,6 +451,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                         cte_id: t.cte_id, // Preserve CTE ID from outer query refs
                         cte_definition_only: t.cte_definition_only,
                         rowid_referenced: false,
+                        scope_depth: t.scope_depth + 1,
                     }),
             )
             .collect::<Vec<_>>()

--- a/testing/sqltests/tests/nested-subquery-scope-depth.sqltest
+++ b/testing/sqltests/tests/nested-subquery-scope-depth.sqltest
@@ -1,0 +1,70 @@
+@database :memory:
+
+# Regression test: nested correlated subqueries with the same column name
+# at different scope depths should not produce false "ambiguous column" errors.
+# The column resolver must match the nearest (shallowest) outer scope and not
+# consider deeper scopes, which would otherwise trigger ambiguity.
+
+setup schema {
+    CREATE TABLE t1(x INTEGER, y INTEGER);
+    INSERT INTO t1 VALUES(1, 10);
+    INSERT INTO t1 VALUES(2, 20);
+    INSERT INTO t1 VALUES(3, 30);
+
+    CREATE TABLE t2(x INTEGER, z INTEGER);
+    INSERT INTO t2 VALUES(1, 100);
+    INSERT INTO t2 VALUES(2, 200);
+    INSERT INTO t2 VALUES(4, 400);
+}
+
+# Two-level nesting: innermost subquery references 'x' which exists in both
+# the immediate outer scope (t2) and the grandparent scope (t1). The resolver
+# should bind to the nearest scope (t2.x) without an ambiguity error.
+@setup schema
+test nested-correlated-same-column-name {
+    SELECT * FROM t1
+    WHERE x IN (
+        SELECT t2.x FROM t2
+        WHERE EXISTS (
+            SELECT 1 FROM t1 AS t3 WHERE t3.x = x
+        )
+    );
+}
+expect {
+    1|10
+    2|20
+}
+
+# Explicit outer reference via alias in deeply nested subquery should resolve
+# to the correct scope level.
+@setup schema
+test nested-explicit-outer-ref {
+    SELECT * FROM t1 AS a
+    WHERE EXISTS (
+        SELECT 1 FROM t2 AS b
+        WHERE b.x = a.x
+        AND EXISTS (
+            SELECT 1 FROM t1 AS c WHERE c.x = b.x
+        )
+    );
+}
+expect {
+    1|10
+    2|20
+}
+
+# Three-level nesting where innermost references a column from the outermost scope.
+@setup schema
+test three-level-outer-ref {
+    SELECT y FROM t1 AS a
+    WHERE EXISTS (
+        SELECT 1 FROM t2 AS b
+        WHERE EXISTS (
+            SELECT 1 FROM t2 AS c WHERE c.x = a.x
+        )
+    );
+}
+expect {
+    10
+    20
+}


### PR DESCRIPTION
Nested correlated subqueries with the same column name at multiple outer scope levels could trigger false "ambiguous column" errors. The resolver walked all outer query refs and reported ambiguity even when the matches lived at different nesting depths, where SQLite resolves to the nearest enclosing scope.

Add a scope_depth field to OuterQueryReference, increment it when propagating refs into an inner subquery, and stop considering deeper scopes once a match is found at depth N.