### PR TITLE
core/vdbe: refactor `vacuum into` state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3123,6 +3123,7 @@ dependencies = [
  "similar-asserts",
  "sql_generation",
  "strum",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "turso_core",

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -38,7 +38,6 @@ use crate::vdbe::hash_table::{
 };
 use crate::vdbe::insn::InsertFlags;
 use crate::vdbe::metrics::HashJoinMetrics;
-use crate::vdbe::vacuum::{classify_schema_entries, SchemaEntry};
 use crate::vdbe::value::ComparisonOp;
 use crate::vdbe::{
     registers_to_ref_values, DeferredSeekState, EndStatement, OpHashBuildState, OpHashProbeState,
@@ -13684,93 +13683,20 @@ pub(crate) enum OpVacuumIntoSubState {
     /// Initial state - validate preconditions and create destination database
     #[default]
     Init,
-    /// Step through schema query to collect rows
-    CollectSchemaRows {
-        dest_conn: Arc<Connection>,
-        schema_stmt: Box<crate::Statement>,
-    },
-    /// Prepare CREATE TABLE statement on destination (idx into tables_to_create)
-    PrepareCreateTable {
-        dest_conn: Arc<Connection>,
-        idx: usize,
-    },
-    /// Step through CREATE TABLE statement on destination (async)
-    StepCreateTable {
-        dest_conn: Arc<Connection>,
-        dest_schema_stmt: Box<crate::Statement>,
-        idx: usize,
-    },
-    /// Start copying a table's data
-    StartCopyTable {
-        dest_conn: Arc<Connection>,
-        table_idx: usize,
-    },
-    /// Select rows from source table and insert into destination
-    CopyRows {
-        dest_conn: Arc<Connection>,
-        select_stmt: Box<crate::Statement>,
-        dest_insert_stmt: Box<crate::Statement>,
-        table_idx: usize,
-    },
-    /// Step through INSERT statement on destination (async)
-    StepDestInsert {
-        dest_conn: Arc<Connection>,
-        select_stmt: Box<crate::Statement>,
-        dest_insert_stmt: Box<crate::Statement>,
-        table_idx: usize,
-    },
-    /// Copy meta values (user_version, application_id) from source to destination
-    CopyMetaValues { dest_conn: Arc<Connection> },
-    /// Prepare CREATE INDEX statement on destination (idx into indexes_to_create)
-    PrepareCreateIndex {
-        dest_conn: Arc<Connection>,
-        idx: usize,
-    },
-    /// Step through CREATE INDEX statement on destination (async)
-    StepCreateIndex {
-        dest_conn: Arc<Connection>,
-        dest_schema_stmt: Box<crate::Statement>,
-        idx: usize,
-    },
-    /// Prepare post-data schema objects (triggers, views, rootpage = 0 entries)
-    PreparePostData {
-        dest_conn: Arc<Connection>,
-        idx: usize,
-    },
-    /// Step through post-data CREATE statement on destination
-    StepPostData {
-        dest_conn: Arc<Connection>,
-        dest_schema_stmt: Box<crate::Statement>,
-        idx: usize,
-    },
+    /// Build compacted destination database
+    Build(Box<crate::vdbe::vacuum::VacuumInto>),
     /// Operation complete
-    Done { dest_conn: Arc<Connection> },
+    Done,
 }
 
 /// Holds the state for the VACUUM INTO operation.
 #[derive(Default)]
 pub(crate) struct OpVacuumIntoState {
     sub_state: OpVacuumIntoSubState,
-    /// Escaped schema name for safe SQL interpolation
-    escaped_schema_name: String,
     /// Database index for the target schema
     database_id: usize,
-    /// Keep dest_db alive while vacuum is in progress.
-    #[allow(dead_code)]
-    dest_db: Option<Arc<crate::Database>>,
-    /// Typed schema entries collected from sqlite_schema, ordered by rowid.
-    schema_entries: Vec<SchemaEntry>,
-    /// Storage-backed tables to CREATE (excludes sqlite_sequence).
-    tables_to_create: Vec<usize>,
-    /// Storage-backed tables whose data to copy.
-    tables_to_copy: Vec<usize>,
-    /// User-defined secondary indexes to CREATE (deferred for performance).
-    indexes_to_create: Vec<usize>,
-    /// Triggers, views, and rootpage = 0 objects (deferred to avoid trigger firing).
-    post_data_entries: Vec<usize>,
-    /// Meta values read from source database header
-    source_user_version: i32,
-    source_application_id: i32,
+    /// Escaped schema name for safe SQL interpolation
+    escaped_schema_name: String,
 }
 
 /// VACUUM INTO - create a compacted copy of the database at the specified path.
@@ -13822,6 +13748,8 @@ fn op_vacuum_into_inner(
     state: &mut ProgramState,
     insn: &Insn,
 ) -> Result<InsnFunctionStepResult> {
+    use crate::vdbe::vacuum::{VacuumInto, VacuumIntoConfig};
+
     load_insn!(
         VacuumInto {
             schema_name,
@@ -13885,7 +13813,7 @@ fn op_vacuum_into_inner(
 
                 // Pin source metadata before building the destination. The
                 // BEGIN and pragma helpers here are blocking convenience wrappers;
-                // async work starts with the schema scan below.
+                // async work starts with the schema scan in vacuum_into_step.
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
                 let source_db = program.connection.get_source_database(database_id);
                 program.connection.execute("BEGIN")?;
@@ -13951,524 +13879,49 @@ fn op_vacuum_into_inner(
                 // must be set before page 1 is allocated (before any schema operations)
                 dest_conn.set_reserved_bytes(reserved_space)?;
 
-                // Enable MVCC on destination if source has it enabled
-                // Must be done before any schema operations to ensure the log file is created
-                if source_db.mvcc_enabled() {
-                    dest_conn.execute("PRAGMA journal_mode = 'mvcc'")?;
-                }
-
-                // Performance optimizations for destination database (matches SQLite vacuum.c):
-                // 1. Disable fsync - destination is a new file, if crash occurs we just delete it
-                // 2. Disable foreign key checks - source data is already consistent
-                // These match SQLite's vacuum.c optimizations (PAGER_SYNCHRONOUS_OFF, ~SQLITE_ForeignKeys)
-                dest_conn.set_sync_mode(crate::SyncMode::Off);
-                dest_conn.set_foreign_keys_enabled(false);
-
-                // Mirror source symbols needed for schema replay (functions, vtab
-                // modules, index methods). We skip vtabs - those are live instances
-                // tied to the source connection and not needed for compiling schema SQL.
-                {
-                    let source_syms = program.connection.syms.read();
-                    let mut dest_syms = dest_conn.syms.write();
-                    dest_syms.functions.extend(
-                        source_syms
-                            .functions
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    dest_syms.vtab_modules.extend(
-                        source_syms
-                            .vtab_modules
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    dest_syms.index_methods.extend(
-                        source_syms
-                            .index_methods
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                }
-
-                // Mirror source custom type definitions into destination schema
-                // so that STRICT tables with custom type columns can resolve
-                // those types during CREATE TABLE replay.
-                {
-                    let source_types: Vec<(String, std::sync::Arc<crate::schema::TypeDef>)> = {
-                        program
-                            .connection
-                            .with_schema(database_id, |source_schema| {
-                                source_schema
-                                    .type_registry
-                                    .iter()
-                                    .filter(|(_, td)| !td.is_builtin)
-                                    .map(|(name, td)| (name.clone(), td.clone()))
-                                    .collect()
-                            })
-                    };
-                    if !source_types.is_empty() {
-                        dest_conn.with_schema_mut(|dest_schema| {
-                            for (name, td) in source_types {
-                                dest_schema.type_registry.insert(name, td);
-                            }
-                        });
-                    }
-                }
-
-                // Wrap all operations in a single transaction for atomicity.
-                dest_conn.execute("BEGIN")?;
-
-                // Query sqlite_schema with rootpage, ordered by rowid.
-                // Exclude the MVCC metadata table - it is an internal artifact.
-                let schema_sql = format!(
-                    "SELECT type, name, tbl_name, rootpage, sql \
-                     FROM \"{escaped_schema_name}\".sqlite_schema \
-                     WHERE sql IS NOT NULL AND name <> '{}' ORDER BY rowid",
-                    crate::mvcc::database::MVCC_META_TABLE_NAME
-                );
-                let schema_stmt = program.connection.prepare_internal(schema_sql.as_str())?;
-
-                vacuum_state.dest_db = Some(dest_db);
-                vacuum_state.source_user_version = user_version;
-                vacuum_state.source_application_id = application_id;
-
-                vacuum_state.sub_state = OpVacuumIntoSubState::CollectSchemaRows {
-                    dest_conn,
-                    schema_stmt: Box::new(schema_stmt),
-                };
-                continue;
-            }
-
-            OpVacuumIntoSubState::CollectSchemaRows {
-                dest_conn,
-                mut schema_stmt,
-            } => {
-                // Collect rows from sqlite_schema: (type, name, tbl_name, rootpage, sql)
-                match schema_stmt.step()? {
-                    crate::StepResult::Row => {
-                        let row = schema_stmt
-                            .row()
-                            .expect("StepResult::Row but row() returned None");
-                        vacuum_state
-                            .schema_entries
-                            .push(SchemaEntry::from_row(row)?);
-                        vacuum_state.sub_state = OpVacuumIntoSubState::CollectSchemaRows {
-                            dest_conn,
-                            schema_stmt,
-                        };
-                        continue;
-                    }
-                    crate::StepResult::Done => {
-                        // Classify schema entries into replay phases using rootpage.
-                        let (tables_create, tables_copy, indexes_create, post_data) =
-                            classify_schema_entries(&vacuum_state.schema_entries);
-                        vacuum_state.tables_to_create = tables_create;
-                        vacuum_state.tables_to_copy = tables_copy;
-                        // Backing-btree indexes are implementation details of custom index
-                        // methods. i.e. when custom indexes are created, they are created automatically
-                        // The user-visible custom-index CREATE in post_data_entries
-                        // recreates and backfills those backing indexes from the copied rows.
-                        // for now, we will skip them
-                        vacuum_state.indexes_to_create = indexes_create
-                            .into_iter()
-                            .filter(|entry_ordinal| {
-                                let entry = &vacuum_state.schema_entries[*entry_ordinal];
-                                !program.connection.with_schema(database_id, |schema| {
-                                    schema
-                                        .get_index(&entry.tbl_name, &entry.name)
-                                        .is_some_and(|idx| idx.is_backing_btree_index())
-                                })
-                            })
-                            .collect();
-                        vacuum_state.post_data_entries = post_data;
-
-                        vacuum_state.sub_state =
-                            OpVacuumIntoSubState::PrepareCreateTable { dest_conn, idx: 0 };
-                        continue;
-                    }
-                    crate::StepResult::IO => {
-                        let io = schema_stmt
-                            .take_io_completions()
-                            .expect("StepResult::IO returned but no completions available");
-                        vacuum_state.sub_state = OpVacuumIntoSubState::CollectSchemaRows {
-                            dest_conn,
-                            schema_stmt,
-                        };
-                        return Ok(InsnFunctionStepResult::IO(io));
-                    }
-                    crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                        return Err(LimboError::Busy);
-                    }
-                }
-            }
-
-            // Phase 1: Create storage-backed tables (rootpage != 0, type=table),
-            // excluding sqlite_sequence (auto-created by AUTOINCREMENT tables).
-            OpVacuumIntoSubState::PrepareCreateTable { dest_conn, idx } => {
-                let entries_len = vacuum_state.tables_to_create.len();
-                if idx >= entries_len {
-                    // Done creating tables, start copying data
-                    vacuum_state.sub_state = OpVacuumIntoSubState::StartCopyTable {
-                        dest_conn,
-                        table_idx: 0,
-                    };
-                    continue;
-                }
-
-                let entry_ordinal = vacuum_state.tables_to_create[idx];
-                let entry = &vacuum_state.schema_entries[entry_ordinal];
-                let sql_str = &entry.sql;
-
-                // System tables (sqlite_stat1, __turso_internal_types, etc.) have
-                // reserved name prefixes that translate_create_table rejects for
-                // user SQL. Temporarily mark the dest connection as nested during
-                // prepare() so the reserved-name check is bypassed at compile
-                // time. The guard is only for prepare: keeping it during step()
-                // would make this CREATE TABLE look nested, so its Transaction
-                // opcode would skip write setup.
-                let is_system = crate::schema::is_system_table(&entry.name);
-                if is_system {
-                    dest_conn.start_nested();
-                }
-                let dest_stmt = dest_conn.prepare(sql_str);
-                if is_system {
-                    dest_conn.end_nested();
-                }
-                let dest_stmt = dest_stmt?;
-                vacuum_state.sub_state = OpVacuumIntoSubState::StepCreateTable {
-                    dest_conn,
-                    dest_schema_stmt: Box::new(dest_stmt),
-                    idx,
-                };
-                continue;
-            }
-
-            OpVacuumIntoSubState::StepCreateTable {
-                dest_conn,
-                mut dest_schema_stmt,
-                idx,
-            } => match dest_schema_stmt.step()? {
-                crate::StepResult::Row => {
-                    unreachable!("CREATE TABLE statement unexpectedly returned a row");
-                }
-                crate::StepResult::Done => {
-                    vacuum_state.sub_state = OpVacuumIntoSubState::PrepareCreateTable {
-                        dest_conn,
-                        idx: idx + 1,
-                    };
-                    continue;
-                }
-                crate::StepResult::IO => {
-                    let io = dest_schema_stmt
-                        .take_io_completions()
-                        .expect("StepResult::IO returned but no completions available");
-                    vacuum_state.sub_state = OpVacuumIntoSubState::StepCreateTable {
-                        dest_conn,
-                        dest_schema_stmt,
-                        idx,
-                    };
-                    return Ok(InsnFunctionStepResult::IO(io));
-                }
-                crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
-                }
-            },
-
-            // Phase 2: Copy data for all storage-backed tables.
-            // Column lists are derived from BTreeTable.columns in the schema,
-            // not PRAGMA table_info, because table_info omits generated columns
-            // while SELECT * includes them - causing a column count mismatch.
-            OpVacuumIntoSubState::StartCopyTable {
-                dest_conn,
-                table_idx,
-            } => {
-                let tables_len = vacuum_state.tables_to_copy.len();
-                if table_idx >= tables_len {
-                    // Done copying all tables, proceed to meta values
-                    vacuum_state.sub_state = OpVacuumIntoSubState::CopyMetaValues { dest_conn };
-                    continue;
-                }
-
-                let entry_ordinal = vacuum_state.tables_to_copy[table_idx];
-                let entry = &vacuum_state.schema_entries[entry_ordinal];
-                let table_name = &entry.name;
-
-                // sqlite_sequence: only copy data if the destination has it
-                // (auto-created when an AUTOINCREMENT table was created in
-                // phase 1). If not present, skip — no AUTOINCREMENT tables
-                // means no counters to preserve. The explicit copy is needed
-                // because inserting rows with the `rowid` pseudo-column does
-                // not update sqlite_sequence counters automatically.
-                if entry.is_sqlite_sequence() {
-                    let dest_has_sequence = dest_conn
-                        .schema
-                        .read()
-                        .get_btree_table(crate::schema::SQLITE_SEQUENCE_TABLE_NAME)
-                        .is_some();
-                    if !dest_has_sequence {
-                        vacuum_state.sub_state = OpVacuumIntoSubState::StartCopyTable {
-                            dest_conn,
-                            table_idx: table_idx + 1,
-                        };
-                        continue;
-                    }
-                }
-
-                let escaped_table_name = table_name.replace('"', "\"\"");
-                // Derive copy-column list from BTreeTable.columns in schema,
-                // filtering out virtual generated columns so the SELECT and
-                // INSERT arities stay aligned.
-                let source_btree_table = program
+                // Capture source custom type definitions so that STRICT tables with
+                // custom type columns can resolve those types during CREATE TABLE
+                // replay on the destination.
+                let source_custom_types: Vec<(String, Arc<crate::schema::TypeDef>)> = program
                     .connection
-                    .with_schema(database_id, |schema| schema.get_btree_table(table_name));
+                    .with_schema(database_id, |source_schema| {
+                        source_schema
+                            .type_registry
+                            .iter()
+                            .filter(|(_, td)| !td.is_builtin)
+                            .map(|(name, td)| (name.clone(), td.clone()))
+                            .collect()
+                    });
 
-                let (select_sql, insert_sql) = build_copy_sql(
-                    escaped_schema_name,
-                    &escaped_table_name,
-                    source_btree_table.as_deref(),
-                )?;
-
-                // SELECT from source, INSERT into destination.
-                let select_stmt = program.connection.prepare_internal(&select_sql)?;
-
-                // System tables need nested mode during prepare() to bypass
-                // "may not be modified" checks. Can't use prepare_internal()
-                // because the nested guard must not persist into step() - the
-                // Transaction opcode needs to run for page-level write setup.
-                let is_system = crate::schema::is_system_table(table_name);
-                if is_system {
-                    dest_conn.start_nested();
-                }
-                let dest_insert_stmt = dest_conn.prepare(&insert_sql);
-                if is_system {
-                    dest_conn.end_nested();
-                }
-                let dest_insert_stmt = dest_insert_stmt?;
-
-                vacuum_state.sub_state = OpVacuumIntoSubState::CopyRows {
-                    dest_conn,
-                    select_stmt: Box::new(select_stmt),
-                    dest_insert_stmt: Box::new(dest_insert_stmt),
-                    table_idx,
+                let config = VacuumIntoConfig {
+                    source_conn: program.connection.clone(),
+                    escaped_schema_name: escaped_schema_name.clone(),
+                    database_id,
+                    source_user_version: user_version,
+                    source_application_id: application_id,
+                    source_custom_types,
+                    source_mvcc_enabled: source_db.mvcc_enabled(),
                 };
-                continue;
-            }
-            OpVacuumIntoSubState::CopyRows {
-                dest_conn,
-                mut select_stmt,
-                mut dest_insert_stmt,
-                table_idx,
-            } => match select_stmt.step()? {
-                crate::StepResult::Row => {
-                    let row = select_stmt
-                        .row()
-                        .expect("StepResult::Row but row() returned None");
 
-                    dest_insert_stmt.reset()?;
-                    dest_insert_stmt.clear_bindings();
-                    for (i, value) in row.get_values().cloned().enumerate() {
-                        let index =
-                            std::num::NonZero::new(i + 1).expect("i + 1 is always non-zero");
-                        dest_insert_stmt.bind_at(index, value);
-                    }
-
-                    vacuum_state.sub_state = OpVacuumIntoSubState::StepDestInsert {
-                        dest_conn,
-                        select_stmt,
-                        dest_insert_stmt,
-                        table_idx,
-                    };
-                    continue;
-                }
-                crate::StepResult::Done => {
-                    // Move to next table
-                    vacuum_state.sub_state = OpVacuumIntoSubState::StartCopyTable {
-                        dest_conn,
-                        table_idx: table_idx + 1,
-                    };
-                    continue;
-                }
-                crate::StepResult::IO => {
-                    let io = select_stmt
-                        .take_io_completions()
-                        .expect("StepResult::IO returned but no completions available");
-                    vacuum_state.sub_state = OpVacuumIntoSubState::CopyRows {
-                        dest_conn,
-                        select_stmt,
-                        dest_insert_stmt,
-                        table_idx,
-                    };
-                    return Ok(InsnFunctionStepResult::IO(io));
-                }
-                crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
-                }
-            },
-
-            OpVacuumIntoSubState::StepDestInsert {
-                dest_conn,
-                select_stmt,
-                mut dest_insert_stmt,
-                table_idx,
-            } => match dest_insert_stmt.step()? {
-                crate::StepResult::Row => {
-                    unreachable!("INSERT statement unexpectedly returned a row");
-                }
-                crate::StepResult::Done => {
-                    // Go back to get next row from source
-                    vacuum_state.sub_state = OpVacuumIntoSubState::CopyRows {
-                        dest_conn,
-                        select_stmt,
-                        dest_insert_stmt,
-                        table_idx,
-                    };
-                    continue;
-                }
-                crate::StepResult::IO => {
-                    let io = dest_insert_stmt
-                        .take_io_completions()
-                        .expect("StepResult::IO returned but no completions available");
-                    vacuum_state.sub_state = OpVacuumIntoSubState::StepDestInsert {
-                        dest_conn,
-                        select_stmt,
-                        dest_insert_stmt,
-                        table_idx,
-                    };
-                    return Ok(InsnFunctionStepResult::IO(io));
-                }
-                crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
-                }
-            },
-
-            OpVacuumIntoSubState::CopyMetaValues { dest_conn } => {
-                // Copy meta values to destination database
-                // Use pragma_update to set user_version and application_id
-                // Note: schema_version is not copied - VACUUM INTO creates a new file so
-                // there's no cache to invalidate. The destination will have its own
-                // schema_version based on the schema operations performed.
-                dest_conn
-                    .pragma_update("user_version", vacuum_state.source_user_version.to_string())?;
-                dest_conn.pragma_update(
-                    "application_id",
-                    vacuum_state.source_application_id.to_string(),
-                )?;
-
-                // Phase 3: Create user-defined secondary indexes after data copy
-                // for performance (avoids maintaining indexes during bulk insert).
-                vacuum_state.sub_state =
-                    OpVacuumIntoSubState::PrepareCreateIndex { dest_conn, idx: 0 };
+                vacuum_state.sub_state = OpVacuumIntoSubState::Build(Box::new(VacuumInto::new(
+                    config, dest_db, dest_conn,
+                )));
                 continue;
             }
 
-            // Phase 3: Create user-defined secondary indexes.
-            OpVacuumIntoSubState::PrepareCreateIndex { dest_conn, idx } => {
-                let entries_len = vacuum_state.indexes_to_create.len();
-                if idx >= entries_len {
-                    // Done creating indexes, move to post-data objects
-                    vacuum_state.sub_state =
-                        OpVacuumIntoSubState::PreparePostData { dest_conn, idx: 0 };
+            OpVacuumIntoSubState::Build(mut vacuum_into) => match vacuum_into.step()? {
+                IOResult::Done(()) => {
+                    vacuum_state.sub_state = OpVacuumIntoSubState::Done;
                     continue;
                 }
-
-                let entry_ordinal = vacuum_state.indexes_to_create[idx];
-                let entry = &vacuum_state.schema_entries[entry_ordinal];
-                // Backing-btree indexes for custom index methods were filtered
-                // out when indexes_to_create was built. The remaining CREATE
-                // INDEX statements are user-visible and can use ordinary prepare.
-                let dest_stmt = dest_conn.prepare(&entry.sql)?;
-                vacuum_state.sub_state = OpVacuumIntoSubState::StepCreateIndex {
-                    dest_conn,
-                    dest_schema_stmt: Box::new(dest_stmt),
-                    idx,
-                };
-                continue;
-            }
-
-            OpVacuumIntoSubState::StepCreateIndex {
-                dest_conn,
-                mut dest_schema_stmt,
-                idx,
-            } => match dest_schema_stmt.step()? {
-                crate::StepResult::Row => {
-                    unreachable!("CREATE INDEX statement unexpectedly returned a row");
-                }
-                crate::StepResult::Done => {
-                    vacuum_state.sub_state = OpVacuumIntoSubState::PrepareCreateIndex {
-                        dest_conn,
-                        idx: idx + 1,
-                    };
-                    continue;
-                }
-                crate::StepResult::IO => {
-                    let io = dest_schema_stmt
-                        .take_io_completions()
-                        .expect("StepResult::IO returned but no completions available");
-                    vacuum_state.sub_state = OpVacuumIntoSubState::StepCreateIndex {
-                        dest_conn,
-                        dest_schema_stmt,
-                        idx,
-                    };
+                IOResult::IO(io) => {
+                    vacuum_state.sub_state = OpVacuumIntoSubState::Build(vacuum_into);
                     return Ok(InsnFunctionStepResult::IO(io));
-                }
-                crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
                 }
             },
 
-            // Phase 4: Create triggers, views, and rootpage=0 schema objects.
-            OpVacuumIntoSubState::PreparePostData { dest_conn, idx } => {
-                let entries_len = vacuum_state.post_data_entries.len();
-                if idx >= entries_len {
-                    vacuum_state.sub_state = OpVacuumIntoSubState::Done { dest_conn };
-                    continue;
-                }
-
-                let entry_ordinal = vacuum_state.post_data_entries[idx];
-                let entry = &vacuum_state.schema_entries[entry_ordinal];
-                let dest_stmt = dest_conn.prepare(&entry.sql)?;
-                vacuum_state.sub_state = OpVacuumIntoSubState::StepPostData {
-                    dest_conn,
-                    dest_schema_stmt: Box::new(dest_stmt),
-                    idx,
-                };
-                continue;
-            }
-
-            OpVacuumIntoSubState::StepPostData {
-                dest_conn,
-                mut dest_schema_stmt,
-                idx,
-            } => match dest_schema_stmt.step()? {
-                crate::StepResult::Row => {
-                    unreachable!("CREATE statement unexpectedly returned a row");
-                }
-                crate::StepResult::Done => {
-                    vacuum_state.sub_state = OpVacuumIntoSubState::PreparePostData {
-                        dest_conn,
-                        idx: idx + 1,
-                    };
-                    continue;
-                }
-                crate::StepResult::IO => {
-                    let io = dest_schema_stmt
-                        .take_io_completions()
-                        .expect("StepResult::IO returned but no completions available");
-                    vacuum_state.sub_state = OpVacuumIntoSubState::StepPostData {
-                        dest_conn,
-                        dest_schema_stmt,
-                        idx,
-                    };
-                    return Ok(InsnFunctionStepResult::IO(io));
-                }
-                crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
-                }
-            },
-
-            OpVacuumIntoSubState::Done { dest_conn } => {
-                // Commit the transactions started in Init state.
-                dest_conn.execute("COMMIT")?;
+            OpVacuumIntoSubState::Done => {
+                // Commit the source transaction started in Init.
                 program.connection.execute("COMMIT")?;
                 state.auto_txn_cleanup = TxnCleanup::None;
 
@@ -14477,146 +13930,6 @@ fn op_vacuum_into_inner(
             }
         }
     }
-}
-
-// Build the SELECT and INSERT SQL strings for copying a table's data.
-//
-// Uses the in-memory `BTreeTable` column metadata from the schema to derive
-// the copy-column list. Virtual generated columns are excluded from both
-// SELECT and INSERT since they are computed, not stored. This keeps both
-// lists tied to the same stored-column model.
-//
-// For e.g. given a schema:
-// CREATE TABLE employees (
-//       id INTEGER PRIMARY KEY,
-//       name TEXT,
-//       salary INTEGER,
-//       bonus INTEGER GENERATED ALWAYS AS (salary * 0.1) VIRTUAL
-//   )
-//
-//   Output:
-//   - select_sql: SELECT rowid, "name", "salary" FROM "main"."employees"
-//   - insert_sql: INSERT INTO "main"."employees" (rowid, "name", "salary") VALUES (?, ?, ?)
-fn build_copy_sql(
-    escaped_schema_name: &str,
-    escaped_table_name: &str,
-    source_btree_table: Option<&crate::schema::BTreeTable>,
-) -> Result<(String, String)> {
-    let Some(btree) = source_btree_table else {
-        // Storage-backed tables must have schema metadata. If we get here,
-        // the schema is inconsistent - somewhere it has gone terribly wrong
-        return Err(LimboError::Corrupt(format!(
-            "no schema metadata for storage-backed table \"{escaped_table_name}\""
-        )));
-    };
-
-    // Collect non-virtual-generated columns with their quoted names.
-    let mut data_columns: Vec<String> = Vec::new();
-    let mut rowid_alias_col_idx: Option<usize> = None;
-    for (i, col) in btree.columns.iter().enumerate() {
-        if col.is_virtual_generated() {
-            continue;
-        }
-        if col.is_rowid_alias() {
-            rowid_alias_col_idx = Some(i);
-        }
-        let Some(name) = col.name.as_deref() else {
-            return Err(LimboError::Corrupt(format!(
-                "missing column name for table \"{escaped_table_name}\""
-            )));
-        };
-        let escaped = name.replace('"', "\"\"");
-        data_columns.push(format!("\"{escaped}\""));
-    }
-
-    if data_columns.is_empty() {
-        return Err(LimboError::Corrupt(
-            "found a table without any columns".to_string(),
-        ));
-    }
-
-    // Determine rowid handling: for has_rowid tables, we need to preserve the
-    // rowid. Find an alias name (rowid, _rowid_, or oid) that doesn't conflict
-    // with an actual column name.
-    let rowid_alias = if btree.has_rowid {
-        ["rowid", "_rowid_", "oid"]
-            .iter()
-            .copied()
-            .find(|alias| btree.get_column(alias).is_none())
-    } else {
-        None
-    };
-
-    // Build the column lists. If there's a rowid alias column (INTEGER PRIMARY KEY),
-    // we exclude it from the data columns and use the rowid alias instead, since
-    // the rowid alias column IS the rowid.
-    //
-    // Track bind_count explicitly instead of parsing the joined string - column
-    // names can contain commas inside quotes which would miscount.
-    let (select_cols, insert_cols, bind_count) = if let Some(alias) = rowid_alias {
-        if let Some(alias_idx) = rowid_alias_col_idx {
-            // Remove the rowid alias column from data_columns (it IS the rowid)
-            let mut filtered: Vec<&str> = Vec::new();
-            let mut col_physical_idx = 0;
-            for (i, col) in btree.columns.iter().enumerate() {
-                if col.is_virtual_generated() {
-                    continue;
-                }
-                if i != alias_idx {
-                    filtered.push(&data_columns[col_physical_idx]);
-                }
-                col_physical_idx += 1;
-            }
-            if filtered.is_empty() {
-                // Table only has the rowid alias column
-                (alias.to_string(), alias.to_string(), 1)
-            } else {
-                let count = filtered.len() + 1; // +1 for rowid alias
-                let cols = filtered.join(", ");
-                (
-                    format!("{alias}, {cols}"),
-                    format!("{alias}, {cols}"),
-                    count,
-                )
-            }
-        } else {
-            // has_rowid but no explicit alias column - prepend the chosen rowid
-            // pseudo-column to the stored column list.
-            let count = data_columns.len() + 1; // +1 for rowid alias
-            let cols = data_columns.join(", ");
-            (
-                format!("{alias}, {cols}"),
-                format!("{alias}, {cols}"),
-                count,
-            )
-        }
-    } else {
-        // Either WITHOUT ROWID, or a rowid table where all three pseudo-names
-        // are shadowed by real columns. In the shadowed case SQL cannot name
-        // the hidden rowid, and SQLite does not require rowid stability for
-        // tables without an INTEGER PRIMARY KEY during VACUUM.
-        let count = data_columns.len();
-        let cols = data_columns.join(", ");
-        (cols.clone(), cols, count)
-    };
-
-    // The first placeholder is just "?"; each later placeholder adds ", ?".
-    // Reserve 3 bytes per placeholder, then subtract the 2-byte separator that
-    // the first placeholder does not need.
-    let mut placeholders = String::with_capacity(bind_count.saturating_mul(3).saturating_sub(2));
-    for i in 0..bind_count {
-        if i > 0 {
-            placeholders.push_str(", ");
-        }
-        placeholders.push('?');
-    }
-
-    let select_sql =
-        format!("SELECT {select_cols} FROM \"{escaped_schema_name}\".\"{escaped_table_name}\"");
-    let insert_sql =
-        format!("INSERT INTO \"{escaped_table_name}\" ({insert_cols}) VALUES ({placeholders})");
-
-    Ok((select_sql, insert_sql))
 }
 
 fn with_header<T, F>(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -38,6 +38,7 @@ use crate::vdbe::hash_table::{
 };
 use crate::vdbe::insn::InsertFlags;
 use crate::vdbe::metrics::HashJoinMetrics;
+use crate::vdbe::vacuum::{classify_schema_entries, SchemaEntry};
 use crate::vdbe::value::ComparisonOp;
 use crate::vdbe::{
     registers_to_ref_values, DeferredSeekState, EndStatement, OpHashBuildState, OpHashProbeState,
@@ -13688,13 +13689,13 @@ pub(crate) enum OpVacuumIntoSubState {
         dest_conn: Arc<Connection>,
         schema_stmt: Box<crate::Statement>,
     },
-    /// Prepare CREATE statement on destination (idx into schema_rows)
-    PrepareDestSchema {
+    /// Prepare CREATE TABLE statement on destination (idx into tables_to_create)
+    PrepareCreateTable {
         dest_conn: Arc<Connection>,
         idx: usize,
     },
-    /// Step through CREATE statement on destination (async)
-    StepDestSchema {
+    /// Step through CREATE TABLE statement on destination (async)
+    StepCreateTable {
         dest_conn: Arc<Connection>,
         dest_schema_stmt: Box<crate::Statement>,
         idx: usize,
@@ -13752,12 +13753,16 @@ pub(crate) struct OpVacuumIntoState {
     /// Keep dest_db alive while vacuum is in progress.
     #[allow(dead_code)]
     dest_db: Option<Arc<crate::Database>>,
-    /// Schema rows: [(type, name, tbl_name, sql), ...]
-    schema_rows: Vec<Vec<Value>>,
-    /// Names of tables to copy data for
-    table_names: Vec<String>,
-    /// Column names for the current table being copied
-    current_table_columns: Vec<String>,
+    /// Typed schema entries collected from sqlite_schema, ordered by rowid.
+    schema_entries: Vec<SchemaEntry>,
+    /// Storage-backed tables to CREATE (excludes sqlite_sequence).
+    tables_to_create: Vec<usize>,
+    /// Storage-backed tables whose data to copy.
+    tables_to_copy: Vec<usize>,
+    /// User-defined secondary indexes to CREATE (deferred for performance).
+    indexes_to_create: Vec<usize>,
+    /// Triggers, views, and rootpage = 0 objects (deferred to avoid trigger firing).
+    post_data_entries: Vec<usize>,
     /// Meta values read from source database header
     source_user_version: i32,
     source_application_id: i32,
@@ -13767,13 +13772,19 @@ pub(crate) struct OpVacuumIntoState {
 ///
 /// This is an async state machine implementation that yields on I/O operations.
 /// It:
-/// 1. Creates a new database at the destination path with matching page_size
-/// 2. Queries sqlite_schema for all schema objects (tables, indexes, triggers, views)
-/// 3. Creates tables and indexes in destination (skipping sqlite_sequence - it's
-///    auto-created when AUTOINCREMENT tables are created, see translate/schema.rs)
-/// 4. Copies data for each table, including sqlite_sequence to preserve AUTOINCREMENT counters
-/// 5. Copies meta values (user_version, application_id) from source to destination
-/// 6. Creates triggers and views last (after data copy to avoid triggers firing during copy)
+/// 1. Creates a new database at the destination path with matching page_size and
+///    source feature flags and schema-replay symbols
+/// 2. Queries sqlite_schema for all schema objects including rootpage, ordered by rowid
+/// 3. Creates storage-backed tables (rootpage != 0) in destination, excluding
+///    sqlite_sequence (auto-created when AUTOINCREMENT tables are created)
+/// 4. Copies data for all storage-backed tables, including sqlite_stat1 and other
+///    internal storage-backed tables
+/// 5. Creates user-defined secondary indexes after data copy for performance
+///    (backing-btree indexes for custom index methods are excluded here)
+/// 6. Copies meta values (user_version, application_id) from source to destination
+/// 7. Creates triggers, views, and rootpage = 0 objects last (after data copy).
+///    Custom index methods (FTS, vector) recreate and backfill their backing
+///    indexes from the copied table data in this phase.
 pub fn op_vacuum_into(
     program: &Program,
     state: &mut ProgramState,
@@ -13846,15 +13857,15 @@ fn op_vacuum_into_inner(
                         "cannot VACUUM INTO from within a transaction".to_string(),
                     ));
                 }
+                // This VACUUM INTO statement itself is the one active root
+                // statement. Any count other than 1 means some other
+                // top-level statement on the same connection is still active.
                 if program
                     .connection
                     .n_active_root_statements
                     .load(Ordering::SeqCst)
                     != 1
                 {
-                    // This VACUUM INTO statement itself is the one active root
-                    // statement. Any count other than 1 means some other
-                    // top-level statement on the same connection is still active.
                     return Err(LimboError::TxError(
                         "cannot VACUUM - SQL statements in progress".to_string(),
                     ));
@@ -13867,9 +13878,9 @@ fn op_vacuum_into_inner(
                     )));
                 }
 
-                // make sure to create destination database with same experimental features as source
-                // Always use PlatformIO for the destination file, even if source is in-memory.
-                // This ensures VACUUM INTO actually writes to disk.
+                // Pin source metadata before building the destination. The
+                // BEGIN and pragma helpers here are blocking convenience wrappers;
+                // async work starts with the schema scan below.
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
                 let source_db = program.connection.get_source_database(database_id);
                 let dest_opts = crate::DatabaseOpts::new()
@@ -13945,14 +13956,15 @@ fn op_vacuum_into_inner(
                 // This batches all writes and ensures destination is either empty or complete.
                 dest_conn.execute("BEGIN")?;
 
-                // Exclude the MVCC metadata table from the vacuum destination — it is an
-                // internal artifact of mvcc mode and must not appear in a
-                // standalone SQLite file produced by VACUUM INTO.
+                // Query sqlite_schema with rootpage, ordered by rowid.
+                // Exclude the MVCC metadata table - it is an internal artifact.
                 let schema_sql = format!(
-                    "SELECT type, name, tbl_name, sql FROM \"{escaped_schema_name}\".sqlite_schema WHERE sql IS NOT NULL AND name <> '{}' ORDER BY CASE type WHEN 'table' THEN 1 WHEN 'index' THEN 2 WHEN 'trigger' THEN 3 WHEN 'view' THEN 4 ELSE 5 END",
+                    "SELECT type, name, tbl_name, rootpage, sql \
+                     FROM \"{escaped_schema_name}\".sqlite_schema \
+                     WHERE sql IS NOT NULL AND name <> '{}' ORDER BY rowid",
                     crate::mvcc::database::MVCC_META_TABLE_NAME
                 );
-                let schema_stmt = program.connection.prepare(schema_sql.as_str())?;
+                let schema_stmt = program.connection.prepare_internal(schema_sql.as_str())?;
 
                 vacuum_state.dest_db = Some(dest_db);
                 vacuum_state.source_user_version = user_version;
@@ -13969,15 +13981,15 @@ fn op_vacuum_into_inner(
                 dest_conn,
                 mut schema_stmt,
             } => {
-                // Collect rows from sqlite_schema query: (type, name, tbl_name, sql)
-                // These define all tables, indexes, triggers, and views to recreate in destination
+                // Collect rows from sqlite_schema: (type, name, tbl_name, rootpage, sql)
                 match schema_stmt.step()? {
                     crate::StepResult::Row => {
                         let row = schema_stmt
                             .row()
                             .expect("StepResult::Row but row() returned None");
-                        let values: Vec<Value> = row.get_values().cloned().collect();
-                        vacuum_state.schema_rows.push(values);
+                        vacuum_state
+                            .schema_entries
+                            .push(SchemaEntry::from_row(row)?);
                         vacuum_state.sub_state = OpVacuumIntoSubState::CollectSchemaRows {
                             dest_conn,
                             schema_stmt,
@@ -13985,32 +13997,31 @@ fn op_vacuum_into_inner(
                         continue;
                     }
                     crate::StepResult::Done => {
-                        // Extract table names for data copy phase
-                        // Include sqlite_sequence for AUTOINCREMENT counters, but not other sqlite_ tables
-                        vacuum_state.table_names = vacuum_state
-                            .schema_rows
-                            .iter()
-                            .filter_map(|row| {
-                                if row.len() >= 2 {
-                                    if let (Value::Text(type_val), Value::Text(name_val)) =
-                                        (&row[0], &row[1])
-                                    {
-                                        let name = name_val.as_str();
-                                        if type_val.as_str() == "table"
-                                            && (!name.starts_with("sqlite_")
-                                                || name == "sqlite_sequence")
-                                            && name != crate::mvcc::database::MVCC_META_TABLE_NAME
-                                        {
-                                            return Some(name.to_string());
-                                        }
-                                    }
-                                }
-                                None
+                        // Classify schema entries into replay phases using rootpage.
+                        let (tables_create, tables_copy, indexes_create, post_data) =
+                            classify_schema_entries(&vacuum_state.schema_entries);
+                        vacuum_state.tables_to_create = tables_create;
+                        vacuum_state.tables_to_copy = tables_copy;
+                        // Backing-btree indexes are implementation details of custom index
+                        // methods. i.e. when custom indexes are created, they are created automatically
+                        // The user-visible custom-index CREATE in post_data_entries
+                        // recreates and backfills those backing indexes from the copied rows.
+                        // for now, we will skip them
+                        vacuum_state.indexes_to_create = indexes_create
+                            .into_iter()
+                            .filter(|entry_ordinal| {
+                                let entry = &vacuum_state.schema_entries[*entry_ordinal];
+                                !program.connection.with_schema(database_id, |schema| {
+                                    schema
+                                        .get_index(&entry.tbl_name, &entry.name)
+                                        .is_some_and(|idx| idx.is_backing_btree_index())
+                                })
                             })
                             .collect();
+                        vacuum_state.post_data_entries = post_data;
 
                         vacuum_state.sub_state =
-                            OpVacuumIntoSubState::PrepareDestSchema { dest_conn, idx: 0 };
+                            OpVacuumIntoSubState::PrepareCreateTable { dest_conn, idx: 0 };
                         continue;
                     }
                     crate::StepResult::IO => {
@@ -14029,15 +14040,12 @@ fn op_vacuum_into_inner(
                 }
             }
 
-            OpVacuumIntoSubState::PrepareDestSchema { dest_conn, idx } => {
-                let schema_rows_len = vacuum_state.schema_rows.len();
-                turso_assert!(
-                    idx <= schema_rows_len,
-                    "idx incremented past end of schema_rows",
-                    { "idx": idx, "schema_rows_len": schema_rows_len }
-                );
-                if idx == schema_rows_len {
-                    // Done creating schema, start copying data
+            // Phase 1: Create storage-backed tables (rootpage != 0, type=table),
+            // excluding sqlite_sequence (auto-created by AUTOINCREMENT tables).
+            OpVacuumIntoSubState::PrepareCreateTable { dest_conn, idx } => {
+                let entries_len = vacuum_state.tables_to_create.len();
+                if idx >= entries_len {
+                    // Done creating tables, start copying data
                     vacuum_state.sub_state = OpVacuumIntoSubState::StartCopyTable {
                         dest_conn,
                         table_idx: 0,
@@ -14045,65 +14053,27 @@ fn op_vacuum_into_inner(
                     continue;
                 }
 
-                let row = &vacuum_state.schema_rows[idx];
-                turso_assert!(
-                    row.len() == 4,
-                    "schema row should have exactly 4 columns (type, name, tbl_name, sql)",
-                    { "row_len": row.len() }
-                );
+                let entry_ordinal = vacuum_state.tables_to_create[idx];
+                let entry = &vacuum_state.schema_entries[entry_ordinal];
+                let sql_str = &entry.sql;
 
-                // Skip triggers and views - they'll be created after data copy
-                // to avoid triggers firing during data copy
-                if let Value::Text(type_val) = &row[0] {
-                    let type_str = type_val.as_str();
-                    if type_str == "trigger" || type_str == "view" {
-                        vacuum_state.sub_state = OpVacuumIntoSubState::PrepareDestSchema {
-                            dest_conn,
-                            idx: idx + 1,
-                        };
-                        continue;
-                    }
-                }
-
-                // Skip sqlite_sequence in schema creation phase. When we create an AUTOINCREMENT
-                // table, Turso automatically creates sqlite_sequence if it doesn't exist (see
-                // translate/schema.rs). Since schema_rows order depends on sqlite_schema rowids,
-                // an AUTOINCREMENT table may appear before sqlite_sequence. If we create that
-                // table first (which auto-creates sqlite_sequence), then later try to run
-                // "CREATE TABLE sqlite_sequence(name,seq)", it fails with "table already exists".
-                // We still copy sqlite_sequence data in StartCopyTable to preserve counters.
-                if let Value::Text(name_val) = &row[1] {
-                    if name_val.as_str() == "sqlite_sequence" {
-                        vacuum_state.sub_state = OpVacuumIntoSubState::PrepareDestSchema {
-                            dest_conn,
-                            idx: idx + 1,
-                        };
-                        continue;
-                    }
-                }
-
-                // Query filters WHERE sql IS NOT NULL, so sql column must be text
-                let Value::Text(sql) = &row[3] else {
-                    unreachable!("sql column should be text (query has WHERE sql IS NOT NULL)");
-                };
-                let sql_str = sql.as_str();
-
-                // Internal tables (e.g. __turso_internal_types) have a reserved
-                // name prefix that translate_create_table rejects for user SQL.
-                // Temporarily mark the dest connection as nested during prepare()
-                // so the reserved-name check is bypassed at compile time. We must
-                // NOT keep it nested during step() because that would prevent
-                // sub-statements from upgrading to write transactions.
-                let is_internal = matches!(&row[1], Value::Text(n) if n.as_str().starts_with(crate::schema::TURSO_INTERNAL_PREFIX));
-                if is_internal {
+                // System tables (sqlite_stat1, __turso_internal_types, etc.) have
+                // reserved name prefixes that translate_create_table rejects for
+                // user SQL. Temporarily mark the dest connection as nested during
+                // prepare() so the reserved-name check is bypassed at compile
+                // time. The guard is only for prepare: keeping it during step()
+                // would make this CREATE TABLE look nested, so its Transaction
+                // opcode would skip write setup.
+                let is_system = crate::schema::is_system_table(&entry.name);
+                if is_system {
                     dest_conn.start_nested();
                 }
                 let dest_stmt = dest_conn.prepare(sql_str);
-                if is_internal {
+                if is_system {
                     dest_conn.end_nested();
                 }
                 let dest_stmt = dest_stmt?;
-                vacuum_state.sub_state = OpVacuumIntoSubState::StepDestSchema {
+                vacuum_state.sub_state = OpVacuumIntoSubState::StepCreateTable {
                     dest_conn,
                     dest_schema_stmt: Box::new(dest_stmt),
                     idx,
@@ -14111,41 +14081,16 @@ fn op_vacuum_into_inner(
                 continue;
             }
 
-            OpVacuumIntoSubState::StepDestSchema {
+            OpVacuumIntoSubState::StepCreateTable {
                 dest_conn,
                 mut dest_schema_stmt,
                 idx,
             } => match dest_schema_stmt.step()? {
                 crate::StepResult::Row => {
-                    unreachable!("CREATE statement unexpectedly returned a row");
+                    unreachable!("CREATE TABLE statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    // After creating __turso_internal_types in the dest, load
-                    // custom type definitions from the source so that subsequent
-                    // CREATE TABLE statements for STRICT tables with custom type
-                    // columns can resolve those types.
-                    let row = &vacuum_state.schema_rows[idx];
-                    if matches!(&row[1], Value::Text(n) if n.as_str() == crate::schema::TURSO_TYPES_TABLE_NAME)
-                    {
-                        let source_types: Vec<(String, std::sync::Arc<crate::schema::TypeDef>)> =
-                            program
-                                .connection
-                                .with_schema(database_id, |source_schema| {
-                                    source_schema
-                                        .type_registry
-                                        .iter()
-                                        .filter(|(_, td)| !td.is_builtin)
-                                        .map(|(name, td)| (name.clone(), td.clone()))
-                                        .collect()
-                                });
-                        dest_conn.with_schema_mut(|dest_schema| {
-                            for (name, td) in source_types {
-                                dest_schema.type_registry.insert(name, td);
-                            }
-                        });
-                    }
-
-                    vacuum_state.sub_state = OpVacuumIntoSubState::PrepareDestSchema {
+                    vacuum_state.sub_state = OpVacuumIntoSubState::PrepareCreateTable {
                         dest_conn,
                         idx: idx + 1,
                     };
@@ -14155,7 +14100,7 @@ fn op_vacuum_into_inner(
                     let io = dest_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    vacuum_state.sub_state = OpVacuumIntoSubState::StepDestSchema {
+                    vacuum_state.sub_state = OpVacuumIntoSubState::StepCreateTable {
                         dest_conn,
                         dest_schema_stmt,
                         idx,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13721,13 +13721,24 @@ pub(crate) enum OpVacuumIntoSubState {
     },
     /// Copy meta values (user_version, application_id) from source to destination
     CopyMetaValues { dest_conn: Arc<Connection> },
-    /// Create triggers and views after data copy (to avoid triggers firing during copy)
-    PrepareTriggersViews {
+    /// Prepare CREATE INDEX statement on destination (idx into indexes_to_create)
+    PrepareCreateIndex {
         dest_conn: Arc<Connection>,
         idx: usize,
     },
-    /// Step through CREATE TRIGGER/VIEW statement on destination
-    StepTriggersViews {
+    /// Step through CREATE INDEX statement on destination (async)
+    StepCreateIndex {
+        dest_conn: Arc<Connection>,
+        dest_schema_stmt: Box<crate::Statement>,
+        idx: usize,
+    },
+    /// Prepare post-data schema objects (triggers, views, rootpage = 0 entries)
+    PreparePostData {
+        dest_conn: Arc<Connection>,
+        idx: usize,
+    },
+    /// Step through post-data CREATE statement on destination
+    StepPostData {
         dest_conn: Arc<Connection>,
         dest_schema_stmt: Box<crate::Statement>,
         idx: usize,
@@ -14286,62 +14297,47 @@ fn op_vacuum_into_inner(
                     vacuum_state.source_application_id.to_string(),
                 )?;
 
-                // Now create triggers and views (after data copy to avoid triggers firing)
+                // Phase 3: Create user-defined secondary indexes after data copy
+                // for performance (avoids maintaining indexes during bulk insert).
                 vacuum_state.sub_state =
-                    OpVacuumIntoSubState::PrepareTriggersViews { dest_conn, idx: 0 };
+                    OpVacuumIntoSubState::PrepareCreateIndex { dest_conn, idx: 0 };
                 continue;
             }
 
-            OpVacuumIntoSubState::PrepareTriggersViews { dest_conn, idx } => {
-                let schema_rows_len = vacuum_state.schema_rows.len();
-                turso_assert!(
-                    idx <= schema_rows_len,
-                    "idx incremented past end of schema_rows",
-                    { "idx": idx, "schema_rows_len": schema_rows_len }
-                );
-                if idx == schema_rows_len {
-                    // Done creating triggers and views
-                    vacuum_state.sub_state = OpVacuumIntoSubState::Done { dest_conn };
+            // Phase 3: Create user-defined secondary indexes.
+            OpVacuumIntoSubState::PrepareCreateIndex { dest_conn, idx } => {
+                let entries_len = vacuum_state.indexes_to_create.len();
+                if idx >= entries_len {
+                    // Done creating indexes, move to post-data objects
+                    vacuum_state.sub_state =
+                        OpVacuumIntoSubState::PreparePostData { dest_conn, idx: 0 };
                     continue;
                 }
 
-                // We validated row.len() == 4 in PrepareDestSchema
-                let row = &vacuum_state.schema_rows[idx];
-
-                // Only process triggers and views in this phase
-                if let Value::Text(type_val) = &row[0] {
-                    let type_str = type_val.as_str();
-                    if type_str == "trigger" || type_str == "view" {
-                        if let Value::Text(sql) = &row[3] {
-                            let sql_str = sql.as_str();
-                            let dest_stmt = dest_conn.prepare(sql_str)?;
-                            vacuum_state.sub_state = OpVacuumIntoSubState::StepTriggersViews {
-                                dest_conn,
-                                dest_schema_stmt: Box::new(dest_stmt),
-                                idx,
-                            };
-                            continue;
-                        }
-                    }
-                }
-
-                // Skip non-trigger/view entries
-                vacuum_state.sub_state = OpVacuumIntoSubState::PrepareTriggersViews {
+                let entry_ordinal = vacuum_state.indexes_to_create[idx];
+                let entry = &vacuum_state.schema_entries[entry_ordinal];
+                // Backing-btree indexes for custom index methods were filtered
+                // out when indexes_to_create was built. The remaining CREATE
+                // INDEX statements are user-visible and can use ordinary prepare.
+                let dest_stmt = dest_conn.prepare(&entry.sql)?;
+                vacuum_state.sub_state = OpVacuumIntoSubState::StepCreateIndex {
                     dest_conn,
-                    idx: idx + 1,
+                    dest_schema_stmt: Box::new(dest_stmt),
+                    idx,
                 };
+                continue;
             }
 
-            OpVacuumIntoSubState::StepTriggersViews {
+            OpVacuumIntoSubState::StepCreateIndex {
                 dest_conn,
                 mut dest_schema_stmt,
                 idx,
             } => match dest_schema_stmt.step()? {
                 crate::StepResult::Row => {
-                    unreachable!("CREATE TRIGGER/VIEW statement unexpectedly returned a row");
+                    unreachable!("CREATE INDEX statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    vacuum_state.sub_state = OpVacuumIntoSubState::PrepareTriggersViews {
+                    vacuum_state.sub_state = OpVacuumIntoSubState::PrepareCreateIndex {
                         dest_conn,
                         idx: idx + 1,
                     };
@@ -14351,7 +14347,57 @@ fn op_vacuum_into_inner(
                     let io = dest_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    vacuum_state.sub_state = OpVacuumIntoSubState::StepTriggersViews {
+                    vacuum_state.sub_state = OpVacuumIntoSubState::StepCreateIndex {
+                        dest_conn,
+                        dest_schema_stmt,
+                        idx,
+                    };
+                    return Ok(InsnFunctionStepResult::IO(io));
+                }
+                crate::StepResult::Busy | crate::StepResult::Interrupt => {
+                    return Err(LimboError::Busy);
+                }
+            },
+
+            // Phase 4: Create triggers, views, and rootpage=0 schema objects.
+            OpVacuumIntoSubState::PreparePostData { dest_conn, idx } => {
+                let entries_len = vacuum_state.post_data_entries.len();
+                if idx >= entries_len {
+                    vacuum_state.sub_state = OpVacuumIntoSubState::Done { dest_conn };
+                    continue;
+                }
+
+                let entry_ordinal = vacuum_state.post_data_entries[idx];
+                let entry = &vacuum_state.schema_entries[entry_ordinal];
+                let dest_stmt = dest_conn.prepare(&entry.sql)?;
+                vacuum_state.sub_state = OpVacuumIntoSubState::StepPostData {
+                    dest_conn,
+                    dest_schema_stmt: Box::new(dest_stmt),
+                    idx,
+                };
+                continue;
+            }
+
+            OpVacuumIntoSubState::StepPostData {
+                dest_conn,
+                mut dest_schema_stmt,
+                idx,
+            } => match dest_schema_stmt.step()? {
+                crate::StepResult::Row => {
+                    unreachable!("CREATE statement unexpectedly returned a row");
+                }
+                crate::StepResult::Done => {
+                    vacuum_state.sub_state = OpVacuumIntoSubState::PreparePostData {
+                        dest_conn,
+                        idx: idx + 1,
+                    };
+                    continue;
+                }
+                crate::StepResult::IO => {
+                    let io = dest_schema_stmt
+                        .take_io_completions()
+                        .expect("StepResult::IO returned but no completions available");
+                    vacuum_state.sub_state = OpVacuumIntoSubState::StepPostData {
                         dest_conn,
                         dest_schema_stmt,
                         idx,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13888,10 +13888,6 @@ fn op_vacuum_into_inner(
                 // async work starts with the schema scan below.
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
                 let source_db = program.connection.get_source_database(database_id);
-                let dest_opts = crate::DatabaseOpts::new()
-                    .with_views(source_db.experimental_views_enabled())
-                    .with_index_method(source_db.experimental_index_method_enabled());
-
                 program.connection.execute("BEGIN")?;
                 // Set the same meta values from the source db (schema)
                 let user_version: i32 = extract_pragma_int(
@@ -13930,6 +13926,17 @@ fn op_vacuum_into_inner(
                     io.block(|| pager.with_header(|header| header.reserved_space))?
                 };
 
+                // Mirror source feature flags to the destination so schema replay
+                // can resolve custom types, generated columns, vtab modules, etc.
+                let dest_opts = crate::DatabaseOpts::new()
+                    .with_views(source_db.experimental_views_enabled())
+                    .with_index_method(source_db.experimental_index_method_enabled())
+                    .with_custom_types(source_db.experimental_custom_types_enabled())
+                    .with_generated_columns(source_db.experimental_generated_columns_enabled());
+
+                // Always use PlatformIO for the destination file, even if source
+                // is in-memory. This ensures VACUUM INTO writes to disk.
+                let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
                 let dest_db = crate::Database::open_file_with_flags(
                     io,
                     dest_path,
@@ -13950,15 +13957,65 @@ fn op_vacuum_into_inner(
                     dest_conn.execute("PRAGMA journal_mode = 'mvcc'")?;
                 }
 
-                // Performance optimizations for destination database:
+                // Performance optimizations for destination database (matches SQLite vacuum.c):
                 // 1. Disable fsync - destination is a new file, if crash occurs we just delete it
                 // 2. Disable foreign key checks - source data is already consistent
                 // These match SQLite's vacuum.c optimizations (PAGER_SYNCHRONOUS_OFF, ~SQLITE_ForeignKeys)
-                dest_conn.execute("PRAGMA synchronous = OFF")?;
-                dest_conn.execute("PRAGMA foreign_keys = OFF")?;
+                dest_conn.set_sync_mode(crate::SyncMode::Off);
+                dest_conn.set_foreign_keys_enabled(false);
 
-                // Wrap all operations in a single transaction for atomicity and performance.
-                // This batches all writes and ensures destination is either empty or complete.
+                // Mirror source symbols needed for schema replay (functions, vtab
+                // modules, index methods). We skip vtabs - those are live instances
+                // tied to the source connection and not needed for compiling schema SQL.
+                {
+                    let source_syms = program.connection.syms.read();
+                    let mut dest_syms = dest_conn.syms.write();
+                    dest_syms.functions.extend(
+                        source_syms
+                            .functions
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                    dest_syms.vtab_modules.extend(
+                        source_syms
+                            .vtab_modules
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                    dest_syms.index_methods.extend(
+                        source_syms
+                            .index_methods
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                }
+
+                // Mirror source custom type definitions into destination schema
+                // so that STRICT tables with custom type columns can resolve
+                // those types during CREATE TABLE replay.
+                {
+                    let source_types: Vec<(String, std::sync::Arc<crate::schema::TypeDef>)> = {
+                        program
+                            .connection
+                            .with_schema(database_id, |source_schema| {
+                                source_schema
+                                    .type_registry
+                                    .iter()
+                                    .filter(|(_, td)| !td.is_builtin)
+                                    .map(|(name, td)| (name.clone(), td.clone()))
+                                    .collect()
+                            })
+                    };
+                    if !source_types.is_empty() {
+                        dest_conn.with_schema_mut(|dest_schema| {
+                            for (name, td) in source_types {
+                                dest_schema.type_registry.insert(name, td);
+                            }
+                        });
+                    }
+                }
+
+                // Wrap all operations in a single transaction for atomicity.
                 dest_conn.execute("BEGIN")?;
 
                 // Query sqlite_schema with rootpage, ordered by rowid.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13889,7 +13889,7 @@ fn op_vacuum_into_inner(
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
                 let source_db = program.connection.get_source_database(database_id);
                 program.connection.execute("BEGIN")?;
-                // Set the same meta values from the source db (schema)
+                state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
                 let user_version: i32 = extract_pragma_int(
                     &program
                         .connection
@@ -14467,9 +14467,10 @@ fn op_vacuum_into_inner(
             },
 
             OpVacuumIntoSubState::Done { dest_conn } => {
-                // Commit the transaction that was started in Init state
+                // Commit the transactions started in Init state.
                 dest_conn.execute("COMMIT")?;
                 program.connection.execute("COMMIT")?;
+                state.auto_txn_cleanup = TxnCleanup::None;
 
                 state.pc += 1;
                 return Ok(InsnFunctionStepResult::Step);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13700,15 +13700,9 @@ pub(crate) enum OpVacuumIntoSubState {
         dest_schema_stmt: Box<crate::Statement>,
         idx: usize,
     },
-    /// Start copying a table - prepare column info query
+    /// Start copying a table's data
     StartCopyTable {
         dest_conn: Arc<Connection>,
-        table_idx: usize,
-    },
-    /// Collect column info for current table
-    CollectColumnInfo {
-        dest_conn: Arc<Connection>,
-        column_stmt: Box<crate::Statement>,
         table_idx: usize,
     },
     /// Select rows from source table and insert into destination
@@ -14112,185 +14106,85 @@ fn op_vacuum_into_inner(
                 }
             },
 
+            // Phase 2: Copy data for all storage-backed tables.
+            // Column lists are derived from BTreeTable.columns in the schema,
+            // not PRAGMA table_info, because table_info omits generated columns
+            // while SELECT * includes them - causing a column count mismatch.
             OpVacuumIntoSubState::StartCopyTable {
                 dest_conn,
                 table_idx,
             } => {
-                let table_names_len = vacuum_state.table_names.len();
-                turso_assert!(
-                    table_idx <= table_names_len,
-                    "table_idx incremented past end of table_names",
-                    { "table_idx": table_idx, "table_names_len": table_names_len }
-                );
-                if table_idx == table_names_len {
-                    // Done copying all tables, now copy meta values
+                let tables_len = vacuum_state.tables_to_copy.len();
+                if table_idx >= tables_len {
+                    // Done copying all tables, proceed to meta values
                     vacuum_state.sub_state = OpVacuumIntoSubState::CopyMetaValues { dest_conn };
                     continue;
                 }
 
-                let table_name = &vacuum_state.table_names[table_idx];
-                // Escape double quotes in table name for safe SQL
+                let entry_ordinal = vacuum_state.tables_to_copy[table_idx];
+                let entry = &vacuum_state.schema_entries[entry_ordinal];
+                let table_name = &entry.name;
+
+                // sqlite_sequence: only copy data if the destination has it
+                // (auto-created when an AUTOINCREMENT table was created in
+                // phase 1). If not present, skip — no AUTOINCREMENT tables
+                // means no counters to preserve. The explicit copy is needed
+                // because inserting rows with the `rowid` pseudo-column does
+                // not update sqlite_sequence counters automatically.
+                if entry.is_sqlite_sequence() {
+                    let dest_has_sequence = dest_conn
+                        .schema
+                        .read()
+                        .get_btree_table(crate::schema::SQLITE_SEQUENCE_TABLE_NAME)
+                        .is_some();
+                    if !dest_has_sequence {
+                        vacuum_state.sub_state = OpVacuumIntoSubState::StartCopyTable {
+                            dest_conn,
+                            table_idx: table_idx + 1,
+                        };
+                        continue;
+                    }
+                }
+
                 let escaped_table_name = table_name.replace('"', "\"\"");
-                let pragma_sql = format!(
-                    "PRAGMA \"{escaped_schema_name}\".table_info(\"{escaped_table_name}\")"
-                );
-                let column_stmt = program.connection.prepare(&pragma_sql)?;
-                vacuum_state.current_table_columns.clear();
-                vacuum_state.sub_state = OpVacuumIntoSubState::CollectColumnInfo {
+                // Derive copy-column list from BTreeTable.columns in schema,
+                // filtering out virtual generated columns so the SELECT and
+                // INSERT arities stay aligned.
+                let source_btree_table = program
+                    .connection
+                    .with_schema(database_id, |schema| schema.get_btree_table(table_name));
+
+                let (select_sql, insert_sql) = build_copy_sql(
+                    escaped_schema_name,
+                    &escaped_table_name,
+                    source_btree_table.as_deref(),
+                )?;
+
+                // SELECT from source, INSERT into destination.
+                let select_stmt = program.connection.prepare_internal(&select_sql)?;
+
+                // System tables need nested mode during prepare() to bypass
+                // "may not be modified" checks. Can't use prepare_internal()
+                // because the nested guard must not persist into step() - the
+                // Transaction opcode needs to run for page-level write setup.
+                let is_system = crate::schema::is_system_table(table_name);
+                if is_system {
+                    dest_conn.start_nested();
+                }
+                let dest_insert_stmt = dest_conn.prepare(&insert_sql);
+                if is_system {
+                    dest_conn.end_nested();
+                }
+                let dest_insert_stmt = dest_insert_stmt?;
+
+                vacuum_state.sub_state = OpVacuumIntoSubState::CopyRows {
                     dest_conn,
-                    column_stmt: Box::new(column_stmt),
+                    select_stmt: Box::new(select_stmt),
+                    dest_insert_stmt: Box::new(dest_insert_stmt),
                     table_idx,
                 };
                 continue;
             }
-
-            OpVacuumIntoSubState::CollectColumnInfo {
-                dest_conn,
-                mut column_stmt,
-                table_idx,
-            } => {
-                match column_stmt.step()? {
-                    crate::StepResult::Row => {
-                        let row = column_stmt
-                            .row()
-                            .expect("StepResult::Row but row() returned None");
-                        // Column name is at index 1
-                        if let Value::Text(name) = row.get_value(1) {
-                            // Escape double quotes in column name for safe SQL
-                            let escaped_name = name.as_str().replace('"', "\"\"");
-                            let col_name = format!("\"{escaped_name}\"");
-                            vacuum_state.current_table_columns.push(col_name);
-                        }
-                        vacuum_state.sub_state = OpVacuumIntoSubState::CollectColumnInfo {
-                            dest_conn,
-                            column_stmt,
-                            table_idx,
-                        };
-                        continue;
-                    }
-                    crate::StepResult::Done => {
-                        if vacuum_state.current_table_columns.is_empty() {
-                            // if no columns, then db is corrupt
-                            return Err(LimboError::Corrupt(
-                                "found a table without any columns".to_string(),
-                            ));
-                        }
-
-                        // Prepare SELECT and INSERT statements for this table
-                        let table_name = &vacuum_state.table_names[table_idx];
-                        let escaped_table_name = table_name.replace('"', "\"\"");
-                        let source_btree_table = program
-                            .connection
-                            .with_schema(database_id, |s| s.get_btree_table(table_name));
-                        let rowid_alias = source_btree_table
-                            .as_ref()
-                            .filter(|table| table.has_rowid)
-                            .and_then(|table| {
-                                ["rowid", "_rowid_", "oid"]
-                                    .iter()
-                                    .copied()
-                                    .find(|alias| table.get_column(alias).is_none())
-                            });
-                        let rowid_alias_column_index = source_btree_table
-                            .as_ref()
-                            .and_then(|table| table.get_rowid_alias_column().map(|(idx, _)| idx));
-
-                        let mut data_columns: Vec<&str> = vacuum_state
-                            .current_table_columns
-                            .iter()
-                            .map(String::as_str)
-                            .collect();
-                        let mut excluded_rowid_alias_column = false;
-                        if rowid_alias.is_some() {
-                            if let Some(idx) = rowid_alias_column_index {
-                                turso_assert!(
-                                    idx < data_columns.len(),
-                                    "rowid alias column index out of bounds for table columns",
-                                    { "idx": idx, "columns_len": data_columns.len() }
-                                );
-                                data_columns.remove(idx);
-                                excluded_rowid_alias_column = true;
-                            }
-                        }
-                        let column_names = data_columns.join(", ");
-
-                        let qualified_table =
-                            format!("\"{escaped_schema_name}\".\"{escaped_table_name}\"");
-                        let select_sql = match rowid_alias {
-                            Some(alias)
-                                if excluded_rowid_alias_column && column_names.is_empty() =>
-                            {
-                                format!("SELECT {alias} FROM {qualified_table}")
-                            }
-                            Some(alias) if excluded_rowid_alias_column => {
-                                format!("SELECT {alias}, {column_names} FROM {qualified_table}")
-                            }
-                            Some(alias) => {
-                                format!("SELECT {alias}, * FROM {qualified_table}")
-                            }
-                            None => format!("SELECT * FROM {qualified_table}"),
-                        };
-                        let select_stmt = program.connection.prepare(&select_sql)?;
-
-                        // Prepare INSERT statement once per table (reused for all rows)
-                        let bind_count = if rowid_alias.is_some() {
-                            data_columns.len() + 1
-                        } else {
-                            data_columns.len()
-                        };
-                        let placeholders: String =
-                            (0..bind_count).map(|_| "?").collect::<Vec<_>>().join(", ");
-                        let insert_columns = if let Some(alias) = rowid_alias {
-                            if column_names.is_empty() {
-                                alias.to_string()
-                            } else {
-                                format!("{alias}, {column_names}")
-                            }
-                        } else {
-                            column_names
-                        };
-                        let insert_sql = format!(
-                            "INSERT INTO \"{escaped_table_name}\" ({insert_columns}) VALUES ({placeholders})"
-                        );
-
-                        // Internal tables need nested mode to bypass "may not
-                        // be modified" checks during prepare (compile time).
-                        let is_internal =
-                            table_name.starts_with(crate::schema::TURSO_INTERNAL_PREFIX);
-                        if is_internal {
-                            dest_conn.start_nested();
-                        }
-                        let dest_insert_stmt = dest_conn.prepare(&insert_sql);
-                        if is_internal {
-                            dest_conn.end_nested();
-                        }
-                        let dest_insert_stmt = dest_insert_stmt?;
-
-                        vacuum_state.sub_state = OpVacuumIntoSubState::CopyRows {
-                            dest_conn,
-                            select_stmt: Box::new(select_stmt),
-                            dest_insert_stmt: Box::new(dest_insert_stmt),
-                            table_idx,
-                        };
-                        continue;
-                    }
-                    crate::StepResult::IO => {
-                        let io = column_stmt
-                            .take_io_completions()
-                            .expect("StepResult::IO returned but no completions available");
-                        vacuum_state.sub_state = OpVacuumIntoSubState::CollectColumnInfo {
-                            dest_conn,
-                            column_stmt,
-                            table_idx,
-                        };
-                        return Ok(InsnFunctionStepResult::IO(io));
-                    }
-                    crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                        return Err(LimboError::Busy);
-                    }
-                }
-            }
-
             OpVacuumIntoSubState::CopyRows {
                 dest_conn,
                 mut select_stmt,
@@ -14302,14 +14196,12 @@ fn op_vacuum_into_inner(
                         .row()
                         .expect("StepResult::Row but row() returned None");
 
-                    let values: Vec<Value> = row.get_values().cloned().collect();
-
                     dest_insert_stmt.reset()?;
                     dest_insert_stmt.clear_bindings();
-                    for (i, value) in values.iter().enumerate() {
+                    for (i, value) in row.get_values().cloned().enumerate() {
                         let index =
                             std::num::NonZero::new(i + 1).expect("i + 1 is always non-zero");
-                        dest_insert_stmt.bind_at(index, value.clone());
+                        dest_insert_stmt.bind_at(index, value);
                     }
 
                     vacuum_state.sub_state = OpVacuumIntoSubState::StepDestInsert {
@@ -14481,6 +14373,146 @@ fn op_vacuum_into_inner(
             }
         }
     }
+}
+
+// Build the SELECT and INSERT SQL strings for copying a table's data.
+//
+// Uses the in-memory `BTreeTable` column metadata from the schema to derive
+// the copy-column list. Virtual generated columns are excluded from both
+// SELECT and INSERT since they are computed, not stored. This keeps both
+// lists tied to the same stored-column model.
+//
+// For e.g. given a schema:
+// CREATE TABLE employees (
+//       id INTEGER PRIMARY KEY,
+//       name TEXT,
+//       salary INTEGER,
+//       bonus INTEGER GENERATED ALWAYS AS (salary * 0.1) VIRTUAL
+//   )
+//
+//   Output:
+//   - select_sql: SELECT rowid, "name", "salary" FROM "main"."employees"
+//   - insert_sql: INSERT INTO "main"."employees" (rowid, "name", "salary") VALUES (?, ?, ?)
+fn build_copy_sql(
+    escaped_schema_name: &str,
+    escaped_table_name: &str,
+    source_btree_table: Option<&crate::schema::BTreeTable>,
+) -> Result<(String, String)> {
+    let Some(btree) = source_btree_table else {
+        // Storage-backed tables must have schema metadata. If we get here,
+        // the schema is inconsistent - somewhere it has gone terribly wrong
+        return Err(LimboError::Corrupt(format!(
+            "no schema metadata for storage-backed table \"{escaped_table_name}\""
+        )));
+    };
+
+    // Collect non-virtual-generated columns with their quoted names.
+    let mut data_columns: Vec<String> = Vec::new();
+    let mut rowid_alias_col_idx: Option<usize> = None;
+    for (i, col) in btree.columns.iter().enumerate() {
+        if col.is_virtual_generated() {
+            continue;
+        }
+        if col.is_rowid_alias() {
+            rowid_alias_col_idx = Some(i);
+        }
+        let Some(name) = col.name.as_deref() else {
+            return Err(LimboError::Corrupt(format!(
+                "missing column name for table \"{escaped_table_name}\""
+            )));
+        };
+        let escaped = name.replace('"', "\"\"");
+        data_columns.push(format!("\"{escaped}\""));
+    }
+
+    if data_columns.is_empty() {
+        return Err(LimboError::Corrupt(
+            "found a table without any columns".to_string(),
+        ));
+    }
+
+    // Determine rowid handling: for has_rowid tables, we need to preserve the
+    // rowid. Find an alias name (rowid, _rowid_, or oid) that doesn't conflict
+    // with an actual column name.
+    let rowid_alias = if btree.has_rowid {
+        ["rowid", "_rowid_", "oid"]
+            .iter()
+            .copied()
+            .find(|alias| btree.get_column(alias).is_none())
+    } else {
+        None
+    };
+
+    // Build the column lists. If there's a rowid alias column (INTEGER PRIMARY KEY),
+    // we exclude it from the data columns and use the rowid alias instead, since
+    // the rowid alias column IS the rowid.
+    //
+    // Track bind_count explicitly instead of parsing the joined string - column
+    // names can contain commas inside quotes which would miscount.
+    let (select_cols, insert_cols, bind_count) = if let Some(alias) = rowid_alias {
+        if let Some(alias_idx) = rowid_alias_col_idx {
+            // Remove the rowid alias column from data_columns (it IS the rowid)
+            let mut filtered: Vec<&str> = Vec::new();
+            let mut col_physical_idx = 0;
+            for (i, col) in btree.columns.iter().enumerate() {
+                if col.is_virtual_generated() {
+                    continue;
+                }
+                if i != alias_idx {
+                    filtered.push(&data_columns[col_physical_idx]);
+                }
+                col_physical_idx += 1;
+            }
+            if filtered.is_empty() {
+                // Table only has the rowid alias column
+                (alias.to_string(), alias.to_string(), 1)
+            } else {
+                let count = filtered.len() + 1; // +1 for rowid alias
+                let cols = filtered.join(", ");
+                (
+                    format!("{alias}, {cols}"),
+                    format!("{alias}, {cols}"),
+                    count,
+                )
+            }
+        } else {
+            // has_rowid but no explicit alias column - prepend the chosen rowid
+            // pseudo-column to the stored column list.
+            let count = data_columns.len() + 1; // +1 for rowid alias
+            let cols = data_columns.join(", ");
+            (
+                format!("{alias}, {cols}"),
+                format!("{alias}, {cols}"),
+                count,
+            )
+        }
+    } else {
+        // Either WITHOUT ROWID, or a rowid table where all three pseudo-names
+        // are shadowed by real columns. In the shadowed case SQL cannot name
+        // the hidden rowid, and SQLite does not require rowid stability for
+        // tables without an INTEGER PRIMARY KEY during VACUUM.
+        let count = data_columns.len();
+        let cols = data_columns.join(", ");
+        (cols.clone(), cols, count)
+    };
+
+    // The first placeholder is just "?"; each later placeholder adds ", ?".
+    // Reserve 3 bytes per placeholder, then subtract the 2-byte separator that
+    // the first placeholder does not need.
+    let mut placeholders = String::with_capacity(bind_count.saturating_mul(3).saturating_sub(2));
+    for i in 0..bind_count {
+        if i > 0 {
+            placeholders.push_str(", ");
+        }
+        placeholders.push('?');
+    }
+
+    let select_sql =
+        format!("SELECT {select_cols} FROM \"{escaped_schema_name}\".\"{escaped_table_name}\"");
+    let insert_sql =
+        format!("INSERT INTO \"{escaped_table_name}\" ({insert_cols}) VALUES ({placeholders})");
+
+    Ok((select_sql, insert_sql))
 }
 
 fn with_header<T, F>(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -31,6 +31,7 @@ pub mod insn;
 pub mod metrics;
 pub mod rowset;
 pub mod sorter;
+pub mod vacuum;
 pub mod value;
 // for benchmarks
 pub use crate::translate::collate::CollationSeq;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2009,6 +2009,11 @@ impl Program {
 
         let mut abort_error: Option<LimboError> = None;
 
+        // VACUUM INTO state can own internal helper statements whose drop path
+        // releases nested guards. Drop them before checking whether this program
+        // is itself nested; otherwise abort could skip top-level cleanup.
+        state.op_vacuum_into_state = None;
+
         // Only end trigger execution if the subprogram was actually running.
         // Cached (pooled) statements may be dropped after their trigger execution
         // was already ended by op_program; calling end again would pop the wrong

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1,0 +1,135 @@
+use turso_macros::turso_assert;
+
+/// A representation of a row from `sqlite_schema`.
+///
+/// Carries `rootpage` so we can distinguish storage-backed tables/indexes
+/// (rootpage != 0) from virtual tables, custom index-method indexes, views,
+/// and triggers (rootpage = 0).
+#[derive(Debug)]
+pub(crate) struct SchemaEntry {
+    pub entry_type: SchemaEntryType,
+    pub name: String,
+    /// `sqlite_schema.tbl_name`: for indexes and triggers, this is the table
+    /// the object belongs to; for tables and views it usually matches `name`.
+    pub tbl_name: String,
+    pub rootpage: i64,
+    pub sql: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SchemaEntryType {
+    Table,
+    Index,
+    Trigger,
+    View,
+}
+
+impl SchemaEntryType {
+    pub fn from_str(s: &str) -> crate::Result<Self> {
+        match s {
+            "table" => Ok(Self::Table),
+            "index" => Ok(Self::Index),
+            "trigger" => Ok(Self::Trigger),
+            "view" => Ok(Self::View),
+            other => Err(crate::error::LimboError::Corrupt(format!(
+                "unexpected sqlite_schema type: {other}"
+            ))),
+        }
+    }
+}
+
+impl SchemaEntry {
+    /// Parse from a sqlite_schema row: (type, name, tbl_name, rootpage, sql)
+    pub fn from_row(row: &crate::vdbe::Row) -> crate::Result<Self> {
+        let entry_type = SchemaEntryType::from_str(row.get::<&str>(0)?)?;
+        Ok(Self {
+            entry_type,
+            name: row.get::<&str>(1)?.to_string(),
+            tbl_name: row.get::<&str>(2)?.to_string(),
+            rootpage: row.get::<i64>(3)?,
+            sql: row.get::<&str>(4)?.to_string(),
+        })
+    }
+
+    /// Whether this entry represents a storage-backed object (table or index
+    /// with rootpage != 0). MVCC can use negative rootpage values before
+    /// checkpointing, so this checks `!= 0` rather than `> 0`.
+    pub fn is_storage_backed(&self) -> bool {
+        self.rootpage != 0
+    }
+
+    pub fn is_sqlite_sequence(&self) -> bool {
+        self.name == "sqlite_sequence"
+    }
+}
+
+/// Split rowid-ordered schema entries into the replay phases used by VACUUM.
+/// Returns indices into `entries` for `(tables_to_create, tables_to_copy,
+/// indexes_to_create, post_data_entries)`.
+pub(crate) fn classify_schema_entries(
+    entries: &[SchemaEntry],
+) -> (Vec<usize>, Vec<usize>, Vec<usize>, Vec<usize>) {
+    let mut tables_to_create: Vec<usize> = Vec::new();
+    let mut tables_to_copy: Vec<usize> = Vec::new();
+    let mut indexes_to_create: Vec<usize> = Vec::new();
+    let mut post_data_entries: Vec<usize> = Vec::new();
+
+    for (idx, entry) in entries.iter().enumerate() {
+        match entry.entry_type {
+            SchemaEntryType::Table if entry.is_storage_backed() => {
+                // Skip sqlite_sequence in the schema creation phase. When we
+                // create an AUTOINCREMENT table, Turso automatically creates
+                // sqlite_sequence if it doesn't exist (see translate/schema.rs).
+                // Since entries are ordered by rowid, an AUTOINCREMENT table may
+                // appear before sqlite_sequence. If we create that table first
+                // (which auto-creates sqlite_sequence), then later try to run
+                // "CREATE TABLE sqlite_sequence(name,seq)", it fails with
+                // "table already exists".
+                if !entry.is_sqlite_sequence() {
+                    tables_to_create.push(idx);
+                }
+                // All storage-backed tables get their data copied, including
+                // sqlite_stat1 and other internal storage-backed tables.
+                // sqlite_sequence data copy is handled specially by the caller
+                // (only if destination materialized it).
+                tables_to_copy.push(idx);
+            }
+            SchemaEntryType::Index if entry.is_storage_backed() => {
+                // Storage-backed index (rootpage != 0). Includes both normal
+                // user-defined indexes and backing_btree indexes for custom index
+                // methods. The caller filters out backing_btree indexes since
+                // those are recreated by the parent index method in the post-data
+                // phase.
+                indexes_to_create.push(idx);
+            }
+            SchemaEntryType::Trigger | SchemaEntryType::View => {
+                // Triggers and views are replayed after data copy to avoid
+                // triggers firing during the copy phase.
+                post_data_entries.push(idx);
+            }
+            SchemaEntryType::Table => {
+                // Virtual tables (rootpage = 0, type = table) land here.
+                // Replayed after data copy alongside triggers and views.
+                turso_assert!(
+                    !entry.is_storage_backed(),
+                    "unexpected storage-backed table (rootpage = 0): {entry.name}"
+                );
+                post_data_entries.push(idx);
+            }
+            SchemaEntryType::Index => {
+                // Custom index-method indexes (FTS, vector, etc.) have rootpage = 0
+                // in sqlite_schema because their storage is managed by the index
+                // method, not a B-tree.
+                // Replayed after data copy.
+                post_data_entries.push(idx);
+            }
+        }
+    }
+
+    (
+        tables_to_create,
+        tables_to_copy,
+        indexes_to_create,
+        post_data_entries,
+    )
+}

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -418,6 +418,228 @@ fn vacuum_into_step(
                 }
             }
 
+            // Phase 1: Create storage-backed tables (rootpage != 0, type=table),
+            // excluding sqlite_sequence (auto-created by AUTOINCREMENT tables).
+            VacuumIntoSubState::PrepareCreateTable { idx } => {
+                let entries_len = state.tables_to_create.len();
+                if idx >= entries_len {
+                    // Done creating tables, start copying data
+                    state.sub_state = VacuumIntoSubState::StartCopyTable { table_idx: 0 };
+                    continue;
+                }
+
+                let entry_ordinal = state.tables_to_create[idx];
+                let entry = &state.schema_entries[entry_ordinal];
+                let sql_str = &entry.sql;
+
+                // System tables (sqlite_stat1, __turso_internal_types, etc.) have
+                // reserved name prefixes that translate_create_table rejects for
+                // user SQL. Temporarily mark the dest connection as nested during
+                // prepare() so the reserved-name check is bypassed at compile
+                // time. The guard is only for prepare: keeping it during step()
+                // would make this CREATE TABLE look nested, so its Transaction
+                // opcode would skip write setup.
+                let is_system = crate::schema::is_system_table(&entry.name);
+                if is_system {
+                    state.dest_conn.start_nested();
+                }
+                let dest_stmt = state.dest_conn.prepare(sql_str);
+                if is_system {
+                    state.dest_conn.end_nested();
+                }
+                let dest_stmt = dest_stmt?;
+                state.sub_state = VacuumIntoSubState::StepCreateTable {
+                    dest_schema_stmt: Box::new(dest_stmt),
+                    idx,
+                };
+                continue;
+            }
+
+            VacuumIntoSubState::StepCreateTable {
+                mut dest_schema_stmt,
+                idx,
+            } => match dest_schema_stmt.step()? {
+                crate::StepResult::Row => {
+                    unreachable!("CREATE TABLE statement unexpectedly returned a row");
+                }
+                crate::StepResult::Done => {
+                    state.sub_state = VacuumIntoSubState::PrepareCreateTable { idx: idx + 1 };
+                    continue;
+                }
+                crate::StepResult::IO => {
+                    let io = dest_schema_stmt
+                        .take_io_completions()
+                        .expect("StepResult::IO returned but no completions available");
+                    state.sub_state = VacuumIntoSubState::StepCreateTable {
+                        dest_schema_stmt,
+                        idx,
+                    };
+                    return Ok(IOResult::IO(io));
+                }
+                crate::StepResult::Busy | crate::StepResult::Interrupt => {
+                    return Err(LimboError::Busy);
+                }
+            },
+
+            // Phase 2: Copy data for all storage-backed tables.
+            // Column lists are derived from BTreeTable.columns in the schema,
+            // not PRAGMA table_info, because table_info omits generated columns
+            // while SELECT * includes them - causing a column count mismatch.
+            VacuumIntoSubState::StartCopyTable { table_idx } => {
+                let tables_len = state.tables_to_copy.len();
+                if table_idx >= tables_len {
+                    // Done copying all tables, proceed to meta values
+                    state.sub_state = VacuumIntoSubState::CopyMetaValues;
+                    continue;
+                }
+
+                let entry_ordinal = state.tables_to_copy[table_idx];
+                let entry = &state.schema_entries[entry_ordinal];
+                let table_name = &entry.name;
+
+                // sqlite_sequence: only copy data if the destination has it
+                // (auto-created when an AUTOINCREMENT table was created in
+                // phase 1). If not present, skip — no AUTOINCREMENT tables
+                // means no counters to preserve. The explicit copy is needed
+                // because inserting rows with the `rowid` pseudo-column does
+                // not update sqlite_sequence counters automatically.
+                if entry.is_sqlite_sequence() {
+                    let dest_has_sequence = state
+                        .dest_conn
+                        .schema
+                        .read()
+                        .get_btree_table(crate::schema::SQLITE_SEQUENCE_TABLE_NAME)
+                        .is_some();
+                    if !dest_has_sequence {
+                        state.sub_state = VacuumIntoSubState::StartCopyTable {
+                            table_idx: table_idx + 1,
+                        };
+                        continue;
+                    }
+                }
+
+                let escaped_table_name = table_name.replace('"', "\"\"");
+                // Derive copy-column list from BTreeTable.columns in schema,
+                // filtering out virtual generated columns so the SELECT and
+                // INSERT arities stay aligned.
+                let source_btree_table = config
+                    .source_conn
+                    .with_schema(config.database_id, |schema| {
+                        schema.get_btree_table(table_name)
+                    });
+
+                let (select_sql, insert_sql) = build_copy_sql(
+                    &config.escaped_schema_name,
+                    &escaped_table_name,
+                    source_btree_table.as_deref(),
+                )?;
+
+                // SELECT from source, INSERT into destination.
+                let select_stmt = config.source_conn.prepare_internal(&select_sql)?;
+
+                // System tables need nested mode during prepare() to bypass
+                // "may not be modified" checks. Can't use prepare_internal()
+                // because the nested guard must not persist into step() - the
+                // Transaction opcode needs to run for page-level write setup.
+                let is_system = crate::schema::is_system_table(table_name);
+                if is_system {
+                    state.dest_conn.start_nested();
+                }
+                let dest_insert_stmt = state.dest_conn.prepare(&insert_sql);
+                if is_system {
+                    state.dest_conn.end_nested();
+                }
+                let dest_insert_stmt = dest_insert_stmt?;
+
+                state.sub_state = VacuumIntoSubState::CopyRows {
+                    select_stmt: Box::new(select_stmt),
+                    dest_insert_stmt: Box::new(dest_insert_stmt),
+                    table_idx,
+                };
+                continue;
+            }
+
+            VacuumIntoSubState::CopyRows {
+                mut select_stmt,
+                mut dest_insert_stmt,
+                table_idx,
+            } => match select_stmt.step()? {
+                crate::StepResult::Row => {
+                    let row = select_stmt
+                        .row()
+                        .expect("StepResult::Row but row() returned None");
+
+                    dest_insert_stmt.reset()?;
+                    dest_insert_stmt.clear_bindings();
+                    for (i, value) in row.get_values().cloned().enumerate() {
+                        let index =
+                            std::num::NonZero::new(i + 1).expect("i + 1 is always non-zero");
+                        dest_insert_stmt.bind_at(index, value);
+                    }
+
+                    state.sub_state = VacuumIntoSubState::StepDestInsert {
+                        select_stmt,
+                        dest_insert_stmt,
+                        table_idx,
+                    };
+                    continue;
+                }
+                crate::StepResult::Done => {
+                    // Move to next table
+                    state.sub_state = VacuumIntoSubState::StartCopyTable {
+                        table_idx: table_idx + 1,
+                    };
+                    continue;
+                }
+                crate::StepResult::IO => {
+                    let io = select_stmt
+                        .take_io_completions()
+                        .expect("StepResult::IO returned but no completions available");
+                    state.sub_state = VacuumIntoSubState::CopyRows {
+                        select_stmt,
+                        dest_insert_stmt,
+                        table_idx,
+                    };
+                    return Ok(IOResult::IO(io));
+                }
+                crate::StepResult::Busy | crate::StepResult::Interrupt => {
+                    return Err(LimboError::Busy);
+                }
+            },
+
+            VacuumIntoSubState::StepDestInsert {
+                select_stmt,
+                mut dest_insert_stmt,
+                table_idx,
+            } => match dest_insert_stmt.step()? {
+                crate::StepResult::Row => {
+                    unreachable!("INSERT statement unexpectedly returned a row");
+                }
+                crate::StepResult::Done => {
+                    // Go back to get next row from source
+                    state.sub_state = VacuumIntoSubState::CopyRows {
+                        select_stmt,
+                        dest_insert_stmt,
+                        table_idx,
+                    };
+                    continue;
+                }
+                crate::StepResult::IO => {
+                    let io = dest_insert_stmt
+                        .take_io_completions()
+                        .expect("StepResult::IO returned but no completions available");
+                    state.sub_state = VacuumIntoSubState::StepDestInsert {
+                        select_stmt,
+                        dest_insert_stmt,
+                        table_idx,
+                    };
+                    return Ok(IOResult::IO(io));
+                }
+                crate::StepResult::Busy | crate::StepResult::Interrupt => {
+                    return Err(LimboError::Busy);
+                }
+            },
+
             _ => todo!("VACUUM INTO engine phase not moved yet"),
         }
     }

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1,3 +1,10 @@
+use std::sync::Arc;
+
+use crate::error::LimboError;
+use crate::schema::TypeDef;
+use crate::types::IOResult;
+use crate::Result;
+use crate::{Connection, Database};
 use turso_macros::turso_assert;
 
 /// A representation of a row from `sqlite_schema`.
@@ -132,4 +139,275 @@ pub(crate) fn classify_schema_entries(
         indexes_to_create,
         post_data_entries,
     )
+}
+
+/// Configuration for the VACUUM INTO engine. Provided by the caller (opcode
+/// handler) after reading source metadata and setting up the destination DB.
+pub(crate) struct VacuumIntoConfig {
+    /// Source connection - used for `prepare_internal` and `with_schema` during
+    /// schema collection and data copy.
+    pub source_conn: Arc<Connection>,
+    /// Escaped schema name for safe SQL interpolation (e.g. `"main"`).
+    pub escaped_schema_name: String,
+    /// Database index for schema lookups on the source connection.
+    pub database_id: usize,
+    /// Source `user_version` pragma value to copy to destination.
+    pub source_user_version: i32,
+    /// Source `application_id` pragma value to copy to destination.
+    pub source_application_id: i32,
+    /// Pre-captured source custom type definitions for STRICT table replay.
+    pub source_custom_types: Vec<(String, Arc<TypeDef>)>,
+    /// Whether the source database has MVCC enabled.
+    pub source_mvcc_enabled: bool,
+}
+
+pub(crate) struct VacuumInto {
+    config: VacuumIntoConfig,
+    state: VacuumIntoState,
+}
+
+impl VacuumInto {
+    pub fn new(
+        config: VacuumIntoConfig,
+        dest_db: Arc<Database>,
+        dest_conn: Arc<Connection>,
+    ) -> Self {
+        Self {
+            config,
+            state: VacuumIntoState::new(dest_db, dest_conn),
+        }
+    }
+
+    pub fn step(&mut self) -> Result<IOResult<()>> {
+        vacuum_into_step(&self.config, &mut self.state)
+    }
+}
+
+/// State for the VACUUM INTO engine. Holds the destination connection and all
+/// intermediate state needed across async yields.
+struct VacuumIntoState {
+    /// Keep the destination database alive while VACUUM INTO is in progress.
+    #[allow(dead_code)]
+    dest_db: Arc<Database>,
+    /// Destination connection - lives here, not in each sub-state variant.
+    dest_conn: Arc<Connection>,
+    sub_state: VacuumIntoSubState,
+    /// Typed schema entries collected from sqlite_schema, ordered by rowid.
+    schema_entries: Vec<SchemaEntry>,
+    /// Storage-backed tables to CREATE (excludes sqlite_sequence).
+    tables_to_create: Vec<usize>,
+    /// Storage-backed tables whose data to copy.
+    tables_to_copy: Vec<usize>,
+    /// User-defined secondary indexes to CREATE (deferred for performance).
+    indexes_to_create: Vec<usize>,
+    /// Triggers, views, and rootpage = 0 objects (deferred to avoid trigger firing).
+    post_data_entries: Vec<usize>,
+}
+
+impl VacuumIntoState {
+    fn new(dest_db: Arc<Database>, dest_conn: Arc<Connection>) -> Self {
+        Self {
+            dest_db,
+            dest_conn,
+            sub_state: VacuumIntoSubState::Init,
+            schema_entries: Vec::new(),
+            tables_to_create: Vec::new(),
+            tables_to_copy: Vec::new(),
+            indexes_to_create: Vec::new(),
+            post_data_entries: Vec::new(),
+        }
+    }
+}
+
+/// Sub-states for the VACUUM INTO engine state machine.
+#[derive(Default)]
+enum VacuumIntoSubState {
+    /// Mirror symbols/types, set perf flags, begin dest tx, prepare schema query.
+    #[default]
+    Init,
+    /// Step through schema query to collect rows
+    CollectSchemaRows { schema_stmt: Box<crate::Statement> },
+    /// Prepare CREATE TABLE statement on destination (idx into tables_to_create)
+    PrepareCreateTable { idx: usize },
+    /// Step through CREATE TABLE statement on destination (async)
+    StepCreateTable {
+        dest_schema_stmt: Box<crate::Statement>,
+        idx: usize,
+    },
+    /// Start copying a table's data
+    StartCopyTable { table_idx: usize },
+    /// Select rows from source table and insert into destination
+    CopyRows {
+        select_stmt: Box<crate::Statement>,
+        dest_insert_stmt: Box<crate::Statement>,
+        table_idx: usize,
+    },
+    /// Step through INSERT statement on destination (async)
+    StepDestInsert {
+        select_stmt: Box<crate::Statement>,
+        dest_insert_stmt: Box<crate::Statement>,
+        table_idx: usize,
+    },
+    /// Copy meta values (user_version, application_id) from source to destination
+    CopyMetaValues,
+    /// Prepare CREATE INDEX statement on destination (idx into indexes_to_create)
+    PrepareCreateIndex { idx: usize },
+    /// Step through CREATE INDEX statement on destination (async)
+    StepCreateIndex {
+        dest_schema_stmt: Box<crate::Statement>,
+        idx: usize,
+    },
+    /// Prepare post-data schema objects (triggers, views, rootpage = 0 entries)
+    PreparePostData { idx: usize },
+    /// Step through post-data CREATE statement on destination
+    StepPostData {
+        dest_schema_stmt: Box<crate::Statement>,
+        idx: usize,
+    },
+    /// Operation complete
+    Done,
+}
+
+// ---------------------------------------------------------------------------
+// SQL generation for table data copy
+// ---------------------------------------------------------------------------
+
+// Build the SELECT and INSERT SQL strings for copying a table's data.
+//
+// Uses the in-memory `BTreeTable` column metadata from the schema to derive
+// the copy-column list. Virtual generated columns are excluded from both
+// SELECT and INSERT since they are computed, not stored. This keeps both
+// lists tied to the same stored-column model.
+//
+// For e.g. given a schema:
+// CREATE TABLE employees (
+//       id INTEGER PRIMARY KEY,
+//       name TEXT,
+//       salary INTEGER,
+//       bonus INTEGER GENERATED ALWAYS AS (salary * 0.1) VIRTUAL
+//   )
+//
+//   Output:
+//   - select_sql: SELECT rowid, "name", "salary" FROM "main"."employees"
+//   - insert_sql: INSERT INTO "main"."employees" (rowid, "name", "salary") VALUES (?, ?, ?)
+pub(crate) fn build_copy_sql(
+    escaped_schema_name: &str,
+    escaped_table_name: &str,
+    source_btree_table: Option<&crate::schema::BTreeTable>,
+) -> Result<(String, String)> {
+    let Some(btree) = source_btree_table else {
+        // Storage-backed tables must have schema metadata. If we get here,
+        // the schema is inconsistent - somewhere it has gone terribly wrong
+        return Err(LimboError::Corrupt(format!(
+            "no schema metadata for storage-backed table \"{escaped_table_name}\""
+        )));
+    };
+
+    // Collect non-virtual-generated columns with their quoted names.
+    let mut data_columns: Vec<String> = Vec::new();
+    let mut rowid_alias_col_idx: Option<usize> = None;
+    for (i, col) in btree.columns.iter().enumerate() {
+        if col.is_virtual_generated() {
+            continue;
+        }
+        if col.is_rowid_alias() {
+            rowid_alias_col_idx = Some(i);
+        }
+        let Some(name) = col.name.as_deref() else {
+            return Err(LimboError::Corrupt(format!(
+                "missing column name for table \"{escaped_table_name}\""
+            )));
+        };
+        let escaped = name.replace('"', "\"\"");
+        data_columns.push(format!("\"{escaped}\""));
+    }
+
+    if data_columns.is_empty() {
+        return Err(LimboError::Corrupt(
+            "found a table without any columns".to_string(),
+        ));
+    }
+
+    // Determine rowid handling: for has_rowid tables, we need to preserve the
+    // rowid. Find an alias name (rowid, _rowid_, or oid) that doesn't conflict
+    // with an actual column name.
+    let rowid_alias = if btree.has_rowid {
+        ["rowid", "_rowid_", "oid"]
+            .iter()
+            .copied()
+            .find(|alias| btree.get_column(alias).is_none())
+    } else {
+        None
+    };
+
+    // Build the column lists. If there's a rowid alias column (INTEGER PRIMARY KEY),
+    // we exclude it from the data columns and use the rowid alias instead, since
+    // the rowid alias column IS the rowid.
+    //
+    // Track bind_count explicitly instead of parsing the joined string - column
+    // names can contain commas inside quotes which would miscount.
+    let (select_cols, insert_cols, bind_count) = if let Some(alias) = rowid_alias {
+        if let Some(alias_idx) = rowid_alias_col_idx {
+            // Remove the rowid alias column from data_columns (it IS the rowid)
+            let mut filtered: Vec<&str> = Vec::new();
+            let mut col_physical_idx = 0;
+            for (i, col) in btree.columns.iter().enumerate() {
+                if col.is_virtual_generated() {
+                    continue;
+                }
+                if i != alias_idx {
+                    filtered.push(&data_columns[col_physical_idx]);
+                }
+                col_physical_idx += 1;
+            }
+            if filtered.is_empty() {
+                // Table only has the rowid alias column
+                (alias.to_string(), alias.to_string(), 1)
+            } else {
+                let count = filtered.len() + 1; // +1 for rowid alias
+                let cols = filtered.join(", ");
+                (
+                    format!("{alias}, {cols}"),
+                    format!("{alias}, {cols}"),
+                    count,
+                )
+            }
+        } else {
+            // has_rowid but no explicit alias column - prepend the chosen rowid
+            // pseudo-column to the stored column list.
+            let count = data_columns.len() + 1; // +1 for rowid alias
+            let cols = data_columns.join(", ");
+            (
+                format!("{alias}, {cols}"),
+                format!("{alias}, {cols}"),
+                count,
+            )
+        }
+    } else {
+        // Either WITHOUT ROWID, or a rowid table where all three pseudo-names
+        // are shadowed by real columns. In the shadowed case SQL cannot name
+        // the hidden rowid, and SQLite does not require rowid stability for
+        // tables without an INTEGER PRIMARY KEY during VACUUM.
+        let count = data_columns.len();
+        let cols = data_columns.join(", ");
+        (cols.clone(), cols, count)
+    };
+
+    // The first placeholder is just "?"; each later placeholder adds ", ?".
+    // Reserve 3 bytes per placeholder, then subtract the 2-byte separator that
+    // the first placeholder does not need.
+    let mut placeholders = String::with_capacity(bind_count.saturating_mul(3).saturating_sub(2));
+    for i in 0..bind_count {
+        if i > 0 {
+            placeholders.push_str(", ");
+        }
+        placeholders.push('?');
+    }
+
+    let select_sql =
+        format!("SELECT {select_cols} FROM \"{escaped_schema_name}\".\"{escaped_table_name}\"");
+    let insert_sql =
+        format!("INSERT INTO \"{escaped_table_name}\" ({insert_cols}) VALUES ({placeholders})");
+
+    Ok((select_sql, insert_sql))
 }

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -268,6 +268,161 @@ enum VacuumIntoSubState {
     Done,
 }
 
+/// VACUUM INTO - create a compacted copy of the database at the specified path.
+///
+/// This is an async state machine implementation that yields on I/O operations.
+/// The caller creates a new database at the destination path with matching
+/// page_size, reserved bytes, source feature flags, and schema-replay symbols.
+///
+/// It:
+/// 1. Mirrors source symbols and custom types to destination
+/// 2. Queries sqlite_schema for all schema objects including rootpage, ordered by rowid
+/// 3. Creates storage-backed tables (rootpage != 0) in destination, excluding
+///    sqlite_sequence (auto-created when AUTOINCREMENT tables are created)
+/// 4. Copies data for all storage-backed tables, including sqlite_stat1 and other
+///    internal storage-backed tables
+/// 5. Creates user-defined secondary indexes after data copy for performance
+///    (backing-btree indexes for custom index methods are excluded here)
+/// 6. Copies meta values (user_version, application_id) from source to destination
+/// 7. Creates triggers, views, and rootpage = 0 objects last (after data copy).
+///    Custom index methods (FTS, vector) recreate and backfill their backing
+///    indexes from the copied table data in this phase.
+fn vacuum_into_step(
+    config: &VacuumIntoConfig,
+    state: &mut VacuumIntoState,
+) -> Result<IOResult<()>> {
+    loop {
+        let current_sub_state = std::mem::take(&mut state.sub_state);
+
+        match current_sub_state {
+            VacuumIntoSubState::Init => {
+                // Mirror source symbols needed for schema replay (functions, vtab
+                // modules, index methods). We skip vtabs - those are live instances
+                // tied to the source connection and not needed for compiling schema SQL.
+                {
+                    let source_syms = config.source_conn.syms.read();
+                    let mut dest_syms = state.dest_conn.syms.write();
+                    dest_syms.functions.extend(
+                        source_syms
+                            .functions
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                    dest_syms.vtab_modules.extend(
+                        source_syms
+                            .vtab_modules
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                    dest_syms.index_methods.extend(
+                        source_syms
+                            .index_methods
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                }
+
+                // Mirror source custom type definitions into destination schema
+                // so that STRICT tables with custom type columns can resolve
+                // those types during CREATE TABLE replay.
+                if !config.source_custom_types.is_empty() {
+                    state.dest_conn.with_schema_mut(|dest_schema| {
+                        for (name, td) in &config.source_custom_types {
+                            dest_schema.type_registry.insert(name.clone(), td.clone());
+                        }
+                    });
+                }
+
+                // Enable MVCC on destination if source has it enabled
+                // Must be done before any schema operations to ensure the log file is created
+                if config.source_mvcc_enabled {
+                    state.dest_conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+                }
+
+                // Performance optimizations for destination database (matches SQLite vacuum.c):
+                // 1. Disable fsync - destination is a new file, if crash occurs we just delete it
+                // 2. Disable foreign key checks - source data is already consistent
+                // These match SQLite's vacuum.c optimizations (PAGER_SYNCHRONOUS_OFF, ~SQLITE_ForeignKeys)
+                state.dest_conn.set_sync_mode(crate::SyncMode::Off);
+                state.dest_conn.set_foreign_keys_enabled(false);
+
+                // Wrap all operations in a single transaction for atomicity.
+                state.dest_conn.execute("BEGIN")?;
+
+                // Query sqlite_schema with rootpage, ordered by rowid.
+                // Exclude the MVCC metadata table - it is an internal artifact.
+                let escaped_schema_name = &config.escaped_schema_name;
+                let schema_sql = format!(
+                    "SELECT type, name, tbl_name, rootpage, sql \
+                     FROM \"{escaped_schema_name}\".sqlite_schema \
+                     WHERE sql IS NOT NULL AND name <> '{}' ORDER BY rowid",
+                    crate::mvcc::database::MVCC_META_TABLE_NAME
+                );
+                let schema_stmt = config.source_conn.prepare_internal(schema_sql.as_str())?;
+
+                state.sub_state = VacuumIntoSubState::CollectSchemaRows {
+                    schema_stmt: Box::new(schema_stmt),
+                };
+                continue;
+            }
+
+            VacuumIntoSubState::CollectSchemaRows { mut schema_stmt } => {
+                match schema_stmt.step()? {
+                    crate::StepResult::Row => {
+                        let row = schema_stmt
+                            .row()
+                            .expect("StepResult::Row but row() returned None");
+                        state.schema_entries.push(SchemaEntry::from_row(row)?);
+                        state.sub_state = VacuumIntoSubState::CollectSchemaRows { schema_stmt };
+                        continue;
+                    }
+                    crate::StepResult::Done => {
+                        // Classify schema entries into replay phases using rootpage.
+                        let (tables_create, tables_copy, indexes_create, post_data) =
+                            classify_schema_entries(&state.schema_entries);
+                        state.tables_to_create = tables_create;
+                        state.tables_to_copy = tables_copy;
+                        // Backing-btree indexes are implementation details of custom index
+                        // methods. i.e. when custom indexes are created, they are created automatically
+                        // The user-visible custom-index CREATE in post_data_entries
+                        // recreates and backfills those backing indexes from the copied rows.
+                        // for now, we will skip them
+                        state.indexes_to_create = indexes_create
+                            .into_iter()
+                            .filter(|entry_ordinal| {
+                                let entry = &state.schema_entries[*entry_ordinal];
+                                !config
+                                    .source_conn
+                                    .with_schema(config.database_id, |schema| {
+                                        schema
+                                            .get_index(&entry.tbl_name, &entry.name)
+                                            .is_some_and(|idx| idx.is_backing_btree_index())
+                                    })
+                            })
+                            .collect();
+                        state.post_data_entries = post_data;
+
+                        state.sub_state = VacuumIntoSubState::PrepareCreateTable { idx: 0 };
+                        continue;
+                    }
+                    crate::StepResult::IO => {
+                        let io = schema_stmt
+                            .take_io_completions()
+                            .expect("StepResult::IO returned but no completions available");
+                        state.sub_state = VacuumIntoSubState::CollectSchemaRows { schema_stmt };
+                        return Ok(IOResult::IO(io));
+                    }
+                    crate::StepResult::Busy | crate::StepResult::Interrupt => {
+                        return Err(LimboError::Busy);
+                    }
+                }
+            }
+
+            _ => todo!("VACUUM INTO engine phase not moved yet"),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // SQL generation for table data copy
 // ---------------------------------------------------------------------------

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -640,7 +640,122 @@ fn vacuum_into_step(
                 }
             },
 
-            _ => todo!("VACUUM INTO engine phase not moved yet"),
+            VacuumIntoSubState::CopyMetaValues => {
+                // Copy meta values to destination database
+                // Use pragma_update to set user_version and application_id
+                // Note: schema_version is not copied - VACUUM INTO creates a new file so
+                // there's no cache to invalidate. The destination will have its own
+                // schema_version based on the schema operations performed.
+                state
+                    .dest_conn
+                    .pragma_update("user_version", config.source_user_version.to_string())?;
+                state
+                    .dest_conn
+                    .pragma_update("application_id", config.source_application_id.to_string())?;
+
+                // Phase 3: Create user-defined secondary indexes after data copy
+                // for performance (avoids maintaining indexes during bulk insert).
+                state.sub_state = VacuumIntoSubState::PrepareCreateIndex { idx: 0 };
+                continue;
+            }
+
+            // Phase 3: Create user-defined secondary indexes.
+            VacuumIntoSubState::PrepareCreateIndex { idx } => {
+                let entries_len = state.indexes_to_create.len();
+                if idx >= entries_len {
+                    // Done creating indexes, move to post-data objects
+                    state.sub_state = VacuumIntoSubState::PreparePostData { idx: 0 };
+                    continue;
+                }
+
+                let entry_ordinal = state.indexes_to_create[idx];
+                let entry = &state.schema_entries[entry_ordinal];
+                // Backing-btree indexes for custom index methods were filtered
+                // out when indexes_to_create was built. The remaining CREATE
+                // INDEX statements are user-visible and can use ordinary prepare.
+                let dest_stmt = state.dest_conn.prepare(&entry.sql)?;
+                state.sub_state = VacuumIntoSubState::StepCreateIndex {
+                    dest_schema_stmt: Box::new(dest_stmt),
+                    idx,
+                };
+                continue;
+            }
+
+            VacuumIntoSubState::StepCreateIndex {
+                mut dest_schema_stmt,
+                idx,
+            } => match dest_schema_stmt.step()? {
+                crate::StepResult::Row => {
+                    unreachable!("CREATE INDEX statement unexpectedly returned a row");
+                }
+                crate::StepResult::Done => {
+                    state.sub_state = VacuumIntoSubState::PrepareCreateIndex { idx: idx + 1 };
+                    continue;
+                }
+                crate::StepResult::IO => {
+                    let io = dest_schema_stmt
+                        .take_io_completions()
+                        .expect("StepResult::IO returned but no completions available");
+                    state.sub_state = VacuumIntoSubState::StepCreateIndex {
+                        dest_schema_stmt,
+                        idx,
+                    };
+                    return Ok(IOResult::IO(io));
+                }
+                crate::StepResult::Busy | crate::StepResult::Interrupt => {
+                    return Err(LimboError::Busy);
+                }
+            },
+
+            // Phase 4: Create triggers, views, and rootpage=0 schema objects.
+            VacuumIntoSubState::PreparePostData { idx } => {
+                let entries_len = state.post_data_entries.len();
+                if idx >= entries_len {
+                    state.sub_state = VacuumIntoSubState::Done;
+                    continue;
+                }
+
+                let entry_ordinal = state.post_data_entries[idx];
+                let entry = &state.schema_entries[entry_ordinal];
+                let dest_stmt = state.dest_conn.prepare(&entry.sql)?;
+                state.sub_state = VacuumIntoSubState::StepPostData {
+                    dest_schema_stmt: Box::new(dest_stmt),
+                    idx,
+                };
+                continue;
+            }
+
+            VacuumIntoSubState::StepPostData {
+                mut dest_schema_stmt,
+                idx,
+            } => match dest_schema_stmt.step()? {
+                crate::StepResult::Row => {
+                    unreachable!("CREATE statement unexpectedly returned a row");
+                }
+                crate::StepResult::Done => {
+                    state.sub_state = VacuumIntoSubState::PreparePostData { idx: idx + 1 };
+                    continue;
+                }
+                crate::StepResult::IO => {
+                    let io = dest_schema_stmt
+                        .take_io_completions()
+                        .expect("StepResult::IO returned but no completions available");
+                    state.sub_state = VacuumIntoSubState::StepPostData {
+                        dest_schema_stmt,
+                        idx,
+                    };
+                    return Ok(IOResult::IO(io));
+                }
+                crate::StepResult::Busy | crate::StepResult::Interrupt => {
+                    return Err(LimboError::Busy);
+                }
+            },
+
+            VacuumIntoSubState::Done => {
+                // Commit the destination transaction started in Init state.
+                state.dest_conn.execute("COMMIT")?;
+                return Ok(IOResult::Done(()));
+            }
         }
     }
 }

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -189,7 +189,6 @@ struct VacuumIntoState {
     /// Keep the destination database alive while VACUUM INTO is in progress.
     #[allow(dead_code)]
     dest_db: Arc<Database>,
-    /// Destination connection - lives here, not in each sub-state variant.
     dest_conn: Arc<Connection>,
     sub_state: VacuumIntoSubState,
     /// Typed schema entries collected from sqlite_schema, ordered by rowid.
@@ -198,9 +197,9 @@ struct VacuumIntoState {
     tables_to_create: Vec<usize>,
     /// Storage-backed tables whose data to copy.
     tables_to_copy: Vec<usize>,
-    /// User-defined secondary indexes to CREATE (deferred for performance).
+    /// User-defined secondary indexes to CREATE.
     indexes_to_create: Vec<usize>,
-    /// Triggers, views, and rootpage = 0 objects (deferred to avoid trigger firing).
+    /// Triggers, views, custom indexes, and rootpage = 0 objects.
     post_data_entries: Vec<usize>,
 }
 
@@ -242,7 +241,7 @@ enum VacuumIntoSubState {
         dest_insert_stmt: Box<crate::Statement>,
         table_idx: usize,
     },
-    /// Step through INSERT statement on destination (async)
+    /// Step through INSERT statement on destination
     StepDestInsert {
         select_stmt: Box<crate::Statement>,
         dest_insert_stmt: Box<crate::Statement>,
@@ -252,7 +251,7 @@ enum VacuumIntoSubState {
     CopyMetaValues,
     /// Prepare CREATE INDEX statement on destination (idx into indexes_to_create)
     PrepareCreateIndex { idx: usize },
-    /// Step through CREATE INDEX statement on destination (async)
+    /// Step through CREATE INDEX statement on destination
     StepCreateIndex {
         dest_schema_stmt: Box<crate::Statement>,
         idx: usize,
@@ -759,10 +758,6 @@ fn vacuum_into_step(
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// SQL generation for table data copy
-// ---------------------------------------------------------------------------
 
 // Build the SELECT and INSERT SQL strings for copying a table's data.
 //

--- a/testing/simulator/Cargo.toml
+++ b/testing/simulator/Cargo.toml
@@ -44,6 +44,7 @@ chrono = { workspace = true, default-features = true, features = ["serde"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow.workspace = true
+tempfile.workspace = true
 hex = { workspace = true }
 itertools = { workspace = true }
 sql_generation = { workspace = true }

--- a/testing/simulator/runner/memory/statement_abandon.rs
+++ b/testing/simulator/runner/memory/statement_abandon.rs
@@ -8,38 +8,49 @@ use crate::runner::SimIO;
 use crate::runner::memory::io::MemorySimIO;
 
 fn make_conn(seed: u64) -> Result<(Arc<Connection>, Arc<MemorySimIO>)> {
-    let io = Arc::new(MemorySimIO::new(
+    let io = make_io(seed);
+    let path = format!("sim_stmt_abandon_{seed}.db");
+    let conn = open_conn(io.clone(), &path)?;
+    Ok((conn, io))
+}
+
+fn make_two_conns(seed: u64) -> Result<(Arc<Connection>, Arc<Connection>, Arc<MemorySimIO>)> {
+    let io = make_io(seed);
+    let path = format!("sim_stmt_abandon_two_conns_{seed}.db");
+    let (conn1, conn2) = open_two_conns(io.clone(), &path)?;
+    Ok((conn1, conn2, io))
+}
+
+fn make_io(seed: u64) -> Arc<MemorySimIO> {
+    Arc::new(MemorySimIO::new(
         seed, 4096, 100, // Always schedule operations asynchronously.
         1, 5,
-    ));
-    let path = format!("sim_stmt_abandon_{seed}.db");
+    ))
+}
+
+fn open_conn(io: Arc<MemorySimIO>, path: &str) -> Result<Arc<Connection>> {
     let db = Database::open_file_with_flags(
-        io.clone() as Arc<dyn IO>,
-        &path,
+        io as Arc<dyn IO>,
+        path,
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
     )?;
     let conn = db.connect()?;
-    Ok((conn, io))
+    Ok(conn)
 }
 
-fn make_two_conns(seed: u64) -> Result<(Arc<Connection>, Arc<Connection>, Arc<MemorySimIO>)> {
-    let io = Arc::new(MemorySimIO::new(
-        seed, 4096, 100, // Always schedule operations asynchronously.
-        1, 5,
-    ));
-    let path = format!("sim_stmt_abandon_two_conns_{seed}.db");
+fn open_two_conns(io: Arc<MemorySimIO>, path: &str) -> Result<(Arc<Connection>, Arc<Connection>)> {
     let db = Database::open_file_with_flags(
-        io.clone() as Arc<dyn IO>,
-        &path,
+        io as Arc<dyn IO>,
+        path,
         OpenFlags::default(),
         DatabaseOpts::new(),
         None,
     )?;
     let conn1 = db.connect()?;
     let conn2 = db.connect()?;
-    Ok((conn1, conn2, io))
+    Ok((conn1, conn2))
 }
 
 fn query_count(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<i64> {
@@ -267,6 +278,103 @@ fn sim_reset_releases_subjournal_when_abort_called_without_error() -> Result<()>
     assert_eq!(
         query_rows(&conn, io.as_ref())?,
         vec![(99, "ok".to_string())]
+    );
+    Ok(())
+}
+
+/// Verify that a completed VACUUM INTO does not leak source transaction state.
+/// After a successful vacuum, the source connection must be back in auto-commit
+/// mode and usable for new writes.
+#[test]
+fn sim_vacuum_into_cleans_up_source_transaction() -> Result<()> {
+    let (conn, io) = make_conn(7)?;
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")?;
+    for i in 0..20 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, 'row_{i}')"))?;
+    }
+
+    let dest_dir = tempfile::TempDir::new()?;
+    let dest_path = dest_dir.path().join("vacuumed.db");
+    let dest_path_str = dest_path.to_str().expect("temp dir should be valid UTF-8");
+
+    assert!(
+        conn.get_auto_commit(),
+        "should be in auto-commit before VACUUM INTO"
+    );
+
+    let mut stmt = conn.prepare(format!("VACUUM INTO '{dest_path_str}'"))?;
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Done => break,
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+    drop(stmt);
+
+    // Source connection must be back in auto-commit mode after vacuum.
+    assert!(
+        conn.get_auto_commit(),
+        "source connection should be in auto-commit mode after VACUUM INTO completes"
+    );
+
+    // Source connection must be usable for new writes.
+    conn.execute("INSERT INTO t VALUES (999, 'after_vacuum')")?;
+    let count = query_count(&conn, io.as_ref())?;
+    assert_eq!(
+        count, 21,
+        "should have 20 original rows + 1 new row after vacuum"
+    );
+    Ok(())
+}
+
+/// Abandoning VACUUM INTO while it is still running must roll back the manually
+/// owned source transaction.
+#[test]
+fn sim_abandon_vacuum_into_cleans_up_source_transaction() -> Result<()> {
+    let io = make_io(8);
+    let path = "sim_stmt_abandon_vacuum_reopen.db";
+    // Reopen so VACUUM reads source pages from simulated storage; with warm
+    // cache, this can complete synchronously and not exercise abandon cleanup.
+    {
+        let conn = open_conn(io.clone(), path)?;
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")?;
+        let payload = "x".repeat(256);
+        for i in 0..400 {
+            conn.execute(format!("INSERT INTO t VALUES ({i}, '{payload}')"))?;
+        }
+    }
+
+    let conn = open_conn(io.clone(), path)?;
+
+    let dest_dir = tempfile::TempDir::new()?;
+    let dest_path = dest_dir.path().join("abandoned_vacuum.db");
+    let dest_path_str = dest_path.to_str().expect("temp dir should be valid UTF-8");
+
+    let mut stmt = conn.prepare(format!("VACUUM INTO '{dest_path_str}'"))?;
+    let first = stmt.step()?;
+    assert!(
+        matches!(first, StepResult::IO),
+        "expected IO while VACUUM INTO is running, got {first:?}"
+    );
+    assert!(
+        !conn.get_auto_commit(),
+        "VACUUM INTO should own a source transaction while it is running"
+    );
+
+    drop(stmt);
+    io.step()?;
+
+    assert!(
+        conn.get_auto_commit(),
+        "source connection should return to auto-commit after abandoned VACUUM INTO"
+    );
+    conn.execute("INSERT INTO t VALUES (999, 'after_abandon')")?;
+    let count = query_count(&conn, io.as_ref())?;
+    assert_eq!(
+        count, 401,
+        "should have 400 original rows + 1 new row after abandoned vacuum"
     );
     Ok(())
 }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -593,6 +593,29 @@ pub fn compute_dbhash_with_options(
     turso_dbhash::hash_database(path, options).expect("dbhash failed")
 }
 
+/// Compute dbhash while opening the database with explicit feature flags.
+pub fn compute_dbhash_with_database_opts(
+    tmp_db: &TempDatabase,
+    database_opts: turso_core::DatabaseOpts,
+) -> turso_dbhash::DbHashResult {
+    compute_dbhash_with_options_and_database_opts(
+        tmp_db,
+        &turso_dbhash::DbHashOptions::default(),
+        database_opts,
+    )
+}
+
+/// Compute dbhash with custom hash options and explicit database feature flags.
+pub fn compute_dbhash_with_options_and_database_opts(
+    tmp_db: &TempDatabase,
+    options: &turso_dbhash::DbHashOptions,
+    database_opts: turso_core::DatabaseOpts,
+) -> turso_dbhash::DbHashResult {
+    let path = tmp_db.path.to_str().unwrap();
+    turso_dbhash::hash_database_with_database_opts(path, options, database_opts)
+        .expect("dbhash failed")
+}
+
 /// Assert that checkpoint does not change database content.
 /// Computes hash before and after checkpoint, asserts they match.
 pub fn assert_checkpoint_preserves_content(conn: &Arc<Connection>, tmp_db: &TempDatabase) {

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -1,4 +1,7 @@
-use crate::common::{compute_dbhash, compute_dbhash_with_options, ExecRows, TempDatabase};
+use crate::common::{
+    compute_dbhash, compute_dbhash_with_database_opts, compute_dbhash_with_options,
+    compute_dbhash_with_options_and_database_opts, ExecRows, TempDatabase,
+};
 use rusqlite::Connection as SqliteConnection;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -883,12 +886,16 @@ fn test_vacuum_into_rowid_compat_with_sqlite_reference(tmp_db: TempDatabase) -> 
     conn.execute("CREATE TABLE t (a TEXT)")?;
     conn.execute("INSERT INTO t(rowid, a) VALUES(5, 'x')")?;
     conn.execute("INSERT INTO t(rowid, a) VALUES(42, 'y')")?;
+    let source_hash = compute_dbhash(&tmp_db);
 
     let dest_dir = TempDir::new()?;
     let turso_dest = dest_dir.path().join("turso_rowid_vacuum.db");
     conn.execute(format!("VACUUM INTO '{}'", turso_dest.to_str().unwrap()))?;
     let turso_dest_db = TempDatabase::new_with_existent(&turso_dest);
     let turso_dest_conn = turso_dest_db.connect_limbo();
+    if !tmp_db.enable_mvcc {
+        assert_eq!(source_hash.hash, compute_dbhash(&turso_dest_db).hash);
+    }
     let turso_rows: Vec<(i64, String)> =
         turso_dest_conn.exec_rows("SELECT rowid, a FROM t ORDER BY rowid");
 
@@ -938,12 +945,16 @@ fn test_vacuum_into_integer_pk_and_indexes_compat_with_sqlite(
     conn.execute("INSERT INTO t_idx(id, a, b) VALUES (10, 'alpha', 50)")?;
     conn.execute("INSERT INTO t_idx(id, a, b) VALUES (25, 'beta', 150)")?;
     conn.execute("INSERT INTO t_idx(id, a, b) VALUES (50, 'gamma', 200)")?;
+    let source_hash = compute_dbhash(&tmp_db);
 
     let dest_dir = TempDir::new()?;
     let turso_dest = dest_dir.path().join("turso_index_vacuum.db");
     conn.execute(format!("VACUUM INTO '{}'", turso_dest.to_str().unwrap()))?;
     let turso_dest_db = TempDatabase::new_with_existent(&turso_dest);
     let turso_dest_conn = turso_dest_db.connect_limbo();
+    if !tmp_db.enable_mvcc {
+        assert_eq!(source_hash.hash, compute_dbhash(&turso_dest_db).hash);
+    }
     let turso_rows: Vec<(i64, i64, String, i64)> =
         turso_dest_conn.exec_rows("SELECT rowid, id, a, b FROM t_idx ORDER BY id");
     let turso_index_names_rows: Vec<(String,)> = turso_dest_conn.exec_rows(
@@ -1028,6 +1039,7 @@ fn test_vacuum_into_preserves_rowid_when_rowid_alias_is_shadowed(
         source_rows,
         vec![(77, "visible".to_string(), "x".to_string())]
     );
+    let source_hash = compute_dbhash(&tmp_db);
 
     let dest_dir = TempDir::new()?;
     let dest_path = dest_dir.path().join("vacuumed_rowid_shadowed.db");
@@ -1036,6 +1048,9 @@ fn test_vacuum_into_preserves_rowid_when_rowid_alias_is_shadowed(
     let dest_db = TempDatabase::new_with_existent(&dest_path);
     let dest_conn = dest_db.connect_limbo();
     assert_eq!(run_integrity_check(&dest_conn), "ok");
+    if !tmp_db.enable_mvcc {
+        assert_eq!(source_hash.hash, compute_dbhash(&dest_db).hash);
+    }
 
     let dest_rows: Vec<(i64, String, String)> =
         dest_conn.exec_rows("SELECT _rowid_, rowid, a FROM t ORDER BY _rowid_");
@@ -1077,6 +1092,7 @@ fn test_vacuum_into_when_all_rowid_aliases_are_shadowed(
             ),
         ]
     );
+    let source_hash = compute_dbhash(&tmp_db);
 
     let dest_dir = TempDir::new()?;
     let dest_path = dest_dir.path().join("vacuumed_all_aliases_shadowed.db");
@@ -1085,6 +1101,9 @@ fn test_vacuum_into_when_all_rowid_aliases_are_shadowed(
     let dest_db = TempDatabase::new_with_existent(&dest_path);
     let dest_conn = dest_db.connect_limbo();
     assert_eq!(run_integrity_check(&dest_conn), "ok");
+    if !tmp_db.enable_mvcc {
+        assert_eq!(source_hash.hash, compute_dbhash(&dest_db).hash);
+    }
 
     let dest_rows: Vec<(String, String, String, String)> =
         dest_conn.exec_rows("SELECT rowid, _rowid_, oid, a FROM t ORDER BY a");
@@ -1455,6 +1474,63 @@ fn test_vacuum_into_large_data_multi_page(tmp_db: TempDatabase) -> anyhow::Resul
     Ok(())
 }
 
+/// VACUUM INTO must leave the main destination file self-contained, even when
+/// the copied image is larger than the WAL auto-checkpoint threshold.
+#[turso_macros::test]
+fn test_vacuum_into_large_destination_survives_without_wal(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE large_data (id INTEGER PRIMARY KEY, data BLOB)")?;
+    conn.execute(
+        "INSERT INTO large_data \
+         SELECT value, randomblob(4096) \
+         FROM generate_series(1, 1200)",
+    )?;
+
+    let source_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert!(
+        source_pages[0].0 > 1000,
+        "source should exceed the auto-checkpoint threshold, got {} pages",
+        source_pages[0].0
+    );
+    let source_hash = compute_dbhash(&tmp_db);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("vacuumed_large_no_wal.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let copied_dir = TempDir::new()?;
+    let copied_path = copied_dir.path().join("copied.db");
+    std::fs::copy(&dest_path, &copied_path)?;
+    assert!(
+        !copied_dir.path().join("copied.db-wal").exists(),
+        "test must copy only the destination database file"
+    );
+
+    let copied_db = TempDatabase::new_with_existent(&copied_path);
+    let copied_conn = copied_db.connect_limbo();
+
+    assert_eq!(run_integrity_check(&copied_conn), "ok");
+    assert_eq!(source_hash.hash, compute_dbhash(&copied_db).hash);
+
+    let copied_pages: Vec<(i64,)> = copied_conn.exec_rows("PRAGMA page_count");
+    assert!(
+        copied_pages[0].0 > 1000,
+        "copied destination should remain large, got {} pages",
+        copied_pages[0].0
+    );
+
+    let stats: Vec<(i64, i64, i64)> = copied_conn
+        .exec_rows("SELECT COUNT(*), MIN(length(data)), MAX(length(data)) FROM large_data");
+    assert_eq!(stats, vec![(1200, 4096, 4096)]);
+
+    Ok(())
+}
+
 #[turso_macros::test(mvcc)]
 fn test_vacuum_into_with_foreign_keys(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
@@ -1668,6 +1744,45 @@ fn test_vacuum_into_with_table_valued_functions(tmp_db: TempDatabase) -> anyhow:
     assert!(
         json_paths.iter().any(|(_, path, _)| path.contains("root")),
         "Should have root path"
+    );
+
+    Ok(())
+}
+
+/// VACUUM INTO must handle deferred index creation after a large
+/// generate_series-backed data load.
+#[turso_macros::test]
+fn test_vacuum_into_large_generate_series_with_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT)")?;
+    conn.execute(
+        "INSERT INTO t1 \
+         SELECT value, 'padding_padding_padding_padding_' || value \
+         FROM generate_series(1, 10000)",
+    )?;
+    conn.execute("CREATE INDEX idx ON t1(b)")?;
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("vacuumed_generate_series_index.db");
+
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
+
+    let dest_db = TempDatabase::new_with_existent(&dest_path);
+    let dest_conn = dest_db.connect_limbo();
+
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+
+    let count: Vec<(i64,)> = dest_conn.exec_rows("SELECT COUNT(*) FROM t1");
+    assert_eq!(count, vec![(10000,)]);
+
+    let row: Vec<(i64, String)> = dest_conn.exec_rows(
+        "SELECT a, b FROM t1 INDEXED BY idx \
+         WHERE b = 'padding_padding_padding_padding_9999'",
+    );
+    assert_eq!(
+        row,
+        vec![(9999, "padding_padding_padding_padding_9999".to_string())]
     );
 
     Ok(())
@@ -2546,6 +2661,38 @@ fn test_vacuum_into_attached_database(tmp_db: TempDatabase) -> anyhow::Result<()
     Ok(())
 }
 
+/// Column names containing commas must not confuse the
+/// bind-parameter count in the generated INSERT statement.
+#[turso_macros::test(mvcc)]
+fn test_vacuum_into_column_name_with_comma(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t(\"a,b\" INTEGER, c TEXT)")?;
+    conn.execute("INSERT INTO t VALUES (1, 'hello')")?;
+    conn.execute("INSERT INTO t VALUES (2, 'world')")?;
+    let source_hash = compute_dbhash(&tmp_db);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("comma_col.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let dest_db = TempDatabase::new_with_existent(&dest_path);
+    let dest_conn = dest_db.connect_limbo();
+    if !tmp_db.enable_mvcc {
+        assert_eq!(source_hash.hash, compute_dbhash(&dest_db).hash);
+    }
+
+    let rows: Vec<(i64, String)> = dest_conn.exec_rows("SELECT \"a,b\", c FROM t ORDER BY \"a,b\"");
+    assert_eq!(
+        rows,
+        vec![(1, "hello".to_string()), (2, "world".to_string())]
+    );
+
+    Ok(())
+}
+
 // checksum feature changes reserved_space which breaks VACUUM INTO hash comparison
 #[cfg_attr(feature = "checksum", ignore)]
 #[turso_macros::test(init_sql = "CREATE TABLE main_t(x INTEGER);")]
@@ -2636,6 +2783,480 @@ fn test_vacuum_into_temp_is_noop(tmp_db: TempDatabase) -> anyhow::Result<()> {
         !dest_path.exists(),
         "VACUUM temp INTO should not create a file"
     );
+
+    Ok(())
+}
+
+/// VACUUM INTO must correctly handle deferred index creation.
+/// Indexes are created after data copy for performance. Verify that the
+/// destination still has working indexes with correct data.
+#[turso_macros::test(mvcc)]
+fn test_vacuum_into_deferred_indexes(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT, b INTEGER)")?;
+    conn.execute("CREATE INDEX idx_a ON t (a)")?;
+    conn.execute("CREATE UNIQUE INDEX idx_b ON t (b)")?;
+
+    for i in 0..30 {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, 'val_{i}', {i})"))?;
+    }
+    let source_hash = compute_dbhash(&tmp_db);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("deferred_idx.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let dest_db = TempDatabase::new_with_existent(&dest_path);
+    let dest_conn = dest_db.connect_limbo();
+
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    if !tmp_db.enable_mvcc {
+        assert_eq!(source_hash.hash, compute_dbhash(&dest_db).hash);
+    }
+
+    let indexes: Vec<(String,)> = dest_conn.exec_rows(
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND sql IS NOT NULL ORDER BY name",
+    );
+    assert_eq!(indexes.len(), 2);
+    assert_eq!(indexes[0].0, "idx_a");
+    assert_eq!(indexes[1].0, "idx_b");
+
+    let count: Vec<(i64,)> = dest_conn.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(count[0].0, 30);
+
+    let eqp_a: Vec<(i64, i64, i64, String)> =
+        dest_conn.exec_rows("EXPLAIN QUERY PLAN SELECT id, a FROM t WHERE a = 'val_15'");
+    assert!(
+        eqp_a
+            .iter()
+            .any(|(_, _, _, detail)| detail.contains("INDEX") && detail.contains("idx_a")),
+        "expected lookup by a to use idx_a, got plan: {eqp_a:?}",
+    );
+    let row: Vec<(i64, String)> = dest_conn.exec_rows("SELECT id, a FROM t WHERE a = 'val_15'");
+    assert_eq!(row, vec![(15, "val_15".to_string())]);
+    let row: Vec<(i64, String)> =
+        dest_conn.exec_rows("SELECT id, a FROM t INDEXED BY idx_a WHERE a = 'val_15'");
+    assert_eq!(row, vec![(15, "val_15".to_string())]);
+
+    let eqp_b: Vec<(i64, i64, i64, String)> =
+        dest_conn.exec_rows("EXPLAIN QUERY PLAN SELECT id, b FROM t WHERE b = 20");
+    assert!(
+        eqp_b
+            .iter()
+            .any(|(_, _, _, detail)| detail.contains("INDEX") && detail.contains("idx_b")),
+        "expected lookup by b to use idx_b, got plan: {eqp_b:?}",
+    );
+    let row: Vec<(i64, i64)> = dest_conn.exec_rows("SELECT id, b FROM t WHERE b = 20");
+    assert_eq!(row, vec![(20, 20)]);
+    let row: Vec<(i64, i64)> =
+        dest_conn.exec_rows("SELECT id, b FROM t INDEXED BY idx_b WHERE b = 20");
+    assert_eq!(row, vec![(20, 20)]);
+
+    Ok(())
+}
+
+/// VACUUM INTO must copy storage-backed internal tables such as sqlite_stat1.
+#[turso_macros::test]
+fn test_vacuum_into_preserves_sqlite_stat1(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, category TEXT, value INTEGER)")?;
+    conn.execute("CREATE INDEX idx_t_category_value ON t(category, value)")?;
+    for i in 0..50 {
+        let category = if i % 2 == 0 { "even" } else { "odd" };
+        conn.execute(format!(
+            "INSERT INTO t VALUES ({i}, '{category}', {})",
+            i * 10
+        ))?;
+    }
+    conn.execute("ANALYZE")?;
+
+    let source_stats: Vec<(String, String, String)> =
+        conn.exec_rows("SELECT tbl, COALESCE(idx, ''), stat FROM sqlite_stat1 ORDER BY tbl, idx");
+    assert!(
+        !source_stats.is_empty(),
+        "ANALYZE should populate sqlite_stat1"
+    );
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("sqlite_stat1.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let dest_db = TempDatabase::new_with_existent(&dest_path);
+    let dest_conn = dest_db.connect_limbo();
+
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    let dest_stats: Vec<(String, String, String)> = dest_conn
+        .exec_rows("SELECT tbl, COALESCE(idx, ''), stat FROM sqlite_stat1 ORDER BY tbl, idx");
+    assert_eq!(dest_stats, source_stats);
+
+    let count: Vec<(i64,)> = dest_conn.exec_rows("SELECT COUNT(*) FROM t WHERE category = 'even'");
+    assert_eq!(count, vec![(25,)]);
+
+    Ok(())
+}
+
+/// VACUUM INTO must preserve generated column values.
+/// Generated columns are excluded from the data-copy column list (they're
+/// computed, not stored), but the destination schema includes them and the
+/// values should be recomputed correctly from the copied base columns.
+#[test]
+fn test_vacuum_into_preserves_generated_columns() -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let opts = turso_core::DatabaseOpts::new().with_generated_columns(true);
+    let tmp_db = TempDatabase::builder().with_opts(opts).build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute(
+        "CREATE TABLE t (
+            a INTEGER,
+            b INTEGER,
+            c INTEGER GENERATED ALWAYS AS (a + b) VIRTUAL
+        )",
+    )?;
+    conn.execute("INSERT INTO t (a, b) VALUES (10, 20)")?;
+    conn.execute("INSERT INTO t (a, b) VALUES (100, 200)")?;
+
+    // Verify generated column works on source
+    let source_rows: Vec<(i64, i64, i64)> = conn.exec_rows("SELECT a, b, c FROM t ORDER BY a");
+    assert_eq!(source_rows, vec![(10, 20, 30), (100, 200, 300)]);
+    let source_hash = compute_dbhash_with_database_opts(&tmp_db, opts);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("gencol.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, opts);
+    let dest_conn = dest_db.connect_limbo();
+
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    assert_eq!(
+        source_hash.hash,
+        compute_dbhash_with_database_opts(&dest_db, opts).hash
+    );
+
+    // Generated column values should be recomputed correctly on destination
+    let dest_rows: Vec<(i64, i64, i64)> = dest_conn.exec_rows("SELECT a, b, c FROM t ORDER BY a");
+    assert_eq!(dest_rows, vec![(10, 20, 30), (100, 200, 300)]);
+
+    Ok(())
+}
+
+/// VACUUM INTO with generated columns that reference the rowid
+/// alias, after deletes that create gaps. Verifies that rowid values are preserved
+/// and the generated column recomputes correctly from the rowid on the destination.
+#[test]
+fn test_vacuum_into_generated_column_with_rowid_and_deletes() -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let opts = turso_core::DatabaseOpts::new().with_generated_columns(true);
+    let tmp_db = TempDatabase::builder().with_opts(opts).build();
+    let conn = tmp_db.connect_limbo();
+
+    // id is INTEGER PRIMARY KEY (rowid alias), label is generated from id
+    conn.execute(
+        "CREATE TABLE t (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            label TEXT GENERATED ALWAYS AS ('item_' || id) VIRTUAL
+        )",
+    )?;
+    conn.execute("INSERT INTO t (id, name) VALUES (1, 'a')")?;
+    conn.execute("INSERT INTO t (id, name) VALUES (2, 'b')")?;
+    conn.execute("INSERT INTO t (id, name) VALUES (3, 'c')")?;
+    conn.execute("INSERT INTO t (id, name) VALUES (4, 'd')")?;
+    conn.execute("INSERT INTO t (id, name) VALUES (5, 'e')")?;
+
+    // Delete some rows to create gaps in rowid space
+    conn.execute("DELETE FROM t WHERE id IN (2, 4)")?;
+
+    // Source should have rows 1, 3, 5 with correct generated labels
+    let source_rows: Vec<(i64, String, String)> =
+        conn.exec_rows("SELECT id, name, label FROM t ORDER BY id");
+    assert_eq!(
+        source_rows,
+        vec![
+            (1, "a".to_string(), "item_1".to_string()),
+            (3, "c".to_string(), "item_3".to_string()),
+            (5, "e".to_string(), "item_5".to_string()),
+        ]
+    );
+    let source_hash = compute_dbhash_with_database_opts(&tmp_db, opts);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("gencol_rowid.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, opts);
+    let dest_conn = dest_db.connect_limbo();
+
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    assert_eq!(
+        source_hash.hash,
+        compute_dbhash_with_database_opts(&dest_db, opts).hash
+    );
+
+    // Rowids must be preserved (not compacted), and generated labels must match
+    let dest_rows: Vec<(i64, String, String)> =
+        dest_conn.exec_rows("SELECT id, name, label FROM t ORDER BY id");
+    assert_eq!(source_rows, dest_rows);
+
+    Ok(())
+}
+
+/// VACUUM INTO must preserve custom type definitions so that
+/// STRICT tables with custom type columns are correctly created on the destination
+/// and encode/decode values properly.
+#[test]
+fn test_vacuum_into_preserves_custom_types() -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let opts = turso_core::DatabaseOpts::new().with_custom_types(true);
+    let tmp_db = TempDatabase::builder().with_opts(opts).build();
+    let conn = tmp_db.connect_limbo();
+
+    // Create a custom type with encode/decode transforms
+    conn.execute("CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100")?;
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, amount cents) STRICT")?;
+    conn.execute("INSERT INTO t VALUES (1, 42)")?;
+    conn.execute("INSERT INTO t VALUES (2, 100)")?;
+
+    // Verify decoded values on source
+    let source_rows: Vec<(i64, i64)> = conn.exec_rows("SELECT id, amount FROM t ORDER BY id");
+    assert_eq!(source_rows, vec![(1, 42), (2, 100)]);
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("t".to_string()),
+        ..Default::default()
+    };
+    let source_hash = compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, opts);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("custom_types.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, opts);
+    let dest_conn = dest_db.connect_limbo();
+
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    assert_eq!(
+        source_hash.hash,
+        compute_dbhash_with_options_and_database_opts(&dest_db, &hash_opts, opts).hash
+    );
+
+    // Destination must decode values correctly (42, 100 - not raw 4200, 10000)
+    let dest_rows: Vec<(i64, i64)> = dest_conn.exec_rows("SELECT id, amount FROM t ORDER BY id");
+    assert_eq!(dest_rows, source_rows);
+
+    Ok(())
+}
+
+/// VACUUM INTO must preserve AUTOINCREMENT counters so that
+/// new inserts on both source and destination get the same next rowid.
+#[turso_macros::test]
+fn test_vacuum_into_preserves_autoincrement_counter(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, val TEXT)")?;
+    conn.execute("INSERT INTO t (val) VALUES ('a')")?;
+    conn.execute("INSERT INTO t (val) VALUES ('b')")?;
+    conn.execute("INSERT INTO t (val) VALUES ('c')")?;
+    // Delete some rows to create a gap - AUTOINCREMENT should never reuse rowids
+    conn.execute("DELETE FROM t WHERE id = 2")?;
+    let source_hash = compute_dbhash(&tmp_db);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("autoincr.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    // Insert a new row on the source - should get id=4 (not 2, because AUTOINCREMENT)
+    conn.execute("INSERT INTO t (val) VALUES ('d')")?;
+    let source_new: Vec<(i64, String)> = conn.exec_rows("SELECT id, val FROM t WHERE val = 'd'");
+    assert_eq!(source_new, vec![(4, "d".to_string())]);
+
+    // Insert a new row on the destination - should also get id=4
+    let dest_db = TempDatabase::new_with_existent(&dest_path);
+    assert_eq!(source_hash.hash, compute_dbhash(&dest_db).hash);
+    let dest_conn = dest_db.connect_limbo();
+    dest_conn.execute("INSERT INTO t (val) VALUES ('d')")?;
+    let dest_new: Vec<(i64, String)> = dest_conn.exec_rows("SELECT id, val FROM t WHERE val = 'd'");
+    assert_eq!(
+        dest_new, source_new,
+        "AUTOINCREMENT counter should produce the same next rowid on both databases"
+    );
+
+    Ok(())
+}
+
+/// VACUUM INTO preserves custom index-method indexes by replaying the
+/// user-visible custom index after copying table data. The index method then
+/// recreates and backfills its backing storage from destination rows.
+#[turso_macros::test]
+fn test_vacuum_into_preserves_custom_index_method(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE vectors (id INTEGER PRIMARY KEY, label TEXT, embedding BLOB)")?;
+    conn.execute("CREATE INDEX vec_idx ON vectors USING toy_vector_sparse_ivf (embedding)")?;
+    conn.execute("INSERT INTO vectors VALUES (1, 'cat', vector32_sparse('[1, 0, 0, 0]'))")?;
+    conn.execute("INSERT INTO vectors VALUES (2, 'dog', vector32_sparse('[0, 1, 0, 0]'))")?;
+    conn.execute("INSERT INTO vectors VALUES (3, 'fish', vector32_sparse('[0, 0, 1, 0]'))")?;
+    let source_hash = compute_dbhash_with_database_opts(&tmp_db, tmp_db.db_opts);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("vectors.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, tmp_db.db_opts);
+    let dest_conn = dest_db.connect_limbo();
+    assert_eq!(
+        source_hash.hash,
+        compute_dbhash_with_database_opts(&dest_db, tmp_db.db_opts).hash
+    );
+
+    let indexes: Vec<(String,)> = dest_conn.exec_rows(
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'vectors' ORDER BY name",
+    );
+    assert_eq!(
+        indexes,
+        vec![
+            ("vec_idx".to_string(),),
+            ("vec_idx_inverted_index".to_string(),),
+            ("vec_idx_stats".to_string(),),
+        ],
+    );
+
+    let eqp: Vec<(i64, i64, i64, String)> = dest_conn.exec_rows(
+        "EXPLAIN QUERY PLAN \
+         SELECT id, label, vector_distance_jaccard(embedding, vector32_sparse('[1, 0, 0, 0]')) AS distance \
+         FROM vectors ORDER BY distance LIMIT 1",
+    );
+    assert!(
+        eqp.iter()
+            .any(|(_, _, _, detail)| detail.contains("INDEX METHOD")),
+        "nearest-neighbor query should use custom index method, got plan: {eqp:?}",
+    );
+
+    let nearest: Vec<(i64, String, f64)> = dest_conn.exec_rows(
+        "SELECT id, label, vector_distance_jaccard(embedding, vector32_sparse('[1, 0, 0, 0]')) AS distance \
+         FROM vectors ORDER BY distance LIMIT 1",
+    );
+    assert_eq!(nearest.len(), 1);
+    assert_eq!(nearest[0].0, 1);
+    assert_eq!(nearest[0].1, "cat");
+    assert!(nearest[0].2.abs() < 1e-9);
+
+    Ok(())
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn test_vacuum_into_preserves_fts_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE articles(id INTEGER PRIMARY KEY, title TEXT, body TEXT)")?;
+    conn.execute("CREATE INDEX fts_articles ON articles USING fts (title, body)")?;
+    conn.execute("INSERT INTO articles VALUES (1, 'Database Performance', 'Optimizing database queries is important for performance')")?;
+    conn.execute("INSERT INTO articles VALUES (2, 'Web Development', 'Modern web applications use JavaScript and APIs')")?;
+    conn.execute("INSERT INTO articles VALUES (3, 'Database Design', 'Good database design leads to better performance')")?;
+    conn.execute("INSERT INTO articles VALUES (4, 'API Development', 'RESTful APIs are common in web services')")?;
+
+    let source_database_matches: Vec<(i64,)> = conn
+        .exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'database') ORDER BY id");
+    assert_eq!(source_database_matches, vec![(1,), (3,)]);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("fts_vacuumed.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, tmp_db.db_opts);
+    let dest_conn = dest_db.connect_limbo();
+
+    let dest_database_matches: Vec<(i64,)> = dest_conn
+        .exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'database') ORDER BY id");
+    assert_eq!(dest_database_matches, source_database_matches);
+
+    let dest_web_matches: Vec<(i64,)> = dest_conn
+        .exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'web') ORDER BY id");
+    assert_eq!(dest_web_matches, vec![(2,), (4,)]);
+
+    let eqp: Vec<(i64, i64, i64, String)> = dest_conn.exec_rows(
+        "EXPLAIN QUERY PLAN \
+         SELECT id FROM articles WHERE fts_match(title, body, 'database')",
+    );
+    assert!(
+        eqp.iter()
+            .any(|(_, _, _, detail)| detail.contains("INDEX METHOD")),
+        "FTS query should use an index method after VACUUM INTO, got plan: {eqp:?}",
+    );
+
+    dest_conn.execute(
+        "INSERT INTO articles VALUES (5, 'Vacuum Export', 'Full text search stays usable after vacuum')",
+    )?;
+    let dest_vacuum_matches: Vec<(i64,)> = dest_conn
+        .exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'vacuum') ORDER BY id");
+    assert_eq!(dest_vacuum_matches, vec![(5,)]);
+
+    Ok(())
+}
+
+/// Test VACUUM INTO preserves vector data stored as blobs (without a vector index).
+/// Verifies that vector32() encoded blobs survive the vacuum round-trip
+/// and produce the same distance calculations on the destination.
+#[turso_macros::test]
+fn test_vacuum_into_preserves_vector_blobs(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE vectors (id INTEGER PRIMARY KEY, label TEXT, embedding BLOB)")?;
+    conn.execute("INSERT INTO vectors VALUES (1, 'cat', vector32('[1.0, 0.0, 0.0, 0.0]'))")?;
+    conn.execute("INSERT INTO vectors VALUES (2, 'dog', vector32('[0.0, 1.0, 0.0, 0.0]'))")?;
+    conn.execute("INSERT INTO vectors VALUES (3, 'fish', vector32('[0.0, 0.0, 1.0, 0.0]'))")?;
+    let source_hash = compute_dbhash(&tmp_db);
+
+    // Compute a distance on the source for comparison
+    let source_dist: Vec<(f64,)> = conn.exec_rows(
+        "SELECT vector_distance_cos(
+            (SELECT embedding FROM vectors WHERE id = 1),
+            (SELECT embedding FROM vectors WHERE id = 2)
+        )",
+    );
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("vectors.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+
+    let dest_db = TempDatabase::new_with_existent(&dest_path);
+    let dest_conn = dest_db.connect_limbo();
+
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    assert_eq!(source_hash.hash, compute_dbhash(&dest_db).hash);
+
+    let count: Vec<(i64,)> = dest_conn.exec_rows("SELECT COUNT(*) FROM vectors");
+    assert_eq!(count[0].0, 3);
+
+    // Verify vector distance matches source - confirms blobs survived intact
+    let dest_dist: Vec<(f64,)> = dest_conn.exec_rows(
+        "SELECT vector_distance_cos(
+            (SELECT embedding FROM vectors WHERE id = 1),
+            (SELECT embedding FROM vectors WHERE id = 2)
+        )",
+    );
+    assert_eq!(source_dist, dest_dist);
 
     Ok(())
 }

--- a/tools/dbhash/src/lib.rs
+++ b/tools/dbhash/src/lib.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 
 use sha1::{Digest, Sha1};
 use std::num::NonZero;
-use turso_core::{Database, LimboError, PlatformIO, StepResult, Value, IO};
+use turso_core::{
+    Database, DatabaseOpts, LimboError, OpenFlags, PlatformIO, StepResult, Value, IO,
+};
 
 pub use encoder::encode_value;
 
@@ -44,12 +46,27 @@ pub struct DbHashResult {
 ///
 /// System tables (sqlite_%), virtual tables, and statistics tables are excluded.
 pub fn hash_database(path: &str, options: &DbHashOptions) -> Result<DbHashResult, LimboError> {
+    hash_database_with_database_opts(path, options, DatabaseOpts::new())
+}
+
+/// Compute content hash of a database, opening it with explicit feature flags.
+pub fn hash_database_with_database_opts(
+    path: &str,
+    options: &DbHashOptions,
+    database_opts: DatabaseOpts,
+) -> Result<DbHashResult, LimboError> {
     assert!(
         !(options.schema_only && options.without_schema),
         "`schema_only` and `without_schema` cannot both be true"
     );
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new()?);
-    let db = Database::open_file(io.clone(), path)?;
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        path,
+        OpenFlags::default(),
+        database_opts,
+        None,
+    )?;
     let conn = db.connect()?;
 
     let mut hasher = Sha1::new();


### PR DESCRIPTION
## Description

Refactor `vacuum into` state machine to resuable components so that it can be used with `vacuum`

The PR shows large diff, but depends on #6244. No logical changes are made in this PR.

## Motivation and context

Previously, `op_vacuum_into_inner` owned the full `VACUUM INTO` state machine and did most of the copy/replay work directly in `execute.rs`.

Now the vdbe opcode only handles validation, source transaction setup, source metadata capture, and destination DB creation. It then constructs the config drives the vacuum engine via `VacuumInto::step()`.

The vacuum into state machine owns the destination DB/connection, schema collection, table copy, metadata copy, index replay, and post-data replay phases. This should make it easier for plain `VACUUM` to reuse the same rebuild path for its temporary database later.

## Description of AI Usage

prompted codex with above description 