### PR TITLE
fix: allow VACUUM INTO with an existing empty file

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14232,11 +14232,14 @@ fn op_vacuum_into_inner(
                     ));
                 }
 
-                // we always vacuum into a new file, so check if it exists
-                if std::path::Path::new(dest_path).exists() {
-                    return Err(LimboError::ParseError(format!(
-                        "output file already exists: {dest_path}"
-                    )));
+                // We allows vaccum into new file or a empty file, so check if it exits and, if it does, ensure it is empty.
+                match std::fs::metadata(dest_path) {
+                    Ok(meta) if meta.len() > 0 => {
+                        return Err(LimboError::ParseError(format!(
+                            "output file already exists: {dest_path}"
+                        )));
+                    }
+                    _ => {}
                 }
 
                 // Pin source metadata before building the destination. The

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14232,14 +14232,11 @@ fn op_vacuum_into_inner(
                     ));
                 }
 
-                // We allows vaccum into new file or a empty file, so check if it exits and, if it does, ensure it is empty.
-                match std::fs::metadata(dest_path) {
-                    Ok(meta) if meta.len() > 0 => {
-                        return Err(LimboError::ParseError(format!(
-                            "output file already exists: {dest_path}"
-                        )));
-                    }
-                    _ => {}
+                // we always vacuum into a new file, so check if it exists
+                if std::path::Path::new(dest_path).exists() {
+                    return Err(LimboError::ParseError(format!(
+                        "output file already exists: {dest_path}"
+                    )));
                 }
 
                 // Pin source metadata before building the destination. The

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14232,11 +14232,14 @@ fn op_vacuum_into_inner(
                     ));
                 }
 
-                // we always vacuum into a new file, so check if it exists
-                if std::path::Path::new(dest_path).exists() {
-                    return Err(LimboError::ParseError(format!(
-                        "output file already exists: {dest_path}"
-                    )));
+                // We allows vaccum into new file or a empty file, so check if it exits and, if it does, ensure it is empty.
+                match std::fs::metadata(dest_path) {
+                    Ok(meta) if meta.len() > 0 => {
+                        return Err(LimboError::ParseError(format!(
+                            "output file already exists: {dest_path}"
+                        )));
+                    }
+                    _ => {}
                 }
 
                 // Pin source metadata before building the destination. The
@@ -14306,6 +14309,12 @@ fn op_vacuum_into_inner(
                 // this is important for databases using encryption or checksums
                 // must be set before page 1 is allocated (before any schema operations)
                 dest_conn.set_reserved_bytes(reserved_space)?;
+
+                // The source database doesn't use checksums, so we must disable them
+                // in the destination to prevent them from overwriting our data.
+                if reserved_space != crate::storage::checksum::CHECKSUM_REQUIRED_RESERVED_BYTES {
+                    dest_conn.pager.load().reset_checksum_context();
+                }
 
                 // Capture source custom type definitions so that STRICT tables with
                 // custom type columns can resolve those types during CREATE TABLE

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14880,11 +14880,14 @@ fn op_vacuum_into_inner(
                     ));
                 }
 
-                // we always vacuum into a new file, so check if it exists
-                if std::path::Path::new(dest_path).exists() {
-                    return Err(LimboError::ParseError(format!(
-                        "output file already exists: {dest_path}"
-                    )));
+                // We allows vaccum into new file or a empty file, so check if it exits and, if it does, ensure it is empty.
+                match std::fs::metadata(dest_path) {
+                    Ok(meta) if meta.len() > 0 => {
+                        return Err(LimboError::ParseError(format!(
+                            "output file already exists: {dest_path}"
+                        )));
+                    }
+                    _ => {}
                 }
 
                 // Pin source metadata before building the output database. The

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14880,14 +14880,11 @@ fn op_vacuum_into_inner(
                     ));
                 }
 
-                // We allows vaccum into new file or a empty file, so check if it exits and, if it does, ensure it is empty.
-                match std::fs::metadata(dest_path) {
-                    Ok(meta) if meta.len() > 0 => {
-                        return Err(LimboError::ParseError(format!(
-                            "output file already exists: {dest_path}"
-                        )));
-                    }
-                    _ => {}
+                // we always vacuum into a new file, so check if it exists
+                if std::path::Path::new(dest_path).exists() {
+                    return Err(LimboError::ParseError(format!(
+                        "output file already exists: {dest_path}"
+                    )));
                 }
 
                 // Pin source metadata before building the output database. The

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14880,11 +14880,14 @@ fn op_vacuum_into_inner(
                     ));
                 }
 
