### PR TITLE
fix: enforce FK constraints on columns added via ALTER TABLE ADD COLUMN

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1237,6 +1237,7 @@ pub fn translate_alter_table(
                         table: table_name.to_owned(),
                         column: Box::new(column),
                         check_constraints: btree.check_constraints.clone(),
+                        foreign_keys: btree.foreign_keys.clone(),
                     });
                 },
             )?

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11885,7 +11885,8 @@ pub fn op_add_column(
             db,
             table,
             column,
-            check_constraints
+            check_constraints,
+            foreign_keys
         },
         insn
     );
@@ -11911,6 +11912,8 @@ pub fn op_add_column(
             crate::schema::BTreeTable::build_logical_to_physical_map(&btree.columns);
         // Update CHECK constraints to include any constraints from the new column
         btree.check_constraints.clone_from(check_constraints);
+        // Update foreign keys to include any FK constraints from the new column
+        btree.foreign_keys.clone_from(foreign_keys);
 
         // Resolve generated column expressions and update virtual column metadata
         btree.prepare_generated_columns()?;

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -12,7 +12,7 @@ pub fn to_u16(v: usize) -> u16 {
 
 use super::{execute, AggFunc, BranchOffset, CursorID, FuncCtx, InsnFunction, PageIdx};
 use crate::{
-    schema::{BTreeTable, CheckConstraint, Column, Index},
+    schema::{BTreeTable, CheckConstraint, Column, ForeignKey, Index},
     storage::{pager::CreateBTreeFlags, wal::CheckpointMode},
     translate::{collate::CollationSeq, emitter::TransactionMode},
     types::KeyInfo,
@@ -1461,6 +1461,7 @@ pub enum Insn {
         table: String,
         column: Box<Column>,
         check_constraints: Vec<CheckConstraint>,
+        foreign_keys: Vec<Arc<ForeignKey>>,
     },
     AlterColumn {
         db: usize,

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -2878,3 +2878,32 @@ test fk-update-or-replace-no-action-blocks {
 }
 expect error {
 }
+
+# FK added via ALTER TABLE ADD COLUMN should be enforced on INSERT
+@cross-check-integrity
+test fk-alter-table-add-column-enforced {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(p TEXT UNIQUE);
+    CREATE TABLE child(a INTEGER);
+    ALTER TABLE child ADD COLUMN p TEXT REFERENCES parent(p) ON DELETE RESTRICT ON UPDATE RESTRICT;
+    INSERT INTO parent VALUES ('ok');
+    INSERT INTO child(a,p) VALUES (1,'ok');
+    INSERT INTO child(a,p) VALUES (2,NULL);
+    SELECT * FROM child ORDER BY a;
+}
+expect {
+    1|ok
+    2|
+}
+
+# FK added via ALTER TABLE ADD COLUMN should reject missing parent
+@cross-check-integrity
+test fk-alter-table-add-column-rejects-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(p TEXT UNIQUE);
+    CREATE TABLE child(a INTEGER);
+    ALTER TABLE child ADD COLUMN p TEXT REFERENCES parent(p) ON DELETE RESTRICT ON UPDATE RESTRICT;
+    INSERT INTO child(a,p) VALUES (1,'missing');
+}
+expect error {
+}


### PR DESCRIPTION
## Description
When adding a column using ALTER TABLE ADD COLUMN, the foreign key constraints defined on that new column were silently dropped. AddColumn instruction ignored the fk attribute and did not pass the foreign key constraints to the add-column operation, resulting in the constraints not being created

## Motivation and context
Fixes: https://github.com/tursodatabase/turso/issues/5503


## Description of AI Usage
I used AI to navigate the codebase and understand concepts and implementations I was not familiar with.
