### PR TITLE
deps: Bump aegis to 0.9.8 to fix build with clang 22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "aegis"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba3d914d59750379281289041a0411a5d6f7b606f05d9bd7382846ed1764e29"
+checksum = "78412fa53e6da95324e8902c3641b3ff32ab45258582ea997eb9169c68ffa219"
 dependencies = [
  "cc",
  "softaes",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1921,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "findshlibs"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -129,10 +129,10 @@ shuttle = { workspace = true }
 # Use pure-rust for Android and MacOS to avoid C cross-compilation issues.
 # Other targets can opt in via the `pure-rust-crypto` feature.
 [target.'cfg(any(target_os = "android", target_os = "macos"))'.dependencies]
-aegis = { version = "0.9.5", features = ["pure-rust"] }
+aegis = { version = "0.9.8", features = ["pure-rust"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "macos")))'.dependencies]
-aegis = { version = "0.9.5" }
+aegis = { version = "0.9.8" }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"


### PR DESCRIPTION
fix build on Arch
<img width="1464" height="222" alt="image" src="https://github.com/user-attachments/assets/f35e9d27-d02f-44d7-8b39-5ce027a9d1ba" />
