### PR TITLE
fix: materialize UPDATE write set for WHERE subqueries

### DIFF
--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -1,7 +1,7 @@
 use crate::schema::Table;
 use crate::sync::Arc;
 use crate::translate::emitter::{emit_program, Resolver};
-use crate::translate::expr::{process_returning_clause, walk_expr, WalkControl};
+use crate::translate::expr::{expr_contains_subquery, process_returning_clause};
 use crate::translate::optimizer::optimize_plan;
 use crate::translate::plan::{
     DeletePlan, DmlSafety, DmlSafetyReason, IterationDirection, JoinOrderMember, Operation, Plan,
@@ -290,26 +290,7 @@ pub fn prepare_delete_plan(
 
 /// Check if any WHERE predicate contains a subquery (Subquery, InSelect, or Exists).
 fn where_clause_has_subquery(predicates: &[WhereTerm]) -> bool {
-    for pred in predicates {
-        let mut found = false;
-        let _ = walk_expr(&pred.expr, &mut |e| {
-            if matches!(
-                e,
-                Expr::Subquery(_) | Expr::InSelect { .. } | Expr::Exists(_)
-            ) {
-                found = true;
-            }
-            Ok(if found {
-                WalkControl::SkipChildren
-            } else {
-                WalkControl::Continue
-            })
-        });
-        if found {
-            return true;
-        }
-    }
-    false
+    predicates.iter().any(|pred| expr_contains_subquery(&pred.expr))
 }
 
 fn estimate_num_instructions(plan: &DeletePlan) -> usize {

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -288,9 +288,10 @@ pub fn prepare_delete_plan(
     Ok(Plan::Delete(Box::new(delete_plan)))
 }
 
-/// Check if any WHERE predicate contains a subquery (Subquery, InSelect, or Exists).
 fn where_clause_has_subquery(predicates: &[WhereTerm]) -> bool {
-    predicates.iter().any(|pred| expr_contains_subquery(&pred.expr))
+    predicates
+        .iter()
+        .any(|pred| expr_contains_subquery(&pred.expr))
 }
 
 fn estimate_num_instructions(plan: &DeletePlan) -> usize {

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -108,6 +108,6 @@ pub use utils::{
 };
 pub use vectors::expr_vector_size;
 pub use walk::{
-    expr_references_any_subquery, expr_references_subquery_id, walk_expr, walk_expr_mut,
-    WalkControl,
+    expr_contains_subquery, expr_references_any_subquery, expr_references_subquery_id, walk_expr,
+    walk_expr_mut, WalkControl,
 };

--- a/core/translate/expr/walk.rs
+++ b/core/translate/expr/walk.rs
@@ -210,6 +210,22 @@ pub fn expr_references_any_subquery(expr: &ast::Expr) -> bool {
     found
 }
 
+/// Check if an expression contains a subquery (Subquery, InSelect, or Exists).
+pub fn expr_contains_subquery(expr: &ast::Expr) -> bool {
+    let mut found = false;
+    let _ = walk_expr(expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
+        if matches!(
+            e,
+            ast::Expr::Subquery(_) | ast::Expr::InSelect { .. } | ast::Expr::Exists(_)
+        ) {
+            found = true;
+            return Ok(WalkControl::SkipChildren);
+        }
+        Ok(WalkControl::Continue)
+    });
+    found
+}
+
 pub(super) fn walk_expr_frame_bound<'a, F>(
     bound: &'a ast::FrameBound,
     func: &mut F,

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -17,7 +17,7 @@ use crate::{
 use turso_parser::ast::{self, Expr};
 
 use super::emitter::emit_program;
-use super::expr::{process_returning_clause, walk_expr, WalkControl};
+use super::expr::{expr_contains_subquery, process_returning_clause};
 use super::optimizer::optimize_plan;
 use super::plan::{
     ColumnUsedMask, DmlSafety, DmlSafetyReason, JoinedTable, Plan, TableReferences, UpdatePlan,
@@ -466,26 +466,7 @@ fn prepare_update_plan(
 
 /// Check if any WHERE predicate contains a subquery (Subquery, InSelect, or Exists).
 fn where_clause_has_subquery(predicates: &[WhereTerm]) -> bool {
-    for pred in predicates {
-        let mut found = false;
-        let _ = walk_expr(&pred.expr, &mut |e| {
-            if matches!(
-                e,
-                Expr::Subquery(_) | Expr::InSelect { .. } | Expr::Exists(_)
-            ) {
-                found = true;
-            }
-            Ok(if found {
-                WalkControl::SkipChildren
-            } else {
-                WalkControl::Continue
-            })
-        });
-        if found {
-            return true;
-        }
-    }
-    false
+    predicates.iter().any(|pred| expr_contains_subquery(&pred.expr))
 }
 
 fn collect_update_set_clauses(

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -17,10 +17,11 @@ use crate::{
 use turso_parser::ast::{self, Expr};
 
 use super::emitter::emit_program;
-use super::expr::process_returning_clause;
+use super::expr::{process_returning_clause, walk_expr, WalkControl};
 use super::optimizer::optimize_plan;
 use super::plan::{
-    ColumnUsedMask, DmlSafety, JoinedTable, Plan, TableReferences, UpdatePlan, UpdateSetClause,
+    ColumnUsedMask, DmlSafety, DmlSafetyReason, JoinedTable, Plan, TableReferences, UpdatePlan,
+    UpdateSetClause, WhereTerm,
 };
 use super::planner::{append_vtab_predicates_to_where_clause, parse_from, parse_where};
 use super::subquery::{
@@ -421,6 +422,11 @@ fn prepare_update_plan(
         resolver,
     )?;
 
+    let mut safety = DmlSafety::default();
+    if where_clause_has_subquery(&where_clause) {
+        safety.require(DmlSafetyReason::SubqueryInWhere);
+    }
+
     let (limit, offset) = body
         .limit
         .map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
@@ -454,8 +460,32 @@ fn prepare_update_plan(
         write_set_plan: None,
         cdc_update_alter_statement: None,
         non_from_clause_subqueries,
-        safety: DmlSafety::default(),
+        safety,
     })
+}
+
+/// Check if any WHERE predicate contains a subquery (Subquery, InSelect, or Exists).
+fn where_clause_has_subquery(predicates: &[WhereTerm]) -> bool {
+    for pred in predicates {
+        let mut found = false;
+        let _ = walk_expr(&pred.expr, &mut |e| {
+            if matches!(
+                e,
+                Expr::Subquery(_) | Expr::InSelect { .. } | Expr::Exists(_)
+            ) {
+                found = true;
+            }
+            Ok(if found {
+                WalkControl::SkipChildren
+            } else {
+                WalkControl::Continue
+            })
+        });
+        if found {
+            return true;
+        }
+    }
+    false
 }
 
 fn collect_update_set_clauses(

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -464,9 +464,10 @@ fn prepare_update_plan(
     })
 }
 
-/// Check if any WHERE predicate contains a subquery (Subquery, InSelect, or Exists).
 fn where_clause_has_subquery(predicates: &[WhereTerm]) -> bool {
-    predicates.iter().any(|pred| expr_contains_subquery(&pred.expr))
+    predicates
+        .iter()
+        .any(|pred| expr_contains_subquery(&pred.expr))
 }
 
 fn collect_update_set_clauses(

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -1,6 +1,6 @@
 use crate::generation::{
-    gen_random_text, pick_index, pick_n_unique, pick_unique, Arbitrary, ArbitraryFrom,
-    ArbitrarySized, GenerationContext, InsertOpts,
+    Arbitrary, ArbitraryFrom, ArbitrarySized, GenerationContext, InsertOpts, gen_random_text,
+    pick_index, pick_n_unique, pick_unique,
 };
 use crate::model::query::alter_table::{AlterTable, AlterTableType, AlterTableTypeDiscriminants};
 use crate::model::query::predicate::Predicate;
@@ -16,11 +16,91 @@ use crate::model::table::{
     Column, ColumnType, Index, JoinType, JoinedTable, Name, SimValue, Table, TableContext,
 };
 use indexmap::IndexSet;
-use rand::seq::IndexedRandom;
 use rand::Rng;
-use turso_parser::ast::{ColumnConstraint, Expr, SortOrder};
+use rand::seq::IndexedRandom;
+use turso_parser::ast::{
+    As, ColumnConstraint, Expr, Literal, OneSelect, Operator, QualifiedName,
+    ResultColumn as AstResultColumn, Select as AstSelect, SelectBody as AstSelectBody,
+    SelectTable as AstSelectTable, SortOrder,
+};
 
 use super::{backtrack, pick};
+
+const CORRELATED_EXISTS_PREDICATE_PROB: f64 = 0.15;
+
+fn random_exists_predicate<R: Rng + ?Sized>(rng: &mut R, table: &Table) -> Option<Predicate> {
+    // Keep generation conservative: this pattern relies on table-qualified outer references.
+    if table.name.contains('.') {
+        return None;
+    }
+
+    let pk_col = table.columns.iter().find(|c| c.is_primary_key())?;
+    let numeric_cols: Vec<&Column> = table
+        .columns
+        .iter()
+        .filter(|c| matches!(c.column_type, ColumnType::Integer | ColumnType::Float))
+        .collect();
+    let probe_col = *pick(&numeric_cols, rng);
+
+    let alias = "t2".to_string();
+    let zero = Expr::Literal(Literal::Numeric("0".to_string()));
+
+    let inner_probe = Expr::Qualified(
+        turso_parser::ast::Name::exact(alias.clone()),
+        turso_parser::ast::Name::exact(probe_col.name.clone()),
+    );
+    let inner_pk = Expr::Qualified(
+        turso_parser::ast::Name::exact(alias.clone()),
+        turso_parser::ast::Name::exact(pk_col.name.clone()),
+    );
+    let outer_pk = Expr::Qualified(
+        turso_parser::ast::Name::exact(table.name.clone()),
+        turso_parser::ast::Name::exact(pk_col.name.clone()),
+    );
+
+    let where_expr = Expr::Binary(
+        Box::new(Expr::Binary(
+            Box::new(inner_probe),
+            Operator::Greater,
+            Box::new(zero),
+        )),
+        Operator::And,
+        Box::new(Expr::Binary(
+            Box::new(inner_pk),
+            Operator::NotEquals,
+            Box::new(outer_pk),
+        )),
+    );
+
+    let subquery = AstSelect {
+        with: None,
+        body: AstSelectBody {
+            select: OneSelect::Select {
+                distinctness: None,
+                columns: vec![AstResultColumn::Expr(
+                    Box::new(Expr::Literal(Literal::Numeric("1".to_string()))),
+                    None,
+                )],
+                from: Some(turso_parser::ast::FromClause {
+                    select: Box::new(AstSelectTable::Table(
+                        QualifiedName::single(turso_parser::ast::Name::exact(table.name.clone())),
+                        Some(As::As(turso_parser::ast::Name::exact(alias))),
+                        None,
+                    )),
+                    joins: vec![],
+                }),
+                where_clause: Some(Box::new(where_expr)),
+                group_by: None,
+                window_clause: vec![],
+            },
+            compounds: vec![],
+        },
+        order_by: vec![],
+        limit: None,
+    };
+
+    Some(Predicate(Expr::Exists(subquery)).parens())
+}
 
 impl Arbitrary for Create {
     fn arbitrary<R: Rng + ?Sized, C: GenerationContext>(rng: &mut R, context: &C) -> Self {
@@ -557,9 +637,15 @@ fn gen_insert_upsert_values<R: Rng + ?Sized, C: GenerationContext>(
 impl Arbitrary for Delete {
     fn arbitrary<R: Rng + ?Sized, C: GenerationContext>(rng: &mut R, env: &C) -> Self {
         let table = pick(env.tables(), rng);
+        let predicate = if rng.random_bool(CORRELATED_EXISTS_PREDICATE_PROB) {
+            random_exists_predicate(rng, table)
+                .unwrap_or_else(|| Predicate::arbitrary_from(rng, env, table))
+        } else {
+            Predicate::arbitrary_from(rng, env, table)
+        };
         Self {
             table: table.name.clone(),
-            predicate: Predicate::arbitrary_from(rng, env, table),
+            predicate,
         }
     }
 }
@@ -710,7 +796,16 @@ impl Arbitrary for Update {
             let unique_value = SimValue::unique_for_type(&column.column_type, base_offset);
             let set_values = vec![(column.name.clone(), SetValue::Simple(unique_value))];
 
-            let predicate = if !table.rows.is_empty() {
+            let predicate = if rng.random_bool(CORRELATED_EXISTS_PREDICATE_PROB) {
+                random_exists_predicate(rng, table).unwrap_or_else(|| {
+                    if !table.rows.is_empty() {
+                        let row = pick(&table.rows, rng);
+                        Predicate::arbitrary_from(rng, env, (table, row))
+                    } else {
+                        Predicate::arbitrary_from(rng, env, table)
+                    }
+                })
+            } else if !table.rows.is_empty() {
                 let row = pick(&table.rows, rng);
                 Predicate::arbitrary_from(rng, env, (table, row))
             } else {
@@ -735,7 +830,12 @@ impl Arbitrary for Update {
                     })
                     .collect();
 
-            let predicate = Predicate::arbitrary_from(rng, env, table);
+            let predicate = if rng.random_bool(CORRELATED_EXISTS_PREDICATE_PROB) {
+                random_exists_predicate(rng, table)
+                    .unwrap_or_else(|| Predicate::arbitrary_from(rng, env, table))
+            } else {
+                Predicate::arbitrary_from(rng, env, table)
+            };
             (set_values, predicate)
         };
 

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -1,6 +1,6 @@
 use crate::generation::{
-    Arbitrary, ArbitraryFrom, ArbitrarySized, GenerationContext, InsertOpts, gen_random_text,
-    pick_index, pick_n_unique, pick_unique,
+    gen_random_text, pick_index, pick_n_unique, pick_unique, Arbitrary, ArbitraryFrom,
+    ArbitrarySized, GenerationContext, InsertOpts,
 };
 use crate::model::query::alter_table::{AlterTable, AlterTableType, AlterTableTypeDiscriminants};
 use crate::model::query::predicate::Predicate;
@@ -16,8 +16,8 @@ use crate::model::table::{
     Column, ColumnType, Index, JoinType, JoinedTable, Name, SimValue, Table, TableContext,
 };
 use indexmap::IndexSet;
-use rand::Rng;
 use rand::seq::IndexedRandom;
+use rand::Rng;
 use turso_parser::ast::{
     As, ColumnConstraint, Expr, Literal, OneSelect, Operator, QualifiedName,
     ResultColumn as AstResultColumn, Select as AstSelect, SelectBody as AstSelectBody,

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -28,6 +28,13 @@ use super::{backtrack, pick};
 
 const CORRELATED_EXISTS_PREDICATE_PROB: f64 = 0.15;
 
+/// generates a predicate like:
+///
+/// ```ignore
+/// WHERE EXISTS (SELECT 1 FROM t WHERE t.random_col > 0 AND t.pk_col != outer_table.pk_col)
+/// ```
+///
+/// where `random_col` is a random column, and `t` and `outer_table` are the same table.
 fn random_exists_predicate<R: Rng + ?Sized>(rng: &mut R, table: &Table) -> Option<Predicate> {
     // Keep generation conservative: this pattern relies on table-qualified outer references.
     if table.name.contains('.') {

--- a/sql_generation/model/query/predicate.rs
+++ b/sql_generation/model/query/predicate.rs
@@ -110,23 +110,14 @@ pub fn expr_to_value<T: TableContext>(
     match expr {
         ast::Expr::DoublyQualified(_, _, col_name)
         | ast::Expr::Qualified(_, col_name)
-        | ast::Expr::Id(col_name) => {
-            let columns = table.columns().collect::<Vec<_>>();
-            let col_name = col_name.as_str();
-            assert_eq!(row.len(), columns.len());
-            columns
-                .iter()
-                .zip(row.iter())
-                .find(|(column, _)| column.column.name == col_name)
-                .map(|(_, value)| value)
-                .cloned()
-        }
+        | ast::Expr::Id(col_name) => lookup_column_value(row, table, col_name.as_str()),
         ast::Expr::Literal(literal) => Some(literal.into()),
         ast::Expr::Binary(lhs, op, rhs) => {
             let lhs = expr_to_value(lhs, row, table)?;
             let rhs = expr_to_value(rhs, row, table)?;
             Some(lhs.binary_compare(&rhs, *op))
         }
+        ast::Expr::Exists(select) => eval_exists_subquery(select, row, table),
         ast::Expr::Like {
             lhs,
             not,
@@ -149,6 +140,148 @@ pub fn expr_to_value<T: TableContext>(
             expr_to_value(&exprs[0], row, table)
         }
         _ => unreachable!("{:?}", expr),
+    }
+}
+
+fn lookup_column_value<T: TableContext>(
+    row: &[SimValue],
+    table: &T,
+    column_name: &str,
+) -> Option<SimValue> {
+    let columns = table.columns().collect::<Vec<_>>();
+    assert_eq!(row.len(), columns.len());
+    columns
+        .iter()
+        .zip(row.iter())
+        .find(|(column, _)| column.column.name == column_name)
+        .map(|(_, value)| value)
+        .cloned()
+}
+
+fn eval_exists_subquery<T: TableContext>(
+    select: &ast::Select,
+    outer_row: &[SimValue],
+    table: &T,
+) -> Option<SimValue> {
+    let ast::Select {
+        with: None,
+        body:
+            ast::SelectBody {
+                select:
+                    ast::OneSelect::Select {
+                        from: Some(from),
+                        where_clause,
+                        ..
+                    },
+                compounds,
+            },
+        order_by,
+        limit,
+    } = select
+    else {
+        return None;
+    };
+
+    if !compounds.is_empty() || !order_by.is_empty() || limit.is_some() || !from.joins.is_empty() {
+        return None;
+    }
+
+    let ast::SelectTable::Table(tbl_name, alias, _) = from.select.as_ref() else {
+        return None;
+    };
+
+    let inner_table_name = alias
+        .as_ref()
+        .map(|a| a.name().as_str().to_string())
+        .unwrap_or_else(|| tbl_name.name.as_str().to_string());
+    let outer_table_name = table.columns().next().map(|c| c.table_name.to_string())?;
+
+    let matches = table.rows().iter().any(|inner_row| {
+        where_clause.as_ref().is_none_or(|where_expr| {
+            eval_correlated_exists_expr(
+                where_expr,
+                outer_row,
+                inner_row,
+                table,
+                &outer_table_name,
+                &inner_table_name,
+            )
+            .is_some_and(|v| v.as_bool())
+        })
+    });
+
+    Some(if matches {
+        SimValue::TRUE
+    } else {
+        SimValue::FALSE
+    })
+}
+
+fn eval_correlated_exists_expr<T: TableContext>(
+    expr: &ast::Expr,
+    outer_row: &[SimValue],
+    inner_row: &[SimValue],
+    table: &T,
+    outer_table_name: &str,
+    inner_table_name: &str,
+) -> Option<SimValue> {
+    match expr {
+        ast::Expr::Literal(literal) => Some(literal.into()),
+        ast::Expr::Unary(op, expr) => {
+            let value = eval_correlated_exists_expr(
+                expr,
+                outer_row,
+                inner_row,
+                table,
+                outer_table_name,
+                inner_table_name,
+            )?;
+            Some(value.unary_exec(*op))
+        }
+        ast::Expr::Parenthesized(exprs) => {
+            assert_eq!(exprs.len(), 1);
+            eval_correlated_exists_expr(
+                &exprs[0],
+                outer_row,
+                inner_row,
+                table,
+                outer_table_name,
+                inner_table_name,
+            )
+        }
+        ast::Expr::Binary(lhs, op, rhs) => {
+            let lhs = eval_correlated_exists_expr(
+                lhs,
+                outer_row,
+                inner_row,
+                table,
+                outer_table_name,
+                inner_table_name,
+            )?;
+            let rhs = eval_correlated_exists_expr(
+                rhs,
+                outer_row,
+                inner_row,
+                table,
+                outer_table_name,
+                inner_table_name,
+            )?;
+            Some(lhs.binary_compare(&rhs, *op))
+        }
+        ast::Expr::Qualified(table_name, col_name)
+        | ast::Expr::DoublyQualified(_, table_name, col_name) => {
+            let table_name = table_name.as_str();
+            if table_name == inner_table_name {
+                lookup_column_value(inner_row, table, col_name.as_str())
+            } else if table_name == outer_table_name {
+                lookup_column_value(outer_row, table, col_name.as_str())
+            } else {
+                None
+            }
+        }
+        ast::Expr::Id(col_name) => lookup_column_value(inner_row, table, col_name.as_str())
+            .or_else(|| lookup_column_value(outer_row, table, col_name.as_str())),
+        _ => None,
     }
 }
 

--- a/sql_generation/model/query/predicate.rs
+++ b/sql_generation/model/query/predicate.rs
@@ -183,11 +183,11 @@ fn eval_exists_subquery<T: TableContext>(
     };
 
     if !compounds.is_empty() || !order_by.is_empty() || limit.is_some() || !from.joins.is_empty() {
-        return None;
+        panic!("compound selects, order by, limit, and joins not supported in simulated EXISTS clauses");
     }
 
     let ast::SelectTable::Table(tbl_name, alias, _) = from.select.as_ref() else {
-        return None;
+        panic!("only tables are supported in simulated EXISTS clauses");
     };
 
     let inner_table_name = alias
@@ -281,7 +281,7 @@ fn eval_correlated_exists_expr<T: TableContext>(
         }
         ast::Expr::Id(col_name) => lookup_column_value(inner_row, table, col_name.as_str())
             .or_else(|| lookup_column_value(outer_row, table, col_name.as_str())),
-        _ => None,
+        other => panic!("expression type not supported in correlated EXISTS subqueries: {other:?}"),
     }
 }
 

--- a/testing/sqltests/tests/update.sqltest
+++ b/testing/sqltests/tests/update.sqltest
@@ -1088,6 +1088,27 @@ expect {
     3|pending
 }
 
+# Regression: UPDATE with correlated EXISTS reading the same table must materialize
+# the write set before applying row updates.
+@cross-check-integrity
+test update-correlated-exists-same-table-materializes-write-set {
+    CREATE TABLE t_subq(id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO t_subq VALUES(1,1),(2,2),(3,3);
+    UPDATE t_subq SET val = 0
+    WHERE EXISTS (
+        SELECT 1
+        FROM t_subq AS t2
+        WHERE t2.val > 0
+          AND t2.id != t_subq.id
+    );
+    SELECT id, val FROM t_subq ORDER BY id;
+}
+expect {
+    1|0
+    2|0
+    3|0
+}
+
 # Test UPDATE with scalar comparison subquery (=)
 
 @cross-check-integrity


### PR DESCRIPTION
## Description

This PR fixes UPDATE behavior when the WHERE clause contains a subquery (including correlated EXISTS) that reads from the same target table.

Changes included:
- mark UPDATE as requiring a stable write set when WHERE contains subqueries (`Subquery`, `InSelect`, `Exists`)
- add a regression SQL test for correlated `EXISTS` on the same table
- extend simulator SQL generation to produce correlated `EXISTS` predicates for UPDATE/DELETE
- extend simulator predicate evaluation to support `EXISTS` predicates so generated cases are modeled correctly

## Motivation and context

Without write-set materialization in this case, UPDATE can observe in-flight row changes while scanning and skip rows that should be updated. This diverges from SQLite behavior.

The regression test demonstrates the issue with:
`UPDATE t SET val = 0 WHERE EXISTS (SELECT 1 FROM t AS t2 WHERE t2.val > 0 AND t2.id != t.id)`

Expected final state is `1|0, 2|0, 3|0`.

## Validation

- `cargo check -p turso_core -p sql_generation`
- `cargo check --manifest-path testing/simulator/Cargo.toml`
- `cargo run -q --bin test-runner -- run tests/update.sqltest --backend cli --binary /home/depinfo/Musique/turso/turso/target/debug/tursodb --filter update-correlated-exists-same-table-materializes-write-set --jobs 1`

## Description of AI Usage

N/A
