### PR TITLE
core/mvcc: Serialize schema rows before data rows in MVCC logical log

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1283,9 +1283,49 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         // reference it. The SkipSet iteration order sorts by table_id (most negative
         // first), which would otherwise place data table rows (e.g. table_id=-3)
         // before schema rows (table_id=-1).
-        let collect_versions =
-            |id: &RowID, log_record: &mut LogRecord, did_commit_schema: &mut bool| {
-                if let Some(row_versions) = mvcc_store.rows.get(id) {
+        let collect_versions = |id: &RowID,
+                                log_record: &mut LogRecord,
+                                did_commit_schema: &mut bool| {
+            if let Some(row_versions) = mvcc_store.rows.get(id) {
+                let row_versions = row_versions.value().read();
+                for row_version in row_versions.iter() {
+                    let mut committed_version = row_version.clone();
+                    let mut changed = false;
+                    if let Some(TxTimestampOrID::TxID(vid)) = committed_version.begin {
+                        if vid == self.tx_id {
+                            // New version is valid STARTING FROM the committing
+                            // transaction's end timestamp. See Hekaton page 299.
+                            committed_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
+                            changed = true;
+                            if committed_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                                *did_commit_schema = true;
+                            }
+                        }
+                    }
+                    if let Some(TxTimestampOrID::TxID(vid)) = committed_version.end {
+                        if vid == self.tx_id {
+                            // Old version is valid UNTIL the committing
+                            // transaction's end timestamp. See Hekaton page 299.
+                            committed_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
+                            changed = true;
+                            if committed_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                                *did_commit_schema = true;
+                            }
+                        }
+                    }
+                    if changed {
+                        mvcc_store
+                            .insert_version_raw(&mut log_record.row_versions, committed_version);
+                    }
+                }
+            }
+
+            if let Some(index) = mvcc_store.index_rows.get(&id.table_id) {
+                let index = index.value();
+                let RowKey::Record(ref index_key) = id.row_id else {
+                    panic!("Index writes must have a record key");
+                };
+                if let Some(row_versions) = index.get(index_key) {
                     let row_versions = row_versions.value().read();
                     for row_version in row_versions.iter() {
                         let mut committed_version = row_version.clone();
@@ -1294,14 +1334,8 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                             if vid == self.tx_id {
                                 // New version is valid STARTING FROM the committing
                                 // transaction's end timestamp. See Hekaton page 299.
-                                committed_version.begin =
-                                    Some(TxTimestampOrID::Timestamp(end_ts));
+                                committed_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
                                 changed = true;
-                                if committed_version.row.id.table_id
-                                    == SQLITE_SCHEMA_MVCC_TABLE_ID
-                                {
-                                    *did_commit_schema = true;
-                                }
                             }
                         }
                         if let Some(TxTimestampOrID::TxID(vid)) = committed_version.end {
@@ -1310,11 +1344,6 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                                 // transaction's end timestamp. See Hekaton page 299.
                                 committed_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
                                 changed = true;
-                                if committed_version.row.id.table_id
-                                    == SQLITE_SCHEMA_MVCC_TABLE_ID
-                                {
-                                    *did_commit_schema = true;
-                                }
                             }
                         }
                         if changed {
@@ -1325,45 +1354,8 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                         }
                     }
                 }
-
-                if let Some(index) = mvcc_store.index_rows.get(&id.table_id) {
-                    let index = index.value();
-                    let RowKey::Record(ref index_key) = id.row_id else {
-                        panic!("Index writes must have a record key");
-                    };
-                    if let Some(row_versions) = index.get(index_key) {
-                        let row_versions = row_versions.value().read();
-                        for row_version in row_versions.iter() {
-                            let mut committed_version = row_version.clone();
-                            let mut changed = false;
-                            if let Some(TxTimestampOrID::TxID(vid)) = committed_version.begin {
-                                if vid == self.tx_id {
-                                    // New version is valid STARTING FROM the committing
-                                    // transaction's end timestamp. See Hekaton page 299.
-                                    committed_version.begin =
-                                        Some(TxTimestampOrID::Timestamp(end_ts));
-                                    changed = true;
-                                }
-                            }
-                            if let Some(TxTimestampOrID::TxID(vid)) = committed_version.end {
-                                if vid == self.tx_id {
-                                    // Old version is valid UNTIL the committing
-                                    // transaction's end timestamp. See Hekaton page 299.
-                                    committed_version.end =
-                                        Some(TxTimestampOrID::Timestamp(end_ts));
-                                    changed = true;
-                                }
-                            }
-                            if changed {
-                                mvcc_store.insert_version_raw(
-                                    &mut log_record.row_versions,
-                                    committed_version,
-                                );
-                            }
-                        }
-                    }
-                }
-            };
+            }
+        };
 
         // First pass: schema rows only
         for id in &self.write_set {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1278,65 +1278,43 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             log_record.header = Some(*tx.header.read());
         }
 
