### PR TITLE
fix(alter): don't rewrite ORDER BY identifiers that bind to output aliases (#6332)

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -2948,7 +2948,20 @@ fn apply_select_for_column_rename(
         _ => outer_target_qualifiers.to_vec(),
     };
 
+    // Per SQLite's ORDER BY resolution rules (https://sqlite.org/lang_select.html),
+    // an ORDER BY expression that is a bare identifier matching an *output column
+    // alias* binds to that alias, NOT to a same-named column in the FROM tables.
+    // For `SELECT a AS b FROM src ORDER BY b`, the `b` in ORDER BY refers to the
+    // alias for `a`, so renaming `src.b` to `src.c` must leave the ORDER BY alone
+    // (#6332). Without this guard, the rewriter blindly turned `ORDER BY b` into
+    // `ORDER BY c`, which then binds to the renamed column and produces wrong
+    // results when the trigger fires.
+    let output_aliases = select_output_aliases(&select.body.select);
+
     for sorted_col in &mut select.order_by {
+        if is_bare_id_matching_alias(&sorted_col.expr, &output_aliases) {
+            continue;
+        }
         apply_expr_for_column_rename(
             mode,
             &mut sorted_col.expr,
@@ -3610,6 +3623,41 @@ fn merge_target_qualifiers(outer: &[String], local: &[String]) -> Vec<String> {
         }
     }
     merged
+}
+
+/// Collect the set of user-provided output column aliases from a `SELECT`
+/// body (explicit `AS x` or elided `x`). Used by the ORDER BY rewriter to
+/// avoid mis-rewriting identifiers that bind to an alias rather than to a
+/// FROM-clause column (#6332).
+///
+/// Implicit column names (`As::ImplicitColumnName`) are intentionally
+/// *excluded*: those are synthetic names derived from the expression text
+/// for display purposes only, and unqualified ORDER BY references against
+/// them should still resolve against the FROM tables per SQLite semantics.
+fn select_output_aliases(body: &ast::OneSelect) -> Vec<String> {
+    let ast::OneSelect::Select { columns, .. } = body else {
+        return Vec::new();
+    };
+    columns
+        .iter()
+        .filter_map(|c| match c {
+            ast::ResultColumn::Expr(_, Some(ast::As::As(name)))
+            | ast::ResultColumn::Expr(_, Some(ast::As::Elided(name))) => {
+                Some(normalize_ident(name.as_str()))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Returns `true` when `expr` is a bare identifier whose normalized name
+/// matches one of the provided output aliases.
+fn is_bare_id_matching_alias(expr: &ast::Expr, aliases: &[String]) -> bool {
+    let ast::Expr::Id(name) = expr else {
+        return false;
+    };
+    let col_norm = normalize_ident(name.as_str());
+    aliases.iter().any(|alias| alias == &col_norm)
 }
 
 /// Rewrite a trigger command to replace column references.

--- a/tests/integration/trigger.rs
+++ b/tests/integration/trigger.rs
@@ -2012,3 +2012,80 @@ fn test_trigger_upsert_clause_persists_after_rename() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// Regression for #6332: ALTER TABLE RENAME COLUMN must NOT rewrite an
+// ORDER BY identifier that binds to an output alias. SQLite's ORDER BY
+// resolution rule prefers the output alias over a same-named FROM column,
+// so renaming `src.b` to `src.c` must leave `ORDER BY b` alone when `b` is
+// an `AS` alias.
+//
+// Note: this asserts the *stored* trigger body only. The runtime trigger
+// execution path has a separate binding quirk that causes the ORDER BY to
+// still resolve against the FROM column rather than the alias — that is a
+// different bug surfaced by the same issue, not addressed in this PR.
+#[turso_macros::test(mvcc)]
+fn test_alter_table_rename_column_preserves_order_by_alias_in_trigger(db: TempDatabase) {
+    let conn = db.connect_limbo();
+
+    conn.execute("CREATE TABLE src(a, b)").unwrap();
+    conn.execute("CREATE TABLE dst(x)").unwrap();
+    conn.execute("CREATE TABLE log(v)").unwrap();
+
+    conn.execute(
+        "CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
+           INSERT INTO log SELECT a AS b FROM src ORDER BY b;
+         END",
+    )
+    .unwrap();
+
+    conn.execute("ALTER TABLE src RENAME COLUMN b TO c")
+        .unwrap();
+
+    // The rewrite must leave the ORDER BY alias reference alone. Before the
+    // fix, it was rewritten to `ORDER BY c`, which is a plain lie about what
+    // the trigger body says and rules out ever getting the correct alias
+    // binding at execution time.
+    let trigger_sql: Vec<(String,)> =
+        conn.exec_rows("SELECT sql FROM sqlite_schema WHERE type='trigger' AND name='trig'");
+    assert_eq!(trigger_sql.len(), 1);
+    let body = &trigger_sql[0].0;
+    assert!(
+        body.contains("ORDER BY b"),
+        "ORDER BY must still reference the alias `b` after rename, got: {body}"
+    );
+    assert!(
+        !body.contains("ORDER BY c"),
+        "ORDER BY alias `b` must not have been rewritten to the renamed column `c`, got: {body}"
+    );
+}
+
+// Companion regression: also exercise an elided alias (`SELECT a b` without
+// the explicit `AS`). SQLite treats both forms as user-provided aliases for
+// ORDER BY resolution.
+#[turso_macros::test(mvcc)]
+fn test_alter_table_rename_column_preserves_order_by_elided_alias_in_trigger(db: TempDatabase) {
+    let conn = db.connect_limbo();
+
+    conn.execute("CREATE TABLE src(a, b)").unwrap();
+    conn.execute("CREATE TABLE dst(x)").unwrap();
+    conn.execute("CREATE TABLE log(v)").unwrap();
+
+    conn.execute(
+        "CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
+           INSERT INTO log SELECT a b FROM src ORDER BY b;
+         END",
+    )
+    .unwrap();
+
+    conn.execute("ALTER TABLE src RENAME COLUMN b TO c")
+        .unwrap();
+
+    let trigger_sql: Vec<(String,)> =
+        conn.exec_rows("SELECT sql FROM sqlite_schema WHERE type='trigger' AND name='trig'");
+    assert_eq!(trigger_sql.len(), 1);
+    let body = &trigger_sql[0].0;
+    assert!(
+        body.contains("ORDER BY b"),
+        "ORDER BY must still reference the elided alias `b` after rename, got: {body}"
+    );
+}


### PR DESCRIPTION
## Summary

Refs #6332.

\`ALTER TABLE RENAME COLUMN\` was blindly rewriting any ORDER BY identifier that matched the old column name, even when that identifier actually bound to an output column alias rather than a FROM-clause column. Per SQLite's [ORDER BY resolution rules](https://sqlite.org/lang_select.html), an ORDER BY expression that is a bare identifier matching an output column alias binds to that alias.

Before the fix, this trigger body:

\`\`\`sql
CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
  INSERT INTO log SELECT a AS b FROM src ORDER BY b;
END;
ALTER TABLE src RENAME COLUMN b TO c;
\`\`\`

ended up stored as \`... ORDER BY c\`. The stored schema then lied about what the trigger body says, and any future parse saw the wrong ORDER BY target.

## Change

Collect the set of user-provided output aliases (\`AS name\` and elided \`name\`) from the SELECT body in \`apply_select_for_column_rename\`, and skip the ORDER BY rewrite for bare identifiers matching one of those aliases. \`As::ImplicitColumnName\` (synthetic names derived from expression text) is intentionally NOT treated as an alias — those can over-suppress legitimate rewrites.

Two small helpers in \`alter.rs\`:
- \`select_output_aliases(body)\` — collects \`As::As\` / \`As::Elided\` names.
- \`is_bare_id_matching_alias(expr, aliases)\` — guard applied to each ORDER BY item.

## Follow-up observed in the same scenario (not addressed here)

Even with the stored body preserved as \`ORDER BY b\` (alias reference intact), the trigger **execution** path still binds \`b\` to the FROM column rather than the alias, so the output is ordered as if \`ORDER BY src.c\` were written. A plain \`SELECT a AS b FROM src ORDER BY b\` (both before and after the rename) correctly binds to the alias, so the divergence is specific to the trigger execution path. That looks like a separate bug in how triggers resolve ORDER BY and should probably be tracked under its own issue. I did not try to fix it in this PR to keep the scope tight and reviewable.

Happy to open a follow-up issue if maintainers want it tracked separately.

## Test plan

- [x] 2 new regression tests cover explicit \`AS b\` and elided \`b\` aliases.
- [x] \`cargo test -p core_tester --test integration_tests trigger::test_alter_table\` — 56/56 pass (52 existing + 4 new, regular + MVCC).
- [x] \`cargo clippy -p turso_core --lib -- -D warnings\` — clean.
- [x] \`cargo fmt -p turso_core -- --check\` — clean.

## AI-assisted disclosure

Drafted with Claude Code. I read the issue, located \`apply_select_for_column_rename\`, confirmed with an empty-trigger-body experiment that stored SQL \`ORDER BY c\` was indeed being produced, and added the alias guard. During testing I also verified the follow-up runtime-binding quirk and scoped this PR to the rewriter fix only. I understand what the code does.