### PR TITLE
core/vdbe: Short-circuit index seek on NULL keys in LEFT JOIN

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4277,7 +4277,7 @@ pub fn op_seek(
     insn: &Insn,
     pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    let (cursor_id, is_index, record_source, target_pc) = match insn {
+    let (cursor_id, is_index, start_reg, num_regs, target_pc) = match insn {
         Insn::SeekGE {
             cursor_id,
             is_index,
@@ -4309,15 +4309,7 @@ pub fn op_seek(
             num_regs,
             target_pc,
             ..
-        } => (
-            cursor_id,
-            *is_index,
-            RecordSource::Unpacked {
-                start_reg: *start_reg,
-                num_regs: *num_regs,
-            },
-            target_pc,
-        ),
+        } => (cursor_id, *is_index, *start_reg, *num_regs, target_pc),
         _ => unreachable!("unexpected Insn {:?}", insn),
     };
     assert!(
@@ -4330,20 +4322,23 @@ pub fn op_seek(
         _ => false,
     };
 
-    if is_eq_only {
-        // We only care about Unpacked record sources for this short-circuit
-        if let RecordSource::Unpacked { start_reg, .. } = record_source {
-            // Check only the primary register (no need for a loop 'i' here)
-            if state.registers[start_reg].is_null() {
-                let offset = match target_pc {
-                    crate::vdbe::BranchOffset::Offset(o) => *o,
-                    _ => unreachable!("Seek target must be an offset"),
-                };
-                state.pc = offset;
-                return Ok(InsnFunctionStepResult::Step);
-            }
-        }
+    if is_eq_only
+        && state.registers[start_reg..start_reg + num_regs]
+            .iter()
+            .any(|value| value.is_null())
+    {
+        // Exact-match seeks use "=" semantics across the full unpacked key.
+        // If any key column is NULL, the comparison is unknown, so no row can match.
+        // Translation often emits IsNull guards earlier, but outer joins can still
+        // null-extend these registers at runtime after non-null analysis has run.
+        state.pc = target_pc.as_offset_int();
+        return Ok(InsnFunctionStepResult::Step);
     }
+
+    let record_source = RecordSource::Unpacked {
+        start_reg,
+        num_regs,
+    };
 
     let op = match insn {
         Insn::SeekGE { eq_only, .. } => SeekOp::GE { eq_only: *eq_only },

--- a/testing/sqltests/tests/joins/left_join_null_index_bug.sqltest
+++ b/testing/sqltests/tests/joins/left_join_null_index_bug.sqltest
@@ -1,6 +1,6 @@
 @database :memory:
 
-test left-join-null-index-bug {
+setup left-join-null-index-bug-single-column-schema {
     CREATE TABLE a(id INTEGER PRIMARY KEY);
     CREATE TABLE b(id INTEGER PRIMARY KEY, a_id INTEGER);
     CREATE TABLE c(id INTEGER PRIMARY KEY, b_id INTEGER);
@@ -10,11 +10,39 @@ test left-join-null-index-bug {
     INSERT INTO c VALUES (1,NULL);
 
     CREATE INDEX idx_c_bid ON c(b_id);
+}
 
+@setup left-join-null-index-bug-single-column-schema
+test left-join-null-index-bug {
     SELECT a.id, b.id AS bid, c.id AS cid 
     FROM a 
     LEFT JOIN b ON a.id = b.a_id 
     LEFT JOIN c ON b.id = c.b_id 
+    ORDER BY a.id;
+}
+expect {
+1|1|
+2||
+}
+
+setup left-join-null-index-bug-composite-index-schema {
+    CREATE TABLE a(id INTEGER PRIMARY KEY);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, a_id INTEGER);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, x INTEGER, y INTEGER);
+
+    INSERT INTO a VALUES (1),(2);
+    INSERT INTO b VALUES (1,1);
+    INSERT INTO c VALUES (1,7,NULL);
+
+    CREATE INDEX idx_c_x_y ON c(x, y);
+}
+
+@setup left-join-null-index-bug-composite-index-schema
+test left-join-null-index-bug-composite-key {
+    SELECT a.id, b.id AS bid, c.id AS cid
+    FROM a
+    LEFT JOIN b ON a.id = b.a_id
+    LEFT JOIN c ON c.x = 7 AND c.y = b.id
     ORDER BY a.id;
 }
 expect {


### PR DESCRIPTION
Fixes: #6077 

Description
Fixes a query optimizer bug where chained LEFT JOINs producing virtual NULL keys were incorrectly matching literal NULLs in downstream indexed tables.

Root Cause & Fix
The VDBE op_seek instruction was evaluating NULL keys against the index instead of short-circuiting (violating NULL = NULL is false).

In core/vdbe/execute.rs (op_seek):

Intercepted RecordSource::Unpacked registers before calling seek_internal.

If any search register evaluates to Null, the seek instantly aborts.

Extracted target_pc to update state.pc directly and returned InsnFunctionStepResult::Step to correctly trigger the "not found" branch.

Testing
Added left_join_null_index_bug.sqltest using the exact schema/query from the issue.

Suite now passes cleanly with correct empty columns for unmatched rows.