### PR TITLE
MVCC stale row version fix during Checkpoint

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -277,14 +277,14 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         }
     }
 
-    /// Determine whether the newest valid version of a row should be checkpointed.
-    /// Returns the version to checkpoint if it should be checkpointed, otherwise None.
-    fn maybe_get_checkpointable_version(
+    /// Returns all checkpointable [RowVersion]s for that `table_id`
+    fn maybe_get_checkpointable_versions(
         &self,
         versions: &[RowVersion],
         table_id: MVTableId,
-    ) -> Option<RowVersion> {
-        let mut version_to_checkpoint = None;
+    ) -> smallvec::SmallVec<[RowVersion; 1]> {
+        let mut versions_to_checkpoint: smallvec::SmallVec<[_; 1]> =
+            smallvec::SmallVec::with_capacity(1);
         let mut exists_in_db_file = false;
         // Iterate versions from oldest-to-newest to determine if the row exists in the database file and whether the newest version should be checkpointed.
         for version in versions.iter() {
@@ -342,10 +342,15 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             let should_checkpoint =
                 is_uncheckpointed_insert || is_delete_and_exists_in_db_file || is_schema_delete;
             if should_checkpoint {
-                version_to_checkpoint = Some(version.clone());
+                if versions_to_checkpoint.is_empty() || table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                    versions_to_checkpoint.push(version.clone());
+                } else if table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+                    // For non schema rows we only maintain the latest version
+                    versions_to_checkpoint[0] = version.clone();
+                }
             }
         }
-        version_to_checkpoint
+        versions_to_checkpoint
     }
 
     /// Collect all committed versions that need to be written to the B-tree.
@@ -375,9 +380,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
             let row_versions = entry.value().read();
 
