### PR TITLE
fix: use round-half-away-from-zero for ROUND() with precision > 0

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -790,9 +790,8 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        let f: f64 = crate::numeric::str_to_f64(format!("{f:.precision$}"))
-            .expect("formatted float should always parse successfully")
-            .into();
+        let factor = 10f64.powi(precision as i32);
+        let f = (f * factor + if f < 0.0 { -0.5 } else { 0.5 }).trunc() / factor;
 
         Value::from_f64(f)
     }
@@ -2712,6 +2711,26 @@ mod tests {
         let input_val = Value::from_f64(100.123);
         let expected_val = Value::Null;
         assert_eq!(input_val.exec_round(Some(&Value::Null)), expected_val);
+
+        // round-half-away-from-zero tie-breaking (issue #5748)
+        let input_val = Value::from_f64(2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(2.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(-2.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(2.55);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(2.6);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(2.5);
+        let expected_val = Value::from_f64(3.0);
+        assert_eq!(input_val.exec_round(None), expected_val);
     }
 
     #[test]

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -790,27 +790,45 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        // Rust's format! uses banker's rounding (round-half-to-even), which differs
-        // from SQLite's round-half-away-from-zero only at exact midpoint ties.
-        // Format with extra precision to detect ties, then handle them explicitly.
+        // Format once with extra fractional digits, then round that decimal
+        // buffer in place using SQLite's round-half-away-from-zero rule.
         let abs_f = f.abs();
         let extra_prec = precision + 20;
-        let extended = format!("{abs_f:.extra_prec$}");
-        let dot_pos = extended.find('.').unwrap();
-        let after_dot = &extended.as_bytes()[dot_pos + 1..];
+        let mut buf = format!("{abs_f:.extra_prec$}");
+        let dot_pos = buf
+            .find('.')
+            .expect("fixed-precision format should contain '.'");
+        let round_pos = dot_pos + 1 + precision;
+        let round_up = buf.as_bytes()[round_pos] >= b'5';
+        buf.truncate(round_pos);
 
-        let is_exact_tie =
-            after_dot[precision] == b'5' && after_dot[precision + 1..].iter().all(|&b| b == b'0');
+        if round_up {
+            // Safe: we only mutate ASCII digits and keep the existing '.' intact,
+            // so the string remains valid UTF-8.
+            let bytes = unsafe { buf.as_mut_vec() };
+            let mut i = bytes.len();
+            loop {
+                // Walk right-to-left over e.g. "12.349", turning trailing 9s into 0s
+                // until we can increment one kept digit, yielding "12.350".
 
-        let result = if is_exact_tie {
-            let truncated: f64 = extended[..dot_pos + 1 + precision].parse().unwrap();
-            let unit = 10f64.powi(-(precision as i32));
-            format!("{:.precision$}", truncated + unit)
-                .parse::<f64>()
-                .unwrap()
-        } else {
-            format!("{abs_f:.precision$}").parse::<f64>().unwrap()
-        };
+                // If we've reached the leftmost digit, we've seen only digit 9s so prepend a 1 to round up
+                if i == 0 {
+                    bytes.insert(0, b'1');
+                    break;
+                }
+                i -= 1;
+                if bytes[i] == b'.' {
+                    continue;
+                }
+                if bytes[i] < b'9' {
+                    bytes[i] += 1;
+                    break;
+                }
+                bytes[i] = b'0';
+            }
+        }
+
+        let result = buf.parse::<f64>().unwrap();
 
         Value::from_f64(if f < 0.0 { -result } else { result })
     }
@@ -2763,6 +2781,11 @@ mod tests {
         let input_val = Value::from_f64(2.5);
         let expected_val = Value::from_f64(3.0);
         assert_eq!(input_val.exec_round(None), expected_val);
+
+        let input_val = Value::from_f64(1.125);
+        let precision_val = Value::from_i64(2);
+        let expected_val = Value::from_f64(1.13);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
     }
 
     #[test]

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -790,10 +790,29 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        let factor = 10f64.powi(precision as i32);
-        let f = (f * factor + if f < 0.0 { -0.5 } else { 0.5 }).trunc() / factor;
+        // Rust's format! uses banker's rounding (round-half-to-even), which differs
+        // from SQLite's round-half-away-from-zero only at exact midpoint ties.
+        // Format with extra precision to detect ties, then handle them explicitly.
+        let abs_f = f.abs();
+        let extra_prec = precision + 20;
+        let extended = format!("{abs_f:.extra_prec$}");
+        let dot_pos = extended.find('.').unwrap();
+        let after_dot = &extended.as_bytes()[dot_pos + 1..];
 
-        Value::from_f64(f)
+        let is_exact_tie =
+            after_dot[precision] == b'5' && after_dot[precision + 1..].iter().all(|&b| b == b'0');
+
+        let result = if is_exact_tie {
+            let truncated: f64 = extended[..dot_pos + 1 + precision].parse().unwrap();
+            let unit = 10f64.powi(-(precision as i32));
+            format!("{:.precision$}", truncated + unit)
+                .parse::<f64>()
+                .unwrap()
+        } else {
+            format!("{abs_f:.precision$}").parse::<f64>().unwrap()
+        };
+
+        Value::from_f64(if f < 0.0 { -result } else { result })
     }
 
     fn _exec_trim(&self, pattern: Option<&Value>, trim_type: TrimType) -> Value {
@@ -2723,7 +2742,20 @@ mod tests {
         let expected_val = Value::from_f64(-2.3);
         assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
 
+        // 2.55 in f64 is 2.54999... (below midpoint), rounds down
         let input_val = Value::from_f64(2.55);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(2.5);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        // 2.45 in f64 is 2.45000...018 (above midpoint), rounds up
+        let input_val = Value::from_f64(2.45);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(2.5);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        // 2.65 in f64 is 2.64999... (below midpoint), rounds down
+        let input_val = Value::from_f64(2.65);
         let precision_val = Value::from_i64(1);
         let expected_val = Value::from_f64(2.6);
         assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,3 +34,7 @@ path = "fuzz_targets/cast_real.rs"
 [[bin]]
 name = "scalar_func"
 path = "fuzz_targets/scalar_func.rs"
+
+[[bin]]
+name = "round"
+path = "fuzz_targets/round.rs"

--- a/fuzz/fuzz_targets/round.rs
+++ b/fuzz/fuzz_targets/round.rs
@@ -1,0 +1,188 @@
+#![no_main]
+
+use std::cell::RefCell;
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use rusqlite::{params, types::Value as SqlValue};
+use turso_core::Value as CoreValue;
+
+#[derive(Debug, Clone)]
+enum FuzzValue {
+    Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+impl FuzzValue {
+    fn to_core_value(&self) -> CoreValue {
+        match self {
+            Self::Null => CoreValue::Null,
+            Self::Integer(v) => CoreValue::from_i64(*v),
+            Self::Real(v) => CoreValue::from_f64(*v),
+            Self::Text(v) => CoreValue::from_text(v.clone()),
+            Self::Blob(v) => CoreValue::from_blob(v.clone()),
+        }
+    }
+
+    fn to_sql_value(&self) -> SqlValue {
+        match self {
+            Self::Null => SqlValue::Null,
+            Self::Integer(v) => SqlValue::Integer(*v),
+            Self::Real(v) => {
+                if v.is_nan() {
+                    SqlValue::Null
+                } else {
+                    SqlValue::Real(*v)
+                }
+            }
+            Self::Text(v) => SqlValue::Text(v.clone()),
+            Self::Blob(v) => SqlValue::Blob(v.clone()),
+        }
+    }
+
+    fn arbitrary_value(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(match u.int_in_range(0..=4u8)? {
+            0 => Self::Null,
+            1 => Self::Integer(i64::arbitrary(u)?),
+            2 => Self::Real(f64::arbitrary(u)?),
+            3 => Self::Text(Self::arbitrary_text(u)?),
+            4 => Self::Blob(Vec::<u8>::arbitrary(u)?),
+            _ => unreachable!(),
+        })
+    }
+
+    fn arbitrary_text(u: &mut Unstructured<'_>) -> arbitrary::Result<String> {
+        Ok(match u.int_in_range(0..=6u8)? {
+            0 => i64::arbitrary(u)?.to_string(),
+            1 => {
+                let f = f64::arbitrary(u)?;
+                if f.is_nan() {
+                    "NaN".to_string()
+                } else {
+                    f.to_string()
+                }
+            }
+            2 => format!(" {} ", u.int_in_range(-40i16..=40i16)?),
+            3 => format!("{}.5", u.int_in_range(-10_000i32..=10_000i32)?),
+            4 => String::new(),
+            5 => "not-a-number".to_string(),
+            6 => String::arbitrary(u)?,
+            _ => unreachable!(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RoundCase {
+    value: FuzzValue,
+    precision: Option<FuzzValue>,
+}
+
+impl RoundCase {
+    fn exact_tie(u: &mut Unstructured<'_>, text_value: bool) -> arbitrary::Result<Self> {
+        let precision = u.int_in_range(1..=30u8)? as usize;
+        let odd = (u.int_in_range(0..=4095u16)? as u64) * 2 + 1;
+        let sign = if bool::arbitrary(u)? { -1.0 } else { 1.0 };
+        // For precision p, odd / 2^(p+1) is an exact midpoint once scaled by 10^p.
+        let tie = sign * (odd as f64) / ((1u64 << (precision as u32 + 1)) as f64);
+        let value = if text_value {
+            FuzzValue::Text(tie.to_string())
+        } else {
+            FuzzValue::Real(tie)
+        };
+        let precision = if bool::arbitrary(u)? {
+            Some(FuzzValue::Integer(precision as i64))
+        } else {
+            Some(FuzzValue::Text(precision.to_string()))
+        };
+        Ok(Self { value, precision })
+    }
+
+    fn random_numeric(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        let value = match u.int_in_range(0..=2u8)? {
+            0 => FuzzValue::Real(f64::arbitrary(u)?),
+            1 => FuzzValue::Integer(i64::arbitrary(u)?),
+            2 => FuzzValue::Text(FuzzValue::arbitrary_text(u)?),
+            _ => unreachable!(),
+        };
+        let precision = match u.int_in_range(0..=5u8)? {
+            0 => None,
+            1 => Some(FuzzValue::Null),
+            2 => Some(FuzzValue::Integer(u.int_in_range(-100i16..=100i16)? as i64)),
+            3 => Some(FuzzValue::Real(f64::arbitrary(u)?)),
+            4 => Some(FuzzValue::Text(FuzzValue::arbitrary_text(u)?)),
+            5 => Some(FuzzValue::Blob(Vec::<u8>::arbitrary(u)?)),
+            _ => unreachable!(),
+        };
+        Ok(Self { value, precision })
+    }
+
+    fn coercion_heavy(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        let precision = match u.int_in_range(0..=4u8)? {
+            0 => None,
+            1 => Some(FuzzValue::Text(FuzzValue::arbitrary_text(u)?)),
+            2 => Some(FuzzValue::Blob(Vec::<u8>::arbitrary(u)?)),
+            3 => Some(FuzzValue::Null),
+            4 => Some(FuzzValue::Real(f64::arbitrary(u)?)),
+            _ => unreachable!(),
+        };
+        Ok(Self {
+            value: FuzzValue::arbitrary_value(u)?,
+            precision,
+        })
+    }
+}
+
+impl<'a> Arbitrary<'a> for RoundCase {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        match u.int_in_range(0..=9u8)? {
+            0..=4 => Self::exact_tie(u, false),
+            5..=6 => Self::exact_tie(u, true),
+            7..=8 => Self::random_numeric(u),
+            9 => Self::coercion_heavy(u),
+            _ => unreachable!(),
+        }
+    }
+}
+
+thread_local! {
+    static SQLITE: RefCell<rusqlite::Connection> = RefCell::new(
+        rusqlite::Connection::open_in_memory().expect("sqlite fuzz oracle should open")
+    );
+}
+
+fn sqlite_round(case: &RoundCase) -> rusqlite::Result<CoreValue> {
+    SQLITE.with(|conn| {
+        let conn = conn.borrow();
+        let value = match case.precision.as_ref() {
+            Some(precision) => conn.query_row(
+                "SELECT round(?1, ?2)",
+                params![case.value.to_sql_value(), precision.to_sql_value()],
+                |row| row.get::<_, SqlValue>(0),
+            )?,
+            None => conn.query_row(
+                "SELECT round(?1)",
+                params![case.value.to_sql_value()],
+                |row| row.get::<_, SqlValue>(0),
+            )?,
+        };
+        Ok(match value {
+            SqlValue::Null => CoreValue::Null,
+            SqlValue::Integer(v) => CoreValue::from_f64(v as f64),
+            SqlValue::Real(v) => CoreValue::from_f64(v),
+            SqlValue::Text(v) => CoreValue::from_text(v),
+            SqlValue::Blob(v) => CoreValue::from_blob(v),
+        })
+    })
+}
+
+fuzz_target!(|case: RoundCase| {
+    let value = case.value.to_core_value();
+    let precision = case.precision.as_ref().map(FuzzValue::to_core_value);
+    let expected = sqlite_round(&case).expect("sqlite round should succeed");
+    let found = value.exec_round(precision.as_ref());
+    assert_eq!(expected, found, "round case: {case:?}");
+});

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -855,6 +855,37 @@ test round-null-precision {
 expect {
 }
 
+test round-half-away-from-zero-positive {
+    SELECT round(2.25, 1);
+}
+expect {
+    2.3
+}
+
+test round-half-away-from-zero-negative {
+    SELECT round(-2.25, 1);
+}
+expect {
+    -2.3
+}
+
+test round-half-away-from-zero-precision0 {
+    SELECT round(2.5);
+}
+expect {
+    3.0
+}
+expect @js {
+    3
+}
+
+test round-half-away-from-zero-255 {
+    SELECT round(2.55, 1);
+}
+expect {
+    2.6
+}
+
 test length-text {
     SELECT length('limbo');
 }

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -883,6 +883,20 @@ test round-half-away-from-zero-255 {
     SELECT round(2.55, 1);
 }
 expect {
+    2.5
+}
+
+test round-half-away-from-zero-245 {
+    SELECT round(2.45, 1);
+}
+expect {
+    2.5
+}
+
+test round-half-away-from-zero-265 {
+    SELECT round(2.65, 1);
+}
+expect {
     2.6
 }
 


### PR DESCRIPTION
Fixes #5748

## Description

`exec_round()` in `core/vdbe/value.rs` used `format!("{f:.precision$}")` for rounding when precision > 0. Rust's `format!` uses banker's rounding (round-half-to-even), so `ROUND(2.25, 1)` returned `2.2` instead of `2.3`. SQLite uses round-half-away-from-zero.

The fix formats with 20 extra decimal digits to detect exact midpoint ties, then rounds away from zero for those cases. Non-tie values still go through `format!` which already rounds them correctly.

## Motivation and context

SQLite's `ROUND()` docs specify round-half-away-from-zero behavior. The precision == 0 path already did this correctly via the `trunc()` approach at line 790, but the precision > 0 path delegated to Rust's `format!` which uses a different rounding mode.

## Description of AI Usage

AI-assisted: used Claude to identify the root cause (banker's rounding in `format!`) and iterate on the fix approach. All code was reviewed and tested manually.