### PR TITLE
ci: restrict PR labeler to main branch

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,8 @@
 name: "Pull Request Labeler"
 on:
-  - pull_request_target
+  pull_request_target:
+    branches:
+      - main
 
 jobs:
   labeler:


### PR DESCRIPTION
## Summary

- Restrict the Pull Request Labeler workflow to only run on PRs targeting `main`

## Why this matters

The labeler was the only GitHub Action in this repo without a branch filter — it triggered on `pull_request_target` for PRs against **any** branch. This is a security concern: `pull_request_target` runs with write permissions to the repo (issues and pull-requests write access) and executes in the context of the **base** branch. Without a branch filter, any PR opened against any branch — including forks targeting arbitrary branches — would trigger this privileged workflow.

Restricting to `main` aligns the labeler with every other workflow in the repo and reduces the attack surface for potential `pull_request_target` abuse.

## Test plan

- [x] Verified all other workflows already have branch filters
- [ ] Open a PR against `main` and confirm labels are applied
- [ ] Verify PRs against non-main branches no longer trigger the labeler

🤖 Generated with [Claude Code](https://claude.com/claude-code)