### PR TITLE
MVCC: remap root page ids so that we don't miss rows on recovery

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1283,6 +1283,26 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         // reference it. The SkipSet iteration order sorts by table_id (most negative
         // first), which would otherwise place data table rows (e.g. table_id=-3)
         // before schema rows (table_id=-1).
+
+        // Remap a table_id to its canonical form for the log. After checkpoint,
+        // a table's in-memory table_id (e.g. -53) may differ from -(root_page)
+        // (e.g. -58). On recovery, bootstrap reconstructs the map using
+        // -(root_page), so log records must use that canonical form to be found.
+        let canonicalize_table_id = |version: &mut RowVersion| {
+            let table_id = version.row.id.table_id;
+            if table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                return;
+            }
+            if let Some(entry) = mvcc_store.table_id_to_rootpage.get(&table_id) {
+                if let Some(root_page) = *entry.value() {
+                    let canonical = MVTableId::from(-(root_page as i64));
+                    if canonical != table_id {
+                        version.row.id.table_id = canonical;
+                    }
+                }
+            }
+        };
+
         let collect_versions = |id: &RowID,
                                 log_record: &mut LogRecord,
                                 did_commit_schema: &mut bool| {
@@ -1314,6 +1334,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                         }
                     }
                     if changed {
+                        canonicalize_table_id(&mut committed_version);
                         mvcc_store
                             .insert_version_raw(&mut log_record.row_versions, committed_version);
                     }
