### PR TITLE
replace HashSet<usize> with ColumnMask

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -142,7 +142,7 @@ use crate::storage::btree::{BTreeCursor, CursorTrait};
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::translate::collate::CollationSeq;
-use crate::translate::plan::{BitSet, ColumnUsedMask, Plan, TableReferences};
+use crate::translate::plan::{BitSet, ColumnMask, ColumnUsedMask, Plan, TableReferences};
 use crate::util::{
     module_args_from_sql, module_name_from_sql, type_from_name, UnparsedFromSqlIndex,
 };
@@ -2764,21 +2764,30 @@ pub fn collect_column_dependencies_of_expr(expr: &Expr, columns: &[Column]) -> H
 // columns_affected_by_update could just do a union of the dependencies of all columns.
 pub(crate) fn columns_affected_by_update(
     columns: &[Column],
-    updated_cols: &HashSet<usize>,
-) -> HashSet<usize> {
-    let mut affected = updated_cols.clone();
+    updated_cols: impl IntoIterator<Item = usize>,
+) -> ColumnMask {
+    let mut affected = ColumnMask::default();
+    for idx in updated_cols {
+        // We remove ROWID_SENTINEL because it would blow up ColumnMask (a dense bitset).
+        // Luckily, since the rowid column cannot be referenced by generated columns, it's safe to
+        // omit in this particular case.
+        if idx == ROWID_SENTINEL {
+            continue;
+        }
+        affected.set(idx);
+    }
     let mut changed = true;
     while changed {
         changed = false;
         for (idx, col) in columns.iter().enumerate() {
-            if affected.contains(&idx) {
+            if affected.get(idx) {
                 continue;
             }
             let GeneratedType::Virtual { ref expr, .. } = col.generated_type() else {
                 continue;
             };
             if expr_refers_one_of(expr, columns, &affected) {
-                affected.insert(idx);
+                affected.set(idx);
                 changed = true;
             }
         }
@@ -2848,7 +2857,7 @@ pub(crate) fn dependencies_of_columns(
 }
 
 /// Returns true if `expr` references any column in `target_set`.
-fn expr_refers_one_of(expr: &Expr, columns: &[Column], target_set: &HashSet<usize>) -> bool {
+fn expr_refers_one_of(expr: &Expr, columns: &[Column], target_set: &ColumnUsedMask) -> bool {
     let mut found = false;
     let _ = walk_expr(expr, &mut |e| {
         if found {
@@ -2856,18 +2865,18 @@ fn expr_refers_one_of(expr: &Expr, columns: &[Column], target_set: &HashSet<usiz
         }
         match e {
             Expr::Column { table, column, .. } if table.is_self_table() => {
-                found = target_set.contains(column);
+                found = target_set.get(*column);
                 Ok(WalkControl::Continue)
             }
             Expr::Id(name) | Expr::Name(name) => {
                 if let Some(idx) = find_column_index_by_name(columns, name.as_str()) {
-                    found = target_set.contains(&idx);
+                    found = target_set.get(idx);
                 }
                 Ok(WalkControl::Continue)
             }
             Expr::Qualified(_, col) | Expr::DoublyQualified(_, _, col) => {
                 if let Some(idx) = find_column_index_by_name(columns, col.as_str()) {
-                    found = target_set.contains(&idx);
+                    found = target_set.get(idx);
                 }
                 Ok(WalkControl::Continue)
             }
@@ -3712,7 +3721,7 @@ impl ResolvedFkRef {
     /// Returns if any referenced parent column can change when these column positions are updated.
     pub fn parent_key_may_change(
         &self,
-        updated_parent_positions: &HashSet<usize>,
+        updated_parent_positions: &ColumnMask,
         parent_tbl: &BTreeTable,
     ) -> bool {
         if self.parent_uses_rowid {
@@ -3723,32 +3732,32 @@ impl ResolvedFkRef {
                 .enumerate()
                 .find(|(_, c)| c.is_rowid_alias())
             {
-                return updated_parent_positions.contains(&idx);
+                return updated_parent_positions.get(idx);
             }
             // Without a rowid alias, a direct rowid update is represented separately with ROWID_SENTINEL
             return true;
         }
         let affected = columns_affected_by_update(&parent_tbl.columns, updated_parent_positions);
-        self.parent_pos.iter().any(|p| affected.contains(p))
+        self.parent_pos.iter().any(|p| affected.get(*p))
     }
 
     /// Returns if any child column of this FK is in `updated_child_positions`
     pub fn child_key_changed(
         &self,
-        updated_child_positions: &HashSet<usize>,
+        updated_child_positions: &ColumnMask,
         child_tbl: &BTreeTable,
     ) -> bool {
         if self
             .child_pos
             .iter()
-            .any(|p| updated_child_positions.contains(p))
+            .any(|p| updated_child_positions.get(*p))
         {
             return true;
         }
         // special case: if FK uses a rowid alias on child, and rowid changed
         if self.child_cols.len() == 1 {
             let (i, col) = child_tbl.get_column(&self.child_cols[0]).unwrap();
-            if col.is_rowid_alias() && updated_child_positions.contains(&i) {
+            if col.is_rowid_alias() && updated_child_positions.get(i) {
                 return true;
             }
         }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2768,12 +2768,6 @@ pub(crate) fn columns_affected_by_update(
 ) -> ColumnMask {
     let mut affected = ColumnMask::default();
     for idx in updated_cols {
-        // We remove ROWID_SENTINEL because it would blow up ColumnMask (a dense bitset).
-        // Luckily, since the rowid column cannot be referenced by generated columns, it's safe to
-        // omit in this particular case.
-        if idx == ROWID_SENTINEL {
-            continue;
-        }
         affected.set(idx);
     }
     let mut changed = true;
@@ -2857,7 +2851,7 @@ pub(crate) fn dependencies_of_columns(
 }
 
 /// Returns true if `expr` references any column in `target_set`.
-fn expr_refers_one_of(expr: &Expr, columns: &[Column], target_set: &ColumnUsedMask) -> bool {
+fn expr_refers_one_of(expr: &Expr, columns: &[Column], target_set: &ColumnMask) -> bool {
     let mut found = false;
     let _ = walk_expr(expr, &mut |e| {
         if found {

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -5,6 +5,10 @@ use turso_parser::{
     parser::Parser,
 };
 
+use super::{
+    schema::{validate_check_expr, SQLITE_TABLEID},
+    update::translate_update_for_schema_change,
+};
 use crate::{
     error::SQLITE_CONSTRAINT_CHECK,
     function::{AlterTableFunc, Func},
@@ -30,11 +34,6 @@ use crate::{
 };
 use either::Either;
 use rustc_hash::FxHashSet as HashSet;
-
-use super::{
-    schema::{validate_check_expr, SQLITE_TABLEID},
-    update::translate_update_for_schema_change,
-};
 
 fn validate(alter_table: &ast::AlterTableBody, table_name: &str) -> Result<()> {
     // Check if someone is trying to ALTER a system table
@@ -876,12 +875,10 @@ pub fn translate_alter_table(
 
             // Check if any virtual column depends on the dropped column
             {
-                let mut dropped_set = rustc_hash::FxHashSet::default();
-                dropped_set.insert(dropped_index);
                 let affected =
-                    crate::schema::columns_affected_by_update(&btree.columns, &dropped_set);
+                    crate::schema::columns_affected_by_update(&btree.columns, [dropped_index]);
                 for idx in &affected {
-                    if *idx != dropped_index && btree.columns[*idx].is_virtual_generated() {
+                    if idx != dropped_index && btree.columns[idx].is_virtual_generated() {
                         return Err(LimboError::ParseError(format!(
                             "error in table {table_name} after drop column: no such column: {column_name}"
                         )));

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2,6 +2,7 @@ use super::gencol::compute_virtual_columns;
 use super::TranslateCtx;
 use crate::schema::{columns_affected_by_update, ColumnLayout, GeneratedType, Table};
 use crate::translate::insert::halt_desc_and_on_error;
+use crate::translate::plan::ColumnMask;
 use crate::translate::stmt_journal::any_effective_replace;
 use crate::vdbe::builder::SelfTableContext;
 use crate::{
@@ -470,7 +471,7 @@ fn emit_update_column_values<'a>(
     let target_table_columns = target_table.table.columns();
     let affected_columns = columns_affected_by_update(
         target_table_columns,
-        &set_clauses.iter().map(|(idx, _)| *idx).collect(),
+        set_clauses.iter().map(|(idx, _)| *idx),
     );
 
     for (idx, table_column) in target_table_columns.iter().enumerate() {
@@ -485,11 +486,11 @@ fn emit_update_column_values<'a>(
             .find(|(i, _)| *i == idx)
             .map(|(_, expr)| expr.as_ref())
             .or_else(|| {
-                affected_columns
-                    .get(&idx)
-                    .into_iter()
-                    .flat_map(|_| table_column.generated_expr())
-                    .next()
+                if affected_columns.get(idx) {
+                    table_column.generated_expr()
+                } else {
+                    None
+                }
             });
 
         if let Some(expr) = update_expr {
@@ -940,8 +941,7 @@ fn emit_update_insns<'a>(
     let not_exists_check_required = updates_rowid || iteration_cursor_id != target_table_cursor_id;
     let update_database_id = target_table.database_id;
     let has_before_update_triggers = if let Some(btree_table) = target_table.table.btree() {
-        let updated_column_indices: HashSet<usize> =
-            set_clauses.iter().map(|(col_idx, _)| *col_idx).collect();
+        let updated_column_indices = set_clauses.iter().map(|(col_idx, _)| *col_idx).collect();
         has_triggers_including_temp(
             &t_ctx.resolver,
             update_database_id,
@@ -1083,7 +1083,7 @@ fn emit_update_insns<'a>(
     let preserved_old_registers: Option<Vec<usize>> = if let Some(btree_table) =
         target_table.table.btree()
     {
-        let updated_column_indices: HashSet<usize> =
+        let updated_column_indices: ColumnMask =
             set_clauses.iter().map(|(col_idx, _)| *col_idx).collect();
         let relevant_before_update_triggers = get_triggers_including_temp(
             &t_ctx.resolver,
@@ -1356,14 +1356,13 @@ fn emit_update_insns<'a>(
             .insert(rowid_reg, Affinity::Integer);
     }
 
-    let affected_columns = columns_affected_by_update(
-        target_table.table.columns(),
-        &HashSet::from_iter(set_clauses.iter().map(|(idx, _)| idx).cloned()),
-    );
-    let update_affects_virtual_columns = set_clauses
-        .iter()
-        .map(|(idx, _)| idx)
-        .any(|idx| affected_columns.contains(idx));
+    let mut set_clause_cols = ColumnMask::default();
+    for (idx, _) in set_clauses {
+        set_clause_cols.set(*idx);
+    }
+    let affected_columns =
+        columns_affected_by_update(target_table.table.columns(), &set_clause_cols);
+    let update_affects_virtual_columns = affected_columns.count() > set_clause_cols.count();
     let has_returning = returning.as_ref().is_some_and(|r| !r.is_empty());
     let has_check_constraints = target_table
         .table
@@ -1517,10 +1516,10 @@ fn emit_update_insns<'a>(
             // column in the SET clause. Build a set of updated column names to filter.
             let mut updated_col_names: HashSet<String> = columns_affected_by_update(
                 &btree_table.columns,
-                &set_clauses.iter().map(|(idx, _)| *idx).collect(),
+                set_clauses.iter().map(|(idx, _)| *idx),
             )
             .iter()
-            .filter_map(|col_idx| btree_table.columns.get(*col_idx))
+            .filter_map(|col_idx| btree_table.columns.get(col_idx))
             .filter_map(|col| col.name.as_deref())
             .map(normalize_ident)
             .collect();
@@ -1580,6 +1579,14 @@ fn emit_update_insns<'a>(
         if let Some(table_btree) = target_table.table.btree() {
             if t_ctx.resolver.schema().has_child_fks(table_name) {
                 let rowid_new_reg = rowid_set_clause_reg.unwrap_or(beg);
+                let directly_and_indirectly_updated_columns: ColumnMask = set_clauses
+                    .iter()
+                    .map(|(i, _)| *i)
+                    .flat_map(|col| {
+                        columns_affected_by_update(&table_btree.columns, [col].iter().cloned())
+                    })
+                    .collect();
+
                 emit_fk_child_update_counters(
                     program,
                     &table_btree,
@@ -1587,7 +1594,7 @@ fn emit_update_insns<'a>(
                     target_table_cursor_id,
                     start,
                     rowid_new_reg,
-                    &set_clauses.iter().map(|(i, _)| *i).collect::<HashSet<_>>(),
+                    &directly_and_indirectly_updated_columns,
                     update_database_id,
                     &t_ctx.resolver,
                     &layout,
@@ -2289,7 +2296,7 @@ fn emit_update_insns<'a>(
 
             // Fire AFTER UPDATE triggers
             if let Some(btree_table) = target_table.table.btree() {
-                let updated_column_indices: HashSet<usize> =
+                let updated_column_indices: ColumnMask =
                     set_clauses.iter().map(|(col_idx, _)| *col_idx).collect();
                 let relevant_triggers = get_triggers_including_temp(
                     &t_ctx.resolver,

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1518,7 +1518,7 @@ fn emit_update_insns<'a>(
                 &btree_table.columns,
                 set_clauses.iter().map(|(idx, _)| *idx),
             )
-            .iter()
+            .into_iter()
             .filter_map(|col_idx| btree_table.columns.get(col_idx))
             .filter_map(|col| col.name.as_deref())
             .map(normalize_ident)

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -4,6 +4,7 @@ use turso_parser::ast::{self, Expr, Literal, Name, QualifiedName, RefAct};
 use super::{translate_inner, ProgramBuilder, ProgramBuilderOpts};
 use crate::translate::emitter::emit_columns_and_dependencies;
 use crate::translate::expr::emit_table_column_for_dml;
+use crate::translate::plan::ColumnMask;
 use crate::{
     error::SQLITE_CONSTRAINT_FOREIGNKEY,
     schema::{BTreeTable, ColumnLayout, ForeignKey, Index, ResolvedFkRef, ROWID_SENTINEL},
@@ -307,7 +308,7 @@ pub fn emit_parent_key_change_checks(
     database_id: usize,
     resolver: &Resolver,
 ) -> Result<()> {
-    let updated_positions: HashSet<usize> = set_clauses.iter().map(|(i, _)| *i).collect();
+    let updated_positions: ColumnMask = set_clauses.iter().map(|(i, _)| *i).collect();
     let incoming = resolver.with_schema(database_id, |s| {
         s.resolved_fks_referencing(&table_btree.name)
     })?;
@@ -592,7 +593,7 @@ pub fn emit_fk_parent_new_key_reconcile(
     database_id: usize,
     resolver: &Resolver,
 ) -> Result<()> {
-    let updated_positions: HashSet<usize> = set_clauses.iter().map(|(i, _)| *i).collect();
+    let updated_positions: ColumnMask = set_clauses.iter().map(|(i, _)| *i).collect();
     let incoming = resolver.with_schema(database_id, |s| {
         s.resolved_fks_referencing(&table_btree.name)
     })?;
@@ -834,7 +835,7 @@ pub fn emit_fk_child_update_counters(
     child_cursor_id: usize,
     new_start_reg: usize,
     new_rowid_reg: usize,
-    updated_cols: &HashSet<usize>,
+    updated_cols: &ColumnMask,
     database_id: usize,
     resolver: &Resolver,
     layout: &ColumnLayout,
@@ -1181,7 +1182,7 @@ pub fn emit_fk_update_parent_actions(
     database_id: usize,
     resolver: &Resolver,
 ) -> Result<()> {
-    let updated_positions: HashSet<usize> = set_clauses.iter().map(|(i, _)| *i).collect();
+    let updated_positions: ColumnMask = set_clauses.iter().map(|(i, _)| *i).collect();
     let incoming = resolver.with_schema(database_id, |s| {
         s.resolved_fks_referencing(&table_btree.name)
     })?;

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -9,7 +9,7 @@ use super::{
     },
 };
 use crate::translate::expression_index::expression_index_column_usage;
-use crate::translate::plan::MultiIndexBranchAccess;
+use crate::translate::plan::{ColumnMask, MultiIndexBranchAccess};
 use crate::{
     function::{AggFunc, Deterministic},
     index_method::IndexMethodCostEstimate,
@@ -835,7 +835,7 @@ fn first_update_safety_reason(
         }
 
         // Check if there are UPDATE triggers
-        let updated_cols: HashSet<usize> = plan.set_clauses.iter().map(|(i, _)| *i).collect();
+        let updated_cols: ColumnMask = plan.set_clauses.iter().map(|(i, _)| *i).collect();
         let database_id = table_ref.database_id;
         if has_triggers_including_temp(
             resolver,
@@ -889,7 +889,7 @@ fn first_update_safety_reason(
         if index
             .columns
             .iter()
-            .any(|c| affected_cols.contains(&c.pos_in_table))
+            .any(|c| affected_cols.get(c.pos_in_table))
         {
             break 'requires Some(DmlSafetyReason::KeyMutation);
         }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -221,6 +221,7 @@ impl From<Expr> for WhereTerm {
 }
 
 use crate::ast::Expr;
+use crate::schema::ROWID_SENTINEL;
 use crate::util::exprs_are_equivalent;
 
 /// The loop index where to evaluate the condition.
@@ -1360,22 +1361,101 @@ impl TableReferences {
 /// Tracks which columns are used in a query.
 pub type ColumnUsedMask = BitSet;
 
-//TODO instead of using this alias, ideally we wouldn't carry naked usize's around, and we would
-// have `ColumnID`, `UsedColumnID`, `TableID`, etc. aliases, just like we have `CursorID`.
-// Then, we can have types like `BitSet<ColumnID>` and type-safe associated functions.
-pub type ColumnMask = BitSet;
+/// ColumnMask wraps [BitSet] and adds a special-case so that it can store [ROWID_SENTINEL]
+/// in `O(1)` space
+//TODO instead of carrying naked usize's around, we should ideally have a `ColumnID` type alias,
+// just like we have `CursorID`, so that we can make [ColumnMask] type-safe.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct ColumnMask {
+    columns: BitSet,
+    has_rowid_update: bool,
+}
+
+impl ColumnMask {
+    pub fn set(&mut self, idx: usize) {
+        if idx == ROWID_SENTINEL {
+            self.has_rowid_update = true;
+        } else {
+            self.columns.set(idx);
+        }
+    }
+
+    pub fn get(&self, idx: usize) -> bool {
+        if idx == ROWID_SENTINEL {
+            self.has_rowid_update
+        } else {
+            self.columns.get(idx)
+        }
+    }
+
+    pub fn count(&self) -> usize {
+        self.columns.count() + self.has_rowid_update as usize
+    }
+}
+
+impl FromIterator<usize> for ColumnMask {
+    fn from_iter<I: IntoIterator<Item = usize>>(iter: I) -> Self {
+        let mut mask = ColumnMask::default();
+        for idx in iter {
+            mask.set(idx);
+        }
+        mask
+    }
+}
+
+pub struct ColumnMaskIter<B: std::borrow::Borrow<BitSet>> {
+    inner: BitSetIter<B>,
+    pending_rowid: bool,
+}
+
+impl<B: std::borrow::Borrow<BitSet>> Iterator for ColumnMaskIter<B> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(v) = self.inner.next() {
+            return Some(v);
+        }
+        if self.pending_rowid {
+            self.pending_rowid = false;
+            return Some(ROWID_SENTINEL);
+        }
+        None
+    }
+}
+
+impl<'a> IntoIterator for &'a ColumnMask {
+    type Item = usize;
+    type IntoIter = ColumnMaskIter<&'a BitSet>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ColumnMaskIter {
+            inner: (&self.columns).into_iter(),
+            pending_rowid: self.has_rowid_update,
+        }
+    }
+}
+
+impl IntoIterator for ColumnMask {
+    type Item = usize;
+    type IntoIter = ColumnMaskIter<BitSet>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ColumnMaskIter {
+            inner: self.columns.into_iter(),
+            pending_rowid: self.has_rowid_update,
+        }
+    }
+}
 
 /// Dense bitset optimized for the common case where all elements ≤64, with heap-allocated overflow.
-/// As a special case, this bitset can accomodate `usize::MAX` with O(1) space.
 ///
 /// *WARNING*: This bitset occupies `O(max_num)` space when `max_num > 64`,
 /// so it is best used for smaller numbers.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct BitSet {
     inline: u64,
-    /// invariant: `overflow` is `None` iff no bits ≥ 64 and < `usize::MAX` are set.
+    /// invariant: `overflow` is `None` iff no bits ≥ 64 are set.
     overflow: Option<Vec<u64>>,
-    has_usize_max: bool,
 }
 
 /// This iterator, inspired by Kernighan's bit-counting algorighm, is `O(num_words + popcount)`
@@ -1386,7 +1466,6 @@ pub struct BitSetIter<B: std::borrow::Borrow<BitSet>> {
     current: u64,
     /// `0` = inline word, `1..=overflow.len()` = `overflow[word - 1]`.
     word: usize,
-    pending_usize_max: bool,
 }
 
 impl<B: std::borrow::Borrow<BitSet>> Iterator for BitSetIter<B> {
@@ -1405,22 +1484,8 @@ impl<B: std::borrow::Borrow<BitSet>> Iterator for BitSetIter<B> {
                 return Some(base + bit);
             }
             self.word += 1;
-            let next_word = self
-                .bitset
-                .borrow()
-                .overflow
-                .as_ref()
-                .and_then(|ov| ov.get(self.word - 1).copied());
-            match next_word {
-                Some(w) => self.current = w,
-                None => {
-                    if self.pending_usize_max {
-                        self.pending_usize_max = false;
-                        return Some(usize::MAX);
-                    }
-                    return None;
-                }
-            }
+            let overflow = self.bitset.borrow().overflow.as_ref()?;
+            self.current = *overflow.get(self.word - 1)?;
         }
     }
 }
@@ -1432,7 +1497,6 @@ impl<'a> IntoIterator for &'a BitSet {
     fn into_iter(self) -> Self::IntoIter {
         BitSetIter {
             current: self.inline,
-            pending_usize_max: self.has_usize_max,
             bitset: self,
             word: 0,
         }
@@ -1446,7 +1510,6 @@ impl IntoIterator for BitSet {
     fn into_iter(self) -> Self::IntoIter {
         BitSetIter {
             current: self.inline,
-            pending_usize_max: self.has_usize_max,
             bitset: self,
             word: 0,
         }
@@ -1457,10 +1520,6 @@ impl BitSet {
     const INLINE_BITS: usize = 64;
 
     pub fn set(&mut self, index: usize) {
-        if index == usize::MAX {
-            self.has_usize_max = true;
-            return;
-        }
         if index < Self::INLINE_BITS {
             self.inline |= 1 << index;
         } else {
@@ -1475,9 +1534,6 @@ impl BitSet {
     }
 
     pub fn get(&self, index: usize) -> bool {
-        if index == usize::MAX {
-            return self.has_usize_max;
-        }
         if index < Self::INLINE_BITS {
             (self.inline >> index) & 1 != 0
         } else {
@@ -1493,10 +1549,6 @@ impl BitSet {
     }
 
     pub fn clear(&mut self, index: usize) {
-        if index == usize::MAX {
-            self.has_usize_max = false;
-            return;
-        }
         if index < Self::INLINE_BITS {
             self.inline &= !(1 << index);
         } else if let Some(overflow) = &mut self.overflow {
@@ -1510,9 +1562,6 @@ impl BitSet {
     }
 
     pub fn contains_all_set_bits_of(&self, other: &Self) -> bool {
-        if other.has_usize_max && !self.has_usize_max {
-            return false;
-        }
         if (self.inline & other.inline) != other.inline {
             return false;
         }
@@ -1532,21 +1581,10 @@ impl BitSet {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.inline == 0 && self.overflow.is_none() && !self.has_usize_max
+        self.inline == 0 && self.overflow.is_none()
     }
 
     pub fn is_only(&self, index: usize) -> bool {
-        if index == usize::MAX {
-            return self.has_usize_max
-                && self.inline == 0
-                && self
-                    .overflow
-                    .as_ref()
-                    .is_none_or(|ov| ov.iter().all(|&w| w == 0));
-        }
-        if self.has_usize_max {
-            return false;
-        }
         if index < Self::INLINE_BITS {
             self.inline == (1 << index)
                 && self
@@ -1577,9 +1615,6 @@ impl BitSet {
     }
 
     pub fn subtract(&mut self, other: &Self) {
-        if other.has_usize_max {
-            self.has_usize_max = false;
-        }
         self.inline &= !other.inline;
         if let (Some(self_ov), Some(other_ov)) = (&mut self.overflow, &other.overflow) {
             for (s, &o) in self_ov.iter_mut().zip(other_ov.iter()) {
@@ -1592,7 +1627,6 @@ impl BitSet {
     pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
         BitSetIter {
             current: self.inline,
-            pending_usize_max: self.has_usize_max,
             bitset: self,
             word: 0,
         }
@@ -1606,7 +1640,7 @@ impl BitSet {
                 count += word.count_ones() as usize;
             }
         }
-        count + self.has_usize_max as usize
+        count
     }
 
     /// Returns the number of set bits strictly below `index`.
@@ -1641,9 +1675,6 @@ impl BitSet {
     }
 
     pub(crate) fn intersects(&self, other: &Self) -> bool {
-        if self.has_usize_max && other.has_usize_max {
-            return true;
-        }
         if (self.inline & other.inline) != 0 {
             return true;
         }
@@ -1671,7 +1702,6 @@ impl BitSet {
 impl std::ops::BitOrAssign<&Self> for ColumnUsedMask {
     fn bitor_assign(&mut self, rhs: &Self) {
         self.inline |= rhs.inline;
-        self.has_usize_max |= rhs.has_usize_max;
         if let Some(rhs_ov) = &rhs.overflow {
             let self_ov = self.overflow.get_or_insert_with(Vec::new);
             if self_ov.len() < rhs_ov.len() {
@@ -1700,7 +1730,6 @@ impl From<u128> for BitSet {
         Self {
             inline: from as u64,
             overflow: (high != 0).then(|| vec![high]),
-            has_usize_max: false,
         }
     }
 }
@@ -3362,32 +3391,20 @@ mod tests {
     }
 
     #[test]
-    fn test_column_used_mask_usize_max_sentinel() {
-        // `usize::MAX` is stored out-of-band (see `BitSet::has_usize_max`) because the
-        // dense overflow vec can't address it. Every method that touches positions must
-        // honor this; this test pins the behavior down method-by-method.
+    fn test_column_mask_rowid_sentinel() {
+        // ColumnMask stores `usize::MAX` (ROWID_SENTINEL) in an out-of-band bool
+        // so that the underlying dense BitSet never sees it. The small API surface
+        // that ColumnMask exposes must all honor the sentinel consistently.
 
-        // --- set / get / clear round-trip
-        let mut mask = ColumnUsedMask::default();
+        // set / get round-trip on the sentinel alone
+        let mut mask = ColumnMask::default();
         assert!(!mask.get(usize::MAX));
         mask.set(usize::MAX);
         assert!(mask.get(usize::MAX));
-        mask.clear(usize::MAX);
-        assert!(!mask.get(usize::MAX));
+        assert_eq!(mask.count(), 1);
 
-        // --- is_empty / count / is_only with only the sentinel
-        let mut only_max = ColumnUsedMask::default();
-        only_max.set(usize::MAX);
-        assert!(!only_max.is_empty());
-        assert_eq!(only_max.count(), 1);
-        assert!(only_max.is_only(usize::MAX));
-        assert!(!only_max.is_only(0));
-        assert!(!only_max.is_only(63));
-        assert!(!only_max.is_only(64));
-        assert!(!only_max.is_only(1000));
-
-        // --- sentinel coexists with dense bits
-        let mut mixed = ColumnUsedMask::default();
+        // sentinel coexists with dense bits
+        let mut mixed = ColumnMask::default();
         mixed.set(0);
         mixed.set(63);
         mixed.set(64); // crosses into overflow
@@ -3399,91 +3416,22 @@ mod tests {
         assert!(mixed.get(500));
         assert!(mixed.get(usize::MAX));
         assert_eq!(mixed.count(), 5);
-        assert!(!mixed.is_only(usize::MAX)); // not alone
-        assert!(!mixed.is_only(0));
 
-        // iter() yields dense positions in ascending order, then `usize::MAX` at the end.
-        let collected: Vec<usize> = mixed.iter().collect();
+        // iter yields dense positions in ascending order, then usize::MAX at the end
+        let collected: Vec<usize> = (&mixed).into_iter().collect();
         assert_eq!(collected, vec![0, 63, 64, 500, usize::MAX]);
-        // count() and iter().count() must agree.
-        assert_eq!(mixed.count(), mixed.iter().count());
+        // count() and iter().count() must agree
+        assert_eq!(mixed.count(), (&mixed).into_iter().count());
 
-        // --- FromIterator and iter->collect round-trips through the sentinel
-        let built: BitSet = [0usize, 63, 64, 500, usize::MAX].into_iter().collect();
+        // FromIterator round-trip through the sentinel
+        let built: ColumnMask = [0usize, 63, 64, 500, usize::MAX].into_iter().collect();
         assert_eq!(built, mixed);
-        let round: BitSet = mixed.iter().collect();
+        let round: ColumnMask = (&mixed).into_iter().collect();
         assert_eq!(round, mixed);
 
-        // --- contains_all_set_bits_of
-        let mut superset = ColumnUsedMask::default();
-        superset.set(0);
-        superset.set(usize::MAX);
-        let mut subset = ColumnUsedMask::default();
-        subset.set(usize::MAX);
-        assert!(superset.contains_all_set_bits_of(&subset));
-        assert!(!subset.contains_all_set_bits_of(&superset));
-        assert!(superset.contains_all_set_bits_of(&superset));
-        // A mask without the sentinel never contains a mask that has it
-        let mut dense_only = ColumnUsedMask::default();
-        dense_only.set(0);
-        dense_only.set(12345);
-        let mut with_sentinel = ColumnUsedMask::default();
-        with_sentinel.set(usize::MAX);
-        assert!(!dense_only.contains_all_set_bits_of(&with_sentinel));
-
-        // --- subtract clears the sentinel when present in `other`
-        let mut a = ColumnUsedMask::default();
-        a.set(5);
-        a.set(usize::MAX);
-        let mut b = ColumnUsedMask::default();
-        b.set(usize::MAX);
-        a.subtract(&b);
-        assert!(a.get(5));
-        assert!(!a.get(usize::MAX));
-        // Subtracting a mask without the sentinel must not touch self's sentinel
-        let mut c = ColumnUsedMask::default();
-        c.set(usize::MAX);
-        c.set(10);
-        let mut d = ColumnUsedMask::default();
-        d.set(10);
-        c.subtract(&d);
-        assert!(c.get(usize::MAX));
-        assert!(!c.get(10));
-
-        // --- BitOrAssign ORs the sentinels
-        let mut e = ColumnUsedMask::default();
-        e.set(1);
-        let mut f = ColumnUsedMask::default();
-        f.set(usize::MAX);
-        e |= &f;
-        assert!(e.get(1));
-        assert!(e.get(usize::MAX));
-
-        // --- intersects is true iff both have the sentinel (or overlap densely)
-        let mut g = ColumnUsedMask::default();
-        g.set(usize::MAX);
-        let mut h = ColumnUsedMask::default();
-        h.set(usize::MAX);
-        assert!(g.intersects(&h));
-        let mut i = ColumnUsedMask::default();
-        i.set(0);
-        // `g` has only the sentinel; `i` has only 0; they don't intersect.
-        assert!(!g.intersects(&i));
-        assert!(!i.intersects(&g));
-
-        // --- rank(usize::MAX) counts positions STRICTLY below usize::MAX — so it
-        // deliberately excludes the sentinel. `count() == rank(usize::MAX) + get(MAX)`.
-        assert_eq!(
-            mixed.count(),
-            mixed.rank(usize::MAX) + mixed.get(usize::MAX) as usize
-        );
-
-        // --- clearing the sentinel leaves `is_empty` true when nothing else is set
-        let mut k = ColumnUsedMask::default();
-        k.set(usize::MAX);
-        k.clear(usize::MAX);
-        assert!(k.is_empty());
-        assert_eq!(k.count(), 0);
+        // owned IntoIterator (used by flat_map in the UPDATE emitter)
+        let mixed_owned: Vec<usize> = mixed.clone().into_iter().collect();
+        assert_eq!(mixed_owned, vec![0, 63, 64, 500, usize::MAX]);
     }
 
     fn rng_from_env_or_time() -> (ChaCha8Rng, u64) {
@@ -3538,16 +3486,8 @@ mod tests {
 
     #[test]
     fn test_column_used_mask_fuzz() {
-        // Pick an index in `0..max_index`, but with ~5% probability return `usize::MAX`
-        // to exercise the out-of-band sentinel slot alongside dense-range positions.
-        // `ReferenceMask` wraps `BTreeSet<usize>` which handles `usize::MAX` trivially,
-        // so the existing oracle comparisons keep working.
         fn pick_index(rng: &mut ChaCha8Rng, max_index: u32) -> usize {
-            if rng.next_u32() % 20 == 0 {
-                usize::MAX
-            } else {
-                (rng.next_u32() % max_index) as usize
-            }
+            (rng.next_u32() % max_index) as usize
         }
 
         let (mut rng, seed) = rng_from_env_or_time();

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1357,15 +1357,78 @@ impl TableReferences {
     }
 }
 
-/// Tracks which columns are used in a query. Optimized for the common case
-/// of ≤64 columns (single u64), with heap-allocated overflow
+/// Tracks which columns are used in a query.
 pub type ColumnUsedMask = BitSet;
 
+//TODO instead of using this alias, ideally we wouldn't carry naked usize's around, and we would
+// have `ColumnID`, `UsedColumnID`, `TableID`, etc. aliases, just like we have `CursorID`.
+// Then, we can have types like `BitSet<ColumnID>` and type-safe associated functions.
+pub type ColumnMask = BitSet;
+
+/// Bitset optimized for the common case where all elements ≤64, with heap-allocated overflow.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct BitSet {
     inline: u64,
     /// invariant: `overflow` is `None` iff no bits ≥ 64 are set.
     overflow: Option<Vec<u64>>,
+}
+
+/// This iterator, inspired by Kernighan's bit-counting algorighm, is `O(num_words + popcount)`
+/// for the whole bitset.
+pub struct BitSetIter<B: std::borrow::Borrow<BitSet>> {
+    bitset: B,
+    /// Remaining bits to drain from the word currently pointed at by `word`.
+    current: u64,
+    /// `0` = inline word, `1..=overflow.len()` = `overflow[word - 1]`.
+    word: usize,
+}
+
+impl<B: std::borrow::Borrow<BitSet>> Iterator for BitSetIter<B> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.current != 0 {
+                let bit = self.current.trailing_zeros() as usize;
+                self.current &= self.current - 1;
+                let base = if self.word == 0 {
+                    0
+                } else {
+                    BitSet::INLINE_BITS + (self.word - 1) * 64
+                };
+                return Some(base + bit);
+            }
+            self.word += 1;
+            let overflow = self.bitset.borrow().overflow.as_ref()?;
+            self.current = *overflow.get(self.word - 1)?;
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a BitSet {
+    type Item = usize;
+    type IntoIter = BitSetIter<&'a BitSet>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        BitSetIter {
+            current: self.inline,
+            bitset: self,
+            word: 0,
+        }
+    }
+}
+
+impl IntoIterator for BitSet {
+    type Item = usize;
+    type IntoIter = BitSetIter<BitSet>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        BitSetIter {
+            current: self.inline,
+            bitset: self,
+            word: 0,
+        }
+    }
 }
 
 impl BitSet {
@@ -1477,33 +1540,11 @@ impl BitSet {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
-        // this iterator, derived from Kernighan's bitcount algorithm, is O(num_words + popcount)
-        let mut inline = self.inline;
-        let inline_iter = std::iter::from_fn(move || {
-            if inline == 0 {
-                return None;
-            }
-            let bit = inline.trailing_zeros() as usize;
-            inline &= inline - 1; // clear lowest set bit
-            Some(bit)
-        });
-        let overflow_iter = self
-            .overflow
-            .iter()
-            .flat_map(|ov| ov.iter().enumerate())
-            .flat_map(|(word_idx, &word)| {
-                let mut w = word;
-                let base = Self::INLINE_BITS + word_idx * 64;
-                std::iter::from_fn(move || {
-                    if w == 0 {
-                        return None;
-                    }
-                    let bit = w.trailing_zeros() as usize;
-                    w &= w - 1; // clear lowest set bit
-                    Some(base + bit)
-                })
-            });
-        inline_iter.chain(overflow_iter)
+        BitSetIter {
+            current: self.inline,
+            bitset: self,
+            word: 0,
+        }
     }
 
     /// returns the number of set bits

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1365,12 +1365,17 @@ pub type ColumnUsedMask = BitSet;
 // Then, we can have types like `BitSet<ColumnID>` and type-safe associated functions.
 pub type ColumnMask = BitSet;
 
-/// Bitset optimized for the common case where all elements ≤64, with heap-allocated overflow.
+/// Dense bitset optimized for the common case where all elements ≤64, with heap-allocated overflow.
+/// As a special case, this bitset can accomodate `usize::MAX` with O(1) space.
+///
+/// *WARNING*: This bitset occupies `O(max_num)` space when `max_num > 64`,
+/// so it is best used for smaller numbers.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct BitSet {
     inline: u64,
-    /// invariant: `overflow` is `None` iff no bits ≥ 64 are set.
+    /// invariant: `overflow` is `None` iff no bits ≥ 64 and < `usize::MAX` are set.
     overflow: Option<Vec<u64>>,
+    has_usize_max: bool,
 }
 
 /// This iterator, inspired by Kernighan's bit-counting algorighm, is `O(num_words + popcount)`
@@ -1381,6 +1386,7 @@ pub struct BitSetIter<B: std::borrow::Borrow<BitSet>> {
     current: u64,
     /// `0` = inline word, `1..=overflow.len()` = `overflow[word - 1]`.
     word: usize,
+    pending_usize_max: bool,
 }
 
 impl<B: std::borrow::Borrow<BitSet>> Iterator for BitSetIter<B> {
@@ -1399,8 +1405,22 @@ impl<B: std::borrow::Borrow<BitSet>> Iterator for BitSetIter<B> {
                 return Some(base + bit);
             }
             self.word += 1;
-            let overflow = self.bitset.borrow().overflow.as_ref()?;
-            self.current = *overflow.get(self.word - 1)?;
+            let next_word = self
+                .bitset
+                .borrow()
+                .overflow
+                .as_ref()
+                .and_then(|ov| ov.get(self.word - 1).copied());
+            match next_word {
+                Some(w) => self.current = w,
+                None => {
+                    if self.pending_usize_max {
+                        self.pending_usize_max = false;
+                        return Some(usize::MAX);
+                    }
+                    return None;
+                }
+            }
         }
     }
 }
@@ -1412,6 +1432,7 @@ impl<'a> IntoIterator for &'a BitSet {
     fn into_iter(self) -> Self::IntoIter {
         BitSetIter {
             current: self.inline,
+            pending_usize_max: self.has_usize_max,
             bitset: self,
             word: 0,
         }
@@ -1425,6 +1446,7 @@ impl IntoIterator for BitSet {
     fn into_iter(self) -> Self::IntoIter {
         BitSetIter {
             current: self.inline,
+            pending_usize_max: self.has_usize_max,
             bitset: self,
             word: 0,
         }
@@ -1435,6 +1457,10 @@ impl BitSet {
     const INLINE_BITS: usize = 64;
 
     pub fn set(&mut self, index: usize) {
+        if index == usize::MAX {
+            self.has_usize_max = true;
+            return;
+        }
         if index < Self::INLINE_BITS {
             self.inline |= 1 << index;
         } else {
@@ -1449,6 +1475,9 @@ impl BitSet {
     }
 
     pub fn get(&self, index: usize) -> bool {
+        if index == usize::MAX {
+            return self.has_usize_max;
+        }
         if index < Self::INLINE_BITS {
             (self.inline >> index) & 1 != 0
         } else {
@@ -1464,6 +1493,10 @@ impl BitSet {
     }
 
     pub fn clear(&mut self, index: usize) {
+        if index == usize::MAX {
+            self.has_usize_max = false;
+            return;
+        }
         if index < Self::INLINE_BITS {
             self.inline &= !(1 << index);
         } else if let Some(overflow) = &mut self.overflow {
@@ -1477,6 +1510,9 @@ impl BitSet {
     }
 
     pub fn contains_all_set_bits_of(&self, other: &Self) -> bool {
+        if other.has_usize_max && !self.has_usize_max {
+            return false;
+        }
         if (self.inline & other.inline) != other.inline {
             return false;
         }
@@ -1496,10 +1532,21 @@ impl BitSet {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.inline == 0 && self.overflow.is_none()
+        self.inline == 0 && self.overflow.is_none() && !self.has_usize_max
     }
 
     pub fn is_only(&self, index: usize) -> bool {
+        if index == usize::MAX {
+            return self.has_usize_max
+                && self.inline == 0
+                && self
+                    .overflow
+                    .as_ref()
+                    .is_none_or(|ov| ov.iter().all(|&w| w == 0));
+        }
+        if self.has_usize_max {
+            return false;
+        }
         if index < Self::INLINE_BITS {
             self.inline == (1 << index)
                 && self
@@ -1530,6 +1577,9 @@ impl BitSet {
     }
 
     pub fn subtract(&mut self, other: &Self) {
+        if other.has_usize_max {
+            self.has_usize_max = false;
+        }
         self.inline &= !other.inline;
         if let (Some(self_ov), Some(other_ov)) = (&mut self.overflow, &other.overflow) {
             for (s, &o) in self_ov.iter_mut().zip(other_ov.iter()) {
@@ -1542,6 +1592,7 @@ impl BitSet {
     pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
         BitSetIter {
             current: self.inline,
+            pending_usize_max: self.has_usize_max,
             bitset: self,
             word: 0,
         }
@@ -1555,7 +1606,7 @@ impl BitSet {
                 count += word.count_ones() as usize;
             }
         }
-        count
+        count + self.has_usize_max as usize
     }
 
     /// Returns the number of set bits strictly below `index`.
@@ -1590,6 +1641,9 @@ impl BitSet {
     }
 
     pub(crate) fn intersects(&self, other: &Self) -> bool {
+        if self.has_usize_max && other.has_usize_max {
+            return true;
+        }
         if (self.inline & other.inline) != 0 {
             return true;
         }
@@ -1617,6 +1671,7 @@ impl BitSet {
 impl std::ops::BitOrAssign<&Self> for ColumnUsedMask {
     fn bitor_assign(&mut self, rhs: &Self) {
         self.inline |= rhs.inline;
+        self.has_usize_max |= rhs.has_usize_max;
         if let Some(rhs_ov) = &rhs.overflow {
             let self_ov = self.overflow.get_or_insert_with(Vec::new);
             if self_ov.len() < rhs_ov.len() {
@@ -1645,6 +1700,7 @@ impl From<u128> for BitSet {
         Self {
             inline: from as u64,
             overflow: (high != 0).then(|| vec![high]),
+            has_usize_max: false,
         }
     }
 }
@@ -3305,6 +3361,131 @@ mod tests {
         assert!(mask3.is_only(64));
     }
 
+    #[test]
+    fn test_column_used_mask_usize_max_sentinel() {
+        // `usize::MAX` is stored out-of-band (see `BitSet::has_usize_max`) because the
+        // dense overflow vec can't address it. Every method that touches positions must
+        // honor this; this test pins the behavior down method-by-method.
+
+        // --- set / get / clear round-trip
+        let mut mask = ColumnUsedMask::default();
+        assert!(!mask.get(usize::MAX));
+        mask.set(usize::MAX);
+        assert!(mask.get(usize::MAX));
+        mask.clear(usize::MAX);
+        assert!(!mask.get(usize::MAX));
+
+        // --- is_empty / count / is_only with only the sentinel
+        let mut only_max = ColumnUsedMask::default();
+        only_max.set(usize::MAX);
+        assert!(!only_max.is_empty());
+        assert_eq!(only_max.count(), 1);
+        assert!(only_max.is_only(usize::MAX));
+        assert!(!only_max.is_only(0));
+        assert!(!only_max.is_only(63));
+        assert!(!only_max.is_only(64));
+        assert!(!only_max.is_only(1000));
+
+        // --- sentinel coexists with dense bits
+        let mut mixed = ColumnUsedMask::default();
+        mixed.set(0);
+        mixed.set(63);
+        mixed.set(64); // crosses into overflow
+        mixed.set(500);
+        mixed.set(usize::MAX);
+        assert!(mixed.get(0));
+        assert!(mixed.get(63));
+        assert!(mixed.get(64));
+        assert!(mixed.get(500));
+        assert!(mixed.get(usize::MAX));
+        assert_eq!(mixed.count(), 5);
+        assert!(!mixed.is_only(usize::MAX)); // not alone
+        assert!(!mixed.is_only(0));
+
+        // iter() yields dense positions in ascending order, then `usize::MAX` at the end.
+        let collected: Vec<usize> = mixed.iter().collect();
+        assert_eq!(collected, vec![0, 63, 64, 500, usize::MAX]);
+        // count() and iter().count() must agree.
+        assert_eq!(mixed.count(), mixed.iter().count());
+
+        // --- FromIterator and iter->collect round-trips through the sentinel
+        let built: BitSet = [0usize, 63, 64, 500, usize::MAX].into_iter().collect();
+        assert_eq!(built, mixed);
+        let round: BitSet = mixed.iter().collect();
+        assert_eq!(round, mixed);
+
+        // --- contains_all_set_bits_of
+        let mut superset = ColumnUsedMask::default();
+        superset.set(0);
+        superset.set(usize::MAX);
+        let mut subset = ColumnUsedMask::default();
+        subset.set(usize::MAX);
+        assert!(superset.contains_all_set_bits_of(&subset));
+        assert!(!subset.contains_all_set_bits_of(&superset));
+        assert!(superset.contains_all_set_bits_of(&superset));
+        // A mask without the sentinel never contains a mask that has it
+        let mut dense_only = ColumnUsedMask::default();
+        dense_only.set(0);
+        dense_only.set(12345);
+        let mut with_sentinel = ColumnUsedMask::default();
+        with_sentinel.set(usize::MAX);
+        assert!(!dense_only.contains_all_set_bits_of(&with_sentinel));
+
+        // --- subtract clears the sentinel when present in `other`
+        let mut a = ColumnUsedMask::default();
+        a.set(5);
+        a.set(usize::MAX);
+        let mut b = ColumnUsedMask::default();
+        b.set(usize::MAX);
+        a.subtract(&b);
+        assert!(a.get(5));
+        assert!(!a.get(usize::MAX));
+        // Subtracting a mask without the sentinel must not touch self's sentinel
+        let mut c = ColumnUsedMask::default();
+        c.set(usize::MAX);
+        c.set(10);
+        let mut d = ColumnUsedMask::default();
+        d.set(10);
+        c.subtract(&d);
+        assert!(c.get(usize::MAX));
+        assert!(!c.get(10));
+
+        // --- BitOrAssign ORs the sentinels
+        let mut e = ColumnUsedMask::default();
+        e.set(1);
+        let mut f = ColumnUsedMask::default();
+        f.set(usize::MAX);
+        e |= &f;
+        assert!(e.get(1));
+        assert!(e.get(usize::MAX));
+
+        // --- intersects is true iff both have the sentinel (or overlap densely)
+        let mut g = ColumnUsedMask::default();
+        g.set(usize::MAX);
+        let mut h = ColumnUsedMask::default();
+        h.set(usize::MAX);
+        assert!(g.intersects(&h));
+        let mut i = ColumnUsedMask::default();
+        i.set(0);
+        // `g` has only the sentinel; `i` has only 0; they don't intersect.
+        assert!(!g.intersects(&i));
+        assert!(!i.intersects(&g));
+
+        // --- rank(usize::MAX) counts positions STRICTLY below usize::MAX — so it
+        // deliberately excludes the sentinel. `count() == rank(usize::MAX) + get(MAX)`.
+        assert_eq!(
+            mixed.count(),
+            mixed.rank(usize::MAX) + mixed.get(usize::MAX) as usize
+        );
+
+        // --- clearing the sentinel leaves `is_empty` true when nothing else is set
+        let mut k = ColumnUsedMask::default();
+        k.set(usize::MAX);
+        k.clear(usize::MAX);
+        assert!(k.is_empty());
+        assert_eq!(k.count(), 0);
+    }
+
     fn rng_from_env_or_time() -> (ChaCha8Rng, u64) {
         let seed = std::env::var("TEST_SEED")
             .ok()
@@ -3357,6 +3538,18 @@ mod tests {
 
     #[test]
     fn test_column_used_mask_fuzz() {
+        // Pick an index in `0..max_index`, but with ~5% probability return `usize::MAX`
+        // to exercise the out-of-band sentinel slot alongside dense-range positions.
+        // `ReferenceMask` wraps `BTreeSet<usize>` which handles `usize::MAX` trivially,
+        // so the existing oracle comparisons keep working.
+        fn pick_index(rng: &mut ChaCha8Rng, max_index: u32) -> usize {
+            if rng.next_u32() % 20 == 0 {
+                usize::MAX
+            } else {
+                (rng.next_u32() % max_index) as usize
+            }
+        }
+
         let (mut rng, seed) = rng_from_env_or_time();
         eprintln!("test_column_used_mask_random_ops seed: {seed}");
 
@@ -3368,7 +3561,7 @@ mod tests {
 
         for _ in 0..num_ops {
             let op = rng.next_u32() % 10;
-            let idx = (rng.next_u32() % max_index) as usize;
+            let idx = pick_index(&mut rng, max_index);
 
             match op {
                 0..=2 => {
@@ -3410,7 +3603,7 @@ mod tests {
                     let mut other_mask = ColumnUsedMask::default();
                     let mut other_ref = ReferenceMask::new();
                     for _ in 0..(rng.next_u32() % 20) {
-                        let other_idx = (rng.next_u32() % max_index) as usize;
+                        let other_idx = pick_index(&mut rng, max_index);
                         other_mask.set(other_idx);
                         other_ref.set(other_idx);
                     }
@@ -3425,7 +3618,7 @@ mod tests {
                     let mut other_mask = ColumnUsedMask::default();
                     let mut other_ref = ReferenceMask::new();
                     for _ in 0..(rng.next_u32() % 20) {
-                        let other_idx = (rng.next_u32() % max_index) as usize;
+                        let other_idx = pick_index(&mut rng, max_index);
                         other_mask.set(other_idx);
                         other_ref.set(other_idx);
                     }
@@ -3437,7 +3630,7 @@ mod tests {
                     let mut other_mask = ColumnUsedMask::default();
                     let mut other_ref = ReferenceMask::new();
                     for _ in 0..(rng.next_u32() % 20) {
-                        let other_idx = (rng.next_u32() % max_index) as usize;
+                        let other_idx = pick_index(&mut rng, max_index);
                         other_mask.set(other_idx);
                         other_ref.set(other_idx);
                     }

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -25,7 +25,7 @@ use crate::translate::emitter::Resolver;
 use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
 use crate::translate::trigger_exec::has_triggers_including_temp;
 use crate::vdbe::builder::ProgramBuilder;
-use crate::{sync::Arc, Connection, HashSet, Result};
+use crate::{sync::Arc, Connection, Result};
 use turso_parser::ast::{ResolveType, TriggerEvent};
 
 /// Check whether any DDL-level constraint (IPK or index) uses REPLACE.
@@ -195,7 +195,7 @@ pub(crate) fn set_update_stmt_journal_flags(
     };
     let database_id = target_table.database_id;
 
-    let updated_cols: HashSet<usize> = plan.set_clauses.iter().map(|(i, _)| *i).collect();
+    let updated_cols = plan.set_clauses.iter().map(|(i, _)| *i).collect();
     let has_triggers = has_triggers_including_temp(
         resolver,
         database_id,

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -1,6 +1,7 @@
 use crate::schema::{BTreeTable, Trigger};
 use crate::sync::Arc;
 use crate::translate::expr::WalkControl;
+use crate::translate::plan::ColumnMask;
 use crate::translate::subquery::{
     emit_non_from_clause_subquery, plan_subqueries_from_trigger_when_clause,
 };
@@ -14,7 +15,6 @@ use crate::util::normalize_ident;
 use crate::vdbe::affinity::Affinity;
 use crate::vdbe::insn::Insn;
 use crate::vdbe::BranchOffset;
-use crate::HashSet;
 use crate::{bail_parse_error, QueryMode, Result};
 use std::cell::RefCell;
 use std::num::NonZero;
@@ -669,7 +669,7 @@ fn execute_trigger_commands(
 pub fn has_relevant_triggers_type_only(
     schema: &crate::schema::Schema,
     event: TriggerEvent,
-    updated_column_indices: Option<&HashSet<usize>>,
+    updated_column_indices: Option<&ColumnMask>,
     table: &BTreeTable,
 ) -> bool {
     let mut triggers = schema.get_triggers_for_table(table.name.as_str());
@@ -690,7 +690,7 @@ pub fn has_relevant_triggers_type_only(
                 trigger_cols.iter().any(|col_name| {
                     let normalized_col = normalize_ident(col_name.as_str());
                     if let Some((col_idx, _)) = table.get_column(&normalized_col) {
-                        updated_cols.contains(&col_idx)
+                        updated_cols.get(col_idx)
                     } else {
                         // Column doesn't exist - according to SQLite docs, unrecognized
                         // column names in UPDATE OF are silently ignored
@@ -711,7 +711,7 @@ pub fn get_relevant_triggers_type_and_time<'a>(
     schema: &'a crate::schema::Schema,
     event: TriggerEvent,
     time: TriggerTime,
-    updated_column_indices: Option<HashSet<usize>>,
+    updated_column_indices: Option<ColumnMask>,
     table: &'a BTreeTable,
 ) -> impl Iterator<Item = Arc<Trigger>> + 'a + Clone {
     let triggers = schema.get_triggers_for_table(table.name.as_str());
@@ -732,7 +732,7 @@ pub fn get_relevant_triggers_type_and_time<'a>(
                         trigger_cols.iter().any(|col_name| {
                             let normalized_col = normalize_ident(col_name.as_str());
                             if let Some((col_idx, _)) = table.get_column(&normalized_col) {
-                                updated_cols.contains(&col_idx)
+                                updated_cols.get(col_idx)
                             } else {
                                 // Column doesn't exist - according to SQLite docs, unrecognized
                                 // column names in UPDATE OF are silently ignored
@@ -764,7 +764,7 @@ pub fn get_triggers_including_temp(
     database_id: usize,
     event: TriggerEvent,
     time: TriggerTime,
-    updated_column_indices: Option<HashSet<usize>>,
+    updated_column_indices: Option<ColumnMask>,
     table: &BTreeTable,
 ) -> Vec<Arc<Trigger>> {
     let mut triggers: Vec<Arc<Trigger>> = resolver.with_schema(database_id, |s| {
@@ -808,7 +808,7 @@ pub fn has_triggers_including_temp(
     resolver: &Resolver,
     database_id: usize,
     event: TriggerEvent,
-    updated_column_indices: Option<&HashSet<usize>>,
+    updated_column_indices: Option<&ColumnMask>,
     table: &BTreeTable,
 ) -> bool {
     let found = resolver.with_schema(database_id, |s| {

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -1,11 +1,11 @@
 use crate::sync::Arc;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::schema::{columns_affected_by_update, ROWID_SENTINEL};
 use crate::translate::emitter::Resolver;
 use crate::translate::expr::{bind_and_rewrite_expr, BindingBehavior};
 use crate::translate::expression_index::expression_index_column_usage;
-use crate::translate::plan::{Operation, Scan};
+use crate::translate::plan::{ColumnMask, Operation, Scan};
 use crate::translate::planner::{parse_limit, ROWID_STRS};
 use crate::{
     bail_parse_error,
@@ -452,7 +452,7 @@ pub fn prepare_update_plan(
     let updated_cols = (!rowid_alias_used).then(|| set_clauses.iter().map(|(i, _)| *i).collect());
     let affected_cols = updated_cols
         .as_ref()
-        .map(|updated_cols: &HashSet<usize>| columns_affected_by_update(columns, updated_cols));
+        .map(|updated_cols: &ColumnMask| columns_affected_by_update(columns, updated_cols));
     let mut indexes_to_update = Vec::new();
 
     for idx in indexes {
@@ -469,7 +469,7 @@ pub fn prepare_update_plan(
 
                 if !must_update
                     && affected_cols.as_ref().is_some_and(|affected_cols| {
-                        cols_used.iter().any(|cidx| affected_cols.contains(&cidx))
+                        cols_used.iter().any(|cidx| affected_cols.get(cidx))
                     })
                 {
                     // an index must be updated if any of the affected columns is used in an indexed expression
@@ -478,7 +478,7 @@ pub fn prepare_update_plan(
             } else if !must_update
                 && affected_cols
                     .as_ref()
-                    .is_some_and(|affected_cols| affected_cols.contains(&col.pos_in_table))
+                    .is_some_and(|affected_cols| affected_cols.get(col.pos_in_table))
             {
                 // an index must be updated if any of its columns is affected by the update
                 must_update = true;
@@ -494,7 +494,7 @@ pub fn prepare_update_plan(
                 )?;
                 // a partial index must be updated if any column of its WHERE clause is affected
                 must_update = affected_cols.as_ref().is_some_and(|affected_cols| {
-                    cols_used.iter().any(|cidx| affected_cols.contains(&cidx))
+                    cols_used.iter().any(|cidx| affected_cols.get(cidx))
                 });
             }
         }

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -15,6 +15,7 @@ use crate::translate::fkeys::{
     emit_fk_child_update_counters, emit_parent_key_change_checks, fire_fk_update_actions,
 };
 use crate::translate::insert::{format_unique_violation_desc, InsertEmitCtx};
+use crate::translate::plan::ColumnMask;
 use crate::translate::planner::ROWID_STRS;
 use crate::translate::trigger_exec::{
     fire_trigger, get_triggers_including_temp, has_triggers_including_temp, TriggerContext,
@@ -165,16 +166,15 @@ pub fn upsert_matches_rowid_alias(upsert: &Upsert, table: &Table) -> bool {
 fn collect_changed_cols(
     table: &Table,
     set_pairs: &[(usize, Box<ast::Expr>)],
-) -> (HashSet<usize>, bool) {
-    let mut cols_changed =
-        HashSet::with_capacity_and_hasher(table.columns().len(), Default::default());
+) -> (ColumnMask, bool) {
+    let mut cols_changed = ColumnMask::default();
     let mut rowid_changed = false;
     for (col_idx, _) in set_pairs {
         if let Some(c) = table.columns().get(*col_idx) {
             if c.is_rowid_alias() {
                 rowid_changed = true;
             } else {
-                cols_changed.insert(*col_idx);
+                cols_changed.set(*col_idx);
             }
         }
     }
@@ -185,7 +185,7 @@ fn collect_changed_cols(
 fn upsert_index_is_affected(
     table: &Table,
     idx: &Index,
-    changed_cols: &HashSet<usize>,
+    changed_cols: &ColumnMask,
     rowid_changed: bool,
 ) -> bool {
     if rowid_changed {
@@ -198,7 +198,7 @@ fn upsert_index_is_affected(
         .collect();
     let pm = referenced_index_cols(idx, table);
     for c in km.iter().chain(pm.iter()) {
-        if changed_cols.contains(c) {
+        if changed_cols.get(*c) {
             return true;
         }
     }
@@ -674,7 +674,7 @@ pub fn emit_upsert(
     // Fire BEFORE UPDATE triggers
     let upsert_database_id = ctx.database_id;
     let preserved_old_registers: Option<Vec<usize>> = if let Some(btree_table) = table.btree() {
-        let updated_column_indices: HashSet<usize> =
+        let updated_column_indices: ColumnMask =
             set_pairs.iter().map(|(col_idx, _)| *col_idx).collect();
         let relevant_before_update_triggers = get_triggers_including_temp(
             resolver,
@@ -1232,7 +1232,7 @@ pub fn emit_upsert(
 
     // Fire AFTER UPDATE triggers
     if let (Some(btree_table), Some(old_regs)) = (table.btree(), preserved_old_registers) {
-        let updated_column_indices: HashSet<usize> =
+        let updated_column_indices: ColumnMask =
             set_pairs.iter().map(|(col_idx, _)| *col_idx).collect();
         let relevant_triggers = get_triggers_including_temp(
             resolver,


### PR DESCRIPTION
## Description

This makes the code a little more expressive and cuts down on allocations (`BitSet` is 0-alloc in most cases).

This will help with what I want to do in `columns_affected_by_update` (intersect a bunch of sets).

## Description of AI Usage

Claude wrote the iterators.