### PR TITLE
cli: sqlite-backed sqltests support for .schema and .tables

### DIFF
--- a/testing/sqltests/docs/backends/cli.md
+++ b/testing/sqltests/docs/backends/cli.md
@@ -101,7 +101,7 @@ echo "SELECT 1, 'hello';" | tursodb :memory: -m list
 
 ## Limitations
 
-1. **Interactive commands**: Dot commands (`.tables`, `.schema`) may not work as expected
+1. **Interactive commands**: sqlite-backed CLI tests support `.tables` and `.schema`, but broader shell-command coverage is still limited
 2. **Multi-statement**: Each `execute()` call is a separate CLI invocation
 3. **Transactions**: Not persisted across `execute()` calls for `:memory:` databases
 

--- a/testing/sqltests/docs/backends/cli.md
+++ b/testing/sqltests/docs/backends/cli.md
@@ -101,7 +101,7 @@ echo "SELECT 1, 'hello';" | tursodb :memory: -m list
 
 ## Limitations
 
-1. **Interactive commands**: sqlite-backed CLI tests support `.tables` and `.schema`, but broader shell-command coverage is still limited
+1. **Interactive commands**: sqlite-backed CLI tests support a single `.tables` or `.schema` (must be the last output-producing statement in the test). Broader shell-command coverage is still limited
 2. **Multi-statement**: Each `execute()` call is a separate CLI invocation
 3. **Transactions**: Not persisted across `execute()` calls for `:memory:` databases
 