@@ -1347,6 +1368,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                             }
                         }
                         if changed {
+                            canonicalize_table_id(&mut committed_version);
                             mvcc_store.insert_version_raw(
                                 &mut log_record.row_versions,
                                 committed_version,

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8499,3 +8499,189 @@ fn test_encrypted_recovery_corrupted_ciphertext() {
     assert_eq!(rows[0][0].as_int().unwrap(), 1);
     assert_eq!(rows[0][1].to_string(), "survives");
 }
+
+/// Reproducer for a bug where log replay after checkpoint-restart-checkpoint-restart
+/// panics with "table id that does not exist in the table_id_to_rootpage map".
+///
+/// The scenario from the simulator:
+/// 1. Create many tables, insert data, checkpoint (tables get positive root pages)
+/// 2. Restart (recovery rebuilds table_id_to_rootpage from btree schema)
+/// 3. Create more tables + insert into old and new tables
+/// 4. Checkpoint (all tables now have positive root pages, log is truncated)
+/// 5. Insert more data into all tables (un-checkpointed, written to log with
+///    table IDs assigned in this server incarnation)
+/// 6. Restart → bootstrap rebuilds map from btree root pages, then log replay
+///    sees row inserts for table IDs that may not match the bootstrap mapping
+#[test]
+fn test_recovery_many_tables_checkpoint_restart_checkpoint_restart() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    let num_initial_tables = 50;
+    let num_extra_tables = 30;
+
+    // Step 1: Create many tables, insert data, checkpoint
+    {
+        let conn = db.connect();
+        for i in 0..num_initial_tables {
+            conn.execute(format!("CREATE TABLE t{i}(id INTEGER PRIMARY KEY, v TEXT)"))
+                .unwrap();
+            conn.execute(format!("INSERT INTO t{i} VALUES (1, 'init')"))
+                .unwrap();
+        }
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+
+    // Step 2: Restart (simulates server redeploy)
+    db.restart();
+
+    // Step 3: Create more tables + insert into old tables, then checkpoint
+    {
+        let conn = db.connect();
+        // Create new tables (these get new negative table IDs)
+        for i in 0..num_extra_tables {
+            conn.execute(format!(
+                "CREATE TABLE extra{i}(id INTEGER PRIMARY KEY, v TEXT)"
+            ))
+            .unwrap();
+            conn.execute(format!("INSERT INTO extra{i} VALUES (1, 'extra')"))
+                .unwrap();
+        }
+        // Insert into the original tables
+        for i in 0..num_initial_tables {
+            conn.execute(format!("INSERT INTO t{i} VALUES (2, 'after_restart')"))
+                .unwrap();
+        }
+        // Step 4: Checkpoint - all tables get positive root pages, log truncated
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+        // Step 5: More writes after checkpoint (un-checkpointed, in the log)
+        for i in 0..num_initial_tables {
+            conn.execute(format!("INSERT INTO t{i} VALUES (3, 'post_ckpt2')"))
+                .unwrap();
+        }
+        for i in 0..num_extra_tables {
+            conn.execute(format!(
+                "INSERT INTO extra{i} VALUES (2, 'extra_post_ckpt')"
+            ))
+            .unwrap();
+        }
+        conn.close().unwrap();
+    }
+
+    // Step 6: Restart again - log replay should not panic
+    db.restart();
+
+    // Verify data integrity
+    {
+        let conn = db.connect();
+        for i in 0..num_initial_tables {
+            let rows = get_rows(&conn, &format!("SELECT id, v FROM t{i} ORDER BY id"));
+            assert_eq!(
+                rows.len(),
+                3,
+                "table t{i} should have 3 rows, got {}",
+                rows.len()
+            );
+        }
+        for i in 0..num_extra_tables {
+            let rows = get_rows(&conn, &format!("SELECT id, v FROM extra{i} ORDER BY id"));
+            assert_eq!(
+                rows.len(),
+                2,
+                "table extra{i} should have 2 rows, got {}",
+                rows.len()
+            );
+        }
+    }
+}
+
+/// Variant that does 3 restart cycles with tables created across each incarnation.
+/// This stresses the table_id_to_rootpage mapping more aggressively.
+#[test]
+fn test_recovery_three_restarts_with_table_creation() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+
+    // Incarnation 1: create tables, checkpoint
+    {
+        let conn = db.connect();
+        for i in 0..20 {
+            conn.execute(format!("CREATE TABLE a{i}(id INTEGER PRIMARY KEY, v TEXT)"))
+                .unwrap();
+            conn.execute(format!("INSERT INTO a{i} VALUES (1, 'a')"))
+                .unwrap();
+        }
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+
+    // Incarnation 2: create more tables, insert into old, checkpoint, then more writes
+    {
+        let conn = db.connect();
+        for i in 0..20 {
+            conn.execute(format!("CREATE TABLE b{i}(id INTEGER PRIMARY KEY, v TEXT)"))
+                .unwrap();
+            conn.execute(format!("INSERT INTO b{i} VALUES (1, 'b')"))
+                .unwrap();
+        }
+        for i in 0..20 {
+            conn.execute(format!("INSERT INTO a{i} VALUES (2, 'a2')"))
+                .unwrap();
+        }
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        // Un-checkpointed writes
+        for i in 0..20 {
+            conn.execute(format!("INSERT INTO a{i} VALUES (3, 'a3')"))
+                .unwrap();
+            conn.execute(format!("INSERT INTO b{i} VALUES (2, 'b2')"))
+                .unwrap();
+        }
+        conn.close().unwrap();
+    }
+
+    db.restart();
+
+    // Incarnation 3: create even more tables, insert everywhere, checkpoint, more writes
+    {
+        let conn = db.connect();
+        for i in 0..20 {
+            conn.execute(format!("CREATE TABLE c{i}(id INTEGER PRIMARY KEY, v TEXT)"))
+                .unwrap();
+            conn.execute(format!("INSERT INTO c{i} VALUES (1, 'c')"))
+                .unwrap();
+        }
+        for i in 0..20 {
+            conn.execute(format!("INSERT INTO a{i} VALUES (4, 'a4')"))
+                .unwrap();
+            conn.execute(format!("INSERT INTO b{i} VALUES (3, 'b3')"))
+                .unwrap();
+        }
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        // Un-checkpointed writes to all tables
+        for i in 0..20 {
+            conn.execute(format!("INSERT INTO a{i} VALUES (5, 'a5')"))
+                .unwrap();
+            conn.execute(format!("INSERT INTO b{i} VALUES (4, 'b4')"))
+                .unwrap();
+            conn.execute(format!("INSERT INTO c{i} VALUES (2, 'c2')"))
+                .unwrap();
+        }
+        conn.close().unwrap();
+    }
+
+    // Final restart - should not panic during log replay
+    db.restart();
+
+    {
+        let conn = db.connect();
+        for i in 0..20 {
+            let rows = get_rows(&conn, &format!("SELECT id FROM a{i} ORDER BY id"));
+            assert_eq!(rows.len(), 5, "table a{i} should have 5 rows");
+            let rows = get_rows(&conn, &format!("SELECT id FROM b{i} ORDER BY id"));
+            assert_eq!(rows.len(), 4, "table b{i} should have 4 rows");
+            let rows = get_rows(&conn, &format!("SELECT id FROM c{i} ORDER BY id"));
+            assert_eq!(rows.len(), 2, "table c{i} should have 2 rows");
+        }
+    }
+}

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -300,7 +300,7 @@ fn checksum_buffer(page_idx: usize, buffer: Arc<Buffer>, ctx: &ChecksumContext) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{File, MemoryIO, IO};
+    use crate::File;
 
     struct MockFile {
         read_result: std::result::Result<i32, CompletionError>,

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -346,6 +346,8 @@ mod tests {
     #[cfg(feature = "checksum")]
     #[test]
     fn checksum_read_wrapper_propagates_callback_errors() {
+        use crate::{MemoryIO, IO};
+
         let db_file = DatabaseFile {
             file: Arc::new(MockFile { read_result: Ok(0) }),
         };
@@ -386,6 +388,8 @@ mod tests {
     #[cfg(feature = "checksum")]
     #[test]
     fn checksum_read_wrapper_propagates_transport_errors_to_original_completion() {
+        use crate::{MemoryIO, IO};
+
         let db_file = DatabaseFile {
             file: Arc::new(MockFile {
                 read_result: Err(CompletionError::Aborted),


### PR DESCRIPTION
## Description
I'm not that aware of how exactly MVCC recovery is supposed to work, but it seems that it relies on the `root_page` values to recover the logical log. However, it seems there is some way that we can diverge `table_ids` in the log file and in-memory so this code just attempts at making sure we use the same table ids to avoid losing rows. 

Currently rebased on top of #6342 

## Motivation and context
Fix panics and losing rows.


## Description of AI Usage
Did the reproducers first with AI and then explored the fix with AI as well