-                // we always vacuum into a new file, so check if it exists
-                if std::path::Path::new(dest_path).exists() {
-                    return Err(LimboError::ParseError(format!(
-                        "output file already exists: {dest_path}"
-                    )));
+                // We allows vaccum into new file or a empty file, so check if it exits and, if it does, ensure it is empty.
+                match std::fs::metadata(dest_path) {
+                    Ok(meta) if meta.len() > 0 => {
+                        return Err(LimboError::ParseError(format!(
+                            "output file already exists: {dest_path}"
+                        )));
+                    }
+                    _ => {}
                 }
 
                 // Pin source metadata before building the output database. The
@@ -14956,6 +14959,12 @@ fn op_vacuum_into_inner(
                 // this is important for databases using encryption or checksums
                 // must be set before page 1 is allocated (before any schema operations)
                 output_conn.set_reserved_bytes(reserved_space)?;
+
+                // The source database doesn't use checksums, so we must disable them
+                // in the destination to prevent them from overwriting our data.
+                if reserved_space != crate::storage::checksum::CHECKSUM_REQUIRED_RESERVED_BYTES {
+                    output_conn.pager.load().reset_checksum_context();
+                }
 
                 mirror_symbols(&program.connection, &output_conn);
                 let source_custom_types = capture_custom_types(&program.connection, source_db_id);

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -115,7 +115,7 @@ fn test_vacuum_into_error_cases(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let result = conn.execute("VACUUM");
     assert!(result.is_err(), "Plain VACUUM should fail");
 
-    // 2. VACUUM INTO existing file should fail
+    // 2. VACUUM INTO existing non-empty file should fail
     let existing_path = dest_dir.path().join("existing.db");
     std::fs::write(&existing_path, b"existing content")?;
     let result = conn.execute(format!("VACUUM INTO '{}'", existing_path.to_str().unwrap()));
@@ -124,6 +124,16 @@ fn test_vacuum_into_error_cases(tmp_db: TempDatabase) -> anyhow::Result<()> {
     assert!(
         err_msg.contains("already exists") || err_msg.contains("output file"),
         "Error should mention file exists, got: {err_msg}"
+    );
+
+    // 2b. VACUUM INTO an existing but empty file should succeed
+    let empty_path = dest_dir.path().join("empty.db");
+    std::fs::write(&empty_path, b"")?;
+    assert!(empty_path.exists() && std::fs::metadata(&empty_path)?.len() == 0);
+    conn.execute(format!("VACUUM INTO '{}'", empty_path.to_str().unwrap()))?;
+    assert!(
+        std::fs::metadata(&empty_path)?.len() > 0,
+        "Destination should be populated after VACUUM INTO"
     );
 
     // 3. VACUUM INTO within transaction should fail

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -576,7 +576,7 @@ fn test_vacuum_into_error_cases(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let result = conn.execute("VACUUM");
     assert!(result.is_ok(), "Plain VACUUM should succeed");
 
-    // 2. VACUUM INTO existing file should fail
+    // 2. VACUUM INTO existing non-empty file should fail
     let existing_path = dest_dir.path().join("existing.db");
     std::fs::write(&existing_path, b"existing content")?;
     let result = conn.execute(format!("VACUUM INTO '{}'", existing_path.to_str().unwrap()));
@@ -585,6 +585,16 @@ fn test_vacuum_into_error_cases(tmp_db: TempDatabase) -> anyhow::Result<()> {
     assert!(
         err_msg.contains("already exists") || err_msg.contains("output file"),
         "Error should mention file exists, got: {err_msg}"
+    );
+
+    // 2b. VACUUM INTO an existing but empty file should succeed
+    let empty_path = dest_dir.path().join("empty.db");
+    std::fs::write(&empty_path, b"")?;
+    assert!(empty_path.exists() && std::fs::metadata(&empty_path)?.len() == 0);
+    conn.execute(format!("VACUUM INTO '{}'", empty_path.to_str().unwrap()))?;
+    assert!(
+        std::fs::metadata(&empty_path)?.len() > 0,
+        "Destination should be populated after VACUUM INTO"
     );
 
     // 3. VACUUM INTO within transaction should fail


### PR DESCRIPTION
## Description
VACUUM INTO was previously only checking whether the file exists. Added a check to verify if the file is empty before failing the VACUUM INTO operation.

## Motivation and context
Fixes: https://github.com/tursodatabase/turso/issues/5804

## Description of AI Usage
I used AI to navigate the codebase and understand concepts and implementations I was not familiar with.