### PR TITLE
fix: reject invalid UTF-8 TEXT payloads in record decode

### DIFF
--- a/bindings/java/rs_src/turso_statement.rs
+++ b/bindings/java/rs_src/turso_statement.rs
@@ -111,10 +111,9 @@ fn row_to_obj_array<'local>(
                 env.new_object("java/lang/Double", "(D)V", &[JValue::Double(f64::from(*f))])?
             }
             turso_core::Value::Text(s) => env
-                .new_string(
-                    s.try_as_str()
-                        .map_err(|e| TursoError::CustomError(format!("invalid UTF-8 in TEXT value: {e}")))?,
-                )?
+                .new_string(s.try_as_str().map_err(|e| {
+                    TursoError::CustomError(format!("invalid UTF-8 in TEXT value: {e}"))
+                })?)?
                 .into(),
             turso_core::Value::Blob(b) => env.byte_array_from_slice(b.as_slice())?.into(),
         };

--- a/bindings/java/rs_src/turso_statement.rs
+++ b/bindings/java/rs_src/turso_statement.rs
@@ -110,7 +110,12 @@ fn row_to_obj_array<'local>(
             turso_core::Value::Numeric(turso_core::Numeric::Float(f)) => {
                 env.new_object("java/lang/Double", "(D)V", &[JValue::Double(f64::from(*f))])?
             }
-            turso_core::Value::Text(s) => env.new_string(s.as_str())?.into(),
+            turso_core::Value::Text(s) => env
+                .new_string(
+                    s.try_as_str()
+                        .map_err(|e| TursoError::CustomError(format!("invalid UTF-8 in TEXT value: {e}")))?,
+                )?
+                .into(),
             turso_core::Value::Blob(b) => env.byte_array_from_slice(b.as_slice())?.into(),
         };
         if let Err(e) = env.set_object_array_element(&obj_array, i as i32, obj) {

--- a/bindings/javascript/packages/native/compat.test.ts
+++ b/bindings/javascript/packages/native/compat.test.ts
@@ -111,6 +111,18 @@ test('blobs', () => {
     expect(rows).toEqual([{ x: Buffer.from([16, 32]) }])
 })
 
+test('raw invalid text is returned as bytes', () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t(val TEXT)");
+    db.exec("INSERT INTO t VALUES(CAST(X'FF' AS TEXT))");
+
+    const stmt = db.prepare("SELECT val FROM t");
+    stmt.raw(true);
+
+    const rows = stmt.all();
+    expect(rows).toEqual([[Buffer.from([0xFF])]])
+})
+
 test('encryption', () => {
     const path = `test-encryption-${(Math.random() * 10000) | 0}.db`;
     const hexkey = 'b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327';

--- a/bindings/javascript/packages/native/index.d.ts
+++ b/bindings/javascript/packages/native/index.d.ts
@@ -5,10 +5,6 @@ export declare class BatchExecutor {
   reset(): void
 }
 
-export interface QueryOptions {
-  queryTimeout?: number
-}
-
 /** A database connection. */
 export declare class Database {
   /**
@@ -179,4 +175,8 @@ export interface EncryptionOpts {
   cipher: EncryptionCipher
   /** The hex-encoded encryption key */
   hexkey: string
+}
+
+export interface QueryOptions {
+  queryTimeout?: number
 }

--- a/bindings/javascript/packages/native/index.js
+++ b/bindings/javascript/packages/native/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-android-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-android-arm-eabi')
         const bindingPackageVersion = require('@tursodatabase/database-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-win32-x64-msvc')
         const bindingPackageVersion = require('@tursodatabase/database-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-win32-ia32-msvc')
         const bindingPackageVersion = require('@tursodatabase/database-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-win32-arm64-msvc')
         const bindingPackageVersion = require('@tursodatabase/database-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@tursodatabase/database-darwin-universal')
       const bindingPackageVersion = require('@tursodatabase/database-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-darwin-x64')
         const bindingPackageVersion = require('@tursodatabase/database-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-darwin-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-freebsd-x64')
         const bindingPackageVersion = require('@tursodatabase/database-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-freebsd-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-x64-musl')
           const bindingPackageVersion = require('@tursodatabase/database-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-x64-gnu')
           const bindingPackageVersion = require('@tursodatabase/database-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm64-musl')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm64-gnu')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm-musleabihf')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-riscv64-musl')
           const bindingPackageVersion = require('@tursodatabase/database-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-riscv64-gnu')
           const bindingPackageVersion = require('@tursodatabase/database-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-linux-ppc64-gnu')
         const bindingPackageVersion = require('@tursodatabase/database-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -408,8 +408,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-linux-s390x-gnu')
         const bindingPackageVersion = require('@tursodatabase/database-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -428,8 +428,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-openharmony-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-openharmony-x64')
         const bindingPackageVersion = require('@tursodatabase/database-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-openharmony-arm')
         const bindingPackageVersion = require('@tursodatabase/database-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/javascript/packages/native/promise.test.ts
+++ b/bindings/javascript/packages/native/promise.test.ts
@@ -270,6 +270,18 @@ test('blobs', async () => {
     expect(rows).toEqual([{ x: Buffer.from([16, 32]) }])
 })
 
+test('raw invalid text is returned as bytes', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t(val TEXT)");
+    await db.exec("INSERT INTO t VALUES(CAST(X'FF' AS TEXT))");
+
+    const stmt = db.prepare("SELECT val FROM t");
+    stmt.raw(true);
+
+    const rows = await stmt.all();
+    expect(rows).toEqual([[Buffer.from([0xFF])]])
+})
+
 
 test('example-1', async () => {
     const db = await connect(':memory:');

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -955,7 +955,11 @@ fn to_js_value<'a>(
         turso_core::Value::Numeric(turso_core::Numeric::Float(f)) => {
             ToNapiValue::into_unknown(f64::from(*f), env)
         }
-        turso_core::Value::Text(s) => ToNapiValue::into_unknown(s.as_str(), env),
+        turso_core::Value::Text(s) => ToNapiValue::into_unknown(
+            s.try_as_str()
+                .map_err(|e| to_generic_error("invalid UTF-8 in TEXT value", e))?,
+            env,
+        ),
         turso_core::Value::Blob(b) => {
             #[cfg(not(feature = "browser"))]
             {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -808,7 +808,7 @@ impl Statement {
             PresentationMode::Raw => {
                 let mut raw_array = env.create_array(row_data.len() as u32)?;
                 for (idx, value) in row_data.get_values().enumerate() {
-                    let js_value = to_js_value(env, value, safe_integers)?;
+                    let js_value = to_js_raw_value(env, value, safe_integers)?;
                     raw_array.set(idx as u32, js_value)?;
                 }
                 raw_array.coerce_to_object()?.to_unknown()
@@ -973,5 +973,34 @@ fn to_js_value<'a>(
                 ToNapiValue::into_unknown(buffer, env)
             }
         }
+    }
+}
+
+/// Convert a Turso value to a JavaScript value for raw row mode.
+///
+/// Raw mode keeps strict string semantics for valid TEXT, but preserves invalid
+/// TEXT bytes as byte arrays so callers can decide how to render them.
+fn to_js_raw_value<'a>(
+    env: &'a napi::Env,
+    value: &turso_core::Value,
+    safe_integers: bool,
+) -> napi::Result<Unknown<'a>> {
+    match value {
+        turso_core::Value::Text(s) => match s.try_as_str() {
+            Ok(text) => ToNapiValue::into_unknown(text, env),
+            Err(_) => {
+                #[cfg(not(feature = "browser"))]
+                {
+                    let buffer = Buffer::from(s.as_bytes());
+                    ToNapiValue::into_unknown(buffer, env)
+                }
+                #[cfg(feature = "browser")]
+                {
+                    let buffer = Uint8Array::from(s.as_bytes());
+                    ToNapiValue::into_unknown(buffer, env)
+                }
+            }
+        },
+        _ => to_js_value(env, value, safe_integers),
     }
 }

--- a/bindings/javascript/sync/src/js_protocol_io.rs
+++ b/bindings/javascript/sync/src/js_protocol_io.rs
@@ -229,23 +229,26 @@ impl SyncEngineIo for JsProtocolIo {
         &self,
         mutations: Vec<turso_sync_engine::types::DatabaseRowMutation>,
     ) -> turso_sync_engine::Result<Self::DataCompletionTransform> {
-        Ok(self.add_request(JsProtocolRequest::Transform {
-            mutations: mutations
-                .into_iter()
-                .filter_map(|mutation| {
-                    let change_type = core_change_type_to_js(mutation.change_type)?;
-                    Some(DatabaseRowMutationJs {
-                        change_time: mutation.change_time as i64,
-                        table_name: mutation.table_name,
-                        id: mutation.id,
-                        change_type,
-                        before: mutation.before.map(core_values_map_to_js),
-                        after: mutation.after.map(core_values_map_to_js),
-                        updates: mutation.updates.map(core_values_map_to_js),
-                    })
+        let mutations = mutations
+            .into_iter()
+            .filter_map(|mutation| {
+                core_change_type_to_js(mutation.change_type)
+                    .map(|change_type| (mutation, change_type))
+            })
+            .map(|(mutation, change_type)| {
+                Ok(DatabaseRowMutationJs {
+                    change_time: mutation.change_time as i64,
+                    table_name: mutation.table_name,
+                    id: mutation.id,
+                    change_type,
+                    before: mutation.before.map(core_values_map_to_js).transpose()?,
+                    after: mutation.after.map(core_values_map_to_js).transpose()?,
+                    updates: mutation.updates.map(core_values_map_to_js).transpose()?,
                 })
-                .collect(),
-        }))
+            })
+            .collect::<turso_sync_engine::Result<Vec<_>>>()?;
+
+        Ok(self.add_request(JsProtocolRequest::Transform { mutations }))
     }
 
     fn add_io_callback(&self, callback: Box<dyn FnMut() -> bool + Send>) {

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -76,7 +76,7 @@ fn core_value_to_js(value: turso_core::Value) -> Either5<Null, i64, f64, String,
             Either5::<Null, i64, f64, String, Vec<u8>>::C(f64::from(value))
         }
         turso_core::Value::Text(value) => {
-            Either5::<Null, i64, f64, String, Vec<u8>>::D(value.as_str().to_string())
+            Either5::<Null, i64, f64, String, Vec<u8>>::D(value.as_str_lossy().into_owned())
         }
         turso_core::Value::Blob(value) => Either5::<Null, i64, f64, String, Vec<u8>>::E(value),
     }

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -66,8 +66,10 @@ fn js_value_to_core(value: Either5<Null, i64, f64, String, Vec<u8>>) -> turso_co
         Either5::E(value) => turso_core::Value::Blob(value),
     }
 }
-fn core_value_to_js(value: turso_core::Value) -> Either5<Null, i64, f64, String, Vec<u8>> {
-    match value {
+fn core_value_to_js(
+    value: turso_core::Value,
+) -> turso_sync_engine::Result<Either5<Null, i64, f64, String, Vec<u8>>> {
+    Ok(match value {
         turso_core::Value::Null => Either5::<Null, i64, f64, String, Vec<u8>>::A(Null),
         turso_core::Value::Numeric(turso_core::Numeric::Integer(value)) => {
             Either5::<Null, i64, f64, String, Vec<u8>>::B(value)
@@ -75,20 +77,27 @@ fn core_value_to_js(value: turso_core::Value) -> Either5<Null, i64, f64, String,
         turso_core::Value::Numeric(turso_core::Numeric::Float(value)) => {
             Either5::<Null, i64, f64, String, Vec<u8>>::C(f64::from(value))
         }
-        turso_core::Value::Text(value) => {
-            Either5::<Null, i64, f64, String, Vec<u8>>::D(value.as_str_lossy().into_owned())
-        }
+        turso_core::Value::Text(value) => Either5::<Null, i64, f64, String, Vec<u8>>::D(
+            value
+                .try_as_str()
+                .map_err(|err| {
+                    turso_sync_engine::errors::Error::DatabaseSyncEngineError(format!(
+                        "invalid UTF-8 in TEXT value: {err}"
+                    ))
+                })?
+                .to_owned(),
+        ),
         turso_core::Value::Blob(value) => Either5::<Null, i64, f64, String, Vec<u8>>::E(value),
-    }
+    })
 }
 fn core_values_map_to_js(
     value: HashMap<String, turso_core::Value>,
-) -> HashMap<String, Either5<Null, i64, f64, String, Vec<u8>>> {
-    let mut result = HashMap::new();
+) -> turso_sync_engine::Result<HashMap<String, Either5<Null, i64, f64, String, Vec<u8>>>> {
+    let mut result = HashMap::with_capacity(value.len());
     for (key, value) in value {
-        result.insert(key, core_value_to_js(value));
+        result.insert(key, core_value_to_js(value)?);
     }
-    result
+    Ok(result)
 }
 
 #[napi(object)]
@@ -540,4 +549,17 @@ fn try_unwrap<'a>(
         ));
     };
     Ok(sync_engine)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_core_value_to_js_rejects_invalid_utf8_text() {
+        let value = turso_core::Value::Text(turso_core::types::Text::new(vec![0xFF]));
+        let err = core_value_to_js(value).unwrap_err();
+
+        assert!(err.to_string().contains("invalid UTF-8 in TEXT value"));
+    }
 }

--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -362,7 +362,10 @@ fn db_value_to_py(py: Python, value: Value) -> PyResult<Py<PyAny>> {
         Value::Null => Ok(py.None()),
         Value::Numeric(Numeric::Integer(i)) => Ok(i.into_pyobject(py)?.into()),
         Value::Numeric(Numeric::Float(f)) => Ok(f64::from(f).into_pyobject(py)?.into()),
-        Value::Text(s) => Ok(s.value.as_ref().into_pyobject(py)?.into()),
+        Value::Text(s) => match s.try_as_str() {
+            Ok(text) => Ok(text.into_pyobject(py)?.into()),
+            Err(_) => Ok(PyBytes::new(py, s.as_bytes()).into()),
+        },
         Value::Blob(b) => Ok(PyBytes::new(py, &b).into()),
     }
 }

--- a/bindings/python/tests/test_database.py
+++ b/bindings/python/tests/test_database.py
@@ -1012,6 +1012,20 @@ def test_blob_data(provider):
     conn.close()
 
 
+def test_invalid_utf8_text_returns_bytes_turso():
+    conn = turso.connect(":memory:")
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE test (value TEXT)")
+    cursor.execute("INSERT INTO test VALUES (CAST(X'FF' AS TEXT))")
+
+    cursor.execute("SELECT value FROM test")
+    row = cursor.fetchone()
+
+    assert row == (b"\xFF",)
+
+    conn.close()
+
+
 @pytest.mark.parametrize("provider", ["sqlite3", "turso"])
 def test_limit_offset(provider):
     conn = connect(provider, ":memory:")

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -47,7 +47,7 @@ pub mod sync;
 
 pub use connection::Connection;
 use turso_sdk_kit::rsapi::TursoError;
-pub use value::Value;
+pub use value::{Value, ValueRef};
 
 pub use params::params_from_iter;
 pub use params::IntoParams;

--- a/bindings/rust/src/rows.rs
+++ b/bindings/rust/src/rows.rs
@@ -1,4 +1,4 @@
-use crate::{assert_send_sync, Column, Error, Result, Statement, Value};
+use crate::{assert_send_sync, Column, Error, Result, Statement, Value, ValueRef};
 use std::fmt::Debug;
 use std::future::Future;
 
