### PR TITLE
fix: spurious sqlite_stat1 NULL-idx rows emitted by ANALYZE

### DIFF
--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -372,7 +372,6 @@ pub fn translate_analyze(
         let emit_table_stat =
             !is_specific_index_target && !indexes.iter().any(|index| index.where_clause.is_none());
         if emit_table_stat {
-            let rowid_reg = program.alloc_register();
             let indexname_reg = program.alloc_register();
             let stat_text_reg = program.alloc_register();
             let record_reg = program.alloc_register();
@@ -409,6 +408,7 @@ pub fn translate_analyze(
                 index_name: None,
                 affinity_str: None,
             });
+            let rowid_reg = program.alloc_register();
             program.emit_insn(Insn::NewRowid {
                 cursor: stat_cursor,
                 rowid_reg,

--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -350,65 +350,14 @@ pub fn translate_analyze(
             root_page: target_table.root_page,
             db: database_id,
         });
-        let rowid_reg = program.alloc_register();
         let tablename_reg = program.alloc_register();
-        let indexname_reg = program.alloc_register();
-        let stat_text_reg = program.alloc_register();
-        let record_reg = program.alloc_register();
-        let count_reg = program.alloc_register();
         program.emit_insn(Insn::String8 {
             value: target_table.name.to_string(),
             dest: tablename_reg,
         });
         program.mark_last_insn_constant();
-        program.emit_insn(Insn::Count {
-            cursor_id: target_cursor,
-            target_reg: count_reg,
-            exact: true,
-        });
-        let after_insert = program.allocate_label();
-        program.emit_insn(Insn::IfNot {
-            reg: count_reg,
-            target_pc: after_insert,
-            jump_if_null: false,
-        });
-        program.emit_insn(Insn::Null {
-            dest: indexname_reg,
-            dest_end: None,
-        });
-        // stat = CAST(count AS TEXT)
-        program.emit_insn(Insn::Copy {
-            src_reg: count_reg,
-            dst_reg: stat_text_reg,
-            extra_amount: 0,
-        });
-        program.emit_insn(Insn::Cast {
-            reg: stat_text_reg,
-            affinity: Affinity::Text,
-        });
-        program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(tablename_reg),
-            count: to_u16(3),
-            dest_reg: to_u16(record_reg),
-            index_name: None,
-            affinity_str: None,
-        });
-        program.emit_insn(Insn::NewRowid {
-            cursor: stat_cursor,
-            rowid_reg,
-            prev_largest_reg: 0,
-        });
-        // FIXME: SQLite sets OPFLAG_APPEND on the insert, but that's not supported in turso right now.
-        // SQLite doesn't emit the table name, but like... why not?
-        program.emit_insn(Insn::Insert {
-            cursor: stat_cursor,
-            key_reg: rowid_reg,
-            record_reg,
-            flag: Default::default(),
-            table_name: "sqlite_stat1".to_string(),
-        });
-        program.preassign_label_to_next_insn(after_insert);
         // Emit index stats for this table (or for a single index target).
