### PR TITLE
fix: unhex(X, Y) ignores separator characters inside the input

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -652,15 +652,37 @@ impl Value {
                 },
                 Some(ignore) => match ignore {
                     Value::Text(_) => {
-                        let pat = ignore.to_string();
-                        let trimmed = self
-                            .to_string()
-                            .trim_start_matches(|x| pat.contains(x))
-                            .trim_end_matches(|x| pat.contains(x))
-                            .to_string();
-                        match hex::decode(trimmed) {
-                            Ok(bytes) => Value::Blob(bytes),
-                            _ => Value::Null,
+                        let input = self.to_string();
+                        let ignore = ignore.to_string();
+                        let mut chars = input.chars().peekable();
+                        let mut out = Vec::with_capacity(input.len() / 2);
+
+                        let is_sep = |c: char| ignore.contains(c) && !c.is_ascii_hexdigit();
+
+                        loop {
+                            while let Some(&c) = chars.peek() {
+                                if is_sep(c) {
+                                    chars.next();
+                                } else {
+                                    break;
+                                }
+                            }
+
+                            let Some(c1) = chars.next() else {
+                                return Value::Blob(out);
+                            };
+                            let Some(hi) = c1.to_digit(16) else {
+                                return Value::Null;
+                            };
+
+                            let Some(c2) = chars.next() else {
+                                return Value::Null;
+                            };
+                            let Some(lo) = c2.to_digit(16) else {
+                                return Value::Null;
+                            };
+
+                            out.push(((hi << 4) | lo) as u8);
                         }
                     }
                     _ => Value::Null,
@@ -2438,6 +2460,38 @@ mod tests {
         let input = Value::Null;
         let expected = Value::Null;
         assert_eq!(input.exec_unhex(None), expected);
+
+        let input = Value::build_text("aa-bb");
+        let expected = Value::Blob(vec![0xaa, 0xbb]);
+        assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
+
+        let input = Value::build_text("aa--bb");
+        let expected = Value::Blob(vec![0xaa, 0xbb]);
+        assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
+
+        let input = Value::build_text("aa-bb-cc");
+        let expected = Value::Blob(vec![0xaa, 0xbb, 0xcc]);
+        assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
+
+        let input = Value::build_text("aa bb");
+        let expected = Value::Blob(vec![0xaa, 0xbb]);
+        assert_eq!(input.exec_unhex(Some(&Value::build_text(" "))), expected);
+
+        let input = Value::build_text("A BCD");
+        let expected = Value::Null;
+        assert_eq!(input.exec_unhex(Some(&Value::build_text(" "))), expected);
+
+        let input = Value::build_text("yx2xEzyx");
+        let expected = Value::Null;
+        assert_eq!(input.exec_unhex(Some(&Value::build_text("xyz"))), expected);
+
+        let input = Value::build_text("aa?bb");
+        let expected = Value::Null;
+        assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
+
+        let input = Value::build_text("aabb");
+        let expected = Value::Null;
+        assert_eq!(input.exec_unhex(Some(&Value::Null)), expected);
     }
 
     #[test]

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -537,6 +537,27 @@ test unhex-x-y-character-outside-set {
 expect {
 }
 
+test unhex-dash-separated {
+    SELECT quote(unhex('aa--bb', '-'));
+}
+expect {
+    X'AABB'
+}
+
+test unhex-multi-dash-separated {
+    SELECT quote(unhex('aa-bb-cc', '-'));
+}
+expect {
+    X'AABBCC'
+}
+
+test unhex-space-separated {
+    SELECT quote(unhex('aa bb', ' '));
+}
+expect {
+    X'AABB'
+}
+
 test trim {
     SELECT trim('   Limbo    ');
 }


### PR DESCRIPTION
## Description

Fix unhex(X, Y) to match SQLite’s separator-handling semantics.

The previous implementation treated the second argument like a set of characters to trim or remove too broadly, which caused mismatches with SQLite for inputs containing ignored separator characters between byte pairs. This change updates the decoding logic so ignored characters are accepted only where SQLite allows them and adds regression coverage in both unit tests and sqltests.

## Motivation and context

This change fixes a SQLite compatibility bug in unhex(X, Y).

Examples of the mismatch before this change:

`unhex('aa--bb', '-')` should decode to X'AABB'
`unhex('aa-bb-cc', '-')` should decode to X'AABBCC'
`unhex('aa bb', ' ')` should decode to X'AABB'
At the same time, SQLite correctly rejects cases where ignored characters appear in invalid positions, for example:

`unhex('A BCD', ' ')` -> NULL
`unhex('yx2xEzyx', 'xyz')` -> NULL
This PR aligns Turso with SQLite for these cases and adds tests to prevent regressions.

## Description of AI Usage

AI was used as an assistant during investigation and implementation planning.