### PR TITLE
fix: allow dropping user-created UNIQUE indexes (#6359)

### DIFF
--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -25,7 +25,7 @@ use crate::{bail_parse_error, CaptureDataChangesExt, LimboError, MAIN_DB_ID};
 use crate::{
     schema::{BTreeTable, Index, IndexColumn, PseudoCursorType},
     storage::pager::CreateBTreeFlags,
-    util::{escape_sql_string_literal, normalize_ident},
+    util::{escape_sql_string_literal, normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX},
     vdbe::{
         builder::{CursorType, ProgramBuilder},
         insn::{IdxInsertFlags, Insn, RegisterOrLiteral},
@@ -939,9 +939,13 @@ pub fn translate_drop_index(
             )));
         }
     }
-    // Return an error if the index is associated with a unique or primary key constraint.
+    // Return an error if the index is an auto-generated constraint-backing index.
+    // User-created UNIQUE indexes (via CREATE UNIQUE INDEX) are allowed to be dropped.
     if let Some(ref idx) = maybe_index {
-        if idx.name.starts_with("sqlite_autoindex_") {
+        if idx
+            .name
+            .starts_with(PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX)
+        {
             return Err(crate::error::LimboError::InvalidArgument(
                 "index associated with UNIQUE or PRIMARY KEY constraint cannot be dropped"
                     .to_string(),

--- a/testing/sqltests/tests/drop_index.sqltest
+++ b/testing/sqltests/tests/drop_index.sqltest
@@ -90,3 +90,44 @@ test drop-explicit-unique-index {
 expect {
     0
 }
+
+# Test dropping user-created UNIQUE index with IF EXISTS
+@cross-check-integrity
+test drop-index-user-unique-if-exists {
+    CREATE TABLE t16b (a INTEGER PRIMARY KEY, b TEXT);
+    CREATE UNIQUE INDEX ux_t16b_b ON t16b(b);
+    DROP INDEX IF EXISTS ux_t16b_b;
+    SELECT count(*) FROM sqlite_schema WHERE type='index' AND name='ux_t16b_b';
+}
+expect {
+    0
+}
+
+# Test data is still accessible after dropping user-created UNIQUE index
+@cross-check-integrity
+test drop-index-user-unique-data-intact {
+    CREATE TABLE t16c (a INTEGER PRIMARY KEY, b TEXT);
+    CREATE UNIQUE INDEX ux_t16c_b ON t16c(b);
+    INSERT INTO t16c VALUES (1, 'hello');
+    INSERT INTO t16c VALUES (2, 'world');
+    DROP INDEX ux_t16c_b;
+    SELECT a, b FROM t16c ORDER BY a;
+}
+expect {
+    1|hello
+    2|world
+}
+
+# Test dropping user-created UNIQUE composite index
+@cross-check-integrity
+test drop-index-user-unique-composite {
+    CREATE TABLE t16d (a INTEGER PRIMARY KEY, b TEXT, c INT);
+    CREATE UNIQUE INDEX ux_t16d_bc ON t16d(b, c);
+    INSERT INTO t16d VALUES (1, 'x', 10);
+    DROP INDEX ux_t16d_bc;
+    SELECT count(*) FROM sqlite_schema WHERE type='index' AND name='ux_t16d_bc';
+}
+expect {
+    0
+}
+


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

`DROP INDEX` previously rejected any index with `unique = true`, which incorrectly blocked indexes created via `CREATE UNIQUE INDEX` from being dropped. SQLite only protects auto-generated constraint-backing indexes (`sqlite_autoindex_*`); user-defined indexes are always droppable.

The guard in `core/translate/index.rs` is changed from `idx.unique` to `idx.name.starts_with("sqlite_autoindex_")`, matching SQLite semantics and how the rest of the codebase already identifies auto-generated indexes (e.g. `core/translate/pragma.rs`). The `on_conflict` field is not a reliable discriminator since it is `None` for auto-generated indexes when the constraint has no explicit ON CONFLICT clause.

New `.sqltest` cases cover:
- Dropping a user-created `UNIQUE` index
- `DROP INDEX IF EXISTS` for a user-created `UNIQUE` index
- Data still accessible after dropping a user-created `UNIQUE` index
- Dropping a user-created composite `UNIQUE` index

Behavior verified directly against SQLite 3.53.0:

| Case | SQLite | tursodb (after fix) |
|---|---|---|
| `DROP INDEX <user_unique>` | succeeds | succeeds |
| `DROP INDEX sqlite_autoindex_*` | error | error (same message) |

## Motivation and context

Fixes #6359.

Reproduction from the issue:
```sql
CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
CREATE UNIQUE INDEX ux_t_ab ON t(a, b);
DROP INDEX ux_t_ab;
-- Before: error "index associated with UNIQUE or PRIMARY KEY constraint cannot be dropped"
-- After:  succeeds (matches SQLite)
```

Auto-generated `sqlite_autoindex_*` indexes remain protected, preserving the existing behavior tested by `drop-index-primary-key-index` and `drop-index-unique-index`.

## Description of AI Usage

This PR was authored with the assistance of Claude Code (Opus 4.6). The model was used to:
- Locate the buggy guard in `core/translate/index.rs` and survey how the rest of the codebase distinguishes user-created vs. auto-generated indexes
- Cross-check the SQLite documentation and verify behavior against a local `sqlite3` binary
- Draft the new `.sqltest` cases and the commit message

The committer reviewed the diagnosis, the fix, and the test cases before committing.