+        let is_specific_index_target = target_index.is_some();
         let indexes: Vec<Arc<Index>> = match target_index {
             Some(idx) => vec![idx],
             None => resolver.with_schema(database_id, |s| {
@@ -418,6 +367,64 @@ pub fn translate_analyze(
                     .collect()
             }),
         };
+        // Match SQLite: emit the table-level sqlite_stat1 row only when ANALYZE
+        // targets a table and there are no non-partial indexes contributing stats.
+        let emit_table_stat =
+            !is_specific_index_target && !indexes.iter().any(|index| index.where_clause.is_none());
+        if emit_table_stat {
+            let rowid_reg = program.alloc_register();
+            let indexname_reg = program.alloc_register();
+            let stat_text_reg = program.alloc_register();
+            let record_reg = program.alloc_register();
+            let count_reg = program.alloc_register();
+            program.emit_insn(Insn::Count {
+                cursor_id: target_cursor,
+                target_reg: count_reg,
+                exact: true,
+            });
+            let after_insert = program.allocate_label();
+            program.emit_insn(Insn::IfNot {
+                reg: count_reg,
+                target_pc: after_insert,
+                jump_if_null: false,
+            });
+            program.emit_insn(Insn::Null {
+                dest: indexname_reg,
+                dest_end: None,
+            });
+            // stat = CAST(count AS TEXT)
+            program.emit_insn(Insn::Copy {
+                src_reg: count_reg,
+                dst_reg: stat_text_reg,
+                extra_amount: 0,
+            });
+            program.emit_insn(Insn::Cast {
+                reg: stat_text_reg,
+                affinity: Affinity::Text,
+            });
+            program.emit_insn(Insn::MakeRecord {
+                start_reg: to_u16(tablename_reg),
+                count: to_u16(3),
+                dest_reg: to_u16(record_reg),
+                index_name: None,
+                affinity_str: None,
+            });
+            program.emit_insn(Insn::NewRowid {
+                cursor: stat_cursor,
+                rowid_reg,
+                prev_largest_reg: 0,
+            });
+            // FIXME: SQLite sets OPFLAG_APPEND on the insert, but that's not supported in turso right now.
+            // SQLite doesn't emit the table name, but like... why not?
+            program.emit_insn(Insn::Insert {
+                cursor: stat_cursor,
+                key_reg: rowid_reg,
+                record_reg,
+                flag: Default::default(),
+                table_name: "sqlite_stat1".to_string(),
+            });
+            program.preassign_label_to_next_insn(after_insert);
+        }
         for index in indexes {
             emit_index_stats(program, stat_cursor, &target_table, &index, database_id);
         }

--- a/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-all-stat1-exists.snap
+++ b/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-all-stat1-exists.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4                  p5  comment
-   0  Init          0  60   0                       0  Start at 60
+   0  Init          0  52   0                       0  Start at 52
    1  Null          0   1   0                       0  r[1]=NULL
    2  OpenWrite     0   5   0                       0  root=5; iDb=0
    3  Rewind        0  10   0                       0  Rewind  sqlite_stat1
@@ -23,60 +23,52 @@ addr  opcode       p1  p2  p3  p4                  p5  comment
    8    Next        0   4   0                       0
    9  Next          0   4   0                       0
   10  OpenRead      1   2   0  k(3,B,B,B)           0  =items, root=2, iDb=0
-  11  Count         1  10   0                       0
-  12  IfNot        10  19   0                       0  if !r[10] goto 19
-  13  Null          0   7   0                       0  r[7]=NULL
-  14  Copy         10   8   0                       0  r[8]=r[10]
-  15  Cast          8   0   0                       0  affinity(r[8]=Text)
-  16  MakeRecord    6   3   9                       0  r[9]=mkrec(r[6..8])
-  17  NewRowid      0   5   0                       0  r[5]=rowid
-  18  Insert        0   9   5  sqlite_stat1         0  intkey=r[5] data=r[9]
-  19  OpenRead      2   4   0  k(2,B)               0  =idx_items_category, root=4, iDb=0
-  20  Integer       1  12   0                       0  r[12]=1
-  21  Function      0  12  11  stat_init            0  r[11]=func(r[12])
-  22  Rewind        2  39   0                       0  Rewind  idx_items_category
-  23  Integer       0  12   0                       0  r[12]=0
-  24  Goto          0  30   0                       0
-  25    Integer     0  12   0                       0  r[12]=0
-  26    Column      2   0  14                       0  r[14]=idx_items_category.category
-  27    Ne         14  13  30                       0  if r[14]!=r[13] goto 30
-  28    Integer     1  12   0                       0  r[12]=1
-  29    Goto        0  31   0                       0
-  30    Column      2   0  13                       0  r[13]=idx_items_category.category
-  31    Function    0  11  11  stat_push            0  r[11]=func(r[11..12])
-  32  Next          2  25   0                       0
-  33  Function      0  11  15  stat_get             0  r[15]=func(r[11])
-  34  IsNull       15  39   0                       0  if (r[15]==NULL) goto 39
-  35  Copy         15  18   0                       0  r[18]=r[15]
-  36  MakeRecord   16   3  19                       0  r[19]=mkrec(r[16..18])
-  37  NewRowid      0  20   0                       0  r[20]=rowid
-  38  Insert        0  19  20  sqlite_stat1         0  intkey=r[20] data=r[19]
-  39  OpenRead      3   3   0  k(2,B)               0  =idx_items_name, root=3, iDb=0
-  40  Integer       1  22   0                       0  r[22]=1
-  41  Function      0  22  21  stat_init            0  r[21]=func(r[22])
-  42  Rewind        3  59   0                       0  Rewind  idx_items_name
-  43  Integer       0  22   0                       0  r[22]=0
-  44  Goto          0  50   0                       0
-  45    Integer     0  22   0                       0  r[22]=0
-  46    Column      3   0  24                       0  r[24]=idx_items_name.name
-  47    Ne         24  23  50                       0  if r[24]!=r[23] goto 50
-  48    Integer     1  22   0                       0  r[22]=1
-  49    Goto        0  51   0                       0
-  50    Column      3   0  23                       0  r[23]=idx_items_name.name
-  51    Function    0  21  21  stat_push            0  r[21]=func(r[21..22])
-  52  Next          3  45   0                       0
-  53  Function      0  21  25  stat_get             0  r[25]=func(r[21])
-  54  IsNull       25  59   0                       0  if (r[25]==NULL) goto 59
-  55  Copy         25  28   0                       0  r[28]=r[25]
-  56  MakeRecord   26   3  29                       0  r[29]=mkrec(r[26..28])
-  57  NewRowid      0  30   0                       0  r[30]=rowid
-  58  Insert        0  29  30  sqlite_stat1         0  intkey=r[30] data=r[29]
-  59  Halt          0   0   0                       0
-  60  Transaction   0   2   4                       0  iDb=0 tx_mode=Write
-  61  String8       0   3   0  items                0  r[3]='items'
-  62  String8       0   6   0  items                0  r[6]='items'
-  63  String8       0  16   0  items                0  r[16]='items'
-  64  String8       0  17   0  idx_items_category   0  r[17]='idx_items_category'
-  65  String8       0  26   0  items                0  r[26]='items'
-  66  String8       0  27   0  idx_items_name       0  r[27]='idx_items_name'
-  67  Goto          0   1   0                       0
+  11  OpenRead      2   4   0  k(2,B)               0  =idx_items_category, root=4, iDb=0
+  12  Integer       1   7   0                       0  r[7]=1
+  13  Function      0   7   6  stat_init            0  r[6]=func(r[7])
+  14  Rewind        2  31   0                       0  Rewind  idx_items_category
+  15  Integer       0   7   0                       0  r[7]=0
+  16  Goto          0  22   0                       0
+  17    Integer     0   7   0                       0  r[7]=0
+  18    Column      2   0   9                       0  r[9]=idx_items_category.category
+  19    Ne          9   8  22                       0  if r[9]!=r[8] goto 22
+  20    Integer     1   7   0                       0  r[7]=1
+  21    Goto        0  23   0                       0
+  22    Column      2   0   8                       0  r[8]=idx_items_category.category
+  23    Function    0   6   6  stat_push            0  r[6]=func(r[6..7])
+  24  Next          2  17   0                       0
+  25  Function      0   6  10  stat_get             0  r[10]=func(r[6])
+  26  IsNull       10  31   0                       0  if (r[10]==NULL) goto 31
+  27  Copy         10  13   0                       0  r[13]=r[10]
+  28  MakeRecord   11   3  14                       0  r[14]=mkrec(r[11..13])
+  29  NewRowid      0  15   0                       0  r[15]=rowid
+  30  Insert        0  14  15  sqlite_stat1         0  intkey=r[15] data=r[14]
+  31  OpenRead      3   3   0  k(2,B)               0  =idx_items_name, root=3, iDb=0
+  32  Integer       1  17   0                       0  r[17]=1
+  33  Function      0  17  16  stat_init            0  r[16]=func(r[17])
+  34  Rewind        3  51   0                       0  Rewind  idx_items_name
+  35  Integer       0  17   0                       0  r[17]=0
+  36  Goto          0  42   0                       0
+  37    Integer     0  17   0                       0  r[17]=0
+  38    Column      3   0  19                       0  r[19]=idx_items_name.name
+  39    Ne         19  18  42                       0  if r[19]!=r[18] goto 42
+  40    Integer     1  17   0                       0  r[17]=1
+  41    Goto        0  43   0                       0
+  42    Column      3   0  18                       0  r[18]=idx_items_name.name
+  43    Function    0  16  16  stat_push            0  r[16]=func(r[16..17])
+  44  Next          3  37   0                       0
+  45  Function      0  16  20  stat_get             0  r[20]=func(r[16])
+  46  IsNull       20  51   0                       0  if (r[20]==NULL) goto 51
+  47  Copy         20  23   0                       0  r[23]=r[20]
+  48  MakeRecord   21   3  24                       0  r[24]=mkrec(r[21..23])
+  49  NewRowid      0  25   0                       0  r[25]=rowid
+  50  Insert        0  24  25  sqlite_stat1         0  intkey=r[25] data=r[24]
+  51  Halt          0   0   0                       0
+  52  Transaction   0   2   4                       0  iDb=0 tx_mode=Write
+  53  String8       0   3   0  items                0  r[3]='items'
+  54  String8       0   5   0  items                0  r[5]='items'
+  55  String8       0  11   0  items                0  r[11]='items'
+  56  String8       0  12   0  idx_items_category   0  r[12]='idx_items_category'
+  57  String8       0  21   0  items                0  r[21]='items'
+  58  String8       0  22   0  idx_items_name       0  r[22]='idx_items_name'
+  59  Goto          0   1   0                       0

--- a/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-all.snap
+++ b/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-all.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1   p2   p3  p4                                               p5  comment
-   0  Init          0  196    0                                                    0  Start at 196
+   0  Init          0  172    0                                                    0  Start at 172
    1  Null          0    1    0                                                    0  r[1]=NULL
    2  CreateBtree   0    2    1                                                    0  r[2]=root iDb=0 flags=1
    3  OpenWrite     0    1    0                                                    0  root=1; iDb=0
@@ -35,196 +35,172 @@ addr  opcode       p1   p2   p3  p4                                             
   20    Next        1   16    0                                                    0
   21  Next          1   16    0                                                    0
   22  OpenRead      2    2    0  k(6,B,B,B,B,B,B)                                  0  =products, root=2, iDb=0
-  23  Count         2   18    0                                                    0
-  24  IfNot        18   31    0                                                    0  if !r[18] goto 31
-  25  Null          0   15    0                                                    0  r[15]=NULL
-  26  Copy         18   16    0                                                    0  r[16]=r[18]
-  27  Cast         16    0    0                                                    0  affinity(r[16]=Text)
-  28  MakeRecord   14    3   17                                                    0  r[17]=mkrec(r[14..16])
-  29  NewRowid      1   13    0                                                    0  r[13]=rowid
-  30  Insert        1   17   13  sqlite_stat1                                      0  intkey=r[13] data=r[17]
-  31  OpenRead      3    5    0  k(2,B)                                            0  =idx_products_price, root=5, iDb=0
-  32  Integer       1   20    0                                                    0  r[20]=1
-  33  Function      0   20   19  stat_init                                         0  r[19]=func(r[20])
-  34  Rewind        3   51    0                                                    0  Rewind  idx_products_price
-  35  Integer       0   20    0                                                    0  r[20]=0
-  36  Goto          0   42    0                                                    0
-  37    Integer     0   20    0                                                    0  r[20]=0
-  38    Column      3    0   22                                                    0  r[22]=idx_products_price.price
-  39    Ne         22   21   42                                                    0  if r[22]!=r[21] goto 42
-  40    Integer     1   20    0                                                    0  r[20]=1
-  41    Goto        0   43    0                                                    0
-  42    Column      3    0   21                                                    0  r[21]=idx_products_price.price
-  43    Function    0   19   19  stat_push                                         0  r[19]=func(r[19..20])
-  44  Next          3   37    0                                                    0
-  45  Function      0   19   23  stat_get                                          0  r[23]=func(r[19])
-  46  IsNull       23   51    0                                                    0  if (r[23]==NULL) goto 51
-  47  Copy         23   26    0                                                    0  r[26]=r[23]
-  48  MakeRecord   24    3   27                                                    0  r[27]=mkrec(r[24..26])
-  49  NewRowid      1   28    0                                                    0  r[28]=rowid
-  50  Insert        1   27   28  sqlite_stat1                                      0  intkey=r[28] data=r[27]
-  51  OpenRead      4    4    0  k(2,B)                                            0  =idx_products_category, root=4, iDb=0
-  52  Integer       1   30    0                                                    0  r[30]=1
-  53  Function      0   30   29  stat_init                                         0  r[29]=func(r[30])
-  54  Rewind        4   71    0                                                    0  Rewind  idx_products_category
-  55  Integer       0   30    0                                                    0  r[30]=0
-  56  Goto          0   62    0                                                    0
-  57    Integer     0   30    0                                                    0  r[30]=0
-  58    Column      4    0   32                                                    0  r[32]=idx_products_category.category
-  59    Ne         32   31   62                                                    0  if r[32]!=r[31] goto 62
-  60    Integer     1   30    0                                                    0  r[30]=1
-  61    Goto        0   63    0                                                    0
-  62    Column      4    0   31                                                    0  r[31]=idx_products_category.category
-  63    Function    0   29   29  stat_push                                         0  r[29]=func(r[29..30])
-  64  Next          4   57    0                                                    0
-  65  Function      0   29   33  stat_get                                          0  r[33]=func(r[29])
-  66  IsNull       33   71    0                                                    0  if (r[33]==NULL) goto 71
-  67  Copy         33   36    0                                                    0  r[36]=r[33]
-  68  MakeRecord   34    3   37                                                    0  r[37]=mkrec(r[34..36])
-  69  NewRowid      1   38    0                                                    0  r[38]=rowid
-  70  Insert        1   37   38  sqlite_stat1                                      0  intkey=r[38] data=r[37]
-  71  OpenRead      5    3    0  k(2,B)                                            0  =idx_products_sku, root=3, iDb=0
-  72  Integer       1   40    0                                                    0  r[40]=1
-  73  Function      0   40   39  stat_init                                         0  r[39]=func(r[40])
-  74  Rewind        5   91    0                                                    0  Rewind  idx_products_sku
-  75  Integer       0   40    0                                                    0  r[40]=0
-  76  Goto          0   82    0                                                    0
-  77    Integer     0   40    0                                                    0  r[40]=0
-  78    Column      5    0   42                                                    0  r[42]=idx_products_sku.sku
-  79    Ne         42   41   82                                                    0  if r[42]!=r[41] goto 82
-  80    Integer     1   40    0                                                    0  r[40]=1
-  81    Goto        0   83    0                                                    0
-  82    Column      5    0   41                                                    0  r[41]=idx_products_sku.sku
-  83    Function    0   39   39  stat_push                                         0  r[39]=func(r[39..40])
-  84  Next          5   77    0                                                    0
-  85  Function      0   39   43  stat_get                                          0  r[43]=func(r[39])
-  86  IsNull       43   91    0                                                    0  if (r[43]==NULL) goto 91
-  87  Copy         43   46    0                                                    0  r[46]=r[43]
-  88  MakeRecord   44    3   47                                                    0  r[47]=mkrec(r[44..46])
-  89  NewRowid      1   48    0                                                    0  r[48]=rowid
-  90  Insert        1   47   48  sqlite_stat1                                      0  intkey=r[48] data=r[47]
-  91  Rewind        1   98    0                                                    0  Rewind  sqlite_stat1
-  92      Column    1    0   49                                                    0  r[49]=sqlite_stat1.tbl
-  93      Ne       49   50   97                                                    0  if r[49]!=r[50] goto 97
-  94      RowId     1   51    0                                                    0  r[51]=sqlite_stat1.rowid
-  95      Delete    1    0    0  sqlite_stat1                                      0
-  96    Next        1   92    0                                                    0
-  97  Next          1   92    0                                                    0
-  98  OpenRead      6    9    0  k(5,B,B,B,B,B)                                    0  =inventory, root=9, iDb=0
-  99  Count         6   57    0                                                    0
- 100  IfNot        57  107    0                                                    0  if !r[57] goto 107
- 101  Null          0   54    0                                                    0  r[54]=NULL
- 102  Copy         57   55    0                                                    0  r[55]=r[57]
- 103  Cast         55    0    0                                                    0  affinity(r[55]=Text)
- 104  MakeRecord   53    3   56                                                    0  r[56]=mkrec(r[53..55])
- 105  NewRowid      1   52    0                                                    0  r[52]=rowid
- 106  Insert        1   56   52  sqlite_stat1                                      0  intkey=r[52] data=r[56]
- 107  OpenRead      7   10    0  k(4,B,B,B)                                        0  =idx_inventory_location, root=10, iDb=0
- 108  Integer       3   59    0                                                    0  r[59]=3
- 109  Function      0   59   58  stat_init                                         0  r[58]=func(r[59])
- 110  Rewind        7  135    0                                                    0  Rewind  idx_inventory_location
- 111  Integer       0   59    0                                                    0  r[59]=0
- 112  Goto          0  124    0                                                    0
- 113    Integer     0   59    0                                                    0  r[59]=0
- 114    Column      7    0   63                                                    0  r[63]=idx_inventory_location.warehouse_id
- 115    Ne         63   60  124                                                    0  if r[63]!=r[60] goto 124
- 116    Integer     1   59    0                                                    0  r[59]=1
- 117    Column      7    1   63                                                    0  r[63]=idx_inventory_location.product_id
- 118    Ne         63   61  125                                                    0  if r[63]!=r[61] goto 125
- 119    Integer     2   59    0                                                    0  r[59]=2
- 120    Column      7    2   63                                                    0  r[63]=idx_inventory_location.bin_location
- 121    Ne         63   62  126                                                    0  if r[63]!=r[62] goto 126
- 122    Integer     3   59    0                                                    0  r[59]=3
- 123    Goto        0  127    0                                                    0
- 124    Column      7    0   60                                                    0  r[60]=idx_inventory_location.warehouse_id
- 125    Column      7    1   61                                                    0  r[61]=idx_inventory_location.product_id
- 126    Column      7    2   62                                                    0  r[62]=idx_inventory_location.bin_location
- 127    Function    0   58   58  stat_push                                         0  r[58]=func(r[58..59])
- 128  Next          7  113    0                                                    0
- 129  Function      0   58   64  stat_get                                          0  r[64]=func(r[58])
- 130  IsNull       64  135    0                                                    0  if (r[64]==NULL) goto 135
- 131  Copy         64   67    0                                                    0  r[67]=r[64]
- 132  MakeRecord   65    3   68                                                    0  r[68]=mkrec(r[65..67])
- 133  NewRowid      1   69    0                                                    0  r[69]=rowid
- 134  Insert        1   68   69  sqlite_stat1                                      0  intkey=r[69] data=r[68]
- 135  Rewind        1  142    0                                                    0  Rewind  sqlite_stat1
- 136      Column    1    0   70                                                    0  r[70]=sqlite_stat1.tbl
- 137      Ne       70   71  141                                                    0  if r[70]!=r[71] goto 141
- 138      RowId     1   72    0                                                    0  r[72]=sqlite_stat1.rowid
- 139      Delete    1    0    0  sqlite_stat1                                      0
- 140    Next        1  136    0                                                    0
- 141  Next          1  136    0                                                    0
- 142  OpenRead      8    6    0  k(5,B,B,B,B,B)                                    0  =orders, root=6, iDb=0
- 143  Count         8   78    0                                                    0
- 144  IfNot        78  151    0                                                    0  if !r[78] goto 151
- 145  Null          0   75    0                                                    0  r[75]=NULL
- 146  Copy         78   76    0                                                    0  r[76]=r[78]
- 147  Cast         76    0    0                                                    0  affinity(r[76]=Text)
- 148  MakeRecord   74    3   77                                                    0  r[77]=mkrec(r[74..76])
- 149  NewRowid      1   73    0                                                    0  r[73]=rowid
- 150  Insert        1   77   73  sqlite_stat1                                      0  intkey=r[73] data=r[77]
- 151  OpenRead      9    8    0  k(2,B)                                            0  =idx_orders_status, root=8, iDb=0
- 152  Integer       1   80    0                                                    0  r[80]=1
- 153  Function      0   80   79  stat_init                                         0  r[79]=func(r[80])
- 154  Rewind        9  171    0                                                    0  Rewind  idx_orders_status
- 155  Integer       0   80    0                                                    0  r[80]=0
- 156  Goto          0  162    0                                                    0
- 157    Integer     0   80    0                                                    0  r[80]=0
- 158    Column      9    0   82                                                    0  r[82]=idx_orders_status.status
- 159    Ne         82   81  162                                                    0  if r[82]!=r[81] goto 162
- 160    Integer     1   80    0                                                    0  r[80]=1
- 161    Goto        0  163    0                                                    0
- 162    Column      9    0   81                                                    0  r[81]=idx_orders_status.status
- 163    Function    0   79   79  stat_push                                         0  r[79]=func(r[79..80])
- 164  Next          9  157    0                                                    0
- 165  Function      0   79   83  stat_get                                          0  r[83]=func(r[79])
- 166  IsNull       83  171    0                                                    0  if (r[83]==NULL) goto 171
- 167  Copy         83   86    0                                                    0  r[86]=r[83]
- 168  MakeRecord   84    3   87                                                    0  r[87]=mkrec(r[84..86])
- 169  NewRowid      1   88    0                                                    0  r[88]=rowid
- 170  Insert        1   87   88  sqlite_stat1                                      0  intkey=r[88] data=r[87]
- 171  OpenRead     10    7    0  k(3,B,B)                                          0  =idx_orders_customer_date, root=7, iDb=0
- 172  Integer       2   90    0                                                    0  r[90]=2
- 173  Function      0   90   89  stat_init                                         0  r[89]=func(r[90])
- 174  Rewind       10  195    0                                                    0  Rewind  idx_orders_customer_date
- 175  Integer       0   90    0                                                    0  r[90]=0
- 176  Goto          0  185    0                                                    0
- 177    Integer     0   90    0                                                    0  r[90]=0
- 178    Column     10    0   93                                                    0  r[93]=idx_orders_customer_date.customer_id
- 179    Ne         93   91  185                                                    0  if r[93]!=r[91] goto 185
- 180    Integer     1   90    0                                                    0  r[90]=1
- 181    Column     10    1   93                                                    0  r[93]=idx_orders_customer_date.order_date
- 182    Ne         93   92  186                                                    0  if r[93]!=r[92] goto 186
- 183    Integer     2   90    0                                                    0  r[90]=2
- 184    Goto        0  187    0                                                    0
- 185    Column     10    0   91                                                    0  r[91]=idx_orders_customer_date.customer_id
- 186    Column     10    1   92                                                    0  r[92]=idx_orders_customer_date.order_date
- 187    Function    0   89   89  stat_push                                         0  r[89]=func(r[89..90])
- 188  Next         10  177    0                                                    0
- 189  Function      0   89   94  stat_get                                          0  r[94]=func(r[89])
- 190  IsNull       94  195    0                                                    0  if (r[94]==NULL) goto 195
- 191  Copy         94   97    0                                                    0  r[97]=r[94]
- 192  MakeRecord   95    3   98                                                    0  r[98]=mkrec(r[95..97])
- 193  NewRowid      1   99    0                                                    0  r[99]=rowid
- 194  Insert        1   98   99  sqlite_stat1                                      0  intkey=r[99] data=r[98]
- 195  Halt          0    0    0                                                    0
- 196  Transaction   0    2    9                                                    0  iDb=0 tx_mode=Write
- 197  String8       0   11    0  products                                          0  r[11]='products'
- 198  String8       0   14    0  products                                          0  r[14]='products'
- 199  String8       0   24    0  products                                          0  r[24]='products'
- 200  String8       0   25    0  idx_products_price                                0  r[25]='idx_products_price'
- 201  String8       0   34    0  products                                          0  r[34]='products'
- 202  String8       0   35    0  idx_products_category                             0  r[35]='idx_products_category'
- 203  String8       0   44    0  products                                          0  r[44]='products'
- 204  String8       0   45    0  idx_products_sku                                  0  r[45]='idx_products_sku'
- 205  String8       0   50    0  inventory                                         0  r[50]='inventory'
- 206  String8       0   53    0  inventory                                         0  r[53]='inventory'
- 207  String8       0   65    0  inventory                                         0  r[65]='inventory'
- 208  String8       0   66    0  idx_inventory_location                            0  r[66]='idx_inventory_location'
- 209  String8       0   71    0  orders                                            0  r[71]='orders'
- 210  String8       0   74    0  orders                                            0  r[74]='orders'
- 211  String8       0   84    0  orders                                            0  r[84]='orders'
- 212  String8       0   85    0  idx_orders_status                                 0  r[85]='idx_orders_status'
- 213  String8       0   95    0  orders                                            0  r[95]='orders'
- 214  String8       0   96    0  idx_orders_customer_date                          0  r[96]='idx_orders_customer_date'
- 215  Goto          0    1    0                                                    0
+  23  OpenRead      3    5    0  k(2,B)                                            0  =idx_products_price, root=5, iDb=0
+  24  Integer       1   15    0                                                    0  r[15]=1
+  25  Function      0   15   14  stat_init                                         0  r[14]=func(r[15])
+  26  Rewind        3   43    0                                                    0  Rewind  idx_products_price
+  27  Integer       0   15    0                                                    0  r[15]=0
+  28  Goto          0   34    0                                                    0
+  29    Integer     0   15    0                                                    0  r[15]=0
+  30    Column      3    0   17                                                    0  r[17]=idx_products_price.price
+  31    Ne         17   16   34                                                    0  if r[17]!=r[16] goto 34
+  32    Integer     1   15    0                                                    0  r[15]=1
+  33    Goto        0   35    0                                                    0
+  34    Column      3    0   16                                                    0  r[16]=idx_products_price.price
+  35    Function    0   14   14  stat_push                                         0  r[14]=func(r[14..15])
+  36  Next          3   29    0                                                    0
+  37  Function      0   14   18  stat_get                                          0  r[18]=func(r[14])
+  38  IsNull       18   43    0                                                    0  if (r[18]==NULL) goto 43
+  39  Copy         18   21    0                                                    0  r[21]=r[18]
+  40  MakeRecord   19    3   22                                                    0  r[22]=mkrec(r[19..21])
+  41  NewRowid      1   23    0                                                    0  r[23]=rowid
+  42  Insert        1   22   23  sqlite_stat1                                      0  intkey=r[23] data=r[22]
+  43  OpenRead      4    4    0  k(2,B)                                            0  =idx_products_category, root=4, iDb=0
+  44  Integer       1   25    0                                                    0  r[25]=1
+  45  Function      0   25   24  stat_init                                         0  r[24]=func(r[25])
+  46  Rewind        4   63    0                                                    0  Rewind  idx_products_category
+  47  Integer       0   25    0                                                    0  r[25]=0
+  48  Goto          0   54    0                                                    0
+  49    Integer     0   25    0                                                    0  r[25]=0
+  50    Column      4    0   27                                                    0  r[27]=idx_products_category.category
+  51    Ne         27   26   54                                                    0  if r[27]!=r[26] goto 54
+  52    Integer     1   25    0                                                    0  r[25]=1
+  53    Goto        0   55    0                                                    0
+  54    Column      4    0   26                                                    0  r[26]=idx_products_category.category
+  55    Function    0   24   24  stat_push                                         0  r[24]=func(r[24..25])
+  56  Next          4   49    0                                                    0
+  57  Function      0   24   28  stat_get                                          0  r[28]=func(r[24])
+  58  IsNull       28   63    0                                                    0  if (r[28]==NULL) goto 63
+  59  Copy         28   31    0                                                    0  r[31]=r[28]
+  60  MakeRecord   29    3   32                                                    0  r[32]=mkrec(r[29..31])
+  61  NewRowid      1   33    0                                                    0  r[33]=rowid
+  62  Insert        1   32   33  sqlite_stat1                                      0  intkey=r[33] data=r[32]
+  63  OpenRead      5    3    0  k(2,B)                                            0  =idx_products_sku, root=3, iDb=0
+  64  Integer       1   35    0                                                    0  r[35]=1
+  65  Function      0   35   34  stat_init                                         0  r[34]=func(r[35])
+  66  Rewind        5   83    0                                                    0  Rewind  idx_products_sku
+  67  Integer       0   35    0                                                    0  r[35]=0
+  68  Goto          0   74    0                                                    0
+  69    Integer     0   35    0                                                    0  r[35]=0
+  70    Column      5    0   37                                                    0  r[37]=idx_products_sku.sku
+  71    Ne         37   36   74                                                    0  if r[37]!=r[36] goto 74
+  72    Integer     1   35    0                                                    0  r[35]=1
+  73    Goto        0   75    0                                                    0
+  74    Column      5    0   36                                                    0  r[36]=idx_products_sku.sku
+  75    Function    0   34   34  stat_push                                         0  r[34]=func(r[34..35])
+  76  Next          5   69    0                                                    0
+  77  Function      0   34   38  stat_get                                          0  r[38]=func(r[34])
+  78  IsNull       38   83    0                                                    0  if (r[38]==NULL) goto 83
+  79  Copy         38   41    0                                                    0  r[41]=r[38]
+  80  MakeRecord   39    3   42                                                    0  r[42]=mkrec(r[39..41])
+  81  NewRowid      1   43    0                                                    0  r[43]=rowid
+  82  Insert        1   42   43  sqlite_stat1                                      0  intkey=r[43] data=r[42]
+  83  Rewind        1   90    0                                                    0  Rewind  sqlite_stat1
+  84      Column    1    0   44                                                    0  r[44]=sqlite_stat1.tbl
+  85      Ne       44   45   89                                                    0  if r[44]!=r[45] goto 89
+  86      RowId     1   46    0                                                    0  r[46]=sqlite_stat1.rowid
+  87      Delete    1    0    0  sqlite_stat1                                      0
+  88    Next        1   84    0                                                    0
+  89  Next          1   84    0                                                    0
+  90  OpenRead      6    9    0  k(5,B,B,B,B,B)                                    0  =inventory, root=9, iDb=0
+  91  OpenRead      7   10    0  k(4,B,B,B)                                        0  =idx_inventory_location, root=10, iDb=0
+  92  Integer       3   49    0                                                    0  r[49]=3
+  93  Function      0   49   48  stat_init                                         0  r[48]=func(r[49])
+  94  Rewind        7  119    0                                                    0  Rewind  idx_inventory_location
+  95  Integer       0   49    0                                                    0  r[49]=0
+  96  Goto          0  108    0                                                    0
+  97    Integer     0   49    0                                                    0  r[49]=0
+  98    Column      7    0   53                                                    0  r[53]=idx_inventory_location.warehouse_id
+  99    Ne         53   50  108                                                    0  if r[53]!=r[50] goto 108
+ 100    Integer     1   49    0                                                    0  r[49]=1
+ 101    Column      7    1   53                                                    0  r[53]=idx_inventory_location.product_id
+ 102    Ne         53   51  109                                                    0  if r[53]!=r[51] goto 109
+ 103    Integer     2   49    0                                                    0  r[49]=2
+ 104    Column      7    2   53                                                    0  r[53]=idx_inventory_location.bin_location
+ 105    Ne         53   52  110                                                    0  if r[53]!=r[52] goto 110
+ 106    Integer     3   49    0                                                    0  r[49]=3
+ 107    Goto        0  111    0                                                    0
+ 108    Column      7    0   50                                                    0  r[50]=idx_inventory_location.warehouse_id
+ 109    Column      7    1   51                                                    0  r[51]=idx_inventory_location.product_id
+ 110    Column      7    2   52                                                    0  r[52]=idx_inventory_location.bin_location
+ 111    Function    0   48   48  stat_push                                         0  r[48]=func(r[48..49])
+ 112  Next          7   97    0                                                    0
+ 113  Function      0   48   54  stat_get                                          0  r[54]=func(r[48])
+ 114  IsNull       54  119    0                                                    0  if (r[54]==NULL) goto 119
+ 115  Copy         54   57    0                                                    0  r[57]=r[54]
+ 116  MakeRecord   55    3   58                                                    0  r[58]=mkrec(r[55..57])
+ 117  NewRowid      1   59    0                                                    0  r[59]=rowid
+ 118  Insert        1   58   59  sqlite_stat1                                      0  intkey=r[59] data=r[58]
+ 119  Rewind        1  126    0                                                    0  Rewind  sqlite_stat1
+ 120      Column    1    0   60                                                    0  r[60]=sqlite_stat1.tbl
+ 121      Ne       60   61  125                                                    0  if r[60]!=r[61] goto 125
+ 122      RowId     1   62    0                                                    0  r[62]=sqlite_stat1.rowid
+ 123      Delete    1    0    0  sqlite_stat1                                      0
+ 124    Next        1  120    0                                                    0
+ 125  Next          1  120    0                                                    0
+ 126  OpenRead      8    6    0  k(5,B,B,B,B,B)                                    0  =orders, root=6, iDb=0
+ 127  OpenRead      9    8    0  k(2,B)                                            0  =idx_orders_status, root=8, iDb=0
+ 128  Integer       1   65    0                                                    0  r[65]=1
+ 129  Function      0   65   64  stat_init                                         0  r[64]=func(r[65])
+ 130  Rewind        9  147    0                                                    0  Rewind  idx_orders_status
+ 131  Integer       0   65    0                                                    0  r[65]=0
+ 132  Goto          0  138    0                                                    0
+ 133    Integer     0   65    0                                                    0  r[65]=0
+ 134    Column      9    0   67                                                    0  r[67]=idx_orders_status.status
+ 135    Ne         67   66  138                                                    0  if r[67]!=r[66] goto 138
+ 136    Integer     1   65    0                                                    0  r[65]=1
+ 137    Goto        0  139    0                                                    0
+ 138    Column      9    0   66                                                    0  r[66]=idx_orders_status.status
+ 139    Function    0   64   64  stat_push                                         0  r[64]=func(r[64..65])
+ 140  Next          9  133    0                                                    0
+ 141  Function      0   64   68  stat_get                                          0  r[68]=func(r[64])
+ 142  IsNull       68  147    0                                                    0  if (r[68]==NULL) goto 147
+ 143  Copy         68   71    0                                                    0  r[71]=r[68]
+ 144  MakeRecord   69    3   72                                                    0  r[72]=mkrec(r[69..71])
+ 145  NewRowid      1   73    0                                                    0  r[73]=rowid
+ 146  Insert        1   72   73  sqlite_stat1                                      0  intkey=r[73] data=r[72]
+ 147  OpenRead     10    7    0  k(3,B,B)                                          0  =idx_orders_customer_date, root=7, iDb=0
+ 148  Integer       2   75    0                                                    0  r[75]=2
+ 149  Function      0   75   74  stat_init                                         0  r[74]=func(r[75])
+ 150  Rewind       10  171    0                                                    0  Rewind  idx_orders_customer_date
+ 151  Integer       0   75    0                                                    0  r[75]=0
+ 152  Goto          0  161    0                                                    0
+ 153    Integer     0   75    0                                                    0  r[75]=0
+ 154    Column     10    0   78                                                    0  r[78]=idx_orders_customer_date.customer_id
+ 155    Ne         78   76  161                                                    0  if r[78]!=r[76] goto 161
+ 156    Integer     1   75    0                                                    0  r[75]=1
+ 157    Column     10    1   78                                                    0  r[78]=idx_orders_customer_date.order_date
+ 158    Ne         78   77  162                                                    0  if r[78]!=r[77] goto 162
+ 159    Integer     2   75    0                                                    0  r[75]=2
+ 160    Goto        0  163    0                                                    0
+ 161    Column     10    0   76                                                    0  r[76]=idx_orders_customer_date.customer_id
+ 162    Column     10    1   77                                                    0  r[77]=idx_orders_customer_date.order_date
+ 163    Function    0   74   74  stat_push                                         0  r[74]=func(r[74..75])
+ 164  Next         10  153    0                                                    0
+ 165  Function      0   74   79  stat_get                                          0  r[79]=func(r[74])
+ 166  IsNull       79  171    0                                                    0  if (r[79]==NULL) goto 171
+ 167  Copy         79   82    0                                                    0  r[82]=r[79]
+ 168  MakeRecord   80    3   83                                                    0  r[83]=mkrec(r[80..82])
+ 169  NewRowid      1   84    0                                                    0  r[84]=rowid
+ 170  Insert        1   83   84  sqlite_stat1                                      0  intkey=r[84] data=r[83]
+ 171  Halt          0    0    0                                                    0
+ 172  Transaction   0    2    9                                                    0  iDb=0 tx_mode=Write
+ 173  String8       0   11    0  products                                          0  r[11]='products'
+ 174  String8       0   13    0  products                                          0  r[13]='products'
+ 175  String8       0   19    0  products                                          0  r[19]='products'
+ 176  String8       0   20    0  idx_products_price                                0  r[20]='idx_products_price'
+ 177  String8       0   29    0  products                                          0  r[29]='products'
+ 178  String8       0   30    0  idx_products_category                             0  r[30]='idx_products_category'
+ 179  String8       0   39    0  products                                          0  r[39]='products'
+ 180  String8       0   40    0  idx_products_sku                                  0  r[40]='idx_products_sku'
+ 181  String8       0   45    0  inventory                                         0  r[45]='inventory'
+ 182  String8       0   47    0  inventory                                         0  r[47]='inventory'
+ 183  String8       0   55    0  inventory                                         0  r[55]='inventory'
+ 184  String8       0   56    0  idx_inventory_location                            0  r[56]='idx_inventory_location'
+ 185  String8       0   61    0  orders                                            0  r[61]='orders'
+ 186  String8       0   63    0  orders                                            0  r[63]='orders'
+ 187  String8       0   69    0  orders                                            0  r[69]='orders'
+ 188  String8       0   70    0  idx_orders_status                                 0  r[70]='idx_orders_status'
+ 189  String8       0   80    0  orders                                            0  r[80]='orders'
+ 190  String8       0   81    0  idx_orders_customer_date                          0  r[81]='idx_orders_customer_date'
+ 191  Goto          0    1    0                                                    0

--- a/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-database.snap
+++ b/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-database.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1   p2   p3  p4                                               p5  comment
-   0  Init          0  196    0                                                    0  Start at 196
+   0  Init          0  172    0                                                    0  Start at 172
    1  Null          0    1    0                                                    0  r[1]=NULL
    2  CreateBtree   0    2    1                                                    0  r[2]=root iDb=0 flags=1
    3  OpenWrite     0    1    0                                                    0  root=1; iDb=0
@@ -35,196 +35,172 @@ addr  opcode       p1   p2   p3  p4                                             
   20    Next        1   16    0                                                    0
   21  Next          1   16    0                                                    0
   22  OpenRead      2    2    0  k(6,B,B,B,B,B,B)                                  0  =products, root=2, iDb=0
-  23  Count         2   18    0                                                    0
-  24  IfNot        18   31    0                                                    0  if !r[18] goto 31
-  25  Null          0   15    0                                                    0  r[15]=NULL
-  26  Copy         18   16    0                                                    0  r[16]=r[18]
-  27  Cast         16    0    0                                                    0  affinity(r[16]=Text)
-  28  MakeRecord   14    3   17                                                    0  r[17]=mkrec(r[14..16])
-  29  NewRowid      1   13    0                                                    0  r[13]=rowid
-  30  Insert        1   17   13  sqlite_stat1                                      0  intkey=r[13] data=r[17]
-  31  OpenRead      3    5    0  k(2,B)                                            0  =idx_products_price, root=5, iDb=0
-  32  Integer       1   20    0                                                    0  r[20]=1
-  33  Function      0   20   19  stat_init                                         0  r[19]=func(r[20])
-  34  Rewind        3   51    0                                                    0  Rewind  idx_products_price
-  35  Integer       0   20    0                                                    0  r[20]=0
-  36  Goto          0   42    0                                                    0
-  37    Integer     0   20    0                                                    0  r[20]=0
-  38    Column      3    0   22                                                    0  r[22]=idx_products_price.price
-  39    Ne         22   21   42                                                    0  if r[22]!=r[21] goto 42
-  40    Integer     1   20    0                                                    0  r[20]=1
-  41    Goto        0   43    0                                                    0
-  42    Column      3    0   21                                                    0  r[21]=idx_products_price.price
-  43    Function    0   19   19  stat_push                                         0  r[19]=func(r[19..20])
-  44  Next          3   37    0                                                    0
-  45  Function      0   19   23  stat_get                                          0  r[23]=func(r[19])
-  46  IsNull       23   51    0                                                    0  if (r[23]==NULL) goto 51
-  47  Copy         23   26    0                                                    0  r[26]=r[23]
-  48  MakeRecord   24    3   27                                                    0  r[27]=mkrec(r[24..26])
-  49  NewRowid      1   28    0                                                    0  r[28]=rowid
-  50  Insert        1   27   28  sqlite_stat1                                      0  intkey=r[28] data=r[27]
-  51  OpenRead      4    4    0  k(2,B)                                            0  =idx_products_category, root=4, iDb=0
-  52  Integer       1   30    0                                                    0  r[30]=1
-  53  Function      0   30   29  stat_init                                         0  r[29]=func(r[30])
-  54  Rewind        4   71    0                                                    0  Rewind  idx_products_category
-  55  Integer       0   30    0                                                    0  r[30]=0
-  56  Goto          0   62    0                                                    0
-  57    Integer     0   30    0                                                    0  r[30]=0
-  58    Column      4    0   32                                                    0  r[32]=idx_products_category.category
-  59    Ne         32   31   62                                                    0  if r[32]!=r[31] goto 62
-  60    Integer     1   30    0                                                    0  r[30]=1
-  61    Goto        0   63    0                                                    0
-  62    Column      4    0   31                                                    0  r[31]=idx_products_category.category
-  63    Function    0   29   29  stat_push                                         0  r[29]=func(r[29..30])
-  64  Next          4   57    0                                                    0
-  65  Function      0   29   33  stat_get                                          0  r[33]=func(r[29])
-  66  IsNull       33   71    0                                                    0  if (r[33]==NULL) goto 71
-  67  Copy         33   36    0                                                    0  r[36]=r[33]
-  68  MakeRecord   34    3   37                                                    0  r[37]=mkrec(r[34..36])
-  69  NewRowid      1   38    0                                                    0  r[38]=rowid
-  70  Insert        1   37   38  sqlite_stat1                                      0  intkey=r[38] data=r[37]
-  71  OpenRead      5    3    0  k(2,B)                                            0  =idx_products_sku, root=3, iDb=0
-  72  Integer       1   40    0                                                    0  r[40]=1
-  73  Function      0   40   39  stat_init                                         0  r[39]=func(r[40])
-  74  Rewind        5   91    0                                                    0  Rewind  idx_products_sku
-  75  Integer       0   40    0                                                    0  r[40]=0
-  76  Goto          0   82    0                                                    0
-  77    Integer     0   40    0                                                    0  r[40]=0
-  78    Column      5    0   42                                                    0  r[42]=idx_products_sku.sku
-  79    Ne         42   41   82                                                    0  if r[42]!=r[41] goto 82
-  80    Integer     1   40    0                                                    0  r[40]=1
-  81    Goto        0   83    0                                                    0
-  82    Column      5    0   41                                                    0  r[41]=idx_products_sku.sku
-  83    Function    0   39   39  stat_push                                         0  r[39]=func(r[39..40])
-  84  Next          5   77    0                                                    0
-  85  Function      0   39   43  stat_get                                          0  r[43]=func(r[39])
-  86  IsNull       43   91    0                                                    0  if (r[43]==NULL) goto 91
-  87  Copy         43   46    0                                                    0  r[46]=r[43]
-  88  MakeRecord   44    3   47                                                    0  r[47]=mkrec(r[44..46])
-  89  NewRowid      1   48    0                                                    0  r[48]=rowid
-  90  Insert        1   47   48  sqlite_stat1                                      0  intkey=r[48] data=r[47]
-  91  Rewind        1   98    0                                                    0  Rewind  sqlite_stat1
-  92      Column    1    0   49                                                    0  r[49]=sqlite_stat1.tbl
-  93      Ne       49   50   97                                                    0  if r[49]!=r[50] goto 97
-  94      RowId     1   51    0                                                    0  r[51]=sqlite_stat1.rowid
-  95      Delete    1    0    0  sqlite_stat1                                      0
-  96    Next        1   92    0                                                    0
-  97  Next          1   92    0                                                    0
-  98  OpenRead      6    9    0  k(5,B,B,B,B,B)                                    0  =inventory, root=9, iDb=0
-  99  Count         6   57    0                                                    0
- 100  IfNot        57  107    0                                                    0  if !r[57] goto 107
- 101  Null          0   54    0                                                    0  r[54]=NULL
- 102  Copy         57   55    0                                                    0  r[55]=r[57]
- 103  Cast         55    0    0                                                    0  affinity(r[55]=Text)
- 104  MakeRecord   53    3   56                                                    0  r[56]=mkrec(r[53..55])
- 105  NewRowid      1   52    0                                                    0  r[52]=rowid
- 106  Insert        1   56   52  sqlite_stat1                                      0  intkey=r[52] data=r[56]
- 107  OpenRead      7   10    0  k(4,B,B,B)                                        0  =idx_inventory_location, root=10, iDb=0
- 108  Integer       3   59    0                                                    0  r[59]=3
- 109  Function      0   59   58  stat_init                                         0  r[58]=func(r[59])
- 110  Rewind        7  135    0                                                    0  Rewind  idx_inventory_location
- 111  Integer       0   59    0                                                    0  r[59]=0
- 112  Goto          0  124    0                                                    0
- 113    Integer     0   59    0                                                    0  r[59]=0
- 114    Column      7    0   63                                                    0  r[63]=idx_inventory_location.warehouse_id
- 115    Ne         63   60  124                                                    0  if r[63]!=r[60] goto 124
- 116    Integer     1   59    0                                                    0  r[59]=1
- 117    Column      7    1   63                                                    0  r[63]=idx_inventory_location.product_id
- 118    Ne         63   61  125                                                    0  if r[63]!=r[61] goto 125
- 119    Integer     2   59    0                                                    0  r[59]=2
- 120    Column      7    2   63                                                    0  r[63]=idx_inventory_location.bin_location
- 121    Ne         63   62  126                                                    0  if r[63]!=r[62] goto 126
- 122    Integer     3   59    0                                                    0  r[59]=3
- 123    Goto        0  127    0                                                    0
- 124    Column      7    0   60                                                    0  r[60]=idx_inventory_location.warehouse_id
- 125    Column      7    1   61                                                    0  r[61]=idx_inventory_location.product_id
- 126    Column      7    2   62                                                    0  r[62]=idx_inventory_location.bin_location
- 127    Function    0   58   58  stat_push                                         0  r[58]=func(r[58..59])
- 128  Next          7  113    0                                                    0
- 129  Function      0   58   64  stat_get                                          0  r[64]=func(r[58])
- 130  IsNull       64  135    0                                                    0  if (r[64]==NULL) goto 135
- 131  Copy         64   67    0                                                    0  r[67]=r[64]
- 132  MakeRecord   65    3   68                                                    0  r[68]=mkrec(r[65..67])
- 133  NewRowid      1   69    0                                                    0  r[69]=rowid
- 134  Insert        1   68   69  sqlite_stat1                                      0  intkey=r[69] data=r[68]
- 135  Rewind        1  142    0                                                    0  Rewind  sqlite_stat1
- 136      Column    1    0   70                                                    0  r[70]=sqlite_stat1.tbl
- 137      Ne       70   71  141                                                    0  if r[70]!=r[71] goto 141
- 138      RowId     1   72    0                                                    0  r[72]=sqlite_stat1.rowid
- 139      Delete    1    0    0  sqlite_stat1                                      0
- 140    Next        1  136    0                                                    0
- 141  Next          1  136    0                                                    0
- 142  OpenRead      8    6    0  k(5,B,B,B,B,B)                                    0  =orders, root=6, iDb=0
- 143  Count         8   78    0                                                    0
- 144  IfNot        78  151    0                                                    0  if !r[78] goto 151
- 145  Null          0   75    0                                                    0  r[75]=NULL
- 146  Copy         78   76    0                                                    0  r[76]=r[78]
- 147  Cast         76    0    0                                                    0  affinity(r[76]=Text)
- 148  MakeRecord   74    3   77                                                    0  r[77]=mkrec(r[74..76])
- 149  NewRowid      1   73    0                                                    0  r[73]=rowid
- 150  Insert        1   77   73  sqlite_stat1                                      0  intkey=r[73] data=r[77]
- 151  OpenRead      9    8    0  k(2,B)                                            0  =idx_orders_status, root=8, iDb=0
- 152  Integer       1   80    0                                                    0  r[80]=1
- 153  Function      0   80   79  stat_init                                         0  r[79]=func(r[80])
- 154  Rewind        9  171    0                                                    0  Rewind  idx_orders_status
- 155  Integer       0   80    0                                                    0  r[80]=0
- 156  Goto          0  162    0                                                    0
- 157    Integer     0   80    0                                                    0  r[80]=0
- 158    Column      9    0   82                                                    0  r[82]=idx_orders_status.status
- 159    Ne         82   81  162                                                    0  if r[82]!=r[81] goto 162
- 160    Integer     1   80    0                                                    0  r[80]=1
- 161    Goto        0  163    0                                                    0
- 162    Column      9    0   81                                                    0  r[81]=idx_orders_status.status
- 163    Function    0   79   79  stat_push                                         0  r[79]=func(r[79..80])
- 164  Next          9  157    0                                                    0
- 165  Function      0   79   83  stat_get                                          0  r[83]=func(r[79])
- 166  IsNull       83  171    0                                                    0  if (r[83]==NULL) goto 171
- 167  Copy         83   86    0                                                    0  r[86]=r[83]
- 168  MakeRecord   84    3   87                                                    0  r[87]=mkrec(r[84..86])
- 169  NewRowid      1   88    0                                                    0  r[88]=rowid
- 170  Insert        1   87   88  sqlite_stat1                                      0  intkey=r[88] data=r[87]
- 171  OpenRead     10    7    0  k(3,B,B)                                          0  =idx_orders_customer_date, root=7, iDb=0
- 172  Integer       2   90    0                                                    0  r[90]=2
- 173  Function      0   90   89  stat_init                                         0  r[89]=func(r[90])
- 174  Rewind       10  195    0                                                    0  Rewind  idx_orders_customer_date
- 175  Integer       0   90    0                                                    0  r[90]=0
- 176  Goto          0  185    0                                                    0
- 177    Integer     0   90    0                                                    0  r[90]=0
- 178    Column     10    0   93                                                    0  r[93]=idx_orders_customer_date.customer_id
- 179    Ne         93   91  185                                                    0  if r[93]!=r[91] goto 185
- 180    Integer     1   90    0                                                    0  r[90]=1
- 181    Column     10    1   93                                                    0  r[93]=idx_orders_customer_date.order_date
- 182    Ne         93   92  186                                                    0  if r[93]!=r[92] goto 186
- 183    Integer     2   90    0                                                    0  r[90]=2
- 184    Goto        0  187    0                                                    0
- 185    Column     10    0   91                                                    0  r[91]=idx_orders_customer_date.customer_id
- 186    Column     10    1   92                                                    0  r[92]=idx_orders_customer_date.order_date
- 187    Function    0   89   89  stat_push                                         0  r[89]=func(r[89..90])
- 188  Next         10  177    0                                                    0
- 189  Function      0   89   94  stat_get                                          0  r[94]=func(r[89])
- 190  IsNull       94  195    0                                                    0  if (r[94]==NULL) goto 195
- 191  Copy         94   97    0                                                    0  r[97]=r[94]
- 192  MakeRecord   95    3   98                                                    0  r[98]=mkrec(r[95..97])
- 193  NewRowid      1   99    0                                                    0  r[99]=rowid
- 194  Insert        1   98   99  sqlite_stat1                                      0  intkey=r[99] data=r[98]
- 195  Halt          0    0    0                                                    0
- 196  Transaction   0    2    9                                                    0  iDb=0 tx_mode=Write
- 197  String8       0   11    0  products                                          0  r[11]='products'
- 198  String8       0   14    0  products                                          0  r[14]='products'
- 199  String8       0   24    0  products                                          0  r[24]='products'
- 200  String8       0   25    0  idx_products_price                                0  r[25]='idx_products_price'
- 201  String8       0   34    0  products                                          0  r[34]='products'
- 202  String8       0   35    0  idx_products_category                             0  r[35]='idx_products_category'
- 203  String8       0   44    0  products                                          0  r[44]='products'
- 204  String8       0   45    0  idx_products_sku                                  0  r[45]='idx_products_sku'
- 205  String8       0   50    0  inventory                                         0  r[50]='inventory'
- 206  String8       0   53    0  inventory                                         0  r[53]='inventory'
- 207  String8       0   65    0  inventory                                         0  r[65]='inventory'
- 208  String8       0   66    0  idx_inventory_location                            0  r[66]='idx_inventory_location'
- 209  String8       0   71    0  orders                                            0  r[71]='orders'
- 210  String8       0   74    0  orders                                            0  r[74]='orders'
- 211  String8       0   84    0  orders                                            0  r[84]='orders'
- 212  String8       0   85    0  idx_orders_status                                 0  r[85]='idx_orders_status'
- 213  String8       0   95    0  orders                                            0  r[95]='orders'
- 214  String8       0   96    0  idx_orders_customer_date                          0  r[96]='idx_orders_customer_date'
- 215  Goto          0    1    0                                                    0
+  23  OpenRead      3    5    0  k(2,B)                                            0  =idx_products_price, root=5, iDb=0
+  24  Integer       1   15    0                                                    0  r[15]=1
+  25  Function      0   15   14  stat_init                                         0  r[14]=func(r[15])
+  26  Rewind        3   43    0                                                    0  Rewind  idx_products_price
+  27  Integer       0   15    0                                                    0  r[15]=0
+  28  Goto          0   34    0                                                    0
+  29    Integer     0   15    0                                                    0  r[15]=0
+  30    Column      3    0   17                                                    0  r[17]=idx_products_price.price
+  31    Ne         17   16   34                                                    0  if r[17]!=r[16] goto 34
+  32    Integer     1   15    0                                                    0  r[15]=1
+  33    Goto        0   35    0                                                    0
+  34    Column      3    0   16                                                    0  r[16]=idx_products_price.price
+  35    Function    0   14   14  stat_push                                         0  r[14]=func(r[14..15])
+  36  Next          3   29    0                                                    0
+  37  Function      0   14   18  stat_get                                          0  r[18]=func(r[14])
+  38  IsNull       18   43    0                                                    0  if (r[18]==NULL) goto 43
+  39  Copy         18   21    0                                                    0  r[21]=r[18]
+  40  MakeRecord   19    3   22                                                    0  r[22]=mkrec(r[19..21])
+  41  NewRowid      1   23    0                                                    0  r[23]=rowid
+  42  Insert        1   22   23  sqlite_stat1                                      0  intkey=r[23] data=r[22]
+  43  OpenRead      4    4    0  k(2,B)                                            0  =idx_products_category, root=4, iDb=0
+  44  Integer       1   25    0                                                    0  r[25]=1
+  45  Function      0   25   24  stat_init                                         0  r[24]=func(r[25])
+  46  Rewind        4   63    0                                                    0  Rewind  idx_products_category
+  47  Integer       0   25    0                                                    0  r[25]=0
+  48  Goto          0   54    0                                                    0
+  49    Integer     0   25    0                                                    0  r[25]=0
+  50    Column      4    0   27                                                    0  r[27]=idx_products_category.category
+  51    Ne         27   26   54                                                    0  if r[27]!=r[26] goto 54
+  52    Integer     1   25    0                                                    0  r[25]=1
+  53    Goto        0   55    0                                                    0
+  54    Column      4    0   26                                                    0  r[26]=idx_products_category.category
+  55    Function    0   24   24  stat_push                                         0  r[24]=func(r[24..25])
+  56  Next          4   49    0                                                    0
+  57  Function      0   24   28  stat_get                                          0  r[28]=func(r[24])
+  58  IsNull       28   63    0                                                    0  if (r[28]==NULL) goto 63
+  59  Copy         28   31    0                                                    0  r[31]=r[28]
+  60  MakeRecord   29    3   32                                                    0  r[32]=mkrec(r[29..31])
+  61  NewRowid      1   33    0                                                    0  r[33]=rowid
+  62  Insert        1   32   33  sqlite_stat1                                      0  intkey=r[33] data=r[32]
+  63  OpenRead      5    3    0  k(2,B)                                            0  =idx_products_sku, root=3, iDb=0
+  64  Integer       1   35    0                                                    0  r[35]=1
+  65  Function      0   35   34  stat_init                                         0  r[34]=func(r[35])
+  66  Rewind        5   83    0                                                    0  Rewind  idx_products_sku
+  67  Integer       0   35    0                                                    0  r[35]=0
+  68  Goto          0   74    0                                                    0
+  69    Integer     0   35    0                                                    0  r[35]=0
+  70    Column      5    0   37                                                    0  r[37]=idx_products_sku.sku
+  71    Ne         37   36   74                                                    0  if r[37]!=r[36] goto 74
+  72    Integer     1   35    0                                                    0  r[35]=1
+  73    Goto        0   75    0                                                    0
+  74    Column      5    0   36                                                    0  r[36]=idx_products_sku.sku
+  75    Function    0   34   34  stat_push                                         0  r[34]=func(r[34..35])
+  76  Next          5   69    0                                                    0
+  77  Function      0   34   38  stat_get                                          0  r[38]=func(r[34])
+  78  IsNull       38   83    0                                                    0  if (r[38]==NULL) goto 83
+  79  Copy         38   41    0                                                    0  r[41]=r[38]
+  80  MakeRecord   39    3   42                                                    0  r[42]=mkrec(r[39..41])
+  81  NewRowid      1   43    0                                                    0  r[43]=rowid
+  82  Insert        1   42   43  sqlite_stat1                                      0  intkey=r[43] data=r[42]
+  83  Rewind        1   90    0                                                    0  Rewind  sqlite_stat1
+  84      Column    1    0   44                                                    0  r[44]=sqlite_stat1.tbl
+  85      Ne       44   45   89                                                    0  if r[44]!=r[45] goto 89
+  86      RowId     1   46    0                                                    0  r[46]=sqlite_stat1.rowid
+  87      Delete    1    0    0  sqlite_stat1                                      0
+  88    Next        1   84    0                                                    0
+  89  Next          1   84    0                                                    0
+  90  OpenRead      6    9    0  k(5,B,B,B,B,B)                                    0  =inventory, root=9, iDb=0
+  91  OpenRead      7   10    0  k(4,B,B,B)                                        0  =idx_inventory_location, root=10, iDb=0
+  92  Integer       3   49    0                                                    0  r[49]=3
+  93  Function      0   49   48  stat_init                                         0  r[48]=func(r[49])
+  94  Rewind        7  119    0                                                    0  Rewind  idx_inventory_location
+  95  Integer       0   49    0                                                    0  r[49]=0
+  96  Goto          0  108    0                                                    0
+  97    Integer     0   49    0                                                    0  r[49]=0
+  98    Column      7    0   53                                                    0  r[53]=idx_inventory_location.warehouse_id
+  99    Ne         53   50  108                                                    0  if r[53]!=r[50] goto 108
+ 100    Integer     1   49    0                                                    0  r[49]=1
+ 101    Column      7    1   53                                                    0  r[53]=idx_inventory_location.product_id
+ 102    Ne         53   51  109                                                    0  if r[53]!=r[51] goto 109
+ 103    Integer     2   49    0                                                    0  r[49]=2
+ 104    Column      7    2   53                                                    0  r[53]=idx_inventory_location.bin_location
+ 105    Ne         53   52  110                                                    0  if r[53]!=r[52] goto 110
+ 106    Integer     3   49    0                                                    0  r[49]=3
+ 107    Goto        0  111    0                                                    0
+ 108    Column      7    0   50                                                    0  r[50]=idx_inventory_location.warehouse_id
+ 109    Column      7    1   51                                                    0  r[51]=idx_inventory_location.product_id
+ 110    Column      7    2   52                                                    0  r[52]=idx_inventory_location.bin_location
+ 111    Function    0   48   48  stat_push                                         0  r[48]=func(r[48..49])
+ 112  Next          7   97    0                                                    0
+ 113  Function      0   48   54  stat_get                                          0  r[54]=func(r[48])
+ 114  IsNull       54  119    0                                                    0  if (r[54]==NULL) goto 119
+ 115  Copy         54   57    0                                                    0  r[57]=r[54]
+ 116  MakeRecord   55    3   58                                                    0  r[58]=mkrec(r[55..57])
+ 117  NewRowid      1   59    0                                                    0  r[59]=rowid
+ 118  Insert        1   58   59  sqlite_stat1                                      0  intkey=r[59] data=r[58]
+ 119  Rewind        1  126    0                                                    0  Rewind  sqlite_stat1
+ 120      Column    1    0   60                                                    0  r[60]=sqlite_stat1.tbl
+ 121      Ne       60   61  125                                                    0  if r[60]!=r[61] goto 125
+ 122      RowId     1   62    0                                                    0  r[62]=sqlite_stat1.rowid
+ 123      Delete    1    0    0  sqlite_stat1                                      0
+ 124    Next        1  120    0                                                    0
+ 125  Next          1  120    0                                                    0
+ 126  OpenRead      8    6    0  k(5,B,B,B,B,B)                                    0  =orders, root=6, iDb=0
+ 127  OpenRead      9    8    0  k(2,B)                                            0  =idx_orders_status, root=8, iDb=0
+ 128  Integer       1   65    0                                                    0  r[65]=1
+ 129  Function      0   65   64  stat_init                                         0  r[64]=func(r[65])
+ 130  Rewind        9  147    0                                                    0  Rewind  idx_orders_status
+ 131  Integer       0   65    0                                                    0  r[65]=0
+ 132  Goto          0  138    0                                                    0
+ 133    Integer     0   65    0                                                    0  r[65]=0
+ 134    Column      9    0   67                                                    0  r[67]=idx_orders_status.status
+ 135    Ne         67   66  138                                                    0  if r[67]!=r[66] goto 138
+ 136    Integer     1   65    0                                                    0  r[65]=1
+ 137    Goto        0  139    0                                                    0
+ 138    Column      9    0   66                                                    0  r[66]=idx_orders_status.status
+ 139    Function    0   64   64  stat_push                                         0  r[64]=func(r[64..65])
+ 140  Next          9  133    0                                                    0
+ 141  Function      0   64   68  stat_get                                          0  r[68]=func(r[64])
+ 142  IsNull       68  147    0                                                    0  if (r[68]==NULL) goto 147
+ 143  Copy         68   71    0                                                    0  r[71]=r[68]
+ 144  MakeRecord   69    3   72                                                    0  r[72]=mkrec(r[69..71])
+ 145  NewRowid      1   73    0                                                    0  r[73]=rowid
+ 146  Insert        1   72   73  sqlite_stat1                                      0  intkey=r[73] data=r[72]
+ 147  OpenRead     10    7    0  k(3,B,B)                                          0  =idx_orders_customer_date, root=7, iDb=0
+ 148  Integer       2   75    0                                                    0  r[75]=2
+ 149  Function      0   75   74  stat_init                                         0  r[74]=func(r[75])
+ 150  Rewind       10  171    0                                                    0  Rewind  idx_orders_customer_date
+ 151  Integer       0   75    0                                                    0  r[75]=0
+ 152  Goto          0  161    0                                                    0
+ 153    Integer     0   75    0                                                    0  r[75]=0
+ 154    Column     10    0   78                                                    0  r[78]=idx_orders_customer_date.customer_id
+ 155    Ne         78   76  161                                                    0  if r[78]!=r[76] goto 161
+ 156    Integer     1   75    0                                                    0  r[75]=1
+ 157    Column     10    1   78                                                    0  r[78]=idx_orders_customer_date.order_date
+ 158    Ne         78   77  162                                                    0  if r[78]!=r[77] goto 162
+ 159    Integer     2   75    0                                                    0  r[75]=2
+ 160    Goto        0  163    0                                                    0
+ 161    Column     10    0   76                                                    0  r[76]=idx_orders_customer_date.customer_id
+ 162    Column     10    1   77                                                    0  r[77]=idx_orders_customer_date.order_date
+ 163    Function    0   74   74  stat_push                                         0  r[74]=func(r[74..75])
+ 164  Next         10  153    0                                                    0
+ 165  Function      0   74   79  stat_get                                          0  r[79]=func(r[74])
+ 166  IsNull       79  171    0                                                    0  if (r[79]==NULL) goto 171
+ 167  Copy         79   82    0                                                    0  r[82]=r[79]
+ 168  MakeRecord   80    3   83                                                    0  r[83]=mkrec(r[80..82])
+ 169  NewRowid      1   84    0                                                    0  r[84]=rowid
+ 170  Insert        1   83   84  sqlite_stat1                                      0  intkey=r[84] data=r[83]
+ 171  Halt          0    0    0                                                    0
+ 172  Transaction   0    2    9                                                    0  iDb=0 tx_mode=Write
+ 173  String8       0   11    0  products                                          0  r[11]='products'
+ 174  String8       0   13    0  products                                          0  r[13]='products'
+ 175  String8       0   19    0  products                                          0  r[19]='products'
+ 176  String8       0   20    0  idx_products_price                                0  r[20]='idx_products_price'
+ 177  String8       0   29    0  products                                          0  r[29]='products'
+ 178  String8       0   30    0  idx_products_category                             0  r[30]='idx_products_category'
+ 179  String8       0   39    0  products                                          0  r[39]='products'
+ 180  String8       0   40    0  idx_products_sku                                  0  r[40]='idx_products_sku'
+ 181  String8       0   45    0  inventory                                         0  r[45]='inventory'
+ 182  String8       0   47    0  inventory                                         0  r[47]='inventory'
+ 183  String8       0   55    0  inventory                                         0  r[55]='inventory'
+ 184  String8       0   56    0  idx_inventory_location                            0  r[56]='idx_inventory_location'
+ 185  String8       0   61    0  orders                                            0  r[61]='orders'
+ 186  String8       0   63    0  orders                                            0  r[63]='orders'
+ 187  String8       0   69    0  orders                                            0  r[69]='orders'
+ 188  String8       0   70    0  idx_orders_status                                 0  r[70]='idx_orders_status'
+ 189  String8       0   80    0  orders                                            0  r[80]='orders'
+ 190  String8       0   81    0  idx_orders_customer_date                          0  r[81]='idx_orders_customer_date'
+ 191  Goto          0    1    0                                                    0

--- a/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-empty-table.snap
+++ b/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-empty-table.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4                                               p5  comment
-   0  Init          0  92   0                                                    0  Start at 92
+   0  Init          0  84   0                                                    0  Start at 84
    1  Null          0   1   0                                                    0  r[1]=NULL
    2  CreateBtree   0   2   1                                                    0  r[2]=root iDb=0 flags=1
    3  OpenWrite     0   1   0                                                    0  root=1; iDb=0
@@ -35,82 +35,74 @@ addr  opcode       p1  p2  p3  p4                                               
   20    Next        1  16   0                                                    0
   21  Next          1  16   0                                                    0
   22  OpenRead      2   2   0  k(6,B,B,B,B,B,B)                                  0  =products, root=2, iDb=0
-  23  Count         2  18   0                                                    0
-  24  IfNot        18  31   0                                                    0  if !r[18] goto 31
-  25  Null          0  15   0                                                    0  r[15]=NULL
-  26  Copy         18  16   0                                                    0  r[16]=r[18]
-  27  Cast         16   0   0                                                    0  affinity(r[16]=Text)
-  28  MakeRecord   14   3  17                                                    0  r[17]=mkrec(r[14..16])
-  29  NewRowid      1  13   0                                                    0  r[13]=rowid
-  30  Insert        1  17  13  sqlite_stat1                                      0  intkey=r[13] data=r[17]
-  31  OpenRead      3   5   0  k(2,B)                                            0  =idx_products_price, root=5, iDb=0
-  32  Integer       1  20   0                                                    0  r[20]=1
-  33  Function      0  20  19  stat_init                                         0  r[19]=func(r[20])
-  34  Rewind        3  51   0                                                    0  Rewind  idx_products_price
-  35  Integer       0  20   0                                                    0  r[20]=0
-  36  Goto          0  42   0                                                    0
-  37    Integer     0  20   0                                                    0  r[20]=0
-  38    Column      3   0  22                                                    0  r[22]=idx_products_price.price
-  39    Ne         22  21  42                                                    0  if r[22]!=r[21] goto 42
-  40    Integer     1  20   0                                                    0  r[20]=1
-  41    Goto        0  43   0                                                    0
-  42    Column      3   0  21                                                    0  r[21]=idx_products_price.price
-  43    Function    0  19  19  stat_push                                         0  r[19]=func(r[19..20])
-  44  Next          3  37   0                                                    0
-  45  Function      0  19  23  stat_get                                          0  r[23]=func(r[19])
-  46  IsNull       23  51   0                                                    0  if (r[23]==NULL) goto 51
-  47  Copy         23  26   0                                                    0  r[26]=r[23]
-  48  MakeRecord   24   3  27                                                    0  r[27]=mkrec(r[24..26])
-  49  NewRowid      1  28   0                                                    0  r[28]=rowid
-  50  Insert        1  27  28  sqlite_stat1                                      0  intkey=r[28] data=r[27]
-  51  OpenRead      4   4   0  k(2,B)                                            0  =idx_products_category, root=4, iDb=0
-  52  Integer       1  30   0                                                    0  r[30]=1
-  53  Function      0  30  29  stat_init                                         0  r[29]=func(r[30])
-  54  Rewind        4  71   0                                                    0  Rewind  idx_products_category
-  55  Integer       0  30   0                                                    0  r[30]=0
-  56  Goto          0  62   0                                                    0
-  57    Integer     0  30   0                                                    0  r[30]=0
-  58    Column      4   0  32                                                    0  r[32]=idx_products_category.category
-  59    Ne         32  31  62                                                    0  if r[32]!=r[31] goto 62
-  60    Integer     1  30   0                                                    0  r[30]=1
-  61    Goto        0  63   0                                                    0
-  62    Column      4   0  31                                                    0  r[31]=idx_products_category.category
-  63    Function    0  29  29  stat_push                                         0  r[29]=func(r[29..30])
-  64  Next          4  57   0                                                    0
-  65  Function      0  29  33  stat_get                                          0  r[33]=func(r[29])
-  66  IsNull       33  71   0                                                    0  if (r[33]==NULL) goto 71
-  67  Copy         33  36   0                                                    0  r[36]=r[33]
-  68  MakeRecord   34   3  37                                                    0  r[37]=mkrec(r[34..36])
-  69  NewRowid      1  38   0                                                    0  r[38]=rowid
-  70  Insert        1  37  38  sqlite_stat1                                      0  intkey=r[38] data=r[37]
-  71  OpenRead      5   3   0  k(2,B)                                            0  =idx_products_sku, root=3, iDb=0
-  72  Integer       1  40   0                                                    0  r[40]=1
-  73  Function      0  40  39  stat_init                                         0  r[39]=func(r[40])
-  74  Rewind        5  91   0                                                    0  Rewind  idx_products_sku
-  75  Integer       0  40   0                                                    0  r[40]=0
-  76  Goto          0  82   0                                                    0
-  77    Integer     0  40   0                                                    0  r[40]=0
-  78    Column      5   0  42                                                    0  r[42]=idx_products_sku.sku
-  79    Ne         42  41  82                                                    0  if r[42]!=r[41] goto 82
-  80    Integer     1  40   0                                                    0  r[40]=1
-  81    Goto        0  83   0                                                    0
-  82    Column      5   0  41                                                    0  r[41]=idx_products_sku.sku
-  83    Function    0  39  39  stat_push                                         0  r[39]=func(r[39..40])
-  84  Next          5  77   0                                                    0
-  85  Function      0  39  43  stat_get                                          0  r[43]=func(r[39])
-  86  IsNull       43  91   0                                                    0  if (r[43]==NULL) goto 91
-  87  Copy         43  46   0                                                    0  r[46]=r[43]
-  88  MakeRecord   44   3  47                                                    0  r[47]=mkrec(r[44..46])
-  89  NewRowid      1  48   0                                                    0  r[48]=rowid
-  90  Insert        1  47  48  sqlite_stat1                                      0  intkey=r[48] data=r[47]
-  91  Halt          0   0   0                                                    0
-  92  Transaction   0   2   9                                                    0  iDb=0 tx_mode=Write
-  93  String8       0  11   0  products                                          0  r[11]='products'
-  94  String8       0  14   0  products                                          0  r[14]='products'
-  95  String8       0  24   0  products                                          0  r[24]='products'
-  96  String8       0  25   0  idx_products_price                                0  r[25]='idx_products_price'
-  97  String8       0  34   0  products                                          0  r[34]='products'
-  98  String8       0  35   0  idx_products_category                             0  r[35]='idx_products_category'
-  99  String8       0  44   0  products                                          0  r[44]='products'
- 100  String8       0  45   0  idx_products_sku                                  0  r[45]='idx_products_sku'
- 101  Goto          0   1   0                                                    0
+  23  OpenRead      3   5   0  k(2,B)                                            0  =idx_products_price, root=5, iDb=0
+  24  Integer       1  15   0                                                    0  r[15]=1
+  25  Function      0  15  14  stat_init                                         0  r[14]=func(r[15])
+  26  Rewind        3  43   0                                                    0  Rewind  idx_products_price
+  27  Integer       0  15   0                                                    0  r[15]=0
+  28  Goto          0  34   0                                                    0
+  29    Integer     0  15   0                                                    0  r[15]=0
+  30    Column      3   0  17                                                    0  r[17]=idx_products_price.price
+  31    Ne         17  16  34                                                    0  if r[17]!=r[16] goto 34
+  32    Integer     1  15   0                                                    0  r[15]=1
+  33    Goto        0  35   0                                                    0
+  34    Column      3   0  16                                                    0  r[16]=idx_products_price.price
+  35    Function    0  14  14  stat_push                                         0  r[14]=func(r[14..15])
+  36  Next          3  29   0                                                    0
+  37  Function      0  14  18  stat_get                                          0  r[18]=func(r[14])
+  38  IsNull       18  43   0                                                    0  if (r[18]==NULL) goto 43
+  39  Copy         18  21   0                                                    0  r[21]=r[18]
+  40  MakeRecord   19   3  22                                                    0  r[22]=mkrec(r[19..21])
+  41  NewRowid      1  23   0                                                    0  r[23]=rowid
+  42  Insert        1  22  23  sqlite_stat1                                      0  intkey=r[23] data=r[22]
+  43  OpenRead      4   4   0  k(2,B)                                            0  =idx_products_category, root=4, iDb=0
+  44  Integer       1  25   0                                                    0  r[25]=1
+  45  Function      0  25  24  stat_init                                         0  r[24]=func(r[25])
+  46  Rewind        4  63   0                                                    0  Rewind  idx_products_category
+  47  Integer       0  25   0                                                    0  r[25]=0
+  48  Goto          0  54   0                                                    0
+  49    Integer     0  25   0                                                    0  r[25]=0
+  50    Column      4   0  27                                                    0  r[27]=idx_products_category.category
+  51    Ne         27  26  54                                                    0  if r[27]!=r[26] goto 54
+  52    Integer     1  25   0                                                    0  r[25]=1
+  53    Goto        0  55   0                                                    0
+  54    Column      4   0  26                                                    0  r[26]=idx_products_category.category
+  55    Function    0  24  24  stat_push                                         0  r[24]=func(r[24..25])
+  56  Next          4  49   0                                                    0
+  57  Function      0  24  28  stat_get                                          0  r[28]=func(r[24])
+  58  IsNull       28  63   0                                                    0  if (r[28]==NULL) goto 63
+  59  Copy         28  31   0                                                    0  r[31]=r[28]
+  60  MakeRecord   29   3  32                                                    0  r[32]=mkrec(r[29..31])
+  61  NewRowid      1  33   0                                                    0  r[33]=rowid
+  62  Insert        1  32  33  sqlite_stat1                                      0  intkey=r[33] data=r[32]
+  63  OpenRead      5   3   0  k(2,B)                                            0  =idx_products_sku, root=3, iDb=0
+  64  Integer       1  35   0                                                    0  r[35]=1
+  65  Function      0  35  34  stat_init                                         0  r[34]=func(r[35])
+  66  Rewind        5  83   0                                                    0  Rewind  idx_products_sku
+  67  Integer       0  35   0                                                    0  r[35]=0
+  68  Goto          0  74   0                                                    0
+  69    Integer     0  35   0                                                    0  r[35]=0
+  70    Column      5   0  37                                                    0  r[37]=idx_products_sku.sku
+  71    Ne         37  36  74                                                    0  if r[37]!=r[36] goto 74
+  72    Integer     1  35   0                                                    0  r[35]=1
+  73    Goto        0  75   0                                                    0
+  74    Column      5   0  36                                                    0  r[36]=idx_products_sku.sku
+  75    Function    0  34  34  stat_push                                         0  r[34]=func(r[34..35])
+  76  Next          5  69   0                                                    0
+  77  Function      0  34  38  stat_get                                          0  r[38]=func(r[34])
+  78  IsNull       38  83   0                                                    0  if (r[38]==NULL) goto 83
+  79  Copy         38  41   0                                                    0  r[41]=r[38]
+  80  MakeRecord   39   3  42                                                    0  r[42]=mkrec(r[39..41])
+  81  NewRowid      1  43   0                                                    0  r[43]=rowid
+  82  Insert        1  42  43  sqlite_stat1                                      0  intkey=r[43] data=r[42]
+  83  Halt          0   0   0                                                    0
+  84  Transaction   0   2   9                                                    0  iDb=0 tx_mode=Write
+  85  String8       0  11   0  products                                          0  r[11]='products'
+  86  String8       0  13   0  products                                          0  r[13]='products'
+  87  String8       0  19   0  products                                          0  r[19]='products'
+  88  String8       0  20   0  idx_products_price                                0  r[20]='idx_products_price'
+  89  String8       0  29   0  products                                          0  r[29]='products'
+  90  String8       0  30   0  idx_products_category                             0  r[30]='idx_products_category'
+  91  String8       0  39   0  products                                          0  r[39]='products'
+  92  String8       0  40   0  idx_products_sku                                  0  r[40]='idx_products_sku'
+  93  Goto          0   1   0                                                    0

--- a/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-index-stat1-exists.snap
+++ b/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-index-stat1-exists.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4              p5  comment
-   0  Init          0  42   0                   0  Start at 42
+   0  Init          0  34   0                   0  Start at 34
    1  Null          0   1   0                   0  r[1]=NULL
    2  OpenWrite     0   5   0                   0  root=5; iDb=0
    3  Rewind        0  12   0                   0  Rewind  sqlite_stat1
@@ -25,39 +25,31 @@ addr  opcode       p1  p2  p3  p4              p5  comment
   10    Next        0   4   0                   0
   11  Next          0   4   0                   0
   12  OpenRead      1   2   0  k(3,B,B,B)       0  =items, root=2, iDb=0
-  13  Count         1  12   0                   0
-  14  IfNot        12  21   0                   0  if !r[12] goto 21
-  15  Null          0   9   0                   0  r[9]=NULL
-  16  Copy         12  10   0                   0  r[10]=r[12]
-  17  Cast         10   0   0                   0  affinity(r[10]=Text)
-  18  MakeRecord    8   3  11                   0  r[11]=mkrec(r[8..10])
-  19  NewRowid      0   7   0                   0  r[7]=rowid
-  20  Insert        0  11   7  sqlite_stat1     0  intkey=r[7] data=r[11]
-  21  OpenRead      2   3   0  k(2,B)           0  =idx_items_name, root=3, iDb=0
-  22  Integer       1  14   0                   0  r[14]=1
-  23  Function      0  14  13  stat_init        0  r[13]=func(r[14])
-  24  Rewind        2  41   0                   0  Rewind  idx_items_name
-  25  Integer       0  14   0                   0  r[14]=0
-  26  Goto          0  32   0                   0
-  27    Integer     0  14   0                   0  r[14]=0
-  28    Column      2   0  16                   0  r[16]=idx_items_name.name
-  29    Ne         16  15  32                   0  if r[16]!=r[15] goto 32
-  30    Integer     1  14   0                   0  r[14]=1
-  31    Goto        0  33   0                   0
-  32    Column      2   0  15                   0  r[15]=idx_items_name.name
-  33    Function    0  13  13  stat_push        0  r[13]=func(r[13..14])
-  34  Next          2  27   0                   0
-  35  Function      0  13  17  stat_get         0  r[17]=func(r[13])
-  36  IsNull       17  41   0                   0  if (r[17]==NULL) goto 41
-  37  Copy         17  20   0                   0  r[20]=r[17]
-  38  MakeRecord   18   3  21                   0  r[21]=mkrec(r[18..20])
-  39  NewRowid      0  22   0                   0  r[22]=rowid
-  40  Insert        0  21  22  sqlite_stat1     0  intkey=r[22] data=r[21]
-  41  Halt          0   0   0                   0
-  42  Transaction   0   2   4                   0  iDb=0 tx_mode=Write
-  43  String8       0   3   0  items            0  r[3]='items'
-  44  String8       0   5   0  idx_items_name   0  r[5]='idx_items_name'
-  45  String8       0   8   0  items            0  r[8]='items'
-  46  String8       0  18   0  items            0  r[18]='items'
-  47  String8       0  19   0  idx_items_name   0  r[19]='idx_items_name'
-  48  Goto          0   1   0                   0
+  13  OpenRead      2   3   0  k(2,B)           0  =idx_items_name, root=3, iDb=0
+  14  Integer       1   9   0                   0  r[9]=1
+  15  Function      0   9   8  stat_init        0  r[8]=func(r[9])
+  16  Rewind        2  33   0                   0  Rewind  idx_items_name
+  17  Integer       0   9   0                   0  r[9]=0
+  18  Goto          0  24   0                   0
+  19    Integer     0   9   0                   0  r[9]=0
+  20    Column      2   0  11                   0  r[11]=idx_items_name.name
+  21    Ne         11  10  24                   0  if r[11]!=r[10] goto 24
+  22    Integer     1   9   0                   0  r[9]=1
+  23    Goto        0  25   0                   0
+  24    Column      2   0  10                   0  r[10]=idx_items_name.name
+  25    Function    0   8   8  stat_push        0  r[8]=func(r[8..9])
+  26  Next          2  19   0                   0
+  27  Function      0   8  12  stat_get         0  r[12]=func(r[8])
+  28  IsNull       12  33   0                   0  if (r[12]==NULL) goto 33
+  29  Copy         12  15   0                   0  r[15]=r[12]
+  30  MakeRecord   13   3  16                   0  r[16]=mkrec(r[13..15])
+  31  NewRowid      0  17   0                   0  r[17]=rowid
+  32  Insert        0  16  17  sqlite_stat1     0  intkey=r[17] data=r[16]
+  33  Halt          0   0   0                   0
+  34  Transaction   0   2   4                   0  iDb=0 tx_mode=Write
+  35  String8       0   3   0  items            0  r[3]='items'
+  36  String8       0   5   0  idx_items_name   0  r[5]='idx_items_name'
+  37  String8       0   7   0  items            0  r[7]='items'
+  38  String8       0  13   0  items            0  r[13]='items'
+  39  String8       0  14   0  idx_items_name   0  r[14]='idx_items_name'
+  40  Goto          0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-specific-index.snap
+++ b/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-specific-index.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4                                               p5  comment
-   0  Init          0  54   0                                                    0  Start at 54
+   0  Init          0  46   0                                                    0  Start at 46
    1  Null          0   1   0                                                    0  r[1]=NULL
    2  CreateBtree   0   2   1                                                    0  r[2]=root iDb=0 flags=1
    3  OpenWrite     0   1   0                                                    0  root=1; iDb=0
@@ -37,39 +37,31 @@ addr  opcode       p1  p2  p3  p4                                               
   22    Next        1  16   0                                                    0
   23  Next          1  16   0                                                    0
   24  OpenRead      2   2   0  k(6,B,B,B,B,B,B)                                  0  =products, root=2, iDb=0
-  25  Count         2  20   0                                                    0
-  26  IfNot        20  33   0                                                    0  if !r[20] goto 33
-  27  Null          0  17   0                                                    0  r[17]=NULL
-  28  Copy         20  18   0                                                    0  r[18]=r[20]
-  29  Cast         18   0   0                                                    0  affinity(r[18]=Text)
-  30  MakeRecord   16   3  19                                                    0  r[19]=mkrec(r[16..18])
-  31  NewRowid      1  15   0                                                    0  r[15]=rowid
-  32  Insert        1  19  15  sqlite_stat1                                      0  intkey=r[15] data=r[19]
-  33  OpenRead      3   3   0  k(2,B)                                            0  =idx_products_sku, root=3, iDb=0
-  34  Integer       1  22   0                                                    0  r[22]=1
-  35  Function      0  22  21  stat_init                                         0  r[21]=func(r[22])
-  36  Rewind        3  53   0                                                    0  Rewind  idx_products_sku
-  37  Integer       0  22   0                                                    0  r[22]=0
-  38  Goto          0  44   0                                                    0
-  39    Integer     0  22   0                                                    0  r[22]=0
-  40    Column      3   0  24                                                    0  r[24]=idx_products_sku.sku
-  41    Ne         24  23  44                                                    0  if r[24]!=r[23] goto 44
-  42    Integer     1  22   0                                                    0  r[22]=1
-  43    Goto        0  45   0                                                    0
-  44    Column      3   0  23                                                    0  r[23]=idx_products_sku.sku
-  45    Function    0  21  21  stat_push                                         0  r[21]=func(r[21..22])
-  46  Next          3  39   0                                                    0
-  47  Function      0  21  25  stat_get                                          0  r[25]=func(r[21])
-  48  IsNull       25  53   0                                                    0  if (r[25]==NULL) goto 53
-  49  Copy         25  28   0                                                    0  r[28]=r[25]
-  50  MakeRecord   26   3  29                                                    0  r[29]=mkrec(r[26..28])
-  51  NewRowid      1  30   0                                                    0  r[30]=rowid
-  52  Insert        1  29  30  sqlite_stat1                                      0  intkey=r[30] data=r[29]
-  53  Halt          0   0   0                                                    0
-  54  Transaction   0   2   9                                                    0  iDb=0 tx_mode=Write
-  55  String8       0  11   0  products                                          0  r[11]='products'
-  56  String8       0  13   0  idx_products_sku                                  0  r[13]='idx_products_sku'
-  57  String8       0  16   0  products                                          0  r[16]='products'
-  58  String8       0  26   0  products                                          0  r[26]='products'
-  59  String8       0  27   0  idx_products_sku                                  0  r[27]='idx_products_sku'
-  60  Goto          0   1   0                                                    0
+  25  OpenRead      3   3   0  k(2,B)                                            0  =idx_products_sku, root=3, iDb=0
+  26  Integer       1  17   0                                                    0  r[17]=1
+  27  Function      0  17  16  stat_init                                         0  r[16]=func(r[17])
+  28  Rewind        3  45   0                                                    0  Rewind  idx_products_sku
+  29  Integer       0  17   0                                                    0  r[17]=0
+  30  Goto          0  36   0                                                    0
+  31    Integer     0  17   0                                                    0  r[17]=0
+  32    Column      3   0  19                                                    0  r[19]=idx_products_sku.sku
+  33    Ne         19  18  36                                                    0  if r[19]!=r[18] goto 36
+  34    Integer     1  17   0                                                    0  r[17]=1
+  35    Goto        0  37   0                                                    0
+  36    Column      3   0  18                                                    0  r[18]=idx_products_sku.sku
+  37    Function    0  16  16  stat_push                                         0  r[16]=func(r[16..17])
+  38  Next          3  31   0                                                    0
+  39  Function      0  16  20  stat_get                                          0  r[20]=func(r[16])
+  40  IsNull       20  45   0                                                    0  if (r[20]==NULL) goto 45
+  41  Copy         20  23   0                                                    0  r[23]=r[20]
+  42  MakeRecord   21   3  24                                                    0  r[24]=mkrec(r[21..23])
+  43  NewRowid      1  25   0                                                    0  r[25]=rowid
+  44  Insert        1  24  25  sqlite_stat1                                      0  intkey=r[25] data=r[24]
+  45  Halt          0   0   0                                                    0
+  46  Transaction   0   2   9                                                    0  iDb=0 tx_mode=Write
+  47  String8       0  11   0  products                                          0  r[11]='products'
+  48  String8       0  13   0  idx_products_sku                                  0  r[13]='idx_products_sku'
+  49  String8       0  15   0  products                                          0  r[15]='products'
+  50  String8       0  21   0  products                                          0  r[21]='products'
+  51  String8       0  22   0  idx_products_sku                                  0  r[22]='idx_products_sku'
+  52  Goto          0   1   0                                                    0

--- a/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-stat1-exists.snap
+++ b/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__analyze-stat1-exists.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4                  p5  comment
-   0  Init          0  60   0                       0  Start at 60
+   0  Init          0  52   0                       0  Start at 52
    1  Null          0   1   0                       0  r[1]=NULL
    2  OpenWrite     0   5   0                       0  root=5; iDb=0
    3  Rewind        0  10   0                       0  Rewind  sqlite_stat1
@@ -23,60 +23,52 @@ addr  opcode       p1  p2  p3  p4                  p5  comment
    8    Next        0   4   0                       0
    9  Next          0   4   0                       0
   10  OpenRead      1   2   0  k(3,B,B,B)           0  =items, root=2, iDb=0
-  11  Count         1  10   0                       0
-  12  IfNot        10  19   0                       0  if !r[10] goto 19
-  13  Null          0   7   0                       0  r[7]=NULL
-  14  Copy         10   8   0                       0  r[8]=r[10]
-  15  Cast          8   0   0                       0  affinity(r[8]=Text)
-  16  MakeRecord    6   3   9                       0  r[9]=mkrec(r[6..8])
-  17  NewRowid      0   5   0                       0  r[5]=rowid
-  18  Insert        0   9   5  sqlite_stat1         0  intkey=r[5] data=r[9]
-  19  OpenRead      2   4   0  k(2,B)               0  =idx_items_category, root=4, iDb=0
-  20  Integer       1  12   0                       0  r[12]=1
-  21  Function      0  12  11  stat_init            0  r[11]=func(r[12])
-  22  Rewind        2  39   0                       0  Rewind  idx_items_category
-  23  Integer       0  12   0                       0  r[12]=0
-  24  Goto          0  30   0                       0
-  25    Integer     0  12   0                       0  r[12]=0
-  26    Column      2   0  14                       0  r[14]=idx_items_category.category
-  27    Ne         14  13  30                       0  if r[14]!=r[13] goto 30
-  28    Integer     1  12   0                       0  r[12]=1
-  29    Goto        0  31   0                       0
-  30    Column      2   0  13                       0  r[13]=idx_items_category.category
-  31    Function    0  11  11  stat_push            0  r[11]=func(r[11..12])
-  32  Next          2  25   0                       0
-  33  Function      0  11  15  stat_get             0  r[15]=func(r[11])
-  34  IsNull       15  39   0                       0  if (r[15]==NULL) goto 39
-  35  Copy         15  18   0                       0  r[18]=r[15]
-  36  MakeRecord   16   3  19                       0  r[19]=mkrec(r[16..18])
-  37  NewRowid      0  20   0                       0  r[20]=rowid
-  38  Insert        0  19  20  sqlite_stat1         0  intkey=r[20] data=r[19]
-  39  OpenRead      3   3   0  k(2,B)               0  =idx_items_name, root=3, iDb=0
-  40  Integer       1  22   0                       0  r[22]=1
-  41  Function      0  22  21  stat_init            0  r[21]=func(r[22])
-  42  Rewind        3  59   0                       0  Rewind  idx_items_name
-  43  Integer       0  22   0                       0  r[22]=0
-  44  Goto          0  50   0                       0
-  45    Integer     0  22   0                       0  r[22]=0
-  46    Column      3   0  24                       0  r[24]=idx_items_name.name
-  47    Ne         24  23  50                       0  if r[24]!=r[23] goto 50
-  48    Integer     1  22   0                       0  r[22]=1
-  49    Goto        0  51   0                       0
-  50    Column      3   0  23                       0  r[23]=idx_items_name.name
-  51    Function    0  21  21  stat_push            0  r[21]=func(r[21..22])
-  52  Next          3  45   0                       0
-  53  Function      0  21  25  stat_get             0  r[25]=func(r[21])
-  54  IsNull       25  59   0                       0  if (r[25]==NULL) goto 59
-  55  Copy         25  28   0                       0  r[28]=r[25]
-  56  MakeRecord   26   3  29                       0  r[29]=mkrec(r[26..28])
-  57  NewRowid      0  30   0                       0  r[30]=rowid
-  58  Insert        0  29  30  sqlite_stat1         0  intkey=r[30] data=r[29]
-  59  Halt          0   0   0                       0
-  60  Transaction   0   2   4                       0  iDb=0 tx_mode=Write
-  61  String8       0   3   0  items                0  r[3]='items'
-  62  String8       0   6   0  items                0  r[6]='items'
-  63  String8       0  16   0  items                0  r[16]='items'
-  64  String8       0  17   0  idx_items_category   0  r[17]='idx_items_category'
-  65  String8       0  26   0  items                0  r[26]='items'
-  66  String8       0  27   0  idx_items_name       0  r[27]='idx_items_name'
-  67  Goto          0   1   0                       0
+  11  OpenRead      2   4   0  k(2,B)               0  =idx_items_category, root=4, iDb=0
+  12  Integer       1   7   0                       0  r[7]=1
+  13  Function      0   7   6  stat_init            0  r[6]=func(r[7])
+  14  Rewind        2  31   0                       0  Rewind  idx_items_category
+  15  Integer       0   7   0                       0  r[7]=0
+  16  Goto          0  22   0                       0
+  17    Integer     0   7   0                       0  r[7]=0
+  18    Column      2   0   9                       0  r[9]=idx_items_category.category
+  19    Ne          9   8  22                       0  if r[9]!=r[8] goto 22
+  20    Integer     1   7   0                       0  r[7]=1
+  21    Goto        0  23   0                       0
+  22    Column      2   0   8                       0  r[8]=idx_items_category.category
+  23    Function    0   6   6  stat_push            0  r[6]=func(r[6..7])
+  24  Next          2  17   0                       0
+  25  Function      0   6  10  stat_get             0  r[10]=func(r[6])
+  26  IsNull       10  31   0                       0  if (r[10]==NULL) goto 31
+  27  Copy         10  13   0                       0  r[13]=r[10]
+  28  MakeRecord   11   3  14                       0  r[14]=mkrec(r[11..13])
+  29  NewRowid      0  15   0                       0  r[15]=rowid
+  30  Insert        0  14  15  sqlite_stat1         0  intkey=r[15] data=r[14]
+  31  OpenRead      3   3   0  k(2,B)               0  =idx_items_name, root=3, iDb=0
+  32  Integer       1  17   0                       0  r[17]=1
+  33  Function      0  17  16  stat_init            0  r[16]=func(r[17])
+  34  Rewind        3  51   0                       0  Rewind  idx_items_name
+  35  Integer       0  17   0                       0  r[17]=0
+  36  Goto          0  42   0                       0
+  37    Integer     0  17   0                       0  r[17]=0
+  38    Column      3   0  19                       0  r[19]=idx_items_name.name
+  39    Ne         19  18  42                       0  if r[19]!=r[18] goto 42
+  40    Integer     1  17   0                       0  r[17]=1
+  41    Goto        0  43   0                       0
+  42    Column      3   0  18                       0  r[18]=idx_items_name.name
+  43    Function    0  16  16  stat_push            0  r[16]=func(r[16..17])
+  44  Next          3  37   0                       0
+  45  Function      0  16  20  stat_get             0  r[20]=func(r[16])
+  46  IsNull       20  51   0                       0  if (r[20]==NULL) goto 51
+  47  Copy         20  23   0                       0  r[23]=r[20]
+  48  MakeRecord   21   3  24                       0  r[24]=mkrec(r[21..23])
+  49  NewRowid      0  25   0                       0  r[25]=rowid
+  50  Insert        0  24  25  sqlite_stat1         0  intkey=r[25] data=r[24]
+  51  Halt          0   0   0                       0
+  52  Transaction   0   2   4                       0  iDb=0 tx_mode=Write
+  53  String8       0   3   0  items                0  r[3]='items'
+  54  String8       0   5   0  items                0  r[5]='items'
+  55  String8       0  11   0  items                0  r[11]='items'
+  56  String8       0  12   0  idx_items_category   0  r[12]='idx_items_category'
+  57  String8       0  21   0  items                0  r[21]='items'
+  58  String8       0  22   0  idx_items_name       0  r[22]='idx_items_name'
+  59  Goto          0   1   0                       0

--- a/testing/sqltests/tests/snapshot_tests/analyze/stat1_rows.sqltest
+++ b/testing/sqltests/tests/snapshot_tests/analyze/stat1_rows.sqltest
@@ -1,0 +1,14 @@
+@database :memory:
+
+test analyze-indexed-table-does-not-insert-null-stat1-row {
+    CREATE TABLE t(a, b);
+    CREATE INDEX i_t_a ON t(a);
+    INSERT INTO t VALUES (1, 10), (2, 20), (2, 30);
+    ANALYZE;
+    SELECT tbl, coalesce(idx, '<null>'), stat
+    FROM sqlite_stat1
+    ORDER BY tbl, idx IS NOT NULL, idx;
+}
+expect {
+    t|i_t_a|3 2
+}


### PR DESCRIPTION
## Description

Make ANALYZE stop emitting the table-level sqlite_stat1(tbl, NULL, stat) row for indexed tables. Turso was inserting it unconditionally, unlike SQLite. Added a focused regression test for the reported repro.

## Motivation and context

This is a planner-statistics correctness bug. Indexed tables should only get index stat rows here, matching SQLite.

Closes #6299