### PR TITLE
fix: reject TEMP database qualifier instead of silently misrouting

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -301,7 +301,9 @@ impl<'a> Resolver<'a> {
             let name_bytes = db_name_normalized.as_bytes();
             match_ignore_ascii_case!(match name_bytes {
                 b"main" => Ok(0),
-                b"temp" => Ok(1),
+                b"temp" => Err(LimboError::ParseError(
+                    "TEMPORARY database not supported yet".to_string(),
+                )),
                 _ => {
                     // Look up attached database
                     if let Some((idx, _attached_db)) =

--- a/testing/sqltests/tests/temp-qualifier-rejected.sqltest
+++ b/testing/sqltests/tests/temp-qualifier-rejected.sqltest
@@ -1,0 +1,24 @@
+@database :memory:
+
+test temp-create-table-rejected {
+    CREATE TABLE temp.t1(x)
+}
+expect error {
+    TEMPORARY database not supported yet
+}
+
+test temp-drop-table-rejected {
+    CREATE TABLE t1(x);
+    DROP TABLE temp.t1
+}
+expect error {
+    TEMPORARY database not supported yet
+}
+
+test temp-insert-rejected {
+    CREATE TABLE t2(x);
+    INSERT INTO temp.t2 VALUES(1)
+}
+expect error {
+    TEMPORARY database not supported yet
+}


### PR DESCRIPTION
## Summary
- The `temp.` qualifier in `CREATE TABLE temp.t1(x)` was mapped to database index 1 which does not correspond to an actual temporary database
- Limbo does not support TEMPORARY databases yet, so this returns a clear `ParseError` instead of producing undefined behaviour
- Adds sqltest covering the rejection

## Test plan
- [x] `cargo clippy -p turso_core -- --deny=warnings` passes
- [x] `CI=1 make -C testing/sqltests run-rust` passes (939 tests)
- [x] New test `temp-qualifier-rejected.sqltest` verifies the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)