### PR TITLE
sqlite3: Implement `sqlite3_stmt_readonly`

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -484,7 +484,7 @@ Modifiers:
 | sqlite3_step                | ✅ Yes     |         |
 | sqlite3_reset               | ✅ Yes     |         |
 | sqlite3_exec                | ✅ Yes     |         |
-| sqlite3_stmt_readonly       | ❌ No      | Stub    |
+| sqlite3_stmt_readonly       | ✅ Yes     |         |
 | sqlite3_stmt_busy           | ❌ No      | Stub    |
 | sqlite3_stmt_status         | ❌ No      |         |
 | sqlite3_sql                 | ❌ No      |         |

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -235,6 +235,10 @@ pub struct ProgramBuilder {
     /// This flag is used in combination with is_multi_write to determine if statement subjournaling is required.
     /// Defaults to true for safety; specific translate paths (e.g., INSERT with no constraints) set false.
     may_abort: bool,
+    /// True until the builder emits an opcode that may directly modify persistent
+    /// database contents, mirroring sqlite3_stmt_readonly() classification over
+    /// compiled bytecode.
+    readonly: bool,
     /// If this ProgramBuilder is building trigger subprogram, a ref to the trigger is stored here.
     pub trigger: Option<Arc<Trigger>>,
     /// Whether this is a subprogram (trigger or FK action). Subprograms skip Transaction instructions.
@@ -515,6 +519,7 @@ impl ProgramBuilder {
             reg_result_cols_start: None,
             is_multi_write: true,
             may_abort: true,
+            readonly: true,
             trigger,
             is_subprogram,
             resolve_type: ResolveType::Abort,
@@ -858,6 +863,7 @@ impl ProgramBuilder {
     pub fn emit_insn(&mut self, insn: Insn) {
         // This seemingly empty trace here is needed so that a function span is emmited with it
         tracing::trace!("");
+        self.readonly &= insn.is_readonly();
         self.insns.push((insn, self.insns.len()));
     }
 
@@ -1772,6 +1778,7 @@ impl ProgramBuilder {
             comments: self.comments,
             parameters: self.parameters,
             change_cnt_on,
+            readonly: self.readonly,
             result_columns: self.result_columns,
             table_references: self.table_references,
             sql: sql.to_string(),

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1922,6 +1922,49 @@ impl Insn {
         // InsnVariants::from(self).to_function_fast()
         INSN_VTABLE[self.discriminant() as usize]
     }
+
+    /// Returns true if this opcode cannot directly modify persistent database
+    /// contents. This is used to compute PreparedProgram::readonly, mirroring
+    /// SQLite's sqlite3_stmt_readonly() classification over compiled bytecode.
+    pub fn is_readonly(&self) -> bool {
+        match self {
+            Self::Checkpoint { .. }
+            | Self::VCreate { .. }
+            | Self::VUpdate { .. }
+            | Self::VDestroy { .. }
+            | Self::VRename { .. }
+            | Self::Transaction {
+                tx_mode: TransactionMode::Write | TransactionMode::Concurrent,
+                ..
+            }
+            | Self::Insert { .. }
+            | Self::Delete { .. }
+            | Self::IdxDelete { .. }
+            | Self::OpenWrite { .. }
+            | Self::CreateBtree { .. }
+            | Self::IndexMethodCreate { .. }
+            | Self::IndexMethodDestroy { .. }
+            | Self::IndexMethodOptimize { .. }
+            | Self::Destroy { .. }
+            | Self::DropTable { .. }
+            | Self::DropView { .. }
+            | Self::DropIndex { .. }
+            | Self::DropTrigger { .. }
+            | Self::DropType { .. }
+            | Self::AddType { .. }
+            | Self::ParseSchema { .. }
+            | Self::PopulateMaterializedViews { .. }
+            | Self::SetCookie { .. }
+            | Self::RenameTable { .. }
+            | Self::DropColumn { .. }
+            | Self::AddColumn { .. }
+            | Self::AlterColumn { .. }
+            | Self::JournalMode { .. } => false,
+            Self::MaxPgcnt { new_max, .. } => *new_max == 0,
+            Self::Program { program, .. } => program.is_readonly(),
+            _ => true,
+        }
+    }
 }
 
 // TODO: Add remaining cookies.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1029,6 +1029,9 @@ pub struct PreparedProgram {
     pub comments: Vec<(InsnReference, &'static str)>,
     pub parameters: crate::parameters::Parameters,
     pub change_cnt_on: bool,
+    /// Flag that detect if the sqlite statement will directly manipulate the database file.\
+    /// mirrors: https://sqlite.org/c3ref/stmt_readonly.html.
+    pub readonly: bool,
     pub result_columns: Vec<ResultSetColumn>,
     pub table_references: TableReferences,
     pub sql: String,
@@ -1105,9 +1108,15 @@ impl PreparedProgram {
     pub fn is_compatible_with(&self, connection: &Connection) -> bool {
         self.prepare_context.matches_connection(connection)
     }
+
+    #[inline]
+    pub fn is_readonly(&self) -> bool {
+        self.readonly
+    }
 }
 
 impl Program {
+    #[inline]
     pub fn prepared(&self) -> &Arc<PreparedProgram> {
         &self.prepared
     }
@@ -1117,6 +1126,11 @@ impl Program {
             prepared,
             connection,
         }
+    }
+
+    #[inline]
+    pub fn is_readonly(&self) -> bool {
+        self.prepared().is_readonly()
     }
 }
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -1193,8 +1193,15 @@ pub unsafe extern "C" fn sqlite3_changes(db: *mut sqlite3) -> ffi::c_int {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sqlite3_stmt_readonly(_stmt: *mut sqlite3_stmt) -> ffi::c_int {
-    stub!();
+pub unsafe extern "C" fn sqlite3_stmt_readonly(stmt: *mut sqlite3_stmt) -> ffi::c_int {
+    if stmt.is_null() {
+        return 1;
+    }
+    if (*stmt).stmt.get_program().is_readonly() {
+        1
+    } else {
+        0
+    }
 }
 
 #[no_mangle]

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -14,6 +14,7 @@ mod query_processing;
 mod query_timeout;
 mod statement_reset;
 mod stmt_journal;
+mod stmt_readonly;
 mod storage;
 mod trigger;
 mod wal;

--- a/tests/integration/stmt_readonly.rs
+++ b/tests/integration/stmt_readonly.rs
@@ -1,0 +1,42 @@
+use crate::common::TempDatabase;
+use std::sync::Arc;
+
+fn is_stmt_readonly(conn: &Arc<turso_core::Connection>, sql: &str) -> bool {
+    let stmt = conn.prepare(sql).unwrap();
+    stmt.get_program().prepared().is_readonly()
+}
+
+#[turso_macros::test]
+fn select_is_readonly(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(is_stmt_readonly(&conn, "SELECT 1"));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn begin_deferred_is_readonly(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(is_stmt_readonly(&conn, "BEGIN"));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn begin_immediate_is_not_readonly(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(!is_stmt_readonly(&conn, "BEGIN IMMEDIATE"));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn pragma_journal_mode_is_not_readonly(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(!is_stmt_readonly(&conn, "PRAGMA journal_mode"));
+    Ok(())
+}
+
+#[turso_macros::test(init_sql = "CREATE TABLE t(x)")]
+fn create_table_if_not_exists_existing_is_not_readonly(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(!is_stmt_readonly(&conn, "CREATE TABLE IF NOT EXISTS t(x)"));
+    Ok(())
+}


### PR DESCRIPTION
## Description
Implements `https://sqlite.org/c3ref/stmt_readonly.html`. Implementation is simple: just incrementally update the `readonly` flag in `ProgramBuilder` on `emit_insn`

## Motivation and context
Bridge compatibility with `libsql` for server code


## Description of AI Usage
Asked it to look at the sqlite codebase to see what opcodes were considered not readonly
