### PR TITLE
bindings/react-native: Add invalidate hook on iOS

### DIFF
--- a/bindings/react-native/ios/TursoModule.h
+++ b/bindings/react-native/ios/TursoModule.h
@@ -1,7 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTInvalidating.h>
 
-@interface Turso : NSObject <RCTBridgeModule>
+@interface Turso : NSObject <RCTBridgeModule, RCTInvalidating>
 
 @property (nonatomic, assign) BOOL setBridgeOnMainQueue;
 

--- a/bindings/react-native/ios/TursoModule.mm
+++ b/bindings/react-native/ios/TursoModule.mm
@@ -86,6 +86,11 @@ RCT_EXPORT_MODULE()
     turso::install(*runtime, callInvoker, [documentsPath UTF8String]);
 }
 
+- (void)invalidate {
+    turso::invalidate();
+    [super invalidate];
+}
+
 // Synchronous method to check if the module is installed
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     [self installLibrary];


### PR DESCRIPTION
## Summary

Add `RCTInvalidating` lifecycle hook to the iOS React Native module to properly clean up JSI objects before the runtime is torn down.

- Conform `Turso` to the [`RCTInvalidating`](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Base/RCTInvalidating.h) protocol in `TursoModule.h`
- Implement `invalidate` in `TursoModule.mm` to call `turso::invalidate()`, releasing `g_loggerFn`, `g_callInvoker`, and `g_runtime`

## Problem

On iOS, Fast Refresh (or any bridge reload) destroys the old `jsi::Runtime` and calls `install()` with a new one. Since the iOS module never called `turso::invalidate()`, the global `shared_ptr<jsi::Function>` (`g_loggerFn`) still referenced the dead runtime. When `setup()` reassigned it, the old `jsi::Function` destructor tried to release its JSI pointer through the destroyed runtime → `EXC_BAD_ACCESS` at `jsi::Pointer::~Pointer` (null deref).

Android already had this wired up correctly via `TursoModule.invalidate()` → `TursoBridge.clearStateNativeJsi()`.

## Docs

- [Native Modules: Lifecycle Events](https://reactnative.dev/docs/the-new-architecture/native-modules-lifecycle) — documents `RCTInvalidating` as the iOS protocol for module cleanup
- Examples in React Native core: [`RCTAppearance`](https://github.com/facebook/react-native/blob/0617accecdcb11159ba15c34885f294bc206aa89/packages/react-native/React/CoreModules/RCTAppearance.mm#L151-L155), [`RCTDeviceInfo`](https://github.com/facebook/react-native/blob/0617accecdcb11159ba15c34885f294bc206aa89/packages/react-native/React/CoreModules/RCTDeviceInfo.mm#L127-L133)
