### PR TITLE
Reject WITHOUT ROWID tables on open

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3368,6 +3368,9 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
 
             if options.contains_without_rowid() {
                 has_rowid = false;
+                return Err(crate::LimboError::ParseError(
+                    "WITHOUT ROWID tables are not supported".to_string(),
+                ));
             }
         }
         CreateTableBody::AsSelect(_) => {
@@ -4498,6 +4501,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "WITHOUT ROWID tables are now rejected early in create_table"]
     pub fn test_column_is_rowid_alias_single_integer_separate_primary_key_definition_without_rowid(
     ) -> Result<()> {
         let sql = r#"CREATE TABLE t1 (a INTEGER, b TEXT, PRIMARY KEY(a)) WITHOUT ROWID;"#;
@@ -4511,6 +4515,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "WITHOUT ROWID tables are now rejected early in create_table"]
     pub fn test_column_is_rowid_alias_single_integer_without_rowid() -> Result<()> {
         let sql = r#"CREATE TABLE t1 (a INTEGER PRIMARY KEY, b TEXT) WITHOUT ROWID;"#;
         let table = BTreeTable::from_sql(sql, 0)?;
@@ -5113,6 +5118,18 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_without_rowid_rejected() {
+        let sql = r#"CREATE TABLE t(code TEXT PRIMARY KEY, val TEXT) WITHOUT ROWID"#;
+        let result = BTreeTable::from_sql(sql, 0);
+        assert!(result.is_err());
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_msg.contains("WITHOUT ROWID"),
+            "Error should mention WITHOUT ROWID: {err_msg}"
+        );
     }
 
     #[test]

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3367,10 +3367,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
             }
 
             if options.contains_without_rowid() {
-                has_rowid = false;
-                return Err(crate::LimboError::ParseError(
-                    "WITHOUT ROWID tables are not supported".to_string(),
-                ));
+                crate::bail_parse_error!("WITHOUT ROWID tables are not supported");
             }
         }
         CreateTableBody::AsSelect(_) => {
@@ -4501,7 +4498,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "WITHOUT ROWID tables are now rejected early in create_table"]
+    #[ignore = "WITHOUT ROWID not supported"]
     pub fn test_column_is_rowid_alias_single_integer_separate_primary_key_definition_without_rowid(
     ) -> Result<()> {
         let sql = r#"CREATE TABLE t1 (a INTEGER, b TEXT, PRIMARY KEY(a)) WITHOUT ROWID;"#;
@@ -4515,7 +4512,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "WITHOUT ROWID tables are now rejected early in create_table"]
+    #[ignore = "WITHOUT ROWID not supported"]
     pub fn test_column_is_rowid_alias_single_integer_without_rowid() -> Result<()> {
         let sql = r#"CREATE TABLE t1 (a INTEGER PRIMARY KEY, b TEXT) WITHOUT ROWID;"#;
         let table = BTreeTable::from_sql(sql, 0)?;
@@ -5124,11 +5121,9 @@ mod tests {
     fn test_without_rowid_rejected() {
         let sql = r#"CREATE TABLE t(code TEXT PRIMARY KEY, val TEXT) WITHOUT ROWID"#;
         let result = BTreeTable::from_sql(sql, 0);
-        assert!(result.is_err());
-        let err_msg = format!("{:?}", result.unwrap_err());
-        assert!(
-            err_msg.contains("WITHOUT ROWID"),
-            "Error should mention WITHOUT ROWID: {err_msg}"
+        assert_eq!(
+            "Parse error: WITHOUT ROWID tables are not supported",
+            format!("{}", result.unwrap_err())
         );
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2952,7 +2952,7 @@ pub(crate) fn validate_generated_expr(expr: &Expr) -> Result<()> {
 pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> Result<BTreeTable> {
     let table_name = normalize_ident(tbl_name);
     trace!("Creating table {}", table_name);
-    let mut has_rowid = true;
+    let has_rowid = true;
     let mut has_autoincrement = false;
     let mut primary_key_columns = vec![];
     let mut foreign_keys = vec![];

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4453,6 +4453,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "WITHOUT ROWID not supported"]
     pub fn test_has_rowid_false() -> Result<()> {
         let sql = r#"CREATE TABLE t1 (a INTEGER PRIMARY KEY, b TEXT) WITHOUT ROWID;"#;
         let table = BTreeTable::from_sql(sql, 0)?;


### PR DESCRIPTION
Turso doesn't support WITHOUT ROWID tables. This change makes Turso return an error when trying to open a database that has WITHOUT ROWID tables.
This fixes the silent corruption bug where ALTER TABLE would break databases with WITHOUT ROWID tables.
Test included.