### PR TITLE
simulator: self-ref UPDATE and RETURNING

### DIFF
--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -188,6 +188,8 @@ pub struct InsertOpts {
     pub max_rows: NonZeroU32,
     #[garde(range(min = 0.0, max = 1.0))]
     pub upsert_prob: f64,
+    #[garde(range(min = 0.0, max = 1.0))]
+    pub returning_prob: f64,
 }
 
 impl Default for InsertOpts {
@@ -196,17 +198,33 @@ impl Default for InsertOpts {
             min_rows: NonZero::new(1).unwrap(),
             max_rows: NonZero::new(10).unwrap(),
             upsert_prob: 0.15,
+            returning_prob: 0.10,
         }
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Validate)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Validate)]
 #[serde(deny_unknown_fields, default)]
 pub struct UpdateOpts {
     #[garde(skip)]
     pub padding_size: Option<usize>,
     #[garde(skip)]
     pub force_late_failure: bool,
+    #[garde(range(min = 0.0, max = 1.0))]
+    pub self_ref_subquery_prob: f64,
+    #[garde(range(min = 0.0, max = 1.0))]
+    pub returning_prob: f64,
+}
+
+impl Default for UpdateOpts {
+    fn default() -> Self {
+        Self {
+            padding_size: None,
+            force_late_failure: false,
+            self_ref_subquery_prob: 0.20,
+            returning_prob: 0.15,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Validate)]

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -8,7 +8,7 @@ use crate::model::query::select::{
     CompoundOperator, CompoundSelect, Distinctness, FromClause, OrderBy, ResultColumn, SelectBody,
     SelectInner, SelectTable,
 };
-use crate::model::query::update::{SetValue, Update};
+use crate::model::query::update::{SelfRefSubquery, SetValue, Update};
 use crate::model::query::{
     Create, CreateIndex, Delete, Drop, DropIndex, Insert, OnConflict, Select, UpdateSetItem,
 };
@@ -291,6 +291,7 @@ impl Arbitrary for Insert {
             Some(Insert::Select {
                 table: table.name.clone(),
                 select: Box::new(select),
+                returning: None,
             })
         };
 
@@ -308,6 +309,7 @@ impl Arbitrary for Insert {
             Some(Insert::Select {
                 table: select_table.name.clone(),
                 select: Box::new(select),
+                returning: None,
             })
         };
 
@@ -330,8 +332,43 @@ impl Arbitrary for Insert {
             choices.push((1, Box::new(gen_select)));
         }
 
-        backtrack(choices, rng).expect("backtrack should with these arguments not return None")
+        let mut insert =
+            backtrack(choices, rng).expect("backtrack should with these arguments not return None");
+
+        if rng.random_bool(insert_opts.returning_prob) {
+            let table_name = insert.table().to_string();
+            let returning = env
+                .tables()
+                .iter()
+                .find(|t| t.name == table_name)
+                .and_then(|t| gen_returning_columns_for_table(rng, t));
+            match &mut insert {
+                Insert::Values { returning: r, .. } | Insert::Select { returning: r, .. } => {
+                    *r = returning
+                }
+            }
+        }
+
+        insert
     }
+}
+
+fn gen_returning_columns_for_table<R: Rng + ?Sized>(
+    rng: &mut R,
+    table: &Table,
+) -> Option<Vec<String>> {
+    if table.columns.is_empty() {
+        return Some(vec![]);
+    }
+    if rng.random_bool(0.5) {
+        return Some(vec![]);
+    }
+    let max_cols = table.columns.len().min(3);
+    let num_cols = rng.random_range(1..=max_cols);
+    let cols = pick_unique(&table.columns, num_cols, rng)
+        .map(|c| c.name.clone())
+        .collect();
+    Some(cols)
 }
 
 fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
@@ -379,6 +416,7 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
         table: table.name.clone(),
         values,
         on_conflict: None,
+        returning: None,
     })
 }
 
@@ -550,6 +588,7 @@ fn gen_insert_upsert_values<R: Rng + ?Sized, C: GenerationContext>(
             target_column: target_col.name.clone(),
             assignments,
         }),
