### PR TITLE
bindings/rust: discard local sync server child stdio in tests

### DIFF
--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -804,10 +804,15 @@ mod tests {
                 let port: u16 = rand::rng().random_range(10_000..=65_535);
                 let server_bin = env::var("LOCAL_SYNC_SERVER").unwrap();
 
+                // IMPORTANT: do not use Stdio::piped() here. Nothing reads from
+                // those pipes, so once the kernel pipe buffer (~64 KiB on Linux)
+                // fills, the child blocks forever inside write() and stops
+                // servicing HTTP requests, deadlocking sync operations in
+                // long-running tests like test_sync_parallel_writes_with_sync_ops.
                 let child = Command::new(server_bin)
                     .args(["--sync-server", &format!("0.0.0.0:{port}")])
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::piped())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .spawn()
                     .context("failed to spawn local sync server")?;
 


### PR DESCRIPTION
The TursoServer test helper spawns a local tursodb child as the sync
server with both stdout and stderr set to Stdio::piped(), but nothing
ever reads from those pipes. Once the kernel pipe buffer (~64 KiB on
Linux) fills, the child blocks forever inside write() and stops
servicing HTTP requests. Subsequent push/pull/checkpoint operations
hang inside hyper's body frame().await, the single-threaded IoWorker
gets stuck on that one request, and writers waiting on extra_io wakes
never make progress either.

This shows up in CI as test_sync_parallel_writes_with_sync_ops timing
out after 20 minutes (it generates ~160 MiB of WAL traffic, more than
enough to fill the log pipe), and is the same root cause that forced
test_busy_snapshot_immediate to be excluded from the coverage run.

Use Stdio::null() so the child never blocks on log output.
