### PR TITLE
sqlite3: Implement `sqlite3_progress_handler` + `sqlite3_interrupt`

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -607,7 +607,7 @@ Modifiers:
 | sqlite3_busy_handler     | ✅ Yes     |         |
 | sqlite3_busy_timeout     | ✅ Yes     |         |
 | sqlite3_trace_v2         | ❌ No      | Stub    |
-| sqlite3_progress_handler | ❌ No      | Stub    |
+| sqlite3_progress_handler | ✅ Yes     | Step-time callbacks only |
 | sqlite3_set_authorizer   | ❌ No      | Stub    |
 | sqlite3_commit_hook      | ❌ No      |         |
 | sqlite3_rollback_hook    | ❌ No      |         |
@@ -700,7 +700,7 @@ Modifiers:
 | sqlite3_sourceid       | ❌ No      |         |
 | sqlite3_threadsafe     | ✅ Yes     | Returns 1 |
 | sqlite3_complete       | ❌ No      | Stub    |
-| sqlite3_interrupt      | ❌ No      | Stub    |
+| sqlite3_interrupt      | ✅ Yes     |         |
 | sqlite3_sleep          | ❌ No      | Stub    |
 | sqlite3_randomness     | ❌ No      |         |
 | sqlite3_get_table      | ✅ Yes     |         |

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -18,7 +18,9 @@ use crate::MAIN_DB_ID;
 use crate::{
     ast, function,
     io::{MemoryIO, IO},
-    parse_schema_rows, refresh_analyze_stats, translate,
+    parse_schema_rows,
+    progress::{ProgressHandler, ProgressHandlerCallback},
+    refresh_analyze_stats, translate,
     util::IOExt,
     vdbe, AllViewsTxState, AtomicCipherMode, AtomicSyncMode, AtomicTempStore, BusyHandler,
     BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
@@ -126,9 +128,13 @@ pub struct Connection {
     /// Busy handler for lock contention
     /// Default is BusyHandler::None (return SQLITE_BUSY immediately)
     pub(super) busy_handler: RwLock<BusyHandler>,
+    /// Step-based progress callback for SQLite-compatible cancellation hooks.
+    pub(super) progress_handler: ProgressHandler,
     /// Maximum execution time for a single statement on this connection.
     /// `Duration::ZERO` means disabled.
     pub(super) query_timeout_ms: AtomicU64,
+    /// True when sqlite3_interrupt()-style cancellation is pending for active root statements.
+    pub(super) interrupt_requested: AtomicBool,
     /// Whether this is an internal connection used for MVCC bootstrap
     pub(super) is_mvcc_bootstrap_connection: AtomicBool,
     /// Whether pragma foreign_keys=ON for this connection
@@ -2275,6 +2281,37 @@ impl Connection {
     /// Get a reference to the busy handler.
     pub fn get_busy_handler(&self) -> crate::sync::RwLockReadGuard<'_, BusyHandler> {
         self.busy_handler.read()
+    }
+
+    /// Sets a progress handler invoked approximately every `ops` VM steps.
+    /// Passing `ops == 0` or `None` disables the progress handler.
+    pub fn set_progress_handler(&self, ops: u64, handler: Option<ProgressHandlerCallback>) {
+        self.progress_handler.set(ops, handler);
+    }
+
+    /// Returns true when the step-based progress handler requests interruption.
+    pub fn should_interrupt_for_progress(&self, vm_steps: u64) -> bool {
+        self.progress_handler.should_interrupt(vm_steps)
+    }
+
+    /// Request interruption of currently running root statements on this connection.
+    /// If no root statement is active, the request is ignored to match SQLite semantics.
+    pub fn interrupt(&self) {
+        if self.n_active_root_statements.load(Ordering::SeqCst) > 0 {
+            self.interrupt_requested.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// Returns true if an interrupt is currently pending for this connection.
+    pub fn is_interrupted(&self) -> bool {
+        self.interrupt_requested.load(Ordering::SeqCst)
+    }
+
+    /// Clear the connection interrupt once no root statements remain active.
+    pub(crate) fn clear_interrupt_if_idle(&self) {
+        if self.n_active_root_statements.load(Ordering::SeqCst) == 0 {
+            self.interrupt_requested.store(false, Ordering::SeqCst);
+        }
     }
 
     pub(crate) fn set_tx_state(&self, state: TransactionState) {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -39,6 +39,7 @@ mod json;
 mod numeric;
 mod parameters;
 mod pragma;
+mod progress;
 mod pseudo;
 mod regexp;
 #[cfg(feature = "series")]
@@ -63,6 +64,7 @@ use crate::{
     busy::{BusyHandler, BusyHandlerCallback},
     incremental::view::AllViewsTxState,
     index_method::IndexMethod,
+    progress::ProgressHandler,
     schema::Trigger,
     stats::refresh_analyze_stats,
     storage::{
@@ -1423,7 +1425,9 @@ impl Database {
             temp_store: AtomicTempStore::new(TempStore::Default),
             data_sync_retry: AtomicBool::new(false),
             busy_handler: RwLock::new(BusyHandler::None),
+            progress_handler: ProgressHandler::new(),
             query_timeout_ms: AtomicU64::new(0),
+            interrupt_requested: AtomicBool::new(false),
             is_mvcc_bootstrap_connection: AtomicBool::new(is_mvcc_bootstrap_connection),
             full_column_names: AtomicBool::new(false),
             short_column_names: AtomicBool::new(true),

--- a/core/progress.rs
+++ b/core/progress.rs
@@ -1,0 +1,141 @@
+use crate::sync::{atomic::AtomicU64, RwLock};
+use std::sync::atomic::Ordering;
+
+pub(crate) type ProgressHandlerCallback = Box<dyn Fn() -> bool + Send + Sync>;
+
+/// Connection-scoped progress callback state.
+///
+/// This models SQLite's `sqlite3_progress_handler()` contract for step-time
+/// execution:
+/// - one handler per connection
+/// - the callback runs approximately every `N` virtual machine instructions
+/// - a non-zero callback result interrupts the running operation
+#[derive(Default)]
+pub(crate) struct ProgressHandler {
+    callback: RwLock<Option<ProgressHandlerCallback>>,
+    ops: AtomicU64,
+}
+
+impl std::fmt::Debug for ProgressHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProgressHandler")
+            .field("enabled", &self.is_enabled())
+            .field("ops", &self.ops())
+            .finish()
+    }
+}
+
+impl ProgressHandler {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Install or clear the progress handler.
+    ///
+    /// SQLite disables the handler when `N < 1` or the callback is null, so we
+    /// do the same here by clearing both the callback and opcode interval.
+    pub(crate) fn set(&self, ops: u64, callback: Option<ProgressHandlerCallback>) {
+        if ops == 0 || callback.is_none() {
+            *self.callback.write() = None;
+            self.ops.store(0, Ordering::SeqCst);
+            return;
+        }
+        *self.callback.write() = callback;
+        self.ops.store(ops, Ordering::SeqCst);
+    }
+
+    pub(crate) fn ops(&self) -> u64 {
+        self.ops.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.ops() != 0
+    }
+
+    /// Returns true when the callback requests interruption at this VM step.
+    ///
+    /// The cadence is approximate by design, matching SQLite's documentation:
+    /// the callback is consulted only when the current VM-step count crosses a
+    /// configured multiple of `ops`.
+    pub(crate) fn should_interrupt(&self, vm_steps: u64) -> bool {
+        let ops = self.ops();
+        if ops == 0 || vm_steps % ops != 0 {
+            return false;
+        }
+        let callback = self.callback.read();
+        match callback.as_ref() {
+            Some(callback) => callback(),
+            None => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    #[test]
+    fn disabled_handler_never_interrupts() {
+        let handler = ProgressHandler::new();
+        assert!(!handler.should_interrupt(1));
+        assert!(!handler.is_enabled());
+    }
+
+    #[test]
+    fn handler_runs_only_on_configured_interval() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = ProgressHandler::new();
+        let callback_calls = Arc::clone(&calls);
+        handler.set(
+            3,
+            Some(Box::new(move || {
+                callback_calls.fetch_add(1, Ordering::SeqCst);
+                false
+            })),
+        );
+
+        assert!(!handler.should_interrupt(1));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(!handler.should_interrupt(2));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(!handler.should_interrupt(3));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(!handler.should_interrupt(4));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(!handler.should_interrupt(6));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn handler_can_request_interrupt() {
+        let handler = ProgressHandler::new();
+        handler.set(2, Some(Box::new(|| true)));
+
+        assert!(!handler.should_interrupt(1));
+        assert!(handler.should_interrupt(2));
+    }
+
+    #[test]
+    fn disabling_clears_handler() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = ProgressHandler::new();
+        let callback_calls = Arc::clone(&calls);
+        handler.set(
+            1,
+            Some(Box::new(move || {
+                callback_calls.fetch_add(1, Ordering::SeqCst);
+                true
+            })),
+        );
+        assert!(handler.should_interrupt(1));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        handler.set(0, None);
+        assert!(!handler.should_interrupt(2));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -236,20 +236,16 @@ impl Statement {
         self.state.query_deadline = Some(self.pager.io.current_time_monotonic() + timeout);
     }
 
-    fn maybe_interrupt_for_query_timeout(&mut self) {
-        if let Some(deadline) = self.state.query_deadline {
-            if self.pager.io.current_time_monotonic() >= deadline {
-                self.state.interrupt();
-            }
-        }
-    }
-
     fn release_active_root_if_counted(&mut self) {
         if self.counted_as_active_root {
-            self.program
+            let previous = self
+                .program
                 .connection
                 .n_active_root_statements
                 .fetch_sub(1, Ordering::SeqCst);
+            if previous == 1 {
+                self.program.connection.clear_interrupt_if_idle();
+            }
             self.counted_as_active_root = false;
         }
     }
@@ -275,7 +271,6 @@ impl Statement {
         }
 
         self.arm_query_timeout_if_needed();
-        self.maybe_interrupt_for_query_timeout();
 
         // If we're waiting for a busy handler timeout, check if we can proceed
         if let Some(busy_state) = self.busy_handler_state.as_ref() {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -623,6 +623,10 @@ impl ProgramState {
         self.execution_state = ProgramExecutionState::Interrupting;
     }
 
+    pub fn is_interrupted(&self) -> bool {
+        matches!(self.execution_state, ProgramExecutionState::Interrupting)
+    }
+
     pub fn bind_at(&mut self, index: NonZero<usize>, value: Value) {
         let i = index.get() - 1;
         if i >= self.parameters.len() {
@@ -1125,6 +1129,24 @@ impl Program {
         self.connection.get_pager_from_database_index(idx)
     }
 
+    #[inline]
+    fn maybe_request_interrupt<I>(&self, state: &mut ProgramState, io: &I) -> bool
+    where
+        I: crate::IO + ?Sized,
+    {
+        let connection_interrupt = self.connection.is_interrupted();
+        let hit_query_deadline = state
+            .query_deadline
+            .is_some_and(|deadline| io.current_time_monotonic() >= deadline);
+        let progress_interrupt = self
+            .connection
+            .should_interrupt_for_progress(state.metrics.vm_steps);
+        if connection_interrupt || hit_query_deadline || progress_interrupt {
+            state.interrupt();
+        }
+        state.is_interrupted()
+    }
+
     pub fn step(
         &self,
         state: &mut ProgramState,
@@ -1163,13 +1185,7 @@ impl Program {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
 
-        if let Some(deadline) = state.query_deadline {
-            if pager.io.current_time_monotonic() >= deadline {
-                state.execution_state = ProgramExecutionState::Interrupting;
-            }
-        }
-
-        if matches!(state.execution_state, ProgramExecutionState::Interrupting) {
+        if self.maybe_request_interrupt(state, pager.io.as_ref()) {
             return Ok(StepResult::Interrupt);
         }
 
@@ -1270,13 +1286,7 @@ impl Program {
                 return Err(LimboError::InternalError("Connection closed".to_string()));
             }
 
-            if let Some(deadline) = state.query_deadline {
-                if pager.io.current_time_monotonic() >= deadline {
-                    state.execution_state = ProgramExecutionState::Interrupting;
-                }
-            }
-
-            if matches!(state.execution_state, ProgramExecutionState::Interrupting) {
+            if self.maybe_request_interrupt(state, pager.io.as_ref()) {
                 return Ok(StepResult::Interrupt);
             }
 
@@ -1323,12 +1333,7 @@ impl Program {
                 }
                 return Err(LimboError::InternalError("Connection closed".to_string()));
             }
-            if let Some(deadline) = state.query_deadline {
-                if pager.io.current_time_monotonic() >= deadline {
-                    state.execution_state = ProgramExecutionState::Interrupting;
-                }
-            }
-            if matches!(state.execution_state, ProgramExecutionState::Interrupting) {
+            if self.maybe_request_interrupt(state, pager.io.as_ref()) {
                 self.abort(pager, None, state)?;
                 return Ok(StepResult::Interrupt);
             }

--- a/sqlite3/include/sqlite3.h
+++ b/sqlite3/include/sqlite3.h
@@ -83,7 +83,7 @@ int sqlite3_trace_v2(sqlite3 *_db,
                      void (*_callback)(unsigned int, void*, void*, void*),
                      void *_context);
 
-int sqlite3_progress_handler(sqlite3 *_db, int _n, int (*_callback)(void), void *_context);
+void sqlite3_progress_handler(sqlite3 *_db, int _n, int (*_callback)(void *), void *_context);
 
 int sqlite3_busy_timeout(sqlite3 *_db, int _ms);
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -631,12 +631,34 @@ pub unsafe extern "C" fn sqlite3_trace_v2(
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_progress_handler(
-    _db: *mut sqlite3,
-    _n: ffi::c_int,
-    _callback: Option<unsafe extern "C" fn() -> ffi::c_int>,
-    _context: *mut ffi::c_void,
-) -> ffi::c_int {
-    stub!();
+    db: *mut sqlite3,
+    n: ffi::c_int,
+    callback: Option<unsafe extern "C" fn(*mut ffi::c_void) -> ffi::c_int>,
+    context: *mut ffi::c_void,
+) {
+    if db.is_null() {
+        return;
+    }
+
+    let db_ref = &*db;
+    let inner = match db_ref.inner.lock() {
+        Ok(guard) => guard,
+        Err(_) => return,
+    };
+
+    match callback {
+        Some(c_callback) if n > 0 => {
+            let ctx = context as usize;
+            let cb = c_callback;
+            inner.conn.set_progress_handler(
+                n as u64,
+                Some(Box::new(move || unsafe {
+                    cb(ctx as *mut ffi::c_void) != 0
+                })),
+            );
+        }
+        _ => inner.conn.set_progress_handler(0, None),
+    }
 }
 
 /// Type for C busy handler callback function.
@@ -1272,8 +1294,16 @@ pub unsafe extern "C" fn sqlite3_last_insert_rowid(db: *mut sqlite3) -> ffi::c_i
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sqlite3_interrupt(_db: *mut sqlite3) {
-    stub!();
+pub unsafe extern "C" fn sqlite3_interrupt(db: *mut sqlite3) {
+    if db.is_null() {
+        return;
+    }
+    let db_ref = &*db;
+    let inner = match db_ref.inner.lock() {
+        Ok(guard) => guard,
+        Err(_) => return,
+    };
+    inner.conn.interrupt();
 }
 
 #[no_mangle]

--- a/sqlite3/tests/compat/mod.rs
+++ b/sqlite3/tests/compat/mod.rs
@@ -118,7 +118,14 @@ extern "C" {
         callback: Option<unsafe extern "C" fn(*mut libc::c_void, i32) -> i32>,
         arg: *mut libc::c_void,
     ) -> i32;
+    fn sqlite3_progress_handler(
+        db: *mut sqlite3,
+        n: i32,
+        callback: Option<unsafe extern "C" fn(*mut libc::c_void) -> i32>,
+        arg: *mut libc::c_void,
+    );
     fn sqlite3_busy_timeout(db: *mut sqlite3, ms: i32) -> i32;
+    fn sqlite3_interrupt(db: *mut sqlite3);
     fn sqlite3_get_table(
         db: *mut sqlite3,
         sql: *const libc::c_char,
@@ -176,6 +183,7 @@ const SQLITE_ERROR: i32 = 1;
 const SQLITE_MISUSE: i32 = 21;
 const SQLITE_RANGE: i32 = 25;
 const SQLITE_CANTOPEN: i32 = 14;
+const SQLITE_INTERRUPT: i32 = 9;
 const SQLITE_ROW: i32 = 100;
 const SQLITE_DONE: i32 = 101;
 const SQLITE_PREPARE_PERSISTENT: u32 = 0x01;
@@ -2585,6 +2593,148 @@ mod tests {
                 SQLITE_OK
             );
 
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    struct ProgressContext {
+        calls: std::sync::atomic::AtomicI32,
+        interrupt_after: i32,
+    }
+
+    unsafe extern "C" fn progress_handler_interrupt_after(data: *mut libc::c_void) -> i32 {
+        let ctx = &*(data as *const ProgressContext);
+        let current = ctx.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        if current >= ctx.interrupt_after {
+            1
+        } else {
+            0
+        }
+    }
+
+    #[test]
+    fn test_sqlite3_progress_handler_interrupts_statement() {
+        unsafe {
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+            assert_eq!(
+                sqlite3_exec(
+                    db,
+                    c"CREATE TABLE numbers(v INTEGER); INSERT INTO numbers(v) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);".as_ptr(),
+                    None,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+
+            let ctx = ProgressContext {
+                calls: std::sync::atomic::AtomicI32::new(0),
+                interrupt_after: 8,
+            };
+            sqlite3_progress_handler(
+                db,
+                1,
+                Some(progress_handler_interrupt_after),
+                &ctx as *const ProgressContext as *mut libc::c_void,
+            );
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT count(*) FROM numbers AS a, numbers AS b, numbers AS c, numbers AS d, numbers AS e, numbers AS f, numbers AS g".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+
+            assert_eq!(sqlite3_step(stmt), SQLITE_INTERRUPT);
+            assert!(
+                ctx.calls.load(std::sync::atomic::Ordering::SeqCst) >= ctx.interrupt_after,
+                "progress handler did not fire enough times"
+            );
+
+            sqlite3_progress_handler(db, 0, None, ptr::null_mut());
+            let finalize_rc = sqlite3_finalize(stmt);
+            assert!(
+                matches!(finalize_rc, SQLITE_OK | SQLITE_INTERRUPT),
+                "unexpected finalize rc: {finalize_rc}"
+            );
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_sqlite3_interrupt_without_active_statement_is_ignored() {
+        unsafe {
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(db, c"SELECT 1".as_ptr(), -1, &mut stmt, ptr::null_mut()),
+                SQLITE_OK
+            );
+
+            sqlite3_interrupt(db);
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_sqlite3_interrupt_active_statement() {
+        unsafe {
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+            assert_eq!(
+                sqlite3_exec(
+                    db,
+                    c"CREATE TABLE numbers(v INTEGER); INSERT INTO numbers(v) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);".as_ptr(),
+                    None,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT a.v FROM numbers AS a, numbers AS b, numbers AS c, numbers AS d, numbers AS e, numbers AS f, numbers AS g, numbers AS h".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+
+            let db_addr = db as usize;
+            let interrupter = std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                sqlite3_interrupt(db_addr as *mut sqlite3);
+            });
+
+            let rc = loop {
+                let rc = sqlite3_step(stmt);
+                if rc != SQLITE_ROW {
+                    break rc;
+                }
+            };
+            interrupter.join().unwrap();
+            assert_eq!(rc, SQLITE_INTERRUPT, "expected SQLITE_INTERRUPT, got {rc}");
+
+            let finalize_rc = sqlite3_finalize(stmt);
+            assert!(
+                matches!(finalize_rc, SQLITE_OK | SQLITE_INTERRUPT),
+                "unexpected finalize rc: {finalize_rc}"
+            );
             assert_eq!(sqlite3_close(db), SQLITE_OK);
         }
     }


### PR DESCRIPTION
## Description
Implements `https://sqlite.org/c3ref/progress_handler.html` and `https://sqlite.org/c3ref/interrupt.html`. 
From the docs, SQLite can for some reason call the progress handler in the `prepare` phase for complex queries. I don't know what those complex queries are, so I just implemented the progress handler based on the VM steps metrics. 

## Motivation and context
Compatibility and needed for some server code

## Description of AI Usage
Implemented with Codex, but went back and forth with it a good bit. I also asked to look at SQLite codebase to see properly implement it in turso.