-            if let Some(version) =
-                self.maybe_get_checkpointable_version(&row_versions, key.table_id)
-            {
+            for version in self.maybe_get_checkpointable_versions(&row_versions, key.table_id) {
                 let is_delete = version.end.is_some();
 
                 let mut special_write = None;
@@ -534,7 +537,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             for entry in index_rows_map.iter() {
                 let versions = entry.value().read();
 
-                if let Some(version) = self.maybe_get_checkpointable_version(&versions, index_id) {
+                for version in self.maybe_get_checkpointable_versions(&versions, index_id) {
                     let is_delete = version.end.is_some();
 
                     // Only write the row to the B-tree if it is not a delete, or if it is a delete and it exists in

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -160,6 +160,84 @@ pub enum SpecialWrite {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SqliteSchemaBtreeKind {
+    Table,
+    Index,
+}
+
+impl SqliteSchemaBtreeKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::Index => "index",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SqliteSchemaBtreeIdentity {
+    kind: SqliteSchemaBtreeKind,
+    root_page: i64,
+}
+
+/// Identity of a sqlite_schema row version that refers to a B-tree-backed object.
+/// Schema rewrites that preserve this identity are metadata-only and should not be
+/// treated as create/drop lifecycle changes.
+fn sqlite_schema_btree_identity(version: &RowVersion) -> Option<SqliteSchemaBtreeIdentity> {
+    if version.row.id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+        return None;
+    }
+
+    let row_data = ImmutableRecord::from_bin_record(version.row.payload().to_vec());
+    let (col0, col3) = row_data
+        .get_two_values(0, 3)
+        .expect("failed to get columns 0 and 3 (type, rootpage) from sqlite_schema");
+
+    let kind = match col0 {
+        ValueRef::Text(type_str) => match type_str.as_str() {
+            "table" => SqliteSchemaBtreeKind::Table,
+            "index" => SqliteSchemaBtreeKind::Index,
+            _ => return None,
+        },
+        _ => panic!("sqlite_schema.type column must be TEXT, got {col0:?}"),
+    };
+
+    let ValueRef::Numeric(Numeric::Integer(root_page)) = col3 else {
+        panic!("sqlite_schema.rootpage column must be INTEGER, got {col3:?}");
+    };
+
+    if root_page == 0 {
+        return None;
+    }
+
+    Some(SqliteSchemaBtreeIdentity { kind, root_page })
+}
+
+fn sqlite_schema_versions_refer_to_same_object(lhs: &RowVersion, rhs: &RowVersion) -> bool {
+    sqlite_schema_btree_identity(lhs)
+        .zip(sqlite_schema_btree_identity(rhs))
+        .is_some_and(|(lhs_id, rhs_id)| lhs_id == rhs_id)
+}
+
+fn sqlite_schema_transition_crosses_object_boundary(
+    current: &RowVersion,
+    next: Option<&RowVersion>,
+) -> bool {
+    if current.end.is_none() {
+        return false;
+    }
+
+    let Some(_current_identity) = sqlite_schema_btree_identity(current) else {
+        return false;
+    };
+
+    match next {
+        Some(next) => !sqlite_schema_versions_refer_to_same_object(current, next),
+        None => true,
+    }
+}
+
 impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
     pub fn new(
         pager: Arc<Pager>,
@@ -388,19 +466,10 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 // These don't need to be written to the B-tree, we just need to track them.
                 let mut skip_write = false;
 
-                if version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                    let row_data = ImmutableRecord::from_bin_record(version.row.payload().to_vec());
-
-                    let (col0, col3) = row_data.get_two_values(0, 3).expect(
-                        "failed to get columns 0 and 3 (type, rootpage) from sqlite_schema",
-                    );
-
-                    let ValueRef::Text(type_str) = col0 else {
-                        panic!("sqlite_schema.type column must be TEXT, got {col0:?}");
-                    };
-
-                    if let ValueRef::Numeric(Numeric::Integer(root_page)) = col3 {
-                        if type_str.as_str() == "index" {
+                if let Some(schema_identity) = sqlite_schema_btree_identity(&version) {
+                    let root_page = schema_identity.root_page;
+                    match schema_identity.kind {
+                        SqliteSchemaBtreeKind::Index => {
                             // This is an index schema change
                             if is_delete {
                                 // DROP INDEX
@@ -455,7 +524,8 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                                 // to index SQL). No B-tree creation needed; the row itself is written
                                 // to sqlite_schema below. See: test_checkpoint_allows_index_schema_update_after_rename_column.
                             }
-                        } else if type_str.as_str() == "table" {
+                        }
+                        SqliteSchemaBtreeKind::Table => {
                             // This is a table schema change (existing logic)
                             tracing::trace!("table schema change with root page {root_page}, is_delete={is_delete}");
                             if is_delete {
@@ -1543,5 +1613,113 @@ impl<Clock: LogicalClock> StateTransition for CheckpointStateMachine<Clock> {
 
     fn is_finalized(&self) -> bool {
         matches!(self.state, CheckpointState::Finalize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sqlite_schema_row_version(
+        rowid: i64,
+        entry_type: &'static str,
+        name: &'static str,
+        table_name: &'static str,
+        root_page: i64,
+        begin: Option<u64>,
+        end: Option<u64>,
+    ) -> RowVersion {
+        let record = ImmutableRecord::from_values(
+            &[
+                Value::build_text(entry_type),
+                Value::build_text(name),
+                Value::build_text(table_name),
+                Value::from_i64(root_page),
+                Value::build_text(format!("sql:{entry_type}:{name}:{root_page}")),
+            ],
+            5,
+        );
+        RowVersion {
+            id: 1,
+            begin: begin.map(TxTimestampOrID::Timestamp),
+            end: end.map(TxTimestampOrID::Timestamp),
+            row: Row::new_table_row(
+                RowID::new(SQLITE_SCHEMA_MVCC_TABLE_ID, RowKey::Int(rowid)),
+                record.as_blob().to_vec(),
+                5,
+            ),
+            btree_resident: false,
+        }
+    }
+
+    #[test]
+    fn sqlite_schema_identity_treats_index_sql_rewrite_as_same_object() {
+        let old = sqlite_schema_row_version(3, "index", "idx_t_a", "t", 7, Some(1), Some(2));
+        let new = sqlite_schema_row_version(3, "index", "idx_t_a", "t", 7, Some(2), None);
+
+        assert_eq!(
+            sqlite_schema_btree_identity(&old),
+            Some(SqliteSchemaBtreeIdentity {
+                kind: SqliteSchemaBtreeKind::Index,
+                root_page: 7,
+            })
+        );
+        assert!(sqlite_schema_versions_refer_to_same_object(&old, &new));
+        assert!(!sqlite_schema_transition_crosses_object_boundary(
+            &old,
+            Some(&new)
+        ));
+    }
+
+    #[test]
+    fn sqlite_schema_identity_treats_table_sql_rewrite_as_same_object() {
+        let old = sqlite_schema_row_version(2, "table", "t", "t", 5, Some(1), Some(2));
+        let new = sqlite_schema_row_version(2, "table", "t", "t", 5, Some(2), None);
+
+        assert!(sqlite_schema_versions_refer_to_same_object(&old, &new));
+        assert!(!sqlite_schema_transition_crosses_object_boundary(
+            &old,
+            Some(&new)
+        ));
+    }
+
+    #[test]
+    fn sqlite_schema_identity_detects_drop_recreate_as_different_objects() {
+        let dropped = sqlite_schema_row_version(3, "index", "idx_t_v", "t", -4, Some(1), Some(2));
+        let recreated = sqlite_schema_row_version(3, "index", "idx_t_v", "t", -5, Some(2), None);
+
+        assert!(!sqlite_schema_versions_refer_to_same_object(
+            &dropped, &recreated
+        ));
+        assert!(sqlite_schema_transition_crosses_object_boundary(
+            &dropped,
+            Some(&recreated)
+        ));
+    }
+
+    #[test]
+    fn sqlite_schema_identity_detects_drop_without_successor() {
+        let dropped = sqlite_schema_row_version(3, "index", "idx_t_v", "t", 11, Some(1), Some(2));
+
+        assert!(sqlite_schema_transition_crosses_object_boundary(
+            &dropped, None
+        ));
+    }
+
+    #[test]
+    fn sqlite_schema_identity_ignores_non_btree_schema_entries() {
+        let trigger = sqlite_schema_row_version(9, "trigger", "trg_t", "t", 0, Some(1), Some(2));
+        let rewritten_trigger =
+            sqlite_schema_row_version(9, "trigger", "trg_t", "t", 0, Some(2), None);
+
+        assert_eq!(sqlite_schema_btree_identity(&trigger), None);
+        assert!(!sqlite_schema_versions_refer_to_same_object(
+            &trigger,
+            &rewritten_trigger
+        ));
+        assert!(!sqlite_schema_transition_crosses_object_boundary(
+            &trigger,
+            Some(&rewritten_trigger)
+        ));
     }
 }

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -212,7 +212,7 @@ fn sqlite_schema_btree_identity(version: &RowVersion) -> Option<SqliteSchemaBtre
     Some(SqliteSchemaBtreeIdentity { kind, root_page })
 }
 
-fn sqlite_schema_versions_refer_to_same_object(lhs: &RowVersion, rhs: &RowVersion) -> bool {
+fn sqlite_schema_versions_refer_to_btree(lhs: &RowVersion, rhs: &RowVersion) -> bool {
     sqlite_schema_btree_identity(lhs)
         .zip(sqlite_schema_btree_identity(rhs))
         .is_some_and(|(lhs_id, rhs_id)| lhs_id == rhs_id)
@@ -220,16 +220,13 @@ fn sqlite_schema_versions_refer_to_same_object(lhs: &RowVersion, rhs: &RowVersio
 
 /// A single `sqlite_schema` rowid can be reused across multiple row versions. Some of those
 /// transitions are metadata-only rewrites of the same B-tree object, while others represent a
-/// real object lifecycle boundary.
+/// real change that mutates the BTREE.
 ///
-/// Checkpoint needs to preserve ended schema versions only for lifecycle boundaries so it can
+/// Checkpoint needs to preserve ended schema versions only for the types of changes so it can
 /// register destroyed tables/indexes and skip stale recovered rows. Same-object rewrites, such as
 /// `ALTER TABLE ... RENAME COLUMN`, must collapse to the latest version; otherwise checkpoint
 /// treats one schema row chain as a DROP+CREATE pair and emits duplicate work for the same rowid.
-fn sqlite_schema_transition_crosses_object_boundary(
-    current: &RowVersion,
-    next: Option<&RowVersion>,
-) -> bool {
+fn is_schema_metadata_only_rewrite(current: &RowVersion, next: Option<&RowVersion>) -> bool {
     if current.end.is_none() {
         return false;
     }
@@ -239,7 +236,7 @@ fn sqlite_schema_transition_crosses_object_boundary(
     };
 
     match next {
-        Some(next) => !sqlite_schema_versions_refer_to_same_object(current, next),
+        Some(next) => !sqlite_schema_versions_refer_to_btree(current, next),
         None => true,
     }
 }
@@ -437,10 +434,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
                 if let Some(previous_version) = versions_to_checkpoint.last() {
                     let should_drop_previous = previous_version.end.is_some()
-                        && !sqlite_schema_transition_crosses_object_boundary(
-                            previous_version,
-                            Some(version),
-                        );
+                        && !is_schema_metadata_only_rewrite(previous_version, Some(version));
                     if should_drop_previous {
                         versions_to_checkpoint.pop();
                     }
@@ -1702,11 +1696,8 @@ mod tests {
                 root_page: 7,
             })
         );
-        assert!(sqlite_schema_versions_refer_to_same_object(&old, &new));
-        assert!(!sqlite_schema_transition_crosses_object_boundary(
-            &old,
-            Some(&new)
-        ));
+        assert!(sqlite_schema_versions_refer_to_btree(&old, &new));
+        assert!(!is_schema_metadata_only_rewrite(&old, Some(&new)));
     }
 
     #[test]
@@ -1714,11 +1705,8 @@ mod tests {
         let old = sqlite_schema_row_version(2, "table", "t", "t", 5, Some(1), Some(2));
         let new = sqlite_schema_row_version(2, "table", "t", "t", 5, Some(2), None);
 
-        assert!(sqlite_schema_versions_refer_to_same_object(&old, &new));
-        assert!(!sqlite_schema_transition_crosses_object_boundary(
-            &old,
-            Some(&new)
-        ));
+        assert!(sqlite_schema_versions_refer_to_btree(&old, &new));
+        assert!(!is_schema_metadata_only_rewrite(&old, Some(&new)));
     }
 
     #[test]
@@ -1726,22 +1714,15 @@ mod tests {
         let dropped = sqlite_schema_row_version(3, "index", "idx_t_v", "t", -4, Some(1), Some(2));
         let recreated = sqlite_schema_row_version(3, "index", "idx_t_v", "t", -5, Some(2), None);
 
-        assert!(!sqlite_schema_versions_refer_to_same_object(
-            &dropped, &recreated
-        ));
-        assert!(sqlite_schema_transition_crosses_object_boundary(
-            &dropped,
-            Some(&recreated)
-        ));
+        assert!(!sqlite_schema_versions_refer_to_btree(&dropped, &recreated));
+        assert!(is_schema_metadata_only_rewrite(&dropped, Some(&recreated)));
     }
 
     #[test]
     fn sqlite_schema_identity_detects_drop_without_successor() {
         let dropped = sqlite_schema_row_version(3, "index", "idx_t_v", "t", 11, Some(1), Some(2));
 
-        assert!(sqlite_schema_transition_crosses_object_boundary(
-            &dropped, None
-        ));
+        assert!(is_schema_metadata_only_rewrite(&dropped, None));
     }
 
     #[test]
@@ -1751,11 +1732,11 @@ mod tests {
             sqlite_schema_row_version(9, "trigger", "trg_t", "t", 0, Some(2), None);
 
         assert_eq!(sqlite_schema_btree_identity(&trigger), None);
-        assert!(!sqlite_schema_versions_refer_to_same_object(
+        assert!(!sqlite_schema_versions_refer_to_btree(
             &trigger,
             &rewritten_trigger
         ));
-        assert!(!sqlite_schema_transition_crosses_object_boundary(
+        assert!(!is_schema_metadata_only_rewrite(
             &trigger,
             Some(&rewritten_trigger)
         ));
@@ -1776,8 +1757,6 @@ mod tests {
         };
 
         assert_eq!(sqlite_schema_btree_identity(&tombstone), None);
-        assert!(!sqlite_schema_transition_crosses_object_boundary(
-            &tombstone, None
-        ));
+        assert!(!is_schema_metadata_only_rewrite(&tombstone, None));
     }
 }

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -702,10 +702,19 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         );
         let lwm = self.mvstore.compute_lwm();
         let ckpt_max = self.durable_txid_max_new;
+        let mut table_rows_to_gc = std::collections::BTreeSet::new();
+        let mut index_rows_to_gc = std::collections::BTreeSet::new();
 
         for (row_version, _special_write) in &self.write_set {
-            let row_id = &row_version.row.id;
-            let Some(entry) = self.mvstore.rows.get(row_id) else {
+            table_rows_to_gc.insert((
+                row_version.row.id.table_id,
+                row_version.row.id.row_id.clone(),
+            ));
+        }
+
+        for (table_id, row_key) in table_rows_to_gc {
+            let row_id = RowID::new(table_id, row_key);
+            let Some(entry) = self.mvstore.rows.get(&row_id) else {
                 // The MVCC metadata table row (persistent_tx_ts_max) is staged
                 // directly into the write set by maybe_stage_mvcc_metadata_write() and do not
                 // have a backing in-memory MVCC version chain. Skip GC for these.
@@ -722,7 +731,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 versions.is_empty()
             };
             if is_now_empty {
-                self.mvstore.rows.remove(row_id);
+                self.mvstore.rows.remove(&row_id);
             }
         }
 
@@ -730,22 +739,29 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             let RowKey::Record(sortable_key) = &row_version.row.id.row_id else {
                 unreachable!("index row versions always have Record keys");
             };
+            index_rows_to_gc.insert((*index_id, RowKey::Record(sortable_key.clone())));
+        }
+
+        for (index_id, row_key) in index_rows_to_gc {
+            let RowKey::Record(sortable_key) = row_key else {
+                unreachable!("index row versions always have Record keys");
+            };
             let outer_entry = self
                 .mvstore
                 .index_rows
-                .get(index_id)
+                .get(&index_id)
                 .expect("index_id from write set must exist in index_rows");
             let inner_map = outer_entry.value();
             let is_now_empty = {
                 let inner_entry = inner_map
-                    .get(sortable_key)
+                    .get(&sortable_key)
                     .expect("index row from write set must exist in inner map");
                 let mut versions = inner_entry.value().write();
                 MvStore::<Clock>::gc_version_chain(&mut versions, lwm, ckpt_max);
                 versions.is_empty()
             };
             if is_now_empty {
-                inner_map.remove(sortable_key);
+                inner_map.remove(&sortable_key);
             }
         }
     }

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -166,15 +166,6 @@ enum SqliteSchemaBtreeKind {
     Index,
 }
 
-impl SqliteSchemaBtreeKind {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Table => "table",
-            Self::Index => "index",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SqliteSchemaBtreeIdentity {
     kind: SqliteSchemaBtreeKind,
@@ -220,6 +211,14 @@ fn sqlite_schema_versions_refer_to_same_object(lhs: &RowVersion, rhs: &RowVersio
         .is_some_and(|(lhs_id, rhs_id)| lhs_id == rhs_id)
 }
 
+/// A single `sqlite_schema` rowid can be reused across multiple row versions. Some of those
+/// transitions are metadata-only rewrites of the same B-tree object, while others represent a
+/// real object lifecycle boundary.
+///
+/// Checkpoint needs to preserve ended schema versions only for lifecycle boundaries so it can
+/// register destroyed tables/indexes and skip stale recovered rows. Same-object rewrites, such as
+/// `ALTER TABLE ... RENAME COLUMN`, must collapse to the latest version; otherwise checkpoint
+/// treats one schema row chain as a DROP+CREATE pair and emits duplicate work for the same rowid.
 fn sqlite_schema_transition_crosses_object_boundary(
     current: &RowVersion,
     next: Option<&RowVersion>,
@@ -420,14 +419,30 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             let should_checkpoint =
                 is_uncheckpointed_insert || is_delete_and_exists_in_db_file || is_schema_delete;
             if should_checkpoint {
-                if versions_to_checkpoint.is_empty() || table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                    versions_to_checkpoint.push(version.clone());
-                } else if table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
-                    // For non schema rows we only maintain the latest version
-                    versions_to_checkpoint[0] = version.clone();
+                if table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+                    if versions_to_checkpoint.is_empty() {
+                        versions_to_checkpoint.push(version.clone())
+                    } else {
+                        versions_to_checkpoint[0] = version.clone()
+                    }
+                    continue;
                 }
+
+                if let Some(previous_version) = versions_to_checkpoint.last() {
+                    let should_drop_previous = previous_version.end.is_some()
+                        && !sqlite_schema_transition_crosses_object_boundary(
+                            previous_version,
+                            Some(version),
+                        );
+                    if should_drop_previous {
+                        versions_to_checkpoint.pop();
+                    }
+                }
+
+                versions_to_checkpoint.push(version.clone());
             }
         }
+
         versions_to_checkpoint
     }
 

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -180,10 +180,17 @@ fn sqlite_schema_btree_identity(version: &RowVersion) -> Option<SqliteSchemaBtre
         return None;
     }
 
+    // Recovery can synthesize payload-less sqlite_schema tombstones when the
+    // pre-delete record is no longer available. Those versions do not carry
+    // enough information to recover B-tree identity.
+    if version.row.payload().is_empty() {
+        return None;
+    }
+
     let row_data = ImmutableRecord::from_bin_record(version.row.payload().to_vec());
-    let (col0, col3) = row_data
-        .get_two_values(0, 3)
-        .expect("failed to get columns 0 and 3 (type, rootpage) from sqlite_schema");
+    let Ok((col0, col3)) = row_data.get_two_values(0, 3) else {
+        return None;
+    };
 
     let kind = match col0 {
         ValueRef::Text(type_str) => match type_str.as_str() {
@@ -1735,6 +1742,26 @@ mod tests {
         assert!(!sqlite_schema_transition_crosses_object_boundary(
             &trigger,
             Some(&rewritten_trigger)
+        ));
+    }
+
+    #[test]
+    fn sqlite_schema_identity_ignores_payloadless_tombstones() {
+        let tombstone = RowVersion {
+            id: 1,
+            begin: None,
+            end: Some(TxTimestampOrID::Timestamp(2)),
+            row: Row::new_table_row(
+                RowID::new(SQLITE_SCHEMA_MVCC_TABLE_ID, RowKey::Int(9)),
+                Vec::new(),
+                0,
+            ),
+            btree_resident: false,
+        };
+
+        assert_eq!(sqlite_schema_btree_identity(&tombstone), None);
+        assert!(!sqlite_schema_transition_crosses_object_boundary(
+            &tombstone, None
         ));
     }
 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4762,6 +4762,22 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         // serialized before the schema INSERT that registers the table_id.
                         self.insert_table_id_to_rootpage(rowid.table_id, None);
                     }
+                    let tombstone_row = if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                        let rowid_int = rowid.row_id.to_int_or_panic();
+                        if let Some(record) = schema_rows.get(&rowid_int) {
+                            // Preserve the pre-delete sqlite_schema record in recovered
+                            // tombstones so checkpoint can still recover B-tree identity.
+                            Row::new_table_row(
+                                rowid.clone(),
+                                record.as_blob().clone(),
+                                record.column_count(),
+                            )
+                        } else {
+                            Row::new_table_row(rowid.clone(), Vec::new(), 0)
+                        }
+                    } else {
+                        Row::new_table_row(rowid.clone(), Vec::new(), 0)
+                    };
                     if let Some(versions) = self.rows.get(&rowid) {
                         // Row exists in memory — try to find the current (non-ended) version
                         // that was committed before this delete, and mark it as ended. If no
@@ -4775,24 +4791,22 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             existing.end = Some(TxTimestampOrID::Timestamp(commit_ts));
                         } else {
                             let version_id = self.get_version_id();
-                            let row = Row::new_table_row(rowid.clone(), Vec::new(), 0);
                             let row_version = RowVersion {
                                 id: version_id,
                                 begin: None,
                                 end: Some(TxTimestampOrID::Timestamp(commit_ts)),
-                                row,
+                                row: tombstone_row.clone(),
                                 btree_resident,
                             };
                             self.insert_version_raw(&mut versions, row_version);
                         }
                     } else {
                         let version_id = self.get_version_id();
-                        let row = Row::new_table_row(rowid.clone(), Vec::new(), 0);
                         let row_version = RowVersion {
                             id: version_id,
                             begin: None,
                             end: Some(TxTimestampOrID::Timestamp(commit_ts)),
-                            row,
+                            row: tombstone_row,
                             btree_resident,
                         };
                         let versions = self

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8919,7 +8919,6 @@ fn test_checkpoint_recovers_after_crash_restart_drop_recreate_index() {
     conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
     conn.execute("INSERT INTO t VALUES (2, 'post_2', hex(randomblob(16)))")
         .unwrap();
-    dbg!("herere");
     conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 
     let rows = get_rows(&conn, "SELECT id, v FROM t ORDER BY id");
@@ -8943,4 +8942,54 @@ fn test_checkpoint_recovers_after_crash_restart_drop_recreate_index() {
     assert_eq!(rows[0][1].to_string(), "seed_1");
     assert_eq!(rows[1][0].as_int().unwrap(), 2);
     assert_eq!(rows[1][1].to_string(), "post_2");
+}
+
+/// Reproducer for recovery of a dropped checkpointed index.
+///
+/// Sequence:
+/// 1. Create and checkpoint a table plus index.
+/// 2. Drop the checkpointed index.
+/// 3. Simulate an abrupt process death before checkpoint.
+/// 4. Restart and checkpoint.
+///
+/// Recovery must preserve the deleted sqlite_schema record so checkpoint can
+/// retire the dropped index without losing its object identity.
+#[test]
+fn test_checkpoint_recovers_after_restart_drop_checkpointed_index() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+            .unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'seed_1')").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.execute("DROP INDEX idx_t_v").unwrap();
+    }
+
+    force_close_for_artifact_tamper(&mut db);
+    db.restart();
+
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(&conn, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "seed_1");
+
+    let rows = get_rows(
+        &conn,
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND name = 'idx_t_v'",
+    );
+    assert_eq!(rows.len(), 0);
+
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
 }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8685,3 +8685,174 @@ fn test_recovery_three_restarts_with_table_creation() {
         }
     }
 }
+
+fn create_wide_table_like_schema(conn: &Arc<Connection>) {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS core(
+            id INTEGER PRIMARY KEY,
+            row_number INTEGER NOT NULL,
+            sheet_id INTEGER NOT NULL,
+            created_by TEXT,
+            updated_by TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            col_1 TEXT,
+            col_2 TEXT,
+            col_3 TEXT,
+            col_4 TEXT,
+            col_5 TEXT,
+            col_6 TEXT,
+            col_7 TEXT,
+            col_8 TEXT
+        )",
+    )
+    .unwrap();
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_core_sheet_row ON core(sheet_id, row_number)")
+        .unwrap();
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_core_created ON core(created_at)")
+        .unwrap();
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_core_updated ON core(updated_at, sheet_id)")
+        .unwrap();
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_core_created_by ON core(created_by, sheet_id)")
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS metadata(
+            sheet_id INTEGER PRIMARY KEY,
+            next_row_number INTEGER NOT NULL DEFAULT 1,
+            row_count INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT DEFAULT (datetime('now'))
+        )",
+    )
+    .unwrap();
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS audit_log(
+            id INTEGER PRIMARY KEY,
+            sheet_id INTEGER NOT NULL,
+            action TEXT NOT NULL,
+            row_id INTEGER,
+            row_number INTEGER,
+            created_at TEXT DEFAULT (datetime('now')),
+            details TEXT
+        )",
+    )
+    .unwrap();
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS trigger_gate(
+            id INTEGER PRIMARY KEY,
+            sheet_id INTEGER NOT NULL,
+            trigger_type TEXT NOT NULL,
+            payload TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        )",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT OR IGNORE INTO metadata(sheet_id, next_row_number, row_count, updated_at)
+         VALUES (1, 1, 0, datetime('now'))",
+    )
+    .unwrap();
+}
+
+fn drop_wide_table_like_schema(conn: &Arc<Connection>) {
+    conn.execute("DROP TABLE IF EXISTS trigger_gate").unwrap();
+    conn.execute("DROP TABLE IF EXISTS audit_log").unwrap();
+    conn.execute("DROP TABLE IF EXISTS metadata").unwrap();
+    conn.execute("DROP INDEX IF EXISTS idx_core_sheet_row")
+        .unwrap();
+    conn.execute("DROP INDEX IF EXISTS idx_core_created")
+        .unwrap();
+    conn.execute("DROP INDEX IF EXISTS idx_core_updated")
+        .unwrap();
+    conn.execute("DROP INDEX IF EXISTS idx_core_created_by")
+        .unwrap();
+    conn.execute("DROP TABLE IF EXISTS core").unwrap();
+}
+
+fn insert_wide_table_like_batch(conn: &Arc<Connection>, start_row_number: i64, rows: usize) {
+    conn.execute("BEGIN").unwrap();
+
+    for offset in 0..rows {
+        let row_number = start_row_number + offset as i64;
+        conn.execute(format!(
+            "INSERT INTO core(
+                row_number, sheet_id, created_by, updated_by,
+                created_at, updated_at,
+                col_1, col_2, col_3, col_4, col_5, col_6, col_7, col_8
+             ) VALUES (
+                {row_number}, 1, 'seed', 'seed',
+                datetime('now'), datetime('now'),
+                hex(randomblob(8)), hex(randomblob(8)), hex(randomblob(8)), hex(randomblob(8)),
+                hex(randomblob(8)), hex(randomblob(8)), hex(randomblob(8)), hex(randomblob(8))
+             )",
+        ))
+        .unwrap();
+
+        conn.execute(format!(
+            "INSERT INTO audit_log(sheet_id, action, row_number, details, created_at)
+             VALUES (1, 'INSERT', {row_number}, 'wide table repro', datetime('now'))",
+        ))
+        .unwrap();
+    }
+
+    conn.execute(format!(
+        "UPDATE metadata
+         SET next_row_number = next_row_number + {rows},
+             row_count = row_count + {rows},
+             updated_at = datetime('now')
+         WHERE sheet_id = 1",
+    ))
+    .unwrap();
+    conn.execute(
+        "INSERT INTO trigger_gate(sheet_id, trigger_type, payload, created_at)
+         VALUES (1, 'ROW_INSERT', '{\"count\": 1}', datetime('now'))",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO trigger_gate(sheet_id, trigger_type, payload, created_at)
+         VALUES (1, 'RECALC', '{\"sheet_id\": 1}', datetime('now'))",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO trigger_gate(sheet_id, trigger_type, payload, created_at)
+         VALUES (1, 'WEBHOOK', '{\"event\": \"rows_added\"}', datetime('now'))",
+    )
+    .unwrap();
+
+    conn.execute("COMMIT").unwrap();
+}
+
+/// Reproducer for an MVCC crash-restart bug in checkpointing.
+///
+/// Sequence:
+/// 1. Create a wide-table style schema and write one row.
+/// 2. Simulate an abrupt process death (no clean connection close).
+/// 3. Restart, drop the old schema, recreate it, write one new row.
+/// 4. Checkpoint.
+///
+/// Current behavior: checkpoint panics because stale pre-crash table rows remain
+/// in MVCC state even though the old table-id to root-page mapping has been removed.
+#[test]
+#[ignore = "reproducer for crash-restart checkpoint panic"]
+#[should_panic(expected = "Table ID does not have a root page")]
+fn repro_crash_restart_drop_recreate_then_checkpoint_panics() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+            .unwrap();
+        create_wide_table_like_schema(&conn);
+        insert_wide_table_like_batch(&conn, 1, 1);
+    }
+
+    force_close_for_artifact_tamper(&mut db);
+    db.restart();
+
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+        .unwrap();
+    drop_wide_table_like_schema(&conn);
+    create_wide_table_like_schema(&conn);
+    insert_wide_table_like_batch(&conn, 1, 1);
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+}

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8829,12 +8829,10 @@ fn insert_wide_table_like_batch(conn: &Arc<Connection>, start_row_number: i64, r
 /// 3. Restart, drop the old schema, recreate it, write one new row.
 /// 4. Checkpoint.
 ///
-/// Current behavior: checkpoint panics because stale pre-crash table rows remain
-/// in MVCC state even though the old table-id to root-page mapping has been removed.
+/// Checkpoint should retire the dropped table before creating the replacement table,
+/// even when sqlite_schema rowids are reused across a crash + restart cycle.
 #[test]
-#[ignore = "reproducer for crash-restart checkpoint panic"]
-#[should_panic(expected = "Table ID does not have a root page")]
-fn repro_crash_restart_drop_recreate_then_checkpoint_panics() {
+fn test_checkpoint_recovers_after_crash_restart_drop_recreate_table() {
     let mut db = MvccTestDbNoConn::new_with_random_db();
 
     {
@@ -8855,4 +8853,94 @@ fn repro_crash_restart_drop_recreate_then_checkpoint_panics() {
     create_wide_table_like_schema(&conn);
     insert_wide_table_like_batch(&conn, 1, 1);
     conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT row_number, sheet_id, created_by FROM core ORDER BY id",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].as_int().unwrap(), 1);
+    assert_eq!(rows[0][2].to_string(), "seed");
+
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+
+    conn.close().unwrap();
+    db.restart();
+
+    let conn = db.connect();
+    let rows = get_rows(
+        &conn,
+        "SELECT row_number, sheet_id, created_by FROM core ORDER BY id",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].as_int().unwrap(), 1);
+    assert_eq!(rows[0][2].to_string(), "seed");
+}
+
+/// Reproducer for the original index-side panic:
+/// "Index struct for index_id ... must exist when checkpointing index rows".
+///
+/// Sequence:
+/// 1. Create and checkpoint a table with one row.
+/// 2. Create an index on that existing table.
+/// 3. Simulate an abrupt process death before the index is checkpointed.
+/// 4. Restart, drop and recreate the index, insert one more row.
+/// 5. Checkpoint.
+///
+/// Checkpoint should retire the dropped index before processing recovered index rows,
+/// even when sqlite_schema reuses the same rowid for the recreated index.
+#[test]
+fn test_checkpoint_recovers_after_crash_restart_drop_recreate_index() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+            .unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, payload TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'seed_1', hex(randomblob(16)))")
+            .unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+    }
+
+    force_close_for_artifact_tamper(&mut db);
+    db.restart();
+
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+        .unwrap();
+    conn.execute("DROP INDEX IF EXISTS idx_t_v").unwrap();
+    conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+    conn.execute("INSERT INTO t VALUES (2, 'post_2', hex(randomblob(16)))")
+        .unwrap();
+    dbg!("herere");
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(&conn, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "seed_1");
+    assert_eq!(rows[1][0].as_int().unwrap(), 2);
+    assert_eq!(rows[1][1].to_string(), "post_2");
+
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+
+    conn.close().unwrap();
+    db.restart();
+
+    let conn = db.connect();
+    let rows = get_rows(&conn, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "seed_1");
+    assert_eq!(rows[1][0].as_int().unwrap(), 2);
+    assert_eq!(rows[1][1].to_string(), "post_2");
 }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8993,3 +8993,46 @@ fn test_checkpoint_recovers_after_restart_drop_checkpointed_index() {
     assert_eq!(rows.len(), 1);
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
+
+#[test]
+fn test_drop_recreate_indexed_table_many_inserts_restart() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+
+    for round in 0..2 {
+        {
+            let conn = db.connect();
+            let mv_store = db.get_mvcc_store();
+            mv_store.set_checkpoint_threshold(4096);
+
+            if round > 0 {
+                conn.execute("DROP TABLE IF EXISTS t").unwrap();
+            }
+
+            conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT, c INTEGER)")
+                .unwrap();
+            conn.execute("CREATE INDEX idx_a ON t(a)").unwrap();
+            conn.execute("CREATE INDEX idx_b ON t(b)").unwrap();
+            conn.execute("CREATE INDEX idx_c ON t(c)").unwrap();
+
+            for i in 0..1000 {
+                conn.execute(format!("INSERT INTO t VALUES({i}, 'a_{i}', 'b_{i}', {i})"))
+                    .unwrap();
+            }
+
+            conn.close().unwrap();
+        }
+
+        db.restart();
+
+        {
+            let conn = db.connect();
+            let rows = get_rows(&conn, "SELECT count(*) FROM t");
+            assert_eq!(
+                rows[0][0].as_int().unwrap(),
+                1000,
+                "round {round}: expected 1000 rows"
+            );
+            conn.close().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
## Description
Essentially, the problem is that we need to checkpoint schema row versions in order, so that we properly drop rows that are dropped in between `Create` -> `Insert` -> `Drop` -> `Create`. The checkpoint algorithm was optimizing for only maintaining the latest `table_id` DDL change for a particular table or index, but this meant that it could skip the `Create` -> `Drop` part and just coalesce the second `Create` and still maintain the inserts that should have been dropped (because we did not add the table_id of the index to the `destroyed_indexes` field). This seems to be a similar type/idea of problem we tackled in the simulator around Table rows merging at Commit time @jussisaurio.

Reproducer (test `test_checkpoint_recovers_after_crash_restart_drop_recreate_index`):

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, payload TEXT);
INSERT INTO t VALUES (1, 'seed_1', hex(randomblob(16)));
PRAGMA wal_checkpoint(TRUNCATE);
CREATE INDEX idx_t_v ON t(v);
-- restart DB

DROP INDEX IF EXISTS idx_t_v;
CREATE INDEX idx_t_v ON t(v);
INSERT INTO t VALUES (2, 'post_2', hex(randomblob(16)));
PRAGMA wal_checkpoint(TRUNCATE); -- this panics
```

On checkpoint here, we have the latest checkpointable `RowVersion` of `idx_t_v` to be an `insert` into the `schema` table, and so we skip the `delete` row of the `schema` coming from the `DROP INDEX`. If we don't capture this delete, we won't be able to add the index to `destroyed_indexes` and thus delete the `index_rows` for the previous `table_id` Index.  

## Motivation and context
Correct recovery and checkpoint

## Description of AI Usage
Generated by Codex