### PR TITLE
don't try to recompute virtual columns for materialized inputs

### DIFF
--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -421,7 +421,9 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
                     .get(col_idx)
                     .map(|c| c.generated_type())
                 {
-                    Some(GeneratedType::Virtual { resolved: expr, .. }) => {
+                    Some(GeneratedType::Virtual { resolved: expr, .. })
+                        if !config.use_materialized_keys =>
+                    {
                         planner.program.with_self_table_context(
                             Some(&SelfTableContext::ForSelect {
                                 table_ref_id: build_table.internal_id,
@@ -444,9 +446,11 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
                             build_table.columns()[col_idx].affinity(),
                         );
                     }
-                    Some(GeneratedType::NotGenerated) | None => planner
-                        .program
-                        .emit_column_or_rowid(payload_source_cursor_id, col_idx, payload_reg + i),
+                    _ => planner.program.emit_column_or_rowid(
+                        payload_source_cursor_id,
+                        col_idx,
+                        payload_reg + i,
+                    ),
                 };
             }
             (

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -55,7 +55,9 @@ fn infer_type_from_expr(
 
 #[derive(Debug, Clone)]
 pub struct ResultSetColumn {
+    /// `a + 1` in `SELECT a + 1 FROM t`
     pub expr: ast::Expr,
+    /// `col` in `SELECT a AS col FROM t`
     pub alias: Option<String>,
     /// Original SQL expression text for display as column name.
     /// Only used when there is no explicit alias and the expression is not

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4335,3 +4335,106 @@ test update-virtual-not-null-transitive-deferred-trigger-abort {
 expect error {
     trigger rejects null
 }
+
+test gencol-virtual-join-inner-inner {
+    CREATE TABLE t1(a, b AS (a*2));
+    CREATE TABLE t2(x);
+    CREATE TABLE t3(y);
+    INSERT INTO t1(a) VALUES(1),(2),(3);
+    INSERT INTO t2 VALUES(1),(2),(3);
+    INSERT INTO t3 VALUES(1),(2),(3);
+    SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.x JOIN t3 ON t1.a = t3.y;
+}
+expect {
+    1
+    2
+    3
+}
+
+test gencol-virtual-join-left-inner {
+    CREATE TABLE t1(a, b AS (a*2));
+    CREATE TABLE t2(x);
+    CREATE TABLE t3(y);
+    INSERT INTO t1(a) VALUES(1),(2),(3);
+    INSERT INTO t2 VALUES(1),(2),(3);
+    INSERT INTO t3 VALUES(1),(2),(3);
+    SELECT t1.a FROM t1 LEFT JOIN t2 ON t1.a = t2.x JOIN t3 ON t1.a = t3.y;
+}
+expect {
+    1
+    2
+    3
+}
+
+test gencol-virtual-join-t1-second {
+    CREATE TABLE t1(a, b AS (a*2));
+    CREATE TABLE t2(x);
+    CREATE TABLE t3(y);
+    INSERT INTO t1(a) VALUES(1),(2),(3);
+    INSERT INTO t2 VALUES(1),(2),(3);
+    INSERT INTO t3 VALUES(1),(2),(3);
+    SELECT t1.a FROM t2 JOIN t1 ON t2.x = t1.a JOIN t3 ON t1.a = t3.y;
+}
+expect {
+    1
+    2
+    3
+}
+
+test gencol-virtual-join-two-table {
+    CREATE TABLE t1(a, b AS (a*2));
+    CREATE TABLE t2(x);
+    INSERT INTO t1(a) VALUES(1),(2),(3);
+    INSERT INTO t2 VALUES(1),(2),(3);
+    SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.x;
+}
+expect {
+    1
+    2
+    3
+}
+
+test gencol-virtual-join-cross {
+    CREATE TABLE t1(a, b AS (a*2));
+    CREATE TABLE t2(x);
+    CREATE TABLE t3(y);
+    INSERT INTO t1(a) VALUES(1),(2),(3);
+    INSERT INTO t2 VALUES(1),(2),(3);
+    INSERT INTO t3 VALUES(1),(2),(3);
+    SELECT t1.a FROM t1 CROSS JOIN t2 CROSS JOIN t3 WHERE t1.a = t2.x AND t2.x = t3.y;
+}
+expect {
+    1
+    2
+    3
+}
+
+test gencol-virtual-join-comma {
+    CREATE TABLE t1(a, b AS (a*2));
+    CREATE TABLE t2(x);
+    CREATE TABLE t3(y);
+    INSERT INTO t1(a) VALUES(1),(2),(3);
+    INSERT INTO t2 VALUES(1),(2),(3);
+    INSERT INTO t3 VALUES(1),(2),(3);
+    SELECT t1.a FROM t1, t2, t3 WHERE t1.a = t2.x AND t2.x = t3.y;
+}
+expect {
+    1
+    2
+    3
+}
+
+test gencol-virtual-join-all-left {
+    CREATE TABLE t1(a, b AS (a*2));
+    CREATE TABLE t2(x);
+    CREATE TABLE t3(y);
+    INSERT INTO t1(a) VALUES(1),(2),(3);
+    INSERT INTO t2 VALUES(1),(2),(3);
+    INSERT INTO t3 VALUES(1),(2),(3);
+    SELECT t1.a FROM t1 LEFT JOIN t2 ON t1.a = t2.x LEFT JOIN t3 ON t1.a = t3.y;
+}
+expect {
+    1
+    2
+    3
+}


### PR DESCRIPTION
## Description

When we build a hash table for hash join, the input we use is either just rowids, or complete payloads (rows). In the second case, we materialize the rows in an ephemeral table, and we read from the ephemeral table when building the hash table. 

But in the materialized path, when building the hash table, we were computing virtual columns using the build table's cursor after it had already been advanced past the last row, so virtual columns evaluated to `NULL` and it broke joins. The fix is simply to not try to recompute virtual columns when using a materialized input.

Closes https://github.com/tursodatabase/turso/issues/6151

## Description of AI Usage

Used Claude to help me understand the hash join code and the bug. I banged my head on this for a solid 3 hours, but now I understand the bug and the fix.