### PR TITLE
core/translate: Fix GROUP BY out-of-range error message to say "GROUP BY"

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -532,7 +532,11 @@ fn prepare_one_select_plan(
                 if !group_by.exprs.is_empty() {
                     // Normal GROUP BY with expressions
                     for expr in group_by.exprs.iter_mut() {
-                        replace_column_number_with_copy_of_column_expr(expr, &plan.result_columns)?;
+                        replace_column_number_with_copy_of_column_expr(
+                            expr,
+                            &plan.result_columns,
+                            "GROUP BY",
+                        )?;
                         bind_and_rewrite_expr(
                             expr,
                             Some(&mut plan.table_references),
@@ -582,7 +586,11 @@ fn prepare_one_select_plan(
                 .is_some_and(|gb| !gb.exprs.is_empty());
 
             for mut o in order_by {
-                replace_column_number_with_copy_of_column_expr(&mut o.expr, &plan.result_columns)?;
+                replace_column_number_with_copy_of_column_expr(
+                    &mut o.expr,
+                    &plan.result_columns,
+                    "ORDER BY",
+                )?;
 
                 bind_and_rewrite_expr(
                     &mut o.expr,
@@ -1058,6 +1066,7 @@ fn vtab_predicate_table_id(expr: &Expr) -> Option<ast::TableInternalId> {
 fn replace_column_number_with_copy_of_column_expr(
     order_by_or_group_by_expr: &mut ast::Expr,
     columns: &[ResultSetColumn],
+    clause_name: &str,
 ) -> Result<()> {
     // Extract the numeric literal string, handling both bare integers (e.g. `2`)
     // and unary-plus integers (e.g. `+2`). In SQLite, `ORDER BY +2` strips the
@@ -1075,7 +1084,8 @@ fn replace_column_number_with_copy_of_column_expr(
             if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner.as_ref() {
                 if num.parse::<usize>().is_ok() {
                     crate::bail_parse_error!(
-                        "1st ORDER BY term out of range - should be between 1 and {}",
+                        "1st {} term out of range - should be between 1 and {}",
+                        clause_name,
                         columns.len()
                     );
                 }
@@ -1090,7 +1100,8 @@ fn replace_column_number_with_copy_of_column_expr(
         if let Ok(column_number) = num.parse::<usize>() {
             if column_number == 0 || column_number > columns.len() {
                 crate::bail_parse_error!(
-                    "1st ORDER BY term out of range - should be between 1 and {}",
+                    "1st {} term out of range - should be between 1 and {}",
+                    clause_name,
                     columns.len()
                 );
             }

--- a/testing/sqltests/tests/groupby/memory.sqltest
+++ b/testing/sqltests/tests/groupby/memory.sqltest
@@ -362,3 +362,29 @@ expect {
     2|2
     3|3
 }
+
+# GROUP BY column-number out-of-range errors must mention "GROUP BY",
+# not "ORDER BY". Regression test for select3-2.10 in testing/sqlite3/select3.test.
+test group-by-zero {
+    CREATE TABLE t_gb_zero(n INT, log INT);
+    SELECT log, count(*) FROM t_gb_zero GROUP BY 0 ORDER BY log;
+}
+expect error {
+    1st GROUP BY term out of range - should be between 1 and 2
+}
+
+test group-by-out-of-range {
+    CREATE TABLE t_gb_oor(n INT, log INT);
+    SELECT log, count(*) FROM t_gb_oor GROUP BY 3 ORDER BY log;
+}
+expect error {
+    1st GROUP BY term out of range - should be between 1 and 2
+}
+
+test group-by-negative {
+    CREATE TABLE t_gb_neg(n INT, log INT);
+    SELECT log, count(*) FROM t_gb_neg GROUP BY -1 ORDER BY log;
+}
+expect error {
+    1st GROUP BY term out of range - should be between 1 and 2
+}


### PR DESCRIPTION
The shared replace_column_number_with_copy_of_column_expr() helper hardcoded "ORDER BY" in its out-of-range error, so a query like `SELECT log, count(*) FROM t1 GROUP BY 0` reported an ORDER BY error. Pass the calling clause name through so the message matches SQLite.