+        returning: None,
     })
 }
 
@@ -559,6 +598,11 @@ impl Arbitrary for Delete {
         Self {
             table: table.name.clone(),
             predicate: Predicate::arbitrary_from(rng, env, table),
+            returning: if rng.random_bool(env.opts().query.update.returning_prob) {
+                gen_returning_columns_for_table(rng, table)
+            } else {
+                None
+            },
         }
     }
 }
@@ -633,6 +677,15 @@ impl Arbitrary for Update {
     fn arbitrary<R: Rng + ?Sized, C: GenerationContext>(rng: &mut R, env: &C) -> Self {
         let table = pick(env.tables(), rng);
         let update_opts = &env.opts().query.update;
+
+        if rng.random_bool(update_opts.self_ref_subquery_prob) {
+            if let Some(mut update) = gen_self_referential_update(rng, env, table) {
+                if rng.random_bool(update_opts.returning_prob) {
+                    update.returning = gen_returning_columns_for_table(rng, table);
+                }
+                return update;
+            }
+        }
 
         let unique_columns: Vec<(usize, &Column)> = table
             .columns
@@ -738,12 +791,85 @@ impl Arbitrary for Update {
             (set_values, predicate)
         };
 
-        Update {
+        let mut update = Update {
             table: table.name.clone(),
             set_values,
             predicate,
+            returning: None,
+        };
+
+        if rng.random_bool(update_opts.returning_prob) {
+            update.returning = gen_returning_columns_for_table(rng, table);
         }
+
+        update
     }
+}
+
+fn gen_self_referential_update<R: Rng + ?Sized, C: GenerationContext>(
+    rng: &mut R,
+    env: &C,
+    table: &Table,
+) -> Option<Update> {
+    if table.rows.len() < 2 {
+        return None;
+    }
+
+    let indexed_cols: IndexSet<&str> = table
+        .indexes
+        .iter()
+        .flat_map(|idx| idx.columns.iter().map(|(name, _)| name.as_str()))
+        .collect();
+
+    let key_candidates: Vec<&Column> = table
+        .columns
+        .iter()
+        .filter(|c| c.has_unique_or_pk() && !matches!(c.column_type, ColumnType::Blob))
+        .collect();
+    if key_candidates.is_empty() {
+        return None;
+    }
+
+    let target_candidates: Vec<&Column> = table
+        .columns
+        .iter()
+        .filter(|c| c.has_unique_or_pk() || indexed_cols.contains(c.name.as_str()))
+        .collect();
+    if target_candidates.is_empty() {
+        return None;
+    }
+
+    let target_col = *pick(&target_candidates, rng);
+    let key_col = *pick(&key_candidates, rng);
+
+    let order_candidates: Vec<&Column> = table
+        .columns
+        .iter()
+        .filter(|c| {
+            matches!(c.column_type, ColumnType::Integer | ColumnType::Float)
+                && (c.has_unique_or_pk() || indexed_cols.contains(c.name.as_str()))
+        })
+        .collect();
+
+    let subquery = if !order_candidates.is_empty() && rng.random_bool(0.5) {
+        let order_col = *pick(&order_candidates, rng);
+        SelfRefSubquery::PreviousByOrder {
+            source_column: target_col.name.clone(),
+            order_column: order_col.name.clone(),
+        }
+    } else {
+        SelfRefSubquery::MatchByColumn {
+            source_column: target_col.name.clone(),
+            key_column: key_col.name.clone(),
+        }
+    };
+
+    Some(Update {
+        table: table.name.clone(),
+        set_values: vec![(target_col.name.clone(), SetValue::SelfRefSubquery(subquery))],
+        predicate: Predicate::arbitrary_from(rng, env, table),
+        returning: None,
+    })
 }
 
 const ALTER_TABLE_ALL: &[AlterTableTypeDiscriminants] = &[

--- a/sql_generation/model/query/delete.rs
+++ b/sql_generation/model/query/delete.rs
@@ -8,10 +8,36 @@ use super::predicate::Predicate;
 pub struct Delete {
     pub table: String,
     pub predicate: Predicate,
+    #[serde(default)]
+    pub returning: Option<Vec<String>>,
 }
 
 impl Display for Delete {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DELETE FROM {} WHERE {}", self.table, self.predicate)
+        write!(f, "DELETE FROM {} WHERE {}", self.table, self.predicate)?;
+        if let Some(cols) = &self.returning {
+            if cols.is_empty() {
+                write!(f, " RETURNING *")?;
+            } else {
+                write!(f, " RETURNING {}", cols.join(", "))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_formats_returning_columns() {
+        let q = Delete {
+            table: "t".to_string(),
+            predicate: Predicate::true_(),
+            returning: Some(vec!["id".to_string(), "k".to_string()]),
+        };
+
+        assert!(q.to_string().contains("RETURNING id, k"));
     }
 }

--- a/sql_generation/model/query/insert.rs
+++ b/sql_generation/model/query/insert.rs
@@ -25,10 +25,14 @@ pub enum Insert {
         values: Vec<Vec<SimValue>>,
         #[serde(default)]
         on_conflict: Option<OnConflict>,
+        #[serde(default)]
+        returning: Option<Vec<String>>,
     },
     Select {
         table: String,
         select: Box<Select>,
+        #[serde(default)]
+        returning: Option<Vec<String>>,
     },
 }
 
@@ -54,6 +58,7 @@ impl Display for Insert {
                 table,
                 values,
                 on_conflict,
+                returning,
             } => {
                 write!(f, "INSERT INTO {table} VALUES ")?;
                 for (i, row) in values.iter().enumerate() {
@@ -72,11 +77,30 @@ impl Display for Insert {
                 if let Some(on_conflict) = &on_conflict {
                     write!(f, " {on_conflict}")?;
                 }
+                if let Some(cols) = returning {
+                    if cols.is_empty() {
+                        write!(f, " RETURNING *")?;
+                    } else {
+                        write!(f, " RETURNING {}", cols.join(", "))?;
+                    }
+                }
                 Ok(())
             }
-            Insert::Select { table, select } => {
+            Insert::Select {
+                table,
+                select,
+                returning,
+            } => {
                 write!(f, "INSERT INTO {table} ")?;
-                write!(f, "{select}")
+                write!(f, "{select}")?;
+                if let Some(cols) = returning {
+                    if cols.is_empty() {
+                        write!(f, " RETURNING *")?;
+                    } else {
+                        write!(f, " RETURNING {}", cols.join(", "))?;
+                    }
+                }
+                Ok(())
             }
         }
     }
@@ -98,5 +122,34 @@ impl Display for OnConflict {
 impl Display for UpdateSetItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{} = excluded.{}", self.column, self.excluded_column)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::query::predicate::Predicate;
+
+    #[test]
+    fn insert_values_formats_returning() {
+        let q = Insert::Values {
+            table: "t".to_string(),
+            values: vec![vec![SimValue::TRUE]],
+            on_conflict: None,
+            returning: Some(vec![]),
+        };
+
+        assert!(q.to_string().ends_with("RETURNING *"));
+    }
+
+    #[test]
+    fn insert_select_formats_returning_columns() {
+        let q = Insert::Select {
+            table: "t".to_string(),
+            select: Box::new(Select::simple("t".to_string(), Predicate::true_())),
+            returning: Some(vec!["id".to_string(), "k".to_string()]),
+        };
+
+        assert!(q.to_string().contains("RETURNING id, k"));
     }
 }

--- a/sql_generation/model/query/update.rs
+++ b/sql_generation/model/query/update.rs
@@ -18,24 +18,55 @@ pub enum SetValue {
         then_value: SimValue,
         else_column: String,
     },
+    SelfRefSubquery(SelfRefSubquery),
 }
 
-impl Display for SetValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum SelfRefSubquery {
+    MatchByColumn {
+        source_column: String,
+        key_column: String,
+    },
+    PreviousByOrder {
+        source_column: String,
+        order_column: String,
+    },
+}
+
+impl SetValue {
+    pub fn to_sql_with_context(&self, outer_table: &str) -> String {
         match self {
-            SetValue::Simple(v) => write!(f, "{v}"),
+            SetValue::Simple(v) => format!("{v}"),
             SetValue::CaseWhen {
                 condition,
                 then_value,
                 else_column,
             } => {
-                // else_column is printed as identifier (no quotes)
-                write!(
-                    f,
-                    "CASE WHEN {condition} THEN {then_value} ELSE {else_column} END"
+                format!("CASE WHEN {condition} THEN {then_value} ELSE {else_column} END")
+            }
+            SetValue::SelfRefSubquery(SelfRefSubquery::MatchByColumn {
+                source_column,
+                key_column,
+            }) => {
+                format!(
+                    "(SELECT t2.{source_column} FROM {outer_table} AS t2 WHERE t2.{key_column} = {outer_table}.{key_column} LIMIT 1)"
+                )
+            }
+            SetValue::SelfRefSubquery(SelfRefSubquery::PreviousByOrder {
+                source_column,
+                order_column,
+            }) => {
+                format!(
+                    "(SELECT t2.{source_column} FROM {outer_table} AS t2 WHERE t2.{order_column} < {outer_table}.{order_column} ORDER BY t2.{order_column} DESC LIMIT 1)"
                 )
             }
         }
+    }
+}
+
+impl Display for SetValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_sql_with_context("t"))
     }
 }
 
@@ -44,6 +75,8 @@ pub struct Update {
     pub table: String,
     pub set_values: Vec<(String, SetValue)>, // Pair of value for set expressions => SET name=value
     pub predicate: Predicate,
+    #[serde(default)]
+    pub returning: Option<Vec<String>>,
 }
 
 impl Update {
@@ -59,9 +92,54 @@ impl Display for Update {
             if i != 0 {
                 write!(f, ", ")?;
             }
-            write!(f, "{name} = {value}")?;
+            write!(f, "{name} = {}", value.to_sql_with_context(&self.table))?;
         }
         write!(f, " WHERE {}", self.predicate)?;
+        if let Some(cols) = &self.returning {
+            if cols.is_empty() {
+                write!(f, " RETURNING *")?;
+            } else {
+                write!(f, " RETURNING {}", cols.join(", "))?;
+            }
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_formats_self_ref_subquery() {
+        let update = Update {
+            table: "t".to_string(),
+            set_values: vec![(
+                "v".to_string(),
+                SetValue::SelfRefSubquery(SelfRefSubquery::MatchByColumn {
+                    source_column: "v".to_string(),
+                    key_column: "k".to_string(),
+                }),
+            )],
+            predicate: Predicate::true_(),
+            returning: None,
+        };
+
+        let sql = update.to_string();
+        assert!(sql.contains("UPDATE t SET"));
+        assert!(sql.contains("SELECT t2.v FROM t AS t2"));
+        assert!(sql.contains("t2.k = t.k"));
+    }
+
+    #[test]
+    fn update_formats_returning_star() {
+        let update = Update {
+            table: "t".to_string(),
+            set_values: vec![("v".to_string(), SetValue::Simple(SimValue::TRUE))],
+            predicate: Predicate::true_(),
+            returning: Some(vec![]),
+        };
+
+        assert!(update.to_string().ends_with("RETURNING *"));
     }
 }

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -76,6 +76,7 @@ impl Property {
                         Query::Delete(Delete {
                             table: t,
                             predicate,
+                            ..
                         }) if t == &table.name && predicate.test(row, table) => {
                             // The inserted row will not be deleted.
                             None
@@ -89,6 +90,7 @@ impl Property {
                             table: t,
                             set_values: _,
                             predicate,
+                            ..
                         }) if t == &table.name && predicate.test(row, table) => {
                             // The inserted row will not be updated.
                             None
@@ -174,6 +176,7 @@ impl Property {
                         Query::Insert(Insert::Select {
                             table: t,
                             select: _,
+                            ..
                         }) if t == &table.name => {
                             // A row that holds for the predicate will not be inserted.
                             None
@@ -407,6 +410,9 @@ impl Property {
                                                         )));
                                                     }
                                                 }
+                                                SetValue::SelfRefSubquery(_) => {
+                                                    // noop
+                                                }
                                             }
                                         }
                                     }
