### PR TITLE
fix(json): handle `$[#]` / `$.key[#]` path locator instead of panicking (#3225)

### DIFF
--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -2594,7 +2594,30 @@ impl Jsonb {
                                 bail_parse_error!("Element with negative index not found")
                             }
                         }
-                        _ => unreachable!(),
+                        // The `[#]` locator (no index) maps to "the slot just
+                        // past the last element" per SQLite semantics — an
+                        // append position for insert-capable modes like
+                        // json_set / json_insert (#3225). Pre-fix this hit
+                        // `unreachable!()` and panicked.
+                        None => {
+                            if mode.allows_insert() {
+                                let placeholder =
+                                    JsonbHeader::new(ElementType::OBJECT, 0).into_bytes();
+                                let placeholder_bytes = placeholder.as_bytes();
+
+                                self.data
+                                    .splice(end_pos..end_pos, placeholder_bytes.iter().copied());
+
+                                return Ok(JsonTraversalResult::with_array_index(
+                                    pos,
+                                    JsonLocationKind::ArrayEntry,
+                                    placeholder_bytes.len() as isize,
+                                    end_pos,
+                                ));
+                            }
+                            bail_parse_error!("Path [#] requires an insert-capable mode");
+                        }
+                        Some(_) => unreachable!(),
                     }
                 } else {
                     if root_type == ElementType::OBJECT
@@ -2773,7 +2796,27 @@ impl Jsonb {
                                 bail_parse_error!("Element with negative index not found")
                             }
                         }
-                        _ => unreachable!(),
+                        // `$[#]` at the document root: append slot for
+                        // insert-capable modes (#3225).
+                        None => {
+                            if mode.allows_insert() {
+                                let placeholder =
+                                    JsonbHeader::new(ElementType::OBJECT, 0).into_bytes();
+                                let placeholder_bytes = placeholder.as_bytes();
+
+                                self.data
+                                    .splice(end_pos..end_pos, placeholder_bytes.iter().copied());
+
+                                return Ok(JsonTraversalResult::with_array_index(
+                                    pos,
+                                    JsonLocationKind::DocumentRoot,
+                                    placeholder_bytes.len() as isize,
+                                    end_pos,
+                                ));
+                            }
+                            bail_parse_error!("Path [#] requires an insert-capable mode");
+                        }
+                        Some(_) => unreachable!(),
                     }
                 } else {
                     bail_parse_error!("Root is not an array");
@@ -2948,6 +2991,17 @@ impl Jsonb {
                             }
                         }
                         Some(_) => unreachable!(),
+                        // `$.key[#]`: append to the keyed array (#3225).
+                        // The pre-existing None branch here only `insert`-ed
+                        // a single placeholder byte, skipped updating the
+                        // containing array header, and fell through without
+                        // returning a `JsonTraversalResult` — so the slot was
+                        // silently dropped and the function reported
+                        // "Not found". Mirror the `Some(idx) if idx >= 0`
+                        // append path above so the placeholder is actually
+                        // spliced in, the array header is rewritten with the
+                        // new size, and the caller receives the insertion
+                        // location.
                         None => {
                             if mode.allows_insert() {
                                 let placeholder =
@@ -2955,10 +3009,24 @@ impl Jsonb {
                                 let placeholder_bytes = placeholder.as_bytes();
                                 let insertion_point = value_idx + value_size + value_header_size;
 
-                                self.data.insert(insertion_point, placeholder_bytes[0]);
-                            } else {
-                                bail_parse_error!("Cant insert")
+                                self.data.splice(
+                                    insertion_point..insertion_point,
+                                    placeholder_bytes.iter().copied(),
+                                );
+                                self.write_element_header(
+                                    value_idx,
+                                    ElementType::ARRAY,
+                                    value_size + placeholder_bytes.len(),
+                                    true,
+                                )?;
+                                return Ok(JsonTraversalResult::with_array_index(
+                                    value_idx,
+                                    JsonLocationKind::ObjectProperty(key_idx),
+                                    placeholder_bytes.len() as isize,
+                                    insertion_point,
+                                ));
                             }
+                            bail_parse_error!("Path [#] requires an insert-capable mode");
                         }
                     }
                 }

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -1744,6 +1744,66 @@ mod tests {
         assert_eq!(result.unwrap().to_text().unwrap(), "[123,456]");
     }
 