--- a/testing/sqltests/src/backends/cli.rs
+++ b/testing/sqltests/src/backends/cli.rs
@@ -432,7 +432,10 @@ mod tests {
     #[test]
     fn normalize_sqlite_tables_output_preserves_single_spaces() {
         assert_eq!(
-            CliDatabaseInstance::normalize_sqlite_dot_command_output(".tables", "t1  v1\nuser logs"),
+            CliDatabaseInstance::normalize_sqlite_dot_command_output(
+                ".tables",
+                "t1  v1\nuser logs"
+            ),
             vec![vec!["t1 v1".to_string()], vec!["user logs".to_string()]]
         );
     }

--- a/testing/sqltests/src/backends/cli.rs
+++ b/testing/sqltests/src/backends/cli.rs
@@ -160,9 +160,80 @@ pub struct CliDatabaseInstance {
 }
 
 impl CliDatabaseInstance {
+    const DOT_COMMANDS: &[&str] = &[".schema", ".tables"];
+
+    fn final_supported_sqlite_dot_command(sql: &str) -> Option<&str> {
+        sql.lines().rev().map(str::trim).find(|line| {
+            !line.is_empty()
+                && Self::DOT_COMMANDS.iter().any(|cmd| {
+                    *line == *cmd
+                        || line
+                            .strip_prefix(cmd)
+                            .is_some_and(|rest| rest.is_empty() || rest.starts_with(' '))
+                })
+        })
+    }
+
+    fn normalize_sqlite_dot_command_script(sql: &str) -> String {
+        let final_dot_command = Self::final_supported_sqlite_dot_command(sql);
+
+        sql.lines()
+            .map(|line| {
+                if let Some(dot_command) = final_dot_command.filter(|cmd| line.trim() == *cmd) {
+                    dot_command.to_string()
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn collapse_repeated_spaces(input: &str) -> String {
+        let mut normalized = input.to_string();
+        while normalized.contains("  ") {
+            normalized = normalized.replace("  ", " ");
+        }
+        normalized
+    }
+
+    fn normalize_sqlite_schema_line(line: &str) -> String {
+        const PREFIXES: &[&str] = &["CREATE TABLE ", "CREATE TABLE IF NOT EXISTS "];
+
+        for prefix in PREFIXES {
+            if let Some(rest) = line.strip_prefix(prefix) {
+                if let Some(paren_idx) = rest.find('(') {
+                    let name_part = &rest[..paren_idx];
+                    if !name_part.ends_with(' ') {
+                        return format!("{prefix}{name_part} {}", &rest[paren_idx..]);
+                    }
+                }
+            }
+        }
+
+        line.to_string()
+    }
+
+    fn normalize_sqlite_dot_command_output(dot_command: &str, stdout: &str) -> Vec<Vec<String>> {
+        stdout
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(|line| match dot_command {
+                ".tables" => vec![Self::collapse_repeated_spaces(line)],
+                ".schema" => vec![Self::normalize_sqlite_schema_line(line)],
+                _ => vec![line.to_string()],
+            })
+            .collect()
+    }
+
     /// Execute SQL by spawning a CLI process
     async fn run_sql(&self, sql: &str) -> Result<QueryResult, BackendError> {
         let mut cmd = Command::new(&self.binary_path);
+        let sqlite_dot_command = self
+            .is_sqlite
+            .then(|| Self::final_supported_sqlite_dot_command(sql))
+            .flatten();
+        let is_sqlite_dot_command = sqlite_dot_command.is_some();
 
         let file_name = self
             .binary_path
@@ -218,6 +289,11 @@ impl CliDatabaseInstance {
         } else {
             sql.to_string()
         };
+        let sql_to_execute = if is_sqlite_dot_command {
+            Self::normalize_sqlite_dot_command_script(&sql_to_execute)
+        } else {
+            sql_to_execute
+        };
 
         // Write SQL to stdin
         if let Some(stdin) = child.stdin.as_mut() {
@@ -261,18 +337,27 @@ impl CliDatabaseInstance {
             return Ok(QueryResult::error(error_msg));
         }
 
-        let mut rows = parse_list_output(&stdout);
+        if is_sqlite_dot_command {
+            let rows = Self::normalize_sqlite_dot_command_output(
+                sqlite_dot_command.expect("checked above"),
+                &stdout,
+            );
 
-        // Filter out MVCC pragma output if present
-        if self.mvcc && !rows.is_empty() {
-            if let Some(first_row) = rows.first() {
-                if first_row.len() == 1 && first_row[0] == "mvcc" {
-                    rows.remove(0);
+            Ok(QueryResult::success(rows))
+        } else {
+            let mut rows = parse_list_output(&stdout);
+
+            // Filter out MVCC pragma output if present
+            if self.mvcc && !rows.is_empty() {
+                if let Some(first_row) = rows.first() {
+                    if first_row.len() == 1 && first_row[0] == "mvcc" {
+                        rows.remove(0);
+                    }
                 }
             }
-        }
 
-        Ok(QueryResult::success(rows))
+            Ok(QueryResult::success(rows))
+        }
     }
 }
 
@@ -319,5 +404,50 @@ impl DatabaseInstance for CliDatabaseInstance {
             Some(tf) => Ok(DatabaseFileHandle::temp(tf)),
             None => Ok(DatabaseFileHandle::none()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CliDatabaseInstance;
+
+    #[test]
+    fn final_supported_sqlite_dot_command_detects_last_line() {
+        let sql = "CREATE TABLE t1(a);\nSELECT '__SETUP_END_MARKER_7f3a9b2c__';\n    .schema";
+        assert_eq!(
+            CliDatabaseInstance::final_supported_sqlite_dot_command(sql),
+            Some(".schema")
+        );
+    }
+
+    #[test]
+    fn normalize_sqlite_dot_command_script_left_aligns_final_command_only() {
+        let sql = "CREATE TABLE t1(a);\n    .schema";
+        assert_eq!(
+            CliDatabaseInstance::normalize_sqlite_dot_command_script(sql),
+            "CREATE TABLE t1(a);\n.schema"
+        );
+    }
+
+    #[test]
+    fn normalize_sqlite_tables_output_preserves_single_spaces() {
+        assert_eq!(
+            CliDatabaseInstance::normalize_sqlite_dot_command_output(".tables", "t1  v1\nuser logs"),
+            vec![vec!["t1 v1".to_string()], vec!["user logs".to_string()]]
+        );
+    }
+
+    #[test]
+    fn normalize_sqlite_schema_output_only_adjusts_create_table_prefix() {
+        assert_eq!(
+            CliDatabaseInstance::normalize_sqlite_dot_command_output(
+                ".schema",
+                "CREATE TABLE t1(a CHECK(abs(a) > 0));\nCREATE TRIGGER trg AFTER INSERT ON t1 BEGIN SELECT 1; END;"
+            ),
+            vec![
+                vec!["CREATE TABLE t1 (a CHECK(abs(a) > 0));".to_string()],
+                vec!["CREATE TRIGGER trg AFTER INSERT ON t1 BEGIN SELECT 1; END;".to_string()]
+            ]
+        );
     }
 }

--- a/testing/sqltests/tests/cmdlineshell_schema.sqltest
+++ b/testing/sqltests/tests/cmdlineshell_schema.sqltest
@@ -1,7 +1,6 @@
 @database :memory:
 
 @backend cli
-@skip-if sqlite "sqlite backend in sqltests does not support .schema dot command here"
 test schema-includes-trigger {
     CREATE TABLE t1(a);
     CREATE TRIGGER trg AFTER INSERT ON t1 BEGIN SELECT 1; END;

--- a/testing/sqltests/tests/cmdlineshell_tables.sqltest
+++ b/testing/sqltests/tests/cmdlineshell_tables.sqltest
@@ -1,7 +1,6 @@
 @database :memory:
 
 @backend cli
-@skip-if sqlite "sqlite backend in sqltests does not support .tables dot command here"
 test tables-includes-views {
     CREATE TABLE t1(a);
     CREATE VIEW v1 AS SELECT a FROM t1;


### PR DESCRIPTION
## Description

Add sqlite-backed sqltests support for .schema and .tables in the CLI backend. The change updates the sqltests CLI harness to execute these sqlite shell commands correctly and normalize their output so the same .sqltest expectations work for both sqlite3 and tursodb

## Motivation and context

These tests were previously skipped for sqlite because the harness treated .schema and .tables like regular SQL, causing parse errors. This change removes that gap and improves CLI parity coverage against real sqlite shell behavior.
