### PR TITLE
fix: REAL affinity must not convert integers to float for comparisons

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -253,6 +253,14 @@ fn apply_affinity_to_value(value: &mut Value, affinity: Affinity) {
             Either::Right(val) => val,
         };
     }
+    // REAL affinity for storage: also convert integers to floats.
+    // (Affinity::Real::convert no longer does this, to preserve precision
+    // in comparison instructions where sqlite_int_float_cmp is used.)
+    if matches!(affinity, Affinity::Real) {
+        if let Value::Numeric(Numeric::Integer(i)) = value {
+            *value = Value::from_f64(*i as f64);
+        }
+    }
 }
 
 fn strict_default_type_mismatch(column: &Column) -> Result<bool> {

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -207,15 +207,16 @@ impl Affinity {
             }
 
             Affinity::Real => {
-                let mut left = is_text
+                // Convert text to numeric (like Numeric affinity).
+                // Do NOT convert integers to floats here — the comparison
+                // handler's Numeric::cmp uses sqlite_int_float_cmp for
+                // precise mixed-type comparison without precision loss.
+                // (Integer→float for column storage is handled separately
+                // in builder.rs and the Cast instruction.)
+                is_text
                     .then(|| apply_numeric_affinity(val, false))
-                    .flatten();
-
-                if let ValueRef::Numeric(Numeric::Integer(i)) = left.unwrap_or(val) {
-                    left = Some(ValueRef::from_f64(i as f64));
-                }
-
-                left.map(Either::Left)
+                    .flatten()
+                    .map(Either::Left)
             }
 
             Affinity::Blob => None, // Do nothing for blob affinity.

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1728,6 +1728,14 @@ impl ProgramBuilder {
                     either::Either::Right(val) => val,
                 };
             }
+            // REAL column affinity: also convert integers to floats for storage.
+            // This is separate from the comparison affinity path (which must NOT
+            // do this conversion to preserve precision for sqlite_int_float_cmp).
+            if matches!(affinity, Affinity::Real) {
+                if let crate::Value::Numeric(crate::numeric::Numeric::Integer(i)) = &value {
+                    value = crate::Value::from_f64(*i as f64);
+                }
+            }
 
             Some(value)
         };

--- a/testing/sqltests/tests/math/cast-real-integer-comparison.sqltest
+++ b/testing/sqltests/tests/math/cast-real-integer-comparison.sqltest
@@ -1,0 +1,57 @@
+@database :memory:
+
+test cast-real-large-int-not-equal {
+    SELECT CAST(9007199254740993 AS REAL) = 9007199254740993
+}
+expect {
+    0
+}
+
+test cast-real-large-int-equal-to-truncated {
+    SELECT CAST(9007199254740993 AS REAL) = 9007199254740992
+}
+expect {
+    1
+}
+
+test cast-real-both-sides-equal {
+    SELECT CAST(9007199254740993 AS REAL) = CAST(9007199254740993 AS REAL)
+}
+expect {
+    1
+}
+
+test cast-real-negative-large-int-not-equal {
+    SELECT CAST(-9007199254740993 AS REAL) = -9007199254740993
+}
+expect {
+    0
+}
+
+test cast-real-larger-beyond-2pow54 {
+    SELECT CAST(18014398509481985 AS REAL) = 18014398509481985
+}
+expect {
+    0
+}
+
+test cast-real-exact-2pow54 {
+    SELECT CAST(18014398509481984 AS REAL) = 18014398509481984
+}
+expect {
+    1
+}
+
+test cast-real-small-int-equal {
+    SELECT CAST(1 AS REAL) = 1
+}
+expect {
+    1
+}
+
+test cast-real-zero-equal {
+    SELECT CAST(0 AS REAL) = 0
+}
+expect {
+    1
+}


### PR DESCRIPTION
## Summary
- `Affinity::Real` was converting integer values to float before comparison, losing precision for values outside the exact f64 range
- E.g. `CAST(9007199254740993 AS REAL) = 9007199254740993` returned 1 instead of 0 because both sides became the same float
- The fix separates comparison (leaves integers for `sqlite_int_float_cmp`) from storage (converts integers to float for REAL column affinity)
- Touches `affinity.rs`, `builder.rs`, and `alter.rs`

## Test plan
- [x] `cargo clippy -p turso_core -- --deny=warnings` passes
- [x] `CI=1 make -C testing/sqltests run-rust` passes (939 tests)
- [x] New test `cast-real-integer-comparison.sqltest` verifies precision
- [x] Verified differentially against sqlite3

🤖 Generated with [Claude Code](https://claude.com/claude-code)