### PR TITLE
fix: bare columns with MIN/MAX return values from wrong row

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -345,6 +345,7 @@ pub fn translate_aggregation_step(
     agg_arg_source: AggArgumentSource,
     target_register: usize,
     resolver: &Resolver,
+    flag_reg: Option<usize>,
 ) -> Result<usize> {
     let num_args = agg_arg_source.num_args();
     let func = agg_arg_source.agg_func();
@@ -361,6 +362,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::Avg,
                 comparator: None,
+                flag_reg: None,
             });
             target_register
         }
@@ -374,6 +376,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::Count0,
                 comparator: None,
+                flag_reg: None,
             });
             target_register
         }
@@ -389,6 +392,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::Count,
                 comparator: None,
+                flag_reg: None,
             });
             target_register
         }
@@ -414,6 +418,7 @@ pub fn translate_aggregation_step(
                 delimiter: delimiter_reg,
                 func: AggFunc::GroupConcat,
                 comparator: None,
+                flag_reg: None,
             });
 
             target_register
@@ -434,6 +439,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::Max,
                 comparator,
+                flag_reg,
             });
             target_register
         }
@@ -453,6 +459,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::Min,
                 comparator,
+                flag_reg,
             });
             target_register
         }
@@ -471,6 +478,7 @@ pub fn translate_aggregation_step(
                 delimiter: value_reg,
                 func: AggFunc::JsonGroupObject,
                 comparator: None,
+                flag_reg: None,
             });
             target_register
         }
@@ -487,6 +495,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::JsonGroupArray,
                 comparator: None,
+                flag_reg: None,
             });
             target_register
         }
@@ -505,6 +514,7 @@ pub fn translate_aggregation_step(
                 delimiter: delimiter_reg,
                 func: AggFunc::StringAgg,
                 comparator: None,
+                flag_reg: None,
             });
 
             target_register
@@ -521,6 +531,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::Sum,
                 comparator: None,
+                flag_reg: None,
             });
             target_register
         }
@@ -536,6 +547,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::Total,
                 comparator: None,
+                flag_reg: None,
             });
             target_register
         }
@@ -552,6 +564,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::ArrayAgg,
                 comparator: None,
+                flag_reg: None,
             });
             target_register
         }