-        for id in &self.write_set {
-            if let Some(row_versions) = mvcc_store.rows.get(id) {
-                let row_versions = row_versions.value().read();
-                for row_version in row_versions.iter() {
-                    let mut committed_version = row_version.clone();
-                    let mut changed = false;
-                    if let Some(TxTimestampOrID::TxID(id)) = committed_version.begin {
-                        if id == self.tx_id {
-                            // New version is valid STARTING FROM the committing
-                            // transaction's end timestamp. See Hekaton page 299.
-                            committed_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
-                            changed = true;
-                            if committed_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                                self.did_commit_schema_change = true;
-                            }
-                        }
-                    }
-                    if let Some(TxTimestampOrID::TxID(id)) = committed_version.end {
-                        if id == self.tx_id {
-                            // Old version is valid UNTIL the committing
-                            // transaction's end timestamp. See Hekaton page 299.
-                            committed_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
-                            changed = true;
-                            if committed_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                                self.did_commit_schema_change = true;
-                            }
-                        }
-                    }
-                    if changed {
-                        mvcc_store
-                            .insert_version_raw(&mut log_record.row_versions, committed_version);
-                    }
-                }
-            }
-
-            if let Some(index) = mvcc_store.index_rows.get(&id.table_id) {
-                let index = index.value();
-                let RowKey::Record(ref index_key) = id.row_id else {
-                    panic!("Index writes must have a record key");
-                };
-                if let Some(row_versions) = index.get(index_key) {
+        // Process schema rows (sqlite_schema) before data rows so that during log
+        // replay the table_id_to_rootpage map is populated before data row inserts
+        // reference it. The SkipSet iteration order sorts by table_id (most negative
+        // first), which would otherwise place data table rows (e.g. table_id=-3)
+        // before schema rows (table_id=-1).
+        let collect_versions =
+            |id: &RowID, log_record: &mut LogRecord, did_commit_schema: &mut bool| {
+                if let Some(row_versions) = mvcc_store.rows.get(id) {
                     let row_versions = row_versions.value().read();
                     for row_version in row_versions.iter() {
                         let mut committed_version = row_version.clone();
                         let mut changed = false;
-                        if let Some(TxTimestampOrID::TxID(id)) = committed_version.begin {
-                            if id == self.tx_id {
+                        if let Some(TxTimestampOrID::TxID(vid)) = committed_version.begin {
+                            if vid == self.tx_id {
                                 // New version is valid STARTING FROM the committing
                                 // transaction's end timestamp. See Hekaton page 299.
-                                committed_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
+                                committed_version.begin =
+                                    Some(TxTimestampOrID::Timestamp(end_ts));
                                 changed = true;
+                                if committed_version.row.id.table_id
+                                    == SQLITE_SCHEMA_MVCC_TABLE_ID
+                                {
+                                    *did_commit_schema = true;
+                                }
                             }
                         }
-                        if let Some(TxTimestampOrID::TxID(id)) = committed_version.end {
-                            if id == self.tx_id {
+                        if let Some(TxTimestampOrID::TxID(vid)) = committed_version.end {
+                            if vid == self.tx_id {
                                 // Old version is valid UNTIL the committing
                                 // transaction's end timestamp. See Hekaton page 299.
                                 committed_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
                                 changed = true;
+                                if committed_version.row.id.table_id
+                                    == SQLITE_SCHEMA_MVCC_TABLE_ID
+                                {
+                                    *did_commit_schema = true;
+                                }
                             }
                         }
                         if changed {
@@ -1347,6 +1325,56 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                         }
                     }
                 }
+
+                if let Some(index) = mvcc_store.index_rows.get(&id.table_id) {
+                    let index = index.value();
+                    let RowKey::Record(ref index_key) = id.row_id else {
+                        panic!("Index writes must have a record key");
+                    };
+                    if let Some(row_versions) = index.get(index_key) {
+                        let row_versions = row_versions.value().read();
+                        for row_version in row_versions.iter() {
+                            let mut committed_version = row_version.clone();
+                            let mut changed = false;
+                            if let Some(TxTimestampOrID::TxID(vid)) = committed_version.begin {
+                                if vid == self.tx_id {
+                                    // New version is valid STARTING FROM the committing
+                                    // transaction's end timestamp. See Hekaton page 299.
+                                    committed_version.begin =
+                                        Some(TxTimestampOrID::Timestamp(end_ts));
+                                    changed = true;
+                                }
+                            }
+                            if let Some(TxTimestampOrID::TxID(vid)) = committed_version.end {
+                                if vid == self.tx_id {
+                                    // Old version is valid UNTIL the committing
+                                    // transaction's end timestamp. See Hekaton page 299.
+                                    committed_version.end =
+                                        Some(TxTimestampOrID::Timestamp(end_ts));
+                                    changed = true;
+                                }
+                            }
+                            if changed {
+                                mvcc_store.insert_version_raw(
+                                    &mut log_record.row_versions,
+                                    committed_version,
+                                );
+                            }
+                        }
+                    }
+                }
+            };
+
+        // First pass: schema rows only
+        for id in &self.write_set {
+            if id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                collect_versions(id, &mut log_record, &mut self.did_commit_schema_change);
+            }
+        }
+        // Second pass: all non-schema rows
+        for id in &self.write_set {
+            if id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+                collect_versions(id, &mut log_record, &mut self.did_commit_schema_change);
             }
         }
 
@@ -4670,12 +4698,14 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let rowid_int = rowid.row_id.to_int_or_panic();
                         schema_rows.insert(rowid_int, record);
                         needs_schema_rebuild.set(true);
-                    } else {
-                        turso_assert!(self.table_id_to_rootpage.get(&rowid.table_id).is_some(),
-                        "Logical log contains a row version insert with a table id that does not exist in the table_id_to_rootpage map",
-                        {"table_id": rowid.table_id,
-                            "table_id_to_rootpage_map": format!("{:?}", self.table_id_to_rootpage.iter().collect::<Vec<_>>())
-                        });
+                    } else if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
+                        // Data row references a table_id not yet in the map. This can happen
+                        // with logs written before the schema-first serialization fix: in a
+                        // same-transaction CREATE TABLE + INSERT + DROP TABLE, data rows were
+                        // serialized before the schema INSERT that registers the table_id.
+                        // The schema INSERT (or DELETE) for this table will follow later in
+                        // this transaction frame, so we register the table_id now.
+                        self.insert_table_id_to_rootpage(rowid.table_id, None);
                     }
 
                     let version_id = self.get_version_id();
@@ -4705,9 +4735,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     if commit_ts <= replay_cutoff_ts {
                         continue;
                     }
-                    turso_assert!(self.table_id_to_rootpage.get(&rowid.table_id).is_some(),
-                        "Logical log contains a row version delete with a table id that does not exist in the table_id_to_rootpage map",
-                        {"rootpage_map": rowid.table_id});
+                    if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
+                        // See comment in UpsertTableRow: old logs may have data rows
+                        // serialized before the schema INSERT that registers the table_id.
+                        self.insert_table_id_to_rootpage(rowid.table_id, None);
+                    }
                     if let Some(versions) = self.rows.get(&rowid) {
                         // Row exists in memory — try to find the current (non-ended) version
                         // that was committed before this delete, and mark it as ended. If no

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -932,3 +932,125 @@ fn test_add_then_drop_table_in_same_tx_then_recover(db: TempDatabase) -> anyhow:
 
     Ok(())
 }
+
+/// Reproducer for #6207-like panic: create table, insert data, drop table across
+/// transactions, checkpoint, then recover. The logical log may contain data row
+/// inserts for a table whose schema entry was checkpointed and then dropped,
+/// leaving the table_id absent from table_id_to_rootpage on recovery.
+#[turso_macros::test]
+fn test_create_insert_drop_checkpoint_recover(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.execute("pragma journal_mode = 'mvcc'")?;
+
+        // Tx1: create table and insert rows
+        conn.execute("begin")?;
+        conn.execute("create table t(a integer, b text)")?;
+        for i in 0..100 {
+            conn.execute(format!("insert into t values({i}, 'row_{i}')"))?;
+        }
+        conn.execute("commit")?;
+
+        // Tx2: drop the table
+        conn.execute("begin")?;
+        conn.execute("drop table t")?;
+        conn.execute("commit")?;
+
+        // Checkpoint to flush to btree and advance persistent_tx_ts_max
+        let conn2 = db.connect_limbo();
+        conn2.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+        // Tx3: create another table and insert (this will be above cutoff if
+        // the pod is killed before next checkpoint)
+        conn.execute("begin")?;
+        conn.execute("create table t2(x integer)")?;
+        for i in 0..50 {
+            conn.execute(format!("insert into t2 values({i})"))?;
+        }
+        conn.execute("commit")?;
+    }
+    drop(db);
+
+    // Reopen — triggers bootstrap / log replay
+    Database::open_file(io.clone(), path.to_str().unwrap())?;
+
+    Ok(())
+}
+
+/// Same-tx create + insert + drop: data rows reference a table_id whose schema
+/// entry is created and destroyed in the same transaction.
+#[turso_macros::test]
+fn test_create_insert_drop_same_tx_recover(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.execute("pragma journal_mode = 'mvcc'")?;
+
+        conn.execute("begin")?;
+        conn.execute("create table t(a integer)")?;
+        for i in 0..100 {
+            conn.execute(format!("insert into t values({i})"))?;
+        }
+        conn.execute("drop table t")?;
+        conn.execute("commit")?;
+    }
+    drop(db);
+
+    Database::open_file(io, path.to_str().unwrap())?;
+
+    Ok(())
+}
+
+/// Multiple create/drop cycles then recover: exercises the log replay path
+/// with multiple table_ids that may or may not be in table_id_to_rootpage.
+#[turso_macros::test]
+fn test_multiple_create_drop_cycles_recover(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.execute("pragma journal_mode = 'mvcc'")?;
+
+        for cycle in 0..5 {
+            conn.execute("begin")?;
+            conn.execute("create table t(a integer, b text)")?;
+            for i in 0..50 {
+                conn.execute(format!(
+                    "insert into t values({i}, 'cycle_{cycle}_row_{i}')"
+                ))?;
+            }
+            conn.execute("commit")?;
+
+            conn.execute("begin")?;
+            conn.execute("drop table t")?;
+            conn.execute("commit")?;
+        }
+
+        // Checkpoint midway
+        let conn2 = db.connect_limbo();
+        conn2.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+        // One more cycle after checkpoint
+        conn.execute("begin")?;
+        conn.execute("create table t(a integer, b text)")?;
+        for i in 0..50 {
+            conn.execute(format!("insert into t values({i}, 'final_row_{i}')"))?;
+        }
+        conn.execute("commit")?;
+
+        conn.execute("begin")?;
+        conn.execute("drop table t")?;
+        conn.execute("commit")?;
+    }
+    drop(db);
+
+    Database::open_file(io, path.to_str().unwrap())?;
+
+    Ok(())
+}

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -980,6 +980,32 @@ fn test_create_insert_drop_checkpoint_recover(db: TempDatabase) -> anyhow::Resul
     Ok(())
 }
 
