### PR TITLE
bindings/rust: Allow passing custom IO implementation to Builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6255,6 +6255,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "turso_core",
  "turso_sdk_kit",
  "turso_sync_sdk_kit",
 ]

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -26,6 +26,7 @@ sync = [
 ]
 
 [dependencies]
+turso_core = { workspace = true }
 turso_sdk_kit = { workspace = true }
 turso_sync_sdk_kit = { workspace = true }
 thiserror = { workspace = true }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -61,6 +61,9 @@ use std::task::Poll;
 // Re-exports rows
 pub use crate::rows::{Row, Rows};
 
+// Re-export turso_core
+pub use turso_core as core;
+
 /// Assert that a type implements both Send and Sync at compile time.
 /// Usage: assert_send_sync!(MyType);
 /// Usage: assert_send_sync!(Type1, Type2, Type3);
@@ -144,6 +147,7 @@ pub struct Builder {
     enable_generated_columns: bool,
     vfs: Option<String>,
     encryption_opts: Option<turso_sdk_kit::rsapi::EncryptionOpts>,
+    io: Option<Arc<dyn turso_core::IO>>,
 }
 
 impl Builder {
@@ -159,6 +163,7 @@ impl Builder {
             enable_generated_columns: false,
             vfs: None,
             encryption_opts: None,
+            io: None,
         }
     }
 
@@ -211,6 +216,13 @@ impl Builder {
         self.vfs = Some(vfs);
         self
     }
+
+    /// Can pass custom IO implementation
+    pub fn with_io_impl(mut self, io: Arc<dyn turso_core::IO>) -> Self {
+        self.io = Some(io);
+        self
+    }
+
     fn build_features_string(&self) -> Option<String> {
         let mut features = Vec::new();
         if self.enable_encryption {
@@ -248,7 +260,7 @@ impl Builder {
                 async_io: true,
                 encryption: self.encryption_opts,
                 vfs: self.vfs,
-                io: None,
+                io: self.io,
                 db_file: None,
             });
         while let Some(io_c) = db.open()?.io() {


### PR DESCRIPTION
## Description

This change enables users of the Rust SDK to provide a custom I/O implementation via the Builder pattern.

- Added `turso_core` dependency to rust bindings.
- Added `io` field to `Builder` struct.
- Implemented `with_io_impl` for custom I/O injection.
- Re-exported `turso_core` for easier access to I/O traits.

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

I used it for the commit message, not for the code
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
