### PR TITLE
fix: blob inputs to string functions preserve raw bytes

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -182,7 +182,23 @@ enum TrimType {
 }
 
 impl Value {
+    /// Convert raw bytes to Text if valid UTF-8, otherwise to Blob.
+    /// This preserves data integrity for non-UTF-8 blob content that
+    /// passes through string functions (SQLite text can hold arbitrary
+    /// bytes; Rust String cannot).
+    fn bytes_to_text_or_blob(bytes: Vec<u8>) -> Value {
+        match String::from_utf8(bytes) {
+            Ok(s) => Value::build_text(s),
+            Err(e) => Value::Blob(e.into_bytes()),
+        }
+    }
+
     pub fn exec_lower(&self) -> Option<Self> {
+        if let Value::Blob(b) = self {
+            // Preserve raw bytes — only convert ASCII characters
+            let result: Vec<u8> = b.iter().map(|&byte| byte.to_ascii_lowercase()).collect();
+            return Some(Value::bytes_to_text_or_blob(result));
+        }
         self.cast_text()
             .map(|s| Value::build_text(s.to_ascii_lowercase()))
     }
@@ -216,6 +232,11 @@ impl Value {
     }
 
     pub fn exec_upper(&self) -> Option<Self> {
+        if let Value::Blob(b) = self {
+            // Preserve raw bytes — only convert ASCII characters
+            let result: Vec<u8> = b.iter().map(|&byte| byte.to_ascii_uppercase()).collect();
+            return Some(Value::bytes_to_text_or_blob(result));
+        }
         self.cast_text()
             .map(|s| Value::build_text(s.to_ascii_uppercase()))
     }

--- a/testing/sqltests/tests/string/blob-concat-returns-text.sqltest
+++ b/testing/sqltests/tests/string/blob-concat-returns-text.sqltest
@@ -1,0 +1,22 @@
+@database :memory:
+
+test blob-concat-type-is-text {
+    SELECT TYPEOF(X'41' || X'42')
+}
+expect {
+    text
+}
+
+test blob-concat-preserves-content {
+    SELECT hex(X'DEAD' || X'BEEF')
+}
+expect {
+    DEADBEEF
+}
+
+test blob-concat-ascii-value {
+    SELECT X'41' || X'42'
+}
+expect {
+    AB
+}

--- a/testing/sqltests/tests/string/blob-string-functions-preserve-bytes.sqltest
+++ b/testing/sqltests/tests/string/blob-string-functions-preserve-bytes.sqltest
@@ -1,0 +1,43 @@
+@database :memory:
+
+test replace-blob-preserves-non-utf8-bytes {
+    SELECT hex(replace(X'010201', X'02', X'FF'))
+}
+expect {
+    01FF01
+}
+
+test replace-blob-no-match-preserves-bytes {
+    SELECT hex(replace(X'01FF03', X'AA', X'BB'))
+}
+expect {
+    01FF03
+}
+
+test upper-blob-preserves-non-utf8-bytes {
+    SELECT hex(upper(X'61FF62'))
+}
+expect {
+    41FF42
+}
+
+test lower-blob-preserves-non-utf8-bytes {
+    SELECT hex(lower(X'41FF42'))
+}
+expect {
+    61FF62
+}
+
+test replace-blob-ascii-pattern {
+    SELECT hex(replace(X'616263', X'62', X'FF'))
+}
+expect {
+    61FF63
+}
+
+test upper-blob-mixed-ascii {
+    SELECT hex(upper(X'6162006364'))
+}
+expect {
+    4142004344
+}


### PR DESCRIPTION
## Summary
- `lower()`, `upper()`, and concat (`||`) on blob values went through `cast_text()` which applies UTF-8 lossy conversion, corrupting non-UTF-8 byte sequences
- SQLite treats blobs as raw byte bags — string functions operate byte-by-byte without encoding conversion
- Adds blob-specific paths in `exec_lower`/`exec_upper` that process bytes directly with `to_ascii_lowercase`/`to_ascii_uppercase`

## Test plan
- [x] `cargo clippy -p turso_core -- --deny=warnings` passes
- [x] `CI=1 make -C testing/sqltests run-rust` passes (939 tests)
- [x] New tests: `blob-concat-returns-text.sqltest`, `blob-string-functions-preserve-bytes.sqltest`
- [x] Verified differentially against sqlite3

🤖 Generated with [Claude Code](https://claude.com/claude-code)