+/// Same-tx CREATE INDEX + DROP INDEX: the index schema row is inserted and
+/// deleted in the same transaction, producing an insert-delete cycle in
+/// sqlite_schema that must not panic during log replay.
+#[turso_macros::test]
+fn test_create_drop_index_same_tx_recover(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.execute("pragma journal_mode = 'mvcc'")?;
+        conn.execute("create table t(id integer primary key, v text)")?;
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+        conn.execute("begin")?;
+        conn.execute("create index idx_t_v on t(v)")?;
+        conn.execute("drop index idx_t_v")?;
+        conn.execute("commit")?;
+    }
+    drop(db);
+
+    Database::open_file(io, path.to_str().unwrap())?;
+
+    Ok(())
+}
+
 /// Same-tx create + insert + drop: data rows reference a table_id whose schema
 /// entry is created and destroyed in the same transaction.
 #[turso_macros::test]


### PR DESCRIPTION
## Description

The SkipSet<RowID> write set orders by table_id, placing data rows
(e.g. table_id=-3) before schema rows (table_id=-1) in the logical
log. During recovery, data row inserts were validated against
table_id_to_rootpage before the schema INSERT that populates it,
causing a panic.

`test_create_insert_drop_same_tx_recover` failed without this
change. Other tests passed but where good to have for more
coverage.

Fixes: #6007 
## Description of AI Usage

I left claude analyzing the bug and finding the reproducer which he found and wrote the code and later asked to write better comments.