### PR TITLE
fix: guard FK counter reconciliation with REPLACE conflict check

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2174,7 +2174,11 @@ fn emit_update_insns<'a>(
             // If Phase 1 REPLACE deleted a parent row referenced by deferred FK children,
             // the counter was incremented. Now that the new row is inserted with the
             // (potentially same) parent key, scan children and decrement.
-            if connection.foreign_keys_enabled() {
+            // Only needed for REPLACE conflict resolution — emit_fk_update_parent_actions
+            // already handles the increment/decrement for normal UPDATE.
+            if connection.foreign_keys_enabled()
+                && matches!(effective_rowid_alias_conflict, ResolveType::Replace)
+            {
                 emit_fk_parent_new_key_reconcile(
                     program,
                     table,

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2174,11 +2174,11 @@ fn emit_update_insns<'a>(
             // If Phase 1 REPLACE deleted a parent row referenced by deferred FK children,
             // the counter was incremented. Now that the new row is inserted with the
             // (potentially same) parent key, scan children and decrement.
-            // Only needed for REPLACE conflict resolution — emit_fk_update_parent_actions
-            // already handles the increment/decrement for normal UPDATE.
-            if connection.foreign_keys_enabled()
-                && matches!(effective_rowid_alias_conflict, ResolveType::Replace)
-            {
+            // Only needed when REPLACE conflict resolution fired — either via
+            // rowid alias (PRIMARY KEY) or a UNIQUE index with ON CONFLICT REPLACE.
+            let has_replace_conflict = matches!(effective_rowid_alias_conflict, ResolveType::Replace)
+                || indexes_to_update.iter().any(|idx| idx.on_conflict == Some(ResolveType::Replace));
+            if connection.foreign_keys_enabled() && has_replace_conflict {
                 emit_fk_parent_new_key_reconcile(
                     program,
                     table,

--- a/testing/sqltests/tests/savepoint.sqltest
+++ b/testing/sqltests/tests/savepoint.sqltest
@@ -270,3 +270,41 @@ test savepoint-not-reusable-after-transaction-boundary {
 expect error {
     no such savepoint
 }
+
+@cross-check-integrity
+test deferred-fk-update-parent-pk-in-savepoint-rejects-commit {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE p (id INTEGER PRIMARY KEY, tag TEXT);
+    CREATE TABLE c (id INTEGER PRIMARY KEY, pid INT, note TEXT, FOREIGN KEY(pid) REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES (24, 'tag24');
+    INSERT INTO c VALUES (1, 24, 'c1');
+    INSERT INTO c VALUES (2, 24, 'c2');
+    BEGIN;
+    SAVEPOINT sp0;
+    UPDATE p SET id = 4 WHERE id = 24;
+    RELEASE sp0;
+    COMMIT;
+}
+expect error {
+    deferred foreign key constraint failed
+}
+
+@cross-check-integrity
+test deferred-fk-update-parent-pk-rollback-restores-state {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE p (id INTEGER PRIMARY KEY, tag TEXT);
+    CREATE TABLE c (id INTEGER PRIMARY KEY, pid INT, note TEXT, FOREIGN KEY(pid) REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES (1, 'a');
+    INSERT INTO c VALUES (10, 1, 'child');
+    BEGIN;
+    SAVEPOINT sp0;
+    UPDATE p SET id = 99 WHERE id = 1;
+    ROLLBACK TO sp0;
+    SELECT * FROM p;
+    SELECT * FROM c;
+    COMMIT;
+}
+expect {
+    1|a
+    10|1|child
+}


### PR DESCRIPTION
## Summary

Fixes #6218 — deferred FK violation counter double-decremented during UPDATE on parent table.

The issue: `emit_fk_parent_new_key_reconcile` was called unconditionally for all UPDATE operations on parent tables with deferred FK children. `emit_fk_update_parent_actions` already handles the correct increment (OLD key) and decrement (NEW key) cycle. The unconditional second call produces a duplicate decrement loop in the bytecode, causing the FK counter to drift to zero and allowing `COMMIT` to succeed when it should fail.

The fix: guard the call with `matches!(effective_rowid_alias_conflict, ResolveType::Replace)` so it only runs during REPLACE conflict resolution, which is what the function's own documentation says it should do.

### Before fix
```sql
PRAGMA foreign_keys = ON;
CREATE TABLE p (id INTEGER PRIMARY KEY);
CREATE TABLE c (id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
INSERT INTO p VALUES (24);
INSERT INTO c VALUES (1, 24);
INSERT INTO c VALUES (2, 24);
BEGIN;
SAVEPOINT sp0;
UPDATE p SET id = 4 WHERE id = 24;
RELEASE sp0;  -- Turso: succeeds (BUG, counter is 0)
COMMIT;       -- Turso: succeeds (BUG, orphans c rows)
```

### After fix
```
RELEASE sp0;  -- succeeds (deferred, correct)
COMMIT;       -- Error: deferred foreign key constraint failed (correct, matches SQLite)
```

### Tests
Two new sqltest regression tests in `testing/sqltests/tests/savepoint.sqltest`:
- `deferred-fk-update-parent-pk-in-savepoint-rejects-commit` — verifies COMMIT fails
- `deferred-fk-update-parent-pk-rollback-restores-state` — verifies ROLLBACK TO restores state

All 23 savepoint tests pass.

## Description of AI Usage

Used AI assistance for code exploration and understanding the bytecode generation pipeline. The fix itself is a one-line guard, as identified in the issue by @LeMikaelF.