### PR TITLE
fix: json_set/json_insert support $[#] array append syntax

### DIFF
--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -2594,6 +2594,31 @@ impl Jsonb {
                                 bail_parse_error!("Element with negative index not found")
                             }
                         }
+                        None => {
+                            // $[#] — append to end of array
+                            let mut arr_pos = pos + root_header_size;
+                            while arr_pos < end_pos {
+                                arr_pos = self.skip_element(arr_pos)?;
+                            }
+
+                            if mode.allows_insert() {
+                                let placeholder =
+                                    JsonbHeader::new(ElementType::OBJECT, 0).into_bytes();
+                                let placeholder_bytes = placeholder.as_bytes();
+
+                                self.data
+                                    .splice(arr_pos..arr_pos, placeholder_bytes.iter().copied());
+
+                                return Ok(JsonTraversalResult::with_array_index(
+                                    pos,
+                                    JsonLocationKind::ArrayEntry,
+                                    placeholder_bytes.len() as isize,
+                                    arr_pos,
+                                ));
+                            }
+
+                            bail_parse_error!("Not found!");
+                        }
                         _ => unreachable!(),
                     }
                 } else {
@@ -2772,6 +2797,31 @@ impl Jsonb {
                             } else {
                                 bail_parse_error!("Element with negative index not found")
                             }
+                        }
+                        None => {
+                            // $[#] — append to end of array
+                            let mut arr_pos = pos + root_header_size;
+                            while arr_pos < end_pos {
+                                arr_pos = self.skip_element(arr_pos)?;
+                            }
+
+                            if mode.allows_insert() {
+                                let placeholder =
+                                    JsonbHeader::new(ElementType::OBJECT, 0).into_bytes();
+                                let placeholder_bytes = placeholder.as_bytes();
+
+                                self.data
+                                    .splice(arr_pos..arr_pos, placeholder_bytes.iter().copied());
+
+                                return Ok(JsonTraversalResult::with_array_index(
+                                    pos,
+                                    JsonLocationKind::DocumentRoot,
+                                    placeholder_bytes.len() as isize,
+                                    arr_pos,
+                                ));
+                            }
+
+                            bail_parse_error!("Not found!");
                         }
                         _ => unreachable!(),
                     }

--- a/testing/sqltests/tests/json/json-set-array-append.sqltest
+++ b/testing/sqltests/tests/json/json-set-array-append.sqltest
@@ -1,0 +1,43 @@
+@database :memory:
+
+test json-set-append-empty-array {
+    SELECT json_set('[]', '$[#]', 1)
+}
+expect {
+    [1]
+}
+
+test json-set-append-existing-array {
+    SELECT json_set('[1,2,3]', '$[#]', 4)
+}
+expect {
+    [1,2,3,4]
+}
+
+test json-set-append-string {
+    SELECT json_set('[]', '$[#]', 'hello')
+}
+expect {
+    ["hello"]
+}
+
+test json-insert-append {
+    SELECT json_insert('[10,20]', '$[#]', 30)
+}
+expect {
+    [10,20,30]
+}
+
+test json-set-append-nested-object {
+    SELECT json_set('[1]', '$[#]', json('{"a":2}'))
+}
+expect {
+    [1,{"a":2}]
+}
+
+test json-set-append-nested-array {
+    SELECT json_set('["a"]', '$[#]', json('[1,2]'))
+}
+expect {
+    ["a",[1,2]]
+}


### PR DESCRIPTION
## Summary
- SQLite's `json_set()` and `json_insert()` support `$[#]` path syntax to append to the end of an array (where `#` means "one past the last index")
- Limbo was hitting `unreachable!()` because the `None` variant of `ArrayLocator` (representing `#`) was unhandled in both traversal paths
- Adds `None =>` match arms that scan to array end, insert a placeholder, and return the result for the caller to fill in

## Test plan
- [x] `cargo clippy -p turso_core -- --deny=warnings` passes
- [x] `CI=1 make -C testing/sqltests run-rust` passes (939 tests)
- [x] New test `json-set-array-append.sqltest` covering empty arrays, populated arrays, nested arrays, json_insert
- [x] Verified differentially against sqlite3

🤖 Generated with [Claude Code](https://claude.com/claude-code)