### PR TITLE
core/translate: Don't NULL constant virtual generated columns in INSERT body

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1,4 +1,5 @@
 use crate::schema::{ColumnLayout, GeneratedType};
+use crate::translate::optimizer::Optimizable;
 use crate::turso_debug_assert;
 use crate::{
     error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
@@ -2625,6 +2626,14 @@ fn translate_column(
         program.emit_insn(Insn::SoftNull {
             reg: column_register,
         });
+    } else if matches!(
+        column.generated_type(),
+        GeneratedType::Virtual { resolved, .. } if resolved.is_constant(resolver)
+    ) {
+        // Constant virtual generated columns are hoisted to the program init
+        // section by translate_expr in compute_virtual_columns. Emitting NULL
+        // here would clobber the hoisted value before constraint checks
+        // (e.g. NOT NULL) and triggers read it.
     } else if column.hidden() || column.is_virtual_generated() {
         // Emit NULL for not-explicitly-mentioned hidden or virtual columns, even ignoring DEFAULT.
         program.emit_insn(Insn::Null {

--- a/testing/sqltests/tests/gencol-virtual-constant.sqltest
+++ b/testing/sqltests/tests/gencol-virtual-constant.sqltest
@@ -1,0 +1,74 @@
+@database :memory:
+
+# Regression test: a VIRTUAL generated column whose expression is a constant
+# must produce the constant value when constraint checks (NOT NULL) and
+# index entries materialize the column register during INSERT.
+#
+# Previously, constant-folding hoisted the expression into the program init
+# section, but the main INSERT body re-initialized the column register to
+# NULL afterwards. NOT NULL checks then saw NULL and the INSERT failed.
+
+setup schema-notnull-text {
+    CREATE TABLE t1(a INTEGER, b AS ('Y') VIRTUAL NOT NULL);
+    INSERT INTO t1(a) VALUES(1);
+    INSERT INTO t1(a) VALUES(2);
+}
+
+@setup schema-notnull-text
+test gencol-virtual-constant-notnull-text-select {
+    SELECT a, b FROM t1 ORDER BY a;
+}
+expect {
+    1|Y
+    2|Y
+}
+
+setup schema-notnull-int {
+    CREATE TABLE t2(a INTEGER, b AS (42) VIRTUAL NOT NULL);
+    INSERT INTO t2(a) VALUES(10);
+    INSERT INTO t2(a) VALUES(20);
+}
+
+@setup schema-notnull-int
+test gencol-virtual-constant-notnull-int-select {
+    SELECT a, b FROM t2 ORDER BY a;
+}
+expect {
+    10|42
+    20|42
+}
+
+# Mixed: a NOT NULL constant virtual column alongside an expression virtual
+# column. The expression column is non-constant so its register must be
+# computed inline; the constant column is hoisted to init.
+setup schema-mixed-notnull {
+    CREATE TABLE t3(a INTEGER, b AS ('K') VIRTUAL NOT NULL, c AS (a*2) VIRTUAL);
+    INSERT INTO t3(a) VALUES(3);
+    INSERT INTO t3(a) VALUES(7);
+}
+
+@setup schema-mixed-notnull
+test gencol-virtual-mixed-notnull-select {
+    SELECT a, b, c FROM t3 ORDER BY a;
+}
+expect {
+    3|K|6
+    7|K|14
+}
+
+# Indexes on constant virtual columns should also produce the constant.
+setup schema-indexed {
+    CREATE TABLE t4(a INTEGER, b AS ('Z') VIRTUAL);
+    CREATE INDEX t4_b ON t4(b);
+    INSERT INTO t4(a) VALUES(1);
+    INSERT INTO t4(a) VALUES(2);
+}
+
+@setup schema-indexed
+test gencol-virtual-constant-index-lookup {
+    SELECT a FROM t4 WHERE b = 'Z' ORDER BY a;
+}
+expect {
+    1
+    2
+}


### PR DESCRIPTION
When a virtual generated column expression is a constant (e.g. AS('Y')), translate_expr hoists it into the program init section so the column register is set once before the per-row body runs. The body then emitted a Null instruction for the same register, clobbering the hoisted value before NOT NULL checks and trigger bodies could read it. INSERTs into tables like `CREATE TABLE t(a, b AS ('Y') VIRTUAL NOT NULL)` failed with a spurious NOT NULL constraint violation.

Skip the Null emit in translate_column when the virtual column's expression is constant, since compute_virtual_columns will populate the register via the hoisted init code.