+    // Regression tests for #3225: the `[#]` array locator (a path segment of
+    // `#` with no index) means "the slot just past the last element" per
+    // SQLite semantics. For insert-capable modes this is an append. Before
+    // the fix, navigate_path hit `unreachable!()` and panicked.
+    #[test]
+    fn test_json_set_root_hash_appends_to_array() {
+        let json_cache = JsonCacheCell::new();
+        let result = json_set(
+            &[
+                Value::build_text("[0,1,2]"),
+                Value::build_text("$[#]"),
+                Value::build_text("new"),
+            ],
+            &json_cache,
+        );
+        assert_eq!(result.unwrap().to_text().unwrap(), r#"[0,1,2,"new"]"#);
+    }
+
+    #[test]
+    fn test_json_set_root_hash_on_empty_array() {
+        let json_cache = JsonCacheCell::new();
+        let result = json_set(
+            &[
+                Value::build_text("[]"),
+                Value::build_text("$[#]"),
+                Value::build_text("first"),
+            ],
+            &json_cache,
+        );
+        assert_eq!(result.unwrap().to_text().unwrap(), r#"["first"]"#);
+    }
+
+    #[test]
+    fn test_json_set_keyed_hash_appends_to_nested_array() {
+        let json_cache = JsonCacheCell::new();
+        let result = json_set(
+            &[
+                Value::build_text(r#"{"a":[0,1]}"#),
+                Value::build_text("$.a[#]"),
+                Value::from_i64(42),
+            ],
+            &json_cache,
+        );
+        assert_eq!(result.unwrap().to_text().unwrap(), r#"{"a":[0,1,42]}"#);
+    }
+
+    #[test]
+    fn test_json_set_keyed_hash_on_empty_nested_array() {
+        let json_cache = JsonCacheCell::new();
+        let result = json_set(
+            &[
+                Value::build_text(r#"{"a":[]}"#),
+                Value::build_text("$.a[#]"),
+                Value::build_text("first"),
+            ],
+            &json_cache,
+        );
+        assert_eq!(result.unwrap().to_text().unwrap(), r#"{"a":["first"]}"#);
+    }
+
     #[test]
     fn test_json_set_add_value_to_array_out_of_bounds() {
         let json_cache = JsonCacheCell::new();


### PR DESCRIPTION
## Summary

Fixes #3225.

\`json_set('[0,1,2]','\$[#]','new')\` panicked with \`unreachable!()\` in \`JsonbHeader\` path navigation. The \`#\` array locator with no explicit index is documented in SQLite ([docs](https://sqlite.org/json1.html#path_arguments)) as meaning \"the slot just past the last element\" — an append position for insert-capable modes.

## Change

Three code paths in \`navigate_path\` matched \`ArrayLocator(idx)\` and fell through to \`unreachable!()\` when \`idx == None\`:

1. **\`SegmentVariant::Single(ArrayLocator(None))\`** — e.g. \`\$[#]\` against an array document root. Now splices a placeholder at \`end_pos\` and returns a traversal result when the mode allows insert.

2. **\`SegmentVariant::KeyWithArrayIndex(Root(), ArrayLocator(None))\`** — same shape from a two-segment path. Same fix.

3. **\`SegmentVariant::KeyWithArrayIndex(Key, ArrayLocator(None))\`** — e.g. \`\$.a[#]\`. A \`None\` branch already existed here, but it wrote only the **first byte** of the placeholder (\`self.data.insert(insertion_point, placeholder_bytes[0])\`), never rewrote the containing array header to reflect the new size, and never returned a \`JsonTraversalResult\`. The caller then reported \`Not found\` and the write was silently dropped. Replaced with a proper \`splice\` + \`write_element_header\` + \`return\`, mirroring the \`Some(idx) if idx >= 0 && arr_pos == end_pos\` branch above.

## Verified behavior

| Query | Before | After (matches SQLite) |
|---|---|---|
| \`json_set('[0,1,2]','\$[#]','new')\` | panic | \`[0,1,2,\"new\"]\` |
| \`json_set('[]','\$[#]','first')\` | panic | \`[\"first\"]\` |
| \`json_set('{\"a\":[0,1]}','\$.a[#]',42)\` | silent no-op (returned input unchanged) | \`{\"a\":[0,1,42]}\` |
| \`json_set('{\"a\":[]}','\$.a[#]','first')\` | silent no-op | \`{\"a\":[\"first\"]}\` |
| \`json_insert('[0,1,2]','\$[#]','new')\` | panic | \`[0,1,2,\"new\"]\` |
| \`json_replace('[0,1,2]','\$[#]','x')\` | panic | \`[0,1,2]\` (no-op: [#] doesn't exist for replace) |
| \`json_extract('[0,1,2]','\$[#]')\` | panic | NULL |

## Known follow-up (out of scope)

\`json_insert('{\"a\":[0,1]}','\$.a[#]','new')\` still returns the input unchanged. This is a separate mode-gating issue: the existing-key access path is gated behind \`mode.allows_replace()\`, which \`json_insert\` doesn't set. Fixing it would require restructuring that gate to let \`allows_insert()\` through for the specific case of appending to a pre-existing keyed array. Happy to do that as a follow-up PR if maintainers prefer.

## Test plan

- [x] 4 new regression tests in \`json::tests\` cover root and keyed variants on both non-empty and empty target arrays.
- [x] \`cargo test -p turso_core --lib json\` — 158/158 pass (154 existing + 4 new).
- [x] \`cargo clippy -p turso_core --lib -- -D warnings\` — clean.
- [x] \`cargo fmt -p turso_core\` applied.

## AI-assisted disclosure

Drafted with Claude Code. I reproduced the panic on current \`main\`, traced it to the three \`unreachable!()\` sites in \`navigate_path\`, spotted the third site's broken \`None\` branch that was silently dropping writes, and confirmed the end-to-end behavior against SQLite's documented semantics. I understand what the code does.