### PR TITLE
bindings/javascript: Replace Promise<any> with proper TableColumn[] type

### DIFF
--- a/bindings/javascript/packages/common/types.ts
+++ b/bindings/javascript/packages/common/types.ts
@@ -59,7 +59,10 @@ export const STEP_IO = 3;
 
 export interface TableColumn {
     name: string,
-    type: string
+    type: string | null,
+    column: null,
+    table: null,
+    database: null
 }
 
 export interface NativeExecutor {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -187,6 +187,16 @@ pub struct QueryOptions {
     pub query_timeout: Option<u32>,
 }
 
+#[napi(object)]
+pub struct TableColumn {
+    pub name: String,
+    #[napi(ts_type = "string | null")]
+    pub r#type: Option<String>,
+    pub column: Option<()>,
+    pub table: Option<()>,
+    pub database: Option<()>,
+}
+
 fn step_sync(stmt: &StatementHandle) -> napi::Result<u32> {
     let mut guard = stmt.borrow_mut();
     let core_stmt = guard
@@ -872,7 +882,7 @@ impl Statement {
     }
 
     /// Get column information for the statement
-    #[napi(ts_return_type = "Promise<any>")]
+    #[napi(ts_return_type = "Promise<TableColumn[]>")]
     pub fn columns<'env>(&self, env: &'env Env) -> Result<Array<'env>> {
         let guard = self.statement_handle()?.borrow();
         let stmt = guard


### PR DESCRIPTION
## Summary
- Fixes issue #6377: Excessive use of \`any\` in @tursodatabase/database package
- Replaces \`Promise<any>\` return type in \`columns()\` method with properly typed \`Promise<TableColumn[]>\`

## Changes
1. **Rust code** (\`bindings/javascript/src/lib.rs\`):
   - Added \`TableColumn\` struct definition with \`#[napi(object)]\` attribute
   - Updated \`columns()\` return type to \`Promise<TableColumn[]>\`

2. **TypeScript interface** (\`bindings/javascript/packages/common/types.ts\`):
   - Extended \`TableColumn\` interface to include all returned fields: \`name\`, \`type\`, \`column\`, \`table\`, \`database\`

## Testing
The \`columns()\` method now returns properly typed \`TableColumn\` objects:
```typescript
interface TableColumn {
    name: string;
    type: string | null;
    column: null;
    table: null;
    database: null;
}
```

This improves TypeScript type safety and developer experience when using the database library.