@@ -73,6 +73,16 @@ pub struct Row {
 }
 
 impl Row {
+    pub fn get_value_ref(&self, idx: usize) -> Result<ValueRef<'_>> {
+        let val = self.values.get(idx).ok_or_else(|| {
+            Error::Misuse(format!(
+                "column index {idx} out of bounds (row has {} columns)",
+                self.values.len()
+            ))
+        })?;
+        Ok(val.into())
+    }
+
     pub fn get_value(&self, idx: usize) -> Result<Value> {
         let val = self.values.get(idx).ok_or_else(|| {
             Error::Misuse(format!(
@@ -88,9 +98,12 @@ impl Row {
                 Ok(Value::Real(f64::from(*f)))
             }
             turso_sdk_kit::rsapi::Value::Null => Ok(Value::Null),
-            turso_sdk_kit::rsapi::Value::Text(text) => {
-                Ok(Value::Text(text.value.clone().into_owned()))
-            }
+            turso_sdk_kit::rsapi::Value::Text(text) => text
+                .try_as_str()
+                .map(|text| Value::Text(text.to_owned()))
+                .map_err(|err| {
+                    Error::ConversionFailure(format!("invalid UTF-8 in TEXT value: {err}"))
+                }),
             turso_sdk_kit::rsapi::Value::Blob(items) => Ok(Value::Blob(items.to_vec())),
         }
     }

--- a/bindings/rust/src/value.rs
+++ b/bindings/rust/src/value.rs
@@ -378,6 +378,22 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
     }
 }
 
+impl<'a> From<&'a turso_sdk_kit::rsapi::Value> for ValueRef<'a> {
+    fn from(v: &'a turso_sdk_kit::rsapi::Value) -> ValueRef<'a> {
+        match v {
+            turso_sdk_kit::rsapi::Value::Null => ValueRef::Null,
+            turso_sdk_kit::rsapi::Value::Numeric(turso_sdk_kit::rsapi::Numeric::Integer(i)) => {
+                ValueRef::Integer(*i)
+            }
+            turso_sdk_kit::rsapi::Value::Numeric(turso_sdk_kit::rsapi::Numeric::Float(r)) => {
+                ValueRef::Real(f64::from(*r))
+            }
+            turso_sdk_kit::rsapi::Value::Text(text) => ValueRef::Text(text.as_bytes()),
+            turso_sdk_kit::rsapi::Value::Blob(blob) => ValueRef::Blob(blob),
+        }
+    }
+}
+
 impl<'a, T> From<Option<T>> for ValueRef<'a>
 where
     T: Into<ValueRef<'a>>,

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1,5 +1,5 @@
 use tokio::fs;
-use turso::{Builder, EncryptionOpts, Error, Value};
+use turso::{Builder, EncryptionOpts, Error, Value, ValueRef};
 
 #[tokio::test]
 async fn test_rows_next() {
@@ -300,6 +300,29 @@ async fn test_row_get_conversion_error() {
 
     // Attempt to convert TEXT into integer (should fail)
     let result: Result<u32, _> = row.get(0);
+    assert!(matches!(result, Err(Error::ConversionFailure(_))));
+}
+
+#[tokio::test]
+async fn test_invalid_text_bytes_require_raw_access() {
+    let db = Builder::new_local(":memory:").build().await.unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("CREATE TABLE t (x TEXT)", ()).await.unwrap();
+    conn.execute("INSERT INTO t VALUES (CAST(X'FF' AS TEXT))", ())
+        .await
+        .unwrap();
+
+    let mut rows = conn.query("SELECT x FROM t", ()).await.unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+
+    assert!(matches!(
+        row.get_value_ref(0).unwrap(),
+        ValueRef::Text(b"\xFF")
+    ));
+    assert!(matches!(row.get_value(0), Err(Error::ConversionFailure(_))));
+
+    let result: Result<String, _> = row.get(0);
     assert!(matches!(result, Err(Error::ConversionFailure(_))));
 }
 

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1961,19 +1961,24 @@ impl Limbo {
             Value::Numeric(Numeric::Integer(i)) => out.write_all(format!("{i}").as_bytes()),
             Value::Numeric(Numeric::Float(f)) => write!(out, "{}", f64::from(*f)).map(|_| ()),
             Value::Text(s) => {
-                out.write_all(b"'")?;
-                let bytes = s.as_bytes();
-                let mut i = 0;
-                while i < bytes.len() {
-                    let b = bytes[i];
-                    if b == b'\'' {
-                        out.write_all(b"''")?;
-                    } else {
-                        out.write_all(&[b])?;
+                if let Ok(text) = s.try_as_str() {
+                    out.write_all(b"'")?;
+                    for ch in text.bytes() {
+                        if ch == b'\'' {
+                            out.write_all(b"''")?;
+                        } else {
+                            out.write_all(&[ch])?;
+                        }
                     }
-                    i += 1;
+                    out.write_all(b"'")
+                } else {
+                    out.write_all(b"CAST(X'")?;
+                    const HEX: &[u8; 16] = b"0123456789abcdef";
+                    for &byte in s.as_bytes() {
+                        out.write_all(&[HEX[(byte >> 4) as usize], HEX[(byte & 0x0F) as usize]])?;
+                    }
+                    out.write_all(b"' AS TEXT)")
                 }
-                out.write_all(b"'")
             }
             Value::Blob(b) => {
                 out.write_all(b"X'")?;
@@ -2352,6 +2357,8 @@ fn normalize_db_path(db_file: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use turso_core::{DatabaseOpts, MemoryIO, IO};
 
     #[test]
     fn test_normalize_db_path_adds_file_prefix_for_query_params() {
@@ -2418,5 +2425,52 @@ mod tests {
             normalize_db_path("foo.bar?mode=ro?mode=ro".into()),
             "file:foo.bar%3Fmode=ro?mode=ro"
         );
+    }
+
+    #[test]
+    fn test_dump_round_trips_invalid_text_bytes() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io.clone(),
+            ":memory:",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        Limbo::exec_all_conn(&conn, "CREATE TABLE t(val TEXT);").unwrap();
+        Limbo::exec_all_conn(&conn, "INSERT INTO t VALUES(CAST(X'FF' AS TEXT));").unwrap();
+
+        let mut dump = Vec::new();
+        Limbo::dump_database_from_conn(false, conn.clone(), &mut dump, NoopProgress).unwrap();
+        let dump_sql = std::str::from_utf8(&dump).unwrap();
+        assert!(dump_sql.contains("INSERT INTO \"t\" VALUES(CAST(X'ff' AS TEXT));"));
+
+        let restored_io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let restored = Database::open_file_with_flags(
+            restored_io,
+            ":memory:",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let restored_conn = restored.connect().unwrap();
+        let mut applier = ApplyWriter::new(&restored_conn);
+        applier.write_all(&dump).unwrap();
+        applier.finish().unwrap();
+
+        let mut rows = restored_conn
+            .query("SELECT hex(val) FROM t")
+            .unwrap()
+            .unwrap();
+        let mut result = None;
+        rows.run_with_row_callback(|row| {
+            result = Some(row.get::<&str>(0)?.to_string());
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(result.as_deref(), Some("FF"));
     }
 }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1371,12 +1371,12 @@ impl Limbo {
             row.get::<&Value>(2),
         ) {
             let modified_schema = if db_display_name == "main" {
-                schema.as_str().to_string()
+                schema.as_str_lossy().into_owned()
             } else {
                 // We need to modify the SQL to include the database prefix in table names
                 // This is a simple approach - for CREATE TABLE statements, insert db name after "TABLE "
                 // For CREATE INDEX statements, insert db name after "ON "
-                let schema_str = schema.as_str();
+                let schema_str = schema.as_str_lossy();
                 if schema_str.to_uppercase().contains("CREATE TABLE ") {
                     // Find "CREATE TABLE " and insert database name after it
                     if let Some(pos) = schema_str.to_uppercase().find("CREATE TABLE ") {
@@ -1401,11 +1401,15 @@ impl Limbo {
             };
             let _ = self.writeln_fmt(format_args!("{modified_schema};"));
             // For views, add the column comment like SQLite does
-            if obj_type.as_str() == "view" {
+            if obj_type.as_bytes() == b"view" {
                 let columns = self
-                    .get_view_columns(obj_name.as_str())
+                    .get_view_columns(&obj_name.as_str_lossy())
                     .unwrap_or_else(|_| "x".to_string());
-                let _ = self.writeln_fmt(format_args!("/* {}({}) */", obj_name.as_str(), columns));
+                let _ = self.writeln_fmt(format_args!(
+                    "/* {}({}) */",
+                    obj_name.as_str_lossy(),
+                    columns
+                ));
             }
             true
         } else {
@@ -1422,7 +1426,7 @@ impl Limbo {
         let handler = |row: &turso_core::Row| {
             // Column name is in the second column (index 1) of PRAGMA table_info
             if let Ok(Value::Text(col_name)) = row.get::<&Value>(1) {
-                columns.push(col_name.as_str().to_string());
+                columns.push(col_name.as_str_lossy().into_owned());
             }
             Ok(())
         };
@@ -1579,7 +1583,7 @@ impl Limbo {
                         indexes.push_str(prefix);
                         indexes.push('.');
                     }
-                    indexes.push_str(idx.as_str());
+                    indexes.push_str(&idx.as_str_lossy());
                     indexes.push(' ');
                 }
                 Ok(())
@@ -1617,7 +1621,7 @@ impl Limbo {
                         tables.push_str(prefix);
                         tables.push('.');
                     }
-                    tables.push_str(table.as_str());
+                    tables.push_str(&table.as_str_lossy());
                     tables.push(' ');
                 }
                 Ok(())
@@ -1700,9 +1704,9 @@ impl Limbo {
                 row.get::<&Value>(2),
             ) {
                 let file = match file_value {
-                    Value::Text(path) => path.as_str(),
-                    Value::Null => "",
-                    _ => "",
+                    Value::Text(path) => path.as_str_lossy(),
+                    Value::Null => std::borrow::Cow::Borrowed(""),
+                    _ => std::borrow::Cow::Borrowed(""),
                 };
 
                 // Format like SQLite: "main: /path/to/file r/w"
@@ -1719,7 +1723,12 @@ impl Limbo {
                     "r/w"
                 };
 
-                databases.push(format!("{}: {} {}", name.as_str(), file_display, mode));
+                databases.push(format!(
+                    "{}: {} {}",
+                    name.as_str_lossy(),
+                    file_display,
+                    mode
+                ));
             }
             Ok(())
         })?;
@@ -1953,7 +1962,7 @@ impl Limbo {
             Value::Numeric(Numeric::Float(f)) => write!(out, "{}", f64::from(*f)).map(|_| ()),
             Value::Text(s) => {
                 out.write_all(b"'")?;
-                let bytes = s.value.as_bytes();
+                let bytes = s.as_bytes();
                 let mut i = 0;
                 while i < bytes.len() {
                     let b = bytes[i];

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -241,12 +241,28 @@ impl TursoSyncServer {
                         })
                         .collect();
 
-                    let result_rows: Vec<Row> = rows
+                    let result_rows = match rows
                         .into_iter()
-                        .map(|row| Row {
-                            values: row.into_iter().map(convert_core_to_value).collect(),
+                        .map(|row| {
+                            let values = row
+                                .into_iter()
+                                .map(convert_core_to_value)
+                                .collect::<Result<Vec<_>>>()?;
+                            Ok(Row { values })
                         })
-                        .collect();
+                        .collect::<Result<Vec<_>>>()
+                    {
+                        Ok(rows) => rows,
+                        Err(e) => {
+                            error!("Failed to encode result rows: {}", e);
+                            return StreamResult::Error {
+                                error: Error {
+                                    message: e.to_string(),
+                                    code: "ROW_ENCODING_ERROR".to_string(),
+                                },
+                            };
+                        }
+                    };
 
                     StreamResult::Ok {
                         response: StreamResponse::Execute(ExecuteStreamResp {
@@ -407,10 +423,14 @@ impl TursoSyncServer {
 
             let result_rows: Vec<Row> = rows
                 .into_iter()
-                .map(|row| Row {
-                    values: row.into_iter().map(convert_core_to_value).collect(),
+                .map(|row| {
+                    let values = row
+                        .into_iter()
+                        .map(convert_core_to_value)
+                        .collect::<Result<Vec<_>>>()?;
+                    Ok(Row { values })
                 })
-                .collect();
+                .collect::<Result<Vec<_>>>()?;
 
             Ok(StmtResult {
                 cols,
@@ -657,25 +677,46 @@ fn convert_value_to_core(value: &Value) -> CoreValue {
         Value::Integer { value } => CoreValue::from_i64(*value),
         Value::Float { value } => CoreValue::from_f64(*value),
         Value::Text { value } => CoreValue::Text(turso_core::types::Text {
-            value: std::borrow::Cow::Owned(value.clone()),
+            value: std::borrow::Cow::Owned(value.clone().into_bytes()),
             subtype: turso_core::types::TextSubtype::Text,
         }),
         Value::Blob { value } => CoreValue::Blob(value.to_vec()),
     }
 }
 
-fn convert_core_to_value(value: CoreValue) -> Value {
+fn convert_core_to_value(value: CoreValue) -> Result<Value> {
     match value {
-        CoreValue::Null => Value::Null,
-        CoreValue::Numeric(turso_core::Numeric::Integer(v)) => Value::Integer { value: v },
-        CoreValue::Numeric(turso_core::Numeric::Float(v)) => Value::Float {
+        CoreValue::Null => Ok(Value::Null),
+        CoreValue::Numeric(turso_core::Numeric::Integer(v)) => Ok(Value::Integer { value: v }),
+        CoreValue::Numeric(turso_core::Numeric::Float(v)) => Ok(Value::Float {
             value: f64::from(v),
-        },
-        CoreValue::Text(t) => Value::Text {
-            value: t.value.to_string(),
-        },
-        CoreValue::Blob(b) => Value::Blob {
+        }),
+        CoreValue::Text(t) => Ok(Value::Text {
+            value: t
+                .try_as_str()
+                .map(str::to_owned)
+                .map_err(|err| anyhow!("invalid UTF-8 in TEXT value: {err}"))?,
+        }),
+        CoreValue::Blob(b) => Ok(Value::Blob {
             value: Bytes::from(b),
-        },
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::convert_core_to_value;
+    use turso_core::Value as CoreValue;
+
+    #[test]
+    fn convert_core_to_value_rejects_invalid_text() {
+        let err = convert_core_to_value(CoreValue::from_text(vec![0xFF])).unwrap_err();
+        assert!(err.to_string().contains("invalid UTF-8 in TEXT value"));
+    }
+
+    #[test]
+    fn convert_core_to_value_keeps_valid_text() {
+        let value = convert_core_to_value(CoreValue::from_text("hello")).unwrap();
+        assert!(matches!(value, super::Value::Text { value } if value == "hello"));
     }
 }

--- a/core/btree_dump.rs
+++ b/core/btree_dump.rs
@@ -157,11 +157,11 @@ impl InternalVirtualTableCursor for BtreeDumpCursor {
         }
 
         let name = match args.first() {
-            Some(Value::Text(s)) => s.as_str(),
+            Some(Value::Text(s)) => s.as_str_lossy(),
             _ => return Ok(false),
         };
 
-        let root_page = match self.find_root_page(name) {
+        let root_page = match self.find_root_page(name.as_ref()) {
             Some(rp) if rp > 0 => rp,
             Some(_) => {
                 return Err(crate::LimboError::InternalError(format!(

--- a/core/dbpage.rs
+++ b/core/dbpage.rs
@@ -155,7 +155,12 @@ impl InternalVirtualTableCursor for DbPageCursor {
 
         if (idx_num & 2) != 0 {
             if let Some(Value::Text(schema)) = args.get(arg_idx) {
-                if schema.as_str() != "main" {
+                let schema = schema.try_as_str().map_err(|_| {
+                    LimboError::InvalidArgument(
+                        "sqlite_dbpage schema must be valid UTF-8".to_string(),
+                    )
+                })?;
+                if schema != "main" {
                     self.schema_mismatch = true;
                     return Ok(false);
                 }
@@ -218,11 +223,18 @@ fn parse_rowid(value: &Value) -> Result<Option<i64>> {
 fn ensure_main_schema(value: &Value) -> Result<()> {
     match value {
         Value::Null => Ok(()),
-        Value::Text(schema) if schema.as_str() == "main" => Ok(()),
-        Value::Text(schema) => Err(LimboError::InvalidArgument(format!(
-            "sqlite_dbpage only supports main schema (got {})",
-            schema.as_str()
-        ))),
+        Value::Text(schema) => {
+            let schema = schema.try_as_str().map_err(|_| {
+                LimboError::InvalidArgument("sqlite_dbpage schema must be valid UTF-8".to_string())
+            })?;
+            if schema == "main" {
+                Ok(())
+            } else {
+                Err(LimboError::InvalidArgument(format!(
+                    "sqlite_dbpage only supports main schema (got {schema})"
+                )))
+            }
+        }
         _ => Err(LimboError::InvalidArgument(
             "sqlite_dbpage schema must be text or null".to_string(),
         )),

--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -871,7 +871,8 @@ where
         let first = values.next().unwrap();
         match first.as_value_ref() {
             ValueRef::Text(s) => {
-                if parse_date_or_time(s.as_str(), &mut p).is_err() {
+                let s = s.as_str_lossy();
+                if parse_date_or_time(&s, &mut p).is_err() {
                     return Value::Null;
                 }
             }
@@ -898,7 +899,8 @@ where
     for (i, val) in values.enumerate() {
         has_modifier = true;
         if let ValueRef::Text(s) = val.as_value_ref() {
-            if parse_modifier(&mut p, s.as_str(), i).is_err() {
+            let s = s.as_str_lossy();
+            if parse_modifier(&mut p, &s, i).is_err() {
                 return Value::Null;
             }
         } else {
@@ -1041,7 +1043,8 @@ where
     let val1 = values.next().unwrap();
     match val1.as_value_ref() {
         ValueRef::Text(s) => {
-            if parse_date_or_time(s.as_str(), &mut d1).is_err() {
+            let s = s.as_str_lossy();
+            if parse_date_or_time(&s, &mut d1).is_err() {
                 return Value::Null;
             }
         }
@@ -1068,7 +1071,8 @@ where
     let val2 = values.next().unwrap();
     match val2.as_value_ref() {
         ValueRef::Text(s) => {
-            if parse_date_or_time(s.as_str(), &mut d2).is_err() {
+            let s = s.as_str_lossy();
+            if parse_date_or_time(&s, &mut d2).is_err() {
                 return Value::Null;
             }
         }
@@ -1189,7 +1193,7 @@ where
 
     let fmt_val = values.next().unwrap();
     let fmt_str = match fmt_val.as_value_ref() {
-        ValueRef::Text(s) => Cow::Borrowed(s.as_str()),
+        ValueRef::Text(s) => s.as_str_lossy(),
         ValueRef::Null => return Value::Null,
         val => Cow::Owned(val.to_string()),
     };
@@ -1201,7 +1205,7 @@ where
         let init_val = values.next().unwrap();
         match init_val.as_value_ref() {
             ValueRef::Text(s) => {
-                let s_str = s.as_str();
+                let s_str = s.as_str_lossy();
                 if s_str.eq_ignore_ascii_case("now") {
                     set_to_current(&mut p);
                 } else if let Ok(val) = s_str.parse::<f64>() {
@@ -1213,7 +1217,7 @@ where
                     }
                 } else {
                     let mut temp_p = DateTime::default();
-                    if parse_date_or_time(s_str, &mut temp_p).is_ok() {
+                    if parse_date_or_time(&s_str, &mut temp_p).is_ok() {
                         p = temp_p;
                     } else {
                         return Value::Null;
@@ -1241,7 +1245,8 @@ where
 
         for (i, val) in values.enumerate() {
             if let ValueRef::Text(s) = val.as_value_ref() {
-                if parse_modifier(&mut p, s.as_str(), i).is_err() {
+                let s = s.as_str_lossy();
+                if parse_modifier(&mut p, &s, i).is_err() {
                     return Value::Null;
                 }
             } else {
@@ -1632,7 +1637,7 @@ mod tests {
         for (input, expected) in test_cases {
             let result = exec_time(&[input]);
             if let Value::Text(result_str) = result {
-                assert_eq!(result_str.as_str(), expected);
+                assert_eq!(result_str.try_as_str().unwrap(), expected);
             } else {
                 panic!("Expected Value::Text, but got: {result:?}");
             }

--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -164,7 +164,7 @@ fn coerce_to_i64(value: &Value) -> i64 {
     match value {
         Value::Numeric(Numeric::Integer(i)) => *i,
         Value::Numeric(Numeric::Float(f)) => f64::from(*f) as i64,
-        Value::Text(t) => str_to_i64(t.as_str()).unwrap_or(0),
+        Value::Text(t) => str_to_i64(t.as_str_lossy()).unwrap_or(0),
         Value::Blob(b) => {
             let s = String::from_utf8_lossy(b);
             str_to_i64(s.as_ref()).unwrap_or(0)
@@ -191,7 +191,7 @@ fn coerce_to_string(value: &Value) -> String {
         Value::Null => String::new(),
         Value::Numeric(Numeric::Integer(i)) => i.to_string(),
         Value::Numeric(Numeric::Float(f)) => format_float(f64::from(*f)),
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.as_str_lossy().into_owned(),
         Value::Blob(b) => String::from_utf8_lossy(b).to_string(),
     }
 }
@@ -1073,7 +1073,7 @@ fn format_string(output: &mut String, value: &Value, spec: &FormatSpec) {
 fn format_char(output: &mut String, value: &Value, spec: &FormatSpec) {
     // In SQLite SQL context, %c takes the first character of the string representation
     let c = match value {
-        Value::Text(t) => t.value.chars().next().unwrap_or('\0'),
+        Value::Text(t) => t.as_str_lossy().chars().next().unwrap_or('\0'),
         _ => {
             let s = coerce_to_string(value);
             s.chars().next().unwrap_or('\0')
@@ -1255,19 +1255,19 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
     let format_value = values[0].get_value();
     let fmt_owned: String;
     let format_str = match &format_value {
-        Value::Text(t) => t.as_str(),
+        Value::Text(t) => t.as_str_lossy(),
         Value::Null => return Ok(Value::Null),
         Value::Numeric(Numeric::Integer(i)) => {
             fmt_owned = i.to_string();
-            fmt_owned.as_str()
+            std::borrow::Cow::Borrowed(fmt_owned.as_str())
         }
         Value::Numeric(Numeric::Float(f)) => {
             fmt_owned = format_float(f64::from(*f));
-            fmt_owned.as_str()
+            std::borrow::Cow::Borrowed(fmt_owned.as_str())
         }
         Value::Blob(b) => {
             fmt_owned = String::from_utf8_lossy(b).to_string();
-            fmt_owned.as_str()
+            std::borrow::Cow::Borrowed(fmt_owned.as_str())
         }
     };
 
@@ -1471,7 +1471,7 @@ mod tests {
         // Huge finite float must not overflow rounding to produce "inf"
         let huge = exec_printf(&[text("%f"), float(1e308)]).unwrap();
         let huge_str = match &huge {
-            Value::Text(t) => t.as_str().to_string(),
+            Value::Text(t) => t.try_as_str().unwrap().to_string(),
             _ => panic!("expected text"),
         };
         assert!(huge_str.starts_with("9999999999999999"));
@@ -1778,7 +1778,7 @@ mod tests {
         // infinity without flag_zeropad → "Inf"
         let inf_f = exec_printf(&[text("%020f"), float(f64::INFINITY)]).unwrap();
         let inf_str = match &inf_f {
-            Value::Text(t) => t.as_str().to_string(),
+            Value::Text(t) => t.try_as_str().unwrap().to_string(),
             _ => panic!("expected text"),
         };
         assert!(inf_str.starts_with("9000"));
@@ -1836,7 +1836,7 @@ mod tests {
         // ! flag with %f infinity: strips trailing fractional zeros
         let inf_bang_f = exec_printf(&[text("%!0f"), float(f64::INFINITY)]).unwrap();
         let inf_bang_str = match &inf_bang_f {
-            Value::Text(t) => t.as_str().to_string(),
+            Value::Text(t) => t.try_as_str().unwrap().to_string(),
             _ => panic!("expected text"),
         };
         assert!(

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -3145,9 +3145,9 @@ mod tests {
             if let (Value::Text(name), Value::Numeric(Numeric::Float(sum))) =
                 (&row.values[0], &row.values[1])
             {
-                if name.as_str() == "Alice" {
+                if name.try_as_str().unwrap() == "Alice" {
                     assert_eq!(*sum, 55.0, "Alice should have sum 55");
-                } else if name.as_str() == "Bob" {
+                } else if name.try_as_str().unwrap() == "Bob" {
                     assert_eq!(*sum, 20.0, "Bob should have sum 20");
                 }
             }
@@ -3815,7 +3815,7 @@ mod tests {
             .iter()
             .map(|(row, _)| {
                 if let Value::Text(name) = &row.values[1] {
-                    name.as_str().to_string()
+                    name.try_as_str().unwrap().to_string()
                 } else {
                     panic!("Expected text value");
                 }
@@ -5065,7 +5065,11 @@ mod tests {
                 Value::Numeric(Numeric::Float(total)),
             ) = (&row.values[0], &row.values[1], &row.values[2])
             {
-                let key = format!("{}-{}", name.as_ref(), product.as_ref());
+                let key = format!(
+                    "{}-{}",
+                    name.try_as_str().unwrap(),
+                    product.try_as_str().unwrap()
+                );
                 found_results.insert(key.clone());
 
                 match key.as_str() {
@@ -5663,10 +5667,10 @@ mod tests {
 
             // Check the aggregated values
             if let Value::Text(name) = &row.values[0] {
-                if name.as_ref() == "Alice" {
+                if name.try_as_str().unwrap() == "Alice" {
                     // Alice should have total quantity of 8 (5 + 3)
                     assert_eq!(row.values[1], Value::from_i64(8));
-                } else if name.as_ref() == "Bob" {
+                } else if name.try_as_str().unwrap() == "Bob" {
                     // Bob should have total quantity of 7
                     assert_eq!(row.values[1], Value::from_i64(7));
                 }

--- a/core/incremental/dbsp.rs
+++ b/core/incremental/dbsp.rs
@@ -60,7 +60,7 @@ impl Hash128 {
                 }
                 Value::Text(t) => {
                     s.push_str("T:");
-                    s.push_str(t.as_str());
+                    s.push_str(&t.as_str_lossy());
                 }
                 Value::Blob(b) => {
                     s.push_str("B:");

--- a/core/incremental/dbsp.rs
+++ b/core/incremental/dbsp.rs
@@ -60,7 +60,7 @@ impl Hash128 {
                 }
                 Value::Text(t) => {
                     s.push_str("T:");
-                    s.push_str(&t.as_str_lossy());
+                    s.push_str(&hex::encode(t.as_bytes()));
                 }
                 Value::Blob(b) => {
                     s.push_str("B:");
@@ -544,5 +544,16 @@ mod tests {
         let final_row = &delta.changes[0];
         assert_eq!(final_row.0.rowid, 2);
         assert_eq!(final_row.1, 2);
+    }
+
+    #[test]
+    fn test_hash_values_distinguishes_invalid_text_bytes() {
+        let ff = Value::Text(crate::types::Text::new(vec![0xFF]));
+        let fe = Value::Text(crate::types::Text::new(vec![0xFE]));
+
+        let ff_hash = Hash128::hash_values(&[ff]);
+        let fe_hash = Hash128::hash_values(&[fe]);
+
+        assert_ne!(ff_hash, fe_hash);
     }
 }

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -591,9 +591,9 @@ mod tests {
         for (row, weight) in &state.changes {
             assert_eq!(*weight, 1);
             if let Value::Text(team) = &row.values[0] {
-                if team.as_str() == "red" {
+                if team.try_as_str().unwrap() == "red" {
                     red_sum = Some(&row.values[1]);
-                } else if team.as_str() == "blue" {
+                } else if team.try_as_str().unwrap() == "blue" {
                     blue_sum = Some(&row.values[1]);
                 }
             }
@@ -643,7 +643,11 @@ mod tests {
 
         for (row, weight) in &output_delta.changes {
             if let Value::Text(team) = &row.values[0] {
-                assert_eq!(team.as_str(), "red", "Only red team should have changes");
+                assert_eq!(
+                    team.try_as_str().unwrap(),
+                    "red",
+                    "Only red team should have changes"
+                );
 
                 if *weight == -1 {
                     // Retraction of old value
@@ -3679,7 +3683,7 @@ mod tests {
 
             // Extract name (column 1 from left) and quantity (column 3 from right)
             let name = match &row.values[1] {
-                Value::Text(t) => t.as_str().to_string(),
+                Value::Text(t) => t.try_as_str().unwrap().to_string(),
                 _ => panic!("Expected text value for name"),
             };
             let quantity = match &row.values[4] {
@@ -4501,7 +4505,7 @@ mod tests {
             .iter()
             .map(|(row, _)| {
                 let category = match &row.values[0] {
-                    Value::Text(s) => s.value.clone().into_owned(),
+                    Value::Text(s) => s.try_as_str().unwrap().to_string(),
                     _ => panic!("Expected text for category"),
                 };
                 let value = match &row.values[1] {

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -779,7 +779,7 @@ impl HybridBTreeDirectory {
 
             // Extract and validate
             let found_path = record.get_value_opt(0).and_then(|v| match v {
-                crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
+                crate::types::ValueRef::Text(t) => Some(t.as_str_lossy().into_owned()),
                 _ => None,
             });
             let found_chunk = record.get_value_opt(1).and_then(|v| match v {
@@ -2058,7 +2058,7 @@ impl FtsCursor {
                     let record = return_if_io!(cursor.record());
                     let current_path = record.as_ref().and_then(|r| {
                         r.get_value_opt(0).and_then(|v| match v {
-                            crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
+                            crate::types::ValueRef::Text(t) => Some(t.as_str_lossy().into_owned()),
                             _ => None,
                         })
                     });
@@ -2284,7 +2284,9 @@ impl FtsCursor {
                     let record = return_if_io!(cursor.record());
                     let matches = if let Some(record) = record {
                         match record.get_value_opt(0) {
-                            Some(crate::types::ValueRef::Text(t)) => t.value == path_str,
+                            Some(crate::types::ValueRef::Text(t)) => {
+                                t.as_bytes() == path_str.as_bytes()
+                            }
                             _ => false,
                         }
                     } else {
@@ -2714,7 +2716,7 @@ impl IndexMethodCursor for FtsCursor {
                     let record = return_if_io!(cursor.record());
                     if let Some(record) = record {
                         let path_str = record.get_value_opt(0).and_then(|v| match v {
-                            crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
+                            crate::types::ValueRef::Text(t) => Some(t.as_str_lossy().into_owned()),
                             _ => None,
                         });
                         let chunk_no = record.get_value_opt(1).and_then(|v| match v {
@@ -2985,7 +2987,10 @@ impl IndexMethodCursor for FtsCursor {
         for ((_col, field), reg) in self.text_fields.iter().zip(&values[..values.len() - 1]) {
             match reg {
                 Register::Value(Value::Text(t)) => {
-                    doc.add_text(*field, t.as_str());
+                    let text = t.try_as_str().map_err(|_| {
+                        LimboError::ConversionError("FTS text values must be valid UTF-8".into())
+                    })?;
+                    doc.add_text(*field, text);
                 }
                 Register::Value(Value::Null) => continue,
                 _ => continue,
@@ -3063,7 +3068,10 @@ impl IndexMethodCursor for FtsCursor {
 
         // values[1] = query string
         let query_str = match &values[1] {
-            Register::Value(Value::Text(t)) => t.as_str().to_string(),
+            Register::Value(Value::Text(t)) => t
+                .try_as_str()
+                .map(str::to_owned)
+                .map_err(|_| LimboError::ConversionError("FTS query must be valid UTF-8".into()))?,
             _ => return Err(LimboError::InternalError("FTS query must be text".into())),
         };
 

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -366,10 +366,10 @@ impl VectorSparseInvertedIndexMethodCursor {
             _ => 1.0,
         };
         let scan_order = match configuration.parameters.get("scan_order") {
-            Some(Value::Text(scan_order)) if scan_order.as_str() == "dataset_frequency_asc" => {
+            Some(Value::Text(scan_order)) if scan_order.as_bytes() == b"dataset_frequency_asc" => {
                 ScanOrder::DatasetFrequencyAsc
             }
-            Some(Value::Text(scan_order)) if scan_order.as_str() == "query_weight_desc" => {
+            Some(Value::Text(scan_order)) if scan_order.as_bytes() == b"query_weight_desc" => {
                 ScanOrder::QueryWeightDesc
             }
             _ => ScanOrder::QueryWeightDesc,

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -922,7 +922,10 @@ mod tests {
         let input = Value::build_text("{ key: 'value' }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.try_as_str().unwrap().contains("\"key\":\"value\""));
+            assert!(result_str
+                .try_as_str()
+                .unwrap()
+                .contains("\"key\":\"value\""));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -946,7 +949,10 @@ mod tests {
         let input = Value::build_text("{ \"key\": -Infinity }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.try_as_str().unwrap().contains("{\"key\":-9e999}"));
+            assert!(result_str
+                .try_as_str()
+                .unwrap()
+                .contains("{\"key\":-9e999}"));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -980,7 +986,10 @@ mod tests {
         let input = Value::build_text("{\"key\":\"value\"}");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.try_as_str().unwrap().contains("\"key\":\"value\""));
+            assert!(result_str
+                .try_as_str()
+                .unwrap()
+                .contains("\"key\":\"value\""));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1410,7 +1419,10 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.try_as_str().unwrap(), r#"{"key":{"json":"value"}}"#);
+        assert_eq!(
+            json_text.try_as_str().unwrap(),
+            r#"{"key":{"json":"value"}}"#
+        );
     }
 
     #[test]

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -131,11 +131,17 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
     match val {
         ValueRef::Text(text) => {
             let res = if text.subtype == TextSubtype::Json || matches!(strict, Conv::Strict) {
-                Jsonb::from_str_with_mode(&text, strict)
+                let text = text
+                    .try_as_str()
+                    .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))?;
+                Jsonb::from_str_with_mode(text, strict)
             } else {
                 // Handle as a string literal otherwise
                 // Escape backslashes first, then double quotes
-                let mut str = text.replace('\\', "\\\\").replace('"', "\\\"");
+                let mut str = text
+                    .as_str_lossy()
+                    .replace('\\', "\\\\")
+                    .replace('"', "\\\"");
                 // Quote the string to make it a JSON string
                 str.insert(0, '"');
                 str.push('"');
@@ -687,24 +693,32 @@ fn json_path_from_db_value<'a>(
     let path = path.as_value_ref();
     let json_path = if strict {
         match path {
-            ValueRef::Text(t) => json_path(t.as_str())?,
+            ValueRef::Text(t) => {
+                let text = t.try_as_str().map_err(|_| {
+                    LimboError::Constraint(format!("JSON path error near: {:?}", t.as_str_lossy()))
+                })?;
+                json_path(text)?
+            }
             ValueRef::Null => return Ok(None),
             _ => crate::bail_constraint_error!("JSON path error near: {:?}", path.to_string()),
         }
     } else {
         match path {
-            ValueRef::Text(t) => {
-                if t.as_str().starts_with("$") {
-                    json_path(t.as_str())?
-                } else {
-                    JsonPath {
-                        elements: vec![
-                            PathElement::Root(),
-                            PathElement::Key(Cow::Borrowed(t.as_str()), false),
-                        ],
-                    }
-                }
-            }
+            ValueRef::Text(t) => match t.try_as_str() {
+                Ok(text) if text.starts_with("$") => json_path(text)?,
+                Ok(text) => JsonPath {
+                    elements: vec![
+                        PathElement::Root(),
+                        PathElement::Key(Cow::Borrowed(text), false),
+                    ],
+                },
+                Err(_) => JsonPath {
+                    elements: vec![
+                        PathElement::Root(),
+                        PathElement::Key(Cow::Owned(t.as_str_lossy().into_owned()), false),
+                    ],
+                },
+            },
             ValueRef::Null => return Ok(None),
             ValueRef::Numeric(Numeric::Integer(i)) => JsonPath {
                 elements: vec![
@@ -727,7 +741,7 @@ fn json_path_from_db_value<'a>(
 
 pub fn json_error_position(json: impl AsValueRef) -> crate::Result<Value> {
     match json.as_value_ref() {
-        ValueRef::Text(t) => match Jsonb::from_str(t.as_str()) {
+        ValueRef::Text(t) => match Jsonb::from_str(&t.as_str_lossy()) {
             Ok(_) => Ok(Value::from_i64(0)),
             Err(JsonError::Message { location, .. }) => {
                 if let Some(loc) = location {
@@ -871,7 +885,7 @@ pub fn json_quote(value: impl AsValueRef) -> crate::Result<Value> {
             let mut escaped_value = String::with_capacity(t.value.len() + 4);
             escaped_value.push('"');
 
-            for c in t.as_str().chars() {
+            for c in t.as_str_lossy().chars() {
                 match c {
                     '"' | '\\' | '\n' | '\r' | '\t' | '\u{0008}' | '\u{000c}' => {
                         escaped_value.push('\\');
@@ -908,7 +922,7 @@ mod tests {
         let input = Value::build_text("{ key: 'value' }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("\"key\":\"value\""));
+            assert!(result_str.try_as_str().unwrap().contains("\"key\":\"value\""));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -920,7 +934,7 @@ mod tests {
         let input = Value::build_text("{ \"key\": Infinity }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("{\"key\":9e999}"));
+            assert!(result_str.try_as_str().unwrap().contains("{\"key\":9e999}"));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -932,7 +946,7 @@ mod tests {
         let input = Value::build_text("{ \"key\": -Infinity }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("{\"key\":-9e999}"));
+            assert!(result_str.try_as_str().unwrap().contains("{\"key\":-9e999}"));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -944,7 +958,7 @@ mod tests {
         let input = Value::build_text("{ \"key\": NaN }");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("{\"key\":null}"));
+            assert!(result_str.try_as_str().unwrap().contains("{\"key\":null}"));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -966,7 +980,7 @@ mod tests {
         let input = Value::build_text("{\"key\":\"value\"}");
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains("\"key\":\"value\""));
+            assert!(result_str.try_as_str().unwrap().contains("\"key\":\"value\""));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -989,7 +1003,7 @@ mod tests {
         let input = Value::Blob(binary_json);
         let result = get_json(&input, None).unwrap();
         if let Value::Text(result_str) = result {
-            assert!(result_str.as_str().contains(r#"{"hey":"yo"}"#));
+            assert!(result_str.try_as_str().unwrap().contains(r#"{"hey":"yo"}"#));
             assert_eq!(result_str.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1027,7 +1041,7 @@ mod tests {
 
         let result = json_array(&input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "[\"value1\",\"value2\",1,1.1]");
+            assert_eq!(res.try_as_str().unwrap(), "[\"value1\",\"value2\",1,1.1]");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1042,7 +1056,7 @@ mod tests {
 
         let result = json_array(&input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "[1,9.0e+999,-9.0e+999]");
+            assert_eq!(res.try_as_str().unwrap(), "[1,9.0e+999,-9.0e+999]");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1057,7 +1071,7 @@ mod tests {
 
         let result = json_object(&input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), r#"{"k":9.0e+999}"#);
+            assert_eq!(res.try_as_str().unwrap(), r#"{"k":9.0e+999}"#);
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1072,7 +1086,7 @@ mod tests {
 
         let result = json_object(&input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), r#"{"k":-9.0e+999}"#);
+            assert_eq!(res.try_as_str().unwrap(), r#"{"k":-9.0e+999}"#);
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1084,7 +1098,7 @@ mod tests {
         let infinity = Value::from_f64(f64::INFINITY);
         let result = get_json(&infinity, None).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "9e999");
+            assert_eq!(res.try_as_str().unwrap(), "9e999");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text, got {result:?}");
@@ -1096,7 +1110,7 @@ mod tests {
         let neg_infinity = Value::from_f64(f64::NEG_INFINITY);
         let result = get_json(&neg_infinity, None).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "-9e999");
+            assert_eq!(res.try_as_str().unwrap(), "-9e999");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text, got {result:?}");
@@ -1109,7 +1123,7 @@ mod tests {
 
         let result = json_array(input).unwrap();
         if let Value::Text(res) = result {
-            assert_eq!(res.as_str(), "[]");
+            assert_eq!(res.try_as_str().unwrap(), "[]");
             assert_eq!(res.subtype, TextSubtype::Json);
         } else {
             panic!("Expected Value::Text");
@@ -1347,7 +1361,7 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"key":"value"}"#);
+        assert_eq!(json_text.try_as_str().unwrap(), r#"{"key":"value"}"#);
     }
 
     #[test]
@@ -1381,7 +1395,7 @@ mod tests {
             panic!("Expected Value::Text");
         };
         assert_eq!(
-            json_text.as_str(),
+            json_text.try_as_str().unwrap(),
             r#"{"text_key":"text_value","json_key":{"json":"value","number":1},"integer_key":1,"float_key":1.1,"null_key":null}"#
         );
     }
@@ -1396,7 +1410,7 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"key":{"json":"value"}}"#);
+        assert_eq!(json_text.try_as_str().unwrap(), r#"{"key":{"json":"value"}}"#);
     }
 
     #[test]
@@ -1409,7 +1423,10 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"key":"{\"json\":\"value\"}"}"#);
+        assert_eq!(
+            json_text.try_as_str().unwrap(),
+            r#"{"key":"{\"json\":\"value\"}"}"#
+        );
     }
 
     #[test]
@@ -1427,7 +1444,10 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"parent_key":{"key":"value"}}"#);
+        assert_eq!(
+            json_text.try_as_str().unwrap(),
+            r#"{"parent_key":{"key":"value"}}"#
+        );
     }
 
     #[test]
@@ -1440,7 +1460,10 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{"key":"value","key":"value"}"#);
+        assert_eq!(
+            json_text.try_as_str().unwrap(),
+            r#"{"key":"value","key":"value"}"#
+        );
     }
 
     #[test]
@@ -1451,7 +1474,7 @@ mod tests {
         let Value::Text(json_text) = result else {
             panic!("Expected Value::Text");
         };
-        assert_eq!(json_text.as_str(), r#"{}"#);
+        assert_eq!(json_text.try_as_str().unwrap(), r#"{}"#);
     }
 
     #[test]
@@ -1499,7 +1522,7 @@ mod tests {
                 panic!("Expected Value::Text");
             };
             assert_eq!(
-                json_text.as_str(),
+                json_text.try_as_str().unwrap(),
                 expected,
                 "Failed for key={key:?}, value={value:?}"
             );

--- a/core/json/ops.rs
+++ b/core/json/ops.rs
@@ -28,7 +28,7 @@ pub fn json_patch(
         // Explicit handling for the case json_path('{}', 'null') case. If the patch value is
         // the text null, the result will also be the text null. No extra parsing required.
         (_, ValueRef::Text(t)) => {
-            if t.value == "null" {
+            if t.as_bytes() == b"null" {
                 return Ok(Value::Text(Text::new("null")));
             }
         }
@@ -103,7 +103,7 @@ where
     let mut json = json_cache.get_or_insert_with(first_arg, make_jsonb_fn)?;
     for arg in args {
         if let ValueRef::Text(s) = arg.as_value_ref() {
-            if s.as_str() == "$" {
+            if s.as_str_lossy() == "$" {
                 return Ok(Value::Null);
             }
         }
@@ -136,7 +136,7 @@ where
     let mut json = json_cache.get_or_insert_with(first_arg, make_jsonb_fn)?;
     for arg in args {
         if let ValueRef::Text(s) = arg.as_value_ref() {
-            if s.as_str() == "$" {
+            if s.as_str_lossy() == "$" {
                 return Ok(Value::Null);
             }
         }
@@ -432,7 +432,7 @@ mod tests {
         let json_cache = JsonCacheCell::new();
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
-            Value::Text(t) => assert_eq!(t.as_str(), "[1,2,4,5]"),
+            Value::Text(t) => assert_eq!(t.try_as_str().unwrap(), "[1,2,4,5]"),
             _ => panic!("Expected Text value"),
         }
     }
@@ -448,7 +448,7 @@ mod tests {
         let json_cache = JsonCacheCell::new();
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
-            Value::Text(t) => assert_eq!(t.as_str(), r#"{"b":2}"#),
+            Value::Text(t) => assert_eq!(t.try_as_str().unwrap(), r#"{"b":2}"#),
             _ => panic!("Expected Text value"),
         }
     }
@@ -463,7 +463,7 @@ mod tests {
         let json_cache = JsonCacheCell::new();
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
-            Value::Text(t) => assert_eq!(t.as_str(), r#"{"a":{"b":{"d":2}}}"#),
+            Value::Text(t) => assert_eq!(t.try_as_str().unwrap(), r#"{"a":{"b":{"d":2}}}"#),
             _ => panic!("Expected Text value"),
         }
     }
@@ -478,7 +478,7 @@ mod tests {
         let json_cache = JsonCacheCell::new();
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
-            Value::Text(t) => assert_eq!(t.as_str(), r#"{"a":2,"a":3}"#),
+            Value::Text(t) => assert_eq!(t.try_as_str().unwrap(), r#"{"a":2,"a":3}"#),
             _ => panic!("Expected Text value"),
         }
     }
@@ -507,7 +507,7 @@ mod tests {
         let result = json_remove(&args, &json_cache).unwrap();
         match result {
             Value::Text(t) => {
-                let value = t.as_str();
+                let value = t.try_as_str().unwrap();
                 assert!(value.contains(r#"[1,3]"#));
                 assert!(value.contains(r#"{"x":2}"#));
             }

--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -259,11 +259,7 @@ impl InternalVirtualTableCursor for JsonEachCursor {
         if args.len() == 2 && matches!(self.traversal_mode, JsonTraversalMode::Tree) {
             if let Value::Text(ref text) = args[1] {
                 if !text.value.is_empty()
-                    && text
-                        .value
-                        .as_bytes()
-                        .windows(3)
-                        .any(|chars| chars == b"[#-")
+                    && text.value.as_ref().windows(3).any(|chars| chars == b"[#-")
                 {
                     return Err(LimboError::InvalidArgument(
                         "Json paths with negative indices in json_tree are not supported yet"
@@ -276,7 +272,7 @@ impl InternalVirtualTableCursor for JsonEachCursor {
         let mut jsonb = convert_dbtype_to_jsonb(&args[0], Conv::Strict)?;
 
         let (path, root_json) = if args.len() == 1 {
-            let path = "$";
+            let path = "$".to_string();
             (path, jsonb)
         } else {
             let Value::Text(path) = &args[1] else {
@@ -289,12 +285,12 @@ impl InternalVirtualTableCursor for JsonEachCursor {
             } else {
                 return Ok(false);
             };
-            (path.as_str(), root_json)
+            (path.as_str_lossy().into_owned(), root_json)
         };
 
         self.json = root_json;
         self.path_to_current_value =
-            InPlaceJsonPath::from_json_path(path.to_owned(), json_path(path)?);
+            InPlaceJsonPath::from_json_path(path.clone(), json_path(&path)?);
         let iterator_state = json_iterator_from(&self.json)?;
         let innermost_container_path = if matches!(self.traversal_mode, JsonTraversalMode::Tree)
             && matches!(iterator_state, IteratorState::Primitive(_))

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -356,7 +356,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
     ///    * The row is not a delete (we inserted or changed an existing row), OR
     ///    * The row is a delete AND it exists in the database file already.
     ///      If the row didn't exist in the database file and was deleted, we can simply not write it.
-    fn collect_committed_table_row_versions(&mut self) {
+    fn collect_committed_table_row_versions(&mut self) -> Result<()> {
         // Invariant: RowID ordering is (table_id, row_id) with table_id ascending.
         // Since MV table IDs are negative and sqlite_schema is table_id=-1, iterating
         // in reverse visits sqlite_schema first so CREATE/DROP metadata is applied
@@ -395,9 +395,12 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     let ValueRef::Text(type_str) = col0 else {
                         panic!("sqlite_schema.type column must be TEXT, got {col0:?}");
                     };
+                    let type_str = type_str.try_as_str().map_err(|_| {
+                        LimboError::Corrupt("sqlite_schema.type must be valid UTF-8".into())
+                    })?;
 
                     if let ValueRef::Numeric(Numeric::Integer(root_page)) = col3 {
-                        if type_str.as_str() == "index" {
+                        if type_str == "index" {
                             // This is an index schema change
                             if is_delete {
                                 // DROP INDEX
@@ -452,7 +455,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                                 // to index SQL). No B-tree creation needed; the row itself is written
                                 // to sqlite_schema below. See: test_checkpoint_allows_index_schema_update_after_rename_column.
                             }
-                        } else if type_str.as_str() == "table" {
+                        } else if type_str == "table" {
                             // This is a table schema change (existing logic)
                             tracing::trace!("table schema change with root page {root_page}, is_delete={is_delete}");
                             if is_delete {
@@ -512,6 +515,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 version.0.row.id.row_id.clone(),
             )
         });
+        Ok(())
     }
 
     /// Collect all committed index row versions that need to be written to the B-tree.
@@ -713,7 +717,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 }
                 self.lock_states.blocking_checkpoint_lock_held = true;
 
-                self.collect_committed_table_row_versions();
+                self.collect_committed_table_row_versions()?;
                 tracing::info!("Collected {} committed versions", self.write_set.len());
 
                 self.collect_committed_index_row_versions();

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4477,7 +4477,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
                 for record in schema_rows.values() {
                     let ty = match record.get_value_opt(0) {
-                        Some(ValueRef::Text(v)) => v.as_str(),
+                        Some(ValueRef::Text(v)) => v.try_as_str().map_err(|_| {
+                            LimboError::Corrupt("sqlite_schema type must be valid UTF-8".into())
+                        })?,
                         _ => {
                             return Err(LimboError::Corrupt(
                                 "sqlite_schema type must be text".to_string(),
@@ -4485,7 +4487,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         }
                     };
                     let name = match record.get_value_opt(1) {
-                        Some(ValueRef::Text(v)) => v.as_str(),
+                        Some(ValueRef::Text(v)) => v.try_as_str().map_err(|_| {
+                            LimboError::Corrupt("sqlite_schema name must be valid UTF-8".into())
+                        })?,
                         _ => {
                             return Err(LimboError::Corrupt(
                                 "sqlite_schema name must be text".to_string(),
@@ -4493,7 +4497,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         }
                     };
                     let table_name = match record.get_value_opt(2) {
-                        Some(ValueRef::Text(v)) => v.as_str(),
+                        Some(ValueRef::Text(v)) => v.try_as_str().map_err(|_| {
+                            LimboError::Corrupt("sqlite_schema tbl_name must be valid UTF-8".into())
+                        })?,
                         _ => {
                             return Err(LimboError::Corrupt(
                                 "sqlite_schema tbl_name must be text".to_string(),
@@ -4509,7 +4515,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         }
                     };
                     let sql = match record.get_value_opt(4) {
-                        Some(ValueRef::Text(v)) => Some(v.as_str()),
+                        Some(ValueRef::Text(v)) => Some(v.try_as_str().map_err(|_| {
+                            LimboError::Corrupt("sqlite_schema sql must be valid UTF-8".into())
+                        })?),
                         _ => None,
                     };
                     fresh.handle_schema_row(
@@ -4612,7 +4620,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                 "sqlite_schema type must be text".to_string(),
                             ));
                         };
-                        let row_type = row_type.as_str();
+                        let row_type = row_type.try_as_str().map_err(|_| {
+                            LimboError::Corrupt("sqlite_schema type must be valid UTF-8".into())
+                        })?;
                         let val = match record.get_value_opt(3) {
                             Some(v) => v,
                             None => {
@@ -4626,7 +4636,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             panic!("Expected integer value for root page, got {val:?}");
                         };
                         let sql = match record.get_value_opt(4) {
-                            Some(ValueRef::Text(v)) => Some(v.as_str()),
+                            Some(ValueRef::Text(v)) => Some(v.try_as_str().map_err(|_| {
+                                LimboError::Corrupt("sqlite_schema sql must be valid UTF-8".into())
+                            })?),
                             _ => None,
                         };
                         let is_virtual_table = row_type == "table"
@@ -4765,7 +4777,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                 "sqlite_schema type must be text".to_string(),
                             ));
                         };
-                        let row_type = row_type.as_str();
+                        let row_type = row_type.try_as_str().map_err(|_| {
+                            LimboError::Corrupt("sqlite_schema type must be valid UTF-8".into())
+                        })?;
                         let Some(ValueRef::Numeric(Numeric::Integer(root_page))) =
                             record.get_value_opt(3)
                         else {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -459,7 +459,7 @@ fn tamper_db_metadata_row_value(db_path: &str, metadata_root_page: u32, new_valu
     };
     let new_record = ImmutableRecord::from_values(
         &[
-            Value::Text(Text::new(key.as_str().to_string())),
+            Value::Text(Text::new(key.try_as_str().unwrap().to_string())),
             Value::from_i64(new_value),
         ],
         2,
@@ -486,7 +486,7 @@ fn tamper_db_metadata_row_value_by_key(
         let ValueRef::Text(key) = key else {
             panic!("metadata key must be text");
         };
-        if key.as_str() != target_key {
+        if key.try_as_str().unwrap() != target_key {
             continue;
         }
         let new_record = ImmutableRecord::from_values(
@@ -4187,7 +4187,7 @@ fn test_restart() {
         let record = get_record_value(&row);
         match record.get_value(0).unwrap() {
             ValueRef::Text(text) => {
-                assert_eq!(text.as_str(), "bar");
+                assert_eq!(text.try_as_str().unwrap(), "bar");
             }
             _ => panic!("Expected Text value"),
         }
@@ -8098,7 +8098,7 @@ fn test_mvcc_encrypted_log_recovery_and_wrong_key() {
             .unwrap();
         let record = get_record_value(&row);
         match record.get_value(0).unwrap() {
-            ValueRef::Text(text) => assert_eq!(text.as_str(), "encrypted_value"),
+            ValueRef::Text(text) => assert_eq!(text.try_as_str().unwrap(), "encrypted_value"),
             other => panic!("Expected Text, got {other:?}"),
         }
         conn.close().unwrap();

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1974,7 +1974,7 @@ mod tests {
         let ValueRef::Text(foo) = foo else {
             unreachable!()
         };
-        assert_eq!(foo.as_str(), "foo");
+        assert_eq!(foo.try_as_str().unwrap(), "foo");
     }
 
     /// What this test checks: A long sequence of committed frames is replayed in order without dropping or reordering transactions.
@@ -2052,7 +2052,7 @@ mod tests {
             let ValueRef::Text(foo) = foo else {
                 unreachable!()
             };
-            assert_eq!(foo.as_str(), value.as_str());
+            assert_eq!(foo.try_as_str().unwrap(), value.as_str());
         }
     }
 
@@ -2173,7 +2173,7 @@ mod tests {
             };
 
             assert_eq!(
-                foo.as_str(),
+                foo.try_as_str().unwrap(),
                 format!("row_{}", present_rowid.row_id.to_int_or_panic())
             );
         }
@@ -2252,7 +2252,7 @@ mod tests {
             let ValueRef::Text(data_text) = data_value else {
                 panic!("Data column should be text");
             };
-            assert_eq!(data_text.as_str(), expected_data);
+            assert_eq!(data_text.try_as_str().unwrap(), expected_data);
         }
 
         // Verify index rows can be read
@@ -2297,7 +2297,11 @@ mod tests {
             let ValueRef::Text(index_data) = values[0] else {
                 panic!("First index column should be text");
             };
-            assert_eq!(index_data.as_str(), data_value, "Index data should match");
+            assert_eq!(
+                index_data.try_as_str().unwrap(),
+                data_value,
+                "Index data should match"
+            );
             let ValueRef::Numeric(crate::numeric::Numeric::Integer(index_rowid_val)) = values[1]
             else {
                 panic!("Second index column should be integer (rowid)");

--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -53,7 +53,7 @@ impl Numeric {
         match value {
             ValueRef::Null => None,
             ValueRef::Numeric(v) => Some(v),
-            ValueRef::Text(text) => Some(Numeric::from(text.as_str())),
+            ValueRef::Text(text) => Some(Numeric::from(text.as_str_lossy())),
             ValueRef::Blob(blob) => {
                 let text = String::from_utf8_lossy(blob);
                 Some(Numeric::from(&text))
@@ -67,15 +67,15 @@ impl Numeric {
             Value::Null | Value::Blob(_) => None,
             Value::Numeric(n) => Some(*n),
             Value::Text(text) => {
-                let s = text.as_str();
+                let s = text.as_str_lossy();
 
-                match str_to_f64(s) {
+                match str_to_f64(&s) {
                     None
                     | Some(StrToF64::FractionalPrefix(_))
                     | Some(StrToF64::DecimalPrefix(_)) => None,
                     Some(StrToF64::Fractional(value)) => Some(Self::Float(value)),
                     Some(StrToF64::Decimal(real)) => {
-                        let integer = str_to_i64(s).unwrap_or(0);
+                        let integer = str_to_i64(&s).unwrap_or(0);
 
                         Some(if real == integer as f64 {
                             Self::Integer(integer)
@@ -220,7 +220,7 @@ impl From<&Value> for Option<Numeric> {
         match value {
             Value::Null => None,
             Value::Numeric(n) => Some(*n),
-            Value::Text(text) => Some(Numeric::from(text.as_str())),
+            Value::Text(text) => Some(Numeric::from(text.as_str_lossy())),
             Value::Blob(blob) => {
                 let text = String::from_utf8_lossy(blob.as_slice());
                 Some(Numeric::from(&text))
@@ -343,7 +343,7 @@ impl From<&Value> for NullableInteger {
             Value::Null => Self::Null,
             Value::Numeric(Numeric::Integer(v)) => Self::Integer(*v),
             Value::Numeric(Numeric::Float(v)) => Self::Integer(f64::from(*v) as i64),
-            Value::Text(text) => Self::from(text.as_str()),
+            Value::Text(text) => Self::from(text.as_str_lossy()),
             Value::Blob(blob) => {
                 let text = String::from_utf8_lossy(blob.as_slice());
                 Self::from(text)

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1050,16 +1050,31 @@ impl Schema {
                         ValueRef::Text(sql) => Some(sql),
                         _ => None,
                     };
-                    let sql = sql_textref.map(|s| s.as_str());
+                    let ty = ty.try_as_str().map_err(|_| {
+                        LimboError::Corrupt("sqlite_schema type must be valid UTF-8".into())
+                    })?;
+                    let name = name.try_as_str().map_err(|_| {
+                        LimboError::Corrupt("sqlite_schema name must be valid UTF-8".into())
+                    })?;
+                    let table_name = table_name.try_as_str().map_err(|_| {
+                        LimboError::Corrupt("sqlite_schema tbl_name must be valid UTF-8".into())
+                    })?;
+                    let sql = sql_textref
+                        .map(|s| {
+                            s.try_as_str().map_err(|_| {
+                                LimboError::Corrupt("sqlite_schema sql must be valid UTF-8".into())
+                            })
+                        })
+                        .transpose()?;
 
                     let acc = state
                         .accumulators
                         .as_mut()
                         .expect("accumulators must be initialized in Init phase");
                     self.handle_schema_row(
-                        &ty,
-                        &name,
-                        &table_name,
+                        ty,
+                        name,
+                        table_name,
                         root_page,
                         sql,
                         syms,

--- a/core/stats.rs
+++ b/core/stats.rs
@@ -137,11 +137,11 @@ fn load_sqlite_stat1_from_stmt(
 
         let idx_name = match idx_value {
             Value::Null => None,
-            Value::Text(s) => Some(s.as_str()),
+            Value::Text(s) => Some(s.as_str_lossy()),
             _ => None,
         };
         let stat = match stat_value {
-            Value::Text(s) => s.as_str(),
+            Value::Text(s) => s.as_str_lossy(),
             _ => return Ok(()),
         };
 
@@ -149,7 +149,7 @@ fn load_sqlite_stat1_from_stmt(
         if schema.get_btree_table(table_name).is_none() {
             return Ok(());
         }
-        let Some(numbers) = parse_stat_numbers(stat) else {
+        let Some(numbers) = parse_stat_numbers(&stat) else {
             return Ok(());
         };
         if numbers.is_empty() {
@@ -163,7 +163,7 @@ fn load_sqlite_stat1_from_stmt(
         }
 
         // Index-level entry: only keep if the index exists on this table.
-        let idx_name = normalize_ident(idx_name.unwrap());
+        let idx_name = normalize_ident(idx_name.as_deref().unwrap());
         if schema.get_index(table_name, &idx_name).is_none() {
             return Ok(());
         }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -957,6 +957,12 @@ pub fn validate_serial_type(value: u64) -> Result<()> {
     Ok(())
 }
 
+#[inline(always)]
+pub(crate) fn decode_text_serial_type(data: &[u8]) -> Result<&str> {
+    std::str::from_utf8(data)
+        .map_err(|e| LimboError::Corrupt(format!("Invalid UTF-8 in TEXT serial type: {e}")))
+}
+
 /// Reads a value that might reference the buffer it is reading from. Be sure to store RefValue with the buffer
 /// always.
 #[inline(always)]
@@ -1078,8 +1084,7 @@ pub fn read_value<'a>(buf: &'a [u8], serial_type: SerialType) -> Result<(ValueRe
                     content_size
                 ))
             })?;
-            // SAFETY: SerialTypeKind is Text so this buffer is a valid string
-            let val = unsafe { std::str::from_utf8_unchecked(data) };
+            let val = decode_text_serial_type(data)?;
             Ok((
                 ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
                 content_size,
@@ -1206,8 +1211,7 @@ pub fn read_value_serial_type<'a>(
                         content_size
                     ))
                 })?;
-                // SAFETY: SerialTypeKind is Text so this buffer is a valid string
-                let val = unsafe { std::str::from_utf8_unchecked(data) };
+                let val = decode_text_serial_type(data)?;
                 Ok((
                     ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
                     content_size,
@@ -2077,6 +2081,24 @@ mod tests {
     ) {
         let result = read_value(buf, serial_type).unwrap();
         assert_eq!(result.0.to_owned(), expected);
+    }
+
+    #[test]
+    fn test_read_value_rejects_invalid_utf8_text() {
+        let result = read_value(&[0xFF], SerialType::text(1));
+        assert!(
+            matches!(result, Err(LimboError::Corrupt(ref msg)) if msg.contains("Invalid UTF-8 in TEXT serial type")),
+            "expected invalid UTF-8 TEXT error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_read_value_serial_type_rejects_invalid_utf8_text() {
+        let result = read_value_serial_type(&[0xFF], 15);
+        assert!(
+            matches!(result, Err(LimboError::Corrupt(ref msg)) if msg.contains("Invalid UTF-8 in TEXT serial type")),
+            "expected invalid UTF-8 TEXT error, got {result:?}"
+        );
     }
 
     #[test]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -957,12 +957,6 @@ pub fn validate_serial_type(value: u64) -> Result<()> {
     Ok(())
 }
 
-#[inline(always)]
-pub(crate) fn decode_text_serial_type(data: &[u8]) -> Result<&str> {
-    std::str::from_utf8(data)
-        .map_err(|e| LimboError::Corrupt(format!("Invalid UTF-8 in TEXT serial type: {e}")))
-}
-
 /// Reads a value that might reference the buffer it is reading from. Be sure to store RefValue with the buffer
 /// always.
 #[inline(always)]
@@ -1084,9 +1078,8 @@ pub fn read_value<'a>(buf: &'a [u8], serial_type: SerialType) -> Result<(ValueRe
                     content_size
                 ))
             })?;
-            let val = decode_text_serial_type(data)?;
             Ok((
-                ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
+                ValueRef::Text(TextRef::new(data, TextSubtype::Text)),
                 content_size,
             ))
         }
@@ -1211,9 +1204,8 @@ pub fn read_value_serial_type<'a>(
                         content_size
                     ))
                 })?;
-                let val = decode_text_serial_type(data)?;
                 Ok((
-                    ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
+                    ValueRef::Text(TextRef::new(data, TextSubtype::Text)),
                     content_size,
                 ))
             }
@@ -2084,21 +2076,23 @@ mod tests {
     }
 
     #[test]
-    fn test_read_value_rejects_invalid_utf8_text() {
-        let result = read_value(&[0xFF], SerialType::text(1));
-        assert!(
-            matches!(result, Err(LimboError::Corrupt(ref msg)) if msg.contains("Invalid UTF-8 in TEXT serial type")),
-            "expected invalid UTF-8 TEXT error, got {result:?}"
-        );
+    fn test_read_value_preserves_invalid_text_bytes() {
+        let (value, consumed) = read_value(&[0xFF], SerialType::text(1)).unwrap();
+        assert_eq!(consumed, 1);
+        match value {
+            ValueRef::Text(text) => assert_eq!(text.as_bytes(), &[0xFF]),
+            other => panic!("expected text value, got {other:?}"),
+        }
     }
 
     #[test]
-    fn test_read_value_serial_type_rejects_invalid_utf8_text() {
-        let result = read_value_serial_type(&[0xFF], 15);
-        assert!(
-            matches!(result, Err(LimboError::Corrupt(ref msg)) if msg.contains("Invalid UTF-8 in TEXT serial type")),
-            "expected invalid UTF-8 TEXT error, got {result:?}"
-        );
+    fn test_read_value_serial_type_preserves_invalid_text_bytes() {
+        let (value, consumed) = read_value_serial_type(&[0xFF], 15).unwrap();
+        assert_eq!(consumed, 1);
+        match value {
+            ValueRef::Text(text) => assert_eq!(text.as_bytes(), &[0xFF]),
+            other => panic!("expected text value, got {other:?}"),
+        }
     }
 
     #[test]

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -46,6 +46,11 @@ impl CollationSeq {
 
     #[inline(always)]
     pub fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
+        self.compare_texts(lhs.as_bytes(), rhs.as_bytes())
+    }
+
+    #[inline(always)]
+    pub fn compare_texts(&self, lhs: &[u8], rhs: &[u8]) -> Ordering {
         match self {
             CollationSeq::Unset | CollationSeq::Binary => Self::binary_cmp(lhs, rhs),
             CollationSeq::NoCase => Self::nocase_cmp(lhs, rhs),
@@ -54,20 +59,37 @@ impl CollationSeq {
     }
 
     #[inline(always)]
-    fn binary_cmp(lhs: &str, rhs: &str) -> Ordering {
+    fn binary_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
         lhs.cmp(rhs)
     }
 
     #[inline(always)]
-    fn nocase_cmp(lhs: &str, rhs: &str) -> Ordering {
-        let nocase_lhs = uncased::UncasedStr::new(lhs);
-        let nocase_rhs = uncased::UncasedStr::new(rhs);
-        nocase_lhs.cmp(nocase_rhs)
+    fn nocase_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        let common_len = lhs.len().min(rhs.len());
+        for i in 0..common_len {
+            let l = lhs[i].to_ascii_lowercase();
+            let r = rhs[i].to_ascii_lowercase();
+            match l.cmp(&r) {
+                Ordering::Equal => continue,
+                non_eq => return non_eq,
+            }
+        }
+        lhs.len().cmp(&rhs.len())
     }
 
     #[inline(always)]
-    fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
-        lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' '))
+    fn rtrim_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        let lhs = lhs
+            .iter()
+            .rposition(|&b| b != b' ')
+            .map(|i| &lhs[..=i])
+            .unwrap_or(&[]);
+        let rhs = rhs
+            .iter()
+            .rposition(|&b| b != b' ')
+            .map(|i| &rhs[..=i])
+            .unwrap_or(&[]);
+        lhs.cmp(rhs)
     }
 }
 

--- a/core/types.rs
+++ b/core/types.rs
@@ -68,66 +68,93 @@ pub enum TextSubtype {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Text {
-    pub value: Cow<'static, str>,
+    pub value: Cow<'static, [u8]>,
     pub subtype: TextSubtype,
 }
 
 impl Display for Text {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
+        write!(f, "{}", self.as_str_lossy())
     }
 }
 
 impl Text {
-    pub fn new(value: impl Into<Cow<'static, str>>) -> Self {
+    pub fn new(value: impl Into<Vec<u8>>) -> Self {
         Self {
-            value: value.into(),
+            value: Cow::Owned(value.into()),
             subtype: TextSubtype::Text,
         }
     }
     #[cfg(feature = "json")]
     pub fn json(value: String) -> Self {
         Self {
-            value: value.into(),
+            value: Cow::Owned(value.into_bytes()),
             subtype: TextSubtype::Json,
         }
     }
 
-    pub fn as_str(&self) -> &str {
-        &self.value
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.value.as_ref()
+    }
+
+    #[inline]
+    pub fn try_as_str(&self) -> std::result::Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(self.as_bytes())
+    }
+
+    #[inline]
+    pub fn as_str_lossy(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(self.as_bytes())
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct TextRef<'a> {
-    pub value: &'a str,
+    pub value: &'a [u8],
     pub subtype: TextSubtype,
 }
 
 impl<'a> TextRef<'a> {
-    pub fn new(value: &'a str, subtype: TextSubtype) -> Self {
-        Self { value, subtype }
+    pub fn new<T>(value: &'a T, subtype: TextSubtype) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        Self {
+            value: value.as_ref(),
+            subtype,
+        }
     }
 
     #[inline]
-    pub fn as_str(&self) -> &'a str {
+    pub fn as_bytes(&self) -> &'a [u8] {
         self.value
+    }
+
+    #[inline]
+    pub fn try_as_str(&self) -> std::result::Result<&'a str, std::str::Utf8Error> {
+        std::str::from_utf8(self.as_bytes())
+    }
+
+    #[inline]
+    pub fn as_str_lossy(&self) -> Cow<'a, str> {
+        String::from_utf8_lossy(self.as_bytes())
     }
 }
 
-impl<'a> Borrow<str> for TextRef<'a> {
+impl<'a> Borrow<[u8]> for TextRef<'a> {
     #[inline]
-    fn borrow(&self) -> &str {
-        self.as_str()
+    fn borrow(&self) -> &[u8] {
+        self.as_bytes()
     }
 }
 
 impl<'a> Deref for TextRef<'a> {
-    type Target = str;
+    type Target = [u8];
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.as_str()
+        self.as_bytes()
     }
 }
 
@@ -138,27 +165,33 @@ pub trait Extendable<T> {
 impl<T: AnyText> Extendable<T> for Text {
     #[inline(always)]
     fn do_extend(&mut self, other: &T) {
-        let other_str = other.as_ref();
+        let other_bytes = other.as_bytes();
         match &mut self.value {
-            Cow::Owned(s) => {
-                let needed = other_str.len();
-                if s.capacity() >= needed {
-                    // SAFETY: capacity >= needed, source is valid UTF-8
+            Cow::Owned(bytes) => {
+                let needed = other_bytes.len();
+                if bytes.capacity() >= needed {
+                    // SAFETY: capacity >= needed.
                     turso_debug_assert!(
-                        s.as_ptr().wrapping_add(s.len()) <= other_str.as_ptr()
-                            || other_str.as_ptr().wrapping_add(other_str.len()) <= s.as_ptr(),
+                        bytes.as_ptr().wrapping_add(bytes.len()) <= other_bytes.as_ptr()
+                            || other_bytes.as_ptr().wrapping_add(other_bytes.len())
+                                <= bytes.as_ptr(),
                         "source and destination ranges must not overlap"
                     );
                     unsafe {
-                        std::ptr::copy_nonoverlapping(other_str.as_ptr(), s.as_mut_ptr(), needed);
-                        s.as_mut_vec().set_len(needed);
+                        std::ptr::copy_nonoverlapping(
+                            other_bytes.as_ptr(),
+                            bytes.as_mut_ptr(),
+                            needed,
+                        );
+                        bytes.set_len(needed);
                     }
                 } else {
-                    other_str.clone_into(s);
+                    bytes.clear();
+                    bytes.extend_from_slice(other_bytes);
                 }
             }
             Cow::Borrowed(_) => {
-                self.value = Cow::Owned(other_str.to_owned());
+                self.value = Cow::Owned(other_bytes.to_vec());
             }
         }
         self.subtype = other.subtype();
@@ -188,19 +221,48 @@ impl<T: AnyBlob> Extendable<T> for Vec<u8> {
     }
 }
 
-pub trait AnyText: AsRef<str> {
+pub trait AnyText {
+    fn as_bytes(&self) -> &[u8];
     fn subtype(&self) -> TextSubtype;
 }
 
 impl AnyText for Text {
+    fn as_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
+
     fn subtype(&self) -> TextSubtype {
         self.subtype
     }
 }
 
 impl AnyText for &str {
+    fn as_bytes(&self) -> &[u8] {
+        (*self).as_bytes()
+    }
+
     fn subtype(&self) -> TextSubtype {
         TextSubtype::Text
+    }
+}
+
+impl AnyText for &[u8] {
+    fn as_bytes(&self) -> &[u8] {
+        self
+    }
+
+    fn subtype(&self) -> TextSubtype {
+        TextSubtype::Text
+    }
+}
+
+impl AnyText for TextRef<'_> {
+    fn as_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
+
+    fn subtype(&self) -> TextSubtype {
+        self.subtype
     }
 }
 
@@ -220,16 +282,16 @@ impl AnyBlob for &[u8] {
     }
 }
 
-impl AsRef<str> for Text {
-    fn as_ref(&self) -> &str {
-        self.as_str()
+impl AsRef<[u8]> for Text {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
     }
 }
 
 impl From<&str> for Text {
     fn from(value: &str) -> Self {
         Text {
-            value: value.to_owned().into(),
+            value: Cow::Owned(value.as_bytes().to_vec()),
             subtype: TextSubtype::Text,
         }
     }
@@ -238,7 +300,16 @@ impl From<&str> for Text {
 impl From<String> for Text {
     fn from(value: String) -> Self {
         Text {
-            value: Cow::from(value),
+            value: Cow::Owned(value.into_bytes()),
+            subtype: TextSubtype::Text,
+        }
+    }
+}
+
+impl From<Vec<u8>> for Text {
+    fn from(value: Vec<u8>) -> Self {
+        Text {
+            value: Cow::Owned(value),
             subtype: TextSubtype::Text,
         }
     }
@@ -246,7 +317,7 @@ impl From<String> for Text {
 
 impl From<Text> for String {
     fn from(value: Text) -> Self {
-        value.value.into_owned()
+        String::from_utf8_lossy(value.as_bytes()).into_owned()
     }
 }
 
@@ -277,8 +348,7 @@ impl Debug for ValueRef<'_> {
                 f.debug_tuple("Float").field(&fval).finish()
             }
             ValueRef::Text(text_ref) => {
-                // truncate string to at most 256 chars
-                let text = text_ref.as_str();
+                let text = text_ref.as_str_lossy();
                 let max_len = text.len().min(256);
                 f.debug_struct("Text")
                     .field("data", &&text[0..max_len])
@@ -361,7 +431,7 @@ impl Value {
             Value::Null => ValueRef::Null,
             Value::Numeric(n) => ValueRef::Numeric(*n),
             Value::Text(v) => ValueRef::Text(TextRef {
-                value: &v.value,
+                value: v.as_bytes(),
                 subtype: v.subtype,
             }),
             Value::Blob(v) => ValueRef::Blob(v.as_slice()),
@@ -369,8 +439,8 @@ impl Value {
     }
 
     // A helper function that makes building a text Value easier.
-    pub fn build_text(text: impl Into<Cow<'static, str>>) -> Self {
-        Self::Text(Text::new(text))
+    pub fn build_text(text: impl Into<Text>) -> Self {
+        Self::Text(text.into())
     }
 
     pub fn to_blob(&self) -> Option<&[u8]> {
@@ -386,7 +456,7 @@ impl Value {
 
     pub fn to_text(&self) -> Option<&str> {
         match self {
-            Value::Text(t) => Some(t.as_str()),
+            Value::Text(t) => t.try_as_str().ok(),
             _ => None,
         }
     }
@@ -434,8 +504,8 @@ impl Value {
         }
     }
 
-    pub fn from_text(text: impl Into<Cow<'static, str>>) -> Self {
-        Value::Text(Text::new(text))
+    pub fn from_text(text: impl Into<Text>) -> Self {
+        Value::Text(text.into())
     }
 
     pub fn value_type(&self) -> ValueType {
@@ -466,7 +536,7 @@ impl Value {
                 let fval: f64 = (*f).into();
                 out.extend_from_slice(&fval.to_be_bytes());
             }
-            Value::Text(t) => out.extend_from_slice(t.value.as_bytes()),
+            Value::Text(t) => out.extend_from_slice(t.as_bytes()),
             Value::Blob(b) => out.extend_from_slice(b),
         };
     }
@@ -504,7 +574,7 @@ impl Display for Value {
             Self::Null => write!(f, ""),
             Self::Numeric(Numeric::Integer(i)) => write!(f, "{i}"),
             Self::Numeric(Numeric::Float(fl)) => f.write_str(&format_float(f64::from(*fl))),
-            Self::Text(s) => write!(f, "{}", s.as_str()),
+            Self::Text(s) => write!(f, "{}", s.as_str_lossy()),
             Self::Blob(b) => write!(f, "{}", String::from_utf8_lossy(b)),
         }
     }
@@ -516,7 +586,7 @@ impl Value {
             Self::Null => ExtValue::null(),
             Self::Numeric(Numeric::Integer(i)) => ExtValue::from_integer(*i),
             Self::Numeric(Numeric::Float(fl)) => ExtValue::from_float(f64::from(*fl)),
-            Self::Text(text) => ExtValue::from_text(text.as_str().to_string()),
+            Self::Text(text) => ExtValue::from_text(text.as_str_lossy().into_owned()),
             Self::Blob(blob) => ExtValue::from_blob(blob.to_vec()),
         }
     }
@@ -639,7 +709,10 @@ impl FromValue for String {
     fn from_sql(val: Value) -> Result<Self> {
         match val {
             Value::Null => Err(LimboError::NullValue),
-            Value::Text(s) => Ok(s.to_string()),
+            Value::Text(s) => s
+                .try_as_str()
+                .map(str::to_owned)
+                .map_err(|_| LimboError::ConversionError("Expected valid UTF-8 text value".into())),
             _ => unreachable!("invalid value type"),
         }
     }
@@ -819,26 +892,37 @@ impl std::ops::AddAssign for Value {
                 *self = sum.into();
             }
             (Self::Text(string_left), Self::Text(string_right)) => {
-                string_left.value.to_mut().push_str(&string_right.value);
+                string_left
+                    .value
+                    .to_mut()
+                    .extend_from_slice(string_right.as_bytes());
                 string_left.subtype = TextSubtype::Text;
             }
             (Self::Text(string_left), Self::Numeric(Numeric::Integer(int_right))) => {
                 let string_right = int_right.to_string();
-                string_left.value.to_mut().push_str(&string_right);
+                string_left
+                    .value
+                    .to_mut()
+                    .extend_from_slice(string_right.as_bytes());
                 string_left.subtype = TextSubtype::Text;
             }
             (Self::Numeric(Numeric::Integer(int_left)), Self::Text(string_right)) => {
-                let string_left = int_left.to_string();
-                *self = Self::build_text(string_left + string_right.as_str());
+                let mut string_left = int_left.to_string().into_bytes();
+                string_left.extend_from_slice(string_right.as_bytes());
+                *self = Self::from_text(string_left);
             }
             (Self::Text(string_left), Self::Numeric(Numeric::Float(_))) => {
                 let string_right = rhs.to_string();
-                string_left.value.to_mut().push_str(&string_right);
+                string_left
+                    .value
+                    .to_mut()
+                    .extend_from_slice(string_right.as_bytes());
                 string_left.subtype = TextSubtype::Text;
             }
             (Self::Numeric(Numeric::Float(_)), Self::Text(string_right)) => {
-                let string_left = self.to_string();
-                *self = Self::build_text(string_left + string_right.as_str());
+                let mut string_left = self.to_string().into_bytes();
+                string_left.extend_from_slice(string_right.as_bytes());
+                *self = Self::from_text(string_left);
             }
             (_, Self::Null) => {}
             (Self::Null, _) => *self = rhs,
@@ -915,7 +999,9 @@ impl<'a> TryFrom<ValueRef<'a>> for &'a str {
     #[inline]
     fn try_from(value: ValueRef<'a>) -> Result<Self, Self::Error> {
         match value {
-            ValueRef::Text(s) => Ok(s.as_str()),
+            ValueRef::Text(s) => s
+                .try_as_str()
+                .map_err(|_| LimboError::ConversionError("Expected valid UTF-8 text value".into())),
             _ => Err(LimboError::ConversionError("Expected text value".into())),
         }
     }
@@ -979,7 +1065,7 @@ impl std::fmt::Debug for ImmutableRecord {
                 write!(f, "ImmutableRecord {{ payload: {preview} }}")
             }
             Value::Text(s) => {
-                let string = s.as_str();
+                let string = s.as_str_lossy();
                 let preview = if string.len() > 20 {
                     format!("{:?} ... ({} chars total)", &string[..20], string.len())
                 } else {
@@ -1255,7 +1341,7 @@ impl ImmutableRecord {
                     writer.extend_from_slice(&fval.to_be_bytes());
                 }
                 ValueRef::Text(t) => {
-                    writer.extend_from_slice(t.value.as_bytes());
+                    writer.extend_from_slice(t.as_bytes());
                 }
                 ValueRef::Blob(b) => {
                     writer.extend_from_slice(b);
@@ -1652,7 +1738,7 @@ impl<'a> ValueRef<'a> {
             Self::Null => ExtValue::null(),
             Self::Numeric(Numeric::Integer(i)) => ExtValue::from_integer(*i),
             Self::Numeric(Numeric::Float(fl)) => ExtValue::from_float(f64::from(*fl)),
-            Self::Text(text) => ExtValue::from_text(text.as_str().to_string()),
+            Self::Text(text) => ExtValue::from_text(text.as_str_lossy().into_owned()),
             Self::Blob(blob) => ExtValue::from_blob(blob.to_vec()),
         }
     }
@@ -1666,7 +1752,7 @@ impl<'a> ValueRef<'a> {
 
     pub fn to_text(&self) -> Option<&'a str> {
         match self {
-            Self::Text(t) => Some(t.as_str()),
+            Self::Text(t) => t.try_as_str().ok(),
             _ => None,
         }
     }
@@ -1706,7 +1792,7 @@ impl<'a> ValueRef<'a> {
             ValueRef::Null => Value::Null,
             ValueRef::Numeric(n) => Value::from(*n),
             ValueRef::Text(text) => Value::Text(Text {
-                value: text.value.to_string().into(),
+                value: Cow::Owned(text.as_bytes().to_vec()),
                 subtype: text.subtype,
             }),
             ValueRef::Blob(b) => Value::Blob(b.to_vec()),
@@ -1733,7 +1819,7 @@ impl Display for ValueRef<'_> {
                 let fval: f64 = (*fl).into();
                 write!(f, "{fval:?}")
             }
-            Self::Text(s) => write!(f, "{}", s.as_str()),
+            Self::Text(s) => write!(f, "{}", s.as_str_lossy()),
             Self::Blob(b) => write!(f, "{}", String::from_utf8_lossy(b)),
         }
     }
@@ -1745,7 +1831,7 @@ impl<'a> PartialEq<ValueRef<'a>> for ValueRef<'a> {
             (Self::Null, Self::Null) => true,
             (Self::Numeric(a), Self::Numeric(b)) => a == b,
             (Self::Text(text_left), Self::Text(text_right)) => {
-                text_left.value.as_bytes() == text_right.value.as_bytes()
+                text_left.as_bytes() == text_right.as_bytes()
             }
             (Self::Blob(blob_left), Self::Blob(blob_right)) => blob_left.eq(blob_right),
             _ => false,
@@ -1782,7 +1868,7 @@ impl<'a> Ord for ValueRef<'a> {
             (_, Self::Numeric(_)) => std::cmp::Ordering::Greater,
 
             (Self::Text(text_left), Self::Text(text_right)) => {
-                text_left.value.as_bytes().cmp(text_right.value.as_bytes())
+                text_left.as_bytes().cmp(text_right.as_bytes())
             }
             (Self::Text(_), Self::Blob(_)) => std::cmp::Ordering::Less,
             (Self::Blob(_), Self::Text(_)) => std::cmp::Ordering::Greater,
@@ -1937,7 +2023,9 @@ where
     let l = l.as_value_ref();
     let r = r.as_value_ref();
     match (l, r) {
-        (ValueRef::Text(left), ValueRef::Text(right)) => collation.compare_strings(&left, &right),
+        (ValueRef::Text(left), ValueRef::Text(right)) => {
+            collation.compare_texts(left.as_bytes(), right.as_bytes())
+        }
         _ => l.cmp(&r),
     }
 }
@@ -2201,7 +2289,7 @@ where
     };
 
     let collation = index_info.key_info[0].collation;
-    let comparison = collation.compare_strings(&lhs_text, &rhs_text);
+    let comparison = collation.compare_texts(lhs_text.as_bytes(), rhs_text.as_bytes());
 
     let final_comparison = match index_info.key_info[0].sort_order {
         SortOrder::Asc => comparison,
@@ -2328,7 +2416,7 @@ where
         let comparison = match (&lhs_value, rhs_value) {
             (ValueRef::Text(lhs_text), ValueRef::Text(rhs_text)) => index_info.key_info[field_idx]
                 .collation
-                .compare_strings(lhs_text, rhs_text),
+                .compare_texts(lhs_text.as_bytes(), rhs_text.as_bytes()),
 
             _ => lhs_value.cmp(rhs_value),
         };
@@ -2535,7 +2623,7 @@ impl<T: AsValueRef> From<T> for SerialType {
                 _ => SerialType::i64(),
             },
             ValueRef::Numeric(Numeric::Float(_)) => SerialType::f64(),
-            ValueRef::Text(t) => SerialType::text(t.value.len() as u64),
+            ValueRef::Text(t) => SerialType::text(t.as_bytes().len() as u64),
             ValueRef::Blob(b) => SerialType::blob(b.len() as u64),
         }
     }
@@ -2633,7 +2721,7 @@ impl Record {
                 Value::Numeric(Numeric::Float(f)) => {
                     buf.extend_from_slice(&f64::from(*f).to_be_bytes())
                 }
-                Value::Text(t) => buf.extend_from_slice(t.value.as_bytes()),
+                Value::Text(t) => buf.extend_from_slice(t.as_bytes()),
                 Value::Blob(b) => buf.extend_from_slice(b),
             };
         }
@@ -3136,7 +3224,7 @@ mod tests {
 
             let cmp = match (&l[i], &r[i]) {
                 (ValueRef::Text(left), ValueRef::Text(right)) => {
-                    collation.compare_strings(left, right)
+                    collation.compare_texts(left.as_bytes(), right.as_bytes())
                 }
                 _ => l[i].partial_cmp(&r[i]).unwrap_or(std::cmp::Ordering::Equal),
             };

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -547,8 +547,7 @@ pub fn apply_numeric_affinity(val: ValueRef, try_for_int: bool) -> Option<ValueR
         return None; // Only apply to text values
     };
 
-    let text_str = text.as_str();
-    let (parse_result, parsed_value) = try_for_float(text_str.as_bytes());
+    let (parse_result, parsed_value) = try_for_float(text.as_bytes());
 
     // Only convert if we have a complete valid number (not just a prefix)
     match parse_result {

--- a/core/vdbe/array.rs
+++ b/core/vdbe/array.rs
@@ -23,7 +23,7 @@ pub(crate) fn array_values_from_blob(blob: &[u8]) -> Result<Vec<Value>> {
 pub(crate) fn array_values_from_any(arr: &Value) -> Option<Vec<Value>> {
     match arr {
         Value::Blob(blob) => array_values_from_blob(blob).ok(),
-        Value::Text(text) => parse_text_array(text.as_str()),
+        Value::Text(text) => parse_text_array(&text.as_str_lossy()),
         Value::Null => Some(Vec::new()),
         _ => None,
     }
@@ -186,7 +186,7 @@ fn write_value_ref_pg(result: &mut String, val: &crate::ValueRef<'_>) {
             }
         }
         crate::ValueRef::Text(t) => {
-            write_pg_text_element(result, t.as_str());
+            write_pg_text_element(result, &t.as_str_lossy());
         }
         crate::ValueRef::Blob(b) => {
             result.push_str("\"X'");
@@ -243,7 +243,7 @@ pub(crate) fn compute_array_length(val: &Value) -> Option<i64> {
             Ok(iter) => Some(iter.count() as i64),
             Err(_) => None,
         },
-        Value::Text(t) => parse_text_array(t.as_str()).map(|v| v.len() as i64),
+        Value::Text(t) => parse_text_array(&t.as_str_lossy()).map(|v| v.len() as i64),
         _ => None,
     }
 }
@@ -377,13 +377,13 @@ pub(crate) fn exec_string_to_array(
     null_str: Option<&Value>,
 ) -> Value {
     let text_str = match text {
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.as_str_lossy().into_owned(),
         Value::Null => return Value::Null,
         other => other.to_string(),
     };
 
     let null_match: Option<String> = match null_str {
-        Some(Value::Text(t)) => Some(t.as_str().to_string()),
+        Some(Value::Text(t)) => Some(t.as_str_lossy().into_owned()),
         Some(Value::Null) | None => None,
         Some(other) => Some(other.to_string()),
     };
@@ -406,7 +406,7 @@ pub(crate) fn exec_string_to_array(
     }
 
     let delim_str = match delimiter {
-        Value::Text(d) => d.as_str().to_string(),
+        Value::Text(d) => d.as_str_lossy().into_owned(),
         other => other.to_string(),
     };
 
@@ -445,13 +445,13 @@ pub(crate) fn exec_array_to_string(
     }
 
     let delim = match delimiter {
-        Value::Text(t) => t.as_str().to_string(),
+        Value::Text(t) => t.as_str_lossy().into_owned(),
         Value::Null => return Value::Null,
         other => other.to_string(),
     };
 
     let null_replacement: Option<String> = match null_str {
-        Some(Value::Text(t)) => Some(t.as_str().to_string()),
+        Some(Value::Text(t)) => Some(t.as_str_lossy().into_owned()),
         Some(Value::Null) | None => None,
         Some(other) => Some(other.to_string()),
     };
@@ -473,7 +473,7 @@ pub(crate) fn exec_array_to_string(
                             continue;
                         }
                     }
-                    crate::ValueRef::Text(t) => t.as_str().to_string(),
+                    crate::ValueRef::Text(t) => t.as_str_lossy().into_owned(),
                     other => format!("{other}"),
                 };
                 if !first {
@@ -501,7 +501,7 @@ pub(crate) fn exec_array_to_string(
                     continue;
                 }
             }
-            Value::Text(t) => t.as_str().to_string(),
+            Value::Text(t) => t.as_str_lossy().into_owned(),
             other => other.to_string(),
         };
         if !first {

--- a/core/vdbe/bloom_filter.rs
+++ b/core/vdbe/bloom_filter.rs
@@ -161,7 +161,7 @@ fn hash_value<H: Hasher>(hasher: &mut H, value: &ValueRef) {
         }
         ValueRef::Text(s) => {
             3u8.hash(hasher);
-            s.as_str().hash(hasher);
+            s.as_bytes().hash(hasher);
         }
         ValueRef::Blob(b) => {
             4u8.hash(hasher);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -182,8 +182,11 @@ fn value_to_bigdecimal(val: &Value) -> Result<bigdecimal::BigDecimal> {
         Value::Numeric(Numeric::Integer(i)) => Ok(BigDecimal::from(*i)),
         Value::Numeric(Numeric::Float(f)) => BigDecimal::from_str(&f.to_string())
             .map_err(|_| LimboError::Constraint(format!("invalid numeric value: {f}"))),
-        Value::Text(t) => BigDecimal::from_str(&t.value)
-            .map_err(|_| LimboError::Constraint(format!("invalid numeric value: \"{}\"", t.value))),
+        Value::Text(t) => {
+            let text = t.as_str_lossy();
+            BigDecimal::from_str(&text)
+                .map_err(|_| LimboError::Constraint(format!("invalid numeric value: \"{text}\"")))
+        }
         Value::Blob(b) => crate::numeric::decimal::blob_to_bigdecimal(b),
         _ => Err(LimboError::Constraint(format!(
             "cannot convert to numeric: \"{val}\""
@@ -221,7 +224,7 @@ fn make_sort_comparator(
             std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Ordering {
                 fn reverse_str(v: &ValueRef) -> String {
                     match v {
-                        ValueRef::Text(t) => t.to_string().chars().rev().collect(),
+                        ValueRef::Text(t) => t.as_str_lossy().chars().rev().collect(),
                         _ => String::new(),
                     }
                 }
@@ -245,7 +248,7 @@ fn make_sort_comparator(
                                 None
                             }
                         }
-                        ValueRef::Text(t) => t.to_string().parse::<u64>().ok(),
+                        ValueRef::Text(t) => t.as_str_lossy().parse::<u64>().ok(),
                         _ => None,
                     }
                 }
@@ -271,8 +274,10 @@ fn make_sort_comparator(
                             .unwrap_or(Ordering::Equal)
                     }
                     (ValueRef::Text(a_text), ValueRef::Text(b_text)) => {
-                        let a_vals = crate::vdbe::array::parse_text_array(a_text);
-                        let b_vals = crate::vdbe::array::parse_text_array(b_text);
+                        let a_text = a_text.as_str_lossy();
+                        let b_text = b_text.as_str_lossy();
+                        let a_vals = crate::vdbe::array::parse_text_array(&a_text);
+                        let b_vals = crate::vdbe::array::parse_text_array(&b_text);
                         match (a_vals, b_vals) {
                             (Some(av), Some(bv)) => {
                                 let a_blob = crate::vdbe::array::values_to_record_blob(&av);
@@ -304,7 +309,7 @@ fn compare_with_collation(
     match (lhs, rhs) {
         (Value::Text(lhs_text), Value::Text(rhs_text)) => {
             if let Some(coll) = collation {
-                coll.compare_strings(lhs_text.as_str(), rhs_text.as_str())
+                coll.compare_texts(lhs_text.as_bytes(), rhs_text.as_bytes())
             } else {
                 lhs.cmp(rhs)
             }
@@ -1981,7 +1986,7 @@ pub fn op_array_encode(
     // Extract elements from either blob (MakeArray) or text (JSON literal)
     let raw_elements = match val {
         Value::Blob(b) => array_values_from_blob(b).ok(),
-        Value::Text(text) => parse_text_array(text.as_str()),
+        Value::Text(text) => parse_text_array(&text.as_str_lossy()),
         _ => None,
     };
     let Some(raw_elements) = raw_elements else {
@@ -2114,19 +2119,7 @@ pub fn op_array_element(
             Ok(mut iter) => iter
                 .nth(idx)
                 .and_then(|r| r.ok())
-                .map(|vref| {
-                    // The blob may not be a real record — text fields could
-                    // contain invalid UTF-8 (from_utf8_unchecked in the
-                    // record decoder). Validate and demote to blob if needed.
-                    if let ValueRef::Text(t) = &vref {
-                        if t.value.as_bytes().iter().any(|&b| b > 0x7F)
-                            && std::str::from_utf8(t.value.as_bytes()).is_err()
-                        {
-                            return Value::Blob(t.value.as_bytes().to_vec());
-                        }
-                    }
-                    vref.to_owned()
-                })
+                .map(|vref| vref.to_owned())
                 .unwrap_or(Value::Null),
             Err(_) => Value::Null,
         },
@@ -5137,7 +5130,7 @@ fn update_agg_payload(
             let val = match arg {
                 Value::Numeric(Numeric::Integer(i)) => i as f64,
                 Value::Numeric(Numeric::Float(f)) => f64::from(f),
-                Value::Text(t) => match try_for_float(t.as_str().as_bytes()).1 {
+                Value::Text(t) => match try_for_float(t.as_bytes()).1 {
                     ParsedNumber::Integer(i) => i as f64,
                     ParsedNumber::Float(f) => f,
                     ParsedNumber::None => 0.0,
@@ -5237,7 +5230,7 @@ fn update_agg_payload(
                     _ => unreachable!("Sum/Total accumulator initialized to Null/Integer/Float"),
                 },
                 Value::Text(t) => {
-                    let (parse_result, parsed_number) = try_for_float(t.as_str().as_bytes());
+                    let (parse_result, parsed_number) = try_for_float(t.as_bytes());
                     handle_text_sum(acc, &mut sum_state, parsed_number, parse_result, false);
                 }
                 Value::Blob(b) => {
@@ -5283,7 +5276,7 @@ fn update_agg_payload(
             let acc = &mut payload[0];
             if matches!(acc, Value::Null) {
                 // First non-null value: convert to Text
-                *acc = Value::build_text(arg.to_string());
+                *acc = arg.exec_cast("TEXT");
             } else {
                 acc.exec_group_concat(&delimiter);
                 acc.exec_group_concat(&arg);
@@ -6273,19 +6266,26 @@ pub fn op_function(
                 // However, Rust strings uses utf-8
                 // so the behavior at the moment is slightly different
                 // To the way blobs are parsed here in SQLite.
+                let indent_buf;
                 let indent = match indent {
                     Some(value) => match value.get_value() {
-                        Value::Text(text) => text.as_str(),
-                        Value::Numeric(Numeric::Integer(val)) => &val.to_string(),
-                        Value::Numeric(Numeric::Float(val)) => &f64::from(*val).to_string(),
-                        Value::Blob(val) => &String::from_utf8_lossy(val),
-                        _ => "    ",
+                        Value::Text(text) => text.as_str_lossy(),
+                        Value::Numeric(Numeric::Integer(val)) => {
+                            indent_buf = val.to_string();
+                            std::borrow::Cow::Borrowed(indent_buf.as_str())
+                        }
+                        Value::Numeric(Numeric::Float(val)) => {
+                            indent_buf = f64::from(*val).to_string();
+                            std::borrow::Cow::Borrowed(indent_buf.as_str())
+                        }
+                        Value::Blob(val) => String::from_utf8_lossy(val),
+                        _ => std::borrow::Cow::Borrowed("    "),
                     },
                     // If the second argument is omitted or is NULL, then indentation is four spaces per level
-                    None => "    ",
+                    None => std::borrow::Cow::Borrowed("    "),
                 };
 
-                let json_str = get_json(json_value.get_value(), Some(indent))?;
+                let json_str = get_json(json_value.get_value(), Some(indent.as_ref()))?;
                 state.registers[*dest].set_value(json_str);
             }
             JsonFunc::JsonSet => {
@@ -6340,7 +6340,7 @@ pub fn op_function(
                 };
                 let result = reg_value_argument
                     .get_value()
-                    .exec_cast(reg_value_type.as_str());
+                    .exec_cast(&reg_value_type.as_str_lossy());
                 state.registers[*dest].set_value(result);
             }
             ScalarFunc::Changes => {
@@ -6383,7 +6383,7 @@ pub fn op_function(
                     state.registers[*dest].set_null();
                 } else {
                     let pattern_cow = match pattern_value {
-                        Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                        Value::Text(s) => s.as_str_lossy(),
                         v => match v.exec_cast("TEXT") {
                             Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                             _ => unreachable!("Cast to TEXT should yield Text"),
@@ -6391,7 +6391,7 @@ pub fn op_function(
                     };
 
                     let match_cow = match match_value {
-                        Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                        Value::Text(s) => s.as_str_lossy(),
                         v => match v.exec_cast("TEXT") {
                             Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                             _ => unreachable!("Cast to TEXT should yield Text"),
@@ -6438,7 +6438,7 @@ pub fn op_function(
                             }
                             _ => {
                                 let escape_cow = match escape_value {
-                                    Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                                    Value::Text(s) => s.as_str_lossy(),
                                     v => match v.exec_cast("TEXT") {
                                         Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                                         _ => unreachable!("Cast to TEXT should yield Text"),
@@ -6462,7 +6462,7 @@ pub fn op_function(
                     } else {
                         // 3. Prepare Pattern and Text
                         let pattern_cow = match pattern_value {
-                            Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                            Value::Text(s) => s.as_str_lossy(),
                             v => match v.exec_cast("TEXT") {
                                 Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                                 _ => unreachable!("Cast to TEXT should yield Text"),
@@ -6470,7 +6470,7 @@ pub fn op_function(
                         };
 
                         let match_cow = match match_value {
-                            Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                            Value::Text(s) => s.as_str_lossy(),
                             v => match v.exec_cast("TEXT") {
                                 Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
                                 _ => unreachable!("Cast to TEXT should yield Text"),
@@ -6744,7 +6744,7 @@ pub fn op_function(
                     };
                     let table = {
                         let schema = program.connection.schema.read();
-                        match schema.get_table(table.as_str()) {
+                        match schema.get_table(&table.as_str_lossy()) {
                             Some(table) => table,
                             None => {
                                 return Err(LimboError::InvalidArgument(format!(
@@ -6806,7 +6806,7 @@ pub fn op_function(
                         ));
                     };
                     let mut columns_json_array =
-                        json::jsonb::Jsonb::from_str(columns_str.as_str())?;
+                        json::jsonb::Jsonb::from_str(&columns_str.as_str_lossy())?;
                     let columns_len = columns_json_array.array_len()?;
 
                     let mut payload_iterator = ValueIterator::new(bin_record.as_slice())?;
@@ -6873,7 +6873,7 @@ pub fn op_function(
 
                 program
                     .connection
-                    .attach_database(filename_str.as_str(), dbname_str.as_str())?;
+                    .attach_database(&filename_str.as_str_lossy(), &dbname_str.as_str_lossy())?;
 
                 state.registers[*dest].set_null();
             }
@@ -6888,7 +6888,9 @@ pub fn op_function(
                 };
 
                 // Call the detach_database method on the connection
-                program.connection.detach_database(dbname_str.as_str())?;
+                program
+                    .connection
+                    .detach_database(&dbname_str.as_str_lossy())?;
 
                 // Set result to NULL (detach doesn't return a value)
                 state.registers[*dest].set_null();
@@ -7107,7 +7109,7 @@ pub fn op_function(
                         }
                     },
                     Value::Text(t) => {
-                        let v = &t.value;
+                        let v = t.as_str_lossy();
                         match v.to_ascii_lowercase().as_str() {
                             "true" | "t" | "yes" | "on" | "1" => Value::from_i64(1),
                             "false" | "f" | "no" | "off" | "0" => Value::from_i64(0),
@@ -7142,7 +7144,7 @@ pub fn op_function(
                 let result = match val.get_value() {
                     Value::Null => Value::Null,
                     Value::Text(t) => {
-                        let v = &t.value;
+                        let v = t.as_str_lossy();
                         v.parse::<std::net::IpAddr>().map_err(|_| {
                             LimboError::Constraint(format!("invalid input for type inet: \"{v}\""))
                         })?;
@@ -7189,7 +7191,7 @@ pub fn op_function(
                         let text = match other {
                             Value::Numeric(Numeric::Integer(i)) => i.to_string(),
                             Value::Numeric(Numeric::Float(f)) => f.to_string(),
-                            Value::Text(t) => t.value.to_string(),
+                            Value::Text(t) => t.as_str_lossy().into_owned(),
                             _ => {
                                 return Err(LimboError::Constraint(format!(
                                     "invalid input for type numeric: \"{other}\""
@@ -7532,7 +7534,9 @@ pub fn op_function(
                 AlterTableFunc::RenameTable => {
                     let rename_from = {
                         match &state.registers[*start_reg + 5].get_value() {
-                            Value::Text(rename_from) => normalize_ident(rename_from.as_str()),
+                            Value::Text(rename_from) => {
+                                normalize_ident(&rename_from.as_str_lossy())
+                            }
                             _ => panic!("rename_from parameter should be TEXT"),
                         }
                     };
@@ -7543,7 +7547,7 @@ pub fn op_function(
                             _ => panic!("rename_to parameter should be TEXT"),
                         }
                     };
-                    let rename_to = normalize_ident(original_rename_to.as_str());
+                    let rename_to = normalize_ident(&original_rename_to.as_str_lossy());
 
                     let new_name = if let Some(column) =
                         &name.strip_prefix(&format!("sqlite_autoindex_{rename_from}_"))
@@ -7566,7 +7570,8 @@ pub fn op_function(
                             break 'sql None;
                         };
 
-                        let mut parser = Parser::new(sql.as_str().as_bytes());
+                        let sql = sql.as_str_lossy();
+                        let mut parser = Parser::new(sql.as_bytes());
                         let ast::Cmd::Stmt(stmt) =
                             parser.next().expect("parser should have next item")?
                         else {
@@ -7637,7 +7642,7 @@ pub fn op_function(
                                         any_change |= rewrite_fk_parent_table_if_needed(
                                             clause,
                                             &rename_from,
-                                            original_rename_to.as_str(),
+                                            &original_rename_to.as_str_lossy(),
                                         );
                                     }
                                 }
@@ -7645,7 +7650,7 @@ pub fn op_function(
                                     any_change |= rewrite_inline_col_fk_target_if_needed(
                                         col,
                                         &rename_from,
-                                        original_rename_to.as_str(),
+                                        &original_rename_to.as_str_lossy(),
                                     );
                                 }
 
@@ -7770,7 +7775,7 @@ pub fn op_function(
                                     rewrite_check_expr_table_refs(
                                         when,
                                         &rename_from,
-                                        original_rename_to.as_str(),
+                                        &original_rename_to.as_str_lossy(),
                                     );
                                 }
 
@@ -7779,7 +7784,7 @@ pub fn op_function(
                                     rewrite_trigger_cmd_table_refs(
                                         cmd,
                                         &rename_from,
-                                        original_rename_to.as_str(),
+                                        &original_rename_to.as_str_lossy(),
                                     );
                                 }
 
@@ -7807,7 +7812,7 @@ pub fn op_function(
                 AlterTableFunc::AlterColumn | AlterTableFunc::RenameColumn => {
                     let table = {
                         match &state.registers[*start_reg + 5].get_value() {
-                            Value::Text(rename_to) => normalize_ident(rename_to.as_str()),
+                            Value::Text(rename_to) => normalize_ident(&rename_to.as_str_lossy()),
                             _ => panic!("table parameter should be TEXT"),
                         }
                     };
@@ -7818,11 +7823,11 @@ pub fn op_function(
                             _ => panic!("rename_from parameter should be TEXT"),
                         }
                     };
-                    let rename_from = normalize_ident(original_rename_from.as_str());
+                    let rename_from = normalize_ident(&original_rename_from.as_str_lossy());
 
                     let column_def = {
                         match &state.registers[*start_reg + 7].get_value() {
-                            Value::Text(column_def) => column_def.as_str(),
+                            Value::Text(column_def) => column_def.as_str_lossy(),
                             _ => panic!("rename_to parameter should be TEXT"),
                         }
                     };
@@ -7837,7 +7842,8 @@ pub fn op_function(
                             break 'sql None;
                         };
 
-                        let mut parser = Parser::new(sql.as_str().as_bytes());
+                        let sql = sql.as_str_lossy();
+                        let mut parser = Parser::new(sql.as_bytes());
                         let ast::Cmd::Stmt(stmt) =
                             parser.next().expect("parser should have next item")?
                         else {
@@ -9388,7 +9394,7 @@ pub fn op_must_be_int(
             Ok(i) => state.registers[*reg].set_int(i),
             Err(_) => bail_constraint_error!("datatype mismatch"),
         },
-        Value::Text(text) => match checked_cast_text_to_numeric(text.as_str(), true) {
+        Value::Text(text) => match checked_cast_text_to_numeric(&text.as_str_lossy(), true) {
             Ok(Value::Numeric(Numeric::Integer(i))) => state.registers[*reg].set_int(i),
             Ok(Value::Numeric(Numeric::Float(f))) => match cast_real_to_integer(f64::from(f)) {
                 Ok(i) => state.registers[*reg].set_int(i),
@@ -10792,7 +10798,7 @@ pub fn op_add_imm(
     let int_val = match current_value {
         Value::Numeric(Numeric::Integer(i)) => i + value,
         Value::Numeric(Numeric::Float(f)) => (f64::from(*f) as i64) + value,
-        Value::Text(s) => s.as_str().parse::<i64>().unwrap_or(0) + value,
+        Value::Text(s) => parse_sqlite_int_from_bytes(s.as_bytes()) + value,
         Value::Blob(_) => *value, // BLOB becomes the added value
         Value::Null => *value,    // NULL becomes the added value
     };
@@ -13150,7 +13156,8 @@ fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
                 }
 
                 if let Value::Text(t) = value {
-                    let text = trim_ascii_whitespace(t.as_str());
+                    let text = t.as_str_lossy();
+                    let text = trim_ascii_whitespace(&text);
 
                     // Handle hex numbers - they shouldn't be converted
                     if text.starts_with("0x") {
@@ -13202,7 +13209,8 @@ fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
                     return true;
                 }
                 Value::Text(t) => {
-                    let text = trim_ascii_whitespace(t.as_str());
+                    let text = t.as_str_lossy();
+                    let text = trim_ascii_whitespace(&text);
                     if text.starts_with("0x") {
                         return false;
                     }
@@ -13287,6 +13295,26 @@ fn execute_turso_version(version_integer: i64) -> String {
     format!("{major}.{minor}.{release}")
 }
 
+fn parsed_number_to_i64(parsed: ParsedNumber) -> i64 {
+    match parsed {
+        ParsedNumber::Integer(i) => i,
+        ParsedNumber::Float(f) => {
+            if f < -9223372036854774784.0 {
+                i64::MIN
+            } else if f > 9223372036854774784.0 {
+                i64::MAX
+            } else {
+                f as i64
+            }
+        }
+        ParsedNumber::None => 0,
+    }
+}
+
+fn parse_sqlite_int_from_bytes(bytes: &[u8]) -> i64 {
+    parsed_number_to_i64(try_for_float(bytes).1)
+}
+
 pub fn extract_int_value<V: AsValueRef>(value: V) -> i64 {
     let value = value.as_value_ref();
     match value {
@@ -13304,15 +13332,11 @@ pub fn extract_int_value<V: AsValueRef>(value: V) -> i64 {
         }
         ValueRef::Text(t) => {
             // Try to parse as integer, return 0 if failed
-            t.as_str().parse::<i64>().unwrap_or(0)
+            parse_sqlite_int_from_bytes(t.as_bytes())
         }
         ValueRef::Blob(b) => {
             // Try to parse blob as string then as integer
-            if let Ok(s) = std::str::from_utf8(b) {
-                s.parse::<i64>().unwrap_or(0)
-            } else {
-                0
-            }
+            parse_sqlite_int_from_bytes(b)
         }
         ValueRef::Null => 0,
     }
@@ -13948,27 +13972,33 @@ fn op_vacuum_into_inner(
                     crate::StepResult::Done => {
                         // Extract table names for data copy phase
                         // Include sqlite_sequence for AUTOINCREMENT counters, but not other sqlite_ tables
-                        vacuum_state.table_names = vacuum_state
-                            .schema_rows
-                            .iter()
-                            .filter_map(|row| {
-                                if row.len() >= 2 {
-                                    if let (Value::Text(type_val), Value::Text(name_val)) =
-                                        (&row[0], &row[1])
-                                    {
-                                        let name = name_val.as_str();
-                                        if type_val.as_str() == "table"
-                                            && (!name.starts_with("sqlite_")
-                                                || name == "sqlite_sequence")
-                                            && name != crate::mvcc::database::MVCC_META_TABLE_NAME
-                                        {
-                                            return Some(name.to_string());
-                                        }
-                                    }
-                                }
-                                None
-                            })
-                            .collect();
+                        let mut table_names = Vec::new();
+                        for row in &vacuum_state.schema_rows {
+                            if row.len() < 2 {
+                                continue;
+                            }
+                            let (Value::Text(type_val), Value::Text(name_val)) = (&row[0], &row[1])
+                            else {
+                                continue;
+                            };
+                            let type_str = type_val.try_as_str().map_err(|_| {
+                                LimboError::Corrupt(
+                                    "sqlite_schema.type must be valid UTF-8".to_string(),
+                                )
+                            })?;
+                            let name = name_val.try_as_str().map_err(|_| {
+                                LimboError::Corrupt(
+                                    "sqlite_schema.name must be valid UTF-8".to_string(),
+                                )
+                            })?;
+                            if type_str == "table"
+                                && (!name.starts_with("sqlite_") || name == "sqlite_sequence")
+                                && name != crate::mvcc::database::MVCC_META_TABLE_NAME
+                            {
+                                table_names.push(name.to_string());
+                            }
+                        }
+                        vacuum_state.table_names = table_names;
 
                         vacuum_state.sub_state =
                             OpVacuumIntoSubState::PrepareDestSchema { dest_conn, idx: 0 };
@@ -14016,7 +14046,9 @@ fn op_vacuum_into_inner(
                 // Skip triggers and views - they'll be created after data copy
                 // to avoid triggers firing during data copy
                 if let Value::Text(type_val) = &row[0] {
-                    let type_str = type_val.as_str();
+                    let type_str = type_val.try_as_str().map_err(|_| {
+                        LimboError::Corrupt("sqlite_schema.type must be valid UTF-8".to_string())
+                    })?;
                     if type_str == "trigger" || type_str == "view" {
                         vacuum_state.sub_state = OpVacuumIntoSubState::PrepareDestSchema {
                             dest_conn,
@@ -14034,7 +14066,10 @@ fn op_vacuum_into_inner(
                 // "CREATE TABLE sqlite_sequence(name,seq)", it fails with "table already exists".
                 // We still copy sqlite_sequence data in StartCopyTable to preserve counters.
                 if let Value::Text(name_val) = &row[1] {
-                    if name_val.as_str() == "sqlite_sequence" {
+                    if name_val.try_as_str().map_err(|_| {
+                        LimboError::Corrupt("sqlite_schema.name must be valid UTF-8".to_string())
+                    })? == "sqlite_sequence"
+                    {
                         vacuum_state.sub_state = OpVacuumIntoSubState::PrepareDestSchema {
                             dest_conn,
                             idx: idx + 1,
@@ -14047,7 +14082,9 @@ fn op_vacuum_into_inner(
                 let Value::Text(sql) = &row[3] else {
                     unreachable!("sql column should be text (query has WHERE sql IS NOT NULL)");
                 };
-                let sql_str = sql.as_str();
+                let sql_str = sql.try_as_str().map_err(|_| {
+                    LimboError::Corrupt("sqlite_schema.sql must be valid UTF-8".to_string())
+                })?;
 
                 // Internal tables (e.g. __turso_internal_types) have a reserved
                 // name prefix that translate_create_table rejects for user SQL.
@@ -14055,7 +14092,17 @@ fn op_vacuum_into_inner(
                 // so the reserved-name check is bypassed at compile time. We must
                 // NOT keep it nested during step() because that would prevent
                 // sub-statements from upgrading to write transactions.
-                let is_internal = matches!(&row[1], Value::Text(n) if n.as_str().starts_with(crate::schema::TURSO_INTERNAL_PREFIX));
+                let is_internal = match &row[1] {
+                    Value::Text(name) => name
+                        .try_as_str()
+                        .map_err(|_| {
+                            LimboError::Corrupt(
+                                "sqlite_schema.name must be valid UTF-8".to_string(),
+                            )
+                        })?
+                        .starts_with(crate::schema::TURSO_INTERNAL_PREFIX),
+                    _ => false,
+                };
                 if is_internal {
                     dest_conn.start_nested();
                 }
@@ -14086,8 +14133,17 @@ fn op_vacuum_into_inner(
                     // CREATE TABLE statements for STRICT tables with custom type
                     // columns can resolve those types.
                     let row = &vacuum_state.schema_rows[idx];
-                    if matches!(&row[1], Value::Text(n) if n.as_str() == crate::schema::TURSO_TYPES_TABLE_NAME)
-                    {
+                    let is_types_table = match &row[1] {
+                        Value::Text(name) => {
+                            name.try_as_str().map_err(|_| {
+                                LimboError::Corrupt(
+                                    "sqlite_schema.name must be valid UTF-8".to_string(),
+                                )
+                            })? == crate::schema::TURSO_TYPES_TABLE_NAME
+                        }
+                        _ => false,
+                    };
+                    if is_types_table {
                         let source_types: Vec<(String, std::sync::Arc<crate::schema::TypeDef>)> = {
                             let source_schema = program.connection.schema.read();
                             source_schema
@@ -14169,7 +14225,14 @@ fn op_vacuum_into_inner(
                         // Column name is at index 1
                         if let Value::Text(name) = row.get_value(1) {
                             // Escape double quotes in column name for safe SQL
-                            let escaped_name = name.as_str().replace('"', "\"\"");
+                            let escaped_name = name
+                                .try_as_str()
+                                .map_err(|_| {
+                                    LimboError::Corrupt(
+                                        "PRAGMA table_info name must be valid UTF-8".to_string(),
+                                    )
+                                })?
+                                .replace('"', "\"\"");
                             let col_name = format!("\"{escaped_name}\"");
                             vacuum_state.current_table_columns.push(col_name);
                         }
@@ -14429,10 +14492,16 @@ fn op_vacuum_into_inner(
 
                 // Only process triggers and views in this phase
                 if let Value::Text(type_val) = &row[0] {
-                    let type_str = type_val.as_str();
+                    let type_str = type_val.try_as_str().map_err(|_| {
+                        LimboError::Corrupt("sqlite_schema.type must be valid UTF-8".to_string())
+                    })?;
                     if type_str == "trigger" || type_str == "view" {
                         if let Value::Text(sql) = &row[3] {
-                            let sql_str = sql.as_str();
+                            let sql_str = sql.try_as_str().map_err(|_| {
+                                LimboError::Corrupt(
+                                    "sqlite_schema.sql must be valid UTF-8".to_string(),
+                                )
+                            })?;
                             let dest_stmt = dest_conn.prepare(sql_str)?;
                             vacuum_state.sub_state = OpVacuumIntoSubState::StepTriggersViews {
                                 dest_conn,
@@ -14783,7 +14852,7 @@ mod tests {
             match register {
                 Register::Value(Value::Text(t)) => {
                     assert_eq!(
-                        t.as_str().chars().count(),
+                        t.try_as_str().unwrap().chars().count(),
                         expected_len,
                         "String '{input}' should have {expected_len} characters",
                     );
@@ -14805,7 +14874,11 @@ mod tests {
             apply_affinity_char(&mut register, Affinity::Integer);
             match register {
                 Register::Value(Value::Text(t)) => {
-                    assert_eq!(t.as_str(), input, "Unexpected conversion for '{input}'");
+                    assert_eq!(
+                        t.try_as_str().unwrap(),
+                        input,
+                        "Unexpected conversion for '{input}'"
+                    );
                 }
                 other => {
                     panic!("'{input}' should remain text, got {other:?}");
@@ -14816,7 +14889,11 @@ mod tests {
             apply_affinity_char(&mut register, Affinity::Numeric);
             match register {
                 Register::Value(Value::Text(t)) => {
-                    assert_eq!(t.as_str(), input, "Unexpected conversion for '{input}'");
+                    assert_eq!(
+                        t.try_as_str().unwrap(),
+                        input,
+                        "Unexpected conversion for '{input}'"
+                    );
                 }
                 other => {
                     panic!("'{input}' should remain text, got {other:?}");

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -15168,8 +15168,9 @@ mod tests {
     #[test]
     fn test_negate_blob_subscript_invalid_utf8_no_panic() {
         // Negating a blob subscript that extracts a "text" value containing
-        // invalid UTF-8 bytes must not panic. The record decoder uses
-        // from_utf8_unchecked, so ArrayElement must validate extracted text.
+        // invalid UTF-8 bytes must not panic. Record decode preserves the raw
+        // TEXT bytes, so ArrayElement must not assume extracted text is valid
+        // UTF-8.
         //
         // Reproduces fuzzer bug at seed 27035.
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -44,8 +44,8 @@ const BLOB_HASH: u8 = 4;
 #[inline]
 /// Hash text case-insensitively without allocation (ASCII-only for SQLite NOCASE).
 /// SQLite's NOCASE collation only considers ASCII case, so to_ascii_lowercase() is correct.
-fn hash_text_nocase(hasher: &mut impl Hasher, text: &str) {
-    for byte in text.bytes() {
+fn hash_text_nocase(hasher: &mut impl Hasher, text: &[u8]) {
+    for &byte in text {
         hasher.write_u8(byte.to_ascii_lowercase());
     }
 }
@@ -83,11 +83,16 @@ fn hash_join_key(key_values: &[ValueRef], collations: &[CollationSeq]) -> u64 {
                 hasher.write_u8(TEXT_HASH);
                 match collation {
                     CollationSeq::NoCase => {
-                        hash_text_nocase(&mut hasher, text.as_str());
+                        hash_text_nocase(&mut hasher, text.as_bytes());
                     }
                     CollationSeq::Rtrim => {
-                        let trimmed = text.as_str().trim_end();
-                        hasher.write(trimmed.as_bytes());
+                        let trimmed = text
+                            .as_bytes()
+                            .iter()
+                            .rposition(|&b| b != b' ')
+                            .map(|i| &text.as_bytes()[..=i])
+                            .unwrap_or(&[]);
+                        hasher.write(trimmed);
                     }
                     CollationSeq::Binary | CollationSeq::Unset => {
                         hasher.write(text.as_bytes());
@@ -150,7 +155,7 @@ fn values_equal(v1: ValueRef, v2: ValueRef, collation: CollationSeq) -> bool {
         (ValueRef::Blob(b1), ValueRef::Blob(b2)) => b1 == b2,
         (ValueRef::Text(t1), ValueRef::Text(t2)) => {
             // Use collation for text comparison
-            collation.compare_strings(t1.as_str(), t2.as_str()) == Ordering::Equal
+            collation.compare_texts(t1.as_bytes(), t2.as_bytes()) == Ordering::Equal
         }
         _ => false,
     }
@@ -269,7 +274,7 @@ impl HashEntry {
         let value_size = |v: &Value| match v {
             Value::Null => 1,
             Value::Numeric(_) => 8,
-            Value::Text(t) => t.as_str().len(),
+            Value::Text(t) => t.as_bytes().len(),
             Value::Blob(b) => b.len(),
         };
         let key_size: usize = key_values.iter().map(value_size).sum();
@@ -284,7 +289,7 @@ impl HashEntry {
             Value::Null => 0,
             Value::Numeric(_) => 8,
             Value::Text(t) => {
-                let len = t.as_str().len();
+                let len = t.as_bytes().len();
                 varint_len(len as u64) + len
             }
             Value::Blob(b) => varint_len(b.len() as u64) + b.len(),
@@ -350,7 +355,7 @@ impl HashEntry {
             Value::Text(t) => {
                 buf[offset] = TEXT_HASH;
                 offset += 1;
-                let bytes = t.as_str().as_bytes();
+                let bytes = t.as_bytes();
                 offset += write_varint(&mut buf[offset..], bytes.len() as u64);
                 buf[offset..offset + bytes.len()].copy_from_slice(bytes);
                 offset += bytes.len();
@@ -405,7 +410,7 @@ impl HashEntry {
             }
             Value::Text(t) => {
                 buf.push(TEXT_HASH);
-                let bytes = t.as_str().as_bytes();
+                let bytes = t.as_bytes();
                 let len = write_varint(varint_buf, bytes.len() as u64);
                 buf.extend_from_slice(&varint_buf[..len]);
                 buf.extend_from_slice(bytes);
@@ -508,14 +513,9 @@ impl HashEntry {
                         "HashEntry: buffer too small for text".to_string(),
                     ));
                 }
-                // SAFETY: We serialized this data ourselves, so it should be valid UTF-8.
-                // Skipping validation here for performance in the spill/reload path.
-                // Doing checked utf8 construction here is a massive performance hit.
-                let s = unsafe {
-                    String::from_utf8_unchecked(buf[offset..offset + str_len as usize].to_vec())
-                };
+                let s = buf[offset..offset + str_len as usize].to_vec();
                 offset += str_len as usize;
-                Value::Text(s.into())
+                Value::from_text(s)
             }
             BLOB_HASH => {
                 let (blob_len, varint_len) = read_varint(&buf[offset..])?;
@@ -3451,7 +3451,9 @@ mod hashtests {
                 (Value::Numeric(Numeric::Integer(i1)), Value::Numeric(Numeric::Integer(i2))) => {
                     assert_eq!(i1, i2)
                 }
-                (Value::Text(t1), Value::Text(t2)) => assert_eq!(t1.as_str(), t2.as_str()),
+                (Value::Text(t1), Value::Text(t2)) => {
+                    assert_eq!(t1.try_as_str().unwrap(), t2.try_as_str().unwrap())
+                }
                 (Value::Numeric(Numeric::Float(f1)), Value::Numeric(Numeric::Float(f2))) => {
                     assert!((f64::from(*f1) - f64::from(*f2)).abs() < 1e-10)
                 }
@@ -4617,7 +4619,9 @@ mod hashtests {
                     let expected_payload = format!("payload_{}", build_entry.rowid);
                     assert_eq!(build_entry.payload_values.len(), 1);
                     match &build_entry.payload_values[0] {
-                        Value::Text(t) => assert_eq!(t.as_str(), expected_payload.as_str()),
+                        Value::Text(t) => {
+                            assert_eq!(t.try_as_str().unwrap(), expected_payload.as_str())
+                        }
                         other => panic!("expected text payload, got {other:?}"),
                     }
                     match_count += 1;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2513,19 +2513,11 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 }
                 self.set_data_section(&data[content_size..]);
                 let text_data = &data[..content_size];
-                // SAFETY: TEXT serial type contains valid UTF-8
-                let text_str = if cfg!(debug_assertions) {
-                    match std::str::from_utf8(text_data) {
+                let text_str =
+                    match crate::storage::sqlite3_ondisk::decode_text_serial_type(text_data) {
                         Ok(s) => s,
-                        Err(e) => {
-                            return Some(Err(LimboError::InternalError(format!(
-                                "Invalid UTF-8 in TEXT serial type: {e}"
-                            ))));
-                        }
-                    }
-                } else {
-                    unsafe { std::str::from_utf8_unchecked(text_data) }
-                };
+                        Err(e) => return Some(Err(e)),
+                    };
                 match dest {
                     Register::Value(Value::Text(existing_text)) => {
                         existing_text.do_extend(&text_str);
@@ -2544,6 +2536,29 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
         }
 
         Some(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Register, ValueIteratorExt};
+    use crate::{
+        error::LimboError,
+        types::{Value, ValueIterator},
+    };
+
+    #[test]
+    fn test_nth_into_register_rejects_invalid_utf8_text() {
+        let payload = [2, 15, 0xFF];
+        let mut iter = ValueIterator::new(&payload).unwrap();
+        let mut dest = Register::Value(Value::Null);
+
+        let result = iter.nth_into_register(0, &mut dest);
+
+        assert!(
+            matches!(result, Some(Err(LimboError::Corrupt(ref msg))) if msg.contains("Invalid UTF-8 in TEXT serial type")),
+            "expected invalid UTF-8 TEXT error, got {result:?}"
+        );
     }
 }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -187,6 +187,27 @@ impl BranchOffset {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{Register, ValueIteratorExt};
+    use crate::types::{Value, ValueIterator};
+
+    #[test]
+    fn test_nth_into_register_preserves_invalid_text_bytes() {
+        let payload = [2, 15, 0xFF];
+        let mut iter = ValueIterator::new(&payload).unwrap();
+        let mut dest = Register::Value(Value::Null);
+
+        let result = iter.nth_into_register(0, &mut dest);
+
+        assert!(matches!(result, Some(Ok(()))));
+        match dest {
+            Register::Value(Value::Text(text)) => assert_eq!(text.as_bytes(), &[0xFF]),
+            other => panic!("expected text register, got {other:?}"),
+        }
+    }
+}
+
 pub type CursorID = usize;
 
 pub type PageIdx = i64;
@@ -2264,7 +2285,10 @@ impl<'a> FromValueRow<'a> for f64 {
 impl<'a> FromValueRow<'a> for String {
     fn from_value(value: &'a Value) -> Result<Self> {
         match value {
-            Value::Text(s) => Ok(s.as_str().to_string()),
+            Value::Text(s) => s
+                .try_as_str()
+                .map(str::to_owned)
+                .map_err(|_| LimboError::ConversionError("Expected valid UTF-8 text value".into())),
             _ => Err(LimboError::ConversionError("Expected text value".into())),
         }
     }
@@ -2273,7 +2297,9 @@ impl<'a> FromValueRow<'a> for String {
 impl<'a> FromValueRow<'a> for &'a str {
     fn from_value(value: &'a Value) -> Result<Self> {
         match value {
-            Value::Text(s) => Ok(s.as_str()),
+            Value::Text(s) => s
+                .try_as_str()
+                .map_err(|_| LimboError::ConversionError("Expected valid UTF-8 text value".into())),
             _ => Err(LimboError::ConversionError("Expected text value".into())),
         }
     }
@@ -2513,17 +2539,12 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 }
                 self.set_data_section(&data[content_size..]);
                 let text_data = &data[..content_size];
-                let text_str =
-                    match crate::storage::sqlite3_ondisk::decode_text_serial_type(text_data) {
-                        Ok(s) => s,
-                        Err(e) => return Some(Err(e)),
-                    };
                 match dest {
                     Register::Value(Value::Text(existing_text)) => {
-                        existing_text.do_extend(&text_str);
+                        existing_text.do_extend(&text_data);
                     }
                     _ => {
-                        dest.set_text(Text::new(text_str.to_string()));
+                        dest.set_text(Text::from(text_data.to_vec()));
                     }
                 }
             }
@@ -2536,29 +2557,6 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
         }
 
         Some(Ok(()))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Register, ValueIteratorExt};
-    use crate::{
-        error::LimboError,
-        types::{Value, ValueIterator},
-    };
-
-    #[test]
-    fn test_nth_into_register_rejects_invalid_utf8_text() {
-        let payload = [2, 15, 0xFF];
-        let mut iter = ValueIterator::new(&payload).unwrap();
-        let mut dest = Register::Value(Value::Null);
-
-        let result = iter.nth_into_register(0, &mut dest);
-
-        assert!(
-            matches!(result, Some(Err(LimboError::Corrupt(ref msg))) if msg.contains("Invalid UTF-8 in TEXT serial type")),
-            "expected invalid UTF-8 TEXT error, got {result:?}"
-        );
     }
 }
 
@@ -2603,7 +2601,7 @@ mod shuttle_tests {
                         Register::Value(Value::Numeric(Numeric::Integer(42)))
                     ));
                     if let Register::Value(Value::Text(t)) = &state.registers[1] {
-                        assert_eq!(t.as_str(), "test");
+                        assert_eq!(t.try_as_str().unwrap(), "test");
                     } else {
                         panic!("Expected text value");
                     }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -833,9 +833,9 @@ impl Ord for ArenaSortableRecord {
                 comparator(&self_val, &other_val)
             } else {
                 match (self_val, other_val) {
-                    (ValueRef::Text(left), ValueRef::Text(right)) => {
-                        key_info.collation.compare_strings(&left, &right)
-                    }
+                    (ValueRef::Text(left), ValueRef::Text(right)) => key_info
+                        .collation
+                        .compare_texts(left.as_bytes(), right.as_bytes()),
                     _ => self_val.partial_cmp(&other_val).unwrap_or(Ordering::Equal),
                 }
             };
@@ -948,9 +948,9 @@ impl Ord for BoxedSortableRecord {
                 comparator(&self_val, &other_val)
             } else {
                 match (self_val, other_val) {
-                    (ValueRef::Text(left), ValueRef::Text(right)) => {
-                        key_info.collation.compare_strings(&left, &right)
-                    }
+                    (ValueRef::Text(left), ValueRef::Text(right)) => key_info
+                        .collation
+                        .compare_texts(left.as_bytes(), right.as_bytes()),
                     _ => self_val.partial_cmp(&other_val).unwrap_or(Ordering::Equal),
                 }
             };

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -303,8 +303,16 @@ fn trim_text_bytes(bytes: &[u8], pattern: Option<&[u8]>, trim_type: TrimType) ->
 
 impl Value {
     pub fn exec_lower(&self) -> Option<Self> {
-        self.cast_text()
-            .map(|s| Value::build_text(s.to_ascii_lowercase()))
+        match self.exec_cast("TEXT") {
+            Value::Text(text) => Some(Value::build_text(
+                text.as_bytes()
+                    .iter()
+                    .map(|byte| byte.to_ascii_lowercase())
+                    .collect::<Vec<_>>(),
+            )),
+            Value::Null => None,
+            _ => unreachable!("TEXT cast should always return TEXT or NULL"),
+        }
     }
 
     pub fn exec_length(&self) -> Self {
@@ -329,8 +337,16 @@ impl Value {
     }
 
     pub fn exec_upper(&self) -> Option<Self> {
-        self.cast_text()
-            .map(|s| Value::build_text(s.to_ascii_uppercase()))
+        match self.exec_cast("TEXT") {
+            Value::Text(text) => Some(Value::build_text(
+                text.as_bytes()
+                    .iter()
+                    .map(|byte| byte.to_ascii_uppercase())
+                    .collect::<Vec<_>>(),
+            )),
+            Value::Null => None,
+            _ => unreachable!("TEXT cast should always return TEXT or NULL"),
+        }
     }
 
     pub fn exec_sign(&self) -> Option<Value> {

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1,12 +1,13 @@
 use crate::turso_assert;
 use crate::{
     function::MathFunc,
-    numeric::{format_float, format_float_for_quote, NullableInteger, Numeric},
+    numeric::{format_float_for_quote, NullableInteger, Numeric},
     translate::collate::CollationSeq,
     types::{compare_immutable_single, AsValueRef, SeekOp},
     vdbe::affinity::{real_to_i64, Affinity},
     LimboError, Result, Value, ValueRef,
 };
+use std::borrow::Cow;
 
 // we use math functions from Rust stdlib in order to be as portable as possible for the production version of the tursodb
 #[cfg(not(test))]
@@ -181,6 +182,152 @@ enum TrimType {
     Right,
 }
 
+fn coerce_to_text_bytes(value: &Value) -> Option<Cow<'_, [u8]>> {
+    match value {
+        Value::Null => None,
+        Value::Text(text) => Some(Cow::Borrowed(text.as_bytes())),
+        Value::Blob(blob) => Some(Cow::Borrowed(blob.as_slice())),
+        Value::Numeric(_) => Some(Cow::Owned(value.to_string().into_bytes())),
+    }
+}
+
+fn count_text_units(bytes: &[u8], stop_at_nul: bool) -> usize {
+    let mut count = 0;
+
+    for chunk in bytes.utf8_chunks() {
+        let valid = chunk.valid();
+        if stop_at_nul {
+            if let Some(pos) = valid.as_bytes().iter().position(|&b| b == 0) {
+                count += valid[..pos].chars().count();
+                return count;
+            }
+        }
+
+        count += valid.chars().count();
+        if !chunk.invalid().is_empty() {
+            count += 1;
+        }
+    }
+
+    count
+}
+
+fn boundary_after_text_units(bytes: &[u8], target: usize) -> usize {
+    if target == 0 {
+        return 0;
+    }
+
+    let mut count = 0;
+    let mut offset = 0;
+
+    for chunk in bytes.utf8_chunks() {
+        let valid = chunk.valid();
+        for (_, ch) in valid.char_indices() {
+            count += 1;
+            offset += ch.len_utf8();
+            if count == target {
+                return offset;
+            }
+        }
+
+        if !chunk.invalid().is_empty() {
+            count += 1;
+            offset += chunk.invalid().len();
+            if count == target {
+                return offset;
+            }
+        }
+    }
+
+    bytes.len()
+}
+
+fn collect_text_units(bytes: &[u8], stop_at_nul: bool) -> Vec<(usize, usize)> {
+    let mut units = Vec::new();
+    let mut offset = 0;
+
+    for chunk in bytes.utf8_chunks() {
+        let valid = chunk.valid();
+        for (idx, ch) in valid.char_indices() {
+            let start = offset + idx;
+            let end = start + ch.len_utf8();
+            if stop_at_nul && bytes[start] == 0 {
+                return units;
+            }
+            units.push((start, end));
+        }
+        offset += valid.len();
+
+        if !chunk.invalid().is_empty() {
+            let invalid_len = chunk.invalid().len();
+            units.push((offset, offset + invalid_len));
+            offset += invalid_len;
+        }
+    }
+
+    units
+}
+
+fn trim_text_bytes(bytes: &[u8], pattern: Option<&[u8]>, trim_type: TrimType) -> Vec<u8> {
+    let units = collect_text_units(bytes, false);
+    if units.is_empty() {
+        return bytes.to_vec();
+    }
+
+    let pattern_storage;
+    let pattern_units: Vec<&[u8]> = match pattern {
+        None => vec![b" "],
+        Some(pattern) => {
+            pattern_storage = collect_text_units(pattern, false);
+            if pattern_storage.is_empty() {
+                return bytes.to_vec();
+            }
+            pattern_storage
+                .iter()
+                .map(|(start, end)| &pattern[*start..*end])
+                .collect()
+        }
+    };
+
+    let mut start_idx = 0;
+    let mut end_idx = units.len();
+
+    if matches!(trim_type, TrimType::All | TrimType::Left) {
+        while start_idx < end_idx {
+            let unit = &bytes[units[start_idx].0..units[start_idx].1];
+            if pattern_units.contains(&unit) {
+                start_idx += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    if matches!(trim_type, TrimType::All | TrimType::Right) {
+        while end_idx > start_idx {
+            let unit = &bytes[units[end_idx - 1].0..units[end_idx - 1].1];
+            if pattern_units.contains(&unit) {
+                end_idx -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    let start_byte = units
+        .get(start_idx)
+        .map_or(bytes.len(), |(start, _)| *start);
+    let end_byte = if end_idx == 0 {
+        0
+    } else if end_idx == units.len() {
+        bytes.len()
+    } else {
+        units[end_idx - 1].1
+    };
+
+    bytes[start_byte..end_byte].to_vec()
+}
+
 impl Value {
     pub fn exec_lower(&self) -> Option<Self> {
         self.cast_text()
@@ -190,12 +337,15 @@ impl Value {
     pub fn exec_length(&self) -> Self {
         match self {
             Value::Text(t) => {
-                let s = t.as_str();
-                let len_before_null = s.find('\0').map_or_else(
-                    || s.chars().count(),
-                    |null_pos| s[..null_pos].chars().count(),
-                );
-                Value::from_i64(len_before_null as i64)
+                if let Ok(s) = t.try_as_str() {
+                    let len_before_null = s.find('\0').map_or_else(
+                        || s.chars().count(),
+                        |null_pos| s[..null_pos].chars().count(),
+                    );
+                    Value::from_i64(len_before_null as i64)
+                } else {
+                    Value::from_i64(count_text_units(t.as_bytes(), true) as i64)
+                }
             }
             Value::Numeric(_) => {
                 // For numbers, SQLite returns the length of the string representation
@@ -208,7 +358,7 @@ impl Value {
 
     pub fn exec_octet_length(&self) -> Self {
         match self {
-            Value::Text(s) => Value::from_i64(s.as_str().len() as i64),
+            Value::Text(s) => Value::from_i64(s.as_bytes().len() as i64),
             Value::Blob(blob) => Value::from_i64(blob.len() as i64),
             Value::Numeric(_) => Value::from_i64(self.to_string().len() as i64),
             _ => self.to_owned(),
@@ -235,7 +385,10 @@ impl Value {
     /// Generates the Soundex code for a given word
     pub fn exec_soundex(&self) -> Value {
         let s = match self {
-            Value::Text(s) => s.as_str(),
+            Value::Text(s) => match s.try_as_str() {
+                Ok(s) => s,
+                Err(_) => return Value::build_text("?000"),
+            },
             Value::Null => return Value::build_text("?000"),
             _ => return Value::build_text("?000"),
         };
@@ -303,7 +456,7 @@ impl Value {
             Value::Numeric(Numeric::Float(non_nan)) => Value::from_f64(f64::from(*non_nan).abs()),
             _ => {
                 let s = match self {
-                    Value::Text(text) => std::borrow::Cow::Borrowed(text.as_str()),
+                    Value::Text(text) => text.as_str_lossy(),
                     Value::Blob(blob) => String::from_utf8_lossy(blob),
                     _ => unreachable!(),
                 };
@@ -332,7 +485,7 @@ impl Value {
         let length = match self {
             Value::Numeric(Numeric::Integer(i)) => *i,
             Value::Numeric(Numeric::Float(f)) => f64::from(*f) as i64,
-            Value::Text(t) => t.as_str().parse().unwrap_or(1),
+            Value::Text(t) => t.as_str_lossy().parse().unwrap_or(1),
             _ => 1,
         }
         .max(1);
@@ -365,9 +518,10 @@ impl Value {
                 Value::build_text(quoted)
             }
             Value::Text(s) => {
-                let mut quoted = String::with_capacity(s.as_str().len() + 2);
+                let s = s.as_str_lossy();
+                let mut quoted = String::with_capacity(s.len() + 2);
                 quoted.push('\'');
-                for c in s.as_str().chars() {
+                for c in s.chars() {
                     if c == '\0' {
                         break;
                     } else if c == '\'' {
@@ -388,7 +542,7 @@ impl Value {
 
         match self {
             Value::Text(s) => {
-                let s = s.as_str();
+                let s = s.as_str_lossy();
                 let mut end = s.len();
                 let mut has_ctrl = false;
 
@@ -455,32 +609,6 @@ impl Value {
         start_value: &Value,
         length_value: Option<&Value>,
     ) -> Value {
-        /// Function is stabilized but not released for version 1.88 \
-        /// https://doc.rust-lang.org/src/core/str/mod.rs.html#453
-        const fn ceil_char_boundary(s: &str, index: usize) -> usize {
-            const fn is_utf8_char_boundary(c: u8) -> bool {
-                // This is bit magic equivalent to: b < 128 || b >= 192
-                (c as i8) >= -0x40
-            }
-
-            if index >= s.len() {
-                s.len()
-            } else {
-                let mut i = index;
-                while i < s.len() {
-                    if is_utf8_char_boundary(s.as_bytes()[i]) {
-                        break;
-                    }
-                    i += 1;
-                }
-
-                //  The character boundary will be within four bytes of the index
-                debug_assert!(i <= index + 3);
-
-                i
-            }
-        }
-
         // Match SQLite's substr algorithm exactly (func.c substrFunc)
         // Uses wrapping arithmetic to match C overflow behavior
         fn calculate_postions(
@@ -545,14 +673,37 @@ impl Value {
                 Value::from_blob(b[start..end].to_vec())
             }
             (value, Value::Numeric(Numeric::Integer(start))) => {
-                if let Some(text) = value.cast_text() {
-                    // Use character count to accurately resolve negative offsets in UTF-8 strings
-                    let char_count = text.chars().count();
+                let Some(text) = coerce_to_text_bytes(value) else {
+                    return Value::Null;
+                };
+                let bytes = text.as_ref();
+                if let Ok(s) = std::str::from_utf8(bytes) {
+                    /// Function is stabilized but not released for version 1.88 \
+                    /// https://doc.rust-lang.org/src/core/str/mod.rs.html#453
+                    const fn ceil_char_boundary(s: &str, index: usize) -> usize {
+                        const fn is_utf8_char_boundary(c: u8) -> bool {
+                            (c as i8) >= -0x40
+                        }
+
+                        if index >= s.len() {
+                            s.len()
+                        } else {
+                            let mut i = index;
+                            while i < s.len() {
+                                if is_utf8_char_boundary(s.as_bytes()[i]) {
+                                    break;
+                                }
+                                i += 1;
+                            }
+                            debug_assert!(i <= index + 3);
+                            i
+                        }
+                    }
+
+                    let char_count = s.chars().count();
                     let (mut start, mut end) =
                         calculate_postions(start, char_count, length_value.as_ref());
 
-                    // https://github.com/sqlite/sqlite/blob/a248d84f/src/func.c#L417
-                    let s = text.as_str();
                     let mut start_byte_idx = 0;
                     end -= start;
                     while start > 0 {
@@ -564,10 +715,19 @@ impl Value {
                         end_byte_idx = ceil_char_boundary(s, end_byte_idx + 1);
                         end -= 1;
                     }
-                    Value::build_text(s[start_byte_idx..end_byte_idx].to_string())
-                } else {
-                    Value::Null
+                    return Value::build_text(s[start_byte_idx..end_byte_idx].to_string());
                 }
+
+                let char_count = count_text_units(bytes, false);
+                let (start, end) = calculate_postions(start, char_count, length_value.as_ref());
+
+                if start >= end || start >= char_count {
+                    return Value::build_text(Vec::new());
+                }
+
+                let start_byte = boundary_after_text_units(bytes, start);
+                let end_byte = boundary_after_text_units(bytes, end);
+                Value::build_text(bytes[start_byte..end_byte].to_vec())
             }
             _ => Value::Null,
         }
@@ -590,28 +750,25 @@ impl Value {
             return Value::from_i64(result as i64);
         }
 
-        let reg_str;
-        let reg = match self {
-            Value::Text(s) => s.as_str(),
-            _ => {
-                reg_str = self.to_string();
-                reg_str.as_str()
-            }
+        let Some(reg) = coerce_to_text_bytes(self) else {
+            return Value::Null;
         };
-
-        let pattern_str;
-        let pattern = match pattern {
-            Value::Text(s) => s.as_str(),
-            _ => {
-                pattern_str = pattern.to_string();
-                pattern_str.as_str()
-            }
+        let Some(pattern) = coerce_to_text_bytes(pattern) else {
+            return Value::Null;
         };
+        let reg = reg.as_ref();
+        let pattern = pattern.as_ref();
 
-        match reg.find(pattern) {
+        if pattern.is_empty() {
+            return Value::from_i64(1);
+        }
+
+        match reg
+            .windows(pattern.len())
+            .position(|window| window == pattern)
+        {
             Some(byte_pos) => {
-                // Convert byte position to character position (1-indexed)
-                let char_pos = reg[..byte_pos].chars().count() + 1;
+                let char_pos = count_text_units(&reg[..byte_pos], false) + 1;
                 Value::from_i64(char_pos as i64)
             }
             None => Value::from_i64(0),
@@ -630,10 +787,8 @@ impl Value {
 
     pub fn exec_hex(&self) -> Value {
         match self {
-            Value::Text(_) | Value::Numeric(_) => {
-                let text = self.to_string();
-                Value::build_text(hex::encode_upper(text))
-            }
+            Value::Text(text) => Value::build_text(hex::encode_upper(text.as_bytes())),
+            Value::Numeric(_) => Value::build_text(hex::encode_upper(self.to_string())),
             Value::Blob(blob_bytes) => Value::build_text(hex::encode_upper(blob_bytes)),
             Value::Null => Value::build_text(""),
         }
@@ -710,7 +865,7 @@ impl Value {
 
     pub fn exec_unistr(&self) -> Result<Value> {
         let text = match self {
-            Value::Text(t) => std::borrow::Cow::Borrowed(t.as_str()),
+            Value::Text(t) => t.as_str_lossy(),
             Value::Numeric(_) | Value::Blob(_) => std::borrow::Cow::Owned(self.to_string()),
             _ => return Ok(Value::Null),
         };
@@ -798,34 +953,56 @@ impl Value {
     }
 
     fn _exec_trim(&self, pattern: Option<&Value>, trim_type: TrimType) -> Value {
-        let text_cow = match self {
-            Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
-            Value::Null => return Value::Null,
-            _ => std::borrow::Cow::Owned(self.to_string()),
+        let Some(text) = coerce_to_text_bytes(self) else {
+            return Value::Null;
         };
+        if let Ok(text_str) = std::str::from_utf8(text.as_ref()) {
+            let trimmed = match pattern {
+                Some(p) => {
+                    if matches!(p, Value::Null) {
+                        return Value::Null;
+                    }
+                    let Some(pattern) = coerce_to_text_bytes(p) else {
+                        return Value::Null;
+                    };
+                    let Ok(pattern_str) = std::str::from_utf8(pattern.as_ref()) else {
+                        return Value::build_text(trim_text_bytes(
+                            text.as_ref(),
+                            Some(pattern.as_ref()),
+                            trim_type,
+                        ));
+                    };
+                    match trim_type {
+                        TrimType::All => text_str.trim_matches(|c| pattern_str.contains(c)),
+                        TrimType::Left => text_str.trim_start_matches(|c| pattern_str.contains(c)),
+                        TrimType::Right => text_str.trim_end_matches(|c| pattern_str.contains(c)),
+                    }
+                    .as_bytes()
+                    .to_vec()
+                }
+                None => match trim_type {
+                    TrimType::All => text_str.trim_matches(' '),
+                    TrimType::Left => text_str.trim_start_matches(' '),
+                    TrimType::Right => text_str.trim_end_matches(' '),
+                }
+                .as_bytes()
+                .to_vec(),
+            };
+            return Value::build_text(trimmed);
+        }
         let trimmed = match pattern {
             Some(p) => {
                 if matches!(p, Value::Null) {
                     return Value::Null;
                 }
-                let pat_cow = match p {
-                    Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
-                    _ => std::borrow::Cow::Owned(p.to_string()),
+                let Some(pattern) = coerce_to_text_bytes(p) else {
+                    return Value::Null;
                 };
-                let p_str = pat_cow.as_ref();
-                match trim_type {
-                    TrimType::All => text_cow.trim_matches(|c| p_str.contains(c)),
-                    TrimType::Left => text_cow.trim_start_matches(|c| p_str.contains(c)),
-                    TrimType::Right => text_cow.trim_end_matches(|c| p_str.contains(c)),
-                }
+                trim_text_bytes(text.as_ref(), Some(pattern.as_ref()), trim_type)
             }
-            None => match trim_type {
-                TrimType::All => text_cow.trim_matches(' '),
-                TrimType::Left => text_cow.trim_start_matches(' '),
-                TrimType::Right => text_cow.trim_end_matches(' '),
-            },
+            None => trim_text_bytes(text.as_ref(), None, trim_type),
         };
-        Value::build_text(trimmed.to_string())
+        Value::build_text(trimmed)
     }
 
     // Implements TRIM pattern matching.
@@ -846,7 +1023,7 @@ impl Value {
         let length: i64 = match self {
             Value::Numeric(Numeric::Integer(i)) => *i,
             Value::Numeric(Numeric::Float(f)) => f64::from(*f) as i64,
-            Value::Text(s) => s.as_str().parse().unwrap_or(0),
+            Value::Text(s) => s.as_str_lossy().parse().unwrap_or(0),
             _ => 0,
         }
         .max(0);
@@ -873,19 +1050,18 @@ impl Value {
         match Affinity::affinity(datatype) {
             // NONE	Casting a value to a type-name with no affinity causes the value to be converted into a BLOB. Casting to a BLOB consists of first casting the value to TEXT in the encoding of the database connection, then interpreting the resulting byte sequence as a BLOB instead of as TEXT.
             // Historically called NONE, but it's the same as BLOB
-            Affinity::Blob => {
-                // Convert to TEXT first, then interpret as BLOB
-                // TODO: handle encoding
-                let text = self.to_string();
-                Value::Blob(text.into_bytes())
-            }
+            Affinity::Blob => match self {
+                Value::Text(text) => Value::Blob(text.as_bytes().to_vec()),
+                Value::Blob(blob) => Value::Blob(blob.clone()),
+                _ => Value::Blob(self.to_string().into_bytes()),
+            },
             // TEXT To cast a BLOB value to TEXT, the sequence of bytes that make up the BLOB is interpreted as text encoded using the database encoding.
             // Casting an INTEGER or REAL value into TEXT renders the value as if via sqlite3_snprintf() except that the resulting TEXT uses the encoding of the database connection.
-            Affinity::Text => {
-                // Convert everything to text representation
-                // TODO: handle encoding and whatever sqlite3_snprintf does
-                Value::build_text(self.to_string())
-            }
+            Affinity::Text => match self {
+                Value::Text(text) => Value::Text(text.clone()),
+                Value::Blob(blob) => Value::build_text(blob.clone()),
+                _ => Value::build_text(self.to_string()),
+            },
             Affinity::Real => match self {
                 Value::Blob(b) => {
                     let text = String::from_utf8_lossy(b);
@@ -895,9 +1071,11 @@ impl Value {
                             .unwrap_or(0.0),
                     )
                 }
-                Value::Text(t) => {
-                    Value::from_f64(crate::numeric::str_to_f64(t).map(f64::from).unwrap_or(0.0))
-                }
+                Value::Text(t) => Value::from_f64(
+                    crate::numeric::str_to_f64(t.as_str_lossy())
+                        .map(f64::from)
+                        .unwrap_or(0.0),
+                ),
                 Value::Numeric(Numeric::Integer(i)) => Value::from_f64(*i as f64),
                 Value::Numeric(Numeric::Float(f)) => Value::Numeric(Numeric::Float(*f)),
                 _ => Value::from_f64(0.0),
@@ -908,7 +1086,9 @@ impl Value {
                     let text = String::from_utf8_lossy(b);
                     Value::from_i64(crate::numeric::str_to_i64(&text).unwrap_or(0))
                 }
-                Value::Text(t) => Value::from_i64(crate::numeric::str_to_i64(t).unwrap_or(0)),
+                Value::Text(t) => {
+                    Value::from_i64(crate::numeric::str_to_i64(t.as_str_lossy()).unwrap_or(0))
+                }
                 Value::Numeric(Numeric::Integer(i)) => Value::from_i64(*i),
                 // A cast of a REAL value into an INTEGER follows SQLite's sqlite3RealToI64:
                 // truncate toward zero and clamp to i64::MIN/MAX if outside the safe range.
@@ -921,7 +1101,7 @@ impl Value {
                 Value::Numeric(Numeric::Float(v)) => Value::Numeric(Numeric::Float(*v)),
                 _ => {
                     let s = match self {
-                        Value::Text(text) => text.as_str().into(),
+                        Value::Text(text) => text.as_str_lossy(),
                         Value::Blob(blob) => String::from_utf8_lossy(blob.as_slice()),
                         _ => unreachable!(),
                     };
@@ -953,13 +1133,25 @@ impl Value {
         // If any of the casts failed, panic as text casting is not expected to fail.
         match (&source, &pattern, &replacement) {
             (Value::Text(source), Value::Text(pattern), Value::Text(replacement)) => {
-                if pattern.as_str().is_empty() || pattern.as_str().starts_with('\0') {
+                let source_bytes = source.as_bytes();
+                let pattern_bytes = pattern.as_bytes();
+                let replacement_bytes = replacement.as_bytes();
+
+                if pattern_bytes.is_empty() || pattern_bytes[0] == 0 {
                     return Value::Text(source.clone());
                 }
 
-                let result = source
-                    .as_str()
-                    .replace(pattern.as_str(), replacement.as_str());
+                let mut result = Vec::with_capacity(source_bytes.len());
+                let mut offset = 0;
+                while offset < source_bytes.len() {
+                    if source_bytes[offset..].starts_with(pattern_bytes) {
+                        result.extend_from_slice(replacement_bytes);
+                        offset += pattern_bytes.len();
+                    } else {
+                        result.push(source_bytes[offset]);
+                        offset += 1;
+                    }
+                }
                 Value::build_text(result)
             }
             _ => unreachable!("text cast should never fail"),
@@ -1139,15 +1331,18 @@ impl Value {
             return Value::Blob([lhs.as_slice(), rhs.as_slice()].concat().to_vec());
         }
 
-        let Some(lhs) = self.cast_text() else {
+        let Some(lhs) = coerce_to_text_bytes(self) else {
             return Value::Null;
         };
 
-        let Some(rhs) = rhs.cast_text() else {
+        let Some(rhs) = coerce_to_text_bytes(rhs) else {
             return Value::Null;
         };
 
-        Value::build_text(lhs + &rhs)
+        let mut result = Vec::with_capacity(lhs.len() + rhs.len());
+        result.extend_from_slice(lhs.as_ref());
+        result.extend_from_slice(rhs.as_ref());
+        Value::build_text(result)
     }
 
     pub fn exec_and(&self, rhs: &Value) -> Value {
@@ -1288,18 +1483,16 @@ impl Value {
         let Value::Text(text) = self else {
             panic!("concat_to_text must be called only on Value::Text");
         };
-        text.value.to_mut().push_str(&other.to_string());
+        if let Some(other) = coerce_to_text_bytes(other) {
+            text.value.to_mut().extend_from_slice(other.as_ref());
+        }
     }
 
     pub fn exec_concat_strings<'a, T: Iterator<Item = &'a Self>>(registers: T) -> Self {
-        let mut result = String::new();
+        let mut result = Vec::new();
         for val in registers {
-            match val {
-                Value::Null => continue,
-                Value::Text(s) => result.push_str(s.as_str()),
-                Value::Blob(b) => result.push_str(&String::from_utf8_lossy(b)),
-                Value::Numeric(Numeric::Integer(i)) => result.push_str(&i.to_string()),
-                Value::Numeric(Numeric::Float(f)) => result.push_str(&format_float(f64::from(*f))),
+            if let Some(bytes) = coerce_to_text_bytes(val) {
+                result.extend_from_slice(bytes.as_ref());
             }
         }
         Value::build_text(result)
@@ -1315,15 +1508,27 @@ impl Value {
             .expect("registers should have at least one element after length check")
         {
             Value::Null | Value::Blob(_) => return Value::Null,
-            v => format!("{v}"),
+            Value::Text(text) => Cow::Borrowed(text.as_bytes()),
+            v => Cow::Owned(v.to_string().into_bytes()),
         };
 
-        let parts = registers.filter_map(|val| match val {
-            Value::Text(_) | Value::Numeric(_) => Some(format!("{val}")),
-            _ => None,
-        });
+        let mut result = Vec::new();
+        let mut first = true;
+        for val in registers {
+            let Some(bytes) = (match val {
+                Value::Text(text) => Some(Cow::Borrowed(text.as_bytes())),
+                Value::Numeric(_) => Some(Cow::Owned(val.to_string().into_bytes())),
+                _ => None,
+            }) else {
+                continue;
+            };
 
-        let result = parts.collect::<Vec<_>>().join(&separator);
+            if !first {
+                result.extend_from_slice(separator.as_ref());
+            }
+            result.extend_from_slice(bytes.as_ref());
+            first = false;
+        }
         Value::build_text(result)
     }
 

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -191,25 +191,44 @@ fn coerce_to_text_bytes(value: &Value) -> Option<Cow<'_, [u8]>> {
     }
 }
 
-fn count_text_units(bytes: &[u8], stop_at_nul: bool) -> usize {
-    let mut count = 0;
+fn text_units(bytes: &[u8], stop_at_nul: bool) -> impl Iterator<Item = (usize, usize)> + '_ {
+    let mut chunks = bytes.utf8_chunks();
+    let mut chunk_offset = 0;
+    let mut valid_chars: Option<std::str::CharIndices<'_>> = None;
+    let mut valid_len = 0;
+    let mut invalid_len = 0;
 
-    for chunk in bytes.utf8_chunks() {
-        let valid = chunk.valid();
-        if stop_at_nul {
-            if let Some(pos) = valid.as_bytes().iter().position(|&b| b == 0) {
-                count += valid[..pos].chars().count();
-                return count;
+    std::iter::from_fn(move || loop {
+        if let Some(chars) = valid_chars.as_mut() {
+            if let Some((idx, ch)) = chars.next() {
+                let start = chunk_offset + idx;
+                if stop_at_nul && bytes[start] == 0 {
+                    return None;
+                }
+                return Some((start, start + ch.len_utf8()));
+            }
+
+            valid_chars = None;
+            chunk_offset += valid_len;
+            valid_len = 0;
+
+            if invalid_len != 0 {
+                let start = chunk_offset;
+                chunk_offset += invalid_len;
+                invalid_len = 0;
+                return Some((start, chunk_offset));
             }
         }
 
-        count += valid.chars().count();
-        if !chunk.invalid().is_empty() {
-            count += 1;
-        }
-    }
+        let chunk = chunks.next()?;
+        valid_len = chunk.valid().len();
+        valid_chars = Some(chunk.valid().char_indices());
+        invalid_len = chunk.invalid().len();
+    })
+}
 
-    count
+fn count_text_units(bytes: &[u8], stop_at_nul: bool) -> usize {
+    text_units(bytes, stop_at_nul).count()
 }
 
 fn boundary_after_text_units(bytes: &[u8], target: usize) -> usize {
@@ -217,68 +236,22 @@ fn boundary_after_text_units(bytes: &[u8], target: usize) -> usize {
         return 0;
     }
 
-    let mut count = 0;
-    let mut offset = 0;
-
-    for chunk in bytes.utf8_chunks() {
-        let valid = chunk.valid();
-        for (_, ch) in valid.char_indices() {
-            count += 1;
-            offset += ch.len_utf8();
-            if count == target {
-                return offset;
-            }
-        }
-
-        if !chunk.invalid().is_empty() {
-            count += 1;
-            offset += chunk.invalid().len();
-            if count == target {
-                return offset;
-            }
-        }
-    }
-
-    bytes.len()
-}
-
-fn collect_text_units(bytes: &[u8], stop_at_nul: bool) -> Vec<(usize, usize)> {
-    let mut units = Vec::new();
-    let mut offset = 0;
-
-    for chunk in bytes.utf8_chunks() {
-        let valid = chunk.valid();
-        for (idx, ch) in valid.char_indices() {
-            let start = offset + idx;
-            let end = start + ch.len_utf8();
-            if stop_at_nul && bytes[start] == 0 {
-                return units;
-            }
-            units.push((start, end));
-        }
-        offset += valid.len();
-
-        if !chunk.invalid().is_empty() {
-            let invalid_len = chunk.invalid().len();
-            units.push((offset, offset + invalid_len));
-            offset += invalid_len;
-        }
-    }
-
-    units
+    text_units(bytes, false)
+        .nth(target - 1)
+        .map_or(bytes.len(), |(_, end)| end)
 }
 
 fn trim_text_bytes(bytes: &[u8], pattern: Option<&[u8]>, trim_type: TrimType) -> Vec<u8> {
-    let units = collect_text_units(bytes, false);
+    let units: Vec<_> = text_units(bytes, false).collect();
     if units.is_empty() {
         return bytes.to_vec();
     }
 
-    let pattern_storage;
+    let pattern_storage: Vec<(usize, usize)>;
     let pattern_units: Vec<&[u8]> = match pattern {
         None => vec![b" "],
         Some(pattern) => {
-            pattern_storage = collect_text_units(pattern, false);
+            pattern_storage = text_units(pattern, false).collect();
             if pattern_storage.is_empty() {
                 return bytes.to_vec();
             }
@@ -336,17 +309,7 @@ impl Value {
 
     pub fn exec_length(&self) -> Self {
         match self {
-            Value::Text(t) => {
-                if let Ok(s) = t.try_as_str() {
-                    let len_before_null = s.find('\0').map_or_else(
-                        || s.chars().count(),
-                        |null_pos| s[..null_pos].chars().count(),
-                    );
-                    Value::from_i64(len_before_null as i64)
-                } else {
-                    Value::from_i64(count_text_units(t.as_bytes(), true) as i64)
-                }
-            }
+            Value::Text(t) => Value::from_i64(count_text_units(t.as_bytes(), true) as i64),
             Value::Numeric(_) => {
                 // For numbers, SQLite returns the length of the string representation
                 Value::from_i64(self.to_string().chars().count() as i64)
@@ -677,47 +640,6 @@ impl Value {
                     return Value::Null;
                 };
                 let bytes = text.as_ref();
-                if let Ok(s) = std::str::from_utf8(bytes) {
-                    /// Function is stabilized but not released for version 1.88 \
-                    /// https://doc.rust-lang.org/src/core/str/mod.rs.html#453
-                    const fn ceil_char_boundary(s: &str, index: usize) -> usize {
-                        const fn is_utf8_char_boundary(c: u8) -> bool {
-                            (c as i8) >= -0x40
-                        }
-
-                        if index >= s.len() {
-                            s.len()
-                        } else {
-                            let mut i = index;
-                            while i < s.len() {
-                                if is_utf8_char_boundary(s.as_bytes()[i]) {
-                                    break;
-                                }
-                                i += 1;
-                            }
-                            debug_assert!(i <= index + 3);
-                            i
-                        }
-                    }
-
-                    let char_count = s.chars().count();
-                    let (mut start, mut end) =
-                        calculate_postions(start, char_count, length_value.as_ref());
-
-                    let mut start_byte_idx = 0;
-                    end -= start;
-                    while start > 0 {
-                        start_byte_idx = ceil_char_boundary(s, start_byte_idx + 1);
-                        start -= 1;
-                    }
-                    let mut end_byte_idx = start_byte_idx;
-                    while end > 0 {
-                        end_byte_idx = ceil_char_boundary(s, end_byte_idx + 1);
-                        end -= 1;
-                    }
-                    return Value::build_text(s[start_byte_idx..end_byte_idx].to_string());
-                }
-
                 let char_count = count_text_units(bytes, false);
                 let (start, end) = calculate_postions(start, char_count, length_value.as_ref());
 
@@ -956,40 +878,6 @@ impl Value {
         let Some(text) = coerce_to_text_bytes(self) else {
             return Value::Null;
         };
-        if let Ok(text_str) = std::str::from_utf8(text.as_ref()) {
-            let trimmed = match pattern {
-                Some(p) => {
-                    if matches!(p, Value::Null) {
-                        return Value::Null;
-                    }
-                    let Some(pattern) = coerce_to_text_bytes(p) else {
-                        return Value::Null;
-                    };
-                    let Ok(pattern_str) = std::str::from_utf8(pattern.as_ref()) else {
-                        return Value::build_text(trim_text_bytes(
-                            text.as_ref(),
-                            Some(pattern.as_ref()),
-                            trim_type,
-                        ));
-                    };
-                    match trim_type {
-                        TrimType::All => text_str.trim_matches(|c| pattern_str.contains(c)),
-                        TrimType::Left => text_str.trim_start_matches(|c| pattern_str.contains(c)),
-                        TrimType::Right => text_str.trim_end_matches(|c| pattern_str.contains(c)),
-                    }
-                    .as_bytes()
-                    .to_vec()
-                }
-                None => match trim_type {
-                    TrimType::All => text_str.trim_matches(' '),
-                    TrimType::Left => text_str.trim_start_matches(' '),
-                    TrimType::Right => text_str.trim_end_matches(' '),
-                }
-                .as_bytes()
-                .to_vec(),
-            };
-            return Value::build_text(trimmed);
-        }
         let trimmed = match pattern {
             Some(p) => {
                 if matches!(p, Value::Null) {

--- a/perf/memory/src/main.rs
+++ b/perf/memory/src/main.rs
@@ -13,6 +13,9 @@ use turso::params::Params;
 
 use crate::measure::{MemoryReport, MemorySnapshot, file_size, take_snapshot};
 
+// Workspace clippy enables `turso`'s `mimalloc` feature, so avoid registering
+// a second allocator during lint-only builds.
+#[cfg(not(clippy))]
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -1855,7 +1855,7 @@ pub unsafe extern "C" fn sqlite3_column_bytes(
         None => return 0,
     };
     match row.get::<&Value>(idx as usize) {
-        Ok(turso_core::Value::Text(text)) => text.as_str().len() as ffi::c_int,
+        Ok(turso_core::Value::Text(text)) => text.as_bytes().len() as ffi::c_int,
         Ok(turso_core::Value::Blob(blob)) => blob.len() as ffi::c_int,
         _ => 0,
     }
@@ -1998,7 +1998,7 @@ pub unsafe extern "C" fn sqlite3_column_text(
     match row.get::<&Value>(i) {
         Ok(turso_core::Value::Text(text)) => {
             let buf = &mut stmt.text_cache[i];
-            buf.extend(text.as_str().as_bytes());
+            buf.extend(text.as_bytes());
             buf.push(0);
             buf.as_ptr() as *const ffi::c_uchar
         }
@@ -2039,7 +2039,11 @@ pub unsafe extern "C" fn sqlite3_column_value(
         Ok(turso_core::Value::Numeric(turso_core::Numeric::Float(f))) => {
             ExtValue::from_float(f64::from(*f))
         }
-        Ok(turso_core::Value::Text(t)) => ExtValue::from_text(t.value.to_string()),
+        Ok(turso_core::Value::Text(t)) => {
+            // The extension value API still models TEXT as String, so this bridge is lossy
+            // until raw-byte TEXT is supported there too.
+            ExtValue::from_text(t.as_str_lossy().into_owned())
+        }
         Ok(turso_core::Value::Blob(b)) => ExtValue::from_blob(b.clone()),
         _ => ExtValue::null(),
     };
@@ -2878,13 +2882,19 @@ pub unsafe extern "C" fn sqlite3_table_column_metadata(
                     let mut found_column = false;
                     for row in rows {
                         let col_name: &str = match &row[1] {
-                            turso_core::Value::Text(text) => text.as_str(),
+                            turso_core::Value::Text(text) => match text.try_as_str() {
+                                Ok(text) => text,
+                                Err(_) => return SQLITE_ERROR,
+                            },
                             _ => return SQLITE_ERROR,
                         }; // name column
                         if col_name == column_name {
                             // Found the column, extract metadata
                             let col_type: String = match &row[2] {
-                                turso_core::Value::Text(text) => text.as_str().to_string(),
+                                turso_core::Value::Text(text) => match text.try_as_str() {
+                                    Ok(text) => text.to_string(),
+                                    Err(_) => return SQLITE_ERROR,
+                                },
                                 _ => return SQLITE_ERROR,
                             }; // type column
                             let col_notnull: i64 = row[3].as_int().unwrap(); // notnull column

--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -238,15 +238,14 @@ impl DatabaseReplayGenerator {
                     let mut ast = parser
                         .next()
                         .ok_or_else(|| {
-                            Error::DatabaseTapeError(format!("unexpected DDL query: {}", sql))
+                            Error::DatabaseTapeError(format!("unexpected DDL query: {sql}"))
                         })?
                         .map_err(|e| {
-                            Error::DatabaseTapeError(format!("unexpected DDL query {}: {}", e, sql))
+                            Error::DatabaseTapeError(format!("unexpected DDL query {e}: {sql}"))
                         })?;
                     let turso_parser::ast::Cmd::Stmt(stmt) = &mut ast else {
                         return Err(Error::DatabaseTapeError(format!(
-                            "unexpected DDL query: {}",
-                            sql
+                            "unexpected DDL query: {sql}"
                         )));
                     };
                     match stmt {

--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -201,7 +201,17 @@ impl DatabaseReplayGenerator {
                             before.get(1)
                         );
                     };
-                    let query = format!("DROP {} {}", entity_type.as_str(), entity_name.as_str());
+                    let entity_type = entity_type.try_as_str().map_err(|_| {
+                        Error::DatabaseTapeError(
+                            "sqlite_schema.type must be valid UTF-8".to_string(),
+                        )
+                    })?;
+                    let entity_name = entity_name.try_as_str().map_err(|_| {
+                        Error::DatabaseTapeError(
+                            "sqlite_schema.name must be valid UTF-8".to_string(),
+                        )
+                    })?;
+                    let query = format!("DROP {entity_type} {entity_name}");
                     let delete = ReplayInfo {
                         change_type: DatabaseChangeType::Delete,
                         query,
@@ -219,26 +229,24 @@ impl DatabaseReplayGenerator {
                             after.last()
                         )));
                     };
-                    let mut parser = Parser::new(sql.as_str().as_bytes());
+                    let sql = sql.try_as_str().map_err(|_| {
+                        Error::DatabaseTapeError(
+                            "sqlite_schema.sql must be valid UTF-8".to_string(),
+                        )
+                    })?;
+                    let mut parser = Parser::new(sql.as_bytes());
                     let mut ast = parser
                         .next()
                         .ok_or_else(|| {
-                            Error::DatabaseTapeError(format!(
-                                "unexpected DDL query: {}",
-                                sql.as_str()
-                            ))
+                            Error::DatabaseTapeError(format!("unexpected DDL query: {}", sql))
                         })?
                         .map_err(|e| {
-                            Error::DatabaseTapeError(format!(
-                                "unexpected DDL query {}: {}",
-                                e,
-                                sql.as_str()
-                            ))
+                            Error::DatabaseTapeError(format!("unexpected DDL query {}: {}", e, sql))
                         })?;
                     let turso_parser::ast::Cmd::Stmt(stmt) = &mut ast else {
                         return Err(Error::DatabaseTapeError(format!(
                             "unexpected DDL query: {}",
-                            sql.as_str()
+                            sql
                         )));
                     };
                     match stmt {
@@ -278,7 +286,11 @@ impl DatabaseReplayGenerator {
                     };
                     let update = ReplayInfo {
                         change_type: DatabaseChangeType::Update,
-                        query: ddl_stmt.as_str().to_string(),
+                        query: ddl_stmt.try_as_str().map(str::to_owned).map_err(|_| {
+                            Error::DatabaseTapeError(
+                                "sqlite_schema.sql must be valid UTF-8".to_string(),
+                            )
+                        })?,
                         pk_column_indices: None,
                         column_names: Vec::new(),
                         is_ddl_replay: true,
@@ -538,7 +550,9 @@ impl DatabaseReplayGenerator {
             if *pk == 1 {
                 pk_column_indices.push(*column_id as usize);
             }
-            column_names.push(name.as_str().to_string());
+            column_names.push(name.try_as_str().map(str::to_owned).map_err(|_| {
+                Error::DatabaseTapeError("PRAGMA table_info name must be valid UTF-8".to_string())
+            })?);
         }
         Ok((column_names, pk_column_indices))
     }

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -676,23 +676,25 @@ pub const TURSO_SYNC_UPDATE_LAST_CHANGE_ID: &str =
 const TURSO_SYNC_SELECT_LAST_CHANGE_ID: &str =
     "SELECT pull_gen, change_id FROM turso_sync_last_change_id WHERE client_id = ?";
 
-fn convert_to_args(values: Vec<turso_core::Value>) -> Vec<server_proto::Value> {
+fn convert_to_args(values: Vec<turso_core::Value>) -> Result<Vec<server_proto::Value>> {
     values
         .into_iter()
         .map(|value| match value {
-            Value::Null => server_proto::Value::Null,
+            Value::Null => Ok(server_proto::Value::Null),
             Value::Numeric(turso_core::Numeric::Integer(value)) => {
-                server_proto::Value::Integer { value }
+                Ok(server_proto::Value::Integer { value })
             }
-            Value::Numeric(turso_core::Numeric::Float(value)) => server_proto::Value::Float {
+            Value::Numeric(turso_core::Numeric::Float(value)) => Ok(server_proto::Value::Float {
                 value: f64::from(value),
-            },
-            Value::Text(value) => server_proto::Value::Text {
-                value: value.as_str().to_string(),
-            },
-            Value::Blob(value) => server_proto::Value::Blob {
+            }),
+            Value::Text(value) => Ok(server_proto::Value::Text {
+                value: value.try_as_str().map(str::to_owned).map_err(|err| {
+                    Error::DatabaseSyncEngineError(format!("invalid UTF-8 in TEXT value: {err}"))
+                })?,
+            }),
+            Value::Blob(value) => Ok(server_proto::Value::Blob {
                 value: value.into(),
-            },
+            }),
         })
         .collect()
 }
@@ -1031,7 +1033,7 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                 panic!("Commit operation must not be emited at this stage")
             }
             DatabaseTapeOperation::StmtReplay(replay) => {
-                sql_over_http_requests.push(step(replay.sql, convert_to_args(replay.values)))
+                sql_over_http_requests.push(step(replay.sql, convert_to_args(replay.values)?))
             }
             DatabaseTapeOperation::RowChange(change) => {
                 let replay_info = generator.replay_info(ctx.coro, &change).await?;
@@ -1049,7 +1051,7 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                             None,
                         );
                         sql_over_http_requests
-                            .push(step(replay_info.query.clone(), convert_to_args(values)))
+                            .push(step(replay_info.query.clone(), convert_to_args(values)?))
                     }
                     DatabaseTapeRowChangeType::Insert { after } => {
                         let values = generator.replay_values(
@@ -1060,7 +1062,7 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                             None,
                         );
                         sql_over_http_requests
-                            .push(step(replay_info.query.clone(), convert_to_args(values)));
+                            .push(step(replay_info.query.clone(), convert_to_args(values)?));
                     }
                     DatabaseTapeRowChangeType::Update {
                         after,
@@ -1075,7 +1077,7 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                             Some(updates),
                         );
                         sql_over_http_requests
-                            .push(step(replay_info.query.clone(), convert_to_args(values)));
+                            .push(step(replay_info.query.clone(), convert_to_args(values)?));
                     }
                     DatabaseTapeRowChangeType::Update {
                         after,
@@ -1090,7 +1092,7 @@ pub async fn push_logical_changes<IO: SyncEngineIo, Ctx>(
                             None,
                         );
                         sql_over_http_requests
-                            .push(step(replay_info.query.clone(), convert_to_args(values)));
+                            .push(step(replay_info.query.clone(), convert_to_args(values)?));
                     }
                 }
                 if is_alter_add_column {
@@ -1719,11 +1721,12 @@ mod tests {
 
     use bytes::{Bytes, BytesMut};
     use prost::Message;
+    use turso_core::Value;
 
     use crate::{
         database_sync_engine::DataStats,
         database_sync_engine_io::{DataCompletion, DataPollResult},
-        database_sync_operations::wait_proto_message,
+        database_sync_operations::{convert_to_args, wait_proto_message},
         server_proto::PageData,
         types::Coro,
         Result,
@@ -1814,5 +1817,11 @@ mod tests {
     fn test_remote_encryption_key_header_constant() {
         use super::ENCRYPTION_KEY_HEADER;
         assert_eq!(ENCRYPTION_KEY_HEADER, "x-turso-encryption-key");
+    }
+
+    #[test]
+    fn convert_to_args_rejects_invalid_text() {
+        let err = convert_to_args(vec![Value::from_text(vec![0xFF])]).unwrap_err();
+        assert!(err.to_string().contains("invalid UTF-8 in TEXT value"));
     }
 }

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -212,7 +212,7 @@ impl Property for IntegrityCheckProperty {
                     );
                 }
                 match &row[0] {
-                    Value::Text(text) if text.as_str() == "ok" => Ok(()),
+                    Value::Text(text) if text.try_as_str() == Ok("ok") => Ok(()),
                     other => {
                         bail!(
                             "step {step}, fiber {fiber_id}: integrity_check returned {:?}, expected \"ok\"",
@@ -714,7 +714,10 @@ fn parse_read_result(result: &OpResult) -> Option<Vec<i64>> {
         } else if let Some(row) = rows.first() {
             if let Some(value) = row.first() {
                 match value {
-                    Value::Text(csv_str) => parse_comma_separated_ints(csv_str.as_str()),
+                    Value::Text(csv_str) => csv_str
+                        .try_as_str()
+                        .ok()
+                        .and_then(parse_comma_separated_ints),
                     Value::Null => Some(vec![]),
                     _ => Some(vec![]),
                 }

--- a/testing/differential-oracle/fuzzer/custom_types_fuzzer.rs
+++ b/testing/differential-oracle/fuzzer/custom_types_fuzzer.rs
@@ -482,7 +482,7 @@ fn execute_turso_rows(conn: &Arc<turso_core::Connection>, sql: &str) -> Result<V
                         values.push(f.to_string());
                     }
                     turso_core::Value::Text(s) => {
-                        values.push(s.as_str().to_string());
+                        values.push(s.as_str_lossy().into_owned());
                     }
                     turso_core::Value::Blob(b) => {
                         let hex: String = b.iter().map(|byte| format!("{byte:02x}")).collect();

--- a/testing/differential-oracle/fuzzer/oracle.rs
+++ b/testing/differential-oracle/fuzzer/oracle.rs
@@ -281,7 +281,7 @@ impl DifferentialOracle {
             Value::Null => SqlValue::Null,
             Value::Numeric(Numeric::Integer(i)) => SqlValue::Integer(i),
             Value::Numeric(Numeric::Float(f)) => SqlValue::Real(f64::from(f)),
-            Value::Text(s) => SqlValue::Text(s.as_str().to_string()),
+            Value::Text(s) => SqlValue::Text(s.as_str_lossy().into_owned()),
             Value::Blob(b) => SqlValue::Blob(b),
         }
     }

--- a/testing/differential-oracle/fuzzer/schema.rs
+++ b/testing/differential-oracle/fuzzer/schema.rs
@@ -74,10 +74,25 @@ impl SchemaIntrospector {
         rows.run_with_row_callback(|row| {
             if let turso_core::Value::Text(name) = row.get_value(0) {
                 let strict = match row.get_value(1) {
-                    turso_core::Value::Text(sql) => Self::sql_is_strict(sql.as_str()),
+                    turso_core::Value::Text(sql) => Self::sql_is_strict(sql.try_as_str().map_err(
+                        |_| {
+                            turso_core::LimboError::ConversionError(
+                                "sqlite_master.sql must be valid UTF-8".into(),
+                            )
+                        },
+                    )?),
                     _ => false,
                 };
-                tables.push((name.as_str().to_string(), strict));
+                tables.push((
+                    name.try_as_str()
+                        .map_err(|_| {
+                            turso_core::LimboError::ConversionError(
+                                "sqlite_master.name must be valid UTF-8".into(),
+                            )
+                        })?
+                        .to_string(),
+                    strict,
+                ));
             }
             Ok(())
         })
@@ -143,12 +158,26 @@ impl SchemaIntrospector {
         rows.run_with_row_callback(|row| {
             // PRAGMA table_info returns: cid, name, type, notnull, dflt_value, pk
             let name = match row.get_value(1) {
-                turso_core::Value::Text(s) => s.as_str().to_string(),
+                turso_core::Value::Text(s) => s
+                    .try_as_str()
+                    .map_err(|_| {
+                        turso_core::LimboError::ConversionError(
+                            "PRAGMA table_info name must be valid UTF-8".into(),
+                        )
+                    })?
+                    .to_string(),
                 _ => return Ok(()),
             };
 
             let type_str = match row.get_value(2) {
-                turso_core::Value::Text(s) => s.as_str().to_uppercase(),
+                turso_core::Value::Text(s) => s
+                    .try_as_str()
+                    .map_err(|_| {
+                        turso_core::LimboError::ConversionError(
+                            "PRAGMA table_info type must be valid UTF-8".into(),
+                        )
+                    })?
+                    .to_uppercase(),
                 _ => "TEXT".to_string(),
             };
 
@@ -336,7 +365,13 @@ impl SchemaIntrospector {
 
         rows.run_with_row_callback(|row| {
             if let turso_core::Value::Text(name) = row.get_value(1) {
-                let name = name.as_str();
+                let name = name
+                    .try_as_str()
+                    .map_err(|_| {
+                        turso_core::LimboError::ConversionError(
+                            "PRAGMA database_list name must be valid UTF-8".into(),
+                        )
+                    })?;
                 if name != "main" && name != "temp" {
                     databases.push(name.to_string());
                 }
@@ -377,12 +412,26 @@ impl SchemaIntrospector {
 
         rows.run_with_row_callback(|row| {
             let name = match row.get_value(1) {
-                turso_core::Value::Text(s) => s.as_str().to_string(),
+                turso_core::Value::Text(s) => s
+                    .try_as_str()
+                    .map_err(|_| {
+                        turso_core::LimboError::ConversionError(
+                            "PRAGMA table_info name must be valid UTF-8".into(),
+                        )
+                    })?
+                    .to_string(),
                 _ => return Ok(()),
             };
 
             let type_str = match row.get_value(2) {
-                turso_core::Value::Text(s) => s.as_str().to_uppercase(),
+                turso_core::Value::Text(s) => s
+                    .try_as_str()
+                    .map_err(|_| {
+                        turso_core::LimboError::ConversionError(
+                            "PRAGMA table_info type must be valid UTF-8".into(),
+                        )
+                    })?
+                    .to_uppercase(),
                 _ => "TEXT".to_string(),
             };
 

--- a/testing/differential-oracle/fuzzer/schema.rs
+++ b/testing/differential-oracle/fuzzer/schema.rs
@@ -74,13 +74,13 @@ impl SchemaIntrospector {
         rows.run_with_row_callback(|row| {
             if let turso_core::Value::Text(name) = row.get_value(0) {
                 let strict = match row.get_value(1) {
-                    turso_core::Value::Text(sql) => Self::sql_is_strict(sql.try_as_str().map_err(
-                        |_| {
+                    turso_core::Value::Text(sql) => {
+                        Self::sql_is_strict(sql.try_as_str().map_err(|_| {
                             turso_core::LimboError::ConversionError(
                                 "sqlite_master.sql must be valid UTF-8".into(),
                             )
-                        },
-                    )?),
+                        })?)
+                    }
                     _ => false,
                 };
                 tables.push((
@@ -365,13 +365,11 @@ impl SchemaIntrospector {
 
         rows.run_with_row_callback(|row| {
             if let turso_core::Value::Text(name) = row.get_value(1) {
-                let name = name
-                    .try_as_str()
-                    .map_err(|_| {
-                        turso_core::LimboError::ConversionError(
-                            "PRAGMA database_list name must be valid UTF-8".into(),
-                        )
-                    })?;
+                let name = name.try_as_str().map_err(|_| {
+                    turso_core::LimboError::ConversionError(
+                        "PRAGMA database_list name must be valid UTF-8".into(),
+                    )
+                })?;
                 if name != "main" && name != "temp" {
                     databases.push(name.to_string());
                 }

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -329,7 +329,7 @@ fn limbo_integrity_check(conn: &Arc<Connection>) -> Result<()> {
 
     rows.run_with_row_callback(|row| {
         let val = match row.get_value(0) {
-            turso_core::Value::Text(text) => text.as_str().to_string(),
+            turso_core::Value::Text(text) => text.as_str_lossy().into_owned(),
             _ => unreachable!(),
         };
         result.push(val);

--- a/testing/sqltests/src/backends/rust.rs
+++ b/testing/sqltests/src/backends/rust.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tempfile::NamedTempFile;
-use turso::{Builder, Connection, Database, Value};
+#[cfg(test)]
+use turso::Value;
+use turso::{Builder, Connection, Database, ValueRef};
 
 /// Native Rust backend using Turso bindings directly
 pub struct RustBackend {
@@ -170,8 +172,8 @@ impl RustDatabaseInstance {
                             let mut row_values = Vec::new();
                             let col_count = row.column_count();
                             for i in 0..col_count {
-                                let value = row.get_value(i)?;
-                                row_values.push(value_to_string(&value));
+                                let value = row.get_value_ref(i)?;
+                                row_values.push(value_ref_to_string(value));
                             }
                             all_rows.push(row_values);
                         }
@@ -233,6 +235,7 @@ impl DatabaseInstance for RustDatabaseInstance {
 /// - Integer and Real use standard formatting
 /// - Text is used as-is
 /// - Blob is converted to UTF-8 string (matching CLI list mode behavior)
+#[cfg(test)]
 fn value_to_string(value: &Value) -> String {
     match value {
         Value::Null => String::new(),
@@ -240,6 +243,15 @@ fn value_to_string(value: &Value) -> String {
         Value::Real(f) => format_real(*f),
         Value::Text(s) => s.clone(),
         Value::Blob(bytes) => String::from_utf8_lossy(bytes).to_string(),
+    }
+}
+
+fn value_ref_to_string(value: ValueRef<'_>) -> String {
+    match value {
+        ValueRef::Null => String::new(),
+        ValueRef::Integer(i) => i.to_string(),
+        ValueRef::Real(f) => format_real(f),
+        ValueRef::Text(bytes) | ValueRef::Blob(bytes) => String::from_utf8_lossy(bytes).to_string(),
     }
 }
 

--- a/testing/sqltests/tests/invalid_text.sqltest
+++ b/testing/sqltests/tests/invalid_text.sqltest
@@ -20,7 +20,7 @@ test invalid-text-lossy-text-functions {
     FROM t;
 }
 expect {
-    FF|1|1|'�'|65533|EFBFBD|EFBFBD|0|0
+    FF|1|1|'�'|65533|FF|FF|0|0
 }
 
 @setup invalid-text-row
@@ -140,9 +140,10 @@ test mixed-invalid-text-case-folding {
     FROM t;
 }
 expect {
-    61EFBFBD62|41EFBFBD42
+    61FF62|41FF42
 }
 
+@skip-if sqlite "sqlite shell .dump output is lossy for invalid TEXT and differs in formatting"
 @backend cli
 @setup invalid-text-row
 test invalid-text-dump-emits-replayable-sql {

--- a/testing/sqltests/tests/invalid_text.sqltest
+++ b/testing/sqltests/tests/invalid_text.sqltest
@@ -94,3 +94,64 @@ test truncated-invalid-text-units {
 expect {
     E282|1|2|E282|1|
 }
+
+setup invalid-text-comparison-rows {
+    CREATE TABLE t(val TEXT);
+    INSERT INTO t VALUES
+        (CAST(X'FF' AS TEXT)),
+        (CAST(X'FE' AS TEXT)),
+        (CAST(X'FF' AS TEXT));
+}
+
+@setup invalid-text-comparison-rows
+test invalid-text-set-ops-and-grouping {
+    SELECT
+        (SELECT group_concat(hex(val), ',') FROM (SELECT DISTINCT val FROM t ORDER BY val)),
+        (SELECT group_concat(hex(val), ',') FROM (SELECT val FROM t UNION SELECT val FROM t ORDER BY val)),
+        (SELECT group_concat(hex(val) || ':' || cnt, ',') FROM (SELECT val, count(*) AS cnt FROM t GROUP BY val ORDER BY val));
+}
+expect {
+    FE,FF|FE,FF|FE:1,FF:2
+}
+
+@setup invalid-text-comparison-rows
+test invalid-text-comparisons-and-collations {
+    SELECT
+        CAST(X'FF' AS TEXT) = CAST(X'FF' AS TEXT),
+        CAST(X'FF' AS TEXT) = CAST(X'FE' AS TEXT),
+        (SELECT group_concat(hex(val), ',') FROM (SELECT val FROM t ORDER BY val COLLATE BINARY, rowid)),
+        (SELECT group_concat(hex(val), ',') FROM (SELECT val FROM t ORDER BY val COLLATE NOCASE, rowid)),
+        (SELECT group_concat(hex(val), ',') FROM (SELECT val FROM t ORDER BY val COLLATE RTRIM, rowid));
+}
+expect {
+    1|0|FE,FF,FF|FE,FF,FF|FE,FF,FF
+}
+
+setup mixed-case-invalid-text-row {
+    CREATE TABLE t(val TEXT);
+    INSERT INTO t VALUES(CAST(X'41FF42' AS TEXT));
+}
+
+@setup mixed-case-invalid-text-row
+test mixed-invalid-text-case-folding {
+    SELECT
+        hex(lower(val)),
+        hex(upper(val))
+    FROM t;
+}
+expect {
+    61EFBFBD62|41EFBFBD42
+}
+
+@backend cli
+@setup invalid-text-row
+test invalid-text-dump-emits-replayable-sql {
+    .dump
+}
+expect raw {
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE t (val TEXT);
+INSERT INTO "t" VALUES(CAST(X'ff' AS TEXT));
+COMMIT;
+}

--- a/testing/sqltests/tests/invalid_text.sqltest
+++ b/testing/sqltests/tests/invalid_text.sqltest
@@ -1,0 +1,96 @@
+@database :memory:
+
+setup invalid-text-row {
+    CREATE TABLE t(val TEXT);
+    INSERT INTO t VALUES(CAST(X'FF' AS TEXT));
+}
+
+@setup invalid-text-row
+test invalid-text-lossy-text-functions {
+    SELECT
+        hex(val),
+        length(val),
+        octet_length(val),
+        quote(val),
+        unicode(val),
+        hex(lower(val)),
+        hex(upper(val)),
+        val LIKE '%a%',
+        instr(val, 'a')
+    FROM t;
+}
+expect {
+    FF|1|1|'�'|65533|EFBFBD|EFBFBD|0|0
+}
+
+@setup invalid-text-row
+test invalid-text-byte-preserving-functions {
+    SELECT
+        hex(val || 'x'),
+        hex(concat(val, 'x')),
+        hex(group_concat(val)),
+        hex(trim(val, ' ')),
+        hex(replace(val, 'a', 'x')),
+        hex(replace(val, CAST(X'FF' AS TEXT), 'x')),
+        hex(substr(val, 1, 1)),
+        hex(CAST(val AS TEXT)),
+        hex(CAST(val AS BLOB))
+    FROM t;
+}
+expect {
+    FF78|FF78|FF|FF|FF|78|FF|FF|FF
+}
+
+@setup invalid-text-row
+test invalid-text-trim-invalid-pattern {
+    SELECT
+        hex(trim(val, CAST(X'FF' AS TEXT))),
+        hex(ltrim(val, CAST(X'FF' AS TEXT))),
+        hex(rtrim(val, CAST(X'FF' AS TEXT)))
+    FROM t;
+}
+expect {
+        ||
+}
+
+setup mixed-invalid-text-row {
+    CREATE TABLE t(val TEXT);
+    INSERT INTO t VALUES(CAST(X'61FF62E282AC63C32864' AS TEXT));
+}
+
+@setup mixed-invalid-text-row
+test mixed-invalid-text-byte-walks {
+    SELECT
+        hex(val),
+        length(val),
+        octet_length(val),
+        hex(substr(val, 1, 6)),
+        instr(val, CAST(X'E282AC' AS TEXT)),
+        instr(val, CAST(X'C328' AS TEXT)),
+        hex(trim(val, CAST(X'61FF' AS TEXT))),
+        hex(trim(val, CAST(X'64' AS TEXT)))
+    FROM t;
+}
+expect {
+    61FF62E282AC63C32864|8|10|61FF62E282AC63C3|4|6|62E282AC63C32864|61FF62E282AC63C328
+}
+
+setup truncated-invalid-text-row {
+    CREATE TABLE t(val TEXT);
+    INSERT INTO t VALUES(CAST(X'E282' AS TEXT));
+}
+
+@setup truncated-invalid-text-row
+test truncated-invalid-text-units {
+    SELECT
+        hex(val),
+        length(val),
+        octet_length(val),
+        hex(substr(val, 1, 2)),
+        instr(val, CAST(X'E282' AS TEXT)),
+        hex(trim(val, CAST(X'E282' AS TEXT)))
+    FROM t;
+}
+expect {
+    E282|1|2|E282|1|
+}

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -410,7 +410,9 @@ pub fn limbo_exec_rows(
                 turso_core::Value::Numeric(turso_core::Numeric::Float(x)) => {
                     rusqlite::types::Value::Real(f64::from(*x))
                 }
-                turso_core::Value::Text(x) => rusqlite::types::Value::Text(x.as_str().to_string()),
+                turso_core::Value::Text(x) => {
+                    rusqlite::types::Value::Text(x.as_str_lossy().into_owned())
+                }
                 turso_core::Value::Blob(x) => rusqlite::types::Value::Blob(x.to_vec()),
             })
             .collect();
@@ -443,7 +445,9 @@ pub fn try_limbo_exec_rows(
                 turso_core::Value::Numeric(turso_core::Numeric::Float(x)) => {
                     rusqlite::types::Value::Real(f64::from(*x))
                 }
-                turso_core::Value::Text(x) => rusqlite::types::Value::Text(x.as_str().to_string()),
+                turso_core::Value::Text(x) => {
+                    rusqlite::types::Value::Text(x.as_str_lossy().into_owned())
+                }
                 turso_core::Value::Blob(x) => rusqlite::types::Value::Blob(x.to_vec()),
             })
             .collect();
@@ -487,7 +491,9 @@ pub fn limbo_exec_rows_fallible(
                 turso_core::Value::Numeric(turso_core::Numeric::Float(x)) => {
                     rusqlite::types::Value::Real(f64::from(*x))
                 }
-                turso_core::Value::Text(x) => rusqlite::types::Value::Text(x.as_str().to_string()),
+                turso_core::Value::Text(x) => {
+                    rusqlite::types::Value::Text(x.as_str_lossy().into_owned())
+                }
                 turso_core::Value::Blob(x) => rusqlite::types::Value::Blob(x.to_vec()),
             })
             .collect();

--- a/tests/integration/integrity_check.rs
+++ b/tests/integration/integrity_check.rs
@@ -28,7 +28,11 @@ fn run_integrity_check(conn: &Arc<turso_core::Connection>) -> String {
         .filter_map(|row| {
             row.into_iter().next().and_then(|v| {
                 if let Value::Text(text) = v {
-                    Some(text.as_str().to_string())
+                    Some(
+                        text.try_as_str()
+                            .expect("integrity_check output must be valid UTF-8")
+                            .to_string(),
+                    )
                 } else {
                     None
                 }
@@ -48,7 +52,11 @@ fn run_quick_check(conn: &Arc<turso_core::Connection>) -> String {
         .filter_map(|row| {
             row.into_iter().next().and_then(|v| {
                 if let Value::Text(text) = v {
-                    Some(text.as_str().to_string())
+                    Some(
+                        text.try_as_str()
+                            .expect("quick_check output must be valid UTF-8")
+                            .to_string(),
+                    )
                 } else {
                     None
                 }
@@ -97,7 +105,11 @@ fn run_integrity_check_or_error(conn: &Arc<turso_core::Connection>) -> Result<St
                 .filter_map(|row| {
                     row.into_iter().next().and_then(|v| {
                         if let Value::Text(text) = v {
-                            Some(text.as_str().to_string())
+                            Some(
+                                text.try_as_str()
+                                    .expect("integrity_check output must be valid UTF-8")
+                                    .to_string(),
+                            )
                         } else {
                             None
                         }
@@ -213,7 +225,11 @@ fn test_integrity_check_max_errors(db: TempDatabase) {
         .filter_map(|row| {
             row.into_iter().next().and_then(|v| {
                 if let Value::Text(text) = v {
-                    Some(text.as_str().to_string())
+                    Some(
+                        text.try_as_str()
+                            .expect("integrity_check output must be valid UTF-8")
+                            .to_string(),
+                    )
                 } else {
                     None
                 }

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -48,7 +48,11 @@ fn test_pragma_module_list_generate_series(db: TempDatabase) {
         while let StepResult::Row = rows.step().unwrap() {
             let row = rows.row().unwrap();
             if let Value::Text(name) = row.get_value(0) {
-                if name.as_str() == "generate_series" {
+                if name
+                    .try_as_str()
+                    .expect("module_list entries must be valid UTF-8")
+                    == "generate_series"
+                {
                     found = true;
                     break;
                 }
@@ -152,7 +156,12 @@ fn test_pragma_page_sizes_with_writes_persists(db: TempDatabase) {
                 let Value::Text(value) = row.get_value(0) else {
                     panic!("expected text value");
                 };
-                assert_eq!(value.as_str(), "test data");
+                assert_eq!(
+                    value
+                        .try_as_str()
+                        .expect("stored test data must be valid UTF-8"),
+                    "test data"
+                );
                 Ok(())
             })
             .unwrap();

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -52,11 +52,17 @@ fn test_statement_bind(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
     stmt.run_with_row_callback(|row| {
         if let turso_core::Value::Text(s) = row.get::<&Value>(0).unwrap() {
-            assert_eq!(s.as_str(), "hello")
+            assert_eq!(
+                s.try_as_str().expect("bound text must be valid UTF-8"),
+                "hello"
+            )
         }
 
         if let turso_core::Value::Text(s) = row.get::<&Value>(1).unwrap() {
-            assert_eq!(s.as_str(), "hello")
+            assert_eq!(
+                s.try_as_str().expect("bound text must be valid UTF-8"),
+                "hello"
+            )
         }
 
         if let turso_core::Value::Numeric(Numeric::Integer(i)) = row.get::<&Value>(2).unwrap() {

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -398,7 +398,12 @@ fn test_mvcc_update_same_row_twice(tmp_db: TempDatabase) {
     let Value::Text(value) = &row[0] else {
         panic!("expected text value");
     };
-    assert_eq!(value.as_str(), "second");
+    assert_eq!(
+        value
+            .try_as_str()
+            .expect("updated text must be valid UTF-8"),
+        "second"
+    );
 
     conn1
         .execute("UPDATE test SET value = 'third' WHERE id = 1")
@@ -412,7 +417,12 @@ fn test_mvcc_update_same_row_twice(tmp_db: TempDatabase) {
     let Value::Text(value) = &row[0] else {
         panic!("expected text value");
     };
-    assert_eq!(value.as_str(), "third");
+    assert_eq!(
+        value
+            .try_as_str()
+            .expect("updated text must be valid UTF-8"),
+        "third"
+    );
 }
 
 #[test]
@@ -1583,7 +1593,8 @@ fn test_wal_savepoint_rollback_on_constraint_violation() {
         panic!("Expected text value");
     };
     assert_eq!(
-        val.as_str(),
+        val.try_as_str()
+            .expect("rolled back text value must be valid UTF-8"),
         &padding,
         "Row should have original value after failed UPDATE rollback"
     );

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -14,7 +14,11 @@ fn run_integrity_check(conn: &Arc<Connection>) -> String {
         .filter_map(|row| {
             row.into_iter().next().and_then(|v| {
                 if let Value::Text(text) = v {
-                    Some(text.as_str().to_string())
+                    Some(
+                        text.try_as_str()
+                            .expect("integrity_check output must be valid UTF-8")
+                            .to_string(),
+                    )
                 } else {
                     None
                 }

--- a/tools/dbhash/src/encoder.rs
+++ b/tools/dbhash/src/encoder.rs
@@ -4,7 +4,7 @@
 //! - '0' = NULL (no data)
 //! - '1' + 8 bytes big-endian = INTEGER
 //! - '2' + 8 bytes big-endian IEEE 754 bits = FLOAT
-//! - '3' + raw UTF-8 bytes = TEXT
+//! - '3' + raw bytes = TEXT
 //! - '4' + raw bytes = BLOB
 
 use turso_core::{Numeric, Value};
@@ -29,7 +29,7 @@ pub fn encode_value(value: &Value, output: &mut Vec<u8>) {
         }
         Value::Text(text) => {
             output.push(b'3');
-            output.extend_from_slice(text.as_str().as_bytes());
+            output.extend_from_slice(text.as_bytes());
         }
         Value::Blob(b) => {
             output.push(b'4');


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

This PR fixes the release-only crash from invalid UTF-8 in `TEXT` values by changing the engine to store `TEXT` as raw bytes, which matches SQLite behavior.

  The earlier approach in this branch validated UTF-8 while decoding records. That fixed the crash, but it added work on a hot path and still assumed that `TEXT` must always be valid
  UTF-8 internally. This PR replaces that approach.

  What changed:
  - store internal `TEXT` values as raw bytes instead of `String`
  - keep record decode zero-copy and byte-based
  - add three explicit text access paths:
    - raw bytes
    - checked UTF-8 view
    - lossy UTF-8 view
  - update call sites to use the right boundary:
    - bytewise operations use raw bytes
    - display and logging use lossy text
    - strict APIs and bindings use checked UTF-8 and return an error on invalid text
    - character-style SQL functions use lossy UTF-8 semantics that match SQLite behavior
  - make `.dump` preserve invalid `TEXT` by emitting `CAST(X'..' AS TEXT)` when needed
  - add regression coverage for invalid `TEXT` across decode, VDBE, SQL functions, set operations, collations, dump/replay, bindings, and sync paths

  Closes #5164.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

SQLite stores `TEXT` payloads as raw bytes and does not require them to be valid UTF-8 at decode time. Turso was storing `TEXT` as `String`, which led to `from_utf8_unchecked` on
  corrupted or non-UTF-8 bytes. In release builds that caused UB and a crash.

  This PR fixes that at the right level:
  - no UTF-8 validation in the on-disk decode path
  - invalid `TEXT` survives round-trip as bytes
  - UTF-8 validation only happens at boundaries that really require a Rust string

  This keeps the hot path fast and makes behavior closer to SQLite.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

AI was used as an engineering assistant for this PR.

  It helped with:
  - auditing the `TEXT` call sites after the internal type change
  - classifying each use into bytewise, lossy display, strict boundary, or character-semantics behavior
  - drafting and refining code changes
  - suggesting missing regression tests and SQL compatibility cases
  - reviewing the final diff for correctness, API traps, and performance risks

All code changes, behavior changes, and tests were reviewed locally and validated with builds, sqltests, and clippy before keeping them.
 
PR body generated by agent

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