@@ -468,6 +474,7 @@ impl Property {
                     table,
                     values,
                     on_conflict: None,
+                    ..
                 } = insert
                 {
                     (table, values)
@@ -707,6 +714,7 @@ impl Property {
                 let delete = InteractionType::Query(Query::Delete(Delete {
                     table: table.clone(),
                     predicate: predicate.clone(),
+                    returning: None,
                 }));
 
                 let select = InteractionType::Query(Query::Select(Select::simple(
@@ -1308,6 +1316,7 @@ fn property_insert_values_select<R: rand::Rng + ?Sized>(
         table: table.name.clone(),
         values: rows,
         on_conflict: None,
+        returning: None,
     });
 
     // Choose if we want queries to be executed in an interactive transaction

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -12,7 +12,7 @@ use sql_generation::model::{
         pragma::Pragma,
         select::{CompoundOperator, FromClause, ResultColumn, SelectInner},
         transaction::{Begin, Commit, Rollback},
-        update::{SetValue, Update},
+        update::{SelfRefSubquery, SetValue, Update},
     },
     table::{Column, ColumnType, Index, JoinTable, JoinType, SimValue, Table, TableContext},
 };
@@ -587,7 +587,7 @@ impl Shadow for Insert {
     //FIXME this doesn't handle type affinity
     fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         match self {
-            Insert::Select { table, select } => {
+            Insert::Select { table, select, .. } => {
                 let table_name = table.clone();
                 let raw_rows = select.shadow(tables)?;
 
@@ -610,6 +610,7 @@ impl Shadow for Insert {
                 table,
                 values,
                 on_conflict,
+                ..
             } => {
                 let table_name = table.clone();
 
@@ -1040,6 +1041,65 @@ impl Shadow for Update {
                                         new_row[idx] = then_value.clone();
                                     }
                                 }
+                                SetValue::SelfRefSubquery(subquery) => match subquery {
+                                    SelfRefSubquery::MatchByColumn {
+                                        source_column,
+                                        key_column,
+                                    } => {
+                                        if let (Some(source_idx), Some(key_idx)) = (
+                                            columns.iter().position(|c| c.name == *source_column),
+                                            columns.iter().position(|c| c.name == *key_column),
+                                        ) {
+                                            let val = t2
+                                                .rows
+                                                .iter()
+                                                .find(|r| r[key_idx] == old_row[key_idx])
+                                                .map(|r| r[source_idx].clone())
+                                                .unwrap_or(SimValue::NULL);
+                                            new_row[idx] = val;
+                                        }
+                                    }
+                                    SelfRefSubquery::PreviousByOrder {
+                                        source_column,
+                                        order_column,
+                                    } => {
+                                        if let (Some(source_idx), Some(order_idx)) = (
+                                            columns.iter().position(|c| c.name == *source_column),
+                                            columns.iter().position(|c| c.name == *order_column),
+                                        ) {
+                                            let mut best_row: Option<&Vec<SimValue>> = None;
+                                            for candidate in &t2.rows {
+                                                let is_less_than_outer = candidate[order_idx]
+                                                    .binary_compare(
+                                                        &old_row[order_idx],
+                                                        turso_parser::ast::Operator::Less,
+                                                    )
+                                                    .as_bool();
+                                                if !is_less_than_outer {
+                                                    continue;
+                                                }
+
+                                                let is_better = match best_row {
+                                                    None => true,
+                                                    Some(best) => best[order_idx]
+                                                        .binary_compare(
+                                                            &candidate[order_idx],
+                                                            turso_parser::ast::Operator::Less,
+                                                        )
+                                                        .as_bool(),
+                                                };
+
+                                                if is_better {
+                                                    best_row = Some(candidate);
+                                                }
+                                            }
+
+                                            new_row[idx] = best_row
+                                                .map(|r| r[source_idx].clone())
+                                                .unwrap_or(SimValue::NULL);
+                                        }
+                                    }
+                                },
                             }
                         }
                     }

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -107,11 +107,14 @@ impl Profile {
                         insert: InsertOpts {
                             min_rows: NonZeroU32::new(50).unwrap(),
                             max_rows: NonZeroU32::new(200).unwrap(),
+                            returning_prob: 0.25,
                             ..Default::default()
                         },
                         update: UpdateOpts {
                             padding_size: Some(20_000),
                             force_late_failure: true,
+                            self_ref_subquery_prob: 0.45,
+                            returning_prob: 0.35,
                         },
                         ..Default::default()
                     },

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -459,44 +459,63 @@ fn execute_query_rusqlite(
         );
     }
     match query {
-        Query::Select(select) => {
-            let mut stmt = connection.prepare(select.to_string().as_str())?;
-            let rows = stmt.query_map([], |row| {
-                let mut values = vec![];
-                for i in 0.. {
-                    let value = match row.get(i) {
-                        Ok(value) => value,
-                        Err(err) => match err {
-                            rusqlite::Error::InvalidColumnIndex(_) => break,
-                            _ => {
-                                tracing::error!(?err);
-                                panic!("{err}")
-                            }
-                        },
-                    };
-                    let value = match value {
-                        rusqlite::types::Value::Null => Value::Null,
-                        rusqlite::types::Value::Integer(i) => Value::from_i64(i),
-                        rusqlite::types::Value::Real(f) => Value::from_f64(f),
-                        rusqlite::types::Value::Text(s) => Value::build_text(s),
-                        rusqlite::types::Value::Blob(b) => Value::Blob(b),
-                    };
-                    values.push(SimValue(value));
-                }
-                Ok(values)
-            })?;
-            let mut result = vec![];
-            for row in rows {
-                result.push(row?);
-            }
-            Ok(result)
-        }
         Query::Placeholder => {
             unreachable!("simulation cannot have a placeholder Query for execution")
         }
+        _ if query_returns_rows(query) => execute_query_rows_rusqlite(connection, query),
         _ => {
             connection.execute(query.to_string().as_str(), ())?;
             Ok(vec![])
         }
     }
+}
+
+fn query_returns_rows(query: &Query) -> bool {
+    match query {
+        Query::Select(_) => true,
+        Query::Insert(insert) => match insert {
+            sql_generation::model::query::Insert::Values { returning, .. }
+            | sql_generation::model::query::Insert::Select { returning, .. } => returning.is_some(),
+        },
+        Query::Update(update) => update.returning.is_some(),
+        Query::Delete(delete) => delete.returning.is_some(),
+        _ => false,
+    }
+}
+
+fn execute_query_rows_rusqlite(
+    connection: &rusqlite::Connection,
+    query: &Query,
+) -> rusqlite::Result<Vec<Vec<SimValue>>> {
+    let sql = query.to_string();
+    let mut stmt = connection.prepare(sql.as_str())?;
+    let rows = stmt.query_map([], |row| {
+        let mut values = vec![];
+        for i in 0.. {
+            let value = match row.get(i) {
+                Ok(value) => value,
+                Err(err) => match err {
+                    rusqlite::Error::InvalidColumnIndex(_) => break,
+                    _ => {
+                        tracing::error!(?err);
+                        panic!("{err}")
+                    }
+                },
+            };
+            let value = match value {
+                rusqlite::types::Value::Null => Value::Null,
+                rusqlite::types::Value::Integer(i) => Value::from_i64(i),
+                rusqlite::types::Value::Real(f) => Value::from_f64(f),
+                rusqlite::types::Value::Text(s) => Value::build_text(s),
+                rusqlite::types::Value::Blob(b) => Value::Blob(b),
+            };
+            values.push(SimValue(value));
+        }
+        Ok(values)
+    })?;
+    let mut result = vec![];
+    for row in rows {
+        result.push(row?);
+    }
+    Ok(result)
 }


### PR DESCRIPTION
Self-referential UPDATE with correlated subqueries
RETURNING clause for INSERT/UPDATE/DELETE  
Differential mode vs SQLite to catch divergences