### PR TITLE
cli: includes trigger in .schema like SQLite

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1457,7 +1457,7 @@ impl Limbo {
             _ => {}
         }
         let sql = format!(
-            "SELECT sql, type, name FROM {db_prefix}.sqlite_schema WHERE type IN ('table', 'index', 'view') AND (tbl_name = '{table_name}' OR name = '{table_name}') AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '__turso_internal_%' ORDER BY CASE type WHEN 'table' THEN 1 WHEN 'view' THEN 2 WHEN 'index' THEN 3 END, rowid"
+            "SELECT sql, type, name FROM {db_prefix}.sqlite_schema WHERE type IN ('table', 'index', 'view', 'trigger') AND (tbl_name = '{table_name}' OR name = '{table_name}') AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '__turso_internal_%' ORDER BY CASE type WHEN 'table' THEN 1 WHEN 'view' THEN 2 WHEN 'index' THEN 3 WHEN 'trigger' THEN 4 END, rowid"
         );
 
         let mut found = false;
@@ -1489,7 +1489,7 @@ impl Limbo {
         db_prefix: &str,
         db_display_name: &str,
     ) -> anyhow::Result<()> {
-        let sql = format!("SELECT sql, type, name FROM {db_prefix}.sqlite_schema WHERE type IN ('table', 'index', 'view') AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '__turso_internal_%' ORDER BY CASE type WHEN 'table' THEN 1 WHEN 'view' THEN 2 WHEN 'index' THEN 3 END, rowid");
+        let sql = format!("SELECT sql, type, name FROM {db_prefix}.sqlite_schema WHERE type IN ('table', 'index', 'view', 'trigger') AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '__turso_internal_%' ORDER BY CASE type WHEN 'table' THEN 1 WHEN 'view' THEN 2 WHEN 'index' THEN 3 WHEN 'trigger' THEN 4 END, rowid");
 
         match self.conn.query(&sql) {
             Ok(Some(ref mut rows)) => {

--- a/testing/sqltests/tests/cmdlineshell_schema.sqltest
+++ b/testing/sqltests/tests/cmdlineshell_schema.sqltest
@@ -1,0 +1,13 @@
+@database :memory:
+
+@backend cli
+@skip-if sqlite "sqlite backend in sqltests does not support .schema dot command here"
+test schema-includes-trigger {
+    CREATE TABLE t1(a);
+    CREATE TRIGGER trg AFTER INSERT ON t1 BEGIN SELECT 1; END;
+    .schema
+}
+expect raw {
+CREATE TABLE t1 (a);
+CREATE TRIGGER trg AFTER INSERT ON t1 BEGIN SELECT 1; END;
+}


### PR DESCRIPTION
## Description

Extend the CLI .schema command to include trigger definitions alongside tables, views, and indexes, bringing its output closer to SQLite shell behavior.

## Motivation and context

.schema currently omits triggers because the CLI filters them out from sqlite_schema. That makes schema inspection incomplete and can hide important database behavior.