@@ -582,6 +595,7 @@ pub fn translate_aggregation_step(
                 delimiter: 0,
                 func: AggFunc::External(func.clone()),
                 comparator: None,
+                flag_reg: None,
             });
             target_register
         }

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -729,6 +729,7 @@ pub fn group_by_process_single_group(
                     agg_arg_source,
                     agg_result_reg,
                     &t_ctx.resolver,
+                    None,
                 )?;
                 if let Distinctness::Distinct { ctx } = &agg.distinctness {
                     let ctx = ctx
@@ -757,6 +758,7 @@ pub fn group_by_process_single_group(
                     agg_arg_source,
                     agg_result_reg,
                     &t_ctx.resolver,
+                    None,
                 )?;
                 if let Distinctness::Distinct { ctx } = &agg.distinctness {
                     let ctx = ctx

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -1,3 +1,4 @@
+use crate::function::AggFunc;
 use crate::translate::plan::SimpleAggregate;
 use crate::translate::{
     aggregation::emit_collseq_if_needed,
@@ -263,6 +264,7 @@ fn emit_loop_source<'a>(
                     delimiter: 0,
                     func: min_max.func.clone(),
                     comparator,
+                    flag_reg: None,
                 });
                 program.emit_insn(Insn::Goto {
                     target_pc: loop_end,
@@ -278,14 +280,45 @@ fn emit_loop_source<'a>(
             // a more complex expression. Some examples: length(sum(x)), sum(x) + avg(y), sum(x) + 1, etc.
             // The result of those more complex expressions depends on the final result of the aggregate, so we don't translate the complete expressions here.
             // Instead, we accumulate the intermediate results of all aggreagates, and evaluate any expressions that do not contain aggregates.
+            // Determine if exactly one MIN/MAX aggregate is present alongside
+            // bare (non-aggregate) columns.  When true the once-flag register is
+            // passed to AggStep so the VDBE resets it whenever the extremum is
+            // updated, causing bare columns to be re-read from the winning row
+            // instead of being frozen to the first row scanned.
+            let sole_minmax_index: Option<usize> =
+                if t_ctx.reg_nonagg_emit_once_flag.is_some() {
+                    let minmax_positions: Vec<usize> = plan
+                        .aggregates
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, a)| {
+                            matches!(a.func, AggFunc::Min | AggFunc::Max)
+                        })
+                        .map(|(i, _)| i)
+                        .collect();
+                    if minmax_positions.len() == 1 {
+                        Some(minmax_positions[0])
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
             for (i, agg) in plan.aggregates.iter().enumerate() {
                 let reg = start_reg + i;
+                let agg_flag = if sole_minmax_index == Some(i) {
+                    t_ctx.reg_nonagg_emit_once_flag
+                } else {
+                    None
+                };
                 translate_aggregation_step(
                     program,
                     &plan.table_references,
                     AggArgumentSource::new_from_expression(&agg.func, &agg.args, &agg.distinctness),
                     reg,
                     &t_ctx.resolver,
+                    agg_flag,
                 )?;
                 if let Distinctness::Distinct { ctx } = &agg.distinctness {
                     let ctx = ctx

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -1006,6 +1006,7 @@ fn emit_aggregation_step(
             AggArgumentSource::new_from_expression(agg_func, &args, &Distinctness::NonDistinct),
             reg_acc_start,
             resolver,
+            None,
         )?;
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5080,6 +5080,10 @@ fn init_agg_payload(func: &AggFunc, payload: &mut Vec<Value>) -> Result<()> {
 /// - **Min/Max**: `[current_extreme: Value]` - tracks min/max seen so far
 /// - **GroupConcat/StringAgg**: `[accumulated: Null|Text]` - Null until first value, then Text
 /// - **JsonGroup***: `[raw_jsonb: Blob]` - accumulated raw JSONB bytes
+///
+/// Returns `Ok(true)` when a MIN/MAX aggregate's accumulator was actually
+/// updated (including first-value initialization). All other aggregate
+/// types unconditionally return `Ok(false)`.
 fn update_agg_payload(
     func: &AggFunc,
     arg: Value,                // most agg functions take one argument
@@ -5087,7 +5091,7 @@ fn update_agg_payload(
     payload: &mut [Value],
     collation: CollationSeq,
     comparator: &Option<crate::vdbe::sorter::SortComparator>,
-) -> Result<()> {
+) -> Result<bool> {
     match func {
         AggFunc::Count => {
             // COUNT(column) increments only when arg is not NULL. Empty args treated as non-NULL
@@ -5115,7 +5119,7 @@ fn update_agg_payload(
         }
         AggFunc::Avg => {
             if matches!(arg, Value::Null) {
-                return Ok(());
+                return Ok(false);
             }
             // invariant as per init_agg_payload: payload[0] is Float (sum), payload[1] is Float (r_err), payload[2] is Integer (count)
             let [sum_val, r_err_val, count_val, ..] = payload else {
@@ -5125,7 +5129,7 @@ fn update_agg_payload(
                 ));
             };
             if matches!(*sum_val, Value::Null) {
-                return Ok(());
+                return Ok(false);
             }
             let r_err = r_err_val.to_float_or_zero();
             let Value::Numeric(Numeric::Integer(count)) = count_val else {
@@ -5192,7 +5196,7 @@ fn update_agg_payload(
                 ovrfl: *ovrfl_i != 0,
             };
             if matches!(*acc, Value::Null) && sum_state.approx {
-                return Ok(());
+                return Ok(false);
             }
             match arg {
                 Value::Null => {}
@@ -5251,11 +5255,11 @@ fn update_agg_payload(
         }
         AggFunc::Min | AggFunc::Max => {
             if matches!(arg, Value::Null) {
-                return Ok(());
+                return Ok(false);
             }
             if matches!(payload[0], Value::Null) {
                 payload[0] = arg;
-                return Ok(());
+                return Ok(true);
             }
             use std::cmp::Ordering;
             // Use custom type comparator if available, otherwise fall back to collation
@@ -5274,10 +5278,11 @@ fn update_agg_payload(
             if should_update {
                 payload[0] = arg;
             }
+            return Ok(should_update);
         }
         AggFunc::GroupConcat | AggFunc::StringAgg => {
             if matches!(arg, Value::Null) {
-                return Ok(());
+                return Ok(false);
             }
             let delimiter = maybe_arg2.unwrap_or_else(|| Value::build_text(","));
             let acc = &mut payload[0];
@@ -5342,7 +5347,7 @@ fn update_agg_payload(
             vec.append(&mut data);
         }
     }
-    Ok(())
+    Ok(false)
 }
 
 /// Convert the intermediate aggregate state in `payload` into the final result value.
@@ -5466,6 +5471,7 @@ pub fn op_agg_step(
             delimiter,
             func,
             comparator,
+            flag_reg,
         },
         insn
     );
@@ -5559,15 +5565,28 @@ pub fn op_agg_step(
                 };
                 let collation = state.current_collation.unwrap_or(CollationSeq::Binary);
 
-                // Now get mutable borrow on payload
-                let Register::Aggregate(agg) = &mut state.registers[*acc_reg] else {
-                    panic!(
-                        "Unexpected value {:?} in AggStep at register {}",
-                        state.registers[*acc_reg], *acc_reg
-                    );
+                // Scope the mutable borrow on the accumulator register so we
+                // can later write to a different register (flag_reg).
+                let updated = {
+                    let Register::Aggregate(agg) = &mut state.registers[*acc_reg] else {
+                        panic!(
+                            "Unexpected value {:?} in AggStep at register {}",
+                            state.registers[*acc_reg], *acc_reg
+                        );
+                    };
+                    let payload = agg.payload_mut();
+                    update_agg_payload(func, arg, maybe_arg2, payload, collation, &comparator)?
                 };
-                let payload = agg.payload_mut();
-                update_agg_payload(func, arg, maybe_arg2, payload, collation, &comparator)?;
+
+                // For MIN/MAX with bare columns: reset the flag register to 0
+                // whenever the aggregate value is updated (including first
+                // initialization), so the loop body re-reads non-aggregate
+                // columns from the current (winning) row.
+                if let Some(flag) = flag_reg {
+                    if updated {
+                        state.registers[*flag] = Register::Value(Value::from_i64(0));
+                    }
+                }
             }
         }
     };

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1133,6 +1133,7 @@ pub fn insn_to_row(
                 delimiter: _,
                 col,
                 comparator: _,
+                flag_reg: _,
             } => (
                 "AggStep",
                 0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -912,6 +912,10 @@ pub enum Insn {
         func: AggFunc,
         /// Optional custom type comparator for MIN/MAX aggregates.
         comparator: Option<SortComparatorType>,
+        /// For MIN/MAX with bare columns: register to reset to 0 when the
+        /// aggregate value is updated, so non-aggregate columns are re-read
+        /// from the row that produced the new extremum.
+        flag_reg: Option<usize>,
     },
 
     AggFinal {

--- a/testing/sqltests/tests/aggregate-bare-column-minmax.sqltest
+++ b/testing/sqltests/tests/aggregate-bare-column-minmax.sqltest
@@ -1,0 +1,168 @@
+@database :memory:
+
+# Regression tests: bare columns in ungrouped MIN/MAX aggregate queries must
+# return values from the row that produced the extremum, not from the first row
+# scanned.
+#
+# SQLite semantics: when a query contains MIN() or MAX() alongside bare
+# (non-aggregate) columns, those bare columns come from the row where the
+# min/max value was found. Previously Limbo read bare columns once on the first
+# row and never re-read them when MIN/MAX was updated.
+
+setup basic {
+    CREATE TABLE t1(a INTEGER, b TEXT);
+    INSERT INTO t1 VALUES(1, 'first');
+    INSERT INTO t1 VALUES(3, 'third');
+    INSERT INTO t1 VALUES(2, 'second');
+}
+
+@setup basic
+test max-bare-col-returns-max-row {
+    SELECT MAX(a), b FROM t1;
+}
+expect {
+    3|third
+}
+
+@setup basic
+test min-bare-col-returns-min-row {
+    SELECT MIN(a), b FROM t1;
+}
+expect {
+    1|first
+}
+
+# Max value is in the last inserted row
+setup reverse-order {
+    CREATE TABLE t2(x REAL, y TEXT, z INTEGER);
+    INSERT INTO t2 VALUES(5.0, 'five', 50);
+    INSERT INTO t2 VALUES(1.0, 'one', 10);
+    INSERT INTO t2 VALUES(9.0, 'nine', 90);
+    INSERT INTO t2 VALUES(3.0, 'three', 30);
+}
+
+@setup reverse-order
+test max-multiple-bare-cols {
+    SELECT MAX(x), y, z FROM t2;
+}
+expect {
+    9.0|nine|90
+}
+
+@setup reverse-order
+test min-multiple-bare-cols {
+    SELECT MIN(x), y, z FROM t2;
+}
+expect {
+    1.0|one|10
+}
+
+# Bare columns with text comparison
+setup text-minmax {
+    CREATE TABLE t3(name TEXT, score INTEGER);
+    INSERT INTO t3 VALUES('alice', 80);
+    INSERT INTO t3 VALUES('bob', 95);
+    INSERT INTO t3 VALUES('carol', 70);
+    INSERT INTO t3 VALUES('dave', 95);
+}
+
+@setup text-minmax
+test max-score-bare-name {
+    SELECT MAX(score), name FROM t3;
+}
+expect {
+    95|bob
+}
+
+@setup text-minmax
+test min-score-bare-name {
+    SELECT MIN(score), name FROM t3;
+}
+expect {
+    70|carol
+}
+
+# Min on text column, bare integer column
+@setup text-minmax
+test min-name-bare-score {
+    SELECT MIN(name), score FROM t3;
+}
+expect {
+    alice|80
+}
+
+@setup text-minmax
+test max-name-bare-score {
+    SELECT MAX(name), score FROM t3;
+}
+expect {
+    dave|95
+}
+
+# Single row table — bare column must still work
+setup single {
+    CREATE TABLE t4(a INTEGER, b TEXT);
+    INSERT INTO t4 VALUES(42, 'only');
+}
+
+@setup single
+test max-single-row {
+    SELECT MAX(a), b FROM t4;
+}
+expect {
+    42|only
+}
+
+@setup single
+test min-single-row {
+    SELECT MIN(a), b FROM t4;
+}
+expect {
+    42|only
+}
+
+# Empty table — bare column returns NULL (existing behavior, regression guard)
+setup empty {
+    CREATE TABLE t5(a INTEGER, b TEXT);
+}
+
+@setup empty
+test max-empty-table {
+    SELECT MAX(a), b FROM t5;
+}
+expect {
+    |
+}
+
+@setup empty
+test min-empty-table {
+    SELECT MIN(a), b FROM t5;
+}
+expect {
+    |
+}
+
+# NULL handling: NULLs should be skipped by MIN/MAX
+setup with-nulls {
+    CREATE TABLE t6(a INTEGER, b TEXT);
+    INSERT INTO t6 VALUES(NULL, 'null-row');
+    INSERT INTO t6 VALUES(5, 'five');
+    INSERT INTO t6 VALUES(NULL, 'another-null');
+    INSERT INTO t6 VALUES(2, 'two');
+}
+
+@setup with-nulls
+test max-skips-nulls-bare-col {
+    SELECT MAX(a), b FROM t6;
+}
+expect {
+    5|five
+}
+
+@setup with-nulls
+test min-skips-nulls-bare-col {
+    SELECT MIN(a), b FROM t6;
+}
+expect {
+    2|two
+}


### PR DESCRIPTION
## Summary
- `SELECT max(a), b FROM t` returned `b` from the first scanned row instead of from the row where `max(a)` was found
- Root cause: a once-flag read bare columns on the first row and never re-read them when MIN/MAX was updated
- Fix: AggStep resets the once-flag register to 0 when MIN/MAX updates, so the existing `If`/`Integer` pattern re-reads bare columns from the winning row
- `update_agg_payload` now returns `Ok(true)` when MIN/MAX was updated, enabling the flag-reset logic
- Changes across 7 files: `insn.rs`, `explain.rs`, `execute.rs`, `aggregation.rs`, `body.rs`, `group_by.rs`, `window.rs`

## Test plan
- [x] `cargo clippy -p turso_core -- --deny=warnings` passes
- [x] `CI=1 make -C testing/sqltests run-rust` passes (939 tests)
- [x] New test `aggregate-bare-column-minmax.sqltest` with 14 cases covering MAX, MIN, multiple bare columns, text comparison, single row, empty table, NULL handling
- [x] Verified differentially against sqlite3

🤖 Generated with [Claude Code](https://claude.com/claude-code)