### PR TITLE
ci: cache cargo-dist binary across workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,14 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Cache cargo-dist
+        id: cache-dist
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/dist
+          key: cargo-dist-v0.31.0-${{ runner.os }}
       - name: Install dist
+        if: steps.cache-dist.outputs.cache-hit != 'true'
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash


### PR DESCRIPTION
## Summary

The release workflow downloads cargo-dist via curl on every run. This adds `actions/cache` to persist the binary across runs, keyed on the dist version. Cache hits skip the curl download entirely.

## Why this matters

The curl download from GitHub releases often hits network timeouts (especially in CI), blocking the entire release pipeline. With caching, subsequent runs get the binary from the GitHub Actions cache in seconds.

## Changes

- `.github/workflows/release.yml`: Add `actions/cache@v4` step before the `Install dist` step in the `plan` job. The cache key is `cargo-dist-v0.31.0-${{ runner.os }}`, so it busts on version bumps. The curl install is conditional on cache miss.

The existing artifact upload/download pattern for downstream jobs (build-global-artifacts, host) is preserved unchanged.

Fixes #6288

This contribution was developed with AI assistance (Claude Code).