### PR TITLE
core/storage: Clear stale overflow-read state and return corrupt on mismatch

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -8285,9 +8285,7 @@ mod tests {
         io::{Buffer, MemoryIO, OpenFlags, IO},
         schema::IndexColumn,
         storage::{
-            database::DatabaseFile,
-            page_cache::PageCache,
-            pager::{default_page1, CreateBTreeFlags},
+            database::DatabaseFile, page_cache::PageCache, pager::default_page1,
             sqlite3_ondisk::PageSize,
         },
         types::Text,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -942,11 +942,19 @@ impl BTreeCursor {
     ) -> Result<IOResult<()>> {
         loop {
             if self.read_overflow_state.is_none() {
+                let remaining_to_read =
+                    payload_size
+                        .checked_sub(payload.len() as u64)
+                        .ok_or_else(|| {
+                            LimboError::Corrupt(
+                                "payload size is smaller than local payload bytes".to_string(),
+                            )
+                        })? as usize;
                 let (page, c) = self.read_page(start_next_page as i64)?;
                 self.read_overflow_state.replace(ReadPayloadOverflow {
                     payload: payload.to_vec(),
                     next_page: start_next_page,
-                    remaining_to_read: payload_size as usize - payload.len(),
+                    remaining_to_read,
                     page,
                 });
                 if let Some(c) = c {
@@ -985,10 +993,20 @@ impl BTreeCursor {
                 }
                 continue;
             }
-            turso_assert!(
-                *remaining_to_read == 0 && next == 0,
-                "we can't have more pages to read while also have read everything"
-            );
+            if *remaining_to_read != 0 || next != 0 {
+                let chain_page = *next_page;
+                let remaining = *remaining_to_read;
+                self.read_overflow_state.take();
+                tracing::warn!(
+                    chain_page,
+                    next,
+                    remaining,
+                    "inconsistent overflow chain observed during payload read"
+                );
+                return Err(LimboError::Corrupt(
+                    "inconsistent overflow chain observed during payload read".to_string(),
+                ));
+            }
             let payload_swap = std::mem::take(payload);
 
             let mut reuse_immutable = self.get_immutable_record_or_create();
@@ -999,7 +1017,7 @@ impl BTreeCursor {
                 .unwrap()
                 .start_serialization(&payload_swap);
 
-            let _ = self.read_overflow_state.take();
+            self.read_overflow_state.take();
             break Ok(IOResult::Done(()));
         }
     }
@@ -5062,6 +5080,7 @@ impl CursorTrait for BTreeCursor {
         // Reset seek state
         self.seek_state = CursorSeekState::Start;
         self.valid_state = CursorValidState::Valid;
+        self.read_overflow_state = None;
         Ok(IOResult::Done(seek_result))
     }
 
@@ -5781,6 +5800,7 @@ impl CursorTrait for BTreeCursor {
                     let has_record = return_if_io!(self.move_to_rightmost(always_seek));
                     self.invalidate_record();
                     self.set_has_record(has_record);
+                    self.read_overflow_state = None;
                     if !has_record {
                         self.seek_to_last_state = SeekToLastState::IsEmpty;
                         continue;
@@ -8265,7 +8285,9 @@ mod tests {
         io::{Buffer, MemoryIO, OpenFlags, IO},
         schema::IndexColumn,
         storage::{
-            database::DatabaseFile, page_cache::PageCache, pager::default_page1,
+            database::DatabaseFile,
+            page_cache::PageCache,
+            pager::{default_page1, CreateBTreeFlags},
             sqlite3_ondisk::PageSize,
         },
         types::Text,
@@ -9716,6 +9738,37 @@ mod tests {
             }
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_process_overflow_read_inconsistent_chain_returns_corrupt() -> Result<()> {
+        let pager = setup_test_env(3);
+        let mut cursor = BTreeCursor::new_table(pager.clone(), 1, 5);
+
+        let (overflow_page, c) = cursor.read_page(2)?;
+        if let Some(c) = c {
+            pager.io.wait_for_completion(c)?;
+        }
+        while overflow_page.is_locked() {
+            pager.io.step()?;
+        }
+
+        let overflow_contents = overflow_page.get_contents();
+        overflow_contents.write_u32_no_offset(0, 0);
+        overflow_contents.as_ptr()[4..].fill(b'Z');
+
+        let local_payload: &'static [u8] = Box::leak(vec![b'Y'; 32].into_boxed_slice());
+        let payload_size = local_payload.len() as u64 + ((cursor.usable_space() - 4) as u64 * 2);
+        let cursor_pager = cursor.pager.clone();
+
+        let err = run_until_done(
+            || cursor.process_overflow_read(local_payload, 2, payload_size),
+            &cursor_pager,
+        )
+        .expect_err("inconsistent overflow chain should fail with Corrupt");
+        assert!(matches!(err, LimboError::Corrupt(_)));
+        assert!(cursor.read_overflow_state.is_none());
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Fix an intermittent overflow-read panic in the sync parallel writes repro.

Root cause:
`process_overflow_read()` could resume using stale `read_overflow_state` after the cursor context changed. In that case, overflow reading could continue against the wrong record state, which could lead to a panic.

What changed:
- Clear stale `read_overflow_state` on additional cursor reposition paths
- Return `Corrupt` instead of panicking when an overflow-chain mismatch is detected

Validation:
Because this issue is intermittent, I validated it by running the repro command in a loop.

- Fix branch: 90 runs, no overflow panic, 1 known unrelated `Busy` failure
- Main branch: latest observed overflow panic repro was on run 4

## Motivation and context

https://github.com/tursodatabase/turso/issues/6108

## Description of AI Usage
Used AI to help investigate the panic, reason about the stale overflow-read state path, and draft the fix and validation approach. All code changes and conclusions were reviewed and validated with repeated repro runs.

