### PR TITLE
sim: add WITHOUT ROWID support and stress profile to detect silent corruption

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -98,9 +98,6 @@ fn validate(
     if resolver.schema().is_materialized_view(table_name) {
         crate::bail_parse_error!("cannot modify materialized view {}", table_name);
     }
-    if table.btree().is_some_and(|t| !t.has_rowid) {
-        crate::bail_parse_error!("INSERT into WITHOUT ROWID table is not supported");
-    }
     if table.btree().is_some_and(|t| t.has_autoincrement) && conn.mvcc_enabled() {
         crate::bail_parse_error!(
             "AUTOINCREMENT is not supported in MVCC mode (journal_mode=experimental_mvcc)"

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -726,9 +726,6 @@ fn validate(
         constraints,
     } = &body
     {
-        if options.contains_without_rowid() {
-            bail_parse_error!("WITHOUT ROWID tables are not supported");
-        }
         let column_names: Vec<&str> = columns.iter().map(|c| c.col_name.as_str()).collect();
         for i in 0..columns.len() {
             let col_i = &columns[i];

--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -38,6 +38,8 @@ pub struct TableOpts {
     #[garde(range(min = 0.0, max = 1.0))]
     #[serde(alias = "rowid_style_prob")]
     pub rowid_alias_prob: f64,
+    #[garde(range(min = 0.0, max = 1.0))]
+    pub without_rowid_prob: f64,
     /// Range of numbers of columns to generate
     #[garde(custom(range_struct_min(1)))]
     pub column_range: Range<u32>,
@@ -48,6 +50,7 @@ impl Default for TableOpts {
         Self {
             large_table: Default::default(),
             rowid_alias_prob: 0.05,
+            without_rowid_prob: 0.0,
             // Up to 10 columns
             column_range: 1..11,
         }

--- a/sql_generation/generation/table.rs
+++ b/sql_generation/generation/table.rs
@@ -50,6 +50,7 @@ impl Table {
             name,
             columns: Vec::from_iter(column_set),
             indexes: vec![],
+            without_rowid: false,
         }
     }
 }
@@ -57,8 +58,10 @@ impl Table {
 impl Arbitrary for Table {
     fn arbitrary<R: Rng + ?Sized, C: GenerationContext>(rng: &mut R, context: &C) -> Self {
         let name = Name::arbitrary(rng, context).0;
+        let without_rowid_prob = context.opts().table.without_rowid_prob;
+        let without_rowid = without_rowid_prob > 0.0 && rng.random_bool(without_rowid_prob);
 
-        let rowid_alias = rng.random_bool(context.opts().table.rowid_alias_prob);
+        let rowid_alias = !without_rowid && rng.random_bool(context.opts().table.rowid_alias_prob);
         if rowid_alias {
             let pk_name = Name::arbitrary(rng, context).0;
             let payload_name = Name::arbitrary(rng, context).0;
@@ -95,9 +98,12 @@ impl Arbitrary for Table {
                 name,
                 columns,
                 indexes: vec![],
+                without_rowid,
             }
         } else {
-            Table::arbitrary_with_columns(rng, context, name, vec![])
+            let mut table = Table::arbitrary_with_columns(rng, context, name, vec![]);
+            table.without_rowid = without_rowid;
+            table
         }
     }
 }

--- a/sql_generation/model/query/create.rs
+++ b/sql_generation/model/query/create.rs
@@ -21,6 +21,12 @@ impl Display for Create {
             .map(|column| column.to_string())
             .join(", ");
 
-        write!(f, "{cols})")
+        write!(f, "{cols})")?;
+
+        if self.table.without_rowid {
+            write!(f, " WITHOUT ROWID")?;
+        }
+
+        Ok(())
     }
 }

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -47,6 +47,7 @@ pub struct Table {
     pub columns: Vec<Column>,
     pub rows: Vec<Vec<SimValue>>,
     pub indexes: Vec<Index>,
+    pub without_rowid: bool,
 }
 
 impl Table {
@@ -56,6 +57,7 @@ impl Table {
             name: "".to_string(),
             columns: vec![],
             indexes: vec![],
+            without_rowid: false,
         }
     }
 

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -179,7 +179,7 @@ impl Profile {
             query: QueryProfile {
                 gen_opts: Opts {
                     table: TableOpts {
-                        without_rowid_prob: 0.3,
+                        without_rowid_prob: 0.5,
                         ..Default::default()
                     },
                     query: QueryOpts {

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -169,6 +169,40 @@ impl Profile {
         profile
     }
 
+    /// Profile for testing WITHOUT ROWID table corruption paths.
+    /// Generates tables with without_rowid_prob and exercises
+    /// ALTER TABLE ADD COLUMN, DELETE, and UPDATE operations
+    /// that are known to corrupt WITHOUT ROWID tables.
+    pub fn without_rowid_stress() -> Self {
+        let profile = Profile {
+            cache_size_pages: Some(2000),
+            query: QueryProfile {
+                gen_opts: Opts {
+                    table: TableOpts {
+                        without_rowid_prob: 0.3,
+                        ..Default::default()
+                    },
+                    query: QueryOpts {
+                        alter_table: AlterTableOpts { alter_column: true },
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                create_table_weight: 15,
+                insert_weight: 25,
+                delete_weight: 20,
+                update_weight: 20,
+                select_weight: 15,
+                create_index_weight: 5,
+                alter_table_weight: 5,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        profile.validate().unwrap();
+        profile
+    }
+
     pub fn parse_from_type(profile_type: ProfileType) -> anyhow::Result<Self> {
         let profile = match profile_type {
             ProfileType::Default => Self::default(),
@@ -177,6 +211,7 @@ impl Profile {
             ProfileType::Faultless => Self::faultless(),
             ProfileType::SimpleMvcc => Self::simple_mvcc(),
             ProfileType::WriteStress => Self::write_stress(),
+            ProfileType::WithoutRowidStress => Self::without_rowid_stress(),
             ProfileType::Custom(path) => {
                 Self::parse(path).with_context(|| "failed to parse JSON profile")?
             }
@@ -218,6 +253,7 @@ pub enum ProfileType {
     Faultless,
     SimpleMvcc,
     WriteStress,
+    WithoutRowidStress,
     #[strum(disabled)]
     Custom(PathBuf),
 }


### PR DESCRIPTION
## Description
This PR adds support for `WITHOUT ROWID` tables to the SQL generation engine and the simulator. 
Key changes:
- Removed `WITHOUT ROWID` constraints in `core/translate/schema.rs` and `core/translate/insert.rs`.
- Updated `Table` models and SQL generation to support the `WITHOUT ROWID` property.
- Added a new `without_rowid_stress` profile for Deterministic Simulation Testing (DST).

## Motivation and context
Current DST simulator was unable to catch bugs related to `WITHOUT ROWID` tables because they were explicitly disabled. While researching `libSQL`, I found a critical silent data corruption bug that occurs during `ALTER TABLE ... ADD COLUMN` operations on these tables. These changes allow the simulator to generate such scenarios and detect the corruption.

## Description of AI Usage
AI (Gemini/Windsurf) was used as a collaborator to help navigate the codebase, structure the Rust implementation for the simulator, and refine the stress-testing profile logic.